### PR TITLE
Add native LFM2.5-VL 3B support

### DIFF
--- a/README.md
+++ b/README.md
@@ -294,6 +294,7 @@ swift run mere.run model pull image-zimage-nano
 swift run mere.run model pull image-zimage-nano --preflight --json
 swift run mere.run model pull text-chat-lfm25-2.6b-4bit --accept-model-license
 swift run mere.run model pull text-chat-lfm25-a1b-8bit --accept-model-license
+swift run mere.run model pull vision-chat-lfm25-3b-8bit --accept-model-license
 swift run mere.run model pull text-chat-laguna-s-2-1
 swift run mere.run model pull text-chat-laguna-xs-2-1
 swift run mere.run model pull text-chat-nemotron-35-lightning
@@ -422,6 +423,12 @@ swift run mere.run text chat \
 swift run mere.run text chat \
   --model text-chat-lfm25-2.6b-4bit \
   --prompt "Explain why local inference is useful in one paragraph."
+
+# Inspect an image with LiquidAI LFM2.5-VL through the same native runtime
+swift run mere.run text chat \
+  --model vision-chat-lfm25-3b-8bit \
+  --image ./photo.jpg \
+  --prompt "Describe this image and transcribe any visible text."
 
 # Redact PII locally
 swift run mere.run text anonymize \

--- a/Sources/MereRunCLI/Commands/ModelPullCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelPullCommand.swift
@@ -8,7 +8,7 @@ struct ModelPull: AsyncParsableCommand {
         abstract: "Download a managed model into the local model store."
     )
 
-    @Argument(help: "Canonical model id (for example: image-zimage-nano, text-chat-gemma4-max, or text-chat-lfm25-2.6b-4bit). Omit when using --all.")
+    @Argument(help: "Canonical model id (for example: image-zimage-nano, text-chat-gemma4-max, or vision-chat-lfm25-3b-8bit). Omit when using --all.")
     var target: String?
 
     @Flag(name: [.long], help: "Pull every model that has a Hugging Face source.")

--- a/Sources/MereRunCLI/Commands/TextChatCommand.swift
+++ b/Sources/MereRunCLI/Commands/TextChatCommand.swift
@@ -42,6 +42,7 @@ struct TextChat: AsyncParsableCommand {
           - text-chat-inkling-small (Inkling-Small 276B-A12B mixed MLX: routed-expert q2, non-routed BF16)
           - text-chat-lfm25-2.6b-4bit (LiquidAI LFM2.5 2.6B dense MLX 4-bit native Swift runtime)
           - text-chat-lfm25-a1b-8bit (LiquidAI LFM2.5 8B-A1B MLX 8-bit native Swift runtime)
+          - vision-chat-lfm25-3b-8bit (LiquidAI LFM2.5-VL 3B MLX 8-bit native vision-language runtime)
           - text-chat-psi-agent
         Models are cached under ~/Library/Application Support/MereRun/models/<model-id>.
         Thinking output is hidden by default; pass --thinking to include it.
@@ -273,6 +274,7 @@ struct TextChat: AsyncParsableCommand {
         let isLaguna = LagunaResources.handles(modelSpec: normalizedModelId)
         let isMuseGlimmer = MuseGlimmerResources.handles(modelSpec: normalizedModelId)
         let isNemotronH = NemotronHResources.handles(modelSpec: normalizedModelId)
+        let isLFM2Vision = normalizedModelId == LFM2Resources.visionModelId
         let q35KVCacheMode = try resolveQ35KVCacheMode(for: normalizedModelId)
         if let contextSize, contextSize <= 0 {
             throw ValidationError("--context-size must be greater than zero.")
@@ -282,6 +284,7 @@ struct TextChat: AsyncParsableCommand {
             messages: messages,
             maxTokens: maxTokens,
             temperature: temperature
+                ?? (isLFM2Vision ? 0.2 : nil)
                 ?? (isNemotronH ? NemotronHResources.recommendedTemperature : nil)
                 ?? (isMuseGlimmer ? MuseGlimmerResources.recommendedTemperature : nil)
                 ?? (isLaguna ? LagunaResources.recommendedTemperature : recommendedSampling?.temperature)
@@ -292,6 +295,7 @@ struct TextChat: AsyncParsableCommand {
                 ?? (isLaguna ? LagunaResources.recommendedTopP : recommendedSampling?.topP)
                 ?? 0.9,
             topK: topK
+                ?? (isLFM2Vision ? 50 : nil)
                 ?? (isMuseGlimmer ? MuseGlimmerResources.recommendedTopK : nil)
                 ?? (isLaguna ? LagunaResources.recommendedTopK : recommendedSampling?.topK),
             minP: minP ?? (isLaguna ? LagunaResources.recommendedMinP : 0),

--- a/Sources/MereRunCLI/Guides/model-pull.md
+++ b/Sources/MereRunCLI/Guides/model-pull.md
@@ -49,6 +49,7 @@ mere.run model pull image-zimage-nano --preflight --json
 mere.run model pull text-chat-gemma4-nano
 mere.run model pull text-chat-lfm25-2.6b-4bit --accept-model-license
 mere.run model pull text-chat-lfm25-a1b-8bit --accept-model-license
+mere.run model pull vision-chat-lfm25-3b-8bit --accept-model-license
 mere.run model pull text-chat-laguna-s-2-1
 mere.run model pull text-chat-laguna-xs-2-1
 ```

--- a/Sources/MereRunCLI/Guides/text-chat.md
+++ b/Sources/MereRunCLI/Guides/text-chat.md
@@ -6,7 +6,7 @@ Run a local chat-style text model for answers, drafting, analysis, or lightweigh
 
 ## Required Models
 
-Supported native managed ids include `text-chat-gemma4`, `text-chat-gemma4-12b`, `text-chat-gemma4-12b-4bit`, `text-chat-gemma4-turbo`, `text-chat-gemma4-nano`, `text-chat-gemma4-max`, `text-chat-laguna-s-2-1`, `text-chat-laguna-xs-2-1`, `text-chat-q36-nano`, `text-chat-bonsai-27b-1bit`, `text-chat-bonsai-27b-2bit`, `text-agent-ornith-9b`, `text-agent-ornith-35b-mlx`, `text-chat-lfm25-2.6b-4bit`, `text-chat-lfm25-a1b-8bit`, and `text-chat-psi-agent`.
+Supported native managed ids include `text-chat-gemma4`, `text-chat-gemma4-12b`, `text-chat-gemma4-12b-4bit`, `text-chat-gemma4-turbo`, `text-chat-gemma4-nano`, `text-chat-gemma4-max`, `text-chat-laguna-s-2-1`, `text-chat-laguna-xs-2-1`, `text-chat-q36-nano`, `text-chat-bonsai-27b-1bit`, `text-chat-bonsai-27b-2bit`, `text-agent-ornith-9b`, `text-agent-ornith-35b-mlx`, `text-chat-lfm25-2.6b-4bit`, `text-chat-lfm25-a1b-8bit`, `vision-chat-lfm25-3b-8bit`, and `text-chat-psi-agent`.
 `text-chat-gemma4-12b` is the managed dense Google Gemma 4 12B-it checkpoint, routed through the native Swift Gemma 4 runtime for text chat.
 Pulling `text-chat-gemma4-12b` or `vision-chat-gemma4-12b` also installs the managed `text-chat-gemma4-12b-mtp` assistant; greedy serial Gemma 12B decode uses it for verified decode-tail MTP when the prompt is above the configured threshold.
 `text-chat-gemma4-turbo` is the managed MLX NVFP4 Gemma 4 26B-A4B-it MoE tier for 32 GB Apple Silicon Macs.
@@ -21,6 +21,7 @@ ternary checkpoint's additional weight capacity is worth the memory cost.
 `text-agent-ornith-35b-mlx` is the local converted Ornith 1.0 35B Q4 MLX coding-agent target; it also uses the native Qwen-family runtime.
 `text-chat-lfm25-2.6b-4bit` is the managed LiquidAI LFM2.5 2.6B dense MLX 4-bit snapshot and runs through the native Swift LFM2 runtime.
 `text-chat-lfm25-a1b-8bit` is the managed LiquidAI LFM2.5 8B-A1B MLX 8-bit snapshot and runs through the native Swift LFM2 runtime.
+`vision-chat-lfm25-3b-8bit` adds LiquidAI's SigLIP2 vision tower and multimodal projector to the dense LFM2.5 2.6B language backbone. Use `--image` with a local path or base64 data URL.
 `text-chat-laguna-s-2-1` is the opt-in managed Poolside 118B-A8B NVFP4 target
 for 96 GB-and-up Apple Silicon. Pulling it installs the pinned DFlash
 companion; generation defaults to the validated
@@ -44,6 +45,7 @@ serialization. It is opt-in and does not use the Laguna S DFlash companion.
 mere.run model capabilities
 mere.run model pull text-chat-gemma4-12b-4bit
 mere.run model pull text-chat-lfm25-2.6b-4bit --accept-model-license
+mere.run model pull vision-chat-lfm25-3b-8bit --accept-model-license
 mere.run model pull text-chat-laguna-s-2-1
 mere.run model pull text-chat-laguna-xs-2-1
 mere.run text chat --help

--- a/Sources/MereRunCore/LFM2/LFM2Generator.swift
+++ b/Sources/MereRunCore/LFM2/LFM2Generator.swift
@@ -1,11 +1,20 @@
 import Foundation
 import MLX
+import MLXNN
 
 public typealias LFM2ContinuousBatchingStats = RuntimeDecodeBatchingStats
 
 private struct LFM2PrefillOutput {
     let logits: MLXArray
     let hidden: MLXArray
+}
+
+private struct LFM2ModelTypeEnvelope: Decodable {
+    let modelType: String
+
+    private enum CodingKeys: String, CodingKey {
+        case modelType = "model_type"
+    }
 }
 
 private struct LFM2DecodeResult {
@@ -151,9 +160,12 @@ public actor LFM2Generator: ChatGenerator {
     private var prefixKVCacheReusedTokens = 0
 
     private var model: LFM2Model?
+    private var visionModel: LFM2VLModel?
     private var tokenizerAndTemplate: LFM2TokenizerAndTemplate?
     private var loadedModelPath: String?
     private var loadedConfig: LFM2Config?
+    private var loadedVisionConfig: LFM2VLConfig?
+    private var loadedVisionProcessorConfig: LFM2VLProcessorConfig?
 
     private let modelId: String
 
@@ -260,7 +272,17 @@ public actor LFM2Generator: ChatGenerator {
 
         progressHandler?(ChatProgress(stage: .loadingModel, message: "Loading LFM2 config"))
         let configData = try Data(contentsOf: normalizedRoot.appendingPathComponent("config.json"))
-        let config = try JSONDecoder().decode(LFM2Config.self, from: configData)
+        let modelType = try JSONDecoder().decode(LFM2ModelTypeEnvelope.self, from: configData).modelType
+        let config: LFM2Config
+        let visionConfig: LFM2VLConfig?
+        if modelType == "lfm2_vl" {
+            let decoded = try JSONDecoder().decode(LFM2VLConfig.self, from: configData)
+            config = decoded.textConfig
+            visionConfig = decoded
+        } else {
+            config = try JSONDecoder().decode(LFM2Config.self, from: configData)
+            visionConfig = nil
+        }
 
         progressHandler?(ChatProgress(stage: .loadingModel, message: "Loading LFM2 tokenizer"))
         let tokenizer = try await LFM2TokenizerAndTemplate.load(
@@ -271,15 +293,63 @@ public actor LFM2Generator: ChatGenerator {
         try requireCurrentResidency(loadEpoch)
 
         progressHandler?(ChatProgress(stage: .loadingModel, message: "Loading LFM2 weights"))
-        let lfm2Model = LFM2Model(config: config)
         let resources = LFM2Resources(rootURL: normalizedRoot)
-        let groupSize = config.quantization?.groupSize ?? 64
-        let bits = config.quantization?.bits ?? 8
+        let groupSize = visionConfig?.quantization?.groupSize ?? config.quantization?.groupSize ?? 64
+        let bits = visionConfig?.quantization?.bits ?? config.quantization?.bits ?? 8
+        let lfm2Model: LFM2Model
+        let lfm2VisionModel: LFM2VLModel?
+        if let visionConfig {
+            let composite = LFM2VLModel(config: visionConfig)
+            try loadWeights(
+                into: composite,
+                resources: resources,
+                groupSize: groupSize,
+                bits: bits,
+                progressHandler: progressHandler
+            )
+            lfm2Model = composite.languageModel
+            lfm2VisionModel = composite
+        } else {
+            let language = LFM2Model(config: config)
+            try loadWeights(
+                into: language,
+                resources: resources,
+                groupSize: groupSize,
+                bits: bits,
+                progressHandler: progressHandler
+            )
+            lfm2Model = language
+            lfm2VisionModel = nil
+        }
 
+        try Task.checkCancellation()
+        try requireCurrentResidency(loadEpoch)
+        self.model = lfm2Model
+        self.visionModel = lfm2VisionModel
+        self.tokenizerAndTemplate = tokenizer
+        self.loadedConfig = config
+        self.loadedVisionConfig = visionConfig
+        if visionConfig != nil,
+           let data = try? Data(contentsOf: resources.processorConfigURL) {
+            self.loadedVisionProcessorConfig = try JSONDecoder().decode(
+                LFM2VLProcessorConfig.self,
+                from: data
+            )
+        }
+        self.loadedModelPath = normalizedRoot.path
+    }
+
+    private func loadWeights(
+        into model: Module,
+        resources: LFM2Resources,
+        groupSize: Int,
+        bits: Int,
+        progressHandler: (@Sendable (ChatProgress) -> Void)?
+    ) throws {
         if FileManager.default.fileExists(atPath: resources.modelIndexURL.path) {
             try HFSafetensorsWeightsLoader.applyQuantizedWeights(
                 indexURL: resources.modelIndexURL,
-                to: lfm2Model,
+                to: model,
                 groupSize: groupSize,
                 bits: bits,
                 mapper: LFM2Resources.mapWeight(key:value:),
@@ -294,19 +364,12 @@ public actor LFM2Generator: ChatGenerator {
             let arrays = try MLX.loadArrays(url: resources.modelWeightsURL)
             try HFSafetensorsWeightsLoader.applyQuantizedWeightsFromArrays(
                 arrays,
-                to: lfm2Model,
+                to: model,
                 groupSize: groupSize,
                 bits: bits,
                 mapper: LFM2Resources.mapWeight(key:value:)
             )
         }
-
-        try Task.checkCancellation()
-        try requireCurrentResidency(loadEpoch)
-        self.model = lfm2Model
-        self.tokenizerAndTemplate = tokenizer
-        self.loadedConfig = config
-        self.loadedModelPath = normalizedRoot.path
     }
 
     private func generate(
@@ -338,7 +401,49 @@ public actor LFM2Generator: ChatGenerator {
             includeThinking: request.showThinking,
             maxLength: effectiveContext
         )
-        if promptTokens.count > effectiveContext {
+        let imageReferences = request.messages.compactMap { message -> String? in
+            guard let value = message.imageUrl?.trimmingCharacters(in: .whitespacesAndNewlines),
+                  !value.isEmpty else { return nil }
+            return value
+        }
+        let inputEmbeddings: MLXArray?
+        if imageReferences.isEmpty {
+            inputEmbeddings = nil
+        } else {
+            guard let visionModel,
+                  let loadedVisionConfig,
+                  let imageStartTokenId = tokenizerAndTemplate.tokenizer.convertTokenToId("<|image_start|>"),
+                  let imageEndTokenId = tokenizerAndTemplate.tokenizer.convertTokenToId("<|image_end|>") else {
+                throw LFM2Error.generationFailed(
+                    "This LFM2 checkpoint does not provide the LFM2-VL vision tower and image tokens."
+                )
+            }
+            progressHandler?(ChatProgress(stage: .encoding, message: "Encoding \(imageReferences.count) image(s)"))
+            let batch = try LFM2VLImageProcessor.makeBatch(
+                imageReferences: imageReferences,
+                config: loadedVisionConfig,
+                processorConfig: loadedVisionProcessorConfig
+            )
+            promptTokens = try LFM2VLImageProcessor.expandedPromptTokens(
+                promptTokens,
+                grids: batch.grids,
+                downsampleFactor: loadedVisionConfig.downsampleFactor,
+                imageTokenId: loadedVisionConfig.imageTokenId,
+                imageStartTokenId: imageStartTokenId,
+                imageEndTokenId: imageEndTokenId
+            )
+            guard promptTokens.count <= effectiveContext else {
+                throw LFM2Error.generationFailed(
+                    "LFM2-VL prompt requires \(promptTokens.count) tokens after image expansion; context limit is \(effectiveContext)."
+                )
+            }
+            inputEmbeddings = try visionModel.inputEmbeddings(
+                inputTokens: promptTokens,
+                pixelValues: batch.pixelValues,
+                grids: batch.grids
+            )
+        }
+        if imageReferences.isEmpty, promptTokens.count > effectiveContext {
             promptTokens = Array(promptTokens.suffix(effectiveContext))
         }
 
@@ -349,9 +454,10 @@ public actor LFM2Generator: ChatGenerator {
         let generationConfig = GenerationConfig(
             maxTokens: request.maxTokens,
             temperature: Float(request.temperature),
+            topK: request.topK ?? (loadedVisionConfig == nil ? 0 : 50),
             topP: Float(request.topP),
             minP: Float(request.minP),
-            repetitionPenalty: 1.05,
+            repetitionPenalty: loadedVisionConfig == nil ? 1.05 : 1.0,
             repetitionContextSize: 64
         )
 
@@ -365,17 +471,19 @@ public actor LFM2Generator: ChatGenerator {
             effectiveKVCacheMode = .default
         }
         var layerCaches = makeLayerCaches(config: loadedConfig, kvCacheMode: effectiveKVCacheMode)
-        let prefixCheckpoints = semanticPrefixCheckpoints(
-            tokenizerAndTemplate: tokenizerAndTemplate,
-            messages: request.messages,
-            tools: request.tools,
-            includeThinking: request.showThinking,
-            promptTokens: promptTokens,
-            maxContextLength: effectiveContext
-        )
+        let prefixCheckpoints = imageReferences.isEmpty
+            ? semanticPrefixCheckpoints(
+                tokenizerAndTemplate: tokenizerAndTemplate,
+                messages: request.messages,
+                tools: request.tools,
+                includeThinking: request.showThinking,
+                promptTokens: promptTokens,
+                maxContextLength: effectiveContext
+            )
+            : []
         var prefillStartIndex = 0
         var prefillExistingLogits: MLXArray?
-        if let seed = prefixKVCacheSeed(
+        if imageReferences.isEmpty, let seed = prefixKVCacheSeed(
             modelPath: loadedModelPath,
             promptTokens: promptTokens,
             cacheMode: effectiveKVCacheMode
@@ -389,7 +497,8 @@ public actor LFM2Generator: ChatGenerator {
             model: model,
             promptTokens: promptTokens,
             cache: layerCaches,
-            modelPath: loadedModelPath,
+            inputEmbeddings: inputEmbeddings,
+            modelPath: imageReferences.isEmpty ? loadedModelPath : nil,
             startIndex: prefillStartIndex,
             existingLogits: prefillExistingLogits,
             checkpointTokenCounts: prefixCheckpoints,
@@ -819,6 +928,7 @@ public actor LFM2Generator: ChatGenerator {
         model: LFM2Model,
         promptTokens: [Int],
         cache: [LFM2LayerCache?],
+        inputEmbeddings: MLXArray? = nil,
         modelPath: String? = nil,
         startIndex: Int = 0,
         existingLogits: MLXArray? = nil,
@@ -844,7 +954,12 @@ public actor LFM2Generator: ChatGenerator {
             )
             let chunk = Array(promptTokens[offset..<end])
             let input = MLXArray(chunk.map(Int32.init)).reshaped(1, chunk.count)
-            let output = model.forwardPrefill(input, cache: cache)
+            let chunkEmbeddings = inputEmbeddings?[0..., offset..<end, 0...]
+            let output = model.forwardPrefill(
+                input,
+                cache: cache,
+                inputEmbeddings: chunkEmbeddings
+            )
             MLX.eval(output.logits)
             MLX.eval(output.hidden)
             logits = output.logits
@@ -1061,9 +1176,12 @@ public actor LFM2Generator: ChatGenerator {
         let epoch = decodeLoopEpochState.beginResidencyTransition()
         failQueuedDecodeRows(CancellationError())
         model = nil
+        visionModel = nil
         tokenizerAndTemplate = nil
         loadedModelPath = nil
         loadedConfig = nil
+        loadedVisionConfig = nil
+        loadedVisionProcessorConfig = nil
         prefixKVCache.removeAll(keepingCapacity: false)
         Memory.clearCache()
         return epoch

--- a/Sources/MereRunCore/LFM2/LFM2Resources.swift
+++ b/Sources/MereRunCore/LFM2/LFM2Resources.swift
@@ -9,6 +9,10 @@ public struct LFM2Resources: Sendable, Hashable {
     public static let denseUpstreamRepoId = "LiquidAI/LFM2.5-2.6B-MLX"
     public static let denseUpstreamRevision = "58e239c769c4eb2b766fee80f0b7228bff837baf"
     public static let denseVariantSubdirectory = "4bit"
+    public static let visionModelId = "vision-chat-lfm25-3b-8bit"
+    public static let visionUpstreamRepoId = "LiquidAI/LFM2.5-VL-3B-MLX-8bit"
+    public static let visionUpstreamRevision = "4065d2c056a9c54d44fec67cf651812b55c6673f"
+    public static let visionEstimatedDownloadBytes: Int64 = 3_736_739_700
     public static let defaultContextLength = 32_768
 
     public static let snapshotPatterns = [
@@ -36,8 +40,22 @@ public struct LFM2Resources: Sendable, Hashable {
         "\(denseVariantSubdirectory)/model.safetensors.index.json",
     ]
 
-    public static let managedModelIds = [defaultModelId, denseModelId]
-    public static let upstreamRepoIds = [upstreamRepoId, denseUpstreamRepoId]
+    public static let visionSnapshotPatterns = [
+        "LICENSE*",
+        "README.md",
+        "config.json",
+        "generation_config.json",
+        "processor_config.json",
+        "tokenizer.json",
+        "tokenizer_config.json",
+        "chat_template.jinja",
+        "model.safetensors",
+        "model.safetensors.index.json",
+        "*.safetensors",
+    ]
+
+    public static let managedModelIds = [defaultModelId, denseModelId, visionModelId]
+    public static let upstreamRepoIds = [upstreamRepoId, denseUpstreamRepoId, visionUpstreamRepoId]
 
     public static func handles(modelSpec: String) -> Bool {
         let normalized = modelSpec.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
@@ -60,8 +78,12 @@ public struct LFM2Resources: Sendable, Hashable {
     public var tokenizerURL: URL { rootURL.appending(path: "tokenizer.json") }
     public var tokenizerConfigURL: URL { rootURL.appending(path: "tokenizer_config.json") }
     public var chatTemplateURL: URL { rootURL.appending(path: "chat_template.jinja") }
+    public var processorConfigURL: URL { rootURL.appending(path: "processor_config.json") }
 
-    public func validate(fileManager: FileManager = .default) -> [URL] {
+    public func validate(
+        fileManager: FileManager = .default,
+        requireVisionProcessor: Bool = false
+    ) -> [URL] {
         var missing: [URL] = []
         if !fileManager.fileExists(atPath: configURL.path) {
             missing.append(configURL)
@@ -76,6 +98,9 @@ public struct LFM2Resources: Sendable, Hashable {
         }
         if !fileManager.fileExists(atPath: tokenizerConfigURL.path) {
             missing.append(tokenizerConfigURL)
+        }
+        if requireVisionProcessor, !fileManager.fileExists(atPath: processorConfigURL.path) {
+            missing.append(processorConfigURL)
         }
         return missing
     }

--- a/Sources/MereRunCore/LFM2/LFM2VLConfig.swift
+++ b/Sources/MereRunCore/LFM2/LFM2VLConfig.swift
@@ -1,0 +1,116 @@
+import Foundation
+
+public struct LFM2VLVisionConfig: Decodable, Sendable, Hashable {
+    public let modelType: String
+    public let hiddenSize: Int
+    public let intermediateSize: Int
+    public let numHiddenLayers: Int
+    public let numAttentionHeads: Int
+    public let numChannels: Int
+    public let numPatches: Int
+    public let patchSize: Int
+    public let layerNormEpsilon: Float
+
+    private enum CodingKeys: String, CodingKey {
+        case modelType = "model_type"
+        case hiddenSize = "hidden_size"
+        case intermediateSize = "intermediate_size"
+        case numHiddenLayers = "num_hidden_layers"
+        case numAttentionHeads = "num_attention_heads"
+        case numChannels = "num_channels"
+        case numPatches = "num_patches"
+        case patchSize = "patch_size"
+        case layerNormEpsilon = "layer_norm_eps"
+    }
+}
+
+public struct LFM2VLConfig: Decodable, Sendable, Hashable {
+    public let architectures: [String]
+    public let modelType: String
+    public let textConfig: LFM2Config
+    public let visionConfig: LFM2VLVisionConfig
+    public let imageTokenId: Int
+    public let imageTokenIndex: Int
+    public let downsampleFactor: Int
+    public let projectorBias: Bool
+    public let projectorHiddenSize: Int
+    public let projectorUseLayerNorm: Bool
+    public let minImageTokens: Int
+    public let maxImageTokens: Int
+    public let maxNumPatches: Int
+    public let encoderPatchSize: Int
+    public let quantization: LFM2QuantizationConfig?
+
+    private enum CodingKeys: String, CodingKey {
+        case architectures
+        case modelType = "model_type"
+        case textConfig = "text_config"
+        case visionConfig = "vision_config"
+        case imageTokenId = "image_token_id"
+        case imageTokenIndex = "image_token_index"
+        case downsampleFactor = "downsample_factor"
+        case projectorBias = "projector_bias"
+        case projectorHiddenSize = "projector_hidden_size"
+        case projectorUseLayerNorm = "projector_use_layernorm"
+        case minImageTokens = "min_image_tokens"
+        case maxImageTokens = "max_image_tokens"
+        case maxNumPatches = "max_num_patches"
+        case encoderPatchSize = "encoder_patch_size"
+        case quantization
+        case quantizationConfig = "quantization_config"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        architectures = try container.decodeIfPresent([String].self, forKey: .architectures) ?? []
+        modelType = try container.decode(String.self, forKey: .modelType)
+        textConfig = try container.decode(LFM2Config.self, forKey: .textConfig)
+        visionConfig = try container.decode(LFM2VLVisionConfig.self, forKey: .visionConfig)
+        imageTokenId = try container.decode(Int.self, forKey: .imageTokenId)
+        imageTokenIndex = try container.decodeIfPresent(Int.self, forKey: .imageTokenIndex) ?? imageTokenId
+        downsampleFactor = try container.decodeIfPresent(Int.self, forKey: .downsampleFactor) ?? 2
+        projectorBias = try container.decodeIfPresent(Bool.self, forKey: .projectorBias) ?? true
+        projectorHiddenSize = try container.decodeIfPresent(Int.self, forKey: .projectorHiddenSize)
+            ?? textConfig.hiddenSize
+        projectorUseLayerNorm = try container.decodeIfPresent(Bool.self, forKey: .projectorUseLayerNorm)
+            ?? false
+        minImageTokens = try container.decodeIfPresent(Int.self, forKey: .minImageTokens) ?? 64
+        maxImageTokens = try container.decodeIfPresent(Int.self, forKey: .maxImageTokens) ?? 256
+        maxNumPatches = try container.decodeIfPresent(Int.self, forKey: .maxNumPatches)
+            ?? maxImageTokens * downsampleFactor * downsampleFactor
+        encoderPatchSize = try container.decodeIfPresent(Int.self, forKey: .encoderPatchSize)
+            ?? visionConfig.patchSize
+        if let direct = try container.decodeIfPresent(LFM2QuantizationConfig.self, forKey: .quantization) {
+            quantization = direct
+        } else {
+            quantization = try container.decodeIfPresent(
+                LFM2QuantizationConfig.self,
+                forKey: .quantizationConfig
+            )
+        }
+    }
+}
+
+struct LFM2VLProcessorConfig: Decodable, Sendable, Hashable {
+    struct ImageProcessor: Decodable, Sendable, Hashable {
+        let downsampleFactor: Int
+        let encoderPatchSize: Int
+        let minImageTokens: Int
+        let maxImageTokens: Int
+        let maxNumPatches: Int
+
+        private enum CodingKeys: String, CodingKey {
+            case downsampleFactor = "downsample_factor"
+            case encoderPatchSize = "encoder_patch_size"
+            case minImageTokens = "min_image_tokens"
+            case maxImageTokens = "max_image_tokens"
+            case maxNumPatches = "max_num_patches"
+        }
+    }
+
+    let imageProcessor: ImageProcessor
+
+    private enum CodingKeys: String, CodingKey {
+        case imageProcessor = "image_processor"
+    }
+}

--- a/Sources/MereRunCore/LFM2/LFM2VLImageProcessor.swift
+++ b/Sources/MereRunCore/LFM2/LFM2VLImageProcessor.swift
@@ -1,0 +1,181 @@
+import Foundation
+import MediaIO
+import MLX
+
+struct LFM2VLImageGrid: Hashable, Sendable {
+    let rows: Int
+    let columns: Int
+
+    var patchCount: Int { rows * columns }
+
+    func visualTokenCount(downsampleFactor: Int) -> Int {
+        let factor = max(1, downsampleFactor)
+        let paddedRows = rows + ((factor - (rows % factor)) % factor)
+        let paddedColumns = columns + ((factor - (columns % factor)) % factor)
+        return (paddedRows / factor) * (paddedColumns / factor)
+    }
+}
+
+struct LFM2VLImageBatch {
+    let pixelValues: MLXArray
+    let grids: [LFM2VLImageGrid]
+}
+
+enum LFM2VLImageProcessor {
+    static func makeBatch(
+        imageReferences: [String],
+        config: LFM2VLConfig,
+        processorConfig: LFM2VLProcessorConfig?
+    ) throws -> LFM2VLImageBatch {
+        guard !imageReferences.isEmpty else {
+            throw LFM2Error.generationFailed("LFM2-VL image batch is empty.")
+        }
+
+        let patchSize = processorConfig?.imageProcessor.encoderPatchSize ?? config.encoderPatchSize
+        let downsample = processorConfig?.imageProcessor.downsampleFactor ?? config.downsampleFactor
+        let minTokens = processorConfig?.imageProcessor.minImageTokens ?? config.minImageTokens
+        let maxTokens = processorConfig?.imageProcessor.maxImageTokens ?? config.maxImageTokens
+        let maxPatches = processorConfig?.imageProcessor.maxNumPatches ?? config.maxNumPatches
+        let patchDimension = patchSize * patchSize * config.visionConfig.numChannels
+        var packedImages: [[Float]] = []
+        var grids: [LFM2VLImageGrid] = []
+
+        for reference in imageReferences {
+            let image = try decodeImage(reference)
+            let size = smartResize(
+                width: image.width,
+                height: image.height,
+                encoderPatchSize: patchSize,
+                downsampleFactor: downsample,
+                minImageTokens: minTokens,
+                maxImageTokens: maxTokens
+            )
+            let resized = try MediaImageIO.resized(image, width: size.width, height: size.height)
+            let chw = MediaImageIO.rgbCHWFloat(resized, normalizedToMinusOneToOne: true)
+            let rows = size.height / patchSize
+            let columns = size.width / patchSize
+            let grid = LFM2VLImageGrid(rows: rows, columns: columns)
+            guard grid.patchCount <= maxPatches else {
+                throw LFM2Error.generationFailed(
+                    "LFM2-VL image produced \(grid.patchCount) patches; maximum is \(maxPatches)."
+                )
+            }
+
+            var patches = [Float](repeating: 0, count: maxPatches * patchDimension)
+            let channelPlane = size.width * size.height
+            var patchIndex = 0
+            for patchRow in 0..<rows {
+                for patchColumn in 0..<columns {
+                    var outputIndex = patchIndex * patchDimension
+                    for row in 0..<patchSize {
+                        let sourceRow = (patchRow * patchSize) + row
+                        for column in 0..<patchSize {
+                            let sourceColumn = (patchColumn * patchSize) + column
+                            let pixelIndex = (sourceRow * size.width) + sourceColumn
+                            for channel in 0..<config.visionConfig.numChannels {
+                                patches[outputIndex] = chw[(channel * channelPlane) + pixelIndex]
+                                outputIndex += 1
+                            }
+                        }
+                    }
+                    patchIndex += 1
+                }
+            }
+            packedImages.append(patches)
+            grids.append(grid)
+        }
+
+        return LFM2VLImageBatch(
+            pixelValues: MLXArray(
+                packedImages.flatMap { $0 },
+                [imageReferences.count, maxPatches, patchDimension]
+            ),
+            grids: grids
+        )
+    }
+
+    static func expandedPromptTokens(
+        _ tokens: [Int],
+        grids: [LFM2VLImageGrid],
+        downsampleFactor: Int,
+        imageTokenId: Int,
+        imageStartTokenId: Int,
+        imageEndTokenId: Int
+    ) throws -> [Int] {
+        let placeholderCount = tokens.filter { $0 == imageTokenId }.count
+        guard placeholderCount == grids.count else {
+            throw LFM2Error.generationFailed(
+                "LFM2-VL prompt has \(placeholderCount) image placeholders for \(grids.count) image(s)."
+            )
+        }
+
+        var gridIndex = 0
+        var expanded: [Int] = []
+        for token in tokens {
+            guard token == imageTokenId else {
+                expanded.append(token)
+                continue
+            }
+            let count = grids[gridIndex].visualTokenCount(downsampleFactor: downsampleFactor)
+            expanded.append(imageStartTokenId)
+            expanded.append(contentsOf: repeatElement(imageTokenId, count: count))
+            expanded.append(imageEndTokenId)
+            gridIndex += 1
+        }
+        return expanded
+    }
+
+    static func smartResize(
+        width: Int,
+        height: Int,
+        encoderPatchSize: Int,
+        downsampleFactor: Int,
+        minImageTokens: Int,
+        maxImageTokens: Int
+    ) -> (width: Int, height: Int) {
+        let factor = max(1, encoderPatchSize * downsampleFactor)
+        let minPixels = minImageTokens * factor * factor
+        let maxPixels = maxImageTokens * factor * factor
+        var targetHeight = max(factor, Int((Double(height) / Double(factor)).rounded()) * factor)
+        var targetWidth = max(factor, Int((Double(width) / Double(factor)).rounded()) * factor)
+
+        if targetHeight * targetWidth > maxPixels {
+            let scale = sqrt(Double(max(1, height * width)) / Double(maxPixels))
+            targetHeight = max(factor, Int(floor(Double(height) / scale / Double(factor))) * factor)
+            targetWidth = max(factor, Int(floor(Double(width) / scale / Double(factor))) * factor)
+        } else if targetHeight * targetWidth < minPixels {
+            let scale = sqrt(Double(minPixels) / Double(max(1, height * width)))
+            targetHeight = Int(ceil(Double(height) * scale / Double(factor))) * factor
+            targetWidth = Int(ceil(Double(width) * scale / Double(factor))) * factor
+        }
+        return (targetWidth, targetHeight)
+    }
+
+    private static func decodeImage(_ reference: String) throws -> MediaImage {
+        let trimmed = reference.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            throw LFM2Error.generationFailed("Image reference is empty.")
+        }
+        if trimmed.lowercased().hasPrefix("data:") {
+            guard let comma = trimmed.firstIndex(of: ","),
+                  trimmed[..<comma].lowercased().contains(";base64"),
+                  let data = Data(
+                      base64Encoded: String(trimmed[trimmed.index(after: comma)...]),
+                      options: [.ignoreUnknownCharacters]
+                  ) else {
+                throw LFM2Error.generationFailed("Invalid base64 image data URL.")
+            }
+            return try MediaImageIO.decode(data: data)
+        }
+        if let url = URL(string: trimmed), url.scheme?.lowercased() == "file" {
+            return try MediaImageIO.decode(url)
+        }
+        if let scheme = URL(string: trimmed)?.scheme?.lowercased(),
+           scheme == "http" || scheme == "https" {
+            throw LFM2Error.generationFailed(
+                "Remote image URLs are not fetched by the local LFM2-VL runtime; use a file path or data URL."
+            )
+        }
+        return try MediaImageIO.decode(URL(fileURLWithPath: trimmed).standardizedFileURL)
+    }
+}

--- a/Sources/MereRunCore/LFM2/LFM2VLModel.swift
+++ b/Sources/MereRunCore/LFM2/LFM2VLModel.swift
@@ -1,0 +1,268 @@
+import Foundation
+import MLX
+import MLXFast
+import MLXNN
+
+final class LFM2VLVisionAttention: Module {
+    @ModuleInfo(key: "q_proj") var query: Linear
+    @ModuleInfo(key: "k_proj") var key: Linear
+    @ModuleInfo(key: "v_proj") var value: Linear
+    @ModuleInfo(key: "out_proj") var output: Linear
+
+    private let headCount: Int
+    private let headDimension: Int
+    private let scale: Float
+
+    init(config: LFM2VLVisionConfig) {
+        headCount = config.numAttentionHeads
+        headDimension = config.hiddenSize / max(1, config.numAttentionHeads)
+        scale = 1 / sqrt(Float(max(1, headDimension)))
+        _query.wrappedValue = Linear(config.hiddenSize, config.hiddenSize, bias: true)
+        _key.wrappedValue = Linear(config.hiddenSize, config.hiddenSize, bias: true)
+        _value.wrappedValue = Linear(config.hiddenSize, config.hiddenSize, bias: true)
+        _output.wrappedValue = Linear(config.hiddenSize, config.hiddenSize, bias: true)
+        super.init()
+    }
+
+    func callAsFunction(_ input: MLXArray) -> MLXArray {
+        let batch = input.dim(0)
+        let sequence = input.dim(1)
+        let queries = query(input)
+            .reshaped(batch, sequence, headCount, headDimension)
+            .transposed(0, 2, 1, 3)
+        let keys = key(input)
+            .reshaped(batch, sequence, headCount, headDimension)
+            .transposed(0, 2, 1, 3)
+        let values = value(input)
+            .reshaped(batch, sequence, headCount, headDimension)
+            .transposed(0, 2, 1, 3)
+        return output(MLXFast.scaledDotProductAttention(
+            queries: queries,
+            keys: keys,
+            values: values,
+            scale: scale,
+            mask: .none
+        ).transposed(0, 2, 1, 3).reshaped(batch, sequence, headCount * headDimension))
+    }
+}
+
+final class LFM2VLVisionMLP: Module {
+    @ModuleInfo(key: "fc1") var input: Linear
+    @ModuleInfo(key: "fc2") var output: Linear
+
+    init(config: LFM2VLVisionConfig) {
+        _input.wrappedValue = Linear(config.hiddenSize, config.intermediateSize, bias: true)
+        _output.wrappedValue = Linear(config.intermediateSize, config.hiddenSize, bias: true)
+        super.init()
+    }
+
+    func callAsFunction(_ value: MLXArray) -> MLXArray {
+        output(geluApproximate(input(value)))
+    }
+}
+
+final class LFM2VLVisionLayer: Module {
+    @ModuleInfo(key: "self_attn") var attention: LFM2VLVisionAttention
+    @ModuleInfo(key: "mlp") var mlp: LFM2VLVisionMLP
+    @ModuleInfo(key: "layer_norm1") var attentionNorm: LayerNorm
+    @ModuleInfo(key: "layer_norm2") var mlpNorm: LayerNorm
+
+    init(config: LFM2VLVisionConfig) {
+        _attention.wrappedValue = LFM2VLVisionAttention(config: config)
+        _mlp.wrappedValue = LFM2VLVisionMLP(config: config)
+        _attentionNorm.wrappedValue = LayerNorm(dimensions: config.hiddenSize, eps: config.layerNormEpsilon)
+        _mlpNorm.wrappedValue = LayerNorm(dimensions: config.hiddenSize, eps: config.layerNormEpsilon)
+        super.init()
+    }
+
+    func callAsFunction(_ input: MLXArray) -> MLXArray {
+        let attended = input + attention(attentionNorm(input))
+        return attended + mlp(mlpNorm(attended))
+    }
+}
+
+final class LFM2VLVisionEmbeddings: Module {
+    @ModuleInfo(key: "patch_embedding") var patchEmbedding: Linear
+    @ModuleInfo(key: "position_embedding") var positionEmbedding: Embedding
+
+    private let config: LFM2VLVisionConfig
+    private let sourceGridSize: Int
+
+    init(config: LFM2VLVisionConfig) {
+        self.config = config
+        sourceGridSize = Int(Double(config.numPatches).squareRoot())
+        _patchEmbedding.wrappedValue = Linear(
+            config.numChannels * config.patchSize * config.patchSize,
+            config.hiddenSize,
+            bias: true
+        )
+        _positionEmbedding.wrappedValue = Embedding(
+            embeddingCount: config.numPatches,
+            dimensions: config.hiddenSize
+        )
+        super.init()
+    }
+
+    func callAsFunction(pixelValues: MLXArray, grids: [LFM2VLImageGrid]) -> MLXArray {
+        precondition(pixelValues.dim(0) == grids.count)
+        let projected = patchEmbedding(pixelValues.asType(patchEmbedding.weight.dtype))
+        let positions = grids.map { resizedPositions(grid: $0, maxLength: pixelValues.dim(1)) }
+        return projected + MLX.concatenated(positions, axis: 0)
+    }
+
+    private func resizedPositions(grid: LFM2VLImageGrid, maxLength: Int) -> MLXArray {
+        let source = positionEmbedding.weight
+            .reshaped(1, sourceGridSize, sourceGridSize, config.hiddenSize)
+        let resized: MLXArray
+        if grid.rows == sourceGridSize, grid.columns == sourceGridSize {
+            resized = source
+        } else {
+            resized = Upsample(
+                scaleFactor: [
+                    Float(grid.rows) / Float(sourceGridSize),
+                    Float(grid.columns) / Float(sourceGridSize),
+                ],
+                mode: .cubic(alignCorners: false)
+            )(source.asType(.float32)).asType(source.dtype)
+        }
+        let actual = resized.reshaped(1, grid.patchCount, config.hiddenSize)
+        guard grid.patchCount < maxLength else { return actual }
+        let padding = MLX.tiled(
+            actual[0..., 0..<1, 0...],
+            repetitions: [1, maxLength - grid.patchCount, 1]
+        )
+        return MLX.concatenated([actual, padding], axis: 1)
+    }
+}
+
+final class LFM2VLVisionTower: Module {
+    @ModuleInfo(key: "embeddings") var embeddings: LFM2VLVisionEmbeddings
+    @ModuleInfo(key: "encoder") var encoder: LFM2VLVisionEncoder
+    @ModuleInfo(key: "post_layernorm") var outputNorm: LayerNorm
+
+    init(config: LFM2VLVisionConfig) {
+        _embeddings.wrappedValue = LFM2VLVisionEmbeddings(config: config)
+        _encoder.wrappedValue = LFM2VLVisionEncoder(config: config)
+        _outputNorm.wrappedValue = LayerNorm(dimensions: config.hiddenSize, eps: config.layerNormEpsilon)
+        super.init()
+    }
+
+    func callAsFunction(pixelValues: MLXArray, grids: [LFM2VLImageGrid]) -> MLXArray {
+        outputNorm(encoder(embeddings(pixelValues: pixelValues, grids: grids)))
+    }
+}
+
+final class LFM2VLVisionEncoder: Module {
+    @ModuleInfo(key: "layers") var layers: [LFM2VLVisionLayer]
+
+    init(config: LFM2VLVisionConfig) {
+        _layers.wrappedValue = (0..<config.numHiddenLayers).map { _ in
+            LFM2VLVisionLayer(config: config)
+        }
+        super.init()
+    }
+
+    func callAsFunction(_ input: MLXArray) -> MLXArray {
+        layers.reduce(input) { hidden, layer in layer(hidden) }
+    }
+}
+
+final class LFM2VLMultiModalProjector: Module {
+    @ModuleInfo(key: "layer_norm") var layerNorm: LayerNorm?
+    @ModuleInfo(key: "linear_1") var input: Linear
+    @ModuleInfo(key: "linear_2") var output: Linear
+
+    init(config: LFM2VLConfig) {
+        let inputSize = config.visionConfig.hiddenSize * config.downsampleFactor * config.downsampleFactor
+        _layerNorm.wrappedValue = config.projectorUseLayerNorm
+            ? LayerNorm(dimensions: inputSize)
+            : nil
+        _input.wrappedValue = Linear(
+            inputSize,
+            config.projectorHiddenSize,
+            bias: config.projectorBias
+        )
+        _output.wrappedValue = Linear(
+            config.projectorHiddenSize,
+            config.textConfig.hiddenSize,
+            bias: config.projectorBias
+        )
+        super.init()
+    }
+
+    func callAsFunction(_ value: MLXArray) -> MLXArray {
+        let normalized = layerNorm?(value) ?? value
+        return output(gelu(input(normalized)))
+    }
+}
+
+public final class LFM2VLModel: Module, @unchecked Sendable {
+    @ModuleInfo(key: "vision_tower") var visionTower: LFM2VLVisionTower
+    @ModuleInfo(key: "multi_modal_projector") var projector: LFM2VLMultiModalProjector
+    @ModuleInfo(key: "language_model") var languageModel: LFM2Model
+
+    let config: LFM2VLConfig
+
+    public init(config: LFM2VLConfig) {
+        self.config = config
+        _visionTower.wrappedValue = LFM2VLVisionTower(config: config.visionConfig)
+        _projector.wrappedValue = LFM2VLMultiModalProjector(config: config)
+        _languageModel.wrappedValue = LFM2Model(config: config.textConfig)
+        super.init()
+    }
+
+    func inputEmbeddings(
+        inputTokens: [Int],
+        pixelValues: MLXArray,
+        grids: [LFM2VLImageGrid]
+    ) throws -> MLXArray {
+        let inputIds = MLXArray(inputTokens.map(Int32.init)).reshaped(1, inputTokens.count)
+        let tokenEmbeddings = languageModel.embeddings(for: inputIds)
+        let hidden = visionTower(pixelValues: pixelValues, grids: grids)
+        var projectedImages: [MLXArray] = []
+        for (index, grid) in grids.enumerated() {
+            let features = hidden[index..<(index + 1), 0..<grid.patchCount, 0...]
+                .reshaped(1, grid.rows, grid.columns, config.visionConfig.hiddenSize)
+            projectedImages.append(projector(pixelUnshuffle(features)).reshaped(-1, config.textConfig.hiddenSize))
+        }
+        let imageFeatures = MLX.concatenated(projectedImages, axis: 0)
+        let imagePositions = inputTokens.indices.filter { inputTokens[$0] == config.imageTokenIndex }
+        guard imagePositions.count == imageFeatures.dim(0) else {
+            throw LFM2Error.generationFailed(
+                "LFM2-VL image features and prompt tokens do not match: \(imageFeatures.dim(0)) features for \(imagePositions.count) tokens."
+            )
+        }
+
+        var featureIndex = 0
+        let rows = inputTokens.indices.map { tokenIndex -> MLXArray in
+            guard inputTokens[tokenIndex] == config.imageTokenIndex else {
+                return tokenEmbeddings[0..., tokenIndex..<(tokenIndex + 1), 0...]
+            }
+            defer { featureIndex += 1 }
+            return imageFeatures[featureIndex..<(featureIndex + 1), 0...].expandedDimensions(axis: 0)
+        }
+        return MLX.concatenated(rows, axis: 1)
+    }
+
+    private func pixelUnshuffle(_ input: MLXArray) -> MLXArray {
+        let factor = max(1, config.downsampleFactor)
+        guard factor > 1 else { return input }
+        let rows = input.dim(1)
+        let columns = input.dim(2)
+        let rowPadding = (factor - (rows % factor)) % factor
+        let columnPadding = (factor - (columns % factor)) % factor
+        let paddedInput = padded(
+            input,
+            widths: [[0, 0], [0, rowPadding], [0, columnPadding], [0, 0]],
+            value: MLXArray(0).asType(input.dtype)
+        )
+        let paddedRows = rows + rowPadding
+        let paddedColumns = columns + columnPadding
+        let channels = input.dim(3)
+        return paddedInput
+            .reshaped(1, paddedRows, paddedColumns / factor, channels * factor)
+            .transposed(0, 2, 1, 3)
+            .reshaped(1, paddedColumns / factor, paddedRows / factor, channels * factor * factor)
+            .transposed(0, 2, 1, 3)
+    }
+}

--- a/Sources/MereRunCore/LFM2/README.md
+++ b/Sources/MereRunCore/LFM2/README.md
@@ -1,12 +1,13 @@
 # LFM2 Runtime
 
-Native Swift MLX runtime for LiquidAI LFM2 text-chat checkpoints.
+Native Swift MLX runtime for LiquidAI LFM2 text and vision-language checkpoints.
 
 ## Managed models
 
 - `text-chat-lfm25-a1b-8bit` — `LiquidAI/LFM2.5-8B-A1B-MLX-8bit`
 - `text-chat-lfm25-2.6b-4bit` — the `4bit/` partition of
   `LiquidAI/LFM2.5-2.6B-MLX`
+- `vision-chat-lfm25-3b-8bit` — `LiquidAI/LFM2.5-VL-3B-MLX-8bit`
 - Serving engine: `text-chat-lfm2`
 
 The runtime loads MLX-converted directory-root snapshots with:
@@ -15,6 +16,7 @@ The runtime loads MLX-converted directory-root snapshots with:
 - `tokenizer.json`
 - `tokenizer_config.json`
 - `model.safetensors` or `model.safetensors.index.json` plus shards
+- `processor_config.json` for the vision-language checkpoint
 
 ## Architecture
 
@@ -30,6 +32,12 @@ layouts:
   dense prefix
 - sparse MoE feed-forward layers with router top-k, optional `expert_bias`, and
   `SwitchGLU` expert projections
+
+`LFM2VLModel.swift` adds the packed-patch SigLIP2 NaFlex encoder, resized
+positional embeddings, factor-2 pixel unshuffle, and multimodal projector used
+by LFM2.5-VL. `LFM2VLImageProcessor.swift` mirrors the checkpoint's smart
+resize and patch packing contract. Only the multimodal prefill uses those
+components; token decode continues through `LFM2Model` and its typed caches.
 
 `LFM2Generator.swift` is the chat entrypoint. It resolves managed installs or
 downloads through `ManagedModelResolver`, loads tokenizer/template resources,
@@ -48,8 +56,9 @@ fall back to MLX's portable gather path.
 ## Notes
 
 - This runtime is Swift-native and does not bridge to Python.
-- LFM2 is currently text-only. API requests with image content parts are rejected
-  by the `text-chat-lfm2` capability profile.
+- The two `text-chat-*` checkpoints reject image content parts. The
+  `vision-chat-lfm25-3b-8bit` catalog entry enables them through the same
+  serving engine.
 - API serving enables exact token-prefix KV reuse by default and enables
   continuous decode batching when `--max-active-requests` is greater than one.
   Ragged rows carry independent attention offsets and typed short-convolution

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -1371,6 +1371,29 @@ public enum ManagedModelCatalog {
             defaultCLICommands: ["text chat", "api serve"]
         ),
         ManagedModelSpec(
+            id: LFM2Resources.visionModelId,
+            category: .visionChat,
+            installShape: .directoryRoot,
+            hubFallback: HubFallbackConfig(
+                repoId: LFM2Resources.visionUpstreamRepoId,
+                revision: LFM2Resources.visionUpstreamRevision,
+                patterns: LFM2Resources.visionSnapshotPatterns
+            ),
+            upstreamRepoId: LFM2Resources.visionUpstreamRepoId,
+            upstreamRevision: LFM2Resources.visionUpstreamRevision,
+            usageRestriction: usageRestriction(
+                summary: "LFM uses a custom open license; commercial use by entities with at least USD 10M annual revenue is not licensed under its community terms.",
+                license: "LFM Open License v1.0",
+                sourceRepoId: LFM2Resources.visionUpstreamRepoId,
+                sourceRevision: LFM2Resources.visionUpstreamRevision,
+                licenseURL: "https://huggingface.co/LiquidAI/LFM2.5-VL-3B-MLX-8bit/blob/\(LFM2Resources.visionUpstreamRevision)/LICENSE"
+            ),
+            validationKind: .lfm2,
+            runtimeAutoDownloadAllowed: false,
+            estimatedDownloadBytes: LFM2Resources.visionEstimatedDownloadBytes,
+            defaultCLICommands: ["text chat", "api serve"]
+        ),
+        ManagedModelSpec(
             id: "speech-tts-qwen3-nano",
             category: .speechTTS,
             installShape: .directoryRoot,
@@ -2968,7 +2991,10 @@ public extension ManagedModelSpec {
         case .q35:
             return Q35Resources(rootURL: rootURL).validate(fileManager: fileManager)
         case .lfm2:
-            return LFM2Resources(rootURL: rootURL).validate(fileManager: fileManager)
+            return LFM2Resources(rootURL: rootURL).validate(
+                fileManager: fileManager,
+                requireVisionProcessor: id == LFM2Resources.visionModelId
+            )
         case .inkling:
             return InklingResources.validate(rootURL: rootURL, fileManager: fileManager)
         case .museGlimmer:

--- a/Sources/MereRunCore/ManagedModelSupport.swift
+++ b/Sources/MereRunCore/ManagedModelSupport.swift
@@ -454,6 +454,14 @@ public enum ManagedModelCapabilityCatalog {
                 setup: true
             ),
             descriptor(
+                LFM2Resources.visionModelId,
+                "LFM2.5-VL 3B 8-bit",
+                "Runs LiquidAI's compact LFM2.5-VL vision-language model through the native Swift LFM2 runtime.",
+                minimum: 8,
+                recommended: 16,
+                setup: true
+            ),
+            descriptor(
                 "text-chat-q36-nano-gguf",
                 "Qwen3.6 A3B chat nano (GGUF)",
                 "Runs Qwen3.6 35B-A3B GGUF through llama.cpp; the default chat model on Linux CUDA hosts.",

--- a/Sources/MereRunCore/MereRunModelManifest.swift
+++ b/Sources/MereRunCore/MereRunModelManifest.swift
@@ -1146,6 +1146,21 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
                 upstreamRepoId: "\(LFM2Resources.denseUpstreamRepoId)@\(LFM2Resources.denseUpstreamRevision)",
                 createdAt: createdAt
             )
+        case .lfm25VL3B8Bit:
+            return MereRunModelManifest(
+                id: modelID.rawValue,
+                engine: .lfm2,
+                family: .liquid,
+                tier: .nano,
+                variant: .standard,
+                precision: .int8,
+                quantization: Quantization(bits: 8, groupSize: 64, scheme: "mlx-affine"),
+                defaults: nil,
+                supports: [.chat, .visionChat],
+                components: q35TextComponents,
+                upstreamRepoId: "\(LFM2Resources.visionUpstreamRepoId)@\(LFM2Resources.visionUpstreamRevision)",
+                createdAt: createdAt
+            )
         case .qwen35Agent9B:
             return MereRunModelManifest(
                 id: modelID.rawValue,

--- a/Sources/MereRunCore/MereRunModelValidator.swift
+++ b/Sources/MereRunCore/MereRunModelValidator.swift
@@ -641,7 +641,8 @@ public enum MereRunModelValidator {
             return .gemma
         }
         if modelId == ModelResolver.ModelID.lfm25A1B8Bit.rawValue
-            || modelId == ModelResolver.ModelID.lfm25Dense2_6B4Bit.rawValue {
+            || modelId == ModelResolver.ModelID.lfm25Dense2_6B4Bit.rawValue
+            || modelId == ModelResolver.ModelID.lfm25VL3B8Bit.rawValue {
             return .liquid
         }
         if modelId == ModelResolver.ModelID.q36Nano.rawValue

--- a/Sources/MereRunCore/ModelResolver.swift
+++ b/Sources/MereRunCore/ModelResolver.swift
@@ -48,6 +48,7 @@ public struct ModelResolver {
         case bonsai27B2Bit = "text-chat-bonsai-27b-2bit"
         case lfm25A1B8Bit = "text-chat-lfm25-a1b-8bit"
         case lfm25Dense2_6B4Bit = "text-chat-lfm25-2.6b-4bit"
+        case lfm25VL3B8Bit = "vision-chat-lfm25-3b-8bit"
         case qwen35Agent9B = "text-agent-qwen35-9b"
         case ornith9B = "text-agent-ornith-9b"
         case ornith35B = "text-agent-ornith-35b"

--- a/Tests/MereRunCoreTests/LFM2ConfigAndModelTests.swift
+++ b/Tests/MereRunCoreTests/LFM2ConfigAndModelTests.swift
@@ -12,6 +12,60 @@ final class LFM2ConfigAndModelTests: MereRunCoreTestCase {
         return try JSONDecoder().decode(LFM2Config.self, from: data)
     }
 
+    private func decodeVisionConfig(_ object: [String: Any]) throws -> LFM2VLConfig {
+        let data = try JSONSerialization.data(withJSONObject: object, options: [])
+        return try JSONDecoder().decode(LFM2VLConfig.self, from: data)
+    }
+
+    private func makeTinyVisionConfig() -> [String: Any] {
+        [
+            "architectures": ["Lfm2VlForConditionalGeneration"],
+            "model_type": "lfm2_vl",
+            "image_token_id": 63,
+            "downsample_factor": 2,
+            "encoder_patch_size": 2,
+            "min_image_tokens": 1,
+            "max_image_tokens": 1,
+            "max_num_patches": 4,
+            "projector_bias": true,
+            "projector_hidden_size": 16,
+            "projector_use_layernorm": false,
+            "quantization": [
+                "group_size": 64,
+                "bits": 8,
+                "mode": "affine",
+            ],
+            "text_config": [
+                "architectures": ["Lfm2ForCausalLM"],
+                "model_type": "lfm2",
+                "vocab_size": 64,
+                "hidden_size": 16,
+                "intermediate_size": 32,
+                "num_hidden_layers": 2,
+                "num_attention_heads": 4,
+                "num_key_value_heads": 2,
+                "max_position_embeddings": 128,
+                "norm_eps": 0.00001,
+                "conv_bias": false,
+                "conv_L_cache": 2,
+                "layer_types": ["conv", "full_attention"],
+                "eos_token_id": 62,
+                "tie_word_embeddings": true,
+            ],
+            "vision_config": [
+                "model_type": "siglip2_vision_model",
+                "hidden_size": 8,
+                "intermediate_size": 16,
+                "num_hidden_layers": 1,
+                "num_attention_heads": 2,
+                "num_channels": 3,
+                "num_patches": 4,
+                "patch_size": 2,
+                "layer_norm_eps": 0.000001,
+            ],
+        ]
+    }
+
     private func makeBaseConfig(includeQuantization: Bool = true) -> [String: Any] {
         var config: [String: Any] = [
             "architectures": ["Lfm2MoeForCausalLM"],
@@ -172,6 +226,59 @@ final class LFM2ConfigAndModelTests: MereRunCoreTestCase {
         XCTAssertEqual(config.numExpertsPerTok, 1)
         XCTAssertEqual(config.numDenseLayers, config.numHiddenLayers)
         XCTAssertEqual(config.fullAttentionLayerIndexes, Set([1, 3]))
+    }
+
+    func testDecodesLFM25VisionConfigAndFallsBackToImageTokenID() throws {
+        let config = try decodeVisionConfig(makeTinyVisionConfig())
+
+        XCTAssertEqual(config.modelType, "lfm2_vl")
+        XCTAssertEqual(config.imageTokenId, 63)
+        XCTAssertEqual(config.imageTokenIndex, 63)
+        XCTAssertEqual(config.textConfig.modelType, "lfm2")
+        XCTAssertEqual(config.textConfig.intermediateSize, 32)
+        XCTAssertEqual(config.visionConfig.modelType, "siglip2_vision_model")
+        XCTAssertEqual(config.visionConfig.patchSize, 2)
+        XCTAssertEqual(config.downsampleFactor, 2)
+        XCTAssertEqual(config.quantization?.bits, 8)
+    }
+
+    func testLFM25VisionSmartResizeAndPromptExpansionMatchDownsampledGrid() throws {
+        let size = LFM2VLImageProcessor.smartResize(
+            width: 1_600,
+            height: 900,
+            encoderPatchSize: 16,
+            downsampleFactor: 2,
+            minImageTokens: 64,
+            maxImageTokens: 256
+        )
+        XCTAssertEqual(size.width, 672)
+        XCTAssertEqual(size.height, 384)
+
+        let expanded = try LFM2VLImageProcessor.expandedPromptTokens(
+            [10, 63, 11],
+            grids: [LFM2VLImageGrid(rows: 24, columns: 42)],
+            downsampleFactor: 2,
+            imageTokenId: 63,
+            imageStartTokenId: 60,
+            imageEndTokenId: 61
+        )
+        XCTAssertEqual(expanded.count, 256)
+        XCTAssertEqual(expanded.prefix(3), [10, 60, 63])
+        XCTAssertEqual(expanded.suffix(2), [61, 11])
+        XCTAssertEqual(expanded.filter { $0 == 63 }.count, 252)
+    }
+
+    func testLFM25VisionModelReplacesImageTokenWithProjectedFeature() throws {
+        let config = try decodeVisionConfig(makeTinyVisionConfig())
+        let model = LFM2VLModel(config: config)
+        let embeddings = try model.inputEmbeddings(
+            inputTokens: [1, config.imageTokenIndex, 2],
+            pixelValues: MLXArray.zeros([1, 4, 12]),
+            grids: [LFM2VLImageGrid(rows: 2, columns: 2)]
+        )
+
+        MLX.eval(embeddings)
+        XCTAssertEqual(embeddings.shape, [1, 3, 16])
     }
 
     func testRendersLiquidAIChatTemplateShape() throws {

--- a/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
@@ -60,6 +60,7 @@ final class ManagedModelCatalogTests: XCTestCase {
             "image-ideogram4-sdnq-uint4",
             "text-chat-lfm25-a1b-8bit",
             "text-chat-lfm25-2.6b-4bit",
+            "vision-chat-lfm25-3b-8bit",
             "vision-segment-sam31",
             "vision-face-buffalo-l",
             "vision-embed-olmoearth-v12-nano",
@@ -938,6 +939,41 @@ final class ManagedModelCatalogTests: XCTestCase {
         }
 
         XCTAssertEqual(spec.normalizedRootURL(root), variant.standardizedFileURL)
+        XCTAssertTrue(spec.missingPaths(in: root).isEmpty)
+    }
+
+    func testLFM25VisionUsesPinnedLiquidAIMLXCheckpoint() throws {
+        let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: LFM2Resources.visionModelId))
+
+        XCTAssertEqual(spec.category, .visionChat)
+        XCTAssertEqual(spec.installShape, .directoryRoot)
+        XCTAssertEqual(spec.hubFallback?.repoId, LFM2Resources.visionUpstreamRepoId)
+        XCTAssertEqual(spec.hubFallback?.revision, LFM2Resources.visionUpstreamRevision)
+        XCTAssertEqual(spec.hubFallback?.patterns, LFM2Resources.visionSnapshotPatterns)
+        XCTAssertEqual(spec.validationKind, .lfm2)
+        XCTAssertEqual(spec.defaultRuntimeServingEngine, .textChatLFM2)
+        XCTAssertEqual(spec.estimatedDownloadBytes, 3_736_739_700)
+        XCTAssertFalse(spec.runtimeAutoDownloadAllowed)
+        XCTAssertTrue(spec.hubFallback?.patterns.contains("processor_config.json") == true)
+
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        for filename in [
+            "config.json",
+            "tokenizer.json",
+            "tokenizer_config.json",
+            "model.safetensors.index.json",
+        ] {
+            XCTAssertTrue(FileManager.default.createFile(
+                atPath: root.appendingPathComponent(filename).path,
+                contents: Data()
+            ))
+        }
+        XCTAssertEqual(spec.missingPaths(in: root).map(\.lastPathComponent), ["processor_config.json"])
+        XCTAssertTrue(FileManager.default.createFile(
+            atPath: root.appendingPathComponent("processor_config.json").path,
+            contents: Data()
+        ))
         XCTAssertTrue(spec.missingPaths(in: root).isEmpty)
     }
 

--- a/Tests/MereRunCoreTests/ManagedModelSupportTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelSupportTests.swift
@@ -250,6 +250,22 @@ final class ManagedModelSupportTests: XCTestCase {
         XCTAssertEqual(report.descriptor.recommendedUnifiedMemoryGB, 12)
     }
 
+    func testLFM25VisionRunsInCompactMemoryTier() throws {
+        let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: LFM2Resources.visionModelId))
+        let machine = MereRunMachineProfile(
+            physicalMemoryBytes: 16 * 1_073_741_824,
+            processorName: "M2",
+            isAppleSiliconMac: true
+        )
+
+        let report = ManagedModelCapabilityCatalog.support(for: spec, on: machine)
+
+        XCTAssertTrue(report.isSupported)
+        XCTAssertTrue(report.meetsRecommendedMemory)
+        XCTAssertEqual(report.descriptor.minimumUnifiedMemoryGB, 8)
+        XCTAssertEqual(report.descriptor.recommendedUnifiedMemoryGB, 16)
+    }
+
 
     func testNorthMiniCodeIsSupportedOnThirtyTwoGBAndStartable() throws {
         let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: NorthMiniCodeResources.modelId))

--- a/Tests/MereRunCoreTests/MereRunModelValidatorTests.swift
+++ b/Tests/MereRunCoreTests/MereRunModelValidatorTests.swift
@@ -46,7 +46,15 @@ final class MereRunModelValidatorTests: MereRunCoreTestCase {
         try TestFileSystem.createDirectory(root)
         try MereRunModelManifest.template(for: id, createdAt: Date(timeIntervalSince1970: 0)).write(to: root)
 
-        let modelType = id == .lfm25Dense2_6B4Bit ? "lfm2" : "lfm2_moe"
+        let modelType: String
+        switch id {
+        case .lfm25Dense2_6B4Bit:
+            modelType = "lfm2"
+        case .lfm25VL3B8Bit:
+            modelType = "lfm2_vl"
+        default:
+            modelType = "lfm2_moe"
+        }
         try TestFileSystem.writeFile(
             root.appendingPathComponent("config.json"),
             contents: Data(#"{"model_type":"\#(modelType)"}"#.utf8)
@@ -54,6 +62,9 @@ final class MereRunModelValidatorTests: MereRunCoreTestCase {
         try TestFileSystem.writeFile(root.appendingPathComponent("tokenizer.json"), contents: Data("{}".utf8))
         try TestFileSystem.writeFile(root.appendingPathComponent("tokenizer_config.json"), contents: Data("{}".utf8))
         try TestFileSystem.writeFile(root.appendingPathComponent("model.safetensors.index.json"), contents: Data("{}".utf8))
+        if id == .lfm25VL3B8Bit {
+            try TestFileSystem.writeFile(root.appendingPathComponent("processor_config.json"), contents: Data("{}".utf8))
+        }
     }
 
     private func writeMinimalValidGemma4Model(at root: URL, id: ModelResolver.ModelID = .gemma4) throws {
@@ -627,6 +638,29 @@ final class MereRunModelValidatorTests: MereRunCoreTestCase {
         XCTAssertEqual(
             report.manifest?.upstreamRepoId,
             "\(LFM2Resources.denseUpstreamRepoId)@\(LFM2Resources.denseUpstreamRevision)"
+        )
+    }
+
+    func testLFM2VisionRootLayoutPassesValidation() throws {
+        let temp = try TestFileSystem.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: temp) }
+
+        let root = temp.appendingPathComponent(LFM2Resources.visionModelId, isDirectory: true)
+        try writeMinimalValidLFM2Model(at: root, id: .lfm25VL3B8Bit)
+
+        let report = MereRunModelValidator.validate(
+            modelRoot: root,
+            expectedModelID: LFM2Resources.visionModelId
+        )
+        XCTAssertTrue(report.isValid, report.errors.joined(separator: "\n"))
+        XCTAssertTrue(report.errors.isEmpty)
+        XCTAssertEqual(report.manifest?.engine, .lfm2)
+        XCTAssertEqual(report.manifest?.family, .liquid)
+        XCTAssertEqual(report.manifest?.precision, .int8)
+        XCTAssertEqual(Set(report.manifest?.supports ?? []), Set([.chat, .visionChat]))
+        XCTAssertEqual(
+            report.manifest?.upstreamRepoId,
+            "\(LFM2Resources.visionUpstreamRepoId)@\(LFM2Resources.visionUpstreamRevision)"
         )
     }
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -227,7 +227,7 @@ are:
   `image-hidream-o1`, `image-hidream-o1-dev`, `image-krea2-raw`,
   `image-krea2-turbo`,
   `image-ideogram4-sdnq-uint4`
-- Text chat: `text-chat-gemma4`, `text-chat-mebot`, `text-chat-psi-agent`, `text-chat-q36-nano`, `text-chat-lfm25-2.6b-4bit`, `text-chat-lfm25-a1b-8bit`
+- Text chat: `text-chat-gemma4`, `text-chat-mebot`, `text-chat-psi-agent`, `text-chat-q36-nano`, `text-chat-lfm25-2.6b-4bit`, `text-chat-lfm25-a1b-8bit`, `vision-chat-lfm25-3b-8bit`
 - Text code / agents: `text-agent-qwen35-9b`, `text-agent-ornith-9b`, `text-agent-ornith-35b-mlx`, `text-agent-ornith-35b`, `text-code-north-mini`, `text-code-qwen3`
 - Text embed: `text-embed-qwen3-0.6b`
 - Text anonymize: `text-anonymize-privacy-filter`
@@ -851,6 +851,7 @@ swift run mere.run text chat --model text-agent-ornith-9b --prompt "Write a comp
 swift run mere.run text chat --model text-chat-inkling-small --reasoning-effort 0.2 --prompt "Answer directly."
 swift run mere.run text chat --model text-chat-lfm25-2.6b-4bit --prompt "Explain local inference in one paragraph."
 swift run mere.run text chat --model text-chat-lfm25-a1b-8bit --prompt "Summarize LFM2 in one paragraph."
+swift run mere.run text chat --model vision-chat-lfm25-3b-8bit --image ./photo.jpg --prompt "Describe this image."
 swift run mere.run text chat --stream --prompt "Write a short welcome message."
 swift run mere.run text chat --thinking --stats --prompt "How would you design a tokenizer?"
 ```

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -83,6 +83,7 @@ from the runtime catalog used by `mere.run model list`,
 | `text-chat` | `text-agent-deepseek-v4-flash` |
 | `text-chat` | `text-chat-lfm25-a1b-8bit` |
 | `text-chat` | `text-chat-lfm25-2.6b-4bit` |
+| `vision-chat` | `vision-chat-lfm25-3b-8bit` |
 | `speech-tts` | `speech-tts-qwen3-nano` |
 | `speech-tts` | `speech-tts-qwen3-customvoice` |
 | `speech-asr` | `speech-asr-qwen3` |
@@ -184,7 +185,7 @@ validates all configured models before downloading any; both accept the same
 | `image-klein-9b`, `image-klein-base-9b` | FLUX Non-Commercial License v2.1; non-commercial, non-production use |
 | `image-krea2-raw`, `image-krea2-turbo` | Krea 2 Community License; commercial use is limited to entities below USD 1M trailing annual revenue, plus use/distribution conditions |
 | `image-ideogram4-sdnq-uint4` | Ideogram Non-Commercial Model Agreement |
-| `text-chat-lfm25-a1b-8bit`, `text-chat-lfm25-2.6b-4bit` | LFM Open License v1.0; commercial use by entities at or above USD 10M annual revenue is excluded |
+| `text-chat-lfm25-a1b-8bit`, `text-chat-lfm25-2.6b-4bit`, `vision-chat-lfm25-3b-8bit` | LFM Open License v1.0; commercial use by entities at or above USD 10M annual revenue is excluded |
 | `vision-chat-muse-glimmer-30b` | Apache-2.0 plus Meta's bundled usage policy; upstream says the model is not intended for download or use by people under 18 |
 | `vision-segment-sam31` | Meta SAM License custom use, trade-control, attribution, and redistribution conditions |
 | `vision-face-buffalo-l` | InsightFace pretrained weights; non-commercial research use |
@@ -390,6 +391,16 @@ mere.run runs it through the native Swift LFM2 runtime; no Python bridge is used
 the repository license and model card, then normalizes the nested directory
 for the native dense `Lfm2ForCausalLM` runtime. The checkpoint uses affine
 4-bit linear weights with a 6-bit tied embedding and is approximately 1.60 GB.
+
+`vision-chat-lfm25-3b-8bit` uses the public
+`LiquidAI/LFM2.5-VL-3B-MLX-8bit` checkpoint at revision
+`4065d2c056a9c54d44fec67cf651812b55c6673f`. The managed snapshot is
+approximately 3.74 GB and includes the dense LFM2.5 2.6B language backbone,
+SigLIP2 NaFlex vision tower, multimodal projector, tokenizer, chat template,
+and `processor_config.json`. mere.run processes local file paths and base64
+data URLs natively, expands each `<image>` placeholder to the downsampled
+patch grid, and continues generation through the shared LFM2 decode engine.
+Remote image URLs are not fetched by the local runtime.
 
 Useful environment variables for that path:
 
@@ -602,6 +613,7 @@ swift run mere.run model pull image-zimage-nano
 MERERUN_MODELS_DIR=/Volumes/Models swift run mere.run model pull text-chat-q36-nano
 MERERUN_MODELS_DIR=/Volumes/Models swift run mere.run model pull text-chat-lfm25-a1b-8bit --accept-model-license
 MERERUN_MODELS_DIR=/Volumes/Models swift run mere.run model pull text-chat-lfm25-2.6b-4bit --accept-model-license
+MERERUN_MODELS_DIR=/Volumes/Models swift run mere.run model pull vision-chat-lfm25-3b-8bit --accept-model-license
 
 # Inspect what is currently installed
 swift run mere.run status

--- a/docs/runtime/api-server.md
+++ b/docs/runtime/api-server.md
@@ -140,6 +140,13 @@ swift run mere.run model pull text-chat-lfm25-2.6b-4bit --accept-model-license
 swift run mere.run api serve --engine text-chat-lfm2 --model text-chat-lfm25-2.6b-4bit
 ```
 
+For LFM2.5-VL image content parts, select the pinned vision model explicitly:
+
+```bash
+swift run mere.run model pull vision-chat-lfm25-3b-8bit --accept-model-license
+swift run mere.run api serve --engine text-chat-lfm2 --model vision-chat-lfm25-3b-8bit
+```
+
 For the opt-in Laguna S 2.1 target with its automatically installed DFlash
 companion:
 
@@ -492,6 +499,10 @@ Engine compatibility:
 - `text-chat-lfm25-2.6b-4bit`: uses the same native LFM2 serving engine with
   LiquidAI's dense 2.6B MLX 4-bit weights, accepts function tools, and rejects
   image content parts.
+- `vision-chat-lfm25-3b-8bit`: uses the native LFM2 serving engine with
+  LiquidAI's dense language backbone, SigLIP2 vision tower, and multimodal
+  projector. It accepts local-file and base64 image content parts; it does not
+  fetch remote image URLs.
 - `text-chat-klein`: supports `response_format: {"type":"json_object"}` with
   local JSON retry behavior.
 - `text-code`: accepts plain text chat requests and OpenAI `stop` sequences;

--- a/docs/runtime/model-management.md
+++ b/docs/runtime/model-management.md
@@ -102,7 +102,7 @@ button opens the configured model store in Finder; it does not start a download.
 Examples:
 
 - images: `image-klein-nano`, `image-bonsai-binary`, `image-bonsai-ternary`, `image-zimage-nano`, `image-klein-max`, `image-zimage-max`
-- text: `text-chat-gemma4`, `text-chat-laguna-s-2-1`, `text-chat-laguna-xs-2-1`, `text-chat-nemotron-35-lightning`, `text-chat-q36-nano`, `text-chat-bonsai-27b-1bit`, `text-chat-bonsai-27b-2bit`, `text-chat-lfm25-2.6b-4bit`, `text-chat-lfm25-a1b-8bit`, `text-agent-deepseek-v4-flash`, `text-agent-qwen35-9b`, `text-agent-ornith-9b`, `text-agent-ornith-35b-mlx`, `text-agent-ornith-35b`, `text-code-north-mini`, `text-code-qwen3`, `text-embed-qwen3-0.6b`
+- text: `text-chat-gemma4`, `text-chat-laguna-s-2-1`, `text-chat-laguna-xs-2-1`, `text-chat-nemotron-35-lightning`, `text-chat-q36-nano`, `text-chat-bonsai-27b-1bit`, `text-chat-bonsai-27b-2bit`, `text-chat-lfm25-2.6b-4bit`, `text-chat-lfm25-a1b-8bit`, `vision-chat-lfm25-3b-8bit`, `text-agent-deepseek-v4-flash`, `text-agent-qwen35-9b`, `text-agent-ornith-9b`, `text-agent-ornith-35b-mlx`, `text-agent-ornith-35b`, `text-code-north-mini`, `text-code-qwen3`, `text-embed-qwen3-0.6b`
 - speech: `speech-tts-qwen3-nano`, `speech-asr-parakeet`
 - vision: `vision-ocr-lighton`
 - music: `music-acestep`, `music-acestep-xl-turbo`, `music-acestep-xl-turbo-lm4b`, `music-acestep-xl-sft`, `music-acestep-xl-base`, `music-acestep-lm-1.7b`, `music-acestep-lm-4b`, `music-magenta-rt2-small`, `music-magenta-rt2-base`

--- a/docs/runtime/text.md
+++ b/docs/runtime/text.md
@@ -47,6 +47,7 @@ help in the repository gate.
 - `text-chat-bonsai-27b-2bit` (managed packed 2-bit ternary dense Qwen3.6 27B vision/reasoning snapshot)
 - `text-chat-lfm25-2.6b-4bit` (managed LiquidAI LFM2.5 2.6B dense MLX 4-bit snapshot)
 - `text-chat-lfm25-a1b-8bit` (managed LiquidAI LFM2.5 8B-A1B MLX 8-bit snapshot)
+- `vision-chat-lfm25-3b-8bit` (managed LiquidAI LFM2.5-VL 3B MLX 8-bit vision-language snapshot)
 - `text-agent-ornith-9b` (experimental native MLX/OptiQ coding-agent snapshot)
 - `text-agent-ornith-35b-mlx` (local native MLX Q4 coding-agent snapshot)
 - `text-agent-deepseek-v4-flash` (API/agent serving)
@@ -165,6 +166,20 @@ Concurrent serve workloads use ragged, cache-safe decode batching when
 `--max-active-requests` is above `1` (`MERERUN_LFM2_CONTINUOUS_BATCHING`
 overrides); rows at different prompt lengths share a forward only when every
 attention and short-conv cache proves compatibility.
+
+`vision-chat-lfm25-3b-8bit` adds the checkpoint's SigLIP2 vision tower and
+multimodal projector to that native LFM2 engine. Pass a local image path or
+base64 data URL through `--image`; the runtime smart-resizes the image to the
+checkpoint's 16-pixel patch grid, projects the downsampled visual tokens into
+the language prompt, then reuses the normal LFM2 decode path.
+
+```bash
+swift run mere.run model pull vision-chat-lfm25-3b-8bit --accept-model-license
+swift run mere.run text chat \
+  --model vision-chat-lfm25-3b-8bit \
+  --image ./document.png \
+  --prompt "Summarize this document and list its key figures."
+```
 
 `text-chat-laguna-s-2-1` is an opt-in 96 GB-and-up Apple Silicon lane and is
 never selected by setup or hardware-aware defaults. Its roughly 72 GB target


### PR DESCRIPTION
## Summary

- add the managed `vision-chat-lfm25-3b-8bit` model, pinned to `LiquidAI/LFM2.5-VL-3B-MLX-8bit@4065d2c056a9c54d44fec67cf651812b55c6673f`
- implement typed LFM2-VL configuration, SigLIP2 vision encoding, smart image resizing and patch packing, multimodal projection, and visual-token prefill in the native Swift/MLX runtime
- wire model resolution, capability reporting, manifest validation, license acceptance, CLI sampling defaults, tests, and public documentation

## Why

This makes LiquidAI's compact 3B vision-language checkpoint available through the existing local `mere.run text chat --image` workflow without requiring a Python or Transformers runtime.

## User impact

After explicitly accepting the LFM Open License, users can pull the managed model and run local image description and OCR on Apple Silicon:

```bash
mere.run model pull vision-chat-lfm25-3b-8bit --accept-model-license
mere.run text chat \
  --model vision-chat-lfm25-3b-8bit \
  --image ./photo.jpg \
  --prompt "Describe this image and transcribe any visible text."
```

The install manifest records the immutable upstream revision, MLX 8-bit quantization metadata, supported `chat` and `vision_chat` capabilities, and usage-terms acknowledgement.

## Validation

- `./scripts/check.sh`
  - SwiftLint strict, build, CLI help sweep, docs/hygiene scans: passed
  - XCTest: 2,713 executed, 197 expected skips, 0 failures
  - Swift Testing: 26 passed
- licensed pull of the exact pinned checkpoint: 3.74 GB, manifest `isValid: true`
- real native MLX/Metal image smoke using the branch-built CLI:
  - shape prompt returned: `The colored shapes in the image are a blue square and an orange rectangle.`
  - OCR prompt returned exactly: `MERE VISION 25`
  - first run: 4.16s wall time, 41.75 decode tokens/s
  - OCR run: 2.36s wall time, 82.17 decode tokens/s
- `git diff --check`: passed
