### PR TITLE
Add managed MiniMax-H3 Ref2VA 8-bit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,15 @@ The format is based on Keep a Changelog.
 
 ### Video
 
+- added `video-minimax-h3-ref2va-mlx` as a self-contained explicit managed
+  pull from the immutable public `Sawfwair/MiniMax-H3-Ref2VA-MLX-8bit`
+  artifact. Its transformer and conditioner use MLX affine INT8/group-64;
+  8-bit is the supported Ref2VA quality floor.
+- fixed the MiniMax-H3 ConvRot converter to honor each source tensor's embedded
+  rotation group independently from MLX's output quantization group. The
+  corrected release reverses group-256 transformer matrices and group-64 AdaLN
+  matrices before requantizing to MLX affine INT8/group-64, and the managed
+  model validates the pinned source/output receipt.
 - added `minimax-h3-lightx2v-4step` as a second immutable, checksum-pinned
   MiniMax-H3 managed adapter. The native runtime reads LightX2V's published
   312-pair PEFT checkpoint directly, preserves its separate Q/K/V projections

--- a/README.md
+++ b/README.md
@@ -785,10 +785,11 @@ swift run mere.run video generate \
   --h3-adapter minimax-h3-lightx2v-4step \
   --output ./street-dialogue-h3.mp4
 
-# A locally converted Ref2VA root preserves reference order semantically
+# Managed 8-bit Ref2VA preserves reference order semantically
+swift run mere.run model pull video-minimax-h3-ref2va-mlx --accept-model-license
 swift run mere.run video generate \
   "keep the subject, borrow the camera move, and follow the vocal rhythm" \
-  --model-root ./MiniMax-H3-Ref2VA-MLX \
+  --model video-minimax-h3-ref2va-mlx \
   --reference image:./subject.png \
   --reference video:./camera-and-soundtrack.mp4 \
   --reference audio:./voice.wav \

--- a/Sources/MereRunCLI/Commands/VideoCommand.swift
+++ b/Sources/MereRunCLI/Commands/VideoCommand.swift
@@ -244,7 +244,7 @@ struct VideoGenerate: AsyncParsableCommand {
           swift run mere.run video generate "dialogue with clean background music" --quality final --output-mode audio-video --duration 15 --fps 24
           swift run mere.run video generate "a kinetic live performance" --audio song.wav --audio-start-time 30 --duration 5 --image performer.png
           swift run mere.run video generate "the camera walks forward" --model video-wan22-ti2v-5b-mlx --image frame.png --num-frames 41 --width 1280 --height 704
-          swift run mere.run video generate "use this subject and motion" --model-root ./MiniMax-H3-Ref2VA-MLX --reference image:subject.png --reference video:motion.mp4
+          swift run mere.run video generate "use this subject and motion" --model video-minimax-h3-ref2va-mlx --reference image:subject.png --reference video:motion.mp4
           swift run mere.run video generate "one continuous tracking shot" --model minimax-h3-fl2va-bf16-mlx --duration 15 --h3-window-frames 124 --h3-window-overlap 35
           swift run mere.run video generate "the actor crosses three sets" --model minimax-h3-fl2va-bf16-mlx --h3-frame 72:second-set.png --h3-frame 144:third-set.png
         """

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -2551,12 +2551,17 @@ public enum ManagedModelCatalog {
             id: ModelResolver.ModelID.miniMaxH3Ref2VAMLX.rawValue,
             category: .video,
             installShape: .structuredRoot,
-            upstreamRepoId: MiniMaxH3Resources.conversionSourceRepository,
-            upstreamRevision: MiniMaxH3Resources.conversionSourceRevision,
+            hubFallback: HubFallbackConfig(
+                repoId: MiniMaxH3Resources.ref2vaArtifactRepository,
+                revision: MiniMaxH3Resources.ref2vaArtifactRevision,
+                patterns: MiniMaxH3Resources.ref2vaArtifactFiles
+            ),
+            upstreamRepoId: MiniMaxH3Resources.ref2vaArtifactRepository,
+            upstreamRevision: MiniMaxH3Resources.ref2vaArtifactRevision,
             usageRestriction: miniMaxH3UsageRestriction,
             validationKind: .miniMaxH3MLX,
             runtimeAutoDownloadAllowed: false,
-            estimatedDownloadBytes: 70_060_217_720,
+            estimatedDownloadBytes: 70_067_281_810,
             defaultCLICommands: ["video generate"]
         ),
         ManagedModelSpec(
@@ -3018,6 +3023,18 @@ public extension ManagedModelSpec {
                 let expectedTask = id == ModelResolver.ModelID.miniMaxH3Ref2VAMLX.rawValue ? "ref2va" : "fl2va"
                 guard configuration.task == expectedTask else {
                     return ["MiniMax-H3 model \(id) requires partition \(expectedTask), got \(configuration.task)."]
+                }
+                if id == ModelResolver.ModelID.miniMaxH3Ref2VAMLX.rawValue {
+                    let expectedQuantization = MiniMaxH3QuantizationConfiguration(
+                        bits: 8,
+                        groupSize: 64,
+                        mode: "affine"
+                    )
+                    guard configuration.quantization == expectedQuantization,
+                          configuration.textEncoderQuantization == expectedQuantization else {
+                        return ["MiniMax-H3 Ref2VA requires MLX affine INT8/group-64 transformer and conditioner weights."]
+                    }
+                    return resources.validateManagedRef2VAArtifact(fileManager: fileManager)
                 }
                 return []
             } catch {

--- a/Sources/MereRunCore/ManagedModelSupport.swift
+++ b/Sources/MereRunCore/ManagedModelSupport.swift
@@ -936,7 +936,7 @@ public enum ManagedModelCapabilityCatalog {
             descriptor(
                 ModelResolver.ModelID.miniMaxH3Ref2VAMLX.rawValue,
                 "MiniMax-H3 Ref2VA MLX",
-                "Runs a locally converted Ref2VA root with ordered image, video, and audio references; no redistributable managed snapshot is bundled.",
+                "Runs the explicit-pull 8-bit Ref2VA package with ordered image, video, and audio references and synchronized generated audio.",
                 minimum: 96,
                 recommended: 128
             ),

--- a/Sources/MereRunCore/MereRunModelManifest.swift
+++ b/Sources/MereRunCore/MereRunModelManifest.swift
@@ -2037,7 +2037,7 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
                     vae: .local(path: "."),
                     scheduler: nil
                 ),
-                upstreamRepoId: "\(MiniMaxH3Resources.conversionSourceRepository)@\(MiniMaxH3Resources.conversionSourceRevision)",
+                upstreamRepoId: "\(MiniMaxH3Resources.ref2vaArtifactRepository)@\(MiniMaxH3Resources.ref2vaArtifactRevision)",
                 createdAt: createdAt
             )
         case .cosmos3EdgeMLX:

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Resources.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Resources.swift
@@ -23,6 +23,42 @@ public struct MiniMaxH3QuantizationConfiguration: Codable, Hashable, Sendable {
     }
 }
 
+struct MiniMaxH3Ref2VAConversionReceipt: Decodable, Sendable {
+    struct FileIdentity: Decodable, Sendable {
+        let byteCount: Int64
+        let filename: String
+        let repository: String?
+        let revision: String?
+        let sha256: String
+
+        enum CodingKeys: String, CodingKey {
+            case byteCount = "byte_count"
+            case filename
+            case repository
+            case revision
+            case sha256
+        }
+    }
+
+    let converter: String
+    let converterVersion: Int
+    let partition: String
+    let source: FileIdentity
+    let output: FileIdentity
+    let sourceConvRotGroups: [String: Int]
+    let quantization: MiniMaxH3QuantizationConfiguration
+
+    enum CodingKeys: String, CodingKey {
+        case converter
+        case converterVersion = "converter_version"
+        case partition
+        case source
+        case output
+        case sourceConvRotGroups = "source_convrot_groups"
+        case quantization
+    }
+}
+
 public struct MiniMaxH3Configuration: Decodable, Hashable, Sendable {
     public let modelType: String
     public let task: String
@@ -169,14 +205,19 @@ public struct MiniMaxH3Resources: Sendable {
     public static let artifactRevision = "e1244ad93d60c737c7e0f065a1c9372f3de7caf8"
     public static let bf16ArtifactRepository = "pipenetwork/MiniMax-H3-MLX-bf16"
     public static let bf16ArtifactRevision = "1486555759eed9e3037edf29f9e055a0713bab2f"
+    public static let ref2vaArtifactRepository = "Sawfwair/MiniMax-H3-Ref2VA-MLX-8bit"
+    public static let ref2vaArtifactRevision = "abb9114fe9d6e3cccc6376eee1abaf09d3f2a9fe"
     public static let bf16TransformerDirectory = "transformer-bf16"
     public static let officialTransformerSourceIdentity =
         "MiniMaxAI/MiniMax-H3@ec19cc6daf5d8add9417c18e86b6b58cc6c55027:"
         + "FL2VA/transformer:index-sha256:fb457a26ffa6294660e249b0ddd03a337f2e5393f770b5c34c8b8f90a29a7efb"
     public static let conversionSourceRepository = "Comfy-Org/MiniMax-H3"
     public static let conversionSourceRevision = "fd70b39279d1ae6eb214c903f53e1bec3af19a77"
+    public static let ref2vaSourceFilename = "minimax_h3_ref2va_int8_convrot.safetensors"
     public static let ref2vaSourceSHA256 = "9eef934046a0671bc8a5daf87100705e1478419c574cfde70c50fbe6885f76a9"
-    public static let ref2vaConvertedSHA256 = "c3ddde0dc29503281cd4c03c1f82b9cb640f4670da68caa5f55e3cec8f2045e8"
+    public static let ref2vaSourceByteCount: Int64 = 34_038_894_550
+    public static let ref2vaConvertedSHA256 = "234f22f69f8d40d6ed81cceed8259fa287f3c9417d40fba5274e3a7aa84e18a2"
+    public static let ref2vaConvertedByteCount: Int64 = 36_024_412_656
 
     public static let requiredFiles = [
         "config.json",
@@ -199,6 +240,11 @@ public struct MiniMaxH3Resources: Sendable {
     public static let bf16SupportArtifactFiles = compactArtifactFiles.filter {
         $0 != "transformer.safetensors" && $0 != MiniMaxH3AdaLNCache.filename
     }
+    public static let ref2vaArtifactFiles = requiredFiles + [
+        "SOURCE_MANIFEST.json",
+        "transformer.conversion.json",
+        "SHA256SUMS",
+    ]
     public static let bf16ArtifactFiles = [
         "README.md",
         "LICENSE",
@@ -229,6 +275,7 @@ public struct MiniMaxH3Resources: Sendable {
     public var videoVAEWeightsURL: URL { rootURL.appending(path: "video_vae.safetensors") }
     public var audioVAEWeightsURL: URL { rootURL.appending(path: "audio_vae.safetensors") }
     public var adaLNCacheURL: URL { rootURL.appending(path: MiniMaxH3AdaLNCache.filename) }
+    public var conversionReceiptURL: URL { rootURL.appending(path: "transformer.conversion.json") }
 
     public func transformerWeightsLayout(fileManager: FileManager = .default) -> TransformerWeightsLayout? {
         if fileManager.fileExists(atPath: bf16TransformerIndexURL.path) {
@@ -339,5 +386,75 @@ public struct MiniMaxH3Resources: Sendable {
             throw MiniMaxH3ResourcesError.invalidConfiguration(configURL, issues.joined(separator: "; "))
         }
         return configuration
+    }
+
+    func validateManagedRef2VAArtifact(fileManager: FileManager = .default) -> [String] {
+        let requiredProvenance = [
+            rootURL.appending(path: "SOURCE_MANIFEST.json"),
+            conversionReceiptURL,
+            rootURL.appending(path: "SHA256SUMS"),
+        ]
+        let missing = requiredProvenance.filter { !fileManager.fileExists(atPath: $0.path) }
+        guard missing.isEmpty else {
+            return missing.map { "Missing required Ref2VA provenance file: \($0.lastPathComponent)" }
+        }
+
+        let receipt: MiniMaxH3Ref2VAConversionReceipt
+        do {
+            receipt = try JSONDecoder().decode(
+                MiniMaxH3Ref2VAConversionReceipt.self,
+                from: Data(contentsOf: conversionReceiptURL)
+            )
+        } catch {
+            return ["Invalid Ref2VA conversion receipt: \(error.localizedDescription)"]
+        }
+
+        var issues: [String] = []
+        if receipt.converter != "scripts/model-conversion/convert_minimax_h3_convrot.py"
+            || receipt.converterVersion != 2 {
+            issues.append("Ref2VA conversion receipt must use the pinned ConvRot converter version 2.")
+        }
+        if receipt.partition != "ref2va" {
+            issues.append("Ref2VA conversion receipt partition must be ref2va.")
+        }
+        if receipt.source.repository != Self.conversionSourceRepository
+            || receipt.source.revision != Self.conversionSourceRevision
+            || receipt.source.filename != Self.ref2vaSourceFilename
+            || receipt.source.byteCount != Self.ref2vaSourceByteCount
+            || receipt.source.sha256 != Self.ref2vaSourceSHA256 {
+            issues.append("Ref2VA conversion receipt does not match the pinned source artifact.")
+        }
+        if receipt.output.filename != transformerWeightsURL.lastPathComponent
+            || receipt.output.repository != nil
+            || receipt.output.revision != nil
+            || receipt.output.byteCount != Self.ref2vaConvertedByteCount
+            || receipt.output.sha256 != Self.ref2vaConvertedSHA256 {
+            issues.append("Ref2VA conversion receipt does not match the pinned MLX transformer.")
+        }
+        if receipt.sourceConvRotGroups != ["64": 50, "256": 200] {
+            issues.append("Ref2VA conversion receipt has unexpected ConvRot source-group counts.")
+        }
+        if receipt.quantization != MiniMaxH3QuantizationConfiguration(
+            bits: 8,
+            groupSize: 64,
+            mode: "affine"
+        ) {
+            issues.append("Ref2VA conversion receipt must declare MLX affine INT8/group-64 output.")
+        }
+        let actualBytes = try? transformerWeightsURL.resourceValues(forKeys: [.fileSizeKey]).fileSize
+        if Int64(actualBytes ?? -1) != Self.ref2vaConvertedByteCount {
+            issues.append("Ref2VA transformer byte count does not match the pinned artifact.")
+        }
+        do {
+            let metadata = try transformerMetadata()
+            if metadata["quantization"] != "affine 8-bit g64"
+                || metadata["source_repository"] != Self.conversionSourceRepository
+                || metadata["source_revision"] != Self.conversionSourceRevision {
+                issues.append("Ref2VA transformer metadata does not match the pinned conversion source.")
+            }
+        } catch {
+            issues.append("Ref2VA transformer metadata is invalid: \(error.localizedDescription)")
+        }
+        return issues
     }
 }

--- a/Sources/MereRunCore/MiniMaxH3/README.md
+++ b/Sources/MereRunCore/MiniMaxH3/README.md
@@ -104,14 +104,20 @@ source manifest and conversion hashes alongside the runtime files. Its 52
 fused transformer QKV matrices are deinterleaved from the released per-head
 rows into the global Q/K/V slabs expected by the native runtime before Q4
 packing.
-Ref2VA is a local conversion lane because this repository does not publish a
-redistributable converted snapshot. Convert the pinned
-`Comfy-Org/MiniMax-H3` ConvRot source with
-`scripts/model-conversion/convert_minimax_h3_convrot.py`, then stage the
-result as `transformer.safetensors` beside the FL package's exact conditioner,
-VAEs, tokenizer, configuration, license, notice, and modification files.
-Change only `partition` in `config.json` to `ref2va`; retain the conversion
-receipt next to the root as provenance.
+The explicit-pull Ref2VA package is published as
+`Sawfwair/MiniMax-H3-Ref2VA-MLX-8bit` and pinned to Hub commit
+`abb9114fe9d6e3cccc6376eee1abaf09d3f2a9fe`. Its transformer comes from the exact
+`Comfy-Org/MiniMax-H3@fd70b39279d1ae6eb214c903f53e1bec3af19a77` ConvRot
+source through `scripts/model-conversion/convert_minimax_h3_convrot.py`. The
+converter reads each tensor's embedded ConvRot group size (256 for the 200
+transformer matrices and 64 for the 50 AdaLN matrices) independently from the
+MLX affine output group size of 64. The published transformer is affine
+INT8/group-64, exactly 36,024,412,656 bytes with SHA-256
+`234f22f69f8d40d6ed81cceed8259fa287f3c9417d40fba5274e3a7aa84e18a2`.
+The conditioner is also affine INT8/group-64. Lower Ref2VA precision did not
+meet the visual quality bar, so 8-bit is the supported floor. The package is
+self-contained and retains its source manifest, conversion receipt, hashes,
+license, notice, and modification disclosure.
 
 The implementation follows the published MiniMax/Hugging Face architecture.
 No ComfyUI source is included or used at runtime.

--- a/Tests/MereRunCoreTests/MiniMaxH3Tests.swift
+++ b/Tests/MereRunCoreTests/MiniMaxH3Tests.swift
@@ -523,6 +523,116 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
         )
     }
 
+    func testManagedRef2VAProfileUsesPinnedPublicEightBitArtifact() throws {
+        XCTAssertEqual(
+            MiniMaxH3Resources.ref2vaArtifactRepository,
+            "Sawfwair/MiniMax-H3-Ref2VA-MLX-8bit"
+        )
+        XCTAssertEqual(MiniMaxH3Resources.ref2vaArtifactRevision.count, 40)
+        XCTAssertEqual(
+            MiniMaxH3Resources.ref2vaConvertedSHA256,
+            "234f22f69f8d40d6ed81cceed8259fa287f3c9417d40fba5274e3a7aa84e18a2"
+        )
+        XCTAssertEqual(MiniMaxH3Resources.ref2vaConvertedByteCount, 36_024_412_656)
+        XCTAssertTrue(MiniMaxH3Resources.ref2vaArtifactFiles.contains("SOURCE_MANIFEST.json"))
+        XCTAssertTrue(MiniMaxH3Resources.ref2vaArtifactFiles.contains("transformer.conversion.json"))
+        XCTAssertTrue(MiniMaxH3Resources.ref2vaArtifactFiles.contains("SHA256SUMS"))
+
+        let spec = try XCTUnwrap(
+            ManagedModelCatalog.spec(for: MiniMaxH3Resources.ref2vaModelID)
+        )
+        XCTAssertEqual(spec.hubFallback?.repoId, MiniMaxH3Resources.ref2vaArtifactRepository)
+        XCTAssertEqual(spec.hubFallback?.revision, MiniMaxH3Resources.ref2vaArtifactRevision)
+        XCTAssertEqual(spec.hubFallback?.patterns, MiniMaxH3Resources.ref2vaArtifactFiles)
+        XCTAssertEqual(spec.estimatedDownloadBytes, 70_067_281_810)
+
+        let manifest = MereRunModelManifest.template(
+            for: .miniMaxH3Ref2VAMLX,
+            createdAt: Date(timeIntervalSince1970: 0)
+        )
+        XCTAssertEqual(manifest.precision, .int8)
+        XCTAssertEqual(manifest.quantization?.bits, 8)
+        XCTAssertEqual(manifest.quantization?.groupSize, 64)
+        XCTAssertEqual(manifest.quantization?.scheme, "mlx-affine")
+        XCTAssertEqual(
+            manifest.upstreamRepoId,
+            "\(MiniMaxH3Resources.ref2vaArtifactRepository)@\(MiniMaxH3Resources.ref2vaArtifactRevision)"
+        )
+    }
+
+    func testManagedRef2VAArtifactValidationPinsConversionReceipt() throws {
+        let rootURL = FileManager.default.temporaryDirectory
+            .appending(path: "minimax-h3-ref2va-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: rootURL) }
+
+        for filename in ["SOURCE_MANIFEST.json", "SHA256SUMS"] {
+            try Data("{}".utf8).write(to: rootURL.appending(path: filename))
+        }
+        let receiptURL = rootURL.appending(path: "transformer.conversion.json")
+        let receipt = """
+        {
+          "converter": "scripts/model-conversion/convert_minimax_h3_convrot.py",
+          "converter_version": 2,
+          "output": {
+            "byte_count": 36024412656,
+            "filename": "transformer.safetensors",
+            "sha256": "234f22f69f8d40d6ed81cceed8259fa287f3c9417d40fba5274e3a7aa84e18a2"
+          },
+          "partition": "ref2va",
+          "quantization": {"bits": 8, "group_size": 64, "mode": "affine"},
+          "source": {
+            "byte_count": 34038894550,
+            "filename": "minimax_h3_ref2va_int8_convrot.safetensors",
+            "repository": "Comfy-Org/MiniMax-H3",
+            "revision": "fd70b39279d1ae6eb214c903f53e1bec3af19a77",
+            "sha256": "9eef934046a0671bc8a5daf87100705e1478419c574cfde70c50fbe6885f76a9"
+          },
+          "source_convrot_groups": {"256": 200, "64": 50}
+        }
+        """
+        try Data(receipt.utf8).write(to: receiptURL)
+
+        let metadata = [
+            "__metadata__": [
+                "quantization": "affine 8-bit g64",
+                "source_repository": MiniMaxH3Resources.conversionSourceRepository,
+                "source_revision": MiniMaxH3Resources.conversionSourceRevision,
+            ],
+        ]
+        let header = try JSONEncoder().encode(metadata)
+        var headerLength = UInt64(header.count).littleEndian
+        var transformer = withUnsafeBytes(of: &headerLength) { Data($0) }
+        transformer.append(header)
+        let transformerURL = rootURL.appending(path: "transformer.safetensors")
+        try transformer.write(to: transformerURL)
+        let handle = try FileHandle(forWritingTo: transformerURL)
+        try handle.truncate(atOffset: UInt64(MiniMaxH3Resources.ref2vaConvertedByteCount))
+        try handle.close()
+
+        let resources = MiniMaxH3Resources(rootURL: rootURL)
+        XCTAssertTrue(resources.validateManagedRef2VAArtifact().isEmpty)
+
+        try Data(receipt.replacingOccurrences(of: "\"256\": 200", with: "\"256\": 199").utf8)
+            .write(to: receiptURL)
+        XCTAssertTrue(resources.validateManagedRef2VAArtifact().contains { $0.contains("source-group counts") })
+    }
+
+    func testManagedRef2VAArtifactWhenAvailable() throws {
+        let environment = ProcessInfo.processInfo.environment
+        guard let root = environment["MERERUN_H3_REF2VA_MODEL_ROOT"], !root.isEmpty else {
+            throw XCTSkip("Set MERERUN_H3_REF2VA_MODEL_ROOT to validate the complete managed Ref2VA artifact.")
+        }
+        let spec = try XCTUnwrap(
+            ManagedModelCatalog.spec(for: MiniMaxH3Resources.ref2vaModelID)
+        )
+        let rootURL = URL(fileURLWithPath: root, isDirectory: true)
+        let messages = spec.validationMessages(in: rootURL)
+        XCTAssertTrue(messages.isEmpty, messages.joined(separator: "; "))
+        XCTAssertTrue(spec.isManagedRootComplete(rootURL))
+        XCTAssertTrue(spec.isManagedRuntimeReady(rootURL))
+    }
+
     func testCompactTransformerPreservesAdaLNCacheSourceIdentity() throws {
         let rootURL = FileManager.default.temporaryDirectory
             .appending(path: "minimax-h3-compact-\(UUID().uuidString)")

--- a/docs/benchmarks/minimax-h3-bf16-m4-max.md
+++ b/docs/benchmarks/minimax-h3-bf16-m4-max.md
@@ -105,10 +105,10 @@ SHA-256
 Contact-sheet inspection confirmed a coherent approach to and departure from
 the injected composition without collapse.
 
-These receipts prove FL2VA execution. The same typed continuation layout is
-covered for Ref2VA by unit tests, including continuation rows before ordered
-references and shifted target positions, but a real Ref2VA checkpoint was not
-installed for this run.
+These receipts prove FL2VA execution. Ref2VA now has a separate real-checkpoint
+validation receipt in
+[`minimax-h3-ref2va-mlx-8bit.md`](./minimax-h3-ref2va-mlx-8bit.md), in addition
+to the typed continuation-layout coverage here.
 
 The locked MP4 predates the audio-VAE bias-loading correction documented in
 the kernel lab. Its video remains the accepted visual and timing receipt, but

--- a/docs/benchmarks/minimax-h3-ref2va-mlx-8bit.md
+++ b/docs/benchmarks/minimax-h3-ref2va-mlx-8bit.md
@@ -1,0 +1,63 @@
+# MiniMax-H3 Ref2VA MLX 8-bit validation
+
+This receipt records the corrected managed Ref2VA artifact and one real native
+Swift/MLX generation on an Apple M4 Max MacBook Pro with 128 GB unified memory.
+It is correctness and usability evidence, not a claim of speed parity with
+FL2VA or LTX.
+
+## Artifact identity
+
+- managed ID: `video-minimax-h3-ref2va-mlx`
+- repository: `Sawfwair/MiniMax-H3-Ref2VA-MLX-8bit`
+- immutable revision: `abb9114fe9d6e3cccc6376eee1abaf09d3f2a9fe`
+- managed bytes: `70,067,281,810`
+- source: `Comfy-Org/MiniMax-H3@fd70b39279d1ae6eb214c903f53e1bec3af19a77`
+- source file bytes: `34,038,894,550`
+- source SHA-256: `9eef934046a0671bc8a5daf87100705e1478419c574cfde70c50fbe6885f76a9`
+- converted transformer bytes: `36,024,412,656`
+- converted transformer SHA-256:
+  `234f22f69f8d40d6ed81cceed8259fa287f3c9417d40fba5274e3a7aa84e18a2`
+
+The transformer and Qwen3-VL conditioner are MLX affine INT8/group-64. The
+video VAE is FP16 and the audio VAE is FP32. Lower Ref2VA precision did not
+meet the visual quality bar, so 8-bit is the published floor.
+
+## Conversion correction
+
+The source checkpoint stores per-tensor ConvRot metadata. Two different source
+rotation groups are present: group 256 for 200 transformer matrices and group
+64 for 50 AdaLN matrices. The faulty conversion treated the MLX output group
+size as though it were also the source rotation group, producing noise.
+
+The corrected converter reads and validates every tensor's embedded source
+group, reverses that regular-Hadamard basis, and only then requantizes the
+restored matrix to MLX affine INT8/group-64. Unit fixtures cover both source
+groups and mixed-group conversion. The final artifact records the toolchain,
+source identity, group counts, quantization, output size, and hash in
+`transformer.conversion.json`.
+
+Numerical checks on the corrected route measured approximately `1.729e-6`
+relative L2 error before MLX requantization and `0.0073349` for a packed linear
+operation after INT8 requantization.
+
+## Native generation receipt
+
+The full validation used real reference conditioning and maximum acceleration.
+It produced:
+
+- 512x320 H.264 video;
+- 124 frames at 24 fps (`5.167` seconds);
+- AAC stereo audio at 32 kHz;
+- wall time: `1,724.17` seconds;
+- MP4 SHA-256:
+  `08ce4cfb9fe305ba67297d94f6a54f3ce49c12bb8e242c38561cb6cb6237c9b0`.
+
+The output was visually coherent, retained usable motion and subject structure,
+and generated intelligible synchronized dialogue transcribed as: “You kept up
+the recording? Yeah. Every second.” A preceding 256x160, 22-frame smoke was
+also coherent. This establishes that the corrected artifact executes the real
+Ref2VA path without the all-noise failure.
+
+The 28-minute wall time confirms that this path remains substantially slower
+than desirable. The result should therefore enter the planned LTX/H3 bake-off
+as a quality and conditioning candidate, with performance measured separately.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1885,8 +1885,9 @@ FL2VA accepts `--image`, optional `--end-image`, and up to 12 repeatable
 `--h3-frame FRAME:PATH` conditions at exact zero-based output indices. Ref2VA
 accepts ordered `--reference` values and rejects FL2VA keyframe flags. H3 dimensions snap to
 32-pixel multiples, frame counts snap upward to `17*n+5`, and its
-CFG-distilled transformer needs one evaluation per schedule step. Ref2VA roots
-are locally converted; the public managed pull exists only for FL2VA.
+CFG-distilled transformer needs one evaluation per schedule step. Ref2VA is an
+explicit managed pull with an 8-bit transformer and conditioner; 8-bit is the
+published Ref2VA quality floor.
 When `--steps` is omitted, H3 selects 9, 16, or 21 schedule points from packed
 row cost. Maximum acceleration caps the automatic schedule at 12 points. Its
 source-bound AdaLN cache resamples the exact released 31-point
@@ -2002,9 +2003,10 @@ swift run mere.run video generate \
   --num-frames 65 \
   --output ./car-start-to-end.mp4
 
+swift run mere.run model pull video-minimax-h3-ref2va-mlx --accept-model-license
 swift run mere.run video generate \
   "keep the reference subject and follow the camera movement" \
-  --model-root ./MiniMax-H3-Ref2VA-MLX \
+  --model video-minimax-h3-ref2va-mlx \
   --reference image:./subject.png \
   --reference video:./camera.mp4 \
   --num-frames 124 \

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -824,17 +824,28 @@ QKV matrices are deinterleaved from MiniMax's released per-head row order into
 the global Q/K/V slabs consumed by the native runtime. Runtime auto-download is
 disabled.
 
-Ref2VA is conversion-only. The audited converter accepts only
+The explicit-pull Ref2VA root is the flat
+`Sawfwair/MiniMax-H3-Ref2VA-MLX-8bit` package pinned at immutable Hub commit
+`abb9114fe9d6e3cccc6376eee1abaf09d3f2a9fe`. Its 13-file managed download is exactly
+70,067,281,810 bytes and includes the complete runtime root plus source
+manifest, conversion receipt, hashes, license, notice, and modification
+disclosure. Runtime auto-download is disabled. Eight-bit is the supported
+Ref2VA floor because lower precision did not meet the visual quality bar.
+
+The audited release converter accepts only
 `minimax_h3_ref2va_int8_convrot.safetensors` from
 `Comfy-Org/MiniMax-H3@fd70b39279d1ae6eb214c903f53e1bec3af19a77`, exactly
 34,038,894,550 bytes with SHA-256
 `9eef934046a0671bc8a5daf87100705e1478419c574cfde70c50fbe6885f76a9`.
-It reverses the regular-Hadamard ConvRot basis, reproduces MLX affine INT8
-group-64 packing, and emits a hashed receipt. The verified conversion used for
-runtime validation is 36,024,412,656 bytes with SHA-256
-`c3ddde0dc29503281cd4c03c1f82b9cb640f4670da68caa5f55e3cec8f2045e8`.
-Stage it as `transformer.safetensors` beside the exact FL conditioner, VAEs,
-tokenizer, notices, and a `config.json` whose `partition` is `ref2va`.
+It validates each tensor's embedded ConvRot group size, reverses that
+regular-Hadamard basis, reproduces MLX affine INT8 group-64 packing, and emits
+a hashed receipt. The source uses group 256 for 200 transformer matrices and
+group 64 for 50 AdaLN matrices; these source groups are independent of MLX's
+output group size. The verified CPU conversion from the script's pinned
+PyTorch 2.7.1 toolchain is 36,024,412,656 bytes with SHA-256
+`234f22f69f8d40d6ed81cceed8259fa287f3c9417d40fba5274e3a7aa84e18a2`.
+It is published as `transformer.safetensors` beside the exact FL conditioner,
+VAEs, tokenizer, notices, and a `config.json` whose `partition` is `ref2va`.
 
 `convert_minimax_h3_official_mlx.py` creates the managed FL2VA package in one
 audited pass from the official release. It computes the source-bound AdaLN

--- a/docs/runtime/model-management.md
+++ b/docs/runtime/model-management.md
@@ -65,7 +65,10 @@ Examples:
 - vision: `vision-ocr-lighton`
 - music: `music-acestep`, `music-acestep-xl-turbo`, `music-acestep-xl-turbo-lm4b`, `music-acestep-xl-sft`, `music-acestep-xl-base`, `music-acestep-lm-1.7b`, `music-acestep-lm-4b`, `music-magenta-rt2-small`, `music-magenta-rt2-base`
 - sfx: `sfx-woosh-dflow`, `sfx-woosh-flow`, `sfx-woosh-clap`, `sfx-woosh-synchformer`, `sfx-woosh-dvflow-8s`, `sfx-woosh-vflow-8s`, `sfx-mmaudio-large-44k-v2`
-- video: `video-ltx-av`, `video-ltx23-av-mlx`, `video-ltx23-full-mlx`, `video-ltx23-a2vid-mlx`, `video-wan22-ti2v-5b-mlx`, `video-scail2-14b-mlx`
+- video: `video-minimax-h3-fl2va-mlx`, `video-minimax-h3-fl2va-bf16-mlx`,
+  `video-minimax-h3-ref2va-mlx`, `video-ltx-av`, `video-ltx23-av-mlx`,
+  `video-ltx23-full-mlx`, `video-ltx23-a2vid-mlx`,
+  `video-wan22-ti2v-5b-mlx`, `video-scail2-14b-mlx`
 
 The public runtime resolves these IDs directly, so docs and examples should use
 the canonical names shown by `mere.run model list`.

--- a/docs/runtime/video.md
+++ b/docs/runtime/video.md
@@ -59,12 +59,12 @@ are an escape hatch, not the capability contract.
   Q8 conditioner, FP16 video VAE, and FP32 audio VAE come from the same pinned
   native support package. The managed install is about 100 GB on disk; the
   active transformer is about 40 GB after the cached AdaLN tensors are omitted.
-- `video-minimax-h3-ref2va-mlx`: identifier for a locally converted Ref2VA
-  root. Repeated `--reference image:path|video:path|audio:path` options retain
-  request order. Video soundtracks are conditioned with their video; a
-  standalone audio reference must be paired with an image or video. There is
-  no managed Ref2VA download because mere.run does not publish a converted
-  copy of the territory-restricted weights.
+- `video-minimax-h3-ref2va-mlx`: explicit-pull 8-bit Ref2VA package. Repeated
+  `--reference image:path|video:path|audio:path` options retain request order.
+  Video soundtracks are conditioned with their video; a standalone audio
+  reference must be paired with an image or video. The transformer and Qwen
+  conditioner use MLX affine INT8/group-64; 8-bit is the published Ref2VA
+  quality floor.
 - `video-ltx23-av-mlx`: standalone distilled LTX 2.3 MLX checkpoint for fast
   drafts. This is the default `--quality draft` checkpoint.
 - `video-ltx23-full-mlx`: LTX 2.3 dev checkpoint, official distilled LoRA,
@@ -114,8 +114,9 @@ mere.run video generate "a superhero waits beneath an umbrella at a bus stop" \
   --h3-adapter minimax-h3-lightx2v-4step \
   --output ./bus-stop-turbo.mp4
 
+mere.run model pull video-minimax-h3-ref2va-mlx --accept-model-license
 mere.run video generate "preserve the person and use the reference motion" \
-  --model-root ./MiniMax-H3-Ref2VA-MLX \
+  --model video-minimax-h3-ref2va-mlx \
   --reference image:./person.png \
   --reference video:./motion.mp4 \
   --output ./ref2va.mp4

--- a/scripts/model-conversion/README.md
+++ b/scripts/model-conversion/README.md
@@ -7,22 +7,39 @@ These scripts are audited release tools. They are never invoked by a
 
 `convert_minimax_h3_convrot.py` converts either pinned MiniMax-H3 transformer
 partition from Comfy-Org's exact per-row ConvRot INT8 checkpoint into native
-MLX affine 8-bit tensors with group size 64. It first restores the unrotated
-weight basis, then reproduces MLX's affine scale, bias, and uint32 packing. It
-rejects any source whose filename, byte count, or SHA-256 differs from the
-pinned Hub revision and writes a hashed conversion receipt beside the output.
+MLX affine 8-bit tensors with group size 64. It reads and validates each
+tensor's embedded `convrot_groupsize` before restoring the unrotated weight
+basis; that source rotation group is independent of MLX's output group size.
+It then reproduces MLX's affine scale, bias, and uint32 packing. It rejects any
+source whose filename, byte count, or SHA-256 differs from the pinned Hub
+revision and writes a hashed conversion receipt beside the output.
 
-The converter only handles transformer weights. A self-contained native model
-root must also contain the pinned Qwen3-VL conditioner, video/audio VAEs,
-tokenizer, `config.json`, `LICENSE`, `NOTICE`, and `MODIFICATIONS.md` described
-by `Sources/MereRunCore/MiniMaxH3/README.md`.
+The converter only handles transformer weights. It is release tooling for the
+self-contained public Ref2VA package; users install that package with:
 
 ```bash
-python3 scripts/model-conversion/convert_minimax_h3_convrot.py \
+mere.run model pull video-minimax-h3-ref2va-mlx --accept-model-license
+```
+
+The package is `Sawfwair/MiniMax-H3-Ref2VA-MLX-8bit` at immutable Hub commit
+`abb9114fe9d6e3cccc6376eee1abaf09d3f2a9fe`. Alongside the transformer it carries the pinned
+Qwen3-VL conditioner, video/audio VAEs, tokenizer, `config.json`, `LICENSE`,
+`NOTICE`, `MODIFICATIONS.md`, source manifest, conversion receipt, and hashes.
+Eight-bit is the published Ref2VA quality floor; lower precision did not pass
+the visual quality check.
+
+```bash
+uv run --script scripts/model-conversion/convert_minimax_h3_convrot.py \
   --partition ref2va \
   --source minimax_h3_ref2va_int8_convrot.safetensors \
-  --output transformer.safetensors
+  --output transformer.safetensors \
+  --device cpu
 ```
+
+The script pins its Python conversion dependencies and defaults to CPU for a
+repeatable reference artifact. A different device is allowed for local use and
+is recorded in the receipt, but its byte hash can differ because quantization
+occurs at rounding boundaries.
 
 The MiniMax-H3 Community License restricts territory and redistribution.
 Conversion and use must occur in an allowed territory, and converted packages

--- a/scripts/model-conversion/convert_minimax_h3_convrot.py
+++ b/scripts/model-conversion/convert_minimax_h3_convrot.py
@@ -1,4 +1,13 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.12,<3.13"
+# dependencies = [
+#   "numpy==2.2.6",
+#   "packaging==26.3",
+#   "safetensors==0.6.2",
+#   "torch==2.7.1",
+# ]
+# ///
 """Convert a pinned Comfy-Kitchen ConvRot INT8 H3 transformer to MLX affine INT8.
 
 This is release tooling only. The native Swift runtime never invokes Python.
@@ -7,10 +16,13 @@ This is release tooling only. The native Swift runtime never invokes Python.
 from __future__ import annotations
 
 import argparse
+from collections import Counter
 import hashlib
+import importlib.metadata as importlib_metadata
 import json
 import math
 from pathlib import Path
+import platform
 
 import torch
 from safetensors import safe_open
@@ -31,7 +43,7 @@ SOURCE_FILES = {
         "sha256": "9eef934046a0671bc8a5daf87100705e1478419c574cfde70c50fbe6885f76a9",
     },
 }
-GROUP_SIZE = 64
+MLX_GROUP_SIZE = 64
 BITS = 8
 
 
@@ -73,25 +85,51 @@ def regular_hadamard(size: int, device: torch.device) -> torch.Tensor:
     return matrix / math.sqrt(size)
 
 
+def decode_convrot_group_size(config: torch.Tensor, key: str) -> int:
+    """Decode and validate one Comfy-Kitchen tensorwise ConvRot record."""
+    try:
+        payload = json.loads(bytes(config.tolist()).decode("utf-8").rstrip("\x00"))
+    except (UnicodeDecodeError, json.JSONDecodeError) as error:
+        raise ValueError(f"{key} is not valid UTF-8 JSON") from error
+    if payload.get("format") != "int8_tensorwise" or payload.get("convrot") is not True:
+        raise ValueError(f"{key} is not an INT8 tensorwise ConvRot record")
+    group_size = payload.get("convrot_groupsize")
+    if not isinstance(group_size, int):
+        raise ValueError(f"{key} has no integer convrot_groupsize")
+    if group_size < 4 or group_size & (group_size - 1) or not math.log(group_size, 4).is_integer():
+        raise ValueError(f"{key} has invalid ConvRot group size {group_size}")
+    return group_size
+
+
 def undo_convrot(
     codes: torch.Tensor,
     row_scales: torch.Tensor,
     hadamard: torch.Tensor,
+    group_size: int,
 ) -> torch.Tensor:
     """Dequantize per-row symmetric INT8 and restore the original weight basis."""
     rows, columns = codes.shape
-    if columns % GROUP_SIZE:
-        raise ValueError(f"ConvRot input width {columns} is not divisible by {GROUP_SIZE}")
+    if hadamard.shape != (group_size, group_size):
+        raise ValueError(
+            f"ConvRot basis has shape {tuple(hadamard.shape)}; expected {(group_size, group_size)}"
+        )
+    if columns % group_size:
+        raise ValueError(f"ConvRot input width {columns} is not divisible by {group_size}")
     rotated = codes.to(torch.float32) * row_scales.to(torch.float32)
-    return torch.matmul(rotated.reshape(rows, -1, GROUP_SIZE), hadamard.T).reshape(rows, columns)
+    return torch.matmul(
+        rotated.reshape(rows, -1, group_size),
+        hadamard.T,
+    ).reshape(rows, columns)
 
 
 def mlx_affine_quantize(weight: torch.Tensor) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
     """Reproduce MLX affine 8-bit/group-64 quantization and uint32 packing."""
     rows, columns = weight.shape
-    if columns % GROUP_SIZE:
-        raise ValueError(f"MLX affine input width {columns} is not divisible by {GROUP_SIZE}")
-    grouped = weight.reshape(rows, -1, GROUP_SIZE)
+    if columns % MLX_GROUP_SIZE:
+        raise ValueError(
+            f"MLX affine input width {columns} is not divisible by {MLX_GROUP_SIZE}"
+        )
+    grouped = weight.reshape(rows, -1, MLX_GROUP_SIZE)
     minimum = grouped.amin(dim=-1)
     maximum = grouped.amax(dim=-1)
     scale = torch.maximum((maximum - minimum) / 255.0, torch.tensor(1e-7, device=weight.device))
@@ -108,14 +146,16 @@ def mlx_affine_quantize(weight: torch.Tensor) -> tuple[torch.Tensor, torch.Tenso
     return packed.cpu(), scale.to(torch.bfloat16).cpu(), bias.to(torch.bfloat16).cpu()
 
 
-def convert(source: Path, output: Path, device: torch.device) -> None:
+def convert(source: Path, output: Path, device: torch.device) -> dict[int, int]:
     if output.exists():
         raise ValueError(f"Output path already exists: {output}")
     output.parent.mkdir(parents=True, exist_ok=True)
     converted: dict[str, torch.Tensor] = {}
     with safe_open(source, framework="pt", device="cpu") as archive:
         keys = set(archive.keys())
-        hadamard = regular_hadamard(GROUP_SIZE, device)
+        hadamards: dict[int, torch.Tensor] = {}
+        convrot_group_counts: Counter[int] = Counter()
+        used_config_keys: set[str] = set()
         quantized_count = 0
         dense_count = 0
         for index, key in enumerate(sorted(keys), start=1):
@@ -124,18 +164,42 @@ def convert(source: Path, output: Path, device: torch.device) -> None:
             value = archive.get_tensor(key)
             scale_key = f"{key}_scale"
             if key.endswith(".weight") and value.dtype == torch.int8 and scale_key in keys:
+                base = key.removesuffix(".weight")
+                config_key = f"{base}.comfy_quant"
+                if config_key not in keys:
+                    raise ValueError(f"{key} has {scale_key} but no {config_key}")
+                group_size = decode_convrot_group_size(
+                    archive.get_tensor(config_key),
+                    config_key,
+                )
+                hadamard = hadamards.get(group_size)
+                if hadamard is None:
+                    hadamard = regular_hadamard(group_size, device)
+                    hadamards[group_size] = hadamard
                 row_scales = archive.get_tensor(scale_key)
-                dense = undo_convrot(value.to(device), row_scales.to(device), hadamard)
+                dense = undo_convrot(
+                    value.to(device),
+                    row_scales.to(device),
+                    hadamard,
+                    group_size,
+                )
                 packed, scales, biases = mlx_affine_quantize(dense)
                 converted[key] = packed
-                converted[f"{key.removesuffix('.weight')}.scales"] = scales
-                converted[f"{key.removesuffix('.weight')}.biases"] = biases
+                converted[f"{base}.scales"] = scales
+                converted[f"{base}.biases"] = biases
                 quantized_count += 1
+                convrot_group_counts[group_size] += 1
+                used_config_keys.add(config_key)
                 del dense, packed, scales, biases
             else:
                 converted[key] = value.contiguous()
                 dense_count += 1
             print(f"[{index}/{len(keys)}] {key}", flush=True)
+
+        config_keys = {key for key in keys if key.endswith(".comfy_quant")}
+        if used_config_keys != config_keys:
+            unused = ", ".join(sorted(config_keys - used_config_keys))
+            raise ValueError(f"Unused ConvRot records: {unused}")
 
     save_file(
         converted,
@@ -148,12 +212,19 @@ def convert(source: Path, output: Path, device: torch.device) -> None:
             "source_revision": SOURCE_REVISION,
         },
     )
+    return dict(convrot_group_counts)
 
 
-def write_receipt(source: Path, output: Path, partition: str) -> None:
+def write_receipt(
+    source: Path,
+    output: Path,
+    partition: str,
+    convrot_group_counts: dict[int, int],
+    device: torch.device,
+) -> None:
     receipt = {
         "converter": "scripts/model-conversion/convert_minimax_h3_convrot.py",
-        "converter_version": 1,
+        "converter_version": 2,
         "partition": partition,
         "source": {
             "repository": SOURCE_REPOSITORY,
@@ -167,7 +238,21 @@ def write_receipt(source: Path, output: Path, partition: str) -> None:
             "byte_count": output.stat().st_size,
             "sha256": file_sha256(output),
         },
-        "quantization": {"bits": BITS, "group_size": GROUP_SIZE, "mode": "affine"},
+        "source_convrot_groups": {
+            str(group_size): count
+            for group_size, count in sorted(convrot_group_counts.items())
+        },
+        "toolchain": {
+            "device": str(device),
+            "python": platform.python_version(),
+            "safetensors": importlib_metadata.version("safetensors"),
+            "torch": torch.__version__,
+        },
+        "quantization": {
+            "bits": BITS,
+            "group_size": MLX_GROUP_SIZE,
+            "mode": "affine",
+        },
     }
     receipt_path = output.with_suffix(".conversion.json")
     receipt_path.write_text(json.dumps(receipt, indent=2, sort_keys=True) + "\n", encoding="utf-8")
@@ -180,14 +265,15 @@ def main() -> None:
     parser.add_argument("--partition", choices=sorted(SOURCE_FILES), required=True)
     parser.add_argument("--source", type=Path, required=True)
     parser.add_argument("--output", type=Path, required=True)
-    parser.add_argument("--device", default="cuda" if torch.cuda.is_available() else "cpu")
+    parser.add_argument("--device", default="cpu")
     args = parser.parse_args()
 
     source = args.source.expanduser().resolve()
     output = args.output.expanduser().resolve()
+    device = torch.device(args.device)
     verify_source(source, args.partition)
-    convert(source, output, torch.device(args.device))
-    write_receipt(source, output, args.partition)
+    convrot_group_counts = convert(source, output, device)
+    write_receipt(source, output, args.partition, convrot_group_counts, device)
     print(output)
 
 

--- a/scripts/model-conversion/tests/test_convert_minimax_h3_convrot.py
+++ b/scripts/model-conversion/tests/test_convert_minimax_h3_convrot.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+import importlib.util
+import json
+import math
+from pathlib import Path
+import tempfile
+import unittest
+
+import torch
+from safetensors import safe_open
+from safetensors.torch import save_file
+
+
+CONVERTER_PATH = Path(__file__).parents[1] / "convert_minimax_h3_convrot.py"
+SPEC = importlib.util.spec_from_file_location("convert_minimax_h3_convrot", CONVERTER_PATH)
+assert SPEC is not None and SPEC.loader is not None
+converter = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(converter)
+
+
+def config_tensor(group_size: int) -> torch.Tensor:
+    payload = json.dumps(
+        {
+            "format": "int8_tensorwise",
+            "convrot": True,
+            "convrot_groupsize": group_size,
+        }
+    ).encode("utf-8")
+    return torch.tensor(list(payload), dtype=torch.uint8)
+
+
+class MiniMaxH3ConvRotConverterTests(unittest.TestCase):
+    def test_decodes_source_convrot_group_independently_from_mlx_group(self) -> None:
+        self.assertEqual(
+            converter.decode_convrot_group_size(config_tensor(256), "layer.comfy_quant"),
+            256,
+        )
+        self.assertEqual(converter.MLX_GROUP_SIZE, 64)
+
+    def test_restored_weight_matches_rotated_activation_linear(self) -> None:
+        torch.manual_seed(20260810)
+        group_size = 256
+        codes = torch.randint(-127, 128, (3, group_size * 2), dtype=torch.int8)
+        scales = torch.tensor([[0.003], [0.007], [0.011]], dtype=torch.float32)
+        rotated_weight = codes.to(torch.float32) * scales
+        activation = torch.randn(4, group_size * 2)
+        hadamard = converter.regular_hadamard(group_size, torch.device("cpu"))
+
+        rotated_activation = torch.matmul(
+            activation.reshape(-1, group_size),
+            hadamard,
+        ).reshape_as(activation)
+        source_output = rotated_activation @ rotated_weight.T
+        restored_weight = converter.undo_convrot(
+            codes,
+            scales,
+            hadamard,
+            group_size,
+        )
+        restored_output = activation @ restored_weight.T
+
+        self.assertTrue(
+            torch.allclose(source_output, restored_output, rtol=2e-5, atol=2e-5),
+            msg=f"maximum error: {(source_output - restored_output).abs().max().item()}",
+        )
+
+    def test_conversion_uses_each_tensor_source_group_and_mlx_group64_output(self) -> None:
+        torch.manual_seed(7)
+        tensors: dict[str, torch.Tensor] = {"model.bias": torch.randn(4)}
+        for name, source_group in (("adaln", 64), ("attention", 256)):
+            rows = 4
+            tensors[f"{name}.weight"] = torch.randint(
+                -127,
+                128,
+                (rows, source_group),
+                dtype=torch.int8,
+            )
+            tensors[f"{name}.weight_scale"] = torch.rand(rows, 1) / math.sqrt(source_group)
+            tensors[f"{name}.comfy_quant"] = config_tensor(source_group)
+
+        with tempfile.TemporaryDirectory() as temporary_directory:
+            root = Path(temporary_directory)
+            source = root / "source.safetensors"
+            output = root / "output.safetensors"
+            save_file(tensors, source)
+
+            counts = converter.convert(source, output, torch.device("cpu"))
+
+            self.assertEqual(counts, {64: 1, 256: 1})
+            with safe_open(output, framework="pt", device="cpu") as archive:
+                self.assertEqual(tuple(archive.get_tensor("adaln.scales").shape), (4, 1))
+                self.assertEqual(tuple(archive.get_tensor("attention.scales").shape), (4, 4))
+                self.assertNotIn("adaln.comfy_quant", archive.keys())
+                self.assertNotIn("attention.weight_scale", archive.keys())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- publish and pin `Sawfwair/MiniMax-H3-Ref2VA-MLX-8bit@abb9114fe9d6e3cccc6376eee1abaf09d3f2a9fe` as the self-contained managed `video-minimax-h3-ref2va-mlx` package
- fix the ConvRot converter to read each tensor's source rotation group before requantizing to MLX affine INT8/group-64
- validate the published source/output receipt, hashes, sizes, group counts, metadata, and transformer/conditioner quantization during managed installation
- add converter fixtures, managed-model tests, CLI/docs updates, and a native generation receipt

## Root cause

The source checkpoint uses ConvRot group 256 for 200 transformer matrices and group 64 for 50 AdaLN matrices. The old converter reused the MLX output group size (64) as the source rotation group, so most matrices were restored in the wrong basis and generated noise.

The corrected converter treats source rotation grouping and MLX output quantization grouping as separate concerns. It reverses each recorded source basis, then emits MLX affine INT8/group-64 weights. Eight-bit is the supported Ref2VA quality floor; the earlier 4-bit result did not meet the visual quality bar.

## Artifact proof

- source: `Comfy-Org/MiniMax-H3@fd70b39279d1ae6eb214c903f53e1bec3af19a77`
- source file: `minimax_h3_ref2va_int8_convrot.safetensors`
- source bytes: `34,038,894,550`
- source SHA-256: `9eef934046a0671bc8a5daf87100705e1478419c574cfde70c50fbe6885f76a9`
- converted transformer bytes: `36,024,412,656`
- converted transformer SHA-256: `234f22f69f8d40d6ed81cceed8259fa287f3c9417d40fba5274e3a7aa84e18a2`
- managed runtime payload: 13 files, `70,067,281,810` bytes
- public Hub repository verified ungated at the immutable revision above

A normal `mere.run model pull video-minimax-h3-ref2va-mlx --accept-model-license` completed, recorded the requested/resolved Hub commit for all 13 files, installed the default manifest as INT8/group-64, and passed managed Ref2VA preflight as `reference_to_video_audio` with generated audio enabled.

## Native validation

A real Swift/MLX run produced a coherent 512x320, 124-frame, 24 fps MP4 with 32 kHz stereo audio. The 5.167-second output took 1,724.17 seconds wall time and had SHA-256 `08ce4cfb9fe305ba67297d94f6a54f3ce49c12bb8e242c38561cb6cb6237c9b0`.

This proves the corrected artifact executes the Ref2VA path without the prior all-noise failure. It is not a speed claim: the result remains slow and should enter the LTX/H3 bake-off as a quality and conditioning candidate.

## Validation

- `./scripts/check.sh` — pass (2,597 XCTest tests, 173 skipped, 0 failures; 25 Swift Testing tests)
- `pnpm docs:build` — pass
- converter unit suite — 3 tests pass
- managed receipt tests — pass with sparse fixture and the full published artifact
- normal managed pull, model-info validation, and Ref2VA video preflight — pass
