### PR TITLE
Add unified model catalog locations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+### Model management
+
+- added a unified, deterministic model catalog over one writable primary store
+  plus ordered read-only search roots and explicit canonical-ID directory
+  bindings. `model list`, `info`, pull/preflight, runtime resolution, agent and
+  Open WebUI pulls now recognize external models without copying them. New
+  `model location` commands manage registrations; remove, garbage collection,
+  manifest repair, and forced pulls never mutate externally owned payloads.
+
 ### Text
 
 - added `text-chat-nemotron-35-lightning`, a pinned native Swift/MLX runtime for

--- a/README.md
+++ b/README.md
@@ -911,6 +911,26 @@ export MERERUN_MODELS_DIR=/path/to/models
 swift run mere.run --models-root /path/to/models model list
 ```
 
+Keep one writable store while unifying models already held on other disks:
+
+```bash
+# Search a catalog laid out as <root>/<canonical-model-id>/
+mere.run model location add /Volumes/Models
+
+# Or bind an arbitrary folder name to one canonical model id
+mere.run model location bind video-ltx23-full-mlx /Volumes/SALVATION/models/LTX-2.3 \
+  --accept-model-license
+
+mere.run model location list
+```
+
+Registered roots and bindings are read-only. Resolution is deterministic:
+primary store, explicit bindings in registration order, then search roots in
+registration order. Pulls still write only to the primary store; removing an
+external binding only unregisters it and never deletes its payload. Explicit
+`MERERUN_MODELS_DIR` and `--models-root` overrides remain isolated for
+reproducible jobs and do not merge registered locations.
+
 ### Hugging Face snapshot cache
 
 `mere.run model pull` and runtime auto-download paths use the native Hugging

--- a/Sources/MereRunCLI/Commands/AgentCommand.swift
+++ b/Sources/MereRunCLI/Commands/AgentCommand.swift
@@ -294,10 +294,7 @@ struct AgentOnboard: AsyncParsableCommand {
     private func pullRecommendedModels(_ reports: [ManagedModelSupportReport]) async throws {
         for report in reports {
             guard report.spec.hasAnyManagedDownloadSource() else { continue }
-            let isInstalled = ManagedModelResolver.isManagedInstallComplete(
-                spec: report.spec,
-                at: report.spec.managedInstallRootURL()
-            )
+            let isInstalled = report.spec.managedRuntimeURL() != nil
             if let restriction = report.spec.usageRestriction,
                !isInstalled,
                !acceptModelLicense {
@@ -314,6 +311,12 @@ struct AgentOnboard: AsyncParsableCommand {
                     CLIStderr.write("  \(term.component): \(term.license) \(term.licenseURL)\n")
                 }
                 CLIStderr.write("  You are responsible for determining whether your use complies.\n")
+            }
+            if isInstalled {
+                if !quiet {
+                    CLIStderr.write("[\(report.spec.id)] already available in the unified model catalog\n")
+                }
+                continue
             }
             if !quiet {
                 CLIStderr.write("[\(report.spec.id)] installing recommended model\n")

--- a/Sources/MereRunCLI/Commands/ModelCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelCommand.swift
@@ -3,9 +3,10 @@ import ArgumentParser
 struct Model: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "model",
-        abstract: "List, pull, remove, inspect, optimize, and clean up models.",
+        abstract: "List, pull, locate, remove, inspect, optimize, and clean up models.",
         subcommands: [
             ModelList.self,
+            ModelLocation.self,
             ModelPull.self,
             ModelRemove.self,
             ModelStorage.self,

--- a/Sources/MereRunCLI/Commands/ModelInfoCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelInfoCommand.swift
@@ -23,6 +23,7 @@ struct ModelInfo: ParsableCommand {
         let resolved: ModelResolver.Resolution?
         let rootURL: URL
         let expectedModelID: String?
+        let resolver = ModelResolver()
 
         let asPath = URL(fileURLWithPath: target).standardizedFileURL
         if fm.fileExists(atPath: asPath.path) {
@@ -31,7 +32,7 @@ struct ModelInfo: ParsableCommand {
             expectedModelID = nil
         } else if let id = ModelResolver.ModelID(rawValue: target) {
             do {
-                let r = try ModelResolver().resolve(id)
+                let r = try resolver.resolve(id)
                 resolved = r
                 rootURL = r.rootURL
                 expectedModelID = id.rawValue
@@ -39,13 +40,25 @@ struct ModelInfo: ParsableCommand {
                 if id == .gemma4 {
                     throw ValidationError("Model \(id.rawValue) is not installed in the local model store. Gemma4 resolves through the native Hugging Face snapshot path on first use, or you can point info at a local model path.")
                 }
-                throw ValidationError("Model \(id.rawValue) not found. Pull it with `\(CLICommandDisplay.modelPullCommand(for: id.rawValue))` or point info at a local model path.")
+                throw ValidationError("Model \(id.rawValue) not found. Pull it with `\(CLICommandDisplay.modelPullCommand(for: id.rawValue))`, register its catalog location, or point info at a local model path.")
             }
         } else {
             throw ValidationError("Not a path and not a known model id: \(target)")
         }
 
-        let report = MereRunModelValidator.validate(modelRoot: rootURL, expectedModelID: expectedModelID)
+        let report: MereRunModelValidationReport
+        if let resolved, resolved.source == .registeredBinding {
+            let termsAcknowledged = resolver.locationCandidates(for: resolved.modelID)
+                .first { $0.kind == .registeredBinding && $0.rootURL == resolved.rootURL }?
+                .usageTermsAcknowledged ?? false
+            report = MereRunModelValidator.validateRegisteredBinding(
+                modelRoot: rootURL,
+                expectedModelID: resolved.modelID.rawValue,
+                usageTermsAcknowledged: termsAcknowledged
+            )
+        } else {
+            report = MereRunModelValidator.validate(modelRoot: rootURL, expectedModelID: expectedModelID)
+        }
         let manifest = report.manifest
 
         if json {
@@ -68,6 +81,10 @@ struct ModelInfo: ParsableCommand {
         if let resolved {
             print("Model ID: \(resolved.modelID.rawValue)")
             print("Source: \(resolved.source.rawValue)")
+            print("Ownership: \(resolved.isExternallyManaged ? "external-read-only" : "primary-managed")")
+            if let catalogRootURL = resolved.catalogRootURL {
+                print("Catalog Root: \(catalogRootURL.path)")
+            }
         }
 
         let usage = FileSystemHelper.directoryUsage(at: rootURL)

--- a/Sources/MereRunCLI/Commands/ModelLocationCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelLocationCommand.swift
@@ -88,7 +88,7 @@ struct ModelLocationList: ParsableCommand {
 struct ModelLocationAdd: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "add",
-        abstract: "Register a read-only root containing canonical <model-id> directories."
+        abstract: "Register a read-only root containing directories named for canonical model IDs."
     )
 
     @Argument(help: "Existing directory to search for canonical model subdirectories.")

--- a/Sources/MereRunCLI/Commands/ModelLocationCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelLocationCommand.swift
@@ -1,0 +1,279 @@
+import ArgumentParser
+import Foundation
+import MereRunCore
+
+struct ModelLocation: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "location",
+        abstract: "Manage read-only model catalog locations.",
+        discussion: """
+        The primary model store remains the only location mere.run writes to. Registered
+        roots and bindings are read-only: removing a registration never deletes its payload.
+        """,
+        subcommands: [
+            ModelLocationList.self,
+            ModelLocationAdd.self,
+            ModelLocationRemove.self,
+            ModelLocationBind.self,
+            ModelLocationUnbind.self,
+        ],
+        defaultSubcommand: ModelLocationList.self
+    )
+}
+
+struct ModelLocationList: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "list",
+        abstract: "List the writable store, search roots, and explicit bindings."
+    )
+
+    @Flag(name: [.long], help: "Emit structured JSON.")
+    var json: Bool = false
+
+    func run() throws {
+        let fileManager = FileManager.default
+        let registry = try ModelLocationRegistry.load(fileManager: fileManager)
+        let output = ModelLocationListOutput(
+            primaryStore: .init(
+                path: MereRunModelPaths.modelsDir.path,
+                available: Self.isDirectory(MereRunModelPaths.modelsDir, fileManager: fileManager)
+            ),
+            searchRoots: registry.searchRoots.map { path in
+                let url = URL(fileURLWithPath: path, isDirectory: true)
+                return .init(path: url.path, available: Self.isDirectory(url, fileManager: fileManager))
+            },
+            bindings: registry.bindings.map { binding in
+                let url = URL(fileURLWithPath: binding.path, isDirectory: true)
+                return .init(
+                    modelID: binding.modelID,
+                    path: url.path,
+                    available: Self.isDirectory(url, fileManager: fileManager),
+                    usageTermsAcknowledged: binding.usageTermsAcknowledged
+                )
+            }
+        )
+
+        if json {
+            print(try ModelStorageCommandOutput.encode(output))
+            return
+        }
+
+        print("Primary store (writable)")
+        print("  \(output.primaryStore.path)\(output.primaryStore.available ? "" : " (unavailable)")")
+        print("\nSearch roots (read-only)")
+        if output.searchRoots.isEmpty {
+            print("  (none)")
+        } else {
+            for root in output.searchRoots {
+                print("  \(root.path)\(root.available ? "" : " (offline)")")
+            }
+        }
+        print("\nExplicit bindings (read-only)")
+        if output.bindings.isEmpty {
+            print("  (none)")
+        } else {
+            for binding in output.bindings {
+                print("  \(binding.modelID) -> \(binding.path)\(binding.available ? "" : " (offline)")")
+            }
+        }
+    }
+
+    private static func isDirectory(_ url: URL, fileManager: FileManager) -> Bool {
+        var isDirectory: ObjCBool = false
+        return fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory)
+            && isDirectory.boolValue
+    }
+}
+
+struct ModelLocationAdd: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "add",
+        abstract: "Register a read-only root containing canonical <model-id> directories."
+    )
+
+    @Argument(help: "Existing directory to search for canonical model subdirectories.")
+    var path: String
+
+    func run() throws {
+        let url = try ModelLocationSupport.existingDirectory(path)
+        guard url != MereRunModelPaths.modelsDir.standardizedFileURL else {
+            throw ValidationError("That directory is already the writable primary model store.")
+        }
+        var registry = try ModelLocationRegistry.load()
+        registry.addSearchRoot(url)
+        try registry.save()
+        print(url.path)
+    }
+}
+
+struct ModelLocationRemove: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "remove",
+        abstract: "Unregister a search root without deleting its files."
+    )
+
+    @Argument(help: "Registered search-root path.")
+    var path: String
+
+    func run() throws {
+        let url = ModelLocationSupport.normalizedURL(path)
+        var registry = try ModelLocationRegistry.load()
+        guard registry.removeSearchRoot(url) else {
+            throw ValidationError("Search root is not registered: \(url.path)")
+        }
+        try registry.save()
+        print(url.path)
+    }
+}
+
+struct ModelLocationBind: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "bind",
+        abstract: "Bind a canonical model id to an arbitrary read-only directory."
+    )
+
+    @Argument(help: "Canonical model id.")
+    var modelID: String
+
+    @Argument(help: "Existing model directory.")
+    var path: String
+
+    @Flag(
+        name: [.customLong("accept-model-license")],
+        help: "Confirm acceptance of this model's listed third-party terms for the binding."
+    )
+    var acceptModelLicense: Bool = false
+
+    func run() throws {
+        let normalizedID = modelID.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard let spec = ManagedModelCatalog.spec(for: normalizedID) else {
+            throw ValidationError("Unknown canonical model id: \(modelID)")
+        }
+        let url = try ModelLocationSupport.existingDirectory(path)
+        let primaryPath = MereRunModelPaths.modelsDir.standardizedFileURL.path
+        guard url.path != primaryPath, !url.path.hasPrefix(primaryPath + "/") else {
+            throw ValidationError(
+                "Bindings are for external read-only directories; this path is inside the writable primary store."
+            )
+        }
+        let manifest = try MereRunModelManifest.loadIfPresent(from: url)
+        if let manifest, manifest.id != spec.id {
+            throw ValidationError(
+                "Manifest identifies \(manifest.id), so it cannot be bound as \(spec.id)."
+            )
+        }
+        let termsAcknowledged = acceptModelLicense || manifest?.usageTermsAcknowledged == true
+        if let restriction = spec.usageRestriction, !termsAcknowledged {
+            let terms = restriction.terms.map {
+                "- \($0.component): \($0.license)\n  \($0.licenseURL)"
+            }.joined(separator: "\n")
+            throw ValidationError(
+                """
+                Model \(spec.id) has third-party usage terms: \(restriction.summary)
+                \(terms)
+                Pass --accept-model-license after reviewing them and confirming your acceptance.
+                """
+            )
+        }
+
+        let report = MereRunModelValidator.validateRegisteredBinding(
+            modelRoot: url,
+            expectedModelID: spec.id,
+            usageTermsAcknowledged: termsAcknowledged
+        )
+        guard report.isValid else {
+            throw MereRunModelValidator.ValidationError.invalidModelRoot(
+                url,
+                details: report.errors
+            )
+        }
+
+        var registry = try ModelLocationRegistry.load()
+        registry.addBinding(
+            modelID: spec.id,
+            url: url,
+            usageTermsAcknowledged: termsAcknowledged
+        )
+        try registry.save()
+        print("\(spec.id)\t\(url.path)")
+    }
+}
+
+struct ModelLocationUnbind: ParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "unbind",
+        abstract: "Remove explicit bindings without deleting model files."
+    )
+
+    @Argument(help: "Canonical model id.")
+    var modelID: String
+
+    @Argument(help: "Optional exact bound path; omit to remove every binding for the id.")
+    var path: String?
+
+    func run() throws {
+        let normalizedID = modelID.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard ManagedModelCatalog.spec(for: normalizedID) != nil else {
+            throw ValidationError("Unknown canonical model id: \(modelID)")
+        }
+        let url = path.map(ModelLocationSupport.normalizedURL)
+        var registry = try ModelLocationRegistry.load()
+        let removed = registry.removeBindings(modelID: normalizedID, url: url)
+        guard removed > 0 else {
+            throw ValidationError("No matching binding is registered for \(normalizedID).")
+        }
+        try registry.save()
+        print("\(normalizedID)\t\(removed)")
+    }
+}
+
+private enum ModelLocationSupport {
+    static func normalizedURL(_ path: String) -> URL {
+        let expanded = (path as NSString).expandingTildeInPath
+        return URL(fileURLWithPath: expanded, isDirectory: true).standardizedFileURL
+    }
+
+    static func existingDirectory(_ path: String, fileManager: FileManager = .default) throws -> URL {
+        let url = normalizedURL(path)
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory),
+              isDirectory.boolValue else {
+            throw ValidationError("Directory does not exist: \(url.path)")
+        }
+        guard fileManager.isReadableFile(atPath: url.path) else {
+            throw ValidationError("Directory is not readable: \(url.path)")
+        }
+        return url
+    }
+}
+
+struct ModelLocationListOutput: Codable, Equatable {
+    struct Root: Codable, Equatable {
+        let path: String
+        let available: Bool
+    }
+
+    struct Binding: Codable, Equatable {
+        let modelID: String
+        let path: String
+        let available: Bool
+        let usageTermsAcknowledged: Bool
+
+        enum CodingKeys: String, CodingKey {
+            case modelID = "model_id"
+            case path
+            case available
+            case usageTermsAcknowledged = "usage_terms_acknowledged"
+        }
+    }
+
+    let primaryStore: Root
+    let searchRoots: [Root]
+    let bindings: [Binding]
+
+    enum CodingKeys: String, CodingKey {
+        case primaryStore = "primary_store"
+        case searchRoots = "search_roots"
+        case bindings
+    }
+}

--- a/Sources/MereRunCLI/Commands/ModelPullCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelPullCommand.swift
@@ -69,10 +69,7 @@ struct ModelPull: AsyncParsableCommand {
                     continue
                 }
                 let requiresUsageTermsAcknowledgement = spec.usageRestriction != nil
-                    && (force || !ManagedModelResolver.isManagedInstallComplete(
-                        spec: spec,
-                        at: spec.managedInstallRootURL()
-                    ))
+                    && (force || !isInstalledInUnifiedCatalog(spec))
                 if requiresUsageTermsAcknowledgement, !acceptModelLicense {
                     if !quiet {
                         stderr(
@@ -130,6 +127,17 @@ struct ModelPull: AsyncParsableCommand {
 
     private func pull(_ spec: ManagedModelSpec) async throws {
         let modelDir = spec.managedInstallRootURL()
+        if !force, isInstalledInUnifiedCatalog(spec) {
+            if !quiet {
+                let resolution = spec.modelID.flatMap { ModelResolver().resolveIfPresent($0) }
+                if let resolution, resolution.isExternallyManaged {
+                    stderr("[\(spec.id)] already available at read-only external location \(resolution.rootURL.path), skipping")
+                } else {
+                    stderr("[\(spec.id)] already installed, skipping (use --force to install into the primary store)")
+                }
+            }
+            return
+        }
         if !force, ManagedModelResolver.isManagedInstallComplete(spec: spec, at: modelDir) {
             if !quiet {
                 if !spec.isManagedRuntimeReady(modelDir),
@@ -204,7 +212,7 @@ struct ModelPull: AsyncParsableCommand {
                 }
             }
             var errors = report.errors
-            if spec.managedRuntimeURL() == nil {
+            if !spec.isManagedRuntimeReady(modelDir) {
                 if spec.requiresManagedConversion,
                    ManagedModelResolver.isManagedInstallComplete(spec: spec, at: modelDir),
                    let guidance = spec.managedConversionGuidance(at: modelDir) {
@@ -224,6 +232,13 @@ struct ModelPull: AsyncParsableCommand {
         }
 
         print(modelDir.path)
+    }
+
+    private func isInstalledInUnifiedCatalog(_ spec: ManagedModelSpec) -> Bool {
+        guard let modelID = spec.modelID else {
+            return spec.managedRuntimeURL() != nil
+        }
+        return ModelResolver().resolveIfPresent(modelID) != nil
     }
 
     private func stderr(_ message: String) {
@@ -252,6 +267,7 @@ struct ModelPull: AsyncParsableCommand {
         fileManager: FileManager = .default,
         hubCacheURL: URL? = nil,
         modelStoreURL: URL? = nil,
+        modelLocations: ModelLocationSnapshot? = nil,
         diskAvailableBytes: ((URL) -> Int64?)? = nil,
         now: @escaping () -> Date = Date.init
     ) -> ModelPullPreflightEnvelope {
@@ -269,6 +285,7 @@ struct ModelPull: AsyncParsableCommand {
             fileManager: fileManager,
             hubCacheURL: hubCacheURL,
             modelStoreURL: modelStoreURL,
+            modelLocations: modelLocations,
             diskAvailableBytes: diskAvailableBytes,
             now: now
         ).envelope()

--- a/Sources/MereRunCLI/Commands/ModelRemoveCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelRemoveCommand.swift
@@ -32,9 +32,12 @@ struct ModelRemove: ParsableCommand {
         let resolver = ModelResolver()
         let modelID = ModelResolver.ModelID(rawValue: id)
         let installURL: URL
+        let resolution: ModelResolver.Resolution?
         if let modelID, let resolved = resolver.resolveIfPresent(modelID) {
+            resolution = resolved
             installURL = resolved.rootURL
         } else {
+            resolution = nil
             if let aliasFallback = gemmaAliasInstallURL(for: id) {
                 installURL = aliasFallback
             } else {
@@ -44,6 +47,26 @@ struct ModelRemove: ParsableCommand {
                     throw ValidationError("\(id) is not installed.")
                 }
                 installURL = flatDir
+            }
+        }
+
+        if let resolution, resolution.isExternallyManaged {
+            switch resolution.source {
+            case .registeredBinding:
+                try unregisterExternalBinding(
+                    id: id,
+                    installURL: installURL,
+                    resolution: resolution
+                )
+                return
+            case .registeredSearchRoot:
+                let root = resolution.catalogRootURL?.path ?? "the registered search root"
+                throw ValidationError(
+                    "\(id) is in read-only catalog root \(root). "
+                        + "Unregister the root with `mere.run model location remove \(root)`; no model files were deleted."
+                )
+            case .localModelStore:
+                break
             }
         }
 
@@ -87,6 +110,8 @@ struct ModelRemove: ParsableCommand {
         let garbageResult = keepCache ? nil : try storageManager.execute(garbagePlan)
         let reclaimedBytes = (garbageResult?.reclaimedBytes ?? 0) + (storageUsage?.localBytes ?? 0)
         let result = ModelRemoveOutput(
+            action: "removed",
+            payloadDeleted: true,
             id: id,
             installPath: installURL.path,
             referencedBytes: referencedBytes,
@@ -111,6 +136,63 @@ struct ModelRemove: ParsableCommand {
                 message += "; Hub payload retained"
             }
             print(message)
+        }
+    }
+
+    private func unregisterExternalBinding(
+        id: String,
+        installURL: URL,
+        resolution: ModelResolver.Resolution
+    ) throws {
+        let referencedBytes = FileSystemHelper.directorySize(at: installURL)
+        if !force {
+            print("Unregister \(id)?")
+            print("  Path: \(installURL.path)")
+            print("  Ownership: external read-only")
+            print("  The model payload will be preserved.")
+            print("")
+            print("Confirm? [y/N] ", terminator: "")
+            guard let answer = readLine()?.lowercased(), answer == "y" || answer == "yes" else {
+                print("Aborted.")
+                return
+            }
+        }
+
+        var registry = try ModelLocationRegistry.load()
+        let path = installURL.standardizedFileURL.path
+        let fallbackIDs = ManagedModelCatalog.spec(for: id)?.resolutionFallbackIDs ?? []
+        let boundIDs = Set([id] + fallbackIDs)
+        var removed = 0
+        for boundID in boundIDs {
+            removed += registry.removeBindings(
+                modelID: boundID,
+                url: URL(fileURLWithPath: path, isDirectory: true)
+            )
+        }
+        guard removed > 0 else {
+            throw ValidationError(
+                "Resolved external binding is no longer registered. No model files were deleted."
+            )
+        }
+        try registry.save()
+
+        let result = ModelRemoveOutput(
+            action: "unregistered",
+            payloadDeleted: false,
+            id: id,
+            installPath: installURL.path,
+            referencedBytes: referencedBytes,
+            expectedReclaimableBytes: 0,
+            reclaimedBytes: 0,
+            retainedSharedBytes: 0,
+            retainedExternalBytes: referencedBytes,
+            cacheRetained: true,
+            deletedCacheItemCount: 0
+        )
+        if json {
+            print(try ModelStorageCommandOutput.encode(result))
+        } else {
+            print("Unregistered \(id); external payload preserved at \(installURL.path)")
         }
     }
 
@@ -162,6 +244,8 @@ struct ModelRemove: ParsableCommand {
 }
 
 struct ModelRemoveOutput: Codable, Equatable {
+    let action: String
+    let payloadDeleted: Bool
     let id: String
     let installPath: String
     let referencedBytes: Int64

--- a/Sources/MereRunCLI/Commands/OpenWebUICommand.swift
+++ b/Sources/MereRunCLI/Commands/OpenWebUICommand.swift
@@ -280,6 +280,12 @@ struct OpenWebUIQuickstart: AsyncParsableCommand {
                 CLIStderr.write("[open-webui] \(modelID) has no managed download source; install it from a local path.\n")
                 continue
             }
+            if spec.managedRuntimeURL() != nil {
+                if !quiet {
+                    CLIStderr.write("[open-webui] \(modelID) already available in the unified model catalog\n")
+                }
+                continue
+            }
             if !quiet {
                 CLIStderr.write("[open-webui] Pulling \(modelID)\n")
             }
@@ -326,11 +332,7 @@ struct OpenWebUIQuickstart: AsyncParsableCommand {
             .filter { spec in
                 spec.usageRestriction != nil
                     && spec.hasAnyManagedDownloadSource()
-                    && !ManagedModelResolver.isManagedInstallComplete(
-                        spec: spec,
-                        at: spec.managedInstallRootURL(),
-                        fileManager: fileManager
-                    )
+                    && spec.managedRuntimeURL(fileManager: fileManager) == nil
             }
         guard !restricted.isEmpty else { return nil }
 

--- a/Sources/MereRunCLI/Support/CLIModelStoreBootstrap.swift
+++ b/Sources/MereRunCLI/Support/CLIModelStoreBootstrap.swift
@@ -7,21 +7,27 @@ enum CLIModelStoreBootstrap {
         environment: [String: String] = ProcessInfo.processInfo.environment,
         defaults: UserDefaults = .standard
     ) {
-        guard let rawPath = resolvedOverridePath(
-            arguments: arguments,
-            environment: environment,
-            defaults: defaults
-        ) else {
-            return
+        if let rawPath = modelsRootArgument(in: arguments), !rawPath.isEmpty {
+            applyOverridePath(rawPath)
+        } else if let rawPath = environment[MereRunModelPaths.modelsDirEnvironmentKey], !rawPath.isEmpty {
+            applyOverridePath(rawPath)
+        } else if let rawPath = defaults.string(
+            forKey: MereRunModelPaths.modelStorageActivePathDefaultsKey
+        ), !rawPath.isEmpty {
+            applyOverridePath(rawPath, includeRegisteredLocations: true)
         }
-
-        applyOverridePath(rawPath)
     }
 
-    static func applyOverridePath(_ rawPath: String) {
+    static func applyOverridePath(
+        _ rawPath: String,
+        includeRegisteredLocations: Bool = false
+    ) {
         let expanded = (rawPath as NSString).expandingTildeInPath
         let url = URL(fileURLWithPath: expanded).standardizedFileURL
-        MereRunModelPaths.setProcessModelsDirOverride(url)
+        MereRunModelPaths.setProcessModelsDirOverride(
+            url,
+            includeRegisteredLocations: includeRegisteredLocations
+        )
         setenv(MereRunModelPaths.modelsDirEnvironmentKey, url.path, 1)
     }
 

--- a/Sources/MereRunCLI/Support/ModelInventory.swift
+++ b/Sources/MereRunCLI/Support/ModelInventory.swift
@@ -26,6 +26,8 @@ enum ModelInventory {
 
             let modelID = ModelResolver.ModelID(rawValue: id)
             let resolvedViaResolver = modelID.flatMap { resolver.resolveIfPresent($0) }
+            let registeredBindings = (modelID.map { resolver.locationCandidates(for: $0) } ?? [])
+                .filter { $0.kind == .registeredBinding }
 
             let flatDir = MereRunModelPaths.modelDir(id)
             let flatInstalled = isNonEmptyDirectory(flatDir, fileManager: fileManager)
@@ -79,6 +81,17 @@ enum ModelInventory {
                 status = hasManagedManifest ? "invalid" : "installed"
                 let bytes = FileSystemHelper.directorySize(at: flatDir)
                 size = ByteCountFormatter.string(fromByteCount: bytes, countStyle: .file)
+            } else if !registeredBindings.isEmpty {
+                let availableBinding = registeredBindings.first {
+                    isNonEmptyDirectory($0.rootURL, fileManager: fileManager)
+                }
+                status = availableBinding == nil ? "offline" : "invalid"
+                if let availableBinding {
+                    let bytes = FileSystemHelper.directorySize(at: availableBinding.rootURL)
+                    size = ByteCountFormatter.string(fromByteCount: bytes, countStyle: .file)
+                } else {
+                    size = "—"
+                }
             } else {
                 status = "missing"
                 size = "—"

--- a/Sources/MereRunCLI/Support/ModelPullPreflight.swift
+++ b/Sources/MereRunCLI/Support/ModelPullPreflight.swift
@@ -123,6 +123,7 @@ struct ModelPullPreflightAnalyzer {
     let fileManager: FileManager
     let hubCacheURL: URL?
     let modelStoreURL: URL?
+    let modelLocations: ModelLocationSnapshot?
     let diskAvailableBytes: (URL) -> Int64?
     let now: () -> Date
 
@@ -131,6 +132,7 @@ struct ModelPullPreflightAnalyzer {
         fileManager: FileManager = .default,
         hubCacheURL: URL? = nil,
         modelStoreURL: URL? = nil,
+        modelLocations: ModelLocationSnapshot? = nil,
         diskAvailableBytes: ((URL) -> Int64?)? = nil,
         now: @escaping () -> Date = Date.init
     ) {
@@ -138,6 +140,7 @@ struct ModelPullPreflightAnalyzer {
         self.fileManager = fileManager
         self.hubCacheURL = hubCacheURL
         self.modelStoreURL = modelStoreURL
+        self.modelLocations = modelLocations
         self.diskAvailableBytes = diskAvailableBytes ?? {
             ModelPullDiskPreflight.availableBytes(onFileSystemContaining: $0, fileManager: fileManager)
         }
@@ -245,19 +248,36 @@ struct ModelPullPreflightAnalyzer {
         let support = ManagedModelCapabilityCatalog.support(for: spec)
         let hasSource = spec.hasAnyManagedDownloadSource()
         let installPath = modelStore.appendingPathComponent(spec.id, isDirectory: true).standardizedFileURL
-        let installed = ManagedModelResolver.isManagedInstallComplete(spec: spec, at: installPath, fileManager: fileManager)
-        let runtimeURL = runtimeURL(for: spec, installPath: installPath, installed: installed)
+        let installedInPrimary = ManagedModelResolver.isManagedInstallComplete(
+            spec: spec,
+            at: installPath,
+            fileManager: fileManager
+        )
+        let resolver: ModelResolver? = if let modelLocations {
+            ModelResolver(fileManager: fileManager, locations: modelLocations)
+        } else if modelStoreURL == nil {
+            ModelResolver(fileManager: fileManager)
+        } else {
+            nil
+        }
+        let unifiedResolution = spec.modelID.flatMap { resolver?.resolveIfPresent($0) }
+        let installed = installedInPrimary || unifiedResolution != nil
+        let runtimeURL = unifiedResolution?.rootURL
+            ?? runtimeURL(for: spec, installPath: installPath, installed: installedInPrimary)
         let runtimeReady = runtimeURL != nil
-        let conversionRequired = spec.requiresManagedConversion && installed && !runtimeReady
+        let conversionRequired = spec.requiresManagedConversion && installedInPrimary && !runtimeReady
         let selected = input.all || spec.id == input.target
         let blockedBySupport = !input.allowUnsupported && !support.isSupported
         let blockedBySource = !hasSource
         let requiresUsageTermsAcknowledgement = spec.usageRestriction != nil && (input.force || !installed)
         let blockedByUsageTerms = requiresUsageTermsAcknowledgement && !input.acceptUsageTerms
         let installedUsageTermsAcknowledged = (try? MereRunModelManifest.loadIfPresent(
-            from: installPath,
+            from: runtimeURL ?? installPath,
             fileManager: fileManager
-        ))?.usageTermsAcknowledged == true
+        ))?.usageTermsAcknowledged == true || bindingAcknowledgesUsageTerms(
+            resolution: unifiedResolution,
+            resolver: resolver
+        )
         let estimatedDownloadBytes = ModelPullDiskPreflight.estimatedDownloadBytes(
             for: spec,
             modelDir: installPath,
@@ -376,6 +396,22 @@ struct ModelPullPreflightAnalyzer {
         guard installed, spec.isManagedRuntimeReady(installPath, fileManager: fileManager) else { return nil }
         guard modelStoreURL == nil else { return installPath }
         return spec.managedRuntimeURL(fileManager: fileManager)
+    }
+
+    private func bindingAcknowledgesUsageTerms(
+        resolution: ModelResolver.Resolution?,
+        resolver: ModelResolver?
+    ) -> Bool {
+        guard let resolution,
+              resolution.source == .registeredBinding,
+              let resolver else {
+            return false
+        }
+        return resolver.locationCandidates(for: resolution.modelID).contains {
+            $0.kind == .registeredBinding
+                && $0.rootURL == resolution.rootURL
+                && $0.usageTermsAcknowledged
+        }
     }
 
     private func appendAggregateDiskDiagnostics(

--- a/Sources/MereRunCLI/Support/WorkflowRunner.swift
+++ b/Sources/MereRunCLI/Support/WorkflowRunner.swift
@@ -1732,7 +1732,10 @@ struct WorkflowRunner: @unchecked Sendable {
             }
         }
         return job.requirements.models.filter { modelIDs.contains($0.id) }.map { provenance in
-            let manifestURL = MereRunModelPaths.modelDir(provenance.id)
+            let modelRoot = ModelResolver.ModelID(rawValue: provenance.id)
+                .flatMap { ModelResolver(fileManager: fileManager).resolveIfPresent($0)?.rootURL }
+                ?? MereRunModelPaths.modelDir(provenance.id)
+            let manifestURL = modelRoot
                 .appendingPathComponent(MereRunModelManifest.filename)
             let manifestDigest = fileManager.fileExists(atPath: manifestURL.path)
                 ? try? ModelArtifactPin.fileSHA256(manifestURL)

--- a/Sources/MereRunCore/DeepseekV4Flash/DeepseekV4FlashGenerator.swift
+++ b/Sources/MereRunCore/DeepseekV4Flash/DeepseekV4FlashGenerator.swift
@@ -342,6 +342,12 @@ public actor DeepseekV4FlashGenerator: ChatGenerator {
             return aliasURL
         }
 
+        if let spec = ManagedModelCatalog.spec(for: DeepseekV4FlashResources.defaultModelId),
+           let registered = spec.managedRuntimeURL(),
+           FileManager.default.fileExists(atPath: registered.path) {
+            return registered
+        }
+
         // 2. Prefer the pinned 0731 artifact, retain older imatrix installs,
         //    then accept any other GGUF in the install directory.
         let modelDir = MereRunModelPaths.modelDir(DeepseekV4FlashResources.defaultModelId)

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -3313,6 +3313,15 @@ public extension ManagedModelSpec {
             let root = normalizedRootURL(managedInstallRootURL(), fileManager: fileManager)
             return validateRuntimeURL(root, fileManager: fileManager).isEmpty ? root : nil
         case .singleFile(let relativePath):
+            if let modelID,
+               let resolved = ModelResolver(fileManager: fileManager).resolveIfPresent(modelID),
+               let externalFile = Self.findFirstGGUFFile(
+                   in: resolved.rootURL,
+                   fileManager: fileManager
+               ),
+               validateRuntimeURL(externalFile, fileManager: fileManager).isEmpty {
+                return externalFile
+            }
             let aliasURL = MereRunModelPaths.resolveModelFile(relativePath: relativePath) { candidate in
                 self.validateRuntimeURL(candidate, fileManager: fileManager).isEmpty
             }

--- a/Sources/MereRunCore/MereRunModelPaths.swift
+++ b/Sources/MereRunCore/MereRunModelPaths.swift
@@ -36,6 +36,7 @@ public enum MereRunModelPaths {
     private static let resolvedBase = resolveApplicationSupportBase()
     private static let modelOverrideQueue = DispatchQueue(label: "MereRunModelPaths.modelsOverride")
     nonisolated(unsafe) private static var processModelsDirOverride: URL?
+    nonisolated(unsafe) private static var processOverrideIncludesRegisteredLocations = false
 
     public static var applicationSupportBase: URL {
         resolvedBase
@@ -46,9 +47,24 @@ public enum MereRunModelPaths {
         applicationSupportBase.appendingPathComponent("models", isDirectory: true)
     }
 
-    public static func setProcessModelsDirOverride(_ url: URL?) {
+    public static func setProcessModelsDirOverride(
+        _ url: URL?,
+        includeRegisteredLocations: Bool = false
+    ) {
         modelOverrideQueue.sync {
             processModelsDirOverride = url?.standardizedFileURL
+            processOverrideIncludesRegisteredLocations = url == nil ? false : includeRegisteredLocations
+        }
+    }
+
+    public static func includesRegisteredModelLocations(
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> Bool {
+        modelOverrideQueue.sync {
+            if processModelsDirOverride != nil {
+                return processOverrideIncludesRegisteredLocations
+            }
+            return environment[modelsDirEnvironmentKey]?.isEmpty != false
         }
     }
 
@@ -149,9 +165,7 @@ public enum MereRunModelPaths {
     /// Returns the primary `models/<id>` when no candidates validate.
     /// Callers that support nested layouts should return the nested URL from `validator`.
     public static func resolveModelDir(_ id: String, validator: (URL) -> Bool) -> URL {
-        let candidates = candidateModelRootsForLookup().map {
-            $0.appendingPathComponent(id, isDirectory: true)
-        }
+        let candidates = MereRunModelLocations.snapshot().candidates(for: id).map(\.rootURL)
 
         for candidate in candidates {
             if validator(candidate) {
@@ -249,7 +263,8 @@ public enum MereRunModelPaths {
     }
 
     private static func candidateModelRootsForLookup() -> [URL] {
-        let roots = [modelsDir.standardizedFileURL]
+        let snapshot = MereRunModelLocations.snapshot()
+        let roots = [snapshot.primaryRoot] + snapshot.searchRoots
 
         var seen: Set<String> = []
         var unique: [URL] = []

--- a/Sources/MereRunCore/MereRunModelValidator.swift
+++ b/Sources/MereRunCore/MereRunModelValidator.swift
@@ -339,6 +339,55 @@ public enum MereRunModelValidator {
         return MereRunModelValidationReport(rootURL: rootURL, manifest: manifest, warnings: warnings, errors: errors)
     }
 
+    /// Validates a directory whose canonical identity is supplied by an explicit
+    /// external binding rather than by a manifest stored beside the checkpoint.
+    public static func validateRegisteredBinding(
+        modelRoot rootURL: URL,
+        expectedModelID: String,
+        usageTermsAcknowledged: Bool,
+        fileManager: FileManager = .default
+    ) -> MereRunModelValidationReport {
+        if fileManager.fileExists(
+            atPath: rootURL.appendingPathComponent(MereRunModelManifest.filename).path
+        ) {
+            return validate(
+                modelRoot: rootURL,
+                expectedModelID: expectedModelID,
+                fileManager: fileManager
+            )
+        }
+
+        var isDirectory: ObjCBool = false
+        guard fileManager.fileExists(atPath: rootURL.path, isDirectory: &isDirectory),
+              isDirectory.boolValue else {
+            return MereRunModelValidationReport(
+                rootURL: rootURL,
+                manifest: nil,
+                errors: ["Missing model directory"]
+            )
+        }
+        guard let spec = ManagedModelCatalog.spec(for: expectedModelID) else {
+            return MereRunModelValidationReport(
+                rootURL: rootURL,
+                manifest: nil,
+                errors: ["Unknown canonical model id: \(expectedModelID)"]
+            )
+        }
+
+        var errors = spec.validationMessages(in: rootURL, fileManager: fileManager)
+        if spec.usageRestriction != nil, !usageTermsAcknowledged {
+            errors.append("Third-party model terms have not been acknowledged for this binding.")
+        }
+        return MereRunModelValidationReport(
+            rootURL: rootURL,
+            manifest: nil,
+            warnings: [
+                "Identity is supplied by the explicit external binding; no manifest was written to external storage.",
+            ],
+            errors: errors
+        )
+    }
+
     public static func assertValid(
         modelRoot rootURL: URL,
         expectedModelID: String? = nil,

--- a/Sources/MereRunCore/ModelLocationRegistry.swift
+++ b/Sources/MereRunCore/ModelLocationRegistry.swift
@@ -1,0 +1,262 @@
+import Foundation
+
+/// Persisted read-only model locations that augment mere.run's writable primary store.
+///
+/// Search roots use the canonical `<root>/<model-id>` layout. Bindings map a canonical
+/// model id to an arbitrary existing directory without copying files or writing a
+/// manifest into externally managed storage.
+public struct ModelLocationRegistry: Codable, Equatable, Sendable {
+    public static let currentSchemaVersion = 1
+
+    public struct Binding: Codable, Equatable, Hashable, Sendable {
+        public let modelID: String
+        public let path: String
+        public let usageTermsAcknowledged: Bool
+
+        public init(modelID: String, path: String, usageTermsAcknowledged: Bool = false) {
+            self.modelID = modelID
+            self.path = path
+            self.usageTermsAcknowledged = usageTermsAcknowledged
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case modelID = "model_id"
+            case path
+            case usageTermsAcknowledged = "usage_terms_acknowledged"
+        }
+    }
+
+    public var schemaVersion: Int
+    public var searchRoots: [String]
+    public var bindings: [Binding]
+
+    public init(
+        schemaVersion: Int = Self.currentSchemaVersion,
+        searchRoots: [String] = [],
+        bindings: [Binding] = []
+    ) {
+        self.schemaVersion = schemaVersion
+        self.searchRoots = searchRoots
+        self.bindings = bindings
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case schemaVersion = "schema_version"
+        case searchRoots = "search_roots"
+        case bindings
+    }
+
+    public static var fileURL: URL {
+        MereRunModelPaths.applicationSupportBase
+            .appendingPathComponent("model_locations.json", isDirectory: false)
+    }
+
+    public static func load(from url: URL = fileURL, fileManager: FileManager = .default) throws -> Self {
+        guard fileManager.fileExists(atPath: url.path) else {
+            return Self()
+        }
+        let data = try Data(contentsOf: url)
+        let registry = try JSONDecoder().decode(Self.self, from: data)
+        guard registry.schemaVersion == currentSchemaVersion else {
+            throw CocoaError(.fileReadCorruptFile)
+        }
+        return registry.normalized()
+    }
+
+    public func save(to url: URL = fileURL, fileManager: FileManager = .default) throws {
+        let normalized = normalized()
+        try fileManager.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        try encoder.encode(normalized).write(to: url, options: .atomic)
+        try? fileManager.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
+    }
+
+    public mutating func addSearchRoot(_ url: URL) {
+        let path = Self.pathKey(url)
+        searchRoots.removeAll { Self.pathKey(URL(fileURLWithPath: $0)) == path }
+        searchRoots.append(path)
+    }
+
+    @discardableResult
+    public mutating func removeSearchRoot(_ url: URL) -> Bool {
+        let path = Self.pathKey(url)
+        let oldCount = searchRoots.count
+        searchRoots.removeAll { Self.pathKey(URL(fileURLWithPath: $0)) == path }
+        return searchRoots.count != oldCount
+    }
+
+    public mutating func addBinding(
+        modelID: String,
+        url: URL,
+        usageTermsAcknowledged: Bool
+    ) {
+        let normalizedID = modelID.lowercased()
+        let path = Self.pathKey(url)
+        bindings.removeAll {
+            $0.modelID.lowercased() == normalizedID
+                && Self.pathKey(URL(fileURLWithPath: $0.path)) == path
+        }
+        bindings.append(
+            Binding(
+                modelID: normalizedID,
+                path: path,
+                usageTermsAcknowledged: usageTermsAcknowledged
+            )
+        )
+    }
+
+    @discardableResult
+    public mutating func removeBindings(modelID: String, url: URL? = nil) -> Int {
+        let normalizedID = modelID.lowercased()
+        let path = url.map(Self.pathKey)
+        let oldCount = bindings.count
+        bindings.removeAll { binding in
+            guard binding.modelID.lowercased() == normalizedID else { return false }
+            guard let path else { return true }
+            return Self.pathKey(URL(fileURLWithPath: binding.path)) == path
+        }
+        return oldCount - bindings.count
+    }
+
+    public func normalized() -> Self {
+        var rootPaths: [String] = []
+        var seenRoots: Set<String> = []
+        for rawPath in searchRoots {
+            let path = Self.pathKey(URL(fileURLWithPath: rawPath))
+            if seenRoots.insert(path).inserted {
+                rootPaths.append(path)
+            }
+        }
+
+        var normalizedBindings: [Binding] = []
+        var seenBindings: Set<String> = []
+        for binding in bindings {
+            let id = binding.modelID.lowercased()
+            let path = Self.pathKey(URL(fileURLWithPath: binding.path))
+            if seenBindings.insert("\(id)\u{0}\(path)").inserted {
+                normalizedBindings.append(
+                    Binding(
+                        modelID: id,
+                        path: path,
+                        usageTermsAcknowledged: binding.usageTermsAcknowledged
+                    )
+                )
+            }
+        }
+
+        return Self(searchRoots: rootPaths, bindings: normalizedBindings)
+    }
+
+    private static func pathKey(_ url: URL) -> String {
+        let expanded = (url.path as NSString).expandingTildeInPath
+        return URL(fileURLWithPath: expanded).standardizedFileURL.path
+    }
+}
+
+public enum ModelLocationKind: String, Codable, Hashable, Sendable {
+    case primaryStore = "primary_store"
+    case registeredBinding = "registered_binding"
+    case registeredSearchRoot = "registered_search_root"
+
+    public var isExternallyManaged: Bool {
+        self != .primaryStore
+    }
+}
+
+public struct ModelLocationCandidate: Hashable, Sendable {
+    public let modelID: String
+    public let rootURL: URL
+    public let kind: ModelLocationKind
+    public let catalogRootURL: URL?
+    public let usageTermsAcknowledged: Bool
+
+    public init(
+        modelID: String,
+        rootURL: URL,
+        kind: ModelLocationKind,
+        catalogRootURL: URL? = nil,
+        usageTermsAcknowledged: Bool = false
+    ) {
+        self.modelID = modelID
+        self.rootURL = rootURL.standardizedFileURL
+        self.kind = kind
+        self.catalogRootURL = catalogRootURL?.standardizedFileURL
+        self.usageTermsAcknowledged = usageTermsAcknowledged
+    }
+}
+
+public struct ModelLocationSnapshot: Equatable, Sendable {
+    public let primaryRoot: URL
+    public let searchRoots: [URL]
+    public let bindings: [ModelLocationRegistry.Binding]
+
+    public init(
+        primaryRoot: URL,
+        searchRoots: [URL] = [],
+        bindings: [ModelLocationRegistry.Binding] = []
+    ) {
+        self.primaryRoot = primaryRoot.standardizedFileURL
+        self.searchRoots = searchRoots.map(\.standardizedFileURL)
+        self.bindings = bindings
+    }
+
+    public func candidates(for modelID: String) -> [ModelLocationCandidate] {
+        let normalizedID = modelID.lowercased()
+        var candidates = [
+            ModelLocationCandidate(
+                modelID: normalizedID,
+                rootURL: primaryRoot.appendingPathComponent(modelID, isDirectory: true),
+                kind: .primaryStore,
+                catalogRootURL: primaryRoot
+            ),
+        ]
+
+        candidates += bindings
+            .filter { $0.modelID.lowercased() == normalizedID }
+            .map {
+                ModelLocationCandidate(
+                    modelID: normalizedID,
+                    rootURL: URL(fileURLWithPath: $0.path, isDirectory: true),
+                    kind: .registeredBinding,
+                    usageTermsAcknowledged: $0.usageTermsAcknowledged
+                )
+            }
+
+        candidates += searchRoots.map { root in
+            ModelLocationCandidate(
+                modelID: normalizedID,
+                rootURL: root.appendingPathComponent(modelID, isDirectory: true),
+                kind: .registeredSearchRoot,
+                catalogRootURL: root
+            )
+        }
+
+        var seen: Set<String> = []
+        return candidates.filter { seen.insert($0.rootURL.standardizedFileURL.path).inserted }
+    }
+}
+
+public enum MereRunModelLocations {
+    public static func snapshot(
+        fileManager: FileManager = .default,
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        defaults: UserDefaults = .standard,
+        registryURL: URL = ModelLocationRegistry.fileURL
+    ) -> ModelLocationSnapshot {
+        let store = MereRunModelPaths.modelStoreResolution(
+            fileManager: fileManager,
+            environment: environment,
+            defaults: defaults
+        )
+        guard MereRunModelPaths.includesRegisteredModelLocations(environment: environment) else {
+            return ModelLocationSnapshot(primaryRoot: store.activeModelsDir)
+        }
+        let registry = (try? ModelLocationRegistry.load(from: registryURL, fileManager: fileManager)) ?? .init()
+        return ModelLocationSnapshot(
+            primaryRoot: store.activeModelsDir,
+            searchRoots: registry.searchRoots.map { URL(fileURLWithPath: $0, isDirectory: true) },
+            bindings: registry.bindings
+        )
+    }
+}

--- a/Sources/MereRunCore/ModelResolver.swift
+++ b/Sources/MereRunCore/ModelResolver.swift
@@ -129,17 +129,32 @@ public struct ModelResolver {
     public enum Source: String, Hashable, Sendable {
         /// `.../models/<id>` under the configured local mere.run model store.
         case localModelStore
+        /// An explicit canonical-model-id to directory binding.
+        case registeredBinding
+        /// A canonical `<root>/<model-id>` directory under a registered read-only root.
+        case registeredSearchRoot
     }
 
     public struct Resolution: Hashable, Sendable {
         public let modelID: ModelID
         public let rootURL: URL
         public let source: Source
+        public let catalogRootURL: URL?
 
-        public init(modelID: ModelID, rootURL: URL, source: Source) {
+        public init(
+            modelID: ModelID,
+            rootURL: URL,
+            source: Source,
+            catalogRootURL: URL? = nil
+        ) {
             self.modelID = modelID
             self.rootURL = rootURL
             self.source = source
+            self.catalogRootURL = catalogRootURL
+        }
+
+        public var isExternallyManaged: Bool {
+            source != .localModelStore
         }
     }
 
@@ -167,13 +182,18 @@ public struct ModelResolver {
     }
 
     private let fileManager: FileManager
+    private let locations: ModelLocationSnapshot
 
     public init(
         fileManager: FileManager = .default,
-        environment: [String: String] = ProcessInfo.processInfo.environment
+        environment: [String: String] = ProcessInfo.processInfo.environment,
+        locations: ModelLocationSnapshot? = nil
     ) {
         self.fileManager = fileManager
-        _ = environment
+        self.locations = locations ?? MereRunModelLocations.snapshot(
+            fileManager: fileManager,
+            environment: environment
+        )
     }
 
     public func resolve(_ modelID: ModelID) throws -> Resolution {
@@ -187,7 +207,12 @@ public struct ModelResolver {
                   let resolved = resolveDirect(fallbackModelID) else {
                 continue
             }
-            return Resolution(modelID: modelID, rootURL: resolved.rootURL, source: resolved.source)
+            return Resolution(
+                modelID: modelID,
+                rootURL: resolved.rootURL,
+                source: resolved.source,
+                catalogRootURL: resolved.catalogRootURL
+            )
         }
 
         let searchedIDs = [modelID] + (spec?.resolutionFallbackIDs.compactMap(ModelID.init(rawValue:)) ?? [])
@@ -202,8 +227,12 @@ public struct ModelResolver {
         try? resolve(modelID)
     }
 
-    private func candidateModelRoots() -> [URL] {
-        [MereRunModelPaths.modelsDir.standardizedFileURL]
+    /// Ordered locations considered for a canonical model id.
+    ///
+    /// The writable primary store is always first, followed by explicit bindings
+    /// and then canonical directories under registered search roots.
+    public func locationCandidates(for modelID: ModelID) -> [ModelLocationCandidate] {
+        locations.candidates(for: modelID.rawValue)
     }
 
     private func resolveDirect(_ modelID: ModelID) -> Resolution? {
@@ -211,26 +240,31 @@ public struct ModelResolver {
             return nil
         }
 
-        for modelsRoot in candidateModelRoots() {
-            let modelRoot = modelsRoot.appendingPathComponent(modelID.rawValue, isDirectory: true)
-            if isValidModelRoot(modelRoot, spec: spec, expectedModelID: modelID) {
-                return Resolution(modelID: modelID, rootURL: modelRoot, source: .localModelStore)
+        for candidate in locations.candidates(for: modelID.rawValue) {
+            if isValidModelRoot(candidate, spec: spec, expectedModelID: modelID) {
+                return Resolution(
+                    modelID: modelID,
+                    rootURL: candidate.rootURL,
+                    source: source(for: candidate.kind),
+                    catalogRootURL: candidate.catalogRootURL
+                )
             }
         }
         return nil
     }
 
     private func searchedPaths(for modelIDs: [ModelID]) -> [URL] {
-        candidateModelRoots().flatMap { modelsRoot in
-            modelIDs.map { modelsRoot.appendingPathComponent($0.rawValue, isDirectory: true) }
+        modelIDs.flatMap { modelID in
+            locations.candidates(for: modelID.rawValue).map(\.rootURL)
         }
     }
 
     private func isValidModelRoot(
-        _ url: URL,
+        _ candidate: ModelLocationCandidate,
         spec: ManagedModelSpec,
         expectedModelID: ModelID? = nil
     ) -> Bool {
+        let url = candidate.rootURL
         var isDir: ObjCBool = false
         guard fileManager.fileExists(atPath: url.path, isDirectory: &isDir), isDir.boolValue else {
             return false
@@ -240,13 +274,33 @@ public struct ModelResolver {
             return spec.isManagedRuntimeReady(url, fileManager: fileManager)
         }
 
-        let manifestURL = url.appendingPathComponent(MereRunModelManifest.filename)
-        if fileManager.fileExists(atPath: manifestURL.path),
-           let loaded = try? MereRunModelManifest.loadRequired(from: url, fileManager: fileManager),
-           loaded.id == expectedModelID.rawValue {
+        let manifest: MereRunModelManifest?
+        do {
+            manifest = try MereRunModelManifest.loadIfPresent(from: url, fileManager: fileManager)
+        } catch {
+            return false
+        }
+        if let manifest {
+            guard manifest.id == expectedModelID.rawValue else { return false }
+            if candidate.kind.isExternallyManaged,
+               spec.usageRestriction != nil,
+               manifest.usageTermsAcknowledged != true,
+               !candidate.usageTermsAcknowledged {
+                return false
+            }
             return spec.isManagedRuntimeReady(url, fileManager: fileManager)
         }
 
-        return false
+        guard candidate.kind == .registeredBinding else { return false }
+        guard spec.usageRestriction == nil || candidate.usageTermsAcknowledged else { return false }
+        return spec.isManagedRuntimeReady(url, fileManager: fileManager)
+    }
+
+    private func source(for kind: ModelLocationKind) -> Source {
+        switch kind {
+        case .primaryStore: .localModelStore
+        case .registeredBinding: .registeredBinding
+        case .registeredSearchRoot: .registeredSearchRoot
+        }
     }
 }

--- a/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
+++ b/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
@@ -72,6 +72,29 @@ final class CLIModelStoreBootstrapTests: XCTestCase {
         XCTAssertEqual(path, "/persisted/models")
     }
 
+    func testBootstrapIncludesRegisteredLocationsForPersistedPrimaryStore() {
+        let defaults = makeDefaults()
+        defaults.set("/persisted/models", forKey: MereRunModelPaths.modelStorageActivePathDefaultsKey)
+
+        CLIModelStoreBootstrap.bootstrap(
+            arguments: ["mere.run", "model", "list"],
+            environment: [:],
+            defaults: defaults
+        )
+
+        XCTAssertTrue(MereRunModelPaths.includesRegisteredModelLocations(environment: [:]))
+    }
+
+    func testBootstrapKeepsExplicitModelsRootIsolated() {
+        CLIModelStoreBootstrap.bootstrap(
+            arguments: ["mere.run", "--models-root", "/isolated/models", "model", "list"],
+            environment: [:],
+            defaults: makeDefaults()
+        )
+
+        XCTAssertFalse(MereRunModelPaths.includesRegisteredModelLocations(environment: [:]))
+    }
+
     func testResolvedOverridePathIgnoresLegacyEnvironmentVariable() {
         let path = CLIModelStoreBootstrap.resolvedOverridePath(
             arguments: ["mere.run", "model", "list"],

--- a/Tests/MereRunCLITests/ModelPullCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/ModelPullCommandParsingTests.swift
@@ -603,6 +603,57 @@ final class ModelPullCommandParsingTests: XCTestCase {
         XCTAssertTrue(forced.diagnostics.contains { $0.id == "hub_cache_space_insufficient" })
     }
 
+    func testPreflightTreatsExternalBindingAsInstalled() throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let modelStore = root.appendingPathComponent("models", isDirectory: true)
+        let hubCache = root.appendingPathComponent("hub", isDirectory: true)
+        let external = root.appendingPathComponent("external-zimage", isDirectory: true)
+        try writeMinimalExternalZImage(at: external)
+        let locations = ModelLocationSnapshot(
+            primaryRoot: modelStore,
+            bindings: [
+                .init(modelID: ModelResolver.ModelID.zetaNano.rawValue, path: external.path),
+            ]
+        )
+
+        let envelope = try ModelPull.parse([
+            ModelResolver.ModelID.zetaNano.rawValue,
+            "--allow-unsupported",
+            "--preflight",
+            "--json",
+        ]).makePreflightEnvelope(
+            hubCacheURL: hubCache,
+            modelStoreURL: modelStore,
+            modelLocations: locations,
+            diskAvailableBytes: { _ in 100 * ModelPullDiskPreflight.bytesPerGiB }
+        )
+
+        XCTAssertEqual(envelope.result.models.first?.status, "installed")
+        XCTAssertEqual(envelope.result.models.first?.installed, true)
+        XCTAssertEqual(envelope.result.models.first?.runtimePath, external.path)
+        XCTAssertEqual(envelope.result.models.first?.willDownload, false)
+    }
+
+    private func writeMinimalExternalZImage(at root: URL) throws {
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        try Data("{}".utf8).write(to: root.appendingPathComponent("model_index.json"))
+        for component in ["text_encoder", "transformer", "vae"] {
+            let directory = root.appendingPathComponent(component, isDirectory: true)
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+            try Data("{}".utf8).write(to: directory.appendingPathComponent("config.json"))
+            try Data().write(to: directory.appendingPathComponent("model.safetensors"))
+        }
+        let tokenizer = root.appendingPathComponent("tokenizer", isDirectory: true)
+        try FileManager.default.createDirectory(at: tokenizer, withIntermediateDirectories: true)
+        for filename in ["tokenizer.json", "tokenizer_config.json", "merges.txt", "vocab.json"] {
+            try Data("{}".utf8).write(to: tokenizer.appendingPathComponent(filename))
+        }
+        let scheduler = root.appendingPathComponent("scheduler", isDirectory: true)
+        try FileManager.default.createDirectory(at: scheduler, withIntermediateDirectories: true)
+        try Data("{}".utf8).write(to: scheduler.appendingPathComponent("scheduler_config.json"))
+    }
+
     private func makeTemporaryDirectory() throws -> URL {
         let temp = FileManager.default.temporaryDirectory
             .appendingPathComponent("mere-run-model-pull-preflight-\(UUID().uuidString)", isDirectory: true)

--- a/Tests/MereRunCLITests/ModelStorageCommandTests.swift
+++ b/Tests/MereRunCLITests/ModelStorageCommandTests.swift
@@ -7,6 +7,31 @@ final class ModelStorageCommandTests: XCTestCase {
         let names = Set(Model.configuration.subcommands.map { $0.configuration.commandName })
         XCTAssertTrue(names.contains("storage"))
         XCTAssertTrue(names.contains("gc"))
+        XCTAssertTrue(names.contains("location"))
+    }
+
+    func testModelLocationSubcommandsAndFlagsParse() throws {
+        let names = Set(ModelLocation.configuration.subcommands.map { $0.configuration.commandName })
+        XCTAssertEqual(names, ["list", "add", "remove", "bind", "unbind"])
+        XCTAssertTrue(try ModelLocationList.parse(["--json"]).json)
+        XCTAssertEqual(try ModelLocationAdd.parse(["/Volumes/Models"]).path, "/Volumes/Models")
+        XCTAssertEqual(try ModelLocationRemove.parse(["/Volumes/Models"]).path, "/Volumes/Models")
+
+        let binding = try ModelLocationBind.parse([
+            "image-zimage-nano",
+            "/Volumes/Models/ZImage",
+            "--accept-model-license",
+        ])
+        XCTAssertEqual(binding.modelID, "image-zimage-nano")
+        XCTAssertEqual(binding.path, "/Volumes/Models/ZImage")
+        XCTAssertTrue(binding.acceptModelLicense)
+
+        let unbind = try ModelLocationUnbind.parse([
+            "image-zimage-nano",
+            "/Volumes/Models/ZImage",
+        ])
+        XCTAssertEqual(unbind.modelID, "image-zimage-nano")
+        XCTAssertEqual(unbind.path, "/Volumes/Models/ZImage")
     }
 
     func testStorageAndGarbageCollectionFlagsParse() throws {

--- a/Tests/MereRunCoreTests/MereRunModelPathsTests.swift
+++ b/Tests/MereRunCoreTests/MereRunModelPathsTests.swift
@@ -61,6 +61,18 @@ final class MereRunModelPathsTests: XCTestCase {
         )
     }
 
+    func testProcessOverrideCanOptIntoRegisteredLocations() throws {
+        let customRoot = try makeTemporaryDirectory(named: "mererun-models-with-locations")
+        defer { try? FileManager.default.removeItem(at: customRoot) }
+
+        MereRunModelPaths.setProcessModelsDirOverride(
+            customRoot,
+            includeRegisteredLocations: true
+        )
+
+        XCTAssertTrue(MereRunModelPaths.includesRegisteredModelLocations(environment: [:]))
+    }
+
     func testModelStoreResolutionUsesMissingProcessOverrideWithoutFallback() throws {
         let temp = try makeTemporaryDirectory(named: "mererun-models-missing-process-parent")
         defer { try? FileManager.default.removeItem(at: temp) }

--- a/Tests/MereRunCoreTests/ModelLocationRegistryTests.swift
+++ b/Tests/MereRunCoreTests/ModelLocationRegistryTests.swift
@@ -1,0 +1,211 @@
+import Foundation
+import XCTest
+@testable import MereRunCore
+
+final class ModelLocationRegistryTests: XCTestCase {
+    func testRegistryRoundTripsNormalizedOrder() throws {
+        let temp = try TestFileSystem.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: temp) }
+        let registryURL = temp.appendingPathComponent("model_locations.json")
+        let firstRoot = temp.appendingPathComponent("first", isDirectory: true)
+        let secondRoot = temp.appendingPathComponent("second", isDirectory: true)
+        let binding = temp.appendingPathComponent("arbitrary-name", isDirectory: true)
+
+        var registry = ModelLocationRegistry()
+        registry.addSearchRoot(firstRoot)
+        registry.addSearchRoot(secondRoot)
+        registry.addSearchRoot(firstRoot)
+        registry.addBinding(modelID: "IMAGE-ZIMAGE-NANO", url: binding, usageTermsAcknowledged: false)
+        registry.addBinding(modelID: "image-zimage-nano", url: binding, usageTermsAcknowledged: true)
+        try registry.save(to: registryURL)
+
+        let loaded = try ModelLocationRegistry.load(from: registryURL)
+        XCTAssertEqual(loaded.searchRoots, [secondRoot.path, firstRoot.path])
+        XCTAssertEqual(loaded.bindings, [
+            .init(
+                modelID: "image-zimage-nano",
+                path: binding.path,
+                usageTermsAcknowledged: true
+            ),
+        ])
+    }
+
+    func testExplicitBindingResolvesManifestlessDirectory() throws {
+        let temp = try TestFileSystem.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: temp) }
+        let primary = temp.appendingPathComponent("primary", isDirectory: true)
+        let external = temp.appendingPathComponent("LTX-style-arbitrary-name", isDirectory: true)
+        try writeMinimalImageModel(at: external, includeManifest: false)
+
+        let locations = ModelLocationSnapshot(
+            primaryRoot: primary,
+            bindings: [
+                .init(modelID: ModelResolver.ModelID.zetaNano.rawValue, path: external.path),
+            ]
+        )
+        let resolved = try ModelResolver(locations: locations).resolve(.zetaNano)
+
+        XCTAssertEqual(resolved.rootURL, external.standardizedFileURL)
+        XCTAssertEqual(resolved.source, .registeredBinding)
+        XCTAssertTrue(resolved.isExternallyManaged)
+    }
+
+    func testExplicitBindingResolvesAcceptedManifestlessLTX25Checkpoint() throws {
+        let temp = try TestFileSystem.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: temp) }
+        let primary = temp.appendingPathComponent("primary", isDirectory: true)
+        let external = temp.appendingPathComponent("LTX-2.5", isDirectory: true)
+        try TestFileSystem.createDirectory(external)
+        for relativePath in LTX25Resources.requiredRelativePaths {
+            let url = external.appendingPathComponent(relativePath)
+            try TestFileSystem.createDirectory(url.deletingLastPathComponent())
+            try TestFileSystem.writeFile(url, contents: Data())
+        }
+
+        let unacceptedLocations = ModelLocationSnapshot(
+            primaryRoot: primary,
+            bindings: [
+                .init(
+                    modelID: ModelResolver.ModelID.ltxVideo25DistilledBF16.rawValue,
+                    path: external.path
+                ),
+            ]
+        )
+        XCTAssertThrowsError(
+            try ModelResolver(locations: unacceptedLocations).resolve(.ltxVideo25DistilledBF16)
+        )
+
+        let acceptedLocations = ModelLocationSnapshot(
+            primaryRoot: primary,
+            bindings: [
+                .init(
+                    modelID: ModelResolver.ModelID.ltxVideo25DistilledBF16.rawValue,
+                    path: external.path,
+                    usageTermsAcknowledged: true
+                ),
+            ]
+        )
+        let resolved = try ModelResolver(locations: acceptedLocations).resolve(.ltxVideo25DistilledBF16)
+
+        XCTAssertEqual(resolved.rootURL, external.standardizedFileURL)
+        XCTAssertEqual(resolved.source, .registeredBinding)
+        XCTAssertTrue(resolved.isExternallyManaged)
+    }
+
+    func testPrimaryStoreWinsOverExternalLocations() throws {
+        let temp = try TestFileSystem.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: temp) }
+        let primary = temp.appendingPathComponent("primary", isDirectory: true)
+        let primaryModel = primary.appendingPathComponent(
+            ModelResolver.ModelID.zetaNano.rawValue,
+            isDirectory: true
+        )
+        let external = temp.appendingPathComponent("external", isDirectory: true)
+        try writeMinimalImageModel(at: primaryModel, includeManifest: true)
+        try writeMinimalImageModel(at: external, includeManifest: false)
+
+        let locations = ModelLocationSnapshot(
+            primaryRoot: primary,
+            bindings: [
+                .init(modelID: ModelResolver.ModelID.zetaNano.rawValue, path: external.path),
+            ]
+        )
+        let resolved = try ModelResolver(locations: locations).resolve(.zetaNano)
+
+        XCTAssertEqual(resolved.rootURL, primaryModel.standardizedFileURL)
+        XCTAssertEqual(resolved.source, .localModelStore)
+        XCTAssertFalse(resolved.isExternallyManaged)
+    }
+
+    func testSearchRootUsesCanonicalDirectoryAndManifest() throws {
+        let temp = try TestFileSystem.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: temp) }
+        let primary = temp.appendingPathComponent("primary", isDirectory: true)
+        let searchRoot = temp.appendingPathComponent("catalog", isDirectory: true)
+        let modelRoot = searchRoot.appendingPathComponent(
+            ModelResolver.ModelID.zetaNano.rawValue,
+            isDirectory: true
+        )
+        try writeMinimalImageModel(at: modelRoot, includeManifest: true)
+
+        let resolved = try ModelResolver(
+            locations: .init(primaryRoot: primary, searchRoots: [searchRoot])
+        ).resolve(.zetaNano)
+
+        XCTAssertEqual(resolved.rootURL, modelRoot.standardizedFileURL)
+        XCTAssertEqual(resolved.source, .registeredSearchRoot)
+        XCTAssertEqual(resolved.catalogRootURL, searchRoot.standardizedFileURL)
+    }
+
+    func testExplicitBindingResolvesSingleFileModelDirectory() throws {
+        let temp = try TestFileSystem.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: temp) }
+        let external = temp.appendingPathComponent("q36-checkpoint", isDirectory: true)
+        try TestFileSystem.createDirectory(external)
+        try TestFileSystem.writeFile(
+            external.appendingPathComponent("checkpoint.gguf"),
+            contents: Data()
+        )
+        let locations = ModelLocationSnapshot(
+            primaryRoot: temp.appendingPathComponent("primary", isDirectory: true),
+            bindings: [
+                .init(modelID: ModelResolver.ModelID.q36NanoGGUF.rawValue, path: external.path),
+            ]
+        )
+
+        let resolved = try ModelResolver(locations: locations).resolve(.q36NanoGGUF)
+
+        XCTAssertEqual(resolved.rootURL, external.standardizedFileURL)
+        XCTAssertEqual(resolved.source, .registeredBinding)
+    }
+
+    func testExplicitBindingRejectsMalformedManifest() throws {
+        let temp = try TestFileSystem.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: temp) }
+        let external = temp.appendingPathComponent("malformed", isDirectory: true)
+        try writeMinimalImageModel(at: external, includeManifest: false)
+        try TestFileSystem.writeFile(
+            external.appendingPathComponent(MereRunModelManifest.filename),
+            contents: Data("not-json".utf8)
+        )
+        let locations = ModelLocationSnapshot(
+            primaryRoot: temp.appendingPathComponent("primary", isDirectory: true),
+            bindings: [
+                .init(modelID: ModelResolver.ModelID.zetaNano.rawValue, path: external.path),
+            ]
+        )
+
+        XCTAssertThrowsError(try ModelResolver(locations: locations).resolve(.zetaNano))
+    }
+
+    private func writeMinimalImageModel(at root: URL, includeManifest: Bool) throws {
+        try TestFileSystem.createDirectory(root)
+        if includeManifest {
+            try MereRunModelManifest.template(
+                for: .zetaNano,
+                createdAt: Date(timeIntervalSince1970: 0)
+            ).write(to: root)
+        }
+        try TestFileSystem.writeFile(root.appendingPathComponent("model_index.json"), contents: Data("{}".utf8))
+
+        for component in ["text_encoder", "transformer", "vae"] {
+            let directory = root.appendingPathComponent(component, isDirectory: true)
+            try TestFileSystem.createDirectory(directory)
+            try TestFileSystem.writeFile(directory.appendingPathComponent("config.json"), contents: Data("{}".utf8))
+            try TestFileSystem.writeFile(directory.appendingPathComponent("model.safetensors"), contents: Data())
+        }
+
+        let tokenizer = root.appendingPathComponent("tokenizer", isDirectory: true)
+        try TestFileSystem.createDirectory(tokenizer)
+        for filename in ["tokenizer.json", "tokenizer_config.json", "merges.txt", "vocab.json"] {
+            try TestFileSystem.writeFile(tokenizer.appendingPathComponent(filename), contents: Data("{}".utf8))
+        }
+
+        let scheduler = root.appendingPathComponent("scheduler", isDirectory: true)
+        try TestFileSystem.createDirectory(scheduler)
+        try TestFileSystem.writeFile(
+            scheduler.appendingPathComponent("scheduler_config.json"),
+            contents: Data("{}".utf8)
+        )
+    }
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -144,8 +144,14 @@ Public tree:
   - `mere.run run fetch` — Fetch a remote graph run into the standard local run-directory format.
   - `mere.run run cancel` — Cancel a graph run.
   - `mere.run run retry` — Retry an immutable relay graph job.
-- [`mere.run model`](/runtime/model-management) — List, pull, remove, inspect, optimize, and clean up models.
+- [`mere.run model`](/runtime/model-management) — List, pull, locate, remove, inspect, optimize, and clean up models.
   - `mere.run model list` — List all known models with install status.
+  - `mere.run model location` — Manage read-only model catalog locations.
+    - `mere.run model location list` — List the writable store, search roots, and explicit bindings.
+    - `mere.run model location add` — Register a read-only root containing canonical <model-id> directories.
+    - `mere.run model location remove` — Unregister a search root without deleting its files.
+    - `mere.run model location bind` — Bind a canonical model id to an arbitrary read-only directory.
+    - `mere.run model location unbind` — Remove explicit bindings without deleting model files.
   - `mere.run model pull` — Download a managed model into the local model store.
   - `mere.run model remove` — Remove a model from the local model store.
   - `mere.run model storage` — Inspect physical model storage, sharing, and reclaimable space.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -148,7 +148,7 @@ Public tree:
   - `mere.run model list` — List all known models with install status.
   - `mere.run model location` — Manage read-only model catalog locations.
     - `mere.run model location list` — List the writable store, search roots, and explicit bindings.
-    - `mere.run model location add` — Register a read-only root containing canonical <model-id> directories.
+    - `mere.run model location add` — Register a read-only root containing directories named for canonical model IDs.
     - `mere.run model location remove` — Unregister a search root without deleting its files.
     - `mere.run model location bind` — Bind a canonical model id to an arbitrary read-only directory.
     - `mere.run model location unbind` — Remove explicit bindings without deleting model files.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -155,7 +155,7 @@ itself, so it always matches the binary you just built:
 | [`mere.run graph`](/workflows) | Validate, materialize, run, and submit portable workflow graphs. |
 | [`mere.run executor`](/workflows#executor-profiles) | Manage local, SSH, and relay workflow executors. |
 | [`mere.run run`](/workflows#run-directories) | Inspect durable mere.run workflow reports and run directories. |
-| [`mere.run model`](/runtime/model-management) | List, pull, remove, inspect, optimize, and clean up models. |
+| [`mere.run model`](/runtime/model-management) | List, pull, locate, remove, inspect, optimize, and clean up models. |
 | [`mere.run adapter`](/runtime/model-management) | List and pull verified LoRA adapters. |
 | [`mere.run status`](/runtime/model-management) | Show local server, loaded model, and installed model status. |
 | [`mere.run gate`](/gate) | Run the end-to-end quality gate against installed models. |

--- a/docs/index.md
+++ b/docs/index.md
@@ -78,7 +78,7 @@ links to the page that owns that command.
 | [`mere.run graph`](/workflows) | Validate, materialize, run, and submit portable workflow graphs. |
 | [`mere.run executor`](/workflows#executor-profiles) | Manage local, SSH, and relay workflow executors. |
 | [`mere.run run`](/workflows#run-directories) | Inspect durable mere.run workflow reports and run directories. |
-| [`mere.run model`](/runtime/model-management) | List, pull, remove, inspect, optimize, and clean up models. |
+| [`mere.run model`](/runtime/model-management) | List, pull, locate, remove, inspect, optimize, and clean up models. |
 | [`mere.run adapter`](/runtime/model-management) | List and pull verified LoRA adapters. |
 | [`mere.run status`](/runtime/model-management) | Show local server, loaded model, and installed model status. |
 | [`mere.run gate`](/gate) | Run the end-to-end quality gate against installed models. |

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -1,10 +1,12 @@
 # Model Sources
 
-Weights reach `mere.run` in exactly two ways:
+Weights reach `mere.run` in three local-first ways:
 
 1. **Managed pulls** — cataloged Hugging Face snapshots installed into the local
    model store by `mere.run model pull`
-2. **Local paths** — a directory you point at yourself with `--model`,
+2. **Registered locations** — read-only search roots or explicit canonical-ID
+   bindings managed by `mere.run model location`
+3. **Local paths** — a directory you point at yourself with `--model`,
    `--model-root`, or the command's equivalent option
 
 There is no private model archive, no credentialed mirror, and no central host
@@ -18,6 +20,16 @@ The canonical local model store is:
 ```
 
 Override that with `MERERUN_MODELS_DIR` or `--models-root`.
+
+Registered locations augment the normal persisted primary store without
+copying payloads or creating symlinks. Search roots use
+`<root>/<canonical-model-id>/` and require each model's managed manifest.
+Explicit bindings can point a canonical ID at an arbitrarily named directory;
+mere.run validates the checkpoint at registration time and stores its identity
+in `~/Library/Application Support/MereRun/model_locations.json` without writing
+metadata into the external directory. Externally registered files remain
+read-only and are outside `model remove`, `model gc`, manifest repair, and
+storage-reclamation ownership.
 
 ## Canonical Managed Model IDs
 

--- a/docs/runtime/model-management.md
+++ b/docs/runtime/model-management.md
@@ -1,6 +1,6 @@
 # Model Management
 
-One store, canonical IDs, and honest accounting. `mere.run` checks whether this
+One writable store, a unified catalog, canonical IDs, and honest accounting. `mere.run` checks whether this
 machine can run a model before it spends your bandwidth on it, reports what a
 model actually costs on disk once shared payloads are counted once, and shows
 exactly what is safe to delete.
@@ -11,6 +11,7 @@ exactly what is safe to delete.
 | --- | --- |
 | `mere.run model capabilities` | Show which managed models this machine can run. |
 | `mere.run model list` | List all known models with install status. |
+| `mere.run model location` | Register read-only catalog roots and explicit model-directory bindings. |
 | `mere.run model pull` | Download a managed model into the local model store. |
 | `mere.run model info` | Print a model's manifest, validation status, and resolved component paths. |
 | `mere.run model remove` | Remove a model from the local model store. |
@@ -44,6 +45,47 @@ or:
 ```bash
 swift run mere.run --models-root /path/to/models model list
 ```
+
+Explicit `MERERUN_MODELS_DIR` and `--models-root` overrides intentionally use
+only that root. This keeps scripts, tests, and remote jobs reproducible. The
+persisted primary store selected by the macOS app participates in the unified
+catalog normally.
+
+## Registered catalog locations
+
+The primary store is the only writable location. Existing model collections on
+other disks can participate without copying files or building a symlink facade:
+
+```bash
+# A canonical catalog root: /Volumes/Models/<model-id>/
+mere.run model location add /Volumes/Models
+
+# An arbitrary existing directory name
+mere.run model location bind video-ltx23-full-mlx /Volumes/SALVATION/models/LTX-2.3 \
+  --accept-model-license
+
+mere.run model location list
+mere.run model location list --json
+```
+
+Resolution order is deterministic:
+
+1. the writable primary store
+2. explicit bindings, in registration order
+3. registered search roots, in registration order
+
+An unavailable removable disk is skipped, so the next valid location can win.
+Search-root models must live at `<root>/<canonical-model-id>/` and carry a
+matching `mererun_model.json`. A binding supplies the canonical identity for an
+arbitrarily named folder; mere.run validates it but does not write a manifest or
+any other file into external storage. Registrations live in:
+
+```text
+~/Library/Application Support/MereRun/model_locations.json
+```
+
+Use `model location remove <root>` or `model location unbind <id> [path]` to
+remove registrations. Both operations preserve every payload byte.
 
 ## macOS Studio
 
@@ -131,7 +173,9 @@ requirements.
 
 ### `mere.run model info`
 
-Shows the resolved local install for one canonical model ID.
+Shows the resolved install, source, ownership, and catalog root for one
+canonical model ID. Explicit bindings without an on-disk manifest are validated
+using the identity and terms acknowledgement stored in the registry.
 
 ### `mere.run model pull`
 
@@ -139,6 +183,10 @@ Downloads a managed model from its cataloged Hugging Face source. Pulls are
 checked against the managed capability catalog before download so low-memory
 machines do not fetch models they cannot run. Pass `--allow-unsupported` only
 when you intentionally accept that risk or are using external hardware.
+
+A valid model in a registered location satisfies a normal pull and prevents a
+duplicate download. `--force` always installs or replaces the primary-store
+copy; it never modifies the external payload.
 
 Access-gated models and models with material non-commercial, research-only, or
 revenue-limited terms require `--accept-model-license` for new downloads and
@@ -223,6 +271,12 @@ Removes a managed install and its unshared backing payloads, while preserving
 files referenced by another managed or legacy consumer. Confirmation and output
 show referenced versus reclaimable bytes. Pass `--keep-cache` to remove only the
 install links, or `--force --json` for structured automation.
+
+For an explicit external binding, the same command unregisters the binding and
+reports that the payload was preserved. Models found through an external search
+root cannot be deleted individually by mere.run; unregister the root with
+`model location remove`. `model storage`, `model gc`, and manifest repair own
+only the primary store and Mere's Hub cache.
 
 ### `mere.run model repair-manifests`
 


### PR DESCRIPTION
## Summary

- add a persisted model-location registry with one writable primary store, ordered read-only search roots, and explicit canonical-model bindings to arbitrary directories
- unify registered locations across model resolution, list, info, pull/preflight, remove, agent/OpenWebUI setup, DeepSeek runtime lookup, and workflow provenance
- add `mere.run model location list|add|remove|bind|unbind`, including JSON output and explicit restricted-model terms acceptance
- document deterministic precedence, external-storage ownership, override isolation, and safe removal behavior

## Why

Large checkpoints often already live on external or shared volumes. Requiring every model to be copied into one mere.run-owned directory wastes storage and encourages symlink facades with unclear ownership. This change lets mere.run treat multiple folders as one logical catalog while retaining a single writable install destination.

## Behavior and safety

Resolution precedence is deterministic: the writable primary store wins, then explicit bindings, then ordered search roots. Explicit `--models-root` and environment overrides remain isolated unless registered locations are deliberately enabled by the caller.

Registered locations are read-only from mere.run's perspective. Removing an explicit binding unregisters it without deleting the checkpoint. A model discovered through a registered search root cannot be individually deleted; users unregister the root instead. Normal pulls install into the primary store, while `--force` intentionally refreshes the primary copy.

Restricted external checkpoints require recorded terms acceptance. The LTX 2.5 regression coverage proves that a manifestless arbitrary `LTX-2.5` directory is rejected without acceptance and resolves through the unified catalog after acceptance.

## User impact

Existing single-store behavior remains the default. Users can now register canonical catalog roots or bind an existing checkpoint directly:

```sh
mere.run model location add /Volumes/SALVATION/models
mere.run model location bind video-ltx25-distilled-bf16 /Volumes/SALVATION/models/LTX-2.5 --accept-model-license
mere.run model location list --json
```

No checkpoint data is moved, copied, or modified by registration.

## Validation

- `./scripts/check.sh`
  - strict SwiftLint: 1,196 files, zero violations
  - build and metallib provenance checks passed
  - 2,654 XCTest cases, 173 expected asset-dependent skips, zero failures
  - 25 Swift Testing checks passed
  - CLI help sweep, documentation contracts, model catalog/status checks, and hygiene scans passed
- focused post-rebase catalog/resolver/validator/CLI/docs suite: 205 tests, 1 expected skip, zero failures
- focused external LTX 2.5 binding suite: 7 tests, zero failures
