### PR TITLE
Add native LTX 2.5 video generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ current flags.
 | Vision understanding | `vision caption`, `inspect`, `face`, `ground`, `segment`, `track`, `track-live`, `pose`, `flow`, `ocr` | Captioning and VQA, local face detection/identity embeddings, LightOn/GLM/Infinity OCR, Falcon grounding, SAM 3.1 segmentation and tracking, body/hand/face landmarks, and dense optical flow |
 | Depth, geometry, and 3D | `vision depth-video`, `geometry`, `geometry-multiview`, `image-to-3d*`; `image reconstruct-3d*` | Video Depth Anything, MoGe-2, Depth Anything 3, TripoSR, InstantMesh, and TRELLIS.2; depth/confidence EXRs, cameras, point clouds, 3DGS initialization, OBJ, PLY, GLB, and PBR voxel artifacts |
 | Audio enhancement | `audio enhance` | Native AP-BWE speech bandwidth extension and UniverSR general-audio super-resolution to hashed 48 kHz mono WAVs |
-| Video and worlds | `video generate`, `video cosmos3`, `video prepare-masks`, `video animate`, `video session`, `video export-latents`, `world serve` | MiniMax-H3 FL2VA/Ref2VA synchronized video and audio, LTX video and synchronized LTX 2.3 audio/video, resident distilled and full-dev LTX workers, Wan 2.2 TI2V, native Cosmos3-Edge generation/reasoning/action dynamics, native SAM 3.1 mask preparation, native SCAIL-2 subject animation/replacement, and warm DreamX or Cosmos3 world sessions |
+| Video and worlds | `video generate`, `video cosmos3`, `video prepare-masks`, `video animate`, `video session`, `video export-latents`, `world serve` | MiniMax-H3 FL2VA/Ref2VA synchronized video and audio, native LTX 2.5 and LTX 2.3 synchronized audio/video, resident distilled and full-dev LTX workers, Wan 2.2 TI2V, native Cosmos3-Edge generation/reasoning/action dynamics, native SAM 3.1 mask preparation, native SCAIL-2 subject animation/replacement, and warm DreamX or Cosmos3 world sessions |
 | Music and sound | `music analyze`, `generate`, `realtime`, `separate`, `transcribe`; `sfx generate`, `sfx video generate` | ACE-Step generation, analysis, and covers; Magenta RT2 realtime MIDI performance; native RoFormer separation, dereverb, and denoise; MuScriptor full-mix MIDI transcription; Woosh and native MMAudio text/video-conditioned sound |
 | Speech | `speech synthesize`, `speech transcribe`, `speech diarize`, `speech listen`, `speech profile` | Qwen3 TTS, saved voice profiles, Qwen3 live ASR, Parakeet transcription, and native MLX Sortformer speaker diarization |
 | Serving and operations | `api serve`, `open-webui quickstart`, `status`, `run`, `model runtime`, `gate` | OpenAI-compatible chat, embeddings, images, TTS, and STT; resident model pooling, TTL/pinning, memory guards, durable run inspection, and installed-model quality gates |
@@ -766,6 +766,16 @@ swift run mere.run video generate \
   --duration 15 \
   --fps 24 \
   --output ./clip-av.mp4
+
+# Generate synchronized final-quality LTX 2.5 audio/video (gated model)
+swift run mere.run model pull video-ltx25-distilled-bf16 --accept-model-license
+swift run mere.run video generate \
+  "a small red robot walks across a wooden table, tiny mechanical footsteps" \
+  --model video-ltx25-distilled-bf16 \
+  --quality final \
+  --output-mode audio-video \
+  --fps 24 \
+  --output ./clip-ltx25.mp4
 
 # Condition video on a selected source-audio segment and preserve that soundtrack
 swift run mere.run model pull video-ltx23-full-mlx --accept-model-license

--- a/Sources/MereRunCLI/Commands/ModelInfoCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelInfoCommand.swift
@@ -175,7 +175,11 @@ struct ModelInfo: ParsableCommand {
 
         if components {
             print("\nComponents")
-            if Self.usesLTX23FullLayout(manifest: manifest, expectedModelID: expectedModelID) {
+            if Self.usesLTX25Layout(manifest: manifest, expectedModelID: expectedModelID) {
+                for line in Self.ltx25ComponentLines(rootURL: rootURL, fileManager: fm) {
+                    print(line)
+                }
+            } else if Self.usesLTX23FullLayout(manifest: manifest, expectedModelID: expectedModelID) {
                 let companionRoot = ModelResolver()
                     .resolveIfPresent(.ltxGemma3TwelveB4Bit)?
                     .rootURL
@@ -241,6 +245,25 @@ struct ModelInfo: ParsableCommand {
         let id = expectedModelID ?? manifest?.id
         guard let id else { return false }
         return ManagedModelCatalog.spec(for: id)?.validationKind == .ltxVideo23MLX
+    }
+
+    static func usesLTX25Layout(manifest: MereRunModelManifest?, expectedModelID: String?) -> Bool {
+        let id = expectedModelID ?? manifest?.id
+        guard let id else { return false }
+        return ManagedModelCatalog.spec(for: id)?.validationKind == .ltxVideo25
+    }
+
+    static func ltx25ComponentLines(
+        rootURL: URL,
+        fileManager: FileManager = .default
+    ) -> [String] {
+        var lines = ["  layout: official LTX 2.5 packed BF16 files"]
+        for file in ltx25ComponentFiles {
+            let url = rootURL.appendingPathComponent(file.relativePath).standardizedFileURL
+            let suffix = fileManager.fileExists(atPath: url.path) ? "" : "  (missing)"
+            lines.append("  \(file.label): \(url.path)\(suffix)")
+        }
+        return lines
     }
 
     static func usesLTX23A2VidLayout(manifest: MereRunModelManifest?, expectedModelID: String?) -> Bool {
@@ -417,6 +440,14 @@ struct ModelInfo: ParsableCommand {
         ("spatial_upscaler_x1_5_config", "spatial_upscaler_x1_5_v1_0_config.json"),
         ("temporal_upscaler_x2", "temporal_upscaler_x2_v1_0.safetensors"),
         ("temporal_upscaler_x2_config", "temporal_upscaler_x2_v1_0_config.json"),
+    ]
+
+    private static let ltx25ComponentFiles: [(label: String, relativePath: String)] = [
+        ("transformer", LTX25Resources.transformerRelativePath),
+        ("text_encoder", LTX25Resources.textEncoderRelativePath),
+        ("video_vae", LTX25Resources.videoVAERelativePath),
+        ("audio_vae_vocoder", LTX25Resources.audioVAERelativePath),
+        ("spatial_upscaler", LTX25Resources.spatialUpsamplerRelativePath),
     ]
 
     private static let ltx23A2VidComponentFiles: [(label: String, relativePath: String)] = [

--- a/Sources/MereRunCLI/Commands/VideoCommand.swift
+++ b/Sources/MereRunCLI/Commands/VideoCommand.swift
@@ -33,6 +33,7 @@ func resolveLTXVideoGenerationRoute(
             return .fullQualityVideo
         }
         return isLTX23SplitModelRoot(modelRoot, fileManager: fileManager)
+            || isLTX25ModelRoot(modelRoot, fileManager: fileManager)
             ? .splitDistilledVideo
             : .legacyDistilledVideo
     }
@@ -228,10 +229,11 @@ struct VideoGenerate: AsyncParsableCommand {
 
         Quality and output are separate choices. The default is a fast draft
         checkpoint with video-only output. Use --quality final for the full LTX
-        2.3 dev + distilled-LoRA quality pipeline, and --output-mode audio-video
-        when synchronized generated audio is part of the deliverable. Supplying
-        --audio uses the full model for native two-stage A2Vid and preserves the
-        selected source segment as the soundtrack.
+        2.3 dev + distilled-LoRA pipeline or the official LTX 2.5 distilled
+        checkpoint, and --output-mode audio-video when synchronized generated
+        audio is part of the deliverable. Supplying --audio uses the full LTX
+        2.3 model for native two-stage A2Vid and preserves the selected source
+        segment as the soundtrack.
 
         --variant distilled|unified-av remains available for compatibility. Do
         not combine it with --quality or --output-mode.
@@ -259,7 +261,7 @@ struct VideoGenerate: AsyncParsableCommand {
     @Option(name: [.customShort("m"), .long], help: "Managed video model id or local model root. Defaults by operation.")
     var model: String = ""
 
-    @Option(name: [.customLong("quality")], help: "LTX checkpoint quality: draft uses standalone distilled; final uses dev + distilled-LoRA.")
+    @Option(name: [.customLong("quality")], help: "LTX checkpoint quality: draft uses LTX 2.3 standalone distilled; final uses LTX 2.3 dev + distilled-LoRA or LTX 2.5 distilled.")
     var quality: LTXVideoQuality?
 
     @Option(name: [.customLong("output-mode")], help: "LTX deliverable: video-only or synchronized audio-video.")
@@ -400,6 +402,10 @@ struct VideoGenerate: AsyncParsableCommand {
 
     var requestedQuality: LTXVideoQuality {
         if audio?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false {
+            return .final
+        }
+        if let modelRoot,
+           isLTX25ModelRoot(URL(fileURLWithPath: modelRoot).standardizedFileURL) {
             return .final
         }
         if let quality {
@@ -805,7 +811,7 @@ struct VideoGenerate: AsyncParsableCommand {
         )
         if (timings || timingsOutput != nil), !nativeRoute.supportsPhaseTimings {
             throw ValidationError(
-                "--timings and --timings-output require an LTX 2.3 split model, --quality final, --output-mode audio-video, or --audio."
+                "--timings and --timings-output require a split LTX model, --quality final, --output-mode audio-video, or --audio."
             )
         }
         try MLXBundleSupport.ensureAvailable(quiet: quiet)
@@ -850,16 +856,19 @@ struct VideoGenerate: AsyncParsableCommand {
         guard let quality else { return }
         switch quality {
         case .draft:
-            guard !isLTX23FullModelRoot(modelRoot), !isLTX23AudioToVideoModelRoot(modelRoot) else {
+            guard !isLTX23FullModelRoot(modelRoot),
+                  !isLTX23AudioToVideoModelRoot(modelRoot),
+                  !isLTX25ModelRoot(modelRoot) else {
                 throw ValidationError(
-                    "--quality draft requires \(ModelResolver.ModelID.ltxVideo23AVMLX.rawValue), not the full dev checkpoint."
+                    "--quality draft requires \(ModelResolver.ModelID.ltxVideo23AVMLX.rawValue), not a final-quality checkpoint."
                 )
             }
         case .final:
             let supportsRequestedFinalPath = isLTX23AudioToVideoModelRoot(modelRoot)
+                || isLTX25ModelRoot(modelRoot)
             guard supportsRequestedFinalPath else {
                 throw ValidationError(
-                    "--quality final requires \(ModelResolver.ModelID.ltxVideo23FullMLX.rawValue)."
+                    "--quality final requires \(ModelResolver.ModelID.ltxVideo23FullMLX.rawValue) or an official LTX 2.5 root."
                 )
             }
         }
@@ -1105,7 +1114,7 @@ struct VideoGenerate: AsyncParsableCommand {
         let route = resolveLTXVideoGenerationRoute(outputMode: outputMode, modelRoot: rootURL)
         if (timings || timingsOutput != nil), !route.supportsPhaseTimings {
             throw ValidationError(
-                "--timings and --timings-output require an LTX 2.3 split model, --quality final, --output-mode audio-video, or --audio."
+                "--timings and --timings-output require a split LTX model, --quality final, --output-mode audio-video, or --audio."
             )
         }
         if route == .unifiedAV,
@@ -1120,7 +1129,8 @@ struct VideoGenerate: AsyncParsableCommand {
 
         if !quiet {
             CLIStderr.write("Engine: native\n")
-            CLIStderr.write("Quality: \(isLTX23AudioToVideoModelRoot(rootURL) ? LTXVideoQuality.final.rawValue : LTXVideoQuality.draft.rawValue)\n")
+            let isFinalQuality = isLTX23AudioToVideoModelRoot(rootURL) || isLTX25ModelRoot(rootURL)
+            CLIStderr.write("Quality: \(isFinalQuality ? LTXVideoQuality.final.rawValue : LTXVideoQuality.draft.rawValue)\n")
             CLIStderr.write("Output mode: \(outputMode.rawValue)\n")
             CLIStderr.write("Runtime lane: \(route.rawValue)\n")
             CLIStderr.write("Model root: \(rootURL.path)\n")
@@ -1199,7 +1209,8 @@ struct VideoGenerate: AsyncParsableCommand {
         case .splitDistilledVideo:
             let endToEndStart = videoMonotonicSeconds()
             if !quiet {
-                CLIStderr.write("Loading native LTX 2.3 split distilled model for video-only output...\n")
+                let version = isLTX25ModelRoot(rootURL) ? "LTX 2.5" : "LTX 2.3"
+                CLIStderr.write("Loading native \(version) distilled model for video-only output...\n")
             }
             let generator = LTXUnifiedAVGenerator()
             do {
@@ -1565,7 +1576,9 @@ func validateNativeModelRoot(_ rootURL: URL) throws {
         return
     }
 
-    if isLTX23AudioToVideoModelRoot(rootURL) || isLTX23SplitModelRoot(rootURL) {
+    if isLTX23AudioToVideoModelRoot(rootURL)
+        || isLTX23SplitModelRoot(rootURL)
+        || isLTX25ModelRoot(rootURL) {
         return
     }
 

--- a/Sources/MereRunCLI/Guides/video-generate.md
+++ b/Sources/MereRunCLI/Guides/video-generate.md
@@ -14,6 +14,8 @@ Managed ids:
   VAEs, and x2 upscaler for `--quality final`, generated synchronized audio,
   and native source-audio-conditioned video.
 - `video-ltx23-a2vid-mlx`: compatibility ID for existing A2Vid installs.
+- `video-ltx25-distilled-bf16`: official packed LTX 2.5 BF16 checkpoint for
+  native final-quality synchronized video and stereo audio.
 - `video-ltx-av`: legacy merged LTX root. Superseded by LTX 2.3; only still required by
   `video export-latents`. Not recommended for `video generate`.
 
@@ -24,6 +26,7 @@ You can also pass a local LTX model root with `--model-root`.
 ```bash
 mere.run model pull video-ltx23-av-mlx --accept-model-license
 mere.run model pull video-ltx23-full-mlx --accept-model-license
+mere.run model pull video-ltx25-distilled-bf16 --accept-model-license
 mere.run video generate --help
 ```
 

--- a/Sources/MereRunCLI/Support/InstalledModelGateSupport.swift
+++ b/Sources/MereRunCLI/Support/InstalledModelGateSupport.swift
@@ -467,6 +467,22 @@ enum InstalledModelSmokePlans {
                 try await runner.installedA2VidCheck(model: spec.id)
             }
 
+        case .ltxVideo25:
+            return direct(spec, route: "video generate LTX 2.5 final audio-video") { runner in
+                try await runner.installedLTXCheck(
+                    model: spec.id,
+                    id: spec.id,
+                    arguments: [
+                        "--quality", "final",
+                        "--output-mode", "audio-video",
+                        "--width", "256",
+                        "--height", "192",
+                        "--num-frames", "25",
+                    ],
+                    requireAudio: true
+                )
+            }
+
         case .wan22TI2VMLX:
             return direct(spec, route: "video generate Wan image-to-video") { runner in
                 try await runner.installedWanCheck(model: spec.id)

--- a/Sources/MereRunCLI/Support/VideoGenerationPreflight.swift
+++ b/Sources/MereRunCLI/Support/VideoGenerationPreflight.swift
@@ -744,7 +744,7 @@ struct VideoGenerationPreflightAnalyzer {
         model: VideoGenerationModelPreflightSummary
     ) -> LTXVideoQuality? {
         switch model.layout {
-        case "ltx23_full_split", "ltx23_a2vid_split":
+        case "ltx23_full_split", "ltx23_a2vid_split", "ltx25_distilled":
             return .final
         case "ltx23_distilled_split", "ltx_merged":
             return .draft
@@ -959,6 +959,9 @@ struct VideoGenerationPreflightAnalyzer {
         }
         if isLTX23AudioToVideoModelRoot(url, fileManager: fileManager) {
             return "ltx23_a2vid_split"
+        }
+        if isLTX25ModelRoot(url, fileManager: fileManager) {
+            return "ltx25_distilled"
         }
         return isLTX23SplitModelRoot(url, fileManager: fileManager)
             ? "ltx23_distilled_split"

--- a/Sources/MereRunCore/Gemma4/Gemma4Model.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4Model.swift
@@ -32,6 +32,7 @@ struct Gemma4LanguageModelOutput {
     let hidden: MLXArray
     let preNormHidden: MLXArray
     let sharedKVStates: [String: Gemma4SharedKVState]
+    let hiddenStates: [MLXArray]?
 }
 
 struct Gemma4ForwardOutput {
@@ -870,7 +871,8 @@ final class Gemma4Attention: Module {
     func callAsFunction(
         _ x: MLXArray,
         cache: Gemma4AttentionCache?,
-        visionBlockIDs: MLXArray? = nil
+        visionBlockIDs: MLXArray? = nil,
+        attentionMask: MLXArray? = nil
     ) -> MLXArray {
         let batchSize = x.dim(0)
         let sequenceLength = x.dim(1)
@@ -979,7 +981,8 @@ final class Gemma4Attention: Module {
             keyLength: keys.dim(2),
             windowSize: layerType == "sliding_attention" ? windowSize : nil,
             dtype: x.dtype,
-            visionBlockIDs: visionBlockIDs
+            visionBlockIDs: visionBlockIDs,
+            keyPaddingMask: attentionMask
         )
 
         let attended = MLXFast.scaledDotProductAttention(
@@ -1089,9 +1092,10 @@ final class Gemma4Attention: Module {
         keyLength: Int,
         windowSize: Int?,
         dtype: DType,
-        visionBlockIDs: MLXArray?
+        visionBlockIDs: MLXArray?,
+        keyPaddingMask: MLXArray?
     ) -> MLXFast.ScaledDotProductAttentionMaskMode {
-        guard queryLength > 1 else {
+        guard queryLength > 1 || keyPaddingMask != nil else {
             return .none
         }
 
@@ -1102,6 +1106,16 @@ final class Gemma4Attention: Module {
         var allowed = keyPositions .<= queryPositions
         if let windowSize {
             allowed = allowed .&& (keyPositions .> (queryPositions - Int32(windowSize)))
+        }
+        if let keyPaddingMask,
+           queryOffset == 0,
+           keyStart == 0,
+           keyPaddingMask.dim(-1) == keyLength {
+            let padding = keyPaddingMask
+                .asType(.int32)
+                .reshaped(-1, 1, 1, keyLength)
+            allowed = allowed.reshaped(1, 1, queryLength, keyLength)
+                .&& (padding .> MLXArray(Int32(0)))
         }
         if let visionBlockIDs,
            queryOffset == 0,
@@ -1114,8 +1128,8 @@ final class Gemma4Attention: Module {
             allowed = (allowed.asType(.int32) + sameVisionBlock.asType(.int32)) .> MLXArray(Int32(0))
         }
 
-        let allowedTyped = allowed.asType(dtype).reshaped(1, 1, queryLength, keyLength)
-        let zeros = MLXArray.zeros([1, 1, queryLength, keyLength], dtype: dtype)
+        let allowedTyped = allowed.asType(dtype).reshaped(-1, 1, queryLength, keyLength)
+        let zeros = MLXArray.zeros(allowedTyped.shape, dtype: dtype)
         let negative = zeros + MLXArray(-1e9).asType(dtype)
         return .array(MLX.where(allowedTyped .> MLXArray(0).asType(dtype), zeros, negative))
     }
@@ -1180,11 +1194,17 @@ final class Gemma4DecoderLayer: Module {
         _ x: MLXArray,
         cache: Gemma4AttentionCache?,
         perLayerInput: MLXArray?,
-        visionBlockIDs: MLXArray? = nil
+        visionBlockIDs: MLXArray? = nil,
+        attentionMask: MLXArray? = nil
     ) -> MLXArray {
         let attentionResidual = x
         var hidden = inputLayerNorm(x)
-        hidden = selfAttention(hidden, cache: cache, visionBlockIDs: visionBlockIDs)
+        hidden = selfAttention(
+            hidden,
+            cache: cache,
+            visionBlockIDs: visionBlockIDs,
+            attentionMask: attentionMask
+        )
 
         let perLayerInputActive = hasPerLayerInput && perLayerInput != nil
         if let fusedOutput = fusedDecodeFeedForward(
@@ -1442,9 +1462,12 @@ final class Gemma4LanguageModel: Module {
         inputIds: MLXArray?,
         cache: [Gemma4AttentionCache]? = nil,
         mmTokenTypeIds: MLXArray? = nil,
-        captureSharedKV: Bool = true
+        captureSharedKV: Bool = true,
+        attentionMask: MLXArray? = nil,
+        captureHiddenStates: Bool = false
     ) -> Gemma4LanguageModelOutput {
         var hidden = embeddings
+        var hiddenStates: [MLXArray]? = captureHiddenStates ? [hidden] : nil
         let perLayerInputs = inputIds.flatMap { tokenIds -> MLXArray? in
             guard config.hiddenSizePerLayerInput > 0 else { return nil }
             return projectPerLayerInputs(
@@ -1461,17 +1484,44 @@ final class Gemma4LanguageModel: Module {
                 hidden,
                 cache: cacheIndex < caches.count ? caches[cacheIndex] : nil,
                 perLayerInput: perLayerInput,
-                visionBlockIDs: visionBlockIDs
+                visionBlockIDs: visionBlockIDs,
+                attentionMask: attentionMask
             )
+            if captureHiddenStates {
+                MLX.eval(hidden)
+                hiddenStates?.append(hidden)
+            }
         }
         let preNormHidden = hidden
         let normalizedHidden = norm(hidden)
+        if captureHiddenStates, let lastIndex = hiddenStates?.indices.last {
+            hiddenStates?[lastIndex] = normalizedHidden
+        }
         let sharedKVStates = captureSharedKV ? collectSharedKVStates(from: caches) : [:]
         return Gemma4LanguageModelOutput(
             hidden: normalizedHidden,
             preNormHidden: preNormHidden,
-            sharedKVStates: sharedKVStates
+            sharedKVStates: sharedKVStates,
+            hiddenStates: hiddenStates
         )
+    }
+
+    func forwardHiddenStates(
+        inputIds: MLXArray,
+        attentionMask: MLXArray
+    ) -> (lastHiddenState: MLXArray, hiddenStates: [MLXArray]) {
+        var tokenIds = inputIds
+        if tokenIds.dtype != .int32 {
+            tokenIds = tokenIds.asType(.int32)
+        }
+        let output = forwardDetailed(
+            embeddings: embeddings(inputIds: tokenIds),
+            inputIds: tokenIds,
+            captureSharedKV: false,
+            attentionMask: attentionMask,
+            captureHiddenStates: true
+        )
+        return (output.hidden, output.hiddenStates ?? [output.hidden])
     }
 
     func logits(_ inputIds: MLXArray, cache: [Gemma4AttentionCache]? = nil) -> MLXArray {

--- a/Sources/MereRunCore/LTX/LTX25Resources.swift
+++ b/Sources/MereRunCore/LTX/LTX25Resources.swift
@@ -1,0 +1,69 @@
+import Foundation
+
+public struct LTX25Resources: Sendable, Hashable {
+    public static let modelID = "video-ltx25-distilled-bf16"
+    public static let sourceRepository = "Lightricks/LTX-2.5"
+    public static let sourceRevision = "dd53cc2cd45bbeaa3563dfb575cba3f49cf44761"
+    public static let upstreamCodeRepository = "Lightricks/LTX-2"
+    public static let upstreamCodeRevision = "d151147788a9284cca791edc6ce898007e727fe6"
+    public static let upstreamCodeRelease = "v1.2.0"
+    public static let estimatedDownloadBytes: Int64 = 71_098_810_082
+
+    public static let transformerRelativePath =
+        "diffusion_models/ltx-2.5-22b-distilled-transformer-bf16.safetensors"
+    public static let textEncoderRelativePath =
+        "text_encoders/gemma4-12b-with-proj-ltx-2.5-bf16.safetensors"
+    public static let videoVAERelativePath =
+        "vae/ltx-2.5-video-vae-conv-bf16.safetensors"
+    public static let audioVAERelativePath =
+        "vae/ltx-2.5-audio-vae-bf16.safetensors"
+    public static let spatialUpsamplerRelativePath =
+        "latent_upscale_models/ltx-2.5-latent-spatial-upscaler-x2-bf16-1.0.safetensors"
+    public static let durationHeadRelativePath =
+        "model_patches/ltx-2.5-duration-head-bf16.safetensors"
+
+    public static let requiredRelativePaths = [
+        transformerRelativePath,
+        textEncoderRelativePath,
+        videoVAERelativePath,
+        audioVAERelativePath,
+        spatialUpsamplerRelativePath,
+    ]
+
+    public static let snapshotPatterns = [
+        "README.md",
+        transformerRelativePath,
+        textEncoderRelativePath,
+        videoVAERelativePath,
+        audioVAERelativePath,
+        spatialUpsamplerRelativePath,
+        durationHeadRelativePath,
+    ]
+
+    public let rootURL: URL
+
+    public init(rootURL: URL) {
+        self.rootURL = rootURL.standardizedFileURL
+    }
+
+    public var transformerURL: URL { rootURL.appendingPathComponent(Self.transformerRelativePath) }
+    public var textEncoderURL: URL { rootURL.appendingPathComponent(Self.textEncoderRelativePath) }
+    public var videoVAEURL: URL { rootURL.appendingPathComponent(Self.videoVAERelativePath) }
+    public var audioVAEURL: URL { rootURL.appendingPathComponent(Self.audioVAERelativePath) }
+    public var spatialUpsamplerURL: URL { rootURL.appendingPathComponent(Self.spatialUpsamplerRelativePath) }
+    public var durationHeadURL: URL { rootURL.appendingPathComponent(Self.durationHeadRelativePath) }
+
+    public func validate(fileManager: FileManager = .default) -> [URL] {
+        Self.requiredRelativePaths.compactMap { relativePath in
+            let url = rootURL.appendingPathComponent(relativePath)
+            return fileManager.fileExists(atPath: url.path) ? nil : url
+        }
+    }
+}
+
+public func isLTX25ModelRoot(
+    _ rootURL: URL,
+    fileManager: FileManager = .default
+) -> Bool {
+    LTX25Resources(rootURL: rootURL).validate(fileManager: fileManager).isEmpty
+}

--- a/Sources/MereRunCore/LTX/LTXDistilledLatentGenerator.swift
+++ b/Sources/MereRunCore/LTX/LTXDistilledLatentGenerator.swift
@@ -3259,6 +3259,7 @@ public actor LTXUnifiedAVGenerator {
     private var modelWeightsURL: URL?
     private var videoEncoderWeightsURL: URL?
     private var videoVAEWeightLayout: LTXTensorWeightLayout = .pytorch
+    private var videoVAEArchitecture: LTXVideoVAEArchitecture = .legacy
     private var loadedDType: DType = .bfloat16
     private var loadedRoot: URL?
     private var audioVAEWeightsURL: URL?
@@ -3268,6 +3269,7 @@ public actor LTXUnifiedAVGenerator {
     private var loadedForFullTwoStage = false
     private var loadedForReusableFullTwoStage = false
     private var loadedForVideoOnlyOutput = false
+    private var loadedForLTX25 = false
     private var twoStageGenerationConsumed = false
 
     public init() {}
@@ -3480,13 +3482,21 @@ public actor LTXUnifiedAVGenerator {
         await unload()
         let root = modelRoot.standardizedFileURL
         let isLTX23 = isLTX23SplitModelRoot(root)
+        let isLTX25 = isLTX25ModelRoot(root)
+        let ltx25Resources = LTX25Resources(rootURL: root)
         let splitTensorLayout: LTXTensorWeightLayout = isLTX23 ? .mlx : .pytorch
-        let transformerURL = isLTX23
-            ? root.appendingPathComponent("transformer-distilled.safetensors", isDirectory: false)
-            : root.appendingPathComponent("ltx-2-19b-distilled.safetensors", isDirectory: false)
-        let upsamplerURL = isLTX23
-            ? root.appendingPathComponent("spatial_upscaler_x2_v1_1.safetensors", isDirectory: false)
-            : root.appendingPathComponent("ltx-2-spatial-upscaler-x2-1.0.safetensors", isDirectory: false)
+        let transformerURL: URL
+        let upsamplerURL: URL
+        if isLTX25 {
+            transformerURL = ltx25Resources.transformerURL
+            upsamplerURL = ltx25Resources.spatialUpsamplerURL
+        } else if isLTX23 {
+            transformerURL = root.appendingPathComponent("transformer-distilled.safetensors", isDirectory: false)
+            upsamplerURL = root.appendingPathComponent("spatial_upscaler_x2_v1_1.safetensors", isDirectory: false)
+        } else {
+            transformerURL = root.appendingPathComponent("ltx-2-19b-distilled.safetensors", isDirectory: false)
+            upsamplerURL = root.appendingPathComponent("ltx-2-spatial-upscaler-x2-1.0.safetensors", isDirectory: false)
+        }
         guard FileManager.default.fileExists(atPath: transformerURL.path) else {
             throw LTXUnifiedAVGeneratorError.transformerWeightsMissing(transformerURL)
         }
@@ -3523,6 +3533,20 @@ public actor LTXUnifiedAVGenerator {
                 batchSize: 24
             )
             model = splitModel
+        } else if isLTX25 {
+            let packedModel = LTXUnifiedAVTransformerV2()
+            try SafetensorsStreamingLoader.applyWeightsStreaming(
+                url: transformerURL,
+                to: packedModel,
+                dtype: dtype,
+                verify: .none,
+                include: { $0.hasPrefix("model.diffusion_model.") },
+                mapper: { key, value in
+                    mapUnifiedTransformerWeight(key: key, value: value, dtype: dtype)
+                },
+                batchSize: 24
+            )
+            model = packedModel
         } else {
             let mergedModel = LTXUnifiedAVTransformer()
             try SafetensorsStreamingLoader.applyWeightsStreaming(
@@ -3545,11 +3569,16 @@ public actor LTXUnifiedAVGenerator {
         let videoDecoderStart = ltxMonotonicSeconds()
         let vaeDecoder = LTXVideoDecoder(
             timestepConditioning: false,
-            architecture: isLTX23 ? .ltx23Split : .legacy
+            architecture: isLTX23 || isLTX25 ? .ltx23Split : .legacy
         )
-        let videoDecoderURL = isLTX23
-            ? root.appendingPathComponent("vae_decoder.safetensors", isDirectory: false)
-            : transformerURL
+        let videoDecoderURL: URL
+        if isLTX25 {
+            videoDecoderURL = ltx25Resources.videoVAEURL
+        } else if isLTX23 {
+            videoDecoderURL = root.appendingPathComponent("vae_decoder.safetensors", isDirectory: false)
+        } else {
+            videoDecoderURL = transformerURL
+        }
         let decoderStats = try SafetensorsStreamingLoader.loadArrays(
             url: videoDecoderURL,
             where: { key in
@@ -3561,6 +3590,8 @@ public actor LTXUnifiedAVGenerator {
                     || key == "vae_decoder.per_channel_statistics.std-of-means"
                     || key == "vae_decoder.per_channel_statistics.mean"
                     || key == "vae_decoder.per_channel_statistics.std"
+                    || key == "per_channel_statistics.mean-of-means"
+                    || key == "per_channel_statistics.std-of-means"
             },
             dtype: .float32
         )
@@ -3568,13 +3599,15 @@ public actor LTXUnifiedAVGenerator {
         if let mean = decoderStats["latents_mean"]
             ?? decoderStats["vae.per_channel_statistics.mean-of-means"]
             ?? decoderStats["vae_decoder.per_channel_statistics.mean-of-means"]
-            ?? decoderStats["vae_decoder.per_channel_statistics.mean"] {
+            ?? decoderStats["vae_decoder.per_channel_statistics.mean"]
+            ?? decoderStats["per_channel_statistics.mean-of-means"] {
             vaeDecoder.latentsMean = mean.asType(.float32)
         }
         if let std = decoderStats["latents_std"]
             ?? decoderStats["vae.per_channel_statistics.std-of-means"]
             ?? decoderStats["vae_decoder.per_channel_statistics.std-of-means"]
-            ?? decoderStats["vae_decoder.per_channel_statistics.std"] {
+            ?? decoderStats["vae_decoder.per_channel_statistics.std"]
+            ?? decoderStats["per_channel_statistics.std-of-means"] {
             vaeDecoder.latentsStd = std.asType(.float32)
         }
 
@@ -3616,9 +3649,14 @@ public actor LTXUnifiedAVGenerator {
         if loadAudioOutput {
             let audioDecoderStart = ltxMonotonicSeconds()
             let audioDecoder = LTXAudioDecoder()
-            let audioDecoderURL = isLTX23
-                ? root.appendingPathComponent("audio_vae.safetensors", isDirectory: false)
-                : transformerURL
+            let audioDecoderURL: URL
+            if isLTX25 {
+                audioDecoderURL = ltx25Resources.audioVAEURL
+            } else if isLTX23 {
+                audioDecoderURL = root.appendingPathComponent("audio_vae.safetensors", isDirectory: false)
+            } else {
+                audioDecoderURL = transformerURL
+            }
             try SafetensorsStreamingLoader.applyWeightsStreaming(
                 url: audioDecoderURL,
                 to: audioDecoder,
@@ -3639,17 +3677,26 @@ public actor LTXUnifiedAVGenerator {
                 batchSize: 24
             )
 
-            let vocoderURL = isLTX23
-                ? root.appendingPathComponent("vocoder.safetensors", isDirectory: false)
-                : transformerURL
+            let vocoderURL: URL
+            if isLTX25 {
+                vocoderURL = ltx25Resources.audioVAEURL
+            } else if isLTX23 {
+                vocoderURL = root.appendingPathComponent("vocoder.safetensors", isDirectory: false)
+            } else {
+                vocoderURL = transformerURL
+            }
             let vocoderMetadata = try SafetensorsStreamingLoader.metadata(url: vocoderURL)
             let vocoderFlavor = detectLTXVocoderFlavor(keys: vocoderMetadata.keys)
-            let vocoder: LTXAudioVocoderBase = switch vocoderFlavor {
+            let vocoder: LTXAudioVocoderBase
+            switch vocoderFlavor {
             case .legacy:
-                LTXVocoder()
+                vocoder = LTXVocoder()
             case .bandwidthExtension:
-                if let config = try loadLTXBWEVocoderConfig(modelRoot: root) {
-                    LTXVocoderWithBWE(config: config)
+                let config = isLTX25
+                    ? try loadLTXPackedBWEVocoderConfig(weightsURL: vocoderURL)
+                    : try loadLTXBWEVocoderConfig(modelRoot: root)
+                if let config {
+                    vocoder = LTXVocoderWithBWE(config: config)
                 } else {
                     throw LTXUnifiedAVGeneratorError.bweVocoderConfigMissing(root)
                 }
@@ -3688,11 +3735,13 @@ public actor LTXUnifiedAVGenerator {
         self.modelWeightsURL = transformerURL
         self.videoEncoderWeightsURL = isLTX23
             ? root.appendingPathComponent("vae_encoder.safetensors", isDirectory: false)
-            : transformerURL
+            : (isLTX25 ? ltx25Resources.videoVAEURL : transformerURL)
         self.videoVAEWeightLayout = splitTensorLayout
+        self.videoVAEArchitecture = isLTX23 || isLTX25 ? .ltx23Split : .legacy
         self.loadedDType = dtype
         self.loadedRoot = root
         self.loadedForVideoOnlyOutput = !loadAudioOutput
+        self.loadedForLTX25 = isLTX25
         return LTXLoadTimings(
             textEncoderSeconds: textEncoderSeconds,
             transformerSeconds: transformerSeconds,
@@ -3718,6 +3767,7 @@ public actor LTXUnifiedAVGenerator {
         modelWeightsURL = nil
         videoEncoderWeightsURL = nil
         videoVAEWeightLayout = .pytorch
+        videoVAEArchitecture = .legacy
         loadedRoot = nil
         audioVAEWeightsURL = nil
         distilledLoRAURL = nil
@@ -3726,6 +3776,7 @@ public actor LTXUnifiedAVGenerator {
         loadedForFullTwoStage = false
         loadedForReusableFullTwoStage = false
         loadedForVideoOnlyOutput = false
+        loadedForLTX25 = false
         twoStageGenerationConsumed = false
         Memory.clearCache()
     }
@@ -3754,9 +3805,7 @@ public actor LTXUnifiedAVGenerator {
         }
         let encoderURL = videoEncoderWeightsURL ?? modelWeightsURL
 
-        let vaeEncoder = LTXVideoEncoder(
-            architecture: videoVAEWeightLayout == .mlx ? .ltx23Split : .legacy
-        )
+        let vaeEncoder = LTXVideoEncoder(architecture: videoVAEArchitecture)
         if let decoder {
             vaeEncoder.latentsMean = decoder.latentsMean.asType(.float32)
             vaeEncoder.latentsStd = decoder.latentsStd.asType(.float32)
@@ -4543,7 +4592,8 @@ public actor LTXUnifiedAVGenerator {
                 audioContext: audioContext,
                 transformer: transformer,
                 sigmas: stage1Sigmas,
-                videoConditioning: stage1ConditioningState
+                videoConditioning: stage1ConditioningState,
+                ancestralNoiseSeed: loadedForLTX25 ? options.seed &+ 10_000 : nil
             )
         }
         MLX.eval(videoLatents, audioLatents)
@@ -5257,11 +5307,15 @@ private func denoiseAVLoop(
     audioContext: MLXArray,
     transformer: any LTXUnifiedAVTransformerRuntime,
     sigmas: [Float],
-    videoConditioning: LTXLatentConditioningState?
+    videoConditioning: LTXLatentConditioningState?,
+    ancestralNoiseSeed: Int? = nil
 ) -> (MLXArray, MLXArray) {
     var currentVideo = videoLatents
     var currentAudio = audioLatents
     let dtype = videoLatents.dtype
+    if let ancestralNoiseSeed {
+        MLXRandom.seed(UInt64(bitPattern: Int64(ancestralNoiseSeed)))
+    }
 
     for i in 0..<(max(0, sigmas.count - 1)) {
         let sigma = sigmas[i]
@@ -5324,7 +5378,29 @@ private func denoiseAVLoop(
         let denoisedAudio = toDenoised(noisy: currentAudio, velocity: audioVelocity, sigma: sigma)
         MLX.eval(denoisedVideo, denoisedAudio)
 
-        if nextSigma > 0 {
+        if nextSigma > 0, ancestralNoiseSeed != nil {
+            let videoNoise = MLXRandom.normal(currentVideo.shape).asType(dtype)
+            let audioNoise = MLXRandom.normal(currentAudio.shape).asType(dtype)
+            currentVideo = ltxAncestralEulerStep(
+                sample: currentVideo,
+                denoised: denoisedVideo,
+                sigma: sigma,
+                nextSigma: nextSigma,
+                noise: videoNoise
+            )
+            currentAudio = ltxAncestralEulerStep(
+                sample: currentAudio,
+                denoised: denoisedAudio,
+                sigma: sigma,
+                nextSigma: nextSigma,
+                noise: audioNoise
+            )
+            if let videoConditioning {
+                let one = MLXArray(1.0).asType(currentVideo.dtype)
+                currentVideo = currentVideo * videoConditioning.denoiseMask
+                    + videoConditioning.cleanLatent * (one - videoConditioning.denoiseMask)
+            }
+        } else if nextSigma > 0 {
             let sigmaArr = MLXArray(sigma).asType(dtype)
             let nextArr = MLXArray(nextSigma).asType(dtype)
             currentVideo = denoisedVideo + nextArr * (currentVideo - denoisedVideo) / sigmaArr
@@ -5337,6 +5413,33 @@ private func denoiseAVLoop(
     }
 
     return (currentVideo, currentAudio)
+}
+
+private func ltxAncestralEulerStep(
+    sample: MLXArray,
+    denoised: MLXArray,
+    sigma: Float,
+    nextSigma: Float,
+    noise: MLXArray
+) -> MLXArray {
+    guard nextSigma > 0 else {
+        return denoised.asType(sample.dtype)
+    }
+
+    let sigmaDown = nextSigma * (nextSigma / sigma)
+    let sigmaDownRatio = sigmaDown / sigma
+    let alphaNext = 1.0 - nextSigma
+    let alphaDown = 1.0 - sigmaDown
+    let alphaRatio = alphaNext / alphaDown
+    let variance = max(0, nextSigma * nextSigma - sigmaDown * sigmaDown * alphaRatio * alphaRatio)
+    let renoiseCoefficient = sqrt(variance)
+
+    let sample32 = sample.asType(.float32)
+    let denoised32 = denoised.asType(.float32)
+    var next = MLXArray(sigmaDownRatio) * sample32
+        + MLXArray(1.0 - sigmaDownRatio) * denoised32
+    next = MLXArray(alphaRatio) * next + MLXArray(renoiseCoefficient) * noise.asType(.float32)
+    return next.asType(sample.dtype)
 }
 
 private func predictJointAVDenoised(
@@ -6408,6 +6511,7 @@ private func mapUnifiedTransformerWeight(
     if mapped.hasPrefix("video_embeddings_connector")
         || mapped.hasPrefix("audio_embeddings_connector")
         || mapped.hasPrefix("text_embedding_projection")
+        || mapped.hasPrefix("keyframes_abs_pos_embedding")
     {
         return []
     }
@@ -7269,6 +7373,18 @@ func loadLTXBWEVocoderConfig(modelRoot: URL) throws -> LTXBWEVocoderRuntimeConfi
     }
 
     return nil
+}
+
+func loadLTXPackedBWEVocoderConfig(weightsURL: URL) throws -> LTXBWEVocoderRuntimeConfig? {
+    let metadata = try SafetensorsStreamingLoader.fileMetadata(url: weightsURL)
+    guard let rawConfig = metadata["config"],
+          let data = rawConfig.data(using: .utf8),
+          let envelope = try? JSONDecoder().decode(LTXVocoderConfigEnvelope.self, from: data),
+          let bwe = envelope.bwe else {
+        return nil
+    }
+    let base = envelope.baseVocoder?.runtimeArchitecture(defaultArchitecture: .defaultBWEBase)
+    return bwe.runtimeConfig(baseVocoder: base)
 }
 
 private class LTXAudioVocoderBase: Module {

--- a/Sources/MereRunCore/LTX/LTXGemmaTextEncoder.swift
+++ b/Sources/MereRunCore/LTX/LTXGemmaTextEncoder.swift
@@ -1,4 +1,5 @@
 import Foundation
+@preconcurrency import Hub
 import MLX
 import MLXFast
 import MLXNN
@@ -36,6 +37,7 @@ public enum LTXGemmaTextEncoderError: LocalizedError {
     case missingTransformerWeights(URL)
     case missingConnectorProjection(URL)
     case missingConnectorWeights(URL)
+    case invalidPackedTextEncoder(URL, String)
     case tokenizerUnavailable
     case modelNotLoaded
     case connectorNotLoaded
@@ -56,6 +58,8 @@ public enum LTXGemmaTextEncoderError: LocalizedError {
             return "Missing text embedding projection weight in \(url.path)"
         case .missingConnectorWeights(let url):
             return "Missing LTX connector weights in \(url.path)"
+        case .invalidPackedTextEncoder(let url, let reason):
+            return "Invalid packed LTX text encoder at \(url.path): \(reason)"
         case .tokenizerUnavailable:
             return "Tokenizer is not loaded."
         case .modelNotLoaded:
@@ -73,6 +77,7 @@ public enum LTXGemmaTextEncoderError: LocalizedError {
 public actor LTXGemmaTextEncoder {
     private var tokenizer: (any Tokenizer)?
     private var model: LTXGemmaLanguageModel?
+    private var gemma4Model: Gemma4LanguageModel?
     private var featureExtractor: LTXGemmaFeaturesExtractor?
     private var featureExtractorV2: LTXGemmaFeaturesExtractorV2?
     private var videoConnector: LTXEmbeddings1DConnector?
@@ -89,6 +94,10 @@ public actor LTXGemmaTextEncoder {
     ) async throws {
         let fm = FileManager.default
         let root = modelRoot.standardizedFileURL
+        if isLTX25ModelRoot(root) {
+            try await loadLTX25(modelRoot: root, dtype: dtype, loadConnectorWeights: loadConnectorWeights)
+            return
+        }
         let usesLTX23SplitConnector = isLTX23SplitModelRoot(root)
         let textRoot = (overrideTextEncoderRoot ?? root.appendingPathComponent("text_encoder", isDirectory: true))
             .standardizedFileURL
@@ -256,10 +265,127 @@ public actor LTXGemmaTextEncoder {
         }
 
         self.model = languageModel
+        self.gemma4Model = nil
         self.featureExtractor = usesLTX23SplitConnector ? nil : textFeatures
         self.featureExtractorV2 = usesLTX23SplitConnector ? textFeaturesV2 : nil
         self.videoConnector = usesLTX23SplitConnector ? nil : connector
         self.audioConnector = usesLTX23SplitConnector ? nil : audioConnector
+        self.tokenizer = loadedTokenizer
+        self.loadedRoot = root
+    }
+
+    private func loadLTX25(
+        modelRoot root: URL,
+        dtype: DType,
+        loadConnectorWeights: Bool
+    ) async throws {
+        let resources = LTX25Resources(rootURL: root)
+        let textEncoderURL = resources.textEncoderURL
+        let transformerURL = resources.transformerURL
+        let metadata = try SafetensorsStreamingLoader.fileMetadata(url: textEncoderURL)
+        guard let rawConfig = metadata["gemma_config"],
+              let configData = rawConfig.data(using: .utf8) else {
+            throw LTXGemmaTextEncoderError.invalidPackedTextEncoder(
+                textEncoderURL,
+                "missing gemma_config metadata"
+            )
+        }
+        let config = try JSONDecoder().decode(Gemma4Config.self, from: configData)
+        guard config.modelType == "gemma4_unified" else {
+            throw LTXGemmaTextEncoderError.invalidPackedTextEncoder(
+                textEncoderURL,
+                "expected gemma4_unified, got \(config.modelType)"
+            )
+        }
+
+        let languageModel = Gemma4LanguageModel(config: config.textConfig)
+        try SafetensorsStreamingLoader.applyWeightsStreaming(
+            url: textEncoderURL,
+            to: languageModel,
+            dtype: dtype,
+            verify: .none,
+            include: { key in
+                key == "model.embed_tokens.weight"
+                    || key == "model.norm.weight"
+                    || key.hasPrefix("model.layers.")
+            },
+            mapper: { key, value in
+                guard key.hasPrefix("model.") else { return [] }
+                return [(String(key.dropFirst("model.".count)), value)]
+            },
+            batchSize: 24
+        )
+
+        let textFeatures = LTXGemmaFeaturesExtractorV2(
+            captionChannels: config.textConfig.hiddenSize,
+            numGemmaLayers: config.textConfig.numHiddenLayers + 1,
+            videoDim: 4_096,
+            audioDim: 2_048,
+            numHeads: 32,
+            videoHeadDim: 128,
+            audioHeadDim: 64,
+            numConnectorLayers: 8,
+            numRegisters: 128
+        )
+        if loadConnectorWeights {
+            try SafetensorsStreamingLoader.applyWeightsStreaming(
+                url: textEncoderURL,
+                to: textFeatures,
+                dtype: dtype,
+                verify: .none,
+                include: { $0.hasPrefix("text_embedding_projection.") },
+                mapper: { key, value in [(key, value)] },
+                batchSize: 4
+            )
+            try SafetensorsStreamingLoader.applyWeightsStreaming(
+                url: transformerURL,
+                to: textFeatures,
+                dtype: dtype,
+                verify: .none,
+                include: { key in
+                    key.hasPrefix("model.diffusion_model.video_embeddings_connector.")
+                        || key.hasPrefix("model.diffusion_model.audio_embeddings_connector.")
+                },
+                mapper: { key, value in
+                    mapLTX25TextConnectorWeight(key: key, value: value, dtype: dtype)
+                },
+                batchSize: 24
+            )
+        }
+
+        let assetArrays = try SafetensorsStreamingLoader.loadArrays(
+            url: textEncoderURL,
+            where: { key in
+                key == "tokenizer_json" || key == "hf_asset__tokenizer_config.json"
+            }
+        )
+        guard let tokenizerJSON = assetArrays["tokenizer_json"],
+              let tokenizerConfigJSON = assetArrays["hf_asset__tokenizer_config.json"] else {
+            throw LTXGemmaTextEncoderError.invalidPackedTextEncoder(
+                textEncoderURL,
+                "missing embedded tokenizer assets"
+            )
+        }
+        MLX.eval(tokenizerJSON, tokenizerConfigJSON)
+        let tokenizerData = try JSONDecoder().decode(
+            Config.self,
+            from: Data(tokenizerJSON.asArray(UInt8.self))
+        )
+        let tokenizerConfig = try JSONDecoder().decode(
+            Config.self,
+            from: Data(tokenizerConfigJSON.asArray(UInt8.self))
+        )
+        let loadedTokenizer = try AutoTokenizer.from(
+            tokenizerConfig: tokenizerConfig,
+            tokenizerData: tokenizerData
+        )
+
+        self.model = nil
+        self.gemma4Model = languageModel
+        self.featureExtractor = nil
+        self.featureExtractorV2 = textFeatures
+        self.videoConnector = nil
+        self.audioConnector = nil
         self.tokenizer = loadedTokenizer
         self.loadedRoot = root
     }
@@ -275,7 +401,7 @@ public actor LTXGemmaTextEncoder {
         guard !trimmed.isEmpty else {
             throw LTXGemmaTextEncoderError.emptyPrompt
         }
-        guard let model else {
+        guard model != nil || gemma4Model != nil else {
             throw LTXGemmaTextEncoderError.modelNotLoaded
         }
         guard let tokenizer else {
@@ -286,6 +412,10 @@ public actor LTXGemmaTextEncoder {
         }
 
         var tokenIDs = tokenizer.encode(text: trimmed, addSpecialTokens: true)
+        if gemma4Model != nil, let bosTokenID = tokenizer.bosTokenId,
+           tokenIDs.first != bosTokenID {
+            tokenIDs.insert(bosTokenID, at: 0)
+        }
         if tokenIDs.count > maxLength {
             tokenIDs = Array(tokenIDs.prefix(maxLength))
         }
@@ -298,12 +428,26 @@ public actor LTXGemmaTextEncoder {
         let inputArray = MLXArray(inputIDs.map(Int32.init)).reshaped(1, maxLength)
         let maskArray = MLXArray(attention.map(Int32.init)).reshaped(1, maxLength)
 
-        let result = model.forward(
-            inputIds: inputArray,
-            attentionMask: maskArray,
-            outputHiddenStates: true
-        )
-        let hiddenStates = result.hiddenStates ?? [result.lastHiddenState]
+        let lastHiddenState: MLXArray
+        let hiddenStates: [MLXArray]
+        if let gemma4Model {
+            let result = gemma4Model.forwardHiddenStates(
+                inputIds: inputArray,
+                attentionMask: maskArray
+            )
+            lastHiddenState = result.lastHiddenState
+            hiddenStates = result.hiddenStates
+        } else if let model {
+            let result = model.forward(
+                inputIds: inputArray,
+                attentionMask: maskArray,
+                outputHiddenStates: true
+            )
+            lastHiddenState = result.lastHiddenState
+            hiddenStates = result.hiddenStates ?? [result.lastHiddenState]
+        } else {
+            throw LTXGemmaTextEncoderError.modelNotLoaded
+        }
         if let featureExtractorV2 {
             let normalized = normalizeAndConcatHiddenStatesV2(
                 hiddenStates: hiddenStates,
@@ -311,7 +455,7 @@ public actor LTXGemmaTextEncoder {
             )
             let extraction = featureExtractorV2(normalized, attentionMask: maskArray)
             return LTXGemmaTextEncoding(
-                lastHiddenState: result.lastHiddenState,
+                lastHiddenState: lastHiddenState,
                 attentionMask: maskArray,
                 normalizedStackedHiddenStates: normalized,
                 features: extraction.projectedVideo,
@@ -336,7 +480,7 @@ public actor LTXGemmaTextEncoder {
         }
 
         return LTXGemmaTextEncoding(
-            lastHiddenState: result.lastHiddenState,
+            lastHiddenState: lastHiddenState,
             attentionMask: maskArray,
             normalizedStackedHiddenStates: normalized,
             features: features,
@@ -348,6 +492,7 @@ public actor LTXGemmaTextEncoder {
     public func unload() {
         tokenizer = nil
         model = nil
+        gemma4Model = nil
         featureExtractor = nil
         featureExtractorV2 = nil
         videoConnector = nil
@@ -1178,6 +1323,31 @@ func mapLTX23TextConnectorWeight(
     } else {
         casted = value
     }
+    return [(mapped, casted)]
+}
+
+func mapLTX25TextConnectorWeight(
+    key: String,
+    value: MLXArray,
+    dtype: DType
+) -> [(String, MLXArray)] {
+    let prefix = "model.diffusion_model."
+    guard key.hasPrefix(prefix) else {
+        return []
+    }
+
+    var mapped = String(key.dropFirst(prefix.count))
+    guard mapped.hasPrefix("video_embeddings_connector.")
+            || mapped.hasPrefix("audio_embeddings_connector.") else {
+        return []
+    }
+    mapped = mapped.replacingOccurrences(of: ".ff.net.0.proj.", with: ".ff.proj_in.")
+    mapped = mapped.replacingOccurrences(of: ".ff.net.2.", with: ".ff.proj_out.")
+    mapped = mapped.replacingOccurrences(of: ".to_out.0.", with: ".to_out.")
+
+    let casted = value.dtype.isFloatingPoint && value.dtype != dtype
+        ? value.asType(dtype)
+        : value
     return [(mapped, casted)]
 }
 

--- a/Sources/MereRunCore/LTX/README.md
+++ b/Sources/MereRunCore/LTX/README.md
@@ -5,8 +5,32 @@ This directory owns native video generation for mere.run.
 - `LTXDistilledLatentGenerator.swift`: distilled text-to-video and image-to-video path
 - `LTXInferenceTimings.swift`: typed model-load and generation phase timings
 - `LTXGemmaTextEncoder.swift`: text encoder support for LTX models
+- `LTX25Resources.swift`: immutable official LTX 2.5 source pins and packed-component layout validation
 - `LTXVideoMP4Writer.swift`: final MP4 assembly
 
 Edit here when you are changing native LTX loading, denoising, decode, or export behavior. Do not mix unrelated CLI concerns into this directory; keep command parsing in `Sources/MereRunCLI/Commands/VideoCommand.swift`.
 
 Before stopping, run `swift test`, `./scripts/check.sh`, and a smoke path if your change affects real model execution.
+
+## LTX 2.5
+
+The official LTX 2.5 distilled release runs through the native `LTXUnifiedAVGenerator` with no Python sidecar. `LTX25Resources` validates the packed Hugging Face layout; `LTXGemmaTextEncoder` reads the embedded tokenizer and Gemma 4 weights directly; and the unified generator loads the packed transformer, video VAE, audio VAE/BWE vocoder, and spatial upsampler. Stage one uses the release's ancestral Euler update and stage two uses its deterministic refinement schedule.
+
+Pull the gated checkpoint into the managed model store:
+
+```bash
+mere.run model pull video-ltx25-distilled-bf16 --accept-model-license
+```
+
+The Hugging Face account behind `HF_TOKEN` must already have access. Then use
+the managed ID (or pass an official checkout with `--model-root`):
+
+```bash
+mere.run video generate "a small robot walks across a wooden table" \
+  --model video-ltx25-distilled-bf16 \
+  --quality final \
+  --output-mode audio-video \
+  --fps 24
+```
+
+The first installed-checkpoint acceptance render used source revision `dd53cc2cd45bbeaa3563dfb575cba3f49cf44761` and the upstream `v1.2.0` implementation at `d151147788a9284cca791edc6ce898007e727fe6`. It produced 25 H.264 frames plus a 48 kHz stereo AAC track from the release binary.

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -88,6 +88,7 @@ public enum ManagedModelValidationKind: String, Hashable, Sendable {
     case ltxVideo23MLX
     case ltxVideo23FullMLX
     case ltxVideo23A2VMLX
+    case ltxVideo25
     case wan22TI2VMLX
     case miniMaxH3MLX
     case cosmos3EdgeMLX
@@ -537,7 +538,7 @@ public enum ManagedModelCatalog {
             summary: summary,
             sourceRepoId: sourceRepoId,
             sourceRevision: sourceRevision,
-            licenseURL: "https://github.com/Lightricks/LTX-2/blob/main/LICENSE"
+            licenseURL: "https://github.com/Lightricks/LTX-2/blob/main/LICENSE.md"
         )
         return ManagedModelUsageRestriction(
             summary: summary,
@@ -551,6 +552,15 @@ public enum ManagedModelCatalog {
         summary: "The LTX 2.3 text-encoder companion is distributed under the Gemma Terms of Use and Gemma Prohibited Use Policy.",
         sourceRepoId: ltxGemma3TextEncoderRepoId,
         sourceRevision: ltxGemma3TextEncoderRevision,
+        licenseURL: "https://ai.google.dev/gemma/terms"
+    )
+
+    private static let ltx25GemmaTextEncoderUsageTerm = ManagedModelUsageTerm(
+        component: "Gemma 4 text encoder",
+        license: "Gemma Terms of Use",
+        summary: "The packed LTX 2.5 text encoder includes Gemma 4 weights distributed under the Gemma Terms of Use and Gemma Prohibited Use Policy.",
+        sourceRepoId: LTX25Resources.sourceRepository,
+        sourceRevision: LTX25Resources.sourceRevision,
         licenseURL: "https://ai.google.dev/gemma/terms"
     )
 
@@ -2539,6 +2549,27 @@ public enum ManagedModelCatalog {
             companionModelIDs: [ModelResolver.ModelID.ltxGemma3TwelveB4Bit.rawValue]
         ),
         ManagedModelSpec(
+            id: ModelResolver.ModelID.ltxVideo25DistilledBF16.rawValue,
+            category: .video,
+            installShape: .structuredRoot,
+            hubFallback: HubFallbackConfig(
+                repoId: LTX25Resources.sourceRepository,
+                revision: LTX25Resources.sourceRevision,
+                patterns: LTX25Resources.snapshotPatterns
+            ),
+            upstreamRepoId: LTX25Resources.sourceRepository,
+            upstreamRevision: LTX25Resources.sourceRevision,
+            usageRestriction: ltxUsageRestriction(
+                sourceRepoId: LTX25Resources.sourceRepository,
+                sourceRevision: LTX25Resources.sourceRevision,
+                additionalTerms: [ltx25GemmaTextEncoderUsageTerm]
+            ),
+            validationKind: .ltxVideo25,
+            runtimeAutoDownloadAllowed: false,
+            estimatedDownloadBytes: LTX25Resources.estimatedDownloadBytes,
+            defaultCLICommands: ["video generate"]
+        ),
+        ManagedModelSpec(
             id: ModelResolver.ModelID.wan22TI2V5BMLX.rawValue,
             category: .video,
             installShape: .structuredRoot,
@@ -3041,6 +3072,8 @@ public extension ManagedModelSpec {
             return Self.missingLTXVideo23FullMLXPaths(in: rootURL, fileManager: fileManager)
         case .ltxVideo23A2VMLX:
             return Self.missingLTXVideo23A2VMLXPaths(in: rootURL, fileManager: fileManager)
+        case .ltxVideo25:
+            return LTX25Resources(rootURL: rootURL).validate(fileManager: fileManager)
         case .wan22TI2VMLX:
             return Wan2Resources(rootURL: rootURL).validate(fileManager: fileManager)
         case .miniMaxH3MLX:
@@ -3109,6 +3142,11 @@ public extension ManagedModelSpec {
                 in: normalizedRootURL(rootURL, fileManager: fileManager),
                 fileManager: fileManager
             ).map { "Missing required LTX 2.3 A2Vid MLX file: \($0.path)" }
+        case .ltxVideo25:
+            return LTX25Resources(
+                rootURL: normalizedRootURL(rootURL, fileManager: fileManager)
+            ).validate(fileManager: fileManager)
+                .map { "Missing required LTX 2.5 file: \($0.path)" }
         case .wan22TI2VMLX:
             let resources = Wan2Resources(rootURL: normalizedRootURL(rootURL, fileManager: fileManager))
             let missing = resources.validate(fileManager: fileManager)

--- a/Sources/MereRunCore/ManagedModelSupport.swift
+++ b/Sources/MereRunCore/ManagedModelSupport.swift
@@ -927,6 +927,13 @@ public enum ManagedModelCapabilityCatalog {
                 recommended: 128
             ),
             descriptor(
+                ModelResolver.ModelID.ltxVideo25DistilledBF16.rawValue,
+                "LTX 2.5 Distilled BF16",
+                "Generates final-quality video with synchronized stereo audio using the official packed LTX 2.5 release.",
+                minimum: 96,
+                recommended: 128
+            ),
+            descriptor(
                 ModelResolver.ModelID.wan22TI2V5BMLX.rawValue,
                 "Wan2.2 TI2V 5B MLX",
                 "Generates text- and image-conditioned pixel video with the native Swift MLX Wan2.2 runtime.",

--- a/Sources/MereRunCore/MereRunModelManifest.swift
+++ b/Sources/MereRunCore/MereRunModelManifest.swift
@@ -2023,6 +2023,20 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
                 upstreamRepoId: "dgrauet/ltx-2.3-mlx@baa5f235ea04fd9c95899d751295c4fd825ee4e2",
                 createdAt: createdAt
             )
+        case .ltxVideo25DistilledBF16:
+            return MereRunModelManifest(
+                id: modelID.rawValue,
+                engine: .ltxVideo,
+                family: .video,
+                tier: .latest,
+                variant: .distilled,
+                precision: .bf16,
+                defaults: Defaults(steps: 8, cfg: 3),
+                supports: [.videoGeneration],
+                components: nil,
+                upstreamRepoId: "\(LTX25Resources.sourceRepository)@\(LTX25Resources.sourceRevision)",
+                createdAt: createdAt
+            )
         case .wan22TI2V5BMLX:
             return MereRunModelManifest(
                 id: modelID.rawValue,

--- a/Sources/MereRunCore/MereRunModelValidator.swift
+++ b/Sources/MereRunCore/MereRunModelValidator.swift
@@ -113,6 +113,7 @@ public enum MereRunModelValidator {
                     && spec.validationKind != .wooshClap
                     && spec.validationKind != .wooshSynchformer
                     && spec.validationKind != .mmaudio
+                    && spec.validationKind != .ltxVideo25
                     && spec.validationKind != .insightFaceBuffaloL
                     && spec.validationKind != .moge2
                     && spec.validationKind != .videoDepthAnything
@@ -163,6 +164,7 @@ public enum MereRunModelValidator {
             || spec?.validationKind == .ltxVideo23MLX
             || spec?.validationKind == .ltxVideo23A2VMLX
             || spec?.validationKind == .ltxVideo23FullMLX
+            || spec?.validationKind == .ltxVideo25
             || spec?.validationKind == .insightFaceBuffaloL
             || spec?.validationKind == .moge2
             || spec?.validationKind == .videoDepthAnything

--- a/Sources/MereRunCore/ModelResolver.swift
+++ b/Sources/MereRunCore/ModelResolver.swift
@@ -116,6 +116,7 @@ public struct ModelResolver {
         case ltxVideo23AVMLX = "video-ltx23-av-mlx"
         case ltxVideo23FullMLX = "video-ltx23-full-mlx"
         case ltxVideo23A2VMLX = "video-ltx23-a2vid-mlx"
+        case ltxVideo25DistilledBF16 = "video-ltx25-distilled-bf16"
         case wan22TI2V5BMLX = "video-wan22-ti2v-5b-mlx"
         case miniMaxH3FL2VAMLX = "video-minimax-h3-fl2va-mlx"
         case miniMaxH3FL2VABF16MLX = "video-minimax-h3-fl2va-bf16-mlx"

--- a/Sources/MereRunCore/SafetensorsStreamingLoader.swift
+++ b/Sources/MereRunCore/SafetensorsStreamingLoader.swift
@@ -48,6 +48,11 @@ public enum SafetensorsStreamingLoader {
         return try metadata(fileData: data, fileURL: url)
     }
 
+    public static func fileMetadata(url: URL) throws -> [String: String] {
+        let data = try Data(contentsOf: url, options: .mappedIfSafe)
+        return try parseHeader(fileData: data, fileURL: url).header.fileMetadata
+    }
+
     static func metadata(fileData data: Data, fileURL url: URL) throws -> [String: TensorMetadata] {
         let parsed = try parseHeader(fileData: data, fileURL: url)
         return try parseTensorMetadata(
@@ -262,11 +267,18 @@ public enum SafetensorsStreamingLoader {
 
     private struct SafetensorsHeader: Decodable {
         let tensors: [String: TensorHeader]
+        let fileMetadata: [String: String]
 
         init(from decoder: Decoder) throws {
             let container = try decoder.container(keyedBy: DynamicCodingKey.self)
             var tensors: [String: TensorHeader] = [:]
             tensors.reserveCapacity(container.allKeys.count)
+
+            let metadataKey = DynamicCodingKey("__metadata__")
+            self.fileMetadata = try container.decodeIfPresent(
+                [String: String].self,
+                forKey: metadataKey
+            ) ?? [:]
 
             for key in container.allKeys where key.stringValue != "__metadata__" {
                 do {

--- a/Tests/MereRunCLITests/ModelInfoCommandTests.swift
+++ b/Tests/MereRunCLITests/ModelInfoCommandTests.swift
@@ -48,6 +48,30 @@ final class ModelInfoCommandTests: XCTestCase {
         XCTAssertFalse(lines.contains { $0.contains("(missing)") })
     }
 
+    func testLTX25ComponentLinesShowPackedRuntimeFiles() throws {
+        let root = try makeTempDirectory()
+        for relativePath in LTX25Resources.requiredRelativePaths {
+            let url = root.appendingPathComponent(relativePath)
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try Data("fixture".utf8).write(to: url)
+        }
+        let manifest = MereRunModelManifest.template(
+            for: .ltxVideo25DistilledBF16,
+            createdAt: Date(timeIntervalSince1970: 0)
+        )
+        let lines = ModelInfo.ltx25ComponentLines(rootURL: root)
+
+        XCTAssertTrue(ModelInfo.usesLTX25Layout(manifest: manifest, expectedModelID: nil))
+        XCTAssertTrue(lines.contains("  layout: official LTX 2.5 packed BF16 files"))
+        XCTAssertTrue(lines.contains { $0.contains(LTX25Resources.transformerRelativePath) })
+        XCTAssertTrue(lines.contains { $0.contains(LTX25Resources.textEncoderRelativePath) })
+        XCTAssertTrue(lines.contains { $0.contains(LTX25Resources.audioVAERelativePath) })
+        XCTAssertFalse(lines.contains { $0.contains("(missing)") })
+    }
+
     func testLTX23SplitLayoutDetectionUsesManifestID() {
         let manifest = MereRunModelManifest.template(
             for: .ltxVideo23AVMLX,

--- a/Tests/MereRunCLITests/ModelPullCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/ModelPullCommandParsingTests.swift
@@ -31,6 +31,19 @@ final class ModelPullCommandParsingTests: XCTestCase {
         XCTAssertNil(accepted.licenseAcceptanceMessage(for: restricted))
     }
 
+    func testLTX25PullRequiresExplicitLicenseAcceptance() throws {
+        let id = ModelResolver.ModelID.ltxVideo25DistilledBF16.rawValue
+        let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: id))
+        let blocked = try ModelPull.parse([id])
+        let accepted = try ModelPull.parse([id, "--accept-model-license"])
+
+        XCTAssertEqual(spec.hubFallback?.repoId, "Lightricks/LTX-2.5")
+        XCTAssertEqual(spec.usageRestriction?.terms.count, 2)
+        XCTAssertTrue(try XCTUnwrap(blocked.licenseAcceptanceMessage(for: spec)).contains("Gemma 4"))
+        XCTAssertNil(accepted.licenseAcceptanceMessage(for: spec))
+        XCTAssertTrue(CLICommandDisplay.modelPullCommand(for: id).contains("--accept-model-license"))
+    }
+
     func testPublicOpenModelPullsDoNotRequireLicenseAcceptance() throws {
         let modelIDs = [
             LagunaResources.modelID,

--- a/Tests/MereRunCLITests/VideoCommandTests.swift
+++ b/Tests/MereRunCLITests/VideoCommandTests.swift
@@ -342,6 +342,19 @@ final class VideoCommandTests: XCTestCase {
         XCTAssertNil(cmd.timingsOutput)
     }
 
+    func testVideoGenerateAcceptsManagedLTX25ModelID() throws {
+        let cmd = try VideoGenerate.parse([
+            "a small robot walks across a wooden table",
+            "--model", ModelResolver.ModelID.ltxVideo25DistilledBF16.rawValue,
+            "--quality", "final",
+            "--output-mode", "audio-video",
+        ])
+
+        XCTAssertEqual(cmd.resolvedRequestedModel, LTX25Resources.modelID)
+        XCTAssertEqual(cmd.requestedQuality, .final)
+        XCTAssertEqual(cmd.effectiveOutputMode, .audioVideo)
+    }
+
     func testVideoGenerateParsesMiniMaxH3ReferencesAndStepsInOrder() throws {
         let cmd = try VideoGenerate.parse([
             "preserve the references",
@@ -495,6 +508,29 @@ final class VideoCommandTests: XCTestCase {
         XCTAssertEqual(finalAV.resolvedRequestedModel, ModelResolver.ModelID.ltxVideo23FullMLX.rawValue)
     }
 
+    func testVideoGenerateTreatsOfficialLTX25RootAsFinalQuality() throws {
+        let root = try makeValidLTX25ModelRoot()
+        let command = try VideoGenerate.parse([
+            "a native synchronized shot",
+            "--model-root", root.path,
+            "--quality", "final",
+            "--output-mode", "audio-video",
+        ])
+
+        XCTAssertEqual(command.requestedQuality, .final)
+        XCTAssertEqual(command.effectiveOutputMode, .audioVideo)
+
+        let envelope = command.makePreflightEnvelope(
+            outputURL: makeTempOutput(name: "ltx25.mp4"),
+            fileManager: .default,
+            now: { Date(timeIntervalSince1970: 0) }
+        )
+        XCTAssertEqual(envelope.status, .ok)
+        XCTAssertEqual(envelope.result.model.layout, "ltx25_distilled")
+        XCTAssertEqual(envelope.result.plan.quality, "final")
+        XCTAssertFalse(envelope.diagnostics.contains { $0.id == "video_quality_model_mismatch" })
+    }
+
     func testVideoGenerateLegacyVariantDefaultsRemainCompatible() throws {
         let distilled = try VideoGenerate.parse([
             "a draft",
@@ -536,7 +572,7 @@ final class VideoCommandTests: XCTestCase {
             try await cmd.run()
             XCTFail("Expected timing options with the legacy distilled lane to fail validation.")
         } catch {
-            XCTAssertTrue(String(describing: error).contains("require an LTX 2.3 split model"))
+            XCTAssertTrue(String(describing: error).contains("require a split LTX model"))
         }
     }
 
@@ -545,6 +581,7 @@ final class VideoCommandTests: XCTestCase {
         let splitRoot = try makeValidSplitDistilledModelRoot()
         let a2vRoot = try makeValidA2VidModelRoot()
         let fullRoot = try makeValidFullModelRoot()
+        let ltx25Root = try makeValidLTX25ModelRoot()
 
         let legacy = resolveLTXVideoGenerationRoute(variant: .distilled, modelRoot: legacyRoot)
         XCTAssertEqual(legacy, .legacyDistilledVideo)
@@ -564,6 +601,15 @@ final class VideoCommandTests: XCTestCase {
         let compatibleFullVideo = resolveLTXVideoGenerationRoute(outputMode: .videoOnly, modelRoot: a2vRoot)
         XCTAssertEqual(compatibleFullVideo, .fullQualityVideo)
         XCTAssertFalse(compatibleFullVideo.writesAudio)
+
+        let ltx25Video = resolveLTXVideoGenerationRoute(outputMode: .videoOnly, modelRoot: ltx25Root)
+        XCTAssertEqual(ltx25Video, .splitDistilledVideo)
+        XCTAssertFalse(ltx25Video.writesAudio)
+        XCTAssertTrue(ltx25Video.supportsPhaseTimings)
+
+        let ltx25AV = resolveLTXVideoGenerationRoute(outputMode: .audioVideo, modelRoot: ltx25Root)
+        XCTAssertEqual(ltx25AV, .unifiedAV)
+        XCTAssertTrue(ltx25AV.writesAudio)
 
         let unified = resolveLTXVideoGenerationRoute(variant: .unifiedAV, modelRoot: splitRoot)
         XCTAssertEqual(unified, .unifiedAV)
@@ -1168,6 +1214,10 @@ final class VideoCommandTests: XCTestCase {
         XCTAssertNoThrow(try validateNativeModelRoot(makeValidA2VidModelRoot()))
     }
 
+    func testValidateNativeModelRootAcceptsOfficialLTX25Layout() throws {
+        XCTAssertNoThrow(try validateNativeModelRoot(makeValidLTX25ModelRoot()))
+    }
+
     func testWanPreflightUsesNativeSpatialAndTemporalGeometry() throws {
         let modelRoot = try makeValidWanModelRoot()
         let sourceImage = try makeTempFile(name: "start.png")
@@ -1266,6 +1316,14 @@ final class VideoCommandTests: XCTestCase {
     private func makeValidFullModelRoot() throws -> URL {
         let rootURL = try makeValidA2VidModelRoot()
         try createFile(rootURL.appendingPathComponent("vocoder.safetensors"))
+        return rootURL
+    }
+
+    private func makeValidLTX25ModelRoot() throws -> URL {
+        let rootURL = try makeTempDirectory()
+        for relativePath in LTX25Resources.requiredRelativePaths {
+            try createFile(rootURL.appendingPathComponent(relativePath))
+        }
         return rootURL
     }
 

--- a/Tests/MereRunCoreTests/LTX25ResourcesTests.swift
+++ b/Tests/MereRunCoreTests/LTX25ResourcesTests.swift
@@ -1,0 +1,46 @@
+import Foundation
+@testable import MereRunCore
+import XCTest
+
+final class LTX25ResourcesTests: XCTestCase {
+    func testOfficialDistilledLayoutRequiresEveryRuntimeComponent() throws {
+        let root = try TestFileSystem.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let resources = LTX25Resources(rootURL: root)
+        for relativePath in LTX25Resources.requiredRelativePaths {
+            let url = root.appendingPathComponent(relativePath)
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            XCTAssertTrue(FileManager.default.createFile(atPath: url.path, contents: Data()))
+        }
+
+        XCTAssertTrue(resources.validate().isEmpty)
+        XCTAssertTrue(isLTX25ModelRoot(root))
+
+        try FileManager.default.removeItem(at: resources.audioVAEURL)
+        XCTAssertEqual(resources.validate(), [resources.audioVAEURL])
+        XCTAssertFalse(isLTX25ModelRoot(root))
+    }
+
+    func testSnapshotPinsOfficialImmutableFiles() {
+        XCTAssertEqual(LTX25Resources.sourceRepository, "Lightricks/LTX-2.5")
+        XCTAssertEqual(
+            LTX25Resources.sourceRevision,
+            "dd53cc2cd45bbeaa3563dfb575cba3f49cf44761"
+        )
+        XCTAssertEqual(
+            LTX25Resources.upstreamCodeRevision,
+            "d151147788a9284cca791edc6ce898007e727fe6"
+        )
+        XCTAssertEqual(LTX25Resources.upstreamCodeRelease, "v1.2.0")
+        XCTAssertEqual(LTX25Resources.estimatedDownloadBytes, 71_098_810_082)
+        XCTAssertTrue(LTX25Resources.snapshotPatterns.contains(LTX25Resources.transformerRelativePath))
+        XCTAssertTrue(LTX25Resources.snapshotPatterns.contains(LTX25Resources.textEncoderRelativePath))
+        XCTAssertFalse(LTX25Resources.snapshotPatterns.contains {
+            $0.contains("dev-transformer") || $0.contains("diffusion-video-vae")
+        })
+    }
+}

--- a/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
@@ -83,6 +83,7 @@ final class ManagedModelCatalogTests: XCTestCase {
             "video-ltx23-av-mlx",
             "video-ltx23-full-mlx",
             "video-ltx23-a2vid-mlx",
+            "video-ltx25-distilled-bf16",
             "video-minimax-h3-fl2va-mlx",
             "video-minimax-h3-fl2va-bf16-mlx",
             "video-minimax-h3-ref2va-mlx",
@@ -1572,6 +1573,38 @@ final class ManagedModelCatalogTests: XCTestCase {
         XCTAssertTrue(manifest.supports?.contains(.audioToVideoGeneration) == true)
     }
 
+    func testLTX25SpecPinsOfficialGatedPackedRelease() throws {
+        let id = ModelResolver.ModelID.ltxVideo25DistilledBF16.rawValue
+        let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: id))
+
+        XCTAssertEqual(id, LTX25Resources.modelID)
+        XCTAssertEqual(spec.category, .video)
+        XCTAssertEqual(spec.installShape, .structuredRoot)
+        XCTAssertEqual(spec.validationKind, .ltxVideo25)
+        XCTAssertEqual(spec.hubFallback?.repoId, LTX25Resources.sourceRepository)
+        XCTAssertEqual(spec.hubFallback?.revision, LTX25Resources.sourceRevision)
+        XCTAssertEqual(spec.hubFallback?.patterns, LTX25Resources.snapshotPatterns)
+        XCTAssertEqual(spec.upstreamRepoId, LTX25Resources.sourceRepository)
+        XCTAssertEqual(spec.upstreamRevision, LTX25Resources.sourceRevision)
+        XCTAssertEqual(spec.estimatedDownloadBytes, LTX25Resources.estimatedDownloadBytes)
+        XCTAssertFalse(spec.runtimeAutoDownloadAllowed)
+        XCTAssertEqual(spec.usageRestriction?.terms.count, 2)
+        XCTAssertTrue(spec.usageRestriction?.terms.contains { $0.component == "Gemma 4 text encoder" } == true)
+
+        let manifest = MereRunModelManifest.template(
+            for: .ltxVideo25DistilledBF16,
+            createdAt: Date(timeIntervalSince1970: 0)
+        )
+        XCTAssertEqual(manifest.engine, .ltxVideo)
+        XCTAssertEqual(manifest.family, .video)
+        XCTAssertEqual(manifest.variant, .distilled)
+        XCTAssertEqual(manifest.precision, .bf16)
+        XCTAssertEqual(
+            manifest.upstreamRepoId,
+            "\(LTX25Resources.sourceRepository)@\(LTX25Resources.sourceRevision)"
+        )
+    }
+
     func testSCAIL2SpecPinsImmutableSawfwairRelease() throws {
         let id = ModelResolver.ModelID.scail2Video14BMLX.rawValue
         let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: id))
@@ -1738,6 +1771,21 @@ final class ManagedModelCatalogTests: XCTestCase {
         )
     }
 
+    func testLTX25RootValidationRequiresEveryNativeRuntimeArtifact() throws {
+        let spec = try XCTUnwrap(
+            ManagedModelCatalog.spec(for: ModelResolver.ModelID.ltxVideo25DistilledBF16.rawValue)
+        )
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try writeMinimalLTX25Root(at: root)
+
+        XCTAssertTrue(spec.isManagedRootComplete(root, fileManager: .default))
+        let missing = root.appendingPathComponent(LTX25Resources.videoVAERelativePath)
+        try FileManager.default.removeItem(at: missing)
+        XCTAssertEqual(spec.missingPaths(in: root, fileManager: .default), [missing])
+        XCTAssertTrue(spec.validationMessages(in: root).contains { $0.contains("Missing required LTX 2.5 file") })
+    }
+
     private func makeTemporaryDirectory() throws -> URL {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent("mere-run-managed-model-catalog-\(UUID().uuidString)", isDirectory: true)
@@ -1811,6 +1859,21 @@ final class ManagedModelCatalogTests: XCTestCase {
                 atPath: root.appendingPathComponent(file).path,
                 contents: contents
             ))
+        }
+    }
+
+    private func writeMinimalLTX25Root(at root: URL) throws {
+        try MereRunModelManifest.template(
+            for: .ltxVideo25DistilledBF16,
+            createdAt: Date(timeIntervalSince1970: 0)
+        ).write(to: root)
+        for relativePath in LTX25Resources.requiredRelativePaths {
+            let url = root.appendingPathComponent(relativePath)
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            XCTAssertTrue(FileManager.default.createFile(atPath: url.path, contents: Data()))
         }
     }
 

--- a/Tests/MereRunCoreTests/MereRunModelValidatorTests.swift
+++ b/Tests/MereRunCoreTests/MereRunModelValidatorTests.swift
@@ -440,6 +440,36 @@ final class MereRunModelValidatorTests: MereRunCoreTestCase {
         XCTAssertEqual(report.manifest?.upstreamRepoId, "dgrauet/ltx-2.3-mlx@main")
     }
 
+    func testLTX25PackedRootPassesValidationWithoutDiffusersMarker() throws {
+        let temp = try TestFileSystem.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: temp) }
+
+        let root = temp.appendingPathComponent(
+            ModelResolver.ModelID.ltxVideo25DistilledBF16.rawValue,
+            isDirectory: true
+        )
+        try TestFileSystem.createDirectory(root)
+        try MereRunModelManifest.template(
+            for: .ltxVideo25DistilledBF16,
+            createdAt: Date(timeIntervalSince1970: 0)
+        ).write(to: root)
+        for relativePath in LTX25Resources.requiredRelativePaths {
+            let url = root.appendingPathComponent(relativePath)
+            try TestFileSystem.createDirectory(url.deletingLastPathComponent())
+            try TestFileSystem.writeFile(url, contents: Data())
+        }
+
+        let report = MereRunModelValidator.validate(
+            modelRoot: root,
+            expectedModelID: ModelResolver.ModelID.ltxVideo25DistilledBF16.rawValue
+        )
+        XCTAssertTrue(report.isValid)
+        XCTAssertTrue(report.errors.isEmpty)
+        XCTAssertFalse(report.warnings.contains { $0.contains("model root marker") })
+        XCTAssertEqual(report.manifest?.engine, .ltxVideo)
+        XCTAssertEqual(report.manifest?.family, .video)
+    }
+
     func testLTX23FullCanonicalIDAcceptsCompatibleLegacyManifest() throws {
         let temp = try TestFileSystem.makeTempDir()
         defer { try? FileManager.default.removeItem(at: temp) }

--- a/Tests/MereRunCoreTests/ModelResolverTests.swift
+++ b/Tests/MereRunCoreTests/ModelResolverTests.swift
@@ -184,6 +184,33 @@ final class ModelResolverTests: MereRunCoreTestCase {
         )
     }
 
+    func testResolvesInstalledLTX25PackedRoot() throws {
+        let temp = try TestFileSystem.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: temp) }
+        defer { MereRunModelPaths.setProcessModelsDirOverride(nil) }
+
+        let modelsRoot = temp.appendingPathComponent("models", isDirectory: true)
+        MereRunModelPaths.setProcessModelsDirOverride(modelsRoot)
+        let root = modelsRoot.appendingPathComponent(
+            ModelResolver.ModelID.ltxVideo25DistilledBF16.rawValue,
+            isDirectory: true
+        )
+        try TestFileSystem.createDirectory(root)
+        try MereRunModelManifest.template(
+            for: .ltxVideo25DistilledBF16,
+            createdAt: Date(timeIntervalSince1970: 0)
+        ).write(to: root)
+        for relativePath in LTX25Resources.requiredRelativePaths {
+            let url = root.appendingPathComponent(relativePath)
+            try TestFileSystem.createDirectory(url.deletingLastPathComponent())
+            try TestFileSystem.writeFile(url, contents: Data())
+        }
+
+        let resolved = try ModelResolver().resolve(.ltxVideo25DistilledBF16)
+        XCTAssertEqual(resolved.rootURL.standardizedFileURL, root.standardizedFileURL)
+        XCTAssertEqual(resolved.source, .localModelStore)
+    }
+
     func testResolvesStandaloneMebotModel() throws {
         let temp = try TestFileSystem.makeTempDir()
         defer { try? FileManager.default.removeItem(at: temp) }

--- a/Tests/MereRunCoreTests/SafetensorsStreamingLoaderTests.swift
+++ b/Tests/MereRunCoreTests/SafetensorsStreamingLoaderTests.swift
@@ -26,10 +26,12 @@ final class SafetensorsStreamingLoaderTests: XCTestCase {
 
         let metadata = try SafetensorsStreamingLoader.metadata(url: url)
         let tensor = try XCTUnwrap(metadata["linear.weight"])
+        let fileMetadata = try SafetensorsStreamingLoader.fileMetadata(url: url)
         XCTAssertEqual(metadata.count, 1)
         XCTAssertEqual(tensor.shape, [2])
         XCTAssertEqual(tensor.dtype, .float32)
         XCTAssertEqual(tensor.endOffset - tensor.startOffset, 8)
+        XCTAssertEqual(fileMetadata, ["format": "pt"])
     }
 
     func testMetadataRejectsMalformedTensorHeader() throws {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -241,7 +241,7 @@ are:
 - Face detection and identity embeddings: `vision-face-buffalo-l`
 - Music: `music-acestep`, `music-acestep-xl-turbo`, `music-acestep-xl-turbo-lm4b`, `music-acestep-xl-sft`, `music-acestep-xl-base`, `music-acestep-lm-1.7b`, `music-acestep-lm-4b`, `music-magenta-rt2-small`, `music-magenta-rt2-base`
 - SFX: `sfx-woosh-dflow`, `sfx-woosh-flow`
-- Video: `video-ltx-av`, `video-ltx23-av-mlx`, `video-ltx23-full-mlx`, `video-ltx23-a2vid-mlx`, `video-wan22-ti2v-5b-mlx`, `video-scail2-14b-mlx`
+- Video: `video-ltx-av`, `video-ltx23-av-mlx`, `video-ltx23-full-mlx`, `video-ltx23-a2vid-mlx`, `video-ltx25-distilled-bf16`, `video-wan22-ti2v-5b-mlx`, `video-scail2-14b-mlx`
 
 For subsystem-specific implementation guides, see:
 

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -122,6 +122,7 @@ from the runtime catalog used by `mere.run model list`,
 | `video` | `video-ltx23-av-mlx` |
 | `video` | `video-ltx23-full-mlx` |
 | `video` | `video-ltx23-a2vid-mlx` |
+| `video` | `video-ltx25-distilled-bf16` |
 | `video` | `video-wan22-ti2v-5b-mlx` |
 | `video` | `video-minimax-h3-fl2va-mlx` |
 | `video` | `video-minimax-h3-fl2va-bf16-mlx` |
@@ -181,7 +182,7 @@ validates all configured models before downloading any; both accept the same
 | `music-muscriptor-{small,medium,large}` | CC BY-NC 4.0 model weights |
 | `sfx-woosh-*` | CC BY-NC 4.0 Woosh or MMAudio Synchformer weights |
 | `sfx-mmaudio-large-44k-v2` | CC BY-NC 4.0 MMAudio checkpoints plus Apple's research-only DFN5B encoder terms |
-| `video-ltx-av`, `video-ltx23-av-mlx`, `video-ltx23-full-mlx`, `video-ltx23-a2vid-mlx` | LTX-2 Community License; entities at or above USD 10M annual revenue need a paid commercial license, plus acceptable-use conditions. The 2.3 MLX paths also install a hidden Gemma 3 text encoder under Google's Gemma Terms and Prohibited Use Policy. |
+| `video-ltx-av`, `video-ltx23-av-mlx`, `video-ltx23-full-mlx`, `video-ltx23-a2vid-mlx`, `video-ltx25-distilled-bf16` | LTX-2 Community License; entities at or above USD 10M annual revenue need a paid commercial license, plus acceptable-use conditions. The 2.3 MLX paths also install a hidden Gemma 3 text encoder; the packed 2.5 checkpoint includes Gemma 4 weights. Both are additionally governed by Google's Gemma Terms and Prohibited Use Policy. |
 
 The catalog pins every restricted download source to an immutable commit. New
 managed installs write those repository revisions, every applicable
@@ -843,6 +844,26 @@ Its legacy narrow manifest may omit the vocoder, so it can run final-quality
 video-only and source-audio A2Vid but not generated-audio output. Requests for
 either the legacy ID or the new full ID resolve to an already-installed
 compatible root when possible. New pulls should use `video-ltx23-full-mlx`.
+
+### `video-ltx25-distilled-bf16`
+
+The official packed LTX 2.5 BF16 root is:
+
+```text
+.../models/video-ltx25-distilled-bf16
+```
+
+`mere.run model pull video-ltx25-distilled-bf16 --accept-model-license` pulls
+only the native runtime subset from `Lightricks/LTX-2.5` at immutable revision
+`dd53cc2cd45bbeaa3563dfb575cba3f49cf44761`: the distilled transformer, packed
+Gemma 4 text encoder, video VAE, audio VAE/BWE vocoder, x2 spatial upscaler,
+and optional duration head. The required checkpoint payload is about 71.1 GB.
+The Hugging Face repository is gated, so the account behind `HF_TOKEN` must
+already have access in addition to the explicit local license acknowledgement.
+
+This model runs natively through Swift and MLX; no Python process or sidecar is
+dispatched. Use `--quality final --output-mode audio-video` for synchronized
+video and stereo audio. The packed LTX 2.5 root is not an A2Vid checkpoint.
 
 ### MiniMax-H3 FL2VA and Ref2VA
 

--- a/docs/runtime/model-management.md
+++ b/docs/runtime/model-management.md
@@ -65,7 +65,7 @@ Examples:
 - vision: `vision-ocr-lighton`
 - music: `music-acestep`, `music-acestep-xl-turbo`, `music-acestep-xl-turbo-lm4b`, `music-acestep-xl-sft`, `music-acestep-xl-base`, `music-acestep-lm-1.7b`, `music-acestep-lm-4b`, `music-magenta-rt2-small`, `music-magenta-rt2-base`
 - sfx: `sfx-woosh-dflow`, `sfx-woosh-flow`, `sfx-woosh-clap`, `sfx-woosh-synchformer`, `sfx-woosh-dvflow-8s`, `sfx-woosh-vflow-8s`, `sfx-mmaudio-large-44k-v2`
-- video: `video-ltx-av`, `video-ltx23-av-mlx`, `video-ltx23-full-mlx`, `video-ltx23-a2vid-mlx`, `video-wan22-ti2v-5b-mlx`, `video-scail2-14b-mlx`
+- video: `video-ltx-av`, `video-ltx23-av-mlx`, `video-ltx23-full-mlx`, `video-ltx23-a2vid-mlx`, `video-ltx25-distilled-bf16`, `video-wan22-ti2v-5b-mlx`, `video-scail2-14b-mlx`
 
 The public runtime resolves these IDs directly, so docs and examples should use
 the canonical names shown by `mere.run model list`.

--- a/docs/runtime/video.md
+++ b/docs/runtime/video.md
@@ -72,6 +72,9 @@ are an escape hatch, not the capability contract.
   `--quality final`, generated synchronized audio, and source-audio A2Vid.
 - `video-ltx23-a2vid-mlx`: compatibility ID for existing A2Vid installs. New
   installs should use `video-ltx23-full-mlx`.
+- `video-ltx25-distilled-bf16`: official packed LTX 2.5 BF16 checkpoint for
+  native final-quality synchronized video and stereo audio. Pull it with
+  `--accept-model-license`; gated Hugging Face access is also required.
 - `video-ltx-av`: legacy merged LTX root, superseded by LTX 2.3. Only still required
   by `video export-latents`; not recommended for `video generate`.
 - `video-wan22-ti2v-5b-mlx`: native Wan2.2 TI2V image-to-video lane. `video


### PR DESCRIPTION
## Summary

- add a native Swift/MLX loader and generation route for the official packed LTX 2.5 BF16 checkpoint
- register `video-ltx25-distilled-bf16` as a pinned, gated managed model with exact source revision, runtime file inventory, validation, preflight, and component reporting
- extend the native Gemma 4 text path with padding-mask and hidden-state capture needed by the LTX 2.5 text encoder
- document the managed pull and native video-generation workflow

## Why

The official LTX 2.5 release uses a packed file layout that the existing LTX 2.3 model resolver and loaders could not consume. This change keeps the complete inference path inside mere.run's native Swift/MLX runtime and exposes the checkpoint through the normal managed model catalog instead of dispatching to Python.

## User impact

After accepting the upstream LTX and Gemma terms, users can pull or register the pinned checkpoint and run it through `mere.run video generate`. Model preflight, list, info, manifest repair, and installed-model selection understand the new canonical model ID.

## Validation

- `./scripts/check.sh`
  - strict SwiftLint: 1,193 files, zero violations
  - build and metallib provenance checks passed
  - 2,642 XCTest cases, 173 expected asset/GPU skips, zero failures
  - 25 Swift Testing checks passed
  - CLI help, model catalog/status, and hygiene sweeps passed
- native Swift release smoke against the accepted checkpoint at `/Volumes/SALVATION/models/LTX-2.5`
  - produced a 256x192 H.264 + AAC MP4 with 25 frames at 24 fps
  - output duration: 1.041 seconds
  - SHA-256: `53a3c25f5a68092863e2cc857b775e6730ec490d52c5a3f94ff9ad4750aee09c`

The real-checkpoint smoke is local evidence; checkpoint assets are gated and are not included in the repository.
