### PR TITLE
Prepare mere.run 0.37.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+## 0.37.0 - 2026-08-13
+
+This release adds two substantial native Apple Silicon runtimes: LiquidAI's
+compact LFM2.5-VL 3B vision-language model and MiniMax Music 3 song generation.
+It also completes the native Swift/MLX LTX 2.5 v1.2.0 inference family and fixes
+fresh-checkout Dub-It loading against the official gated audio VAE and IC-LoRA.
+
+The new managed checkpoints remain pinned to immutable upstream revisions and
+retain their upstream license gates. MiniMax Music 3 and the full LTX 2.5 bundle
+are intentionally staged for high-memory systems; neither silently downloads
+at inference time.
+
+### Vision
+
+- added `vision-chat-lfm25-3b-8bit`, a pinned native Swift/MLX implementation of
+  LiquidAI's LFM2.5-VL 3B 8-bit checkpoint. The existing `text chat --image`
+  workflow now supports typed LFM2-VL configuration, SigLIP2 image encoding,
+  smart resizing and patch packing, multimodal projection, visual-token
+  prefill, model-aware defaults, capability reporting, and explicit LFM Open
+  License acceptance without a Python or Transformers runtime.
+
 ### Video and audio
 
 - added `music-minimax-music3`, a pinned selective MiniMax Music 3 checkpoint
@@ -32,6 +53,13 @@ The format is based on Keep a Changelog.
   LoRA weights, official seed/sampler/DFR recipes, and stacked IC-LoRA metadata.
   The local API and macOS Studio advertise and route the same native surfaces;
   no Python inference process or sidecar is used.
+
+### Included pull requests
+
+- exact release range: [#288](https://github.com/sawfwair/mere-run/pull/288),
+  [#289](https://github.com/sawfwair/mere-run/pull/289),
+  [#290](https://github.com/sawfwair/mere-run/pull/290), and
+  [#291](https://github.com/sawfwair/mere-run/pull/291).
 
 ## 0.36.0 - 2026-08-12
 

--- a/Sources/MereRunCLI/Support/MereRunCLIVersion.swift
+++ b/Sources/MereRunCLI/Support/MereRunCLIVersion.swift
@@ -1,3 +1,3 @@
 enum MereRunCLIVersion {
-    static let current = "0.36.0"
+    static let current = "0.37.0"
 }

--- a/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
+++ b/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
@@ -129,7 +129,7 @@ final class CLIModelStoreBootstrapTests: XCTestCase {
     }
 
     func testMereRunCLIExposesReleaseVersion() {
-        XCTAssertEqual(MereRunCLIVersion.current, "0.36.0")
+        XCTAssertEqual(MereRunCLIVersion.current, "0.37.0")
         XCTAssertEqual(MereRunCLI.configuration.version, MereRunCLIVersion.current)
     }
 

--- a/scripts/build_mere_run_app.sh
+++ b/scripts/build_mere_run_app.sh
@@ -15,7 +15,7 @@ cd "$repo_root"
 
 # Version/build derive from git when not provided, so the bundle has a single source of
 # truth in CI. Fall back to a pinned value when git metadata is unavailable.
-default_version="0.36.0"
+default_version="0.37.0"
 if git_version="$(git describe --tags --exact-match 2>/dev/null)"; then
   default_version="${git_version#v}"
 fi


### PR DESCRIPTION
## Summary

- bump the CLI and macOS bundle fallback version to 0.37.0
- promote the four-PR range since v0.36.0 into the changelog
- add the missing LFM2.5-VL release note and exact PR provenance

## Release range

- #288 Add native LFM2.5-VL 3B support
- #289 Bring LTX 2.5 to full native Swift/MLX parity
- #290 Fix native LTX 2.5 Dub-It loading
- #291 Add native MiniMax Music 3 generation

## Validation

- ./scripts/check.sh
  - SwiftLint strict: 0 violations
  - XCTest: 2,815 executed, 205 expected checkpoint skips, 0 failures
  - Swift Testing: 28 passed
  - build, CLI help sweep, agent-readiness, documentation contracts, and hygiene scans passed
- git diff --check

Tagging and artifact publication will target the exact protected-main merge commit after required checks pass.