### PR TITLE
Fix native LTX 2.5 Dub-It loading

### DIFF
--- a/Sources/MereRunCLI/Commands/VideoDubItCommand.swift
+++ b/Sources/MereRunCLI/Commands/VideoDubItCommand.swift
@@ -117,6 +117,7 @@ struct VideoDubIt: AsyncParsableCommand {
     }
 
     mutating func run() async throws {
+        try MLXBundleSupport.ensureAvailable(quiet: quiet)
         let referenceURL = URL(fileURLWithPath: referenceVideo).standardizedFileURL
         guard FileManager.default.fileExists(atPath: referenceURL.path) else {
             throw ValidationError("Reference video not found: \(referenceURL.path)")

--- a/Sources/MereRunCore/LTX/LTX25Resources.swift
+++ b/Sources/MereRunCore/LTX/LTX25Resources.swift
@@ -130,3 +130,18 @@ public func isLTX25FullModelRoot(
 ) -> Bool {
     LTX25Resources(rootURL: rootURL).validateFull(fileManager: fileManager).isEmpty
 }
+
+func ltxStandaloneAudioVAEWeightsURL(
+    modelRoot: URL,
+    isLTX23: Bool,
+    isLTX25: Bool,
+    transformerURL: URL
+) -> URL {
+    if isLTX25 {
+        return LTX25Resources(rootURL: modelRoot).audioVAEURL
+    }
+    if isLTX23 {
+        return modelRoot.appendingPathComponent("audio_vae.safetensors", isDirectory: false)
+    }
+    return transformerURL
+}

--- a/Sources/MereRunCore/LTX/LTXDistilledLatentGenerator.swift
+++ b/Sources/MereRunCore/LTX/LTXDistilledLatentGenerator.swift
@@ -4675,6 +4675,12 @@ public actor LTXUnifiedAVGenerator {
             transformerURL = root.appendingPathComponent("ltx-2-19b-distilled.safetensors", isDirectory: false)
             upsamplerURL = root.appendingPathComponent("ltx-2-spatial-upscaler-x2-1.0.safetensors", isDirectory: false)
         }
+        let standaloneAudioVAEURL = ltxStandaloneAudioVAEWeightsURL(
+            modelRoot: root,
+            isLTX23: isLTX23,
+            isLTX25: isLTX25,
+            transformerURL: transformerURL
+        )
         guard FileManager.default.fileExists(atPath: transformerURL.path) else {
             throw LTXUnifiedAVGeneratorError.transformerWeightsMissing(transformerURL)
         }
@@ -4849,16 +4855,8 @@ public actor LTXUnifiedAVGenerator {
         if loadAudioOutput {
             let audioDecoderStart = ltxMonotonicSeconds()
             let audioDecoder = LTXAudioDecoder()
-            let audioDecoderURL: URL
-            if isLTX25 {
-                audioDecoderURL = ltx25Resources.audioVAEURL
-            } else if isLTX23 {
-                audioDecoderURL = root.appendingPathComponent("audio_vae.safetensors", isDirectory: false)
-            } else {
-                audioDecoderURL = transformerURL
-            }
             try SafetensorsStreamingLoader.applyWeightsStreaming(
-                url: audioDecoderURL,
+                url: standaloneAudioVAEURL,
                 to: audioDecoder,
                 dtype: .float32,
                 verify: .none,
@@ -4941,6 +4939,7 @@ public actor LTXUnifiedAVGenerator {
         self.videoVAEArchitecture = isLTX23 || isLTX25 ? .ltx23Split : .legacy
         self.loadedDType = dtype
         self.loadedRoot = root
+        self.audioVAEWeightsURL = standaloneAudioVAEURL
         self.loadedForVideoOnlyOutput = !loadAudioOutput
         self.loadedForLTX25 = isLTX25
         return LTXLoadTimings(

--- a/Tests/MereRunCLITests/VideoCommandTests.swift
+++ b/Tests/MereRunCLITests/VideoCommandTests.swift
@@ -1230,13 +1230,14 @@ final class VideoCommandTests: XCTestCase {
         let envelope = command.makePreflightEnvelope(outputURL: output)
         let summary = try XCTUnwrap(envelope.result.inputs.detailingLoRAs?.first)
         XCTAssertEqual(summary.requested, ManagedAdapterCatalog.ltx25PixelSpatialUpscalerID)
+        let installedFile = try XCTUnwrap(
+            ManagedAdapterCatalog.spec(for: ManagedAdapterCatalog.ltx25PixelSpatialUpscalerID)
+        ).installedFileURL()
+        XCTAssertEqual(summary.path, installedFile.path)
         XCTAssertEqual(
-            summary.path,
-            try XCTUnwrap(
-                ManagedAdapterCatalog.spec(for: ManagedAdapterCatalog.ltx25PixelSpatialUpscalerID)
-            ).installedFileURL().path
+            envelope.diagnostics.contains { $0.id == "detailing_lora_0_missing" },
+            !FileManager.default.fileExists(atPath: installedFile.path)
         )
-        XCTAssertTrue(envelope.diagnostics.contains { $0.id == "detailing_lora_0_missing" })
     }
 
     func testLTX25SpecificControlsSelectTheDistilledCatalogModel() throws {

--- a/Tests/MereRunCoreTests/LTX25ResourcesTests.swift
+++ b/Tests/MereRunCoreTests/LTX25ResourcesTests.swift
@@ -44,6 +44,21 @@ final class LTX25ResourcesTests: XCTestCase {
         })
     }
 
+    func testStandaloneLoaderResolvesOfficialAudioVAEForReferenceEncoding() {
+        let root = URL(fileURLWithPath: "/tmp/ltx25-official")
+        let transformer = root.appendingPathComponent(LTX25Resources.transformerRelativePath)
+
+        XCTAssertEqual(
+            ltxStandaloneAudioVAEWeightsURL(
+                modelRoot: root,
+                isLTX23: false,
+                isLTX25: true,
+                transformerURL: transformer
+            ),
+            LTX25Resources(rootURL: root).audioVAEURL
+        )
+    }
+
     func testOfficialFullLayoutRequiresDevTransformerAndDistilledLoRA() throws {
         let root = try TestFileSystem.makeTempDir()
         defer { try? FileManager.default.removeItem(at: root) }


### PR DESCRIPTION
## Summary

- bootstrap the bundled MLX Metal runtime before `video dub-it` begins GPU work
- retain the resolved standalone audio VAE path so LTX 2.5 Dub-It can encode reference audio
- cover the official packed audio VAE path and make the DFR preflight assertion valid on both clean CI and provisioned machines

## Root cause

The standalone LTX loader resolved and loaded the official packed audio VAE decoder, but did not retain that URL for later reference-audio encoding. Dub-It therefore reported a missing audio VAE even though the checkpoint was present. The command also skipped the standard MLX bundle bootstrap, so a fresh checkout could fail before model loading with a missing default Metal library.

## Impact

Native Swift/MLX Dub-It now works from a clean checkout with the official gated checkpoint and IC-LoRA, including real video-plus-audio reference conditioning and synchronized generated output.

## Validation

- `./scripts/check.sh`
  - strict SwiftLint: 0 violations
  - build and CLI help sweep passed
  - 2,793 tests passed, 199 expected skips, 0 failures
  - hygiene checks passed
- real gated checkpoint smoke with the official Dub-It IC-LoRA
  - 9 H.264 frames at 64x64 and 24 fps
  - AAC stereo at 48 kHz
  - matched 0.375 s video/audio duration
  - decoded audio was non-silent
