### PR TITLE
Restore ACE-Step upstream LM generation parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -100,6 +100,9 @@ The format is based on Keep a Changelog.
   complete LM sampling contract. ACE-Step quality presets now keep upstream
   Euler and velocity-control defaults and generate one candidate unless
   `--candidates` explicitly opts into local technical ranking.
+- added `--no-lm-caption-rewrite`, matching upstream's
+  `use_cot_caption=false`, so LM metadata and semantic-code generation can stay
+  active without replacing an arrangement-sensitive user caption.
 
 ### Geospatial inference
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -87,6 +87,20 @@ The format is based on Keep a Changelog.
   Both fixed-seed outputs retained all 124 H.264 frames, synchronized 32 kHz
   stereo audio, coherent actors and motion, and the complete two-line dialogue.
 
+### Music
+
+- restored ACE-Step 1.5's upstream two-phase 5 Hz LM contract: metadata planning
+  now uses the model's semantic-token instruction with CFG disabled, while audio
+  codes continue from the planned CoT in an open assistant turn with classifier-
+  free guidance (`2.0` by default) and the training-aligned `NO USER INPUT`
+  unconditional prompt. The DiT still receives the planner's detailed caption;
+  the code phase correctly retains the user's original caption and lyrics.
+- exposed `--lm-cfg-scale`, `--lm-negative-prompt`, and `--instrumental` across
+  the CLI, resident API, recipes, and macOS Studio. Recipe schema 5 records the
+  complete LM sampling contract. ACE-Step quality presets now keep upstream
+  Euler and velocity-control defaults and generate one candidate unless
+  `--candidates` explicitly opts into local technical ranking.
+
 ### Geospatial inference
 
 - added native TerraMind ImpactMesh Fire segmentation, with an immutable

--- a/Sources/MereRunApp/CommandCatalog.swift
+++ b/Sources/MereRunApp/CommandCatalog.swift
@@ -541,6 +541,9 @@ struct CommandDraft: Equatable, Codable {
     var musicLMTopK = 0
     var musicLMTopP = 0.9
     var musicLMRepetitionPenalty = 1.0
+    var musicLMCFGScale = 2.0
+    var musicLMNegativePrompt = "NO USER INPUT"
+    var musicInstrumental = false
     var musicMetadataDuration = ""
     var musicMetadataLanguage = ""
     var musicNoTiledVAE = false
@@ -1113,6 +1116,12 @@ struct CommandTemplate: Identifiable, Equatable {
                 return "Add at least two ordered views."
             }
         case .musicGenerate:
+            if draft.musicInstrumental,
+               !draft.secondaryText.isBlank || !draft.musicLyricsFile.isBlank
+                    || !draft.musicLRCFile.isBlank
+            {
+                return "Instrumental cannot be combined with lyrics."
+            }
             if !draft.musicLRCFile.isBlank
                 && (!draft.secondaryText.isBlank || !draft.musicLyricsFile.isBlank) {
                 return "Use synchronized LRC or plain lyrics, not both."
@@ -2085,9 +2094,11 @@ struct CommandTemplate: Identifiable, Equatable {
             args = ["music", "generate", draft.prompt]
             if !draft.outputPath.isBlank { args += ["--output", draft.outputPath] }
             if !draft.model.isBlank { args += ["--model", draft.model] }
-            if !draft.secondaryText.isBlank { args += ["--lyrics", draft.secondaryText] }
-            if !draft.musicLyricsFile.isBlank { args += ["--lyrics-file", draft.musicLyricsFile] }
-            if !draft.musicLRCFile.isBlank { args += ["--lrc-file", draft.musicLRCFile] }
+            if !draft.musicInstrumental {
+                if !draft.secondaryText.isBlank { args += ["--lyrics", draft.secondaryText] }
+                if !draft.musicLyricsFile.isBlank { args += ["--lyrics-file", draft.musicLyricsFile] }
+                if !draft.musicLRCFile.isBlank { args += ["--lrc-file", draft.musicLRCFile] }
+            }
             if !draft.musicLRCOutput.isBlank { args += ["--lrc-output", draft.musicLRCOutput] }
             args += [
                 "--export-format", draft.musicExportFormat,
@@ -2204,8 +2215,11 @@ struct CommandTemplate: Identifiable, Equatable {
                 "--lm-temperature", format(draft.musicLMTemperature),
                 "--lm-top-k", String(draft.musicLMTopK),
                 "--lm-top-p", format(draft.musicLMTopP),
-                "--lm-repetition-penalty", format(draft.musicLMRepetitionPenalty)
+                "--lm-repetition-penalty", format(draft.musicLMRepetitionPenalty),
+                "--lm-cfg-scale", format(draft.musicLMCFGScale),
+                "--lm-negative-prompt", draft.musicLMNegativePrompt
             ]
+            if draft.musicInstrumental { args.append("--instrumental") }
             if !draft.musicMetadataDuration.isBlank {
                 args += ["--metadata-duration", draft.musicMetadataDuration]
             }

--- a/Sources/MereRunApp/MereRunRootView.swift
+++ b/Sources/MereRunApp/MereRunRootView.swift
@@ -2845,7 +2845,19 @@ private struct MusicGenerationOptions: View {
                         title: "LM repetition penalty",
                         value: $controller.draft.musicLMRepetitionPenalty
                     )
+                    NumberField(
+                        title: "LM CFG scale",
+                        value: $controller.draft.musicLMCFGScale
+                    )
                 }
+                TextField(
+                    "LM negative prompt",
+                    text: $controller.draft.musicLMNegativePrompt
+                )
+                    .textFieldStyle(.plain)
+                    .padding(10)
+                    .merePanel()
+                Toggle("Instrumental", isOn: $controller.draft.musicInstrumental)
                 TextField("Vocal language", text: $controller.draft.musicVocalLanguage)
                     .textFieldStyle(.plain)
                     .padding(10)

--- a/Sources/MereRunApp/StudioComposer.swift
+++ b/Sources/MereRunApp/StudioComposer.swift
@@ -1076,7 +1076,12 @@ struct StudioOptionsPanel: View {
                 "LM repetition penalty",
                 value: $draft.musicLMRepetitionPenalty
             )
+            numberField("LM CFG scale", value: $draft.musicLMCFGScale)
         }
+        TextField("LM negative prompt", text: $draft.musicLMNegativePrompt)
+            .textFieldStyle(.roundedBorder)
+        Toggle("Instrumental", isOn: $draft.musicInstrumental)
+            .font(MereRunTheme.captionFont)
 
         Toggle("Set exact duration", isOn: $draft.useDuration)
             .font(MereRunTheme.captionFont)

--- a/Sources/MereRunApp/StudioTypes.swift
+++ b/Sources/MereRunApp/StudioTypes.swift
@@ -344,6 +344,9 @@ struct StudioDraft: Codable, Equatable {
     var musicLMMode = "auto"
     var musicLMTemperature = 0.85
     var musicLMRepetitionPenalty = 1.0
+    var musicLMCFGScale = 2.0
+    var musicLMNegativePrompt = "NO USER INPUT"
+    var musicInstrumental = false
     var musicAnalyzeSourceAudio = false
     var musicOverrideSteps = false
     var musicCandidates = 0
@@ -460,6 +463,9 @@ struct StudioDraft: Codable, Equatable {
         musicLMMode = "auto"
         musicLMTemperature = 0.85
         musicLMRepetitionPenalty = 1
+        musicLMCFGScale = 2
+        musicLMNegativePrompt = "NO USER INPUT"
+        musicInstrumental = false
         musicAnalyzeSourceAudio = false
         musicOverrideSteps = false
         musicCandidates = 0
@@ -776,6 +782,9 @@ enum StudioCommandAdapter {
             draft.musicLMMode = studioDraft.musicLMMode
             draft.musicLMTemperature = studioDraft.musicLMTemperature
             draft.musicLMRepetitionPenalty = studioDraft.musicLMRepetitionPenalty
+            draft.musicLMCFGScale = studioDraft.musicLMCFGScale
+            draft.musicLMNegativePrompt = studioDraft.musicLMNegativePrompt
+            draft.musicInstrumental = studioDraft.musicInstrumental
             draft.musicAnalyzeSourceAudio = studioDraft.musicAnalyzeSourceAudio
             draft.musicOverrideSteps = studioDraft.musicOverrideSteps
             draft.musicCandidates = studioDraft.musicCandidates

--- a/Sources/MereRunCLI/Commands/MusicGenerateCommand.swift
+++ b/Sources/MereRunCLI/Commands/MusicGenerateCommand.swift
@@ -295,6 +295,12 @@ struct MusicGenerate: AsyncParsableCommand {
     @Option(name: [.customLong("lm-negative-prompt")], help: "LM unconditional prompt used when --lm-cfg-scale is above 1.")
     var lmNegativePrompt: String = "NO USER INPUT"
 
+    @Flag(
+        name: [.customLong("no-lm-caption-rewrite")],
+        help: "Keep the input caption authoritative while still using the LM for metadata and semantic audio codes (upstream use_cot_caption=false)."
+    )
+    var noLMCaptionRewrite: Bool = false
+
     @Option(
         name: [.customLong("metadata-duration")],
         help: "Compatibility alias for --duration; explicit duration always controls planning and rendering."
@@ -661,6 +667,7 @@ struct MusicGenerate: AsyncParsableCommand {
                 lyrics: resolvedLyrics,
                 instruction: resolvedInstruction,
                 userMetadata: planningMetadata,
+                useCotCaption: !noLMCaptionRewrite,
                 lmConfig: .init(
                     maxNewTokens: 1_024,
                     temperature: lmTemperature,
@@ -671,7 +678,9 @@ struct MusicGenerate: AsyncParsableCommand {
                 )
             )
             lmCodeGenerationContext = plan.codeGenerationContext
-            if let plannedCaption = nonEmpty(plan.metadata.caption) {
+            if !noLMCaptionRewrite,
+               let plannedCaption = nonEmpty(plan.metadata.caption)
+            {
                 effectiveCaption = plannedCaption
             }
             if shouldPlanDuration, let plannedDuration = plan.metadata.durationSeconds {
@@ -924,7 +933,8 @@ struct MusicGenerate: AsyncParsableCommand {
                         topP: lmTopP,
                         repetitionPenalty: lmRepetitionPenalty,
                         cfgScale: lmCFGScale,
-                        negativePrompt: lmNegativePrompt
+                        negativePrompt: lmNegativePrompt,
+                        useCotCaption: !noLMCaptionRewrite
                     )
                     : nil,
                 inference: inference,

--- a/Sources/MereRunCLI/Commands/MusicGenerateCommand.swift
+++ b/Sources/MereRunCLI/Commands/MusicGenerateCommand.swift
@@ -41,6 +41,9 @@ struct MusicGenerate: AsyncParsableCommand {
     @Option(name: [.customLong("lyrics-file")], help: "Path to lyrics text file. Cannot be used with --lyrics.")
     var lyricsFile: String?
 
+    @Flag(name: [.customLong("instrumental")], help: "Use upstream's [Instrumental] lyric marker; cannot be combined with lyrics.")
+    var instrumental: Bool = false
+
     @Option(name: [.customLong("lrc-file")], help: "Synchronized LRC lyrics input. Cannot be combined with plain lyrics options.")
     var lrcFile: String?
 
@@ -180,7 +183,7 @@ struct MusicGenerate: AsyncParsableCommand {
 
     @Option(
         name: [.customLong("candidates"), .customLong("best-of")],
-        help: "Generate and rank this many warm-session candidates (preset default: draft 1, song/edit 2, final 4)."
+        help: "Generate and rank this many warm-session candidates (default: 1; upstream auto-scoring is opt-in)."
     )
     var candidateCount: Int?
 
@@ -285,6 +288,12 @@ struct MusicGenerate: AsyncParsableCommand {
         help: "LM repetition penalty (> 0; 1.0 = disabled)."
     )
     var lmRepetitionPenalty: Float = 1.0
+
+    @Option(name: [.customLong("lm-cfg-scale")], help: "LM classifier-free guidance for semantic audio codes (upstream default: 2.0).")
+    var lmCFGScale: Float = 2.0
+
+    @Option(name: [.customLong("lm-negative-prompt")], help: "LM unconditional prompt used when --lm-cfg-scale is above 1.")
+    var lmNegativePrompt: String = "NO USER INPUT"
 
     @Option(
         name: [.customLong("metadata-duration")],
@@ -427,6 +436,9 @@ struct MusicGenerate: AsyncParsableCommand {
         guard lmRepetitionPenalty > 0 else {
             throw ValidationError("--lm-repetition-penalty must be > 0")
         }
+        guard lmCFGScale >= 1, lmCFGScale.isFinite else {
+            throw ValidationError("--lm-cfg-scale must be >= 1")
+        }
         guard vaeChunkSize > 0 else {
             throw ValidationError("--vae-chunk-size must be > 0")
         }
@@ -440,6 +452,9 @@ struct MusicGenerate: AsyncParsableCommand {
             throw ValidationError(
                 "Pass --lrc-file or plain --lyrics/--lyrics-file, not both."
             )
+        }
+        if instrumental, lrcFile != nil || lyricsFile != nil || !lyrics.isEmpty {
+            throw ValidationError("--instrumental cannot be combined with lyrics options.")
         }
         guard targetPeakDB <= 0 else {
             throw ValidationError("--target-peak-db must be <= 0")
@@ -517,7 +532,9 @@ struct MusicGenerate: AsyncParsableCommand {
         try FileManager.default.createDirectory(at: outputURL.deletingLastPathComponent(), withIntermediateDirectories: true)
 
         let inputLRC = try loadLRC()
-        let resolvedLyrics = try inputLRC?.lyrics ?? loadLyrics()
+        let resolvedLyrics = instrumental
+            ? "[Instrumental]"
+            : try inputLRC?.lyrics ?? loadLyrics()
         let effectiveLMRepetitionPenalty = lmRepetitionPenalty == 1
             ? nil
             : lmRepetitionPenalty
@@ -543,6 +560,7 @@ struct MusicGenerate: AsyncParsableCommand {
             && qualityDefaults.automaticDuration
             && !effectiveTask.locksDurationToSource
         var effectiveCaption = caption
+        var lmCodeGenerationContext: ACEStepLMCodeGenerationContext?
         let effectiveLanguage = ACEStepPlanningPolicy.effectiveLanguage(
             vocalLanguage: vocalLanguage,
             metadataLanguage: metadataLanguage
@@ -626,7 +644,7 @@ struct MusicGenerate: AsyncParsableCommand {
             }
         }
 
-        if effectiveUseLM && qualityDefaults.plansMetadata {
+        if effectiveUseLM {
             if !quiet {
                 CLIStderr.write("Planning ACE-Step \(quality.rawValue) metadata with the 5Hz LM\n")
             }
@@ -652,6 +670,7 @@ struct MusicGenerate: AsyncParsableCommand {
                     seed: seed
                 )
             )
+            lmCodeGenerationContext = plan.codeGenerationContext
             if let plannedCaption = nonEmpty(plan.metadata.caption) {
                 effectiveCaption = plannedCaption
             }
@@ -663,6 +682,9 @@ struct MusicGenerate: AsyncParsableCommand {
                 plan: plan.metadata,
                 caption: effectiveCaption,
                 durationSeconds: effectiveDurationSeconds
+            )
+            lmCodeGenerationContext = lmCodeGenerationContext?.applying(
+                userMetadata: userMetadata
             )
             if !quiet {
                 CLIStderr.write(
@@ -733,9 +755,12 @@ struct MusicGenerate: AsyncParsableCommand {
                     temperature: lmTemperature,
                     topK: lmTopK,
                     topP: lmTopP,
-                    repetitionPenalty: effectiveLMRepetitionPenalty
+                    repetitionPenalty: effectiveLMRepetitionPenalty,
+                    cfgScale: lmCFGScale,
+                    negativePrompt: lmNegativePrompt
                 ),
                 lmUserMetadata: userMetadata,
+                lmCodeGenerationContext: lmCodeGenerationContext,
                 sourceAudio48kHz: sourceAudio48kHz,
                 referenceTimbreAudio48kHz: referenceAudio48kHz,
                 audioCoverStrength: audioCoverStrength,
@@ -885,9 +910,11 @@ struct MusicGenerate: AsyncParsableCommand {
                 adapters: loadedAdapters,
                 task: effectiveTask,
                 quality: quality,
+                inputCaption: caption,
                 caption: effectiveCaption,
                 lyrics: resolvedLyrics,
                 instruction: resolvedInstruction,
+                languageModelReasoning: lmCodeGenerationContext?.reasoning,
                 conditioningMetadata:
                     ACEStepRecipeConditioningMetadata(userMetadata),
                 languageModelSampling: effectiveUseLM
@@ -895,7 +922,9 @@ struct MusicGenerate: AsyncParsableCommand {
                         temperature: lmTemperature,
                         topK: lmTopK,
                         topP: lmTopP,
-                        repetitionPenalty: lmRepetitionPenalty
+                        repetitionPenalty: lmRepetitionPenalty,
+                        cfgScale: lmCFGScale,
+                        negativePrompt: lmNegativePrompt
                     )
                     : nil,
                 inference: inference,

--- a/Sources/MereRunCLI/Commands/MusicServeCommand.swift
+++ b/Sources/MereRunCLI/Commands/MusicServeCommand.swift
@@ -190,6 +190,7 @@ struct MusicAPIGenerationRequest: Codable, Sendable {
     var model: String?
     var prompt: String
     var lyrics: String?
+    var instrumental: Bool?
     var instruction: String?
     var durationSeconds: Float?
     var quality: ACEStepQualityPreset?
@@ -213,6 +214,8 @@ struct MusicAPIGenerationRequest: Codable, Sendable {
     var lmTopP: Float?
     var lmTemperature: Float?
     var lmRepetitionPenalty: Float?
+    var lmCFGScale: Float?
+    var lmNegativePrompt: String?
     var bpm: Int?
     var keyscale: String?
     var metadataLanguage: String?
@@ -243,6 +246,7 @@ struct MusicAPIGenerationRequest: Codable, Sendable {
         case model
         case prompt
         case lyrics
+        case instrumental
         case instruction
         case durationSeconds = "duration_seconds"
         case quality
@@ -266,6 +270,8 @@ struct MusicAPIGenerationRequest: Codable, Sendable {
         case lmTopP = "lm_top_p"
         case lmTemperature = "lm_temperature"
         case lmRepetitionPenalty = "lm_repetition_penalty"
+        case lmCFGScale = "lm_cfg_scale"
+        case lmNegativePrompt = "lm_negative_prompt"
         case bpm
         case keyscale
         case metadataLanguage = "metadata_language"
@@ -602,15 +608,31 @@ private final class MusicAPIServer: @unchecked Sendable {
         let lmTopP = payload.lmTopP ?? 0.9
         let lmTemperature = payload.lmTemperature ?? 0.85
         let lmRepetitionPenalty = payload.lmRepetitionPenalty ?? 1.0
+        let lmCFGScale = payload.lmCFGScale ?? 2.0
+        let lmNegativePrompt = payload.lmNegativePrompt ?? "NO USER INPUT"
         guard lmTopK >= 0,
               (0...1).contains(lmTopP),
               (0...2).contains(lmTemperature),
-              lmRepetitionPenalty > 0
+              lmRepetitionPenalty > 0,
+              lmCFGScale >= 1,
+              lmCFGScale.isFinite
         else {
             throw ValidationError(
                 "LM sampling requires lm_top_k >= 0, lm_top_p in [0, 1], "
-                    + "lm_temperature in [0, 2], and lm_repetition_penalty > 0."
+                    + "lm_temperature in [0, 2], lm_repetition_penalty > 0, "
+                    + "and lm_cfg_scale >= 1."
             )
+        }
+        let effectiveLyrics: String
+        if payload.instrumental == true {
+            guard Self.nonEmpty(payload.lyrics) == nil else {
+                throw ValidationError(
+                    "instrumental cannot be combined with lyrics."
+                )
+            }
+            effectiveLyrics = "[Instrumental]"
+        } else {
+            effectiveLyrics = payload.lyrics ?? ""
         }
         let effectiveLMRepetitionPenalty = lmRepetitionPenalty == 1
             ? nil
@@ -668,6 +690,7 @@ private final class MusicAPIServer: @unchecked Sendable {
             && !task.locksDurationToSource
             && !isFlowEdit
         var effectivePrompt = prompt
+        var lmCodeGenerationContext: ACEStepLMCodeGenerationContext?
         let effectiveLanguage = ACEStepPlanningPolicy.effectiveLanguage(
             vocalLanguage: payload.vocalLanguage,
             metadataLanguage: payload.metadataLanguage
@@ -682,10 +705,10 @@ private final class MusicAPIServer: @unchecked Sendable {
             language: effectiveLanguage,
             timesignature: Self.nonEmpty(payload.timeSignature)
         )
-        if useLM && defaults.plansMetadata {
+        if useLM {
             let plan = try session.planMusic(
                 caption: prompt,
-                lyrics: payload.lyrics ?? "",
+                lyrics: effectiveLyrics,
                 instruction: instruction,
                 userMetadata: .init(
                     bpm: metadata.bpm,
@@ -704,6 +727,7 @@ private final class MusicAPIServer: @unchecked Sendable {
                     repetitionPenalty: effectiveLMRepetitionPenalty
                 )
             )
+            lmCodeGenerationContext = plan.codeGenerationContext
             effectivePrompt = Self.nonEmpty(plan.metadata.caption) ?? prompt
             if shouldPlanDuration,
                let plannedDuration = plan.metadata.durationSeconds
@@ -716,6 +740,9 @@ private final class MusicAPIServer: @unchecked Sendable {
                 plan: plan.metadata,
                 caption: effectivePrompt,
                 durationSeconds: duration
+            )
+            lmCodeGenerationContext = lmCodeGenerationContext?.applying(
+                userMetadata: metadata
             )
         }
         let config = ACEStepInferenceConfig(
@@ -761,16 +788,19 @@ private final class MusicAPIServer: @unchecked Sendable {
         return PreparedMusicAPIRequest(
             request: ACEStepSessionRequest(
                 caption: effectivePrompt,
-                lyrics: payload.lyrics ?? "",
+                lyrics: effectiveLyrics,
                 config: config,
                 lmConfig: .init(
                     maxNewTokens: 4_096,
                     temperature: lmTemperature,
                     topK: lmTopK,
                     topP: lmTopP,
-                    repetitionPenalty: effectiveLMRepetitionPenalty
+                    repetitionPenalty: effectiveLMRepetitionPenalty,
+                    cfgScale: lmCFGScale,
+                    negativePrompt: lmNegativePrompt
                 ),
                 lmUserMetadata: metadata,
+                lmCodeGenerationContext: lmCodeGenerationContext,
                 sourceAudio48kHz: sourceAudio,
                 referenceTimbreAudio48kHz:
                     referenceAudio.isEmpty ? nil : referenceAudio,

--- a/Sources/MereRunCLI/Guides/music-generate.md
+++ b/Sources/MereRunCLI/Guides/music-generate.md
@@ -104,10 +104,18 @@ mere.run guide music generate --model music-magenta-rt2-small
   widest boundary fades; aggressive performs pure diffusion.
 - `--repaint-strength`: balanced-mode aggressiveness from `0` to `1`.
 - `--bpm`, `--keyscale`, `--timesignature`: musical metadata.
+- `--instrumental`: use upstream's explicit `[Instrumental]` lyric marker;
+  cannot be combined with lyrics input.
 - `--lm-temperature`, `--lm-top-k`, `--lm-top-p`,
   `--lm-repetition-penalty`: constrained planner sampling controls. Temperature
   defaults to upstream's `0.85`; repetition penalty defaults to the neutral
   upstream value `1.0`.
+- `--lm-cfg-scale`, `--lm-negative-prompt`: classifier-free guidance for the
+  semantic-code phase. Upstream defaults are `2.0` and `NO USER INPUT`;
+  metadata planning always remains unguided at `1.0`.
+- `--candidates`: explicitly opt into local best-of-N technical ranking.
+  Quality presets generate one candidate, matching upstream's disabled
+  auto-score default.
 - `--metadata-duration`: compatibility alias for `--duration`; conflicting
   values are rejected so the planner and renderer cannot diverge.
 - `--metadata-language`: compatibility override for `--vocal-language`.
@@ -266,6 +274,7 @@ mere.run music generate \
 ```bash
 mere.run music generate \
   "dark cinematic synthwave instrumental, pulsing bass, spacious drums, neon tension" \
+  --instrumental \
   --duration 12 \
   --steps 8 \
   --output ./cue.wav

--- a/Sources/MereRunCLI/Support/ACEStepGenerationArtifacts.swift
+++ b/Sources/MereRunCLI/Support/ACEStepGenerationArtifacts.swift
@@ -33,17 +33,21 @@ struct ACEStepRecipeLMSampling: Codable, Equatable {
     var topK: Int
     var topP: Float
     var repetitionPenalty: Float
+    var cfgScale: Float
+    var negativePrompt: String
 
     enum CodingKeys: String, CodingKey {
         case temperature
         case topK = "top_k"
         case topP = "top_p"
         case repetitionPenalty = "repetition_penalty"
+        case cfgScale = "cfg_scale"
+        case negativePrompt = "negative_prompt"
     }
 }
 
 struct ACEStepGenerationRecipe: Codable {
-    static let currentSchemaVersion = 4
+    static let currentSchemaVersion = 5
 
     var schemaVersion: Int
     var createdAt: Date
@@ -59,9 +63,11 @@ struct ACEStepGenerationRecipe: Codable {
     var adapters: [ACEStepAdapterDescriptor]
     var task: ACEStepTask
     var quality: ACEStepQualityPreset
+    var inputCaption: String
     var caption: String
     var lyrics: String
     var instruction: String
+    var languageModelReasoning: String?
     var conditioningMetadata: ACEStepRecipeConditioningMetadata
     var languageModelSampling: ACEStepRecipeLMSampling?
     var inference: ACEStepInferenceConfig
@@ -91,9 +97,11 @@ struct ACEStepGenerationRecipe: Codable {
         case adapters
         case task
         case quality
+        case inputCaption = "input_caption"
         case caption
         case lyrics
         case instruction
+        case languageModelReasoning = "language_model_reasoning"
         case conditioningMetadata = "conditioning_metadata"
         case languageModelSampling = "language_model_sampling"
         case inference

--- a/Sources/MereRunCLI/Support/ACEStepGenerationArtifacts.swift
+++ b/Sources/MereRunCLI/Support/ACEStepGenerationArtifacts.swift
@@ -35,6 +35,7 @@ struct ACEStepRecipeLMSampling: Codable, Equatable {
     var repetitionPenalty: Float
     var cfgScale: Float
     var negativePrompt: String
+    var useCotCaption: Bool
 
     enum CodingKeys: String, CodingKey {
         case temperature
@@ -43,6 +44,7 @@ struct ACEStepRecipeLMSampling: Codable, Equatable {
         case repetitionPenalty = "repetition_penalty"
         case cfgScale = "cfg_scale"
         case negativePrompt = "negative_prompt"
+        case useCotCaption = "use_cot_caption"
     }
 }
 

--- a/Sources/MereRunContract/CommandCapabilityContract.swift
+++ b/Sources/MereRunContract/CommandCapabilityContract.swift
@@ -1021,6 +1021,7 @@ public enum MereRunCapabilityCatalog {
         options: [
             .init(flag: "--lyrics", label: "Lyrics", kind: .string),
             .init(flag: "--lyrics-file", label: "Lyrics file", kind: .file),
+            .init(flag: "--instrumental", label: "Instrumental", kind: .boolean),
             .init(flag: "--lrc-file", label: "LRC file", kind: .file),
             .init(flag: "--lrc-output", label: "LRC output", kind: .file),
             .init(flag: "--output", label: "Audio output", kind: .file),
@@ -1096,6 +1097,8 @@ public enum MereRunCapabilityCatalog {
             .init(flag: "--lm-top-k", label: "LM top-k", kind: .integer),
             .init(flag: "--lm-top-p", label: "LM top-p", kind: .number),
             .init(flag: "--lm-repetition-penalty", label: "LM repetition penalty", kind: .number),
+            .init(flag: "--lm-cfg-scale", label: "LM CFG scale", kind: .number),
+            .init(flag: "--lm-negative-prompt", label: "LM negative prompt", kind: .string),
             .init(flag: "--metadata-duration", label: "Metadata duration", kind: .string),
             .init(flag: "--metadata-language", label: "Metadata language", kind: .string),
             .init(flag: "--no-tiled-vae", label: "Disable tiled VAE", kind: .boolean),

--- a/Sources/MereRunCore/ACEStep/ACEStep5HzLM.swift
+++ b/Sources/MereRunCore/ACEStep/ACEStep5HzLM.swift
@@ -10,6 +10,10 @@ public struct ACEStep5HzLMGenerationConfig: Sendable, Hashable {
     public var topP: Float
     public var repetitionPenalty: Float?
     public var repetitionContextSize: Int
+    /// Classifier-free guidance applied during audio-code generation.
+    /// Upstream keeps metadata planning at 1.0 and uses 2.0 for codes.
+    public var cfgScale: Float
+    public var negativePrompt: String
     public var stopTokenIds: Set<Int>
     public var seed: UInt64?
 
@@ -20,6 +24,8 @@ public struct ACEStep5HzLMGenerationConfig: Sendable, Hashable {
         topP: Float = 0.9,
         repetitionPenalty: Float? = nil,
         repetitionContextSize: Int = 40_960,
+        cfgScale: Float = 1.0,
+        negativePrompt: String = "NO USER INPUT",
         stopTokenIds: Set<Int> = [],
         seed: UInt64? = nil
     ) {
@@ -29,6 +35,8 @@ public struct ACEStep5HzLMGenerationConfig: Sendable, Hashable {
         self.topP = topP
         self.repetitionPenalty = repetitionPenalty
         self.repetitionContextSize = repetitionContextSize
+        self.cfgScale = cfgScale
+        self.negativePrompt = negativePrompt
         self.stopTokenIds = stopTokenIds
         self.seed = seed
     }
@@ -131,6 +139,54 @@ public final class ACEStep5HzLM {
         return tokenizer.encode(prompt, addSpecialTokens: false)
     }
 
+    /// Builds the open assistant-turn prefix used by upstream's second LM
+    /// phase. Audio codes continue immediately after the pre-generated CoT.
+    public func buildAudioCodePromptTokens(
+        caption: String,
+        lyrics: String,
+        reasoning: String,
+        isUnconditional: Bool = false,
+        negativePrompt: String = "NO USER INPUT"
+    ) -> [Int] {
+        let user: String
+        let effectiveReasoning: String
+        if isUnconditional {
+            let trimmedNegative = negativePrompt.trimmingCharacters(in: .whitespacesAndNewlines)
+            user = trimmedNegative.isEmpty || trimmedNegative == "NO USER INPUT"
+                ? "NO USER INPUT"
+                : negativePrompt
+            effectiveReasoning = "<think>\n\n</think>"
+        } else {
+            user = "# Caption\n\(caption)\n\n# Lyric\n\(lyrics)\n"
+            effectiveReasoning = reasoning
+        }
+        let prompt = Self.audioCodePromptText(
+            user: user,
+            reasoning: effectiveReasoning
+        )
+        return tokenizer.encode(prompt, addSpecialTokens: false)
+    }
+
+    static func audioCodePromptText(user: String, reasoning: String) -> String {
+        let system = "# Instruction\n\(ACEStepLMInstructions.defaultInstruction)\n\n"
+        return Self.formatChat(
+            system: system,
+            user: user,
+            assistant: nil,
+            addGenerationPrompt: true
+        ) + reasoning + "\n\n"
+    }
+
+    static func classifierFreeGuidanceLogits(
+        conditional: MLXArray,
+        unconditional: MLXArray,
+        scale: Float
+    ) -> MLXArray {
+        let conditional = conditional.asType(.float32)
+        let unconditional = unconditional.asType(.float32)
+        return unconditional + MLXArray(scale) * (conditional - unconditional)
+    }
+
     public func generate(
         caption: String,
         lyrics: String,
@@ -225,6 +281,63 @@ public final class ACEStep5HzLM {
         )
     }
 
+    /// Generates only semantic audio codes from a pre-generated reasoning
+    /// prefix. This mirrors ACE-Step's two-phase generation path and applies
+    /// LM CFG only to the second phase.
+    public func generateAudioCodes(
+        caption: String,
+        lyrics: String,
+        reasoning: String,
+        config: ACEStep5HzLMGenerationConfig = .init(),
+        sampler: ACEStep5HzLMConstrainedSampler
+    ) -> ACEStep5HzLMResult {
+        var effectiveConfig = config
+        if effectiveConfig.stopTokenIds.isEmpty, let eos = tokenizer.eosTokenId {
+            effectiveConfig.stopTokenIds = [eos]
+        }
+
+        let conditionalPrompt = buildAudioCodePromptTokens(
+            caption: caption,
+            lyrics: lyrics,
+            reasoning: reasoning
+        )
+        sampler.beginAudioCodeGeneration()
+
+        let generated: [Int]
+        if effectiveConfig.cfgScale > 1 {
+            let unconditionalPrompt = buildAudioCodePromptTokens(
+                caption: caption,
+                lyrics: lyrics,
+                reasoning: reasoning,
+                isUnconditional: true,
+                negativePrompt: effectiveConfig.negativePrompt
+            )
+            generated = generateGuidedAudioCodeTokens(
+                conditionalPromptTokens: conditionalPrompt,
+                unconditionalPromptTokens: unconditionalPrompt,
+                config: effectiveConfig,
+                sampler: sampler
+            )
+        } else {
+            generated = generateTokens(
+                promptTokens: conditionalPrompt,
+                config: effectiveConfig,
+                logitsProcessor: { logits, tokens in
+                    sampler.processLogits(logits, tokens: tokens)
+                },
+                didSampleToken: { token in sampler.update(with: token) }
+            )
+        }
+
+        let text = tokenizer.decode(tokens: generated)
+        let values = generated.compactMap { tokenizer.audioCodeTokenIdToValue[$0] }
+        return ACEStep5HzLMResult(
+            generatedText: text,
+            generatedTokens: generated,
+            audioCodeValues: values
+        )
+    }
+
     public func generateConstrained(
         promptTokens: [Int],
         config: ACEStep5HzLMGenerationConfig = .init(),
@@ -253,24 +366,14 @@ public final class ACEStep5HzLM {
         MLX.eval(logits)
 
         let processLogits: (MLXArray, [Int]) -> MLXArray = { logits, tokens in
-            var nextLogits = logitsProcessor?(logits, tokens) ?? logits
-            let topK = max(config.topK, 0)
-            if topK > 0 && topK < nextLogits.dim(-1) {
-                // k-th largest value via argPartition — identical threshold
-                // to the full argSort without sorting the whole vocabulary
-                // every token.
-                let kth = nextLogits.dim(-1) - topK
-                let partition = argPartition(nextLogits, kth: kth, axis: -1)
-                let threshold = nextLogits.take(partition[kth..<(kth + 1)], axis: -1)
-                nextLogits = MLX.where(nextLogits .< threshold, MLXArray(-Float.infinity), nextLogits)
-            }
-            return nextLogits
+            logitsProcessor?(logits, tokens) ?? logits
         }
 
         let topP = (0.0..<1.0).contains(config.topP) ? config.topP : 1.0
         let generationConfig = GenerationConfig(
             maxTokens: config.maxNewTokens,
             temperature: config.temperature,
+            topK: max(config.topK, 0),
             topP: topP,
             repetitionPenalty: config.repetitionPenalty,
             repetitionContextSize: config.repetitionContextSize
@@ -293,6 +396,87 @@ public final class ACEStep5HzLM {
             didSampleToken: didSampleToken
         )
         return result.generatedTokens
+    }
+
+    private func generateGuidedAudioCodeTokens(
+        conditionalPromptTokens: [Int],
+        unconditionalPromptTokens: [Int],
+        config: ACEStep5HzLMGenerationConfig,
+        sampler: ACEStep5HzLMConstrainedSampler
+    ) -> [Int] {
+        let conditionalCache: [KVCache] = (0..<configNumLayers).map { _ in KVCacheSimple(step: 256) }
+        let unconditionalCache: [KVCache] = (0..<configNumLayers).map { _ in KVCacheSimple(step: 256) }
+
+        let conditionalInput = MLXArray(conditionalPromptTokens.map(Int32.init))
+            .reshaped(1, conditionalPromptTokens.count)
+        let unconditionalInput = MLXArray(unconditionalPromptTokens.map(Int32.init))
+            .reshaped(1, unconditionalPromptTokens.count)
+        var conditionalLogits = model.forwardCausal(
+            inputIds: conditionalInput,
+            cache: conditionalCache,
+            lastPositionOnly: true
+        )
+        var unconditionalLogits = model.forwardCausal(
+            inputIds: unconditionalInput,
+            cache: unconditionalCache,
+            lastPositionOnly: true
+        )
+        MLX.eval(conditionalLogits, unconditionalLogits)
+
+        let topP = (0.0..<1.0).contains(config.topP) ? config.topP : 1.0
+        let generationConfig = GenerationConfig(
+            maxTokens: config.maxNewTokens,
+            temperature: config.temperature,
+            topK: max(config.topK, 0),
+            topP: topP,
+            repetitionPenalty: config.repetitionPenalty,
+            repetitionContextSize: config.repetitionContextSize
+        )
+        if let seed = config.seed {
+            MLXRandom.seed(seed)
+        }
+
+        var generated: [Int] = []
+        generated.reserveCapacity(config.maxNewTokens)
+        var repetitionHistory = repetitionHistoryArray(
+            promptTokens: conditionalPromptTokens,
+            config: generationConfig
+        )
+
+        while generated.count < config.maxNewTokens {
+            let conditional = conditionalLogits[0, -1, 0...]
+            let unconditional = unconditionalLogits[0, -1, 0...]
+            var guided = Self.classifierFreeGuidanceLogits(
+                conditional: conditional,
+                unconditional: unconditional,
+                scale: config.cfgScale
+            )
+            guided = sampler.processLogits(guided, tokens: generated)
+
+            let tokenArray = sampledTokenArray(
+                logits: guided,
+                config: generationConfig,
+                previousTokenIndices: repetitionHistory,
+                banMask: nil
+            )
+            MLX.eval(tokenArray)
+            let token = tokenArray.item(Int.self)
+            sampler.update(with: token)
+            if config.stopTokenIds.contains(token) {
+                break
+            }
+            generated.append(token)
+            repetitionHistory = appendingRepetitionHistory(
+                repetitionHistory,
+                token: tokenArray,
+                config: generationConfig
+            )
+
+            let nextInput = tokenArray.asType(.int32).reshaped(1, 1)
+            conditionalLogits = model.forwardCausal(inputIds: nextInput, cache: conditionalCache)
+            unconditionalLogits = model.forwardCausal(inputIds: nextInput, cache: unconditionalCache)
+        }
+        return generated
     }
 
     private var configNumLayers: Int { config.numHiddenLayers }

--- a/Sources/MereRunCore/ACEStep/ACEStep5HzLMConstrainedSampler.swift
+++ b/Sources/MereRunCore/ACEStep/ACEStep5HzLMConstrainedSampler.swift
@@ -78,7 +78,6 @@ public final class ACEStep5HzLMConstrainedSampler {
     private let vocabSize: Int
 
     private let newlineToken: Int32?
-    private let periodToken: Int32?
     private let backtickToken: Int32?
     private let eosTokenId: Int32?
 
@@ -102,6 +101,9 @@ public final class ACEStep5HzLMConstrainedSampler {
 
     private var captionTokenCount: Int = 0
     private let maxCaptionTokens: Int = 512
+    private var captionAfterNewline = false
+    private var captionEnding = false
+    private var pendingFieldName = ""
 
     private var targetCodes: Int?
     private var codesCount: Int = 0
@@ -130,7 +132,6 @@ public final class ACEStep5HzLMConstrainedSampler {
         self.targetCodes = targetDurationSeconds.map { max(0, Int(($0 * 5.0).rounded())) }
 
         self.newlineToken = tokenizer.encode("\n", addSpecialTokens: false).last.map(Int32.init)
-        self.periodToken = tokenizer.encode(".", addSpecialTokens: false).last.map(Int32.init)
         self.backtickToken = tokenizer.encode("`", addSpecialTokens: false).last.map(Int32.init)
         self.eosTokenId = tokenizer.eosTokenId.map(Int32.init)
 
@@ -155,12 +156,34 @@ public final class ACEStep5HzLMConstrainedSampler {
         accumulatedTokenIds = []
         userFieldTokenQueue = []
         captionTokenCount = 0
+        captionAfterNewline = false
+        captionEnding = false
+        pendingFieldName = ""
+        codesCount = 0
+    }
+
+    /// Starts decoding at the audio-code phase when the reasoning block is
+    /// already present in the prompt, as in upstream's two-phase LM path.
+    public func beginAudioCodeGeneration() {
+        state = .codesGeneration
+        positionInFixedString = 0
+        accumulatedTokenIds = []
+        userFieldTokenQueue = []
+        captionTokenCount = 0
+        captionAfterNewline = false
+        captionEnding = false
+        pendingFieldName = ""
         codesCount = 0
     }
 
     public func processLogits(_ logits: MLXArray, tokens: [Int]) -> MLXArray {
         guard enabled else { return logits }
-        if state == .completed { return logits }
+        if state == .completed {
+            if stopAtReasoning, let eos = eosTokenId {
+                return whitelist(logits, allowed: [eos])
+            }
+            return logits
+        }
 
         // User field injection overrides everything else.
         if let next = userFieldTokenQueue.first {
@@ -186,10 +209,6 @@ public final class ACEStep5HzLMConstrainedSampler {
         }
 
         if let fixed = fixedStrings[state] {
-            if state == .thinkEndTag, stopAtReasoning, let eos = eosTokenId {
-                return whitelist(logits, allowed: [eos])
-            }
-
             let allowed = allowedTokensForFixedString(fixed)
             return whitelist(logits, allowed: allowed)
         }
@@ -248,6 +267,22 @@ public final class ACEStep5HzLMConstrainedSampler {
                 }
             }
 
+            if captionAfterNewline {
+                let topToken = Int(MLX.argMax(logits).item(Int32.self))
+                let topText = tokenizer.decode(tokens: [topToken])
+                if let first = topText.first, !first.isWhitespace {
+                    captionAfterNewline = false
+                    captionEnding = true
+                    pendingFieldName = ""
+                    return logits
+                }
+                captionAfterNewline = false
+            }
+
+            if captionEnding {
+                return logits
+            }
+
             let out = logits + audioCodeMask.asType(logits.dtype)
             if let backtick = backtickToken {
                 out[MLXArray([backtick])] = MLXArray([-Float.infinity]).asType(out.dtype)
@@ -255,17 +290,6 @@ public final class ACEStep5HzLMConstrainedSampler {
 
             if captionTokenCount >= maxCaptionTokens, let nl = newlineToken {
                 return whitelist(out, allowed: [nl])
-            }
-
-            if let nl = newlineToken {
-                let allowNewline: Bool = {
-                    guard let last = tokens.last else { return false }
-                    if let periodToken, Int32(last) == periodToken { return true }
-                    return false
-                }()
-                if !allowNewline {
-                    out[MLXArray([nl])] = MLXArray([-Float.infinity]).asType(out.dtype)
-                }
             }
 
             return out
@@ -281,6 +305,10 @@ public final class ACEStep5HzLMConstrainedSampler {
 
         if !userFieldTokenQueue.isEmpty {
             userFieldTokenQueue.removeFirst()
+            if userFieldTokenQueue.isEmpty {
+                transitionToNextState()
+            }
+            return
         }
 
         if state == .codesGeneration {
@@ -305,28 +333,67 @@ public final class ACEStep5HzLMConstrainedSampler {
             positionInFixedString += tokenText.count
             if positionInFixedString >= fixed.count {
                 positionInFixedString = 0
-                transitionToNextState()
+                if state == .thinkEndTag, stopAtReasoning {
+                    state = .completed
+                } else {
+                    transitionToNextState()
+                }
             }
+            return
+        }
+
+        if state == .captionValue {
+            updateCaptionState(with: token)
             return
         }
 
         if let nl = newlineToken, Int32(token) == nl {
             accumulatedTokenIds = []
-            if state == .captionValue {
-                captionTokenCount = 0
-            }
             transitionToNextState()
             return
         }
 
         switch state {
-        case .captionValue:
-            captionTokenCount += 1
         case .bpmValue, .durationValue, .timesigValue, .keyscaleValue, .languageValue:
             accumulatedTokenIds.append(Int32(token))
         default:
             break
         }
+    }
+
+    private func updateCaptionState(with token: Int) {
+        captionTokenCount += 1
+        let tokenText = tokenizer.decode(tokens: [token])
+
+        if captionEnding {
+            pendingFieldName += tokenText
+            guard pendingFieldName.contains(":") else { return }
+
+            let fieldName = pendingFieldName
+                .split(separator: ":", maxSplits: 1)
+                .first?
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .lowercased()
+            let valueState: State? = switch fieldName {
+            case "duration": .durationValue
+            case "keyscale": .keyscaleValue
+            case "language": .languageValue
+            case "timesignature": .timesigValue
+            default: nil
+            }
+
+            captionEnding = false
+            pendingFieldName = ""
+            accumulatedTokenIds = []
+            if let valueState {
+                state = valueState
+            } else {
+                transitionToNextState()
+            }
+            return
+        }
+
+        captionAfterNewline = tokenText.contains("\n")
     }
 
     // MARK: - Setup
@@ -479,6 +546,12 @@ public final class ACEStep5HzLMConstrainedSampler {
         } else {
             state = .completed
         }
+        positionInFixedString = 0
+        accumulatedTokenIds = []
+        captionAfterNewline = false
+        captionTokenCount = 0
+        captionEnding = false
+        pendingFieldName = ""
     }
 
     // MARK: - Logits helpers

--- a/Sources/MereRunCore/ACEStep/ACEStepGenerationSession.swift
+++ b/Sources/MereRunCore/ACEStep/ACEStepGenerationSession.swift
@@ -7,6 +7,7 @@ public struct ACEStepSessionRequest {
     public var config: ACEStepInferenceConfig
     public var lmConfig: ACEStep5HzLMGenerationConfig
     public var lmUserMetadata: ACEStep5HzLMConstrainedSampler.UserMetadata
+    public var lmCodeGenerationContext: ACEStepLMCodeGenerationContext?
     public var sourceLatents25Hz: MLXArray?
     public var sourceAudio48kHz: MLXArray?
     public var referenceTimbreLatents25Hz: [MLXArray]?
@@ -25,6 +26,7 @@ public struct ACEStepSessionRequest {
         config: ACEStepInferenceConfig = .init(),
         lmConfig: ACEStep5HzLMGenerationConfig = .init(),
         lmUserMetadata: ACEStep5HzLMConstrainedSampler.UserMetadata = .init(),
+        lmCodeGenerationContext: ACEStepLMCodeGenerationContext? = nil,
         sourceLatents25Hz: MLXArray? = nil,
         sourceAudio48kHz: MLXArray? = nil,
         referenceTimbreLatents25Hz: [MLXArray]? = nil,
@@ -42,6 +44,7 @@ public struct ACEStepSessionRequest {
         self.config = config
         self.lmConfig = lmConfig
         self.lmUserMetadata = lmUserMetadata
+        self.lmCodeGenerationContext = lmCodeGenerationContext
         self.sourceLatents25Hz = sourceLatents25Hz
         self.sourceAudio48kHz = sourceAudio48kHz
         self.referenceTimbreLatents25Hz = referenceTimbreLatents25Hz
@@ -285,6 +288,7 @@ public final class ACEStepGenerationSession: @unchecked Sendable {
                 config: request.config,
                 lmConfig: request.lmConfig,
                 lmUserMetadata: request.lmUserMetadata,
+                lmCodeGenerationContext: request.lmCodeGenerationContext,
                 sourceLatents25Hz: request.sourceLatents25Hz,
                 sourceAudio48kHz: request.sourceAudio48kHz,
                 referenceTimbreLatents25Hz: request.referenceTimbreLatents25Hz,

--- a/Sources/MereRunCore/ACEStep/ACEStepMusicUnderstanding.swift
+++ b/Sources/MereRunCore/ACEStep/ACEStepMusicUnderstanding.swift
@@ -68,19 +68,105 @@ public struct ACEStepMusicUnderstandingResult: Sendable, Hashable {
 public struct ACEStepMusicPlan: Sendable, Hashable {
     public var metadata: ACEStepMusicUnderstandingMetadata
     public var lmResult: ACEStep5HzLMResult
+    public var codeGenerationContext: ACEStepLMCodeGenerationContext
+
+    public init(
+        metadata: ACEStepMusicUnderstandingMetadata,
+        lmResult: ACEStep5HzLMResult,
+        codeGenerationContext: ACEStepLMCodeGenerationContext
+    ) {
+        self.metadata = metadata
+        self.lmResult = lmResult
+        self.codeGenerationContext = codeGenerationContext
+    }
 
     public init(
         metadata: ACEStepMusicUnderstandingMetadata,
         lmResult: ACEStep5HzLMResult
     ) {
-        self.metadata = metadata
-        self.lmResult = lmResult
+        self.init(
+            metadata: metadata,
+            lmResult: lmResult,
+            codeGenerationContext: .init(
+                caption: "",
+                lyrics: "",
+                reasoning: "<think>\n\n</think>"
+            )
+        )
+    }
+}
+
+/// Inputs that upstream carries from metadata planning into its separate
+/// semantic-code phase. The original prompt stays distinct from the rewritten
+/// caption used by the DiT.
+public struct ACEStepLMCodeGenerationContext: Sendable, Hashable {
+    public var caption: String
+    public var lyrics: String
+    public var reasoning: String
+
+    public init(caption: String, lyrics: String, reasoning: String) {
+        self.caption = caption
+        self.lyrics = lyrics
+        self.reasoning = reasoning
+    }
+
+    /// Rewrites root metadata scalars in the phase-one reasoning block with
+    /// the effective values selected by the caller. Upstream serializes its
+    /// merged metadata again before opening the semantic-code assistant turn;
+    /// doing that here prevents a malformed or stale planner scalar from
+    /// leaking into phase two.
+    public func applying(
+        userMetadata: ACEStep5HzLMConstrainedSampler.UserMetadata
+    ) -> Self {
+        var updated = self
+        updated.reasoning = ACEStepPlanningPolicy.reasoning(
+            reasoning,
+            applying: userMetadata
+        )
+        return updated
     }
 }
 
 /// Applies ACE-Step's documented metadata precedence: explicit user values win,
 /// while the language model fills only fields the caller left unspecified.
 public enum ACEStepPlanningPolicy {
+    public static func reasoning(
+        _ reasoning: String,
+        applying metadata: ACEStep5HzLMConstrainedSampler.UserMetadata
+    ) -> String {
+        var lines = reasoning.components(separatedBy: "\n")
+        guard let closingIndex = lines.lastIndex(where: {
+            $0.trimmingCharacters(in: .whitespacesAndNewlines) == "</think>"
+        }) else {
+            return reasoning
+        }
+
+        let scalars: [(String, String?)] = [
+            ("bpm", nonEmpty(metadata.bpm)),
+            ("duration", nonEmpty(metadata.duration)),
+            ("keyscale", nonEmpty(metadata.keyscale)),
+            ("language", nonEmpty(metadata.language)),
+            ("timesignature", nonEmpty(metadata.timesignature)),
+        ]
+        var insertionIndex = closingIndex
+        for (field, optionalValue) in scalars {
+            guard let value = optionalValue else { continue }
+            let canonicalValue = value
+                .components(separatedBy: .newlines)
+                .joined(separator: " ")
+            if let index = lines[..<insertionIndex].lastIndex(where: {
+                $0 == $0.trimmingCharacters(in: .whitespaces)
+                    && $0.hasPrefix("\(field):")
+            }) {
+                lines[index] = "\(field): \(canonicalValue)"
+            } else {
+                lines.insert("\(field): \(canonicalValue)", at: insertionIndex)
+                insertionIndex += 1
+            }
+        }
+        return lines.joined(separator: "\n")
+    }
+
     public static func effectiveLanguage(
         vocalLanguage: String?,
         metadataLanguage: String?,
@@ -148,6 +234,7 @@ extension ACEStepPipeline {
             topP: 0.9
         )
     ) throws -> ACEStepMusicPlan {
+        _ = instruction
         guard let lm else {
             throw PipelineError.lmNotConfigured
         }
@@ -159,18 +246,35 @@ extension ACEStepPipeline {
             generationPhase: .codes,
             userMetadata: userMetadata
         )
+        var planningConfig = lmConfig
+        planningConfig.cfgScale = 1
         let result = lm.generateConstrained(
             caption: caption,
             lyrics: lyrics,
-            instruction: instruction,
-            systemInstruction: instruction,
-            config: lmConfig,
+            instruction: ACEStepLMInstructions.defaultInstruction,
+            systemInstruction: ACEStepLMInstructions.defaultInstruction,
+            config: planningConfig,
             sampler: sampler
         )
+        let reasoning = Self.reasoningPrefix(from: result.generatedText)
         return ACEStepMusicPlan(
             metadata: Self.parseUnderstandingOutput(result.generatedText),
-            lmResult: result
+            lmResult: result,
+            codeGenerationContext: ACEStepLMCodeGenerationContext(
+                caption: caption,
+                lyrics: lyrics,
+                reasoning: reasoning
+            )
         )
+    }
+
+    static func reasoningPrefix(from generatedText: String) -> String {
+        guard let start = generatedText.range(of: "<think>"),
+              let end = generatedText.range(of: "</think>", range: start.lowerBound..<generatedText.endIndex)
+        else {
+            return "<think>\n\n</think>"
+        }
+        return String(generatedText[start.lowerBound..<end.upperBound])
     }
 
     public func audioCodeString(

--- a/Sources/MereRunCore/ACEStep/ACEStepMusicUnderstanding.swift
+++ b/Sources/MereRunCore/ACEStep/ACEStepMusicUnderstanding.swift
@@ -228,6 +228,7 @@ extension ACEStepPipeline {
         lyrics: String,
         instruction: String = ACEStepLMInstructions.defaultInstruction,
         userMetadata: ACEStep5HzLMConstrainedSampler.UserMetadata = .init(),
+        useCotCaption: Bool = true,
         lmConfig: ACEStep5HzLMGenerationConfig = .init(
             maxNewTokens: 1_024,
             temperature: 0.85,
@@ -240,7 +241,7 @@ extension ACEStepPipeline {
         }
         let sampler = lm.makeConstrainedSampler(
             enabled: true,
-            skipCaption: false,
+            skipCaption: !useCotCaption,
             skipLanguage: false,
             stopAtReasoning: true,
             generationPhase: .codes,

--- a/Sources/MereRunCore/ACEStep/ACEStepPipeline+Generation.swift
+++ b/Sources/MereRunCore/ACEStep/ACEStepPipeline+Generation.swift
@@ -90,7 +90,8 @@ extension ACEStepPipeline {
         targetCodes: Int,
         targetDurationSeconds: Float,
         lmConfig: ACEStep5HzLMGenerationConfig,
-        lmUserMetadata: ACEStep5HzLMConstrainedSampler.UserMetadata
+        lmUserMetadata: ACEStep5HzLMConstrainedSampler.UserMetadata,
+        lmCodeGenerationContext: ACEStepLMCodeGenerationContext?
     ) throws -> ACEStep5HzLMResult {
         let primary = runConstrainedLM(
             lm: lm,
@@ -100,7 +101,8 @@ extension ACEStepPipeline {
             lmSystemInstruction: lmSystemInstruction,
             lmConfig: lmConfig,
             targetDurationSeconds: targetDurationSeconds,
-            userMetadata: lmUserMetadata
+            userMetadata: lmUserMetadata,
+            codeGenerationContext: lmCodeGenerationContext
         )
         if primary.audioCodeValues.count >= targetCodes {
             return primary
@@ -127,7 +129,8 @@ extension ACEStepPipeline {
             lmSystemInstruction: lmSystemInstruction,
             lmConfig: retryConfig,
             targetDurationSeconds: targetDurationSeconds,
-            userMetadata: retryMetadata
+            userMetadata: retryMetadata,
+            codeGenerationContext: lmCodeGenerationContext
         )
         return retry.audioCodeValues.count >= primary.audioCodeValues.count ? retry : primary
     }
@@ -140,7 +143,8 @@ extension ACEStepPipeline {
         lmSystemInstruction: String,
         lmConfig: ACEStep5HzLMGenerationConfig,
         targetDurationSeconds: Float,
-        userMetadata: ACEStep5HzLMConstrainedSampler.UserMetadata
+        userMetadata: ACEStep5HzLMConstrainedSampler.UserMetadata,
+        codeGenerationContext: ACEStepLMCodeGenerationContext?
     ) -> ACEStep5HzLMResult {
         let sampler = lm.makeConstrainedSampler(
             enabled: true,
@@ -149,6 +153,18 @@ extension ACEStepPipeline {
             targetDurationSeconds: targetDurationSeconds,
             userMetadata: userMetadata
         )
+        if let codeGenerationContext {
+            let effectiveContext = codeGenerationContext.applying(
+                userMetadata: userMetadata
+            )
+            return lm.generateAudioCodes(
+                caption: effectiveContext.caption,
+                lyrics: effectiveContext.lyrics,
+                reasoning: effectiveContext.reasoning,
+                config: lmConfig,
+                sampler: sampler
+            )
+        }
         return lm.generateConstrained(
             caption: caption,
             lyrics: lyrics,

--- a/Sources/MereRunCore/ACEStep/ACEStepPipeline.swift
+++ b/Sources/MereRunCore/ACEStep/ACEStepPipeline.swift
@@ -292,6 +292,7 @@ public final class ACEStepPipeline {
         lmConfig: ACEStep5HzLMGenerationConfig = .init(),
         instruction: String = ACEStepLMInstructions.defaultInstruction,
         lmUserMetadata: ACEStep5HzLMConstrainedSampler.UserMetadata = .init(),
+        lmCodeGenerationContext: ACEStepLMCodeGenerationContext? = nil,
         lmSystemInstruction: String = ACEStepLMInstructions.defaultInstruction,
         audioCoverStrength: Float = 1.0
     ) throws -> (audio: MLXArray, lmResult: ACEStep5HzLMResult) {
@@ -318,7 +319,8 @@ public final class ACEStepPipeline {
             targetCodes: targetCodes,
             targetDurationSeconds: targetDurationSeconds,
             lmConfig: effectiveLMConfig,
-            lmUserMetadata: lmUserMetadata
+            lmUserMetadata: lmUserMetadata,
+            lmCodeGenerationContext: lmCodeGenerationContext
         )
 
         guard !lmResult.audioCodeValues.isEmpty else {
@@ -532,6 +534,7 @@ public final class ACEStepPipeline {
         config: ACEStepInferenceConfig = .init(),
         lmConfig: ACEStep5HzLMGenerationConfig = .init(),
         lmUserMetadata: ACEStep5HzLMConstrainedSampler.UserMetadata = .init(),
+        lmCodeGenerationContext: ACEStepLMCodeGenerationContext? = nil,
         sourceLatents25Hz: MLXArray? = nil,
         sourceAudio48kHz: MLXArray? = nil,
         referenceTimbreLatents25Hz: [MLXArray]? = nil,
@@ -556,6 +559,36 @@ public final class ACEStepPipeline {
             ? repaintConfiguration ?? .init()
             : nil
         let effectiveInstruction = instruction ?? task.instruction()
+        var effectiveCaption = caption
+        var effectiveLMUserMetadata = lmUserMetadata
+        var effectiveLMCodeGenerationContext = lmCodeGenerationContext
+        if effectiveLMCodeGenerationContext == nil {
+            var planningMetadata = lmUserMetadata
+            if planningMetadata.duration == nil {
+                planningMetadata.duration = String(
+                    max(1, Int(config.durationSeconds.rounded()))
+                )
+            }
+            if planningMetadata.language == nil {
+                planningMetadata.language = vocalLanguage
+            }
+            let plan = try planMusic(
+                caption: caption,
+                lyrics: lyrics,
+                userMetadata: planningMetadata,
+                lmConfig: lmConfig
+            )
+            effectiveCaption = plan.metadata.caption ?? caption
+            effectiveLMUserMetadata = ACEStepPlanningPolicy.merge(
+                userMetadata: lmUserMetadata,
+                plan: plan.metadata,
+                caption: effectiveCaption,
+                durationSeconds: config.durationSeconds
+            )
+            effectiveLMCodeGenerationContext = plan.codeGenerationContext.applying(
+                userMetadata: effectiveLMUserMetadata
+            )
+        }
         let T = max(1, Int((Double(config.durationSeconds) * 25.0).rounded()))
         let srcLatents = try normalizeSourceLatents(
             sourceLatents25Hz,
@@ -566,11 +599,11 @@ public final class ACEStepPipeline {
 
 
         let conditionInputs = try preparePromptConditionInputs(
-            caption: caption,
+            caption: effectiveCaption,
             lyrics: lyrics,
             srcLatents: srcLatents,
             chunkChannels: chunkChannels,
-            lmUserMetadata: lmUserMetadata,
+            lmUserMetadata: effectiveLMUserMetadata,
             referenceTimbreLatents25Hz: referenceTimbreLatents25Hz,
             referenceTimbreAudio48kHz: referenceTimbreAudio48kHz,
             sourceAudio48kHz: sourceAudio48kHz,
@@ -582,13 +615,14 @@ public final class ACEStepPipeline {
         )
 
         return try generateWithLM(
-            caption: caption,
+            caption: effectiveCaption,
             lyrics: lyrics,
             conditionInputs: conditionInputs,
             config: config,
             lmConfig: lmConfig,
             instruction: effectiveInstruction,
-            lmUserMetadata: lmUserMetadata,
+            lmUserMetadata: effectiveLMUserMetadata,
+            lmCodeGenerationContext: effectiveLMCodeGenerationContext,
             lmSystemInstruction: lmSystemInstruction,
             audioCoverStrength: audioCoverStrength
         )

--- a/Sources/MereRunCore/ACEStep/ACEStepQualityPreset.swift
+++ b/Sources/MereRunCore/ACEStep/ACEStepQualityPreset.swift
@@ -37,35 +37,35 @@ public enum ACEStepQualityPreset: String, CaseIterable, Codable, Hashable, Senda
                 plansMetadata: !task.skipsLanguageModel,
                 automaticDuration: task == .textToMusic || task == .complete,
                 fallbackDurationSeconds: 30,
-                candidateCount: 2
+                candidateCount: 1
             )
         case .final:
             return ACEStepQualityDefaults(
                 inferenceSteps: variant.defaultInferenceSteps,
                 shift: variant.defaultShift,
                 guidanceScale: variant.defaultGuidanceScale,
-                samplerMode: .heun,
-                velocityNormThreshold: 2,
-                velocityEMAFactor: 0.1,
+                samplerMode: .euler,
+                velocityNormThreshold: 0,
+                velocityEMAFactor: 0,
                 usesLanguageModel: !task.skipsLanguageModel,
                 plansMetadata: !task.skipsLanguageModel,
                 automaticDuration: task == .textToMusic || task == .complete,
                 fallbackDurationSeconds: 60,
-                candidateCount: 4
+                candidateCount: 1
             )
         case .edit:
             return ACEStepQualityDefaults(
                 inferenceSteps: variant.defaultInferenceSteps,
                 shift: variant.defaultShift,
                 guidanceScale: variant.defaultGuidanceScale,
-                samplerMode: .heun,
-                velocityNormThreshold: 2,
-                velocityEMAFactor: 0.1,
+                samplerMode: .euler,
+                velocityNormThreshold: 0,
+                velocityEMAFactor: 0,
                 usesLanguageModel: !task.skipsLanguageModel,
                 plansMetadata: !task.skipsLanguageModel,
                 automaticDuration: false,
                 fallbackDurationSeconds: 30,
-                candidateCount: 2
+                candidateCount: 1
             )
         }
     }

--- a/Tests/MereRunCLITests/MusicGenerateCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/MusicGenerateCommandParsingTests.swift
@@ -66,6 +66,7 @@ final class MusicGenerateCommandParsingTests: XCTestCase {
         XCTAssertEqual(cmd.lmRepetitionPenalty, 1.0, accuracy: 0.0001)
         XCTAssertEqual(cmd.lmCFGScale, 2.0, accuracy: 0.0001)
         XCTAssertEqual(cmd.lmNegativePrompt, "NO USER INPUT")
+        XCTAssertFalse(cmd.noLMCaptionRewrite)
         XCTAssertEqual(cmd.coverNoiseStrength, 0.0, accuracy: 0.0001)
         XCTAssertFalse(cmd.resolvedACEStepIsCover)
     }
@@ -95,6 +96,7 @@ final class MusicGenerateCommandParsingTests: XCTestCase {
             "--lm-repetition-penalty", "1.08",
             "--lm-cfg-scale", "2.5",
             "--lm-negative-prompt", "muddy mix",
+            "--no-lm-caption-rewrite",
             "--instrumental",
         ])
 
@@ -120,6 +122,7 @@ final class MusicGenerateCommandParsingTests: XCTestCase {
         XCTAssertEqual(cmd.lmRepetitionPenalty, 1.08, accuracy: 0.0001)
         XCTAssertEqual(cmd.lmCFGScale, 2.5, accuracy: 0.0001)
         XCTAssertEqual(cmd.lmNegativePrompt, "muddy mix")
+        XCTAssertTrue(cmd.noLMCaptionRewrite)
         XCTAssertTrue(cmd.instrumental)
     }
 

--- a/Tests/MereRunCLITests/MusicGenerateCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/MusicGenerateCommandParsingTests.swift
@@ -64,6 +64,8 @@ final class MusicGenerateCommandParsingTests: XCTestCase {
         XCTAssertNil(cmd.guidanceScale)
         XCTAssertEqual(cmd.lmTemperature, 0.85, accuracy: 0.0001)
         XCTAssertEqual(cmd.lmRepetitionPenalty, 1.0, accuracy: 0.0001)
+        XCTAssertEqual(cmd.lmCFGScale, 2.0, accuracy: 0.0001)
+        XCTAssertEqual(cmd.lmNegativePrompt, "NO USER INPUT")
         XCTAssertEqual(cmd.coverNoiseStrength, 0.0, accuracy: 0.0001)
         XCTAssertFalse(cmd.resolvedACEStepIsCover)
     }
@@ -91,6 +93,9 @@ final class MusicGenerateCommandParsingTests: XCTestCase {
             "--velocity-ema-factor", "0.1",
             "--lm-temperature", "0.7",
             "--lm-repetition-penalty", "1.08",
+            "--lm-cfg-scale", "2.5",
+            "--lm-negative-prompt", "muddy mix",
+            "--instrumental",
         ])
 
         XCTAssertEqual(cmd.model, "/tmp/acestep")
@@ -113,6 +118,9 @@ final class MusicGenerateCommandParsingTests: XCTestCase {
         XCTAssertEqual(cmd.velocityEMAFactor, 0.1)
         XCTAssertEqual(cmd.lmTemperature, 0.7, accuracy: 0.0001)
         XCTAssertEqual(cmd.lmRepetitionPenalty, 1.08, accuracy: 0.0001)
+        XCTAssertEqual(cmd.lmCFGScale, 2.5, accuracy: 0.0001)
+        XCTAssertEqual(cmd.lmNegativePrompt, "muddy mix")
+        XCTAssertTrue(cmd.instrumental)
     }
 
     func testMusicGenerateParsesIndependentPlannerModel() throws {

--- a/Tests/MereRunCLITests/MusicServeAndExportTests.swift
+++ b/Tests/MereRunCLITests/MusicServeAndExportTests.swift
@@ -125,7 +125,8 @@ final class MusicServeAndExportTests: XCTestCase {
             topP: 0.85,
             repetitionPenalty: 1.08,
             cfgScale: 2,
-            negativePrompt: "NO USER INPUT"
+            negativePrompt: "NO USER INPUT",
+            useCotCaption: false
         )
         let encoded = try JSONEncoder().encode(sampling)
         let object = try XCTUnwrap(
@@ -149,6 +150,7 @@ final class MusicServeAndExportTests: XCTestCase {
             accuracy: 0.0001
         )
         XCTAssertEqual(object["negative_prompt"] as? String, "NO USER INPUT")
+        XCTAssertEqual(object["use_cot_caption"] as? Bool, false)
         XCTAssertEqual(
             try XCTUnwrap(object["repetition_penalty"] as? Double),
             1.08,

--- a/Tests/MereRunCLITests/MusicServeAndExportTests.swift
+++ b/Tests/MereRunCLITests/MusicServeAndExportTests.swift
@@ -109,7 +109,7 @@ final class MusicServeAndExportTests: XCTestCase {
             JSONSerialization.jsonObject(with: encoded) as? [String: String]
         )
 
-        XCTAssertEqual(ACEStepGenerationRecipe.currentSchemaVersion, 4)
+        XCTAssertEqual(ACEStepGenerationRecipe.currentSchemaVersion, 5)
         XCTAssertEqual(object["bpm"], "118")
         XCTAssertEqual(object["duration"], "12")
         XCTAssertEqual(object["keyscale"], "D major")
@@ -123,7 +123,9 @@ final class MusicServeAndExportTests: XCTestCase {
             temperature: 0.7,
             topK: 32,
             topP: 0.85,
-            repetitionPenalty: 1.08
+            repetitionPenalty: 1.08,
+            cfgScale: 2,
+            negativePrompt: "NO USER INPUT"
         )
         let encoded = try JSONEncoder().encode(sampling)
         let object = try XCTUnwrap(
@@ -141,6 +143,12 @@ final class MusicServeAndExportTests: XCTestCase {
             0.85,
             accuracy: 0.0001
         )
+        XCTAssertEqual(
+            try XCTUnwrap(object["cfg_scale"] as? Double),
+            2,
+            accuracy: 0.0001
+        )
+        XCTAssertEqual(object["negative_prompt"] as? String, "NO USER INPUT")
         XCTAssertEqual(
             try XCTUnwrap(object["repetition_penalty"] as? Double),
             1.08,
@@ -230,6 +238,9 @@ final class MusicServeAndExportTests: XCTestCase {
                   "lm_top_p": 0.85,
                   "lm_temperature": 0.7,
                   "lm_repetition_penalty": 1.08,
+                  "lm_cfg_scale": 2.5,
+                  "lm_negative_prompt": "muddy mix",
+                  "instrumental": true,
                   "bpm": 118,
                   "keyscale": "D major",
                   "metadata_language": "en",
@@ -271,6 +282,9 @@ final class MusicServeAndExportTests: XCTestCase {
         XCTAssertEqual(request.lmTopP, 0.85)
         XCTAssertEqual(request.lmTemperature, 0.7)
         XCTAssertEqual(request.lmRepetitionPenalty, 1.08)
+        XCTAssertEqual(request.lmCFGScale, 2.5)
+        XCTAssertEqual(request.lmNegativePrompt, "muddy mix")
+        XCTAssertEqual(request.instrumental, true)
         XCTAssertEqual(request.bpm, 118)
         XCTAssertEqual(request.keyscale, "D major")
         XCTAssertEqual(request.metadataLanguage, "en")

--- a/Tests/MereRunCoreTests/ACEStep5HzLMConstrainedSamplerTests.swift
+++ b/Tests/MereRunCoreTests/ACEStep5HzLMConstrainedSamplerTests.swift
@@ -5,6 +5,72 @@ import XCTest
 
 final class ACEStep5HzLMConstrainedSamplerTests: MereRunCoreTestCase {
 
+    func testMultilineCaptionKeepsLaterMetadataInjectionAligned() throws {
+        let env = ProcessInfo.processInfo.environment
+        guard let root = env["MERERUN_TEST_ACESTEP_5HZ_ROOT"], !root.isEmpty else {
+            throw XCTSkip("Set MERERUN_TEST_ACESTEP_5HZ_ROOT to an installed ACE-Step planner root.")
+        }
+
+        let resources = ACEStep5HzLMResources(rootURL: URL(fileURLWithPath: root))
+        let configData = try Data(contentsOf: resources.configURL)
+        let modelConfig = try JSONDecoder().decode(ACEStep5HzLMConfig.self, from: configData)
+        let tokenizer = try ACEStep5HzLMTokenizer.load(from: resources.modelRootURL)
+        let sampler = ACEStep5HzLMConstrainedSampler(
+            tokenizer: tokenizer,
+            vocabSize: modelConfig.vocabSize,
+            stopAtReasoning: true,
+            userMetadata: .init(duration: "85", language: "en")
+        )
+
+        func feed(_ text: String) {
+            for token in tokenizer.encode(text, addSpecialTokens: false) {
+                sampler.update(with: token)
+            }
+        }
+
+        feed("<think>\n")
+        feed("bpm: 200\n")
+        feed("caption:")
+        feed(" First line.\n")
+        XCTAssertEqual(sampler.state, .captionValue)
+
+        let continuation = try XCTUnwrap(
+            tokenizer.encode("  Indented continuation.\n", addSpecialTokens: false).first
+        )
+        var logits = MLXArray.full(
+            [modelConfig.vocabSize],
+            values: MLXArray(-Float.infinity),
+            dtype: .float32
+        )
+        logits[continuation] = MLXArray(0)
+        _ = sampler.processLogits(logits, tokens: [])
+        feed("  Indented continuation.\n")
+        XCTAssertEqual(sampler.state, .captionValue)
+
+        let durationFieldTokens = tokenizer.encode("duration:", addSpecialTokens: false)
+        let durationFirst = try XCTUnwrap(durationFieldTokens.first)
+        logits = MLXArray.full(
+            [modelConfig.vocabSize],
+            values: MLXArray(-Float.infinity),
+            dtype: .float32
+        )
+        logits[durationFirst] = MLXArray(0)
+        _ = sampler.processLogits(logits, tokens: [])
+        for token in durationFieldTokens {
+            sampler.update(with: token)
+        }
+        XCTAssertEqual(sampler.state, .durationValue)
+
+        let injectedDuration = try XCTUnwrap(
+            tokenizer.encode(" 85\n", addSpecialTokens: false).first
+        )
+        let masked = sampler.processLogits(
+            MLXArray.zeros([modelConfig.vocabSize], dtype: .float32),
+            tokens: []
+        )
+        XCTAssertTrue(masked[injectedDuration].item(Float.self).isFinite)
+    }
+
     func testUserMetadataInjectionWhitelistsNextToken() throws {
         let env = ProcessInfo.processInfo.environment
         guard let root = env["MERERUN_TEST_ACESTEP_5HZ_ROOT"], !root.isEmpty else {

--- a/Tests/MereRunCoreTests/ACEStepMusicUnderstandingTests.swift
+++ b/Tests/MereRunCoreTests/ACEStepMusicUnderstandingTests.swift
@@ -122,4 +122,37 @@ final class ACEStepMusicUnderstandingTests: MereRunCoreTestCase {
             "ja"
         )
     }
+
+    func testCodeGenerationContextReserializesEffectivePlannerScalars() {
+        let context = ACEStepLMCodeGenerationContext(
+            caption: "original prompt",
+            lyrics: "[Instrumental]",
+            reasoning: """
+            <think>
+            bpm: 200
+            caption: A multiline cinematic description.
+              With an indented continuation.
+            duration: 55)
+            keyscale: G minor
+
+            language: zxx4388
+            </think>
+            """
+        ).applying(
+            userMetadata: .init(
+                bpm: "200",
+                duration: "85",
+                keyscale: "G minor",
+                language: "en",
+                timesignature: "4"
+            )
+        )
+
+        XCTAssertTrue(context.reasoning.contains("duration: 85\n"))
+        XCTAssertTrue(context.reasoning.contains("language: en\n"))
+        XCTAssertTrue(context.reasoning.contains("timesignature: 4\n</think>"))
+        XCTAssertFalse(context.reasoning.contains("55)"))
+        XCTAssertFalse(context.reasoning.contains("zxx4388"))
+        XCTAssertTrue(context.reasoning.contains("  With an indented continuation."))
+    }
 }

--- a/Tests/MereRunCoreTests/ACEStepTaskAndRepaintTests.swift
+++ b/Tests/MereRunCoreTests/ACEStepTaskAndRepaintTests.swift
@@ -374,11 +374,11 @@ final class ACEStepTaskAndRepaintTests: MereRunCoreTestCase {
         )
         XCTAssertEqual(baseFinal.inferenceSteps, 50)
         XCTAssertEqual(baseFinal.guidanceScale, 7)
-        XCTAssertEqual(baseFinal.samplerMode, .heun)
-        XCTAssertEqual(baseFinal.velocityNormThreshold, 2)
-        XCTAssertEqual(baseFinal.velocityEMAFactor, 0.1)
+        XCTAssertEqual(baseFinal.samplerMode, .euler)
+        XCTAssertEqual(baseFinal.velocityNormThreshold, 0)
+        XCTAssertEqual(baseFinal.velocityEMAFactor, 0)
         XCTAssertTrue(baseFinal.automaticDuration)
-        XCTAssertEqual(baseFinal.candidateCount, 4)
+        XCTAssertEqual(baseFinal.candidateCount, 1)
 
         let repaint = ACEStepQualityPreset.edit.defaults(
             for: .xlTurbo,
@@ -406,6 +406,32 @@ final class ACEStepTaskAndRepaintTests: MereRunCoreTestCase {
         XCTAssertFalse(ACEStepTask.coverNoFSQ.usesFSQCoverHints)
         XCTAssertTrue(ACEStepTask.lego.locksDurationToSource)
         XCTAssertFalse(ACEStepTask.complete.locksDurationToSource)
+    }
+
+    func testLMCodePhaseMatchesUpstreamPromptAndGuidanceContract() {
+        let prompt = ACEStep5HzLM.audioCodePromptText(
+            user: "NO USER INPUT",
+            reasoning: "<think>\n\n</think>"
+        )
+        XCTAssertTrue(prompt.contains(ACEStepLMInstructions.defaultInstruction))
+        XCTAssertTrue(prompt.contains("<|im_start|>user\nNO USER INPUT<|im_end|>"))
+        XCTAssertTrue(
+            prompt.hasSuffix("<|im_start|>assistant\n<think>\n\n</think>\n\n")
+        )
+
+        let guided = ACEStep5HzLM.classifierFreeGuidanceLogits(
+            conditional: MLXArray([2.0, 4.0]),
+            unconditional: MLXArray([1.0, 3.0]),
+            scale: 2
+        )
+        XCTAssertEqual(guided.asArray(Float.self), [3, 5])
+
+        XCTAssertEqual(
+            ACEStepPipeline.reasoningPrefix(
+                from: "noise<think>\nbpm: 120\n</think>discard"
+            ),
+            "<think>\nbpm: 120\n</think>"
+        )
     }
 
     func testCheckpointVariantDetectionUsesNameAndConfig() {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1382,6 +1382,7 @@ Key options:
 - `--checkpoints-root`
 - `--lyrics`
 - `--lyrics-file`
+- `--instrumental`: pass upstream's `[Instrumental]` lyric marker; cannot be combined with lyrics
 - `--source-audio`: source song for ACE-Step cover conditioning; implies cover mode unless `--non-cover` is set
 - `--analyze-source-audio`: use ACE-Step 5 Hz LM audio understanding to fill missing cover metadata from `--source-audio`
 - `--reference-audio`: optional ACE-Step timbre reference audio file(s)
@@ -1392,7 +1393,9 @@ Key options:
 - `--lm-subdirectory` (legacy same-root component override)
 - `--lm-temperature`: planner sampling temperature from `0` to `2` (default `0.85`)
 - `--lm-top-k`, `--lm-top-p`: planner candidate and nucleus sampling
-- `--lm-repetition-penalty`: semantic-code repetition penalty; `1.0` disables it
+- `--lm-repetition-penalty`: planner and semantic-code repetition penalty; `1.0` disables it
+- `--lm-cfg-scale`: classifier-free guidance applied only during semantic-code generation (upstream default `2.0`)
+- `--lm-negative-prompt`: unconditional LM prompt used by semantic-code guidance (default `NO USER INPUT`)
 - `--text-subdirectory`
 - `--seed`
 - `--quiet`
@@ -1431,6 +1434,12 @@ swift run mere.run music generate \
   --lm-temperature 0.7 \
   --lm-repetition-penalty 1.08 \
   --output ./controlled-phrasing.wav
+swift run mere.run music generate \
+  "cinematic electronic trailer score with rising builds and drops" \
+  --use-lm \
+  --instrumental \
+  --duration 85 \
+  --output ./instrumental-trailer.wav
 swift run mere.run music generate \
   "dream-pop cover with soft vocals" \
   --source-audio ./song.mp3 \

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1396,6 +1396,7 @@ Key options:
 - `--lm-repetition-penalty`: planner and semantic-code repetition penalty; `1.0` disables it
 - `--lm-cfg-scale`: classifier-free guidance applied only during semantic-code generation (upstream default `2.0`)
 - `--lm-negative-prompt`: unconditional LM prompt used by semantic-code guidance (default `NO USER INPUT`)
+- `--no-lm-caption-rewrite`: preserve the input caption while retaining LM metadata planning and semantic audio codes (upstream `use_cot_caption=false`)
 - `--text-subdirectory`
 - `--seed`
 - `--quiet`

--- a/docs/runtime/acestep-validation.md
+++ b/docs/runtime/acestep-validation.md
@@ -21,8 +21,9 @@ Hugging Face revisions:
 
 Generation recipes repeat the effective repository/revision set, adapter
 SHA-256 and scale, final effective conditioning metadata, complete inference
-configuration, candidate ranking, and input/output hashes. Recipe schema 4
-adds planner temperature, top-k/top-p, and repetition penalty to schema 3's
+configuration, candidate ranking, and input/output hashes. Recipe schema 5
+adds the semantic-code CFG scale and negative prompt to schema 4's planner
+temperature, top-k/top-p, and repetition penalty and schema 3's
 resolved planner source, root, and immutable repository/revision provenance
 and schema 2's post-planning BPM, duration, key/scale, vocal language, and time
 signature. This protects old installs whose original
@@ -44,6 +45,9 @@ The deterministic test surface covers:
 - Python-contract metadata precedence: explicit duration and language survive
   conflicting planner proposals, 1.7B is discovered before 4B, and separately
   managed planners resolve without checkpoint-store symlinks;
+- upstream two-phase LM prompting: metadata uses CFG `1.0`; code generation
+  continues from the planned CoT, guides conditional/unconditional logits at
+  `2.0`, and keeps the sampled token streams synchronized;
 - stable seed fanout, candidate metrics/ranking, batch/session serialization,
   API decoding/security, WAV headers, LRC, recipes, and DAW bundle topology;
 - PEFT LoRA and LyCORIS LoKr key mapping, numerical contributions, alpha/scale,
@@ -82,6 +86,7 @@ specific validation artifacts identifiable without committing model output.
 | XL-Base complete | one-second source, one step, `Drums,Bass` | `1c8861285bcbf0952035b11aa1676c38f516a543c700c15a896105c0f9fdea35` |
 | XL-Turbo flow edit | one-second source, one step | `ae758bdf4b940277fc09145f9340bdd852b1fd48915921ad231b86488353cb27` |
 | XL-Turbo + 4B recipe v2 | one-second LM-planned vocal, one step | `68b170220cf5849635f3f97f2b75d87d7a80045f2401edf9a707d677db2f2122` |
+| XL-Turbo + 4B upstream LM replay | 85-second trailer prompt, seed 4747, 16-step Heun | `65eaaac55db062189ab2d923ad5dcda0ecaa7287dcee00a7c2003af3b999ffad` |
 | Resident API WAV | warm one-second XL-Turbo request, one step | `9c6f3ef3752f15636aa2f4eb7b74b3dcee556e78a62158e4bc4ac344f6eaee32` |
 | Float32 artifact/DAW workflow | recipe, LRC, candidates, bundle | `d44d8386c6b479e209d169c74ff2aa69bd2b13dd980f83a708b9f381c985e629` |
 | LoRA train/save | one real backward and AdamW step, 256 layers | `b7c9c40c3b74aca7fb8f12fb4999c0be1175db82bf9e1504bb9c19794a29c8dd` |
@@ -115,6 +120,16 @@ metadata. A real LM-planned API request returned effective BPM 108, G major,
 the explicit one-second duration, and omitted unsupported planner language.
 Wrong-model, wrong-content-type, and raw-WAV batch requests returned actionable
 HTTP 400 JSON errors.
+
+The 85-second XL-Turbo + 4B replay exercised the full upstream-shaped LM path
+with one candidate: phase-one CFG `1.0`, phase-two CFG `2.0`, the
+`NO USER INPUT` unconditional prompt, temperature `0.85`, top-p `0.9`, and 425
+semantic codes. Its schema 5 recipe records the requested seed `4747`, explicit
+duration `85`, language `en`, and the same effective values inside the CoT used
+for phase two. Diffusion used the explicitly requested 16-step Heun sampler
+with velocity normalization and EMA both disabled. The output is exactly
+85 seconds of float32 stereo audio at 48 kHz; its recipe SHA-256 is
+`3530789814c6f0a98b03378fa989b7b0ebfe5419b7060817f83358a045672252`.
 
 ## Listening regression
 

--- a/docs/runtime/music.md
+++ b/docs/runtime/music.md
@@ -230,21 +230,24 @@ norm/EMA stabilization, and Euler or Heun ODE integration. Turbo remains the
 fast distilled path. Base uniquely enables extract, lego, and complete.
 
 `--quality draft|song|final|edit` is model-aware. It selects checkpoint-safe
-steps, sampler, guidance, velocity stabilization, LM planning policy, automatic
-duration behavior, and a warm best-of-N count. Explicit flags still override
-the preset. The independently managed 1.7B planner is the default; 4B is an
-explicit `--lm-model music-acestep-lm-4b` choice. Best-of-N
+steps, sampler, guidance, LM planning policy, and automatic duration behavior.
+The presets retain upstream's Euler sampler and disabled velocity controls;
+explicit flags still override them. They generate one candidate because
+upstream auto-scoring is disabled by default. `--candidates N` explicitly opts
+into the local warm best-of-N path. The independently managed 1.7B planner is
+the default; 4B is an explicit `--lm-model music-acestep-lm-4b` choice. Best-of-N
 ranking checks finite samples, level, clipping, DC offset, crest factor,
 spectral flatness, frame-energy movement, periodicity, time-varying spectral
 structure, and tail continuity. This prevents loud stationary noise or a
 prematurely dead ending from winning on level statistics alone.
 
 Every ACE-Step generation writes 48 kHz stereo 24-bit WAV by default plus a
-schema 4 reproducible recipe JSON. The recipe records exact checkpoint
+schema 5 reproducible recipe JSON. The recipe records exact checkpoint
 repositories and immutable revisions, adapter hashes and scales,
-prompt/lyrics/instruction, the final effective BPM, duration, key/scale, vocal
+original and planner-rewritten captions, lyrics/instruction, the exact planner
+reasoning prefix, the final effective BPM, duration, key/scale, vocal
 language and time signature, task/edit configuration, planner temperature,
-top-k/top-p, repetition penalty, diffusion controls, candidate seeds and
+top-k/top-p, repetition penalty, LM CFG scale and negative prompt, diffusion controls, candidate seeds and
 technical scores, export policy, and input/output hashes.
 When the 5 Hz LM is active, each candidate also records its semantic audio-code
 count. The generation seed drives both LM sampling and diffusion.
@@ -283,6 +286,9 @@ the independently resolved `language_model_source` alongside the resident DiT.
 Planner sampling fields use the same defaults and validation as the CLI:
 `lm_temperature` defaults to `0.85`, `lm_top_k` to `0`, `lm_top_p` to `0.9`,
 and `lm_repetition_penalty` to neutral `1.0`.
+`lm_cfg_scale` defaults to upstream's `2.0`, and `lm_negative_prompt` defaults
+to `NO USER INPUT`. CFG is applied only to the semantic-code phase; metadata
+planning remains at `1.0` so guidance cannot distort the CoT text.
 
 Batch items may select independent `candidates` values. The server serializes
 them through the warm session, returns every ranked candidate and exactly one

--- a/docs/runtime/music.md
+++ b/docs/runtime/music.md
@@ -247,7 +247,7 @@ repositories and immutable revisions, adapter hashes and scales,
 original and planner-rewritten captions, lyrics/instruction, the exact planner
 reasoning prefix, the final effective BPM, duration, key/scale, vocal
 language and time signature, task/edit configuration, planner temperature,
-top-k/top-p, repetition penalty, LM CFG scale and negative prompt, diffusion controls, candidate seeds and
+top-k/top-p, repetition penalty, LM CFG scale, negative prompt, caption-rewrite policy, diffusion controls, candidate seeds and
 technical scores, export policy, and input/output hashes.
 When the 5 Hz LM is active, each candidate also records its semantic audio-code
 count. The generation seed drives both LM sampling and diffusion.


### PR DESCRIPTION
## Summary

- restore ACE-Step 1.5's upstream two-phase 5 Hz LM flow: unguided metadata CoT, then a separate open assistant turn for semantic codes with CFG 2.0 and the `NO USER INPUT` unconditional prompt
- keep the original caption/lyrics for LM code generation while sending the planner's rewritten caption to the DiT
- expose `--no-lm-caption-rewrite`, matching upstream `use_cot_caption=false`, so metadata and semantic-code generation can remain active without allowing a planner rewrite to replace or leak into an arrangement-sensitive caption
- reserialize effective BPM, duration, key, language, and time signature between phases so explicit user constraints reach the actual code prompt
- port upstream's multiline YAML-caption state handling and add a real-tokenizer regression for the duration/language desynchronization
- expose `--lm-cfg-scale`, `--lm-negative-prompt`, and `--instrumental` across CLI, resident API, Studio, docs, and schema 5 recipes
- align quality presets with upstream's Euler, disabled velocity-control, and one-candidate defaults; local best-of-N ranking remains available through explicit `--candidates`

## Root cause

The native path had drifted at the orchestration boundary rather than in the checkpoints or numerical kernels. It ran planning and semantic-code generation as one constrained decode with the task instruction, omitted upstream LM CFG, let a multiline planner caption desynchronize later metadata fields, always rewrote the caption, and applied local `final` preset inventions (four candidates plus velocity normalization/EMA). The displayed metadata was merged after planning, but the stale raw CoT still reached semantic-code generation.

## Validation

- `./scripts/check.sh`: 2,621 XCTest cases, 173 truthful asset skips, zero failures; 25 Swift Testing cases, zero failures; strict SwiftLint, build, CLI help sweep, readiness, and hygiene scans passed
- installed 1.7B and 4B planner tokenizer suites: 4/4 passed, including multiline caption -> exact duration injection
- exact 85-second XL-Turbo + 4B replay: seed 4747, one candidate, 425 semantic codes, language `en` and duration `85` inside phase-two CoT, CFG 2.0, `NO USER INPUT`, velocity controls disabled
- exact XL-SFT `use_cot_caption=false` replay: phase-one reasoning contained only explicit scalar metadata, the recipe preserved the input caption, and no generated caption could leak into semantic-code conditioning
- controlled XL-SFT direct-DiT comparison reduced the local periodicity diagnostic from `0.8328` with LM semantic codes to `0.7004` without them; this is diagnostic evidence, not a substitute for human listening review
- float32 48 kHz stereo WAV SHA-256: `65eaaac55db062189ab2d923ad5dcda0ecaa7287dcee00a7c2003af3b999ffad`
- schema 5 recipe SHA-256: `3530789814c6f0a98b03378fa989b7b0ebfe5419b7060817f83358a045672252`
- source comparison pinned to upstream ACE-Step commit `6d467e4b5081ccb0abf1ec1bf4fdf9051a2d34b0`

Kept as draft for final human listening review.
