### PR TITLE
feat(graph): retain vision grounding masks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -346,6 +346,11 @@ artifact contracts instead of becoming a model-specific sidecar.
 
 ### Vision and portable workflows
 
+- portable `vision.ground` graph nodes now retain Falcon Perception's native
+  per-detection PNG masks as a verified `masks` artifact directory, matching
+  the existing direct CLI capability without changing their candidate-only
+  evidence boundary.
+
 - added `vision.ground` as a first-class portable graph node across local, SSH,
   and Relay execution. It defaults to the managed Falcon Perception model,
   accepts an image plus typed query array, and emits verified annotated-image

--- a/Sources/MereRunCLI/Guides/vision-ground.md
+++ b/Sources/MereRunCLI/Guides/vision-ground.md
@@ -54,9 +54,9 @@ mere.run vision ground ./street.jpg \
 Use the built-in `vision.ground` graph node to keep grounding portable across
 local, SSH, and Relay execution. It accepts an image asset and a JSON array of
 queries, defaults to the managed Falcon model, and emits verified annotated
-`image` and structured `detections` artifacts. Treat detections as candidate
-geometry until an authoritative source or human review promotes them. Direct
-CLI runs may additionally request per-detection masks with `--mask-output-dir`.
+`image`, structured `detections`, and per-detection PNG `masks` artifacts.
+Treat detections and masks as candidate geometry until an authoritative source
+or human review promotes them.
 
 ## Troubleshooting
 

--- a/Sources/MereRunCLI/Support/WorkflowGraph.swift
+++ b/Sources/MereRunCLI/Support/WorkflowGraph.swift
@@ -863,6 +863,12 @@ enum WorkflowNodeRegistry {
                     description: "Structured candidate detections and normalized geometry.",
                     contentTypes: ["application/json"]
                 ),
+                .init(
+                    name: "masks",
+                    type: .assetDirectory,
+                    description: "Per-detection Falcon candidate masks.",
+                    contentTypes: ["image/png"]
+                ),
             ],
             requirements: .init(
                 modelIDs: [],

--- a/Sources/MereRunCLI/Support/WorkflowJobBundle.swift
+++ b/Sources/MereRunCLI/Support/WorkflowJobBundle.swift
@@ -1334,6 +1334,7 @@ enum WorkflowNodeCommandBuilder {
         case "vision.ground":
             let outputImage = artifacts.appendingPathComponent("image.png")
             let detections = artifacts.appendingPathComponent("detections.json")
+            let masks = artifacts.appendingPathComponent("masks", isDirectory: true)
             var args = [
                 "vision", "ground", try requiredString("image", in: arguments),
                 "--query",
@@ -1343,6 +1344,7 @@ enum WorkflowNodeCommandBuilder {
             args += [
                 "--output", outputImage.path,
                 "--json-output", detections.path,
+                "--mask-output-dir", masks.path,
             ]
             return .init(
                 command: ["vision", "ground"],
@@ -1352,6 +1354,7 @@ enum WorkflowNodeCommandBuilder {
                 outputs: [
                     "image": fileOutput(outputImage, contentTypes: ["image/png"]),
                     "detections": fileOutput(detections, contentTypes: ["application/json"]),
+                    "masks": directoryOutput(masks, contentTypes: ["image/png"]),
                 ],
                 streamsEvents: false
             )

--- a/Tests/MereRunCLITests/WorkflowGraphTests.swift
+++ b/Tests/MereRunCLITests/WorkflowGraphTests.swift
@@ -61,11 +61,15 @@ final class WorkflowGraphTests: XCTestCase {
         )
         XCTAssertEqual(
             entry.outputs.map(\.name),
-            ["image", "detections"]
+            ["image", "detections", "masks"]
         )
         XCTAssertEqual(
             entry.outputs.first(where: { $0.name == "detections" })?.contentTypes,
             ["application/json"]
+        )
+        XCTAssertEqual(
+            entry.outputs.first(where: { $0.name == "masks" })?.type,
+            .assetDirectory
         )
     }
 
@@ -267,9 +271,11 @@ final class WorkflowGraphTests: XCTestCase {
         XCTAssertTrue(invocation.runArguments.contains("debris accumulation"))
         XCTAssertEqual(invocation.outputs["image"]?.type, .asset)
         XCTAssertEqual(invocation.outputs["detections"]?.contentTypes, ["application/json"])
+        XCTAssertEqual(invocation.outputs["masks"]?.type, .assetDirectory)
         XCTAssertTrue(invocation.outputs["image"]?.path?.hasSuffix("/artifacts/image.png") == true)
         XCTAssertTrue(invocation.outputs["detections"]?.path?.hasSuffix("/artifacts/detections.json") == true)
-        XCTAssertFalse(invocation.runArguments.contains("--mask-output-dir"))
+        XCTAssertTrue(invocation.outputs["masks"]?.path?.hasSuffix("/artifacts/masks") == true)
+        XCTAssertTrue(invocation.runArguments.contains("--mask-output-dir"))
     }
 
     func testVisionGroundRequiresAtLeastOneStringQuery() throws {

--- a/docs/runtime/vision.md
+++ b/docs/runtime/vision.md
@@ -211,9 +211,9 @@ annotated image path.
 
 Portable graphs expose the same runtime as the built-in `vision.ground` node.
 The node accepts an image plus a JSON array of queries and produces a verified
-annotated `image` plus structured `detections` JSON. These outputs are candidate
-geometry, not authoritative evidence. Direct CLI runs may additionally export
-per-detection masks with `--mask-output-dir`.
+annotated `image`, structured `detections` JSON, and a portable `masks`
+directory containing per-detection PNG masks. These outputs are candidate
+geometry, not authoritative evidence.
 
 For repeated binary frames, keep Falcon Perception resident behind the generic
 loopback vision service:

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -64,9 +64,10 @@ missing variables. `text.enhance` and `image.describe` require an explicit
 installed model and never trigger a hidden pull.
 
 `vision.ground` uses the managed `vision-ground-falcon-perception` model by
-default. It emits an annotated image and structured detections JSON as verified
-artifacts. Grounding output is candidate geometry; graph execution does not
-promote it into evidence or findings.
+default. It emits an annotated image, structured detections JSON, and a
+portable directory of per-detection PNG masks as verified artifacts. Grounding
+output is candidate geometry; graph execution does not promote it into evidence
+or findings.
 
 `vision.segment` and `vision.track` use the managed `vision-segment-sam31`
 model by default. Both emit an annotated media artifact, structured JSON, and a


### PR DESCRIPTION
## Summary
- expose per-detection PNG masks as the generic `vision.ground` graph node `masks` output
- materialize and content-hash the directory across portable graph execution
- document the existing candidate-output boundary

## Validation
- `./scripts/check.sh` (2,631 XCTest cases, 173 skipped, 0 failures; Swift Testing suites also green)
- `swift test --filter WorkflowGraphTests` (57/57)
- real local graph smoke: 15 masks emitted as a verified `asset_directory` with a durable content hash