### PR TITLE
Add native Muse Glimmer 30B with DFlash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,35 @@ The format is based on Keep a Changelog.
 
 ### Text
 
+- added `vision-chat-muse-glimmer-30b`, an exact-revision managed Sawfwair
+  selective MLX Q4 conversion of Meta Muse Glimmer 30B with a fully native
+  Swift/MLX text and perception stack,
+  interleaved local image input, ATEM tool calls, controllable reasoning
+  strength, CLI/API routing, and audited affine Q4/group-64 conversion. The
+  converter now defaults to a selective 420-matrix layout that keeps the token
+  embedding and vision tower in BF16; the previous 721-matrix compact layout
+  remains available for explicit memory/speed experiments. The native loader
+  discovers quantized modules from checkpoint scales and accepts both released
+  and common MLX Hub key layouts. Vision preprocessing now reproduces the
+  released uint8 Lanczos path, and float32 position interpolation is covered by
+  exact upstream parity fixtures.
+  Managed pulls also install the pinned official 2.56B-parameter assistant;
+  native DFlash performs lossless target verification after text or image
+  prefill, defaults to the measured 3-proposal MLX block, reports acceptance
+  through `text chat --stats`, and falls back to serial target decode when
+  acceptance is poor. A one-time load warmup materializes both the serial target
+  cache and production DFlash verification graph before the first user-visible
+  decode. Two interleaved 128-token M4 Max release diagnostics with
+  the Q4 target improved from 14.73 to 20.07 tok/s on average (1.36x, 36.2%) at
+  54.9% acceptance. In a paired 8,192-token WikiText-2 candidate check,
+  selective Q4 measured 9.535 perplexity versus 9.554 for compact Q4 (mean NLL
+  delta -0.0020, 95% bootstrap CI -0.0035 to -0.0004). This is a bounded local
+  comparison, not full release-quality proof. A separately audited assistant-Q4
+  converter is retained, but BF16 is preferred because assistant quantization
+  was slower in that test.
+  The 21.38 GB artifact carries an exact conversion receipt plus Meta's original
+  license and usage policy; implicit download remains disabled and pulls require
+  explicit acceptance.
 - fixed `text chat --stream --quiet` so `--quiet` suppresses stderr diagnostics
   without disconnecting incremental generated text from stdout.
 

--- a/Package.swift
+++ b/Package.swift
@@ -338,6 +338,7 @@ targets.append(contentsOf: [
       "Krea2/README.md",
       "Laguna/README.md",
       "MuScriptor/README.md",
+      "MuseGlimmer/README.md",
       "LFM2/README.md",
       "LightOnOCR/README.md",
       "LTX/README.md",

--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ swift run mere.run model pull text-chat-lfm25-a1b-8bit --accept-model-license
 swift run mere.run model pull text-chat-laguna-s-2-1
 swift run mere.run model pull text-chat-laguna-xs-2-1
 swift run mere.run model pull text-chat-inkling-small
+swift run mere.run model pull vision-chat-muse-glimmer-30b --accept-model-license
 swift run mere.run model pull text-chat-bonsai-27b-1bit
 swift run mere.run model pull text-chat-bonsai-27b-2bit
 swift run mere.run model pull text-code-north-mini
@@ -314,6 +315,17 @@ swift run mere.run text chat \
   --model text-chat-inkling-small \
   --context-size 32768 \
   --prompt "Plan a recovery-safe repository migration."
+
+# Muse Glimmer is a pinned native Swift/MLX multimodal agent model. The pull
+# installs Sawfwair's 21.38 GB selective MLX Q4 target and Meta's 5.11 GB
+# official DFlash companion;
+# review their shared usage policy first.
+swift run mere.run text chat \
+  --model vision-chat-muse-glimmer-30b \
+  --image ./screenshot.png \
+  --reasoning-effort 0.8 \
+  --stats \
+  --prompt "Inspect this interface and propose the safest next action."
 
 # Pull and apply the promoted Mere Platform Assistant adapter
 swift run mere.run model pull text-chat-gemma4-12b-4bit

--- a/Sources/MereRunCLI/Commands/APIServeCommand.swift
+++ b/Sources/MereRunCLI/Commands/APIServeCommand.swift
@@ -58,6 +58,9 @@ struct APIServe: AsyncParsableCommand {
           # Start the DeepSeek V4 Flash OpenAI-compatible server
           mere.run api serve --engine text-chat-deepseek-v4-flash
 
+          # Start the native Muse Glimmer multimodal agent server
+          mere.run api serve --engine text-chat-muse-glimmer
+
           # Custom host/port (non-loopback binds require an API key)
           export MERERUN_API_KEY=change-me
           mere.run api serve --host 0.0.0.0 --port 11434 --api-key "$MERERUN_API_KEY"
@@ -139,10 +142,10 @@ struct APIServe: AsyncParsableCommand {
     @Option(name: [.long], help: "Host to bind to.")
     var host: String = "127.0.0.1"
 
-    @Option(name: [.customShort("m"), .long, .customLong("model-path")], help: "Model path. For --engine text-code, pass a GGUF file. For --engine text-chat-klein, pass a Klein-root text chat model. For --engine text-chat-gemma4, pass a Gemma 4 model root or repo ID. For --engine text-chat-laguna, pass text-chat-laguna-s-2-1, text-chat-laguna-xs-2-1, or an installed Laguna MLX root. For --engine text-chat-q36, pass a Qwen3.6 text chat model root. For --engine text-chat-lfm2, pass an LFM2 MLX model root or repo ID. For --engine text-chat-deepseek-v4-flash, pass a DS4 GGUF file or managed model root.")
+    @Option(name: [.customShort("m"), .long, .customLong("model-path")], help: "Model path. For --engine text-code, pass a GGUF file. For --engine text-chat-klein, pass a Klein-root text chat model. For --engine text-chat-gemma4, pass a Gemma 4 model root or repo ID. For --engine text-chat-laguna, pass text-chat-laguna-s-2-1, text-chat-laguna-xs-2-1, or an installed Laguna MLX root. For --engine text-chat-q36, pass a Qwen3.6 text chat model root. For --engine text-chat-lfm2, pass an LFM2 MLX model root or repo ID. For --engine text-chat-deepseek-v4-flash, pass a DS4 GGUF file or managed model root. For --engine text-chat-muse-glimmer, pass vision-chat-muse-glimmer-30b or an installed Muse Glimmer MLX root.")
     var model: String?
 
-    @Option(name: [.long], help: "Serving engine: text-chat-q36 (default; serves text-chat-q36-nano), text-code, text-chat-klein, text-chat-gemma4, text-chat-laguna, text-chat-lfm2, or text-chat-deepseek-v4-flash.")
+    @Option(name: [.long], help: "Serving engine: text-chat-q36 (default; serves text-chat-q36-nano), text-code, text-chat-klein, text-chat-gemma4, text-chat-laguna, text-chat-lfm2, text-chat-deepseek-v4-flash, or text-chat-muse-glimmer.")
     var engine: APIEngine = .textChatQ36
 
     @Option(name: [.long], help: "Default cataloged adapter id or local LoRA path for all requests.")
@@ -255,6 +258,8 @@ struct APIServe: AsyncParsableCommand {
             return CodeGenResources.defaultModelId
         case .textChatDeepseekV4Flash:
             return DeepseekV4FlashResources.defaultModelId
+        case .textChatMuseGlimmer:
+            return MuseGlimmerResources.modelId
         }
     }
 
@@ -337,6 +342,11 @@ struct APIServe: AsyncParsableCommand {
             // DeepseekV4FlashGenerator resolves and (if needed) downloads its own GGUF.
             // Honor an explicit --model path if provided.
             return model
+        case .textChatMuseGlimmer:
+            if let explicit = model {
+                return explicit
+            }
+            return ManagedModelResolver.resolveInstalledModel(id: MuseGlimmerResources.modelId)?.path
         }
     }
 
@@ -474,6 +484,7 @@ enum APIEngine: String, ExpressibleByArgument {
     case textChatQ35 = "text-chat-q35"
     case textChatLFM2 = "text-chat-lfm2"
     case textChatDeepseekV4Flash = "text-chat-deepseek-v4-flash"
+    case textChatMuseGlimmer = "text-chat-muse-glimmer"
 
     var runtimeServingEngine: RuntimeServingEngine {
         switch self {
@@ -493,6 +504,8 @@ enum APIEngine: String, ExpressibleByArgument {
             return .textChatLFM2
         case .textChatDeepseekV4Flash:
             return .textChatDeepseekV4Flash
+        case .textChatMuseGlimmer:
+            return .textChatMuseGlimmer
         }
     }
 
@@ -548,6 +561,13 @@ struct APIEngineCapabilities: Equatable, Sendable {
     static let localTextWithToolsAndVision = APIEngineCapabilities(
         supportsTools: true,
         supportsToolChoice: true,
+        supportsVisionContentParts: true
+    )
+
+    static let localTextWithToolsVisionAndReasoning = APIEngineCapabilities(
+        supportsTools: true,
+        supportsToolChoice: true,
+        supportsReasoningEffort: true,
         supportsVisionContentParts: true
     )
 
@@ -4592,7 +4612,7 @@ actor CodeGenServer {
         case .gemma, .laguna, .liquid, .qwen, .sam, .falcon, .terramind, .tessera, .olmoEarth,
              .face, .geometry, .depth, .threeD,
              .tts, .asr, .embed, .code, .ocr, .audio, .music, .sfx, .video, .psi, .privacy, .deepseek,
-             .inkling, nil:
+             .inkling, .muse, nil:
             throw APIRequestValidationError.invalidField(
                 "model",
                 "model \(resolved.modelID) is not an image generation model"

--- a/Sources/MereRunCLI/Commands/ImageGenerateCommand.swift
+++ b/Sources/MereRunCLI/Commands/ImageGenerateCommand.swift
@@ -390,7 +390,7 @@ struct ImageGenerate: AsyncParsableCommand {
             case .gemma, .laguna, .liquid, .qwen, .sam, .falcon, .terramind, .tessera, .olmoEarth,
                  .face, .geometry, .depth, .threeD,
                  .tts, .asr, .embed, .code, .ocr, .audio, .music, .sfx, .video, .psi, .privacy, .deepseek,
-                 .inkling, nil:
+                 .inkling, .muse, nil:
                 throw ValidationError("Unsupported image model family for `mere.run image generate`: \(manifest.id)")
             }
             try editPreparation?.finish(generatedURL: result.outputURL)

--- a/Sources/MereRunCLI/Commands/ModelBenchmarkVLMCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelBenchmarkVLMCommand.swift
@@ -338,6 +338,8 @@ struct ModelBenchmarkVLM: AsyncParsableCommand {
             return .textChatLFM2
         case .textChatDeepseekV4Flash:
             return .textChatDeepseekV4Flash
+        case .textChatMuseGlimmer:
+            return .textChatMuseGlimmer
         case .textCode:
             return .textCode
         }

--- a/Sources/MereRunCLI/Commands/OpenWebUICommand.swift
+++ b/Sources/MereRunCLI/Commands/OpenWebUICommand.swift
@@ -943,6 +943,8 @@ private extension APIEngine {
             self = .textChatLFM2
         case .textChatDeepseekV4Flash:
             self = .textChatDeepseekV4Flash
+        case .textChatMuseGlimmer:
+            self = .textChatMuseGlimmer
         }
     }
 }

--- a/Sources/MereRunCLI/Commands/TextChatCommand.swift
+++ b/Sources/MereRunCLI/Commands/TextChatCommand.swift
@@ -149,7 +149,7 @@ struct TextChat: AsyncParsableCommand {
             + firstTokenSeconds
     }
 
-    @Option(name: [.long], help: "Canonical model id. Default: text-chat-gemma4-12b-4bit (Apple Silicon) / text-chat-q36-nano-gguf (Linux CUDA). Others: text-chat-laguna-s-2-1, text-chat-laguna-xs-2-1, text-chat-inkling-small, text-chat-bonsai-27b-1bit, text-chat-bonsai-27b-2bit, text-chat-q36-nano, text-agent-ornith-9b, text-agent-ornith-35b-mlx, text-chat-gemma4[-12b|-12b-4bit|-turbo|-max|-nano], text-chat-lfm25-2.6b-4bit, text-chat-lfm25-a1b-8bit, text-chat-psi-agent.")
+    @Option(name: [.long], help: "Canonical model id. Default: text-chat-gemma4-12b-4bit (Apple Silicon) / text-chat-q36-nano-gguf (Linux CUDA). Others include vision-chat-muse-glimmer-30b, text-chat-laguna-s-2-1, text-chat-inkling-small, text-chat-bonsai-27b-1bit, text-chat-q36-nano, text-agent-ornith-9b, text-chat-gemma4[-12b|-12b-4bit|-turbo|-max|-nano], and text-chat-lfm25-a1b-8bit.")
     var model: String = TextChat.defaultChatModelId
 
     @Option(
@@ -270,6 +270,7 @@ struct TextChat: AsyncParsableCommand {
 
         let recommendedSampling = Q35Resources.recommendedSampling(forModelId: model)
         let isLaguna = LagunaResources.handles(modelSpec: normalizedModelId)
+        let isMuseGlimmer = MuseGlimmerResources.handles(modelSpec: normalizedModelId)
         let q35KVCacheMode = try resolveQ35KVCacheMode(for: normalizedModelId)
         if let contextSize, contextSize <= 0 {
             throw ValidationError("--context-size must be greater than zero.")
@@ -279,16 +280,21 @@ struct TextChat: AsyncParsableCommand {
             messages: messages,
             maxTokens: maxTokens,
             temperature: temperature
+                ?? (isMuseGlimmer ? MuseGlimmerResources.recommendedTemperature : nil)
                 ?? (isLaguna ? LagunaResources.recommendedTemperature : recommendedSampling?.temperature)
                 ?? 0.7,
             topP: topP
+                ?? (isMuseGlimmer ? MuseGlimmerResources.recommendedTopP : nil)
                 ?? (isLaguna ? LagunaResources.recommendedTopP : recommendedSampling?.topP)
                 ?? 0.9,
             topK: topK
+                ?? (isMuseGlimmer ? MuseGlimmerResources.recommendedTopK : nil)
                 ?? (isLaguna ? LagunaResources.recommendedTopK : recommendedSampling?.topK),
             minP: minP ?? (isLaguna ? LagunaResources.recommendedMinP : 0),
             reasoningEffort: reasoningEffort,
-            showThinking: requiresJSON ? false : (thinking ?? Q35Resources.thinkingDefault(forModelId: model)),
+            showThinking: requiresJSON
+                ? false
+                : (thinking ?? (isMuseGlimmer ? false : Q35Resources.thinkingDefault(forModelId: model))),
             lora: lora,
             requiresJSON: requiresJSON,
             tools: toolDefs,
@@ -308,6 +314,7 @@ struct TextChat: AsyncParsableCommand {
         }
         var lastGemma4MTPStats: Gemma4MTPStats?
         var lastLagunaDFlashStats: LagunaDFlashStats?
+        var lastMuseDFlashStats: MuseGlimmerDFlashStats?
         let lagunaGenerator = isLaguna
             ? LagunaGenerator(
                 dflashModelPath: LagunaResources.installedDFlashPath(
@@ -358,6 +365,15 @@ struct TextChat: AsyncParsableCommand {
             } else if InklingResources.handles(modelSpec: normalizedModelId) {
                 let generator = InklingGenerator(modelID: normalizedModelId)
                 return try await generator.chat(req, modelPath: runtimeModelRoot, progressHandler: progressHandler)
+            } else if MuseGlimmerResources.handles(modelSpec: normalizedModelId) {
+                let generator = MuseGlimmerGenerator(modelID: normalizedModelId)
+                let response = try await generator.chat(
+                    req,
+                    modelPath: runtimeModelRoot,
+                    progressHandler: progressHandler
+                )
+                lastMuseDFlashStats = await generator.dflashStats()
+                return response
             } else if LFM2Resources.handles(modelSpec: normalizedModelId) {
                 let effectiveModelId = normalizedModelId.isEmpty ? LFM2Resources.defaultModelId : normalizedModelId
                 let generator = LFM2Generator(modelId: effectiveModelId)
@@ -476,6 +492,9 @@ struct TextChat: AsyncParsableCommand {
                     if let dflash = lastLagunaDFlashStats {
                         CLIStderr.write(Self.formatLagunaDFlashStats(dflash) + "\n")
                     }
+                    if let dflash = lastMuseDFlashStats {
+                        CLIStderr.write(Self.formatMuseDFlashStats(dflash) + "\n")
+                    }
                 } else {
                     let line = String(format: "time=%.2fs tokens=%d tps=%.2f", elapsed, result.tokensGenerated, e2eTps)
                     CLIStderr.write("\(line)\n")
@@ -484,6 +503,9 @@ struct TextChat: AsyncParsableCommand {
                     }
                     if let dflash = lastLagunaDFlashStats {
                         CLIStderr.write(Self.formatLagunaDFlashStats(dflash) + "\n")
+                    }
+                    if let dflash = lastMuseDFlashStats {
+                        CLIStderr.write(Self.formatMuseDFlashStats(dflash) + "\n")
                     }
                 }
             }
@@ -576,6 +598,32 @@ struct TextChat: AsyncParsableCommand {
         )
     }
 
+    static func formatMuseDFlashStats(_ stats: MuseGlimmerDFlashStats) -> String {
+        let state: String
+        if stats.active {
+            state = "active"
+        } else if stats.enabled {
+            state = stats.assistantModelPath == nil ? "unavailable" : "fallback"
+        } else {
+            state = "disabled"
+        }
+        let reason = stats.reason.map { " reason=\($0)" } ?? ""
+        return String(
+            format: "muse_dflash=%@ proposals=%d rounds=%d drafted=%d accepted=%d acceptance=%.1f%% verify=%d recovery=%d fallback_forwards=%d adaptive_fallbacks=%d%@",
+            state,
+            stats.speculativeTokens,
+            stats.rounds,
+            stats.draftedTokens,
+            stats.acceptedTokens,
+            stats.acceptanceRate * 100,
+            stats.targetVerificationForwards,
+            stats.targetRecoveryForwards,
+            stats.targetFallbackForwards,
+            stats.adaptiveFallbacks,
+            reason
+        )
+    }
+
     static func validate(responseFormat: TextChatResponseFormat, modelID: String) throws {
         guard responseFormat == .jsonObject else { return }
         if ManagedModelCatalog.spec(for: modelID)?.validationKind == .codegenGGUF {
@@ -585,9 +633,10 @@ struct TextChat: AsyncParsableCommand {
         }
         if modelID == Psi3ChatResources.defaultModelId
             || LFM2Resources.handles(modelSpec: modelID)
-            || InklingResources.handles(modelSpec: modelID) {
+            || InklingResources.handles(modelSpec: modelID)
+            || MuseGlimmerResources.handles(modelSpec: modelID) {
             throw ValidationError(
-                "--response-format json_object is supported by native Gemma4 and Qwen-family MLX chat models."
+                "--response-format json_object is supported by native Gemma4 and Qwen-family MLX chat models; Muse Glimmer supports structured tool schemas but not constrained JSON decoding."
             )
         }
         if LagunaResources.handles(modelSpec: modelID) {
@@ -599,11 +648,16 @@ struct TextChat: AsyncParsableCommand {
 
     static func validateReasoningEffort(_ value: Double?, modelID: String) throws {
         guard let value else { return }
-        guard InklingResources.handles(modelSpec: modelID) else {
-            throw ValidationError("--reasoning-effort is supported only for Inkling-Small.")
+        guard InklingResources.handles(modelSpec: modelID)
+                || MuseGlimmerResources.handles(modelSpec: modelID) else {
+            throw ValidationError("--reasoning-effort is supported only for Inkling-Small and Muse Glimmer.")
         }
-        guard (0...0.99).contains(value) else {
-            throw ValidationError("--reasoning-effort must be between 0 and 0.99.")
+        let allowed = InklingResources.handles(modelSpec: modelID)
+            ? (0...0.99).contains(value)
+            : (0...1).contains(value)
+        guard allowed else {
+            let upper = InklingResources.handles(modelSpec: modelID) ? "0.99" : "1"
+            throw ValidationError("--reasoning-effort must be between 0 and \(upper).")
         }
     }
 

--- a/Sources/MereRunCLI/Support/InstalledModelGateSupport.swift
+++ b/Sources/MereRunCLI/Support/InstalledModelGateSupport.swift
@@ -175,7 +175,7 @@ enum InstalledModelSmokePlans {
                 try await runner.installedImageCheck(model: spec.id)
             }
 
-        case .gemma4, .gemma4Unified, .q35:
+        case .gemma4, .gemma4Unified, .q35, .museGlimmer:
             if spec.category == .visionOCR {
                 return direct(spec, route: "vision ocr") { runner in
                     try await runner.installedOCRCheck(model: spec.id)
@@ -219,6 +219,16 @@ enum InstalledModelSmokePlans {
                 installedIDs: installedIDs,
                 candidates: ["text-chat-laguna-s-2-1"],
                 route: "consumed by Laguna text chat"
+            ) { runner, primary in
+                try await runner.installedTextCheck(model: primary)
+            }
+
+        case .museGlimmerAssistant:
+            return companion(
+                spec,
+                installedIDs: installedIDs,
+                candidates: [MuseGlimmerResources.modelId],
+                route: "consumed by Muse Glimmer text and vision chat"
             ) { runner, primary in
                 try await runner.installedTextCheck(model: primary)
             }

--- a/Sources/MereRunCLI/Support/RuntimeModelPool.swift
+++ b/Sources/MereRunCLI/Support/RuntimeModelPool.swift
@@ -1630,6 +1630,11 @@ actor RuntimeModelPool {
                 DeepseekV4FlashGenerator(modelId: resolved.id),
                 modelPath: resolved.installPath
             )
+        case .textChatMuseGlimmer:
+            return .textChatMuseGlimmer(
+                MuseGlimmerGenerator(modelID: resolved.id),
+                modelPath: resolved.installPath
+            )
         }
     }
 
@@ -1853,6 +1858,8 @@ actor RuntimeModelPool {
              .textChatLFM2,
              .textChatDeepseekV4Flash:
             return ManagedModelCategory.textChat.rawValue
+        case .textChatMuseGlimmer:
+            return ManagedModelCategory.visionChat.rawValue
         }
     }
 
@@ -2171,6 +2178,7 @@ enum RuntimeLoadedModel: Sendable {
     case textChatQ35(Q35Generator, modelPath: String?)
     case textChatLFM2(LFM2Generator, modelPath: String?)
     case textChatDeepseekV4Flash(DeepseekV4FlashGenerator, modelPath: String?)
+    case textChatMuseGlimmer(MuseGlimmerGenerator, modelPath: String?)
 
     func prepare(progressHandler: (@Sendable (ChatProgress) -> Void)?) async throws {
         switch self {
@@ -2198,6 +2206,8 @@ enum RuntimeLoadedModel: Sendable {
             try await generator.prepare(modelPath: modelPath, progressHandler: progressHandler)
         case .textChatDeepseekV4Flash(let generator, let modelPath):
             try await generator.prepare(modelPath: modelPath, progressHandler: progressHandler)
+        case .textChatMuseGlimmer(let generator, let modelPath):
+            try await generator.prepare(modelPath: modelPath, progressHandler: progressHandler)
         }
     }
 
@@ -2217,6 +2227,8 @@ enum RuntimeLoadedModel: Sendable {
             await generator.unload()
         case .textChatDeepseekV4Flash(let generator, _):
             await generator.shutdown()
+        case .textChatMuseGlimmer(let generator, _):
+            await generator.unload()
         }
     }
 
@@ -2228,7 +2240,8 @@ enum RuntimeLoadedModel: Sendable {
             return await generator.prefixKVCacheStats()
         case .textChatLFM2(let generator, _):
             return await generator.prefixKVCacheStats()
-        case .textCode, .textChatKlein, .textChatLaguna, .textChatDeepseekV4Flash:
+        case .textCode, .textChatKlein, .textChatLaguna, .textChatDeepseekV4Flash,
+             .textChatMuseGlimmer:
             return nil
         }
     }
@@ -2243,7 +2256,7 @@ enum RuntimeLoadedModel: Sendable {
             return await generator.continuousBatchingStats()
         case .textChatLFM2(let generator, _):
             return await generator.continuousBatchingStats()
-        case .textCode, .textChatKlein, .textChatDeepseekV4Flash:
+        case .textCode, .textChatKlein, .textChatDeepseekV4Flash, .textChatMuseGlimmer:
             return nil
         }
     }
@@ -2253,7 +2266,7 @@ enum RuntimeLoadedModel: Sendable {
         case .textChatGemma4(let generator, _):
             return await generator.mtpStats()
         case .textCode, .textChatKlein, .textChatLaguna, .textChatQ35, .textChatLFM2,
-             .textChatDeepseekV4Flash:
+             .textChatDeepseekV4Flash, .textChatMuseGlimmer:
             return nil
         }
     }
@@ -2294,6 +2307,8 @@ enum RuntimeLoadedModel: Sendable {
             return try await generator.chat(request, modelPath: modelPath, progressHandler: progressHandler)
         case .textChatDeepseekV4Flash(let generator, let modelPath):
             return try await generator.chat(request, modelPath: modelPath, progressHandler: progressHandler)
+        case .textChatMuseGlimmer(let generator, let modelPath):
+            return try await generator.chat(request, modelPath: modelPath, progressHandler: progressHandler)
         }
     }
 
@@ -2307,7 +2322,7 @@ enum RuntimeLoadedModel: Sendable {
                 progressHandler: progressHandler
             )
         case .textCode, .textChatKlein, .textChatGemma4, .textChatLaguna, .textChatQ35,
-             .textChatLFM2:
+             .textChatLFM2, .textChatMuseGlimmer:
             throw RuntimeModelPoolError.rawProxyUnavailable("")
         }
     }
@@ -2330,6 +2345,8 @@ extension RuntimeServingEngine {
             return .localTextWithTools
         case .textChatDeepseekV4Flash:
             return .rawProxy
+        case .textChatMuseGlimmer:
+            return .localTextWithToolsVisionAndReasoning
         }
     }
 }

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -47,6 +47,8 @@ public enum ManagedModelValidationKind: String, Hashable, Sendable {
     case q35
     case lfm2
     case inkling
+    case museGlimmer
+    case museGlimmerAssistant
     case qwen3TTS
     case qwen3ASR
     case parakeet
@@ -1143,6 +1145,36 @@ public enum ManagedModelCatalog {
             runtimeAutoDownloadAllowed: false,
             estimatedDownloadBytes: InklingResources.estimatedDownloadBytes,
             defaultCLICommands: ["text chat", "text train-lora"]
+        ),
+        ManagedModelSpec(
+            id: MuseGlimmerResources.modelId,
+            category: .visionChat,
+            installShape: .directoryRoot,
+            hubFallback: HubFallbackConfig(
+                repoId: MuseGlimmerResources.artifactRepoId,
+                revision: MuseGlimmerResources.artifactRevision,
+                patterns: MuseGlimmerResources.snapshotPatterns
+            ),
+            upstreamRepoId: MuseGlimmerResources.artifactRepoId,
+            upstreamRevision: MuseGlimmerResources.artifactRevision,
+            usageRestriction: ManagedModelUsageRestriction(
+                summary: "Apache-2.0 model subject to Meta's bundled usage policy; upstream states it is not intended for download or use by people under 18.",
+                terms: [
+                    ManagedModelUsageTerm(
+                        component: "Muse Glimmer 30B",
+                        license: "Apache-2.0 with upstream usage policy",
+                        summary: "Review LICENSE and USAGE_POLICY.md before installing or deploying.",
+                        sourceRepoId: MuseGlimmerResources.upstreamRepoId,
+                        sourceRevision: MuseGlimmerResources.upstreamRevision,
+                        licenseURL: "https://huggingface.co/meta-models/Muse-Glimmer-30B/blob/\(MuseGlimmerResources.upstreamRevision)/USAGE_POLICY.md"
+                    ),
+                ]
+            ),
+            validationKind: .museGlimmer,
+            runtimeAutoDownloadAllowed: false,
+            estimatedDownloadBytes: MuseGlimmerResources.estimatedDownloadBytes,
+            defaultCLICommands: ["text chat", "api serve"],
+            companionModelIDs: [MuseGlimmerResources.assistantModelId]
         ),
         ManagedModelSpec(
             id: Q35Resources.q36NanoModelId,
@@ -2661,6 +2693,34 @@ private extension ManagedModelCatalog {
                 estimatedDownloadBytes: LagunaResources.dflashEstimatedDownloadBytes
             ),
             ManagedModelSpec(
+                id: MuseGlimmerResources.assistantModelId,
+                category: .textChat,
+                installShape: .directoryRoot,
+                hubFallback: HubFallbackConfig(
+                    repoId: MuseGlimmerResources.assistantUpstreamRepoId,
+                    revision: MuseGlimmerResources.assistantUpstreamRevision,
+                    patterns: MuseGlimmerResources.assistantSnapshotPatterns
+                ),
+                upstreamRepoId: MuseGlimmerResources.assistantUpstreamRepoId,
+                upstreamRevision: MuseGlimmerResources.assistantUpstreamRevision,
+                usageRestriction: ManagedModelUsageRestriction(
+                    summary: "Apache-2.0 model subject to Meta's bundled usage policy; upstream states it is not intended for download or use by people under 18.",
+                    terms: [
+                        ManagedModelUsageTerm(
+                            component: "Muse Glimmer 30B DFlash assistant",
+                            license: "Apache-2.0 with upstream usage policy",
+                            summary: "Review LICENSE and USAGE_POLICY.md before installing or deploying.",
+                            sourceRepoId: MuseGlimmerResources.assistantUpstreamRepoId,
+                            sourceRevision: MuseGlimmerResources.assistantUpstreamRevision,
+                            licenseURL: "https://huggingface.co/meta-models/Muse-Glimmer-30B-assistant/blob/\(MuseGlimmerResources.assistantUpstreamRevision)/USAGE_POLICY.md"
+                        ),
+                    ]
+                ),
+                validationKind: .museGlimmerAssistant,
+                runtimeAutoDownloadAllowed: false,
+                estimatedDownloadBytes: MuseGlimmerResources.assistantEstimatedDownloadBytes
+            ),
+            ManagedModelSpec(
                 id: ModelResolver.ModelID.ltxGemma3TwelveB4Bit.rawValue,
                 category: .textChat,
                 installShape: .directoryRoot,
@@ -2841,6 +2901,13 @@ public extension ManagedModelSpec {
             return LFM2Resources(rootURL: rootURL).validate(fileManager: fileManager)
         case .inkling:
             return InklingResources.validate(rootURL: rootURL, fileManager: fileManager)
+        case .museGlimmer:
+            return MuseGlimmerResources(rootURL: rootURL).validate(fileManager: fileManager)
+        case .museGlimmerAssistant:
+            return MuseGlimmerResources.validateAssistant(
+                rootURL: rootURL,
+                fileManager: fileManager
+            )
         case .sam31:
             return SAM31Resources(modelRootURL: rootURL).missingRequiredPaths(fileManager: fileManager)
         case .falconPerception:
@@ -3155,10 +3222,14 @@ public extension ManagedModelSpec {
     func managedRuntimeURL(fileManager: FileManager = .default) -> URL? {
         switch installShape {
         case .directoryRoot, .structuredRoot:
-            guard let modelID, let resolved = ModelResolver(fileManager: fileManager).resolveIfPresent(modelID) else {
-                return nil
+            if let modelID {
+                guard let resolved = ModelResolver(fileManager: fileManager).resolveIfPresent(modelID) else {
+                    return nil
+                }
+                return resolved.rootURL
             }
-            return resolved.rootURL
+            let root = normalizedRootURL(managedInstallRootURL(), fileManager: fileManager)
+            return validateRuntimeURL(root, fileManager: fileManager).isEmpty ? root : nil
         case .singleFile(let relativePath):
             let aliasURL = MereRunModelPaths.resolveModelFile(relativePath: relativePath) { candidate in
                 self.validateRuntimeURL(candidate, fileManager: fileManager).isEmpty

--- a/Sources/MereRunCore/ManagedModelSupport.swift
+++ b/Sources/MereRunCore/ManagedModelSupport.swift
@@ -388,6 +388,13 @@ public enum ManagedModelCapabilityCatalog {
                 recommended: 128
             ),
             descriptor(
+                MuseGlimmerResources.modelId,
+                "Muse Glimmer 30B vision agent",
+                "Runs Sawfwair's pinned selective MLX Q4 conversion of Meta Muse Glimmer with its managed DFlash speculative companion through the native Swift/MLX stack.",
+                minimum: 32,
+                recommended: 64
+            ),
+            descriptor(
                 Q35Resources.q36NanoModelId,
                 "Qwen3.6 A3B chat nano",
                 "Runs the Qwen3.6 35B-A3B OptiQ 4-bit MLX/MTP snapshot through the native Qwen-family runtime.",

--- a/Sources/MereRunCore/MereRunModelManifest.swift
+++ b/Sources/MereRunCore/MereRunModelManifest.swift
@@ -106,6 +106,8 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
         case deepseekV4Flash = "deepseek-v4-flash"
         /// Thinking Machines Lab Inkling family via the native Swift/MLX runtime.
         case inkling
+        /// Meta Muse Glimmer multimodal agent family via native Swift/MLX.
+        case museGlimmer = "muse-glimmer"
     }
 
     public enum Family: String, Codable, CaseIterable, Hashable, Sendable {
@@ -140,6 +142,7 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
         case psi
         case deepseek
         case inkling
+        case muse
     }
 
     public enum Tier: String, Codable, CaseIterable, Hashable, Sendable {
@@ -1002,6 +1005,25 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
                 supports: [.chat, .codeGeneration],
                 components: nil,
                 upstreamRepoId: "\(InklingResources.artifactRepoID)@\(InklingResources.artifactRevision)",
+                createdAt: createdAt
+            )
+        case .museGlimmer30B:
+            return MereRunModelManifest(
+                id: modelID.rawValue,
+                engine: .museGlimmer,
+                family: .muse,
+                tier: .latest,
+                variant: .standard,
+                precision: .int4,
+                quantization: Quantization(
+                    bits: 4,
+                    groupSize: 64,
+                    scheme: "mlx-affine"
+                ),
+                defaults: nil,
+                supports: [.chat, .codeGeneration, .visionChat],
+                components: genericTextComponents,
+                upstreamRepoId: "\(MuseGlimmerResources.artifactRepoId)@\(MuseGlimmerResources.artifactRevision)",
                 createdAt: createdAt
             )
         case .q36Nano:

--- a/Sources/MereRunCore/ModelResolver.swift
+++ b/Sources/MereRunCore/ModelResolver.swift
@@ -39,6 +39,7 @@ public struct ModelResolver {
         case lagunaXS21 = "text-chat-laguna-xs-2-1"
         case lagunaS21DFlash = "text-chat-laguna-s-2-1-dflash"
         case inklingSmall = "text-chat-inkling-small"
+        case museGlimmer30B = "vision-chat-muse-glimmer-30b"
         case ltxGemma3TwelveB4Bit = "text-encoder-ltx-gemma3-12b-4bit"
         case q36Nano = "text-chat-q36-nano"
         case bonsai27B1Bit = "text-chat-bonsai-27b-1bit"

--- a/Sources/MereRunCore/MuseGlimmer/MuseGlimmerAssistantModel.swift
+++ b/Sources/MereRunCore/MuseGlimmer/MuseGlimmerAssistantModel.swift
@@ -1,0 +1,270 @@
+import Foundation
+import MLX
+import MLXFast
+import MLXNN
+
+final class MuseGlimmerAssistantMLP: Module {
+    @ModuleInfo(key: "gate_proj") var gateProj: Linear
+    @ModuleInfo(key: "up_proj") var upProj: Linear
+    @ModuleInfo(key: "down_proj") var downProj: Linear
+
+    init(config: MuseGlimmerAssistantConfig) {
+        self._gateProj.wrappedValue = Linear(config.hiddenSize, config.intermediateSize, bias: false)
+        self._upProj.wrappedValue = Linear(config.hiddenSize, config.intermediateSize, bias: false)
+        self._downProj.wrappedValue = Linear(config.intermediateSize, config.hiddenSize, bias: false)
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        downProj(MLXNN.silu(gateProj(x)) * upProj(x))
+    }
+}
+
+final class MuseGlimmerAssistantAttention: Module {
+    @ModuleInfo(key: "q_proj") var qProj: Linear
+    @ModuleInfo(key: "k_proj") var kProj: Linear
+    @ModuleInfo(key: "v_proj") var vProj: Linear
+    @ModuleInfo(key: "o_proj") var oProj: Linear
+    @ModuleInfo(key: "q_norm") var qNorm: MuseGlimmerRMSNorm
+    @ModuleInfo(key: "k_norm") var kNorm: MuseGlimmerRMSNorm
+
+    private let headCount: Int
+    private let keyValueHeadCount: Int
+    private let headDimension: Int
+    private let scale: Float
+    private let slidingWindow: Int
+    private let rope: RoPE
+
+    init(config: MuseGlimmerAssistantConfig) {
+        headCount = config.numAttentionHeads
+        keyValueHeadCount = config.numKeyValueHeads
+        headDimension = config.headDim
+        scale = pow(Float(config.headDim), -0.5)
+        slidingWindow = config.slidingWindow
+        rope = RoPE(
+            dimensions: config.headDim,
+            traditional: false,
+            base: config.ropeParameters.ropeTheta
+        )
+        self._qProj.wrappedValue = Linear(
+            config.hiddenSize,
+            config.numAttentionHeads * config.headDim,
+            bias: false
+        )
+        self._kProj.wrappedValue = Linear(
+            config.hiddenSize,
+            config.numKeyValueHeads * config.headDim,
+            bias: false
+        )
+        self._vProj.wrappedValue = Linear(
+            config.hiddenSize,
+            config.numKeyValueHeads * config.headDim,
+            bias: false
+        )
+        self._oProj.wrappedValue = Linear(
+            config.numAttentionHeads * config.headDim,
+            config.hiddenSize,
+            bias: false
+        )
+        self._qNorm.wrappedValue = MuseGlimmerRMSNorm(
+            dimensions: config.headDim,
+            eps: config.rmsNormEps
+        )
+        self._kNorm.wrappedValue = MuseGlimmerRMSNorm(
+            dimensions: config.headDim,
+            eps: config.rmsNormEps
+        )
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray, cache: Gemma4AttentionCache) -> MLXArray {
+        let batch = x.dim(0)
+        let sequence = x.dim(1)
+        let offset = cache.offset
+        var queries = qProj(x)
+            .reshaped(batch, sequence, headCount, headDimension)
+            .transposed(0, 2, 1, 3)
+        var keys = kProj(x)
+            .reshaped(batch, sequence, keyValueHeadCount, headDimension)
+            .transposed(0, 2, 1, 3)
+        let values = vProj(x)
+            .reshaped(batch, sequence, keyValueHeadCount, headDimension)
+            .transposed(0, 2, 1, 3)
+        queries = rope(qNorm(queries), offset: offset)
+        keys = rope(kNorm(keys), offset: offset)
+        let state = cache.attentionState(appending: keys, values: values)!
+        let mask = bidirectionalSlidingMask(
+            queryLength: sequence,
+            queryOffset: offset,
+            keyLength: state.0.dim(2),
+            dtype: x.dtype
+        )
+        let attended = MLXFast.scaledDotProductAttention(
+            queries: queries,
+            keys: state.0,
+            values: state.1,
+            scale: scale,
+            mask: mask
+        )
+        return oProj(
+            attended.transposed(0, 2, 1, 3)
+                .reshaped(batch, sequence, headCount * headDimension)
+        )
+    }
+
+    func appendContext(_ context: MLXArray, cache: Gemma4AttentionCache) {
+        let batch = context.dim(0)
+        let sequence = context.dim(1)
+        let offset = cache.offset
+        var keys = kProj(context)
+            .reshaped(batch, sequence, keyValueHeadCount, headDimension)
+            .transposed(0, 2, 1, 3)
+        let values = vProj(context)
+            .reshaped(batch, sequence, keyValueHeadCount, headDimension)
+            .transposed(0, 2, 1, 3)
+        keys = rope(kNorm(keys), offset: offset)
+        cache.append(keys: keys, values: values)
+    }
+
+    private func bidirectionalSlidingMask(
+        queryLength: Int,
+        queryOffset: Int,
+        keyLength: Int,
+        dtype: DType
+    ) -> MLXFast.ScaledDotProductAttentionMaskMode {
+        let keyStart = max(0, queryOffset + queryLength - keyLength)
+        let queryPositions = MLXArray(
+            Int32(queryOffset)..<Int32(queryOffset + queryLength)
+        ).reshaped(queryLength, 1)
+        let keyPositions = MLXArray(
+            Int32(keyStart)..<Int32(keyStart + keyLength)
+        ).reshaped(1, keyLength)
+        let allowed = (keyPositions .>= (queryPositions - Int32(slidingWindow)))
+            .&& (keyPositions .<= (queryPositions + Int32(slidingWindow)))
+        let zeros = MLXArray.zeros([1, 1, queryLength, keyLength], dtype: dtype)
+        return .array(MLX.where(
+            allowed.reshaped(1, 1, queryLength, keyLength),
+            zeros,
+            zeros + MLXArray(-1e9).asType(dtype)
+        ))
+    }
+}
+
+final class MuseGlimmerAssistantDecoderLayer: Module {
+    @ModuleInfo(key: "self_attn") var attention: MuseGlimmerAssistantAttention
+    @ModuleInfo(key: "mlp") var mlp: MuseGlimmerAssistantMLP
+    @ModuleInfo(key: "input_layernorm") var inputNorm: MuseGlimmerRMSNorm
+    @ModuleInfo(key: "post_attention_layernorm") var postAttentionNorm: MuseGlimmerRMSNorm
+
+    init(config: MuseGlimmerAssistantConfig) {
+        self._attention.wrappedValue = MuseGlimmerAssistantAttention(config: config)
+        self._mlp.wrappedValue = MuseGlimmerAssistantMLP(config: config)
+        self._inputNorm.wrappedValue = MuseGlimmerRMSNorm(
+            dimensions: config.hiddenSize,
+            eps: config.rmsNormEps
+        )
+        self._postAttentionNorm.wrappedValue = MuseGlimmerRMSNorm(
+            dimensions: config.hiddenSize,
+            eps: config.rmsNormEps
+        )
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray, cache: Gemma4AttentionCache) -> MLXArray {
+        let attended = x + attention(inputNorm(x), cache: cache)
+        return attended + mlp(postAttentionNorm(attended))
+    }
+
+    func appendContext(_ context: MLXArray, cache: Gemma4AttentionCache) {
+        attention.appendContext(context, cache: cache)
+    }
+}
+
+final class MuseGlimmerAssistantContextProjection: Module {
+    @ModuleInfo(key: "fc") var fc: Linear
+    @ModuleInfo(key: "output_norm_enc") var outputNorm: MuseGlimmerRMSNorm
+
+    init(config: MuseGlimmerAssistantConfig) {
+        self._fc.wrappedValue = Linear(
+            config.hiddenSize * config.targetLayerIds.count,
+            config.hiddenSize,
+            bias: false
+        )
+        self._outputNorm.wrappedValue = MuseGlimmerRMSNorm(
+            dimensions: config.hiddenSize,
+            eps: config.rmsNormEps
+        )
+        super.init()
+    }
+
+    func callAsFunction(_ hidden: MLXArray) -> MLXArray {
+        outputNorm(fc(hidden))
+    }
+}
+
+final class MuseGlimmerAssistantModel: Module {
+    @ModuleInfo(key: "encoder") var encoder: MuseGlimmerAssistantContextProjection
+    @ModuleInfo(key: "layers") var layers: [MuseGlimmerAssistantDecoderLayer]
+    @ModuleInfo(key: "norm") var norm: MuseGlimmerRMSNorm
+
+    let config: MuseGlimmerAssistantConfig
+
+    init(config: MuseGlimmerAssistantConfig) {
+        self.config = config
+        self._encoder.wrappedValue = MuseGlimmerAssistantContextProjection(config: config)
+        self._layers.wrappedValue = (0..<config.numHiddenLayers).map { _ in
+            MuseGlimmerAssistantDecoderLayer(config: config)
+        }
+        self._norm.wrappedValue = MuseGlimmerRMSNorm(
+            dimensions: config.hiddenSize,
+            eps: config.rmsNormEps
+        )
+        super.init()
+    }
+
+    func appendTargetContext(
+        _ states: [Int: MLXArray],
+        cache: [Gemma4AttentionCache]
+    ) {
+        precondition(cache.count == layers.count)
+        let context = encoder(concatenated(
+            config.targetLayerIds.map { states[$0]! },
+            axis: -1
+        ))
+        for (index, layer) in layers.enumerated() {
+            layer.appendContext(context, cache: cache[index])
+        }
+    }
+
+    func draftLogits(
+        anchorTokens: MLXArray,
+        speculativeTokenCount: Int,
+        cache: [Gemma4AttentionCache],
+        target: MuseGlimmerModel
+    ) -> MLXArray {
+        precondition(speculativeTokenCount > 0 && speculativeTokenCount < config.blockSize)
+        let batch = anchorTokens.dim(0)
+        let masks = MLX.full(
+            [batch, speculativeTokenCount],
+            values: MLXArray(Int32(config.maskTokenId))
+        )
+        let inputIds = concatenated(
+            [anchorTokens.reshaped(batch, 1).asType(.int32), masks],
+            axis: 1
+        )
+        var hidden = target.rawInputEmbeddings(for: inputIds)
+        for (index, layer) in layers.enumerated() {
+            hidden = layer(hidden, cache: cache[index])
+        }
+        return target.rawOutputLogits(from: norm(hidden))[0..., 1..., 0...]
+    }
+
+    func makeCache(initialOffset: Int = 0) -> [Gemma4AttentionCache] {
+        layers.map { _ in
+            Gemma4SlidingKVCache(
+                maxSize: config.slidingWindow,
+                initialOffset: initialOffset
+            )
+        }
+    }
+}

--- a/Sources/MereRunCore/MuseGlimmer/MuseGlimmerConfig.swift
+++ b/Sources/MereRunCore/MuseGlimmer/MuseGlimmerConfig.swift
@@ -1,0 +1,324 @@
+import Foundation
+
+public struct MuseGlimmerQuantizationConfig: Codable, Sendable, Hashable {
+    public let groupSize: Int
+    public let bits: Int
+    public let mode: String
+
+    private enum CodingKeys: String, CodingKey {
+        case groupSize = "group_size"
+        case bits
+        case mode
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        groupSize = try container.decode(Int.self, forKey: .groupSize)
+        bits = try container.decode(Int.self, forKey: .bits)
+        mode = try container.decodeIfPresent(String.self, forKey: .mode) ?? "affine"
+    }
+}
+
+public struct MuseGlimmerRopeParameters: Codable, Sendable, Hashable {
+    public let ropeTheta: Float
+    public let ropeType: String
+
+    private enum CodingKeys: String, CodingKey {
+        case ropeTheta = "rope_theta"
+        case ropeType = "rope_type"
+    }
+}
+
+public struct MuseGlimmerTextConfig: Codable, Sendable, Hashable {
+    public let modelType: String
+    public let hiddenSize: Int
+    public let intermediateSize: Int
+    public let numHiddenLayers: Int
+    public let numAttentionHeads: Int
+    public let numKeyValueHeads: Int
+    public let headDim: Int
+    public let maxPositionEmbeddings: Int
+    public let slidingWindow: Int
+    public let layerTypes: [String]
+    public let layerRopeTheta: [Float]
+    public let ropeParameters: MuseGlimmerRopeParameters
+    public let rmsNormEps: Float
+    public let postNormEps: Float
+    public let qkScaleFactor: Float
+    public let outputMultiplier: Float
+    public let finalLogitSoftcapping: Float
+    public let hiddenActivation: String
+    public let attentionBias: Bool
+    public let attentionDropout: Float
+    public let vocabSize: Int
+    public let tieWordEmbeddings: Bool
+    public let bosTokenId: Int?
+    public let eosTokenId: Int?
+    public let padTokenId: Int?
+
+    private enum CodingKeys: String, CodingKey {
+        case modelType = "model_type"
+        case hiddenSize = "hidden_size"
+        case intermediateSize = "intermediate_size"
+        case numHiddenLayers = "num_hidden_layers"
+        case numAttentionHeads = "num_attention_heads"
+        case numKeyValueHeads = "num_key_value_heads"
+        case headDim = "head_dim"
+        case maxPositionEmbeddings = "max_position_embeddings"
+        case slidingWindow = "sliding_window"
+        case layerTypes = "layer_types"
+        case layerRopeTheta = "layer_rope_theta"
+        case ropeParameters = "rope_parameters"
+        case rmsNormEps = "rms_norm_eps"
+        case postNormEps = "post_norm_eps"
+        case qkScaleFactor = "qk_scale_factor"
+        case outputMultiplier = "output_multiplier"
+        case finalLogitSoftcapping = "final_logit_softcapping"
+        case hiddenActivation = "hidden_activation"
+        case attentionBias = "attention_bias"
+        case attentionDropout = "attention_dropout"
+        case vocabSize = "vocab_size"
+        case tieWordEmbeddings = "tie_word_embeddings"
+        case bosTokenId = "bos_token_id"
+        case eosTokenId = "eos_token_id"
+        case padTokenId = "pad_token_id"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        modelType = try container.decode(String.self, forKey: .modelType)
+        hiddenSize = try container.decode(Int.self, forKey: .hiddenSize)
+        intermediateSize = try container.decode(Int.self, forKey: .intermediateSize)
+        numHiddenLayers = try container.decode(Int.self, forKey: .numHiddenLayers)
+        numAttentionHeads = try container.decode(Int.self, forKey: .numAttentionHeads)
+        numKeyValueHeads = try container.decode(Int.self, forKey: .numKeyValueHeads)
+        headDim = try container.decode(Int.self, forKey: .headDim)
+        maxPositionEmbeddings = try container.decode(Int.self, forKey: .maxPositionEmbeddings)
+        slidingWindow = try container.decode(Int.self, forKey: .slidingWindow)
+        layerTypes = try container.decode([String].self, forKey: .layerTypes)
+        layerRopeTheta = try container.decode([Float].self, forKey: .layerRopeTheta)
+        ropeParameters = try container.decode(MuseGlimmerRopeParameters.self, forKey: .ropeParameters)
+        rmsNormEps = try container.decode(Float.self, forKey: .rmsNormEps)
+        postNormEps = try container.decode(Float.self, forKey: .postNormEps)
+        qkScaleFactor = try container.decode(Float.self, forKey: .qkScaleFactor)
+        outputMultiplier = try container.decode(Float.self, forKey: .outputMultiplier)
+        finalLogitSoftcapping = try container.decode(Float.self, forKey: .finalLogitSoftcapping)
+        hiddenActivation = try container.decode(String.self, forKey: .hiddenActivation)
+        attentionBias = try container.decodeIfPresent(Bool.self, forKey: .attentionBias) ?? false
+        attentionDropout = try container.decodeIfPresent(Float.self, forKey: .attentionDropout) ?? 0
+        vocabSize = try container.decode(Int.self, forKey: .vocabSize)
+        tieWordEmbeddings = try container.decodeIfPresent(Bool.self, forKey: .tieWordEmbeddings) ?? false
+        bosTokenId = try container.decodeIfPresent(Int.self, forKey: .bosTokenId)
+        eosTokenId = try container.decodeIfPresent(Int.self, forKey: .eosTokenId)
+        padTokenId = try container.decodeIfPresent(Int.self, forKey: .padTokenId)
+
+        guard layerTypes.count == numHiddenLayers,
+              layerRopeTheta.count == numHiddenLayers else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .layerTypes,
+                in: container,
+                debugDescription: "Muse Glimmer layer_types and layer_rope_theta must match num_hidden_layers."
+            )
+        }
+    }
+}
+
+public struct MuseGlimmerVisionConfig: Codable, Sendable, Hashable {
+    public let modelType: String
+    public let hiddenSize: Int
+    public let intermediateSize: Int
+    public let numHiddenLayers: Int
+    public let numAttentionHeads: Int
+    public let patchSize: Int
+    public let patchTemporal: Int
+    public let mergeSize: Int
+    public let posEmbHeight: Int
+    public let posEmbWidth: Int
+    public let maxPositionEmbeddings: Int
+    public let layerNormEps: Float
+    public let hiddenActivation: String
+    public let layerTypes: [String]
+    public let ropeParameters: MuseGlimmerRopeParameters
+
+    private enum CodingKeys: String, CodingKey {
+        case modelType = "model_type"
+        case hiddenSize = "hidden_size"
+        case intermediateSize = "intermediate_size"
+        case numHiddenLayers = "num_hidden_layers"
+        case numAttentionHeads = "num_attention_heads"
+        case patchSize = "patch_size"
+        case patchTemporal = "patch_temporal"
+        case mergeSize = "merge_size"
+        case posEmbHeight = "pos_emb_height"
+        case posEmbWidth = "pos_emb_width"
+        case maxPositionEmbeddings = "max_position_embeddings"
+        case layerNormEps = "layer_norm_eps"
+        case hiddenActivation = "hidden_act"
+        case layerTypes = "layer_types"
+        case ropeParameters = "rope_parameters"
+    }
+}
+
+public struct MuseGlimmerConfig: Decodable, Sendable, Hashable {
+    public let modelType: String
+    public let architectures: [String]
+    public let textConfig: MuseGlimmerTextConfig
+    public let visionConfig: MuseGlimmerVisionConfig
+    public let imageTokenId: Int
+    public let videoTokenId: Int
+    public let outHiddenSize: Int
+    public let projectorHiddenSize: Int
+    public let projectorHiddenActivation: String
+    public let quantization: MuseGlimmerQuantizationConfig?
+
+    private enum CodingKeys: String, CodingKey {
+        case modelType = "model_type"
+        case architectures
+        case textConfig = "text_config"
+        case visionConfig = "vision_config"
+        case imageTokenId = "image_token_id"
+        case videoTokenId = "video_token_id"
+        case outHiddenSize = "out_hidden_size"
+        case projectorHiddenSize = "projector_hidden_size"
+        case projectorHiddenActivation = "projector_hidden_act"
+        case quantization
+        case quantizationConfig = "quantization_config"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        modelType = try container.decode(String.self, forKey: .modelType)
+        architectures = try container.decodeIfPresent([String].self, forKey: .architectures) ?? []
+        textConfig = try container.decode(MuseGlimmerTextConfig.self, forKey: .textConfig)
+        visionConfig = try container.decode(MuseGlimmerVisionConfig.self, forKey: .visionConfig)
+        imageTokenId = try container.decode(Int.self, forKey: .imageTokenId)
+        videoTokenId = try container.decode(Int.self, forKey: .videoTokenId)
+        outHiddenSize = try container.decode(Int.self, forKey: .outHiddenSize)
+        projectorHiddenSize = try container.decode(Int.self, forKey: .projectorHiddenSize)
+        projectorHiddenActivation = try container.decode(String.self, forKey: .projectorHiddenActivation)
+        quantization = try container.decodeIfPresent(MuseGlimmerQuantizationConfig.self, forKey: .quantization)
+            ?? container.decodeIfPresent(MuseGlimmerQuantizationConfig.self, forKey: .quantizationConfig)
+    }
+}
+
+public struct MuseGlimmerAssistantConfig: Decodable, Sendable, Hashable {
+    public let modelType: String
+    public let architectures: [String]
+    public let hiddenSize: Int
+    public let intermediateSize: Int
+    public let numHiddenLayers: Int
+    public let numAttentionHeads: Int
+    public let numKeyValueHeads: Int
+    public let headDim: Int
+    public let rmsNormEps: Float
+    public let ropeParameters: MuseGlimmerRopeParameters
+    public let maxPositionEmbeddings: Int
+    public let slidingWindow: Int
+    public let layerTypes: [String]
+    public let attentionDropout: Float
+    public let hiddenActivation: String
+    public let bosTokenId: Int?
+    public let eosTokenId: Int?
+    public let padTokenId: Int?
+    public let blockSize: Int
+    public let maskTokenId: Int
+    public let targetLayerIds: [Int]
+    public let quantization: MuseGlimmerQuantizationConfig?
+
+    private enum CodingKeys: String, CodingKey {
+        case modelType = "model_type"
+        case architectures
+        case hiddenSize = "hidden_size"
+        case intermediateSize = "intermediate_size"
+        case numHiddenLayers = "num_hidden_layers"
+        case numAttentionHeads = "num_attention_heads"
+        case numKeyValueHeads = "num_key_value_heads"
+        case headDim = "head_dim"
+        case rmsNormEps = "rms_norm_eps"
+        case ropeParameters = "rope_parameters"
+        case maxPositionEmbeddings = "max_position_embeddings"
+        case slidingWindow = "sliding_window"
+        case layerTypes = "layer_types"
+        case attentionDropout = "attention_dropout"
+        case hiddenActivation = "hidden_act"
+        case bosTokenId = "bos_token_id"
+        case eosTokenId = "eos_token_id"
+        case padTokenId = "pad_token_id"
+        case blockSize = "block_size"
+        case maskTokenId = "mask_token_id"
+        case targetLayerIds = "target_layer_ids"
+        case quantization
+        case quantizationConfig = "quantization_config"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        modelType = try container.decode(String.self, forKey: .modelType)
+        architectures = try container.decodeIfPresent([String].self, forKey: .architectures) ?? []
+        hiddenSize = try container.decode(Int.self, forKey: .hiddenSize)
+        intermediateSize = try container.decode(Int.self, forKey: .intermediateSize)
+        numHiddenLayers = try container.decode(Int.self, forKey: .numHiddenLayers)
+        numAttentionHeads = try container.decode(Int.self, forKey: .numAttentionHeads)
+        numKeyValueHeads = try container.decode(Int.self, forKey: .numKeyValueHeads)
+        headDim = try container.decode(Int.self, forKey: .headDim)
+        rmsNormEps = try container.decode(Float.self, forKey: .rmsNormEps)
+        ropeParameters = try container.decode(MuseGlimmerRopeParameters.self, forKey: .ropeParameters)
+        maxPositionEmbeddings = try container.decode(Int.self, forKey: .maxPositionEmbeddings)
+        slidingWindow = try container.decode(Int.self, forKey: .slidingWindow)
+        layerTypes = try container.decode([String].self, forKey: .layerTypes)
+        attentionDropout = try container.decodeIfPresent(Float.self, forKey: .attentionDropout) ?? 0
+        hiddenActivation = try container.decode(String.self, forKey: .hiddenActivation)
+        bosTokenId = try container.decodeIfPresent(Int.self, forKey: .bosTokenId)
+        eosTokenId = try container.decodeIfPresent(Int.self, forKey: .eosTokenId)
+        padTokenId = try container.decodeIfPresent(Int.self, forKey: .padTokenId)
+        blockSize = try container.decode(Int.self, forKey: .blockSize)
+        maskTokenId = try container.decode(Int.self, forKey: .maskTokenId)
+        targetLayerIds = try container.decode([Int].self, forKey: .targetLayerIds)
+        quantization = try container.decodeIfPresent(MuseGlimmerQuantizationConfig.self, forKey: .quantization)
+            ?? container.decodeIfPresent(MuseGlimmerQuantizationConfig.self, forKey: .quantizationConfig)
+
+        guard layerTypes.count == numHiddenLayers,
+              layerTypes.allSatisfy({ $0 == "sliding_attention" }) else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .layerTypes,
+                in: container,
+                debugDescription: "Muse Glimmer DFlash requires one sliding_attention entry per assistant layer."
+            )
+        }
+        guard blockSize > 1, !targetLayerIds.isEmpty else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .blockSize,
+                in: container,
+                debugDescription: "Muse Glimmer DFlash requires a block larger than one token and target layers."
+            )
+        }
+    }
+}
+
+struct MuseGlimmerGenerationConfig: Decodable {
+    let bosTokenId: Int?
+    let eosTokenIds: [Int]
+    let padTokenId: Int?
+    let maxLength: Int?
+
+    private enum CodingKeys: String, CodingKey {
+        case bosTokenId = "bos_token_id"
+        case eosTokenId = "eos_token_id"
+        case padTokenId = "pad_token_id"
+        case maxLength = "max_length"
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        bosTokenId = try container.decodeIfPresent(Int.self, forKey: .bosTokenId)
+        padTokenId = try container.decodeIfPresent(Int.self, forKey: .padTokenId)
+        maxLength = try container.decodeIfPresent(Int.self, forKey: .maxLength)
+        if let values = try? container.decode([Int].self, forKey: .eosTokenId) {
+            eosTokenIds = values
+        } else if let value = try container.decodeIfPresent(Int.self, forKey: .eosTokenId) {
+            eosTokenIds = [value]
+        } else {
+            eosTokenIds = []
+        }
+    }
+}

--- a/Sources/MereRunCore/MuseGlimmer/MuseGlimmerDFlashDecoder.swift
+++ b/Sources/MereRunCore/MuseGlimmer/MuseGlimmerDFlashDecoder.swift
@@ -1,0 +1,462 @@
+import Foundation
+import MLX
+
+public enum MuseGlimmerDFlashPolicy {
+    /// MLX affine-Q4 target verification is fastest with three proposals.
+    /// The checkpoint supports up to 15, but longer blocks become compute-bound
+    /// on Apple GPU quantized matmuls before their extra matches pay back.
+    public static let defaultSpeculativeTokens = 3
+    public static let defaultMinimumOutputTokens = 32
+    public static let defaultMinimumAcceptanceRate = 0.4
+    public static let defaultAcceptanceEvaluationRounds = 2
+
+    static func enabled(environment: [String: String] = ProcessInfo.processInfo.environment) -> Bool {
+        let value = environment["MERERUN_MUSE_GLIMMER_DFLASH"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        return !["0", "false", "no", "off"].contains(value)
+    }
+
+    static func speculativeTokens(
+        maximum: Int,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> Int {
+        let configured = environment["MERERUN_MUSE_GLIMMER_DFLASH_TOKENS"].flatMap(Int.init)
+            ?? defaultSpeculativeTokens
+        return min(max(1, configured), maximum)
+    }
+
+    static func minimumOutputTokens(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> Int {
+        max(
+            1,
+            environment["MERERUN_MUSE_GLIMMER_DFLASH_MIN_OUTPUT"].flatMap(Int.init)
+                ?? defaultMinimumOutputTokens
+        )
+    }
+
+    static func minimumAcceptanceRate(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> Double {
+        let configured = environment["MERERUN_MUSE_GLIMMER_DFLASH_MIN_ACCEPTANCE"]
+            .flatMap(Double.init)
+        return min(max(configured ?? defaultMinimumAcceptanceRate, 0), 1)
+    }
+}
+
+public struct MuseGlimmerDFlashStats: Codable, Equatable, Sendable {
+    public var enabled: Bool
+    public var active: Bool
+    public var assistantModelPath: String?
+    public var speculativeTokens: Int
+    public var rounds: Int
+    public var draftedTokens: Int
+    public var acceptedTokens: Int
+    public var rejectedTokens: Int
+    public var fullAcceptanceRounds: Int
+    public var targetVerificationForwards: Int
+    public var targetRecoveryForwards: Int
+    public var targetFallbackForwards: Int
+    public var adaptiveFallbacks: Int
+    public var reason: String?
+
+    public var acceptanceRate: Double {
+        guard draftedTokens > 0 else { return 0 }
+        return Double(acceptedTokens) / Double(draftedTokens)
+    }
+
+    public init(
+        enabled: Bool = false,
+        active: Bool = false,
+        assistantModelPath: String? = nil,
+        speculativeTokens: Int = 0,
+        rounds: Int = 0,
+        draftedTokens: Int = 0,
+        acceptedTokens: Int = 0,
+        rejectedTokens: Int = 0,
+        fullAcceptanceRounds: Int = 0,
+        targetVerificationForwards: Int = 0,
+        targetRecoveryForwards: Int = 0,
+        targetFallbackForwards: Int = 0,
+        adaptiveFallbacks: Int = 0,
+        reason: String? = nil
+    ) {
+        self.enabled = enabled
+        self.active = active
+        self.assistantModelPath = assistantModelPath
+        self.speculativeTokens = speculativeTokens
+        self.rounds = rounds
+        self.draftedTokens = draftedTokens
+        self.acceptedTokens = acceptedTokens
+        self.rejectedTokens = rejectedTokens
+        self.fullAcceptanceRounds = fullAcceptanceRounds
+        self.targetVerificationForwards = targetVerificationForwards
+        self.targetRecoveryForwards = targetRecoveryForwards
+        self.targetFallbackForwards = targetFallbackForwards
+        self.adaptiveFallbacks = adaptiveFallbacks
+        self.reason = reason
+    }
+}
+
+struct MuseGlimmerDFlashDecodeResult {
+    let generatedTokens: [Int]
+    let decodeSeconds: Double
+    let firstTokenSeconds: Double?
+    let stats: MuseGlimmerDFlashStats
+}
+
+private struct MuseGlimmerPreparedGreedyRound {
+    let anchor: Int
+    let proposals: [Int]
+    let targetTokens: [Int]
+    let candidateTargetCache: [Gemma4AttentionCache]
+    let candidate: MuseGlimmerForwardOutput
+}
+
+enum MuseGlimmerDFlashDecoder {
+    static func decode(
+        initialLogits: MLXArray,
+        target: MuseGlimmerModel,
+        targetCache initialTargetCache: [Gemma4AttentionCache],
+        assistant: MuseGlimmerAssistantModel,
+        assistantCache: [Gemma4AttentionCache],
+        generationConfig: GenerationConfig,
+        eosTokens: Set<Int>,
+        tokenBudget: Int,
+        historySeedTokens: [Int],
+        speculativeTokens: Int,
+        assistantModelPath: String?,
+        decodeToken: ((Int) -> String)? = nil,
+        emitPiece: ((Int, String) -> Void)? = nil,
+        checkCancellation: (() throws -> Void)? = nil
+    ) throws -> MuseGlimmerDFlashDecodeResult {
+        let startedAt = Date()
+        var targetCache = initialTargetCache
+        var logits = initialLogits
+        var generatedTokens: [Int] = []
+        var repetitionHistory = historySeedTokens
+        var firstTokenSeconds: Double?
+        var pendingWhitespace = ""
+        var stats = MuseGlimmerDFlashStats(
+            enabled: true,
+            active: true,
+            assistantModelPath: assistantModelPath,
+            speculativeTokens: speculativeTokens
+        )
+        var assistantActive = true
+        var pendingSampledAnchor: Int?
+
+        func emit(_ token: Int) {
+            generatedTokens.append(token)
+            repetitionHistory.append(token)
+            if firstTokenSeconds == nil {
+                firstTokenSeconds = Date().timeIntervalSince(startedAt)
+            }
+            guard let decodeToken, let emitPiece else { return }
+            let piece = decodeToken(token)
+            if piece.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                pendingWhitespace += piece
+            } else if !piece.isEmpty {
+                emitPiece(token, pendingWhitespace + piece)
+                pendingWhitespace = ""
+            }
+        }
+
+        func result() -> MuseGlimmerDFlashDecodeResult {
+            MuseGlimmerDFlashDecodeResult(
+                generatedTokens: generatedTokens,
+                decodeSeconds: Date().timeIntervalSince(startedAt),
+                firstTokenSeconds: firstTokenSeconds,
+                stats: stats
+            )
+        }
+
+        guard tokenBudget > 0 else { return result() }
+        let captureLayers = Set(assistant.config.targetLayerIds)
+
+        while generatedTokens.count < tokenBudget {
+            try checkCancellation?()
+            let remainingAfterAnchor = tokenBudget - generatedTokens.count - 1
+            let draftCount = min(
+                speculativeTokens,
+                min(assistant.config.blockSize - 1, max(0, remainingAfterAnchor))
+            )
+            let prepared: MuseGlimmerPreparedGreedyRound?
+            if assistantActive,
+               draftCount > 0,
+               generationConfig.temperature == 0,
+               generationConfig.repetitionPenalty == nil,
+               generationConfig.bannedTokens.isEmpty {
+                prepared = prepareGreedyRound(
+                    logits: logits,
+                    target: target,
+                    targetCache: targetCache,
+                    assistant: assistant,
+                    assistantCache: assistantCache,
+                    draftCount: draftCount,
+                    captureLayers: captureLayers
+                )
+            } else {
+                prepared = nil
+            }
+            let anchor = prepared?.anchor
+                ?? pendingSampledAnchor
+                ?? sampleToken(
+                    logits: logits[0, -1, 0...],
+                    config: generationConfig,
+                    previousTokens: repetitionHistory
+                )
+            pendingSampledAnchor = nil
+            guard !eosTokens.contains(anchor) else { break }
+            emit(anchor)
+            guard generatedTokens.count < tokenBudget else { break }
+
+            guard assistantActive, draftCount > 0 else {
+                logits = target(
+                    MLXArray([Int32(anchor)]).reshaped(1, 1),
+                    cache: targetCache
+                )
+                MLX.eval(logits)
+                evaluateGemma4CacheStorage(targetCache)
+                stats.targetFallbackForwards += 1
+                continue
+            }
+
+            let proposals: [Int]
+            var proposalProbabilities: [MLXArray] = []
+            let candidateTargetCache: [Gemma4AttentionCache]
+            let candidate: MuseGlimmerForwardOutput
+            if let prepared {
+                proposals = prepared.proposals
+                candidateTargetCache = prepared.candidateTargetCache
+                candidate = prepared.candidate
+            } else {
+                let candidateAssistantCache = assistantCache.map { $0.fork() }
+                let draftLogits = assistant.draftLogits(
+                    anchorTokens: MLXArray([Int32(anchor)]).reshaped(1, 1),
+                    speculativeTokenCount: draftCount,
+                    cache: candidateAssistantCache,
+                    target: target
+                )
+                MLX.eval(draftLogits)
+                var sampled: [Int] = []
+                var proposalHistory = repetitionHistory
+                sampled.reserveCapacity(draftCount)
+                proposalProbabilities.reserveCapacity(draftCount)
+                for index in 0..<draftCount {
+                    let probabilities = samplingProbabilities(
+                        logits: draftLogits[0, index, 0...],
+                        config: generationConfig,
+                        previousTokens: proposalHistory
+                    )
+                    let token = sampleToken(probabilities: probabilities)
+                    sampled.append(token)
+                    proposalProbabilities.append(probabilities)
+                    proposalHistory.append(token)
+                }
+                proposals = sampled
+                candidateTargetCache = targetCache.map { $0.fork() }
+                candidate = target.forward(
+                    MLXArray(([anchor] + proposals).map(Int32.init))
+                        .reshaped(1, proposals.count + 1),
+                    cache: candidateTargetCache,
+                    captureLayerIndices: captureLayers
+                )
+                MLX.eval(
+                    [candidate.logits]
+                        + Array(candidate.capturedHiddenStates.values)
+                )
+                evaluateGemma4CacheStorage(candidateTargetCache)
+            }
+
+            stats.rounds += 1
+            stats.draftedTokens += proposals.count
+            stats.targetVerificationForwards += 1
+            var accepted = 0
+            var replacement: Int?
+            var verificationHistory = repetitionHistory
+            for (index, proposal) in proposals.enumerated() {
+                let targetLogits = candidate.logits[0, index, 0...]
+                if generationConfig.temperature == 0 {
+                    let targetToken = prepared?.targetTokens[index] ?? sampleToken(
+                        logits: targetLogits,
+                        config: generationConfig,
+                        previousTokens: verificationHistory
+                    )
+                    guard targetToken == proposal else {
+                        replacement = targetToken
+                        break
+                    }
+                } else {
+                    let targetProbabilities = samplingProbabilities(
+                        logits: targetLogits,
+                        config: generationConfig,
+                        previousTokens: verificationHistory
+                    )
+                    let draftProbabilities = proposalProbabilities[index]
+                    let draftProbability = max(
+                        draftProbabilities[proposal].item(Float.self),
+                        Float.leastNonzeroMagnitude
+                    )
+                    let acceptanceProbability = min(
+                        1,
+                        targetProbabilities[proposal].item(Float.self) / draftProbability
+                    )
+                    guard Float.random(in: 0..<1) <= acceptanceProbability else {
+                        replacement = sampleToken(probabilities: rejectionDistribution(
+                            target: targetProbabilities,
+                            draft: draftProbabilities
+                        ))
+                        break
+                    }
+                }
+                accepted += 1
+                verificationHistory.append(proposal)
+            }
+            stats.acceptedTokens += accepted
+
+            if accepted == proposals.count {
+                stats.fullAcceptanceRounds += 1
+                for proposal in proposals {
+                    guard !eosTokens.contains(proposal) else { return result() }
+                    emit(proposal)
+                    guard generatedTokens.count < tokenBudget else { return result() }
+                }
+                targetCache = candidateTargetCache
+                logits = candidate.logits[0..., (candidate.logits.dim(1) - 1)..., 0...]
+                assistant.appendTargetContext(
+                    candidate.capturedHiddenStates,
+                    cache: assistantCache
+                )
+                evaluateGemma4CacheStorage(assistantCache)
+            } else {
+                stats.rejectedTokens += 1
+                for proposal in proposals.prefix(accepted) {
+                    guard !eosTokens.contains(proposal) else { return result() }
+                    emit(proposal)
+                    guard generatedTokens.count < tokenBudget else { return result() }
+                }
+                guard let replacement, !eosTokens.contains(replacement) else { break }
+                let committedCount = accepted + 1
+                targetCache = commitCandidatePrefix(
+                    base: targetCache,
+                    candidate: candidateTargetCache,
+                    tokenCount: committedCount
+                )
+                evaluateGemma4CacheStorage(targetCache)
+                let committedStates = Dictionary(
+                    uniqueKeysWithValues: assistant.config.targetLayerIds.map { layerId in
+                        return (
+                            layerId,
+                            candidate.capturedHiddenStates[layerId]![
+                                0...,
+                                ..<committedCount,
+                                0...
+                            ]
+                        )
+                    }
+                )
+                assistant.appendTargetContext(committedStates, cache: assistantCache)
+                evaluateGemma4CacheStorage(assistantCache)
+                logits = candidate.logits[0..., accepted..<(accepted + 1), 0...]
+                if generationConfig.temperature != 0 {
+                    pendingSampledAnchor = replacement
+                }
+            }
+
+            let minimumAcceptanceRate = MuseGlimmerDFlashPolicy.minimumAcceptanceRate()
+            if stats.rounds >= MuseGlimmerDFlashPolicy.defaultAcceptanceEvaluationRounds,
+               stats.acceptanceRate < minimumAcceptanceRate {
+                assistantActive = false
+                stats.active = false
+                stats.adaptiveFallbacks = 1
+                stats.reason = String(
+                    format: "draft acceptance fell below %.0f%%",
+                    minimumAcceptanceRate * 100
+                )
+            }
+        }
+
+        return result()
+    }
+
+    private static func prepareGreedyRound(
+        logits: MLXArray,
+        target: MuseGlimmerModel,
+        targetCache: [Gemma4AttentionCache],
+        assistant: MuseGlimmerAssistantModel,
+        assistantCache: [Gemma4AttentionCache],
+        draftCount: Int,
+        captureLayers: Set<Int>
+    ) -> MuseGlimmerPreparedGreedyRound {
+        let anchor = MLX.argMax(logits[0, -1, 0...], axis: -1)
+            .asType(.int32)
+            .reshaped(1, 1)
+        let draftLogits = assistant.draftLogits(
+            anchorTokens: anchor,
+            speculativeTokenCount: draftCount,
+            cache: assistantCache.map { $0.fork() },
+            target: target
+        )
+        let proposalTokens = MLX.argMax(draftLogits, axis: -1).asType(.int32)
+        let candidateTargetCache = targetCache.map { $0.fork() }
+        let candidate = target.forward(
+            concatenated([anchor, proposalTokens], axis: 1),
+            cache: candidateTargetCache,
+            captureLayerIndices: captureLayers
+        )
+        let targetTokens = MLX.argMax(
+            candidate.logits[0, 0..<draftCount, 0...],
+            axis: -1
+        ).asType(.int32)
+        MLX.eval(
+            [anchor, proposalTokens, targetTokens, candidate.logits]
+                + Array(candidate.capturedHiddenStates.values)
+        )
+        evaluateGemma4CacheStorage(candidateTargetCache)
+        return MuseGlimmerPreparedGreedyRound(
+            anchor: Int(anchor.item(Int32.self)),
+            proposals: proposalTokens.asArray(Int32.self).map(Int.init),
+            targetTokens: targetTokens.asArray(Int32.self).map(Int.init),
+            candidateTargetCache: candidateTargetCache,
+            candidate: candidate
+        )
+    }
+
+    static func commitCandidatePrefix(
+        base: [Gemma4AttentionCache],
+        candidate: [Gemma4AttentionCache],
+        tokenCount: Int
+    ) -> [Gemma4AttentionCache] {
+        precondition(base.count == candidate.count && tokenCount > 0)
+        return zip(base, candidate).map { baseCache, candidateCache in
+            let appendedCount = candidateCache.offset - baseCache.offset
+            precondition(appendedCount >= tokenCount)
+            let state = candidateCache.currentState()!
+            let appendedStart = state.0.dim(2) - appendedCount
+            let committed = baseCache.fork()
+            committed.append(
+                keys: state.0[
+                    0...,
+                    0...,
+                    appendedStart..<(appendedStart + tokenCount),
+                    0...
+                ],
+                values: state.1[
+                    0...,
+                    0...,
+                    appendedStart..<(appendedStart + tokenCount),
+                    0...
+                ]
+            )
+            return committed
+        }
+    }
+
+    static func rejectionDistribution(target: MLXArray, draft: MLXArray) -> MLXArray {
+        let residual = MLX.maximum(target - draft, MLXArray(0))
+        let mass = residual.sum().item(Float.self)
+        return mass > 1e-6 ? residual / residual.sum() : target
+    }
+}

--- a/Sources/MereRunCore/MuseGlimmer/MuseGlimmerGenerator.swift
+++ b/Sources/MereRunCore/MuseGlimmer/MuseGlimmerGenerator.swift
@@ -1,0 +1,717 @@
+import Foundation
+import MLX
+
+private struct MuseGlimmerDecodeResult {
+    let tokens: [Int]
+    let decodeSeconds: Double
+    let firstTokenSeconds: Double?
+}
+
+enum MuseGlimmerWeightKeys {
+    static func normalized(_ key: String) -> String {
+        if key.hasPrefix("language_model.model.") {
+            return "model.language_model.\(key.dropFirst("language_model.model.".count))"
+        }
+        if key.hasPrefix("language_model.lm_head") {
+            return "lm_head\(key.dropFirst("language_model.lm_head".count))"
+        }
+        if key.hasPrefix("vision_tower.") {
+            return "model.vision_tower.\(key.dropFirst("vision_tower.".count))"
+        }
+        if key.hasPrefix("vision_adapter.") {
+            return "model.vision_adapter.\(key.dropFirst("vision_adapter.".count))"
+        }
+        if key.hasPrefix("vision_projection") {
+            return "model.vision_projection\(key.dropFirst("vision_projection".count))"
+        }
+        return key
+    }
+
+    static func mapped(_ key: String, _ value: MLXArray) -> [(String, MLXArray)] {
+        [(normalized(key), value)]
+    }
+}
+
+public actor MuseGlimmerGenerator: ChatGenerator {
+    private static let textPrefillChunkSize = 512
+
+    private let modelID: String
+    private var model: MuseGlimmerModel?
+    private var tokenizerAndTemplate: MuseGlimmerTokenizerAndTemplate?
+    private var loadedConfig: MuseGlimmerConfig?
+    private var loadedModelPath: String?
+    private var assistantModel: MuseGlimmerAssistantModel?
+    private var loadedAssistantPath: String?
+    private var warmupSignature: String?
+    private var lastDFlashStats = MuseGlimmerDFlashStats()
+
+    public init(modelID: String = MuseGlimmerResources.modelId) {
+        self.modelID = modelID
+    }
+
+    public func chat(
+        _ request: ChatRequest,
+        progressHandler: (@Sendable (ChatProgress) -> Void)?
+    ) async throws -> ChatResponse {
+        try await chat(request, modelPath: nil, progressHandler: progressHandler)
+    }
+
+    public func chat(
+        _ request: ChatRequest,
+        modelPath: String?,
+        progressHandler: (@Sendable (ChatProgress) -> Void)?
+    ) async throws -> ChatResponse {
+        try await Stream.withNewDefaultStream {
+            let root = try await resolveModelRoot(modelPath: modelPath, progressHandler: progressHandler)
+            let loadStart = Date()
+            try await ensureLoaded(rootURL: root, progressHandler: progressHandler)
+            let loadSeconds = Date().timeIntervalSince(loadStart)
+            var response = try generate(request, progressHandler: progressHandler)
+            if var timing = response.timing {
+                timing.loadSeconds = loadSeconds
+                response.timing = timing
+            }
+            return response
+        }
+    }
+
+    public func prepare(
+        modelPath: String? = nil,
+        progressHandler: (@Sendable (ChatProgress) -> Void)? = nil
+    ) async throws {
+        try await Stream.withNewDefaultStream {
+            let root = try await resolveModelRoot(modelPath: modelPath, progressHandler: progressHandler)
+            try await ensureLoaded(rootURL: root, progressHandler: progressHandler)
+        }
+    }
+
+    public func unload() {
+        model = nil
+        tokenizerAndTemplate = nil
+        loadedConfig = nil
+        loadedModelPath = nil
+        assistantModel = nil
+        loadedAssistantPath = nil
+        warmupSignature = nil
+        lastDFlashStats = MuseGlimmerDFlashStats()
+        Memory.clearCache()
+    }
+
+    public func dflashStats() -> MuseGlimmerDFlashStats {
+        lastDFlashStats
+    }
+
+    private func ensureLoaded(
+        rootURL: URL,
+        progressHandler: (@Sendable (ChatProgress) -> Void)?
+    ) async throws {
+        let root = rootURL.standardizedFileURL
+        if loadedModelPath == root.path, model != nil, tokenizerAndTemplate != nil {
+            if assistantModel == nil, MuseGlimmerDFlashPolicy.enabled(), let loadedConfig {
+                try loadAssistantIfAvailable(
+                    targetConfig: loadedConfig,
+                    progressHandler: progressHandler
+                )
+            }
+            try warmLoadedModelsIfNeeded(progressHandler: progressHandler)
+            return
+        }
+        let resources = MuseGlimmerResources(rootURL: root)
+        let missing = resources.validate()
+        guard missing.isEmpty else {
+            throw MuseGlimmerError.missingFiles(missing.map(\.path))
+        }
+
+        progressHandler?(ChatProgress(stage: .loadingModel, message: "Loading Muse Glimmer config"))
+        let config = try JSONDecoder().decode(MuseGlimmerConfig.self, from: Data(contentsOf: resources.configURL))
+        guard config.modelType == "muse_glimmer",
+              config.textConfig.modelType == "muse_glimmer_text",
+              config.visionConfig.modelType == "muse_glimmer_vision" else {
+            throw MuseGlimmerError.unsupportedConfiguration(
+                "Expected muse_glimmer, muse_glimmer_text, and muse_glimmer_vision config types."
+            )
+        }
+        let generationConfig = try JSONDecoder().decode(
+            MuseGlimmerGenerationConfig.self,
+            from: Data(contentsOf: resources.generationConfigURL)
+        )
+        progressHandler?(ChatProgress(stage: .loadingModel, message: "Loading Muse Glimmer tokenizer"))
+        let tokenizer = try await MuseGlimmerTokenizerAndTemplate.load(
+            from: root,
+            generationConfig: generationConfig,
+            maxLengthOverride: min(
+                generationConfig.maxLength ?? MuseGlimmerResources.defaultContextLength,
+                config.textConfig.maxPositionEmbeddings
+            )
+        )
+
+        progressHandler?(ChatProgress(stage: .loadingModel, message: "Loading Muse Glimmer weights"))
+        let loadedModel = MuseGlimmerModel(config: config)
+        if FileManager.default.fileExists(atPath: resources.modelIndexURL.path) {
+            if let quantization = config.quantization {
+                try HFSafetensorsWeightsLoader.applyQuantizedWeights(
+                    indexURL: resources.modelIndexURL,
+                    to: loadedModel,
+                    groupSize: quantization.groupSize,
+                    bits: quantization.bits,
+                    keyMapper: MuseGlimmerWeightKeys.normalized,
+                    mapper: MuseGlimmerWeightKeys.mapped,
+                    progressHandler: { progress in
+                        progressHandler?(ChatProgress(
+                            stage: .loadingModel,
+                            message: "Loading Muse Glimmer shard \(progress.shardIndex + 1)/\(progress.shardCount)"
+                        ))
+                    }
+                )
+            } else {
+                try HFSafetensorsWeightsLoader.applyShardedWeights(
+                    indexURL: resources.modelIndexURL,
+                    to: loadedModel,
+                    mapper: MuseGlimmerWeightKeys.mapped,
+                    progressHandler: { progress in
+                        progressHandler?(ChatProgress(
+                            stage: .loadingModel,
+                            message: "Loading Muse Glimmer shard \(progress.shardIndex + 1)/\(progress.shardCount)"
+                        ))
+                    }
+                )
+            }
+        } else if let quantization = config.quantization {
+            try HFSafetensorsWeightsLoader.applyQuantizedWeightsFromArrays(
+                try MLX.loadArrays(url: resources.modelWeightsURL),
+                to: loadedModel,
+                groupSize: quantization.groupSize,
+                bits: quantization.bits,
+                keyMapper: MuseGlimmerWeightKeys.normalized,
+                mapper: MuseGlimmerWeightKeys.mapped
+            )
+        } else {
+            try HFSafetensorsWeightsLoader.applyWeights(
+                url: resources.modelWeightsURL,
+                to: loadedModel,
+                mapper: MuseGlimmerWeightKeys.mapped
+            )
+        }
+        try Task.checkCancellation()
+        model = loadedModel
+        tokenizerAndTemplate = tokenizer
+        loadedConfig = config
+        loadedModelPath = root.path
+        try loadAssistantIfAvailable(targetConfig: config, progressHandler: progressHandler)
+        try warmLoadedModelsIfNeeded(progressHandler: progressHandler)
+    }
+
+    private func warmLoadedModelsIfNeeded(
+        progressHandler: (@Sendable (ChatProgress) -> Void)?
+    ) throws {
+        guard let model, let loadedModelPath else {
+            throw MuseGlimmerError.modelNotLoaded
+        }
+        let speculativeTokens = assistantModel.map {
+            MuseGlimmerDFlashPolicy.speculativeTokens(maximum: $0.config.blockSize - 1)
+        }
+        let signature = [
+            loadedModelPath,
+            loadedAssistantPath ?? "target-only",
+            speculativeTokens.map(String.init) ?? "serial",
+        ].joined(separator: "|")
+        guard signature != warmupSignature else { return }
+
+        let mode = assistantModel == nil ? "target" : "target and DFlash"
+        progressHandler?(ChatProgress(
+            stage: .loadingModel,
+            message: "Warming Muse Glimmer \(mode) inference"
+        ))
+        try Task.checkCancellation()
+        _ = try Self.warmUp(
+            model: model,
+            assistant: assistantModel,
+            assistantModelPath: loadedAssistantPath,
+            speculativeTokens: speculativeTokens,
+            checkCancellation: { try Task.checkCancellation() }
+        )
+        try Task.checkCancellation()
+        warmupSignature = signature
+    }
+
+    /// Materializes the serial target cache path and the production DFlash
+    /// verification shape before the first user-visible decode. MLX compiles
+    /// lazily, so evaluating only the loaded weights leaves that cost and cache
+    /// lifecycle on the first request.
+    static func warmUp(
+        model: MuseGlimmerModel,
+        assistant: MuseGlimmerAssistantModel?,
+        assistantModelPath: String? = nil,
+        speculativeTokens requestedSpeculativeTokens: Int? = nil,
+        checkCancellation: (() throws -> Void)? = nil
+    ) throws -> MuseGlimmerDFlashStats? {
+        try checkCancellation?()
+        let token = MLXArray([Int32(0)]).reshaped(1, 1)
+        let captureLayers = Set(assistant?.config.targetLayerIds ?? [])
+        let targetCache = model.makeCache()
+        let output = model.forward(
+            token,
+            cache: targetCache,
+            captureLayerIndices: captureLayers
+        )
+        MLX.eval([output.logits] + Array(output.capturedHiddenStates.values))
+        evaluateGemma4CacheStorage(targetCache)
+
+        // Compile and materialize the one-token serial decode independently of
+        // whether DFlash is attached. This is also the adaptive fallback path.
+        let serialCache = targetCache.map { $0.fork() }
+        let serialLogits = model(token, cache: serialCache)
+        MLX.eval(serialLogits)
+        evaluateGemma4CacheStorage(serialCache)
+
+        guard let assistant else { return nil }
+        let assistantCache = assistant.makeCache()
+        assistant.appendTargetContext(output.capturedHiddenStates, cache: assistantCache)
+        evaluateGemma4CacheStorage(assistantCache)
+        let speculativeTokens = requestedSpeculativeTokens
+            ?? MuseGlimmerDFlashPolicy.speculativeTokens(maximum: assistant.config.blockSize - 1)
+        let generation = GenerationConfig(
+            maxTokens: 8,
+            temperature: 0,
+            topK: MuseGlimmerResources.recommendedTopK,
+            topP: 0.95,
+            minP: 0,
+            repetitionPenalty: 1,
+            repetitionContextSize: 64
+        )
+        let result = try MuseGlimmerDFlashDecoder.decode(
+            initialLogits: output.logits,
+            target: model,
+            targetCache: targetCache,
+            assistant: assistant,
+            assistantCache: assistantCache,
+            generationConfig: generation,
+            eosTokens: [],
+            tokenBudget: generation.maxTokens,
+            historySeedTokens: [0],
+            speculativeTokens: speculativeTokens,
+            assistantModelPath: assistantModelPath,
+            checkCancellation: checkCancellation
+        )
+        return result.stats
+    }
+
+    private func loadAssistantIfAvailable(
+        targetConfig: MuseGlimmerConfig,
+        progressHandler: (@Sendable (ChatProgress) -> Void)?
+    ) throws {
+        assistantModel = nil
+        loadedAssistantPath = nil
+        guard MuseGlimmerDFlashPolicy.enabled() else {
+            lastDFlashStats = MuseGlimmerDFlashStats(
+                reason: "disabled by MERERUN_MUSE_GLIMMER_DFLASH"
+            )
+            return
+        }
+        guard let root = resolveAssistantRoot() else {
+            lastDFlashStats = MuseGlimmerDFlashStats(
+                enabled: true,
+                reason: "assistant companion is not installed"
+            )
+            return
+        }
+        let missing = MuseGlimmerResources.validateAssistant(rootURL: root)
+        guard missing.isEmpty else {
+            throw MuseGlimmerError.missingFiles(missing.map(\.path))
+        }
+        progressHandler?(ChatProgress(
+            stage: .loadingModel,
+            message: "Loading Muse Glimmer DFlash assistant"
+        ))
+        let config = try JSONDecoder().decode(
+            MuseGlimmerAssistantConfig.self,
+            from: Data(contentsOf: root.appending(path: "config.json"))
+        )
+        try validateAssistantCompatibility(config, target: targetConfig.textConfig)
+        let assistant = MuseGlimmerAssistantModel(config: config)
+        let index = root.appending(path: "model.safetensors.index.json")
+        let weights = root.appending(path: "model.safetensors")
+        if FileManager.default.fileExists(atPath: index.path) {
+            if let quantization = config.quantization {
+                try HFSafetensorsWeightsLoader.applyQuantizedWeights(
+                    indexURL: index,
+                    to: assistant,
+                    groupSize: quantization.groupSize,
+                    bits: quantization.bits
+                )
+            } else {
+                try HFSafetensorsWeightsLoader.applyShardedWeights(indexURL: index, to: assistant)
+            }
+        } else if let quantization = config.quantization {
+            try HFSafetensorsWeightsLoader.applyQuantizedWeightsFromArrays(
+                try MLX.loadArrays(url: weights),
+                to: assistant,
+                groupSize: quantization.groupSize,
+                bits: quantization.bits
+            )
+        } else {
+            try HFSafetensorsWeightsLoader.applyWeights(url: weights, to: assistant)
+        }
+        assistantModel = assistant
+        loadedAssistantPath = root.path
+        lastDFlashStats = MuseGlimmerDFlashStats(
+            enabled: true,
+            active: true,
+            assistantModelPath: root.path,
+            speculativeTokens: MuseGlimmerDFlashPolicy.speculativeTokens(
+                maximum: config.blockSize - 1
+            )
+        )
+    }
+
+    private func resolveAssistantRoot() -> URL? {
+        let environment = ProcessInfo.processInfo.environment
+        let configured = environment["MERERUN_MUSE_GLIMMER_DFLASH_PATH"]
+            .map { URL(fileURLWithPath: $0).standardizedFileURL }
+        let quantized = MereRunModelPaths.modelsDir
+            .appendingPathComponent(MuseGlimmerResources.assistantQuantizedModelId, isDirectory: true)
+            .standardizedFileURL
+        let managed = ManagedModelResolver.resolveInstalledModel(
+            id: MuseGlimmerResources.assistantModelId
+        )?.standardizedFileURL
+        return [configured, managed, quantized]
+            .compactMap { $0 }
+            .first { MuseGlimmerResources.validateAssistant(rootURL: $0).isEmpty }
+    }
+
+    private func validateAssistantCompatibility(
+        _ assistant: MuseGlimmerAssistantConfig,
+        target: MuseGlimmerTextConfig
+    ) throws {
+        guard assistant.modelType == "muse_glimmer_assistant" else {
+            throw MuseGlimmerError.unsupportedConfiguration(
+                "Expected a muse_glimmer_assistant companion."
+            )
+        }
+        guard assistant.hiddenSize == target.hiddenSize else {
+            throw MuseGlimmerError.unsupportedConfiguration(
+                "Muse DFlash hidden size \(assistant.hiddenSize) does not match target \(target.hiddenSize)."
+            )
+        }
+        guard assistant.targetLayerIds.allSatisfy({ (0..<target.numHiddenLayers).contains($0) }) else {
+            throw MuseGlimmerError.unsupportedConfiguration(
+                "Muse DFlash target_layer_ids are outside the target layer range."
+            )
+        }
+        guard assistant.hiddenActivation == "silu",
+              assistant.attentionDropout == 0 else {
+            throw MuseGlimmerError.unsupportedConfiguration(
+                "Muse DFlash requires SiLU and zero attention dropout."
+            )
+        }
+    }
+
+    private func generate(
+        _ request: ChatRequest,
+        progressHandler: (@Sendable (ChatProgress) -> Void)?
+    ) throws -> ChatResponse {
+        guard let model, let tokenizerAndTemplate, let loadedConfig else {
+            throw MuseGlimmerError.modelNotLoaded
+        }
+        guard request.lora == nil else {
+            throw MuseGlimmerError.generationFailed("Muse Glimmer LoRA loading is not yet supported.")
+        }
+        guard !request.requiresJSON else {
+            throw MuseGlimmerError.generationFailed(
+                "Muse Glimmer constrained JSON generation is not yet supported; use tool schemas for structured actions."
+            )
+        }
+        guard request.kvCacheMode == nil || request.kvCacheMode == .default else {
+            throw MuseGlimmerError.generationFailed("Muse Glimmer currently supports the native BF16 KV cache mode.")
+        }
+        let requestedContext = request.maxContextTokens ?? MuseGlimmerResources.defaultContextLength
+        guard requestedContext > 0 else {
+            throw MuseGlimmerError.generationFailed("maxContextTokens must be greater than zero.")
+        }
+        let effectiveContext = min(
+            requestedContext,
+            loadedConfig.textConfig.maxPositionEmbeddings,
+            tokenizerAndTemplate.maxLength
+        )
+        let imageReferences = request.messages.compactMap { message -> String? in
+            guard let reference = message.imageUrl, !reference.isEmpty else { return nil }
+            return reference
+        }
+        let imageBatch = try imageReferences.isEmpty ? nil : MuseGlimmerImageProcessor.makeBatch(
+            imageReferences: imageReferences,
+            config: loadedConfig.visionConfig
+        )
+        let formatter = DateFormatter()
+        formatter.calendar = Calendar(identifier: .gregorian)
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = .current
+        formatter.dateFormat = "yyyy-MM-dd"
+        var promptTokens = try tokenizerAndTemplate.encodeForGeneration(
+            messages: request.messages,
+            tools: request.tools,
+            reasoningStrength: Self.reasoningStrength(request.reasoningEffort),
+            currentDate: formatter.string(from: Date()),
+            maxLength: effectiveContext
+        )
+        if let imageBatch {
+            promptTokens = try MuseGlimmerImageProcessor.expandedPromptTokens(
+                promptTokens,
+                tokenCounts: imageBatch.tokenCounts,
+                imageTokenId: tokenizerAndTemplate.imageTokenId,
+                imageStartTokenId: tokenizerAndTemplate.imageStartTokenId,
+                imageEndTokenId: tokenizerAndTemplate.imageEndTokenId
+            )
+        }
+        if promptTokens.count > effectiveContext {
+            promptTokens = Array(promptTokens.suffix(effectiveContext))
+        }
+        guard !promptTokens.isEmpty else {
+            throw MuseGlimmerError.generationFailed("Muse Glimmer prompt tokenization produced no tokens.")
+        }
+
+        let tokenBudget = max(0, min(request.maxTokens, effectiveContext - promptTokens.count))
+        let minimumDFlashOutput = MuseGlimmerDFlashPolicy.minimumOutputTokens()
+        let useDFlash = assistantModel != nil && tokenBudget >= minimumDFlashOutput
+        let assistantCache = useDFlash ? assistantModel?.makeCache() : nil
+        let prefillStart = Date()
+        let cache = model.makeCache()
+        let initialLogits: MLXArray
+        if imageBatch == nil {
+            initialLogits = try chunkedTextPrefill(
+                model: model,
+                tokens: promptTokens,
+                cache: cache,
+                assistant: useDFlash ? assistantModel : nil,
+                assistantCache: assistantCache,
+                progressHandler: progressHandler
+            )
+        } else {
+            let output = try model.forwardPrefillDetailed(
+                inputIds: MLXArray(promptTokens.map(Int32.init)).reshaped(1, promptTokens.count),
+                imageBatch: imageBatch,
+                cache: cache,
+                captureLayerIndices: Set(useDFlash ? assistantModel?.config.targetLayerIds ?? [] : [])
+            )
+            initialLogits = output.logits
+            if let assistant = useDFlash ? assistantModel : nil,
+               let assistantCache {
+                assistant.appendTargetContext(output.capturedHiddenStates, cache: assistantCache)
+                evaluateGemma4CacheStorage(assistantCache)
+            }
+            MLX.eval(output.logits)
+            evaluateGemma4CacheStorage(cache)
+        }
+        let prefillSeconds = Date().timeIntervalSince(prefillStart)
+        let sampling = GenerationConfig(
+            maxTokens: tokenBudget,
+            temperature: Float(request.temperature),
+            topK: request.topK ?? MuseGlimmerResources.recommendedTopK,
+            topP: Float(request.topP),
+            minP: Float(request.minP),
+            repetitionPenalty: 1,
+            repetitionContextSize: 64
+        )
+        progressHandler?(ChatProgress(stage: .generating, message: ""))
+        let decoded: MuseGlimmerDecodeResult
+        if let assistant = useDFlash ? assistantModel : nil,
+           let assistantCache {
+            progressHandler?(ChatProgress(
+                stage: .generating,
+                message: "Muse DFlash active"
+            ))
+            let dflash = try MuseGlimmerDFlashDecoder.decode(
+                initialLogits: initialLogits,
+                target: model,
+                targetCache: cache,
+                assistant: assistant,
+                assistantCache: assistantCache,
+                generationConfig: sampling,
+                eosTokens: Set(tokenizerAndTemplate.eosTokenIds),
+                tokenBudget: tokenBudget,
+                historySeedTokens: promptTokens,
+                speculativeTokens: MuseGlimmerDFlashPolicy.speculativeTokens(
+                    maximum: assistant.config.blockSize - 1
+                ),
+                assistantModelPath: loadedAssistantPath,
+                checkCancellation: { try Task.checkCancellation() }
+            )
+            lastDFlashStats = dflash.stats
+            decoded = MuseGlimmerDecodeResult(
+                tokens: dflash.generatedTokens,
+                decodeSeconds: dflash.decodeSeconds,
+                firstTokenSeconds: dflash.firstTokenSeconds
+            )
+        } else {
+            if assistantModel != nil {
+                lastDFlashStats = MuseGlimmerDFlashStats(
+                    enabled: true,
+                    active: false,
+                    assistantModelPath: loadedAssistantPath,
+                    speculativeTokens: assistantModel.map {
+                        MuseGlimmerDFlashPolicy.speculativeTokens(maximum: $0.config.blockSize - 1)
+                    } ?? 0,
+                    reason: "output budget is below \(minimumDFlashOutput) tokens"
+                )
+            }
+            decoded = try decode(
+                model: model,
+                tokenizer: tokenizerAndTemplate,
+                initialLogits: initialLogits,
+                cache: cache,
+                sampling: sampling,
+                tokenBudget: tokenBudget,
+                promptTokens: promptTokens
+            )
+        }
+        var rawText = tokenizerAndTemplate.decode(tokens: decoded.tokens)
+        rawText = Self.truncate(rawText, at: request.stopSequences)
+        let parsed = MuseGlimmerOutputParser.parse(rawText)
+        let response: String
+        if request.showThinking, let reasoning = parsed.reasoning, !reasoning.isEmpty {
+            response = "<think>\n\(reasoning)\n</think>\n\(parsed.visible)"
+        } else {
+            response = parsed.visible
+        }
+        let trimmedResponse = response.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmedResponse.isEmpty {
+            // Muse's recipient protocol emits private reasoning before the user-facing
+            // answer. Buffer decoding so streaming never leaks that hidden channel.
+            progressHandler?(ChatProgress(stage: .generating, message: trimmedResponse))
+        }
+        return ChatResponse(
+            response: trimmedResponse,
+            tokensGenerated: decoded.tokens.count,
+            timing: ChatTiming(
+                loadSeconds: 0,
+                prefillSeconds: prefillSeconds,
+                decodeSeconds: decoded.decodeSeconds,
+                firstTokenSeconds: decoded.firstTokenSeconds,
+                kvCacheMode: .default,
+                prefillKVCache: "native-bf16",
+                decodeKVCache: "native-bf16"
+            ),
+            toolCalls: parsed.toolCalls.isEmpty ? nil : parsed.toolCalls,
+            promptTokens: promptTokens.count,
+            finishReason: decoded.tokens.count >= tokenBudget ? .length : .stop,
+            reasoningContent: parsed.reasoning,
+            reasoningBlockCount: parsed.reasoning == nil ? 0 : 1
+        )
+    }
+
+    private func chunkedTextPrefill(
+        model: MuseGlimmerModel,
+        tokens: [Int],
+        cache: [Gemma4AttentionCache],
+        assistant: MuseGlimmerAssistantModel?,
+        assistantCache: [Gemma4AttentionCache]?,
+        progressHandler: (@Sendable (ChatProgress) -> Void)?
+    ) throws -> MLXArray {
+        var offset = 0
+        var logits: MLXArray?
+        while offset < tokens.count {
+            try Task.checkCancellation()
+            let end = min(tokens.count, offset + Self.textPrefillChunkSize)
+            let chunk = Array(tokens[offset..<end])
+            let output = try model.forwardPrefillDetailed(
+                inputIds: MLXArray(chunk.map(Int32.init)).reshaped(1, chunk.count),
+                imageBatch: nil,
+                cache: cache,
+                captureLayerIndices: Set(assistant?.config.targetLayerIds ?? [])
+            )
+            if let assistant, let assistantCache {
+                assistant.appendTargetContext(output.capturedHiddenStates, cache: assistantCache)
+                evaluateGemma4CacheStorage(assistantCache)
+            }
+            MLX.eval(output.logits)
+            evaluateGemma4CacheStorage(cache)
+            logits = output.logits
+            offset = end
+            progressHandler?(ChatProgress(stage: .encoding, message: "Prefilled \(offset)/\(tokens.count) tokens"))
+        }
+        guard let logits else {
+            throw MuseGlimmerError.generationFailed("Muse Glimmer prefill produced no logits.")
+        }
+        return logits
+    }
+
+    private func decode(
+        model: MuseGlimmerModel,
+        tokenizer: MuseGlimmerTokenizerAndTemplate,
+        initialLogits: MLXArray,
+        cache: [Gemma4AttentionCache],
+        sampling: GenerationConfig,
+        tokenBudget: Int,
+        promptTokens: [Int]
+    ) throws -> MuseGlimmerDecodeResult {
+        let result = try AutoregressiveDecodeEngine.decode(
+            AutoregressiveDecodeRequest(
+                initialLogits: initialLogits,
+                generationConfig: sampling,
+                eosTokens: Set(tokenizer.eosTokenIds),
+                tokenBudget: tokenBudget,
+                historySeedTokens: promptTokens
+            ),
+            stepForward: { token in model(token, cache: cache) },
+            decodeToken: { tokenizer.decode(token: $0) },
+            emitPiece: nil,
+            checkCancellation: { try Task.checkCancellation() }
+        )
+        return MuseGlimmerDecodeResult(
+            tokens: result.generatedTokens,
+            decodeSeconds: result.decodeSeconds,
+            firstTokenSeconds: result.firstTokenSeconds
+        )
+    }
+
+    private func resolveModelRoot(
+        modelPath: String?,
+        progressHandler: (@Sendable (ChatProgress) -> Void)?
+    ) async throws -> URL {
+        if let modelPath = modelPath?.trimmingCharacters(in: .whitespacesAndNewlines), !modelPath.isEmpty {
+            let root = URL(fileURLWithPath: modelPath).standardizedFileURL
+            guard FileManager.default.fileExists(atPath: root.path) else {
+                throw MuseGlimmerError.unsupportedModelLocation(root.path)
+            }
+            return root
+        }
+        guard MuseGlimmerResources.handles(modelSpec: modelID) else {
+            throw MuseGlimmerError.unsupportedModelID(modelID)
+        }
+        do {
+            let resolution = try await ManagedModelResolver.resolveForRuntime(
+                requestedModel: modelID,
+                defaultModelID: MuseGlimmerResources.modelId,
+                progress: { event in
+                    switch event {
+                    case .downloading(let percent):
+                        progressHandler?(ChatProgress(
+                            stage: .loadingModel,
+                            message: "Downloading Muse Glimmer... \(percent)%"
+                        ))
+                    case .extracting:
+                        progressHandler?(ChatProgress(stage: .loadingModel, message: "Extracting Muse Glimmer..."))
+                    }
+                }
+            )
+            return resolution.url.standardizedFileURL
+        } catch let error as ManagedModelResolver.ResolverError {
+            throw MuseGlimmerError.downloadFailed(error.localizedDescription)
+        }
+    }
+
+    private static func reasoningStrength(_ effort: Double?) -> String {
+        guard let effort else { return "high" }
+        switch effort {
+        case ..<0.34: return "low"
+        case ..<0.67: return "medium"
+        case ..<0.9: return "high"
+        default: return "xhigh"
+        }
+    }
+
+    private static func truncate(_ text: String, at stops: [String]) -> String {
+        let ranges = stops.filter { !$0.isEmpty }.compactMap { text.range(of: $0) }
+        guard let first = ranges.min(by: { $0.lowerBound < $1.lowerBound }) else { return text }
+        return String(text[..<first.lowerBound])
+    }
+}

--- a/Sources/MereRunCore/MuseGlimmer/MuseGlimmerImageProcessor.swift
+++ b/Sources/MereRunCore/MuseGlimmer/MuseGlimmerImageProcessor.swift
@@ -1,0 +1,309 @@
+import Foundation
+import MediaIO
+import MLX
+
+struct MuseGlimmerImageBatch {
+    let pixelValues: MLXArray
+    let grids: [(temporal: Int, height: Int, width: Int)]
+    let tokenCounts: [Int]
+}
+
+enum MuseGlimmerImageProcessor {
+    static func makeBatch(
+        imageReferences: [String],
+        config: MuseGlimmerVisionConfig,
+        maxImageTokens: Int = 4_096
+    ) throws -> MuseGlimmerImageBatch {
+        guard !imageReferences.isEmpty else {
+            throw MuseGlimmerError.unsupportedConfiguration("Muse Glimmer image batch is empty.")
+        }
+        let patchDimension = config.patchTemporal * 3 * config.patchSize * config.patchSize
+        var flattened: [Float] = []
+        var grids: [(Int, Int, Int)] = []
+        var tokenCounts: [Int] = []
+
+        for reference in imageReferences {
+            let image = try decodeImage(reference)
+            let target = targetSize(
+                originalWidth: image.width,
+                originalHeight: image.height,
+                patchSize: config.patchSize,
+                mergeSize: config.mergeSize,
+                maxImageTokens: maxImageTokens
+            )
+            // The published processor resizes uint8 RGB with Lanczos-3 before
+            // normalization. Keep this model-specific so other MediaIO callers
+            // retain their existing interpolation contract.
+            let resized = try resizedLanczos(image, width: target.width, height: target.height)
+            let chw = MediaImageIO.rgbCHWFloat(resized, normalizedToMinusOneToOne: true)
+            let gridHeight = resized.height / config.patchSize
+            let gridWidth = resized.width / config.patchSize
+            appendStaticImagePatches(
+                chw: chw,
+                width: resized.width,
+                height: resized.height,
+                patchSize: config.patchSize,
+                patchTemporal: config.patchTemporal,
+                to: &flattened
+            )
+            grids.append((1, gridHeight, gridWidth))
+            tokenCounts.append((gridHeight * gridWidth) / (config.mergeSize * config.mergeSize))
+        }
+
+        return MuseGlimmerImageBatch(
+            pixelValues: MLXArray(flattened, [flattened.count / patchDimension, patchDimension]),
+            grids: grids,
+            tokenCounts: tokenCounts
+        )
+    }
+
+    static func expandedPromptTokens(
+        _ tokens: [Int],
+        tokenCounts: [Int],
+        imageTokenId: Int,
+        imageStartTokenId: Int,
+        imageEndTokenId: Int
+    ) throws -> [Int] {
+        guard !tokenCounts.isEmpty else { return tokens }
+        let occurrences = tokens.filter { $0 == imageTokenId }.count
+        if occurrences == tokenCounts.reduce(0, +) {
+            return tokens
+        }
+        guard occurrences == tokenCounts.count else {
+            throw MuseGlimmerError.unsupportedConfiguration(
+                "Muse Glimmer prompt has \(occurrences) image placeholders for \(tokenCounts.count) image(s)."
+            )
+        }
+        var imageIndex = 0
+        var expanded: [Int] = []
+        for token in tokens {
+            guard token == imageTokenId else {
+                expanded.append(token)
+                continue
+            }
+            expanded.append(imageStartTokenId)
+            expanded.append(contentsOf: repeatElement(imageTokenId, count: tokenCounts[imageIndex]))
+            expanded.append(imageEndTokenId)
+            imageIndex += 1
+        }
+        return expanded
+    }
+
+    static func targetSize(
+        originalWidth: Int,
+        originalHeight: Int,
+        patchSize: Int,
+        mergeSize: Int,
+        maxImageTokens: Int
+    ) -> (width: Int, height: Int) {
+        let factor = max(1, patchSize * mergeSize)
+        let width = max(1, originalWidth)
+        let height = max(1, originalHeight)
+        var idealPatchHeight = Double(height) / Double(factor)
+        var idealPatchWidth = Double(width) / Double(factor)
+        let ratio = idealPatchWidth / idealPatchHeight
+        if idealPatchHeight * idealPatchWidth > Double(maxImageTokens) {
+            idealPatchHeight = sqrt(Double(maxImageTokens) / ratio)
+            idealPatchWidth = idealPatchHeight * ratio
+        }
+
+        let heightCandidates = integerCandidates(idealPatchHeight)
+        let widthCandidates = integerCandidates(idealPatchWidth)
+        var best = (
+            width: 1,
+            height: 1,
+            ratioError: Double.greatestFiniteMagnitude,
+            sizeError: Double.greatestFiniteMagnitude
+        )
+        for candidateHeight in heightCandidates {
+            for candidateWidth in widthCandidates {
+                guard candidateHeight * candidateWidth <= maxImageTokens else { continue }
+                let ratioError = abs(
+                    Double(candidateHeight) / Double(candidateWidth)
+                        - Double(height) / Double(width)
+                )
+                let sizeError = abs(Double(candidateHeight) - idealPatchHeight)
+                    + abs(Double(candidateWidth) - idealPatchWidth)
+                if ratioError < best.ratioError
+                    || (ratioError == best.ratioError && sizeError < best.sizeError) {
+                    best = (candidateWidth, candidateHeight, ratioError, sizeError)
+                }
+            }
+        }
+        return (best.width * factor, best.height * factor)
+    }
+
+    private static func integerCandidates(_ value: Double) -> [Int] {
+        let lower = max(1, Int(floor(value)))
+        let upper = max(1, Int(ceil(value)))
+        return lower == upper ? [lower] : [lower, upper]
+    }
+
+    private static func decodeImage(_ reference: String) throws -> MediaImage {
+        let trimmed = reference.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            throw MuseGlimmerError.unsupportedConfiguration("Muse Glimmer image reference is empty.")
+        }
+        if trimmed.lowercased().hasPrefix("data:") {
+            guard let comma = trimmed.firstIndex(of: ","),
+                  trimmed[..<comma].lowercased().contains(";base64"),
+                  let data = Data(base64Encoded: String(trimmed[trimmed.index(after: comma)...]), options: .ignoreUnknownCharacters) else {
+                throw MuseGlimmerError.unsupportedConfiguration("Invalid base64 Muse Glimmer image data URL.")
+            }
+            return try MediaImageIO.decode(data: data)
+        }
+        if let url = URL(string: trimmed), url.scheme?.lowercased() == "file" {
+            return try MediaImageIO.decode(url)
+        }
+        if let scheme = URL(string: trimmed)?.scheme?.lowercased(), scheme == "http" || scheme == "https" {
+            throw MuseGlimmerError.unsupportedConfiguration(
+                "Remote image URLs are not fetched by the local Muse Glimmer runtime; use a file path or data URL."
+            )
+        }
+        return try MediaImageIO.decode(URL(fileURLWithPath: trimmed).standardizedFileURL)
+    }
+
+    private struct LanczosContribution {
+        let start: Int
+        let coefficients: [Int32]
+    }
+
+    static func resizedLanczos(
+        _ image: MediaImage,
+        width: Int,
+        height: Int
+    ) throws -> MediaImage {
+        guard width > 0, height > 0 else {
+            throw MediaIOError.invalidImageDimensions(width: width, height: height)
+        }
+        if image.width == width, image.height == height {
+            return image
+        }
+
+        let precisionBits = 22
+        let roundingOffset = Int64(1 << (precisionBits - 1))
+        let horizontal = lanczosContributions(
+            sourceSize: image.width,
+            targetSize: width,
+            precisionBits: precisionBits
+        )
+        let vertical = lanczosContributions(
+            sourceSize: image.height,
+            targetSize: height,
+            precisionBits: precisionBits
+        )
+
+        // Match Pillow's uint8 path: round and clamp after each separable pass.
+        // Muse consumes RGB, so alpha is deliberately regenerated as opaque.
+        var intermediate = [UInt8](repeating: 0, count: image.height * width * 3)
+        for sourceY in 0..<image.height {
+            for targetX in 0..<width {
+                let contribution = horizontal[targetX]
+                for channel in 0..<3 {
+                    var sum = roundingOffset
+                    for (offset, coefficient) in contribution.coefficients.enumerated() {
+                        let sourceX = contribution.start + offset
+                        let source = (sourceY * image.width + sourceX) * 4 + channel
+                        sum += Int64(image.rgba8[source]) * Int64(coefficient)
+                    }
+                    intermediate[(sourceY * width + targetX) * 3 + channel] = clippedUInt8(
+                        sum,
+                        precisionBits: precisionBits
+                    )
+                }
+            }
+        }
+
+        var output = [UInt8](repeating: 255, count: width * height * 4)
+        for targetY in 0..<height {
+            let contribution = vertical[targetY]
+            for targetX in 0..<width {
+                for channel in 0..<3 {
+                    var sum = roundingOffset
+                    for (offset, coefficient) in contribution.coefficients.enumerated() {
+                        let sourceY = contribution.start + offset
+                        let source = (sourceY * width + targetX) * 3 + channel
+                        sum += Int64(intermediate[source]) * Int64(coefficient)
+                    }
+                    output[(targetY * width + targetX) * 4 + channel] = clippedUInt8(
+                        sum,
+                        precisionBits: precisionBits
+                    )
+                }
+            }
+        }
+        return try MediaImage(width: width, height: height, rgba8: output)
+    }
+
+    private static func lanczosContributions(
+        sourceSize: Int,
+        targetSize: Int,
+        precisionBits: Int
+    ) -> [LanczosContribution] {
+        let scale = Double(sourceSize) / Double(targetSize)
+        let filterScale = max(1, scale)
+        let support = 3 * filterScale
+        let fixedScale = Double(1 << precisionBits)
+        return (0..<targetSize).map { destination in
+            let center = (Double(destination) + 0.5) * scale
+            let first = max(0, Int(center - support + 0.5))
+            let last = min(sourceSize, Int(center + support + 0.5))
+            var floating: [Double] = []
+            floating.reserveCapacity(max(1, last - first))
+            var total = 0.0
+            for index in first..<last {
+                let distance = (Double(index) - center + 0.5) / filterScale
+                let value = lanczos(distance)
+                floating.append(value)
+                total += value
+            }
+            let coefficients = floating.map { value -> Int32 in
+                let scaled = value / total * fixedScale
+                let rounded = scaled < 0 ? scaled - 0.5 : scaled + 0.5
+                return Int32(rounded.rounded(.towardZero))
+            }
+            return LanczosContribution(start: first, coefficients: coefficients)
+        }
+    }
+
+    @inline(__always)
+    private static func lanczos(_ value: Double) -> Double {
+        let magnitude = abs(value)
+        if magnitude < Double.ulpOfOne { return 1 }
+        if magnitude >= 3 { return 0 }
+        let piValue = Double.pi * value
+        return sin(piValue) / piValue * sin(piValue / 3) / (piValue / 3)
+    }
+
+    @inline(__always)
+    private static func clippedUInt8(_ value: Int64, precisionBits: Int) -> UInt8 {
+        let shifted = value >> precisionBits
+        return UInt8(clamping: shifted)
+    }
+
+    private static func appendStaticImagePatches(
+        chw: [Float],
+        width: Int,
+        height: Int,
+        patchSize: Int,
+        patchTemporal: Int,
+        to output: inout [Float]
+    ) {
+        let channelPlane = width * height
+        for patchY in 0..<(height / patchSize) {
+            for patchX in 0..<(width / patchSize) {
+                for _ in 0..<patchTemporal {
+                    for channel in 0..<3 {
+                        for y in 0..<patchSize {
+                            let sourceY = patchY * patchSize + y
+                            for x in 0..<patchSize {
+                                let sourceX = patchX * patchSize + x
+                                output.append(chw[channel * channelPlane + sourceY * width + sourceX])
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/Sources/MereRunCore/MuseGlimmer/MuseGlimmerModel.swift
+++ b/Sources/MereRunCore/MuseGlimmer/MuseGlimmerModel.swift
@@ -1,0 +1,789 @@
+import Foundation
+import MLX
+import MLXFast
+import MLXNN
+
+@inline(__always)
+private func museGlimmerRMSNormNoScale(_ x: MLXArray, eps: Float) -> MLXArray {
+    let dtype = x.dtype
+    let promoted = x.asType(.float32)
+    let variance = (promoted * promoted).mean(axis: -1, keepDims: true)
+    return (promoted * MLX.rsqrt(variance + MLXArray(eps))).asType(dtype)
+}
+
+final class MuseGlimmerCenteredRMSNorm: Module {
+    @ParameterInfo(key: "weight") var weight: MLXArray
+    private let eps: Float
+
+    init(dimensions: Int, eps: Float) {
+        self._weight.wrappedValue = MLXArray.zeros([dimensions])
+        self.eps = eps
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let dtype = x.dtype
+        let promoted = x.asType(.float32)
+        let variance = (promoted * promoted).mean(axis: -1, keepDims: true)
+        return (promoted * MLX.rsqrt(variance + MLXArray(eps)) * (1 + weight.asType(.float32)))
+            .asType(dtype)
+    }
+}
+
+final class MuseGlimmerRMSNorm: Module {
+    @ParameterInfo(key: "weight") var weight: MLXArray
+    private let eps: Float
+
+    init(dimensions: Int, eps: Float) {
+        self._weight.wrappedValue = MLXArray.ones([dimensions])
+        self.eps = eps
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        let dtype = x.dtype
+        let promoted = x.asType(.float32)
+        let variance = (promoted * promoted).mean(axis: -1, keepDims: true)
+        return (promoted * MLX.rsqrt(variance + MLXArray(eps)) * weight.asType(.float32)).asType(dtype)
+    }
+}
+
+final class MuseGlimmerTextMLP: Module {
+    @ModuleInfo(key: "gate_proj") var gateProj: Linear
+    @ModuleInfo(key: "up_proj") var upProj: Linear
+    @ModuleInfo(key: "down_proj") var downProj: Linear
+
+    init(config: MuseGlimmerTextConfig) {
+        self._gateProj.wrappedValue = Linear(config.hiddenSize, config.intermediateSize, bias: false)
+        self._upProj.wrappedValue = Linear(config.hiddenSize, config.intermediateSize, bias: false)
+        self._downProj.wrappedValue = Linear(config.intermediateSize, config.hiddenSize, bias: false)
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        downProj(MLXNN.silu(gateProj(x)) * upProj(x))
+    }
+}
+
+final class MuseGlimmerTextAttention: Module {
+    @ModuleInfo(key: "q_proj") var qProj: Linear
+    @ModuleInfo(key: "k_proj") var kProj: Linear
+    @ModuleInfo(key: "v_proj") var vProj: Linear
+    @ModuleInfo(key: "o_proj") var oProj: Linear
+    @ModuleInfo(key: "gate_proj") var gateProj: Linear
+
+    private let headCount: Int
+    private let keyValueHeadCount: Int
+    private let headDimension: Int
+    private let slidingWindow: Int?
+    private let qkScaleFactor: Float
+    private let rmsNormEps: Float
+    private let attentionScale: Float
+    private let rope: RoPE?
+
+    init(config: MuseGlimmerTextConfig, layerIndex: Int) {
+        headCount = config.numAttentionHeads
+        keyValueHeadCount = config.numKeyValueHeads
+        headDimension = config.headDim
+        slidingWindow = config.layerTypes[layerIndex] == "sliding_attention" ? config.slidingWindow : nil
+        qkScaleFactor = config.qkScaleFactor
+        rmsNormEps = config.rmsNormEps
+        attentionScale = 1 / sqrt(Float(config.headDim))
+        let theta = config.layerRopeTheta[layerIndex]
+        rope = theta > 0
+            ? RoPE(dimensions: config.headDim, traditional: false, base: theta)
+            : nil
+        self._qProj.wrappedValue = Linear(
+            config.hiddenSize,
+            config.numAttentionHeads * config.headDim,
+            bias: config.attentionBias
+        )
+        self._kProj.wrappedValue = Linear(
+            config.hiddenSize,
+            config.numKeyValueHeads * config.headDim,
+            bias: config.attentionBias
+        )
+        self._vProj.wrappedValue = Linear(
+            config.hiddenSize,
+            config.numKeyValueHeads * config.headDim,
+            bias: config.attentionBias
+        )
+        self._oProj.wrappedValue = Linear(
+            config.numAttentionHeads * config.headDim,
+            config.hiddenSize,
+            bias: config.attentionBias
+        )
+        self._gateProj.wrappedValue = Linear(
+            config.hiddenSize,
+            config.numAttentionHeads * config.headDim,
+            bias: false
+        )
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray, cache: Gemma4AttentionCache?) -> MLXArray {
+        let batch = x.dim(0)
+        let sequence = x.dim(1)
+        let offset = cache?.offset ?? 0
+        var queries = qProj(x).reshaped(batch, sequence, headCount, headDimension).transposed(0, 2, 1, 3)
+        var keys = kProj(x).reshaped(batch, sequence, keyValueHeadCount, headDimension).transposed(0, 2, 1, 3)
+        var values = vProj(x).reshaped(batch, sequence, keyValueHeadCount, headDimension).transposed(0, 2, 1, 3)
+
+        queries = museGlimmerRMSNormNoScale(queries, eps: rmsNormEps) * qkScaleFactor
+        keys = museGlimmerRMSNormNoScale(keys, eps: rmsNormEps)
+        if let rope {
+            queries = rope(queries, offset: offset)
+            keys = rope(keys, offset: offset)
+        }
+
+        if let cache, let state = cache.attentionState(appending: keys, values: values) {
+            keys = state.0
+            values = state.1
+        }
+        let mask = attentionMask(
+            queryLength: sequence,
+            queryOffset: offset,
+            keyLength: keys.dim(2),
+            windowSize: slidingWindow,
+            dtype: x.dtype
+        )
+        let attended = MLXFast.scaledDotProductAttention(
+            queries: queries,
+            keys: keys,
+            values: values,
+            scale: attentionScale,
+            mask: mask
+        )
+        var output = attended.transposed(0, 2, 1, 3)
+            .reshaped(batch, sequence, headCount * headDimension)
+        output = output * MLX.sigmoid(gateProj(x))
+        return oProj(output)
+    }
+
+    private func attentionMask(
+        queryLength: Int,
+        queryOffset: Int,
+        keyLength: Int,
+        windowSize: Int?,
+        dtype: DType
+    ) -> MLXFast.ScaledDotProductAttentionMaskMode {
+        guard queryLength > 1 else { return .none }
+        let keyStart = max(0, queryOffset + queryLength - keyLength)
+        let queryPositions = MLXArray(Int32(queryOffset)..<Int32(queryOffset + queryLength)).reshaped(queryLength, 1)
+        let keyPositions = MLXArray(Int32(keyStart)..<Int32(keyStart + keyLength)).reshaped(1, keyLength)
+        var allowed = keyPositions .<= queryPositions
+        if let windowSize {
+            allowed = allowed .&& (keyPositions .> (queryPositions - Int32(windowSize)))
+        }
+        let typed = allowed.asType(dtype).reshaped(1, 1, queryLength, keyLength)
+        let zeros = MLXArray.zeros([1, 1, queryLength, keyLength], dtype: dtype)
+        return .array(MLX.where(typed .> MLXArray(0).asType(dtype), zeros, zeros - 1e9))
+    }
+}
+
+final class MuseGlimmerTextDecoderLayer: Module {
+    @ModuleInfo(key: "self_attn") var attention: MuseGlimmerTextAttention
+    @ModuleInfo(key: "mlp") var mlp: MuseGlimmerTextMLP
+    @ModuleInfo(key: "input_layernorm") var inputNorm: MuseGlimmerCenteredRMSNorm
+    @ModuleInfo(key: "post_attention_layernorm") var postAttentionNorm: MuseGlimmerCenteredRMSNorm
+    @ModuleInfo(key: "pre_feedforward_layernorm") var preFeedForwardNorm: MuseGlimmerCenteredRMSNorm
+    @ModuleInfo(key: "post_feedforward_layernorm") var postFeedForwardNorm: MuseGlimmerCenteredRMSNorm
+
+    init(config: MuseGlimmerTextConfig, layerIndex: Int) {
+        self._attention.wrappedValue = MuseGlimmerTextAttention(config: config, layerIndex: layerIndex)
+        self._mlp.wrappedValue = MuseGlimmerTextMLP(config: config)
+        self._inputNorm.wrappedValue = MuseGlimmerCenteredRMSNorm(
+            dimensions: config.hiddenSize,
+            eps: config.rmsNormEps
+        )
+        self._postAttentionNorm.wrappedValue = MuseGlimmerCenteredRMSNorm(
+            dimensions: config.hiddenSize,
+            eps: config.postNormEps
+        )
+        self._preFeedForwardNorm.wrappedValue = MuseGlimmerCenteredRMSNorm(
+            dimensions: config.hiddenSize,
+            eps: config.rmsNormEps
+        )
+        self._postFeedForwardNorm.wrappedValue = MuseGlimmerCenteredRMSNorm(
+            dimensions: config.hiddenSize,
+            eps: config.postNormEps
+        )
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray, cache: Gemma4AttentionCache?) -> MLXArray {
+        let afterAttention = x + postAttentionNorm(attention(inputNorm(x), cache: cache))
+        return afterAttention + postFeedForwardNorm(mlp(preFeedForwardNorm(afterAttention)))
+    }
+}
+
+struct MuseGlimmerLanguageModelOutput {
+    let hidden: MLXArray
+    let capturedHiddenStates: [Int: MLXArray]
+}
+
+final class MuseGlimmerLanguageModel: Module {
+    @ModuleInfo(key: "embed_tokens") var embedTokens: Embedding
+    @ModuleInfo(key: "layers") var layers: [MuseGlimmerTextDecoderLayer]
+    @ModuleInfo(key: "norm") var norm: MuseGlimmerRMSNorm
+
+    private let config: MuseGlimmerTextConfig
+
+    init(config: MuseGlimmerTextConfig) {
+        self.config = config
+        self._embedTokens.wrappedValue = Embedding(
+            embeddingCount: config.vocabSize,
+            dimensions: config.hiddenSize
+        )
+        self._layers.wrappedValue = (0..<config.numHiddenLayers).map {
+            MuseGlimmerTextDecoderLayer(config: config, layerIndex: $0)
+        }
+        self._norm.wrappedValue = MuseGlimmerRMSNorm(dimensions: config.hiddenSize, eps: config.rmsNormEps)
+        super.init()
+    }
+
+    func embeddings(_ inputIds: MLXArray) -> MLXArray {
+        museGlimmerRMSNormNoScale(embedTokens(inputIds.asType(.int32)), eps: config.rmsNormEps)
+    }
+
+    func callAsFunction(_ embeddings: MLXArray, cache: [Gemma4AttentionCache]?) -> MLXArray {
+        forward(embeddings, cache: cache).hidden
+    }
+
+    func forward(
+        _ embeddings: MLXArray,
+        cache: [Gemma4AttentionCache]?,
+        captureLayerIndices: Set<Int> = []
+    ) -> MuseGlimmerLanguageModelOutput {
+        var hidden = embeddings
+        var capturedHiddenStates: [Int: MLXArray] = [:]
+        for (index, layer) in layers.enumerated() {
+            hidden = layer(hidden, cache: cache?[index])
+            if captureLayerIndices.contains(index) {
+                capturedHiddenStates[index] = hidden
+            }
+        }
+        return MuseGlimmerLanguageModelOutput(
+            hidden: norm(hidden),
+            capturedHiddenStates: capturedHiddenStates
+        )
+    }
+
+    func makeCache() -> [Gemma4AttentionCache] {
+        config.layerTypes.map { type -> Gemma4AttentionCache in
+            if type == "sliding_attention" {
+                return Gemma4SlidingKVCache(maxSize: config.slidingWindow)
+            }
+            return Gemma4FullKVCache()
+        }
+    }
+}
+
+struct MuseGlimmerForwardOutput {
+    let logits: MLXArray
+    let capturedHiddenStates: [Int: MLXArray]
+}
+
+final class MuseGlimmerVisionPatchEmbedder: Module {
+    @ModuleInfo(key: "patch_embedding") var patchEmbedding: Linear
+    @ModuleInfo(key: "position_embedding_table") var positionEmbeddingTable: Embedding
+
+    private let side: Int
+    private let hiddenSize: Int
+
+    init(config: MuseGlimmerVisionConfig) {
+        side = config.posEmbHeight
+        hiddenSize = config.hiddenSize
+        self._patchEmbedding.wrappedValue = Linear(
+            config.patchTemporal * 3 * config.patchSize * config.patchSize,
+            config.hiddenSize,
+            bias: false
+        )
+        self._positionEmbeddingTable.wrappedValue = Embedding(
+            embeddingCount: config.posEmbHeight * config.posEmbWidth,
+            dimensions: config.hiddenSize
+        )
+        super.init()
+    }
+
+    func callAsFunction(
+        _ patches: MLXArray,
+        grids: [(temporal: Int, height: Int, width: Int)]
+    ) -> MLXArray {
+        let geometry = Self.bilinearPositionGeometry(grids: grids, side: side)
+        let indices = geometry.indices
+        let weights = geometry.weights
+        var position = MLXArray.zeros([patches.dim(0), hiddenSize], dtype: patches.dtype)
+        for corner in 0..<4 {
+            let indexArray = MLXArray(indices[corner])
+            let weightArray = MLXArray(weights[corner], [weights[corner].count, 1]).asType(patches.dtype)
+            position = position + positionEmbeddingTable(indexArray) * weightArray
+        }
+        return patchEmbedding(patches) + position
+    }
+
+    static func bilinearPositionGeometry(
+        grids: [(temporal: Int, height: Int, width: Int)],
+        side: Int
+    ) -> (indices: [[Int32]], weights: [[Float]]) {
+        var indices = [[Int32]](repeating: [], count: 4)
+        var weights = [[Float]](repeating: [], count: 4)
+        for grid in grids {
+            for _ in 0..<grid.temporal {
+                for row in 0..<grid.height {
+                    let rowValue = (Float(row) + 0.5) * (Float(side) / Float(grid.height)) - 0.5
+                    for column in 0..<grid.width {
+                        let columnValue = (Float(column) + 0.5) * (Float(side) / Float(grid.width)) - 0.5
+                        appendBilinear(
+                            row: rowValue,
+                            column: columnValue,
+                            side: side,
+                            indices: &indices,
+                            weights: &weights
+                        )
+                    }
+                }
+            }
+        }
+        return (indices, weights)
+    }
+
+    private static func appendBilinear(
+        row: Float,
+        column: Float,
+        side: Int,
+        indices: inout [[Int32]],
+        weights: inout [[Float]]
+    ) {
+        let floorRow = Int(floor(row))
+        let ceilRow = floorRow + 1
+        let floorColumn = Int(floor(column))
+        let ceilColumn = floorColumn + 1
+        let rowFraction = row - Float(floorRow)
+        let columnFraction = column - Float(floorColumn)
+        let corners = [
+            (floorRow, floorColumn, (1 - rowFraction) * (1 - columnFraction)),
+            (floorRow, ceilColumn, (1 - rowFraction) * columnFraction),
+            (ceilRow, floorColumn, rowFraction * (1 - columnFraction)),
+            (ceilRow, ceilColumn, rowFraction * columnFraction),
+        ]
+        for (index, corner) in corners.enumerated() {
+            let valid = corner.0 >= 0 && corner.0 < side && corner.1 >= 0 && corner.1 < side
+            let clampedRow = min(max(0, corner.0), side - 1)
+            let clampedColumn = min(max(0, corner.1), side - 1)
+            indices[index].append(Int32(clampedRow * side + clampedColumn))
+            weights[index].append(valid ? corner.2 : 0)
+        }
+    }
+}
+
+final class MuseGlimmerVisionAttention: Module {
+    @ModuleInfo(key: "proj") var projection: Linear
+    @ModuleInfo(key: "q_proj") var queryProjection: Linear
+    @ModuleInfo(key: "k_proj") var keyProjection: Linear
+    @ModuleInfo(key: "v_proj") var valueProjection: Linear
+
+    private let headCount: Int
+    private let headDimension: Int
+    private let scale: Float
+
+    init(config: MuseGlimmerVisionConfig) {
+        headCount = config.numAttentionHeads
+        headDimension = config.hiddenSize / config.numAttentionHeads
+        scale = 1 / sqrt(Float(headDimension))
+        self._projection.wrappedValue = Linear(config.hiddenSize, config.hiddenSize, bias: true)
+        self._queryProjection.wrappedValue = Linear(config.hiddenSize, config.hiddenSize, bias: true)
+        self._keyProjection.wrappedValue = Linear(config.hiddenSize, config.hiddenSize, bias: true)
+        self._valueProjection.wrappedValue = Linear(config.hiddenSize, config.hiddenSize, bias: true)
+        super.init()
+    }
+
+    func callAsFunction(
+        _ x: MLXArray,
+        cosine: MLXArray,
+        sine: MLXArray,
+        segments: [Int]
+    ) -> MLXArray {
+        let sequence = x.dim(0)
+        var queries = queryProjection(x).reshaped(1, sequence, headCount, headDimension)
+        var keys = keyProjection(x).reshaped(1, sequence, headCount, headDimension)
+        let values = valueProjection(x).reshaped(1, sequence, headCount, headDimension)
+        queries = applyRotary(queries, cosine: cosine, sine: sine).transposed(0, 2, 1, 3)
+        keys = applyRotary(keys, cosine: cosine, sine: sine).transposed(0, 2, 1, 3)
+        let transposedValues = values.transposed(0, 2, 1, 3)
+        var pieces: [MLXArray] = []
+        for index in 0..<(segments.count - 1) {
+            let start = segments[index]
+            let end = segments[index + 1]
+            guard end > start else { continue }
+            pieces.append(MLXFast.scaledDotProductAttention(
+                queries: queries[0..., 0..., start..<end, 0...],
+                keys: keys[0..., 0..., start..<end, 0...],
+                values: transposedValues[0..., 0..., start..<end, 0...],
+                scale: scale,
+                mask: .none
+            ))
+        }
+        let attended = pieces.count == 1 ? pieces[0] : MLX.concatenated(pieces, axis: 2)
+        return projection(attended.transposed(0, 2, 1, 3).reshaped(sequence, headCount * headDimension))
+    }
+
+    private func applyRotary(_ x: MLXArray, cosine: MLXArray, sine: MLXArray) -> MLXArray {
+        let promoted = x.asType(.float32)
+        let half = x.dim(-1) / 2
+        let rotated = MLX.concatenated([
+            -promoted[0..., 0..., 0..., half...],
+            promoted[0..., 0..., 0..., 0..<half],
+        ], axis: -1)
+        return (promoted * cosine.asType(.float32) + rotated * sine.asType(.float32)).asType(x.dtype)
+    }
+}
+
+final class MuseGlimmerVisionMLP: Module {
+    @ModuleInfo(key: "fc1") var fc1: Linear
+    @ModuleInfo(key: "fc2") var fc2: Linear
+
+    init(config: MuseGlimmerVisionConfig) {
+        self._fc1.wrappedValue = Linear(config.hiddenSize, config.intermediateSize, bias: true)
+        self._fc2.wrappedValue = Linear(config.intermediateSize, config.hiddenSize, bias: true)
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        fc2(MLXNN.gelu(fc1(x)))
+    }
+}
+
+final class MuseGlimmerVisionEncoderLayer: Module {
+    @ModuleInfo(key: "norm1") var norm1: LayerNorm
+    @ModuleInfo(key: "norm2") var norm2: LayerNorm
+    @ModuleInfo(key: "attn") var attention: MuseGlimmerVisionAttention
+    @ModuleInfo(key: "mlp") var mlp: MuseGlimmerVisionMLP
+
+    init(config: MuseGlimmerVisionConfig) {
+        self._norm1.wrappedValue = LayerNorm(dimensions: config.hiddenSize, eps: config.layerNormEps)
+        self._norm2.wrappedValue = LayerNorm(dimensions: config.hiddenSize, eps: config.layerNormEps)
+        self._attention.wrappedValue = MuseGlimmerVisionAttention(config: config)
+        self._mlp.wrappedValue = MuseGlimmerVisionMLP(config: config)
+        super.init()
+    }
+
+    func callAsFunction(
+        _ x: MLXArray,
+        cosine: MLXArray,
+        sine: MLXArray,
+        segments: [Int]
+    ) -> MLXArray {
+        let afterAttention = x + attention(norm1(x), cosine: cosine, sine: sine, segments: segments)
+        return afterAttention + mlp(norm2(afterAttention))
+    }
+}
+
+final class MuseGlimmerVisionTower: Module {
+    @ModuleInfo(key: "patch_embedder") var patchEmbedder: MuseGlimmerVisionPatchEmbedder
+    @ModuleInfo(key: "ln_pre") var preNorm: LayerNorm
+    @ModuleInfo(key: "layers") var layers: [MuseGlimmerVisionEncoderLayer]
+    @ModuleInfo(key: "ln_post") var postNorm: LayerNorm
+
+    private let config: MuseGlimmerVisionConfig
+
+    init(config: MuseGlimmerVisionConfig) {
+        self.config = config
+        self._patchEmbedder.wrappedValue = MuseGlimmerVisionPatchEmbedder(config: config)
+        self._preNorm.wrappedValue = LayerNorm(dimensions: config.hiddenSize, eps: config.layerNormEps)
+        self._layers.wrappedValue = (0..<config.numHiddenLayers).map { _ in
+            MuseGlimmerVisionEncoderLayer(config: config)
+        }
+        self._postNorm.wrappedValue = LayerNorm(dimensions: config.hiddenSize, eps: config.layerNormEps)
+        super.init()
+    }
+
+    func callAsFunction(
+        _ patches: MLXArray,
+        grids: [(temporal: Int, height: Int, width: Int)]
+    ) -> MLXArray {
+        let layout = makeLayout(grids: grids)
+        var hidden = preNorm(patchEmbedder(patches, grids: grids))
+        let order = MLXArray(layout.order.map(Int32.init))
+        hidden = MLX.take(hidden, order, axis: 0)
+        let rotary = makeRotary(positionPairs: layout.positions, dtype: hidden.dtype)
+        for (index, layer) in layers.enumerated() {
+            let segments = config.layerTypes[index] == "full_attention"
+                ? layout.fullSegments
+                : layout.windowSegments
+            hidden = layer(hidden, cosine: rotary.cosine, sine: rotary.sine, segments: segments)
+        }
+        hidden = MLX.take(hidden, MLXArray(layout.reverseOrder.map(Int32.init)), axis: 0)
+        return pixelShuffle(postNorm(hidden), grids: grids)
+    }
+
+    private func makeLayout(
+        grids: [(temporal: Int, height: Int, width: Int)]
+    ) -> (order: [Int], reverseOrder: [Int], positions: [(Int, Int)], fullSegments: [Int], windowSegments: [Int]) {
+        let windowSide = max(1, config.posEmbHeight)
+        var order: [Int] = []
+        var positions: [(Int, Int)] = []
+        var fullSegments = [0]
+        var windowSegments = [0]
+        var base = 0
+        for grid in grids {
+            for frame in 0..<grid.temporal {
+                for windowRow in stride(from: 0, to: grid.height, by: windowSide) {
+                    for windowColumn in stride(from: 0, to: grid.width, by: windowSide) {
+                        var windowCount = 0
+                        for row in windowRow..<min(grid.height, windowRow + windowSide) {
+                            for column in windowColumn..<min(grid.width, windowColumn + windowSide) {
+                                order.append(base + frame * grid.height * grid.width + row * grid.width + column)
+                                positions.append((column + 1, row + 1))
+                                windowCount += 1
+                            }
+                        }
+                        windowSegments.append((windowSegments.last ?? 0) + windowCount)
+                    }
+                }
+                fullSegments.append((fullSegments.last ?? 0) + grid.height * grid.width)
+            }
+            base += grid.temporal * grid.height * grid.width
+        }
+        var reverseOrder = [Int](repeating: 0, count: order.count)
+        for (ordered, original) in order.enumerated() {
+            reverseOrder[original] = ordered
+        }
+        return (order, reverseOrder, positions, fullSegments, windowSegments)
+    }
+
+    private func makeRotary(
+        positionPairs: [(Int, Int)],
+        dtype: DType
+    ) -> (cosine: MLXArray, sine: MLXArray) {
+        let headDimension = config.hiddenSize / config.numAttentionHeads
+        let spatialDimension = headDimension / 2
+        var values: [Float] = []
+        values.reserveCapacity(positionPairs.count * headDimension)
+        for position in positionPairs {
+            var widthFrequencies: [Float] = []
+            var heightFrequencies: [Float] = []
+            for index in stride(from: 0, to: spatialDimension, by: 2) {
+                let inverse = pow(config.ropeParameters.ropeTheta, -Float(index) / Float(spatialDimension))
+                widthFrequencies.append(Float(position.0) * inverse)
+                heightFrequencies.append(Float(position.1) * inverse)
+            }
+            values.append(contentsOf: widthFrequencies)
+            values.append(contentsOf: heightFrequencies)
+            values.append(contentsOf: widthFrequencies)
+            values.append(contentsOf: heightFrequencies)
+        }
+        let angles = MLXArray(values, [1, positionPairs.count, 1, headDimension]).asType(dtype)
+        return (MLX.cos(angles), MLX.sin(angles))
+    }
+
+    private func pixelShuffle(
+        _ hidden: MLXArray,
+        grids: [(temporal: Int, height: Int, width: Int)]
+    ) -> MLXArray {
+        let merge = config.mergeSize
+        let dimensions = hidden.dim(-1)
+        var chunks: [MLXArray] = []
+        var offset = 0
+        for grid in grids {
+            let count = grid.temporal * grid.height * grid.width
+            var indices: [Int32] = []
+            for frame in 0..<grid.temporal {
+                for blockRow in 0..<(grid.height / merge) {
+                    for blockColumn in 0..<(grid.width / merge) {
+                        for innerRow in 0..<merge {
+                            for innerColumn in 0..<merge {
+                                indices.append(Int32(
+                                    frame * grid.height * grid.width
+                                        + (blockRow * merge + innerRow) * grid.width
+                                        + blockColumn * merge + innerColumn
+                                ))
+                            }
+                        }
+                    }
+                }
+            }
+            let chunk = hidden[offset..<(offset + count), 0...]
+            chunks.append(
+                MLX.take(chunk, MLXArray(indices), axis: 0)
+                    .reshaped(count / (merge * merge), merge * merge, dimensions)
+                    .transposed(0, 2, 1)
+                    .reshaped(count / (merge * merge), dimensions * merge * merge)
+            )
+            offset += count
+        }
+        return chunks.count == 1 ? chunks[0] : MLX.concatenated(chunks, axis: 0)
+    }
+}
+
+final class MuseGlimmerVisionAdapter: Module {
+    @ModuleInfo(key: "fc1") var fc1: Linear
+    @ModuleInfo(key: "fc2") var fc2: Linear
+
+    init(config: MuseGlimmerConfig) {
+        self._fc1.wrappedValue = Linear(config.outHiddenSize, config.projectorHiddenSize, bias: false)
+        self._fc2.wrappedValue = Linear(config.projectorHiddenSize, config.projectorHiddenSize, bias: false)
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        MLXNN.gelu(fc2(MLXNN.gelu(fc1(x))))
+    }
+}
+
+final class MuseGlimmerBackbone: Module {
+    @ModuleInfo(key: "vision_tower") var visionTower: MuseGlimmerVisionTower
+    @ModuleInfo(key: "language_model") var languageModel: MuseGlimmerLanguageModel
+    @ModuleInfo(key: "vision_adapter") var visionAdapter: MuseGlimmerVisionAdapter
+    @ModuleInfo(key: "vision_projection") var visionProjection: Linear
+
+    private let config: MuseGlimmerConfig
+
+    init(config: MuseGlimmerConfig) {
+        self.config = config
+        self._visionTower.wrappedValue = MuseGlimmerVisionTower(config: config.visionConfig)
+        self._languageModel.wrappedValue = MuseGlimmerLanguageModel(config: config.textConfig)
+        self._visionAdapter.wrappedValue = MuseGlimmerVisionAdapter(config: config)
+        self._visionProjection.wrappedValue = Linear(
+            config.projectorHiddenSize,
+            config.textConfig.hiddenSize,
+            bias: false
+        )
+        super.init()
+    }
+
+    func embeddings(
+        inputIds: MLXArray,
+        imageBatch: MuseGlimmerImageBatch?
+    ) throws -> MLXArray {
+        var hidden = languageModel.embeddings(inputIds)
+        guard let imageBatch else { return hidden }
+        var features = visionTower(imageBatch.pixelValues, grids: imageBatch.grids)
+        features = museGlimmerRMSNormNoScale(
+            visionProjection(visionAdapter(features)),
+            eps: config.textConfig.rmsNormEps
+        )
+        let ids = inputIds.asType(.int32)
+        MLX.eval(ids)
+        let rawIds = ids.asArray(Int32.self)
+        let positions = rawIds.enumerated().compactMap { index, token in
+            token == Int32(config.imageTokenId) ? index : nil
+        }
+        guard positions.count == features.dim(0) else {
+            throw MuseGlimmerError.unsupportedConfiguration(
+                "Muse Glimmer prompt contains \(positions.count) image tokens but the vision tower produced \(features.dim(0)) features."
+            )
+        }
+        guard !positions.isEmpty else { return hidden }
+        var parts: [MLXArray] = []
+        var cursor = 0
+        for (featureIndex, position) in positions.enumerated() {
+            if position > cursor {
+                parts.append(hidden[0..., cursor..<position, 0...])
+            }
+            parts.append(features[featureIndex..<(featureIndex + 1), 0...].expandedDimensions(axis: 0))
+            cursor = position + 1
+        }
+        if cursor < hidden.dim(1) {
+            parts.append(hidden[0..., cursor..., 0...])
+        }
+        hidden = parts.count == 1 ? parts[0] : MLX.concatenated(parts, axis: 1)
+        return hidden
+    }
+}
+
+public final class MuseGlimmerModel: Module, @unchecked Sendable {
+    @ModuleInfo(key: "model") var model: MuseGlimmerBackbone
+    @ModuleInfo(key: "lm_head") var lmHead: Linear
+
+    public let config: MuseGlimmerConfig
+
+    public init(config: MuseGlimmerConfig) {
+        self.config = config
+        self._model.wrappedValue = MuseGlimmerBackbone(config: config)
+        self._lmHead.wrappedValue = Linear(
+            config.textConfig.hiddenSize,
+            config.textConfig.vocabSize,
+            bias: false
+        )
+        super.init()
+    }
+
+    func forwardPrefill(
+        inputIds: MLXArray,
+        imageBatch: MuseGlimmerImageBatch?,
+        cache: [Gemma4AttentionCache]
+    ) throws -> MLXArray {
+        try forwardPrefillDetailed(
+            inputIds: inputIds,
+            imageBatch: imageBatch,
+            cache: cache
+        ).logits
+    }
+
+    func forwardPrefillDetailed(
+        inputIds: MLXArray,
+        imageBatch: MuseGlimmerImageBatch?,
+        cache: [Gemma4AttentionCache],
+        captureLayerIndices: Set<Int> = []
+    ) throws -> MuseGlimmerForwardOutput {
+        let output = model.languageModel.forward(
+            try model.embeddings(inputIds: inputIds, imageBatch: imageBatch),
+            cache: cache,
+            captureLayerIndices: captureLayerIndices
+        )
+        var hidden = output.hidden
+        if hidden.dim(1) > 1 {
+            hidden = hidden[0..., (hidden.dim(1) - 1)..., 0...]
+        }
+        return MuseGlimmerForwardOutput(
+            logits: logits(hidden),
+            capturedHiddenStates: output.capturedHiddenStates
+        )
+    }
+
+    func callAsFunction(_ inputIds: MLXArray, cache: [Gemma4AttentionCache]) -> MLXArray {
+        var hidden = forward(inputIds, cache: cache).logits
+        if hidden.dim(1) > 1 {
+            hidden = hidden[0..., (hidden.dim(1) - 1)..., 0...]
+        }
+        return hidden
+    }
+
+    func forward(
+        _ inputIds: MLXArray,
+        cache: [Gemma4AttentionCache],
+        captureLayerIndices: Set<Int> = []
+    ) -> MuseGlimmerForwardOutput {
+        let output = model.languageModel.forward(
+            model.languageModel.embeddings(inputIds),
+            cache: cache,
+            captureLayerIndices: captureLayerIndices
+        )
+        return MuseGlimmerForwardOutput(
+            logits: logits(output.hidden),
+            capturedHiddenStates: output.capturedHiddenStates
+        )
+    }
+
+    func makeCache() -> [Gemma4AttentionCache] {
+        model.languageModel.makeCache()
+    }
+
+    func rawInputEmbeddings(for inputIds: MLXArray) -> MLXArray {
+        model.languageModel.embedTokens(inputIds.asType(.int32))
+    }
+
+    func rawOutputLogits(from hidden: MLXArray) -> MLXArray {
+        lmHead(hidden)
+    }
+
+    private func logits(_ hidden: MLXArray) -> MLXArray {
+        var output = lmHead(hidden) * config.textConfig.outputMultiplier
+        let cap = config.textConfig.finalLogitSoftcapping
+        if cap > 0 {
+            output = MLX.tanh(output / cap) * cap
+        }
+        return output
+    }
+}

--- a/Sources/MereRunCore/MuseGlimmer/MuseGlimmerOutputParser.swift
+++ b/Sources/MereRunCore/MuseGlimmer/MuseGlimmerOutputParser.swift
@@ -1,0 +1,45 @@
+import Foundation
+
+struct MuseGlimmerParsedOutput {
+    let visible: String
+    let reasoning: String?
+    let toolCalls: [ToolCall]
+}
+
+enum MuseGlimmerOutputParser {
+    static func parse(_ raw: String) -> MuseGlimmerParsedOutput {
+        let toolCalls = MuseGlimmerToolParser.parseToolCalls(raw)
+        var visible = MuseGlimmerToolParser.visibleText(raw)
+        var reasoning: String?
+
+        let reasoningMarkers = ["to=self<|message|>", " to=self<|message|>"]
+        if let marker = reasoningMarkers.first(where: { visible.contains($0) }),
+           let range = visible.range(of: marker) {
+            let remainder = String(visible[range.upperBound...])
+            if let finalRange = remainder.range(of: "<|start|>assistant to=user<|message|>") {
+                reasoning = String(remainder[..<finalRange.lowerBound])
+                    .replacingOccurrences(of: "<|eom|>", with: "")
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                visible = String(remainder[finalRange.upperBound...])
+            } else {
+                reasoning = remainder
+                    .replacingOccurrences(of: "<|eom|>", with: "")
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                visible = ""
+            }
+        }
+
+        for prefix in [
+            " to=user<|message|>",
+            "to=user<|message|>",
+            "<|start|>assistant to=user<|message|>",
+        ] where visible.hasPrefix(prefix) {
+            visible.removeFirst(prefix.count)
+        }
+        visible = visible
+            .replacingOccurrences(of: "<|eot|>", with: "")
+            .replacingOccurrences(of: "<|eom|>", with: "")
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return MuseGlimmerParsedOutput(visible: visible, reasoning: reasoning, toolCalls: toolCalls)
+    }
+}

--- a/Sources/MereRunCore/MuseGlimmer/MuseGlimmerResources.swift
+++ b/Sources/MereRunCore/MuseGlimmer/MuseGlimmerResources.swift
@@ -1,0 +1,132 @@
+import Foundation
+
+public struct MuseGlimmerResources: Sendable, Hashable {
+    public static let modelId = "vision-chat-muse-glimmer-30b"
+    public static let upstreamRepoId = "meta-models/Muse-Glimmer-30B"
+    public static let upstreamRevision = "f84ecc3a0ea984a4c04542a84269e3d065350a6e"
+    public static let artifactRepoId = "Sawfwair/Muse-Glimmer-30B-MLX-4bit"
+    public static let artifactRevision = "6532e898dc5c1a55b51b1b108cd36728b79be751"
+    public static let defaultContextLength = 131_072
+    public static let estimatedDownloadBytes: Int64 = 21_376_480_452
+    public static let recommendedTemperature = 1.0
+    public static let recommendedTopP = 0.95
+    public static let recommendedTopK = 64
+    public static let assistantModelId = "vision-chat-muse-glimmer-30b-assistant"
+    public static let assistantQuantizedModelId = "vision-chat-muse-glimmer-30b-assistant-q4"
+    public static let assistantUpstreamRepoId = "meta-models/Muse-Glimmer-30B-assistant"
+    public static let assistantUpstreamRevision = "2c86316d689027b91123638739743fef1d425233"
+    public static let assistantEstimatedDownloadBytes: Int64 = 5_111_976_608
+    public static let assistantSnapshotPatterns = [
+        "LICENSE",
+        "README.md",
+        "USAGE_POLICY.md",
+        "config.json",
+        "MERERUN_CONVERSION.json",
+        "model.safetensors",
+        "model.safetensors.index.json",
+        "*.safetensors",
+    ]
+    public static let snapshotPatterns = [
+        "LICENSE",
+        "README.md",
+        "USAGE_POLICY.md",
+        "config.json",
+        "generation_config.json",
+        "processor_config.json",
+        "tokenizer.json",
+        "tokenizer_config.json",
+        "chat_template.jinja",
+        "MERERUN_CONVERSION.json",
+        "model.safetensors",
+        "model.safetensors.index.json",
+        "*.safetensors",
+    ]
+
+    public let rootURL: URL
+
+    public init(rootURL: URL) {
+        self.rootURL = rootURL.standardizedFileURL
+    }
+
+    public var configURL: URL { rootURL.appending(path: "config.json") }
+    public var generationConfigURL: URL { rootURL.appending(path: "generation_config.json") }
+    public var processorConfigURL: URL { rootURL.appending(path: "processor_config.json") }
+    public var tokenizerURL: URL { rootURL.appending(path: "tokenizer.json") }
+    public var tokenizerConfigURL: URL { rootURL.appending(path: "tokenizer_config.json") }
+    public var chatTemplateURL: URL { rootURL.appending(path: "chat_template.jinja") }
+    public var modelIndexURL: URL { rootURL.appending(path: "model.safetensors.index.json") }
+    public var modelWeightsURL: URL { rootURL.appending(path: "model.safetensors") }
+
+    public func validate(fileManager: FileManager = .default) -> [URL] {
+        var missing = [configURL, generationConfigURL, processorConfigURL, tokenizerURL, tokenizerConfigURL]
+            .filter { !fileManager.fileExists(atPath: $0.path) }
+        let hasIndex = fileManager.fileExists(atPath: modelIndexURL.path)
+        let hasSingle = fileManager.fileExists(atPath: modelWeightsURL.path)
+        if !hasIndex && !hasSingle {
+            missing.append(modelIndexURL)
+        }
+        return missing
+    }
+
+    public static func handles(modelSpec raw: String) -> Bool {
+        let normalized = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return normalized == modelId
+            || normalized == upstreamRepoId.lowercased()
+            || normalized == artifactRepoId.lowercased()
+            || normalized.contains("muse-glimmer")
+            || normalized.contains("muse_glimmer")
+    }
+
+    public static func isLikelyHubRepoID(_ raw: String) -> Bool {
+        let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+        return !trimmed.isEmpty
+            && !trimmed.hasPrefix("/")
+            && !trimmed.hasPrefix("~")
+            && !trimmed.hasPrefix(".")
+            && trimmed.split(separator: "/").count == 2
+    }
+
+    public static func validateAssistant(
+        rootURL: URL,
+        fileManager: FileManager = .default
+    ) -> [URL] {
+        let config = rootURL.appending(path: "config.json")
+        let single = rootURL.appending(path: "model.safetensors")
+        let index = rootURL.appending(path: "model.safetensors.index.json")
+        var missing = fileManager.fileExists(atPath: config.path) ? [] : [config]
+        if !fileManager.fileExists(atPath: single.path),
+           !fileManager.fileExists(atPath: index.path) {
+            missing.append(index)
+        }
+        return missing
+    }
+}
+
+public enum MuseGlimmerError: LocalizedError {
+    case modelNotLoaded
+    case missingFiles([String])
+    case generationFailed(String)
+    case unsupportedModelID(String)
+    case unsupportedConfiguration(String)
+    case unsupportedModelLocation(String)
+    case downloadFailed(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .modelNotLoaded:
+            return "Muse Glimmer is not loaded."
+        case .missingFiles(let files):
+            return "Missing required Muse Glimmer files: \(files.joined(separator: ", "))."
+        case .generationFailed(let message):
+            return message
+        case .unsupportedModelID(let modelID):
+            return "Unsupported Muse Glimmer model id: \(modelID)"
+        case .unsupportedConfiguration(let message):
+            return message
+        case .unsupportedModelLocation(let location):
+            return "Could not resolve Muse Glimmer model location: \(location)"
+        case .downloadFailed(let message):
+            return "Muse Glimmer download failed: \(message)"
+        }
+    }
+}

--- a/Sources/MereRunCore/MuseGlimmer/MuseGlimmerTokenizerAndTemplate.swift
+++ b/Sources/MereRunCore/MuseGlimmer/MuseGlimmerTokenizerAndTemplate.swift
@@ -1,0 +1,139 @@
+import Foundation
+@preconcurrency import Hub
+@preconcurrency import Tokenizers
+
+public final class MuseGlimmerTokenizerAndTemplate: @unchecked Sendable {
+    public let tokenizer: any Tokenizer
+    public let maxLength: Int
+    public let eosTokenIds: [Int]
+    public let imageTokenId: Int
+    public let imageStartTokenId: Int
+    public let imageEndTokenId: Int
+
+    private init(
+        tokenizer: any Tokenizer,
+        maxLength: Int,
+        eosTokenIds: [Int],
+        imageTokenId: Int,
+        imageStartTokenId: Int,
+        imageEndTokenId: Int
+    ) {
+        self.tokenizer = tokenizer
+        self.maxLength = maxLength
+        self.eosTokenIds = eosTokenIds
+        self.imageTokenId = imageTokenId
+        self.imageStartTokenId = imageStartTokenId
+        self.imageEndTokenId = imageEndTokenId
+    }
+
+    static func load(
+        from rootURL: URL,
+        generationConfig: MuseGlimmerGenerationConfig,
+        maxLengthOverride: Int? = nil,
+        hubApi: HubApi = .shared
+    ) async throws -> MuseGlimmerTokenizerAndTemplate {
+        let tokenizer = try await AutoTokenizer.from(modelFolder: rootURL, hubApi: hubApi)
+        guard let imageTokenId = tokenizer.convertTokenToId("<|patch|>"),
+              let imageStartTokenId = tokenizer.convertTokenToId("<|image_start|>"),
+              let imageEndTokenId = tokenizer.convertTokenToId("<|image_end|>") else {
+            throw MuseGlimmerError.unsupportedConfiguration(
+                "Muse Glimmer tokenizer is missing one or more required image tokens."
+            )
+        }
+        let configuredMaxLength = generationConfig.maxLength ?? MuseGlimmerResources.defaultContextLength
+        let stopIds = Array(Set(generationConfig.eosTokenIds + [tokenizer.eosTokenId].compactMap { $0 })).sorted()
+        return MuseGlimmerTokenizerAndTemplate(
+            tokenizer: tokenizer,
+            maxLength: maxLengthOverride ?? configuredMaxLength,
+            eosTokenIds: stopIds,
+            imageTokenId: imageTokenId,
+            imageStartTokenId: imageStartTokenId,
+            imageEndTokenId: imageEndTokenId
+        )
+    }
+
+    public func encodeForGeneration(
+        messages: [ChatMessage],
+        tools: [ToolDefinition]? = nil,
+        reasoningStrength: String,
+        currentDate: String,
+        maxLength: Int
+    ) throws -> [Int] {
+        let toolSpecs: [ToolSpec]? = tools?.isEmpty == false ? tools?.map { $0.toToolSpec() } : nil
+        var encoded = try tokenizer.applyChatTemplate(
+            messages: Self.renderMessages(messages),
+            chatTemplate: nil,
+            addGenerationPrompt: true,
+            truncation: false,
+            maxLength: nil,
+            tools: toolSpecs,
+            additionalContext: [
+                "reasoning_strength": reasoningStrength,
+                "current_date": currentDate,
+            ]
+        )
+        let targetLength = min(maxLength, self.maxLength)
+        if encoded.count > targetLength {
+            encoded = Array(encoded.suffix(targetLength))
+        }
+        return encoded
+    }
+
+    public func decode(tokens: [Int]) -> String {
+        tokenizer.decode(tokens: tokens)
+    }
+
+    public func decode(token: Int) -> String {
+        tokenizer.decode(tokens: [token])
+    }
+
+    static func renderMessages(_ messages: [ChatMessage]) -> [Message] {
+        messages.map { message in
+            var rendered: Message = ["role": message.role.rawValue]
+            if let image = message.imageUrl, !image.isEmpty {
+                rendered["content"] = [
+                    ["type": "image", "image_url": image],
+                    ["type": "text", "text": message.content],
+                ] as [[String: String]]
+            } else {
+                rendered["content"] = message.content
+            }
+
+            if let reasoning = message.reasoningContent, !reasoning.isEmpty {
+                rendered["reasoning_content"] = reasoning
+            }
+            if let name = message.name, !name.isEmpty {
+                rendered["name"] = name
+            }
+            if let toolCallID = message.toolCallID, !toolCallID.isEmpty {
+                rendered["tool_call_id"] = toolCallID
+            }
+            if let calls = message.toolCalls, !calls.isEmpty {
+                rendered["tool_calls"] = calls.map { call -> [String: any Sendable] in
+                    var result: [String: any Sendable] = [
+                        "function": [
+                            "name": call.name,
+                            "arguments": call.arguments.mapValues(renderJSONValue),
+                        ] as [String: any Sendable],
+                    ]
+                    if let id = call.id, !id.isEmpty {
+                        result["id"] = id
+                    }
+                    return result
+                }
+            }
+            return rendered
+        }
+    }
+
+    private static func renderJSONValue(_ value: OpenAIJSONValue) -> any Sendable {
+        switch value {
+        case .string(let value): value
+        case .number(let value): value
+        case .bool(let value): value
+        case .object(let value): value.mapValues(renderJSONValue)
+        case .array(let value): value.map(renderJSONValue)
+        case .null: Optional<String>.none
+        }
+    }
+}

--- a/Sources/MereRunCore/MuseGlimmer/MuseGlimmerToolParser.swift
+++ b/Sources/MereRunCore/MuseGlimmer/MuseGlimmerToolParser.swift
@@ -1,0 +1,51 @@
+import Foundation
+
+/// Parses Muse Glimmer's ATEM tool-call protocol without treating it as XML.
+public enum MuseGlimmerToolParser {
+    private static let invokePattern = #"(?s)<atem:invoke\s+name=[\"']([^\"']+)[\"']\s*>(.*?)</atem:invoke>"#
+    private static let parameterPattern = #"(?s)<atem:parameter\s+name=[\"']([^\"']+)[\"']\s*>(.*?)</atem:parameter>"#
+
+    public static func parseToolCalls(_ text: String) -> [ToolCall] {
+        matches(pattern: invokePattern, in: text).compactMap { match in
+            guard match.count == 3 else { return nil }
+            let name = unescape(match[1]).trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !name.isEmpty else { return nil }
+            var arguments: [String: String] = [:]
+            for parameter in matches(pattern: parameterPattern, in: match[2]) where parameter.count == 3 {
+                let key = unescape(parameter[1]).trimmingCharacters(in: .whitespacesAndNewlines)
+                if !key.isEmpty {
+                    arguments[key] = unescape(parameter[2])
+                }
+            }
+            return ToolCall(name: name, arguments: arguments)
+        }
+    }
+
+    public static func visibleText(_ text: String) -> String {
+        text.replacingOccurrences(
+            of: #"(?s)<atem:function_calls>.*?</atem:function_calls>"#,
+            with: "",
+            options: .regularExpression
+        ).trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private static func matches(pattern: String, in text: String) -> [[String]] {
+        guard let expression = try? NSRegularExpression(pattern: pattern) else { return [] }
+        let fullRange = NSRange(text.startIndex..<text.endIndex, in: text)
+        return expression.matches(in: text, range: fullRange).map { match in
+            (0..<match.numberOfRanges).map { index in
+                guard let range = Range(match.range(at: index), in: text) else { return "" }
+                return String(text[range])
+            }
+        }
+    }
+
+    private static func unescape(_ text: String) -> String {
+        text
+            .replacingOccurrences(of: "&lt;", with: "<")
+            .replacingOccurrences(of: "&gt;", with: ">")
+            .replacingOccurrences(of: "&quot;", with: "\"")
+            .replacingOccurrences(of: "&#39;", with: "'")
+            .replacingOccurrences(of: "&amp;", with: "&")
+    }
+}

--- a/Sources/MereRunCore/MuseGlimmer/README.md
+++ b/Sources/MereRunCore/MuseGlimmer/README.md
@@ -1,0 +1,64 @@
+# Muse Glimmer
+
+Native Swift/MLX text-and-image inference for Meta Muse Glimmer 30B.
+
+The audited converter defaults to a selective Q4 layout that leaves the token
+embedding and complete vision tower in BF16. A smaller `compact` scope is
+available for explicit low-memory experiments. The loader discovers quantized
+modules from the checkpoint's `.scales` arrays and accepts both upstream and
+common MLX Hub key layouts, so selective and compact artifacts share the same
+native runtime.
+
+Image preparation performs separable uint8 Lanczos-3 resizing with per-pass
+rounding and clamping before normalization, matching the released Pillow and
+torchvision path. Vision position geometry stays in float32. Exact byte and bit
+pattern fixtures cover both contracts so a visually plausible preprocessing
+change cannot silently alter model input.
+
+- `MuseGlimmerConfig.swift`: typed upstream configuration, including per-layer
+  NoPE/rotary selection and optional MLX quantization metadata.
+- `MuseGlimmerModel.swift`: dense local/global decoder, gated attention,
+  centered residual norms, ViT-G/14 perception encoder, and multimodal scatter.
+- `MuseGlimmerImageProcessor.swift`: aspect-preserving patch preparation and
+  prompt placeholder expansion.
+- `MuseGlimmerTokenizerAndTemplate.swift`: the released ATEM chat/tool template.
+- `MuseGlimmerAssistantModel.swift`: the official five-layer DFlash assistant,
+  including target hidden-state projection and bidirectional sliding attention.
+- `MuseGlimmerDFlashDecoder.swift`: lossless draft verification, rejection
+  correction, and acceptance-aware target-only fallback.
+- `MuseGlimmerGenerator.swift`: managed target/assistant loading and native decode.
+
+The managed target is pinned to Sawfwair's selective MLX Q4 artifact at
+`Sawfwair/Muse-Glimmer-30B-MLX-4bit@6532e898dc5c1a55b51b1b108cd36728b79be751`.
+Its receipt pins the original Meta BF16 source at
+`meta-models/Muse-Glimmer-30B@f84ecc3a0ea984a4c04542a84269e3d065350a6e`,
+including every source and output hash. The automatically installed DFlash
+companion is pinned to
+`meta-models/Muse-Glimmer-30B-assistant@2c86316d689027b91123638739743fef1d425233`.
+Inference never invokes Python. The converters under `scripts/model-conversion/`
+are offline release tooling only.
+
+Native DFlash captures target layers 1, 13, 25, 37, and 49 during prefill,
+projects them through the assistant, drafts from one real anchor plus mask
+tokens, and verifies the entire candidate block with one target forward. The
+replacement selected at a rejected position becomes the next anchor, matching
+the released algorithm without an extra recovery forward. Greedy output is
+covered against serial target decode in `MuseGlimmerTests`.
+
+The checkpoint permits 15 draft tokens per round, but the affine-Q4 target's
+best measured MLX setting on an M4 Max is 3. In two interleaved 128-token
+release runs, target-only decode averaged 14.73 tok/s and native DFlash averaged
+20.07 tok/s with 54.9% draft acceptance: 1.36x, or 36.2% faster. This is a local
+diagnostic, not a cross-machine guarantee. The runtime uses DFlash for output
+budgets of at least 32 tokens and falls back losslessly after two rounds below
+40% acceptance.
+
+A paired 16-window, 8,192-token WikiText-2 candidate check measured 9.535
+perplexity for selective Q4 and 9.554 for compact Q4. The selective-minus-compact
+mean NLL delta was -0.0020 with a 95% bootstrap interval of -0.0035 to -0.0004.
+That bounded sample supports selective Q4 as the default conversion scope; it is
+not a substitute for a full release-quality evaluation.
+
+The official BF16 assistant is preferred even beside a Q4 target. An optional
+Q4 assistant measured slower at the same acceptance rate on this workload, so
+its converter is retained for reproducibility rather than selected first.

--- a/Sources/MereRunCore/Quantization/QuantizedModelManifestWriter.swift
+++ b/Sources/MereRunCore/Quantization/QuantizedModelManifestWriter.swift
@@ -85,6 +85,7 @@ public enum QuantizedModelManifestWriter {
             case .psiChat: return .psi
             case .deepseekV4Flash: return .deepseek
             case .inkling: return .inkling
+            case .museGlimmer: return .muse
             }
         }()
 
@@ -123,6 +124,8 @@ public enum QuantizedModelManifestWriter {
                     return [.txt2img]
                 case .gemma4:
                     return [.chat]
+                case .museGlimmer:
+                    return [.chat, .codeGeneration, .visionChat]
                 case .lfm2:
                     return [.chat]
                 case .laguna:
@@ -248,6 +251,8 @@ public enum QuantizedModelManifestWriter {
             case .ideogram4:
                 manifest.defaults = MereRunModelManifest.Defaults(steps: 20, cfg: 7.0)
             case .gemma4:
+                break
+            case .museGlimmer:
                 break
             case .lfm2:
                 break

--- a/Sources/MereRunCore/RuntimeModelSettings.swift
+++ b/Sources/MereRunCore/RuntimeModelSettings.swift
@@ -9,6 +9,7 @@ public enum RuntimeServingEngine: String, Codable, CaseIterable, Hashable, Senda
     case textChatQ35 = "text-chat-q35"
     case textChatLFM2 = "text-chat-lfm2"
     case textChatDeepseekV4Flash = "text-chat-deepseek-v4-flash"
+    case textChatMuseGlimmer = "text-chat-muse-glimmer"
 
     public var canonical: RuntimeServingEngine {
         switch self {
@@ -419,6 +420,8 @@ public extension ManagedModelSpec {
             return .textChatQ36
         case .lfm2:
             return .textChatLFM2
+        case .museGlimmer:
+            return .textChatMuseGlimmer
         case .deepseekV4FlashIMatrixGGUF:
             return .textChatDeepseekV4Flash
         case .hfTextChat where id == ModelResolver.ModelID.mebot.rawValue:

--- a/Tests/MereRunCLITests/APIServeCommandTests.swift
+++ b/Tests/MereRunCLITests/APIServeCommandTests.swift
@@ -92,6 +92,21 @@ final class APIServeCommandTests: XCTestCase {
         XCTAssertEqual(cmd.quantizedKVStart, 2048)
     }
 
+    func testAPIServeParsesMuseGlimmerVisionAgentEngine() throws {
+        let cmd = try APIServe.parse([
+            "--engine", "text-chat-muse-glimmer",
+            "--model", MuseGlimmerResources.modelId,
+        ])
+
+        XCTAssertEqual(cmd.engine, .textChatMuseGlimmer)
+        XCTAssertEqual(cmd.model, MuseGlimmerResources.modelId)
+        XCTAssertEqual(cmd.defaultRuntimeModelID(modelPath: nil), MuseGlimmerResources.modelId)
+        XCTAssertTrue(cmd.engine.openAICompatibility.supportsTools)
+        XCTAssertTrue(cmd.engine.openAICompatibility.supportsVisionContentParts)
+        XCTAssertTrue(cmd.engine.openAICompatibility.supportsReasoningEffort)
+        XCTAssertFalse(cmd.engine.openAICompatibility.supportsStructuredOutputs)
+    }
+
     func testAPIServeParsesPreflightJSONFlags() throws {
         let cmd = try APIServe.parse([
             "--preflight",

--- a/Tests/MereRunCLITests/TextChatCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/TextChatCommandParsingTests.swift
@@ -175,6 +175,46 @@ final class TextChatCommandParsingTests: XCTestCase {
         )
     }
 
+    func testMuseGlimmerParsesNativeMultimodalReasoningContract() throws {
+        let command = try TextChat.parse([
+            "--model", MuseGlimmerResources.modelId,
+            "--image", "/tmp/muse-glimmer-input.png",
+            "--reasoning-effort", "1",
+            "--prompt", "Inspect this interface",
+        ])
+
+        XCTAssertEqual(command.model, MuseGlimmerResources.modelId)
+        XCTAssertEqual(command.image, "/tmp/muse-glimmer-input.png")
+        XCTAssertEqual(command.reasoningEffort, 1)
+        XCTAssertTrue(TextChat.backendDescription(for: command.model).contains("native MLX"))
+        XCTAssertNoThrow(
+            try TextChat.validateReasoningEffort(command.reasoningEffort, modelID: command.model)
+        )
+        XCTAssertThrowsError(
+            try TextChat.validate(responseFormat: .jsonObject, modelID: command.model)
+        )
+    }
+
+    func testMuseGlimmerDFlashStatsAreMachineScannable() {
+        let formatted = TextChat.formatMuseDFlashStats(MuseGlimmerDFlashStats(
+            enabled: true,
+            active: true,
+            assistantModelPath: "/tmp/muse-assistant",
+            speculativeTokens: 3,
+            rounds: 4,
+            draftedTokens: 12,
+            acceptedTokens: 7,
+            rejectedTokens: 2,
+            fullAcceptanceRounds: 1,
+            targetVerificationForwards: 4
+        ))
+
+        XCTAssertTrue(formatted.contains("muse_dflash=active"))
+        XCTAssertTrue(formatted.contains("proposals=3"))
+        XCTAssertTrue(formatted.contains("acceptance=58.3%"))
+        XCTAssertTrue(formatted.contains("verify=4"))
+    }
+
     func testTextChatBackendDescriptionIdentifiesGGUFModels() {
         let backend = TextChat.backendDescription(for: ModelResolver.ModelID.q36NanoGGUF.rawValue)
 

--- a/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
@@ -66,6 +66,8 @@ final class ManagedModelCatalogTests: XCTestCase {
             "vision-embed-olmoearth-v12-tiny",
             "vision-embed-olmoearth-v12-small",
             "vision-embed-olmoearth-v12-base",
+            MuseGlimmerResources.modelId,
+            MuseGlimmerResources.assistantModelId,
             "image-3d-trellis2-4b",
             "music-muscriptor-small",
             "music-muscriptor-medium",
@@ -621,6 +623,54 @@ final class ManagedModelCatalogTests: XCTestCase {
         XCTAssertFalse(target.runtimeAutoDownloadAllowed)
         XCTAssertNil(target.usageRestriction)
         XCTAssertTrue(LagunaResources.snapshotPatterns.contains("LICENSE*"))
+    }
+
+    func testMuseGlimmerUsesPinnedSawfwairQ4TargetAndOfficialDFlashCompanion() throws {
+        let target = try XCTUnwrap(ManagedModelCatalog.spec(for: MuseGlimmerResources.modelId))
+        let companion = try XCTUnwrap(
+            ManagedModelCatalog.spec(for: MuseGlimmerResources.assistantModelId)
+        )
+
+        XCTAssertEqual(target.hubFallback?.repoId, MuseGlimmerResources.artifactRepoId)
+        XCTAssertEqual(target.hubFallback?.revision, MuseGlimmerResources.artifactRevision)
+        XCTAssertEqual(target.upstreamRepoId, MuseGlimmerResources.artifactRepoId)
+        XCTAssertEqual(target.upstreamRevision, MuseGlimmerResources.artifactRevision)
+        XCTAssertEqual(target.estimatedDownloadBytes, MuseGlimmerResources.estimatedDownloadBytes)
+        XCTAssertEqual(
+            target.usageRestriction?.terms.first?.sourceRepoId,
+            MuseGlimmerResources.upstreamRepoId
+        )
+        XCTAssertEqual(
+            target.usageRestriction?.terms.first?.sourceRevision,
+            MuseGlimmerResources.upstreamRevision
+        )
+        XCTAssertEqual(target.companionModelIDs, [MuseGlimmerResources.assistantModelId])
+        XCTAssertEqual(target.validationKind, .museGlimmer)
+        XCTAssertFalse(target.runtimeAutoDownloadAllowed)
+
+        XCTAssertFalse(ManagedModelCatalog.allSpecs.contains { $0.id == companion.id })
+        XCTAssertEqual(
+            companion.hubFallback?.repoId,
+            MuseGlimmerResources.assistantUpstreamRepoId
+        )
+        XCTAssertEqual(
+            companion.hubFallback?.revision,
+            MuseGlimmerResources.assistantUpstreamRevision
+        )
+        XCTAssertEqual(
+            companion.hubFallback?.patterns,
+            MuseGlimmerResources.assistantSnapshotPatterns
+        )
+        XCTAssertEqual(companion.validationKind, .museGlimmerAssistant)
+        XCTAssertEqual(
+            companion.estimatedDownloadBytes,
+            MuseGlimmerResources.assistantEstimatedDownloadBytes
+        )
+        XCTAssertEqual(
+            companion.usageRestriction?.terms.first?.sourceRepoId,
+            MuseGlimmerResources.assistantUpstreamRepoId
+        )
+        XCTAssertFalse(companion.runtimeAutoDownloadAllowed)
     }
 
     func testQ36NanoUsesOptiQHubSource() throws {

--- a/Tests/MereRunCoreTests/ManagedModelResolverTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelResolverTests.swift
@@ -2,6 +2,31 @@ import XCTest
 @testable import MereRunCore
 
 final class ManagedModelResolverTests: XCTestCase {
+    func testHiddenMuseAssistantResolvesFromManagedInstallRoot() throws {
+        let modelsRoot = try makeTemporaryDirectory()
+        defer {
+            MereRunModelPaths.setProcessModelsDirOverride(nil)
+            try? FileManager.default.removeItem(at: modelsRoot)
+        }
+        MereRunModelPaths.setProcessModelsDirOverride(modelsRoot)
+
+        let assistantRoot = modelsRoot.appendingPathComponent(
+            MuseGlimmerResources.assistantModelId,
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: assistantRoot, withIntermediateDirectories: true)
+        try Data(#"{"model_type":"muse_glimmer_assistant"}"#.utf8).write(
+            to: assistantRoot.appendingPathComponent("config.json")
+        )
+        try Data([0]).write(to: assistantRoot.appendingPathComponent("model.safetensors"))
+
+        XCTAssertNil(ModelResolver.ModelID(rawValue: MuseGlimmerResources.assistantModelId))
+        XCTAssertEqual(
+            ManagedModelResolver.resolveInstalledModel(id: MuseGlimmerResources.assistantModelId),
+            assistantRoot.standardizedFileURL
+        )
+    }
+
     func testRestrictedInstallRequiresCoreAcknowledgementBeforeDownload() async throws {
         let modelsRoot = try makeTemporaryDirectory()
         defer {

--- a/Tests/MereRunCoreTests/ManagedModelSupportTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelSupportTests.swift
@@ -164,6 +164,30 @@ final class ManagedModelSupportTests: XCTestCase {
         XCTAssertEqual(accepted.descriptor.recommendedUnifiedMemoryGB, 128)
     }
 
+    func testMuseGlimmerQ4RequiresThirtyTwoGBAndRecommendsSixtyFourGB() throws {
+        let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: MuseGlimmerResources.modelId))
+        let undersized = MereRunMachineProfile(
+            physicalMemoryBytes: 16 * 1_073_741_824,
+            processorName: "M4 Pro",
+            isAppleSiliconMac: true
+        )
+        let supported = MereRunMachineProfile(
+            physicalMemoryBytes: 64 * 1_073_741_824,
+            processorName: "M4 Max",
+            isAppleSiliconMac: true
+        )
+
+        let rejected = ManagedModelCapabilityCatalog.support(for: spec, on: undersized)
+        let accepted = ManagedModelCapabilityCatalog.support(for: spec, on: supported)
+
+        XCTAssertFalse(rejected.isSupported)
+        XCTAssertTrue(rejected.reasons.joined(separator: " ").contains("Requires at least 32 GB"))
+        XCTAssertTrue(accepted.isSupported)
+        XCTAssertTrue(accepted.meetsRecommendedMemory)
+        XCTAssertEqual(accepted.descriptor.minimumUnifiedMemoryGB, 32)
+        XCTAssertEqual(accepted.descriptor.recommendedUnifiedMemoryGB, 64)
+    }
+
     func testQ36NanoIsSupportedOnThirtyTwoGB() throws {
         let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: Q35Resources.q36NanoModelId))
         let machine = MereRunMachineProfile(

--- a/Tests/MereRunCoreTests/MereRunModelManifestTests.swift
+++ b/Tests/MereRunCoreTests/MereRunModelManifestTests.swift
@@ -85,6 +85,25 @@ final class MereRunModelManifestTests: MereRunCoreTestCase {
         )
     }
 
+    func testMuseGlimmerTemplatePinsSawfwairSelectiveQ4Conversion() {
+        let manifest = MereRunModelManifest.template(
+            for: .museGlimmer30B,
+            createdAt: Date(timeIntervalSince1970: 0)
+        )
+
+        XCTAssertEqual(manifest.id, MuseGlimmerResources.modelId)
+        XCTAssertEqual(manifest.engine, .museGlimmer)
+        XCTAssertEqual(manifest.family, .muse)
+        XCTAssertEqual(manifest.precision, .int4)
+        XCTAssertEqual(manifest.quantization?.bits, 4)
+        XCTAssertEqual(manifest.quantization?.groupSize, 64)
+        XCTAssertEqual(manifest.quantization?.scheme, "mlx-affine")
+        XCTAssertEqual(
+            manifest.upstreamRepoId,
+            "\(MuseGlimmerResources.artifactRepoId)@\(MuseGlimmerResources.artifactRevision)"
+        )
+    }
+
     func testTemplateRoundTrip() throws {
         let temp = try TestFileSystem.makeTempDir()
         defer { try? FileManager.default.removeItem(at: temp) }

--- a/Tests/MereRunCoreTests/MuseGlimmerTests.swift
+++ b/Tests/MereRunCoreTests/MuseGlimmerTests.swift
@@ -1,0 +1,523 @@
+import MLX
+import MediaIO
+@testable import MereRunCore
+import XCTest
+
+final class MuseGlimmerTests: MereRunCoreTestCase {
+    func testConfigDecodesLayerContractsAndQuantization() throws {
+        let config = try Self.config()
+        XCTAssertEqual(config.modelType, "muse_glimmer")
+        XCTAssertEqual(config.textConfig.layerTypes, [
+            "sliding_attention", "sliding_attention", "sliding_attention", "full_attention",
+        ])
+        XCTAssertEqual(config.textConfig.layerRopeTheta, [500_000, 500_000, 500_000, 0])
+        XCTAssertEqual(config.visionConfig.patchTemporal, 2)
+        XCTAssertEqual(config.quantization?.bits, 4)
+        XCTAssertEqual(config.quantization?.groupSize, 64)
+    }
+
+    func testConfigRejectsPerLayerArrayMismatch() throws {
+        let invalid = Self.configJSON.replacingOccurrences(
+            of: #""layer_rope_theta":[500000,500000,500000,0]"#,
+            with: #""layer_rope_theta":[500000,0]"#
+        )
+        XCTAssertThrowsError(
+            try JSONDecoder().decode(MuseGlimmerConfig.self, from: Data(invalid.utf8))
+        )
+    }
+
+    func testImageTargetSizeIsMergedPatchAlignedAndBounded() {
+        let landscape = MuseGlimmerImageProcessor.targetSize(
+            originalWidth: 4_000,
+            originalHeight: 1_000,
+            patchSize: 14,
+            mergeSize: 2,
+            maxImageTokens: 4_096
+        )
+        XCTAssertEqual(landscape.width % 28, 0)
+        XCTAssertEqual(landscape.height % 28, 0)
+        XCTAssertLessThanOrEqual(landscape.width * landscape.height, 4_096 * 28 * 28)
+        XCTAssertGreaterThan(landscape.width, landscape.height)
+
+        let tiny = MuseGlimmerImageProcessor.targetSize(
+            originalWidth: 3,
+            originalHeight: 7,
+            patchSize: 14,
+            mergeSize: 2,
+            maxImageTokens: 4_096
+        )
+        XCTAssertGreaterThanOrEqual(tiny.width, 28)
+        XCTAssertGreaterThanOrEqual(tiny.height, 28)
+    }
+
+    func testImageTargetSizeMatchesUpstreamAspectRatioCandidateSelection() {
+        let landscape = MuseGlimmerImageProcessor.targetSize(
+            originalWidth: 1_920,
+            originalHeight: 1_080,
+            patchSize: 14,
+            mergeSize: 2,
+            maxImageTokens: 4_096
+        )
+
+        XCTAssertEqual(landscape.width, 1_932)
+        XCTAssertEqual(landscape.height, 1_092)
+
+        let nearSquare = MuseGlimmerImageProcessor.targetSize(
+            originalWidth: 101,
+            originalHeight: 103,
+            patchSize: 14,
+            mergeSize: 2,
+            maxImageTokens: 4_096
+        )
+        XCTAssertEqual(nearSquare.width, 112)
+        XCTAssertEqual(nearSquare.height, 112)
+    }
+
+    func testLanczosResizeMatchesPinnedPillowUint8Fixture() throws {
+        var rgba: [UInt8] = []
+        for y in 0..<7 {
+            for x in 0..<5 {
+                rgba.append(UInt8((x * 31 + y * 17) % 256))
+                rgba.append(UInt8((x * 7 + y * 43 + 11) % 256))
+                rgba.append(UInt8((x * 59 + y * 13 + 23) % 256))
+                rgba.append(UInt8((x * 19 + y * 29 + 101) % 256))
+            }
+        }
+        let source = try MediaImage(width: 5, height: 7, rgba8: rgba)
+        let resized = try MuseGlimmerImageProcessor.resizedLanczos(source, width: 8, height: 4)
+
+        // Exported from torchvision 0.28's uint8 LANCZOS/antialias path and
+        // independently matched by Pillow 12.3.0 after RGB conversion.
+        XCTAssertEqual(resized.rgba8, [
+            6, 27, 24, 255, 15, 29, 46, 255, 39, 35, 91, 255, 60, 39, 122, 255,
+            76, 43, 183, 255, 97, 47, 211, 255, 121, 53, 86, 255, 132, 55, 0, 255,
+            33, 96, 46, 255, 44, 98, 68, 255, 68, 104, 113, 255, 89, 108, 143, 255,
+            105, 112, 210, 255, 126, 116, 246, 255, 150, 122, 114, 255, 161, 124, 7, 255,
+            65, 197, 70, 255, 76, 199, 91, 255, 100, 205, 138, 255, 121, 209, 174, 255,
+            137, 213, 215, 255, 158, 217, 214, 255, 182, 223, 113, 255, 193, 225, 37, 255,
+            94, 111, 92, 255, 105, 113, 109, 255, 129, 119, 163, 255, 150, 123, 229, 255,
+            166, 127, 159, 255, 187, 131, 16, 255, 211, 137, 31, 255, 222, 139, 89, 255,
+        ])
+    }
+
+    func testVisionBilinearGeometryMatchesPinnedFloat32Fixture() {
+        let geometry = MuseGlimmerVisionPatchEmbedder.bilinearPositionGeometry(
+            grids: [(temporal: 1, height: 3, width: 5)],
+            side: 4
+        )
+        XCTAssertEqual(geometry.indices, [
+            [0, 0, 1, 2, 3, 4, 4, 5, 6, 7, 8, 8, 9, 10, 11],
+            [0, 1, 2, 3, 3, 4, 5, 6, 7, 7, 8, 9, 10, 11, 11],
+            [4, 4, 5, 6, 7, 8, 8, 9, 10, 11, 12, 12, 13, 14, 15],
+            [4, 5, 6, 7, 7, 8, 9, 10, 11, 11, 12, 13, 14, 15, 15],
+        ])
+        XCTAssertEqual(geometry.weights.map { $0.map(\.bitPattern) }, [
+            [
+                0x00000000, 0x3e7ffffd, 0x3ed55555, 0x3f155556, 0x3f3ffffe,
+                0x00000000, 0x3e199998, 0x3e800000, 0x3eb33334, 0x3ee66664,
+                0x00000000, 0x3d4cccbe, 0x3daaaaa0, 0x3deeeee1, 0x3e19998e,
+            ],
+            [
+                0x3f3fffff, 0x3f155556, 0x3ed55555, 0x3e7ffffd, 0x00000000,
+                0x3ee66666, 0x3eb33334, 0x3e800000, 0x3e199998, 0x00000000,
+                0x3e199990, 0x3deeeee1, 0x3daaaaa0, 0x3d4cccbe, 0x00000000,
+            ],
+            [
+                0x00000000, 0x3d4ccccc, 0x3daaaaac, 0x3deeeef2, 0x3e199999,
+                0x00000000, 0x3e199998, 0x3e800000, 0x3eb33334, 0x3ee66664,
+                0x00000000, 0x3e800000, 0x3ed55558, 0x3f155558, 0x3f400000,
+            ],
+            [
+                0x3e19999b, 0x3deeeef2, 0x3daaaaac, 0x3d4ccccc, 0x00000000,
+                0x3ee66666, 0x3eb33334, 0x3e800000, 0x3e199998, 0x00000000,
+                0x3f400002, 0x3f155558, 0x3ed55558, 0x3e800000, 0x00000000,
+            ],
+        ])
+
+        let batched = MuseGlimmerVisionPatchEmbedder.bilinearPositionGeometry(
+            grids: [
+                (temporal: 2, height: 3, width: 5),
+                (temporal: 1, height: 2, width: 4),
+            ],
+            side: 4
+        )
+        XCTAssertEqual(batched.indices.map(\.count), [38, 38, 38, 38])
+        XCTAssertEqual(batched.weights.map(\.count), [38, 38, 38, 38])
+    }
+
+    func testTextArchitectureDetailsAreLoadBearing() throws {
+        MLXRandom.seed(7_103)
+        let baselineModel = MuseGlimmerModel(config: try Self.config())
+        baselineModel.update(parameters: baselineModel.parameters().mapValues {
+            $0 + MLXArray(Float(0.013))
+        })
+        let tokens = MLXArray((0..<16).map { Int32(($0 * 7 + 3) % 31) }).reshaped(1, 16)
+        let baseline = baselineModel.forward(tokens, cache: baselineModel.makeCache()).logits
+        MLX.eval(baseline)
+
+        func maximumDelta(configJSON: String) throws -> Float {
+            let config = try JSONDecoder().decode(
+                MuseGlimmerConfig.self,
+                from: Data(configJSON.utf8)
+            )
+            let candidate = MuseGlimmerModel(config: config)
+            try candidate.update(parameters: baselineModel.parameters(), verify: .all)
+            let output = candidate.forward(tokens, cache: candidate.makeCache()).logits
+            let delta = MLX.max(MLX.abs(output.asType(.float32) - baseline.asType(.float32)))
+            MLX.eval(delta)
+            return delta.item(Float.self)
+        }
+
+        let brokenQueryScale = Self.configJSON.replacingOccurrences(
+            of: #""qk_scale_factor":3.87"#,
+            with: #""qk_scale_factor":1.0"#
+        )
+        XCTAssertGreaterThan(try maximumDelta(configJSON: brokenQueryScale), 1e-5)
+
+        let brokenNoPE = Self.configJSON.replacingOccurrences(
+            of: #""layer_rope_theta":[500000,500000,500000,0]"#,
+            with: #""layer_rope_theta":[500000,500000,500000,500000]"#
+        )
+        XCTAssertGreaterThan(try maximumDelta(configJSON: brokenNoPE), 1e-5)
+
+        let brokenPostEpsilon = Self.configJSON.replacingOccurrences(
+            of: #""post_norm_eps":0.00000001"#,
+            with: #""post_norm_eps":0.00001"#
+        )
+        XCTAssertGreaterThan(try maximumDelta(configJSON: brokenPostEpsilon), 0)
+    }
+
+    func testPublishedMLXWeightKeysAndImplicitAffineModeAreAccepted() throws {
+        let published = Self.configJSON.replacingOccurrences(
+            of: #""quantization":{"group_size":64,"bits":4,"mode":"affine"}"#,
+            with: #""quantization":{"group_size":64,"bits":4}"#
+        )
+        XCTAssertEqual(
+            try JSONDecoder().decode(MuseGlimmerConfig.self, from: Data(published.utf8))
+                .quantization?.mode,
+            "affine"
+        )
+        XCTAssertEqual(
+            MuseGlimmerWeightKeys.normalized("language_model.model.layers.3.mlp.up_proj.weight"),
+            "model.language_model.layers.3.mlp.up_proj.weight"
+        )
+        XCTAssertEqual(
+            MuseGlimmerWeightKeys.normalized("language_model.lm_head.scales"),
+            "lm_head.scales"
+        )
+        XCTAssertEqual(
+            MuseGlimmerWeightKeys.normalized("vision_tower.layers.2.attn.q_proj.weight"),
+            "model.vision_tower.layers.2.attn.q_proj.weight"
+        )
+        XCTAssertEqual(
+            MuseGlimmerWeightKeys.normalized("model.vision_adapter.fc1.weight"),
+            "model.vision_adapter.fc1.weight"
+        )
+    }
+
+    func testImagePlaceholderExpansionPreservesBoundaries() throws {
+        let expanded = try MuseGlimmerImageProcessor.expandedPromptTokens(
+            [1, 9, 2, 9, 3],
+            tokenCounts: [2, 3],
+            imageTokenId: 9,
+            imageStartTokenId: 10,
+            imageEndTokenId: 11
+        )
+        XCTAssertEqual(expanded, [1, 10, 9, 9, 11, 2, 10, 9, 9, 9, 11, 3])
+    }
+
+    func testATEMToolParserPreservesScalarAndJSONValues() {
+        let raw = """
+        <atem:function_calls>
+        <atem:invoke name="files.write">
+        <atem:parameter name="path">notes/out.txt</atem:parameter>
+        <atem:parameter name="payload">{"ok":true,"items":[1,2]}</atem:parameter>
+        </atem:invoke>
+        </atem:function_calls>
+        """
+        let calls = MuseGlimmerToolParser.parseToolCalls(raw)
+        XCTAssertEqual(calls.count, 1)
+        XCTAssertEqual(calls[0].name, "files.write")
+        XCTAssertEqual(calls[0].arguments["path"], "notes/out.txt")
+        XCTAssertEqual(calls[0].arguments["payload"], #"{"ok":true,"items":[1,2]}"#)
+        XCTAssertEqual(MuseGlimmerToolParser.visibleText(raw), "")
+    }
+
+    func testTinyTextModelUsesFourCenteredNormsAndSerialCache() throws {
+        let model = MuseGlimmerModel(config: try Self.config())
+        let names = Set(model.parameters().flattened().map(\.0))
+        XCTAssertTrue(names.contains("model.language_model.layers.0.input_layernorm.weight"))
+        XCTAssertTrue(names.contains("model.language_model.layers.0.post_attention_layernorm.weight"))
+        XCTAssertTrue(names.contains("model.language_model.layers.0.pre_feedforward_layernorm.weight"))
+        XCTAssertTrue(names.contains("model.language_model.layers.0.post_feedforward_layernorm.weight"))
+        XCTAssertTrue(names.contains("model.language_model.layers.0.self_attn.gate_proj.weight"))
+        XCTAssertTrue(names.contains("model.vision_tower.patch_embedder.position_embedding_table.weight"))
+
+        let logits = try model.forwardPrefill(
+            inputIds: MLXArray([Int32(1), 2, 3]).reshaped(1, 3),
+            imageBatch: nil,
+            cache: model.makeCache()
+        )
+        MLX.eval(logits)
+        XCTAssertEqual(logits.shape, [1, 1, 32])
+    }
+
+    func testManagedSpecPinsArtifactAndSourceProvenanceAndDisablesImplicitDownload() throws {
+        let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: MuseGlimmerResources.modelId))
+        XCTAssertEqual(spec.category, .visionChat)
+        XCTAssertEqual(spec.validationKind, .museGlimmer)
+        XCTAssertEqual(spec.upstreamRepoId, MuseGlimmerResources.artifactRepoId)
+        XCTAssertEqual(spec.upstreamRevision, MuseGlimmerResources.artifactRevision)
+        XCTAssertEqual(
+            spec.usageRestriction?.terms.first?.sourceRepoId,
+            MuseGlimmerResources.upstreamRepoId
+        )
+        XCTAssertEqual(
+            spec.usageRestriction?.terms.first?.sourceRevision,
+            MuseGlimmerResources.upstreamRevision
+        )
+        XCTAssertFalse(spec.runtimeAutoDownloadAllowed)
+        XCTAssertEqual(spec.defaultRuntimeServingEngine, .textChatMuseGlimmer)
+
+        let manifest = MereRunModelManifest.template(for: .museGlimmer30B)
+        XCTAssertEqual(manifest.engine, .museGlimmer)
+        XCTAssertEqual(manifest.family, .muse)
+        XCTAssertEqual(manifest.supports, [.chat, .codeGeneration, .visionChat])
+    }
+
+    func testAssistantConfigAndWeightPathsMatchOfficialContract() throws {
+        let config = try Self.assistantConfig()
+        XCTAssertEqual(config.modelType, "muse_glimmer_assistant")
+        XCTAssertEqual(config.blockSize, 4)
+        XCTAssertEqual(config.maskTokenId, 31)
+        XCTAssertEqual(config.targetLayerIds, [0, 2])
+
+        let assistant = MuseGlimmerAssistantModel(config: config)
+        let names = Set(assistant.parameters().flattened().map(\.0))
+        XCTAssertTrue(names.contains("encoder.fc.weight"))
+        XCTAssertTrue(names.contains("encoder.output_norm_enc.weight"))
+        XCTAssertTrue(names.contains("layers.0.self_attn.q_proj.weight"))
+        XCTAssertTrue(names.contains("layers.0.self_attn.k_norm.weight"))
+        XCTAssertTrue(names.contains("layers.0.mlp.down_proj.weight"))
+        XCTAssertTrue(names.contains("norm.weight"))
+    }
+
+    func testAssistantDraftBlockUsesTargetContextAndRawTargetEmbeddings() throws {
+        let target = MuseGlimmerModel(config: try Self.config())
+        let assistant = MuseGlimmerAssistantModel(config: try Self.assistantConfig())
+        let targetCache = target.makeCache()
+        let prefill = try target.forwardPrefillDetailed(
+            inputIds: MLXArray([Int32(1), 2, 3]).reshaped(1, 3),
+            imageBatch: nil,
+            cache: targetCache,
+            captureLayerIndices: [0, 2]
+        )
+        let assistantCache = assistant.makeCache()
+        assistant.appendTargetContext(prefill.capturedHiddenStates, cache: assistantCache)
+        let logits = assistant.draftLogits(
+            anchorTokens: MLXArray([Int32(4)]).reshaped(1, 1),
+            speculativeTokenCount: 3,
+            cache: assistantCache.map { $0.fork() },
+            target: target
+        )
+        MLX.eval(logits)
+
+        XCTAssertEqual(assistantCache.map(\.offset), [3, 3])
+        XCTAssertEqual(logits.shape, [1, 3, 32])
+    }
+
+    func testGreedyDFlashDecodeMatchesSerialTargetTokens() throws {
+        let target = MuseGlimmerModel(config: try Self.config())
+        let assistant = MuseGlimmerAssistantModel(config: try Self.assistantConfig())
+        let prompt = [1, 4, 7]
+        let serialCache = target.makeCache()
+        let serialInitial = try target.forwardPrefill(
+            inputIds: MLXArray(prompt.map(Int32.init)).reshaped(1, prompt.count),
+            imageBatch: nil,
+            cache: serialCache
+        )
+        let speculativeCache = target.makeCache()
+        let speculativeInitial = try target.forwardPrefillDetailed(
+            inputIds: MLXArray(prompt.map(Int32.init)).reshaped(1, prompt.count),
+            imageBatch: nil,
+            cache: speculativeCache,
+            captureLayerIndices: [0, 2]
+        )
+        let assistantCache = assistant.makeCache()
+        assistant.appendTargetContext(
+            speculativeInitial.capturedHiddenStates,
+            cache: assistantCache
+        )
+        MLX.eval(serialInitial, speculativeInitial.logits)
+        let generation = GenerationConfig(
+            maxTokens: 8,
+            temperature: 0,
+            topK: 0,
+            topP: 1,
+            minP: 0,
+            repetitionPenalty: nil,
+            repetitionContextSize: 8
+        )
+        let serial = try AutoregressiveDecodeEngine.decode(
+            AutoregressiveDecodeRequest(
+                initialLogits: serialInitial,
+                generationConfig: generation,
+                eosTokens: [],
+                tokenBudget: 8,
+                historySeedTokens: prompt
+            ),
+            stepForward: { token in target(token, cache: serialCache) }
+        )
+        let speculative = try MuseGlimmerDFlashDecoder.decode(
+            initialLogits: speculativeInitial.logits,
+            target: target,
+            targetCache: speculativeCache,
+            assistant: assistant,
+            assistantCache: assistantCache,
+            generationConfig: generation,
+            eosTokens: [],
+            tokenBudget: 8,
+            historySeedTokens: prompt,
+            speculativeTokens: 3,
+            assistantModelPath: nil
+        )
+
+        XCTAssertEqual(speculative.generatedTokens, serial.generatedTokens)
+        XCTAssertGreaterThan(speculative.stats.targetVerificationForwards, 0)
+    }
+
+    func testWarmUpMaterializesSerialAndProductionDFlashPaths() throws {
+        MLXRandom.seed(7_103)
+        let target = MuseGlimmerModel(config: try Self.config())
+
+        XCTAssertNil(try MuseGlimmerGenerator.warmUp(model: target, assistant: nil))
+
+        let assistant = MuseGlimmerAssistantModel(config: try Self.assistantConfig())
+        let stats = try XCTUnwrap(MuseGlimmerGenerator.warmUp(
+            model: target,
+            assistant: assistant,
+            speculativeTokens: 3
+        ))
+        XCTAssertEqual(stats.speculativeTokens, 3)
+        XCTAssertGreaterThan(stats.rounds, 0)
+        XCTAssertGreaterThan(stats.draftedTokens, 0)
+        XCTAssertGreaterThan(stats.targetVerificationForwards, 0)
+    }
+
+    func testDFlashPolicyUsesMeasuredMLXProposalWidthAndClampsOverrides() {
+        XCTAssertEqual(MuseGlimmerDFlashPolicy.defaultSpeculativeTokens, 3)
+        XCTAssertEqual(
+            MuseGlimmerDFlashPolicy.speculativeTokens(
+                maximum: 15,
+                environment: ["MERERUN_MUSE_GLIMMER_DFLASH_TOKENS": "9"]
+            ),
+            9
+        )
+        XCTAssertEqual(
+            MuseGlimmerDFlashPolicy.speculativeTokens(
+                maximum: 15,
+                environment: ["MERERUN_MUSE_GLIMMER_DFLASH_TOKENS": "99"]
+            ),
+            15
+        )
+        XCTAssertFalse(
+            MuseGlimmerDFlashPolicy.enabled(
+                environment: ["MERERUN_MUSE_GLIMMER_DFLASH": "off"]
+            )
+        )
+    }
+
+    private static func config() throws -> MuseGlimmerConfig {
+        try JSONDecoder().decode(MuseGlimmerConfig.self, from: Data(configJSON.utf8))
+    }
+
+    private static func assistantConfig() throws -> MuseGlimmerAssistantConfig {
+        try JSONDecoder().decode(
+            MuseGlimmerAssistantConfig.self,
+            from: Data(assistantConfigJSON.utf8)
+        )
+    }
+
+    private static let assistantConfigJSON = #"""
+    {
+      "model_type":"muse_glimmer_assistant",
+      "architectures":["MuseGlimmerAssistantModel"],
+      "hidden_size":16,
+      "intermediate_size":32,
+      "num_hidden_layers":2,
+      "num_attention_heads":4,
+      "num_key_value_heads":2,
+      "head_dim":4,
+      "rms_norm_eps":0.00001,
+      "rope_parameters":{"rope_theta":500000,"rope_type":"default"},
+      "max_position_embeddings":64,
+      "sliding_window":8,
+      "layer_types":["sliding_attention","sliding_attention"],
+      "attention_dropout":0,
+      "hidden_act":"silu",
+      "bos_token_id":1,
+      "eos_token_id":2,
+      "pad_token_id":0,
+      "block_size":4,
+      "mask_token_id":31,
+      "target_layer_ids":[0,2]
+    }
+    """#
+
+    private static let configJSON = #"""
+    {
+      "model_type":"muse_glimmer",
+      "architectures":["MuseGlimmerForConditionalGeneration"],
+      "image_token_id":9,
+      "video_token_id":8,
+      "out_hidden_size":32,
+      "projector_hidden_size":16,
+      "projector_hidden_act":"gelu",
+      "quantization":{"group_size":64,"bits":4,"mode":"affine"},
+      "text_config":{
+        "model_type":"muse_glimmer_text",
+        "hidden_size":16,
+        "intermediate_size":32,
+        "num_hidden_layers":4,
+        "num_attention_heads":4,
+        "num_key_value_heads":2,
+        "head_dim":4,
+        "max_position_embeddings":64,
+        "sliding_window":8,
+        "layer_types":["sliding_attention","sliding_attention","sliding_attention","full_attention"],
+        "layer_rope_theta":[500000,500000,500000,0],
+        "rope_parameters":{"rope_theta":500000,"rope_type":"default"},
+        "rms_norm_eps":0.00001,
+        "post_norm_eps":0.00000001,
+        "qk_scale_factor":3.87,
+        "output_multiplier":0.19611613513818404,
+        "final_logit_softcapping":20,
+        "hidden_activation":"silu",
+        "attention_bias":false,
+        "attention_dropout":0,
+        "vocab_size":32,
+        "tie_word_embeddings":false,
+        "bos_token_id":1,
+        "eos_token_id":2,
+        "pad_token_id":0
+      },
+      "vision_config":{
+        "model_type":"muse_glimmer_vision",
+        "hidden_size":8,
+        "intermediate_size":16,
+        "num_hidden_layers":2,
+        "num_attention_heads":2,
+        "patch_size":2,
+        "patch_temporal":2,
+        "merge_size":2,
+        "pos_emb_height":4,
+        "pos_emb_width":4,
+        "max_position_embeddings":16,
+        "layer_norm_eps":0.00001,
+        "hidden_act":"gelu",
+        "layer_types":["window_attention","full_attention"],
+        "rope_parameters":{"rope_theta":10000,"rope_type":"default"}
+      }
+    }
+    """#
+}

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -186,6 +186,37 @@ processes are pruned automatically. `mere.run status` shows active and queued
 entries, and the typed ledger lives under
 `~/Library/Application Support/MereRun/admission/` without prompts or content.
 
+### `MERERUN_MUSE_GLIMMER_DFLASH`
+
+Muse Glimmer DFlash is enabled by default when the official managed assistant
+companion is installed. Set this to `0`, `false`, `no`, or `off` to force
+target-only decode. The runtime uses the assistant after both text and image
+prefill, verifies every proposal with the target, and preserves the target's
+greedy or sampled output distribution.
+
+### `MERERUN_MUSE_GLIMMER_DFLASH_TOKENS`
+
+Overrides proposals per DFlash round. The checkpoint supports up to `15`, but
+the measured affine-Q4 MLX target defaults to `3`; values are clamped to the
+assistant's supported range.
+
+### `MERERUN_MUSE_GLIMMER_DFLASH_MIN_OUTPUT`
+
+Minimum requested output budget before Muse Glimmer loads DFlash prompt
+context and enters speculative decode. Defaults to `32` tokens.
+
+### `MERERUN_MUSE_GLIMMER_DFLASH_MIN_ACCEPTANCE`
+
+Minimum cumulative draft acceptance retained after the first two DFlash
+rounds. Defaults to `0.4`; lower acceptance triggers a lossless target-only
+fallback for the rest of the request.
+
+### `MERERUN_MUSE_GLIMMER_DFLASH_PATH`
+
+Selects an explicit local Muse Glimmer assistant directory. When unset, the
+runtime prefers the managed official BF16 assistant, then the optional local
+`vision-chat-muse-glimmer-30b-assistant-q4` conversion.
+
 ### `MERERUN_GEMMA4_MTP`
 
 Gemma 4 12B MTP is enabled by default when the managed

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -57,6 +57,7 @@ from the runtime catalog used by `mere.run model list`,
 | `text-chat` | `text-chat-laguna-s-2-1` |
 | `text-chat` | `text-chat-laguna-xs-2-1` |
 | `text-chat` | `text-chat-inkling-small` |
+| `vision-chat` | `vision-chat-muse-glimmer-30b` |
 | `text-chat` | `text-chat-q36-nano` |
 | `text-chat` | `text-chat-bonsai-27b-1bit` |
 | `text-chat` | `text-chat-bonsai-27b-2bit` |
@@ -170,6 +171,7 @@ validates all configured models before downloading any; both accept the same
 | `image-krea2-raw`, `image-krea2-turbo` | Krea 2 Community License; commercial use is limited to entities below USD 1M trailing annual revenue, plus use/distribution conditions |
 | `image-ideogram4-sdnq-uint4` | Ideogram Non-Commercial Model Agreement |
 | `text-chat-lfm25-a1b-8bit`, `text-chat-lfm25-2.6b-4bit` | LFM Open License v1.0; commercial use by entities at or above USD 10M annual revenue is excluded |
+| `vision-chat-muse-glimmer-30b` | Apache-2.0 plus Meta's bundled usage policy; upstream says the model is not intended for download or use by people under 18 |
 | `vision-segment-sam31` | Meta SAM License custom use, trade-control, attribution, and redistribution conditions |
 | `vision-face-buffalo-l` | InsightFace pretrained weights; non-commercial research use |
 | `vision-embed-olmoearth-v12-{nano,tiny,small,base}` | OlmoEarth Artifact License; prohibited military, defense, intelligence, human-surveillance, policing, and listed extractive uses |
@@ -303,6 +305,32 @@ license and notice files.
 `Qwen3.6-35B-A3B-UD-Q4_K_M.gguf` quant. It is the llama.cpp/GGUF companion to
 the Apple Silicon MLX `text-chat-q36-nano` path and is the default chat model
 for Linux CUDA hosts.
+
+`vision-chat-muse-glimmer-30b` pins Sawfwair's 21.38 GB selective MLX Q4
+artifact at revision `6532e898dc5c1a55b51b1b108cd36728b79be751`. Its conversion
+receipt pins Meta's Apache-2.0 Muse Glimmer 30B BF16 source at revision
+`f84ecc3a0ea984a4c04542a84269e3d065350a6e`, records every source and output
+hash, and retains Meta's `LICENSE` and `USAGE_POLICY.md`. The managed artifact
+is never downloaded implicitly. The native Swift/MLX runtime implements its
+52-layer local/local/local/global text stack,
+NoPE global layers, gated attention, 50-layer perception encoder, interleaved
+image tokens, ATEM tool calls, and low/medium/high/xhigh reasoning-strength
+prompt contract. Its image path uses the released uint8 Lanczos resize behavior
+and float32 position interpolation. The released artifact and offline converter
+use selective Q4/group-64 over 420 text/output/adapter matrices while retaining
+the token
+embedding and complete vision tower in BF16; pass `--quantization-scope compact`
+to quantize all 721 eligible matrices for an explicit lower-memory experiment.
+The runtime discovers quantized modules from their `.scales` arrays, so both
+layouts use the same inference implementation. The same pull installs the 5.11
+GB official DFlash assistant
+from `meta-models/Muse-Glimmer-30B-assistant` at revision
+`2c86316d689027b91123638739743fef1d425233`; the native verifier accelerates
+eligible decode without changing target-model output. Pulls require explicit
+review and acceptance of the bundled `LICENSE` and `USAGE_POLICY.md`; upstream
+says the model is not intended for download or use by people under 18. Python
+conversion scripts are offline artifact tooling only and are not part of
+inference.
 
 `text-chat-gemma4-12b` and `vision-chat-gemma4-12b` share Google's dense Gemma
 4 12B-it checkpoint; the text id uses the native chat path, while the vision id

--- a/docs/runtime/api-server.md
+++ b/docs/runtime/api-server.md
@@ -102,6 +102,22 @@ swift run mere.run api serve \
   --model vision-chat-gemma4-12b
 ```
 
+For Muse Glimmer multimodal agent chat (explicit 21.38 GB Q4 target plus the
+5.11 GB assistant):
+
+```bash
+swift run mere.run model pull vision-chat-muse-glimmer-30b --accept-model-license
+swift run mere.run api serve \
+  --engine text-chat-muse-glimmer \
+  --model vision-chat-muse-glimmer-30b
+```
+
+This engine accepts OpenAI image content parts and function tools. It exposes
+reasoning effort, but does not claim constrained `json_object` decoding. The
+managed pull also installs Meta's pinned 5.11 GB DFlash assistant. Requests for
+at least 32 output tokens use native target-verified speculation and fall back
+losslessly when draft acceptance is poor.
+
 For the compact LiquidAI LFM2.5 2.6B MLX 4-bit model:
 
 ```bash

--- a/docs/runtime/text.md
+++ b/docs/runtime/text.md
@@ -38,6 +38,7 @@ help in the repository gate.
 - `text-chat-gemma4-12b` (managed dense Google Gemma 4 12B-it snapshot)
 - `text-chat-gemma4-12b-4bit` (managed MLX 4-bit Gemma 4 12B-it snapshot)
 - `text-chat-gemma4-turbo` (managed MLX NVFP4 Gemma 4 26B-A4B MoE snapshot)
+- `vision-chat-muse-glimmer-30b` (pinned Sawfwair selective MLX Q4 conversion of Meta Muse Glimmer 30B)
 - `text-chat-laguna-s-2-1` (managed Poolside Laguna S 2.1 118B-A8B NVFP4 target plus DFlash)
 - `text-chat-laguna-xs-2-1` (managed Poolside Laguna XS 2.1 33B-A3B NVFP4 target)
 - `text-chat-q36-nano`
@@ -89,6 +90,29 @@ and verified in bursts inside the pipelined loop — output-identical, free on
 non-repetitive text, and worth ~2× when generation echoes the prompt
 (`MERERUN_GEMMA4_PROMPT_LOOKUP=0` disables; see
 [Configuration](../configuration.md#mererun_gemma4_prompt_lookup)).
+
+`vision-chat-muse-glimmer-30b` installs Sawfwair's pinned 21.38 GB selective MLX
+Q4 target plus Meta's official 2.56B-parameter DFlash assistant. The target's
+receipt pins every source and output hash and retains Meta's bundled terms.
+Native DFlash captures the five
+released target hidden-state taps during text or image prefill, drafts masked
+blocks with the assistant, and verifies them against the target without
+changing the target's output distribution. It engages for output budgets of at
+least 32 tokens, defaults to 3 proposals per round on MLX, and returns to
+target-only decode after two rounds below 40% acceptance. Add `--stats` to see
+the proposal width, acceptance, verification forwards, and fallback state.
+Loading performs one target and DFlash warmup before the first user-visible
+decode, so lazy MLX graph compilation is reported in `loadSeconds` and a
+persistent CLI/API model session pays that cost once.
+
+```bash
+swift run mere.run model pull vision-chat-muse-glimmer-30b --accept-model-license
+swift run mere.run text chat \
+  --model vision-chat-muse-glimmer-30b \
+  --prompt "Inspect this rollout plan for unsafe assumptions." \
+  --stats
+```
+
 Use these chat winners by RAM band instead of treating every supported model as
 equally recommended:
 

--- a/scripts/model-conversion/README.md
+++ b/scripts/model-conversion/README.md
@@ -1,5 +1,60 @@
 # Native model conversion
 
+## Muse Glimmer 30B MLX 4-bit
+
+`convert_muse_glimmer_mlx.py` accepts only Meta's exact two-shard BF16 release
+at revision `f84ecc3a0ea984a4c04542a84269e3d065350a6e`. It verifies the byte count
+and SHA-256 of both weight shards, the index, tokenizer, template, processor,
+license, usage policy, and model card before converting to native MLX affine
+Q4/group-64. The default `selective` scope quantizes the 416 text-layer
+projections, `lm_head`, vision adapter, and vision projection (420 matrices),
+while retaining the token embedding and complete vision tower in BF16. This is
+the quality-preserving release candidate. `--quantization-scope compact`
+quantizes all 721 eligible matrices for a lower-memory experimental artifact.
+Norms, biases, and the learned vision position table remain dense BF16 in both
+variants. The transactionally written output includes a sharded index,
+managed-model manifest, and a hashed `MERERUN_CONVERSION.json` receipt naming
+the selected scope.
+
+The managed selective artifact produced by this converter is published at
+`Sawfwair/Muse-Glimmer-30B-MLX-4bit`, pinned to immutable revision
+`6532e898dc5c1a55b51b1b108cd36728b79be751`. Its five remote shard sizes and
+SHA-256 values match the bundled conversion receipt.
+
+The source snapshot is about 59.6 GB. Conversion requires room for the source,
+the new artifact, and temporary shards; inspect available storage before
+starting. Review the bundled `LICENSE` and `USAGE_POLICY.md` first.
+
+```bash
+uv run --script scripts/model-conversion/convert_muse_glimmer_mlx.py \
+  --source /path/to/meta-models--Muse-Glimmer-30B \
+  --output /path/to/vision-chat-muse-glimmer-30b-q4
+```
+
+Build the compact comparison artifact explicitly:
+
+```bash
+uv run --script scripts/model-conversion/convert_muse_glimmer_mlx.py \
+  --source /path/to/meta-models--Muse-Glimmer-30B \
+  --output /path/to/vision-chat-muse-glimmer-30b-q4-compact \
+  --quantization-scope compact
+```
+
+`convert_muse_glimmer_assistant_mlx.py` independently verifies the exact
+5.11 GB DFlash assistant at revision
+`2c86316d689027b91123638739743fef1d425233` and emits an approximately 1.44 GB
+affine Q4/group-64 artifact with its own receipt:
+
+```bash
+uv run --script scripts/model-conversion/convert_muse_glimmer_assistant_mlx.py \
+  --source /path/to/meta-models--Muse-Glimmer-30B-assistant \
+  --output /path/to/vision-chat-muse-glimmer-30b-assistant-q4
+```
+
+The native runtime prefers the official BF16 assistant: the Q4 assistant was
+slower at equal acceptance on the measured M4 Max MLX workload. This converter
+exists for reproducible size/performance experiments, not as the default.
+
 These scripts are audited release tools. They are never invoked by a
 `mere.run` inference command and never become a Python sidecar.
 

--- a/scripts/model-conversion/convert_muse_glimmer_assistant_mlx.py
+++ b/scripts/model-conversion/convert_muse_glimmer_assistant_mlx.py
@@ -1,0 +1,256 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = "==3.14.4"
+# dependencies = [
+#   "mlx==0.32.0",
+# ]
+# ///
+
+"""Convert Meta's exact Muse Glimmer DFlash assistant to native MLX Q4."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.metadata
+import json
+from pathlib import Path
+import shutil
+import tempfile
+from typing import Any
+
+import mlx.core as mx
+
+
+SOURCE_REPOSITORY = "meta-models/Muse-Glimmer-30B-assistant"
+SOURCE_REVISION = "2c86316d689027b91123638739743fef1d425233"
+MODEL_ID = "vision-chat-muse-glimmer-30b-assistant"
+GROUP_SIZE = 64
+BITS = 4
+MODE = "affine"
+EXPECTED_SOURCE_TENSORS = 58
+EXPECTED_QUANTIZED_TENSORS = 36
+EXPECTED_OUTPUT_ARRAYS = 130
+
+PINNED_FILES: dict[str, dict[str, int | str]] = {
+    "model.safetensors": {
+        "byte_count": 5_111_976_608,
+        "sha256": "fd88d337eb84f8d0e6ba33a7684d7efa6722d4460ba4d6badca9699418392a84",
+    },
+    "config.json": {
+        "byte_count": 883,
+        "sha256": "38915167b64b1e6405492aacae5b1b4511b6431163d2960b9bd25821df6fa30a",
+    },
+    "README.md": {
+        "byte_count": 17_339,
+        "sha256": "4a2bcc36dbb8088cd887def9233f3c5524d4ed1e27622f3c4a521d3676952c46",
+    },
+    "LICENSE": {
+        "byte_count": 11_358,
+        "sha256": "cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30",
+    },
+    "USAGE_POLICY.md": {
+        "byte_count": 5_230,
+        "sha256": "98a14dab9fd97de1666dc8589d399efab1e7fc3ba4e6230d037d6637ba9481d3",
+    },
+}
+
+
+def sha256(file_path: Path) -> str:
+    digest = hashlib.sha256()
+    with file_path.open("rb") as handle:
+        while chunk := handle.read(8 * 1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def verify_file(file_path: Path, pin: dict[str, int | str]) -> None:
+    if not file_path.is_file():
+        raise FileNotFoundError(f"Pinned source file is missing: {file_path}")
+    if file_path.stat().st_size != pin["byte_count"]:
+        raise ValueError(
+            f"{file_path.name} has {file_path.stat().st_size} bytes; "
+            f"expected {pin['byte_count']}"
+        )
+    actual_hash = sha256(file_path)
+    if actual_hash != pin["sha256"]:
+        raise ValueError(
+            f"{file_path.name} has SHA-256 {actual_hash}; expected {pin['sha256']}"
+        )
+
+
+def verify_environment() -> None:
+    actual = importlib.metadata.version("mlx")
+    if actual != "0.32.0":
+        raise RuntimeError(f"mlx {actual} is installed; expected 0.32.0")
+
+
+def should_quantize(key: str, value: mx.array) -> bool:
+    return (
+        key.endswith(".weight")
+        and value.ndim == 2
+        and value.shape[-1] % GROUP_SIZE == 0
+    )
+
+
+def converted_config(source: Path) -> dict[str, Any]:
+    config = json.loads((source / "config.json").read_text())
+    if config.get("model_type") != "muse_glimmer_assistant":
+        raise ValueError("Pinned config is not a muse_glimmer_assistant model")
+    if config.get("target_layer_ids") != [1, 13, 25, 37, 49]:
+        raise ValueError("Pinned assistant target_layer_ids changed")
+    if config.get("block_size") != 16 or config.get("mask_token_id") != 201818:
+        raise ValueError("Pinned assistant DFlash block contract changed")
+    config["quantization"] = {
+        "group_size": GROUP_SIZE,
+        "bits": BITS,
+        "mode": MODE,
+    }
+    return config
+
+
+def write_manifest(output: Path) -> None:
+    manifest = {
+        "schemaVersion": 3,
+        "id": MODEL_ID,
+        "engine": "muse-glimmer",
+        "family": "muse",
+        "tier": "latest",
+        "variant": "standard",
+        "precision": "int4",
+        "quantization": {
+            "bits": BITS,
+            "groupSize": GROUP_SIZE,
+            "scheme": "mlx-affine",
+        },
+        "supports": ["chat"],
+        "components": {"text_encoder": {"type": "local", "path": "."}},
+        "upstreamRepoId": f"{SOURCE_REPOSITORY}@{SOURCE_REVISION}",
+        "sources": [
+            {
+                "role": "draft-model",
+                "repository": SOURCE_REPOSITORY,
+                "revision": SOURCE_REVISION,
+                "destination_path": ".",
+            }
+        ],
+    }
+    (output / "mererun_model.json").write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n"
+    )
+
+
+def convert(source: Path, output: Path) -> None:
+    for filename, pin in PINNED_FILES.items():
+        verify_file(source / filename, pin)
+    arrays = mx.load(str(source / "model.safetensors"))
+    if len(arrays) != EXPECTED_SOURCE_TENSORS:
+        raise ValueError(
+            f"Pinned assistant has {len(arrays)} tensors; "
+            f"expected {EXPECTED_SOURCE_TENSORS}"
+        )
+
+    converted: dict[str, mx.array] = {}
+    quantized_count = 0
+    for key in sorted(arrays):
+        value = arrays[key]
+        if should_quantize(key, value):
+            packed, scales, biases = mx.quantize(
+                value,
+                group_size=GROUP_SIZE,
+                bits=BITS,
+                mode=MODE,
+            )
+            prefix = key.removesuffix(".weight")
+            converted[key] = packed
+            converted[prefix + ".scales"] = scales
+            converted[prefix + ".biases"] = biases
+            quantized_count += 1
+        else:
+            converted[key] = (
+                value.astype(mx.bfloat16)
+                if mx.issubdtype(value.dtype, mx.floating)
+                else value
+            )
+    if quantized_count != EXPECTED_QUANTIZED_TENSORS:
+        raise ValueError(
+            f"Quantized {quantized_count} tensors; expected {EXPECTED_QUANTIZED_TENSORS}"
+        )
+    if len(converted) != EXPECTED_OUTPUT_ARRAYS:
+        raise ValueError(
+            f"Converted {len(converted)} arrays; expected {EXPECTED_OUTPUT_ARRAYS}"
+        )
+
+    mx.eval(*converted.values())
+    weights = output / "model.safetensors"
+    mx.save_safetensors(str(weights), converted, metadata={"format": "mlx"})
+    (output / "config.json").write_text(
+        json.dumps(converted_config(source), indent=2, sort_keys=True) + "\n"
+    )
+    for filename in ["README.md", "LICENSE", "USAGE_POLICY.md"]:
+        shutil.copyfile(source / filename, output / filename)
+        verify_file(output / filename, PINNED_FILES[filename])
+    write_manifest(output)
+
+    receipt = {
+        "converter": "scripts/model-conversion/convert_muse_glimmer_assistant_mlx.py",
+        "converter_version": 1,
+        "source": {
+            "repository": SOURCE_REPOSITORY,
+            "revision": SOURCE_REVISION,
+            "files": PINNED_FILES,
+            "tensor_count": EXPECTED_SOURCE_TENSORS,
+        },
+        "quantization": {
+            "bits": BITS,
+            "group_size": GROUP_SIZE,
+            "mode": MODE,
+            "quantized_tensor_count": quantized_count,
+            "dense_dtype": "bfloat16",
+        },
+        "tools": {"python": "3.14.4", "mlx": "0.32.0"},
+        "artifacts": [
+            {
+                "filename": weights.name,
+                "byte_count": weights.stat().st_size,
+                "sha256": sha256(weights),
+            },
+            {
+                "filename": "config.json",
+                "byte_count": (output / "config.json").stat().st_size,
+                "sha256": sha256(output / "config.json"),
+            },
+        ],
+    }
+    (output / "MERERUN_CONVERSION.json").write_text(
+        json.dumps(receipt, indent=2, sort_keys=True) + "\n"
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Convert Meta's pinned Muse Glimmer DFlash assistant to MLX Q4."
+    )
+    parser.add_argument("--source", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    args = parser.parse_args()
+
+    source = args.source.expanduser().resolve()
+    output = args.output.expanduser().resolve()
+    if not source.is_dir():
+        raise FileNotFoundError(f"Source directory does not exist: {source}")
+    if output.exists():
+        raise FileExistsError(f"Output path already exists: {output}")
+    verify_environment()
+    output.parent.mkdir(parents=True, exist_ok=True)
+    temporary = Path(tempfile.mkdtemp(prefix=f".{output.name}.", dir=output.parent))
+    try:
+        convert(source, temporary)
+        temporary.rename(output)
+    except BaseException:
+        shutil.rmtree(temporary, ignore_errors=True)
+        raise
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/model-conversion/convert_muse_glimmer_mlx.py
+++ b/scripts/model-conversion/convert_muse_glimmer_mlx.py
@@ -1,0 +1,415 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = "==3.14.4"
+# dependencies = [
+#   "mlx==0.32.0",
+# ]
+# ///
+
+"""Convert the exact Muse Glimmer 30B BF16 release to native MLX Q4."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import importlib.metadata
+import json
+import os
+from pathlib import Path
+import shutil
+import tempfile
+from typing import Any
+
+import mlx.core as mx
+
+
+SOURCE_REPOSITORY = "meta-models/Muse-Glimmer-30B"
+SOURCE_REVISION = "f84ecc3a0ea984a4c04542a84269e3d065350a6e"
+MODEL_ID = "vision-chat-muse-glimmer-30b"
+GROUP_SIZE = 64
+BITS = 4
+MODE = "affine"
+EXPECTED_SOURCE_TENSORS = 1_436
+EXPECTED_QUANTIZED_TENSORS = {
+    "selective": 420,
+    "compact": 721,
+}
+DEFAULT_SHARD_BYTES = 4 * 1024 * 1024 * 1024
+
+PINNED_FILES: dict[str, dict[str, int | str]] = {
+    "model-00001-of-00002.safetensors": {
+        "byte_count": 49_950_112_952,
+        "sha256": "8eef61530e1283642c77ce2e6721feb5c6f348fa055c00e90f2844a136372694",
+    },
+    "model-00002-of-00002.safetensors": {
+        "byte_count": 9_603_322_320,
+        "sha256": "b58cc2144ba1ba1af4420f67f4ca3ced7f09298510b80464cc75018a0be14381",
+    },
+    "model.safetensors.index.json": {
+        "byte_count": 132_674,
+        "sha256": "7d817b4dccb1b123fc6c1939356c65cee3a0ad462a5b821ac88280990a27d1ba",
+    },
+    "config.json": {
+        "byte_count": 5_109,
+        "sha256": "5a9df2d8a385b3d361ab6ae68d73586f4e775033933bd0cd863fb7f3820e6a14",
+    },
+    "generation_config.json": {
+        "byte_count": 148,
+        "sha256": "b0e427c998641420eb4091cc85d4e15643fb57f89222834a14ec76430625b6fb",
+    },
+    "processor_config.json": {
+        "byte_count": 1_084,
+        "sha256": "97e2a486dd9866b81f40cf4b8bc0c9ced9a7cd8a5bc65aa4cc2f4de0712dae77",
+    },
+    "tokenizer.json": {
+        "byte_count": 28_129_897,
+        "sha256": "c9dbee66967b58f31a7c27f723c3760da3526ccd0427578e8905b0abb0031c4d",
+    },
+    "tokenizer_config.json": {
+        "byte_count": 79_936,
+        "sha256": "781e6c74f571642c71202167b67d9255b28cc439bdda1582ff31346182f5a9c5",
+    },
+    "chat_template.jinja": {
+        "byte_count": 7_167,
+        "sha256": "114f55ebdc1804c1af371197b9fdf2d6bb925966c9dfe46b73782a71bc07965e",
+    },
+    "README.md": {
+        "byte_count": 16_878,
+        "sha256": "1647ac8916f9c3c7c8ad508f6509d79f0c61d434b03b73f57ec6ad629b6adc13",
+    },
+    "LICENSE": {
+        "byte_count": 11_358,
+        "sha256": "cfc7749b96f63bd31c3c42b5c471bf756814053e847c10f3eb003417bc523d30",
+    },
+    "USAGE_POLICY.md": {
+        "byte_count": 5_230,
+        "sha256": "98a14dab9fd97de1666dc8589d399efab1e7fc3ba4e6230d037d6637ba9481d3",
+    },
+}
+
+METADATA_FILES = [
+    "generation_config.json",
+    "processor_config.json",
+    "tokenizer.json",
+    "tokenizer_config.json",
+    "chat_template.jinja",
+    "README.md",
+    "LICENSE",
+    "USAGE_POLICY.md",
+]
+
+
+def sha256(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(8 * 1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def verify_file(path: Path, pin: dict[str, int | str]) -> None:
+    if not path.is_file():
+        raise FileNotFoundError(f"Pinned source file is missing: {path}")
+    actual_bytes = path.stat().st_size
+    if actual_bytes != pin["byte_count"]:
+        raise ValueError(
+            f"{path.name} has {actual_bytes} bytes; expected {pin['byte_count']}"
+        )
+    actual_hash = sha256(path)
+    if actual_hash != pin["sha256"]:
+        raise ValueError(
+            f"{path.name} has SHA-256 {actual_hash}; expected {pin['sha256']}"
+        )
+
+
+def verify_environment() -> None:
+    actual = importlib.metadata.version("mlx")
+    if actual != "0.32.0":
+        raise RuntimeError(f"mlx {actual} is installed; expected 0.32.0")
+
+
+def load_source_index(source: Path) -> dict[str, Any]:
+    value = json.loads((source / "model.safetensors.index.json").read_text())
+    weight_map = value.get("weight_map")
+    if not isinstance(weight_map, dict):
+        raise ValueError("Pinned model index has no weight_map object")
+    if len(weight_map) != EXPECTED_SOURCE_TENSORS:
+        raise ValueError(
+            f"Pinned model index has {len(weight_map)} tensors; "
+            f"expected {EXPECTED_SOURCE_TENSORS}"
+        )
+    expected_shards = {
+        "model-00001-of-00002.safetensors",
+        "model-00002-of-00002.safetensors",
+    }
+    if set(weight_map.values()) != expected_shards:
+        raise ValueError("Pinned model index references an unexpected shard set")
+    return value
+
+
+def should_quantize(key: str, value: mx.array, scope: str) -> bool:
+    if not key.endswith(".weight") or value.ndim != 2:
+        return False
+    if key.endswith("position_embedding_table.weight"):
+        return False
+    if value.shape[-1] % GROUP_SIZE != 0:
+        return False
+    if scope == "compact":
+        return True
+    if key == "lm_head.weight":
+        return True
+    if key in {
+        "model.vision_adapter.fc1.weight",
+        "model.vision_adapter.fc2.weight",
+        "model.vision_projection.weight",
+    }:
+        return True
+    if not key.startswith("model.language_model.layers."):
+        return False
+    return any(
+        fragment in key
+        for fragment in (
+            ".self_attn.q_proj.weight",
+            ".self_attn.k_proj.weight",
+            ".self_attn.v_proj.weight",
+            ".self_attn.o_proj.weight",
+            ".self_attn.gate_proj.weight",
+            ".mlp.gate_proj.weight",
+            ".mlp.up_proj.weight",
+            ".mlp.down_proj.weight",
+        )
+    )
+
+
+def array_bytes(value: mx.array) -> int:
+    return int(value.nbytes)
+
+
+class ShardWriter:
+    def __init__(self, root: Path, target_bytes: int) -> None:
+        self.root = root
+        self.target_bytes = target_bytes
+        self.arrays: dict[str, mx.array] = {}
+        self.bytes = 0
+        self.parts: list[tuple[Path, list[str]]] = []
+
+    def append(self, key: str, value: mx.array) -> None:
+        value_bytes = array_bytes(value)
+        if self.arrays and self.bytes + value_bytes > self.target_bytes:
+            self.flush()
+        self.arrays[key] = value
+        self.bytes += value_bytes
+
+    def flush(self) -> None:
+        if not self.arrays:
+            return
+        mx.eval(*self.arrays.values())
+        path = self.root / f"part-{len(self.parts) + 1:05d}.safetensors"
+        mx.save_safetensors(str(path), self.arrays, metadata={"format": "mlx"})
+        self.parts.append((path, sorted(self.arrays)))
+        self.arrays = {}
+        self.bytes = 0
+
+    def finalize(self) -> tuple[dict[str, str], list[Path]]:
+        self.flush()
+        total = len(self.parts)
+        weight_map: dict[str, str] = {}
+        outputs: list[Path] = []
+        for index, (temporary, keys) in enumerate(self.parts, start=1):
+            filename = f"model-{index:05d}-of-{total:05d}.safetensors"
+            final = temporary.with_name(filename)
+            temporary.rename(final)
+            outputs.append(final)
+            for key in keys:
+                weight_map[key] = filename
+        return weight_map, outputs
+
+
+def converted_config(source: Path) -> dict[str, Any]:
+    config = json.loads((source / "config.json").read_text())
+    if config.get("model_type") != "muse_glimmer":
+        raise ValueError("Pinned config is not a muse_glimmer model")
+    config["quantization"] = {
+        "group_size": GROUP_SIZE,
+        "bits": BITS,
+        "mode": MODE,
+    }
+    return config
+
+
+def write_manifest(output: Path) -> None:
+    manifest = {
+        "schemaVersion": 3,
+        "id": MODEL_ID,
+        "engine": "muse-glimmer",
+        "family": "muse",
+        "tier": "latest",
+        "variant": "standard",
+        "precision": "int4",
+        "quantization": {
+            "bits": BITS,
+            "groupSize": GROUP_SIZE,
+            "scheme": "mlx-affine",
+        },
+        "supports": ["chat", "code_generation", "vision_chat"],
+        "components": {
+            "tokenizer": {"type": "local", "path": "."},
+            "text_encoder": {"type": "local", "path": "."},
+        },
+        "upstreamRepoId": f"{SOURCE_REPOSITORY}@{SOURCE_REVISION}",
+        "sources": [
+            {
+                "role": "base-model",
+                "repository": SOURCE_REPOSITORY,
+                "revision": SOURCE_REVISION,
+                "destination_path": ".",
+            }
+        ],
+    }
+    (output / "mererun_model.json").write_text(
+        json.dumps(manifest, indent=2, sort_keys=True) + "\n"
+    )
+
+
+def convert(source: Path, output: Path, shard_bytes: int, quantization_scope: str) -> None:
+    for filename, pin in PINNED_FILES.items():
+        verify_file(source / filename, pin)
+    source_index = load_source_index(source)
+    writer = ShardWriter(output, shard_bytes)
+    quantized_count = 0
+    source_count = 0
+
+    for shard_name in sorted(set(source_index["weight_map"].values())):
+        arrays = mx.load(str(source / shard_name))
+        expected_keys = sorted(
+            key for key, value in source_index["weight_map"].items()
+            if value == shard_name
+        )
+        if sorted(arrays) != expected_keys:
+            raise ValueError(f"{shard_name} tensor keys do not match the pinned index")
+        for key in expected_keys:
+            value = arrays[key]
+            source_count += 1
+            if should_quantize(key, value, quantization_scope):
+                packed, scales, biases = mx.quantize(
+                    value,
+                    group_size=GROUP_SIZE,
+                    bits=BITS,
+                    mode=MODE,
+                )
+                writer.append(key, packed)
+                writer.append(key.removesuffix(".weight") + ".scales", scales)
+                writer.append(key.removesuffix(".weight") + ".biases", biases)
+                quantized_count += 1
+            else:
+                dense = value.astype(mx.bfloat16) if mx.issubdtype(value.dtype, mx.floating) else value
+                writer.append(key, dense)
+        del arrays
+
+    if source_count != EXPECTED_SOURCE_TENSORS:
+        raise ValueError(f"Converted {source_count} source tensors; expected {EXPECTED_SOURCE_TENSORS}")
+    expected_quantized = EXPECTED_QUANTIZED_TENSORS[quantization_scope]
+    if quantized_count != expected_quantized:
+        raise ValueError(
+            f"Quantized {quantized_count} tensors; expected {expected_quantized} "
+            f"for {quantization_scope} scope"
+        )
+
+    weight_map, weights = writer.finalize()
+    expected_output_arrays = EXPECTED_SOURCE_TENSORS + (2 * expected_quantized)
+    if len(weight_map) != expected_output_arrays:
+        raise ValueError(
+            f"Converted index has {len(weight_map)} arrays; expected {expected_output_arrays}"
+        )
+    total_size = sum(path.stat().st_size for path in weights)
+    index = {"metadata": {"total_size": total_size}, "weight_map": weight_map}
+    (output / "model.safetensors.index.json").write_text(
+        json.dumps(index, indent=2, sort_keys=True) + "\n"
+    )
+    (output / "config.json").write_text(
+        json.dumps(converted_config(source), indent=2, sort_keys=True) + "\n"
+    )
+    for filename in METADATA_FILES:
+        shutil.copyfile(source / filename, output / filename)
+        verify_file(output / filename, PINNED_FILES[filename])
+    write_manifest(output)
+
+    artifacts = [
+        {
+            "filename": path.name,
+            "byte_count": path.stat().st_size,
+            "sha256": sha256(path),
+        }
+        for path in [*weights, output / "model.safetensors.index.json", output / "config.json"]
+    ]
+    receipt = {
+        "converter": "scripts/model-conversion/convert_muse_glimmer_mlx.py",
+        "converter_version": 1,
+        "source": {
+            "repository": SOURCE_REPOSITORY,
+            "revision": SOURCE_REVISION,
+            "files": PINNED_FILES,
+            "tensor_count": source_count,
+        },
+        "quantization": {
+            "bits": BITS,
+            "group_size": GROUP_SIZE,
+            "mode": MODE,
+            "scope": quantization_scope,
+            "quantized_tensor_count": quantized_count,
+            "dense_dtype": "bfloat16",
+        },
+        "tools": {"python": "3.14.4", "mlx": "0.32.0"},
+        "artifacts": artifacts,
+    }
+    (output / "MERERUN_CONVERSION.json").write_text(
+        json.dumps(receipt, indent=2, sort_keys=True) + "\n"
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Verify and convert Meta's pinned Muse Glimmer 30B BF16 release "
+            "to native MLX affine Q4/group-64 with selective or compact scope."
+        )
+    )
+    parser.add_argument("--source", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--shard-bytes", type=int, default=DEFAULT_SHARD_BYTES)
+    parser.add_argument(
+        "--quantization-scope",
+        choices=sorted(EXPECTED_QUANTIZED_TENSORS),
+        default="selective",
+        help=(
+            "selective keeps the vision tower and token embedding BF16; compact "
+            "quantizes every eligible matrix (default: selective)"
+        ),
+    )
+    args = parser.parse_args()
+
+    source = args.source.expanduser().resolve()
+    output = args.output.expanduser().resolve()
+    if not source.is_dir():
+        raise FileNotFoundError(f"Source directory does not exist: {source}")
+    if output.exists():
+        raise FileExistsError(f"Output path already exists: {output}")
+    if args.shard_bytes <= 0:
+        raise ValueError("--shard-bytes must be greater than zero")
+
+    verify_environment()
+    output.parent.mkdir(parents=True, exist_ok=True)
+    temporary = Path(
+        tempfile.mkdtemp(prefix=f".{output.name}.converting-", dir=output.parent)
+    )
+    try:
+        convert(source, temporary, args.shard_bytes, args.quantization_scope)
+        os.replace(temporary, output)
+    except BaseException:
+        shutil.rmtree(temporary, ignore_errors=True)
+        raise
+    print(output)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- add a fully native Swift/MLX runtime for Muse Glimmer 30B text, image understanding, reasoning-channel parsing, and ATEM tool calls
- pin the Sawfwair selective affine-Q4/group-64 target artifact and Meta's official BF16 DFlash assistant at immutable revisions, with explicit license acceptance and no implicit download
- add native DFlash hidden-state capture, block drafting, lossless target verification, acceptance telemetry, adaptive serial fallback, and one-time load warmup
- add audited target/assistant conversion scripts, receipts and source documentation, CLI/API/model-pool routing, managed-model validation, and runtime settings
- cover model architecture, quantized key layouts, image preprocessing parity, tool parsing, managed-model contracts, serial/speculative equivalence, and warmup cache materialization

## Why

Muse Glimmer had no native mere.run path. The upstream model and assistant required a model-specific multimodal stack, quantized weight mapping, recipient/tool protocol parsing, and DFlash cache lifecycle.

During installed-checkpoint validation, the first cold target decode could produce invalid repeated output because MLX lazily compiled the decode graph before the target cache lifecycle had been fully materialized. The runtime now evaluates target, assistant, candidate, and committed cache storage explicitly and performs a one-time serial plus production-shape DFlash warmup during load. Persistent CLI/API sessions pay that compilation cost once in `loadSeconds`, before the first user-visible decode.

## User impact

`vision-chat-muse-glimmer-30b` is now pullable and runnable through text chat, multimodal API serving, Open WebUI, and shared runtime model pools. Managed pulls install both pinned components after explicit terms acceptance. DFlash engages automatically for sufficiently long outputs, reports detailed stats, and falls back safely when measured acceptance is poor.

On an uncontended M4 Max release run, repeated DFlash decodes measured 33.91 and 33.87 tok/s with 66.7% acceptance and zero fallback. Later samples were deliberately not treated as clean performance evidence because the system GPU was already 38-65% utilized by other applications.

## Validation

- `swift build -c release`
- real installed selective-Q4 target-only smoke: correct first user-visible response after cold warmup
- real installed target + official assistant DFlash smoke: correct first user-visible response, active verification, zero fallback
- focused Muse suite: 23 tests, 0 failures
- `./scripts/check.sh`: 2,618 tests passed, 172 fixture-dependent skips, 0 failures; strict lint, build, CLI help sweep, and hygiene scans passed
- `pnpm docs:build`
- `git diff --check`
