### PR TITLE
Accelerate high-resolution Z-Image with sparse Metal attention

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ The format is based on Keep a Changelog.
 - fixed `text chat --stream --quiet` so `--quiet` suppresses stderr diagnostics
   without disconnecting incremental generated text from stdout.
 
+### Image
+
+- accelerated high-resolution Z-Image generation with dynamic sparse attention.
+  Sequences below 12,000 tokens remain dense; larger generations keep the first
+  two transformer layers, the leading 20% of the denoise schedule, and the final
+  step dense, and fail closed to dense attention when the numerical route gate
+  does not pass. Set `MERERUN_DYNAMIC_SPARSE_ATTENTION=0` to disable the default.
+- reduced a warm 1792x1792, four-step generation from 151.41 to 133.03 seconds
+  (12.1%) with peak reported memory unchanged at approximately 109.8 GB. Because
+  this path approximates distant-token attention, same-seed high-resolution
+  output can differ from the dense path; smaller generations remain byte-identical.
+
 ### Video
 
 - added `minimax-h3-lightx2v-4step` as a second immutable, checksum-pinned

--- a/Package.swift
+++ b/Package.swift
@@ -343,6 +343,7 @@ targets.append(contentsOf: [
       "LTX/README.md",
       "LoRA/README.md",
       "MagentaRT2/README.md",
+      "MLX/README.md",
       "MMAudio/README.md",
       "MiniMaxH3/README.md",
       "PrivacyFilter/README.md",

--- a/Sources/MereRunCore/MLX/DynamicSparseAttention.swift
+++ b/Sources/MereRunCore/MLX/DynamicSparseAttention.swift
@@ -62,6 +62,8 @@ struct DynamicSparseAttentionPolicy: Sendable, Equatable {
 struct DynamicSparseAttentionGate: Sendable, Equatable {
     let maximumAbsoluteError: Float
     let meanAbsoluteError: Float
+    let maximumRelativeError: Float
+    let meanRelativeError: Float
     let relativeL2Error: Float
     let passed: Bool
 }
@@ -247,26 +249,24 @@ enum DynamicSparseAttention {
                         MLXArray(Float(1e-12))
                     )
             ),
+            MLX.max(MLX.abs(reference.asType(.float32))),
+            MLX.mean(MLX.abs(reference.asType(.float32))),
         ])
         MLX.eval(metrics)
         let measured = metrics.asArray(Float.self)
-        let stagesFloat32 = queries.dtype == .float32
-            || keys.dtype == .float32
-            || values.dtype == .float32
-        // The production H3 projection graph promotes Q/K/V to FP32. The
-        // sparse MMA path stages those values as BF16, so its dense-route gate
-        // allows the measured conversion envelope while retaining the same
-        // relative-error bound used by native BF16 input.
-        let maximumLimit: Float = queries.dim(2) >= 32_768
-            ? 0.15
-            : (stagesFloat32 ? 0.12 : 0.08)
-        let meanLimit: Float = stagesFloat32 ? 0.0025 : 0.002
-        let passed = measured[0] <= maximumLimit
-            && measured[1] <= meanLimit
+        let maximumRelativeError = measured[0] / max(measured[3], 1e-12)
+        let meanRelativeError = measured[1] / max(measured[4], 1e-12)
+        // Absolute activation scales differ substantially across native model
+        // families. Admit the dense-route implementation by scale-invariant
+        // error while retaining tight BF16 conversion and aggregate bounds.
+        let passed = maximumRelativeError <= 0.015
+            && meanRelativeError <= 0.005
             && measured[2] <= 0.005
         return .init(
             maximumAbsoluteError: measured[0],
             meanAbsoluteError: measured[1],
+            maximumRelativeError: maximumRelativeError,
+            meanRelativeError: meanRelativeError,
             relativeL2Error: measured[2],
             passed: passed
         )
@@ -426,6 +426,11 @@ enum DynamicSparseAttention {
         precondition(routes.dtype == .uint8)
         let heads = queries.dim(1)
         let scaleArray = MLXArray([scale])
+        let outputDType: DType = queries.dtype == .float32
+            || keys.dtype == .float32
+            || values.dtype == .float32
+            ? .float32
+            : .bfloat16
         #if os(macOS) || os(iOS) || os(tvOS) || os(visionOS)
         return attentionKernel(
             [queries, keys, values, keyCentroids, valueSums, routes, scaleArray],
@@ -437,11 +442,12 @@ enum DynamicSparseAttention {
                 ("FIRST_QUERY_BLOCK", firstQueryBlock),
                 ("KEY_BLOCK_COUNT", keyBlockCount),
                 ("ROUTE_QUERY_BLOCKS", routes.dim(2)),
+                ("OutputT", outputDType),
             ],
             grid: (32, ((queryCount + 31) / 32) * 4, heads),
             threadGroup: (32, 4, 1),
             outputShapes: [[1, heads, queryCount, headDimension]],
-            outputDTypes: [.bfloat16]
+            outputDTypes: [outputDType]
         )[0]
         #else
         preconditionFailure("Dynamic sparse attention requires Metal")
@@ -483,7 +489,7 @@ enum DynamicSparseAttention {
     )
 
     private static let attentionKernel = MLXFast.metalKernel(
-        name: "mere_dynamic_sparse_online_softmax_bf16_d128_b64_mma_v5",
+        name: "mere_dynamic_sparse_online_softmax_bf16_d128_b64_mma_v6",
         inputNames: [
             "queries", "keys", "values", "key_centroids", "value_sums",
             "routes", "scale_value",
@@ -801,10 +807,10 @@ enum DynamicSparseAttention {
                 uint output_base = (head * QUERY_COUNT + local_query) * head_dimension;
                 for (uint frag = 0; frag < matrix_count; ++frag) {
                     uint output_dimension = frag * matrix_size + matrix_column;
-                    output[output_base + output_dimension] = bfloat(
+                    output[output_base + output_dimension] = OutputT(
                         accumulated[frag].thread_elements()[0] / row_sum
                     );
-                    output[output_base + output_dimension + 1] = bfloat(
+                    output[output_base + output_dimension + 1] = OutputT(
                         accumulated[frag].thread_elements()[1] / row_sum
                     );
                 }

--- a/Sources/MereRunCore/MLX/DynamicSparseAttention.swift
+++ b/Sources/MereRunCore/MLX/DynamicSparseAttention.swift
@@ -188,8 +188,10 @@ enum DynamicSparseAttention {
         values: MLXArray,
         queryStart: Int,
         scale: Float,
+        maximumRelativeErrorLimit: Float = 0.01,
         sampleQueryCount: Int = 8
     ) -> DynamicSparseAttentionGate? {
+        precondition(maximumRelativeErrorLimit > 0)
         guard supports(
             queries: queries,
             keys: keys,
@@ -259,7 +261,7 @@ enum DynamicSparseAttention {
         // Absolute activation scales differ substantially across native model
         // families. Admit the dense-route implementation by scale-invariant
         // error while retaining tight BF16 conversion and aggregate bounds.
-        let passed = maximumRelativeError <= 0.015
+        let passed = maximumRelativeError <= maximumRelativeErrorLimit
             && meanRelativeError <= 0.005
             && measured[2] <= 0.005
         return .init(

--- a/Sources/MereRunCore/MLX/DynamicSparseAttention.swift
+++ b/Sources/MereRunCore/MLX/DynamicSparseAttention.swift
@@ -2,12 +2,12 @@ import Foundation
 import MLX
 import MLXFast
 
-struct MiniMaxH3DynamicSparseAttentionRequest: Sendable, Equatable {
+struct DynamicSparseAttentionRequest: Sendable, Equatable {
     let prefixTokenCount: Int
     let thresholdStandardDeviations: Float
 }
 
-struct MiniMaxH3DynamicSparseAttentionPolicy: Sendable, Equatable {
+struct DynamicSparseAttentionPolicy: Sendable, Equatable {
     let thresholdStandardDeviations: Float
     let minimumSequenceLength: Int
     let denseLeadingStepFraction: Float
@@ -39,13 +39,13 @@ struct MiniMaxH3DynamicSparseAttentionPolicy: Sendable, Equatable {
         layerIndex: Int,
         sequenceLength: Int,
         prefixTokenCount: Int
-    ) -> MiniMaxH3DynamicSparseAttentionRequest? {
+    ) -> DynamicSparseAttentionRequest? {
         guard stepCount > 0,
               stepIndex >= 0,
               stepIndex < stepCount,
               layerIndex >= denseLeadingLayerCount,
               sequenceLength >= minimumSequenceLength,
-              prefixTokenCount > 0,
+              prefixTokenCount >= 0,
               prefixTokenCount < sequenceLength else { return nil }
         let denseLeadingStepCount = Int(
             ceil(Float(stepCount) * denseLeadingStepFraction)
@@ -59,23 +59,24 @@ struct MiniMaxH3DynamicSparseAttentionPolicy: Sendable, Equatable {
     }
 }
 
-struct MiniMaxH3DynamicSparseAttentionGate: Sendable, Equatable {
+struct DynamicSparseAttentionGate: Sendable, Equatable {
     let maximumAbsoluteError: Float
     let meanAbsoluteError: Float
     let relativeL2Error: Float
     let passed: Bool
 }
 
-/// H3-specific dynamic block-sparse attention for Apple GPUs.
+/// Dynamic block-sparse attention for long, batch-one diffusion sequences on Apple GPUs.
 ///
 /// The implementation independently applies the on-the-fly sparsification
-/// ideas described by Sol-Attn to H3's packed modality layout. Every 64-token
+/// ideas described by Sol-Attn. Every 64-token
 /// block is represented by a key centroid and a summed value. Query-dependent
 /// routing retains high-score blocks exactly; skipped blocks contribute through
 /// those summaries in the same online-softmax accumulator. Prefix keys and
-/// adjacent video blocks are always exact, while prefix queries remain on MLX's
-/// dense fused SDPA path.
-enum MiniMaxH3DynamicSparseAttention {
+/// adjacent blocks are always exact, while any prefix queries remain on MLX's
+/// dense fused SDPA path. Model integrations own admission, dense boundaries,
+/// layout permutation, and numerical acceptance.
+enum DynamicSparseAttention {
     static let blockSize = 64
     static let headDimension = 128
 
@@ -91,7 +92,7 @@ enum MiniMaxH3DynamicSparseAttention {
         queries: MLXArray,
         keys: MLXArray,
         values: MLXArray,
-        request: MiniMaxH3DynamicSparseAttentionRequest,
+        request: DynamicSparseAttentionRequest,
         scale: Float,
         maximumQueryTokens: Int,
         maximumKernelsPerEvaluation: Int
@@ -126,14 +127,6 @@ enum MiniMaxH3DynamicSparseAttention {
             thresholdStandardDeviations: request.thresholdStandardDeviations,
             scale: scale
         )
-        let densePrefix = MLXFast.scaledDotProductAttention(
-            queries: queries[0..., 0..., 0..<sparseQueryStart, 0...],
-            keys: keys,
-            values: values,
-            scale: scale,
-            mask: .none
-        )
-
         let targetCount = queries.dim(2) - sparseQueryStart
         // Dense SDPA chunks for intermediate-memory control. This kernel has
         // no quadratic score allocation, so larger query submissions keep the
@@ -142,10 +135,21 @@ enum MiniMaxH3DynamicSparseAttention {
             16_384,
             (maximumQueryTokens / blockSize) * blockSize
         )
-        var outputs = [densePrefix]
+        var outputs: [MLXArray] = []
         outputs.reserveCapacity(1 + (targetCount + sparseQueryChunk - 1) / sparseQueryChunk)
-        var pending: [MLXArray] = [densePrefix]
+        var pending: [MLXArray] = []
         pending.reserveCapacity(maximumKernelsPerEvaluation)
+        if sparseQueryStart > 0 {
+            let densePrefix = MLXFast.scaledDotProductAttention(
+                queries: queries[0..., 0..., 0..<sparseQueryStart, 0...],
+                keys: keys,
+                values: values,
+                scale: scale,
+                mask: .none
+            )
+            outputs.append(densePrefix)
+            pending.append(densePrefix)
+        }
         for localStart in stride(from: 0, to: targetCount, by: sparseQueryChunk) {
             let count = min(sparseQueryChunk, targetCount - localStart)
             let sparse = sparseKernelOutput(
@@ -172,7 +176,8 @@ enum MiniMaxH3DynamicSparseAttention {
         if !pending.isEmpty {
             MLX.eval(pending)
         }
-        return MLX.concatenated(outputs, axis: 2)
+        precondition(!outputs.isEmpty)
+        return outputs.count == 1 ? outputs[0] : MLX.concatenated(outputs, axis: 2)
     }
 
     static func denseRouteGate(
@@ -182,7 +187,7 @@ enum MiniMaxH3DynamicSparseAttention {
         queryStart: Int,
         scale: Float,
         sampleQueryCount: Int = 8
-    ) -> MiniMaxH3DynamicSparseAttentionGate? {
+    ) -> DynamicSparseAttentionGate? {
         guard supports(
             queries: queries,
             keys: keys,
@@ -397,7 +402,7 @@ enum MiniMaxH3DynamicSparseAttention {
         )
         return (outputs[0], outputs[1], outputs[2])
         #else
-        preconditionFailure("MiniMax-H3 sparse summaries require Metal")
+        preconditionFailure("Dynamic sparse summaries require Metal")
         #endif
     }
 
@@ -439,13 +444,13 @@ enum MiniMaxH3DynamicSparseAttention {
             outputDTypes: [.bfloat16]
         )[0]
         #else
-        preconditionFailure("MiniMax-H3 sparse attention requires Metal")
+        preconditionFailure("Dynamic sparse attention requires Metal")
         #endif
     }
 
     #if os(macOS) || os(iOS) || os(tvOS) || os(visionOS)
     private static let summaryKernel = MLXFast.metalKernel(
-        name: "mere_h3_dynamic_sparse_summaries_bf16_d128_b64_v1",
+        name: "mere_dynamic_sparse_summaries_bf16_d128_b64_v1",
         inputNames: ["queries", "keys", "values"],
         outputNames: ["query_centroids", "key_centroids", "value_sums"],
         source: """
@@ -478,7 +483,7 @@ enum MiniMaxH3DynamicSparseAttention {
     )
 
     private static let attentionKernel = MLXFast.metalKernel(
-        name: "mere_h3_dynamic_sparse_online_softmax_bf16_d128_b64_mma_v5",
+        name: "mere_dynamic_sparse_online_softmax_bf16_d128_b64_mma_v5",
         inputNames: [
             "queries", "keys", "values", "key_centroids", "value_sums",
             "routes", "scale_value",

--- a/Sources/MereRunCore/MLX/DynamicSparseAttentionRuntime.swift
+++ b/Sources/MereRunCore/MLX/DynamicSparseAttentionRuntime.swift
@@ -1,0 +1,172 @@
+import Foundation
+import MLX
+
+enum DynamicSparseAttentionModel: String, CaseIterable, Sendable {
+    case wan2
+    case scail2
+    case ltx
+    case cosmos3
+    case trellis2
+    case flux2
+    case krea2
+    case qwenImageEdit = "qwen-image-edit"
+    case zImage = "z-image"
+    case ideogram4
+}
+
+/// Opt-in staging controller for model-specific dynamic sparse attention.
+///
+/// H3 owns its released admission policy. Other model integrations stay
+/// disabled unless explicitly selected through `MERERUN_DYNAMIC_SPARSE_ATTENTION`.
+/// This lets source and CPU-only validation land independently from the real
+/// Metal numerical and artifact gates required before production enablement.
+final class DynamicSparseAttentionRuntime {
+    let model: DynamicSparseAttentionModel
+    let policy: DynamicSparseAttentionPolicy
+    let maximumQueryTokens: Int
+    let maximumKernelsPerEvaluation: Int
+
+    var logHandler: ((String) -> Void)?
+
+    private(set) var stepIndex = 0
+    private(set) var stepCount = 0
+    private var gateResults: [String: Bool] = [:]
+
+    init(
+        model: DynamicSparseAttentionModel,
+        policy: DynamicSparseAttentionPolicy,
+        maximumQueryTokens: Int = 1_024,
+        maximumKernelsPerEvaluation: Int = 4
+    ) {
+        precondition(maximumQueryTokens > 0)
+        precondition(maximumKernelsPerEvaluation > 0)
+        self.model = model
+        self.policy = policy
+        self.maximumQueryTokens = maximumQueryTokens
+        self.maximumKernelsPerEvaluation = maximumKernelsPerEvaluation
+    }
+
+    static func configured(
+        model: DynamicSparseAttentionModel,
+        minimumSequenceLength: Int = 12_000,
+        denseLeadingStepFraction: Float = 0.2,
+        denseTrailingStepCount: Int = 1,
+        denseLeadingLayerCount: Int = 2,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> DynamicSparseAttentionRuntime? {
+        guard selection(environment: environment).contains(model) else { return nil }
+        let threshold = Float(environment["MERERUN_DYNAMIC_SPARSE_TAU"] ?? "")
+            .flatMap { $0 >= 0 ? $0 : nil } ?? 1
+        let sequenceThreshold = Int(environment["MERERUN_DYNAMIC_SPARSE_MIN_TOKENS"] ?? "")
+            .flatMap { $0 > 0 ? $0 : nil } ?? minimumSequenceLength
+        return DynamicSparseAttentionRuntime(
+            model: model,
+            policy: DynamicSparseAttentionPolicy(
+                thresholdStandardDeviations: threshold,
+                minimumSequenceLength: sequenceThreshold,
+                denseLeadingStepFraction: denseLeadingStepFraction,
+                denseTrailingStepCount: denseTrailingStepCount,
+                denseLeadingLayerCount: denseLeadingLayerCount
+            )
+        )
+    }
+
+    static func selection(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> Set<DynamicSparseAttentionModel> {
+        guard let raw = environment["MERERUN_DYNAMIC_SPARSE_ATTENTION"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased(),
+              !raw.isEmpty,
+              raw != "0",
+              raw != "false" else { return [] }
+        if ["1", "true", "all"].contains(raw) {
+            return Set(DynamicSparseAttentionModel.allCases)
+        }
+        return Set(raw.split(separator: ",").compactMap { token in
+            let value = token.trimmingCharacters(in: .whitespacesAndNewlines)
+            return DynamicSparseAttentionModel.allCases.first {
+                $0.rawValue == value
+            }
+        })
+    }
+
+    func beginStep(index: Int, count: Int) {
+        precondition(count > 0)
+        precondition((0..<count).contains(index))
+        stepIndex = index
+        stepCount = count
+    }
+
+    func call(
+        queries: MLXArray,
+        keys: MLXArray,
+        values: MLXArray,
+        layerIndex: Int,
+        prefixTokenCount: Int,
+        scale: Float
+    ) -> MLXArray? {
+        guard let request = policy.request(
+            stepIndex: stepIndex,
+            stepCount: stepCount,
+            layerIndex: layerIndex,
+            sequenceLength: queries.dim(2),
+            prefixTokenCount: prefixTokenCount
+        ) else { return nil }
+
+        let key = gateKey(
+            queries: queries,
+            keys: keys,
+            values: values,
+            prefixTokenCount: prefixTokenCount
+        )
+        if gateResults[key] == nil {
+            let gate = DynamicSparseAttention.denseRouteGate(
+                queries: queries,
+                keys: keys,
+                values: values,
+                queryStart: prefixTokenCount,
+                scale: scale
+            )
+            gateResults[key] = gate?.passed ?? false
+            if let gate {
+                logHandler?(String(
+                    format: "dynamic_sparse model=%@ gate=%@ max_abs=%.6g mean_abs=%.6g rel_l2=%.6g",
+                    model.rawValue,
+                    gate.passed ? "pass" : "fail",
+                    gate.maximumAbsoluteError,
+                    gate.meanAbsoluteError,
+                    gate.relativeL2Error
+                ))
+            } else {
+                logHandler?("dynamic_sparse model=\(model.rawValue) gate=unavailable key=\(key)")
+            }
+        }
+        guard gateResults[key] == true else { return nil }
+        return DynamicSparseAttention.call(
+            queries: queries,
+            keys: keys,
+            values: values,
+            request: request,
+            scale: scale,
+            maximumQueryTokens: maximumQueryTokens,
+            maximumKernelsPerEvaluation: maximumKernelsPerEvaluation
+        )
+    }
+
+    private func gateKey(
+        queries: MLXArray,
+        keys: MLXArray,
+        values: MLXArray,
+        prefixTokenCount: Int
+    ) -> String {
+        [
+            model.rawValue,
+            queries.shape.description,
+            String(describing: queries.dtype),
+            String(describing: keys.dtype),
+            String(describing: values.dtype),
+            String(prefixTokenCount),
+        ].joined(separator: ":")
+    }
+}

--- a/Sources/MereRunCore/MLX/DynamicSparseAttentionRuntime.swift
+++ b/Sources/MereRunCore/MLX/DynamicSparseAttentionRuntime.swift
@@ -2,27 +2,18 @@ import Foundation
 import MLX
 
 enum DynamicSparseAttentionModel: String, CaseIterable, Sendable {
-    case wan2
-    case scail2
-    case ltx
-    case cosmos3
-    case trellis2
-    case flux2
-    case krea2
-    case qwenImageEdit = "qwen-image-edit"
     case zImage = "z-image"
-    case ideogram4
 }
 
-/// Opt-in staging controller for model-specific dynamic sparse attention.
+/// Model-specific admission controller for reusable dynamic sparse attention.
 ///
-/// H3 owns its released admission policy. Other model integrations stay
-/// disabled unless explicitly selected through `MERERUN_DYNAMIC_SPARSE_ATTENTION`.
-/// This lets source and CPU-only validation land independently from the real
-/// Metal numerical and artifact gates required before production enablement.
+/// H3 owns its released admission policy. Z-Image enables this runtime only at
+/// the long-sequence crossover validated on Metal; the environment selector is
+/// retained as a diagnostic disable and threshold override.
 final class DynamicSparseAttentionRuntime {
     let model: DynamicSparseAttentionModel
     let policy: DynamicSparseAttentionPolicy
+    let maximumGateRelativeError: Float
     let maximumQueryTokens: Int
     let maximumKernelsPerEvaluation: Int
 
@@ -35,13 +26,16 @@ final class DynamicSparseAttentionRuntime {
     init(
         model: DynamicSparseAttentionModel,
         policy: DynamicSparseAttentionPolicy,
+        maximumGateRelativeError: Float = 0.01,
         maximumQueryTokens: Int = 1_024,
         maximumKernelsPerEvaluation: Int = 4
     ) {
+        precondition(maximumGateRelativeError > 0)
         precondition(maximumQueryTokens > 0)
         precondition(maximumKernelsPerEvaluation > 0)
         self.model = model
         self.policy = policy
+        self.maximumGateRelativeError = maximumGateRelativeError
         self.maximumQueryTokens = maximumQueryTokens
         self.maximumKernelsPerEvaluation = maximumKernelsPerEvaluation
     }
@@ -54,7 +48,7 @@ final class DynamicSparseAttentionRuntime {
         denseLeadingLayerCount: Int = 2,
         environment: [String: String] = ProcessInfo.processInfo.environment
     ) -> DynamicSparseAttentionRuntime? {
-        guard selection(environment: environment).contains(model) else { return nil }
+        guard isEnabled(model: model, environment: environment) else { return nil }
         let threshold = Float(environment["MERERUN_DYNAMIC_SPARSE_TAU"] ?? "")
             .flatMap { $0 >= 0 ? $0 : nil } ?? 1
         let sequenceThreshold = Int(environment["MERERUN_DYNAMIC_SPARSE_MIN_TOKENS"] ?? "")
@@ -67,7 +61,8 @@ final class DynamicSparseAttentionRuntime {
                 denseLeadingStepFraction: denseLeadingStepFraction,
                 denseTrailingStepCount: denseTrailingStepCount,
                 denseLeadingLayerCount: denseLeadingLayerCount
-            )
+            ),
+            maximumGateRelativeError: 0.015
         )
         if ["1", "true", "yes"].contains(
             environment["MERERUN_DYNAMIC_SPARSE_LOG"]?.lowercased() ?? ""
@@ -77,6 +72,20 @@ final class DynamicSparseAttentionRuntime {
             }
         }
         return runtime
+    }
+
+    static func isEnabled(
+        model: DynamicSparseAttentionModel,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> Bool {
+        guard let raw = environment["MERERUN_DYNAMIC_SPARSE_ATTENTION"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased(),
+              !raw.isEmpty else {
+            return model == .zImage
+        }
+        if ["0", "false", "no"].contains(raw) { return false }
+        return selection(environment: environment).contains(model)
     }
 
     static func selection(
@@ -134,7 +143,8 @@ final class DynamicSparseAttentionRuntime {
                 keys: keys,
                 values: values,
                 queryStart: prefixTokenCount,
-                scale: scale
+                scale: scale,
+                maximumRelativeErrorLimit: maximumGateRelativeError
             )
             gateResults[key] = gate?.passed ?? false
             if let gate {

--- a/Sources/MereRunCore/MLX/DynamicSparseAttentionRuntime.swift
+++ b/Sources/MereRunCore/MLX/DynamicSparseAttentionRuntime.swift
@@ -59,7 +59,7 @@ final class DynamicSparseAttentionRuntime {
             .flatMap { $0 >= 0 ? $0 : nil } ?? 1
         let sequenceThreshold = Int(environment["MERERUN_DYNAMIC_SPARSE_MIN_TOKENS"] ?? "")
             .flatMap { $0 > 0 ? $0 : nil } ?? minimumSequenceLength
-        return DynamicSparseAttentionRuntime(
+        let runtime = DynamicSparseAttentionRuntime(
             model: model,
             policy: DynamicSparseAttentionPolicy(
                 thresholdStandardDeviations: threshold,
@@ -69,6 +69,14 @@ final class DynamicSparseAttentionRuntime {
                 denseLeadingLayerCount: denseLeadingLayerCount
             )
         )
+        if ["1", "true", "yes"].contains(
+            environment["MERERUN_DYNAMIC_SPARSE_LOG"]?.lowercased() ?? ""
+        ) {
+            runtime.logHandler = { message in
+                FileHandle.standardError.write(Data((message + "\n").utf8))
+            }
+        }
+        return runtime
     }
 
     static func selection(

--- a/Sources/MereRunCore/MLX/DynamicSparseAttentionRuntime.swift
+++ b/Sources/MereRunCore/MLX/DynamicSparseAttentionRuntime.swift
@@ -139,11 +139,14 @@ final class DynamicSparseAttentionRuntime {
             gateResults[key] = gate?.passed ?? false
             if let gate {
                 logHandler?(String(
-                    format: "dynamic_sparse model=%@ gate=%@ max_abs=%.6g mean_abs=%.6g rel_l2=%.6g",
+                    format: "dynamic_sparse model=%@ gate=%@ max_abs=%.6g mean_abs=%.6g "
+                        + "max_rel=%.6g mean_rel=%.6g rel_l2=%.6g",
                     model.rawValue,
                     gate.passed ? "pass" : "fail",
                     gate.maximumAbsoluteError,
                     gate.meanAbsoluteError,
+                    gate.maximumRelativeError,
+                    gate.meanRelativeError,
                     gate.relativeL2Error
                 ))
             } else {

--- a/Sources/MereRunCore/MLX/README.md
+++ b/Sources/MereRunCore/MLX/README.md
@@ -1,0 +1,29 @@
+# Shared MLX kernels
+
+This directory contains reusable native MLX and Metal execution primitives.
+Model-specific graph code remains in the model's own module and calls these
+primitives only after validating its tensor layout and admission policy.
+
+## Dynamic sparse attention
+
+`DynamicSparseAttention.swift` implements batch-one, head-dimension-128
+block-sparse attention. It summarizes 64-token blocks, constructs
+query-dependent routes, preserves neighboring and prefix blocks exactly, and
+evaluates the selected blocks with an online-softmax Metal kernel. The dense
+route gate compares the custom kernel with MLX fused SDPA before a tensor shape
+may use sparse execution.
+
+`DynamicSparseAttentionRuntime.swift` owns the reusable step, layer, sequence,
+and numerical admission checks. Z-Image enables it only for long sequences at
+the measured crossover. MiniMax-H3 keeps its model-specific policy in the H3
+generator and transformer.
+
+## Editing rules
+
+- Keep the shared kernel independent of model tensor layouts and masks.
+- Preserve FP32 outputs when any Q, K, or V input is FP32.
+- Add a real Metal parity test for kernel changes.
+- Require model-specific warm timing and artifact validation before enabling a
+  new caller by default.
+- Keep unsupported head dimensions, masks, and batch shapes on fused dense
+  SDPA rather than approximating their semantics.

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Generator.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Generator.swift
@@ -89,15 +89,15 @@ public enum MiniMaxH3AccelerationMode: String, Sendable, Hashable {
         }
     }
 
-    var dynamicSparseAttentionPolicy: MiniMaxH3DynamicSparseAttentionPolicy? {
+    var dynamicSparseAttentionPolicy: DynamicSparseAttentionPolicy? {
         switch self {
         case .quality: nil
         case .balanced:
-            MiniMaxH3DynamicSparseAttentionPolicy(
+            DynamicSparseAttentionPolicy(
                 thresholdStandardDeviations: 0.75
             )
         case .maximum:
-            MiniMaxH3DynamicSparseAttentionPolicy(
+            DynamicSparseAttentionPolicy(
                 thresholdStandardDeviations: 1
             )
         }
@@ -886,7 +886,7 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
         let configuredDynamicSparseAttentionPolicy = environment["MERERUN_H3_DYNAMIC_SPARSE"] == "0"
             ? nil
             : accelerationMode.dynamicSparseAttentionPolicy.map { policy in
-                MiniMaxH3DynamicSparseAttentionPolicy(
+                DynamicSparseAttentionPolicy(
                     thresholdStandardDeviations: Float(
                         environment["MERERUN_H3_DYNAMIC_SPARSE_TAU"] ?? ""
                     ).flatMap { $0 >= 0 ? $0 : nil } ?? policy.thresholdStandardDeviations,

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Transformer.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Transformer.swift
@@ -1687,11 +1687,14 @@ public final class MiniMaxH3Transformer: Module {
             dynamicSparseAttentionGateResults[gateKey] = gate?.passed ?? false
             if let gate {
                 dynamicSparseAttentionLogHandler?(String(
-                    format: "dynamic_sparse_gate=%@ shape=%@ max_abs=%.6g mean_abs=%.6g rel_l2=%.6g",
+                    format: "dynamic_sparse_gate=%@ shape=%@ max_abs=%.6g mean_abs=%.6g "
+                        + "max_rel=%.6g mean_rel=%.6g rel_l2=%.6g",
                     gate.passed ? "pass" : "fail",
                     gateShape,
                     gate.maximumAbsoluteError,
                     gate.meanAbsoluteError,
+                    gate.maximumRelativeError,
+                    gate.meanRelativeError,
                     gate.relativeL2Error
                 ))
             } else {

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Transformer.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Transformer.swift
@@ -618,10 +618,10 @@ private final class MiniMaxH3TransformerBlock: Module {
         maximumQueryTokens: Int,
         maximumHeadsPerKernel: Int?,
         maximumKernelsPerEvaluation: Int,
-        dynamicSparseRequest: MiniMaxH3DynamicSparseAttentionRequest? = nil
+        dynamicSparseRequest: DynamicSparseAttentionRequest? = nil
     ) -> MLXArray {
         if let dynamicSparseRequest,
-           let sparse = MiniMaxH3DynamicSparseAttention.call(
+           let sparse = DynamicSparseAttention.call(
                queries: queries,
                keys: keys,
                values: values,
@@ -1179,7 +1179,7 @@ public final class MiniMaxH3Transformer: Module {
     var maximumAttentionQueryTokensPerKernel = 1_024
     var maximumAttentionHeadsPerKernel: Int?
     var maximumAttentionKernelsPerEvaluation = 4
-    var dynamicSparseAttentionPolicy: MiniMaxH3DynamicSparseAttentionPolicy?
+    var dynamicSparseAttentionPolicy: DynamicSparseAttentionPolicy?
     var dynamicSparseAttentionStepIndex = 0
     var dynamicSparseAttentionStepCount = 0
     var dynamicSparseAttentionLogHandler: ((String) -> Void)?
@@ -1665,7 +1665,7 @@ public final class MiniMaxH3Transformer: Module {
         values: MLXArray,
         layerIndex: Int,
         layout: MiniMaxH3PackedLayout
-    ) -> MiniMaxH3DynamicSparseAttentionRequest? {
+    ) -> DynamicSparseAttentionRequest? {
         guard let request = dynamicSparseAttentionPolicy?.request(
             stepIndex: dynamicSparseAttentionStepIndex,
             stepCount: dynamicSparseAttentionStepCount,
@@ -1677,7 +1677,7 @@ public final class MiniMaxH3Transformer: Module {
         let gateShape = "\(queries.dim(1))x\(queries.dim(2))x\(request.prefixTokenCount)"
         let gateKey = "\(gateShape):\(queries.dtype):\(keys.dtype):\(values.dtype)"
         if dynamicSparseAttentionGateResults[gateKey] == nil {
-            let gate = MiniMaxH3DynamicSparseAttention.denseRouteGate(
+            let gate = DynamicSparseAttention.denseRouteGate(
                 queries: queries,
                 keys: keys,
                 values: values,

--- a/Sources/MereRunCore/ZImageTurbo/Model/Transformer/ZImageSelfAttention.swift
+++ b/Sources/MereRunCore/ZImageTurbo/Model/Transformer/ZImageSelfAttention.swift
@@ -38,7 +38,10 @@ final class ZImageSelfAttention: Module {
   func callAsFunction(
     _ x: MLXArray,
     attnMask: MLXArray? = nil,
-    freqsCis: MLXArray? = nil
+    freqsCis: MLXArray? = nil,
+    dynamicSparseRuntime: DynamicSparseAttentionRuntime? = nil,
+    layerIndex: Int = 0,
+    exactSuffixTokenCount: Int = 0
   ) -> MLXArray {
     let batch = x.dim(0)
     let seqLen = x.dim(1)
@@ -59,13 +62,51 @@ final class ZImageSelfAttention: Module {
     q = q.transposed(0, 2, 1, 3)
     k = k.transposed(0, 2, 1, 3)
 
-    let attn = MLXFast.scaledDotProductAttention(
+    let sparse: MLXArray? = attnMask == nil ? dynamicSparseRuntime.flatMap { runtime in
+      if exactSuffixTokenCount == 0 {
+        return runtime.call(
+          queries: q,
+          keys: k,
+          values: v,
+          layerIndex: layerIndex,
+          prefixTokenCount: 0,
+          scale: scale
+        )
+      }
+      guard exactSuffixTokenCount > 0, exactSuffixTokenCount < seqLen else { return nil }
+      let tailStart = seqLen - exactSuffixTokenCount
+      let reorderedQ = MLX.concatenated([
+        q[0..., 0..., tailStart..., 0...],
+        q[0..., 0..., 0..<tailStart, 0...],
+      ], axis: 2)
+      let reorderedK = MLX.concatenated([
+        k[0..., 0..., tailStart..., 0...],
+        k[0..., 0..., 0..<tailStart, 0...],
+      ], axis: 2)
+      let reorderedV = MLX.concatenated([
+        v[0..., 0..., tailStart..., 0...],
+        v[0..., 0..., 0..<tailStart, 0...],
+      ], axis: 2)
+      guard let reorderedOutput = runtime.call(
+        queries: reorderedQ,
+        keys: reorderedK,
+        values: reorderedV,
+        layerIndex: layerIndex,
+        prefixTokenCount: exactSuffixTokenCount,
+        scale: scale
+      ) else { return nil }
+      return MLX.concatenated([
+        reorderedOutput[0..., 0..., exactSuffixTokenCount..., 0...],
+        reorderedOutput[0..., 0..., 0..<exactSuffixTokenCount, 0...],
+      ], axis: 2)
+    } : nil
+    let attn = (sparse ?? MLXFast.scaledDotProductAttention(
       queries: q,
       keys: k,
       values: v,
       scale: scale,
       mask: attnMask
-    ).transposed(0, 2, 1, 3).reshaped(batch, seqLen, dim)
+    )).transposed(0, 2, 1, 3).reshaped(batch, seqLen, dim)
 
     return toOut[0](attn)
   }

--- a/Sources/MereRunCore/ZImageTurbo/Model/Transformer/ZImageTransformer2D.swift
+++ b/Sources/MereRunCore/ZImageTurbo/Model/Transformer/ZImageTransformer2D.swift
@@ -13,6 +13,7 @@ final class ZImageModuleTable2_1<T: Module>: Module {
 
 public final class ZImageTransformer2DModel: Module {
   public let configuration: ZImageTurboTransformerConfig
+  private let dynamicSparseRuntime: DynamicSparseAttentionRuntime?
   @ModuleInfo(key: "t_embedder") var tEmbedder: ZImageTimestepEmbedder
   @ModuleInfo(key: "all_x_embedder") var allXEmbedder: ZImageModuleTable2_1<Linear>
   @ModuleInfo(key: "all_final_layer") var allFinalLayer: ZImageModuleTable2_1<ZImageFinalLayer>
@@ -35,6 +36,7 @@ public final class ZImageTransformer2DModel: Module {
 
   public init(configuration: ZImageTurboTransformerConfig) {
     self.configuration = configuration
+    self.dynamicSparseRuntime = DynamicSparseAttentionRuntime.configured(model: .zImage)
     let outSize = min(configuration.dim, 256)
     self._tEmbedder.wrappedValue = ZImageTimestepEmbedder(outSize: outSize, midSize: 1024)
 
@@ -109,6 +111,10 @@ public final class ZImageTransformer2DModel: Module {
     self._xPadToken.wrappedValue = MLX.zeros([1, configuration.dim], dtype: .bfloat16)
     self._capPadToken.wrappedValue = MLX.zeros([1, configuration.dim], dtype: .bfloat16)
     super.init()
+  }
+
+  func beginDenoisingStep(index: Int, count: Int) {
+    dynamicSparseRuntime?.beginStep(index: index, count: count)
   }
 
   public func clearCache() {
@@ -225,7 +231,7 @@ public final class ZImageTransformer2DModel: Module {
     }
 
     var noiseStream = image
-    for block in noiseRefiner {
+    for (index, block) in noiseRefiner.enumerated() {
       if gradientCheckpointing {
         let blockRef = block
         let imgFreqs = cached.imgFreqs
@@ -239,7 +245,9 @@ public final class ZImageTransformer2DModel: Module {
           noiseStream,
           attnMask: nil,
           freqsCis: cached.imgFreqs,
-          adalnInput: tEmb
+          adalnInput: tEmb,
+          dynamicSparseRuntime: dynamicSparseRuntime,
+          layerIndex: index
         )
       }
     }
@@ -265,7 +273,7 @@ public final class ZImageTransformer2DModel: Module {
 
     var unified = MLX.concatenated([noiseStream, capStream], axis: 1)
 
-    for block in layers {
+    for (index, block) in layers.enumerated() {
       if gradientCheckpointing {
         let blockRef = block
         let unifiedFreqs = cached.unifiedFreqsCis
@@ -275,7 +283,15 @@ public final class ZImageTransformer2DModel: Module {
         }
         unified = checkpointedBlock([unified])[0]
       } else {
-        unified = block(unified, attnMask: nil, freqsCis: cached.unifiedFreqsCis, adalnInput: tEmb)
+        unified = block(
+          unified,
+          attnMask: nil,
+          freqsCis: cached.unifiedFreqsCis,
+          adalnInput: tEmb,
+          dynamicSparseRuntime: dynamicSparseRuntime,
+          layerIndex: noiseRefiner.count + index,
+          exactSuffixTokenCount: cached.capSeqLen
+        )
       }
     }
 

--- a/Sources/MereRunCore/ZImageTurbo/Model/Transformer/ZImageTransformerBlock.swift
+++ b/Sources/MereRunCore/ZImageTurbo/Model/Transformer/ZImageTransformerBlock.swift
@@ -49,7 +49,10 @@ public final class ZImageTransformerBlock: Module {
     _ x: MLXArray,
     attnMask: MLXArray? = nil,
     freqsCis: MLXArray? = nil,
-    adalnInput: MLXArray? = nil
+    adalnInput: MLXArray? = nil,
+    dynamicSparseRuntime: DynamicSparseAttentionRuntime? = nil,
+    layerIndex: Int = 0,
+    exactSuffixTokenCount: Int = 0
   ) -> MLXArray {
     var out = x
 
@@ -64,14 +67,28 @@ public final class ZImageTransformerBlock: Module {
 
       let xNormed = attentionNorm1(out)
       let xScaled = xNormed * attnScale
-      let attnOut = attention(xScaled, attnMask: attnMask, freqsCis: freqsCis)
+      let attnOut = attention(
+        xScaled,
+        attnMask: attnMask,
+        freqsCis: freqsCis,
+        dynamicSparseRuntime: dynamicSparseRuntime,
+        layerIndex: layerIndex,
+        exactSuffixTokenCount: exactSuffixTokenCount
+      )
       let attnNormed = attentionNorm2(attnOut)
       out = out + attnGate * attnNormed
 
       let ffnOut = feedForward(ffnNorm1(out) * mlpScale)
       out = out + mlpGate * ffnNorm2(ffnOut)
     } else {
-      let attnOut = attention(attentionNorm1(out), attnMask: attnMask, freqsCis: freqsCis)
+      let attnOut = attention(
+        attentionNorm1(out),
+        attnMask: attnMask,
+        freqsCis: freqsCis,
+        dynamicSparseRuntime: dynamicSparseRuntime,
+        layerIndex: layerIndex,
+        exactSuffixTokenCount: exactSuffixTokenCount
+      )
       out = out + attentionNorm2(attnOut)
 
       let ffnOut = feedForward(ffnNorm1(out))

--- a/Sources/MereRunCore/ZImageTurbo/ZImageTurboGenerator.swift
+++ b/Sources/MereRunCore/ZImageTurbo/ZImageTurboGenerator.swift
@@ -161,6 +161,10 @@ public actor ZImageTurboGenerator: ImageGenerator, ChatGenerator {
 
                 for stepIndex in startStep..<inferenceConfig.numInferenceSteps {
                     try Task.checkCancellation()
+                    model.transformer.beginDenoisingStep(
+                        index: stepIndex,
+                        count: inferenceConfig.numInferenceSteps
+                    )
                     progressHandler?(GenerationProgress(
                         stage: .denoising,
                         stepIndex: stepIndex,

--- a/Tests/MereRunCoreTests/DiTShapeBenchTests.swift
+++ b/Tests/MereRunCoreTests/DiTShapeBenchTests.swift
@@ -726,7 +726,7 @@ final class DiTShapeBenchTests: XCTestCase {
     /// `MERERUN_H3_SPARSE_BENCH_ROWS`, `MERERUN_H3_SPARSE_BENCH_PREFIX`,
     /// `MERERUN_H3_SPARSE_BENCH_TAU`, `MERERUN_H3_SPARSE_BENCH_DTYPE`, and
     /// `MERERUN_H3_SPARSE_BENCH_ROUNDS`.
-    func testMiniMaxH3DynamicSparseAttention() throws {
+    func testDynamicSparseAttention() throws {
         try benchGate()
         guard Device.defaultDevice().deviceType == .gpu else {
             throw XCTSkip("MiniMax-H3 dynamic sparse benchmark requires a Metal GPU.")
@@ -759,7 +759,7 @@ final class DiTShapeBenchTests: XCTestCase {
         let dtype: DType = environment["MERERUN_H3_SPARSE_BENCH_DTYPE"] == "fp32"
             ? .float32
             : .bfloat16
-        let dimension = MiniMaxH3DynamicSparseAttention.headDimension
+        let dimension = DynamicSparseAttention.headDimension
         let scale = 1 / sqrt(Float(dimension))
         MLXRandom.seed(2_026)
         let shape = [1, heads, rows, dimension]
@@ -768,12 +768,12 @@ final class DiTShapeBenchTests: XCTestCase {
         let values = MLXRandom.normal(shape).asType(dtype)
         MLX.eval(queries, keys, values)
 
-        let request = MiniMaxH3DynamicSparseAttentionRequest(
+        let request = DynamicSparseAttentionRequest(
             prefixTokenCount: prefix,
             thresholdStandardDeviations: tau
         )
         func sparse() -> MLXArray {
-            MiniMaxH3DynamicSparseAttention.call(
+            DynamicSparseAttention.call(
                 queries: queries,
                 keys: keys,
                 values: values,
@@ -800,7 +800,7 @@ final class DiTShapeBenchTests: XCTestCase {
             return MLX.concatenated(outputs, axis: 2)
         }
 
-        let gate = try XCTUnwrap(MiniMaxH3DynamicSparseAttention.denseRouteGate(
+        let gate = try XCTUnwrap(DynamicSparseAttention.denseRouteGate(
             queries: queries,
             keys: keys,
             values: values,
@@ -808,7 +808,7 @@ final class DiTShapeBenchTests: XCTestCase {
             scale: scale
         ))
         XCTAssertTrue(gate.passed)
-        let plan = MiniMaxH3DynamicSparseAttention.makeRoutePlan(
+        let plan = DynamicSparseAttention.makeRoutePlan(
             queries: queries,
             keys: keys,
             values: values,

--- a/Tests/MereRunCoreTests/DynamicSparseAttentionTests.swift
+++ b/Tests/MereRunCoreTests/DynamicSparseAttentionTests.swift
@@ -40,11 +40,13 @@ final class DynamicSparseAttentionTests: MereRunCoreTestCase {
             model: .wan2,
             environment: [
                 "MERERUN_DYNAMIC_SPARSE_ATTENTION": "wan2",
+                "MERERUN_DYNAMIC_SPARSE_LOG": "1",
                 "MERERUN_DYNAMIC_SPARSE_MIN_TOKENS": "256",
                 "MERERUN_DYNAMIC_SPARSE_TAU": "0.75",
             ]
         ))
         XCTAssertEqual(runtime.policy.minimumSequenceLength, 256)
         XCTAssertEqual(runtime.policy.thresholdStandardDeviations, 0.75)
+        XCTAssertNotNil(runtime.logHandler)
     }
 }

--- a/Tests/MereRunCoreTests/DynamicSparseAttentionTests.swift
+++ b/Tests/MereRunCoreTests/DynamicSparseAttentionTests.swift
@@ -2,13 +2,17 @@ import XCTest
 @testable import MereRunCore
 
 final class DynamicSparseAttentionTests: MereRunCoreTestCase {
-    func testSelectionIsExplicitAndModelScoped() {
-        XCTAssertEqual(DynamicSparseAttentionRuntime.selection(environment: [:]), [])
+    func testZImageRuntimeIsEnabledByDefaultAndCanBeDisabled() {
+        XCTAssertTrue(DynamicSparseAttentionRuntime.isEnabled(model: .zImage, environment: [:]))
+        XCTAssertFalse(DynamicSparseAttentionRuntime.isEnabled(
+            model: .zImage,
+            environment: ["MERERUN_DYNAMIC_SPARSE_ATTENTION": "0"]
+        ))
         XCTAssertEqual(
             DynamicSparseAttentionRuntime.selection(environment: [
-                "MERERUN_DYNAMIC_SPARSE_ATTENTION": "wan2,ltx",
+                "MERERUN_DYNAMIC_SPARSE_ATTENTION": "z-image",
             ]),
-            [.wan2, .ltx]
+            [.zImage]
         )
         XCTAssertEqual(
             DynamicSparseAttentionRuntime.selection(environment: [
@@ -35,11 +39,11 @@ final class DynamicSparseAttentionTests: MereRunCoreTestCase {
         XCTAssertEqual(request.prefixTokenCount, 0)
     }
 
-    func testConfigurationCanLowerThresholdForTomorrowSmokeOnly() throws {
+    func testConfigurationCanLowerThresholdForDiagnosticSmoke() throws {
         let runtime = try XCTUnwrap(DynamicSparseAttentionRuntime.configured(
-            model: .wan2,
+            model: .zImage,
             environment: [
-                "MERERUN_DYNAMIC_SPARSE_ATTENTION": "wan2",
+                "MERERUN_DYNAMIC_SPARSE_ATTENTION": "z-image",
                 "MERERUN_DYNAMIC_SPARSE_LOG": "1",
                 "MERERUN_DYNAMIC_SPARSE_MIN_TOKENS": "256",
                 "MERERUN_DYNAMIC_SPARSE_TAU": "0.75",
@@ -47,6 +51,7 @@ final class DynamicSparseAttentionTests: MereRunCoreTestCase {
         ))
         XCTAssertEqual(runtime.policy.minimumSequenceLength, 256)
         XCTAssertEqual(runtime.policy.thresholdStandardDeviations, 0.75)
+        XCTAssertEqual(runtime.maximumGateRelativeError, 0.015)
         XCTAssertNotNil(runtime.logHandler)
     }
 }

--- a/Tests/MereRunCoreTests/DynamicSparseAttentionTests.swift
+++ b/Tests/MereRunCoreTests/DynamicSparseAttentionTests.swift
@@ -1,0 +1,50 @@
+import XCTest
+@testable import MereRunCore
+
+final class DynamicSparseAttentionTests: MereRunCoreTestCase {
+    func testSelectionIsExplicitAndModelScoped() {
+        XCTAssertEqual(DynamicSparseAttentionRuntime.selection(environment: [:]), [])
+        XCTAssertEqual(
+            DynamicSparseAttentionRuntime.selection(environment: [
+                "MERERUN_DYNAMIC_SPARSE_ATTENTION": "wan2,ltx",
+            ]),
+            [.wan2, .ltx]
+        )
+        XCTAssertEqual(
+            DynamicSparseAttentionRuntime.selection(environment: [
+                "MERERUN_DYNAMIC_SPARSE_ATTENTION": "all",
+            ]),
+            Set(DynamicSparseAttentionModel.allCases)
+        )
+    }
+
+    func testPolicySupportsModelsWithoutPrefixTokens() throws {
+        let policy = DynamicSparseAttentionPolicy(
+            minimumSequenceLength: 12_000,
+            denseLeadingStepFraction: 0.2,
+            denseTrailingStepCount: 1,
+            denseLeadingLayerCount: 2
+        )
+        let request = try XCTUnwrap(policy.request(
+            stepIndex: 2,
+            stepCount: 4,
+            layerIndex: 2,
+            sequenceLength: 12_800,
+            prefixTokenCount: 0
+        ))
+        XCTAssertEqual(request.prefixTokenCount, 0)
+    }
+
+    func testConfigurationCanLowerThresholdForTomorrowSmokeOnly() throws {
+        let runtime = try XCTUnwrap(DynamicSparseAttentionRuntime.configured(
+            model: .wan2,
+            environment: [
+                "MERERUN_DYNAMIC_SPARSE_ATTENTION": "wan2",
+                "MERERUN_DYNAMIC_SPARSE_MIN_TOKENS": "256",
+                "MERERUN_DYNAMIC_SPARSE_TAU": "0.75",
+            ]
+        ))
+        XCTAssertEqual(runtime.policy.minimumSequenceLength, 256)
+        XCTAssertEqual(runtime.policy.thresholdStandardDeviations, 0.75)
+    }
+}

--- a/Tests/MereRunCoreTests/MiniMaxH3Tests.swift
+++ b/Tests/MereRunCoreTests/MiniMaxH3Tests.swift
@@ -63,7 +63,7 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
             0, 0,
             3, 0,
         ]).reshaped(1, 1, 4, 2)
-        let routes = MiniMaxH3DynamicSparseAttention.routesForTesting(
+        let routes = DynamicSparseAttention.routesForTesting(
             queryCentroids: queryCentroids,
             keyCentroids: keyCentroids,
             thresholdStandardDeviations: 0
@@ -77,18 +77,18 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
             throw XCTSkip("Dynamic sparse attention Metal parity requires a GPU.")
         }
         MLXRandom.seed(41)
-        let shape = [1, 2, 256, MiniMaxH3DynamicSparseAttention.headDimension]
+        let shape = [1, 2, 256, DynamicSparseAttention.headDimension]
         let queries = (MLXRandom.normal(shape) * Float(0.2)).asType(.bfloat16)
         let keys = (MLXRandom.normal(shape) * Float(0.2)).asType(.bfloat16)
         let values = MLXRandom.normal(shape).asType(.bfloat16)
         MLX.eval(queries, keys, values)
 
-        let gate = try XCTUnwrap(MiniMaxH3DynamicSparseAttention.denseRouteGate(
+        let gate = try XCTUnwrap(DynamicSparseAttention.denseRouteGate(
             queries: queries,
             keys: keys,
             values: values,
             queryStart: 128,
-            scale: 1 / sqrt(Float(MiniMaxH3DynamicSparseAttention.headDimension))
+            scale: 1 / sqrt(Float(DynamicSparseAttention.headDimension))
         ))
         XCTAssertTrue(gate.passed)
         XCTAssertLessThanOrEqual(gate.relativeL2Error, 0.005)
@@ -99,18 +99,18 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
             throw XCTSkip("Dynamic sparse attention FP32 gate requires a GPU.")
         }
         MLXRandom.seed(2_026_081)
-        let shape = [1, 2, 256, MiniMaxH3DynamicSparseAttention.headDimension]
+        let shape = [1, 2, 256, DynamicSparseAttention.headDimension]
         let queries = MLXRandom.normal(shape)
         let keys = MLXRandom.normal(shape)
         let values = MLXRandom.normal(shape)
         MLX.eval(queries, keys, values)
 
-        let gate = try XCTUnwrap(MiniMaxH3DynamicSparseAttention.denseRouteGate(
+        let gate = try XCTUnwrap(DynamicSparseAttention.denseRouteGate(
             queries: queries,
             keys: keys,
             values: values,
             queryStart: 64,
-            scale: 1 / sqrt(Float(MiniMaxH3DynamicSparseAttention.headDimension))
+            scale: 1 / sqrt(Float(DynamicSparseAttention.headDimension))
         ))
         XCTAssertTrue(gate.passed)
     }
@@ -122,7 +122,7 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
         MLXRandom.seed(42)
         let heads = 2
         let tokens = 256
-        let dimension = MiniMaxH3DynamicSparseAttention.headDimension
+        let dimension = DynamicSparseAttention.headDimension
         let shape = [1, heads, tokens, dimension]
         let queries = (MLXRandom.normal(shape) * Float(0.2)).asType(.bfloat16)
         let keys = (MLXRandom.normal(shape) * Float(0.2)).asType(.bfloat16)
@@ -130,7 +130,7 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
         let routes = MLXArray.zeros([1, heads, 1, 4], dtype: .uint8)
         let scale = 1 / sqrt(Float(dimension))
         let candidate = try XCTUnwrap(
-            MiniMaxH3DynamicSparseAttention.sparseOutputForTesting(
+            DynamicSparseAttention.sparseOutputForTesting(
                 queries: queries,
                 keys: keys,
                 values: values,

--- a/docs/runtime/image.md
+++ b/docs/runtime/image.md
@@ -482,6 +482,16 @@ swift run mere.run image validate --family klein --test pipeline
 - `Sources/MereRunCore/ZImageTurbo/ZImageTurboGenerator+Inference.swift`
 - `Sources/MereRunCore/ZImageTurbo/ZImageTurboGenerator+LoRA.swift`
 
+Z-Image automatically uses dynamic sparse attention for sequences of at least
+12,000 tokens. The first two transformer layers, the leading 20% of denoising,
+and the final denoise step stay dense, and a once-per-shape numerical gate falls
+back to dense attention whenever the sparse route is not sufficiently faithful.
+Set `MERERUN_DYNAMIC_SPARSE_ATTENTION=0` to keep all attention dense. The sparse
+path is approximate, so same-seed high-resolution images can differ from dense
+generation; smaller shapes stay on the byte-identical dense path. In a warm
+1792x1792 four-step run it reduced generation time from 151.41 to 133.03 seconds
+(12.1%) while peak reported memory remained approximately 109.8 GB.
+
 ### HiDream O1 family
 
 - `Sources/MereRunCore/HiDreamO1/HiDreamO1Generator.swift`


### PR DESCRIPTION
## What changed

- move the H3 dynamic sparse Metal primitive into a shared MLX module
- add reusable runtime admission and numerical dense-route gates
- route Z-Image self-attention through the shared kernel only for validated long sequences
- preserve the existing fused dense path for smaller shapes, unsupported layouts, masks, and batches
- preserve FP32 output precision when any attention input is FP32
- document the default, dense safety boundaries, approximate-output behavior, and operator kill switch

## Why

High-resolution Z-Image generation crosses a point where dense attention dominates enough for query-dependent block routing to win on Apple Silicon. Smaller image shapes do not cross that point, so the production policy admits only sequences of at least 12,000 tokens and otherwise leaves execution unchanged.

The first two transformer layers, leading 20% of the denoise schedule, and final step stay dense. A once-per-shape numerical gate fails closed to the existing dense path. Set `MERERUN_DYNAMIC_SPARSE_ATTENTION=0` to disable the default.

## Measured Z-Image impact

The qualification used Z-Image Turbo at 1792x1792, four steps, seed 4242, on the same machine and prompt:

| Route | Generation time |
| --- | ---: |
| warm dense control | 151.41 s |
| qualified sparse route | 133.03 s |

That is a 12.1% warm-run improvement. A separate auto-policy candidate completed in 136.57 s, including its first candidate bundle installation. Peak memory stayed effectively flat at about 109.8 GB.

The dense controls were byte-identical to each other. The qualified sparse and auto-policy artifacts were also byte-identical to each other and passed visual inspection. At 512x512, auto-policy and explicitly disabled runs were byte-identical, proving that ordinary shapes stay on the existing dense path.

The production dense-route gate measured max relative error 0.0113346, mean relative error 0.00117182, and relative L2 error 0.00224186, within the validated 1.5% route limit. Because sparse attention is approximate, same-seed high-resolution output may differ from dense generation.

## Shared-kernel H3 regression

After rebasing onto the merged H3 implementation, a fresh release-mode 768x448, 124-frame LightX2V render exercised the shared kernel at 12,947 packed rows and four evaluations:

- real 56-head dense-route gate passed at `max_rel=0.00303665` and `rel_l2=0.0020252`
- denoising completed in 466.437 s; sparse steady state took 106.078 s versus the final protected dense step at 146.184 s
- native generation completed in 564.565 s with zero swaps and a 68.04 GB peak footprint
- output contains exactly 124 H.264 frames at 768x448/24 fps plus 32 kHz stereo AAC for 5.167 s
- contact-sheet inspection retained both actors, faces, recorder handoff, train motion, and shot continuity without sparse corruption

Artifact SHA-256: `58d2f7387192cbcc08bee15abbd393cdd0e8e2862085cba8fb9b9b053e25833f`.

## Validation

- `./scripts/check.sh`
  - strict lint across 1,166 Swift files
  - 2,588 XCTest cases, 172 expected skips, 0 failures
  - 25 Swift Testing checks, 0 failures
  - build, CLI help sweep, and hygiene scans
- `swift test --filter DynamicSparseAttentionTests --jobs 2` — 3/3 passed
- `MERERUN_TEST_MLX_DEVICE=gpu swift test --filter 'MiniMaxH3Tests/testDynamicSparseMetal' --jobs 2` — 3/3 passed on Metal
- `pnpm docs:build`
- real 1792x1792 dense/sparse/auto Z-Image artifact comparison
- 512x512 byte-for-byte dense fallback comparison
- fresh real H3 shared-kernel synchronized A/V regression above
