### PR TITLE
Add native MiniMax Music 3 generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on Keep a Changelog.
 
 ### Video and audio
 
+- added `music-minimax-music3`, a pinned selective MiniMax Music 3 checkpoint
+  and native Swift/MLX song-generation runtime covering caption/lyric prompt
+  normalization, Qwen3 semantic-code generation, residual RVQ depth decode,
+  overlap-aware flow matching, and 44.1 kHz stereo vocoding. The approximately
+  26.6 GiB managed pull is restricted, never auto-downloads at runtime, and
+  requires explicit acknowledgement of the upstream community license.
 - expanded native Swift/MLX LTX 2.5 support to the complete pinned upstream
   v1.2.0 inference family: standalone distilled, full dev plus distilled-LoRA,
   HQ Res2s, dev one-stage, arbitrary timed images, generated keyframes,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,11 @@ The format is based on Keep a Changelog.
   overlap-aware flow matching, and 44.1 kHz stereo vocoding. The approximately
   26.6 GiB managed pull is restricted, never auto-downloads at runtime, and
   requires explicit acknowledgement of the upstream community license.
+- completed the MiniMax Music 3 public runtime contract with direct 25 Hz
+  `--max-frames` limit control, staged or resident model loading, native 44.1 kHz or
+  speech-compatible 32 kHz stereo WAV output, model-specific CLI guidance, and
+  a non-streaming `/v1/audio/speech` endpoint. MiniMax invocations now reject
+  ACE-Step-only flags instead of silently accepting controls the model ignores.
 - expanded native Swift/MLX LTX 2.5 support to the complete pinned upstream
   v1.2.0 inference family: standalone distilled, full dev plus distilled-LoRA,
   HQ Res2s, dev one-stage, arbitrary timed images, generated keyframes,

--- a/Package.swift
+++ b/Package.swift
@@ -348,6 +348,7 @@ targets.append(contentsOf: [
       "MLX/README.md",
       "MMAudio/README.md",
       "MiniMaxH3/README.md",
+      "MiniMaxMusic3/README.md",
       "PrivacyFilter/README.md",
       "RoFormer/README.md",
       "UniverSR/README.md",

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ current flags.
 | Depth, geometry, and 3D | `vision depth-video`, `geometry`, `geometry-multiview`, `image-to-3d*`; `image reconstruct-3d*` | Video Depth Anything, MoGe-2, Depth Anything 3, TripoSR, InstantMesh, and TRELLIS.2; depth/confidence EXRs, cameras, point clouds, 3DGS initialization, OBJ, PLY, GLB, and PBR voxel artifacts |
 | Audio enhancement | `audio enhance` | Native AP-BWE speech bandwidth extension and UniverSR general-audio super-resolution to hashed 48 kHz mono WAVs |
 | Video and worlds | `video generate`, `video cosmos3`, `video prepare-masks`, `video animate`, `video session`, `video export-latents`, `world serve` | MiniMax-H3 FL2VA/Ref2VA synchronized video and audio, native LTX 2.5 and LTX 2.3 synchronized audio/video, resident distilled and full-dev LTX workers, Wan 2.2 TI2V, native Cosmos3-Edge generation/reasoning/action dynamics, native SAM 3.1 mask preparation, native SCAIL-2 subject animation/replacement, and warm DreamX or Cosmos3 world sessions |
-| Music and sound | `music analyze`, `generate`, `realtime`, `separate`, `transcribe`; `sfx generate`, `sfx video generate` | ACE-Step generation, analysis, and covers; Magenta RT2 realtime MIDI performance; native RoFormer separation, dereverb, and denoise; MuScriptor full-mix MIDI transcription; Woosh and native MMAudio text/video-conditioned sound |
+| Music and sound | `music analyze`, `generate`, `realtime`, `separate`, `transcribe`; `sfx generate`, `sfx video generate` | Native MiniMax Music 3 full-song generation; ACE-Step generation, analysis, and covers; Magenta RT2 realtime MIDI performance; native RoFormer separation, dereverb, and denoise; MuScriptor full-mix MIDI transcription; Woosh and native MMAudio text/video-conditioned sound |
 | Speech | `speech synthesize`, `speech transcribe`, `speech diarize`, `speech listen`, `speech profile` | Qwen3 TTS, saved voice profiles, Qwen3 live ASR, Parakeet transcription, and native MLX Sortformer speaker diarization |
 | Serving and operations | `api serve`, `open-webui quickstart`, `status`, `run`, `model runtime`, `gate` | OpenAI-compatible chat, embeddings, images, TTS, and STT; resident model pooling, TTL/pinning, memory guards, durable run inspection, and installed-model quality gates |
 | Automation | `--preflight --json`, `--progress-json`, `image run-plan`, `guide` | Typed preflight actions, machine-readable progress, replayable plans, durable run directories, checksums, and offline command cookbooks |
@@ -598,6 +598,17 @@ swift run mere.run model pull music-acestep
 swift run mere.run music generate \
   "upbeat electronic groove" \
   --output ./track.wav
+
+# Generate a lyric-driven stereo song with native MiniMax Music 3
+swift run mere.run model pull music-minimax-music3 --accept-model-license
+swift run mere.run music generate \
+  "cinematic synth-pop, female lead, 118 bpm, wide guitars" \
+  --model music-minimax-music3 \
+  --lyrics-file ./lyrics.txt \
+  --duration 30 \
+  --steps 30 \
+  --seed 7 \
+  --output ./minimax-song.wav
 
 # Generate with ACE-Step XL Turbo on larger Macs
 swift run mere.run model pull music-acestep-xl-turbo

--- a/README.md
+++ b/README.md
@@ -608,7 +608,14 @@ swift run mere.run music generate \
   --duration 30 \
   --steps 30 \
   --seed 7 \
+  --memory-mode staged \
   --output ./minimax-song.wav
+
+# Keep MiniMax Music 3 warm behind its speech-compatible HTTP route
+swift run mere.run music serve \
+  --model music-minimax-music3 \
+  --memory-mode resident \
+  --port 8080
 
 # Generate with ACE-Step XL Turbo on larger Macs
 swift run mere.run model pull music-acestep-xl-turbo

--- a/Sources/MereRunCLI/Commands/GuideCommand.swift
+++ b/Sources/MereRunCLI/Commands/GuideCommand.swift
@@ -62,7 +62,7 @@ struct GuideCommand: ParsableCommand {
     }
 
     static func render(entry: GuideTopic, model: String?, json: Bool) throws -> String {
-        let rawContent = try GuideRegistry.content(for: entry)
+        let rawContent = try GuideRegistry.content(for: entry, model: model)
         let content: String
         if let model, !model.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             content = "> Model focus: `\(model)`\n\n" + rawContent
@@ -427,6 +427,7 @@ enum GuideRegistry {
                 "music-acestep-xl-sft",
                 "music-acestep-xl-turbo",
                 "music-acestep-xl-turbo-lm4b",
+                "music-minimax-music3",
                 "music-magenta-rt2-small",
                 "music-magenta-rt2-base",
             ],
@@ -711,8 +712,14 @@ enum GuideRegistry {
         }
     }
 
-    static func content(for topic: GuideTopic) throws -> String {
-        let resource = topic.resourceName as NSString
+    static func content(for topic: GuideTopic, model: String? = nil) throws -> String {
+        let normalizedModel = model?.trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        let resourceName = topic.topic == "music-generate"
+            && normalizedModel == "music-minimax-music3"
+            ? "music-generate-minimax-music3.md"
+            : topic.resourceName
+        let resource = resourceName as NSString
         let baseName = resource.deletingPathExtension
         let fileExtension = resource.pathExtension
         let nestedURL = Bundle.module.url(
@@ -722,7 +729,7 @@ enum GuideRegistry {
         )
         let flatURL = Bundle.module.url(forResource: baseName, withExtension: fileExtension)
         guard let url = nestedURL ?? flatURL else {
-            throw ValidationError("Guide resource missing: \(topic.resourceName)")
+            throw ValidationError("Guide resource missing: \(resourceName)")
         }
         return try String(contentsOf: url, encoding: .utf8)
     }

--- a/Sources/MereRunCLI/Commands/MiniMaxMusic3Serve.swift
+++ b/Sources/MereRunCLI/Commands/MiniMaxMusic3Serve.swift
@@ -1,0 +1,276 @@
+import ArgumentParser
+import Foundation
+import Hummingbird
+import MereRunCore
+import NIOCore
+
+struct MiniMaxMusic3SpeechRequest: Codable, Sendable {
+    var model: String?
+    var input: String
+    var instructions: String
+    var responseFormat: String?
+    var seed: UInt64?
+    var maxNewTokens: Int?
+    var stream: Bool?
+    var audioDuration: Float?
+    var numInferenceSteps: Int?
+    var guidanceScale: Float?
+    var sampleRate: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case model
+        case input
+        case instructions
+        case responseFormat = "response_format"
+        case seed
+        case maxNewTokens = "max_new_tokens"
+        case stream
+        case audioDuration = "audio_duration"
+        case numInferenceSteps = "num_inference_steps"
+        case guidanceScale = "guidance_scale"
+        case sampleRate = "sample_rate"
+    }
+}
+
+private struct MiniMaxMusic3HealthResponse: Codable {
+    var status: String
+    var model: String
+    var resident: Bool
+    var memoryMode: MiniMaxMusic3LoadingStrategy
+    var nativeSampleRate: Int
+    var speechSampleRate: Int
+
+    enum CodingKeys: String, CodingKey {
+        case status
+        case model
+        case resident
+        case memoryMode = "memory_mode"
+        case nativeSampleRate = "native_sample_rate"
+        case speechSampleRate = "speech_sample_rate"
+    }
+}
+
+private actor MiniMaxMusic3ServerSession {
+    private let pipeline: MiniMaxMusic3Pipeline
+
+    init(
+        resources: MiniMaxMusic3Resources,
+        loadingStrategy: MiniMaxMusic3LoadingStrategy
+    ) throws {
+        self.pipeline = try MiniMaxMusic3Pipeline(
+            resources: resources,
+            loadingStrategy: loadingStrategy
+        )
+    }
+
+    func generate(
+        _ request: MiniMaxMusic3SpeechRequest,
+        modelID: String
+    ) throws -> Data {
+        let options = try Self.options(from: request, modelID: modelID)
+        let result = try pipeline.generate(options: options.generation)
+        let waveform = try ACEStepWAVWriter.resample(
+            result.waveform.transposed(0, 2, 1),
+            from: result.sampleRate,
+            to: options.sampleRate
+        )
+        return try ACEStepWAVWriter.wavData(
+            waveform,
+            sampleRate: options.sampleRate,
+            options: .init(
+                format: .pcm16,
+                normalization: .none,
+                targetPeakDB: 0,
+                fadeInMilliseconds: 0,
+                fadeOutMilliseconds: 0,
+                dither: false
+            )
+        )
+    }
+
+    private static func options(
+        from request: MiniMaxMusic3SpeechRequest,
+        modelID: String
+    ) throws -> (generation: MiniMaxMusic3GenerationOptions, sampleRate: Int) {
+        if let requestedModel = request.model,
+           requestedModel != modelID,
+           requestedModel != MiniMaxMusic3Resources.repository
+        {
+            throw ValidationError(
+                "MiniMax Music 3 server loaded '\(modelID)', not '\(requestedModel)'."
+            )
+        }
+        let caption = request.instructions.trimmingCharacters(in: .whitespacesAndNewlines)
+        let lyrics = request.input.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !caption.isEmpty else {
+            throw ValidationError("instructions must contain a music description.")
+        }
+        guard !lyrics.isEmpty else {
+            throw ValidationError("input must contain lyrics or [Instrumental].")
+        }
+        guard request.responseFormat?.lowercased() ?? "wav" == "wav" else {
+            throw ValidationError("response_format must be wav.")
+        }
+        guard request.stream != true else {
+            throw ValidationError("MiniMax Music 3 supports stream=false only.")
+        }
+        let duration = request.audioDuration ?? 60
+        guard duration > 0, duration <= 360 else {
+            throw ValidationError("audio_duration must be greater than 0 and at most 360 seconds.")
+        }
+        let durationFrames = Int(duration * Float(MiniMaxMusic3Prompt.frameRate))
+        let maximumFrames = request.maxNewTokens ?? durationFrames
+        guard (1...MiniMaxMusic3Prompt.maxAudioFrames).contains(maximumFrames) else {
+            throw ValidationError("max_new_tokens must be between 1 and 9000.")
+        }
+        if request.audioDuration != nil,
+           request.maxNewTokens != nil,
+           durationFrames != maximumFrames
+        {
+            throw ValidationError(
+                "audio_duration and max_new_tokens must describe the same 25 Hz frame limit."
+            )
+        }
+        let steps = request.numInferenceSteps ?? 30
+        guard steps > 0 else {
+            throw ValidationError("num_inference_steps must be positive.")
+        }
+        let guidanceScale = request.guidanceScale ?? 1.7
+        guard guidanceScale >= 1, guidanceScale.isFinite else {
+            throw ValidationError("guidance_scale must be finite and at least 1.")
+        }
+        let sampleRate = request.sampleRate ?? 32_000
+        guard sampleRate == 32_000 || sampleRate == 44_100 else {
+            throw ValidationError("sample_rate must be 32000 or 44100.")
+        }
+        return (
+            MiniMaxMusic3GenerationOptions(
+                caption: caption,
+                lyrics: lyrics,
+                durationSeconds: duration,
+                maximumFrames: maximumFrames,
+                inferenceSteps: steps,
+                seed: request.seed ?? 0,
+                guidanceScale: guidanceScale
+            ),
+            sampleRate
+        )
+    }
+}
+
+final class MiniMaxMusic3APIServer: @unchecked Sendable {
+    private let session: MiniMaxMusic3ServerSession
+    private let modelID: String
+    private let loadingStrategy: MiniMaxMusic3LoadingStrategy
+    private let apiKey: String?
+
+    init(
+        resources: MiniMaxMusic3Resources,
+        modelID: String,
+        loadingStrategy: MiniMaxMusic3LoadingStrategy,
+        apiKey: String?
+    ) throws {
+        self.session = try MiniMaxMusic3ServerSession(
+            resources: resources,
+            loadingStrategy: loadingStrategy
+        )
+        self.modelID = modelID
+        self.loadingStrategy = loadingStrategy
+        self.apiKey = apiKey
+    }
+
+    func run(host: String, port: Int) async throws {
+        let app = Application(
+            router: buildRouter(),
+            configuration: .init(address: .hostname(host, port: port))
+        )
+        CLIStderr.write(
+            "MiniMax Music 3 speech API (\(loadingStrategy.rawValue)): "
+                + "http://\(host):\(port)/v1/audio/speech\n"
+        )
+        try await app.runService()
+    }
+
+    func buildRouter() -> Router<BasicRequestContext> {
+        let router = Router()
+        router.get("/health") { [self] request, _ in
+            guard isAuthorized(request) else {
+                return errorResponse(status: .unauthorized, message: "Invalid API key.")
+            }
+            return try jsonResponse(
+                MiniMaxMusic3HealthResponse(
+                    status: "ok",
+                    model: modelID,
+                    resident: loadingStrategy == .resident,
+                    memoryMode: loadingStrategy,
+                    nativeSampleRate: 44_100,
+                    speechSampleRate: 32_000
+                )
+            )
+        }
+        router.post("/v1/audio/speech") { [self] request, _ in
+            await handleSpeech(request)
+        }
+        return router
+    }
+
+    private func handleSpeech(_ request: Request) async -> Response {
+        guard isAuthorized(request) else {
+            return errorResponse(status: .unauthorized, message: "Invalid API key.")
+        }
+        do {
+            guard request.headers[.contentType]?.lowercased()
+                .contains("application/json") == true
+            else {
+                throw ValidationError("Content-Type must be application/json.")
+            }
+            let body = try await request.body.collect(upTo: 4 * 1_024 * 1_024)
+            let payload = try JSONDecoder().decode(
+                MiniMaxMusic3SpeechRequest.self,
+                from: Data(body.readableBytesView)
+            )
+            let wav = try await session.generate(payload, modelID: modelID)
+            return Response(
+                status: .ok,
+                headers: [.contentType: "audio/wav"],
+                body: .init(byteBuffer: ByteBuffer(bytes: wav))
+            )
+        } catch {
+            return errorResponse(
+                status: .badRequest,
+                message: MusicServe.apiErrorMessage(error)
+            )
+        }
+    }
+
+    private func isAuthorized(_ request: Request) -> Bool {
+        guard let apiKey, !apiKey.isEmpty else {
+            return true
+        }
+        return request.headers[.authorization] == "Bearer \(apiKey)"
+    }
+
+    private func jsonResponse<T: Encodable>(_ value: T) throws -> Response {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        let data = try encoder.encode(value)
+        return Response(
+            status: .ok,
+            headers: [.contentType: "application/json"],
+            body: .init(byteBuffer: ByteBuffer(bytes: data))
+        )
+    }
+
+    private func errorResponse(
+        status: HTTPResponse.Status,
+        message: String
+    ) -> Response {
+        let data = (try? JSONEncoder().encode(["error": message]))
+            ?? Data("{\"error\":\"music API error\"}".utf8)
+        return Response(
+            status: status,
+            headers: [.contentType: "application/json"],
+            body: .init(byteBuffer: ByteBuffer(bytes: data))
+        )
+    }
+}

--- a/Sources/MereRunCLI/Commands/MusicGenerateCommand.swift
+++ b/Sources/MereRunCLI/Commands/MusicGenerateCommand.swift
@@ -24,6 +24,12 @@ struct MusicGenerate: AsyncParsableCommand {
             --duration 4 \
             -o out.wav
 
+          mere.run music generate "cinematic synth-pop, soaring female vocal" \
+            --model music-minimax-music3 \
+            --lyrics "[verse]\nwe turn the dark into gold\n[chorus]\nwe are electric" \
+            --duration 30 \
+            -o minimax.wav
+
           mere.run music generate "dream-pop cover with soft vocals" \
             --source-audio ~/Downloads/song.mp3 \
             --lyrics "[verse]\\nnew words over the old shape" \
@@ -103,7 +109,7 @@ struct MusicGenerate: AsyncParsableCommand {
     )
     var adapterScales: [Float] = []
 
-    @Option(name: [.customShort("m"), .long], help: "Managed model id or local path to the ACE-Step model root/checkpoints root.")
+    @Option(name: [.customShort("m"), .long], help: "Managed music model id or local model root.")
     var model: String = ModelResolver.ModelID.aceStep.rawValue
 
     @Option(name: [.customLong("checkpoints-root")], help: "Root directory containing ACE-Step checkpoint subdirectories. Auto-discovered if not set.")
@@ -148,7 +154,7 @@ struct MusicGenerate: AsyncParsableCommand {
     @Option(name: [.customLong("quality")], help: "Adaptive ACE-Step quality: draft, song, final, or edit.")
     var quality: ACEStepQualityPreset = .song
 
-    @Option(name: [.customShort("s"), .long], help: "Denoise steps (default: Turbo 8; Base/SFT 50).")
+    @Option(name: [.customShort("s"), .long], help: "Denoise steps (MiniMax Music 3: 30; ACE-Step Turbo: 8; Base/SFT: 50).")
     var steps: Int?
 
     @Option(name: [.customLong("shift")], help: "Flow scheduler shift (default: Turbo 3; Base/SFT 1).")
@@ -472,6 +478,11 @@ struct MusicGenerate: AsyncParsableCommand {
             throw ValidationError(
                 "--daw-bundle requires recipe metadata; remove --no-recipe"
             )
+        }
+
+        if isMiniMaxMusic3Request {
+            try runMiniMaxMusic3(explicitDurationSeconds: explicitDurationSeconds)
+            return
         }
 
         if isMagentaRT2Request {
@@ -1057,6 +1068,175 @@ struct MusicGenerate: AsyncParsableCommand {
         }
         let url = URL(fileURLWithPath: model).standardizedFileURL
         return MagentaRT2Resources.looksLikeMagentaRT2Root(url)
+    }
+
+    private var isMiniMaxMusic3Request: Bool {
+        if model == ModelResolver.ModelID.miniMaxMusic3.rawValue {
+            return true
+        }
+        return MiniMaxMusic3Resources.looksLikeRoot(resolveUserPath(model))
+    }
+
+    private func runMiniMaxMusic3(explicitDurationSeconds: Float?) throws {
+        try validateMiniMaxMusic3Options(explicitDurationSeconds: explicitDurationSeconds)
+        let inputLRC = try loadLRC()
+        let resolvedLyrics = instrumental
+            ? "[Instrumental]"
+            : try inputLRC?.lyrics ?? loadLyrics()
+        guard !resolvedLyrics.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw ValidationError(
+                "MiniMax Music 3 requires --lyrics, --lyrics-file, --lrc-file, or --instrumental."
+            )
+        }
+
+        let rootURL: URL
+        if model == ModelResolver.ModelID.miniMaxMusic3.rawValue {
+            do {
+                rootURL = try ModelResolver().resolve(.miniMaxMusic3).rootURL
+            } catch {
+                throw ValidationError(
+                    "MiniMax Music 3 is not installed. Review its license, then run "
+                        + "`mere.run model pull \(MiniMaxMusic3Resources.modelID) --accept-model-license`."
+                )
+            }
+        } else {
+            rootURL = resolveUserPath(model)
+        }
+        let resources = MiniMaxMusic3Resources(rootURL: rootURL)
+        let missing = resources.validate()
+        guard missing.isEmpty else {
+            throw ValidationError(
+                "Incomplete MiniMax Music 3 root at \(rootURL.path): "
+                    + missing.map(\.lastPathComponent).joined(separator: ", ")
+            )
+        }
+
+        let outputURL = CLIOutput.resolveOutputURL(
+            output,
+            defaultPrefix: "mererun-minimax-music3",
+            defaultExtension: "wav"
+        )
+        try FileManager.default.createDirectory(
+            at: outputURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        if !quiet {
+            CLIStderr.write("Loading MiniMax Music 3 from \(rootURL.path)\n")
+        }
+        let pipeline = try MiniMaxMusic3Pipeline(resources: resources)
+        let result = try pipeline.generate(
+            options: MiniMaxMusic3GenerationOptions(
+                caption: caption,
+                lyrics: resolvedLyrics,
+                durationSeconds: explicitDurationSeconds ?? 60,
+                inferenceSteps: steps ?? 30,
+                seed: seed ?? 0,
+                guidanceScale: guidanceScale ?? 1.7
+            ),
+            progress: { event in
+                guard !quiet else { return }
+                switch event {
+                case .semantic(let frame, let maximum):
+                    if frame == 1 || frame == maximum || frame % 25 == 0 {
+                        CLIStderr.write("MiniMax semantic frames: \(frame)/\(maximum)\n")
+                    }
+                case .denoise(let chunk, let chunkCount, let step, let stepCount):
+                    if step == 1 || step == stepCount || step % 5 == 0 {
+                        CLIStderr.write(
+                            "MiniMax flow chunk \(chunk)/\(chunkCount): step \(step)/\(stepCount)\n"
+                        )
+                    }
+                case .decode(let chunk, let chunkCount):
+                    CLIStderr.write("MiniMax vocoder chunk: \(chunk)/\(chunkCount)\n")
+                }
+            }
+        )
+        let exportOptions = ACEStepAudioExportOptions(
+            format: exportFormat,
+            normalization: normalization,
+            targetPeakDB: targetPeakDB,
+            fadeInMilliseconds: fadeInMilliseconds,
+            fadeOutMilliseconds: fadeOutMilliseconds,
+            dither: !noDither
+        )
+        try ACEStepWAVWriter.writeWAV(
+            result.waveform.transposed(0, 2, 1),
+            to: outputURL,
+            sampleRate: result.sampleRate,
+            options: exportOptions
+        )
+        if !noRecipe {
+            let recipeURL = recipeOutput.map(resolveUserPath)
+                ?? outputURL.deletingPathExtension().appendingPathExtension("recipe.json")
+            let recipe = MiniMaxMusic3GenerationRecipe(
+                schemaVersion: MiniMaxMusic3GenerationRecipe.currentSchemaVersion,
+                createdAt: Date(),
+                modelID: model,
+                sourceRepository: MiniMaxMusic3Resources.repository,
+                sourceRevision: MiniMaxMusic3Resources.revision,
+                caption: caption,
+                lyrics: resolvedLyrics,
+                durationSeconds: explicitDurationSeconds ?? 60,
+                generatedFrameCount: result.frameCount,
+                inferenceSteps: steps ?? 30,
+                seed: seed ?? 0,
+                guidanceScale: guidanceScale ?? 1.7,
+                sampleRate: result.sampleRate,
+                export: exportOptions,
+                outputFilename: outputURL.lastPathComponent,
+                outputSHA256: try ModelArtifactPin.fileSHA256(outputURL)
+            )
+            try recipe.write(to: recipeURL)
+            if !quiet {
+                CLIStderr.write("Saved recipe: \(recipeURL.path)\n")
+            }
+        }
+        if !quiet {
+            CLIStderr.write(
+                "Generated \(result.frameCount) MiniMax frames at \(result.sampleRate) Hz stereo\n"
+            )
+            CLIStderr.write("Saved audio: \(outputURL.path)\n")
+        }
+        print(outputURL.path)
+    }
+
+    private func validateMiniMaxMusic3Options(explicitDurationSeconds: Float?) throws {
+        if let explicitDurationSeconds, explicitDurationSeconds > 360 {
+            throw ValidationError("MiniMax Music 3 supports at most 360 seconds (9,000 frames at 25 Hz).")
+        }
+        if useLM || noLM || analyzeSourceAudio || lmModel != nil || lmSubdirectory != nil {
+            throw ValidationError("MiniMax Music 3 uses its built-in autoregressive stage; ACE-Step LM options do not apply.")
+        }
+        if taskType != .textToMusic
+            || sourceAudio != nil
+            || !referenceAudio.isEmpty
+            || nonCover
+            || flowEdit
+            || trackName != nil
+            || completeTrackClasses != nil
+        {
+            throw ValidationError("MiniMax Music 3 currently supports text-and-lyrics generation only.")
+        }
+        if !adapters.isEmpty || !adapterScales.isEmpty || stems != nil {
+            throw ValidationError("MiniMax Music 3 does not support ACE-Step adapters or stem extraction.")
+        }
+        if shift != nil
+            || inferMethod != nil
+            || samplerMode != nil
+            || guidanceMode != nil
+            || cfgIntervalStart != nil
+            || cfgIntervalEnd != nil
+            || velocityNormThreshold != nil
+            || velocityEMAFactor != nil
+        {
+            throw ValidationError("MiniMax Music 3 uses its fixed flow-matching Euler schedule.")
+        }
+        if let candidateCount, candidateCount != 1 {
+            throw ValidationError("MiniMax Music 3 currently supports one candidate per invocation.")
+        }
+        if keepCandidates || dawBundle != nil || lrcOutput != nil {
+            throw ValidationError("Candidate, DAW-bundle, and LRC export are not yet available for MiniMax Music 3.")
+        }
     }
 
     private func candidateOutputURL(

--- a/Sources/MereRunCLI/Commands/MusicGenerateCommand.swift
+++ b/Sources/MereRunCLI/Commands/MusicGenerateCommand.swift
@@ -12,6 +12,11 @@ struct MusicGenerate: AsyncParsableCommand {
         Prints the output WAV path to stdout.
         Progress and diagnostics are printed to stderr.
 
+        MiniMax Music 3 consumes caption, lyrics, duration/max-frames, steps,
+        seed, and guidance scale. Run `mere.run guide music generate --model
+        music-minimax-music3` for the model-specific contract; ACE-Step and
+        Magenta controls are rejected instead of silently ignored.
+
         Example:
           mere.run music generate "upbeat electronic groove" \
             --model music-acestep \
@@ -148,11 +153,29 @@ struct MusicGenerate: AsyncParsableCommand {
     )
     var analyzeSourceAudio: Bool = false
 
-    @Option(name: [.customLong("duration")], help: "Output duration in seconds (omitting it lets song/final quality plan duration).")
+    @Option(name: [.customLong("duration")], help: "Output upper bound in seconds (MiniMax defaults to 60; ACE-Step song/final may plan it when omitted).")
     var durationSeconds: Float?
 
+    @Option(
+        name: [.customLong("max-frames")],
+        help: "MiniMax Music 3 exact 25 Hz acoustic-frame limit (1...9000); must agree with --duration when both are set."
+    )
+    var miniMaxMaximumFrames: Int?
+
+    @Option(
+        name: [.customLong("sample-rate")],
+        help: "MiniMax Music 3 WAV sample rate: native 44100 or SGLang-compatible 32000."
+    )
+    var miniMaxOutputSampleRate: Int?
+
+    @Option(
+        name: [.customLong("memory-mode")],
+        help: "MiniMax Music 3 loading: staged releases each model stage before loading the next; resident keeps all weights loaded."
+    )
+    var miniMaxLoadingStrategy: MiniMaxMusic3LoadingStrategy?
+
     @Option(name: [.customLong("quality")], help: "Adaptive ACE-Step quality: draft, song, final, or edit.")
-    var quality: ACEStepQualityPreset = .song
+    var quality: ACEStepQualityPreset?
 
     @Option(name: [.customShort("s"), .long], help: "Denoise steps (MiniMax Music 3: 30; ACE-Step Turbo: 8; Base/SFT: 50).")
     var steps: Int?
@@ -166,7 +189,7 @@ struct MusicGenerate: AsyncParsableCommand {
     @Option(name: [.customLong("sampler")], help: "ODE sampler: euler or heun (default: euler).")
     var samplerMode: ACEStepSamplerMode?
 
-    @Option(name: [.customLong("guidance-scale")], help: "Base/SFT diffusion guidance (default: 7; Turbo always uses 1).")
+    @Option(name: [.customLong("guidance-scale")], help: "Flow guidance (MiniMax Music 3: 1.7; ACE-Step Base/SFT: 7; Turbo: 1).")
     var guidanceScale: Float?
 
     @Option(name: [.customLong("guidance-mode")], help: "Base/SFT guidance: apg, adg, or cfg (default: apg).")
@@ -374,7 +397,7 @@ struct MusicGenerate: AsyncParsableCommand {
         if let shift, shift <= 0 {
             throw ValidationError("--shift must be > 0")
         }
-        if let guidanceScale, guidanceScale < 1 {
+        if let guidanceScale, guidanceScale < 1 || !guidanceScale.isFinite {
             throw ValidationError("--guidance-scale must be >= 1")
         }
         if let cfgIntervalStart, !(0...1).contains(cfgIntervalStart) {
@@ -485,6 +508,15 @@ struct MusicGenerate: AsyncParsableCommand {
             return
         }
 
+        if miniMaxMaximumFrames != nil
+            || miniMaxOutputSampleRate != nil
+            || miniMaxLoadingStrategy != nil
+        {
+            throw ValidationError(
+                "--max-frames, --sample-rate, and --memory-mode require MiniMax Music 3."
+            )
+        }
+
         if isMagentaRT2Request {
             try await runMagentaRT2()
             return
@@ -526,7 +558,7 @@ struct MusicGenerate: AsyncParsableCommand {
                 )
             }
         }
-        let qualityDefaults = quality.defaults(
+        let qualityDefaults = resolvedQuality.defaults(
             for: checkpointVariant,
             task: effectiveTask
         )
@@ -663,7 +695,7 @@ struct MusicGenerate: AsyncParsableCommand {
 
         if effectiveUseLM {
             if !quiet {
-                CLIStderr.write("Planning ACE-Step \(quality.rawValue) metadata with the 5Hz LM\n")
+                CLIStderr.write("Planning ACE-Step \(resolvedQuality.rawValue) metadata with the 5Hz LM\n")
             }
             let planningMetadata = ACEStep5HzLMConstrainedSampler.UserMetadata(
                 bpm: userMetadata.bpm,
@@ -929,7 +961,7 @@ struct MusicGenerate: AsyncParsableCommand {
                 textEncoderSubdirectory: resolvedTextSubdirectory ?? "",
                 adapters: loadedAdapters,
                 task: effectiveTask,
-                quality: quality,
+                quality: resolvedQuality,
                 inputCaption: caption,
                 caption: effectiveCaption,
                 lyrics: resolvedLyrics,
@@ -1123,12 +1155,25 @@ struct MusicGenerate: AsyncParsableCommand {
         if !quiet {
             CLIStderr.write("Loading MiniMax Music 3 from \(rootURL.path)\n")
         }
-        let pipeline = try MiniMaxMusic3Pipeline(resources: resources)
+        let loadingStrategy = miniMaxLoadingStrategy ?? .staged
+        if !quiet {
+            CLIStderr.write("MiniMax memory mode: \(loadingStrategy.rawValue)\n")
+        }
+        let pipeline = try MiniMaxMusic3Pipeline(
+            resources: resources,
+            loadingStrategy: loadingStrategy
+        )
+        let requestedDuration = explicitDurationSeconds
+            ?? miniMaxMaximumFrames.map {
+                Float($0) / Float(MiniMaxMusic3Prompt.frameRate)
+            }
+            ?? 60
         let result = try pipeline.generate(
             options: MiniMaxMusic3GenerationOptions(
                 caption: caption,
                 lyrics: resolvedLyrics,
-                durationSeconds: explicitDurationSeconds ?? 60,
+                durationSeconds: requestedDuration,
+                maximumFrames: miniMaxMaximumFrames,
                 inferenceSteps: steps ?? 30,
                 seed: seed ?? 0,
                 guidanceScale: guidanceScale ?? 1.7
@@ -1159,10 +1204,16 @@ struct MusicGenerate: AsyncParsableCommand {
             fadeOutMilliseconds: fadeOutMilliseconds,
             dither: !noDither
         )
-        try ACEStepWAVWriter.writeWAV(
+        let outputSampleRate = miniMaxOutputSampleRate ?? result.sampleRate
+        let outputWaveform = try ACEStepWAVWriter.resample(
             result.waveform.transposed(0, 2, 1),
+            from: result.sampleRate,
+            to: outputSampleRate
+        )
+        try ACEStepWAVWriter.writeWAV(
+            outputWaveform,
             to: outputURL,
-            sampleRate: result.sampleRate,
+            sampleRate: outputSampleRate,
             options: exportOptions
         )
         if !noRecipe {
@@ -1176,12 +1227,15 @@ struct MusicGenerate: AsyncParsableCommand {
                 sourceRevision: MiniMaxMusic3Resources.revision,
                 caption: caption,
                 lyrics: resolvedLyrics,
-                durationSeconds: explicitDurationSeconds ?? 60,
+                durationSeconds: requestedDuration,
+                requestedMaximumFrames: miniMaxMaximumFrames,
                 generatedFrameCount: result.frameCount,
                 inferenceSteps: steps ?? 30,
                 seed: seed ?? 0,
                 guidanceScale: guidanceScale ?? 1.7,
-                sampleRate: result.sampleRate,
+                nativeSampleRate: result.sampleRate,
+                outputSampleRate: outputSampleRate,
+                loadingStrategy: loadingStrategy,
                 export: exportOptions,
                 outputFilename: outputURL.lastPathComponent,
                 outputSHA256: try ModelArtifactPin.fileSHA256(outputURL)
@@ -1193,14 +1247,32 @@ struct MusicGenerate: AsyncParsableCommand {
         }
         if !quiet {
             CLIStderr.write(
-                "Generated \(result.frameCount) MiniMax frames at \(result.sampleRate) Hz stereo\n"
+                "Generated \(result.frameCount) MiniMax frames at \(outputSampleRate) Hz stereo\n"
             )
             CLIStderr.write("Saved audio: \(outputURL.path)\n")
         }
         print(outputURL.path)
     }
 
-    private func validateMiniMaxMusic3Options(explicitDurationSeconds: Float?) throws {
+    func validateMiniMaxMusic3Options(explicitDurationSeconds: Float?) throws {
+        if let miniMaxMaximumFrames,
+           !(1...MiniMaxMusic3Prompt.maxAudioFrames).contains(miniMaxMaximumFrames)
+        {
+            throw ValidationError("--max-frames must be between 1 and 9000.")
+        }
+        if let explicitDurationSeconds, let miniMaxMaximumFrames,
+           Int(explicitDurationSeconds * Float(MiniMaxMusic3Prompt.frameRate)) != miniMaxMaximumFrames
+        {
+            throw ValidationError(
+                "--duration and --max-frames must describe the same 25 Hz frame limit."
+            )
+        }
+        if let miniMaxOutputSampleRate,
+           miniMaxOutputSampleRate != 32_000,
+           miniMaxOutputSampleRate != 44_100
+        {
+            throw ValidationError("--sample-rate must be 32000 or 44100 for MiniMax Music 3.")
+        }
         if let explicitDurationSeconds, explicitDurationSeconds > 360 {
             throw ValidationError("MiniMax Music 3 supports at most 360 seconds (9,000 frames at 25 Hz).")
         }
@@ -1236,6 +1308,69 @@ struct MusicGenerate: AsyncParsableCommand {
         }
         if keepCandidates || dawBundle != nil || lrcOutput != nil {
             throw ValidationError("Candidate, DAW-bundle, and LRC export are not yet available for MiniMax Music 3.")
+        }
+        if checkpointsRoot != nil
+            || turboSubdirectory != "acestep-v15-turbo"
+            || vaeSubdirectory != "vae"
+            || textSubdirectory != nil
+            || adapterKind != .auto
+        {
+            throw ValidationError("ACE-Step component-layout options do not apply to MiniMax Music 3.")
+        }
+        if quality != nil
+            || audioCoverStrength != 1
+            || coverNoiseStrength != 0
+            || retakeSeed != nil
+            || retakeVariance != 0
+            || vocalLanguage != "en"
+            || instruction != "Fill the audio semantic mask based on the given conditions:"
+        {
+            throw ValidationError("ACE-Step quality, cover, retake, language, and instruction options do not apply to MiniMax Music 3.")
+        }
+        if repaintStartSeconds != 0
+            || repaintEndSeconds != -1
+            || chunkMaskMode != .auto
+            || repaintMode != .balanced
+            || repaintStrength != 0.5
+            || sourceCaption != nil
+            || !sourceLyrics.isEmpty
+            || flowEditNMin != 0
+            || flowEditNMax != 1
+            || flowEditNAverage != 1
+        {
+            throw ValidationError("ACE-Step repaint and flow-edit controls do not apply to MiniMax Music 3.")
+        }
+        if bpm != nil
+            || keyscale != nil
+            || timesignature != nil
+            || metadataDuration != nil
+            || metadataLanguage != nil
+            || lmTopK != 0
+            || lmTopP != 0.9
+            || lmTemperature != 0.85
+            || lmRepetitionPenalty != 1
+            || lmCFGScale != 2
+            || lmNegativePrompt != "NO USER INPUT"
+            || noLMCaptionRewrite
+        {
+            throw ValidationError("ACE-Step metadata aliases and LM sampling controls do not apply to MiniMax Music 3; put musical details in the caption.")
+        }
+        if noTiledVAE
+            || vaeChunkSize != 512
+            || vaeOverlap != 64
+            || magentaTemperature != 1
+            || magentaStyleConditioning != .streaming
+            || magentaTopK != 100
+            || magentaCFGMusicCoCa != 3
+            || magentaCFGNotes != 5
+            || magentaCFGDrums != 1
+            || magentaDrumless
+            || magentaUnmaskWidth != 0
+            || magentaSeedRotation != 0
+            || magentaPrefillSilence
+            || magentaPrefillDuration != 1.64
+        {
+            throw ValidationError("ACE-Step VAE and Magenta RT2 controls do not apply to MiniMax Music 3.")
         }
     }
 
@@ -1274,7 +1409,7 @@ struct MusicGenerate: AsyncParsableCommand {
         guard !noLM, !task.skipsLanguageModel else {
             return false
         }
-        return useLM || quality.defaults(for: .turbo, task: task).usesLanguageModel
+        return useLM || resolvedQuality.defaults(for: .turbo, task: task).usesLanguageModel
     }
 
     private func runMagentaRT2() async throws {
@@ -1481,7 +1616,7 @@ struct MusicGenerate: AsyncParsableCommand {
         fallback: Float? = nil
     ) -> Float {
         let requestedDuration = fallback ?? durationSeconds
-            ?? quality.defaults(for: .turbo, task: task).fallbackDurationSeconds
+            ?? resolvedQuality.defaults(for: .turbo, task: task).fallbackDurationSeconds
         guard task.locksDurationToSource,
               let sourceAudio48kHz,
               sourceAudio48kHz.ndim >= 2
@@ -1532,8 +1667,12 @@ struct MusicGenerate: AsyncParsableCommand {
     }
 
     func clampedAutomaticDuration(_ duration: Float) -> Float {
-        let upperBound: Float = quality == .song ? 240 : 600
+        let upperBound: Float = resolvedQuality == .song ? 240 : 600
         return min(max(duration, 10), upperBound)
+    }
+
+    var resolvedQuality: ACEStepQualityPreset {
+        quality ?? .song
     }
 
     private func nonEmpty(_ value: String?) -> String? {

--- a/Sources/MereRunCLI/Commands/MusicServeCommand.swift
+++ b/Sources/MereRunCLI/Commands/MusicServeCommand.swift
@@ -7,7 +7,7 @@ import NIOCore
 struct MusicServe: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "serve",
-        abstract: "Start a warm resident ACE-Step music generation API."
+        abstract: "Start an ACE-Step or MiniMax Music 3 generation API."
     )
 
     @Option(name: [.long], help: "Host to bind to.")
@@ -16,8 +16,14 @@ struct MusicServe: AsyncParsableCommand {
     @Option(name: [.short, .long], help: "Port to listen on.")
     var port: Int = 8081
 
-    @Option(name: [.customShort("m"), .long], help: "Managed ACE-Step model id or local checkpoint root.")
+    @Option(name: [.customShort("m"), .long], help: "Managed ACE-Step/MiniMax model id or local checkpoint root.")
     var model: String = ModelResolver.ModelID.aceStep.rawValue
+
+    @Option(
+        name: [.customLong("memory-mode")],
+        help: "MiniMax Music 3 loading: resident keeps all weights warm; staged lowers peak residency by reloading stages per request."
+    )
+    var miniMaxLoadingStrategy: MiniMaxMusic3LoadingStrategy?
 
     @Option(name: [.customLong("checkpoints-root")], help: "Root containing ACE-Step checkpoint directories.")
     var checkpointsRoot: String?
@@ -72,6 +78,14 @@ struct MusicServe: AsyncParsableCommand {
             )
         }
 
+        if isMiniMaxMusic3Request {
+            try await runMiniMaxMusic3(apiKey: resolvedAPIKey)
+            return
+        }
+        if miniMaxLoadingStrategy != nil {
+            throw ValidationError("--memory-mode requires MiniMax Music 3.")
+        }
+
         let root = try await ACEStepCLIHelper.resolveCheckpointsRoot(
             model: model,
             checkpointsRoot: checkpointsRoot,
@@ -124,6 +138,68 @@ struct MusicServe: AsyncParsableCommand {
             languageModelSource: lm.source,
             adapters: loadedAdapters,
             apiKey: resolvedAPIKey
+        )
+        try await server.run(host: host, port: port)
+    }
+
+    private var isMiniMaxMusic3Request: Bool {
+        if model == ModelResolver.ModelID.miniMaxMusic3.rawValue
+            || model == MiniMaxMusic3Resources.repository
+        {
+            return true
+        }
+        return MiniMaxMusic3Resources.looksLikeRoot(
+            ACEStepCLIHelper.resolveUserPath(model)
+        )
+    }
+
+    private func runMiniMaxMusic3(apiKey: String?) async throws {
+        if checkpointsRoot != nil
+            || decoderSubdirectory != "acestep-v15-turbo"
+            || vaeSubdirectory != "vae"
+            || lmSubdirectory != nil
+            || lmModel != nil
+            || textSubdirectory != nil
+            || !adapters.isEmpty
+            || adapterKind != .auto
+            || !adapterScales.isEmpty
+        {
+            throw ValidationError(
+                "ACE-Step component, planner, and adapter options do not apply to MiniMax Music 3."
+            )
+        }
+        let rootURL: URL
+        if model == ModelResolver.ModelID.miniMaxMusic3.rawValue
+            || model == MiniMaxMusic3Resources.repository
+        {
+            do {
+                rootURL = try ModelResolver().resolve(.miniMaxMusic3).rootURL
+            } catch {
+                throw ValidationError(
+                    "MiniMax Music 3 is not installed. Review its license, then run "
+                        + "`mere.run model pull \(MiniMaxMusic3Resources.modelID) --accept-model-license`."
+                )
+            }
+        } else {
+            rootURL = ACEStepCLIHelper.resolveUserPath(model)
+        }
+        let resources = MiniMaxMusic3Resources(rootURL: rootURL)
+        let missing = resources.validate()
+        guard missing.isEmpty else {
+            throw ValidationError(
+                "Incomplete MiniMax Music 3 root at \(rootURL.path): "
+                    + missing.map(\.lastPathComponent).joined(separator: ", ")
+            )
+        }
+        let loadingStrategy = miniMaxLoadingStrategy ?? .resident
+        CLIStderr.write(
+            "Loading MiniMax Music 3 server in \(loadingStrategy.rawValue) memory mode\n"
+        )
+        let server = try MiniMaxMusic3APIServer(
+            resources: resources,
+            modelID: ModelResolver.ModelID.miniMaxMusic3.rawValue,
+            loadingStrategy: loadingStrategy,
+            apiKey: apiKey
         )
         try await server.run(host: host, port: port)
     }

--- a/Sources/MereRunCLI/Guides/music-generate-minimax-music3.md
+++ b/Sources/MereRunCLI/Guides/music-generate-minimax-music3.md
@@ -1,0 +1,150 @@
+# MiniMax Music 3 Generate
+
+## Purpose
+
+Generate a complete lyric-conditioned song locally with the pinned native
+Swift/MLX MiniMax Music 3 runtime.
+
+## Install
+
+Review the pinned MiniMax-Music3 Community License, then pull the selective
+Diffusers-format runtime snapshot:
+
+```bash
+mere.run model pull music-minimax-music3 --accept-model-license
+mere.run model info music-minimax-music3
+```
+
+The managed pull intentionally excludes the duplicate original SGLang weights,
+reference media, figures, and Python example. It contains every file consumed
+by the native runtime and cannot be used as an SGLang checkpoint directory.
+
+## Generation contract
+
+MiniMax Music 3 consumes only these model inputs:
+
+- positional caption: genre, emotional arc, vocals, instrumentation,
+  arrangement, and production profile
+- `--lyrics`, `--lyrics-file`, `--lrc-file`, or `--instrumental`
+- `--duration`: upper-bound seconds; defaults to 60
+- `--max-frames`: exact 25 Hz acoustic-frame upper bound; 1 through 9000
+- `--steps`: flow-Euler steps per chunk; defaults to 30
+- `--seed`: deterministic MLX seed; defaults to 0
+- `--guidance-scale`: flow classifier-free guidance; defaults to 1.7
+- `--memory-mode staged|resident`: staged loads and releases the autoregressive,
+  flow, and vocoder stages separately; resident keeps every component loaded
+- `--sample-rate 44100|32000`: native Diffusers output or SGLang-compatible WAV
+
+When both `--duration` and `--max-frames` are provided, they must describe the
+same limit. The checkpoint hard cap is 9000 frames (360 seconds), while the
+official supported-quality claim is songs up to five minutes.
+
+Incompatible ACE-Step cover, editing, LM-planner, adapter, VAE,
+candidate-ranking, stem, and DAW settings fail explicitly for this model.
+Magenta RT2 settings also fail instead of being silently ignored.
+
+## Upstream parameter map
+
+| Upstream Diffusers input | mere.run surface |
+| --- | --- |
+| `prompt` | positional caption |
+| `lyrics` | `--lyrics`, `--lyrics-file`, `--lrc-file`, or `--instrumental` |
+| `audio_duration` | `--duration` |
+| `generator` | `--seed` |
+| `num_inference_steps` | `--steps` |
+| `output_type=np|pt` | `--export-format float32` with mastering disabled as shown below |
+
+The released autoregressive CFG (`1.5`) and top-k (`50`) remain fixed because
+they are checkpoint behavior, not pipeline inputs. Flow guidance defaults to
+the released `1.7` and is available as `--guidance-scale`. The speech route
+maps upstream `max_new_tokens` to the same frame limit exposed by
+`--max-frames`, accepts only `response_format=wav`, and requires
+`stream=false`. Both upstream paths are single-sample, so mere.run does not
+invent a batch parameter.
+
+## Lyrics
+
+Put structural tags such as `[Verse]`, `[Chorus]`, `[Bridge]`, and
+`[Instrumental]` on their own lines. Text placed after a leading tag on the
+same line is discarded by the upstream checkpoint contract.
+
+```bash
+mere.run music generate \
+  "Genre: acoustic pop. BPM: 96. Warm female lead, intimate verses, wide final chorus." \
+  --model music-minimax-music3 \
+  --lyrics-file ./lyrics.txt \
+  --duration 60 \
+  --steps 30 \
+  --seed 7 \
+  --output ./song.wav
+```
+
+Use `--instrumental` to pass the upstream `[Instrumental]` marker without a
+lyrics file.
+
+## Structured caption companion
+
+MiniMax publishes a separate `music-caption-rewriter` agent skill containing
+its structured-caption workflow and static template library. It is not
+vendored because the companion repository publishes no reusable license.
+Install it directly from the official source when you want it:
+
+```bash
+npx skills add MiniMax-AI/MiniMax-Music3 --skill music-caption-rewriter
+```
+
+Pass the resulting `Global Metadata`, `Vocal Details`, and `Arrangement` text
+as the positional caption, while keeping the original lyrics separate.
+
+## Native and reference-server output
+
+The native vocoder emits 44.1 kHz stereo. `--sample-rate 32000` adds the
+reference-server compatibility resample. WAV export defaults remain mere.run's
+production profile: PCM24, peak normalization to -1 dBFS, short boundary fades,
+and deterministic dither.
+
+For an unmastered Diffusers-style float waveform, use:
+
+```bash
+--export-format float32 --normalize none --fade-in-ms 0 --fade-out-ms 0 --no-dither
+```
+
+## Resident speech API
+
+Start the SGLang-compatible speech route with all weights warm:
+
+```bash
+mere.run music serve \
+  --model music-minimax-music3 \
+  --memory-mode resident \
+  --port 8081
+```
+
+Then send lyrics as `input` and the caption as `instructions`:
+
+```bash
+curl http://127.0.0.1:8081/v1/audio/speech \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "MiniMaxAI/MiniMax-Music3",
+    "input": "[Verse]\nMorning light through the pine",
+    "instructions": "Warm acoustic pop, intimate female vocal, fingerpicked guitar.",
+    "response_format": "wav",
+    "seed": 7,
+    "max_new_tokens": 750,
+    "stream": false
+  }' \
+  --output song.wav
+```
+
+The speech route defaults to 32 kHz PCM16 stereo. Add `"sample_rate": 44100`
+for the native vocoder rate. Streaming and batched generation are not offered
+because the released upstream pipeline is single-sample and non-streaming.
+
+## Provenance
+
+- Checkpoint: `MiniMaxAI/MiniMax-Music3` at the immutable revision recorded by
+  `mere.run model info music-minimax-music3`
+- Runtime reference: Hugging Face Diffusers PR #14456
+- Caption companion: `MiniMax-AI/MiniMax-Music3`, commit
+  `91410fb657c007ae57c60df8240f5ece5be089c7`

--- a/Sources/MereRunCLI/Guides/music-generate.md
+++ b/Sources/MereRunCLI/Guides/music-generate.md
@@ -2,9 +2,10 @@
 
 ## Purpose
 
-Generate a WAV music clip from a caption. ACE-Step supports optional structured
-lyrics, while Magenta RT2 supports native Apple Silicon offline and realtime
-prompt-to-music generation.
+Generate a WAV music clip from a caption. MiniMax Music 3 generates complete
+44.1 kHz stereo songs from a caption plus structured lyrics, ACE-Step supports
+generation and source-audio editing, and Magenta RT2 supports native Apple
+Silicon offline and realtime prompt-to-music generation.
 
 ## Required Models
 
@@ -23,6 +24,8 @@ Managed ids:
 - `music-acestep-lm-1.7b`: independently pullable upstream-default 5 Hz
   planner; pairs with any ACE-Step DiT.
 - `music-acestep-lm-4b`: independently pullable optional 4B 5 Hz planner.
+- `music-minimax-music3`: MiniMax Music 3 language model, RVQ depth decoder,
+  flow transformer, condition encoder, and stereo vocoder.
 - `music-magenta-rt2-small`: Magenta RealTime 2 small exported runtime assets.
 - `music-magenta-rt2-base`: Magenta RealTime 2 base exported runtime assets.
 
@@ -33,11 +36,13 @@ mere.run model pull music-acestep
 mere.run model pull music-acestep-xl-turbo
 mere.run model pull music-acestep-xl-turbo-lm4b
 mere.run model pull music-acestep-lm-1.7b
+mere.run model pull music-minimax-music3 --accept-model-license
 mere.run model pull music-magenta-rt2-small
 mere.run music generate --help
 mere.run music analyze --help
 mere.run guide music generate --model music-acestep
 mere.run guide music generate --model music-acestep-xl-turbo
+mere.run guide music generate --model music-minimax-music3
 mere.run guide music generate --model music-magenta-rt2-small
 ```
 
@@ -72,7 +77,7 @@ mere.run guide music generate --model music-magenta-rt2-small
 - `--use-lm`: enable 5 Hz constrained LM for supported text-to-music tasks.
 - `--lm-model music-acestep-lm-4b`: explicitly select the optional 4B planner.
 - `--duration`: output seconds.
-- `--steps`, `-s`: turbo denoise steps.
+- `--steps`, `-s`: denoise steps; MiniMax Music 3 defaults to `30`.
 - `--shift`: turbo scheduler shift; ACE-Step CLI default is `3.0`, matching upstream.
 - `--seed`: deterministic generation.
 - `--source-audio`: source song for ACE-Step cover, repaint, extract, lego, or
@@ -139,6 +144,16 @@ mere.run guide music generate --model music-magenta-rt2-small
   `seed`, and `onset`.
 - `--quiet`, `-q`: suppress diagnostics.
 
+MiniMax Music 3 requires `--lyrics`, `--lyrics-file`, `--lrc-file`, or
+`--instrumental`. Its native staged runtime autoregressively generates 25 Hz
+semantic and residual codes, conditions a flow transformer, and decodes stereo
+audio without a Python process. `--duration` accepts up to 360 seconds and
+`--guidance-scale` defaults to `1.7`. ACE-Step source audio, adapters, ranked
+candidates, stems, DAW bundles, and LRC export do not apply to this model. A
+reproducibility recipe is written beside the WAV unless `--no-recipe` is used.
+The selective managed download is approximately 26.6 GiB and requires
+explicit acknowledgement of the upstream MiniMax-Music3 Community License.
+
 ACE-Step uses upstream-style native Haar DCW sampler correction by default for
 cleaner diffusion latents before VAE decode.
 
@@ -199,7 +214,22 @@ Use this guide as a command topic, then focus it with `--model` when needed:
 ```bash
 mere.run guide music generate --model music-acestep
 mere.run guide music generate --model music-acestep-xl-turbo
+mere.run guide music generate --model music-minimax-music3
 mere.run guide music generate --model music-magenta-rt2-small
+```
+
+For a MiniMax Music 3 song, make the caption describe the production and pass
+sectioned lyrics separately:
+
+```bash
+mere.run music generate \
+  "cinematic synth-pop, female lead, 118 bpm, wide guitars" \
+  --model music-minimax-music3 \
+  --lyrics-file ./lyrics.txt \
+  --duration 30 \
+  --steps 30 \
+  --seed 7 \
+  --output ./minimax-song.wav
 ```
 
 For ACE-Step text-to-music, start with a direct caption and optional structured

--- a/Sources/MereRunCLI/Support/ACEStepAudioExporter.swift
+++ b/Sources/MereRunCLI/Support/ACEStepAudioExporter.swift
@@ -1,3 +1,4 @@
+import AudioCodecs
 import Foundation
 import MLX
 
@@ -172,6 +173,57 @@ enum ACEStepWAVWriter {
             sampleChannel.asType(.float32).reshaped(-1).asArray(Float.self),
             sampleChannel.dim(1)
         )
+    }
+
+    static func resample(
+        _ audio: MLXArray,
+        from sourceSampleRate: Int,
+        to targetSampleRate: Int
+    ) throws -> MLXArray {
+        guard sourceSampleRate > 0 else {
+            throw WriterError.invalidSampleRate(sourceSampleRate)
+        }
+        guard targetSampleRate > 0 else {
+            throw WriterError.invalidSampleRate(targetSampleRate)
+        }
+        guard sourceSampleRate != targetSampleRate else {
+            return audio
+        }
+        let (interleaved, channels) = try flattenToInterleaved(audio)
+        guard (1...8).contains(channels) else {
+            throw WriterError.invalidChannels(channels)
+        }
+        let frameCount = interleaved.count / channels
+        var channelSamples = [[Float]](
+            repeating: [],
+            count: channels
+        )
+        for channel in 0..<channels {
+            channelSamples[channel].reserveCapacity(frameCount)
+        }
+        for frame in 0..<frameCount {
+            for channel in 0..<channels {
+                channelSamples[channel].append(
+                    interleaved[(frame * channels) + channel]
+                )
+            }
+        }
+        let resampled = channelSamples.map {
+            PCMStreamConverter.resampleLinear(
+                $0,
+                from: sourceSampleRate,
+                to: targetSampleRate
+            )
+        }
+        let outputFrames = resampled.first?.count ?? 0
+        var output = [Float]()
+        output.reserveCapacity(outputFrames * channels)
+        for frame in 0..<outputFrames {
+            for channel in 0..<channels {
+                output.append(resampled[channel][frame])
+            }
+        }
+        return MLXArray(output, [1, outputFrames, channels])
     }
 
     private static func normalize(

--- a/Sources/MereRunCLI/Support/InstalledModelGateSupport.swift
+++ b/Sources/MereRunCLI/Support/InstalledModelGateSupport.swift
@@ -351,6 +351,11 @@ enum InstalledModelSmokePlans {
                 try await runner.installedACEStepCheck(model: spec.id)
             }
 
+        case .miniMaxMusic3:
+            return direct(spec, route: "music generate") { runner in
+                try await runner.installedMiniMaxMusic3Check(model: spec.id)
+            }
+
         case .aceStepLM:
             return companion(
                 spec,
@@ -1198,6 +1203,26 @@ extension GateRunner {
                 "--model", model,
                 "--duration", "2",
                 "--seed-rotation", "7",
+                "--output", output.path,
+                "--quiet",
+            ],
+            timeout: 3_600
+        )
+        return try audioObservation(output, run: run)
+    }
+
+    func installedMiniMaxMusic3Check(model: String) async throws -> GateObservation {
+        let output = artifactURL(model, extension: "wav")
+        let run = try await exec(
+            [
+                "music", "generate",
+                "A short soft electronic pulse.",
+                "--model", model,
+                "--instrumental",
+                "--duration", "2",
+                "--steps", "1",
+                "--seed", "7",
+                "--no-recipe",
                 "--output", output.path,
                 "--quiet",
             ],

--- a/Sources/MereRunCLI/Support/MiniMaxMusic3CLIOptions.swift
+++ b/Sources/MereRunCLI/Support/MiniMaxMusic3CLIOptions.swift
@@ -1,0 +1,4 @@
+import ArgumentParser
+import MereRunCore
+
+extension MiniMaxMusic3LoadingStrategy: ExpressibleByArgument {}

--- a/Sources/MereRunCLI/Support/MiniMaxMusic3GenerationArtifacts.swift
+++ b/Sources/MereRunCLI/Support/MiniMaxMusic3GenerationArtifacts.swift
@@ -1,0 +1,49 @@
+import Foundation
+import MereRunCore
+
+struct MiniMaxMusic3GenerationRecipe: Codable {
+    static let currentSchemaVersion = 1
+
+    var schemaVersion: Int
+    var createdAt: Date
+    var modelID: String
+    var sourceRepository: String
+    var sourceRevision: String
+    var caption: String
+    var lyrics: String
+    var durationSeconds: Float
+    var generatedFrameCount: Int
+    var inferenceSteps: Int
+    var seed: UInt64
+    var guidanceScale: Float
+    var sampleRate: Int
+    var export: ACEStepAudioExportOptions
+    var outputFilename: String
+    var outputSHA256: String
+
+    enum CodingKeys: String, CodingKey {
+        case schemaVersion = "schema_version"
+        case createdAt = "created_at"
+        case modelID = "model_id"
+        case sourceRepository = "source_repository"
+        case sourceRevision = "source_revision"
+        case caption
+        case lyrics
+        case durationSeconds = "duration_seconds"
+        case generatedFrameCount = "generated_frame_count"
+        case inferenceSteps = "inference_steps"
+        case seed
+        case guidanceScale = "guidance_scale"
+        case sampleRate = "sample_rate"
+        case export
+        case outputFilename = "output_filename"
+        case outputSHA256 = "output_sha256"
+    }
+
+    func write(to url: URL) throws {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        try encoder.encode(self).write(to: url, options: .atomic)
+    }
+}

--- a/Sources/MereRunCLI/Support/MiniMaxMusic3GenerationArtifacts.swift
+++ b/Sources/MereRunCLI/Support/MiniMaxMusic3GenerationArtifacts.swift
@@ -2,7 +2,7 @@ import Foundation
 import MereRunCore
 
 struct MiniMaxMusic3GenerationRecipe: Codable {
-    static let currentSchemaVersion = 1
+    static let currentSchemaVersion = 2
 
     var schemaVersion: Int
     var createdAt: Date
@@ -12,11 +12,14 @@ struct MiniMaxMusic3GenerationRecipe: Codable {
     var caption: String
     var lyrics: String
     var durationSeconds: Float
+    var requestedMaximumFrames: Int?
     var generatedFrameCount: Int
     var inferenceSteps: Int
     var seed: UInt64
     var guidanceScale: Float
-    var sampleRate: Int
+    var nativeSampleRate: Int
+    var outputSampleRate: Int
+    var loadingStrategy: MiniMaxMusic3LoadingStrategy
     var export: ACEStepAudioExportOptions
     var outputFilename: String
     var outputSHA256: String
@@ -30,11 +33,14 @@ struct MiniMaxMusic3GenerationRecipe: Codable {
         case caption
         case lyrics
         case durationSeconds = "duration_seconds"
+        case requestedMaximumFrames = "requested_maximum_frames"
         case generatedFrameCount = "generated_frame_count"
         case inferenceSteps = "inference_steps"
         case seed
         case guidanceScale = "guidance_scale"
-        case sampleRate = "sample_rate"
+        case nativeSampleRate = "native_sample_rate"
+        case outputSampleRate = "output_sample_rate"
+        case loadingStrategy = "loading_strategy"
         case export
         case outputFilename = "output_filename"
         case outputSHA256 = "output_sha256"

--- a/Sources/MereRunCore/ACEStep/VAE/OobleckDecoder.swift
+++ b/Sources/MereRunCore/ACEStep/VAE/OobleckDecoder.swift
@@ -40,9 +40,10 @@ final class OobleckWNConvTranspose1d: Module, @unchecked Sendable {
     func callAsFunction(_ x: MLXArray) -> MLXArray {
         // weightV: [out, k, in]
         // weightG: [in, 1, 1] (PyTorch weight_norm dim=0)
-        let vNorm = MLX.sqrt(MLX.sum(weightV * weightV, axes: [0, 1], keepDims: true) + 1e-12) // [1, 1, in]
-        let g = weightG.reshaped(1, 1, -1) // [1, 1, in]
-        let weight = weightV * (g / vNorm)
+        let value = weightV.asType(.float32)
+        let vNorm = MLX.sqrt(MLX.sum(value * value, axes: [0, 1], keepDims: true) + 1e-12) // [1, 1, in]
+        let g = weightG.asType(.float32).reshaped(1, 1, -1) // [1, 1, in]
+        let weight = (value * (g / vNorm)).asType(x.dtype)
 
         var result = MLX.convTransposed1d(x, weight, stride: stride, padding: padding)
         if let bias {

--- a/Sources/MereRunCore/ACEStep/VAE/WNConv1d.swift
+++ b/Sources/MereRunCore/ACEStep/VAE/WNConv1d.swift
@@ -37,8 +37,9 @@ final class WNConv1d: Module, @unchecked Sendable {
     }
 
     func callAsFunction(_ x: MLXArray) -> MLXArray {
-        let vNorm = MLX.sqrt(MLX.sum(weightV * weightV, axes: [1, 2], keepDims: true) + 1e-12)
-        let weight = weightG * (weightV / vNorm)
+        let value = weightV.asType(.float32)
+        let vNorm = MLX.sqrt(MLX.sum(value * value, axes: [1, 2], keepDims: true) + 1e-12)
+        let weight = (weightG.asType(.float32) * (value / vNorm)).asType(x.dtype)
 
         var result = MLX.conv1d(x, weight, stride: stride, padding: padding, dilation: dilation)
         if let bias {

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -2118,7 +2118,7 @@ public enum ManagedModelCatalog {
             validationKind: .miniMaxMusic3,
             runtimeAutoDownloadAllowed: false,
             estimatedDownloadBytes: MiniMaxMusic3Resources.estimatedDownloadBytes,
-            defaultCLICommands: ["music generate"]
+            defaultCLICommands: ["music generate", "music serve"]
         ),
         ManagedModelSpec(
             id: ModelResolver.ModelID.magentaRT2Small.rawValue,

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -75,6 +75,7 @@ public enum ManagedModelValidationKind: String, Hashable, Sendable {
     case trellis2
     case aceStep
     case aceStepLM
+    case miniMaxMusic3
     case magentaRT2
     case muScriptor
     case roFormer
@@ -2084,6 +2085,42 @@ public enum ManagedModelCatalog {
             defaultCLICommands: ["music generate", "music analyze", "music serve"]
         ),
         ManagedModelSpec(
+            id: ModelResolver.ModelID.miniMaxMusic3.rawValue,
+            category: .music,
+            installShape: .structuredRoot,
+            hubFallback: HubFallbackConfig(
+                repoId: MiniMaxMusic3Resources.repository,
+                revision: MiniMaxMusic3Resources.revision,
+                patterns: [
+                    "LICENSE",
+                    "README.md",
+                    "config.json",
+                    "modular_model_index.json",
+                    "condition_encoder/*",
+                    "language_model/*",
+                    "rvq_depth_decoder/*",
+                    "scheduler/*",
+                    "tokenizer/*",
+                    "transformer/*",
+                    "vocoder/*",
+                ]
+            ),
+            upstreamRepoId: MiniMaxMusic3Resources.repository,
+            upstreamRevision: MiniMaxMusic3Resources.revision,
+            usageRestriction: usageRestriction(
+                summary: "MiniMax Music 3 uses the custom MiniMax-Music3 Community License, including product attribution, revenue-threshold authorization, and hosted-generation safeguards.",
+                component: "MiniMax Music 3 weights",
+                license: "MiniMax-Music3 Community License",
+                sourceRepoId: MiniMaxMusic3Resources.repository,
+                sourceRevision: MiniMaxMusic3Resources.revision,
+                licenseURL: "https://huggingface.co/MiniMaxAI/MiniMax-Music3/blob/\(MiniMaxMusic3Resources.revision)/LICENSE"
+            ),
+            validationKind: .miniMaxMusic3,
+            runtimeAutoDownloadAllowed: false,
+            estimatedDownloadBytes: MiniMaxMusic3Resources.estimatedDownloadBytes,
+            defaultCLICommands: ["music generate"]
+        ),
+        ManagedModelSpec(
             id: ModelResolver.ModelID.magentaRT2Small.rawValue,
             category: .music,
             installShape: .structuredRoot,
@@ -3086,6 +3123,8 @@ public extension ManagedModelSpec {
             return Self.missingACEStepPaths(modelID: id, in: rootURL, fileManager: fileManager)
         case .aceStepLM:
             return ACEStep5HzLMResources(rootURL: rootURL).validate(fileManager: fileManager)
+        case .miniMaxMusic3:
+            return MiniMaxMusic3Resources(rootURL: rootURL).validate(fileManager: fileManager)
         case .magentaRT2:
             return Self.missingMagentaRT2Paths(modelID: id, in: rootURL, fileManager: fileManager)
         case .muScriptor:

--- a/Sources/MereRunCore/ManagedModelSupport.swift
+++ b/Sources/MereRunCore/ManagedModelSupport.swift
@@ -781,6 +781,13 @@ public enum ManagedModelCapabilityCatalog {
                 recommended: 32
             ),
             descriptor(
+                ModelResolver.ModelID.miniMaxMusic3.rawValue,
+                "MiniMax Music 3",
+                "Generates complete lyric-driven 44.1 kHz stereo songs with the native staged Swift/MLX runtime.",
+                minimum: 64,
+                recommended: 96
+            ),
+            descriptor(
                 ModelResolver.ModelID.magentaRT2Small.rawValue,
                 "Magenta RealTime 2 small",
                 "Streams controllable Magenta RT2 music on Apple Silicon with the 230M model.",

--- a/Sources/MereRunCore/ManagedModelSupport.swift
+++ b/Sources/MereRunCore/ManagedModelSupport.swift
@@ -784,8 +784,8 @@ public enum ManagedModelCapabilityCatalog {
                 ModelResolver.ModelID.miniMaxMusic3.rawValue,
                 "MiniMax Music 3",
                 "Generates complete lyric-driven 44.1 kHz stereo songs with the native staged Swift/MLX runtime.",
-                minimum: 64,
-                recommended: 96
+                minimum: 32,
+                recommended: 64
             ),
             descriptor(
                 ModelResolver.ModelID.magentaRT2Small.rawValue,

--- a/Sources/MereRunCore/MereRunModelManifest.swift
+++ b/Sources/MereRunCore/MereRunModelManifest.swift
@@ -78,6 +78,8 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
         case lightOnOCR = "lighton-ocr"
         /// ACE-Step music family.
         case aceStep = "ace-step"
+        /// MiniMax Music 3 autoregressive and flow-matching music family.
+        case miniMaxMusic3 = "minimax-music3"
         /// Magenta RealTime 2 streaming music family.
         case magentaRT2 = "magenta-rt2"
         /// MuScriptor multi-instrument audio transcription family.
@@ -1844,6 +1846,20 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
                 upstreamRepoId: modelID == .aceStepLM4B
                     ? "ACE-Step/acestep-5Hz-lm-4B"
                     : "ACE-Step/Ace-Step1.5",
+                createdAt: createdAt
+            )
+        case .miniMaxMusic3:
+            return MereRunModelManifest(
+                id: modelID.rawValue,
+                engine: .miniMaxMusic3,
+                family: .music,
+                tier: .max,
+                variant: .standard,
+                precision: .bf16,
+                defaults: Defaults(steps: 30, cfg: 1.7),
+                supports: [.musicGeneration],
+                components: nil,
+                upstreamRepoId: "\(MiniMaxMusic3Resources.repository)@\(MiniMaxMusic3Resources.revision)",
                 createdAt: createdAt
             )
         case .magentaRT2Small, .magentaRT2Base:

--- a/Sources/MereRunCore/MereRunModelValidator.swift
+++ b/Sources/MereRunCore/MereRunModelValidator.swift
@@ -150,6 +150,7 @@ public enum MereRunModelValidator {
             vaeDir = nil
             tokenizerDir = nil
         } else if spec?.validationKind == .aceStep
+            || spec?.validationKind == .miniMaxMusic3
             || spec?.validationKind == .roFormer
             || spec?.validationKind == .apBWE
             || spec?.validationKind == .univerSR
@@ -472,10 +473,11 @@ public enum MereRunModelValidator {
             case .ocr where engine != .lightOnOCR && engine != .qwen35HybridMoE:
                 warnings.append("Manifest engine mismatch: family=ocr expects lighton-ocr or qwen3.5-hybrid-moe.")
             case .music where engine != .aceStep
+                && engine != .miniMaxMusic3
                 && engine != .roFormer
                 && engine != .magentaRT2
                 && engine != .muScriptor:
-                warnings.append("Manifest engine mismatch: family=music expects ace-step, bs-roformer, magenta-rt2, or muscriptor.")
+                warnings.append("Manifest engine mismatch: family=music expects ace-step, minimax-music3, bs-roformer, magenta-rt2, or muscriptor.")
             case .audio where engine != .apBWE && engine != .univerSR:
                 warnings.append("Manifest engine mismatch: family=audio expects ap-bwe or universr.")
             case .sfx where engine != .woosh && engine != .mmaudio:
@@ -555,7 +557,7 @@ public enum MereRunModelValidator {
                 return true
             }
             switch manifest.engine {
-            case .qwen3Coder?, .northMiniCode?, .inkling?, .aceStep?, .magentaRT2?, .muScriptor?, .roFormer?, .apBWE?, .univerSR?, .woosh?, .mmaudio?, .ltxVideo?,
+            case .qwen3Coder?, .northMiniCode?, .inkling?, .aceStep?, .miniMaxMusic3?, .magentaRT2?, .muScriptor?, .roFormer?, .apBWE?, .univerSR?, .woosh?, .mmaudio?, .ltxVideo?,
                  .wanVideo?, .moge2?, .videoDepthAnything?, .depthAnything3?, .tripoSR?, .instantMesh?, .trellis2?,
                  .insightFace?, .sortformer?, .terramindFlood?, .terramindFire?, .tessera?, .olmoEarth?:
                 return true

--- a/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3ConditionEncoder.swift
+++ b/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3ConditionEncoder.swift
@@ -1,0 +1,49 @@
+import MLX
+import MLXNN
+
+public final class MiniMaxMusic3ConditionEncoder: Module {
+    public let configuration: MiniMaxMusic3ConditionConfiguration
+
+    @ModuleInfo(key: "layer_weight_logits") var layerWeightLogits: MLXArray
+    @ModuleInfo(key: "layer_scale") var layerScale: MLXArray
+    @ModuleInfo(key: "proj") var projection: Conv1d
+
+    public init(configuration: MiniMaxMusic3ConditionConfiguration) {
+        self.configuration = configuration
+        self._layerWeightLogits.wrappedValue = MLXArray.zeros([configuration.numConditionLayers])
+        self._layerScale.wrappedValue = MLXArray.ones([1])
+        self._projection.wrappedValue = Conv1d(
+            inputChannels: configuration.conditionHiddenDim,
+            outputChannels: configuration.outDim,
+            kernelSize: 3,
+            padding: 1
+        )
+    }
+
+    public func callAsFunction(_ hiddenStates: MLXArray) -> MLXArray {
+        let batch = hiddenStates.dim(0)
+        let frames = hiddenStates.dim(1)
+        let layers = configuration.numConditionLayers
+        var hidden = hiddenStates.reshaped(batch, frames, layers, configuration.conditionHiddenDim)
+        let weights = softmax(layerWeightLogits.asType(hidden.dtype), axis: 0).reshaped(1, 1, layers, 1)
+        hidden = MLX.sum(hidden * weights, axis: 2) * layerScale.asType(hidden.dtype)
+        hidden = projection(hidden)
+
+        let length = MiniMaxMusic3Prompt.latentLength(
+            frameCount: frames,
+            inputSamplingRate: configuration.inputSamplingRate,
+            inputHopLength: configuration.inputHopLength,
+            outputSamplingRate: configuration.outputSamplingRate,
+            outputHopLength: configuration.outputHopLength
+        )
+        let indices = MLXArray((0..<length).map { Int32($0 * frames / length) })
+        return MLX.take(hidden, indices, axis: 1)
+    }
+
+    static func mapWeight(key: String, value: MLXArray) -> [(String, MLXArray)] {
+        if key == "proj.weight" {
+            return [(key, value.transposed(0, 2, 1))]
+        }
+        return [(key, value)]
+    }
+}

--- a/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3DepthDecoder.swift
+++ b/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3DepthDecoder.swift
@@ -1,0 +1,114 @@
+import MLX
+import MLXFast
+import MLXNN
+
+final class MiniMaxMusic3DepthAttention: Module {
+    let heads: Int
+    let headDimension: Int
+
+    @ModuleInfo(key: "to_q") var query: Linear
+    @ModuleInfo(key: "to_k") var key: Linear
+    @ModuleInfo(key: "to_v") var value: Linear
+    @ModuleInfo(key: "to_out") var output: Linear
+
+    init(dimensions: Int, heads: Int) {
+        self.heads = heads
+        self.headDimension = dimensions / heads
+        self._query.wrappedValue = Linear(dimensions, dimensions, bias: false)
+        self._key.wrappedValue = Linear(dimensions, dimensions, bias: false)
+        self._value.wrappedValue = Linear(dimensions, dimensions, bias: false)
+        self._output.wrappedValue = Linear(dimensions, dimensions, bias: false)
+    }
+
+    func callAsFunction(_ hidden: MLXArray) -> MLXArray {
+        let batch = hidden.dim(0)
+        let length = hidden.dim(1)
+        let q = query(hidden).reshaped(batch, length, heads, headDimension).transposed(0, 2, 1, 3)
+        let k = key(hidden).reshaped(batch, length, heads, headDimension).transposed(0, 2, 1, 3)
+        let v = value(hidden).reshaped(batch, length, heads, headDimension).transposed(0, 2, 1, 3)
+        let attended = MLXFast.scaledDotProductAttention(
+            queries: q.asType(.float32),
+            keys: k.asType(.float32),
+            values: v.asType(.float32),
+            scale: 1 / Float(headDimension).squareRoot(),
+            mask: .causal
+        )
+        return output(attended.asType(q.dtype).transposed(0, 2, 1, 3).reshaped(batch, length, -1))
+    }
+}
+
+final class MiniMaxMusic3DepthBlock: Module {
+    @ModuleInfo(key: "input_layernorm") var inputLayerNorm: RMSNorm
+    @ModuleInfo(key: "attn") var attention: MiniMaxMusic3DepthAttention
+    @ModuleInfo(key: "post_attention_layernorm") var postAttentionLayerNorm: RMSNorm
+    @ModuleInfo(key: "gate_proj") var gateProjection: Linear
+    @ModuleInfo(key: "up_proj") var upProjection: Linear
+    @ModuleInfo(key: "down_proj") var downProjection: Linear
+
+    init(dimensions: Int, heads: Int, intermediateSize: Int) {
+        self._inputLayerNorm.wrappedValue = RMSNorm(dimensions: dimensions, eps: 1e-6)
+        self._attention.wrappedValue = MiniMaxMusic3DepthAttention(dimensions: dimensions, heads: heads)
+        self._postAttentionLayerNorm.wrappedValue = RMSNorm(dimensions: dimensions, eps: 1e-6)
+        self._gateProjection.wrappedValue = Linear(dimensions, intermediateSize, bias: false)
+        self._upProjection.wrappedValue = Linear(dimensions, intermediateSize, bias: false)
+        self._downProjection.wrappedValue = Linear(intermediateSize, dimensions, bias: false)
+    }
+
+    func callAsFunction(_ input: MLXArray) -> MLXArray {
+        let attended = input + attention(inputLayerNorm(input))
+        let normalized = postAttentionLayerNorm(attended)
+        return attended + downProjection(MLXNN.silu(gateProjection(normalized)) * upProjection(normalized))
+    }
+}
+
+public final class MiniMaxMusic3DepthDecoder: Module {
+    public let configuration: MiniMaxMusic3DepthConfiguration
+
+    @ModuleInfo(key: "audio_embeddings") var audioEmbeddings: Embedding
+    @ModuleInfo(key: "projection") var projection: Linear
+    @ModuleInfo(key: "pos_embedding") var positionEmbedding: Embedding
+    @ModuleInfo(key: "layers") var layers: [MiniMaxMusic3DepthBlock]
+    @ModuleInfo(key: "norm") var norm: RMSNorm
+    @ModuleInfo(key: "audio_heads") var audioHeads: [Linear]
+
+    public init(configuration: MiniMaxMusic3DepthConfiguration) {
+        self.configuration = configuration
+        self._audioEmbeddings.wrappedValue = Embedding(
+            embeddingCount: configuration.audioVocabSize * (configuration.numCodebooks - 1),
+            dimensions: configuration.hiddenSize
+        )
+        self._projection.wrappedValue = Linear(configuration.hiddenSize, configuration.hiddenSize, bias: false)
+        self._positionEmbedding.wrappedValue = Embedding(
+            embeddingCount: configuration.maxPositionEmbeddings,
+            dimensions: configuration.hiddenSize
+        )
+        self._layers.wrappedValue = (0..<configuration.numLayers).map { _ in
+            MiniMaxMusic3DepthBlock(
+                dimensions: configuration.hiddenSize,
+                heads: configuration.numAttentionHeads,
+                intermediateSize: configuration.intermediateSize
+            )
+        }
+        self._norm.wrappedValue = RMSNorm(dimensions: configuration.hiddenSize, eps: 1e-6)
+        self._audioHeads.wrappedValue = (1..<configuration.numCodebooks).map { _ in
+            Linear(configuration.hiddenSize, configuration.audioVocabSize, bias: false)
+        }
+    }
+
+    public func callAsFunction(_ inputEmbeddings: MLXArray) -> MLXArray {
+        let positions = MLXArray((0..<inputEmbeddings.dim(1)).map(Int32.init))
+        var hidden = inputEmbeddings + positionEmbedding(positions).expandedDimensions(axis: 0)
+        for layer in layers {
+            hidden = layer(hidden)
+        }
+        return norm(hidden)
+    }
+
+    public func embedResidualCodes(_ codes: MLXArray, codebookIndex: Int) -> MLXArray {
+        audioEmbeddings(codes.asType(.int32) + MLXArray(Int32(codebookIndex * configuration.audioVocabSize)))
+    }
+
+    public func logits(_ hidden: MLXArray, codebookIndex: Int) -> MLXArray {
+        audioHeads[codebookIndex](hidden)
+    }
+}

--- a/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3LanguageModel.swift
+++ b/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3LanguageModel.swift
@@ -1,0 +1,56 @@
+import MLX
+import MLXNN
+
+public final class MiniMaxMusic3LanguageModel: Module {
+    public let configuration: MiniMaxMusic3LanguageConfiguration
+
+    @ModuleInfo(key: "model") var model: QwenEncoder
+    @ModuleInfo(key: "lm_head") var languageModelHead: Linear
+
+    public init(configuration: MiniMaxMusic3LanguageConfiguration) {
+        self.configuration = configuration
+        let qwenConfiguration = QwenTextEncoderConfiguration(
+            vocabSize: configuration.vocabSize,
+            hiddenSize: configuration.hiddenSize,
+            numHiddenLayers: configuration.numHiddenLayers,
+            numAttentionHeads: configuration.numAttentionHeads,
+            numKeyValueHeads: configuration.numKeyValueHeads,
+            intermediateSize: configuration.intermediateSize,
+            ropeTheta: configuration.ropeParameters.ropeTheta,
+            maxPositionEmbeddings: configuration.maxPositionEmbeddings,
+            rmsNormEps: configuration.rmsNormEps,
+            headDim: configuration.headDim,
+            cachedDecodeAttentionMode: .native
+        )
+        self._model.wrappedValue = QwenEncoder(configuration: qwenConfiguration)
+        self._languageModelHead.wrappedValue = Linear(
+            configuration.hiddenSize,
+            configuration.vocabSize,
+            bias: false
+        )
+    }
+
+    public func makeCache() -> [KVCache] {
+        (0..<configuration.numHiddenLayers).map { _ in KVCacheSimple(step: 256) }
+    }
+
+    public func embed(tokenIDs: MLXArray) -> MLXArray {
+        model.embed(inputIds: tokenIDs)
+    }
+
+    public func hidden(
+        embeddings: MLXArray,
+        cache: [KVCache],
+        lastPositionOnly: Bool = true
+    ) -> MLXArray {
+        model.forwardCausalHidden(
+            embeddings: embeddings,
+            cache: cache,
+            lastPositionOnly: lastPositionOnly
+        )
+    }
+
+    public func logits(_ hidden: MLXArray) -> MLXArray {
+        languageModelHead(hidden)
+    }
+}

--- a/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3ModelLoader.swift
+++ b/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3ModelLoader.swift
@@ -11,13 +11,49 @@ public struct MiniMaxMusic3Models {
     public let tokenizer: ACEStep5HzLMTokenizer
 }
 
+public struct MiniMaxMusic3AutoregressiveModels {
+    public let languageModel: MiniMaxMusic3LanguageModel
+    public let depthDecoder: MiniMaxMusic3DepthDecoder
+    public let tokenizer: ACEStep5HzLMTokenizer
+}
+
+public struct MiniMaxMusic3FlowModels {
+    public let conditionEncoder: MiniMaxMusic3ConditionEncoder
+    public let transformer: MiniMaxMusic3Transformer
+}
+
+public enum MiniMaxMusic3LoadingStrategy: String, CaseIterable, Codable, Sendable {
+    case staged
+    case resident
+}
+
 public enum MiniMaxMusic3ModelLoader {
     public static func load(from resources: MiniMaxMusic3Resources) throws -> MiniMaxMusic3Models {
-        let missing = resources.validate()
-        guard missing.isEmpty else {
-            throw MiniMaxMusic3Error.missingResources(missing)
-        }
+        try validate(resources)
+        let autoregressive = try loadAutoregressive(from: resources)
+        let flow = try loadFlow(from: resources)
+        let vocoder = try loadVocoder(from: resources)
+        MLX.eval(
+            autoregressive.languageModel.parameters(),
+            autoregressive.depthDecoder.parameters(),
+            flow.conditionEncoder.parameters(),
+            flow.transformer.parameters(),
+            vocoder.parameters()
+        )
+        return MiniMaxMusic3Models(
+            languageModel: autoregressive.languageModel,
+            depthDecoder: autoregressive.depthDecoder,
+            conditionEncoder: flow.conditionEncoder,
+            transformer: flow.transformer,
+            vocoder: vocoder,
+            tokenizer: autoregressive.tokenizer
+        )
+    }
 
+    public static func loadAutoregressive(
+        from resources: MiniMaxMusic3Resources
+    ) throws -> MiniMaxMusic3AutoregressiveModels {
+        try validate(resources)
         let languageModel = MiniMaxMusic3LanguageModel(
             configuration: try resources.loadLanguageConfiguration()
         )
@@ -27,7 +63,6 @@ public enum MiniMaxMusic3ModelLoader {
             singleName: "model.safetensors",
             into: languageModel
         )
-
         let depthDecoder = MiniMaxMusic3DepthDecoder(
             configuration: try resources.loadDepthConfiguration()
         )
@@ -35,7 +70,22 @@ public enum MiniMaxMusic3ModelLoader {
             directory: resources.depthDecoderURL,
             into: depthDecoder
         )
+        let tokenizer = try ACEStep5HzLMTokenizer.load(
+            from: resources.tokenizerURL,
+            requireAudioCodeTokens: false
+        )
+        MLX.eval(languageModel.parameters(), depthDecoder.parameters())
+        return MiniMaxMusic3AutoregressiveModels(
+            languageModel: languageModel,
+            depthDecoder: depthDecoder,
+            tokenizer: tokenizer
+        )
+    }
 
+    public static func loadFlow(
+        from resources: MiniMaxMusic3Resources
+    ) throws -> MiniMaxMusic3FlowModels {
+        try validate(resources)
         let conditionEncoder = MiniMaxMusic3ConditionEncoder(
             configuration: try resources.loadConditionConfiguration()
         )
@@ -44,7 +94,6 @@ public enum MiniMaxMusic3ModelLoader {
             into: conditionEncoder,
             mapper: MiniMaxMusic3ConditionEncoder.mapWeight
         )
-
         let transformer = MiniMaxMusic3Transformer(
             configuration: try resources.loadTransformerConfiguration()
         )
@@ -53,7 +102,17 @@ public enum MiniMaxMusic3ModelLoader {
             into: transformer,
             mapper: MiniMaxMusic3Transformer.mapWeight
         )
+        MLX.eval(conditionEncoder.parameters(), transformer.parameters())
+        return MiniMaxMusic3FlowModels(
+            conditionEncoder: conditionEncoder,
+            transformer: transformer
+        )
+    }
 
+    public static func loadVocoder(
+        from resources: MiniMaxMusic3Resources
+    ) throws -> MiniMaxMusic3Vocoder {
+        try validate(resources)
         let vocoder = MiniMaxMusic3Vocoder(
             configuration: try resources.loadVocoderConfiguration()
         )
@@ -62,26 +121,15 @@ public enum MiniMaxMusic3ModelLoader {
             into: vocoder,
             mapper: MiniMaxMusic3Vocoder.mapWeight
         )
+        MLX.eval(vocoder.parameters())
+        return vocoder
+    }
 
-        let tokenizer = try ACEStep5HzLMTokenizer.load(
-            from: resources.tokenizerURL,
-            requireAudioCodeTokens: false
-        )
-        MLX.eval(
-            languageModel.parameters(),
-            depthDecoder.parameters(),
-            conditionEncoder.parameters(),
-            transformer.parameters(),
-            vocoder.parameters()
-        )
-        return MiniMaxMusic3Models(
-            languageModel: languageModel,
-            depthDecoder: depthDecoder,
-            conditionEncoder: conditionEncoder,
-            transformer: transformer,
-            vocoder: vocoder,
-            tokenizer: tokenizer
-        )
+    private static func validate(_ resources: MiniMaxMusic3Resources) throws {
+        let missing = resources.validate()
+        guard missing.isEmpty else {
+            throw MiniMaxMusic3Error.missingResources(missing)
+        }
     }
 
     private static func loadWeights(

--- a/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3ModelLoader.swift
+++ b/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3ModelLoader.swift
@@ -1,0 +1,120 @@
+import Foundation
+import MLX
+import MLXNN
+
+public struct MiniMaxMusic3Models {
+    public let languageModel: MiniMaxMusic3LanguageModel
+    public let depthDecoder: MiniMaxMusic3DepthDecoder
+    public let conditionEncoder: MiniMaxMusic3ConditionEncoder
+    public let transformer: MiniMaxMusic3Transformer
+    public let vocoder: MiniMaxMusic3Vocoder
+    public let tokenizer: ACEStep5HzLMTokenizer
+}
+
+public enum MiniMaxMusic3ModelLoader {
+    public static func load(from resources: MiniMaxMusic3Resources) throws -> MiniMaxMusic3Models {
+        let missing = resources.validate()
+        guard missing.isEmpty else {
+            throw MiniMaxMusic3Error.missingResources(missing)
+        }
+
+        let languageModel = MiniMaxMusic3LanguageModel(
+            configuration: try resources.loadLanguageConfiguration()
+        )
+        try loadWeights(
+            directory: resources.languageModelURL,
+            indexName: "model.safetensors.index.json",
+            singleName: "model.safetensors",
+            into: languageModel
+        )
+
+        let depthDecoder = MiniMaxMusic3DepthDecoder(
+            configuration: try resources.loadDepthConfiguration()
+        )
+        try loadWeights(
+            directory: resources.depthDecoderURL,
+            into: depthDecoder
+        )
+
+        let conditionEncoder = MiniMaxMusic3ConditionEncoder(
+            configuration: try resources.loadConditionConfiguration()
+        )
+        try loadWeights(
+            directory: resources.conditionEncoderURL,
+            into: conditionEncoder,
+            mapper: MiniMaxMusic3ConditionEncoder.mapWeight
+        )
+
+        let transformer = MiniMaxMusic3Transformer(
+            configuration: try resources.loadTransformerConfiguration()
+        )
+        try loadWeights(
+            directory: resources.transformerURL,
+            into: transformer,
+            mapper: MiniMaxMusic3Transformer.mapWeight
+        )
+
+        let vocoder = MiniMaxMusic3Vocoder(
+            configuration: try resources.loadVocoderConfiguration()
+        )
+        try loadWeights(
+            directory: resources.vocoderURL,
+            into: vocoder,
+            mapper: MiniMaxMusic3Vocoder.mapWeight
+        )
+
+        let tokenizer = try ACEStep5HzLMTokenizer.load(
+            from: resources.tokenizerURL,
+            requireAudioCodeTokens: false
+        )
+        MLX.eval(
+            languageModel.parameters(),
+            depthDecoder.parameters(),
+            conditionEncoder.parameters(),
+            transformer.parameters(),
+            vocoder.parameters()
+        )
+        return MiniMaxMusic3Models(
+            languageModel: languageModel,
+            depthDecoder: depthDecoder,
+            conditionEncoder: conditionEncoder,
+            transformer: transformer,
+            vocoder: vocoder,
+            tokenizer: tokenizer
+        )
+    }
+
+    private static func loadWeights(
+        directory: URL,
+        indexName: String = "diffusion_pytorch_model.safetensors.index.json",
+        singleName: String = "diffusion_pytorch_model.safetensors",
+        into model: Module,
+        mapper: (String, MLXArray) -> [(String, MLXArray)] = { [($0, $1)] }
+    ) throws {
+        try ModelWeightsLoader.applyHFSafetensors(
+            indexURL: directory.appendingPathComponent(indexName),
+            singleURL: directory.appendingPathComponent(singleName),
+            to: model,
+            dtype: .bfloat16,
+            verify: .noUnusedKeys,
+            mapper: mapper
+        )
+    }
+}
+
+public enum MiniMaxMusic3Error: LocalizedError {
+    case missingResources([URL])
+    case invalidPrompt(String)
+    case generatedNoFrames
+
+    public var errorDescription: String? {
+        switch self {
+        case .missingResources(let urls):
+            return "MiniMax Music 3 is missing required files: \(urls.map(\.path).joined(separator: ", "))"
+        case .invalidPrompt(let reason):
+            return "Invalid MiniMax Music 3 prompt: \(reason)"
+        case .generatedNoFrames:
+            return "MiniMax Music 3 ended before generating an audio frame."
+        }
+    }
+}

--- a/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3Pipeline.swift
+++ b/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3Pipeline.swift
@@ -1,0 +1,361 @@
+import Foundation
+import MLX
+import MLXRandom
+
+public struct MiniMaxMusic3GenerationOptions: Sendable {
+    public var caption: String
+    public var lyrics: String
+    public var durationSeconds: Float
+    public var inferenceSteps: Int
+    public var seed: UInt64
+    public var guidanceScale: Float
+
+    public init(
+        caption: String,
+        lyrics: String,
+        durationSeconds: Float = 60,
+        inferenceSteps: Int = 30,
+        seed: UInt64 = 0,
+        guidanceScale: Float = 1.7
+    ) {
+        self.caption = caption
+        self.lyrics = lyrics
+        self.durationSeconds = durationSeconds
+        self.inferenceSteps = inferenceSteps
+        self.seed = seed
+        self.guidanceScale = guidanceScale
+    }
+}
+
+public struct MiniMaxMusic3GenerationResult {
+    public let waveform: MLXArray
+    public let sampleRate: Int
+    public let frameCount: Int
+}
+
+public enum MiniMaxMusic3Progress: Sendable, Equatable {
+    case semantic(frame: Int, maximum: Int)
+    case denoise(chunk: Int, chunkCount: Int, step: Int, stepCount: Int)
+    case decode(chunk: Int, chunkCount: Int)
+}
+
+public final class MiniMaxMusic3Pipeline {
+    public let models: MiniMaxMusic3Models
+
+    public init(models: MiniMaxMusic3Models) {
+        self.models = models
+    }
+
+    public convenience init(resources: MiniMaxMusic3Resources) throws {
+        try self.init(models: MiniMaxMusic3ModelLoader.load(from: resources))
+    }
+
+    public func generate(
+        options: MiniMaxMusic3GenerationOptions,
+        progress: (@Sendable (MiniMaxMusic3Progress) -> Void)? = nil
+    ) throws -> MiniMaxMusic3GenerationResult {
+        guard !options.caption.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw MiniMaxMusic3Error.invalidPrompt("the caption is empty")
+        }
+        guard !options.lyrics.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw MiniMaxMusic3Error.invalidPrompt("the lyrics are empty")
+        }
+        guard options.durationSeconds > 0 else {
+            throw MiniMaxMusic3Error.invalidPrompt("duration must be positive")
+        }
+        guard options.inferenceSteps > 0 else {
+            throw MiniMaxMusic3Error.invalidPrompt("inference steps must be positive")
+        }
+
+        MLXRandom.seed(options.seed)
+        let tokenIDs = try promptTokenIDs(caption: options.caption, lyrics: options.lyrics)
+        let frameHiddens = try generateSemanticFrames(
+            textIDs: tokenIDs,
+            durationSeconds: options.durationSeconds,
+            progress: progress
+        )
+        let chunks = denoise(
+            frameHiddens: frameHiddens,
+            steps: options.inferenceSteps,
+            guidanceScale: options.guidanceScale,
+            progress: progress
+        )
+        let waveform = decode(chunks: chunks, progress: progress)
+        MLX.eval(waveform)
+        return MiniMaxMusic3GenerationResult(
+            waveform: waveform,
+            sampleRate: models.vocoder.configuration.samplingRate,
+            frameCount: frameHiddens.dim(1)
+        )
+    }
+
+    private func promptTokenIDs(caption: String, lyrics: String) throws -> MLXArray {
+        let prompt = MiniMaxMusic3Prompt.assemble(caption: caption, lyrics: lyrics)
+        let conditional = models.tokenizer.encode(prompt, addSpecialTokens: false)
+        guard conditional.count <= MiniMaxMusic3Prompt.maxPromptTokens else {
+            throw MiniMaxMusic3Error.invalidPrompt(
+                "the assembled prompt has \(conditional.count) tokens; maximum is \(MiniMaxMusic3Prompt.maxPromptTokens)"
+            )
+        }
+        var unconditional = conditional
+        if unconditional.count > 3 {
+            for index in 1..<(unconditional.count - 2) {
+                unconditional[index] = MiniMaxMusic3Prompt.audioCFGTokenID
+            }
+        }
+        return MLXArray((conditional + unconditional).map(Int32.init)).reshaped(2, conditional.count)
+    }
+
+    private func generateSemanticFrames(
+        textIDs: MLXArray,
+        durationSeconds: Float,
+        progress: (@Sendable (MiniMaxMusic3Progress) -> Void)?
+    ) throws -> MLXArray {
+        let languageModel = models.languageModel
+        let caches = languageModel.makeCache()
+        let textEmbeddings = languageModel.embed(tokenIDs: textIDs)
+        var lastHidden = languageModel.hidden(
+            embeddings: textEmbeddings,
+            cache: caches,
+            lastPositionOnly: true
+        ).squeezed(axis: 1)
+        let requestedFrames = Int(durationSeconds * Float(MiniMaxMusic3Prompt.frameRate))
+        let maximumFrames = min(requestedFrames, MiniMaxMusic3Prompt.maxAudioFrames)
+        guard maximumFrames > 0 else {
+            throw MiniMaxMusic3Error.invalidPrompt("duration is shorter than one 25 Hz audio frame")
+        }
+
+        var frameHiddens: [MLXArray] = []
+        frameHiddens.reserveCapacity(maximumFrames)
+        for frameIndex in 0...maximumFrames {
+            let sampled = sampleSemantic(logits: languageModel.logits(lastHidden))
+            let sampledID = sampled.item(Int.self)
+            if sampledID == MiniMaxMusic3Prompt.audioEndTokenID {
+                break
+            }
+
+            let semantic = sampled.asType(.int32) - MLXArray(Int32(MiniMaxMusic3Prompt.audioCodeOffset))
+            let duplicatedSemantic = MLX.repeated(semantic.reshaped(1), count: 2, axis: 0)
+            let depth = generateDepthCodes(lastHidden: lastHidden, semanticCode: duplicatedSemantic)
+            if frameIndex > 0 {
+                let conditioning = MLX.concatenated([lastHidden[0..<1], depth.hidden], axis: -1)
+                MLX.eval(conditioning)
+                frameHiddens.append(conditioning)
+                progress?(.semantic(frame: frameHiddens.count, maximum: maximumFrames))
+                if frameHiddens.count >= maximumFrames {
+                    break
+                }
+            }
+
+            let feedback = embedAudioFrame(depth.codes)
+            lastHidden = languageModel.hidden(
+                embeddings: feedback,
+                cache: caches,
+                lastPositionOnly: true
+            ).squeezed(axis: 1)
+            MLX.eval(lastHidden)
+        }
+
+        guard !frameHiddens.isEmpty else {
+            throw MiniMaxMusic3Error.generatedNoFrames
+        }
+        return MLX.stacked(frameHiddens, axis: 1)
+    }
+
+    private func sampleSemantic(logits: MLXArray) -> MLXArray {
+        let guided = Self.guidedSemanticLogits(logits)
+        return sampledTokenArray(
+            logits: guided[0],
+            config: GenerationConfig(
+                temperature: 1,
+                topK: 50,
+                topP: 1,
+                repetitionPenalty: nil
+            ),
+            previousTokenIndices: nil,
+            banMask: nil
+        )
+    }
+
+    static func guidedSemanticLogits(_ logits: MLXArray) -> MLXArray {
+        let vocabulary = logits.dim(-1)
+        let tokenIndices = MLXArray((0..<vocabulary).map(Int32.init)).reshaped(1, vocabulary)
+        let semanticStart = MLXArray(Int32(MiniMaxMusic3Prompt.audioCodeOffset))
+        let semanticEnd = MLXArray(Int32(
+            MiniMaxMusic3Prompt.audioCodeOffset + MiniMaxMusic3Prompt.semanticVocabularySize
+        ))
+        let allowedSemantic = (tokenIndices .>= semanticStart) .&& (tokenIndices .< semanticEnd)
+        let allowedEnd = tokenIndices .== MLXArray(Int32(MiniMaxMusic3Prompt.audioEndTokenID))
+        let allowed = allowedSemantic .|| allowedEnd
+
+        // MiniMax masks the language-model vocabulary before choosing the
+        // conditional branch's top candidates. Text-token logits must never
+        // influence the audio-code threshold.
+        let masked = MLX.where(allowed, logits.asType(.float32), MLXArray(-Float.infinity))
+        let conditional = masked[0..<1]
+        let unconditional = masked[1..<2]
+        var guided = unconditional + (conditional - unconditional) * MLXArray(Float(1.5))
+        let firstTopIndex = vocabulary - min(50, vocabulary)
+        let topIndices = MLX.argPartition(conditional, kth: firstTopIndex, axis: -1)[0, firstTopIndex...]
+        let threshold = conditional[0].take(topIndices, axis: -1).min()
+        guided = MLX.where(conditional .< threshold, MLXArray(-Float.infinity), guided)
+        return MLX.where(allowed, guided, MLXArray(-Float.infinity))
+    }
+
+    private func generateDepthCodes(
+        lastHidden: MLXArray,
+        semanticCode: MLXArray
+    ) -> (codes: MLXArray, hidden: MLXArray) {
+        let depthDecoder = models.depthDecoder
+        var sequence = [depthDecoder.projection(lastHidden).expandedDimensions(axis: 1)]
+        let semanticEmbedding = models.languageModel.embed(
+            tokenIDs: semanticCode + MLXArray(Int32(MiniMaxMusic3Prompt.audioCodeOffset))
+        )
+        sequence.append(depthDecoder.projection(semanticEmbedding).expandedDimensions(axis: 1))
+        var codes = [semanticCode]
+        var hiddenParts: [MLXArray] = []
+        for codebook in 1..<depthDecoder.configuration.numCodebooks {
+            let hidden = depthDecoder(MLX.concatenated(sequence, axis: 1))[0..., -1, 0...]
+            hiddenParts.append(hidden[0..<1])
+            let logits = depthDecoder.logits(hidden, codebookIndex: codebook - 1)
+            let conditional = logits[0..<1].asType(.float32)
+            let unconditional = logits[1..<2].asType(.float32)
+            let guided = unconditional + (conditional - unconditional) * MLXArray(Float(1.5))
+            let sampled = sampledTokenArray(
+                logits: guided[0],
+                config: GenerationConfig(
+                    temperature: 1,
+                    topK: 50,
+                    topP: 1,
+                    repetitionPenalty: nil
+                ),
+                previousTokenIndices: nil,
+                banMask: nil
+            )
+            let duplicated = MLX.repeated(sampled.reshaped(1), count: 2, axis: 0)
+            codes.append(duplicated)
+            if codebook < depthDecoder.configuration.numCodebooks - 1 {
+                let embedding = depthDecoder.embedResidualCodes(
+                    duplicated,
+                    codebookIndex: codebook - 1
+                )
+                sequence.append(depthDecoder.projection(embedding).expandedDimensions(axis: 1))
+            }
+        }
+        return (
+            MLX.stacked(codes, axis: 1),
+            MLX.concatenated(hiddenParts, axis: -1)
+        )
+    }
+
+    private func embedAudioFrame(_ frameCodes: MLXArray) -> MLXArray {
+        var embedding = models.languageModel.embed(
+            tokenIDs: frameCodes[0..., 0] + MLXArray(Int32(MiniMaxMusic3Prompt.audioCodeOffset))
+        )
+        for codebook in 1..<models.depthDecoder.configuration.numCodebooks {
+            embedding = embedding + models.depthDecoder.embedResidualCodes(
+                frameCodes[0..., codebook],
+                codebookIndex: codebook - 1
+            ).asType(embedding.dtype)
+        }
+        let scale = 1 / Float(models.depthDecoder.configuration.numCodebooks).squareRoot()
+        return (embedding * MLXArray(scale)).expandedDimensions(axis: 1)
+    }
+
+    private func denoise(
+        frameHiddens: MLXArray,
+        steps: Int,
+        guidanceScale: Float,
+        progress: (@Sendable (MiniMaxMusic3Progress) -> Void)?
+    ) -> [MLXArray] {
+        let starts = MiniMaxMusic3Prompt.chunkStarts(frameCount: frameHiddens.dim(1))
+        var previousLatent: MLXArray?
+        var previousCondition: MLXArray?
+        var chunks: [MLXArray] = []
+        chunks.reserveCapacity(starts.count)
+
+        for (chunkIndex, start) in starts.enumerated() {
+            let end = min(start + 200, frameHiddens.dim(1))
+            var condition = models.conditionEncoder(frameHiddens[0..., start..<end, 0...])
+                .asType(.bfloat16)
+            let overlap = min(previousLatent?.dim(2) ?? 0, condition.dim(1))
+            if overlap > 0, let previousCondition {
+                condition = MLX.concatenated(
+                    [previousCondition[0..., 0..<overlap, 0...], condition[0..., overlap..., 0...]],
+                    axis: 1
+                )
+            }
+            var latents = MLXRandom.normal([
+                1,
+                models.transformer.configuration.inChannels,
+                condition.dim(1),
+            ]).asType(condition.dtype)
+            let noisePrompt = overlap > 0 ? latents[0..., 0..., 0..<overlap] : nil
+
+            for step in 0..<steps {
+                let time = Float(step) / Float(steps)
+                if overlap > 0, let previousLatent, let noisePrompt {
+                    let blended = (1 - (1 - 1e-6) * time) * noisePrompt
+                        + time * previousLatent[0..., 0..., 0..<overlap]
+                    latents = MLX.concatenated(
+                        [blended, latents[0..., 0..., overlap...]],
+                        axis: 2
+                    )
+                }
+                let timestep = MLXArray([time]).asType(latents.dtype)
+                let conditional = models.transformer(
+                    latents: latents,
+                    timestep: timestep,
+                    condition: condition
+                )
+                let unconditional = models.transformer(
+                    latents: latents,
+                    timestep: timestep,
+                    condition: MLXArray.zeros(condition.shape, dtype: condition.dtype)
+                )
+                let velocity = unconditional + (conditional - unconditional) * MLXArray(guidanceScale)
+                latents = latents + velocity * MLXArray(1 / Float(steps))
+                MLX.eval(latents)
+                progress?(.denoise(
+                    chunk: chunkIndex + 1,
+                    chunkCount: starts.count,
+                    step: step + 1,
+                    stepCount: steps
+                ))
+            }
+            if overlap > 0, let previousLatent {
+                latents = MLX.concatenated(
+                    [previousLatent[0..., 0..., 0..<overlap], latents[0..., 0..., overlap...]],
+                    axis: 2
+                )
+            }
+            let overlapStart = max(0, latents.dim(2) - 344)
+            let overlapEnd = max(overlapStart, latents.dim(2) - 172)
+            previousLatent = latents[0..., 0..., overlapStart..<overlapEnd]
+            previousCondition = condition[0..., overlapStart..<overlapEnd, 0...]
+            MLX.eval(latents, previousLatent!, previousCondition!)
+            chunks.append(latents)
+            MLX.Memory.clearCache()
+        }
+        return chunks
+    }
+
+    private func decode(
+        chunks: [MLXArray],
+        progress: (@Sendable (MiniMaxMusic3Progress) -> Void)?
+    ) -> MLXArray {
+        var waveforms: [MLXArray] = []
+        waveforms.reserveCapacity(chunks.count)
+        for (index, chunk) in chunks.enumerated() {
+            let waveform = models.vocoder(chunk.asType(.bfloat16))
+            let left = index == 0 ? 0 : 86 * 512
+            let right = index == chunks.count - 1 ? 0 : 258 * 512
+            let sampleEnd = waveform.dim(2) - right
+            let cropped = waveform[0..., 0..., left..<sampleEnd]
+            MLX.eval(cropped)
+            waveforms.append(cropped)
+            progress?(.decode(chunk: index + 1, chunkCount: chunks.count))
+        }
+        return MLX.clip(MLX.concatenated(waveforms, axis: 2).asType(.float32), min: -1, max: 1)
+    }
+}

--- a/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3Pipeline.swift
+++ b/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3Pipeline.swift
@@ -6,6 +6,7 @@ public struct MiniMaxMusic3GenerationOptions: Sendable {
     public var caption: String
     public var lyrics: String
     public var durationSeconds: Float
+    public var maximumFrames: Int?
     public var inferenceSteps: Int
     public var seed: UInt64
     public var guidanceScale: Float
@@ -14,6 +15,7 @@ public struct MiniMaxMusic3GenerationOptions: Sendable {
         caption: String,
         lyrics: String,
         durationSeconds: Float = 60,
+        maximumFrames: Int? = nil,
         inferenceSteps: Int = 30,
         seed: UInt64 = 0,
         guidanceScale: Float = 1.7
@@ -21,6 +23,7 @@ public struct MiniMaxMusic3GenerationOptions: Sendable {
         self.caption = caption
         self.lyrics = lyrics
         self.durationSeconds = durationSeconds
+        self.maximumFrames = maximumFrames
         self.inferenceSteps = inferenceSteps
         self.seed = seed
         self.guidanceScale = guidanceScale
@@ -40,14 +43,29 @@ public enum MiniMaxMusic3Progress: Sendable, Equatable {
 }
 
 public final class MiniMaxMusic3Pipeline {
-    public let models: MiniMaxMusic3Models
+    private let residentModels: MiniMaxMusic3Models?
+    private let resources: MiniMaxMusic3Resources?
+    public let loadingStrategy: MiniMaxMusic3LoadingStrategy
 
     public init(models: MiniMaxMusic3Models) {
-        self.models = models
+        self.residentModels = models
+        self.resources = nil
+        self.loadingStrategy = .resident
     }
 
-    public convenience init(resources: MiniMaxMusic3Resources) throws {
-        try self.init(models: MiniMaxMusic3ModelLoader.load(from: resources))
+    public init(
+        resources: MiniMaxMusic3Resources,
+        loadingStrategy: MiniMaxMusic3LoadingStrategy = .staged
+    ) throws {
+        let missing = resources.validate()
+        guard missing.isEmpty else {
+            throw MiniMaxMusic3Error.missingResources(missing)
+        }
+        self.resources = resources
+        self.loadingStrategy = loadingStrategy
+        self.residentModels = loadingStrategy == .resident
+            ? try MiniMaxMusic3ModelLoader.load(from: resources)
+            : nil
     }
 
     public func generate(
@@ -66,32 +84,127 @@ public final class MiniMaxMusic3Pipeline {
         guard options.inferenceSteps > 0 else {
             throw MiniMaxMusic3Error.invalidPrompt("inference steps must be positive")
         }
+        if let maximumFrames = options.maximumFrames,
+           !(1...MiniMaxMusic3Prompt.maxAudioFrames).contains(maximumFrames)
+        {
+            throw MiniMaxMusic3Error.invalidPrompt(
+                "maximum frames must be between 1 and \(MiniMaxMusic3Prompt.maxAudioFrames)"
+            )
+        }
 
-        MLXRandom.seed(options.seed)
-        let tokenIDs = try promptTokenIDs(caption: options.caption, lyrics: options.lyrics)
-        let frameHiddens = try generateSemanticFrames(
-            textIDs: tokenIDs,
-            durationSeconds: options.durationSeconds,
+        let generator = MLXRandom.RandomState(seed: options.seed)
+        let frameHiddens = try autoregressiveStage(
+            options: options,
+            generator: generator,
             progress: progress
         )
-        let chunks = denoise(
+        if loadingStrategy == .staged {
+            MLX.Memory.clearCache()
+        }
+        let chunks = try flowStage(
             frameHiddens: frameHiddens,
             steps: options.inferenceSteps,
             guidanceScale: options.guidanceScale,
+            generator: generator,
             progress: progress
         )
-        let waveform = decode(chunks: chunks, progress: progress)
+        if loadingStrategy == .staged {
+            MLX.Memory.clearCache()
+        }
+        let decoded = try vocoderStage(chunks: chunks, progress: progress)
+        if loadingStrategy == .staged {
+            MLX.Memory.clearCache()
+        }
+        let waveform = decoded.waveform
         MLX.eval(waveform)
         return MiniMaxMusic3GenerationResult(
             waveform: waveform,
-            sampleRate: models.vocoder.configuration.samplingRate,
+            sampleRate: decoded.sampleRate,
             frameCount: frameHiddens.dim(1)
         )
     }
 
-    private func promptTokenIDs(caption: String, lyrics: String) throws -> MLXArray {
+    private func autoregressiveStage(
+        options: MiniMaxMusic3GenerationOptions,
+        generator: MLXRandom.RandomState,
+        progress: (@Sendable (MiniMaxMusic3Progress) -> Void)?
+    ) throws -> MLXArray {
+        let models = try residentModels.map {
+            MiniMaxMusic3AutoregressiveModels(
+                languageModel: $0.languageModel,
+                depthDecoder: $0.depthDecoder,
+                tokenizer: $0.tokenizer
+            )
+        } ?? MiniMaxMusic3ModelLoader.loadAutoregressive(from: requiredResources())
+        let tokenIDs = try promptTokenIDs(
+            caption: options.caption,
+            lyrics: options.lyrics,
+            tokenizer: models.tokenizer
+        )
+        let frameHiddens = try generateSemanticFrames(
+            textIDs: tokenIDs,
+            durationSeconds: options.durationSeconds,
+            maximumFrames: options.maximumFrames,
+            languageModel: models.languageModel,
+            depthDecoder: models.depthDecoder,
+            generator: generator,
+            progress: progress
+        )
+        MLX.eval(frameHiddens)
+        return frameHiddens
+    }
+
+    private func flowStage(
+        frameHiddens: MLXArray,
+        steps: Int,
+        guidanceScale: Float,
+        generator: MLXRandom.RandomState,
+        progress: (@Sendable (MiniMaxMusic3Progress) -> Void)?
+    ) throws -> [MLXArray] {
+        let models = try residentModels.map {
+            MiniMaxMusic3FlowModels(
+                conditionEncoder: $0.conditionEncoder,
+                transformer: $0.transformer
+            )
+        } ?? MiniMaxMusic3ModelLoader.loadFlow(from: requiredResources())
+        let chunks = denoise(
+            frameHiddens: frameHiddens,
+            steps: steps,
+            guidanceScale: guidanceScale,
+            conditionEncoder: models.conditionEncoder,
+            transformer: models.transformer,
+            generator: generator,
+            progress: progress
+        )
+        MLX.eval(chunks)
+        return chunks
+    }
+
+    private func vocoderStage(
+        chunks: [MLXArray],
+        progress: (@Sendable (MiniMaxMusic3Progress) -> Void)?
+    ) throws -> (waveform: MLXArray, sampleRate: Int) {
+        let vocoder = try residentModels?.vocoder
+            ?? MiniMaxMusic3ModelLoader.loadVocoder(from: requiredResources())
+        let waveform = decode(chunks: chunks, vocoder: vocoder, progress: progress)
+        MLX.eval(waveform)
+        return (waveform, vocoder.configuration.samplingRate)
+    }
+
+    private func requiredResources() throws -> MiniMaxMusic3Resources {
+        guard let resources else {
+            throw MiniMaxMusic3Error.invalidPrompt("staged resources are unavailable")
+        }
+        return resources
+    }
+
+    private func promptTokenIDs(
+        caption: String,
+        lyrics: String,
+        tokenizer: ACEStep5HzLMTokenizer
+    ) throws -> MLXArray {
         let prompt = MiniMaxMusic3Prompt.assemble(caption: caption, lyrics: lyrics)
-        let conditional = models.tokenizer.encode(prompt, addSpecialTokens: false)
+        let conditional = tokenizer.encode(prompt, addSpecialTokens: false)
         guard conditional.count <= MiniMaxMusic3Prompt.maxPromptTokens else {
             throw MiniMaxMusic3Error.invalidPrompt(
                 "the assembled prompt has \(conditional.count) tokens; maximum is \(MiniMaxMusic3Prompt.maxPromptTokens)"
@@ -109,9 +222,12 @@ public final class MiniMaxMusic3Pipeline {
     private func generateSemanticFrames(
         textIDs: MLXArray,
         durationSeconds: Float,
+        maximumFrames explicitMaximumFrames: Int?,
+        languageModel: MiniMaxMusic3LanguageModel,
+        depthDecoder: MiniMaxMusic3DepthDecoder,
+        generator: MLXRandom.RandomState,
         progress: (@Sendable (MiniMaxMusic3Progress) -> Void)?
     ) throws -> MLXArray {
-        let languageModel = models.languageModel
         let caches = languageModel.makeCache()
         let textEmbeddings = languageModel.embed(tokenIDs: textIDs)
         var lastHidden = languageModel.hidden(
@@ -119,7 +235,8 @@ public final class MiniMaxMusic3Pipeline {
             cache: caches,
             lastPositionOnly: true
         ).squeezed(axis: 1)
-        let requestedFrames = Int(durationSeconds * Float(MiniMaxMusic3Prompt.frameRate))
+        let requestedFrames = explicitMaximumFrames
+            ?? Int(durationSeconds * Float(MiniMaxMusic3Prompt.frameRate))
         let maximumFrames = min(requestedFrames, MiniMaxMusic3Prompt.maxAudioFrames)
         guard maximumFrames > 0 else {
             throw MiniMaxMusic3Error.invalidPrompt("duration is shorter than one 25 Hz audio frame")
@@ -128,7 +245,10 @@ public final class MiniMaxMusic3Pipeline {
         var frameHiddens: [MLXArray] = []
         frameHiddens.reserveCapacity(maximumFrames)
         for frameIndex in 0...maximumFrames {
-            let sampled = sampleSemantic(logits: languageModel.logits(lastHidden))
+            let sampled = sampleSemantic(
+                logits: languageModel.logits(lastHidden),
+                generator: generator
+            )
             let sampledID = sampled.item(Int.self)
             if sampledID == MiniMaxMusic3Prompt.audioEndTokenID {
                 break
@@ -136,7 +256,13 @@ public final class MiniMaxMusic3Pipeline {
 
             let semantic = sampled.asType(.int32) - MLXArray(Int32(MiniMaxMusic3Prompt.audioCodeOffset))
             let duplicatedSemantic = MLX.repeated(semantic.reshaped(1), count: 2, axis: 0)
-            let depth = generateDepthCodes(lastHidden: lastHidden, semanticCode: duplicatedSemantic)
+            let depth = generateDepthCodes(
+                lastHidden: lastHidden,
+                semanticCode: duplicatedSemantic,
+                languageModel: languageModel,
+                depthDecoder: depthDecoder,
+                generator: generator
+            )
             if frameIndex > 0 {
                 let conditioning = MLX.concatenated([lastHidden[0..<1], depth.hidden], axis: -1)
                 MLX.eval(conditioning)
@@ -147,7 +273,11 @@ public final class MiniMaxMusic3Pipeline {
                 }
             }
 
-            let feedback = embedAudioFrame(depth.codes)
+            let feedback = embedAudioFrame(
+                depth.codes,
+                languageModel: languageModel,
+                depthDecoder: depthDecoder
+            )
             lastHidden = languageModel.hidden(
                 embeddings: feedback,
                 cache: caches,
@@ -162,19 +292,12 @@ public final class MiniMaxMusic3Pipeline {
         return MLX.stacked(frameHiddens, axis: 1)
     }
 
-    private func sampleSemantic(logits: MLXArray) -> MLXArray {
+    private func sampleSemantic(
+        logits: MLXArray,
+        generator: MLXRandom.RandomState
+    ) -> MLXArray {
         let guided = Self.guidedSemanticLogits(logits)
-        return sampledTokenArray(
-            logits: guided[0],
-            config: GenerationConfig(
-                temperature: 1,
-                topK: 50,
-                topP: 1,
-                repetitionPenalty: nil
-            ),
-            previousTokenIndices: nil,
-            banMask: nil
-        )
+        return sampleTopK(guided[0], generator: generator)
     }
 
     static func guidedSemanticLogits(_ logits: MLXArray) -> MLXArray {
@@ -204,11 +327,13 @@ public final class MiniMaxMusic3Pipeline {
 
     private func generateDepthCodes(
         lastHidden: MLXArray,
-        semanticCode: MLXArray
+        semanticCode: MLXArray,
+        languageModel: MiniMaxMusic3LanguageModel,
+        depthDecoder: MiniMaxMusic3DepthDecoder,
+        generator: MLXRandom.RandomState
     ) -> (codes: MLXArray, hidden: MLXArray) {
-        let depthDecoder = models.depthDecoder
         var sequence = [depthDecoder.projection(lastHidden).expandedDimensions(axis: 1)]
-        let semanticEmbedding = models.languageModel.embed(
+        let semanticEmbedding = languageModel.embed(
             tokenIDs: semanticCode + MLXArray(Int32(MiniMaxMusic3Prompt.audioCodeOffset))
         )
         sequence.append(depthDecoder.projection(semanticEmbedding).expandedDimensions(axis: 1))
@@ -221,17 +346,7 @@ public final class MiniMaxMusic3Pipeline {
             let conditional = logits[0..<1].asType(.float32)
             let unconditional = logits[1..<2].asType(.float32)
             let guided = unconditional + (conditional - unconditional) * MLXArray(Float(1.5))
-            let sampled = sampledTokenArray(
-                logits: guided[0],
-                config: GenerationConfig(
-                    temperature: 1,
-                    topK: 50,
-                    topP: 1,
-                    repetitionPenalty: nil
-                ),
-                previousTokenIndices: nil,
-                banMask: nil
-            )
+            let sampled = sampleTopK(guided[0], generator: generator)
             let duplicated = MLX.repeated(sampled.reshaped(1), count: 2, axis: 0)
             codes.append(duplicated)
             if codebook < depthDecoder.configuration.numCodebooks - 1 {
@@ -248,17 +363,37 @@ public final class MiniMaxMusic3Pipeline {
         )
     }
 
-    private func embedAudioFrame(_ frameCodes: MLXArray) -> MLXArray {
-        var embedding = models.languageModel.embed(
+    private func sampleTopK(
+        _ logits: MLXArray,
+        generator: MLXRandom.RandomState
+    ) -> MLXArray {
+        let finite = MLX.nanToNum(
+            logits.asType(.float32),
+            nan: -1e9,
+            posInf: 1e9,
+            negInf: -1e9
+        )
+        return MLXRandom.categorical(
+            applyingTopK(finite, topK: min(50, finite.dim(-1))),
+            key: generator
+        ).asType(.int32)
+    }
+
+    private func embedAudioFrame(
+        _ frameCodes: MLXArray,
+        languageModel: MiniMaxMusic3LanguageModel,
+        depthDecoder: MiniMaxMusic3DepthDecoder
+    ) -> MLXArray {
+        var embedding = languageModel.embed(
             tokenIDs: frameCodes[0..., 0] + MLXArray(Int32(MiniMaxMusic3Prompt.audioCodeOffset))
         )
-        for codebook in 1..<models.depthDecoder.configuration.numCodebooks {
-            embedding = embedding + models.depthDecoder.embedResidualCodes(
+        for codebook in 1..<depthDecoder.configuration.numCodebooks {
+            embedding = embedding + depthDecoder.embedResidualCodes(
                 frameCodes[0..., codebook],
                 codebookIndex: codebook - 1
             ).asType(embedding.dtype)
         }
-        let scale = 1 / Float(models.depthDecoder.configuration.numCodebooks).squareRoot()
+        let scale = 1 / Float(depthDecoder.configuration.numCodebooks).squareRoot()
         return (embedding * MLXArray(scale)).expandedDimensions(axis: 1)
     }
 
@@ -266,6 +401,9 @@ public final class MiniMaxMusic3Pipeline {
         frameHiddens: MLXArray,
         steps: Int,
         guidanceScale: Float,
+        conditionEncoder: MiniMaxMusic3ConditionEncoder,
+        transformer: MiniMaxMusic3Transformer,
+        generator: MLXRandom.RandomState,
         progress: (@Sendable (MiniMaxMusic3Progress) -> Void)?
     ) -> [MLXArray] {
         let starts = MiniMaxMusic3Prompt.chunkStarts(frameCount: frameHiddens.dim(1))
@@ -276,7 +414,7 @@ public final class MiniMaxMusic3Pipeline {
 
         for (chunkIndex, start) in starts.enumerated() {
             let end = min(start + 200, frameHiddens.dim(1))
-            var condition = models.conditionEncoder(frameHiddens[0..., start..<end, 0...])
+            var condition = conditionEncoder(frameHiddens[0..., start..<end, 0...])
                 .asType(.bfloat16)
             let overlap = min(previousLatent?.dim(2) ?? 0, condition.dim(1))
             if overlap > 0, let previousCondition {
@@ -287,9 +425,9 @@ public final class MiniMaxMusic3Pipeline {
             }
             var latents = MLXRandom.normal([
                 1,
-                models.transformer.configuration.inChannels,
+                transformer.configuration.inChannels,
                 condition.dim(1),
-            ]).asType(condition.dtype)
+            ], key: generator).asType(condition.dtype)
             let noisePrompt = overlap > 0 ? latents[0..., 0..., 0..<overlap] : nil
 
             for step in 0..<steps {
@@ -303,12 +441,12 @@ public final class MiniMaxMusic3Pipeline {
                     )
                 }
                 let timestep = MLXArray([time]).asType(latents.dtype)
-                let conditional = models.transformer(
+                let conditional = transformer(
                     latents: latents,
                     timestep: timestep,
                     condition: condition
                 )
-                let unconditional = models.transformer(
+                let unconditional = transformer(
                     latents: latents,
                     timestep: timestep,
                     condition: MLXArray.zeros(condition.shape, dtype: condition.dtype)
@@ -342,12 +480,13 @@ public final class MiniMaxMusic3Pipeline {
 
     private func decode(
         chunks: [MLXArray],
+        vocoder: MiniMaxMusic3Vocoder,
         progress: (@Sendable (MiniMaxMusic3Progress) -> Void)?
     ) -> MLXArray {
         var waveforms: [MLXArray] = []
         waveforms.reserveCapacity(chunks.count)
         for (index, chunk) in chunks.enumerated() {
-            let waveform = models.vocoder(chunk.asType(.bfloat16))
+            let waveform = vocoder(chunk.asType(.bfloat16))
             let left = index == 0 ? 0 : 86 * 512
             let right = index == chunks.count - 1 ? 0 : 258 * 512
             let sampleEnd = waveform.dim(2) - right

--- a/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3Prompt.swift
+++ b/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3Prompt.swift
@@ -1,0 +1,83 @@
+import Foundation
+
+public enum MiniMaxMusic3Prompt {
+    public static let audioEndTokenID = 151_670
+    public static let audioCFGTokenID = 151_654
+    public static let audioCodeOffset = 151_675
+    public static let semanticVocabularySize = 16_384
+    public static let maxPromptTokens = 5_000
+    public static let maxAudioFrames = 9_000
+    public static let frameRate = 25
+
+    public static func assemble(caption: String, lyrics: String) -> String {
+        "<|im_start|><|caption_start|>\(cleanCaption(caption))<|caption_end|>"
+            + "<|lyrics_start|>\(normalizeLyrics(lyrics))<|lyrics_end|><|im_end|><|audio_start|>"
+    }
+
+    public static func cleanCaption(_ caption: String) -> String {
+        var text = caption
+        if let specialPattern = try? NSRegularExpression(pattern: #"<\|([^|]*)\|>"#) {
+            let range = NSRange(text.startIndex..<text.endIndex, in: text)
+            for match in specialPattern.matches(in: text, range: range).reversed() {
+                guard let capture = Range(match.range(at: 1), in: text),
+                      let whole = Range(match.range(at: 0), in: text) else { continue }
+                let inner = text[capture].trimmingCharacters(in: .whitespacesAndNewlines)
+                let parts = inner.split(maxSplits: 1, whereSeparator: { $0.isWhitespace })
+                let replacement = parts.count == 2 ? "\(parts[0]) is \(parts[1])" : inner
+                text.replaceSubrange(whole, with: replacement)
+            }
+        }
+        let lines = text.components(separatedBy: .newlines).map { line -> String in
+            var value = line
+            value = value.replacingOccurrences(of: #"^\s{0,3}#{1,6}\s+"#, with: "", options: .regularExpression)
+            value = value.replacingOccurrences(of: #"^\s*[*+-]\s+"#, with: "", options: .regularExpression)
+            value = value.replacingOccurrences(of: #"\*\*([^*]+)\*\*"#, with: "$1", options: .regularExpression)
+            value = value.replacingOccurrences(of: #"\*([^*\n]+)\*"#, with: "$1", options: .regularExpression)
+            return value.trimmingCharacters(in: .whitespaces)
+        }
+        text = lines.joined(separator: "\n")
+        text = text.replacingOccurrences(of: #"(?m)^\s*[-*_]{3,}\s*$"#, with: "", options: .regularExpression)
+        text = text.replacingOccurrences(of: "• ", with: "").replacingOccurrences(of: "    ", with: "")
+        return text.replacingOccurrences(of: #"\n{2,}"#, with: "\n", options: .regularExpression)
+    }
+
+    public static func normalizeLyrics(_ lyrics: String) -> String {
+        let pattern = try? NSRegularExpression(pattern: #"^[ \t]*((?:\[[^\]]+\][ \t]*)+)"#)
+        let lines = lyrics.components(separatedBy: "\n").map { line -> String in
+            let range = NSRange(line.startIndex..<line.endIndex, in: line)
+            guard let match = pattern?.firstMatch(in: line, range: range),
+                  let capture = Range(match.range(at: 1), in: line) else {
+                return line
+            }
+            return String(line[capture]).trimmingCharacters(in: .whitespaces)
+        }
+        var text = lines.joined(separator: "\n")
+        text = text.replacingOccurrences(of: "] ", with: "]\n")
+        text = text.replacingOccurrences(of: " [", with: "\n[")
+        text = text.replacingOccurrences(of: " ^ ", with: "\n")
+        if let tagPattern = try? NSRegularExpression(pattern: #"\[([^\]]+)\]"#) {
+            let fullRange = NSRange(text.startIndex..<text.endIndex, in: text)
+            for match in tagPattern.matches(in: text, range: fullRange).reversed() {
+                guard let capture = Range(match.range(at: 1), in: text),
+                      let whole = Range(match.range(at: 0), in: text) else { continue }
+                text.replaceSubrange(whole, with: "[\(text[capture].lowercased())]")
+            }
+        }
+        return "[start]\n\(text)"
+    }
+
+    public static func chunkStarts(frameCount: Int, chunkFrames: Int = 200, hop: Int = 100) -> [Int] {
+        guard frameCount > chunkFrames else { return [0] }
+        return Array(stride(from: 0, to: frameCount - hop, by: hop))
+    }
+
+    public static func latentLength(
+        frameCount: Int,
+        inputSamplingRate: Int = 24_000,
+        inputHopLength: Int = 960,
+        outputSamplingRate: Int = 44_100,
+        outputHopLength: Int = 512
+    ) -> Int {
+        max(1, frameCount * outputSamplingRate * inputHopLength / inputSamplingRate / outputHopLength)
+    }
+}

--- a/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3Prompt.swift
+++ b/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3Prompt.swift
@@ -27,13 +27,37 @@ public enum MiniMaxMusic3Prompt {
                 text.replaceSubrange(whole, with: replacement)
             }
         }
-        let lines = text.components(separatedBy: .newlines).map { line -> String in
+        text = text.replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
+        var sourceLines = text.components(separatedBy: "\n")
+        if sourceLines.last?.isEmpty == true {
+            sourceLines.removeLast()
+        }
+        let lines = sourceLines.map { line -> String in
             var value = line
             value = value.replacingOccurrences(of: #"^\s{0,3}#{1,6}\s+"#, with: "", options: .regularExpression)
             value = value.replacingOccurrences(of: #"^\s*[*+-]\s+"#, with: "", options: .regularExpression)
-            value = value.replacingOccurrences(of: #"\*\*([^*]+)\*\*"#, with: "$1", options: .regularExpression)
-            value = value.replacingOccurrences(of: #"\*([^*\n]+)\*"#, with: "$1", options: .regularExpression)
-            return value.trimmingCharacters(in: .whitespaces)
+            value = value.replacingOccurrences(of: #"^\s*\*\s+"#, with: "", options: .regularExpression)
+            while value.contains("**") {
+                let updated = value.replacingOccurrences(
+                    of: #"\*\*([^*]+)\*\*"#,
+                    with: "$1",
+                    options: .regularExpression
+                )
+                if updated == value {
+                    break
+                }
+                value = updated
+            }
+            value = value.replacingOccurrences(
+                of: #"(?<!\*)\*([^*\n]+)\*(?!\*)"#,
+                with: "$1",
+                options: .regularExpression
+            )
+            while value.last.map({ $0 == " " || $0 == "\t" }) == true {
+                value.removeLast()
+            }
+            return value
         }
         text = lines.joined(separator: "\n")
         text = text.replacingOccurrences(of: #"(?m)^\s*[-*_]{3,}\s*$"#, with: "", options: .regularExpression)

--- a/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3Resources.swift
+++ b/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3Resources.swift
@@ -1,0 +1,197 @@
+import Foundation
+
+public struct MiniMaxMusic3LanguageConfiguration: Codable, Hashable, Sendable {
+    public struct RopeParameters: Codable, Hashable, Sendable {
+        public let ropeTheta: Float
+
+        enum CodingKeys: String, CodingKey {
+            case ropeTheta = "rope_theta"
+        }
+    }
+
+    public let vocabSize: Int
+    public let hiddenSize: Int
+    public let intermediateSize: Int
+    public let numHiddenLayers: Int
+    public let numAttentionHeads: Int
+    public let numKeyValueHeads: Int
+    public let headDim: Int
+    public let maxPositionEmbeddings: Int
+    public let rmsNormEps: Float
+    public let ropeParameters: RopeParameters
+
+    enum CodingKeys: String, CodingKey {
+        case vocabSize = "vocab_size"
+        case hiddenSize = "hidden_size"
+        case intermediateSize = "intermediate_size"
+        case numHiddenLayers = "num_hidden_layers"
+        case numAttentionHeads = "num_attention_heads"
+        case numKeyValueHeads = "num_key_value_heads"
+        case headDim = "head_dim"
+        case maxPositionEmbeddings = "max_position_embeddings"
+        case rmsNormEps = "rms_norm_eps"
+        case ropeParameters = "rope_parameters"
+    }
+}
+
+public struct MiniMaxMusic3DepthConfiguration: Codable, Hashable, Sendable {
+    public let hiddenSize: Int
+    public let numLayers: Int
+    public let numAttentionHeads: Int
+    public let intermediateSize: Int
+    public let audioVocabSize: Int
+    public let numCodebooks: Int
+    public let maxPositionEmbeddings: Int
+
+    enum CodingKeys: String, CodingKey {
+        case hiddenSize = "hidden_size"
+        case numLayers = "num_layers"
+        case numAttentionHeads = "num_attention_heads"
+        case intermediateSize = "intermediate_size"
+        case audioVocabSize = "audio_vocab_size"
+        case numCodebooks = "num_codebooks"
+        case maxPositionEmbeddings = "max_position_embeddings"
+    }
+}
+
+public struct MiniMaxMusic3ConditionConfiguration: Codable, Hashable, Sendable {
+    public let conditionHiddenDim: Int
+    public let numConditionLayers: Int
+    public let outDim: Int
+    public let inputSamplingRate: Int
+    public let inputHopLength: Int
+    public let outputSamplingRate: Int
+    public let outputHopLength: Int
+
+    enum CodingKeys: String, CodingKey {
+        case conditionHiddenDim = "condition_hidden_dim"
+        case numConditionLayers = "num_condition_layers"
+        case outDim = "out_dim"
+        case inputSamplingRate = "input_sampling_rate"
+        case inputHopLength = "input_hop_length"
+        case outputSamplingRate = "output_sampling_rate"
+        case outputHopLength = "output_hop_length"
+    }
+}
+
+public struct MiniMaxMusic3TransformerConfiguration: Codable, Hashable, Sendable {
+    public let inChannels: Int
+    public let conditionDim: Int
+    public let numLayers: Int
+    public let numAttentionHeads: Int
+    public let attentionHeadDim: Int
+    public let ffInnerDim: Int
+    public let rotaryDim: Int
+    public let fourierEmbeddingDim: Int
+
+    enum CodingKeys: String, CodingKey {
+        case inChannels = "in_channels"
+        case conditionDim = "condition_dim"
+        case numLayers = "num_layers"
+        case numAttentionHeads = "num_attention_heads"
+        case attentionHeadDim = "attention_head_dim"
+        case ffInnerDim = "ff_inner_dim"
+        case rotaryDim = "rotary_dim"
+        case fourierEmbeddingDim = "fourier_embedding_dim"
+    }
+}
+
+public struct MiniMaxMusic3VocoderConfiguration: Codable, Hashable, Sendable {
+    public let latentChannels: Int
+    public let decoderInputDim: Int
+    public let decoderHiddenDim: Int
+    public let upsamplingRatios: [Int]
+    public let samplingRate: Int
+
+    enum CodingKeys: String, CodingKey {
+        case latentChannels = "latent_channels"
+        case decoderInputDim = "decoder_input_dim"
+        case decoderHiddenDim = "decoder_hidden_dim"
+        case upsamplingRatios = "upsampling_ratios"
+        case samplingRate = "sampling_rate"
+    }
+}
+
+public struct MiniMaxMusic3Resources: Sendable, Hashable {
+    public static let modelID = "music-minimax-music3"
+    public static let repository = "MiniMaxAI/MiniMax-Music3"
+    public static let revision = "bd348f9c49ea3c1b39f33ace3436f8fad435f24e"
+    public static let estimatedDownloadBytes: Int64 = 28_517_620_807
+
+    public let rootURL: URL
+
+    public init(rootURL: URL) {
+        self.rootURL = rootURL
+    }
+
+    public var tokenizerURL: URL { rootURL.appendingPathComponent("tokenizer", isDirectory: true) }
+    public var languageModelURL: URL { rootURL.appendingPathComponent("language_model", isDirectory: true) }
+    public var depthDecoderURL: URL { rootURL.appendingPathComponent("rvq_depth_decoder", isDirectory: true) }
+    public var conditionEncoderURL: URL { rootURL.appendingPathComponent("condition_encoder", isDirectory: true) }
+    public var transformerURL: URL { rootURL.appendingPathComponent("transformer", isDirectory: true) }
+    public var vocoderURL: URL { rootURL.appendingPathComponent("vocoder", isDirectory: true) }
+
+    public func validate(fileManager: FileManager = .default) -> [URL] {
+        var missing = Self.requiredFiles.map { rootURL.appendingPathComponent($0) }
+            .filter { !fileManager.fileExists(atPath: $0.path) }
+        for directory in [languageModelURL, transformerURL] {
+            let index = directory.appendingPathComponent("model.safetensors.index.json")
+            let diffusersIndex = directory.appendingPathComponent("diffusion_pytorch_model.safetensors.index.json")
+            let single = directory.appendingPathComponent("model.safetensors")
+            let diffusersSingle = directory.appendingPathComponent("diffusion_pytorch_model.safetensors")
+            if ![index, diffusersIndex, single, diffusersSingle].contains(where: {
+                fileManager.fileExists(atPath: $0.path)
+            }) {
+                missing.append(directory.appendingPathComponent("*.safetensors"))
+            }
+        }
+        return missing
+    }
+
+    public func loadLanguageConfiguration() throws -> MiniMaxMusic3LanguageConfiguration {
+        try Self.decode(MiniMaxMusic3LanguageConfiguration.self, at: languageModelURL.appendingPathComponent("config.json"))
+    }
+
+    public func loadDepthConfiguration() throws -> MiniMaxMusic3DepthConfiguration {
+        try Self.decode(MiniMaxMusic3DepthConfiguration.self, at: depthDecoderURL.appendingPathComponent("config.json"))
+    }
+
+    public func loadConditionConfiguration() throws -> MiniMaxMusic3ConditionConfiguration {
+        try Self.decode(MiniMaxMusic3ConditionConfiguration.self, at: conditionEncoderURL.appendingPathComponent("config.json"))
+    }
+
+    public func loadTransformerConfiguration() throws -> MiniMaxMusic3TransformerConfiguration {
+        try Self.decode(MiniMaxMusic3TransformerConfiguration.self, at: transformerURL.appendingPathComponent("config.json"))
+    }
+
+    public func loadVocoderConfiguration() throws -> MiniMaxMusic3VocoderConfiguration {
+        try Self.decode(MiniMaxMusic3VocoderConfiguration.self, at: vocoderURL.appendingPathComponent("config.json"))
+    }
+
+    public static func looksLikeRoot(_ rootURL: URL, fileManager: FileManager = .default) -> Bool {
+        fileManager.fileExists(atPath: rootURL.appendingPathComponent("modular_model_index.json").path)
+            && fileManager.fileExists(atPath: rootURL.appendingPathComponent("language_model/config.json").path)
+            && fileManager.fileExists(atPath: rootURL.appendingPathComponent("vocoder/config.json").path)
+    }
+
+    private static let requiredFiles = [
+        "LICENSE",
+        "config.json",
+        "modular_model_index.json",
+        "condition_encoder/config.json",
+        "condition_encoder/diffusion_pytorch_model.safetensors",
+        "language_model/config.json",
+        "rvq_depth_decoder/config.json",
+        "rvq_depth_decoder/diffusion_pytorch_model.safetensors",
+        "scheduler/scheduler_config.json",
+        "tokenizer/tokenizer.json",
+        "tokenizer/tokenizer_config.json",
+        "transformer/config.json",
+        "vocoder/config.json",
+        "vocoder/diffusion_pytorch_model.safetensors",
+    ]
+
+    private static func decode<T: Decodable>(_ type: T.Type, at url: URL) throws -> T {
+        try JSONDecoder().decode(type, from: Data(contentsOf: url))
+    }
+}

--- a/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3Transformer.swift
+++ b/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3Transformer.swift
@@ -1,0 +1,203 @@
+import Foundation
+import MLX
+import MLXFast
+import MLXNN
+import MLXRandom
+
+final class MiniMaxMusic3FourierEmbedding: Module {
+    @ModuleInfo(key: "weight") var weight: MLXArray
+
+    init(dimensions: Int) {
+        self._weight.wrappedValue = MLXRandom.normal([dimensions / 2, 1])
+    }
+
+    func callAsFunction(_ timestep: MLXArray) -> MLXArray {
+        let angles = MLXArray(2 * Float.pi).asType(timestep.dtype)
+            * MLX.matmul(timestep.reshaped(-1, 1), weight.transposed())
+        return MLX.concatenated([MLX.cos(angles), MLX.sin(angles)], axis: -1)
+    }
+}
+
+final class MiniMaxMusic3TimestepEmbedding: Module {
+    @ModuleInfo(key: "linear_1") var first: Linear
+    @ModuleInfo(key: "linear_2") var second: Linear
+
+    init(inputDimensions: Int, outputDimensions: Int) {
+        self._first.wrappedValue = Linear(inputDimensions, outputDimensions)
+        self._second.wrappedValue = Linear(outputDimensions, outputDimensions)
+    }
+
+    func callAsFunction(_ input: MLXArray) -> MLXArray {
+        second(MLXNN.silu(first(input)))
+    }
+}
+
+enum MiniMaxMusic3RotaryEmbedding {
+    static func cache(length: Int, dimensions: Int, theta: Float, dtype: DType) -> (MLXArray, MLXArray) {
+        var inverse: [Float] = []
+        inverse.reserveCapacity(dimensions / 2)
+        for index in 0..<(dimensions / 2) {
+            let exponent = -Double(index * 2) / Double(dimensions)
+            inverse.append(Float(Foundation.pow(Double(theta), exponent)))
+        }
+        let positions = MLXArray((0..<length).map(Float.init)).reshaped(length, 1)
+        let frequencies = positions * MLXArray(inverse).reshaped(1, -1)
+        let doubled = MLX.concatenated([frequencies, frequencies], axis: -1)
+        return (MLX.cos(doubled).asType(dtype), MLX.sin(doubled).asType(dtype))
+    }
+
+    static func apply(_ input: MLXArray, cos: MLXArray, sin: MLXArray, dimensions: Int) -> MLXArray {
+        let rotary = input[0..., 0..., 0..., 0..<dimensions]
+        let halves = MLX.split(rotary, parts: 2, axis: -1)
+        let rotatedHalf = MLX.concatenated([-halves[1], halves[0]], axis: -1)
+        let shapedCos = cos.reshaped(1, cos.dim(0), 1, dimensions)
+        let shapedSin = sin.reshaped(1, sin.dim(0), 1, dimensions)
+        let rotated = rotary * shapedCos + rotatedHalf * shapedSin
+        guard dimensions < input.dim(-1) else { return rotated }
+        return MLX.concatenated([rotated, input[0..., 0..., 0..., dimensions...]], axis: -1)
+    }
+}
+
+final class MiniMaxMusic3FlowAttention: Module {
+    let heads: Int
+    let headDimension: Int
+    let rotaryDimension: Int
+
+    @ModuleInfo(key: "to_q") var query: Linear
+    @ModuleInfo(key: "to_k") var key: Linear
+    @ModuleInfo(key: "to_v") var value: Linear
+    @ModuleInfo(key: "to_out") var output: [Linear]
+
+    init(dimensions: Int, heads: Int, headDimension: Int, rotaryDimension: Int) {
+        self.heads = heads
+        self.headDimension = headDimension
+        self.rotaryDimension = rotaryDimension
+        let inner = heads * headDimension
+        self._query.wrappedValue = Linear(dimensions, inner, bias: false)
+        self._key.wrappedValue = Linear(dimensions, inner, bias: false)
+        self._value.wrappedValue = Linear(dimensions, inner, bias: false)
+        self._output.wrappedValue = [Linear(inner, dimensions, bias: false)]
+    }
+
+    func callAsFunction(_ hidden: MLXArray, rotary: (MLXArray, MLXArray)) -> MLXArray {
+        let batch = hidden.dim(0)
+        let length = hidden.dim(1)
+        var q = query(hidden).reshaped(batch, length, heads, headDimension)
+        var k = key(hidden).reshaped(batch, length, heads, headDimension)
+        let v = value(hidden).reshaped(batch, length, heads, headDimension)
+        q = MiniMaxMusic3RotaryEmbedding.apply(q, cos: rotary.0, sin: rotary.1, dimensions: rotaryDimension)
+        k = MiniMaxMusic3RotaryEmbedding.apply(k, cos: rotary.0, sin: rotary.1, dimensions: rotaryDimension)
+        let attended = MLXFast.scaledDotProductAttention(
+            queries: q.transposed(0, 2, 1, 3).asType(.float32),
+            keys: k.transposed(0, 2, 1, 3).asType(.float32),
+            values: v.transposed(0, 2, 1, 3).asType(.float32),
+            scale: 1 / Float(headDimension).squareRoot(),
+            mask: .none
+        )
+        let merged = attended.asType(q.dtype).transposed(0, 2, 1, 3).reshaped(batch, length, -1)
+        return output[0](merged)
+    }
+}
+
+final class MiniMaxMusic3TransformerBlock: Module {
+    @ModuleInfo(key: "norm1") var norm1: LayerNorm
+    @ModuleInfo(key: "attn") var attention: MiniMaxMusic3FlowAttention
+    @ModuleInfo(key: "norm2") var norm2: LayerNorm
+    @ModuleInfo(key: "ff_in") var feedForwardInput: Linear
+    @ModuleInfo(key: "ff_out") var feedForwardOutput: Linear
+
+    init(configuration: MiniMaxMusic3TransformerConfiguration) {
+        let inner = configuration.numAttentionHeads * configuration.attentionHeadDim
+        self._norm1.wrappedValue = LayerNorm(dimensions: inner)
+        self._attention.wrappedValue = MiniMaxMusic3FlowAttention(
+            dimensions: inner,
+            heads: configuration.numAttentionHeads,
+            headDimension: configuration.attentionHeadDim,
+            rotaryDimension: configuration.rotaryDim
+        )
+        self._norm2.wrappedValue = LayerNorm(dimensions: inner)
+        self._feedForwardInput.wrappedValue = Linear(inner, configuration.ffInnerDim * 2)
+        self._feedForwardOutput.wrappedValue = Linear(configuration.ffInnerDim, inner)
+    }
+
+    func callAsFunction(_ input: MLXArray, rotary: (MLXArray, MLXArray)) -> MLXArray {
+        let attended = input + attention(norm1(input), rotary: rotary)
+        let parts = MLX.split(feedForwardInput(norm2(attended)), parts: 2, axis: -1)
+        return attended + feedForwardOutput(parts[0] * MLXNN.silu(parts[1]))
+    }
+}
+
+public final class MiniMaxMusic3Transformer: Module {
+    public let configuration: MiniMaxMusic3TransformerConfiguration
+
+    @ModuleInfo(key: "time_proj") var timeProjection: MiniMaxMusic3FourierEmbedding
+    @ModuleInfo(key: "time_embed") var timeEmbedding: MiniMaxMusic3TimestepEmbedding
+    @ModuleInfo(key: "preprocess_conv") var preprocessConvolution: Conv1d
+    @ModuleInfo(key: "proj_in") var inputProjection: Linear
+    @ModuleInfo(key: "transformer_blocks") var blocks: [MiniMaxMusic3TransformerBlock]
+    @ModuleInfo(key: "proj_out") var outputProjection: Linear
+    @ModuleInfo(key: "postprocess_conv") var postprocessConvolution: Conv1d
+
+    public init(configuration: MiniMaxMusic3TransformerConfiguration) {
+        self.configuration = configuration
+        let inner = configuration.numAttentionHeads * configuration.attentionHeadDim
+        let concatenated = 2 * configuration.inChannels + configuration.conditionDim
+        self._timeProjection.wrappedValue = MiniMaxMusic3FourierEmbedding(
+            dimensions: configuration.fourierEmbeddingDim
+        )
+        self._timeEmbedding.wrappedValue = MiniMaxMusic3TimestepEmbedding(
+            inputDimensions: configuration.fourierEmbeddingDim,
+            outputDimensions: inner
+        )
+        self._preprocessConvolution.wrappedValue = Conv1d(
+            inputChannels: concatenated,
+            outputChannels: concatenated,
+            kernelSize: 1,
+            bias: false
+        )
+        self._inputProjection.wrappedValue = Linear(concatenated, inner, bias: false)
+        self._blocks.wrappedValue = (0..<configuration.numLayers).map { _ in
+            MiniMaxMusic3TransformerBlock(configuration: configuration)
+        }
+        self._outputProjection.wrappedValue = Linear(inner, configuration.inChannels, bias: false)
+        self._postprocessConvolution.wrappedValue = Conv1d(
+            inputChannels: configuration.inChannels,
+            outputChannels: configuration.inChannels,
+            kernelSize: 1,
+            bias: false
+        )
+    }
+
+    public func callAsFunction(
+        latents: MLXArray,
+        timestep: MLXArray,
+        condition: MLXArray
+    ) -> MLXArray {
+        let latentNLC = latents.transposed(0, 2, 1)
+        let zeros = MLXArray.zeros(latentNLC.shape, dtype: latentNLC.dtype)
+        var hidden = MLX.concatenated([latentNLC, zeros, condition], axis: -1)
+        hidden = preprocessConvolution(hidden) + hidden
+        hidden = inputProjection(hidden)
+        let time = timeEmbedding(timeProjection(timestep)).expandedDimensions(axis: 1)
+        hidden = MLX.concatenated([time, hidden], axis: 1)
+        let rotary = MiniMaxMusic3RotaryEmbedding.cache(
+            length: hidden.dim(1),
+            dimensions: configuration.rotaryDim,
+            theta: 10_000,
+            dtype: hidden.dtype
+        )
+        for block in blocks {
+            hidden = block(hidden, rotary: rotary)
+        }
+        hidden = outputProjection(hidden[0..., 1..., 0...])
+        let postprocessed = postprocessConvolution(hidden) + hidden
+        return postprocessed.transposed(0, 2, 1)
+    }
+
+    static func mapWeight(key: String, value: MLXArray) -> [(String, MLXArray)] {
+        if key == "preprocess_conv.weight" || key == "postprocess_conv.weight" {
+            return [(key, value.transposed(0, 2, 1))]
+        }
+        return [(key, value)]
+    }
+}

--- a/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3Vocoder.swift
+++ b/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3Vocoder.swift
@@ -1,0 +1,146 @@
+import MLX
+import MLXNN
+
+final class MiniMaxMusic3Snake: Module {
+    @ModuleInfo(key: "alpha") var alpha: MLXArray
+
+    init(channels: Int) {
+        self._alpha.wrappedValue = MLXArray.ones([1, 1, channels])
+    }
+
+    func callAsFunction(_ input: MLXArray) -> MLXArray {
+        input + MLX.square(MLX.sin(alpha * input)) / (alpha + MLXArray(1e-9).asType(input.dtype))
+    }
+}
+
+final class MiniMaxMusic3VocoderResidualUnit: Module {
+    @ModuleInfo(key: "snake1") var snake1: MiniMaxMusic3Snake
+    @ModuleInfo(key: "conv1") var convolution1: WNConv1d
+    @ModuleInfo(key: "snake2") var snake2: MiniMaxMusic3Snake
+    @ModuleInfo(key: "conv2") var convolution2: WNConv1d
+
+    init(dimensions: Int, dilation: Int) {
+        self._snake1.wrappedValue = MiniMaxMusic3Snake(channels: dimensions)
+        self._convolution1.wrappedValue = WNConv1d(
+            inputChannels: dimensions,
+            outputChannels: dimensions,
+            kernelSize: 7,
+            padding: 3 * dilation,
+            dilation: dilation
+        )
+        self._snake2.wrappedValue = MiniMaxMusic3Snake(channels: dimensions)
+        self._convolution2.wrappedValue = WNConv1d(
+            inputChannels: dimensions,
+            outputChannels: dimensions,
+            kernelSize: 1
+        )
+    }
+
+    func callAsFunction(_ input: MLXArray) -> MLXArray {
+        input + convolution2(snake2(convolution1(snake1(input))))
+    }
+}
+
+final class MiniMaxMusic3VocoderBlock: Module {
+    @ModuleInfo(key: "snake1") var snake1: MiniMaxMusic3Snake
+    @ModuleInfo(key: "conv_t1") var transposedConvolution: OobleckWNConvTranspose1d
+    @ModuleInfo(key: "res_unit1") var residualUnit1: MiniMaxMusic3VocoderResidualUnit
+    @ModuleInfo(key: "res_unit2") var residualUnit2: MiniMaxMusic3VocoderResidualUnit
+    @ModuleInfo(key: "res_unit3") var residualUnit3: MiniMaxMusic3VocoderResidualUnit
+
+    init(inputDimensions: Int, outputDimensions: Int, stride: Int) {
+        self._snake1.wrappedValue = MiniMaxMusic3Snake(channels: inputDimensions)
+        self._transposedConvolution.wrappedValue = OobleckWNConvTranspose1d(
+            inputChannels: inputDimensions,
+            outputChannels: outputDimensions,
+            kernelSize: 2 * stride,
+            stride: stride,
+            padding: (stride + 1) / 2
+        )
+        self._residualUnit1.wrappedValue = MiniMaxMusic3VocoderResidualUnit(
+            dimensions: outputDimensions,
+            dilation: 1
+        )
+        self._residualUnit2.wrappedValue = MiniMaxMusic3VocoderResidualUnit(
+            dimensions: outputDimensions,
+            dilation: 3
+        )
+        self._residualUnit3.wrappedValue = MiniMaxMusic3VocoderResidualUnit(
+            dimensions: outputDimensions,
+            dilation: 9
+        )
+    }
+
+    func callAsFunction(_ input: MLXArray) -> MLXArray {
+        var hidden = transposedConvolution(snake1(input))
+        hidden = residualUnit1(hidden)
+        hidden = residualUnit2(hidden)
+        return residualUnit3(hidden)
+    }
+}
+
+public final class MiniMaxMusic3Vocoder: Module {
+    public let configuration: MiniMaxMusic3VocoderConfiguration
+
+    @ModuleInfo(key: "dec_in_proj") var decoderInputProjection: Conv1d
+    @ModuleInfo(key: "conv_in") var inputConvolution: WNConv1d
+    @ModuleInfo(key: "blocks") var blocks: [MiniMaxMusic3VocoderBlock]
+    @ModuleInfo(key: "snake_out") var outputSnake: MiniMaxMusic3Snake
+    @ModuleInfo(key: "conv_out") var outputConvolution: WNConv1d
+
+    public init(configuration: MiniMaxMusic3VocoderConfiguration) {
+        self.configuration = configuration
+        self._decoderInputProjection.wrappedValue = Conv1d(
+            inputChannels: configuration.latentChannels / 2,
+            outputChannels: configuration.decoderInputDim,
+            kernelSize: 1
+        )
+        self._inputConvolution.wrappedValue = WNConv1d(
+            inputChannels: configuration.decoderInputDim,
+            outputChannels: configuration.decoderHiddenDim,
+            kernelSize: 7,
+            padding: 3
+        )
+        self._blocks.wrappedValue = configuration.upsamplingRatios.enumerated().map { index, stride in
+            MiniMaxMusic3VocoderBlock(
+                inputDimensions: configuration.decoderHiddenDim / (1 << index),
+                outputDimensions: configuration.decoderHiddenDim / (1 << (index + 1)),
+                stride: stride
+            )
+        }
+        let outputDimensions = configuration.decoderHiddenDim / (1 << configuration.upsamplingRatios.count)
+        self._outputSnake.wrappedValue = MiniMaxMusic3Snake(channels: outputDimensions)
+        self._outputConvolution.wrappedValue = WNConv1d(
+            inputChannels: outputDimensions,
+            outputChannels: 1,
+            kernelSize: 7,
+            padding: 3
+        )
+    }
+
+    public func callAsFunction(_ latents: MLXArray) -> MLXArray {
+        let batch = latents.dim(0)
+        let length = latents.dim(2)
+        var hidden = latents.reshaped(batch * 2, configuration.latentChannels / 2, length)
+            .transposed(0, 2, 1)
+        hidden = inputConvolution(decoderInputProjection(hidden))
+        for block in blocks {
+            hidden = block(hidden)
+        }
+        let waveform = MLX.tanh(outputConvolution(outputSnake(hidden)))
+        return waveform.reshaped(batch, 2, waveform.dim(1))
+    }
+
+    static func mapWeight(key: String, value: MLXArray) -> [(String, MLXArray)] {
+        if key.hasSuffix(".alpha") {
+            return [(key, value.transposed(0, 2, 1))]
+        }
+        if key.hasSuffix("conv_t1.weight_v") {
+            return [(key, value.transposed(1, 2, 0))]
+        }
+        if key == "dec_in_proj.weight" || key.hasSuffix(".weight_v") {
+            return [(key, value.transposed(0, 2, 1))]
+        }
+        return [(key, value)]
+    }
+}

--- a/Sources/MereRunCore/MiniMaxMusic3/README.md
+++ b/Sources/MereRunCore/MiniMaxMusic3/README.md
@@ -1,0 +1,15 @@
+# MiniMax Music 3
+
+This directory contains the native Swift/MLX inference path for MiniMax Music
+3. The runtime follows the upstream checkpoint contract in four stages:
+
+1. a Qwen3 global language model and local RVQ depth decoder generate eight
+   audio codes plus the hidden-state conditioning for every 25 Hz frame;
+2. the condition encoder aligns those frame states to the 44.1 kHz latent
+   timeline;
+3. a 1D flow-matching transformer denoises overlapping 200-frame windows;
+4. the DAC-style vocoder decodes and stitches stereo waveform chunks.
+
+Keep the prompt tokens, code offsets, chunk overlap, Euler schedule, and
+weight-name mapping in parity with the pinned upstream revision declared by
+`MiniMaxMusic3Resources`.

--- a/Sources/MereRunCore/MiniMaxMusic3/README.md
+++ b/Sources/MereRunCore/MiniMaxMusic3/README.md
@@ -13,3 +13,8 @@ This directory contains the native Swift/MLX inference path for MiniMax Music
 Keep the prompt tokens, code offsets, chunk overlap, Euler schedule, and
 weight-name mapping in parity with the pinned upstream revision declared by
 `MiniMaxMusic3Resources`.
+
+The default `staged` loading strategy releases each stage before loading the
+next one and clears the MLX cache between stages. `resident` loads the complete
+stack once for lower repeated-request latency. Both strategies execute the same
+model math and generation schedule.

--- a/Sources/MereRunCore/ModelResolver.swift
+++ b/Sources/MereRunCore/ModelResolver.swift
@@ -95,6 +95,7 @@ public struct ModelResolver {
         case aceStepXLTurboLM4B = "music-acestep-xl-turbo-lm4b"
         case aceStepLM17B = "music-acestep-lm-1.7b"
         case aceStepLM4B = "music-acestep-lm-4b"
+        case miniMaxMusic3 = "music-minimax-music3"
         case magentaRT2Small = "music-magenta-rt2-small"
         case magentaRT2Base = "music-magenta-rt2-base"
         case muScriptorSmall = "music-muscriptor-small"

--- a/Sources/MereRunCore/Quantization/QuantizedModelManifestWriter.swift
+++ b/Sources/MereRunCore/Quantization/QuantizedModelManifestWriter.swift
@@ -78,7 +78,7 @@ public enum QuantizedModelManifestWriter {
             case .openAIPrivacyFilter: return .privacy
             case .qwen3Coder, .northMiniCode: return .code
             case .lightOnOCR: return .ocr
-            case .aceStep, .magentaRT2, .muScriptor, .roFormer: return .music
+            case .aceStep, .miniMaxMusic3, .magentaRT2, .muScriptor, .roFormer: return .music
             case .apBWE, .univerSR: return .audio
             case .woosh, .mmaudio: return .sfx
             case .ltxVideo, .wanVideo, .miniMaxH3, .cosmos3Edge: return .video
@@ -171,7 +171,7 @@ public enum QuantizedModelManifestWriter {
                     return [.chat, .codeGeneration]
                 case .lightOnOCR:
                     return [.visionOCR]
-                case .aceStep, .magentaRT2:
+                case .aceStep, .miniMaxMusic3, .magentaRT2:
                     return [.musicGeneration]
                 case .muScriptor:
                     return [.musicTranscription]
@@ -274,6 +274,8 @@ public enum QuantizedModelManifestWriter {
                 break
             case .aceStep, .magentaRT2, .ltxVideo:
                 manifest.defaults = MereRunModelManifest.Defaults(steps: 8, cfg: 1.0)
+            case .miniMaxMusic3:
+                manifest.defaults = MereRunModelManifest.Defaults(steps: 30, cfg: 1.7)
             case .wanVideo:
                 manifest.defaults = MereRunModelManifest.Defaults(steps: 40, cfg: 5.0, sigmaShift: 5.0)
             case .miniMaxH3:

--- a/Sources/MereRunCore/ZImageTurbo/Model/TextEncoder/TextEncoder+Blocks.swift
+++ b/Sources/MereRunCore/ZImageTurbo/Model/TextEncoder/TextEncoder+Blocks.swift
@@ -603,6 +603,29 @@ extension QwenEncoder {
     return embedTokens.asLinear(h)
   }
 
+  /// Runs cached causal decoding from caller-provided embeddings and returns
+  /// the normalized hidden state before any language-model head. Audio-token
+  /// models use this to feed composite codebook embeddings back into Qwen.
+  public func forwardCausalHidden(
+    embeddings: MLXArray,
+    cache: [KVCache]?,
+    positionIds: MLXArray? = nil,
+    lastPositionOnly: Bool = false
+  ) -> MLXArray {
+    var h = embeddings
+    let mask = createCausalMaskForGeneration(h: h, cache: cache?.first)
+
+    for (index, layer) in layers.enumerated() {
+      h = layer(h, mask: mask, cache: cache?[index], positionIds: positionIds)
+    }
+
+    h = norm(h)
+    if lastPositionOnly && h.dim(1) > 1 {
+      h = h[0..., (h.dim(1) - 1)..., 0...]
+    }
+    return h
+  }
+
   private func createCausalMaskForGeneration(h: MLXArray, cache: KVCache?) -> MLXFast.ScaledDotProductAttentionMaskMode {
     let n = h.dim(1)
     if let cache = cache {

--- a/Tests/MereRunCLITests/GuideCommandTests.swift
+++ b/Tests/MereRunCLITests/GuideCommandTests.swift
@@ -18,6 +18,27 @@ final class GuideCommandTests: XCTestCase {
         XCTAssertEqual(entry.topic, "music-generate")
     }
 
+    func testGuideRendersMiniMaxMusic3SpecificContract() throws {
+        let command = try GuideCommand.parse([
+            "music", "generate",
+            "--model", MiniMaxMusic3Resources.modelID,
+        ])
+        let entry = try GuideCommand.resolveEntry(
+            commandPath: command.commandPath,
+            model: command.model
+        )
+        let rendered = try GuideCommand.render(
+            entry: entry,
+            model: command.model,
+            json: false
+        )
+
+        XCTAssertTrue(rendered.contains("# MiniMax Music 3 Generate"))
+        XCTAssertTrue(rendered.contains("--max-frames"))
+        XCTAssertTrue(rendered.contains("/v1/audio/speech"))
+        XCTAssertTrue(rendered.contains("music-caption-rewriter"))
+    }
+
     func testGuideMusicAnalyzeParsesAndResolves() throws {
         let command = try GuideCommand.parse(["music", "analyze"])
         let entry = try GuideCommand.resolveEntry(commandPath: command.commandPath, model: command.model)
@@ -182,6 +203,7 @@ final class GuideCommandTests: XCTestCase {
                 ModelResolver.ModelID.aceStepXLSFT.rawValue,
                 ModelResolver.ModelID.aceStepXLTurbo.rawValue,
                 ModelResolver.ModelID.aceStepXLTurboLM4B.rawValue,
+                MiniMaxMusic3Resources.modelID,
                 ModelResolver.ModelID.magentaRT2Small.rawValue,
                 ModelResolver.ModelID.magentaRT2Base.rawValue,
             ]

--- a/Tests/MereRunCLITests/MusicGenerateCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/MusicGenerateCommandParsingTests.swift
@@ -58,7 +58,8 @@ final class MusicGenerateCommandParsingTests: XCTestCase {
         XCTAssertNil(cmd.lmModel)
         XCTAssertFalse(cmd.useLM)
         XCTAssertNil(cmd.durationSeconds)
-        XCTAssertEqual(cmd.quality, .song)
+        XCTAssertNil(cmd.quality)
+        XCTAssertEqual(cmd.resolvedQuality, .song)
         XCTAssertNil(cmd.steps)
         XCTAssertNil(cmd.shift)
         XCTAssertNil(cmd.guidanceScale)
@@ -77,15 +78,51 @@ final class MusicGenerateCommandParsingTests: XCTestCase {
             "--model", MiniMaxMusic3Resources.modelID,
             "--lyrics", "[verse]\nwe glow",
             "--duration", "30",
+            "--max-frames", "750",
             "--steps", "24",
             "--seed", "7",
+            "--guidance-scale", "1.7",
+            "--sample-rate", "32000",
+            "--memory-mode", "staged",
         ])
 
         XCTAssertEqual(command.model, MiniMaxMusic3Resources.modelID)
         XCTAssertEqual(command.lyrics, "[verse]\nwe glow")
         XCTAssertEqual(command.durationSeconds, 30)
+        XCTAssertEqual(command.miniMaxMaximumFrames, 750)
         XCTAssertEqual(command.steps, 24)
         XCTAssertEqual(command.seed, 7)
+        XCTAssertEqual(command.guidanceScale, 1.7)
+        XCTAssertEqual(command.miniMaxOutputSampleRate, 32_000)
+        XCTAssertEqual(command.miniMaxLoadingStrategy, .staged)
+    }
+
+    func testMiniMaxRejectsSharedControlsInsteadOfIgnoringThem() throws {
+        let rejectedArguments = [
+            ["--quality", "final"],
+            ["--bpm", "118"],
+            ["--metadata-duration", "30 seconds"],
+            ["--lm-temperature", "0.7"],
+            ["--vae-chunk-size", "256"],
+            ["--temperature", "0.8"],
+            ["--checkpoints-root", "/tmp/checkpoints"],
+        ]
+
+        for arguments in rejectedArguments {
+            let command = try MusicGenerate.parse(
+                [
+                    "cinematic synth-pop",
+                    "--model", MiniMaxMusic3Resources.modelID,
+                    "--instrumental",
+                ] + arguments
+            )
+            XCTAssertThrowsError(
+                try command.validateMiniMaxMusic3Options(
+                    explicitDurationSeconds: nil
+                ),
+                arguments.joined(separator: " ")
+            )
+        }
     }
 
     func testMusicGenerateParsesModelAndAdvancedOverrides() throws {

--- a/Tests/MereRunCLITests/MusicGenerateCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/MusicGenerateCommandParsingTests.swift
@@ -71,6 +71,23 @@ final class MusicGenerateCommandParsingTests: XCTestCase {
         XCTAssertFalse(cmd.resolvedACEStepIsCover)
     }
 
+    func testMusicGenerateParsesMiniMaxMusic3Request() throws {
+        let command = try MusicGenerate.parse([
+            "cinematic synth-pop",
+            "--model", MiniMaxMusic3Resources.modelID,
+            "--lyrics", "[verse]\nwe glow",
+            "--duration", "30",
+            "--steps", "24",
+            "--seed", "7",
+        ])
+
+        XCTAssertEqual(command.model, MiniMaxMusic3Resources.modelID)
+        XCTAssertEqual(command.lyrics, "[verse]\nwe glow")
+        XCTAssertEqual(command.durationSeconds, 30)
+        XCTAssertEqual(command.steps, 24)
+        XCTAssertEqual(command.seed, 7)
+    }
+
     func testMusicGenerateParsesModelAndAdvancedOverrides() throws {
         let cmd = try MusicGenerate.parse([
             "club track",

--- a/Tests/MereRunCLITests/MusicServeAndExportTests.swift
+++ b/Tests/MereRunCLITests/MusicServeAndExportTests.swift
@@ -29,6 +29,48 @@ final class MusicServeAndExportTests: XCTestCase {
         XCTAssertEqual(command.adapterScales, [0.8, 0.5])
     }
 
+    func testMusicServeParsesMiniMaxResidentSpeechAPI() throws {
+        let command = try MusicServe.parse([
+            "--model", MiniMaxMusic3Resources.modelID,
+            "--memory-mode", "resident",
+            "--port", "8091",
+        ])
+
+        XCTAssertEqual(command.model, MiniMaxMusic3Resources.modelID)
+        XCTAssertEqual(command.miniMaxLoadingStrategy, .resident)
+        XCTAssertEqual(command.port, 8_091)
+    }
+
+    func testMiniMaxSpeechRequestDecodesReferenceAndNativeControls() throws {
+        let request = try JSONDecoder().decode(
+            MiniMaxMusic3SpeechRequest.self,
+            from: Data(
+                """
+                {
+                  "model": "MiniMaxAI/MiniMax-Music3",
+                  "input": "[Verse]\\nwe glow",
+                  "instructions": "cinematic synth-pop",
+                  "response_format": "wav",
+                  "seed": 7,
+                  "max_new_tokens": 750,
+                  "stream": false,
+                  "audio_duration": 30,
+                  "num_inference_steps": 24,
+                  "guidance_scale": 1.7,
+                  "sample_rate": 44100
+                }
+                """.utf8
+            )
+        )
+
+        XCTAssertEqual(request.maxNewTokens, 750)
+        XCTAssertEqual(request.audioDuration, 30)
+        XCTAssertEqual(request.numInferenceSteps, 24)
+        XCTAssertEqual(request.guidanceScale, 1.7)
+        XCTAssertEqual(request.sampleRate, 44_100)
+        XCTAssertEqual(request.stream, false)
+    }
+
     func testMusicTrainAdapterParsesAndLoadsJSONLManifest() throws {
         let command = try MusicTrainAdapter.parse([
             "--dataset", "/tmp/music.jsonl",
@@ -333,6 +375,24 @@ final class MusicServeAndExportTests: XCTestCase {
             XCTAssertEqual(readUInt16(data, offset: 34), bits)
             XCTAssertEqual(data.count, 44 + 6 * bytesPerSample)
         }
+    }
+
+    func testStereoResamplingPreservesChannelOrderAndDuration() throws {
+        let audio = MLXArray(
+            [Float(0), 10, 1, 11, 2, 12, 3, 13],
+            [1, 4, 2]
+        )
+        let resampled = try ACEStepWAVWriter.resample(
+            audio,
+            from: 4,
+            to: 2
+        )
+
+        XCTAssertEqual(resampled.shape, [1, 2, 2])
+        XCTAssertEqual(
+            resampled.reshaped(-1).asArray(Float.self),
+            [0, 10, 2, 12]
+        )
     }
 
     func testDAWBundleContainsPortableAudioRecipeMarkersAndProject() throws {

--- a/Tests/MereRunCLITests/VideoCommandTests.swift
+++ b/Tests/MereRunCLITests/VideoCommandTests.swift
@@ -1229,14 +1229,15 @@ final class VideoCommandTests: XCTestCase {
 
         let envelope = command.makePreflightEnvelope(outputURL: output)
         let summary = try XCTUnwrap(envelope.result.inputs.detailingLoRAs?.first)
-        XCTAssertEqual(summary.requested, ManagedAdapterCatalog.ltx25PixelSpatialUpscalerID)
-        XCTAssertEqual(
-            summary.path,
-            try XCTUnwrap(
-                ManagedAdapterCatalog.spec(for: ManagedAdapterCatalog.ltx25PixelSpatialUpscalerID)
-            ).installedFileURL().path
+        let spec = try XCTUnwrap(
+            ManagedAdapterCatalog.spec(for: ManagedAdapterCatalog.ltx25PixelSpatialUpscalerID)
         )
-        XCTAssertTrue(envelope.diagnostics.contains { $0.id == "detailing_lora_0_missing" })
+        XCTAssertEqual(summary.requested, ManagedAdapterCatalog.ltx25PixelSpatialUpscalerID)
+        XCTAssertEqual(summary.path, spec.installedFileURL().path)
+        XCTAssertEqual(
+            envelope.diagnostics.contains { $0.id == "detailing_lora_0_missing" },
+            !spec.isInstalled()
+        )
     }
 
     func testLTX25SpecificControlsSelectTheDistilledCatalogModel() throws {

--- a/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
@@ -70,6 +70,7 @@ final class ManagedModelCatalogTests: XCTestCase {
             MuseGlimmerResources.modelId,
             MuseGlimmerResources.assistantModelId,
             "image-3d-trellis2-4b",
+            MiniMaxMusic3Resources.modelID,
             "music-muscriptor-small",
             "music-muscriptor-medium",
             "music-muscriptor-large",

--- a/Tests/MereRunCoreTests/MiniMaxMusic3Tests.swift
+++ b/Tests/MereRunCoreTests/MiniMaxMusic3Tests.swift
@@ -1,0 +1,464 @@
+import MLX
+import XCTest
+@testable import MereRunCore
+
+final class MiniMaxMusic3Tests: MereRunCoreTestCase {
+    func testInstalledConditionEncoderAndVocoderMatchUpstream() throws {
+        let environment = ProcessInfo.processInfo.environment
+        guard let root = environment["MERERUN_MINIMAX_MUSIC3_MODEL_ROOT"],
+              let fixturePath = environment["MERERUN_MINIMAX_MUSIC3_PARITY_FIXTURE"]
+        else {
+            throw XCTSkip("set MiniMax Music 3 model and parity fixture paths to run component parity")
+        }
+        let resources = MiniMaxMusic3Resources(rootURL: URL(fileURLWithPath: root))
+        let fixture = try MLX.loadArrays(url: URL(fileURLWithPath: fixturePath))
+
+        let conditionEncoder = MiniMaxMusic3ConditionEncoder(
+            configuration: try resources.loadConditionConfiguration()
+        )
+        try ModelWeightsLoader.applyHFSafetensors(
+            indexURL: resources.conditionEncoderURL
+                .appendingPathComponent("diffusion_pytorch_model.safetensors.index.json"),
+            singleURL: resources.conditionEncoderURL
+                .appendingPathComponent("diffusion_pytorch_model.safetensors"),
+            to: conditionEncoder,
+            dtype: .bfloat16,
+            verify: .noUnusedKeys,
+            mapper: MiniMaxMusic3ConditionEncoder.mapWeight
+        )
+        let conditionOutput = conditionEncoder(try XCTUnwrap(fixture["condition_input"]).asType(.bfloat16))
+        try assertUpstreamParity(
+            conditionOutput,
+            try XCTUnwrap(fixture["condition_output"]),
+            minimumSNR: 30,
+            component: "condition encoder"
+        )
+
+        let vocoder = MiniMaxMusic3Vocoder(configuration: try resources.loadVocoderConfiguration())
+        try ModelWeightsLoader.applyHFSafetensors(
+            indexURL: resources.vocoderURL
+                .appendingPathComponent("diffusion_pytorch_model.safetensors.index.json"),
+            singleURL: resources.vocoderURL
+                .appendingPathComponent("diffusion_pytorch_model.safetensors"),
+            to: vocoder,
+            dtype: .bfloat16,
+            verify: .noUnusedKeys,
+            mapper: MiniMaxMusic3Vocoder.mapWeight
+        )
+        let vocoderInput = try XCTUnwrap(fixture["vocoder_input"]).asType(.bfloat16)
+        var hidden = vocoderInput.reshaped(2, 64, 2).transposed(0, 2, 1)
+        hidden = vocoder.decoderInputProjection(hidden)
+        try assertUpstreamParity(
+            hidden,
+            try XCTUnwrap(fixture["vocoder_dec"]).transposed(0, 2, 1),
+            minimumSNR: 25,
+            component: "vocoder input projection"
+        )
+        hidden = vocoder.inputConvolution(hidden)
+        try assertUpstreamParity(
+            hidden,
+            try XCTUnwrap(fixture["vocoder_cin"]).transposed(0, 2, 1),
+            minimumSNR: 25,
+            component: "vocoder input convolution"
+        )
+        let block = vocoder.blocks[0]
+        hidden = block.snake1(hidden)
+        try assertUpstreamParity(
+            hidden,
+            try XCTUnwrap(fixture["vocoder_snake0"]).transposed(0, 2, 1),
+            minimumSNR: 25,
+            component: "vocoder block 0 snake"
+        )
+        hidden = block.transposedConvolution(hidden)
+        try assertUpstreamParity(
+            hidden,
+            try XCTUnwrap(fixture["vocoder_conv_t0"]).transposed(0, 2, 1),
+            minimumSNR: 25,
+            component: "vocoder block 0 transposed convolution"
+        )
+        hidden = block.residualUnit1(hidden)
+        try assertUpstreamParity(
+            hidden,
+            try XCTUnwrap(fixture["vocoder_res1_0"]).transposed(0, 2, 1),
+            minimumSNR: 25,
+            component: "vocoder block 0 residual 1"
+        )
+        hidden = block.residualUnit2(hidden)
+        try assertUpstreamParity(
+            hidden,
+            try XCTUnwrap(fixture["vocoder_res2_0"]).transposed(0, 2, 1),
+            minimumSNR: 25,
+            component: "vocoder block 0 residual 2"
+        )
+        hidden = block.residualUnit3(hidden)
+        try assertUpstreamParity(
+            hidden,
+            try XCTUnwrap(fixture["vocoder_res3_0"]).transposed(0, 2, 1),
+            minimumSNR: 25,
+            component: "vocoder block 0 residual 3"
+        )
+
+        let vocoderOutput = vocoder(vocoderInput)
+        try assertUpstreamParity(
+            vocoderOutput,
+            try XCTUnwrap(fixture["vocoder_output"]),
+            minimumSNR: 25,
+            component: "vocoder"
+        )
+    }
+
+    func testInstalledDepthDecoderMatchesUpstream() throws {
+        let environment = ProcessInfo.processInfo.environment
+        guard let root = environment["MERERUN_MINIMAX_MUSIC3_MODEL_ROOT"],
+              let fixturePath = environment["MERERUN_MINIMAX_MUSIC3_PARITY_FIXTURE"]
+        else {
+            throw XCTSkip("set MiniMax Music 3 model and parity fixture paths to run component parity")
+        }
+        let resources = MiniMaxMusic3Resources(rootURL: URL(fileURLWithPath: root))
+        let fixture = try MLX.loadArrays(url: URL(fileURLWithPath: fixturePath))
+        let depthDecoder = MiniMaxMusic3DepthDecoder(
+            configuration: try resources.loadDepthConfiguration()
+        )
+        try ModelWeightsLoader.applyHFSafetensors(
+            indexURL: resources.depthDecoderURL
+                .appendingPathComponent("diffusion_pytorch_model.safetensors.index.json"),
+            singleURL: resources.depthDecoderURL
+                .appendingPathComponent("diffusion_pytorch_model.safetensors"),
+            to: depthDecoder,
+            dtype: .float32,
+            verify: .noUnusedKeys
+        )
+
+        let output = depthDecoder(try XCTUnwrap(fixture["depth_f32_input"]))
+        try assertUpstreamParity(
+            output,
+            try XCTUnwrap(fixture["depth_f32_output"]),
+            minimumSNR: 40,
+            component: "RVQ depth decoder"
+        )
+        try assertUpstreamParity(
+            depthDecoder.logits(output[0..., -1, 0...], codebookIndex: 0),
+            try XCTUnwrap(fixture["depth_f32_logits"]),
+            minimumSNR: 40,
+            component: "RVQ depth head"
+        )
+        try assertUpstreamParity(
+            depthDecoder.embedResidualCodes(MLXArray([Int32(0), 1_023]), codebookIndex: 0),
+            try XCTUnwrap(fixture["depth_f32_embed"]),
+            minimumSNR: 60,
+            component: "RVQ residual embedding"
+        )
+    }
+
+    func testInstalledFlowTransformerMatchesUpstream() throws {
+        let environment = ProcessInfo.processInfo.environment
+        guard let root = environment["MERERUN_MINIMAX_MUSIC3_MODEL_ROOT"],
+              let fixturePath = environment["MERERUN_MINIMAX_MUSIC3_PARITY_FIXTURE"]
+        else {
+            throw XCTSkip("set MiniMax Music 3 model and parity fixture paths to run component parity")
+        }
+        let resources = MiniMaxMusic3Resources(rootURL: URL(fileURLWithPath: root))
+        let fixture = try MLX.loadArrays(url: URL(fileURLWithPath: fixturePath))
+        let transformer = MiniMaxMusic3Transformer(
+            configuration: try resources.loadTransformerConfiguration()
+        )
+        try ModelWeightsLoader.applyHFSafetensors(
+            indexURL: resources.transformerURL
+                .appendingPathComponent("diffusion_pytorch_model.safetensors.index.json"),
+            singleURL: resources.transformerURL
+                .appendingPathComponent("diffusion_pytorch_model.safetensors"),
+            to: transformer,
+            dtype: .float32,
+            verify: .noUnusedKeys,
+            mapper: MiniMaxMusic3Transformer.mapWeight
+        )
+
+        let output = transformer(
+            latents: try XCTUnwrap(fixture["transformer_f32_latents"]),
+            timestep: try XCTUnwrap(fixture["transformer_f32_timestep"]),
+            condition: try XCTUnwrap(fixture["transformer_f32_condition"])
+        )
+        try assertUpstreamParity(
+            output,
+            try XCTUnwrap(fixture["transformer_f32_output"]),
+            minimumSNR: 40,
+            component: "flow transformer"
+        )
+    }
+
+    func testInstalledLanguageModelMatchesUpstream() throws {
+        let environment = ProcessInfo.processInfo.environment
+        guard let root = environment["MERERUN_MINIMAX_MUSIC3_MODEL_ROOT"],
+              let fixturePath = environment["MERERUN_MINIMAX_MUSIC3_PARITY_FIXTURE"]
+        else {
+            throw XCTSkip("set MiniMax Music 3 model and parity fixture paths to run component parity")
+        }
+        let resources = MiniMaxMusic3Resources(rootURL: URL(fileURLWithPath: root))
+        let fixture = try MLX.loadArrays(url: URL(fileURLWithPath: fixturePath))
+        let languageModel = MiniMaxMusic3LanguageModel(
+            configuration: try resources.loadLanguageConfiguration()
+        )
+        try ModelWeightsLoader.applyHFSafetensors(
+            indexURL: resources.languageModelURL.appendingPathComponent("model.safetensors.index.json"),
+            singleURL: resources.languageModelURL.appendingPathComponent("model.safetensors"),
+            to: languageModel,
+            dtype: .float32,
+            verify: .noUnusedKeys
+        )
+
+        let embeddings = languageModel.embed(tokenIDs: try XCTUnwrap(fixture["lm_ids"]))
+        let hidden = languageModel.hidden(
+            embeddings: embeddings,
+            cache: languageModel.makeCache(),
+            lastPositionOnly: false
+        )
+        try assertUpstreamParity(
+            hidden,
+            try XCTUnwrap(fixture["lm_hidden"]),
+            minimumSNR: 40,
+            component: "language model"
+        )
+        try assertUpstreamParity(
+            languageModel.logits(hidden[0..., -1, 0...]),
+            try XCTUnwrap(fixture["lm_logits"]),
+            minimumSNR: 40,
+            component: "language-model head"
+        )
+
+        let cache = languageModel.makeCache()
+        let cachedPrefill = languageModel.hidden(
+            embeddings: languageModel.embed(tokenIDs: try XCTUnwrap(fixture["lm_cached_ids"])),
+            cache: cache,
+            lastPositionOnly: false
+        )
+        try assertUpstreamParity(
+            cachedPrefill,
+            try XCTUnwrap(fixture["lm_cached_prefill_hidden"]),
+            minimumSNR: 40,
+            component: "cached language-model prefill"
+        )
+        let cachedDecode = languageModel.hidden(
+            embeddings: try XCTUnwrap(fixture["lm_next_embeds"]),
+            cache: cache,
+            lastPositionOnly: false
+        )
+        try assertUpstreamParity(
+            cachedDecode,
+            try XCTUnwrap(fixture["lm_cached_decode_hidden"]),
+            minimumSNR: 40,
+            component: "cached language-model decode"
+        )
+        try assertUpstreamParity(
+            languageModel.logits(cachedDecode[0..., -1, 0...]),
+            try XCTUnwrap(fixture["lm_cached_decode_logits"]),
+            minimumSNR: 40,
+            component: "cached language-model head"
+        )
+    }
+
+    func testInstalledTokenizerMatchesUpstreamOfficialPrompt() throws {
+        guard let root = ProcessInfo.processInfo.environment["MERERUN_MINIMAX_MUSIC3_MODEL_ROOT"] else {
+            throw XCTSkip("set MERERUN_MINIMAX_MUSIC3_MODEL_ROOT to run checkpoint parity")
+        }
+        let tokenizer = try ACEStep5HzLMTokenizer.load(
+            from: URL(fileURLWithPath: root).appendingPathComponent("tokenizer"),
+            requireAudioCodeTokens: false
+        )
+        let prompt = MiniMaxMusic3Prompt.assemble(
+            caption: "Genre: acoustic pop. BPM: 96. Key: C major. Warm and intimate, building gently into the chorus. "
+                + "Vocals: soft female lead, close and breathy, light stacked harmonies in the chorus. Arrangement: "
+                + "fingerpicked guitar and soft piano; brushed drums and upright bass enter in the chorus.",
+            lyrics: "[verse]\nMorning light filtering through the pine\nEvery quiet street is yours and mine\n"
+                + "[chorus]\nSoftly the world begins to breathe"
+        )
+
+        XCTAssertEqual(
+            tokenizer.encode(prompt, addSpecialTokens: false),
+            [
+                151_644, 151_671, 37_525, 25, 44_066, 2_420, 13, 88_219, 25, 220, 24, 21, 13, 5_309,
+                25, 356, 3_598, 13, 45_763, 323, 31_387, 11, 4_752, 29_273, 1_119, 279, 55_810, 13,
+                86_045, 1_127, 25, 8_413, 8_778, 2_990, 11, 3_265, 323, 11_486, 88, 11, 3_100, 41_315,
+                17_774, 550, 304, 279, 55_810, 13, 18_418, 56_633, 25, 14_317, 93_499, 16_986, 323,
+                8_413, 26_278, 26, 61_539, 46_289, 323, 48_585, 21_529, 3_725, 304, 279, 55_810, 13,
+                151_672, 151_673, 28_463, 921, 58, 4_450, 921, 84_344, 3_100, 29_670, 1_526, 279,
+                33_597, 198, 11_510, 11_340, 8_592, 374, 18_316, 323, 10_485, 198, 58, 6_150, 355,
+                921, 30_531, 398, 279, 1_879, 12_033, 311, 36_297, 151_674, 151_645, 151_669,
+            ]
+        )
+    }
+
+    func testPromptAssemblyMatchesCheckpointContract() {
+        let prompt = MiniMaxMusic3Prompt.assemble(
+            caption: "# Dream pop\n- <|tempo 118 bpm|>\n**wide guitars**",
+            lyrics: "[Verse] dropped words\nHello [Whisper]\n[CHORUS]\nWe glow"
+        )
+
+        XCTAssertEqual(
+            prompt,
+            "<|im_start|><|caption_start|>Dream pop\ntempo is 118 bpm\nwide guitars<|caption_end|>"
+                + "<|lyrics_start|>[start]\n[verse]\nHello\n[whisper]\n[chorus]\nWe glow"
+                + "<|lyrics_end|><|im_end|><|audio_start|>"
+        )
+    }
+
+    func testChunkAndLatentTimelineMathMatchesReference() {
+        XCTAssertEqual(MiniMaxMusic3Prompt.chunkStarts(frameCount: 200), [0])
+        XCTAssertEqual(MiniMaxMusic3Prompt.chunkStarts(frameCount: 201), [0, 100])
+        XCTAssertEqual(MiniMaxMusic3Prompt.chunkStarts(frameCount: 300), [0, 100])
+        XCTAssertEqual(MiniMaxMusic3Prompt.latentLength(frameCount: 200), 689)
+        XCTAssertEqual(MiniMaxMusic3Prompt.latentLength(frameCount: 100), 344)
+    }
+
+    func testConditionEncoderProducesLatentAlignedShape() {
+        let configuration = MiniMaxMusic3ConditionConfiguration(
+            conditionHiddenDim: 4,
+            numConditionLayers: 2,
+            outDim: 3,
+            inputSamplingRate: 24_000,
+            inputHopLength: 960,
+            outputSamplingRate: 44_100,
+            outputHopLength: 512
+        )
+        let model = MiniMaxMusic3ConditionEncoder(configuration: configuration)
+        let output = model(MLXArray.zeros([1, 10, 8]))
+        MLX.eval(output)
+        XCTAssertEqual(output.shape, [1, 34, 3])
+    }
+
+    func testDepthDecoderTinyConfigurationPreservesSequenceShape() {
+        let configuration = MiniMaxMusic3DepthConfiguration(
+            hiddenSize: 8,
+            numLayers: 1,
+            numAttentionHeads: 2,
+            intermediateSize: 16,
+            audioVocabSize: 16,
+            numCodebooks: 3,
+            maxPositionEmbeddings: 4
+        )
+        let model = MiniMaxMusic3DepthDecoder(configuration: configuration)
+        let output = model(MLXArray.zeros([2, 3, 8]))
+        MLX.eval(output)
+        XCTAssertEqual(output.shape, [2, 3, 8])
+        XCTAssertEqual(model.logits(output[0..., -1, 0...], codebookIndex: 0).shape, [2, 16])
+    }
+
+    func testFlowTransformerTinyConfigurationPreservesLatentShape() {
+        let configuration = MiniMaxMusic3TransformerConfiguration(
+            inChannels: 2,
+            conditionDim: 4,
+            numLayers: 1,
+            numAttentionHeads: 2,
+            attentionHeadDim: 4,
+            ffInnerDim: 16,
+            rotaryDim: 2,
+            fourierEmbeddingDim: 4
+        )
+        let model = MiniMaxMusic3Transformer(configuration: configuration)
+        let output = model(
+            latents: MLXArray.zeros([1, 2, 7]),
+            timestep: MLXArray([Float(0.5)]),
+            condition: MLXArray.zeros([1, 7, 4])
+        )
+        MLX.eval(output)
+        XCTAssertEqual(output.shape, [1, 2, 7])
+    }
+
+    func testSemanticTopKIgnoresTextVocabularyLogits() {
+        let vocabulary = MiniMaxMusic3Prompt.audioCodeOffset
+            + MiniMaxMusic3Prompt.semanticVocabularySize
+        var values = [Float](repeating: -100, count: 2 * vocabulary)
+        for batch in 0..<2 {
+            let base = batch * vocabulary
+            for token in 0..<50 {
+                values[base + token] = 100
+            }
+            for token in 0..<50 {
+                values[base + MiniMaxMusic3Prompt.audioCodeOffset + token] = Float(50 - token)
+            }
+        }
+
+        let guided = MiniMaxMusic3Pipeline.guidedSemanticLogits(
+            MLXArray(values).reshaped(2, vocabulary)
+        )
+        MLX.eval(guided)
+
+        XCTAssertTrue(guided[0, MiniMaxMusic3Prompt.audioCodeOffset].item(Float.self).isFinite)
+        XCTAssertFalse(guided[0, 0].item(Float.self).isFinite)
+    }
+
+    func testManagedCatalogPinsSelectiveRestrictedSnapshot() throws {
+        let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: MiniMaxMusic3Resources.modelID))
+        XCTAssertEqual(spec.upstreamRepoId, MiniMaxMusic3Resources.repository)
+        XCTAssertEqual(spec.upstreamRevision, MiniMaxMusic3Resources.revision)
+        XCTAssertEqual(spec.estimatedDownloadBytes, 28_517_620_807)
+        XCTAssertEqual(spec.validationKind, .miniMaxMusic3)
+        XCTAssertFalse(spec.runtimeAutoDownloadAllowed)
+        XCTAssertNotNil(spec.usageRestriction)
+        XCTAssertEqual(spec.hubFallback?.patterns.contains("qwen_7B/*"), false)
+        XCTAssertEqual(spec.hubFallback?.patterns.contains("transformer/*"), true)
+    }
+
+    func testCapabilityDescriptorRequiresLargeUnifiedMemory() throws {
+        let descriptor = try XCTUnwrap(
+            ManagedModelCapabilityCatalog.descriptor(for: MiniMaxMusic3Resources.modelID)
+        )
+        XCTAssertEqual(descriptor.minimumUnifiedMemoryGB, 64)
+        XCTAssertEqual(descriptor.recommendedUnifiedMemoryGB, 96)
+    }
+
+    func testManagedInstallValidatorUsesMiniMaxComponentContract() throws {
+        let root = try TestFileSystem.makeTempDir(prefix: "minimax-music3-validator")
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try MereRunModelManifest.template(
+            for: .miniMaxMusic3,
+            createdAt: Date(timeIntervalSince1970: 0)
+        ).write(to: root)
+
+        let files = [
+            "LICENSE",
+            "config.json",
+            "modular_model_index.json",
+            "condition_encoder/config.json",
+            "condition_encoder/diffusion_pytorch_model.safetensors",
+            "language_model/config.json",
+            "language_model/model.safetensors",
+            "rvq_depth_decoder/config.json",
+            "rvq_depth_decoder/diffusion_pytorch_model.safetensors",
+            "scheduler/scheduler_config.json",
+            "tokenizer/tokenizer.json",
+            "tokenizer/tokenizer_config.json",
+            "transformer/config.json",
+            "transformer/diffusion_pytorch_model.safetensors",
+            "vocoder/config.json",
+            "vocoder/diffusion_pytorch_model.safetensors",
+        ]
+        for path in files {
+            try TestFileSystem.writeFile(root.appendingPathComponent(path))
+        }
+
+        let report = MereRunModelValidator.validate(
+            modelRoot: root,
+            expectedModelID: MiniMaxMusic3Resources.modelID
+        )
+        XCTAssertTrue(report.isValid, report.errors.joined(separator: "\n"))
+        XCTAssertFalse(report.warnings.contains { $0.contains("engine mismatch") })
+    }
+
+    private func assertUpstreamParity(
+        _ actual: MLXArray,
+        _ expected: MLXArray,
+        minimumSNR: Float,
+        component: String
+    ) throws {
+        XCTAssertEqual(actual.shape, expected.shape, component)
+        let reference = expected.asType(.float32)
+        let error = actual.asType(.float32) - reference
+        MLX.eval(error)
+        let signalPower = MLX.mean(reference * reference).item(Float.self)
+        let errorPower = MLX.mean(error * error).item(Float.self)
+        let snr = 10 * log10(signalPower / max(errorPower, Float.leastNonzeroMagnitude))
+        let maximumError = MLX.max(MLX.abs(error)).item(Float.self)
+        XCTAssertGreaterThanOrEqual(snr, minimumSNR, "\(component): SNR \(snr) dB, max error \(maximumError)")
+    }
+}

--- a/Tests/MereRunCoreTests/MiniMaxMusic3Tests.swift
+++ b/Tests/MereRunCoreTests/MiniMaxMusic3Tests.swift
@@ -3,6 +3,39 @@ import XCTest
 @testable import MereRunCore
 
 final class MiniMaxMusic3Tests: MereRunCoreTestCase {
+    func testInstalledStagedAndResidentGenerationAreSeedEquivalent() throws {
+        let environment = ProcessInfo.processInfo.environment
+        guard environment["MERERUN_MINIMAX_MUSIC3_E2E"] == "1",
+              let root = environment["MERERUN_MINIMAX_MUSIC3_MODEL_ROOT"]
+        else {
+            throw XCTSkip("set the MiniMax Music 3 model root and E2E flag to compare loading modes")
+        }
+        let resources = MiniMaxMusic3Resources(rootURL: URL(fileURLWithPath: root))
+        let options = MiniMaxMusic3GenerationOptions(
+            caption: "Warm acoustic instrumental, fingerpicked guitar, natural room.",
+            lyrics: "[Instrumental]",
+            durationSeconds: 0.08,
+            maximumFrames: 2,
+            inferenceSteps: 1,
+            seed: 7
+        )
+
+        let staged = try MiniMaxMusic3Pipeline(
+            resources: resources,
+            loadingStrategy: .staged
+        ).generate(options: options)
+        let resident = try MiniMaxMusic3Pipeline(
+            resources: resources,
+            loadingStrategy: .resident
+        ).generate(options: options)
+        MLX.eval(staged.waveform, resident.waveform)
+
+        XCTAssertEqual(staged.frameCount, resident.frameCount)
+        XCTAssertEqual(staged.sampleRate, resident.sampleRate)
+        XCTAssertEqual(staged.waveform.shape, resident.waveform.shape)
+        XCTAssertTrue(MLX.allClose(staged.waveform, resident.waveform, rtol: 0, atol: 0).item(Bool.self))
+    }
+
     func testInstalledConditionEncoderAndVocoderMatchUpstream() throws {
         let environment = ProcessInfo.processInfo.environment
         guard let root = environment["MERERUN_MINIMAX_MUSIC3_MODEL_ROOT"],
@@ -301,6 +334,19 @@ final class MiniMaxMusic3Tests: MereRunCoreTestCase {
         )
     }
 
+    func testCaptionCleaningMatchesUpstreamWhitespaceAndMarkdownEdges() {
+        XCTAssertEqual(
+            MiniMaxMusic3Prompt.cleanCaption(
+                "  preserved indent  \n***nested***\n---\nx *italic*  \n"
+            ),
+            "  preserved indent\nnested\nx italic"
+        )
+        XCTAssertEqual(
+            MiniMaxMusic3Prompt.cleanCaption("<|bpm 118|>\r\n# Heading"),
+            "bpm is 118\nHeading"
+        )
+    }
+
     func testChunkAndLatentTimelineMathMatchesReference() {
         XCTAssertEqual(MiniMaxMusic3Prompt.chunkStarts(frameCount: 200), [0])
         XCTAssertEqual(MiniMaxMusic3Prompt.chunkStarts(frameCount: 201), [0, 100])
@@ -394,16 +440,17 @@ final class MiniMaxMusic3Tests: MereRunCoreTestCase {
         XCTAssertEqual(spec.validationKind, .miniMaxMusic3)
         XCTAssertFalse(spec.runtimeAutoDownloadAllowed)
         XCTAssertNotNil(spec.usageRestriction)
+        XCTAssertEqual(spec.defaultCLICommands, ["music generate", "music serve"])
         XCTAssertEqual(spec.hubFallback?.patterns.contains("qwen_7B/*"), false)
         XCTAssertEqual(spec.hubFallback?.patterns.contains("transformer/*"), true)
     }
 
-    func testCapabilityDescriptorRequiresLargeUnifiedMemory() throws {
+    func testCapabilityDescriptorReflectsStagedLoading() throws {
         let descriptor = try XCTUnwrap(
             ManagedModelCapabilityCatalog.descriptor(for: MiniMaxMusic3Resources.modelID)
         )
-        XCTAssertEqual(descriptor.minimumUnifiedMemoryGB, 64)
-        XCTAssertEqual(descriptor.recommendedUnifiedMemoryGB, 96)
+        XCTAssertEqual(descriptor.minimumUnifiedMemoryGB, 32)
+        XCTAssertEqual(descriptor.recommendedUnifiedMemoryGB, 64)
     }
 
     func testManagedInstallValidatorUsesMiniMaxComponentContract() throws {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -83,7 +83,7 @@ Public tree:
   - `mere.run music analyze` — Analyze source audio with ACE-Step audio understanding.
   - `mere.run music generate` — Generate audio from a music prompt.
   - `mere.run music realtime` — Run Magenta RealTime 2 music generation.
-  - `mere.run music serve` — Start a warm resident ACE-Step music generation API.
+  - `mere.run music serve` — Start an ACE-Step or MiniMax Music 3 generation API.
   - `mere.run music separate` — Separate or restore audio with native RoFormer models.
   - `mere.run music train-adapter` — Train a native ACE-Step LoRA or LoKr adapter.
   - `mere.run music transcribe` — Transcribe a full music mix into instrument-separated MIDI with MuScriptor.

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -113,6 +113,7 @@ from the runtime catalog used by `mere.run model list`,
 | `music` | `music-acestep-xl-turbo-lm4b` |
 | `music` | `music-acestep-lm-1.7b` |
 | `music` | `music-acestep-lm-4b` |
+| `music` | `music-minimax-music3` |
 | `music` | `music-magenta-rt2-small` |
 | `music` | `music-magenta-rt2-base` |
 | `music` | `music-muscriptor-small` |
@@ -675,6 +676,40 @@ planner in the selected checkpoint root, then reuse an installed standalone or
 `music-acestep` 1.7B planner, and finally pull `music-acestep-lm-1.7b` when LM
 planning is required. Override that resolution with `--lm-model` or the legacy
 same-root `--lm-subdirectory`.
+
+### `music-minimax-music3`
+
+MiniMax Music 3 comes from `MiniMaxAI/MiniMax-Music3` at immutable revision
+`bd348f9c49ea3c1b39f33ace3436f8fad435f24e`. The managed pull selects the 25
+runtime files needed by the native Swift/MLX implementation and omits the
+duplicate `qwen_7B/` tree and Python-only examples. The selected snapshot is
+28,517,620,807 bytes (approximately 26.6 GiB):
+
+```text
+.../models/music-minimax-music3
+├── condition_encoder/
+├── language_model/
+├── rvq_depth_decoder/
+├── scheduler/
+├── tokenizer/
+├── transformer/
+├── vocoder/
+├── config.json
+├── modular_model_index.json
+└── LICENSE
+```
+
+The checkpoint uses the MiniMax-Music3 Community License rather than an OSI
+open-source license. Managed pulls therefore require
+`--accept-model-license`, runtime auto-download is disabled, and applications
+using the model must preserve the upstream attribution and usage restrictions.
+Review the pinned `LICENSE` before deploying or redistributing the weights.
+
+`mere.run music generate --model music-minimax-music3` assembles the released
+caption-and-lyrics prompt contract, generates 25 Hz semantic plus residual RVQ
+codes, runs the overlap-aware flow transformer, and writes 44.1 kHz stereo WAV
+output through the released vocoder. Generation currently supports text plus
+lyrics (or `--instrumental`) for at most 360 seconds.
 
 ### `music-magenta-rt2-small` and `music-magenta-rt2-base`
 

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -707,9 +707,29 @@ Review the pinned `LICENSE` before deploying or redistributing the weights.
 
 `mere.run music generate --model music-minimax-music3` assembles the released
 caption-and-lyrics prompt contract, generates 25 Hz semantic plus residual RVQ
-codes, runs the overlap-aware flow transformer, and writes 44.1 kHz stereo WAV
-output through the released vocoder. Generation currently supports text plus
-lyrics (or `--instrumental`) for at most 360 seconds.
+codes, runs the overlap-aware flow transformer, and writes native 44.1 kHz
+stereo WAV output through the released vocoder. `--max-frames` exposes the
+upstream 1...9,000-frame contract directly, while `--duration` converts seconds
+at 25 Hz. The model card describes supported-quality generation through five
+minutes; 9,000 frames is the six-minute runtime hard limit.
+
+Generation defaults to `--memory-mode staged`, which releases the language,
+flow, and vocoder weights between stages. `--memory-mode resident` keeps the
+entire stack loaded for repeated work. Staged mode moves the catalog floor to
+32 GB unified memory; 64 GB remains recommended for practical song lengths.
+`--sample-rate 32000` produces the same stereo PCM rate exposed by the upstream
+SGLang speech route; 44,100 Hz remains the native CLI default. `music serve
+--model music-minimax-music3` exposes the non-streaming `/v1/audio/speech`
+request shape with `input`, `instructions`, `seed`, and `max_new_tokens`, plus
+explicit native duration, step, guidance, and sample-rate controls.
+
+MiniMax publishes its optional `music-caption-rewriter` agent skill separately
+in the official
+[MiniMax-Music-3 repository](https://github.com/MiniMax-AI/MiniMax-Music-3/tree/91410fb657c007ae57c60df8240f5ece5be089c7/music-caption-rewriter).
+It is not part of the checkpoint snapshot or this distribution. The
+model-specific `mere.run guide music generate --model music-minimax-music3`
+shows the official install command, the reviewed source commit, and the
+complete raw Diffusers parameter mapping.
 
 ### `music-magenta-rt2-small` and `music-magenta-rt2-base`
 

--- a/docs/runtime/music.md
+++ b/docs/runtime/music.md
@@ -5,8 +5,9 @@ play a model live from a MIDI controller, split a mix into vocal and
 instrumental WAVs, or turn it back into instrument-separated MIDI with tempo,
 meter, and key already filled in.
 Generation, analysis, adapter training, resident serving, realtime steering,
-source separation, and transcription are native Swift and MLX paths — Magenta
-RT2 takes CC knobs while it is still generating.
+source separation, and transcription are native Swift and MLX paths. MiniMax
+Music 3 uses its staged language-model, RVQ, flow-transformer, and stereo
+vocoder stack locally; Magenta RT2 takes CC knobs while it is still generating.
 
 ## Commands
 
@@ -40,6 +41,7 @@ emitted flag absent from `mere.run catalog --json`.
 - `music-acestep-xl-base`
 - `music-acestep-lm-1.7b`
 - `music-acestep-lm-4b`
+- `music-minimax-music3`
 - `music-magenta-rt2-small`
 - `music-magenta-rt2-base`
 - `music-muscriptor-small`
@@ -59,6 +61,7 @@ Music guidance follows the command/cookbook shape used by the rest of
 mere.run guide music generate --model music-acestep
 mere.run guide music generate --model music-acestep-xl-turbo
 mere.run guide music analyze --model music-acestep-xl-turbo-lm4b
+mere.run guide music generate --model music-minimax-music3
 mere.run guide music generate --model music-magenta-rt2-small
 mere.run guide music separate --model music-separate-bs-roformer-viperx-1297
 mere.run guide music separate --model music-separate-bs-roformer-4stem
@@ -77,6 +80,16 @@ style-transfer covers, and source-audio understanding are documented under
 swift run mere.run music generate \
   "upbeat electronic groove" \
   --output ./track.wav
+
+swift run mere.run model pull music-minimax-music3 --accept-model-license
+swift run mere.run music generate \
+  "cinematic synth-pop, female lead, 118 bpm, wide guitars" \
+  --model music-minimax-music3 \
+  --lyrics-file ./lyrics.txt \
+  --duration 30 \
+  --steps 30 \
+  --seed 7 \
+  --output ./minimax-song.wav
 
 swift run mere.run music generate \
   "dream-pop cover with soft vocals" \

--- a/docs/runtime/music.md
+++ b/docs/runtime/music.md
@@ -89,7 +89,18 @@ swift run mere.run music generate \
   --duration 30 \
   --steps 30 \
   --seed 7 \
+  --memory-mode staged \
   --output ./minimax-song.wav
+
+swift run mere.run music serve \
+  --model music-minimax-music3 \
+  --memory-mode resident \
+  --port 8080
+
+curl http://127.0.0.1:8080/v1/audio/speech \
+  -H 'Content-Type: application/json' \
+  -d '{"model":"music-minimax-music3","instructions":"cinematic synth-pop, female lead","input":"[Verse]\nNeon on the avenue","max_new_tokens":750,"seed":7}' \
+  --output ./minimax-speech-route.wav
 
 swift run mere.run music generate \
   "dream-pop cover with soft vocals" \


### PR DESCRIPTION
## Summary

- add `music-minimax-music3` as a managed, license-gated model pinned to `MiniMaxAI/MiniMax-Music3@bd348f9c49ea3c1b39f33ace3436f8fad435f24e`
- implement the checkpoint natively in Swift/MLX: tokenizer and prompt contract, cached Qwen language model, semantic and depth-code sampling, RVQ depth decoder, condition encoder, flow transformer, and Oobleck vocoder
- complete the public parity surface with direct 25 Hz frame limits, staged or resident loading, native 44.1 kHz or speech-compatible 32 kHz output, and `/v1/audio/speech`
- make seed behavior independent of loading strategy with an explicit MLX random state shared by autoregressive sampling and flow noise
- add model-specific guidance, an exact Diffusers parameter map, strict rejection of incompatible shared settings, and the official caption-rewriter integration path

## Upstream parity

The implementation tracks these immutable references:

- checkpoint: `MiniMaxAI/MiniMax-Music3@bd348f9c49ea3c1b39f33ace3436f8fad435f24e`
- Diffusers runtime reference: PR #14456 head `c6da9936e4bda83107943a16eb8682e9a37d8527`
- official caption companion reviewed at `MiniMax-AI/MiniMax-Music3@91410fb657c007ae57c60df8240f5ece5be089c7`

Every released Diffusers input has a concrete CLI mapping: `prompt`, `lyrics`, `audio_duration`, `generator`, `num_inference_steps`, and `output_type`. The released autoregressive CFG 1.5 and top-k 50 remain fixed checkpoint behavior; flow guidance 1.7 is the default and is overridable. The SGLang request shape maps `input`, `instructions`, `seed`, and `max_new_tokens`, accepts WAV only, and explicitly rejects streaming. Both upstream paths are single-sample, so no synthetic batch control is exposed.

The separate `music-caption-rewriter` skill is documented with its official install command and reviewed commit. It is not vendored because the companion repository does not publish a reusable license.

## Memory and serving

`--memory-mode staged` loads autoregressive, flow, and vocoder stages separately and clears the MLX cache between them. `resident` keeps the full stack warm for repeated requests. The catalog floor is now 32 GB for staged short-form generation, with 64 GB recommended for practical song lengths.

`music serve --model music-minimax-music3` exposes an authenticated, serialized `/v1/audio/speech` route plus `/health`. It defaults to 32 kHz PCM16 stereo for SGLang compatibility and can return the native 44.1 kHz rate.

## Validation

- `./scripts/check.sh`
  - SwiftLint strict: 0 violations
  - 2,814 tests passed, 205 expected checkpoint-gated skips, 0 failures
  - build, every CLI help sweep, agent-readiness, documentation contract, and hygiene scans passed
- installed-checkpoint component parity suite: 14/14 passed against upstream fixtures
- installed staged/resident seed-equivalence regression: passed on Metal in 6.8 seconds
- staged and resident unmastered WAVs are byte-identical: `14c2535f90b0a3cb7feded7073ac79fbea166c5aab58f0304756a2c7240cd36a`
- staged Metal smoke: 3.05 seconds, 18.68 GB maximum RSS, 25.21 GB peak footprint, zero swaps
- speech-route smoke: valid 2-channel 32,000 Hz Int16 WAV, SHA-256 `efa895a9ea6fdd6fecb2005ae48f1eba59d786fb34047e1890b89639ddc41a12`
- full native quality smoke retained: 30 denoising steps, 250 semantic frames, 9.996 seconds, 44.1 kHz stereo 24-bit PCM, SHA-256 `1e76deb38d2a61b0c5761487c8e2efe0a8604928bfc02816d35350cbd83b5c9e`
- managed install readback: 28.52 GB, exact pinned source revision, `isValid: true`
