### PR TITLE
Accelerate MiniMax-H3 with sparse Metal attention and adaptive windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,17 @@ The format is based on Keep a Changelog.
   without an expanded converted copy, applies its published alpha/rank scale,
   fuses the deltas into BF16 weights once before denoising, and uses the
   existing exact four-evaluation FL2VA path without per-block LoRA matmuls.
+- added an independently implemented MiniMax-H3 dynamic-sparse attention lane
+  for Apple GPUs. Explicit `balanced` and `maximum` acceleration keep text,
+  conditioning media, generated audio, neighboring video blocks, early layers,
+  and schedule boundaries dense; route distant target-video blocks on the fly;
+  and fail closed behind a once-per-shape dense-route numerical gate. Turbo
+  adapters may use this attention-only lane while continuing to prohibit
+  denoise-step cache reuse.
+- accelerated a real 768x448, 124-frame LightX2V generation from 631.826 to
+  444.216 seconds of denoising and from 736.285 to 535.386 seconds end to end.
+  Both fixed-seed outputs retained all 124 H.264 frames, synchronized 32 kHz
+  stereo audio, coherent actors and motion, and the complete two-line dialogue.
 
 ### Geospatial inference
 

--- a/README.md
+++ b/README.md
@@ -795,6 +795,26 @@ swift run mere.run video generate \
   --num-frames 124 \
   --output ./referenced-h3.mp4
 
+# Resident H3 long-form generation carries prior motion and matching audio
+# through every overlap. The same flags work with FL2VA and Ref2VA roots.
+swift run mere.run video generate \
+  "one continuous tracking shot through the midnight market" \
+  --model video-minimax-h3-fl2va-bf16-mlx \
+  --duration 15 \
+  --h3-window-frames 124 \
+  --h3-window-overlap 35 \
+  --h3-acceleration maximum \
+  --output ./market-long-h3.mp4
+
+# FL2VA can inject up to 12 images at exact zero-based output-frame indices.
+swift run mere.run video generate \
+  "the same actor crosses three connected practical sets" \
+  --model video-minimax-h3-fl2va-bf16-mlx \
+  --num-frames 175 \
+  --h3-frame 72:./second-set.png \
+  --h3-frame 144:./third-set.png \
+  --output ./directed-sets-h3.mp4
+
 # Animate a masked reference subject from a driving video with native SCAIL-2
 swift run mere.run model pull video-scail2-14b-mlx
 swift run mere.run adapter pull scail2-lightx2v-4step

--- a/Sources/MereRunCLI/Commands/VideoCommand.swift
+++ b/Sources/MereRunCLI/Commands/VideoCommand.swift
@@ -303,7 +303,7 @@ struct VideoGenerate: AsyncParsableCommand {
 
     @Option(
         name: [.customLong("h3-acceleration")],
-        help: "MiniMax-H3 denoise mode: quality runs every block; balanced/maximum use adaptive first-block drift guards."
+        help: "MiniMax-H3 acceleration: quality is exact; balanced/maximum add dynamic sparse attention and, without a Turbo adapter, adaptive first-block caching."
     )
     var h3Acceleration: MiniMaxH3CLIAccelerationMode = .quality
 

--- a/Sources/MereRunCLI/Commands/VideoCommand.swift
+++ b/Sources/MereRunCLI/Commands/VideoCommand.swift
@@ -245,6 +245,8 @@ struct VideoGenerate: AsyncParsableCommand {
           swift run mere.run video generate "a kinetic live performance" --audio song.wav --audio-start-time 30 --duration 5 --image performer.png
           swift run mere.run video generate "the camera walks forward" --model video-wan22-ti2v-5b-mlx --image frame.png --num-frames 41 --width 1280 --height 704
           swift run mere.run video generate "use this subject and motion" --model-root ./MiniMax-H3-Ref2VA-MLX --reference image:subject.png --reference video:motion.mp4
+          swift run mere.run video generate "one continuous tracking shot" --model minimax-h3-fl2va-bf16-mlx --duration 15 --h3-window-frames 124 --h3-window-overlap 35
+          swift run mere.run video generate "the actor crosses three sets" --model minimax-h3-fl2va-bf16-mlx --h3-frame 72:second-set.png --h3-frame 144:third-set.png
         """
     )
 
@@ -301,7 +303,7 @@ struct VideoGenerate: AsyncParsableCommand {
 
     @Option(
         name: [.customLong("h3-acceleration")],
-        help: "MiniMax-H3 denoise mode: quality runs every block; balanced/maximum reuse bounded tail-block residuals for speed."
+        help: "MiniMax-H3 denoise mode: quality runs every block; balanced/maximum use adaptive first-block drift guards."
     )
     var h3Acceleration: MiniMaxH3CLIAccelerationMode = .quality
 
@@ -313,6 +315,24 @@ struct VideoGenerate: AsyncParsableCommand {
 
     @Option(name: [.customLong("h3-adapter-strength")], help: "MiniMax-H3 runtime adapter multiplier.")
     var h3AdapterStrength: Float = 1
+
+    @Option(
+        name: [.customLong("h3-frame")],
+        help: "MiniMax-H3 FL2VA image at zero-based FRAME:PATH. Repeat for arbitrary timed frame injection."
+    )
+    var h3FrameArguments: [String] = []
+
+    @Option(
+        name: [.customLong("h3-window-frames")],
+        help: "MiniMax-H3 resident sliding-window size (17*n+5 frames). Enables long-form generation."
+    )
+    var h3WindowFrames: Int?
+
+    @Option(
+        name: [.customLong("h3-window-overlap")],
+        help: "MiniMax-H3 sliding overlap (17*n+1 frames, default 18). Carries motion and matching audio."
+    )
+    var h3WindowOverlap: Int = 18
 
     @Option(name: [.customLong("guidance-scale")], help: "Wan classifier-free guidance scale.")
     var guidanceScale: Float = 5
@@ -565,12 +585,17 @@ struct VideoGenerate: AsyncParsableCommand {
                 baseModelID: ModelResolver.ModelID.miniMaxH3FL2VABF16MLX.rawValue
             ).map { URL(fileURLWithPath: $0).standardizedFileURL }
             let parsedReferences = try parseMiniMaxH3References()
+            let parsedFrameInputs = try parseMiniMaxH3FrameInputs()
             if h3Configuration.task == "fl2va", !parsedReferences.isEmpty {
                 throw ValidationError("--reference requires a MiniMax-H3 Ref2VA model root.")
             }
             if h3Configuration.task == "ref2va" {
-                guard sourceImageURL == nil, endImageURL == nil else {
-                    throw ValidationError("MiniMax-H3 Ref2VA uses ordered --reference inputs, not --image/--end-image.")
+                guard sourceImageURL == nil,
+                      endImageURL == nil,
+                      parsedFrameInputs.isEmpty else {
+                    throw ValidationError(
+                        "MiniMax-H3 Ref2VA uses ordered --reference inputs, not FL2VA frame conditions."
+                    )
                 }
                 guard !parsedReferences.isEmpty else {
                     throw ValidationError("MiniMax-H3 Ref2VA requires at least one --reference.")
@@ -580,6 +605,13 @@ struct VideoGenerate: AsyncParsableCommand {
             let h3Height = max(32, (height / 32) * 32)
             let requestedH3Frames = duration.map { Int(($0 * 24).rounded()) } ?? numFrames
             let h3Frames = try MiniMaxH3Geometry.alignFrameCount(max(22, requestedH3Frames))
+            let slidingWindowOptions = try h3WindowFrames.map {
+                try MiniMaxH3SlidingWindowOptions(
+                    totalFrameCount: h3Frames,
+                    windowFrameCount: $0,
+                    overlapFrameCount: h3WindowOverlap
+                )
+            }
             if !quiet {
                 CLIStderr.write("Engine: native MiniMax-H3 \(h3Configuration.task.uppercased())\n")
                 CLIStderr.write("Model root: \(resolvedRootURL.path)\n")
@@ -591,6 +623,14 @@ struct VideoGenerate: AsyncParsableCommand {
                 }
                 if h3Frames != requestedH3Frames {
                     CLIStderr.write("Adjusted MiniMax-H3 frame count to \(h3Frames) (must have form 17*n+5)\n")
+                }
+                if let slidingWindowOptions {
+                    let plan = MiniMaxH3SlidingWindowPlan(options: slidingWindowOptions)
+                    CLIStderr.write(
+                        "Sliding windows: \(plan.windows.count) x "
+                            + "\(slidingWindowOptions.windowFrameCount) frames, "
+                            + "overlap \(slidingWindowOptions.overlapFrameCount)\n"
+                    )
                 }
             }
             try MLXBundleSupport.ensureAvailable(quiet: quiet)
@@ -607,26 +647,40 @@ struct VideoGenerate: AsyncParsableCommand {
                 adapterStrength: h3AdapterStrength,
                 firstFrameURL: sourceImageURL,
                 lastFrameURL: endImageURL,
+                frameInputs: parsedFrameInputs,
                 references: parsedReferences
             )
-            let generator = MiniMaxH3Generator()
+            let generator = MiniMaxH3Generator(retainsRuntime: slidingWindowOptions != nil)
             let reportsProgress = !quiet
+            let progressHandler: @Sendable (MiniMaxH3GenerationProgress) -> Void = { progress in
+                guard reportsProgress else { return }
+                if progress.stage == .denoising {
+                    CLIStderr.write("Denoising \(progress.stepIndex + 1)/\(progress.totalSteps)\n")
+                } else {
+                    CLIStderr.write("\(progress.stage.rawValue)\n")
+                }
+            }
             let wiredMemoryTicket = MiniMaxH3WiredMemoryPolicy().ticket(
                 size: miniMaxH3WiredMemoryTargetBytes()
             )
             let result = try await wiredMemoryTicket.withWiredLimit {
                 try Stream.withNewDefaultStream {
-                    try generator.generate(
+                    if let slidingWindowOptions {
+                        return try generator.generateSlidingWindows(
+                            options: h3Options,
+                            slidingWindowOptions: slidingWindowOptions,
+                            resources: h3Resources,
+                            windowHandler: { index, count in
+                                guard reportsProgress else { return }
+                                CLIStderr.write("H3 window \(index + 1)/\(count)\n")
+                            },
+                            progressHandler: progressHandler
+                        )
+                    }
+                    return try generator.generate(
                         options: h3Options,
                         resources: h3Resources,
-                        progressHandler: { progress in
-                            guard reportsProgress else { return }
-                            if progress.stage == .denoising {
-                                CLIStderr.write("Denoising \(progress.stepIndex + 1)/\(progress.totalSteps)\n")
-                            } else {
-                                CLIStderr.write("\(progress.stage.rawValue)\n")
-                            }
-                        }
+                        progressHandler: progressHandler
                     )
                 }
             }
@@ -643,6 +697,11 @@ struct VideoGenerate: AsyncParsableCommand {
         }
         if h3Adapter != nil {
             throw ValidationError("--h3-adapter can only be used with a MiniMax-H3 model.")
+        }
+        if !h3FrameArguments.isEmpty || h3WindowFrames != nil {
+            throw ValidationError(
+                "--h3-frame and --h3-window-frames can only be used with a MiniMax-H3 model."
+            )
         }
         if !references.isEmpty {
             throw ValidationError("--reference is only supported by MiniMax-H3 Ref2VA model roots.")
@@ -831,6 +890,24 @@ struct VideoGenerate: AsyncParsableCommand {
                 throw ValidationError("Reference file not found: \(url.path)")
             }
             return MiniMaxH3ReferenceInput(kind: kind, url: url)
+        }
+    }
+
+    private func parseMiniMaxH3FrameInputs() throws -> [MiniMaxH3FrameInput] {
+        try h3FrameArguments.map { raw in
+            guard let separator = raw.firstIndex(of: ":") else {
+                throw ValidationError("--h3-frame must be zero-based FRAME:PATH (got \(raw)).")
+            }
+            let rawIndex = String(raw[..<separator])
+            let rawPath = String(raw[raw.index(after: separator)...])
+            guard let frameIndex = Int(rawIndex), frameIndex >= 0, !rawPath.isEmpty else {
+                throw ValidationError("--h3-frame must be zero-based FRAME:PATH (got \(raw)).")
+            }
+            let url = URL(fileURLWithPath: rawPath).standardizedFileURL
+            guard FileManager.default.fileExists(atPath: url.path) else {
+                throw ValidationError("H3 frame image not found: \(url.path)")
+            }
+            return MiniMaxH3FrameInput(frameIndex: frameIndex, url: url)
         }
     }
 
@@ -1320,6 +1397,9 @@ struct VideoGenerate: AsyncParsableCommand {
             h3AccelerationMode: h3Acceleration.rawValue,
             h3Adapter: h3Adapter,
             h3AdapterStrength: h3AdapterStrength,
+            h3FrameInputs: h3FrameArguments,
+            h3WindowFrames: h3WindowFrames,
+            h3WindowOverlap: h3WindowOverlap,
             duration: duration,
             fps: fps,
             seed: seed,
@@ -1398,6 +1478,15 @@ struct VideoGenerate: AsyncParsableCommand {
             ]
             if let h3Adapter {
                 args += ["--h3-adapter", h3Adapter, "--h3-adapter-strength", String(h3AdapterStrength)]
+            }
+            for frame in h3FrameArguments {
+                args += ["--h3-frame", frame]
+            }
+            if let h3WindowFrames {
+                args += [
+                    "--h3-window-frames", String(h3WindowFrames),
+                    "--h3-window-overlap", String(h3WindowOverlap),
+                ]
             }
         }
         if let duration {

--- a/Sources/MereRunCLI/Support/VideoGenerationPreflight.swift
+++ b/Sources/MereRunCLI/Support/VideoGenerationPreflight.swift
@@ -522,14 +522,6 @@ struct VideoGenerationPreflightAnalyzer {
                 message: "--h3-adapter-strength must be > 0."
             ))
         }
-        if input.h3Adapter != nil, input.h3AccelerationMode != MiniMaxH3AccelerationMode.quality.rawValue {
-            diagnostics.append(PreflightDiagnostic(
-                id: "h3_adapter_acceleration_conflict",
-                severity: .blocker,
-                title: "MiniMax-H3 Turbo already distills the denoise schedule",
-                message: "Use --h3-acceleration quality with --h3-adapter."
-            ))
-        }
         if input.h3Adapter != nil, !input.references.isEmpty {
             diagnostics.append(PreflightDiagnostic(
                 id: "h3_adapter_ref2va_unsupported",

--- a/Sources/MereRunCLI/Support/VideoGenerationPreflight.swift
+++ b/Sources/MereRunCLI/Support/VideoGenerationPreflight.swift
@@ -21,6 +21,9 @@ struct VideoGenerationPreflightInput {
     let h3AccelerationMode: String
     let h3Adapter: String?
     let h3AdapterStrength: Float
+    let h3FrameInputs: [String]
+    let h3WindowFrames: Int?
+    let h3WindowOverlap: Int
     let duration: Double?
     let fps: Int
     let seed: Int?
@@ -59,6 +62,9 @@ struct VideoGenerationPreflightRequest: Codable, Equatable {
     let h3AccelerationMode: String?
     let h3Adapter: String?
     let h3AdapterStrength: Float?
+    let h3FrameInputs: [String]?
+    let h3WindowFrames: Int?
+    let h3WindowOverlap: Int?
     let duration: Double?
     let fps: Int
     let seed: Int?
@@ -94,6 +100,9 @@ struct VideoGenerationPreflightRequest: Codable, Equatable {
         case h3AccelerationMode = "h3_acceleration"
         case h3Adapter = "h3_adapter"
         case h3AdapterStrength = "h3_adapter_strength"
+        case h3FrameInputs = "h3_frames"
+        case h3WindowFrames = "h3_window_frames"
+        case h3WindowOverlap = "h3_window_overlap"
         case duration
         case fps
         case seed
@@ -171,6 +180,7 @@ struct VideoGenerationInputPreflightSummary: Codable, Equatable {
     let sourceAudio: VideoGenerationPathPreflightSummary?
     let sourceImage: VideoGenerationPathPreflightSummary?
     let endImage: VideoGenerationPathPreflightSummary?
+    let h3Frames: [VideoGenerationPathPreflightSummary]?
     let references: [VideoGenerationPathPreflightSummary]?
     let adapter: VideoGenerationPathPreflightSummary?
     let missingCount: Int
@@ -180,6 +190,7 @@ struct VideoGenerationInputPreflightSummary: Codable, Equatable {
         case sourceAudio = "source_audio"
         case sourceImage = "source_image"
         case endImage = "end_image"
+        case h3Frames = "h3_frames"
         case references
         case adapter
         case missingCount = "missing_count"
@@ -216,6 +227,10 @@ struct VideoGenerationPlanPreflightSummary: Codable, Equatable {
     let h3AccelerationMode: String?
     let h3Adapter: String?
     let h3AdapterStrength: Float?
+    let h3FrameCount: Int?
+    let h3WindowFrames: Int?
+    let h3WindowOverlap: Int?
+    let h3WindowCount: Int?
     let fps: Int
     let resolvedNumFrames: Int
     let resolvedDurationSeconds: Double?
@@ -241,6 +256,10 @@ struct VideoGenerationPlanPreflightSummary: Codable, Equatable {
         case h3AccelerationMode = "h3_acceleration"
         case h3Adapter = "h3_adapter"
         case h3AdapterStrength = "h3_adapter_strength"
+        case h3FrameCount = "h3_frame_count"
+        case h3WindowFrames = "h3_window_frames"
+        case h3WindowOverlap = "h3_window_overlap"
+        case h3WindowCount = "h3_window_count"
         case fps
         case resolvedNumFrames = "resolved_num_frames"
         case resolvedDurationSeconds = "resolved_duration_seconds"
@@ -349,6 +368,13 @@ struct VideoGenerationPreflightAnalyzer {
             h3Adapter: usesMiniMaxH3Geometry ? input.h3Adapter : nil,
             h3AdapterStrength: usesMiniMaxH3Geometry && input.h3Adapter != nil
                 ? input.h3AdapterStrength
+                : nil,
+            h3FrameInputs: usesMiniMaxH3Geometry && !input.h3FrameInputs.isEmpty
+                ? input.h3FrameInputs
+                : nil,
+            h3WindowFrames: usesMiniMaxH3Geometry ? input.h3WindowFrames : nil,
+            h3WindowOverlap: usesMiniMaxH3Geometry && input.h3WindowFrames != nil
+                ? input.h3WindowOverlap
                 : nil,
             duration: input.duration,
             fps: input.fps,
@@ -469,6 +495,23 @@ struct VideoGenerationPreflightAnalyzer {
                 severity: .blocker,
                 title: "MiniMax-H3 adapter requires MiniMax-H3",
                 message: "--h3-adapter can only be used with a MiniMax-H3 model."
+            ))
+        }
+        if !usesMiniMaxH3Geometry,
+           (!input.h3FrameInputs.isEmpty || input.h3WindowFrames != nil) {
+            diagnostics.append(PreflightDiagnostic(
+                id: "h3_window_or_frame_with_non_h3_model",
+                severity: .blocker,
+                title: "MiniMax-H3 controls require MiniMax-H3",
+                message: "--h3-frame and --h3-window-frames can only be used with a MiniMax-H3 model."
+            ))
+        }
+        if !input.references.isEmpty, !input.h3FrameInputs.isEmpty {
+            diagnostics.append(PreflightDiagnostic(
+                id: "h3_frame_ref2va_unsupported",
+                severity: .blocker,
+                title: "Timed H3 frames require FL2VA",
+                message: "Use --h3-frame with FL2VA; Ref2VA uses ordered --reference inputs."
             ))
         }
         if input.h3Adapter != nil, input.h3AdapterStrength <= 0 {
@@ -1011,6 +1054,10 @@ struct VideoGenerationPreflightAnalyzer {
         let sourceAudio = usesAudioConditioning ? input.audio.map { pathSummary(requested: $0) } : nil
         let sourceImage = input.image.map { pathSummary(requested: $0) }
         let endImage = input.endImage.map { pathSummary(requested: $0) }
+        let h3Frames = input.h3FrameInputs.map { raw -> VideoGenerationPathPreflightSummary in
+            let path = raw.firstIndex(of: ":").map { String(raw[raw.index(after: $0)...]) } ?? raw
+            return pathSummary(requested: path)
+        }
         let references = input.references.map { raw -> VideoGenerationPathPreflightSummary in
             let path = raw.firstIndex(of: ":").map { String(raw[raw.index(after: $0)...]) } ?? raw
             return pathSummary(requested: path)
@@ -1066,6 +1113,25 @@ struct VideoGenerationPreflightAnalyzer {
                 ))
             }
         }
+        for (index, summary) in h3Frames.enumerated() {
+            if !summary.exists {
+                diagnostics.append(PreflightDiagnostic(
+                    id: "h3_frame_\(index)_missing",
+                    severity: .blocker,
+                    title: "Timed H3 frame missing",
+                    message: "Timed frame image not found: \(summary.path)",
+                    locations: [.init(kind: "file", path: summary.path)]
+                ))
+            } else if summary.isDirectory {
+                diagnostics.append(PreflightDiagnostic(
+                    id: "h3_frame_\(index)_is_directory",
+                    severity: .blocker,
+                    title: "Timed H3 frame is a directory",
+                    message: "Timed frame path is a directory: \(summary.path)",
+                    locations: [.init(kind: "directory", path: summary.path)]
+                ))
+            }
+        }
         if let adapter, !adapter.exists {
             let pullHint = ManagedAdapterCatalog.spec(for: adapter.requested).map {
                 " Run `mere.run adapter pull \($0.id)`."
@@ -1103,12 +1169,15 @@ struct VideoGenerationPreflightAnalyzer {
                 ? "text_to_video"
                 : (endImage == nil ? "image_to_video" : "directed_image_to_video")
         }
-        let allInputs = [sourceAudio, sourceImage, endImage, adapter].compactMap { $0 } + references
+        let allInputs = [sourceAudio, sourceImage, endImage, adapter].compactMap { $0 }
+            + h3Frames
+            + references
         return VideoGenerationInputPreflightSummary(
             mode: mode,
             sourceAudio: sourceAudio,
             sourceImage: sourceImage,
             endImage: endImage,
+            h3Frames: h3Frames.isEmpty ? nil : h3Frames,
             references: references.isEmpty ? nil : references,
             adapter: adapter,
             missingCount: allInputs.filter { !$0.exists }.count
@@ -1150,6 +1219,46 @@ struct VideoGenerationPreflightAnalyzer {
         let resolvedFrames = usesMiniMaxH3Geometry
             ? (try? MiniMaxH3Geometry.alignFrameCount(max(minimumFrames, requestedFrames))) ?? minimumFrames
             : max(minimumFrames, ((requestedFrames - 1) / temporalMultiple) * temporalMultiple + 1)
+        let h3FrameIndices = input.h3FrameInputs.compactMap { value -> Int? in
+            guard let separator = value.firstIndex(of: ":") else { return nil }
+            return Int(value[..<separator])
+        }
+        if usesMiniMaxH3Geometry, h3FrameIndices.count != input.h3FrameInputs.count {
+            diagnostics.append(PreflightDiagnostic(
+                id: "h3_frame_syntax_invalid",
+                severity: .blocker,
+                title: "Timed H3 frame syntax is invalid",
+                message: "Every --h3-frame value must use zero-based FRAME:PATH syntax."
+            ))
+        }
+        if usesMiniMaxH3Geometry,
+           (Set(h3FrameIndices).count != h3FrameIndices.count
+            || h3FrameIndices.contains(where: { !(0..<resolvedFrames).contains($0) })) {
+            diagnostics.append(PreflightDiagnostic(
+                id: "h3_frame_index_invalid",
+                severity: .blocker,
+                title: "Timed H3 frame indices are invalid",
+                message: "--h3-frame indices must be unique and inside the resolved output timeline."
+            ))
+        }
+        var slidingWindowPlan: MiniMaxH3SlidingWindowPlan?
+        if usesMiniMaxH3Geometry, let windowFrames = input.h3WindowFrames {
+            do {
+                let options = try MiniMaxH3SlidingWindowOptions(
+                    totalFrameCount: resolvedFrames,
+                    windowFrameCount: windowFrames,
+                    overlapFrameCount: input.h3WindowOverlap
+                )
+                slidingWindowPlan = MiniMaxH3SlidingWindowPlan(options: options)
+            } catch {
+                diagnostics.append(PreflightDiagnostic(
+                    id: "h3_sliding_window_invalid",
+                    severity: .blocker,
+                    title: "MiniMax-H3 sliding window is invalid",
+                    message: error.localizedDescription
+                ))
+            }
+        }
 
         if input.width >= spatialMultiple,
            input.height >= spatialMultiple,
@@ -1207,7 +1316,8 @@ struct VideoGenerationPreflightAnalyzer {
                 width: resolvedWidth,
                 height: resolvedHeight,
                 numFrames: resolvedFrames,
-                keyframeCount: [input.image, input.endImage].compactMap { $0 }.count,
+                keyframeCount: [input.image, input.endImage].compactMap { $0 }.count
+                    + input.h3FrameInputs.count,
                 referenceKinds: input.references.compactMap { reference in
                     MiniMaxH3ReferenceKind(rawValue: String(reference.prefix { $0 != ":" }))
                 },
@@ -1238,6 +1348,12 @@ struct VideoGenerationPreflightAnalyzer {
             h3AdapterStrength: usesMiniMaxH3Geometry && input.h3Adapter != nil
                 ? input.h3AdapterStrength
                 : nil,
+            h3FrameCount: usesMiniMaxH3Geometry ? input.h3FrameInputs.count : nil,
+            h3WindowFrames: usesMiniMaxH3Geometry ? input.h3WindowFrames : nil,
+            h3WindowOverlap: usesMiniMaxH3Geometry && input.h3WindowFrames != nil
+                ? input.h3WindowOverlap
+                : nil,
+            h3WindowCount: slidingWindowPlan?.windows.count,
             fps: usesMiniMaxH3Geometry ? MiniMaxH3Geometry.framesPerSecond : input.fps,
             resolvedNumFrames: resolvedFrames,
             resolvedDurationSeconds: input.fps > 0

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3DynamicSparseAttention.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3DynamicSparseAttention.swift
@@ -1,0 +1,812 @@
+import Foundation
+import MLX
+import MLXFast
+
+struct MiniMaxH3DynamicSparseAttentionRequest: Sendable, Equatable {
+    let prefixTokenCount: Int
+    let thresholdStandardDeviations: Float
+}
+
+struct MiniMaxH3DynamicSparseAttentionPolicy: Sendable, Equatable {
+    let thresholdStandardDeviations: Float
+    let minimumSequenceLength: Int
+    let denseLeadingStepFraction: Float
+    let denseTrailingStepCount: Int
+    let denseLeadingLayerCount: Int
+
+    init(
+        thresholdStandardDeviations: Float = 1,
+        minimumSequenceLength: Int = 12_000,
+        denseLeadingStepFraction: Float = 0.2,
+        denseTrailingStepCount: Int = 1,
+        denseLeadingLayerCount: Int = 2
+    ) {
+        precondition(thresholdStandardDeviations >= 0)
+        precondition(minimumSequenceLength > 0)
+        precondition((0...1).contains(denseLeadingStepFraction))
+        precondition(denseTrailingStepCount >= 0)
+        precondition(denseLeadingLayerCount >= 0)
+        self.thresholdStandardDeviations = thresholdStandardDeviations
+        self.minimumSequenceLength = minimumSequenceLength
+        self.denseLeadingStepFraction = denseLeadingStepFraction
+        self.denseTrailingStepCount = denseTrailingStepCount
+        self.denseLeadingLayerCount = denseLeadingLayerCount
+    }
+
+    func request(
+        stepIndex: Int,
+        stepCount: Int,
+        layerIndex: Int,
+        sequenceLength: Int,
+        prefixTokenCount: Int
+    ) -> MiniMaxH3DynamicSparseAttentionRequest? {
+        guard stepCount > 0,
+              stepIndex >= 0,
+              stepIndex < stepCount,
+              layerIndex >= denseLeadingLayerCount,
+              sequenceLength >= minimumSequenceLength,
+              prefixTokenCount > 0,
+              prefixTokenCount < sequenceLength else { return nil }
+        let denseLeadingStepCount = Int(
+            ceil(Float(stepCount) * denseLeadingStepFraction)
+        )
+        guard stepIndex >= denseLeadingStepCount,
+              stepIndex < stepCount - denseTrailingStepCount else { return nil }
+        return .init(
+            prefixTokenCount: prefixTokenCount,
+            thresholdStandardDeviations: thresholdStandardDeviations
+        )
+    }
+}
+
+struct MiniMaxH3DynamicSparseAttentionGate: Sendable, Equatable {
+    let maximumAbsoluteError: Float
+    let meanAbsoluteError: Float
+    let relativeL2Error: Float
+    let passed: Bool
+}
+
+/// H3-specific dynamic block-sparse attention for Apple GPUs.
+///
+/// The implementation independently applies the on-the-fly sparsification
+/// ideas described by Sol-Attn to H3's packed modality layout. Every 64-token
+/// block is represented by a key centroid and a summed value. Query-dependent
+/// routing retains high-score blocks exactly; skipped blocks contribute through
+/// those summaries in the same online-softmax accumulator. Prefix keys and
+/// adjacent video blocks are always exact, while prefix queries remain on MLX's
+/// dense fused SDPA path.
+enum MiniMaxH3DynamicSparseAttention {
+    static let blockSize = 64
+    static let headDimension = 128
+
+    struct RoutePlan {
+        let keyCentroids: MLXArray
+        let valueSums: MLXArray
+        let routes: MLXArray
+        let firstQueryBlock: Int
+        let keyBlockCount: Int
+    }
+
+    static func call(
+        queries: MLXArray,
+        keys: MLXArray,
+        values: MLXArray,
+        request: MiniMaxH3DynamicSparseAttentionRequest,
+        scale: Float,
+        maximumQueryTokens: Int,
+        maximumKernelsPerEvaluation: Int
+    ) -> MLXArray? {
+        guard supports(
+            queries: queries,
+            keys: keys,
+            values: values,
+            prefixTokenCount: request.prefixTokenCount
+        ) else { return nil }
+        precondition(maximumQueryTokens > 0)
+        precondition(maximumKernelsPerEvaluation > 0)
+
+        let sparseQueryStart = min(
+            queries.dim(2),
+            ((request.prefixTokenCount + blockSize - 1) / blockSize) * blockSize
+        )
+        guard sparseQueryStart < queries.dim(2) else {
+            return MLXFast.scaledDotProductAttention(
+                queries: queries,
+                keys: keys,
+                values: values,
+                scale: scale,
+                mask: .none
+            )
+        }
+        let plan = makeRoutePlan(
+            queries: queries,
+            keys: keys,
+            values: values,
+            queryStart: sparseQueryStart,
+            thresholdStandardDeviations: request.thresholdStandardDeviations,
+            scale: scale
+        )
+        let densePrefix = MLXFast.scaledDotProductAttention(
+            queries: queries[0..., 0..., 0..<sparseQueryStart, 0...],
+            keys: keys,
+            values: values,
+            scale: scale,
+            mask: .none
+        )
+
+        let targetCount = queries.dim(2) - sparseQueryStart
+        // Dense SDPA chunks for intermediate-memory control. This kernel has
+        // no quadratic score allocation, so larger query submissions keep the
+        // shared summaries resident and avoid CPU/GPU boundary churn.
+        let sparseQueryChunk = max(
+            16_384,
+            (maximumQueryTokens / blockSize) * blockSize
+        )
+        var outputs = [densePrefix]
+        outputs.reserveCapacity(1 + (targetCount + sparseQueryChunk - 1) / sparseQueryChunk)
+        var pending: [MLXArray] = [densePrefix]
+        pending.reserveCapacity(maximumKernelsPerEvaluation)
+        for localStart in stride(from: 0, to: targetCount, by: sparseQueryChunk) {
+            let count = min(sparseQueryChunk, targetCount - localStart)
+            let sparse = sparseKernelOutput(
+                queries: queries,
+                keys: keys,
+                values: values,
+                keyCentroids: plan.keyCentroids,
+                valueSums: plan.valueSums,
+                routes: plan.routes,
+                queryStart: sparseQueryStart + localStart,
+                queryCount: count,
+                prefixTokenCount: request.prefixTokenCount,
+                firstQueryBlock: plan.firstQueryBlock,
+                keyBlockCount: plan.keyBlockCount,
+                scale: scale
+            )
+            outputs.append(sparse)
+            pending.append(sparse)
+            if pending.count == maximumKernelsPerEvaluation {
+                MLX.eval(pending)
+                pending.removeAll(keepingCapacity: true)
+            }
+        }
+        if !pending.isEmpty {
+            MLX.eval(pending)
+        }
+        return MLX.concatenated(outputs, axis: 2)
+    }
+
+    static func denseRouteGate(
+        queries: MLXArray,
+        keys: MLXArray,
+        values: MLXArray,
+        queryStart: Int,
+        scale: Float,
+        sampleQueryCount: Int = 8
+    ) -> MiniMaxH3DynamicSparseAttentionGate? {
+        guard supports(
+            queries: queries,
+            keys: keys,
+            values: values,
+            prefixTokenCount: queryStart
+        ) else { return nil }
+        let alignedQueryStart = min(
+            queries.dim(2),
+            ((queryStart + blockSize - 1) / blockSize) * blockSize
+        )
+        let queryCount = min(sampleQueryCount, queries.dim(2) - alignedQueryStart)
+        guard queryCount > 0 else { return nil }
+        let firstQueryBlock = alignedQueryStart / blockSize
+        let lastQueryBlock = (alignedQueryStart + queryCount - 1) / blockSize
+        let queryBlockCount = lastQueryBlock - firstQueryBlock + 1
+        let keyBlockCount = (queries.dim(2) + blockSize - 1) / blockSize
+        let routes = MLXArray.ones(
+            [1, queries.dim(1), queryBlockCount, keyBlockCount],
+            dtype: .uint8
+        )
+        let emptySummaries = MLXArray.zeros(
+            [1, queries.dim(1), keyBlockCount, headDimension],
+            dtype: .bfloat16
+        )
+        let candidate = sparseKernelOutput(
+            queries: queries,
+            keys: keys,
+            values: values,
+            keyCentroids: emptySummaries,
+            valueSums: emptySummaries,
+            routes: routes,
+            queryStart: alignedQueryStart,
+            queryCount: queryCount,
+            prefixTokenCount: 0,
+            firstQueryBlock: firstQueryBlock,
+            keyBlockCount: keyBlockCount,
+            scale: scale
+        )
+        let reference = MLXFast.scaledDotProductAttention(
+            queries: queries[
+                0..., 0..., alignedQueryStart..<(alignedQueryStart + queryCount), 0...
+            ],
+            keys: keys,
+            values: values,
+            scale: scale,
+            mask: .none
+        )
+        let delta = candidate.asType(.float32) - reference.asType(.float32)
+        let absolute = MLX.abs(delta)
+        let metrics = MLX.stacked([
+            MLX.max(absolute),
+            MLX.mean(absolute),
+            MLX.sqrt(
+                MLX.sum(delta * delta)
+                    / MLX.maximum(
+                        MLX.sum(reference.asType(.float32) * reference.asType(.float32)),
+                        MLXArray(Float(1e-12))
+                    )
+            ),
+        ])
+        MLX.eval(metrics)
+        let measured = metrics.asArray(Float.self)
+        let stagesFloat32 = queries.dtype == .float32
+            || keys.dtype == .float32
+            || values.dtype == .float32
+        // The production H3 projection graph promotes Q/K/V to FP32. The
+        // sparse MMA path stages those values as BF16, so its dense-route gate
+        // allows the measured conversion envelope while retaining the same
+        // relative-error bound used by native BF16 input.
+        let maximumLimit: Float = queries.dim(2) >= 32_768
+            ? 0.15
+            : (stagesFloat32 ? 0.12 : 0.08)
+        let meanLimit: Float = stagesFloat32 ? 0.0025 : 0.002
+        let passed = measured[0] <= maximumLimit
+            && measured[1] <= meanLimit
+            && measured[2] <= 0.005
+        return .init(
+            maximumAbsoluteError: measured[0],
+            meanAbsoluteError: measured[1],
+            relativeL2Error: measured[2],
+            passed: passed
+        )
+    }
+
+    static func makeRoutePlan(
+        queries: MLXArray,
+        keys: MLXArray,
+        values: MLXArray,
+        queryStart: Int,
+        thresholdStandardDeviations: Float,
+        scale: Float
+    ) -> RoutePlan {
+        precondition(queryStart >= 0 && queryStart < queries.dim(2))
+        precondition(thresholdStandardDeviations >= 0)
+        let summaries = summarize(queries: queries, keys: keys, values: values)
+        let firstQueryBlock = queryStart / blockSize
+        let queryCentroids = summaries.queries[0..., 0..., firstQueryBlock..., 0...]
+        let proxyScores = MLX.matmul(
+            queryCentroids,
+            summaries.keys.transposed(0, 1, 3, 2)
+        ).asType(.float32) * scale
+        let mean = proxyScores.mean(axis: -1, keepDims: true)
+        let centered = proxyScores - mean
+        let variance = (centered * centered).mean(axis: -1, keepDims: true)
+        let threshold = mean + thresholdStandardDeviations * MLX.sqrt(variance + 1e-6)
+        let routes = (proxyScores .> threshold).asType(.uint8)
+        return .init(
+            keyCentroids: summaries.keys,
+            valueSums: summaries.values,
+            routes: routes,
+            firstQueryBlock: firstQueryBlock,
+            keyBlockCount: summaries.keys.dim(2)
+        )
+    }
+
+    static func routesForTesting(
+        queryCentroids: MLXArray,
+        keyCentroids: MLXArray,
+        thresholdStandardDeviations: Float,
+        scale: Float = 1
+    ) -> MLXArray {
+        let proxyScores = MLX.matmul(
+            queryCentroids,
+            keyCentroids.transposed(0, 1, 3, 2)
+        ).asType(.float32) * scale
+        let mean = proxyScores.mean(axis: -1, keepDims: true)
+        let centered = proxyScores - mean
+        let variance = (centered * centered).mean(axis: -1, keepDims: true)
+        let threshold = mean + thresholdStandardDeviations * MLX.sqrt(variance + 1e-6)
+        return (proxyScores .> threshold).asType(.uint8)
+    }
+
+    static func sparseOutputForTesting(
+        queries: MLXArray,
+        keys: MLXArray,
+        values: MLXArray,
+        routes: MLXArray,
+        queryStart: Int,
+        queryCount: Int,
+        prefixTokenCount: Int,
+        scale: Float
+    ) -> MLXArray? {
+        guard supports(
+            queries: queries,
+            keys: keys,
+            values: values,
+            prefixTokenCount: prefixTokenCount
+        ) else { return nil }
+        let summaries = summarize(queries: queries, keys: keys, values: values)
+        return sparseKernelOutput(
+            queries: queries,
+            keys: keys,
+            values: values,
+            keyCentroids: summaries.keys,
+            valueSums: summaries.values,
+            routes: routes,
+            queryStart: queryStart,
+            queryCount: queryCount,
+            prefixTokenCount: prefixTokenCount,
+            firstQueryBlock: queryStart / blockSize,
+            keyBlockCount: summaries.keys.dim(2),
+            scale: scale
+        )
+    }
+
+    private static func supports(
+        queries: MLXArray,
+        keys: MLXArray,
+        values: MLXArray,
+        prefixTokenCount: Int
+    ) -> Bool {
+        #if os(macOS) || os(iOS) || os(tvOS) || os(visionOS)
+        return Device.defaultDevice().deviceType == .gpu
+            && [.bfloat16, .float32].contains(queries.dtype)
+            && [.bfloat16, .float32].contains(keys.dtype)
+            && [.bfloat16, .float32].contains(values.dtype)
+            && queries.shape == keys.shape
+            && queries.shape == values.shape
+            && queries.ndim == 4
+            && queries.dim(0) == 1
+            && queries.dim(3) == headDimension
+            && prefixTokenCount >= 0
+            && prefixTokenCount < queries.dim(2)
+        #else
+        return false
+        #endif
+    }
+
+    private static func summarize(
+        queries: MLXArray,
+        keys: MLXArray,
+        values: MLXArray
+    ) -> (queries: MLXArray, keys: MLXArray, values: MLXArray) {
+        let tokenCount = queries.dim(2)
+        let heads = queries.dim(1)
+        let blockCount = (tokenCount + blockSize - 1) / blockSize
+        #if os(macOS) || os(iOS) || os(tvOS) || os(visionOS)
+        let outputs = summaryKernel(
+            [queries, keys, values],
+            template: [
+                ("TOKEN_COUNT", tokenCount),
+                ("BLOCK_COUNT", blockCount),
+            ],
+            grid: (headDimension, blockCount, heads),
+            threadGroup: (headDimension, 1, 1),
+            outputShapes: [
+                [1, heads, blockCount, headDimension],
+                [1, heads, blockCount, headDimension],
+                [1, heads, blockCount, headDimension],
+            ],
+            outputDTypes: [.bfloat16, .bfloat16, .bfloat16]
+        )
+        return (outputs[0], outputs[1], outputs[2])
+        #else
+        preconditionFailure("MiniMax-H3 sparse summaries require Metal")
+        #endif
+    }
+
+    private static func sparseKernelOutput(
+        queries: MLXArray,
+        keys: MLXArray,
+        values: MLXArray,
+        keyCentroids: MLXArray,
+        valueSums: MLXArray,
+        routes: MLXArray,
+        queryStart: Int,
+        queryCount: Int,
+        prefixTokenCount: Int,
+        firstQueryBlock: Int,
+        keyBlockCount: Int,
+        scale: Float
+    ) -> MLXArray {
+        precondition(queryStart >= 0 && queryCount > 0)
+        precondition(queryStart + queryCount <= queries.dim(2))
+        precondition(queryStart.isMultiple(of: blockSize))
+        precondition(routes.dtype == .uint8)
+        let heads = queries.dim(1)
+        let scaleArray = MLXArray([scale])
+        #if os(macOS) || os(iOS) || os(tvOS) || os(visionOS)
+        return attentionKernel(
+            [queries, keys, values, keyCentroids, valueSums, routes, scaleArray],
+            template: [
+                ("TOKEN_COUNT", queries.dim(2)),
+                ("QUERY_START", queryStart),
+                ("QUERY_COUNT", queryCount),
+                ("PREFIX_TOKENS", prefixTokenCount),
+                ("FIRST_QUERY_BLOCK", firstQueryBlock),
+                ("KEY_BLOCK_COUNT", keyBlockCount),
+                ("ROUTE_QUERY_BLOCKS", routes.dim(2)),
+            ],
+            grid: (32, ((queryCount + 31) / 32) * 4, heads),
+            threadGroup: (32, 4, 1),
+            outputShapes: [[1, heads, queryCount, headDimension]],
+            outputDTypes: [.bfloat16]
+        )[0]
+        #else
+        preconditionFailure("MiniMax-H3 sparse attention requires Metal")
+        #endif
+    }
+
+    #if os(macOS) || os(iOS) || os(tvOS) || os(visionOS)
+    private static let summaryKernel = MLXFast.metalKernel(
+        name: "mere_h3_dynamic_sparse_summaries_bf16_d128_b64_v1",
+        inputNames: ["queries", "keys", "values"],
+        outputNames: ["query_centroids", "key_centroids", "value_sums"],
+        source: """
+            constexpr uint block_size = 64;
+            constexpr uint head_dimension = 128;
+
+            uint dimension = thread_position_in_grid.x;
+            uint block = thread_position_in_grid.y;
+            uint head = thread_position_in_grid.z;
+            if (dimension >= head_dimension || block >= BLOCK_COUNT) return;
+
+            uint token_start = block * block_size;
+            uint token_end = metal::min(token_start + block_size, uint(TOKEN_COUNT));
+            float query_total = 0.0f;
+            float key_total = 0.0f;
+            float value_total = 0.0f;
+            for (uint token = token_start; token < token_end; ++token) {
+                uint offset = (head * TOKEN_COUNT + token) * head_dimension + dimension;
+                query_total += float(queries[offset]);
+                key_total += float(keys[offset]);
+                value_total += float(values[offset]);
+            }
+            float inverse_count = 1.0f / float(token_end - token_start);
+            uint output_offset = (head * BLOCK_COUNT + block) * head_dimension + dimension;
+            query_centroids[output_offset] = bfloat(query_total * inverse_count);
+            key_centroids[output_offset] = bfloat(key_total * inverse_count);
+            value_sums[output_offset] = bfloat(value_total);
+        """,
+        ensureRowContiguous: true
+    )
+
+    private static let attentionKernel = MLXFast.metalKernel(
+        name: "mere_h3_dynamic_sparse_online_softmax_bf16_d128_b64_mma_v5",
+        inputNames: [
+            "queries", "keys", "values", "key_centroids", "value_sums",
+            "routes", "scale_value",
+        ],
+        outputNames: ["output"],
+        source: """
+            constexpr uint block_size = 64;
+            constexpr uint head_dimension = 128;
+            constexpr uint matrix_size = 8;
+            constexpr uint matrix_count = head_dimension / matrix_size;
+            constexpr uint query_tile_rows = 32;
+            constexpr uint simdgroup_count = 4;
+            constexpr uint query_stride = head_dimension + 8;
+            constexpr uint key_stride = matrix_size + 8;
+            constexpr uint value_stride = head_dimension + 8;
+            constexpr float log2e = 1.4426950408889634f;
+
+            uint lane = thread_index_in_simdgroup;
+            uint simd_group = simdgroup_index_in_threadgroup;
+            uint thread_linear = thread_position_in_threadgroup.y * 32
+                + thread_position_in_threadgroup.x;
+            uint query_group = threadgroup_position_in_grid.y;
+            uint head = threadgroup_position_in_grid.z;
+            uint quad = lane / 4;
+            uint matrix_row = (quad & 4) + ((lane / 2) % 4);
+            uint matrix_column = (quad & 2) * 2 + (lane % 2) * 2;
+            uint group_query_start = query_group * query_tile_rows;
+            uint local_query = group_query_start
+                + simd_group * matrix_size + matrix_row;
+            bool query_valid = local_query < QUERY_COUNT;
+            uint safe_local_query = metal::min(local_query, uint(QUERY_COUNT - 1));
+            uint query_token = QUERY_START + safe_local_query;
+            uint query_block = query_token / block_size;
+            uint route_query_block = query_block - FIRST_QUERY_BLOCK;
+            float attention_scale = float(scale_value[0]) * log2e;
+
+            threadgroup bfloat query_shared[query_tile_rows * query_stride];
+            threadgroup bfloat key_value_shared[head_dimension * key_stride];
+            for (uint index = thread_linear;
+                 index < query_tile_rows * head_dimension;
+                 index += 32 * simdgroup_count) {
+                uint row = index / head_dimension;
+                uint dimension = index - row * head_dimension;
+                uint candidate = group_query_start + row;
+                bool valid = candidate < QUERY_COUNT;
+                uint token = QUERY_START + metal::min(candidate, uint(QUERY_COUNT - 1));
+                query_shared[row * query_stride + dimension] = valid
+                    ? bfloat(queries[(head * TOKEN_COUNT + token) * head_dimension + dimension])
+                    : bfloat(0.0f);
+            }
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+
+            thread simdgroup_matrix<float, 8, 8> accumulated[matrix_count];
+            for (uint frag = 0; frag < matrix_count; ++frag) {
+                accumulated[frag].thread_elements()[0] = 0.0f;
+                accumulated[frag].thread_elements()[1] = 0.0f;
+            }
+
+            float row_maximum = -INFINITY;
+            float row_sum = 0.0f;
+            for (uint key_block = 0; key_block < KEY_BLOCK_COUNT; ++key_block) {
+                uint key_start = key_block * block_size;
+                uint key_end = metal::min(key_start + block_size, uint(TOKEN_COUNT));
+                uint route_offset =
+                    (head * ROUTE_QUERY_BLOCKS + route_query_block) * KEY_BLOCK_COUNT + key_block;
+                int block_distance = int(query_block) - int(key_block);
+                bool neighboring = block_distance >= -1 && block_distance <= 1;
+                bool prefix_sink = key_start < PREFIX_TOKENS;
+                bool exact = routes[route_offset] != 0 || neighboring || prefix_sink;
+
+                if (exact) {
+                    for (uint key_tile = key_start;
+                         key_tile < key_end;
+                         key_tile += matrix_size) {
+                        threadgroup_barrier(mem_flags::mem_threadgroup);
+                        for (uint index = thread_linear;
+                             index < matrix_size * head_dimension;
+                             index += 32 * simdgroup_count) {
+                            uint dimension = index / matrix_size;
+                            uint key_column = index - dimension * matrix_size;
+                            uint token = key_tile + key_column;
+                            key_value_shared[dimension * key_stride + key_column] = token < key_end
+                                ? bfloat(keys[(head * TOKEN_COUNT + token) * head_dimension + dimension])
+                                : bfloat(0.0f);
+                        }
+                        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+                        thread simdgroup_matrix<float, 8, 8> scores;
+                        scores.thread_elements()[0] = 0.0f;
+                        scores.thread_elements()[1] = 0.0f;
+                        for (uint frag = 0; frag < matrix_count; ++frag) {
+                            thread simdgroup_matrix<bfloat, 8, 8> query_fragment;
+                            thread simdgroup_matrix<bfloat, 8, 8> key_fragment;
+                            uint query_dimension = frag * matrix_size + matrix_column;
+                            uint query_row = simd_group * matrix_size + matrix_row;
+                            query_fragment.thread_elements()[0] =
+                                query_shared[query_row * query_stride + query_dimension];
+                            query_fragment.thread_elements()[1] =
+                                query_shared[query_row * query_stride + query_dimension + 1];
+                            uint key_dimension = frag * matrix_size + matrix_row;
+                            key_fragment.thread_elements()[0] =
+                                key_value_shared[key_dimension * key_stride + matrix_column];
+                            key_fragment.thread_elements()[1] =
+                                key_value_shared[key_dimension * key_stride + matrix_column + 1];
+                            thread simdgroup_matrix<float, 8, 8> next_scores;
+                            simdgroup_multiply_accumulate(
+                                next_scores,
+                                query_fragment,
+                                key_fragment,
+                                scores
+                            );
+                            scores = next_scores;
+                        }
+
+                        float score0 = scores.thread_elements()[0] * attention_scale;
+                        float score1 = scores.thread_elements()[1] * attention_scale;
+                        if (key_tile + matrix_column >= key_end) score0 = -INFINITY;
+                        if (key_tile + matrix_column + 1 >= key_end) score1 = -INFINITY;
+                        float tile_maximum = metal::max(score0, score1);
+                        tile_maximum = metal::max(
+                            tile_maximum,
+                            simd_shuffle_xor(tile_maximum, ushort(1))
+                        );
+                        tile_maximum = metal::max(
+                            tile_maximum,
+                            simd_shuffle_xor(tile_maximum, ushort(8))
+                        );
+                        float new_maximum = metal::max(row_maximum, tile_maximum);
+                        float alpha = metal::fast::exp2(row_maximum - new_maximum);
+                        float probability0 = metal::fast::exp2(score0 - new_maximum);
+                        float probability1 = metal::fast::exp2(score1 - new_maximum);
+                        float probability_sum = probability0 + probability1;
+                        probability_sum += simd_shuffle_xor(probability_sum, ushort(1));
+                        probability_sum += simd_shuffle_xor(probability_sum, ushort(8));
+                        row_sum = row_sum * alpha + probability_sum;
+                        row_maximum = new_maximum;
+
+                        thread simdgroup_matrix<float, 8, 8> probabilities;
+                        probabilities.thread_elements()[0] = probability0;
+                        probabilities.thread_elements()[1] = probability1;
+                        threadgroup_barrier(mem_flags::mem_threadgroup);
+                        for (uint index = thread_linear;
+                             index < matrix_size * head_dimension;
+                             index += 32 * simdgroup_count) {
+                            uint value_row = index / head_dimension;
+                            uint dimension = index - value_row * head_dimension;
+                            uint token = key_tile + value_row;
+                            key_value_shared[value_row * value_stride + dimension] = token < key_end
+                                ? bfloat(values[(head * TOKEN_COUNT + token) * head_dimension + dimension])
+                                : bfloat(0.0f);
+                        }
+                        threadgroup_barrier(mem_flags::mem_threadgroup);
+                        for (uint frag = 0; frag < matrix_count; ++frag) {
+                            accumulated[frag].thread_elements()[0] *= alpha;
+                            accumulated[frag].thread_elements()[1] *= alpha;
+                            thread simdgroup_matrix<bfloat, 8, 8> value_fragment;
+                            uint output_dimension = frag * matrix_size + matrix_column;
+                            value_fragment.thread_elements()[0] =
+                                key_value_shared[matrix_row * value_stride + output_dimension];
+                            value_fragment.thread_elements()[1] =
+                                key_value_shared[matrix_row * value_stride + output_dimension + 1];
+                            thread simdgroup_matrix<float, 8, 8> next_accumulated;
+                            simdgroup_multiply_accumulate(
+                                next_accumulated,
+                                probabilities,
+                                value_fragment,
+                                accumulated[frag]
+                            );
+                            accumulated[frag] = next_accumulated;
+                        }
+                    }
+                }
+            }
+
+            uint skipped_blocks[matrix_size];
+            uint skipped_count = 0;
+            for (uint scan = 0; scan <= KEY_BLOCK_COUNT; ++scan) {
+                bool at_end = scan == KEY_BLOCK_COUNT;
+                if (!at_end) {
+                    uint key_start = scan * block_size;
+                    uint route_offset =
+                        (head * ROUTE_QUERY_BLOCKS + route_query_block) * KEY_BLOCK_COUNT + scan;
+                    int block_distance = int(query_block) - int(scan);
+                    bool neighboring = block_distance >= -1 && block_distance <= 1;
+                    bool prefix_sink = key_start < PREFIX_TOKENS;
+                    bool exact = routes[route_offset] != 0 || neighboring || prefix_sink;
+                    if (!exact) {
+                        skipped_blocks[skipped_count++] = scan;
+                    }
+                }
+                bool batch_ready = skipped_count == matrix_size
+                    || (at_end && skipped_count > 0);
+                if (!batch_ready) continue;
+
+                threadgroup_barrier(mem_flags::mem_threadgroup);
+                for (uint index = thread_linear;
+                     index < matrix_size * head_dimension;
+                     index += 32 * simdgroup_count) {
+                    uint dimension = index / matrix_size;
+                    uint summary_column = index - dimension * matrix_size;
+                    bool valid = summary_column < skipped_count;
+                    uint block = valid ? skipped_blocks[summary_column] : 0;
+                    uint summary_offset =
+                        (head * KEY_BLOCK_COUNT + block) * head_dimension + dimension;
+                    key_value_shared[dimension * key_stride + summary_column] = valid
+                        ? key_centroids[summary_offset]
+                        : bfloat(0.0f);
+                }
+                threadgroup_barrier(mem_flags::mem_threadgroup);
+
+                thread simdgroup_matrix<float, 8, 8> proxy_scores;
+                proxy_scores.thread_elements()[0] = 0.0f;
+                proxy_scores.thread_elements()[1] = 0.0f;
+                for (uint frag = 0; frag < matrix_count; ++frag) {
+                    thread simdgroup_matrix<bfloat, 8, 8> query_fragment;
+                    thread simdgroup_matrix<bfloat, 8, 8> centroid_fragment;
+                    uint query_dimension = frag * matrix_size + matrix_column;
+                    uint query_row = simd_group * matrix_size + matrix_row;
+                    query_fragment.thread_elements()[0] =
+                        query_shared[query_row * query_stride + query_dimension];
+                    query_fragment.thread_elements()[1] =
+                        query_shared[query_row * query_stride + query_dimension + 1];
+                    uint centroid_dimension = frag * matrix_size + matrix_row;
+                    centroid_fragment.thread_elements()[0] =
+                        key_value_shared[centroid_dimension * key_stride + matrix_column];
+                    centroid_fragment.thread_elements()[1] =
+                        key_value_shared[centroid_dimension * key_stride + matrix_column + 1];
+                    thread simdgroup_matrix<float, 8, 8> next_proxy_scores;
+                    simdgroup_multiply_accumulate(
+                        next_proxy_scores,
+                        query_fragment,
+                        centroid_fragment,
+                        proxy_scores
+                    );
+                    proxy_scores = next_proxy_scores;
+                }
+
+                bool valid0 = matrix_column < skipped_count;
+                bool valid1 = matrix_column + 1 < skipped_count;
+                float score0 = valid0
+                    ? proxy_scores.thread_elements()[0] * attention_scale
+                    : -INFINITY;
+                float score1 = valid1
+                    ? proxy_scores.thread_elements()[1] * attention_scale
+                    : -INFINITY;
+                float batch_maximum = metal::max(score0, score1);
+                batch_maximum = metal::max(
+                    batch_maximum,
+                    simd_shuffle_xor(batch_maximum, ushort(1))
+                );
+                batch_maximum = metal::max(
+                    batch_maximum,
+                    simd_shuffle_xor(batch_maximum, ushort(8))
+                );
+                float new_maximum = metal::max(row_maximum, batch_maximum);
+                float alpha = metal::fast::exp2(row_maximum - new_maximum);
+                float probability0 = metal::fast::exp2(score0 - new_maximum);
+                float probability1 = metal::fast::exp2(score1 - new_maximum);
+                uint block0 = valid0 ? skipped_blocks[matrix_column] : 0;
+                uint block1 = valid1 ? skipped_blocks[matrix_column + 1] : 0;
+                uint start0 = block0 * block_size;
+                uint start1 = block1 * block_size;
+                float length0 = valid0
+                    ? float(metal::min(start0 + block_size, uint(TOKEN_COUNT)) - start0)
+                    : 0.0f;
+                float length1 = valid1
+                    ? float(metal::min(start1 + block_size, uint(TOKEN_COUNT)) - start1)
+                    : 0.0f;
+                float weighted_sum = probability0 * length0 + probability1 * length1;
+                weighted_sum += simd_shuffle_xor(weighted_sum, ushort(1));
+                weighted_sum += simd_shuffle_xor(weighted_sum, ushort(8));
+
+                thread simdgroup_matrix<float, 8, 8> probabilities;
+                probabilities.thread_elements()[0] = probability0;
+                probabilities.thread_elements()[1] = probability1;
+                threadgroup_barrier(mem_flags::mem_threadgroup);
+                for (uint index = thread_linear;
+                     index < matrix_size * head_dimension;
+                     index += 32 * simdgroup_count) {
+                    uint summary_row = index / head_dimension;
+                    uint dimension = index - summary_row * head_dimension;
+                    bool valid = summary_row < skipped_count;
+                    uint block = valid ? skipped_blocks[summary_row] : 0;
+                    uint summary_offset =
+                        (head * KEY_BLOCK_COUNT + block) * head_dimension + dimension;
+                    key_value_shared[summary_row * value_stride + dimension] = valid
+                        ? value_sums[summary_offset]
+                        : bfloat(0.0f);
+                }
+                threadgroup_barrier(mem_flags::mem_threadgroup);
+                for (uint frag = 0; frag < matrix_count; ++frag) {
+                    accumulated[frag].thread_elements()[0] *= alpha;
+                    accumulated[frag].thread_elements()[1] *= alpha;
+                    thread simdgroup_matrix<bfloat, 8, 8> value_fragment;
+                    uint output_dimension = frag * matrix_size + matrix_column;
+                    value_fragment.thread_elements()[0] =
+                        key_value_shared[matrix_row * value_stride + output_dimension];
+                    value_fragment.thread_elements()[1] =
+                        key_value_shared[matrix_row * value_stride + output_dimension + 1];
+                    thread simdgroup_matrix<float, 8, 8> next_accumulated;
+                    simdgroup_multiply_accumulate(
+                        next_accumulated,
+                        probabilities,
+                        value_fragment,
+                        accumulated[frag]
+                    );
+                    accumulated[frag] = next_accumulated;
+                }
+                row_sum = row_sum * alpha + weighted_sum;
+                row_maximum = new_maximum;
+                skipped_count = 0;
+            }
+
+            if (query_valid) {
+                uint output_base = (head * QUERY_COUNT + local_query) * head_dimension;
+                for (uint frag = 0; frag < matrix_count; ++frag) {
+                    uint output_dimension = frag * matrix_size + matrix_column;
+                    output[output_base + output_dimension] = bfloat(
+                        accumulated[frag].thread_elements()[0] / row_sum
+                    );
+                    output[output_base + output_dimension + 1] = bfloat(
+                        accumulated[frag].thread_elements()[1] / row_sum
+                    );
+                }
+            }
+        """,
+        header: "#include <metal_simdgroup_matrix>\n",
+        ensureRowContiguous: true
+    )
+    #endif
+}

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Generator.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Generator.swift
@@ -89,6 +89,20 @@ public enum MiniMaxH3AccelerationMode: String, Sendable, Hashable {
         }
     }
 
+    var dynamicSparseAttentionPolicy: MiniMaxH3DynamicSparseAttentionPolicy? {
+        switch self {
+        case .quality: nil
+        case .balanced:
+            MiniMaxH3DynamicSparseAttentionPolicy(
+                thresholdStandardDeviations: 0.75
+            )
+        case .maximum:
+            MiniMaxH3DynamicSparseAttentionPolicy(
+                thresholdStandardDeviations: 1
+            )
+        }
+    }
+
     // Retained as an internal benchmark baseline. Production acceleration
     // selects the adaptive first-block cache unless explicitly overridden.
     var blockReusePolicy: MiniMaxH3BlockReusePolicy? {
@@ -493,11 +507,6 @@ public struct MiniMaxH3GenerationOptions: Sendable, Hashable {
             guard adapterStrength > 0 else {
                 throw MiniMaxH3GeneratorError.invalidOptions("adapter strength must be greater than zero")
             }
-            guard accelerationMode == .quality else {
-                throw MiniMaxH3GeneratorError.invalidOptions(
-                    "MiniMax-H3 Turbo already distills the denoise schedule and cannot be combined with block-reuse acceleration"
-                )
-            }
             guard references.isEmpty else {
                 throw MiniMaxH3GeneratorError.invalidOptions(
                     "MiniMax-H3 Turbo supports FL2VA text/keyframe generation, not Ref2VA references"
@@ -793,6 +802,7 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
         audioSchedule: MiniMaxH3Schedule,
         adaLNCache: MiniMaxH3AdaLNCache?,
         accelerationMode: MiniMaxH3AccelerationMode,
+        permitsCacheReuse: Bool,
         progressHandler: (@Sendable (MiniMaxH3GenerationProgress) -> Void)?
     ) -> (videoRows: MLXArray, audioRows: MLXArray) {
         precondition(videoSchedule.timesteps.count == audioSchedule.timesteps.count)
@@ -836,7 +846,7 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
         let environment = ProcessInfo.processInfo.environment
         let usesScheduledTailCache = environment["MERERUN_H3_CACHE_STRATEGY"] == "scheduled-tail"
         let requestedReuseStreak = Int(environment["MERERUN_H3_REUSE_STREAK"] ?? "")
-        let adaptiveCachePolicy = usesScheduledTailCache
+        let adaptiveCachePolicy = !permitsCacheReuse || usesScheduledTailCache
             ? nil
             : accelerationMode.adaptiveFirstBlockCachePolicy.map { policy in
                 let globalThreshold = Float(environment["MERERUN_H3_FIRST_BLOCK_THRESHOLD"] ?? "")
@@ -858,21 +868,40 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
                     requiredFinalFullSteps: policy.requiredFinalFullSteps
                 )
             }
-        let blockReusePolicy = usesScheduledTailCache ? accelerationMode.blockReusePolicy.map { policy in
-            let requestedCacheDepth = Double(environment["MERERUN_H3_REUSE_DEPTH"] ?? "")
-            let cacheDepth = requestedCacheDepth.flatMap {
-                (0..<1).contains($0) ? $0 : nil
-            } ?? policy.cacheDepth
-            let maximumConsecutiveCachedSteps = requestedReuseStreak.flatMap {
-                $0 >= 0 ? $0 : nil
-            } ?? policy.maximumConsecutiveCachedSteps
-            return MiniMaxH3BlockReusePolicy(
-                cacheDepth: cacheDepth,
-                window: policy.window,
-                maximumConsecutiveCachedSteps: maximumConsecutiveCachedSteps
-            )
-        } : nil
-        let executionMode = adaptiveCachePolicy == nil && blockReusePolicy == nil
+        let blockReusePolicy = permitsCacheReuse && usesScheduledTailCache
+            ? accelerationMode.blockReusePolicy.map { policy in
+                let requestedCacheDepth = Double(environment["MERERUN_H3_REUSE_DEPTH"] ?? "")
+                let cacheDepth = requestedCacheDepth.flatMap {
+                    (0..<1).contains($0) ? $0 : nil
+                } ?? policy.cacheDepth
+                let maximumConsecutiveCachedSteps = requestedReuseStreak.flatMap {
+                    $0 >= 0 ? $0 : nil
+                } ?? policy.maximumConsecutiveCachedSteps
+                return MiniMaxH3BlockReusePolicy(
+                    cacheDepth: cacheDepth,
+                    window: policy.window,
+                    maximumConsecutiveCachedSteps: maximumConsecutiveCachedSteps
+                )
+            } : nil
+        let configuredDynamicSparseAttentionPolicy = environment["MERERUN_H3_DYNAMIC_SPARSE"] == "0"
+            ? nil
+            : accelerationMode.dynamicSparseAttentionPolicy.map { policy in
+                MiniMaxH3DynamicSparseAttentionPolicy(
+                    thresholdStandardDeviations: Float(
+                        environment["MERERUN_H3_DYNAMIC_SPARSE_TAU"] ?? ""
+                    ).flatMap { $0 >= 0 ? $0 : nil } ?? policy.thresholdStandardDeviations,
+                    minimumSequenceLength: policy.minimumSequenceLength,
+                    denseLeadingStepFraction: policy.denseLeadingStepFraction,
+                    denseTrailingStepCount: policy.denseTrailingStepCount,
+                    denseLeadingLayerCount: policy.denseLeadingLayerCount
+                )
+            }
+        let dynamicSparseAttentionPolicy = configuredDynamicSparseAttentionPolicy.flatMap { policy in
+            layout.sequenceLength >= policy.minimumSequenceLength ? policy : nil
+        }
+        let executionMode = adaptiveCachePolicy == nil
+            && blockReusePolicy == nil
+            && dynamicSparseAttentionPolicy == nil
             ? MiniMaxH3DenoiseExecutionPolicy.mode(
                 usesResidentBF16: transformer.usesResidentBF16,
                 sequenceLength: layout.sequenceLength,
@@ -899,6 +928,9 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
             Int(environment["MERERUN_H3_ATTENTION_EVALUATION_BATCH"] ?? "")
                 ?? attentionKernelSchedule.maximumKernelsPerEvaluation
         )
+        transformer.dynamicSparseAttentionPolicy = dynamicSparseAttentionPolicy
+        transformer.dynamicSparseAttentionStepCount = videoSchedule.timesteps.count
+        transformer.dynamicSparseAttentionLogHandler = stepProfileLogger
         transformer.usesFusedPostAttention = ProcessInfo.processInfo
             .environment["MERERUN_H3_FUSED_POST_ATTENTION"] == "1"
         transformer.usesLayerwiseEvaluation = executionMode.usesLayerwiseEvaluation
@@ -911,8 +943,18 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
                 + "attention_query_tokens=\(transformer.maximumAttentionQueryTokensPerKernel) "
                 + "attention_heads_per_kernel=\(attentionHeadsPerKernel) "
                 + "attention_evaluation_batch="
-                + "\(transformer.maximumAttentionKernelsPerEvaluation)"
+                + "\(transformer.maximumAttentionKernelsPerEvaluation) "
+                + "dynamic_sparse=\(dynamicSparseAttentionPolicy != nil)"
         )
+        if let dynamicSparseAttentionPolicy {
+            stepProfileLogger?(
+                "dynamic_sparse_tau=\(dynamicSparseAttentionPolicy.thresholdStandardDeviations) "
+                    + "dense_step_fraction=\(dynamicSparseAttentionPolicy.denseLeadingStepFraction) "
+                    + "dense_trailing_steps=\(dynamicSparseAttentionPolicy.denseTrailingStepCount) "
+                    + "dense_leading_layers=\(dynamicSparseAttentionPolicy.denseLeadingLayerCount) "
+                    + "prefix_sink=\(layout.targetVideoRows.lowerBound)"
+            )
+        }
         if let blockReusePolicy {
             stepProfileLogger?(
                 "cache_strategy=scheduled-tail "
@@ -982,6 +1024,7 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
         var executedBlockCount = 0
 
         for index in videoSchedule.timesteps.indices {
+            transformer.dynamicSparseAttentionStepIndex = index
             let stepStarted = stepProfileLogger.map { _ in CFAbsoluteTimeGetCurrent() }
             progressHandler?(.init(
                 stage: .denoising,
@@ -1388,6 +1431,7 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
                 audioSchedule: audioSchedule,
                 adaLNCache: runtime.adaLNCache,
                 accelerationMode: options.accelerationMode,
+                permitsCacheReuse: options.adapterURL == nil,
                 progressHandler: progressHandler
             )
             phaseProfileLogger?(String(
@@ -1584,6 +1628,7 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
                 audioSchedule: audioSchedule,
                 adaLNCache: runtime.adaLNCache,
                 accelerationMode: options.accelerationMode,
+                permitsCacheReuse: options.adapterURL == nil,
                 progressHandler: progressHandler
             )
         }

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Generator.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Generator.swift
@@ -46,6 +46,16 @@ public struct MiniMaxH3ReferenceInput: Sendable, Hashable {
     }
 }
 
+public struct MiniMaxH3FrameInput: Sendable, Hashable {
+    public let frameIndex: Int
+    public let url: URL
+
+    public init(frameIndex: Int, url: URL) {
+        self.frameIndex = frameIndex
+        self.url = url.standardizedFileURL
+    }
+}
+
 public enum MiniMaxH3TransformerWeightMode: String, Sendable, Hashable {
     case automatic = "auto"
     case quantized
@@ -57,6 +67,30 @@ public enum MiniMaxH3AccelerationMode: String, Sendable, Hashable {
     case balanced
     case maximum
 
+    var adaptiveFirstBlockCachePolicy: MiniMaxH3AdaptiveFirstBlockCachePolicy? {
+        switch self {
+        case .quality: nil
+        case .balanced:
+            MiniMaxH3AdaptiveFirstBlockCachePolicy(
+                globalThreshold: 0.08,
+                temporalThreshold: 0.12,
+                window: 0.1...0.9,
+                maximumConsecutiveCachedSteps: 2,
+                requiredFinalFullSteps: 2
+            )
+        case .maximum:
+            MiniMaxH3AdaptiveFirstBlockCachePolicy(
+                globalThreshold: 0.30,
+                temporalThreshold: 0.40,
+                window: 0.1...0.95,
+                maximumConsecutiveCachedSteps: 4,
+                requiredFinalFullSteps: 1
+            )
+        }
+    }
+
+    // Retained as an internal benchmark baseline. Production acceleration
+    // selects the adaptive first-block cache unless explicitly overridden.
     var blockReusePolicy: MiniMaxH3BlockReusePolicy? {
         switch self {
         case .quality: nil
@@ -73,6 +107,62 @@ public enum MiniMaxH3AccelerationMode: String, Sendable, Hashable {
                 maximumConsecutiveCachedSteps: 4
             )
         }
+    }
+}
+
+struct MiniMaxH3AdaptiveFirstBlockCachePolicy: Sendable, Equatable {
+    let globalThreshold: Float
+    let temporalThreshold: Float
+    let window: ClosedRange<Float>
+    let maximumConsecutiveCachedSteps: Int
+    let minimumFullSteps: Int
+    let requiredFinalFullSteps: Int
+
+    init(
+        globalThreshold: Float,
+        temporalThreshold: Float,
+        window: ClosedRange<Float> = 0.1...0.9,
+        maximumConsecutiveCachedSteps: Int = 2,
+        minimumFullSteps: Int = 2,
+        requiredFinalFullSteps: Int = 1
+    ) {
+        precondition(globalThreshold > 0)
+        precondition(temporalThreshold > 0)
+        precondition((0...1).contains(window.lowerBound))
+        precondition((0...1).contains(window.upperBound))
+        precondition(maximumConsecutiveCachedSteps >= 0)
+        precondition(minimumFullSteps >= 1)
+        precondition(requiredFinalFullSteps >= 1)
+        self.globalThreshold = globalThreshold
+        self.temporalThreshold = temporalThreshold
+        self.window = window
+        self.maximumConsecutiveCachedSteps = maximumConsecutiveCachedSteps
+        self.minimumFullSteps = minimumFullSteps
+        self.requiredFinalFullSteps = requiredFinalFullSteps
+    }
+
+    func canConsiderReuse(
+        stepIndex: Int,
+        stepCount: Int,
+        fullStepCount: Int,
+        consecutiveCachedSteps: Int,
+        hasCachedState: Bool
+    ) -> Bool {
+        guard stepIndex >= 0,
+              stepIndex < stepCount,
+              fullStepCount >= minimumFullSteps,
+              hasCachedState,
+              consecutiveCachedSteps < maximumConsecutiveCachedSteps,
+              stepIndex < stepCount - requiredFinalFullSteps else { return false }
+        return window.contains(Float(stepIndex) / Float(stepCount))
+    }
+
+    func shouldReuse(change: MiniMaxH3FirstBlockChange) -> Bool {
+        change.isFinite
+            && change.videoGlobal <= globalThreshold
+            && change.audioGlobal <= globalThreshold
+            && change.videoTemporalMaximum <= temporalThreshold
+            && change.audioTemporalMaximum <= temporalThreshold
     }
 }
 
@@ -335,6 +425,7 @@ public struct MiniMaxH3GenerationOptions: Sendable, Hashable {
     public let adapterStrength: Float
     public let firstFrameURL: URL?
     public let lastFrameURL: URL?
+    public let frameInputs: [MiniMaxH3FrameInput]
     public let references: [MiniMaxH3ReferenceInput]
 
     public init(
@@ -350,6 +441,7 @@ public struct MiniMaxH3GenerationOptions: Sendable, Hashable {
         adapterStrength: Float = 1,
         firstFrameURL: URL? = nil,
         lastFrameURL: URL? = nil,
+        frameInputs: [MiniMaxH3FrameInput] = [],
         references: [MiniMaxH3ReferenceInput] = []
     ) throws {
         let trimmed = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -362,6 +454,28 @@ public struct MiniMaxH3GenerationOptions: Sendable, Hashable {
         }
         guard lastFrameURL == nil || firstFrameURL != nil else {
             throw MiniMaxH3GeneratorError.invalidOptions("a last frame requires a first frame")
+        }
+        guard frameInputs.count <= 12 else {
+            throw MiniMaxH3GeneratorError.invalidOptions("FL2VA accepts at most 12 positioned frame inputs")
+        }
+        guard frameInputs.allSatisfy({ (0..<numFrames).contains($0.frameIndex) }) else {
+            throw MiniMaxH3GeneratorError.invalidOptions(
+                "positioned frame indices must be inside the output frame range"
+            )
+        }
+        let positionedIndices = frameInputs.map(\.frameIndex)
+        guard Set(positionedIndices).count == positionedIndices.count else {
+            throw MiniMaxH3GeneratorError.invalidOptions("positioned frame indices must be unique")
+        }
+        guard firstFrameURL == nil || !positionedIndices.contains(0) else {
+            throw MiniMaxH3GeneratorError.invalidOptions(
+                "--image and a positioned frame at index 0 cannot be combined"
+            )
+        }
+        guard lastFrameURL == nil || !positionedIndices.contains(numFrames - 1) else {
+            throw MiniMaxH3GeneratorError.invalidOptions(
+                "--end-image and a positioned frame at the final index cannot be combined"
+            )
         }
         guard references.count <= 12 else {
             throw MiniMaxH3GeneratorError.invalidOptions("Ref2VA accepts at most 12 ordered references")
@@ -400,7 +514,8 @@ public struct MiniMaxH3GenerationOptions: Sendable, Hashable {
                 width: width,
                 height: height,
                 numFrames: numFrames,
-                keyframeCount: [firstFrameURL, lastFrameURL].compactMap { $0 }.count,
+                keyframeCount: [firstFrameURL, lastFrameURL].compactMap { $0 }.count
+                    + frameInputs.count,
                 referenceKinds: references.map(\.kind),
                 accelerationMode: accelerationMode
             )
@@ -426,6 +541,7 @@ public struct MiniMaxH3GenerationOptions: Sendable, Hashable {
         self.adapterStrength = adapterStrength
         self.firstFrameURL = firstFrameURL
         self.lastFrameURL = lastFrameURL
+        self.frameInputs = frameInputs.sorted { $0.frameIndex < $1.frameIndex }
         self.references = references
     }
 }
@@ -455,6 +571,19 @@ public struct MiniMaxH3GenerationResult: @unchecked Sendable {
 }
 
 public final class MiniMaxH3Generator: @unchecked Sendable {
+    private struct DenoisingRuntimeCacheKey: Hashable {
+        let modelRoot: URL
+        let schedulePointCount: Int
+        let weightMode: MiniMaxH3TransformerWeightMode
+        let adapterURL: URL?
+        let adapterStrength: Float
+    }
+
+    private struct ReferenceCacheKey: Hashable {
+        let references: [MiniMaxH3ReferenceInput]
+        let maximumFrameCount: Int
+    }
+
     private struct ConditionerPresentation {
         let tokenIDs: [Int]
         let tokenTags: [Int32]
@@ -470,7 +599,44 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
         let geometry: MiniMaxH3PreparedReferenceGeometry
     }
 
-    public init() {}
+    private struct FrameCondition {
+        let url: URL
+        let anchor: MiniMaxH3KeyframeAnchor
+    }
+
+    private struct ContinuationConditions {
+        let videoRows: MLXArray
+        let audioRows: MLXArray
+        let videoAnchors: [MiniMaxH3KeyframeAnchor]
+        let audioAnchors: [MiniMaxH3AudioConditionAnchor]
+    }
+
+    private struct PreparedReferenceRows {
+        let video: MLXArray?
+        let audio: MLXArray?
+    }
+
+    private let retainsRuntime: Bool
+    private var retainedConditioner: (root: URL, model: QwenVLEncoder)?
+    private var retainedVideoVAE: (root: URL, model: MiniMaxH3VideoVAE)?
+    private var retainedAudioVAE: (root: URL, model: MiniMaxH3AudioVAE)?
+    private var retainedPreparedReferences: (
+        key: ReferenceCacheKey,
+        values: [PreparedReference]
+    )?
+    private var retainedPreparedReferenceRows: (
+        key: ReferenceCacheKey,
+        values: PreparedReferenceRows
+    )?
+    private var retainedDenoisingRuntime: (
+        key: DenoisingRuntimeCacheKey,
+        transformer: MiniMaxH3Transformer,
+        adaLNCache: MiniMaxH3AdaLNCache?
+    )?
+
+    public init(retainsRuntime: Bool = false) {
+        self.retainsRuntime = retainsRuntime
+    }
 
     static func mediaFrames(from decodedFrames: MLXArray) -> MLXArray {
         MLX.clip(decodedFrames * 255, min: 0, max: 255).asType(.uint8)
@@ -487,6 +653,21 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
         adapterStrength: Float,
         progressHandler: (@Sendable (MiniMaxH3GenerationProgress) -> Void)?
     ) throws -> (transformer: MiniMaxH3Transformer, adaLNCache: MiniMaxH3AdaLNCache?) {
+        let cacheKey = DenoisingRuntimeCacheKey(
+            modelRoot: resources.rootURL.resolvingSymlinksInPath(),
+            schedulePointCount: videoSchedule.timesteps.count + 1,
+            weightMode: weightMode,
+            adapterURL: adapterURL?.resolvingSymlinksInPath(),
+            adapterStrength: adapterStrength
+        )
+        if retainsRuntime,
+           let retainedDenoisingRuntime,
+           retainedDenoisingRuntime.key == cacheKey {
+            return (
+                retainedDenoisingRuntime.transformer,
+                retainedDenoisingRuntime.adaLNCache
+            )
+        }
         let adaLNCache: MiniMaxH3AdaLNCache?
         let cachedAdaLNForLoading: MiniMaxH3AdaLNCache?
         if resources.usesShardedBF16Transformer {
@@ -556,7 +737,48 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
             ))
             _ = transformer.materializeResidentBF16()
         }
+        if retainsRuntime {
+            retainedDenoisingRuntime = (cacheKey, transformer, resolvedAdaLNCache)
+        }
         return (transformer, resolvedAdaLNCache)
+    }
+
+    private func loadConditioner(
+        resources: MiniMaxH3Resources,
+        configuration: MiniMaxH3Configuration,
+        progressHandler: (@Sendable (HFSafetensorsWeightsLoader.ShardProgress) -> Void)? = nil
+    ) throws -> QwenVLEncoder {
+        let root = resources.rootURL.resolvingSymlinksInPath()
+        if retainsRuntime, let retainedConditioner, retainedConditioner.root == root {
+            return retainedConditioner.model
+        }
+        let model = try MiniMaxH3ModelLoader.loadConditioner(
+            resources: resources,
+            configuration: configuration,
+            progressHandler: progressHandler
+        )
+        if retainsRuntime { retainedConditioner = (root, model) }
+        return model
+    }
+
+    private func loadVideoVAE(resources: MiniMaxH3Resources) throws -> MiniMaxH3VideoVAE {
+        let root = resources.rootURL.resolvingSymlinksInPath()
+        if retainsRuntime, let retainedVideoVAE, retainedVideoVAE.root == root {
+            return retainedVideoVAE.model
+        }
+        let model = try MiniMaxH3ModelLoader.loadVideoVAE(resources: resources)
+        if retainsRuntime { retainedVideoVAE = (root, model) }
+        return model
+    }
+
+    private func loadAudioVAE(resources: MiniMaxH3Resources) throws -> MiniMaxH3AudioVAE {
+        let root = resources.rootURL.resolvingSymlinksInPath()
+        if retainsRuntime, let retainedAudioVAE, retainedAudioVAE.root == root {
+            return retainedAudioVAE.model
+        }
+        let model = try MiniMaxH3ModelLoader.loadAudioVAE(resources: resources)
+        if retainsRuntime { retainedAudioVAE = (root, model) }
+        return model
     }
 
     private func denoise(
@@ -611,13 +833,36 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
         // during a sustained denoise pass. Smaller graphs can still amortize a
         // compiled whole-step transform; very large graphs also stay blockwise
         // to avoid the macOS watchdog.
-        let blockReusePolicy = accelerationMode.blockReusePolicy.map { policy in
-            let environment = ProcessInfo.processInfo.environment
+        let environment = ProcessInfo.processInfo.environment
+        let usesScheduledTailCache = environment["MERERUN_H3_CACHE_STRATEGY"] == "scheduled-tail"
+        let requestedReuseStreak = Int(environment["MERERUN_H3_REUSE_STREAK"] ?? "")
+        let adaptiveCachePolicy = usesScheduledTailCache
+            ? nil
+            : accelerationMode.adaptiveFirstBlockCachePolicy.map { policy in
+                let globalThreshold = Float(environment["MERERUN_H3_FIRST_BLOCK_THRESHOLD"] ?? "")
+                    .flatMap { $0 > 0 ? $0 : nil }
+                    ?? policy.globalThreshold
+                let temporalThreshold = Float(
+                    environment["MERERUN_H3_FIRST_BLOCK_TEMPORAL_THRESHOLD"] ?? ""
+                ).flatMap { $0 > 0 ? $0 : nil }
+                    ?? policy.temporalThreshold
+                let maximumConsecutiveCachedSteps = requestedReuseStreak.flatMap {
+                    $0 >= 0 ? $0 : nil
+                } ?? policy.maximumConsecutiveCachedSteps
+                return MiniMaxH3AdaptiveFirstBlockCachePolicy(
+                    globalThreshold: globalThreshold,
+                    temporalThreshold: temporalThreshold,
+                    window: policy.window,
+                    maximumConsecutiveCachedSteps: maximumConsecutiveCachedSteps,
+                    minimumFullSteps: policy.minimumFullSteps,
+                    requiredFinalFullSteps: policy.requiredFinalFullSteps
+                )
+            }
+        let blockReusePolicy = usesScheduledTailCache ? accelerationMode.blockReusePolicy.map { policy in
             let requestedCacheDepth = Double(environment["MERERUN_H3_REUSE_DEPTH"] ?? "")
             let cacheDepth = requestedCacheDepth.flatMap {
                 (0..<1).contains($0) ? $0 : nil
             } ?? policy.cacheDepth
-            let requestedReuseStreak = Int(environment["MERERUN_H3_REUSE_STREAK"] ?? "")
             let maximumConsecutiveCachedSteps = requestedReuseStreak.flatMap {
                 $0 >= 0 ? $0 : nil
             } ?? policy.maximumConsecutiveCachedSteps
@@ -626,8 +871,8 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
                 window: policy.window,
                 maximumConsecutiveCachedSteps: maximumConsecutiveCachedSteps
             )
-        }
-        let executionMode = blockReusePolicy == nil
+        } : nil
+        let executionMode = adaptiveCachePolicy == nil && blockReusePolicy == nil
             ? MiniMaxH3DenoiseExecutionPolicy.mode(
                 usesResidentBF16: transformer.usesResidentBF16,
                 sequenceLength: layout.sequenceLength,
@@ -641,7 +886,6 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
         let attentionKernelSchedule = MiniMaxH3DenoiseExecutionPolicy.attentionKernelSchedule(
             sequenceLength: layout.sequenceLength
         )
-        let environment = ProcessInfo.processInfo.environment
         transformer.maximumAttentionQueryTokensPerKernel = max(
             1,
             Int(environment["MERERUN_H3_ATTENTION_QUERY_TOKENS"] ?? "")
@@ -671,8 +915,18 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
         )
         if let blockReusePolicy {
             stepProfileLogger?(
-                "reuse_depth=\(blockReusePolicy.cacheDepth) "
+                "cache_strategy=scheduled-tail "
+                    + "reuse_depth=\(blockReusePolicy.cacheDepth) "
                     + "reuse_streak=\(blockReusePolicy.maximumConsecutiveCachedSteps)"
+            )
+        }
+        if let adaptiveCachePolicy {
+            stepProfileLogger?(
+                "cache_strategy=adaptive-first-block "
+                    + "global_threshold=\(adaptiveCachePolicy.globalThreshold) "
+                    + "temporal_threshold=\(adaptiveCachePolicy.temporalThreshold) "
+                    + "reuse_streak=\(adaptiveCachePolicy.maximumConsecutiveCachedSteps) "
+                    + "final_full_steps=\(adaptiveCachePolicy.requiredFinalFullSteps)"
             )
         }
 
@@ -720,8 +974,12 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
         let totalBlockCount = transformer.configuration.layerCount
         let warmBlockCount = blockReusePolicy?.warmBlockCount(totalBlockCount: totalBlockCount)
         var cachedTailResidual: MLXArray?
+        var previousFirstResidual: MLXArray?
+        var cachedTargetTailResidual: MLXArray?
         var consecutiveCachedSteps = 0
         var cachedStepCount = 0
+        var fullStepCount = 0
+        var executedBlockCount = 0
 
         for index in videoSchedule.timesteps.indices {
             let stepStarted = stepProfileLogger.map { _ in CFAbsoluteTimeGetCurrent() }
@@ -747,12 +1005,9 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
                 hasCachedResidual: cachedTailResidual != nil,
                 consecutiveCachedSteps: consecutiveCachedSteps
             ) ?? false
-            if let warmBlockCount {
-                stepProfileLogger?(
-                    "step_plan=\(index + 1)/\(videoSchedule.timesteps.count) "
-                        + "cached_tail=\(reusesTail) blocks=\(reusesTail ? warmBlockCount : totalBlockCount)"
-                )
-            }
+            var cacheHitThisStep = false
+            var executedBlocksThisStep = totalBlockCount
+            var firstBlockChange: MiniMaxH3FirstBlockChange?
             if usesCompiledStep {
                 var inputs = [
                     videoRows,
@@ -769,6 +1024,7 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
                 let outputs = compiledStep(inputs)
                 videoRows = outputs[0]
                 audioRows = outputs[1]
+                fullStepCount += 1
             } else {
                 let videoInput = conditionVideoRows.map {
                     MLX.concatenated([$0, videoRows], axis: 1)
@@ -777,7 +1033,42 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
                     MLX.concatenated([$0, audioRows], axis: 1)
                 } ?? audioRows
                 let predicted: MiniMaxH3TransformerOutput
-                if let warmBlockCount {
+                if let adaptiveCachePolicy {
+                    let canConsiderReuse = adaptiveCachePolicy.canConsiderReuse(
+                        stepIndex: index,
+                        stepCount: videoSchedule.timesteps.count,
+                        fullStepCount: fullStepCount,
+                        consecutiveCachedSteps: consecutiveCachedSteps,
+                        hasCachedState: previousFirstResidual != nil && cachedTargetTailResidual != nil
+                    )
+                    let result = transformer.callWithAdaptiveFirstBlockReuse(
+                        videoRows: videoInput,
+                        audioRows: audioInput,
+                        context: context,
+                        timesteps: timestepValues,
+                        cachedAdaLN: adaLNCache?.step(at: index),
+                        policy: adaptiveCachePolicy,
+                        canConsiderReuse: canConsiderReuse,
+                        previousFirstResidual: previousFirstResidual,
+                        cachedTargetTailResidual: cachedTargetTailResidual
+                    )
+                    predicted = result.output
+                    firstBlockChange = result.change
+                    if result.reusedTail {
+                        cacheHitThisStep = true
+                        executedBlocksThisStep = 1
+                        consecutiveCachedSteps += 1
+                        cachedStepCount += 1
+                    } else if let refreshedFirstResidual = result.refreshedFirstResidual,
+                              let refreshedTargetTailResidual = result.refreshedTargetTailResidual {
+                        previousFirstResidual = refreshedFirstResidual
+                        cachedTargetTailResidual = refreshedTargetTailResidual
+                        consecutiveCachedSteps = 0
+                        fullStepCount += 1
+                    } else {
+                        preconditionFailure("adaptive MiniMax-H3 cache did not return refreshed state")
+                    }
+                } else if let warmBlockCount {
                     let result = transformer.callWithBlockResidualReuse(
                         videoRows: videoInput,
                         audioRows: audioInput,
@@ -791,7 +1082,10 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
                     if let refreshedTailResidual = result.refreshedTailResidual {
                         cachedTailResidual = refreshedTailResidual
                         consecutiveCachedSteps = 0
+                        fullStepCount += 1
                     } else {
+                        cacheHitThisStep = true
+                        executedBlocksThisStep = warmBlockCount
                         consecutiveCachedSteps += 1
                         cachedStepCount += 1
                     }
@@ -803,6 +1097,7 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
                         timesteps: timestepValues,
                         cachedAdaLN: adaLNCache?.step(at: index)
                     )
+                    fullStepCount += 1
                 }
                 videoRows = Self.advance(
                     sample: videoRows,
@@ -814,6 +1109,22 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
                     velocity: predicted.audioVelocityRows,
                     coefficients: audioCoefficients
                 )
+            }
+            executedBlockCount += executedBlocksThisStep
+            if adaptiveCachePolicy != nil || blockReusePolicy != nil {
+                var plan = "step_plan=\(index + 1)/\(videoSchedule.timesteps.count) "
+                    + "cache_hit=\(cacheHitThisStep) blocks=\(executedBlocksThisStep)"
+                if let firstBlockChange {
+                    plan += String(
+                        format: " video_global=%.5f audio_global=%.5f "
+                            + "video_temporal=%.5f audio_temporal=%.5f",
+                        firstBlockChange.videoGlobal,
+                        firstBlockChange.audioGlobal,
+                        firstBlockChange.videoTemporalMaximum,
+                        firstBlockChange.audioTemporalMaximum
+                    )
+                }
+                stepProfileLogger?(plan)
             }
             MLX.eval(videoRows, audioRows)
             if let stepStarted, let stepProfileLogger {
@@ -829,9 +1140,11 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
                 ))
             }
         }
-        if warmBlockCount != nil {
+        if adaptiveCachePolicy != nil || blockReusePolicy != nil {
             stepProfileLogger?(
-                "cached_steps=\(cachedStepCount)/\(videoSchedule.timesteps.count)"
+                "cached_steps=\(cachedStepCount)/\(videoSchedule.timesteps.count) "
+                    + "full_steps=\(fullStepCount) executed_blocks=\(executedBlockCount) "
+                    + "baseline_blocks=\(videoSchedule.timesteps.count * totalBlockCount)"
             )
         }
         return (videoRows, audioRows)
@@ -884,6 +1197,7 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
     public func generate(
         options: MiniMaxH3GenerationOptions,
         resources: MiniMaxH3Resources,
+        continuation: MiniMaxH3ContinuationInput? = nil,
         progressHandler: (@Sendable (MiniMaxH3GenerationProgress) -> Void)? = nil
     ) throws -> MiniMaxH3GenerationResult {
         let phaseProfileLogger = MereRunRuntimeDebug.logger(
@@ -899,6 +1213,7 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
                 options: options,
                 resources: resources,
                 configuration: configuration,
+                continuation: continuation,
                 progressHandler: progressHandler
             )
         }
@@ -909,11 +1224,29 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
         let latentHeight = options.height / 16
         let latentWidth = options.width / 16
         let audioFrames = MiniMaxH3Geometry.audioLatentFrameCount(for: options.numFrames)
+        if let continuation {
+            guard continuation.frames.dim(2) == options.height,
+                  continuation.frames.dim(3) == options.width else {
+                throw MiniMaxH3GeneratorError.invalidOptions(
+                    "continuation dimensions must match the target H3 dimensions"
+                )
+            }
+            guard !options.frameInputs.contains(where: { $0.frameIndex == 0 }),
+                  options.firstFrameURL == nil else {
+                throw MiniMaxH3GeneratorError.invalidOptions(
+                    "continuation already supplies the first target frame"
+                )
+            }
+        }
 
         progressHandler?(.init(stage: .loadingTextEncoder, stepIndex: 0, totalSteps: options.steps - 1))
         let conditionerPreparationStarted = CFAbsoluteTimeGetCurrent()
         let tokenizer = try QwenTokenizer.load(from: resources.tokenizerURL, maxLengthOverride: 262_144)
-        let presentation = try conditionerPresentation(tokenizer: tokenizer, options: options)
+        let presentation = try conditionerPresentation(
+            tokenizer: tokenizer,
+            options: options,
+            continuationFrame: continuation.map(Self.boundaryFrame)
+        )
         guard !presentation.tokenIDs.isEmpty else {
             throw MiniMaxH3GeneratorError.invalidOptions("prompt tokenized to zero rows")
         }
@@ -928,7 +1261,7 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
         ))
         let promptStates: MLXArray = try withMiniMaxH3AutoreleasePool {
             let conditionerLoadStarted = CFAbsoluteTimeGetCurrent()
-            let encoder = try MiniMaxH3ModelLoader.loadConditioner(
+            let encoder = try loadConditioner(
                 resources: resources,
                 configuration: configuration,
                 progressHandler: { shard in
@@ -962,17 +1295,26 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
         }
         Memory.clearCache()
 
-        let keyframeURLs = [options.firstFrameURL, options.lastFrameURL].compactMap { $0 }
-        let keyframeAnchors: [MiniMaxH3KeyframeAnchor] = options.lastFrameURL == nil
-            ? (options.firstFrameURL == nil ? [] : [.first])
-            : [.first, .last]
+        let frameConditions = Self.frameConditions(options: options)
         let keyframeEncodingStarted = CFAbsoluteTimeGetCurrent()
-        var conditionRows = try encodeKeyframes(
-            keyframeURLs,
+        let continuationConditions = try continuation.map {
+            try encodeContinuation(
+                $0,
+                resources: resources,
+                progressHandler: progressHandler
+            )
+        }
+        let keyframeRows = try encodeKeyframes(
+            frameConditions.map(\.url),
             options: options,
             resources: resources,
             progressHandler: progressHandler
         )
+        var conditionVideoRows = Self.concatenateRows([
+            continuationConditions?.videoRows,
+            keyframeRows,
+        ])
+        var conditionAudioRows = continuationConditions?.audioRows
         phaseProfileLogger?(String(
             format: "phase=keyframe_encoding seconds=%.3f",
             CFAbsoluteTimeGetCurrent() - keyframeEncodingStarted
@@ -985,12 +1327,22 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
             latentHeight: latentHeight,
             latentWidth: latentWidth,
             audioLatentFrames: audioFrames,
-            keyframeAnchors: keyframeAnchors
+            keyframeAnchors: (continuationConditions?.videoAnchors ?? [])
+                + frameConditions.map(\.anchor),
+            audioConditionAnchors: continuationConditions?.audioAnchors ?? []
         )
         MLXRandom.seed(options.seed)
-        if let currentConditions = conditionRows {
+        if let currentConditions = conditionVideoRows {
             let conditionNoise = MLXRandom.normal(currentConditions.shape).asType(.float32)
-            conditionRows = MiniMaxH3Schedule.noise(
+            conditionVideoRows = MiniMaxH3Schedule.noise(
+                clean: currentConditions,
+                timestep: 0.999,
+                noise: conditionNoise
+            )
+        }
+        if let currentConditions = conditionAudioRows {
+            let conditionNoise = MLXRandom.normal(currentConditions.shape).asType(.float32)
+            conditionAudioRows = MiniMaxH3Schedule.noise(
                 clean: currentConditions,
                 timestep: 0.999,
                 noise: conditionNoise
@@ -1028,8 +1380,8 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
                 transformer: runtime.transformer,
                 videoRows: videoRows,
                 audioRows: audioRows,
-                conditionVideoRows: conditionRows,
-                conditionAudioRows: nil,
+                conditionVideoRows: conditionVideoRows,
+                conditionAudioRows: conditionAudioRows,
                 promptStates: promptStates,
                 layout: layout,
                 videoSchedule: videoSchedule,
@@ -1054,7 +1406,7 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
         progressHandler?(.init(stage: .decodingVideo, stepIndex: options.steps - 1, totalSteps: options.steps - 1))
         let videoDecodingStarted = CFAbsoluteTimeGetCurrent()
         let frames: MLXArray = try withMiniMaxH3AutoreleasePool {
-            let vae = try MiniMaxH3ModelLoader.loadVideoVAE(resources: resources)
+            let vae = try loadVideoVAE(resources: resources)
             let pixels = Self.mediaFrames(from: vae.decode(video))
             MLX.eval(pixels)
             return pixels
@@ -1067,7 +1419,7 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
         progressHandler?(.init(stage: .decodingAudio, stepIndex: options.steps - 1, totalSteps: options.steps - 1))
         let audioDecodingStarted = CFAbsoluteTimeGetCurrent()
         let waveform: MLXArray = try withMiniMaxH3AutoreleasePool {
-            let vae = try MiniMaxH3ModelLoader.loadAudioVAE(resources: resources)
+            let vae = try loadAudioVAE(resources: resources)
             let decoded = vae.decode(audio)
             MLX.eval(decoded)
             return decoded
@@ -1088,9 +1440,12 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
         options: MiniMaxH3GenerationOptions,
         resources: MiniMaxH3Resources,
         configuration: MiniMaxH3Configuration,
+        continuation: MiniMaxH3ContinuationInput?,
         progressHandler: (@Sendable (MiniMaxH3GenerationProgress) -> Void)?
     ) throws -> MiniMaxH3GenerationResult {
-        guard options.firstFrameURL == nil, options.lastFrameURL == nil else {
+        guard options.firstFrameURL == nil,
+              options.lastFrameURL == nil,
+              options.frameInputs.isEmpty else {
             throw MiniMaxH3GeneratorError.invalidOptions("Ref2VA uses ordered references, not FL2VA keyframes")
         }
         guard !options.references.isEmpty else {
@@ -1100,14 +1455,23 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
         let latentHeight = options.height / 16
         let latentWidth = options.width / 16
         let audioFrames = MiniMaxH3Geometry.audioLatentFrameCount(for: options.numFrames)
-        let prepared = try prepareReferences(options: options)
+        if let continuation {
+            guard continuation.frames.dim(2) == options.height,
+                  continuation.frames.dim(3) == options.width else {
+                throw MiniMaxH3GeneratorError.invalidOptions(
+                    "continuation dimensions must match the target H3 dimensions"
+                )
+            }
+        }
+        let prepared = try preparedReferences(options: options)
 
         progressHandler?(.init(stage: .loadingTextEncoder, stepIndex: 0, totalSteps: options.steps - 1))
         let tokenizer = try QwenTokenizer.load(from: resources.tokenizerURL, maxLengthOverride: 262_144)
         let presentation = try referenceConditionerPresentation(
             tokenizer: tokenizer,
             prompt: options.prompt,
-            references: prepared
+            references: prepared,
+            continuationFrame: continuation.map(Self.boundaryFrame)
         )
         guard !presentation.tokenIDs.isEmpty, presentation.tokenIDs.count <= 262_144 else {
             throw MiniMaxH3GeneratorError.invalidOptions("Ref2VA presentation must contain 1...262144 tokens")
@@ -1115,7 +1479,7 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
         let inputIDs = MLXArray(presentation.tokenIDs.map(Int32.init)).reshaped(1, presentation.tokenIDs.count)
         let attentionMask = MLXArray.ones([1, presentation.tokenIDs.count], dtype: .int32)
         let promptStates: MLXArray = try withMiniMaxH3AutoreleasePool {
-            let encoder = try MiniMaxH3ModelLoader.loadConditioner(
+            let encoder = try loadConditioner(
                 resources: resources,
                 configuration: configuration,
                 progressHandler: { shard in
@@ -1140,37 +1504,27 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
         }
         Memory.clearCache()
 
-        progressHandler?(.init(stage: .encodingReferences, stepIndex: 0, totalSteps: prepared.count))
-        let conditionVideoRows: MLXArray? = try withMiniMaxH3AutoreleasePool {
-            guard prepared.contains(where: { $0.visual != nil }) else { return nil }
-            let vae = try MiniMaxH3ModelLoader.loadVideoVAE(resources: resources)
-            var rows: [MLXArray] = []
-            for (index, reference) in prepared.enumerated() {
-                guard let visual = reference.visual else { continue }
-                let latent = reference.kind == .image
-                    ? vae.encodeKeyframe(visual)
-                    : vae.encodeReferenceVideo(visual)
-                let packed = MiniMaxH3Geometry.patchifyVideo(latent).asType(.float32)
-                MLX.eval(packed)
-                rows.append(packed)
-                progressHandler?(.init(stage: .encodingReferences, stepIndex: index + 1, totalSteps: prepared.count))
-            }
-            return MLX.concatenated(rows, axis: 1)
+        let referenceRows = try encodeReferences(
+            prepared,
+            options: options,
+            resources: resources,
+            progressHandler: progressHandler
+        )
+        let continuationConditions = try continuation.map {
+            try encodeContinuation(
+                $0,
+                resources: resources,
+                progressHandler: progressHandler
+            )
         }
-        Memory.clearCache()
-        let conditionAudioRows: MLXArray? = try withMiniMaxH3AutoreleasePool {
-            guard prepared.contains(where: { $0.waveform != nil }) else { return nil }
-            let vae = try MiniMaxH3ModelLoader.loadAudioVAE(resources: resources)
-            var rows: [MLXArray] = []
-            for (index, reference) in prepared.enumerated() {
-                guard let waveform = reference.waveform else { continue }
-                let packed = MiniMaxH3Geometry.packAudio(vae.encode(waveform)).expandedDimensions(axis: 0)
-                MLX.eval(packed)
-                rows.append(packed)
-                progressHandler?(.init(stage: .encodingReferences, stepIndex: index + 1, totalSteps: prepared.count))
-            }
-            return MLX.concatenated(rows, axis: 1)
-        }
+        let conditionVideoRows = Self.concatenateRows([
+            continuationConditions?.videoRows,
+            referenceRows.video,
+        ])
+        let conditionAudioRows = Self.concatenateRows([
+            continuationConditions?.audioRows,
+            referenceRows.audio,
+        ])
         Memory.clearCache()
 
         let layout = try MiniMaxH3Geometry.buildRef2VA(
@@ -1179,7 +1533,9 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
             videoLatentFrames: latentFrames,
             latentHeight: latentHeight,
             latentWidth: latentWidth,
-            audioLatentFrames: audioFrames
+            audioLatentFrames: audioFrames,
+            keyframeAnchors: continuationConditions?.videoAnchors ?? [],
+            audioConditionAnchors: continuationConditions?.audioAnchors ?? []
         )
         MLXRandom.seed(options.seed)
         let noisedVideoConditions = conditionVideoRows.map {
@@ -1242,7 +1598,7 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
         progressHandler?(.init(stage: .decodingVideo, stepIndex: options.steps - 1, totalSteps: options.steps - 1))
         let frames: MLXArray = try withMiniMaxH3AutoreleasePool {
             let pixels = Self.mediaFrames(
-                from: try MiniMaxH3ModelLoader.loadVideoVAE(resources: resources).decode(video)
+                from: try loadVideoVAE(resources: resources).decode(video)
             )
             MLX.eval(pixels)
             return pixels
@@ -1250,12 +1606,89 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
         Memory.clearCache()
         progressHandler?(.init(stage: .decodingAudio, stepIndex: options.steps - 1, totalSteps: options.steps - 1))
         let waveform: MLXArray = try withMiniMaxH3AutoreleasePool {
-            let decoded = try MiniMaxH3ModelLoader.loadAudioVAE(resources: resources).decode(audio)
+            let decoded = try loadAudioVAE(resources: resources).decode(audio)
             MLX.eval(decoded)
             return decoded
         }
         Memory.clearCache()
         return MiniMaxH3GenerationResult(frames: frames, audio: waveform, seed: options.seed)
+    }
+
+    private func preparedReferences(
+        options: MiniMaxH3GenerationOptions
+    ) throws -> [PreparedReference] {
+        let key = ReferenceCacheKey(
+            references: options.references,
+            maximumFrameCount: options.numFrames
+        )
+        if retainsRuntime,
+           let retainedPreparedReferences,
+           retainedPreparedReferences.key == key {
+            return retainedPreparedReferences.values
+        }
+        let values = try prepareReferences(options: options)
+        if retainsRuntime { retainedPreparedReferences = (key, values) }
+        return values
+    }
+
+    private func encodeReferences(
+        _ prepared: [PreparedReference],
+        options: MiniMaxH3GenerationOptions,
+        resources: MiniMaxH3Resources,
+        progressHandler: (@Sendable (MiniMaxH3GenerationProgress) -> Void)?
+    ) throws -> PreparedReferenceRows {
+        let key = ReferenceCacheKey(
+            references: options.references,
+            maximumFrameCount: options.numFrames
+        )
+        if retainsRuntime,
+           let retainedPreparedReferenceRows,
+           retainedPreparedReferenceRows.key == key {
+            return retainedPreparedReferenceRows.values
+        }
+        progressHandler?(.init(stage: .encodingReferences, stepIndex: 0, totalSteps: prepared.count))
+        let videoRows: MLXArray? = try withMiniMaxH3AutoreleasePool {
+            guard prepared.contains(where: { $0.visual != nil }) else { return nil }
+            let vae = try loadVideoVAE(resources: resources)
+            var rows: [MLXArray] = []
+            for (index, reference) in prepared.enumerated() {
+                guard let visual = reference.visual else { continue }
+                let latent = reference.kind == .image
+                    ? vae.encodeKeyframe(visual)
+                    : vae.encodeReferenceVideo(visual)
+                let packed = MiniMaxH3Geometry.patchifyVideo(latent).asType(.float32)
+                MLX.eval(packed)
+                rows.append(packed)
+                progressHandler?(.init(
+                    stage: .encodingReferences,
+                    stepIndex: index + 1,
+                    totalSteps: prepared.count
+                ))
+            }
+            return MLX.concatenated(rows, axis: 1)
+        }
+        let audioRows: MLXArray? = try withMiniMaxH3AutoreleasePool {
+            guard prepared.contains(where: { $0.waveform != nil }) else { return nil }
+            let vae = try loadAudioVAE(resources: resources)
+            var rows: [MLXArray] = []
+            for (index, reference) in prepared.enumerated() {
+                guard let waveform = reference.waveform else { continue }
+                let packed = MiniMaxH3Geometry.packAudio(
+                    vae.encode(waveform)
+                ).expandedDimensions(axis: 0)
+                MLX.eval(packed)
+                rows.append(packed)
+                progressHandler?(.init(
+                    stage: .encodingReferences,
+                    stepIndex: index + 1,
+                    totalSteps: prepared.count
+                ))
+            }
+            return MLX.concatenated(rows, axis: 1)
+        }
+        let values = PreparedReferenceRows(video: videoRows, audio: audioRows)
+        if retainsRuntime { retainedPreparedReferenceRows = (key, values) }
+        return values
     }
 
     private func prepareReferences(options: MiniMaxH3GenerationOptions) throws -> [PreparedReference] {
@@ -1394,7 +1827,8 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
     private func referenceConditionerPresentation(
         tokenizer: QwenTokenizer,
         prompt: String,
-        references: [PreparedReference]
+        references: [PreparedReference],
+        continuationFrame: MLXArray? = nil
     ) throws -> ConditionerPresentation {
         guard let imageTokenID = tokenizer.imageTokenId,
               let videoTokenID = tokenizer.videoTokenId,
@@ -1432,6 +1866,23 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
                 heightPatchCount: patchHeight,
                 widthPatchCount: patchWidth
             ))
+        }
+        if let continuationFrame {
+            MLX.eval(continuationFrame)
+            let frame = continuationFrame[0, 0]
+            let image = try MediaImageIO.imageFromRGBHWC(
+                frame.asArray(UInt8.self),
+                width: continuationFrame.dim(3),
+                height: continuationFrame.dim(2)
+            )
+            let pixels = try QwenVLImageLoader.pixelValues(
+                image: image,
+                patchSize: 16,
+                spatialMergeSize: 2
+            )
+            imageCount += 1
+            appendText("<Picture \(imageCount)>: ")
+            appendVision(pixels, padToken: imageTokenID)
         }
         for reference in references {
             if reference.waveform != nil {
@@ -1531,7 +1982,7 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
         guard !urls.isEmpty else { return nil }
         progressHandler?(.init(stage: .encodingKeyframes, stepIndex: 0, totalSteps: urls.count))
         return try withMiniMaxH3AutoreleasePool {
-            let vae = try MiniMaxH3ModelLoader.loadVideoVAE(resources: resources)
+            let vae = try loadVideoVAE(resources: resources)
             var rows: [MLXArray] = []
             for (index, url) in urls.enumerated() {
                 let image: MediaImage
@@ -1554,32 +2005,133 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
         }
     }
 
+    private func encodeContinuation(
+        _ continuation: MiniMaxH3ContinuationInput,
+        resources: MiniMaxH3Resources,
+        progressHandler: (@Sendable (MiniMaxH3GenerationProgress) -> Void)?
+    ) throws -> ContinuationConditions {
+        progressHandler?(.init(stage: .encodingKeyframes, stepIndex: 0, totalSteps: 2))
+        let videoVAE = try loadVideoVAE(resources: resources)
+        let rgb = continuation.frames.asType(.float32) / 255
+        var videoRows: [MLXArray] = []
+        var videoAnchors: [MiniMaxH3KeyframeAnchor] = []
+        if continuation.frameCount > 1 {
+            let history = rgb[
+                0...,
+                0..<(continuation.frameCount - 1),
+                0...,
+                0...,
+                0...
+            ]
+            let historyLatent = videoVAE.encodeReferenceVideo(history)
+            videoRows.append(MiniMaxH3Geometry.patchifyVideo(historyLatent).asType(.float32))
+            videoAnchors.append(.history(latentFrameCount: historyLatent.dim(2)))
+        }
+        let boundary = rgb[
+            0...,
+            (continuation.frameCount - 1)..<continuation.frameCount,
+            0...,
+            0...,
+            0...
+        ]
+        let boundaryLatent = videoVAE.encodeKeyframe(boundary.squeezed(axis: 1))
+        videoRows.append(MiniMaxH3Geometry.patchifyVideo(boundaryLatent).asType(.float32))
+        videoAnchors.append(.first)
+        let packedVideo = MLX.concatenated(videoRows, axis: 1)
+        MLX.eval(packedVideo)
+        progressHandler?(.init(stage: .encodingKeyframes, stepIndex: 1, totalSteps: 2))
+
+        let audioVAE = try loadAudioVAE(resources: resources)
+        let audioLatent = audioVAE.encode(continuation.audio.asType(.float32))
+        let boundaryLatentCount = min(
+            audioLatent.dim(3),
+            max(
+                1,
+                Int((Double(MiniMaxH3Geometry.audioLatentsPerSecond)
+                    / Double(MiniMaxH3Geometry.framesPerSecond)).rounded())
+            )
+        )
+        let historyLatentCount = audioLatent.dim(3) - boundaryLatentCount
+        var audioRows: [MLXArray] = []
+        var audioAnchors: [MiniMaxH3AudioConditionAnchor] = []
+        if historyLatentCount > 0 {
+            let history = audioLatent[0..., 0..., 0..., 0..<historyLatentCount]
+            audioRows.append(MiniMaxH3Geometry.packAudio(history).expandedDimensions(axis: 0))
+            audioAnchors.append(.history(latentFrameCount: historyLatentCount))
+        }
+        let first = audioLatent[
+            0...,
+            0...,
+            0...,
+            historyLatentCount..<audioLatent.dim(3)
+        ]
+        audioRows.append(MiniMaxH3Geometry.packAudio(first).expandedDimensions(axis: 0))
+        audioAnchors.append(.first(latentFrameCount: boundaryLatentCount))
+        let packedAudio = MLX.concatenated(audioRows, axis: 1)
+        MLX.eval(packedAudio)
+        progressHandler?(.init(stage: .encodingKeyframes, stepIndex: 2, totalSteps: 2))
+        return ContinuationConditions(
+            videoRows: packedVideo,
+            audioRows: packedAudio,
+            videoAnchors: videoAnchors,
+            audioAnchors: audioAnchors
+        )
+    }
+
+    private static func concatenateRows(_ arrays: [MLXArray?]) -> MLXArray? {
+        let values = arrays.compactMap { $0 }
+        guard !values.isEmpty else { return nil }
+        return values.count == 1 ? values[0] : MLX.concatenated(values, axis: 1)
+    }
+
+    private static func boundaryFrame(_ continuation: MiniMaxH3ContinuationInput) -> MLXArray {
+        continuation.frames[
+            0...,
+            (continuation.frameCount - 1)..<continuation.frameCount,
+            0...,
+            0...,
+            0...
+        ]
+    }
+
     private func conditionerPresentation(
         tokenizer: QwenTokenizer,
-        options: MiniMaxH3GenerationOptions
+        options: MiniMaxH3GenerationOptions,
+        continuationFrame: MLXArray? = nil
     ) throws -> ConditionerPresentation {
-        let keyframeURLs = [options.firstFrameURL, options.lastFrameURL].compactMap { $0 }
+        let keyframeURLs = Self.frameConditions(options: options).map(\.url)
         var tokenIDs: [Int] = []
         var tokenTags: [Int32] = []
         var images: [QwenVLEncoder.ConditioningImage] = []
 
-        if !keyframeURLs.isEmpty {
+        if continuationFrame != nil || !keyframeURLs.isEmpty {
             guard let imageTokenID = tokenizer.imageTokenId,
                   let visionStartTokenID = tokenizer.visionStartTokenId,
                   let visionEndTokenID = tokenizer.visionEndTokenId else {
                 throw MiniMaxH3GeneratorError.invalidOptions("Qwen3-VL tokenizer is missing vision tokens")
             }
-            for (index, url) in keyframeURLs.enumerated() {
-                let prepared: MediaImage
+            var preparedImages: [MediaImage] = []
+            if let continuationFrame {
+                MLX.eval(continuationFrame)
+                let frame = continuationFrame[0, 0]
+                preparedImages.append(try MediaImageIO.imageFromRGBHWC(
+                    frame.asArray(UInt8.self),
+                    width: continuationFrame.dim(3),
+                    height: continuationFrame.dim(2)
+                ))
+            }
+            for url in keyframeURLs {
                 do {
-                    prepared = try MediaImageIO.resized(
+                    preparedImages.append(try MediaImageIO.resized(
                         try MediaImageIO.decode(url),
                         width: options.width,
                         height: options.height
-                    )
+                    ))
                 } catch {
                     throw MiniMaxH3GeneratorError.imageDecodeFailed(url)
                 }
+            }
+            for (index, prepared) in preparedImages.enumerated() {
                 let pixelValues = try QwenVLImageLoader.pixelValues(
                     image: prepared,
                     patchSize: 16,
@@ -1621,5 +2173,30 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
         tokenIDs.append(contentsOf: promptIDs)
         tokenTags.append(contentsOf: repeatElement(MiniMaxH3Modality.text.rawValue, count: promptIDs.count))
         return ConditionerPresentation(tokenIDs: tokenIDs, tokenTags: tokenTags, images: images)
+    }
+
+    private static func frameConditions(options: MiniMaxH3GenerationOptions) -> [FrameCondition] {
+        var conditions: [(index: Int, condition: FrameCondition)] = []
+        if let firstFrameURL = options.firstFrameURL {
+            conditions.append((0, .init(url: firstFrameURL, anchor: .first)))
+        }
+        conditions.append(contentsOf: options.frameInputs.map { input in
+            let anchor: MiniMaxH3KeyframeAnchor
+            if input.frameIndex == 0 {
+                anchor = .first
+            } else if input.frameIndex == options.numFrames - 1 {
+                anchor = .last
+            } else {
+                anchor = .frame(input.frameIndex)
+            }
+            return (input.frameIndex, .init(url: input.url, anchor: anchor))
+        })
+        if let lastFrameURL = options.lastFrameURL {
+            conditions.append((
+                options.numFrames - 1,
+                .init(url: lastFrameURL, anchor: .last)
+            ))
+        }
+        return conditions.sorted { $0.index < $1.index }.map(\.condition)
     }
 }

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Layout.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Layout.swift
@@ -17,9 +17,75 @@ public enum MiniMaxH3Modality: Int32, Sendable {
     case audio = 2
 }
 
-public enum MiniMaxH3KeyframeAnchor: String, Codable, Sendable {
+public enum MiniMaxH3KeyframeAnchor: RawRepresentable, Codable, Sendable, Equatable {
+    public typealias RawValue = String
+
+    case history(latentFrameCount: Int)
     case first
+    case frame(Int)
     case last
+
+    public init?(rawValue: String) {
+        switch rawValue {
+        case "first": self = .first
+        case "last": self = .last
+        default:
+            let components = rawValue.split(separator: ":", maxSplits: 1)
+            guard components.count == 2,
+                  let value = Int(components[1]) else {
+                return nil
+            }
+            switch components[0] {
+            case "history": self = .history(latentFrameCount: value)
+            case "frame": self = .frame(value)
+            default: return nil
+            }
+        }
+    }
+
+    public var rawValue: String {
+        switch self {
+        case .history(let count): "history:\(count)"
+        case .first: "first"
+        case .frame(let index): "frame:\(index)"
+        case .last: "last"
+        }
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let rawValue = try container.decode(String.self)
+        guard let value = Self(rawValue: rawValue) else {
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "invalid MiniMax-H3 keyframe anchor: \(rawValue)"
+            )
+        }
+        self = value
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue)
+    }
+
+    var latentFrameCount: Int {
+        switch self {
+        case .history(let count): count
+        case .first, .frame, .last: 1
+        }
+    }
+}
+
+public enum MiniMaxH3AudioConditionAnchor: Sendable, Equatable {
+    case history(latentFrameCount: Int)
+    case first(latentFrameCount: Int)
+
+    var latentFrameCount: Int {
+        switch self {
+        case .history(let count), .first(let count): count
+        }
+    }
 }
 
 public struct MiniMaxH3ConditionSegment: Sendable {
@@ -181,7 +247,8 @@ public enum MiniMaxH3Geometry {
         latentHeight: Int,
         latentWidth: Int,
         audioLatentFrames: Int,
-        keyframeAnchors: [MiniMaxH3KeyframeAnchor]
+        keyframeAnchors: [MiniMaxH3KeyframeAnchor],
+        audioConditionAnchors: [MiniMaxH3AudioConditionAnchor] = []
     ) throws -> MiniMaxH3PackedLayout {
         guard videoLatentFrames > 0, latentHeight > 0, latentWidth > 0, audioLatentFrames > 0 else {
             throw MiniMaxH3LayoutError.invalidGeometry("all latent dimensions must be positive")
@@ -191,11 +258,19 @@ public enum MiniMaxH3Geometry {
         }
         let textCount = textTokenTags.count
         let rowsPerFrame = (latentHeight / 2) * (latentWidth / 2)
-        let conditionCount = keyframeAnchors.count * rowsPerFrame
+        let conditionVideoCount = keyframeAnchors.reduce(0) {
+            $0 + $1.latentFrameCount * rowsPerFrame
+        }
+        let conditionAudioCount = audioConditionAnchors.reduce(0) {
+            $0 + $1.latentFrameCount * 2
+        }
         let audioCount = audioLatentFrames * 2
         let videoCount = videoLatentFrames * rowsPerFrame
         let textRows = 0..<textCount
-        let conditionRows = textCount..<(textCount + conditionCount)
+        let conditionVideoRows = textCount..<(textCount + conditionVideoCount)
+        let conditionAudioStart = conditionVideoRows.upperBound
+        let conditionAudioRows = conditionAudioStart..<(conditionAudioStart + conditionAudioCount)
+        let conditionRows = textCount..<conditionAudioRows.upperBound
         let audioRows = conditionRows.upperBound..<(conditionRows.upperBound + audioCount)
         let videoRows = audioRows.upperBound..<(audioRows.upperBound + videoCount)
 
@@ -207,51 +282,109 @@ public enum MiniMaxH3Geometry {
         for row in textRows {
             positions[row * 3] = Float(row)
         }
-        for (index, anchor) in keyframeAnchors.enumerated() {
-            let time: Double = switch anchor {
-            case .first: Double(textCount)
-            case .last: Double(textCount) + temporalSpan(videoLatentFrames) - frameSpanScale
+        let historyLatentFrames = keyframeAnchors.reduce(0) { total, anchor in
+            if case .history(let count) = anchor { return total + count }
+            return total
+        }
+        let targetOrigin = Double(textCount) + temporalSpan(historyLatentFrames)
+        let targetTemporal = temporalGrid(videoLatentFrames, origin: targetOrigin)
+        var conditionVideoCursor = conditionVideoRows.lowerBound
+        var historyOrigin = Double(textCount)
+        for anchor in keyframeAnchors {
+            let latentFrameCount = anchor.latentFrameCount
+            let times: [Double] = switch anchor {
+            case .history:
+                temporalGrid(latentFrameCount, origin: historyOrigin)
+            case .first:
+                Array(targetTemporal.prefix(latentFrameCount))
+            case .frame(let frameIndex):
+                [targetOrigin + Double(frameIndex) * frameSpanScale]
+            case .last:
+                [targetOrigin + temporalSpan(videoLatentFrames) - frameSpanScale]
             }
-            for (offset, spatial) in frameGrid.enumerated() {
-                let row = conditionRows.lowerBound + index * rowsPerFrame + offset
-                positions[row * 3] = Float(time)
-                positions[row * 3 + 1] = Float(spatial.0)
-                positions[row * 3 + 2] = Float(spatial.1)
+            if case .history = anchor {
+                historyOrigin += temporalSpan(latentFrameCount)
             }
+            for latentFrame in 0..<latentFrameCount {
+                for (offset, spatial) in frameGrid.enumerated() {
+                    let row = conditionVideoCursor + latentFrame * rowsPerFrame + offset
+                    positions[row * 3] = Float(times[latentFrame])
+                    positions[row * 3 + 1] = Float(spatial.0)
+                    positions[row * 3 + 2] = Float(spatial.1)
+                }
+            }
+            conditionVideoCursor += latentFrameCount * rowsPerFrame
+        }
+        var conditionAudioCursor = conditionAudioRows.lowerBound
+        var audioHistoryOrigin = Double(textCount)
+        for anchor in audioConditionAnchors {
+            let origin: Double = switch anchor {
+            case .history: audioHistoryOrigin
+            case .first: targetOrigin
+            }
+            let rows = conditionAudioCursor..<(conditionAudioCursor + anchor.latentFrameCount * 2)
+            fillAudioPositions(
+                &positions,
+                rows: rows,
+                frames: anchor.latentFrameCount,
+                origin: origin,
+                widthGrid: widthGrid
+            )
+            if case .history = anchor {
+                audioHistoryOrigin += Double(anchor.latentFrameCount)
+            }
+            conditionAudioCursor = rows.upperBound
         }
         for channel in 0..<2 {
             for frame in 0..<audioLatentFrames {
                 let row = audioRows.lowerBound + channel * audioLatentFrames + frame
-                positions[row * 3] = Float(textCount + frame)
+                positions[row * 3] = Float(targetOrigin + Double(frame))
                 positions[row * 3 + 2] = Float(channel == 0 ? widthGrid[0] : widthGrid[widthGrid.count - 1])
             }
         }
-        let temporal = temporalGrid(videoLatentFrames, origin: Double(textCount))
         for frame in 0..<videoLatentFrames {
             for (offset, spatial) in frameGrid.enumerated() {
                 let row = videoRows.lowerBound + frame * rowsPerFrame + offset
-                positions[row * 3] = Float(temporal[frame])
+                positions[row * 3] = Float(targetTemporal[frame])
                 positions[row * 3 + 1] = Float(spatial.0)
                 positions[row * 3 + 2] = Float(spatial.1)
             }
         }
 
         var tags = textTokenTags
-        tags.append(contentsOf: repeatElement(MiniMaxH3Modality.video.rawValue, count: conditionCount))
+        tags.append(contentsOf: repeatElement(
+            MiniMaxH3Modality.video.rawValue,
+            count: conditionVideoCount
+        ))
+        tags.append(contentsOf: repeatElement(
+            MiniMaxH3Modality.audio.rawValue,
+            count: conditionAudioCount
+        ))
         tags.append(contentsOf: repeatElement(MiniMaxH3Modality.audio.rawValue, count: audioCount))
         tags.append(contentsOf: repeatElement(MiniMaxH3Modality.video.rawValue, count: videoCount))
+        var segments: [MiniMaxH3ConditionSegment] = []
+        if !conditionVideoRows.isEmpty {
+            segments.append(.init(
+                modality: .video,
+                packedRows: conditionVideoRows,
+                sourceRows: 0..<conditionVideoRows.count
+            ))
+        }
+        if !conditionAudioRows.isEmpty {
+            segments.append(.init(
+                modality: .audio,
+                packedRows: conditionAudioRows,
+                sourceRows: 0..<conditionAudioRows.count
+            ))
+        }
         return MiniMaxH3PackedLayout(
             positions: MLXArray(positions, [videoRows.upperBound, 3]),
             tokenTags: tags,
             textRows: textRows,
             conditionRows: conditionRows,
-            conditionSegments: conditionRows.isEmpty ? [] : [.init(
-                modality: .video,
-                packedRows: conditionRows,
-                sourceRows: 0..<conditionRows.count
-            )],
-            conditionVideoRowCount: conditionRows.count,
-            conditionAudioRowCount: 0,
+            conditionSegments: segments,
+            conditionVideoRowCount: conditionVideoCount,
+            conditionAudioRowCount: conditionAudioCount,
             targetAudioRows: audioRows,
             targetVideoRows: videoRows,
             videoLatentFrames: videoLatentFrames,
@@ -267,7 +400,9 @@ public enum MiniMaxH3Geometry {
         videoLatentFrames: Int,
         latentHeight: Int,
         latentWidth: Int,
-        audioLatentFrames: Int
+        audioLatentFrames: Int,
+        keyframeAnchors: [MiniMaxH3KeyframeAnchor] = [],
+        audioConditionAnchors: [MiniMaxH3AudioConditionAnchor] = []
     ) throws -> MiniMaxH3PackedLayout {
         guard videoLatentFrames > 0, latentHeight > 0, latentWidth > 0, audioLatentFrames > 0 else {
             throw MiniMaxH3LayoutError.invalidGeometry("all target latent dimensions must be positive")
@@ -293,23 +428,60 @@ public enum MiniMaxH3Geometry {
         }
 
         let textRows = 0..<textTokenTags.count
-        let targetVideoCount = videoLatentFrames * (latentHeight / 2) * (latentWidth / 2)
+        let targetGrid = framePositionGrid(latentHeight: latentHeight, latentWidth: latentWidth)
+        let targetRowsPerFrame = targetGrid.frame.count
+        let targetVideoCount = videoLatentFrames * targetRowsPerFrame
         let targetAudioCount = audioLatentFrames * 2
-        let conditionVideoCount = references.reduce(0) { $0 + $1.videoRowCount }
-        let conditionAudioCount = references.reduce(0) { $0 + $1.audioRowCount }
-        let conditionRows = textRows.upperBound..<(textRows.upperBound + conditionVideoCount + conditionAudioCount)
+        let keyframeVideoCount = keyframeAnchors.reduce(0) {
+            $0 + $1.latentFrameCount * targetRowsPerFrame
+        }
+        let keyframeAudioCount = audioConditionAnchors.reduce(0) {
+            $0 + $1.latentFrameCount * 2
+        }
+        let referenceVideoCount = references.reduce(0) { $0 + $1.videoRowCount }
+        let referenceAudioCount = references.reduce(0) { $0 + $1.audioRowCount }
+        let conditionVideoCount = keyframeVideoCount + referenceVideoCount
+        let conditionAudioCount = keyframeAudioCount + referenceAudioCount
+        let keyframeVideoRows = textRows.upperBound..<(textRows.upperBound + keyframeVideoCount)
+        let keyframeAudioRows = keyframeVideoRows.upperBound..<(
+            keyframeVideoRows.upperBound + keyframeAudioCount
+        )
+        let conditionRows = textRows.upperBound..<(
+            textRows.upperBound + conditionVideoCount + conditionAudioCount
+        )
         let targetAudioRows = conditionRows.upperBound..<(conditionRows.upperBound + targetAudioCount)
         let targetVideoRows = targetAudioRows.upperBound..<(targetAudioRows.upperBound + targetVideoCount)
         var positions = Array(repeating: Float(0), count: targetVideoRows.upperBound * 3)
         for row in textRows { positions[row * 3] = Float(row) }
+        var tags = textTokenTags + Array(
+            repeating: MiniMaxH3Modality.text.rawValue,
+            count: targetVideoRows.upperBound - textRows.count
+        )
+        func mark(_ rows: Range<Int>, as modality: MiniMaxH3Modality) {
+            for row in rows { tags[row] = modality.rawValue }
+        }
 
-        let targetGrid = framePositionGrid(latentHeight: latentHeight, latentWidth: latentWidth)
-        var packedCursor = conditionRows.lowerBound
-        var videoCursor = 0
-        var audioCursor = 0
-        var rotaryTime = Double(textRows.count)
         var segments: [MiniMaxH3ConditionSegment] = []
-        var tags = textTokenTags
+        if !keyframeVideoRows.isEmpty {
+            segments.append(.init(
+                modality: .video,
+                packedRows: keyframeVideoRows,
+                sourceRows: 0..<keyframeVideoCount
+            ))
+            mark(keyframeVideoRows, as: .video)
+        }
+        if !keyframeAudioRows.isEmpty {
+            segments.append(.init(
+                modality: .audio,
+                packedRows: keyframeAudioRows,
+                sourceRows: 0..<keyframeAudioCount
+            ))
+            mark(keyframeAudioRows, as: .audio)
+        }
+        var packedCursor = keyframeAudioRows.upperBound
+        var videoCursor = keyframeVideoCount
+        var audioCursor = keyframeAudioCount
+        var rotaryTime = Double(textRows.count)
         for reference in references {
             switch reference.kind {
             case .image:
@@ -325,7 +497,7 @@ public enum MiniMaxH3Geometry {
                     origin: rotaryTime,
                     singleImage: true
                 )
-                tags.append(contentsOf: repeatElement(MiniMaxH3Modality.video.rawValue, count: packed.count))
+                mark(packed, as: .video)
                 packedCursor = packed.upperBound
                 videoCursor = source.upperBound
                 rotaryTime += 1
@@ -340,7 +512,7 @@ public enum MiniMaxH3Geometry {
                     origin: rotaryTime,
                     widthGrid: targetGrid.width
                 )
-                tags.append(contentsOf: repeatElement(MiniMaxH3Modality.audio.rawValue, count: packed.count))
+                mark(packed, as: .audio)
                 packedCursor = packed.upperBound
                 audioCursor = source.upperBound
                 rotaryTime += Double(reference.audioLatentFrames)
@@ -360,7 +532,7 @@ public enum MiniMaxH3Geometry {
                         origin: rotaryTime,
                         widthGrid: grid.width
                     )
-                    tags.append(contentsOf: repeatElement(MiniMaxH3Modality.audio.rawValue, count: packed.count))
+                    mark(packed, as: .audio)
                     packedCursor = packed.upperBound
                     audioCursor = source.upperBound
                 }
@@ -376,7 +548,7 @@ public enum MiniMaxH3Geometry {
                     origin: rotaryTime,
                     singleImage: false
                 )
-                tags.append(contentsOf: repeatElement(MiniMaxH3Modality.video.rawValue, count: packed.count))
+                mark(packed, as: .video)
                 packedCursor = packed.upperBound
                 videoCursor = source.upperBound
                 rotaryTime += max(
@@ -385,12 +557,66 @@ public enum MiniMaxH3Geometry {
                 )
             }
         }
-
+        let historyLatentFrames = keyframeAnchors.reduce(0) { total, anchor in
+            if case .history(let count) = anchor { return total + count }
+            return total
+        }
+        let targetOrigin = rotaryTime + temporalSpan(historyLatentFrames)
+        let targetTemporal = temporalGrid(videoLatentFrames, origin: targetOrigin)
+        var keyframeVideoCursor = keyframeVideoRows.lowerBound
+        var historyOrigin = rotaryTime
+        for anchor in keyframeAnchors {
+            let latentFrameCount = anchor.latentFrameCount
+            let times: [Double] = switch anchor {
+            case .history:
+                temporalGrid(latentFrameCount, origin: historyOrigin)
+            case .first:
+                Array(targetTemporal.prefix(latentFrameCount))
+            case .frame(let frameIndex):
+                [targetOrigin + Double(frameIndex) * frameSpanScale]
+            case .last:
+                [targetOrigin + temporalSpan(videoLatentFrames) - frameSpanScale]
+            }
+            if case .history = anchor {
+                historyOrigin += temporalSpan(latentFrameCount)
+            }
+            for latentFrame in 0..<latentFrameCount {
+                for (offset, spatial) in targetGrid.frame.enumerated() {
+                    let row = keyframeVideoCursor + latentFrame * targetRowsPerFrame + offset
+                    positions[row * 3] = Float(times[latentFrame])
+                    positions[row * 3 + 1] = Float(spatial.0)
+                    positions[row * 3 + 2] = Float(spatial.1)
+                }
+            }
+            keyframeVideoCursor += latentFrameCount * targetRowsPerFrame
+        }
+        var keyframeAudioCursor = keyframeAudioRows.lowerBound
+        var audioHistoryOrigin = rotaryTime
+        for anchor in audioConditionAnchors {
+            let origin: Double = switch anchor {
+            case .history: audioHistoryOrigin
+            case .first: targetOrigin
+            }
+            let rows = keyframeAudioCursor..<(
+                keyframeAudioCursor + anchor.latentFrameCount * 2
+            )
+            fillAudioPositions(
+                &positions,
+                rows: rows,
+                frames: anchor.latentFrameCount,
+                origin: origin,
+                widthGrid: targetGrid.width
+            )
+            if case .history = anchor {
+                audioHistoryOrigin += Double(anchor.latentFrameCount)
+            }
+            keyframeAudioCursor = rows.upperBound
+        }
         fillAudioPositions(
             &positions,
             rows: targetAudioRows,
             frames: audioLatentFrames,
-            origin: rotaryTime,
+            origin: targetOrigin,
             widthGrid: targetGrid.width
         )
         fillVideoPositions(
@@ -399,11 +625,11 @@ public enum MiniMaxH3Geometry {
             latentFrames: videoLatentFrames,
             latentHeight: latentHeight,
             latentWidth: latentWidth,
-            origin: rotaryTime,
+            origin: targetOrigin,
             singleImage: false
         )
-        tags.append(contentsOf: repeatElement(MiniMaxH3Modality.audio.rawValue, count: targetAudioRows.count))
-        tags.append(contentsOf: repeatElement(MiniMaxH3Modality.video.rawValue, count: targetVideoRows.count))
+        mark(targetAudioRows, as: .audio)
+        mark(targetVideoRows, as: .video)
         return MiniMaxH3PackedLayout(
             positions: MLXArray(positions, [targetVideoRows.upperBound, 3]),
             tokenTags: tags,

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3SlidingWindow.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3SlidingWindow.swift
@@ -1,0 +1,294 @@
+import Foundation
+import MLX
+
+public struct MiniMaxH3SlidingWindowOptions: Sendable, Hashable {
+    public let totalFrameCount: Int
+    public let windowFrameCount: Int
+    public let overlapFrameCount: Int
+
+    public init(
+        totalFrameCount: Int,
+        windowFrameCount: Int,
+        overlapFrameCount: Int
+    ) throws {
+        guard totalFrameCount >= 22, totalFrameCount % 17 == 5 else {
+            throw MiniMaxH3GeneratorError.invalidOptions(
+                "sliding output frame count must be at least 22 and have the form 17*n+5"
+            )
+        }
+        guard windowFrameCount >= 22, windowFrameCount % 17 == 5 else {
+            throw MiniMaxH3GeneratorError.invalidOptions(
+                "--h3-window-frames must be at least 22 and have the form 17*n+5"
+            )
+        }
+        guard overlapFrameCount >= 1, overlapFrameCount % 17 == 1 else {
+            throw MiniMaxH3GeneratorError.invalidOptions(
+                "--h3-window-overlap must have the form 17*n+1"
+            )
+        }
+        guard overlapFrameCount < windowFrameCount else {
+            throw MiniMaxH3GeneratorError.invalidOptions(
+                "--h3-window-overlap must be smaller than --h3-window-frames"
+            )
+        }
+        let continuationTargetCount = windowFrameCount - overlapFrameCount + 1
+        guard continuationTargetCount >= 22 else {
+            throw MiniMaxH3GeneratorError.invalidOptions(
+                "sliding windows must leave at least 22 target frames after overlap"
+            )
+        }
+        self.totalFrameCount = totalFrameCount
+        self.windowFrameCount = windowFrameCount
+        self.overlapFrameCount = overlapFrameCount
+    }
+}
+
+public struct MiniMaxH3SlidingWindowPlan: Sendable, Hashable {
+    public struct Window: Sendable, Hashable {
+        public let index: Int
+        public let boundaryFrameIndex: Int?
+        public let generatedFrameCount: Int
+        public let appendedFrameRange: Range<Int>
+        public let outputFrameRange: Range<Int>
+
+        public var appendedFrameCount: Int { appendedFrameRange.count }
+
+        public func localFrameIndex(for globalFrameIndex: Int) -> Int? {
+            let origin = boundaryFrameIndex ?? outputFrameRange.lowerBound
+            let local = globalFrameIndex - origin
+            return (0..<generatedFrameCount).contains(local) ? local : nil
+        }
+    }
+
+    public let options: MiniMaxH3SlidingWindowOptions
+    public let windows: [Window]
+
+    public init(options: MiniMaxH3SlidingWindowOptions) {
+        self.options = options
+        var windows: [Window] = []
+        let firstCount = min(options.totalFrameCount, options.windowFrameCount)
+        windows.append(.init(
+            index: 0,
+            boundaryFrameIndex: nil,
+            generatedFrameCount: firstCount,
+            appendedFrameRange: 0..<firstCount,
+            outputFrameRange: 0..<firstCount
+        ))
+        let stride = options.windowFrameCount - options.overlapFrameCount
+        let targetCount = stride + 1
+        var emitted = firstCount
+        while emitted < options.totalFrameCount {
+            let appendCount = min(stride, options.totalFrameCount - emitted)
+            windows.append(.init(
+                index: windows.count,
+                boundaryFrameIndex: emitted - 1,
+                generatedFrameCount: targetCount,
+                appendedFrameRange: 1..<(appendCount + 1),
+                outputFrameRange: emitted..<(emitted + appendCount)
+            ))
+            emitted += appendCount
+        }
+        self.windows = windows
+    }
+}
+
+public struct MiniMaxH3ContinuationInput: @unchecked Sendable {
+    public let frames: MLXArray
+    public let audio: MLXArray
+    public let frameCount: Int
+
+    public init(frames: MLXArray, audio: MLXArray, frameCount: Int) throws {
+        guard frameCount >= 1, frameCount % 17 == 1 else {
+            throw MiniMaxH3GeneratorError.invalidOptions(
+                "continuation overlap must have the form 17*n+1"
+            )
+        }
+        guard frames.ndim == 5,
+              frames.dim(0) == 1,
+              frames.dim(1) == frameCount,
+              frames.dim(4) == 3 else {
+            throw MiniMaxH3GeneratorError.invalidOptions(
+                "continuation video must have shape [1, overlap, height, width, 3]"
+            )
+        }
+        guard audio.ndim == 3,
+              audio.dim(0) == 1,
+              audio.dim(2) == 2 else {
+            throw MiniMaxH3GeneratorError.invalidOptions(
+                "continuation audio must have shape [1, samples, 2]"
+            )
+        }
+        self.frames = frames
+        self.audio = audio
+        self.frameCount = frameCount
+    }
+}
+
+extension MiniMaxH3Generator {
+    public func generateSlidingWindows(
+        options: MiniMaxH3GenerationOptions,
+        slidingWindowOptions: MiniMaxH3SlidingWindowOptions,
+        resources: MiniMaxH3Resources,
+        windowHandler: (@Sendable (_ windowIndex: Int, _ windowCount: Int) -> Void)? = nil,
+        progressHandler: (@Sendable (MiniMaxH3GenerationProgress) -> Void)? = nil
+    ) throws -> MiniMaxH3GenerationResult {
+        guard options.numFrames == slidingWindowOptions.totalFrameCount else {
+            throw MiniMaxH3GeneratorError.invalidOptions(
+                "sliding total frame count must match the generation request"
+            )
+        }
+        let plan = MiniMaxH3SlidingWindowPlan(options: slidingWindowOptions)
+        var assembledFrames: MLXArray?
+        var assembledAudio: MLXArray?
+        let sampleRate = MiniMaxH3AudioVAE.samplingRate
+        let framesPerSecond = MiniMaxH3Geometry.framesPerSecond
+
+        for window in plan.windows {
+            windowHandler?(window.index, plan.windows.count)
+            let frameInputs = try positionedFrames(
+                options: options,
+                window: window,
+                totalFrameCount: slidingWindowOptions.totalFrameCount
+            )
+            let windowOptions = try MiniMaxH3GenerationOptions(
+                prompt: options.prompt,
+                width: options.width,
+                height: options.height,
+                numFrames: window.generatedFrameCount,
+                steps: options.steps,
+                seed: options.seed &+ UInt64(window.index),
+                transformerWeightMode: options.transformerWeightMode,
+                accelerationMode: options.accelerationMode,
+                adapterURL: options.adapterURL,
+                adapterStrength: options.adapterStrength,
+                firstFrameURL: window.index == 0 ? options.firstFrameURL : nil,
+                frameInputs: frameInputs,
+                references: options.references
+            )
+            let continuation: MiniMaxH3ContinuationInput?
+            if window.index == 0 {
+                continuation = nil
+            } else {
+                guard let assembledFrames, let assembledAudio else {
+                    preconditionFailure("sliding continuation requires the previous window")
+                }
+                let emittedFrameCount = window.outputFrameRange.lowerBound
+                let overlap = slidingWindowOptions.overlapFrameCount
+                let audioStart = Self.sampleOffset(
+                    frameIndex: emittedFrameCount - overlap,
+                    sampleRate: sampleRate,
+                    framesPerSecond: framesPerSecond
+                )
+                let audioEnd = Self.sampleOffset(
+                    frameIndex: emittedFrameCount,
+                    sampleRate: sampleRate,
+                    framesPerSecond: framesPerSecond
+                )
+                continuation = try MiniMaxH3ContinuationInput(
+                    frames: assembledFrames[
+                        0...,
+                        (emittedFrameCount - overlap)..<emittedFrameCount,
+                        0...,
+                        0...,
+                        0...
+                    ],
+                    audio: assembledAudio[0..., audioStart..<audioEnd, 0...],
+                    frameCount: overlap
+                )
+            }
+            let result = try generate(
+                options: windowOptions,
+                resources: resources,
+                continuation: continuation,
+                progressHandler: progressHandler
+            )
+            let frameSlice = result.frames[
+                0...,
+                window.appendedFrameRange,
+                0...,
+                0...,
+                0...
+            ]
+            let localAudioStart = Self.sampleOffset(
+                frameIndex: window.appendedFrameRange.lowerBound,
+                sampleRate: sampleRate,
+                framesPerSecond: framesPerSecond
+            )
+            let localAudioEnd = Self.sampleOffset(
+                frameIndex: window.appendedFrameRange.upperBound,
+                sampleRate: sampleRate,
+                framesPerSecond: framesPerSecond
+            )
+            let fittedWindowAudio = Self.fitAudio(
+                result.audio,
+                sampleCount: localAudioEnd
+            )
+            let audioSlice = fittedWindowAudio[0..., localAudioStart..<localAudioEnd, 0...]
+            assembledFrames = assembledFrames.map {
+                MLX.concatenated([$0, frameSlice], axis: 1)
+            } ?? frameSlice
+            assembledAudio = assembledAudio.map {
+                MLX.concatenated([$0, audioSlice], axis: 1)
+            } ?? audioSlice
+            if let assembledFrames, let assembledAudio {
+                MLX.eval(assembledFrames, assembledAudio)
+            }
+            Memory.clearCache()
+        }
+        guard let assembledFrames, let assembledAudio else {
+            preconditionFailure("sliding plan must contain at least one window")
+        }
+        let exactSampleCount = Self.sampleOffset(
+            frameIndex: slidingWindowOptions.totalFrameCount,
+            sampleRate: sampleRate,
+            framesPerSecond: framesPerSecond
+        )
+        let exactAudio = Self.fitAudio(assembledAudio, sampleCount: exactSampleCount)
+        MLX.eval(assembledFrames, exactAudio)
+        return MiniMaxH3GenerationResult(
+            frames: assembledFrames,
+            audio: exactAudio,
+            seed: options.seed
+        )
+    }
+
+    private func positionedFrames(
+        options: MiniMaxH3GenerationOptions,
+        window: MiniMaxH3SlidingWindowPlan.Window,
+        totalFrameCount: Int
+    ) throws -> [MiniMaxH3FrameInput] {
+        var globalFrames = options.frameInputs
+        if let lastFrameURL = options.lastFrameURL {
+            globalFrames.append(.init(
+                frameIndex: totalFrameCount - 1,
+                url: lastFrameURL
+            ))
+        }
+        return globalFrames.compactMap { input in
+            guard window.outputFrameRange.contains(input.frameIndex),
+                  let localIndex = window.localFrameIndex(for: input.frameIndex) else {
+                return nil
+            }
+            return MiniMaxH3FrameInput(frameIndex: localIndex, url: input.url)
+        }
+    }
+
+    private static func sampleOffset(
+        frameIndex: Int,
+        sampleRate: Int,
+        framesPerSecond: Int
+    ) -> Int {
+        Int((Double(frameIndex) * Double(sampleRate) / Double(framesPerSecond)).rounded())
+    }
+
+    private static func fitAudio(_ audio: MLXArray, sampleCount: Int) -> MLXArray {
+        if audio.dim(1) == sampleCount { return audio }
+        if audio.dim(1) > sampleCount {
+            return audio[0..., 0..<sampleCount, 0...]
+        }
+        return MLX.padded(
+            audio,
+            widths: [[0, 0], [0, sampleCount - audio.dim(1)], [0, 0]]
+        )
+    }
+}

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Transformer.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Transformer.swift
@@ -116,6 +116,111 @@ struct MiniMaxH3BlockReuseResult {
     let refreshedTailResidual: MLXArray?
 }
 
+struct MiniMaxH3FirstBlockChange: Sendable, Equatable {
+    let videoGlobal: Float
+    let audioGlobal: Float
+    let videoTemporalMaximum: Float
+    let audioTemporalMaximum: Float
+
+    var isFinite: Bool {
+        videoGlobal.isFinite
+            && audioGlobal.isFinite
+            && videoTemporalMaximum.isFinite
+            && audioTemporalMaximum.isFinite
+    }
+
+    static func measure(
+        current: MLXArray,
+        previous: MLXArray,
+        layout: MiniMaxH3PackedLayout
+    ) -> Self {
+        let audioRowCount = layout.targetAudioRows.count
+        let videoRowCount = layout.targetVideoRows.count
+        let totalRowCount = audioRowCount + videoRowCount
+        precondition(current.shape == previous.shape)
+        precondition(current.ndim == 3 && current.dim(0) == 1)
+        precondition(current.dim(1) == totalRowCount)
+        precondition(audioRowCount == layout.audioLatentFrames * 2)
+        precondition(videoRowCount.isMultiple(of: layout.videoLatentFrames))
+
+        let currentFloat = current.asType(.float32)
+        let previousFloat = previous.asType(.float32)
+        let currentAudio = currentFloat[0..., 0..<audioRowCount, 0...]
+        let previousAudio = previousFloat[0..., 0..<audioRowCount, 0...]
+        let currentVideo = currentFloat[0..., audioRowCount..<totalRowCount, 0...]
+        let previousVideo = previousFloat[0..., audioRowCount..<totalRowCount, 0...]
+
+        func relativeGlobal(_ value: MLXArray, _ reference: MLXArray) -> MLXArray {
+            let numerator = MLX.mean(MLX.abs(value - reference))
+            let denominator = MLX.maximum(
+                MLX.mean(MLX.abs(reference)),
+                MLXArray(Float(1e-8))
+            )
+            return numerator / denominator
+        }
+
+        let videoRowsPerFrame = videoRowCount / layout.videoLatentFrames
+        let videoDifference = MLX.abs(currentVideo - previousVideo).reshaped(
+            1,
+            layout.videoLatentFrames,
+            videoRowsPerFrame,
+            current.dim(2)
+        )
+        let videoReference = MLX.abs(previousVideo).reshaped(
+            1,
+            layout.videoLatentFrames,
+            videoRowsPerFrame,
+            current.dim(2)
+        )
+        let videoTemporal = MLX.mean(videoDifference, axes: [0, 2, 3])
+            / MLX.maximum(
+                MLX.mean(videoReference, axes: [0, 2, 3]),
+                MLXArray(Float(1e-8))
+            )
+
+        let audioDifference = MLX.abs(currentAudio - previousAudio).reshaped(
+            1,
+            2,
+            layout.audioLatentFrames,
+            current.dim(2)
+        )
+        let audioReference = MLX.abs(previousAudio).reshaped(
+            1,
+            2,
+            layout.audioLatentFrames,
+            current.dim(2)
+        )
+        let audioTemporal = MLX.mean(audioDifference, axes: [0, 1, 3])
+            / MLX.maximum(
+                MLX.mean(audioReference, axes: [0, 1, 3]),
+                MLXArray(Float(1e-8))
+            )
+
+        let metrics = MLX.stacked([
+            relativeGlobal(currentVideo, previousVideo),
+            relativeGlobal(currentAudio, previousAudio),
+            MLX.max(videoTemporal),
+            MLX.max(audioTemporal),
+        ]).asType(.float32)
+        MLX.eval(metrics)
+        let values = metrics.asArray(Float.self)
+        return .init(
+            videoGlobal: values[0],
+            audioGlobal: values[1],
+            videoTemporalMaximum: values[2],
+            audioTemporalMaximum: values[3]
+        )
+    }
+}
+
+struct MiniMaxH3AdaptiveBlockReuseResult {
+    let output: MiniMaxH3TransformerOutput
+    let refreshedFirstResidual: MLXArray?
+    let refreshedTargetTailResidual: MLXArray?
+    let reusedTail: Bool
+    let change: MiniMaxH3FirstBlockChange?
+}
+
 private final class MiniMaxH3Attention: Module {
     let heads: Int
     let headDimension: Int
@@ -1307,6 +1412,98 @@ public final class MiniMaxH3Transformer: Module {
                 cachedAdaLN: cachedAdaLN
             ),
             refreshedTailResidual: refreshedTailResidual
+        )
+    }
+
+    func callWithAdaptiveFirstBlockReuse(
+        videoRows: MLXArray,
+        audioRows: MLXArray,
+        context: MiniMaxH3TransformerPreparedContext,
+        timesteps: MLXArray,
+        cachedAdaLN: MiniMaxH3AdaLNStep?,
+        policy: MiniMaxH3AdaptiveFirstBlockCachePolicy,
+        canConsiderReuse: Bool,
+        previousFirstResidual: MLXArray?,
+        cachedTargetTailResidual: MLXArray?
+    ) -> MiniMaxH3AdaptiveBlockReuseResult {
+        precondition(blocks.count > 1)
+        let prepared = prepareBlockInput(
+            videoRows: videoRows,
+            audioRows: audioRows,
+            context: context,
+            timesteps: timesteps,
+            cachedAdaLN: cachedAdaLN
+        )
+        let firstHidden = runBlocks(
+            prepared.hidden,
+            range: 0..<1,
+            context: context,
+            timeEmbedding: prepared.timeEmbedding,
+            cachedAdaLN: cachedAdaLN
+        )
+        let targetRows = context.layout.targetAudioRows.lowerBound..<context.layout.targetVideoRows.upperBound
+        let initialTarget = prepared.hidden[0..., targetRows, 0...]
+        let firstTarget = firstHidden[0..., targetRows, 0...]
+        let firstResidual = firstTarget - initialTarget
+
+        let change: MiniMaxH3FirstBlockChange?
+        let reusesTail: Bool
+        if canConsiderReuse,
+           let previousFirstResidual,
+           let cachedTargetTailResidual,
+           previousFirstResidual.shape == firstResidual.shape,
+           cachedTargetTailResidual.shape == firstTarget.shape {
+            let measured = MiniMaxH3FirstBlockChange.measure(
+                current: firstResidual,
+                previous: previousFirstResidual,
+                layout: context.layout
+            )
+            change = measured
+            reusesTail = policy.shouldReuse(change: measured)
+        } else {
+            change = nil
+            reusesTail = false
+        }
+
+        let hidden: MLXArray
+        let refreshedFirstResidual: MLXArray?
+        let refreshedTargetTailResidual: MLXArray?
+        if reusesTail, let cachedTargetTailResidual {
+            let completedTarget = firstTarget + cachedTargetTailResidual
+            hidden = targetRows.lowerBound == 0
+                ? completedTarget
+                : MLX.concatenated([
+                    firstHidden[0..., 0..<targetRows.lowerBound, 0...],
+                    completedTarget,
+                ], axis: 1)
+            MLX.eval(hidden)
+            refreshedFirstResidual = nil
+            refreshedTargetTailResidual = nil
+        } else {
+            hidden = runBlocks(
+                firstHidden,
+                range: 1..<blocks.count,
+                context: context,
+                timeEmbedding: prepared.timeEmbedding,
+                cachedAdaLN: cachedAdaLN
+            )
+            let targetTailResidual = hidden[0..., targetRows, 0...] - firstTarget
+            MLX.eval(firstResidual, targetTailResidual)
+            refreshedFirstResidual = firstResidual
+            refreshedTargetTailResidual = targetTailResidual
+        }
+
+        return MiniMaxH3AdaptiveBlockReuseResult(
+            output: finalize(
+                hidden,
+                context: context,
+                timeEmbedding: prepared.timeEmbedding,
+                cachedAdaLN: cachedAdaLN
+            ),
+            refreshedFirstResidual: refreshedFirstResidual,
+            refreshedTargetTailResidual: refreshedTargetTailResidual,
+            reusedTail: reusesTail,
+            change: change
         )
     }
 

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Transformer.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Transformer.swift
@@ -617,9 +617,22 @@ private final class MiniMaxH3TransformerBlock: Module {
         values: MLXArray,
         maximumQueryTokens: Int,
         maximumHeadsPerKernel: Int?,
-        maximumKernelsPerEvaluation: Int
+        maximumKernelsPerEvaluation: Int,
+        dynamicSparseRequest: MiniMaxH3DynamicSparseAttentionRequest? = nil
     ) -> MLXArray {
-        attention.scaledDotProductAttention(
+        if let dynamicSparseRequest,
+           let sparse = MiniMaxH3DynamicSparseAttention.call(
+               queries: queries,
+               keys: keys,
+               values: values,
+               request: dynamicSparseRequest,
+               scale: attention.scale,
+               maximumQueryTokens: maximumQueryTokens,
+               maximumKernelsPerEvaluation: maximumKernelsPerEvaluation
+           ) {
+            return sparse
+        }
+        return attention.scaledDotProductAttention(
             queries: queries,
             keys: keys,
             values: values,
@@ -1166,6 +1179,10 @@ public final class MiniMaxH3Transformer: Module {
     var maximumAttentionQueryTokensPerKernel = 1_024
     var maximumAttentionHeadsPerKernel: Int?
     var maximumAttentionKernelsPerEvaluation = 4
+    var dynamicSparseAttentionPolicy: MiniMaxH3DynamicSparseAttentionPolicy?
+    var dynamicSparseAttentionStepIndex = 0
+    var dynamicSparseAttentionStepCount = 0
+    var dynamicSparseAttentionLogHandler: ((String) -> Void)?
     var blockTimingHandler: ((Int, TimeInterval, Memory.Snapshot) -> Void)?
     @ModuleInfo(key: "video_patch_proj") var videoInput: Linear
     @ModuleInfo(key: "audio_patch_proj") var audioInput: Linear
@@ -1179,6 +1196,7 @@ public final class MiniMaxH3Transformer: Module {
     private let timeFrequencies: MLXArray
     private var compiledBlockRunner: MiniMaxH3TransformerBlock?
     private var compiledBlockForwards: MiniMaxH3CompiledBlockForwards?
+    private var dynamicSparseAttentionGateResults: [String: Bool] = [:]
     private var adaLNWeightsAvailable: Bool
 
     public init(
@@ -1570,13 +1588,21 @@ public final class MiniMaxH3Transformer: Module {
                 let compiled = compiledBlockForward(for: block)
                 let projectedAttention = compiled.attentionProjection(attentionInputs)
                 MLX.eval(projectedAttention)
+                let dynamicSparseRequest = qualifiedDynamicSparseAttentionRequest(
+                    queries: projectedAttention[0],
+                    keys: projectedAttention[1],
+                    values: projectedAttention[2],
+                    layerIndex: index,
+                    layout: context.layout
+                )
                 let attended = block.scaledDotProductAttention(
                     queries: projectedAttention[0],
                     keys: projectedAttention[1],
                     values: projectedAttention[2],
                     maximumQueryTokens: maximumAttentionQueryTokensPerKernel,
                     maximumHeadsPerKernel: maximumAttentionHeadsPerKernel,
-                    maximumKernelsPerEvaluation: maximumAttentionKernelsPerEvaluation
+                    maximumKernelsPerEvaluation: maximumAttentionKernelsPerEvaluation,
+                    dynamicSparseRequest: dynamicSparseRequest
                 )
                 if usesFusedPostAttention {
                     var postAttentionInputs = [
@@ -1631,6 +1657,53 @@ public final class MiniMaxH3Transformer: Module {
             }
         }
         return hidden
+    }
+
+    private func qualifiedDynamicSparseAttentionRequest(
+        queries: MLXArray,
+        keys: MLXArray,
+        values: MLXArray,
+        layerIndex: Int,
+        layout: MiniMaxH3PackedLayout
+    ) -> MiniMaxH3DynamicSparseAttentionRequest? {
+        guard let request = dynamicSparseAttentionPolicy?.request(
+            stepIndex: dynamicSparseAttentionStepIndex,
+            stepCount: dynamicSparseAttentionStepCount,
+            layerIndex: layerIndex,
+            sequenceLength: layout.sequenceLength,
+            prefixTokenCount: layout.targetVideoRows.lowerBound
+        ) else { return nil }
+
+        let gateShape = "\(queries.dim(1))x\(queries.dim(2))x\(request.prefixTokenCount)"
+        let gateKey = "\(gateShape):\(queries.dtype):\(keys.dtype):\(values.dtype)"
+        if dynamicSparseAttentionGateResults[gateKey] == nil {
+            let gate = MiniMaxH3DynamicSparseAttention.denseRouteGate(
+                queries: queries,
+                keys: keys,
+                values: values,
+                queryStart: request.prefixTokenCount,
+                scale: 1 / sqrt(Float(configuration.attentionHeadDimension))
+            )
+            dynamicSparseAttentionGateResults[gateKey] = gate?.passed ?? false
+            if let gate {
+                dynamicSparseAttentionLogHandler?(String(
+                    format: "dynamic_sparse_gate=%@ shape=%@ max_abs=%.6g mean_abs=%.6g rel_l2=%.6g",
+                    gate.passed ? "pass" : "fail",
+                    gateShape,
+                    gate.maximumAbsoluteError,
+                    gate.meanAbsoluteError,
+                    gate.relativeL2Error
+                ))
+            } else {
+                dynamicSparseAttentionLogHandler?(
+                    "dynamic_sparse_gate=unavailable shape=\(gateShape) "
+                        + "q_dtype=\(queries.dtype) k_dtype=\(keys.dtype) "
+                        + "v_dtype=\(values.dtype) device="
+                        + String(describing: Device.defaultDevice().deviceType)
+                )
+            }
+        }
+        return dynamicSparseAttentionGateResults[gateKey] == true ? request : nil
     }
 
     private func finalize(

--- a/Sources/MereRunCore/MiniMaxH3/README.md
+++ b/Sources/MereRunCore/MiniMaxH3/README.md
@@ -8,10 +8,13 @@ Supported open-checkpoint paths:
 
 - text-to-video-and-audio with the FL2VA checkpoint;
 - first-frame and first/last-frame video-and-audio conditioning with FL2VA;
+- up to 12 arbitrary frame-indexed FL2VA image conditions;
 - ordered image, video (including its soundtrack), and audio reference
   conditioning with Ref2VA. The released limits are 12 total references,
   including at most 9 images, 3 videos, and 3 audio clips; audio cannot be the
-  only reference type.
+  only reference type;
+- resident FL2VA and Ref2VA sliding windows that condition on overlapping
+  motion, the boundary frame, and matching generated stereo audio.
 
 H3 emits 24 fps RGB video and native 32 kHz stereo audio. Frame counts use the
 released `17*n+5` temporal geometry. The transformer is CFG-distilled; the
@@ -39,16 +42,36 @@ schedule cache is built. The LightX2V adapter's 312 native PEFT pairs retain
 their separate Q/K/V projections and published alpha/rank scale while their
 deltas are fused into the BF16 transformer once before denoising. This avoids
 both an expanded converted checkpoint and per-block LoRA matmuls. Neither
-adapter can be combined with Ref2VA or tail-residual reuse.
+adapter can be combined with Ref2VA or H3 cache acceleration.
 
 `--h3-acceleration quality` executes every transformer block and preserves the
 native same-seed trajectory. The explicit `balanced` and `maximum` modes trade
-exact trajectory identity for speed: a full step captures the contribution of
-the trailing 50% or 75% of blocks, eligible adjacent steps recompute the prefix
-and reuse that residual, and a full refresh follows at most two cache hits.
-Both modalities must have a sigma delta below 0.12. At least two complete
-evaluations precede reuse, and the final schedule region always executes all
-50 blocks.
+exact trajectory identity for speed through a modality-aware adaptive cache.
+Every step executes the first transformer block. The runtime then compares its
+target-only residual with the last full refresh using separate global and
+worst-time-slice drift measurements for video and audio. A cache hit reuses the
+target residual from blocks 2 through 50; a rejected or non-finite measurement
+executes all 50 blocks and refreshes both residuals.
+
+`balanced` admits global drift up to 0.08 and worst-time-slice drift up to 0.12,
+allows at most two adjacent cache hits, and reserves the final two evaluations
+for full refreshes. The measured `maximum` envelope is 0.30 global and 0.40
+worst-time-slice drift, with at most four adjacent hits and a mandatory final
+full evaluation. Both modes require two complete evaluations before the first
+reuse. Cache telemetry reports all four drift measurements and exact executed
+block counts. `MERERUN_H3_CACHE_STRATEGY=scheduled-tail` retains the former
+fixed-depth policy only as a reproducible benchmark baseline.
+
+Long-form generation uses a typed global window plan. Window frame counts keep
+the target `17*n+5` geometry and overlap counts use `17*n+1`, so all history
+except the last boundary frame encodes into complete 17-frame video chunks.
+The boundary becomes the next first-frame condition. Its exact overlap
+waveform is encoded once, divided into audio history and two boundary latents,
+and packed beside video history before the target A/V rows. Only the generated
+target after that boundary is appended. Global frame injection is localized
+per window without changing its requested output index. The generator retains
+the Qwen conditioner, transformer and AdaLN schedule, both VAEs, and Ref2VA
+reference encodings across the complete rollout.
 
 The model weights are governed by the MiniMax-H3 Community License, not the
 mere.run source license. In particular, the published license excludes use,

--- a/Sources/MereRunCore/MiniMaxH3/README.md
+++ b/Sources/MereRunCore/MiniMaxH3/README.md
@@ -42,11 +42,25 @@ schedule cache is built. The LightX2V adapter's 312 native PEFT pairs retain
 their separate Q/K/V projections and published alpha/rank scale while their
 deltas are fused into the BF16 transformer once before denoising. This avoids
 both an expanded converted checkpoint and per-block LoRA matmuls. Neither
-adapter can be combined with Ref2VA or H3 cache acceleration.
+adapter can be combined with Ref2VA or denoise-step cache reuse. They can use
+the attention-only `balanced` and `maximum` paths; their four-step schedule
+always executes all 50 blocks.
 
 `--h3-acceleration quality` executes every transformer block and preserves the
-native same-seed trajectory. The explicit `balanced` and `maximum` modes trade
-exact trajectory identity for speed through a modality-aware adaptive cache.
+native same-seed trajectory. At packed sequences of at least 12,000 tokens,
+the explicit `balanced` and `maximum` modes add an independently implemented
+Apple Metal dynamic-sparse attention path inspired by
+[Sol-Attn](https://nvlabs.github.io/Sana/Sol-Attn/). Text, conditioning video,
+and generated-audio prefix queries stay on MLX's dense fused attention path.
+Every target-video query keeps prefix keys and neighboring 64-token video
+blocks exact. Query-dependent high-score blocks are also exact; skipped blocks
+still contribute through key centroids and summed values in the same online
+softmax accumulator. The first two transformer layers, leading denoise region,
+and final evaluation remain dense. A once-per-shape all-dense Metal comparison
+must pass before the sparse path can run.
+
+Without a Turbo adapter, `balanced` and `maximum` also trade exact trajectory
+identity for speed through a modality-aware adaptive cache.
 Every step executes the first transformer block. The runtime then compares its
 target-only residual with the last full refresh using separate global and
 worst-time-slice drift measurements for video and audio. A cache hit reuses the

--- a/Tests/MereRunCLITests/VideoCommandTests.swift
+++ b/Tests/MereRunCLITests/VideoCommandTests.swift
@@ -654,6 +654,39 @@ final class VideoCommandTests: XCTestCase {
         XCTAssertTrue(actionArguments?.contains("maximum") == true)
     }
 
+    func testMiniMaxH3PreflightAllowsAdapterAttentionAcceleration() throws {
+        let adapter = FileManager.default.temporaryDirectory
+            .appendingPathComponent("h3-adapter-\(UUID().uuidString).safetensors")
+        XCTAssertTrue(FileManager.default.createFile(
+            atPath: adapter.path,
+            contents: Data()
+        ))
+        defer { try? FileManager.default.removeItem(at: adapter) }
+
+        let output = makeTempOutput(name: "h3-adapter-maximum.mp4")
+        let cmd = try VideoGenerate.parse([
+            "a cinematic dialogue scene",
+            "--model", ModelResolver.ModelID.miniMaxH3FL2VABF16MLX.rawValue,
+            "--h3-adapter", adapter.path,
+            "--h3-acceleration", "maximum",
+            "--preflight",
+            "--json",
+        ])
+
+        let envelope = cmd.makePreflightEnvelope(
+            outputURL: output,
+            fileManager: .default,
+            now: { Date(timeIntervalSince1970: 0) }
+        )
+
+        XCTAssertFalse(envelope.diagnostics.contains {
+            $0.id == "h3_adapter_acceleration_conflict"
+        })
+        XCTAssertEqual(envelope.result.plan.resolvedSteps, 5)
+        XCTAssertEqual(envelope.result.plan.h3AccelerationMode, "maximum")
+        XCTAssertEqual(envelope.result.plan.h3Adapter, adapter.path)
+    }
+
     func testVideoGenerateParsesStartAndEndKeyframes() throws {
         let cmd = try VideoGenerate.parse([
             "a flower opens from bud to bloom",

--- a/Tests/MereRunCLITests/VideoCommandTests.swift
+++ b/Tests/MereRunCLITests/VideoCommandTests.swift
@@ -329,6 +329,9 @@ final class VideoCommandTests: XCTestCase {
         XCTAssertNil(cmd.steps)
         XCTAssertEqual(cmd.h3WeightMode, .automatic)
         XCTAssertEqual(cmd.h3Acceleration, .quality)
+        XCTAssertTrue(cmd.h3FrameArguments.isEmpty)
+        XCTAssertNil(cmd.h3WindowFrames)
+        XCTAssertEqual(cmd.h3WindowOverlap, 18)
         XCTAssertEqual(cmd.imageStrength, 1.0)
         XCTAssertNil(cmd.endImage)
         XCTAssertEqual(cmd.endImageStrength, 1.0)
@@ -362,6 +365,68 @@ final class VideoCommandTests: XCTestCase {
             "video:/tmp/motion.mp4",
             "audio:/tmp/voice.wav",
         ])
+    }
+
+    func testVideoGenerateParsesH3FrameInjectionAndSlidingWindow() throws {
+        let temporaryDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("h3-frame-preflight-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(
+            at: temporaryDirectory,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: temporaryDirectory) }
+        let secondSet = temporaryDirectory.appendingPathComponent("second-set.png")
+        let thirdSet = temporaryDirectory.appendingPathComponent("third-set.png")
+        XCTAssertTrue(FileManager.default.createFile(atPath: secondSet.path, contents: Data()))
+        XCTAssertTrue(FileManager.default.createFile(atPath: thirdSet.path, contents: Data()))
+        let secondArgument = "72:\(secondSet.path)"
+        let thirdArgument = "144:\(thirdSet.path)"
+        let command = try VideoGenerate.parse([
+            "the actor moves through a continuous scene",
+            "--model", ModelResolver.ModelID.miniMaxH3FL2VABF16MLX.rawValue,
+            "--h3-frame", secondArgument,
+            "--h3-frame", thirdArgument,
+            "--num-frames", "175",
+            "--h3-window-frames", "124",
+            "--h3-window-overlap", "35",
+        ])
+
+        XCTAssertEqual(command.h3FrameArguments, [
+            secondArgument,
+            thirdArgument,
+        ])
+        XCTAssertEqual(command.h3WindowFrames, 124)
+        XCTAssertEqual(command.h3WindowOverlap, 35)
+
+        let envelope = command.makePreflightEnvelope(
+            outputURL: makeTempOutput(name: "h3-sliding.mp4"),
+            fileManager: .default,
+            now: { Date(timeIntervalSince1970: 0) }
+        )
+        XCTAssertEqual(envelope.request.h3FrameInputs, [
+            secondArgument,
+            thirdArgument,
+        ])
+        XCTAssertEqual(envelope.request.h3WindowFrames, 124)
+        XCTAssertEqual(envelope.request.h3WindowOverlap, 35)
+        XCTAssertEqual(envelope.result.plan.h3FrameCount, 2)
+        XCTAssertEqual(envelope.result.plan.h3WindowFrames, 124)
+        XCTAssertEqual(envelope.result.plan.h3WindowOverlap, 35)
+        XCTAssertEqual(envelope.result.plan.h3WindowCount, 2)
+        XCTAssertEqual(envelope.result.inputs.h3Frames?.map(\.path), [
+            secondSet.path,
+            thirdSet.path,
+        ])
+        XCTAssertEqual(envelope.result.inputs.missingCount, 0)
+        let actionArguments = envelope.actions.first {
+            $0.id == "start-video-generation"
+        }?.command?.argv
+        XCTAssertTrue(actionArguments?.contains("--h3-frame") == true)
+        XCTAssertTrue(actionArguments?.contains(secondArgument) == true)
+        XCTAssertTrue(actionArguments?.contains("--h3-window-frames") == true)
+        XCTAssertTrue(actionArguments?.contains("124") == true)
+        XCTAssertTrue(actionArguments?.contains("--h3-window-overlap") == true)
+        XCTAssertTrue(actionArguments?.contains("35") == true)
     }
 
     func testVideoGenerateParsesMiniMaxH3TurboAdapter() throws {

--- a/Tests/MereRunCoreTests/DiTShapeBenchTests.swift
+++ b/Tests/MereRunCoreTests/DiTShapeBenchTests.swift
@@ -720,6 +720,154 @@ final class DiTShapeBenchTests: XCTestCase {
         }
     }
 
+    /// Compares H3's production chunked dense attention with the native Metal
+    /// dynamic sparse path, including summary construction, routing, prefix
+    /// sink, and centroid correction. Configure with
+    /// `MERERUN_H3_SPARSE_BENCH_ROWS`, `MERERUN_H3_SPARSE_BENCH_PREFIX`,
+    /// `MERERUN_H3_SPARSE_BENCH_TAU`, `MERERUN_H3_SPARSE_BENCH_DTYPE`, and
+    /// `MERERUN_H3_SPARSE_BENCH_ROUNDS`.
+    func testMiniMaxH3DynamicSparseAttention() throws {
+        try benchGate()
+        guard Device.defaultDevice().deviceType == .gpu else {
+            throw XCTSkip("MiniMax-H3 dynamic sparse benchmark requires a Metal GPU.")
+        }
+        let environment = ProcessInfo.processInfo.environment
+        let rows = max(
+            256,
+            Int(environment["MERERUN_H3_SPARSE_BENCH_ROWS"] ?? "") ?? 12_930
+        )
+        let heads = max(
+            1,
+            Int(environment["MERERUN_H3_SPARSE_BENCH_HEADS"] ?? "") ?? 56
+        )
+        let prefix = min(
+            rows - 64,
+            max(64, Int(environment["MERERUN_H3_SPARSE_BENCH_PREFIX"] ?? "") ?? 951)
+        )
+        let tau = max(
+            0,
+            Float(environment["MERERUN_H3_SPARSE_BENCH_TAU"] ?? "") ?? 1
+        )
+        let queryChunk = max(
+            1,
+            Int(environment["MERERUN_H3_SPARSE_BENCH_QUERY_TOKENS"] ?? "") ?? 640
+        )
+        let rounds = max(
+            1,
+            Int(environment["MERERUN_H3_SPARSE_BENCH_ROUNDS"] ?? "") ?? 2
+        )
+        let dtype: DType = environment["MERERUN_H3_SPARSE_BENCH_DTYPE"] == "fp32"
+            ? .float32
+            : .bfloat16
+        let dimension = MiniMaxH3DynamicSparseAttention.headDimension
+        let scale = 1 / sqrt(Float(dimension))
+        MLXRandom.seed(2_026)
+        let shape = [1, heads, rows, dimension]
+        let queries = MLXRandom.normal(shape).asType(dtype)
+        let keys = MLXRandom.normal(shape).asType(dtype)
+        let values = MLXRandom.normal(shape).asType(dtype)
+        MLX.eval(queries, keys, values)
+
+        let request = MiniMaxH3DynamicSparseAttentionRequest(
+            prefixTokenCount: prefix,
+            thresholdStandardDeviations: tau
+        )
+        func sparse() -> MLXArray {
+            MiniMaxH3DynamicSparseAttention.call(
+                queries: queries,
+                keys: keys,
+                values: values,
+                request: request,
+                scale: scale,
+                maximumQueryTokens: queryChunk,
+                maximumKernelsPerEvaluation: 1
+            )!
+        }
+        func dense() -> MLXArray {
+            var outputs: [MLXArray] = []
+            for start in stride(from: 0, to: rows, by: queryChunk) {
+                let end = min(start + queryChunk, rows)
+                let output = MLXFast.scaledDotProductAttention(
+                    queries: queries[0..., 0..., start..<end, 0...],
+                    keys: keys,
+                    values: values,
+                    scale: scale,
+                    mask: .none
+                )
+                MLX.eval(output)
+                outputs.append(output)
+            }
+            return MLX.concatenated(outputs, axis: 2)
+        }
+
+        let gate = try XCTUnwrap(MiniMaxH3DynamicSparseAttention.denseRouteGate(
+            queries: queries,
+            keys: keys,
+            values: values,
+            queryStart: prefix,
+            scale: scale
+        ))
+        XCTAssertTrue(gate.passed)
+        let plan = MiniMaxH3DynamicSparseAttention.makeRoutePlan(
+            queries: queries,
+            keys: keys,
+            values: values,
+            queryStart: prefix,
+            thresholdStandardDeviations: tau,
+            scale: scale
+        )
+        let routeDensity = plan.routes.asType(.float32).mean().item(Float.self)
+
+        MLX.eval(dense(), sparse())
+        var denseTotal = 0.0
+        var sparseTotal = 0.0
+        for round in 0..<rounds {
+            if round.isMultiple(of: 2) {
+                var started = CFAbsoluteTimeGetCurrent()
+                MLX.eval(dense())
+                denseTotal += CFAbsoluteTimeGetCurrent() - started
+                started = CFAbsoluteTimeGetCurrent()
+                MLX.eval(sparse())
+                sparseTotal += CFAbsoluteTimeGetCurrent() - started
+            } else {
+                var started = CFAbsoluteTimeGetCurrent()
+                MLX.eval(sparse())
+                sparseTotal += CFAbsoluteTimeGetCurrent() - started
+                started = CFAbsoluteTimeGetCurrent()
+                MLX.eval(dense())
+                denseTotal += CFAbsoluteTimeGetCurrent() - started
+            }
+        }
+        let denseSeconds = denseTotal / Double(rounds)
+        let sparseSeconds = sparseTotal / Double(rounds)
+        let reference = dense().asType(.float32)
+        let candidate = sparse().asType(.float32)
+        let delta = candidate - reference
+        let maximumAbsoluteError = MLX.max(MLX.abs(delta)).item(Float.self)
+        let relativeL2Error = MLX.sqrt(
+            MLX.sum(delta * delta)
+                / MLX.maximum(MLX.sum(reference * reference), MLXArray(Float(1e-12)))
+        ).item(Float.self)
+        print(String(
+            format: "[h3-lab] dynamic-sparse rows=%d prefix=%d heads=%d dtype=%@ tau=%.2f "
+                + "route_density=%.4f dense_ms=%.0f sparse_ms=%.0f speedup=%.3fx "
+                + "max_abs=%.6g rel_l2=%.6g gate_rel_l2=%.6g",
+            rows,
+            prefix,
+            heads,
+            String(describing: dtype),
+            tau,
+            routeDensity,
+            denseSeconds * 1_000,
+            sparseSeconds * 1_000,
+            denseSeconds / sparseSeconds,
+            maximumAbsoluteError,
+            relativeL2Error,
+            gate.relativeL2Error
+        ))
+        XCTAssertTrue(relativeL2Error.isFinite)
+    }
+
     /// Searches exact H3 attention schedules across query chunks, head chunks,
     /// and Metal evaluation batches. Every candidate is compared numerically
     /// with the production 2,048-query/56-head/4-kernel schedule; this is a

--- a/Tests/MereRunCoreTests/MiniMaxH3Tests.swift
+++ b/Tests/MereRunCoreTests/MiniMaxH3Tests.swift
@@ -1,10 +1,173 @@
 import Foundation
 import MLX
+import MLXFast
 import MLXNN
+import MLXRandom
 import XCTest
 @testable import MereRunCore
 
 final class MiniMaxH3Tests: MereRunCoreTestCase {
+    func testDynamicSparseAttentionPolicyProtectsDenseBoundaries() throws {
+        XCTAssertNil(MiniMaxH3AccelerationMode.quality.dynamicSparseAttentionPolicy)
+        let balanced = try XCTUnwrap(
+            MiniMaxH3AccelerationMode.balanced.dynamicSparseAttentionPolicy
+        )
+        let maximum = try XCTUnwrap(
+            MiniMaxH3AccelerationMode.maximum.dynamicSparseAttentionPolicy
+        )
+        XCTAssertEqual(balanced.thresholdStandardDeviations, 0.75)
+        XCTAssertEqual(maximum.thresholdStandardDeviations, 1)
+
+        XCTAssertNil(maximum.request(
+            stepIndex: 1,
+            stepCount: 8,
+            layerIndex: 2,
+            sequenceLength: 12_930,
+            prefixTokenCount: 900
+        ))
+        XCTAssertNil(maximum.request(
+            stepIndex: 2,
+            stepCount: 8,
+            layerIndex: 1,
+            sequenceLength: 12_930,
+            prefixTokenCount: 900
+        ))
+        XCTAssertNotNil(maximum.request(
+            stepIndex: 2,
+            stepCount: 8,
+            layerIndex: 2,
+            sequenceLength: 12_930,
+            prefixTokenCount: 900
+        ))
+        XCTAssertNil(maximum.request(
+            stepIndex: 7,
+            stepCount: 8,
+            layerIndex: 49,
+            sequenceLength: 12_930,
+            prefixTokenCount: 900
+        ))
+        XCTAssertNil(maximum.request(
+            stepIndex: 2,
+            stepCount: 8,
+            layerIndex: 2,
+            sequenceLength: 11_999,
+            prefixTokenCount: 900
+        ))
+    }
+
+    func testDynamicSparseAttentionRoutesAboveAdaptiveThreshold() {
+        let queryCentroids = MLXArray([Float(1), 0]).reshaped(1, 1, 1, 2)
+        let keyCentroids = MLXArray([
+            Float(-2), 0,
+            -1, 0,
+            0, 0,
+            3, 0,
+        ]).reshaped(1, 1, 4, 2)
+        let routes = MiniMaxH3DynamicSparseAttention.routesForTesting(
+            queryCentroids: queryCentroids,
+            keyCentroids: keyCentroids,
+            thresholdStandardDeviations: 0
+        )
+        MLX.eval(routes)
+        XCTAssertEqual(routes.asArray(UInt8.self), [0, 0, 0, 1])
+    }
+
+    func testDynamicSparseMetalDenseRouteMatchesFusedSDPA() throws {
+        guard Device.defaultDevice().deviceType == .gpu else {
+            throw XCTSkip("Dynamic sparse attention Metal parity requires a GPU.")
+        }
+        MLXRandom.seed(41)
+        let shape = [1, 2, 256, MiniMaxH3DynamicSparseAttention.headDimension]
+        let queries = (MLXRandom.normal(shape) * Float(0.2)).asType(.bfloat16)
+        let keys = (MLXRandom.normal(shape) * Float(0.2)).asType(.bfloat16)
+        let values = MLXRandom.normal(shape).asType(.bfloat16)
+        MLX.eval(queries, keys, values)
+
+        let gate = try XCTUnwrap(MiniMaxH3DynamicSparseAttention.denseRouteGate(
+            queries: queries,
+            keys: keys,
+            values: values,
+            queryStart: 128,
+            scale: 1 / sqrt(Float(MiniMaxH3DynamicSparseAttention.headDimension))
+        ))
+        XCTAssertTrue(gate.passed)
+        XCTAssertLessThanOrEqual(gate.relativeL2Error, 0.005)
+    }
+
+    func testDynamicSparseMetalFloat32InputsPassDenseGate() throws {
+        guard Device.defaultDevice().deviceType == .gpu else {
+            throw XCTSkip("Dynamic sparse attention FP32 gate requires a GPU.")
+        }
+        MLXRandom.seed(2_026_081)
+        let shape = [1, 2, 256, MiniMaxH3DynamicSparseAttention.headDimension]
+        let queries = MLXRandom.normal(shape)
+        let keys = MLXRandom.normal(shape)
+        let values = MLXRandom.normal(shape)
+        MLX.eval(queries, keys, values)
+
+        let gate = try XCTUnwrap(MiniMaxH3DynamicSparseAttention.denseRouteGate(
+            queries: queries,
+            keys: keys,
+            values: values,
+            queryStart: 64,
+            scale: 1 / sqrt(Float(MiniMaxH3DynamicSparseAttention.headDimension))
+        ))
+        XCTAssertTrue(gate.passed)
+    }
+
+    func testDynamicSparseMetalRetainsSkippedBlockCentroidContribution() throws {
+        guard Device.defaultDevice().deviceType == .gpu else {
+            throw XCTSkip("Dynamic sparse attention Metal correction requires a GPU.")
+        }
+        MLXRandom.seed(42)
+        let heads = 2
+        let tokens = 256
+        let dimension = MiniMaxH3DynamicSparseAttention.headDimension
+        let shape = [1, heads, tokens, dimension]
+        let queries = (MLXRandom.normal(shape) * Float(0.2)).asType(.bfloat16)
+        let keys = (MLXRandom.normal(shape) * Float(0.2)).asType(.bfloat16)
+        let values = MLXRandom.normal(shape).asType(.bfloat16)
+        let routes = MLXArray.zeros([1, heads, 1, 4], dtype: .uint8)
+        let scale = 1 / sqrt(Float(dimension))
+        let candidate = try XCTUnwrap(
+            MiniMaxH3DynamicSparseAttention.sparseOutputForTesting(
+                queries: queries,
+                keys: keys,
+                values: values,
+                routes: routes,
+                queryStart: 192,
+                queryCount: 1,
+                prefixTokenCount: 64,
+                scale: scale
+            )
+        )
+
+        let skippedCentroid = keys[0..., 0..., 64..<128, 0...]
+            .mean(axis: 2, keepDims: true)
+        let approximatedKeys = MLX.concatenated([
+            keys[0..., 0..., 0..<64, 0...],
+            MLX.broadcast(skippedCentroid, to: [1, heads, 64, dimension]),
+            keys[0..., 0..., 128..., 0...],
+        ], axis: 2)
+        let reference = MLXFast.scaledDotProductAttention(
+            queries: queries[0..., 0..., 192..<193, 0...],
+            keys: approximatedKeys,
+            values: values,
+            scale: scale,
+            mask: .none
+        )
+        let delta = candidate.asType(.float32) - reference.asType(.float32)
+        let relativeL2 = MLX.sqrt(
+            MLX.sum(delta * delta)
+                / MLX.maximum(
+                    MLX.sum(reference.asType(.float32) * reference.asType(.float32)),
+                    MLXArray(Float(1e-12))
+                )
+        )
+        MLX.eval(candidate, reference, relativeL2)
+        XCTAssertLessThanOrEqual(relativeL2.item(Float.self), 0.005)
+    }
+
     func testRuntimeLoRAAppliesDeltaInActivationSpace() {
         let base = Linear(
             weight: MLXArray([Float(1), 0, 0, 1]).reshaped(2, 2),
@@ -113,14 +276,16 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
         XCTAssertEqual(options.steps, 5)
         XCTAssertEqual(options.adapterStrength, 1)
 
-        XCTAssertThrowsError(try MiniMaxH3GenerationOptions(
-            prompt: "invalid compounded acceleration",
+        let sparseTurbo = try MiniMaxH3GenerationOptions(
+            prompt: "Turbo with attention-only acceleration",
             width: 256,
             height: 160,
             numFrames: 22,
             accelerationMode: .maximum,
             adapterURL: URL(fileURLWithPath: "/tmp/minimax-h3-turbo.safetensors")
-        ))
+        )
+        XCTAssertEqual(sparseTurbo.steps, 5)
+        XCTAssertEqual(sparseTurbo.accelerationMode, .maximum)
     }
 
     func testPositionedFrameInputsAreValidatedAndSorted() throws {

--- a/Tests/MereRunCoreTests/MiniMaxH3Tests.swift
+++ b/Tests/MereRunCoreTests/MiniMaxH3Tests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import MLX
 import MLXNN
 import XCTest
@@ -119,6 +120,79 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
             numFrames: 22,
             accelerationMode: .maximum,
             adapterURL: URL(fileURLWithPath: "/tmp/minimax-h3-turbo.safetensors")
+        ))
+    }
+
+    func testPositionedFrameInputsAreValidatedAndSorted() throws {
+        let later = URL(fileURLWithPath: "/tmp/later.png")
+        let earlier = URL(fileURLWithPath: "/tmp/earlier.png")
+        let options = try MiniMaxH3GenerationOptions(
+            prompt: "a continuous staged scene",
+            width: 256,
+            height: 160,
+            numFrames: 90,
+            frameInputs: [
+                .init(frameIndex: 72, url: later),
+                .init(frameIndex: 24, url: earlier),
+            ]
+        )
+
+        XCTAssertEqual(options.frameInputs.map(\.frameIndex), [24, 72])
+        XCTAssertThrowsError(try MiniMaxH3GenerationOptions(
+            prompt: "duplicate frames",
+            width: 256,
+            height: 160,
+            numFrames: 90,
+            frameInputs: [
+                .init(frameIndex: 24, url: earlier),
+                .init(frameIndex: 24, url: later),
+            ]
+        ))
+        XCTAssertThrowsError(try MiniMaxH3GenerationOptions(
+            prompt: "out of range frame",
+            width: 256,
+            height: 160,
+            numFrames: 90,
+            frameInputs: [.init(frameIndex: 90, url: later)]
+        ))
+    }
+
+    func testSlidingWindowPlanPreservesExactGlobalTimeline() throws {
+        let options = try MiniMaxH3SlidingWindowOptions(
+            totalFrameCount: 124,
+            windowFrameCount: 39,
+            overlapFrameCount: 18
+        )
+        let plan = MiniMaxH3SlidingWindowPlan(options: options)
+
+        XCTAssertEqual(plan.windows.count, 6)
+        XCTAssertEqual(plan.windows[0].generatedFrameCount, 39)
+        XCTAssertEqual(plan.windows[0].appendedFrameRange, 0..<39)
+        XCTAssertEqual(plan.windows[1].boundaryFrameIndex, 38)
+        XCTAssertEqual(plan.windows[1].generatedFrameCount, 22)
+        XCTAssertEqual(plan.windows[1].appendedFrameRange, 1..<22)
+        XCTAssertEqual(plan.windows[1].outputFrameRange, 39..<60)
+        XCTAssertEqual(plan.windows[2].localFrameIndex(for: 72), 13)
+        XCTAssertEqual(plan.windows.last?.outputFrameRange, 123..<124)
+        XCTAssertEqual(plan.windows.last?.appendedFrameRange, 1..<2)
+        XCTAssertEqual(plan.windows.reduce(0) { $0 + $1.appendedFrameCount }, 124)
+    }
+
+    func testSlidingWindowOptionsRequireCompatibleTargetGeometry() {
+        XCTAssertThrowsError(try MiniMaxH3SlidingWindowOptions(
+            totalFrameCount: 124,
+            windowFrameCount: 39,
+            overlapFrameCount: 17
+        ))
+        XCTAssertThrowsError(try MiniMaxH3SlidingWindowOptions(
+            totalFrameCount: 124,
+            windowFrameCount: 39,
+            overlapFrameCount: 35
+        ))
+        XCTAssertNoThrow(try MiniMaxH3SlidingWindowOptions(
+            totalFrameCount: 243,
+            windowFrameCount: 124,
+            overlapFrameCount: 35
         ))
     }
 
@@ -411,6 +485,64 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
         XCTAssertTrue(layout.tokenTags[3..<15].allSatisfy { $0 == MiniMaxH3Modality.video.rawValue })
     }
 
+    func testKeyframeAnchorPreservesStringAndCodableCompatibility() throws {
+        let anchors: [MiniMaxH3KeyframeAnchor] = [
+            .first,
+            .last,
+            .history(latentFrameCount: 6),
+            .frame(11),
+        ]
+        XCTAssertEqual(anchors.map(\.rawValue), ["first", "last", "history:6", "frame:11"])
+        XCTAssertEqual(anchors.compactMap { MiniMaxH3KeyframeAnchor(rawValue: $0.rawValue) }, anchors)
+
+        let encoded = try JSONEncoder().encode(anchors)
+        XCTAssertEqual(try JSONDecoder().decode([MiniMaxH3KeyframeAnchor].self, from: encoded), anchors)
+        XCTAssertEqual(
+            try JSONDecoder().decode(MiniMaxH3KeyframeAnchor.self, from: Data("\"first\"".utf8)),
+            .first
+        )
+    }
+
+    func testFL2VAHistoryFrameAndAudioConditionsShareShiftedTargetTimeline() throws {
+        let layout = try MiniMaxH3Geometry.buildFL2VA(
+            textTokenTags: [1, 1],
+            videoLatentFrames: 2,
+            latentHeight: 4,
+            latentWidth: 4,
+            audioLatentFrames: 3,
+            keyframeAnchors: [
+                .history(latentFrameCount: 2),
+                .first,
+                .frame(6),
+                .last,
+            ],
+            audioConditionAnchors: [
+                .history(latentFrameCount: 3),
+                .first(latentFrameCount: 2),
+            ]
+        )
+        XCTAssertEqual(layout.textRows, 0..<2)
+        XCTAssertEqual(layout.conditionRows, 2..<32)
+        XCTAssertEqual(layout.conditionVideoRowCount, 20)
+        XCTAssertEqual(layout.conditionAudioRowCount, 10)
+        XCTAssertEqual(layout.targetAudioRows, 32..<38)
+        XCTAssertEqual(layout.targetVideoRows, 38..<46)
+        XCTAssertEqual(layout.conditionSegments.map(\.modality), [.video, .audio])
+        XCTAssertEqual(layout.conditionSegments.map(\.sourceRows), [0..<20, 0..<10])
+
+        let positions = layout.positions.asArray(Float.self)
+        func time(at row: Int) -> Float { positions[row * 3] }
+        XCTAssertEqual(time(at: 2), 2, accuracy: 1e-5)
+        XCTAssertEqual(time(at: 6), 2 + 5.0 / 3.0, accuracy: 1e-5)
+        XCTAssertEqual(time(at: 10), 2 + 25.0 / 3.0, accuracy: 1e-5)
+        XCTAssertEqual(time(at: 14), 2 + 55.0 / 3.0, accuracy: 1e-5)
+        XCTAssertEqual(time(at: 18), 17, accuracy: 1e-5)
+        XCTAssertEqual(time(at: 22), 2, accuracy: 1e-5)
+        XCTAssertEqual(time(at: 28), 2 + 25.0 / 3.0, accuracy: 1e-5)
+        XCTAssertEqual(time(at: layout.targetAudioRows.lowerBound), 2 + 25.0 / 3.0, accuracy: 1e-5)
+        XCTAssertEqual(time(at: layout.targetVideoRows.lowerBound), 2 + 25.0 / 3.0, accuracy: 1e-5)
+    }
+
     func testVideoAndAudioPackingRoundTrip() {
         let video = MLXArray(0..<384).asType(.float32).reshaped(1, 3, 2, 8, 8)
         let rows = MiniMaxH3Geometry.patchifyVideo(video)
@@ -525,6 +657,69 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
         XCTAssertTrue(layout.tokenTags[12..<24].allSatisfy { $0 == MiniMaxH3Modality.video.rawValue })
     }
 
+    func testRef2VAContinuationPrecedesReferencesAndShiftsTarget() throws {
+        let layout = try MiniMaxH3Geometry.buildRef2VA(
+            textTokenTags: [1, 0],
+            references: [
+                .init(kind: .image, videoLatentFrames: 1, latentHeight: 4, latentWidth: 4),
+                .init(
+                    kind: .video,
+                    videoLatentFrames: 2,
+                    latentHeight: 4,
+                    latentWidth: 6,
+                    audioLatentFrames: 3
+                ),
+                .init(kind: .audio, audioLatentFrames: 2),
+            ],
+            videoLatentFrames: 2,
+            latentHeight: 4,
+            latentWidth: 4,
+            audioLatentFrames: 4,
+            keyframeAnchors: [.history(latentFrameCount: 2), .first],
+            audioConditionAnchors: [
+                .history(latentFrameCount: 3),
+                .first(latentFrameCount: 2),
+            ]
+        )
+
+        XCTAssertEqual(layout.conditionVideoRowCount, 28)
+        XCTAssertEqual(layout.conditionAudioRowCount, 20)
+        XCTAssertEqual(layout.conditionRows, 2..<50)
+        XCTAssertEqual(layout.targetAudioRows, 50..<58)
+        XCTAssertEqual(layout.targetVideoRows, 58..<66)
+        XCTAssertEqual(
+            layout.conditionSegments.map(\.modality),
+            [.video, .audio, .video, .audio, .video, .audio]
+        )
+        XCTAssertEqual(layout.conditionSegments.map(\.packedRows), [
+            2..<14,
+            14..<24,
+            24..<28,
+            28..<34,
+            34..<46,
+            46..<50,
+        ])
+        XCTAssertEqual(layout.conditionSegments.map(\.sourceRows), [
+            0..<12,
+            0..<10,
+            12..<16,
+            10..<16,
+            16..<28,
+            16..<20,
+        ])
+
+        let positions = layout.positions.asArray(Float.self)
+        func time(at row: Int) -> Float { positions[row * 3] }
+        let referenceEnd = Float(40.0 / 3.0)
+        let targetOrigin = Float(65.0 / 3.0)
+        XCTAssertEqual(time(at: 2), referenceEnd, accuracy: 1e-5)
+        XCTAssertEqual(time(at: 10), targetOrigin, accuracy: 1e-5)
+        XCTAssertEqual(time(at: 14), referenceEnd, accuracy: 1e-5)
+        XCTAssertEqual(time(at: 20), targetOrigin, accuracy: 1e-5)
+        XCTAssertEqual(time(at: layout.targetAudioRows.lowerBound), targetOrigin, accuracy: 1e-5)
+        XCTAssertEqual(time(at: layout.targetVideoRows.lowerBound), targetOrigin, accuracy: 1e-5)
+    }
+
     func testShiftedSchedulesTerminateAtCleanEndpoint() throws {
         let video = try MiniMaxH3Schedule(pointCount: 5, shift: 12)
         let audio = try MiniMaxH3Schedule(pointCount: 5, shift: 3)
@@ -599,6 +794,155 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
             }
         }
         XCTAssertEqual(longCachedSteps, 10)
+    }
+
+    func testAdaptiveFirstBlockCachePolicyUsesSafeModalityGuards() throws {
+        XCTAssertNil(MiniMaxH3AccelerationMode.quality.adaptiveFirstBlockCachePolicy)
+        let balanced = try XCTUnwrap(
+            MiniMaxH3AccelerationMode.balanced.adaptiveFirstBlockCachePolicy
+        )
+        XCTAssertEqual(balanced.globalThreshold, 0.08)
+        XCTAssertEqual(balanced.temporalThreshold, 0.12)
+        XCTAssertEqual(balanced.maximumConsecutiveCachedSteps, 2)
+        XCTAssertEqual(balanced.requiredFinalFullSteps, 2)
+        let maximum = try XCTUnwrap(
+            MiniMaxH3AccelerationMode.maximum.adaptiveFirstBlockCachePolicy
+        )
+        XCTAssertEqual(maximum.globalThreshold, 0.30)
+        XCTAssertEqual(maximum.temporalThreshold, 0.40)
+        XCTAssertEqual(maximum.maximumConsecutiveCachedSteps, 4)
+        XCTAssertEqual(maximum.requiredFinalFullSteps, 1)
+
+        XCTAssertFalse(balanced.canConsiderReuse(
+            stepIndex: 1,
+            stepCount: 8,
+            fullStepCount: 1,
+            consecutiveCachedSteps: 0,
+            hasCachedState: true
+        ))
+        XCTAssertTrue(balanced.canConsiderReuse(
+            stepIndex: 2,
+            stepCount: 8,
+            fullStepCount: 2,
+            consecutiveCachedSteps: 0,
+            hasCachedState: true
+        ))
+        XCTAssertFalse(balanced.canConsiderReuse(
+            stepIndex: 6,
+            stepCount: 8,
+            fullStepCount: 2,
+            consecutiveCachedSteps: 0,
+            hasCachedState: true
+        ))
+        XCTAssertFalse(balanced.canConsiderReuse(
+            stepIndex: 3,
+            stepCount: 8,
+            fullStepCount: 2,
+            consecutiveCachedSteps: 2,
+            hasCachedState: true
+        ))
+
+        XCTAssertTrue(balanced.shouldReuse(change: .init(
+            videoGlobal: 0.05,
+            audioGlobal: 0.03,
+            videoTemporalMaximum: 0.10,
+            audioTemporalMaximum: 0.08
+        )))
+        XCTAssertFalse(balanced.shouldReuse(change: .init(
+            videoGlobal: 0.05,
+            audioGlobal: 0.03,
+            videoTemporalMaximum: 0.13,
+            audioTemporalMaximum: 0.08
+        )))
+        XCTAssertFalse(balanced.shouldReuse(change: .init(
+            videoGlobal: 0.05,
+            audioGlobal: .nan,
+            videoTemporalMaximum: 0.10,
+            audioTemporalMaximum: 0.08
+        )))
+
+        var fullSteps = 0
+        var consecutiveCachedSteps = 0
+        var cachedSteps = 0
+        for stepIndex in 0..<19 {
+            let canReuse = maximum.canConsiderReuse(
+                stepIndex: stepIndex,
+                stepCount: 19,
+                fullStepCount: fullSteps,
+                consecutiveCachedSteps: consecutiveCachedSteps,
+                hasCachedState: fullSteps > 0
+            )
+            if canReuse {
+                cachedSteps += 1
+                consecutiveCachedSteps += 1
+            } else {
+                fullSteps += 1
+                consecutiveCachedSteps = 0
+            }
+        }
+        XCTAssertEqual(cachedSteps, 13)
+        XCTAssertEqual(fullSteps, 6)
+        XCTAssertEqual(cachedSteps + fullSteps, 19)
+        XCTAssertEqual(cachedSteps + fullSteps * 50, 313)
+    }
+
+    func testFirstBlockChangeSeparatesGlobalAndTemporalAudioVideoDrift() throws {
+        let layout = try MiniMaxH3Geometry.buildFL2VA(
+            textTokenTags: [MiniMaxH3Modality.text.rawValue, MiniMaxH3Modality.text.rawValue],
+            videoLatentFrames: 2,
+            latentHeight: 4,
+            latentWidth: 4,
+            audioLatentFrames: 3,
+            keyframeAnchors: []
+        )
+        let targetRowCount = layout.targetAudioRows.count + layout.targetVideoRows.count
+        let hiddenSize = 2
+        let previousValues = [Float](repeating: 1, count: targetRowCount * hiddenSize)
+        var currentValues = previousValues
+
+        for row in 0..<layout.targetAudioRows.count {
+            for hidden in 0..<hiddenSize {
+                currentValues[row * hiddenSize + hidden] = 1.02
+            }
+        }
+        for row in layout.targetAudioRows.count..<targetRowCount {
+            for hidden in 0..<hiddenSize {
+                currentValues[row * hiddenSize + hidden] = 1.05
+            }
+        }
+        let uniform = MiniMaxH3FirstBlockChange.measure(
+            current: MLXArray(currentValues, [1, targetRowCount, hiddenSize]),
+            previous: MLXArray(previousValues, [1, targetRowCount, hiddenSize]),
+            layout: layout
+        )
+        XCTAssertEqual(uniform.videoGlobal, 0.05, accuracy: 1e-5)
+        XCTAssertEqual(uniform.audioGlobal, 0.02, accuracy: 1e-5)
+        XCTAssertEqual(uniform.videoTemporalMaximum, 0.05, accuracy: 1e-5)
+        XCTAssertEqual(uniform.audioTemporalMaximum, 0.02, accuracy: 1e-5)
+
+        currentValues = previousValues
+        let audioFrames = layout.audioLatentFrames
+        for row in [1, audioFrames + 1] {
+            for hidden in 0..<hiddenSize {
+                currentValues[row * hiddenSize + hidden] = 1.3
+            }
+        }
+        let videoStart = layout.targetAudioRows.count
+        let videoRowsPerFrame = layout.targetVideoRows.count / layout.videoLatentFrames
+        for row in videoStart..<(videoStart + videoRowsPerFrame) {
+            for hidden in 0..<hiddenSize {
+                currentValues[row * hiddenSize + hidden] = 1.2
+            }
+        }
+        let localized = MiniMaxH3FirstBlockChange.measure(
+            current: MLXArray(currentValues, [1, targetRowCount, hiddenSize]),
+            previous: MLXArray(previousValues, [1, targetRowCount, hiddenSize]),
+            layout: layout
+        )
+        XCTAssertEqual(localized.videoGlobal, 0.10, accuracy: 1e-5)
+        XCTAssertEqual(localized.videoTemporalMaximum, 0.20, accuracy: 1e-5)
+        XCTAssertEqual(localized.audioGlobal, 0.10, accuracy: 1e-5)
+        XCTAssertEqual(localized.audioTemporalMaximum, 0.30, accuracy: 1e-5)
     }
 
     func testResidentBF16PolicyAccountsForGeometryAndMemory() throws {
@@ -1249,11 +1593,41 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
             warmBlockCount: 1,
             cachedTailResidual: try XCTUnwrap(refreshedReuse.refreshedTailResidual)
         )
+        let adaptivePolicy = MiniMaxH3AdaptiveFirstBlockCachePolicy(
+            globalThreshold: 0.1,
+            temporalThreshold: 0.1
+        )
+        let adaptiveRefresh = model.callWithAdaptiveFirstBlockReuse(
+            videoRows: video,
+            audioRows: audio,
+            context: context,
+            timesteps: timesteps,
+            cachedAdaLN: nil,
+            policy: adaptivePolicy,
+            canConsiderReuse: false,
+            previousFirstResidual: nil,
+            cachedTargetTailResidual: nil
+        )
+        let adaptiveReuse = model.callWithAdaptiveFirstBlockReuse(
+            videoRows: video,
+            audioRows: audio,
+            context: context,
+            timesteps: timesteps,
+            cachedAdaLN: nil,
+            policy: adaptivePolicy,
+            canConsiderReuse: true,
+            previousFirstResidual: try XCTUnwrap(adaptiveRefresh.refreshedFirstResidual),
+            cachedTargetTailResidual: try XCTUnwrap(adaptiveRefresh.refreshedTargetTailResidual)
+        )
         MLX.eval(
             refreshedReuse.output.videoVelocityRows,
             refreshedReuse.output.audioVelocityRows,
             reusedTail.output.videoVelocityRows,
-            reusedTail.output.audioVelocityRows
+            reusedTail.output.audioVelocityRows,
+            adaptiveRefresh.output.videoVelocityRows,
+            adaptiveRefresh.output.audioVelocityRows,
+            adaptiveReuse.output.videoVelocityRows,
+            adaptiveReuse.output.audioVelocityRows
         )
         model.usesBlockwiseCompilation = false
         model.usesLayerwiseEvaluation = true
@@ -1323,6 +1697,40 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
             MLX.abs(
                 refreshedReuse.output.audioVelocityRows
                     - reusedTail.output.audioVelocityRows
+            ).max().item(Float.self),
+            1e-5
+        )
+        XCTAssertFalse(adaptiveRefresh.reusedTail)
+        XCTAssertNil(adaptiveRefresh.change)
+        XCTAssertTrue(adaptiveReuse.reusedTail)
+        let adaptiveChange = try XCTUnwrap(adaptiveReuse.change)
+        XCTAssertEqual(adaptiveChange.videoGlobal, 0, accuracy: 1e-6)
+        XCTAssertEqual(adaptiveChange.audioGlobal, 0, accuracy: 1e-6)
+        XCTAssertLessThanOrEqual(
+            MLX.abs(
+                blockwiseCompiled.videoVelocityRows
+                    - adaptiveRefresh.output.videoVelocityRows
+            ).max().item(Float.self),
+            1e-5
+        )
+        XCTAssertLessThanOrEqual(
+            MLX.abs(
+                blockwiseCompiled.audioVelocityRows
+                    - adaptiveRefresh.output.audioVelocityRows
+            ).max().item(Float.self),
+            1e-5
+        )
+        XCTAssertLessThanOrEqual(
+            MLX.abs(
+                adaptiveRefresh.output.videoVelocityRows
+                    - adaptiveReuse.output.videoVelocityRows
+            ).max().item(Float.self),
+            1e-5
+        )
+        XCTAssertLessThanOrEqual(
+            MLX.abs(
+                adaptiveRefresh.output.audioVelocityRows
+                    - adaptiveReuse.output.audioVelocityRows
             ).max().item(Float.self),
             1e-5
         )

--- a/docs/benchmarks/minimax-h3-bf16-m4-max.md
+++ b/docs/benchmarks/minimax-h3-bf16-m4-max.md
@@ -162,6 +162,59 @@ than a claim of parity with the full 19-evaluation trajectory. The prompt
 requested driving rain, so its broadband soundtrack is not a clean-noise or
 hiss acceptance reference.
 
+## Dynamic sparse Metal receipt
+
+The Apple-GPU dynamic-sparse path was accepted with a real synchronized-video
+generation, not from random-tensor timing alone:
+
+- checkpoint: managed `video-minimax-h3-fl2va-bf16-mlx`
+- adapter: checksum-pinned `minimax-h3-lightx2v-4step`, strength `1.0`
+- geometry: 768x448, 124 frames, 24 fps, 13,085 packed rows
+- schedule: five points / four transformer evaluations
+- seed: `20260808`
+- dense arm: resident BF16, exact `quality`
+- sparse arm: resident BF16, attention-only `maximum`, tau `1.0`, no cache reuse
+- prompt: a continuous rain-soaked railway-platform two-shot with a detective,
+  a paramedic, a recorder handoff, a passing train, and two spoken lines
+
+| Phase | Dense | Dynamic sparse |
+| --- | ---: | ---: |
+| Conditioner preparation/load | 0.332 s | 0.311 s |
+| Text encoding | 4.077 s | 4.066 s |
+| Transformer preparation | 14.218 s | 14.093 s |
+| Evaluation 1, protected dense | 211.479 s | 108.017 s |
+| Evaluation 2, sparse plus one-time gate | 154.554 s | 107.196 s |
+| Evaluation 3, sparse steady state | 131.430 s | 101.294 s |
+| Evaluation 4, protected dense | 134.311 s | 127.645 s |
+| Denoising | **631.826 s** | **444.216 s** |
+| Video/audio decode | 85.632 s | 72.503 s |
+| Native generation total | **736.285 s** | **535.386 s** |
+| Process wall time | 737.28 s | 537.28 s |
+
+This is a 29.7% measured denoise reduction and 27.3% measured native
+end-to-end reduction. Both processes reported zero swaps and approximately
+68.0 GB peak footprint. The dense arm paid a larger first-evaluation compile
+cost, while the later sparse process could reuse system Metal compilation
+state. Therefore the complete-run delta is an observed receipt, not a claim
+that every second came from sparsity. The most comparable late dense arm took
+131.430 and 134.311 seconds; sparse steady state took 101.294 seconds. The
+sparse process's final protected dense evaluation took 127.645 seconds, giving
+an in-process thermal control for the 20.6% faster sparse step.
+
+Before sparse execution was admitted, the custom all-routes-dense Metal sample
+matched fused SDPA at `max_abs=0.10026`, `mean_abs=0.00219996`, and
+`rel_l2=0.0027471`. Both outputs then passed the artifact boundary: 768x448
+H.264, exactly 124 frames at 24 fps and 5.167 seconds, plus stereo AAC at
+32 kHz. Eight matched frame samples retained both actor identities, the
+recorder handoff, coherent faces, train movement, and the final composition.
+Native Parakeet transcribed both soundtracks exactly as
+`You kept the recording? Every second.`
+
+The dense artifact SHA-256 is
+`5d1b0ed616a7527ab8fefc1982ac88a21e23ab7087abb51fc574372229dca3ed`.
+The dynamic-sparse artifact SHA-256 is
+`96bdcbe41bbd65fde2784384150c9b9b6ec867dcf61456f8a74b74b0a52c132d`.
+
 ## True-768 one-evaluation boundary
 
 A separate release-mode probe locks the physical 768-line target without

--- a/docs/benchmarks/minimax-h3-bf16-m4-max.md
+++ b/docs/benchmarks/minimax-h3-bf16-m4-max.md
@@ -7,7 +7,7 @@ transformer-only extrapolation.
 ## Locked workload
 
 - checkpoint: managed `video-minimax-h3-fl2va-bf16-mlx`
-- mode: resident BF16 transformer, `maximum` acceleration
+- mode: resident BF16 transformer, historical scheduled-tail `maximum`
 - geometry: 832x480, 124 frames, 24 fps
 - schedule: 20 points / 19 model evaluations
 - seed: `20260804`
@@ -15,6 +15,10 @@ transformer-only extrapolation.
 - execution: blockwise compiled
 - policy: six complete 50-block evaluations and thirteen nine-block cached-tail
   evaluations, with native start, refresh, and endpoint evaluations
+
+This historical artifact is reproducible on the current runtime with
+`MERERUN_H3_CACHE_STRATEGY=scheduled-tail`. Production `maximum` now selects
+the adaptive first-block policy measured below.
 
 The command is reproducible with the repository benchmark harness:
 
@@ -43,6 +47,68 @@ stereo audio. Its SHA-256 is
 Visual acceptance confirmed a coherent caped figure and yellow umbrella,
 wet-street reflections, levitating bus, and luminous dragon motion without the
 spatial lattice rejected in earlier aggressive cache experiments.
+
+## Adaptive first-block cache A/B
+
+A later release-build A/B held checkpoint, prompt, seed, geometry, schedule,
+weight residency, and packed layout fixed while changing only the cache
+decision. This practical proxy used resident BF16 at 416x256, 107 frames,
+20 schedule points / 19 evaluations, and 3,768 packed rows.
+
+| Policy | Full / cached evaluations | Executed blocks | Denoising | End to end |
+| --- | ---: | ---: | ---: | ---: |
+| Scheduled-tail baseline | 6 / 13 | 417 | 222.220 s | 257.814 s |
+| Adaptive first-block `maximum` | 7 / 12 | 362 | **163.953 s** | **194.174 s** |
+
+The adaptive policy reduced denoising time by 26.2%, end-to-end time by 24.7%,
+and transformer block work by 13.2% relative to the fixed scheduled-tail
+baseline. It was run third rather than first, and macOS reported no thermal or
+performance warning at its start. A deliberately conservative 0.12/0.18
+calibration was also measured and rejected: it admitted only 7 cache hits,
+executed 607 blocks, and took 328.364 seconds to denoise.
+
+Both accepted MP4s contain H.264 416x256 video at 24 fps and AAC 32 kHz stereo
+audio. Contact-sheet inspection confirmed the same coherent bus-lift-to-dragon
+trajectory without lattice collapse. The baseline SHA-256 is
+`02fb184e6cc8213197e52ecaf4b6b344eb4b292b6233213605bc36d5d50cb66b`; the
+adaptive output SHA-256 is
+`97409a6aada0e21aca2c6917adad582f86c2d82bfaee05195da79303174920dc`.
+
+## Resident sliding-window and frame-injection receipts
+
+A real two-window FL2VA generation then exercised the long-form path with the
+same managed BF16 checkpoint. It generated 56 frames at 416x256 using 39-frame
+windows, an 18-frame video-and-audio overlap, nine schedule points per window,
+and the adaptive `maximum` policy. The second window reused the resident Qwen
+conditioner and transformer: both model-load phases measured 0.000 seconds.
+
+| Window | Full / cached evaluations | Executed blocks | Denoising | Generation |
+| --- | ---: | ---: | ---: | ---: |
+| First | 5 / 3 | 253 | 43.268 s | 67.796 s |
+| Continuation | 5 / 3 | 253 | 51.273 s | 63.421 s |
+
+The resulting H.264/AAC MP4 contains exactly 56 frames at 24 fps and 32 kHz
+stereo audio, both 2.333 seconds long. At the window boundary, frame-to-frame
+RGB mean absolute difference was 4.128, below every adjacent comparison in the
+local inspection range (6.418–7.609). Audio sample jumps at the same boundary
+were 0.00954 and 0.00616, below the local channel p95 deltas of 0.02284 and
+0.02128. Contact-sheet and spectrogram inspection found neither a visual cut
+nor an audio-click impulse. The artifact SHA-256 is
+`ac51d8eb9623e9f7ea996204a415370058241f912aadffc058dde3a2525f25de`.
+
+A separate release-mode FL2VA generation injected an exact image at output
+frame 11 of a 22-frame, 416x256 shot. The Qwen multimodal presentation and
+video-VAE condition path both consumed the frame; the run completed in 46.944
+seconds with 28.532 seconds of denoising. The valid H.264/AAC output has
+SHA-256
+`cea064abd0c99c0350629f8207e0e1055a2b96f0b2e2f9b76bda2effb17cf940`.
+Contact-sheet inspection confirmed a coherent approach to and departure from
+the injected composition without collapse.
+
+These receipts prove FL2VA execution. The same typed continuation layout is
+covered for Ref2VA by unit tests, including continuation rows before ordered
+references and shifted target positions, but a real Ref2VA checkpoint was not
+installed for this run.
 
 The locked MP4 predates the audio-VAE bias-loading correction documented in
 the kernel lab. Its video remains the accepted visual and timing receipt, but

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1818,6 +1818,9 @@ Key options:
 - `--h3-adapter`: installed MiniMax-H3 adapter catalog id or local safetensors
   path
 - `--h3-adapter-strength`: MiniMax-H3 runtime adapter multiplier
+- `--h3-frame`: repeatable zero-based `FRAME:PATH` FL2VA image injection
+- `--h3-window-frames`: resident H3 sliding-window size in `17*n+5` frames
+- `--h3-window-overlap`: motion/audio overlap in `17*n+1` frames (default `18`)
 - `--guidance-scale`, `--shift`, `--negative-prompt` for Wan2.2
 - `--audio`: source audio path; automatically selects native LTX 2.3 A2Vid
 - `--audio-start-time`: source segment offset in seconds (default `0`)
@@ -1877,8 +1880,9 @@ useful short world-transition baseline. Tiny 128-pixel outputs are structural
 smokes, not quality renders.
 
 MiniMax-H3 always emits synchronized 24 fps video and 32 kHz stereo audio.
-FL2VA accepts `--image` and optional `--end-image`; Ref2VA accepts ordered
-`--reference` values and rejects those keyframe flags. H3 dimensions snap to
+FL2VA accepts `--image`, optional `--end-image`, and up to 12 repeatable
+`--h3-frame FRAME:PATH` conditions at exact zero-based output indices. Ref2VA
+accepts ordered `--reference` values and rejects FL2VA keyframe flags. H3 dimensions snap to
 32-pixel multiples, frame counts snap upward to `17*n+5`, and its
 CFG-distilled transformer needs one evaluation per schedule step. Ref2VA roots
 are locally converted; the public managed pull exists only for FL2VA.
@@ -1890,14 +1894,26 @@ MacBooks below 96 GiB and expands to the faster resident BF16 path on memory-qua
 desktops and 96+ GiB MacBooks when the requested geometry leaves the required
 runtime reserve.
 
-`--h3-acceleration quality` is the exact default. `balanced` reuses the measured
-contribution of the trailing 50% of transformer blocks on eligible adjacent
-schedule steps and refreshes after at most two cache hits. `maximum` is the
-explicit speed lane: it reuses the trailing 82% and refreshes after at most
-four cache hits. Both require two complete evaluations before the first reuse
-and keep the schedule boundaries native. They remain approximate: the same
-prompt and seed may follow a different motion or composition trajectory. Use
+`--h3-acceleration quality` is the exact default. `balanced` and `maximum` use
+a modality-aware adaptive first-block cache. Every evaluation still runs the
+first transformer block, then independently measures global and worst-time-slice
+drift for video and audio against the last full refresh. A qualifying step
+reuses only the target residual from blocks 2 through 50; a rejected or
+non-finite measurement executes all blocks and refreshes the cache. `balanced`
+allows at most two adjacent hits and reserves the final two evaluations for
+full refreshes. `maximum` allows four adjacent hits and always executes the
+final evaluation in full. Both require two complete evaluations before reuse
+and keep schedule boundaries native. They remain approximate: the same prompt
+and seed may follow a different motion or composition trajectory. Use
 `quality` when exact-seed fidelity matters.
+
+`--h3-window-frames` enables resident sliding windows for FL2VA or Ref2VA. The
+window count must be `17*n+5`; `--h3-window-overlap` must be `17*n+1` and leave
+at least 22 target frames. The runtime conditions each new window on prior
+overlap motion, its final boundary frame, and matching generated stereo audio,
+then appends only new frames and samples. The output duration and all
+`--h3-frame` indices stay on one global timeline. Transformer, conditioner,
+AdaLN table, reference encodings, and VAEs remain loaded between windows.
 
 `--h3-adapter minimax-h3-turbo-4step` selects the separately pulled EMA-850
 LoRA, while `--h3-adapter minimax-h3-lightx2v-4step` selects the LightX2V
@@ -1917,7 +1933,8 @@ Preflight mode:
 - the report includes model availability, output path state, source/end image
   and audio state, resolved dimensions, resolved frame count/duration, source
   audio offset, seed, input mode, the resolved H3 steps/weight/acceleration
-  policy when applicable, whether audio conditions generation, whether the
+  policy, timed-frame count, and sliding-window geometry/count when applicable,
+  whether audio conditions generation, whether the
   source soundtrack is preserved, diagnostics, and declarative actions.
 - blockers such as a missing model root, missing image, invalid frame rate, or
   `--end-image` without `--image` produce JSON and a nonzero exit. Requesting

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1894,18 +1894,23 @@ MacBooks below 96 GiB and expands to the faster resident BF16 path on memory-qua
 desktops and 96+ GiB MacBooks when the requested geometry leaves the required
 runtime reserve.
 
-`--h3-acceleration quality` is the exact default. `balanced` and `maximum` use
-a modality-aware adaptive first-block cache. Every evaluation still runs the
-first transformer block, then independently measures global and worst-time-slice
-drift for video and audio against the last full refresh. A qualifying step
-reuses only the target residual from blocks 2 through 50; a rejected or
-non-finite measurement executes all blocks and refreshes the cache. `balanced`
-allows at most two adjacent hits and reserves the final two evaluations for
-full refreshes. `maximum` allows four adjacent hits and always executes the
-final evaluation in full. Both require two complete evaluations before reuse
-and keep schedule boundaries native. They remain approximate: the same prompt
-and seed may follow a different motion or composition trajectory. Use
-`quality` when exact-seed fidelity matters.
+`--h3-acceleration quality` is the dense, exact default. At 12,000 or more
+packed rows, `balanced` and `maximum` add dynamic block-sparse attention for
+target-video queries. Prefix queries and keys, neighboring video blocks, the
+first two layers, the leading schedule region, and the final evaluation stay
+dense. Skipped blocks retain a summary correction, and the Metal path must pass
+a once-per-shape dense-route numerical gate before it can run.
+
+Without an H3 adapter, `balanced` and `maximum` also use a modality-aware
+adaptive first-block cache. Every evaluation still runs block 1, then measures
+global and worst-time-slice drift for video and audio against the last full
+refresh. A qualifying step reuses only the target residual from blocks 2
+through 50. `balanced` admits at most two adjacent hits and reserves the final
+two evaluations; `maximum` admits four adjacent hits and always executes the
+final evaluation in full. Both require two complete evaluations before cache
+reuse. These modes remain approximate: the same prompt and seed may follow a
+different motion or composition trajectory. Use `quality` when exact-seed
+fidelity matters.
 
 `--h3-window-frames` enables resident sliding windows for FL2VA or Ref2VA. The
 window count must be `17*n+5`; `--h3-window-overlap` must be `17*n+1` and leave
@@ -1921,10 +1926,11 @@ PEFT LoRA. Both target `video-minimax-h3-fl2va-bf16-mlx`. When `--steps` is
 omitted they use five schedule points (four transformer evaluations). EMA-850
 runs in activation space; LightX2V is fused once into the BF16 transformer
 before denoising and adds no LoRA matmuls to the generation loop. Both require
-`--h3-acceleration quality`; Ref2VA and the compact quantized H3 package are
-rejected. The preflight report resolves the managed adapter path, verifies its
-presence, and preserves the adapter id, strength, and resolved schedule in the
-declarative action.
+dense execution of all 50 blocks and prohibit denoise-step cache reuse, but
+may use the attention-only `balanced` or `maximum` path. Ref2VA and the compact
+quantized H3 package are rejected. The preflight report resolves the managed
+adapter path, verifies its presence, and preserves the adapter id, strength,
+and resolved schedule in the declarative action.
 
 Preflight mode:
 

--- a/docs/internals/dit-performance.md
+++ b/docs/internals/dit-performance.md
@@ -400,6 +400,57 @@ gate, and improve a matched full-block or denoise-step probe should move into
 the runtime. Full video generation remains a final quality gate, not the inner
 optimization loop.
 
+### Dynamic sparse H3 attention on Apple GPUs
+
+H3's packed sequence is not a homogeneous video grid. It contains dense text,
+conditioning video, generated-audio, and target-video regions, so sparsifying
+the whole sequence would place dialogue and reference fidelity at unnecessary
+risk. The production path instead applies an independently written Metal
+implementation of the dynamic-routing ideas published by
+[Sol-Attn](https://nvlabs.github.io/Sana/Sol-Attn/) only to target-video
+queries. It uses 64-token blocks and a 128-wide BF16 SIMDgroup-matrix kernel.
+Every prefix query stays on MLX's fused dense SDPA path; every prefix key and
+the neighboring target-video blocks remain exact for sparse queries.
+Query-centroid and key-centroid scores route additional exact blocks at
+runtime. Skipped blocks still contribute through key-centroid logits and
+summed values in the same online-softmax accumulator.
+
+The first two transformer layers, the first 20% of schedule evaluations, and
+the final evaluation remain dense. Production eligibility starts at 12,000
+packed rows. Before the first sparse layer at a new shape, an all-routes-dense
+sample compares the custom Metal result with fused SDPA; unsupported devices,
+dtypes, or a failed error envelope fall back to dense attention. On the real
+13,085-row checkpoint tensors, FP32 projection outputs staged through BF16 MMA
+passed at `max_abs=0.10026`, `mean_abs=0.00219996`, and
+`rel_l2=0.0027471`.
+
+The bounded release benchmarks separate kernel throughput from artifact
+quality:
+
+| Input | Rows / prefix / heads | Dense | Sparse | Speedup | Routed blocks |
+| --- | --- | ---: | ---: | ---: | ---: |
+| BF16 | 12,930 / 951 / 56 | 389 ms | 293 ms | 1.327x | 14.44% |
+| FP32 staged to BF16 MMA | 13,085 / 653 / 56 | 717 ms | 371 ms | 1.931x | 15.84% |
+
+Those random-tensor timings establish the execution win, not approximation
+quality. The acceptance boundary was a real fixed-seed LightX2V generation at
+768x448, 124 frames, 24 fps, and four transformer evaluations. Dense denoising
+took 631.826 seconds; dynamic sparse attention took 444.216 seconds, a measured
+29.7% reduction. The clean sparse step measured 101.294 seconds versus
+131.430 and 134.311 seconds for the comparable late dense steps. The final
+protected dense step in the sparse process measured 127.645 seconds, ruling
+out a simple late-run thermal advantage. Complete native generation fell from
+736.285 to 535.386 seconds. The dense run paid a larger first-step compile cost,
+so the end-to-end figure is an observed run receipt rather than an isolated
+kernel attribution.
+
+Both MP4s contain exactly 124 coherent H.264 frames plus synchronized 32 kHz
+stereo AAC. Eight-point matched contact sheets retained the two actors,
+recorder handoff, train motion, faces, and final composition without sparse
+block corruption. Native Parakeet transcribed both soundtracks as
+`You kept the recording? Every second.` The full hashes and phase ledger are in
+[MiniMax-H3 BF16 on M4 Max](../benchmarks/minimax-h3-bf16-m4-max.md).
+
 ### Adaptive first-block cache
 
 Exact attention scheduling and resident BF16 improve each native call, but H3

--- a/docs/internals/dit-performance.md
+++ b/docs/internals/dit-performance.md
@@ -400,44 +400,37 @@ gate, and improve a matched full-block or denoise-step probe should move into
 the runtime. Full video generation remains a final quality gate, not the inner
 optimization loop.
 
-### Bounded tail-block reuse
+### Adaptive first-block cache
 
 Exact attention scheduling and resident BF16 improve each native call, but H3
 still executes 50 sequential transformer blocks. The explicit `balanced` and
-`maximum` acceleration modes reduce the number of blocks on safe adjacent
-schedule steps. A full step stores `finalHidden - warmHidden`; a cache step
-recomputes 25 leading blocks in `balanced` or nine in `maximum`, then adds that
-stored tail residual. Both video and audio sigma deltas must be below 0.12, the
-schedule position must be inside 10%...90%, and at least two complete
-evaluations must precede reuse. Balanced refreshes after two cache steps;
-maximum refreshes after four.
+`maximum` acceleration modes now execute block 1 on every schedule point and
+use its measured change to decide whether blocks 2 through 50 can be reused.
+A full refresh stores the target-only tail residual. The next candidate stacks
+four statistics into one host boundary: global and worst-time-slice relative
+change for video and audio. Reuse requires every finite statistic to fit its
+mode's envelope; otherwise the runtime executes all 50 blocks and refreshes.
 
-This is also the acceleration primitive published by
-[TE-Speed-MiniMaxH3-OSS](https://github.com/HELPMEEADICE/TE-Speed-MiniMaxH3-OSS):
-its defaults use the same 0.12 sigma-delta test and 10%...90% window, while
-recomputing 25% of the blocks and forcing a full refresh after two cached steps.
-`maximum` is already more aggressive, recomputing 18% and allowing four cached
-steps. TE-Speed therefore confirms the existing model-math lane rather than
-supplying a second exact kernel optimization.
+`balanced` uses 0.08 global and 0.12 temporal thresholds, admits at most two
+adjacent hits, and reserves the final two evaluations for complete refreshes.
+`maximum` uses the measured 0.30/0.40 envelope, admits at most four adjacent
+hits, and reserves the final evaluation. Both require two complete evaluations
+before reuse and apply the cached residual only to target rows, never the text
+or media-condition prefix.
 
-Automatic long-geometry schedules use 21 points (20 model evaluations),
-matching the current practical CUDA default instead of the previous 31 points.
-Maximum acceleration caps automatic schedules at 12 points. With an explicit
-20-point schedule, its bounded reuse policy runs six full evaluations and
-recomputes nine of 50 blocks on 13 cache evaluations, for 417 block calls
-versus 950 in exact quality (56.1% less transformer-block work).
+The former fixed-depth scheduled-tail policy remains available solely for
+matched comparisons through `MERERUN_H3_CACHE_STRATEGY=scheduled-tail`. On the
+locked 416x256, 107-frame, 20-point resident-BF16 proxy, scheduled-tail ran 417
+blocks in 222.220 seconds of denoise. Adaptive `maximum` ran 362 blocks in
+163.953 seconds: 26.2% less denoise time and 24.7% less end-to-end time. A
+conservative 0.12/0.18 calibration was explicitly rejected after it admitted
+only seven hits and took 328.364 seconds.
 
-On the M4 Max 128 GB test machine, a matched warm-cache 512x320, 22-frame,
-16-point run measured 112.413 s of denoise in exact `quality` mode and 74.754 s
-in `maximum`: 1.504x faster, or 33.5% less denoise time. Eight of fifteen calls
-used 13 blocks. The same-seed MP4 remained coherent but changed portal framing.
-For the accepted automatic-speed envelope, a matched 512x320, 22-frame,
-12-point same-seed pair measured 62.847 s of denoise and 73.07 s end to end in
-`quality`, versus 41.928 s and 51.45 s in `maximum` (1.499x denoise). The
-accelerated artifact remained free of the spatial lattice seen when reuse began
-after only one full evaluation. This is an approximate trajectory accelerator
-rather than an exact kernel optimization; exact `quality` remains the default
-and video/audio artifacts are the acceptance boundary for speed-mode changes.
+This remains an approximate trajectory accelerator rather than an exact kernel
+optimization. Exact `quality` remains the default, and synchronized video and
+audio artifacts are the acceptance boundary for speed-mode changes. Automatic
+long-geometry schedules use 21 points; maximum acceleration caps automatic
+schedules at 12 points.
 
 The full acceptance receipt, including per-step timings, artifact geometry,
 hash, and the important 124-frame duration boundary, is recorded in

--- a/docs/runtime/video.md
+++ b/docs/runtime/video.md
@@ -155,8 +155,10 @@ the runtime applies its published alpha/rank scale and fuses its deltas into
 the BF16 transformer once before denoising; the PEFT tensors are then released
 and add no per-block LoRA matmuls. Both default to five schedule points, which
 are four model evaluations. They were trained for FL2VA, require the BF16 base
-model, and cannot be combined with Ref2VA references or H3 cache acceleration.
-Omit `--steps` (or set it to `5`) and keep `--h3-acceleration quality`.
+model, and cannot be combined with Ref2VA references or H3 denoise-step cache
+reuse. Omit `--steps` (or set it to `5`). `--h3-acceleration quality` keeps the
+fully dense path; `balanced` and `maximum` may use attention-only dynamic
+sparsity while still executing all 50 blocks on every model evaluation.
 Strength `1.0` applies either adapter's released weights exactly; the strength
 control remains available for prompt-specific tuning.
 
@@ -189,14 +191,23 @@ remains available for compatible locally converted roots that still contain
 the full AdaLN branch.
 
 The denoise policy is independently selectable. `--h3-acceleration quality`
-executes all 50 blocks and is the exact default. `balanced` recomputes the
-leading 50% of blocks on eligible small-sigma-delta steps and refreshes after
-at most two cache hits. `maximum` is the explicitly approximate speed lane: it
-recomputes the leading nine of 50 blocks and refreshes after at most four cache
-hits. Both modes run at least two complete evaluations before reuse and retain
-full evaluations at the schedule boundaries. They can materially reduce
-denoise time, but they are
-approximate and may change motion or composition for the same prompt and seed.
+uses dense attention, executes all 50 blocks, and is the exact default. At
+12,000 or more packed rows, `balanced` and `maximum` dynamically route distant
+target-video attention blocks on Apple GPUs. Prefix queries, all prefix keys,
+neighboring video blocks, the first two transformer layers, the leading
+schedule region, and the final evaluation remain dense. Skipped blocks retain
+a centroid-and-summed-value correction in the online-softmax accumulator, and
+a once-per-shape dense-route gate must pass before sparse execution is admitted.
+
+Without an H3 adapter, those two modes additionally use the modality-aware
+adaptive first-block cache. Every evaluation executes block 1 and measures
+global plus worst-time-slice drift independently for video and audio. A cache
+hit reuses only the target residual from blocks 2 through 50. `balanced`
+refreshes after at most two hits and reserves the final two evaluations;
+`maximum` refreshes after at most four hits and reserves the final evaluation.
+Both require two complete evaluations before reuse. Dynamic attention and cache
+reuse are approximate and may change motion or composition for the same prompt
+and seed; use `quality` when exact-seed fidelity matters.
 
 ### Cosmos3 generation, actions, and reasoning
 

--- a/docs/runtime/video.md
+++ b/docs/runtime/video.md
@@ -119,6 +119,24 @@ mere.run video generate "preserve the person and use the reference motion" \
   --reference image:./person.png \
   --reference video:./motion.mp4 \
   --output ./ref2va.mp4
+
+# Long FL2VA or Ref2VA shots keep the H3 runtime resident and condition each
+# new window on overlapping motion plus its matching generated soundtrack.
+mere.run video generate "one continuous tracking shot through a night market" \
+  --model video-minimax-h3-fl2va-bf16-mlx \
+  --duration 15 \
+  --h3-window-frames 124 \
+  --h3-window-overlap 35 \
+  --h3-acceleration maximum \
+  --output ./market-long.mp4
+
+# Exact zero-based FL2VA frame injection can direct intermediate beats.
+mere.run video generate "the actor crosses three connected sets" \
+  --model video-minimax-h3-fl2va-bf16-mlx \
+  --num-frames 175 \
+  --h3-frame 72:./second-set.png \
+  --h3-frame 144:./third-set.png \
+  --output ./three-sets.mp4
 ```
 
 MiniMax-H3 is CFG-distilled, so `--steps` is a schedule-point count without a
@@ -137,10 +155,23 @@ the runtime applies its published alpha/rank scale and fuses its deltas into
 the BF16 transformer once before denoising; the PEFT tensors are then released
 and add no per-block LoRA matmuls. Both default to five schedule points, which
 are four model evaluations. They were trained for FL2VA, require the BF16 base
-model, and cannot be combined with Ref2VA references or H3 tail-residual reuse.
+model, and cannot be combined with Ref2VA references or H3 cache acceleration.
 Omit `--steps` (or set it to `5`) and keep `--h3-acceleration quality`.
 Strength `1.0` applies either adapter's released weights exactly; the strength
 control remains available for prompt-specific tuning.
+
+`--h3-frame FRAME:PATH` adds an FL2VA keyframe at an exact zero-based output
+frame. Values may be repeated up to the released 12-frame condition limit and
+remain on the global timeline when sliding windows are enabled.
+`--h3-window-frames` enables resident long-form generation for FL2VA or Ref2VA.
+The window count must use H3's `17*n+5` target geometry; overlap supplied by
+`--h3-window-overlap` must use `17*n+1` and leave at least 22 frames for each
+new target. Each continuation encodes all overlap frames except the boundary
+as motion history, uses the final overlap frame as the next first-frame
+condition, and carries the corresponding 32 kHz stereo waveform as history
+and boundary audio latents. Only new frames and samples are appended, so the
+final MP4 has the exact aligned global duration. Conditioner, transformer,
+AdaLN table, reference encodings, and both VAEs remain resident across windows.
 
 The managed package already includes the inference-only AdaLN cache computed
 from the official BF16/F32 projections; no post-pull optimization step is


### PR DESCRIPTION
## Summary

- add resident MiniMax-H3 FL2VA/Ref2VA sliding windows that carry overlapping motion and synchronized audio, plus exact multi-frame FL2VA injection
- replace the fixed scheduled-tail speed lane with a modality-aware adaptive first-block cache for non-adapter generations
- add an independently implemented MLX/Metal dynamic-sparse attention path for practical H3 sequences
- allow four-step H3 adapters to use attention-only acceleration while continuing to prohibit denoise-step cache reuse
- document and test the policy, Metal kernel, numerical gate, real checkpoint timings, and synchronized A/V acceptance receipts

## Sol-Attn relationship

The sparse path independently implements the dynamic block-routing and skipped-block correction ideas published by [Sol-Attn](https://nvlabs.github.io/Sana/Sol-Attn/) for Apple GPUs through MLX and `MLXFast.metalKernel`. It does not vendor or translate the upstream CUDA/Triton implementation.

H3 uses a heterogeneous packed sequence, so the production policy is intentionally model-aware:

- text, conditioning-video, and generated-audio prefix queries stay on MLX fused dense SDPA
- all prefix keys and neighboring 64-token target-video blocks remain exact
- query-dependent high-score blocks execute exactly
- skipped blocks retain key-centroid and summed-value contributions in the same online-softmax accumulator
- the first two transformer layers, leading denoise region, and final evaluation remain dense
- a once-per-shape-and-dtype all-routes-dense comparison must pass before sparse execution is admitted; unsupported or failing shapes fall back to dense attention

The reusable boundary is deliberate. Block summaries, routing, online-softmax correction, the fail-closed dense gate, and Swift-to-Metal submission strategy can support other diffusion transformers. Each model still needs an explicit packed-layout adapter, supported head geometry, dense boundary policy, and real artifact quality gate before opting in; this PR does not silently apply H3 assumptions elsewhere.

## Performance and quality receipts

The dynamic-sparse path was accepted with a fixed-seed, release-mode LightX2V generation using the managed BF16 H3 checkpoint at 768x448, 124 frames, 24 fps, and four transformer evaluations:

| Phase | Dense | Dynamic sparse | Change |
| --- | ---: | ---: | ---: |
| Denoising | 631.826 s | 444.216 s | 29.7% faster |
| Native generation | 736.285 s | 535.386 s | 27.3% faster |
| Comparable late step | 131.430-134.311 s | 101.294 s | 22.9-24.6% faster |

The real Q/K/V dense-route gate passed at `max_abs=0.10026`, `mean_abs=0.00219996`, and `rel_l2=0.0027471`. Both arms reported zero swaps and approximately 68 GB peak footprint.

Both outputs contain exactly 124 coherent H.264 frames and synchronized 32 kHz stereo AAC. Matched-frame inspection retained actor identities, faces, the recorder handoff, train motion, and the final composition without sparse-block corruption. Native Parakeet transcribed both soundtracks as `You kept the recording? Every second.`

The adaptive cache was separately accepted on the existing 416x256, 107-frame, 20-point resident-BF16 proxy: denoising fell from 222.220 to 163.953 seconds versus the fixed scheduled-tail policy while retaining synchronized A/V acceptance. Sliding-window and exact frame-injection receipts are recorded in the benchmark documentation.

## Validation

- `./scripts/check.sh`
  - 2,584 XCTest cases, 172 expected environment/checkpoint skips, 0 failures
  - 25 Swift Testing checks, 0 failures
  - strict lint, build, CLI help sweep, and hygiene scans
- `MERERUN_TEST_MLX_DEVICE=gpu swift test --filter 'MiniMaxH3Tests/testDynamicSparseMetal'`
  - dense-route parity, FP32 input staging, and skipped-block correction all pass on Metal
- `swift build -c release`
- `pnpm docs:build`
- real release-mode dense/sparse H3 synchronized-video A/B, container/frame/audio probes, transcript comparison, and matched visual inspection

Exact `quality` remains the default. `balanced` and `maximum` remain explicit approximate acceleration modes.
