### PR TITLE
Redesign the documentation experience

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -35,17 +35,16 @@ export default defineConfig({
   ],
   markdown: mereMarkdown(),
   themeConfig: {
-    siteTitle: 'mere.run Docs',
+    siteTitle: 'mere.run / docs',
     search: {
       provider: 'local'
     },
     nav: [
-      { text: 'Getting Started', link: '/getting-started' },
-      { text: 'CLI', link: '/cli' },
-      { text: 'Workflows', link: '/workflows' },
-      { text: 'Runtime', link: '/runtime/image' },
-      { text: 'Plugins', link: '/plugins' },
-      { text: 'Contribute', link: '/repository-tour' }
+      { text: 'Create', link: '/runtime/image' },
+      { text: 'Understand', link: '/runtime/vision' },
+      { text: 'Automate', link: '/workflows' },
+      { text: 'Serve', link: '/runtime/api-server' },
+      { text: 'Reference', link: '/cli' }
     ],
     sidebar: [
       {

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -5,6 +5,7 @@ export default createMereProductDocsTheme({
   productDomain: 'docs.mere.run',
   docsUrl: 'https://docs.mere.run/',
   productHref: 'https://mere.run',
+  hero: 'run-proof',
   corePrefix: 'Eight runtime families. One local CLI. No cloud in the loop.',
   guideHref: '/getting-started',
   architectureHref: '/architecture',

--- a/docs/.vitepress/theme/mere/MereLayout.vue
+++ b/docs/.vitepress/theme/mere/MereLayout.vue
@@ -4,6 +4,7 @@ import DefaultTheme from 'vitepress/theme'
 import MereAtlasMap from './components/MereAtlasMap.vue'
 import MereDocSignal from './components/MereDocSignal.vue'
 import MereDocsNetwork from './components/MereDocsNetwork.vue'
+import MereRunProof from './components/MereRunProof.vue'
 import { useMereDocsThemeConfig } from './config'
 
 const { Layout } = DefaultTheme
@@ -26,7 +27,8 @@ const keyColorStyle = computed(() => ({
         <span class="mere-nav-mark" aria-hidden="true" />
       </template>
       <template #home-hero-image>
-        <MereAtlasMap />
+        <MereRunProof v-if="themeConfig.hero === 'run-proof'" />
+        <MereAtlasMap v-else />
       </template>
       <template #doc-before>
         <MereDocSignal />

--- a/docs/.vitepress/theme/mere/components/MereRunProof.vue
+++ b/docs/.vitepress/theme/mere/components/MereRunProof.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import { withBase } from 'vitepress'
+import proofMediaUrl from '../../../../media/demo-inline.gif'
+</script>
+
+<template>
+  <section class="mere-launch-stage" aria-label="Real mere.run session on an M4 Max">
+    <div class="mere-launch-frame">
+      <div class="mere-launch-topline">
+        <div class="mere-window-controls" aria-hidden="true">
+          <span />
+          <span />
+          <span />
+        </div>
+        <span class="mere-launch-title">mere.run / local session</span>
+        <span class="mere-launch-status">running</span>
+      </div>
+
+      <div class="mere-launch-media">
+        <img
+          :src="proofMediaUrl"
+          width="900"
+          height="630"
+          alt="A real terminal session generating text, images, 3D, audio, and video locally with mere.run"
+        >
+        <span class="mere-proof-label">Real output · M4 Max</span>
+      </div>
+
+      <div class="mere-launch-command">
+        <span aria-hidden="true">$</span>
+        <code>mere.run model capabilities --recommended</code>
+        <a :href="withBase('/runtime/image')">Explore runtimes <span aria-hidden="true">↗</span></a>
+      </div>
+    </div>
+  </section>
+</template>

--- a/docs/.vitepress/theme/mere/config.ts
+++ b/docs/.vitepress/theme/mere/config.ts
@@ -51,7 +51,7 @@ export const mereDocsKeyColors = {
   projects: defineMereDocsKeyColor('#7A5B2A', '#614820', '#D8B876', '#E7D09B'),
   zone: defineMereDocsKeyColor('#733E93', '#5B3175', '#C9A0EC', '#DDC0F4'),
   deliver: defineMereDocsKeyColor('#A1661B', '#805014', '#E6BE6D', '#F0D493', '#171714', '#171714'),
-  run: defineMereDocsKeyColor('#3159A8', '#274687', '#93B5F4', '#B9CDF8'),
+  run: defineMereDocsKeyColor('#4658E8', '#3042D0', '#91A0FF', '#B5BFFF'),
 } satisfies Record<string, MereDocsKeyColor>
 
 export type MereDocsKeyColorName = keyof typeof mereDocsKeyColors
@@ -82,6 +82,7 @@ export interface MereDocSectionSignal {
 
 export interface MereDocsThemeConfig {
   keyColor: MereDocsKeyColor
+  hero: 'atlas' | 'run-proof'
   atlas: {
     eyebrowLeft: string
     eyebrowRight: string
@@ -97,6 +98,7 @@ export interface MereDocsThemeConfig {
 
 export type MereDocsThemeUserConfig = Partial<{
   keyColor: MereDocsKeyColorInput
+  hero: MereDocsThemeConfig['hero']
   atlas: Partial<MereDocsThemeConfig['atlas']>
   docsNetworkLabel: string
   docsNetworkLinks: MereDocsLink[]
@@ -106,6 +108,7 @@ export type MereDocsThemeUserConfig = Partial<{
 
 export const defaultMereDocsThemeConfig: MereDocsThemeConfig = {
   keyColor: mereDocsKeyColors.docs,
+  hero: 'atlas',
   atlas: {
     eyebrowLeft: 'mere-docs.mere.world',
     eyebrowRight: 'atlas online',

--- a/docs/.vitepress/theme/mere/index.ts
+++ b/docs/.vitepress/theme/mere/index.ts
@@ -20,6 +20,7 @@ export interface MereProductDocsThemeOptions {
   productDomain: string
   docsUrl: string
   productHref?: string
+  hero?: MereDocsThemeUserConfig['hero']
   keyColor?: MereDocsKeyColorInput
   corePrefix?: string
   coreSuffix?: string
@@ -92,6 +93,7 @@ export function createMereProductDocsTheme(options: MereProductDocsThemeOptions)
 
   return createMereDocsTheme({
     keyColor: resolveMereProductDocsKeyColor(options.productName, options.productDomain, options.keyColor),
+    hero: options.hero ?? 'atlas',
     atlas: {
       eyebrowLeft: options.docsUrl.replace(/^https?:\/\//, '').replace(/\/$/, ''),
       eyebrowRight: 'docs online',

--- a/docs/.vitepress/theme/mere/mere-theme.css
+++ b/docs/.vitepress/theme/mere/mere-theme.css
@@ -1,8 +1,7 @@
 /* ────────────────────────────────────────────────────────────────────────
    Mere docs theme
-   Warm paper, ink typography, per-product key colors, and code rendered
-   as a dark instrument panel in both appearances. Shared by every Mere
-   docs host via @mere/docs-theme.
+   Crisp product UI, high-signal typography, per-product key colors, and
+   code rendered as a dark instrument panel in both appearances.
    ──────────────────────────────────────────────────────────────────────── */
 
 @import './fonts.css';
@@ -10,27 +9,27 @@
 /* ── Tokens ─────────────────────────────────────────────────────────── */
 
 :root {
-  --mere-canvas: #F3F2EE;
-  --mere-paper: #FBFBF9;
-  --mere-surface: #F7F6F2;
-  --mere-surface-raised: #EDEBE5;
-  --mere-surface-muted: #E5E3DC;
-  --mere-ink: #1B1A16;
-  --mere-ink-soft: #55534B;
-  --mere-ink-muted: #767468;
-  --mere-line: #DAD8D1;
+  --mere-canvas: #F6F7FB;
+  --mere-paper: #FFFFFF;
+  --mere-surface: #F0F2F7;
+  --mere-surface-raised: #E8EBF2;
+  --mere-surface-muted: #DEE2EB;
+  --mere-ink: #0A0C10;
+  --mere-ink-soft: #444B59;
+  --mere-ink-muted: #6D7584;
+  --mere-line: #D8DDE7;
   --mere-line-soft: color-mix(in oklch, var(--mere-line) 62%, transparent);
-  --mere-line-strong: #B8B5AC;
-  --mere-accent: #3B4EA0;
+  --mere-line-strong: #AEB6C5;
+  --mere-accent: #4658E8;
   --mere-accent-soft: color-mix(in oklch, var(--mere-accent) 11%, transparent);
-  --mere-accent-hover: #2F3E82;
-  --mere-accent-contrast: #FCFCFB;
+  --mere-accent-hover: #3042D0;
+  --mere-accent-contrast: #FFFFFF;
   --mere-warning: #96691A;
   --mere-danger: #A84E2C;
   --mere-plum: #6E3878;
   --mere-focus: #1C7373;
-  --mere-shadow: 0 18px 42px color-mix(in oklch, var(--mere-ink) 8%, transparent);
-  --mere-shadow-soft: 0 10px 26px color-mix(in oklch, var(--mere-ink) 5%, transparent);
+  --mere-shadow: 0 24px 64px color-mix(in oklch, var(--mere-ink) 13%, transparent);
+  --mere-shadow-soft: 0 12px 32px color-mix(in oklch, var(--mere-ink) 8%, transparent);
 
   /* Code — always a dark panel; light mode sets it on the paper like slate */
   --mere-code-bg: oklch(21.5% 0.014 162);
@@ -66,12 +65,12 @@
   --vp-c-danger-soft: color-mix(in oklch, var(--mere-danger) 12%, transparent);
 
   --vp-font-family-base: 'Instrument Sans', ui-sans-serif, -apple-system, 'Segoe UI', system-ui, sans-serif;
-  --vp-font-family-display: 'Newsreader', 'Iowan Old Style', Georgia, 'Times New Roman', serif;
+  --vp-font-family-display: 'Instrument Sans', ui-sans-serif, -apple-system, 'Segoe UI', system-ui, sans-serif;
   --vp-font-family-mono: 'JetBrains Mono', ui-monospace, 'SF Mono', Menlo, 'Cascadia Code', Consolas, monospace;
 
   --vp-nav-height: 64px;
   --vp-layout-max-width: 1440px;
-  --vp-sidebar-bg-color: color-mix(in oklch, var(--mere-surface) 72%, var(--mere-canvas));
+  --vp-sidebar-bg-color: color-mix(in oklch, var(--mere-paper) 82%, var(--mere-canvas));
 
   /* Code block plumbing */
   --vp-code-block-bg: var(--mere-code-bg);
@@ -105,21 +104,21 @@
 }
 
 .dark {
-  --mere-canvas: oklch(16.5% 0.012 165);
-  --mere-paper: oklch(19.8% 0.013 165);
-  --mere-surface: oklch(22.5% 0.014 165);
-  --mere-surface-raised: oklch(25.5% 0.014 165);
-  --mere-surface-muted: oklch(29% 0.014 165);
-  --mere-ink: oklch(92.5% 0.01 110);
-  --mere-ink-soft: oklch(77% 0.011 120);
-  --mere-ink-muted: oklch(64% 0.012 125);
-  --mere-line: oklch(33% 0.014 165);
+  --mere-canvas: #0B0D12;
+  --mere-paper: #11141B;
+  --mere-surface: #171B24;
+  --mere-surface-raised: #1D222D;
+  --mere-surface-muted: #252B37;
+  --mere-ink: #F4F6FA;
+  --mere-ink-soft: #BBC2CF;
+  --mere-ink-muted: #858E9E;
+  --mere-line: #2A303C;
   --mere-line-soft: color-mix(in oklch, var(--mere-line) 70%, transparent);
-  --mere-line-strong: oklch(46% 0.016 165);
-  --mere-accent: oklch(72% 0.11 268);
+  --mere-line-strong: #434B5A;
+  --mere-accent: #91A0FF;
   --mere-accent-soft: color-mix(in oklch, var(--mere-accent) 15%, transparent);
-  --mere-accent-hover: oklch(80% 0.095 268);
-  --mere-accent-contrast: oklch(16% 0.014 170);
+  --mere-accent-hover: #B5BFFF;
+  --mere-accent-contrast: #0B0D12;
   --mere-warning: oklch(78% 0.1 72);
   --mere-danger: oklch(72% 0.13 30);
   --mere-plum: oklch(75% 0.09 320);
@@ -145,7 +144,7 @@
   --vp-c-brand-2: var(--mere-accent-hover);
   --vp-c-brand-3: color-mix(in oklch, var(--mere-accent) 78%, var(--mere-paper));
   --vp-c-brand-soft: var(--mere-accent-soft);
-  --vp-sidebar-bg-color: color-mix(in oklch, var(--mere-paper) 55%, var(--mere-canvas));
+  --vp-sidebar-bg-color: color-mix(in oklch, var(--mere-paper) 72%, var(--mere-canvas));
   --vp-home-hero-name-color: var(--mere-accent);
 }
 
@@ -1557,6 +1556,652 @@ body {
 
   .vp-code-group div[class*='language-'] {
     border-radius: 0;
+  }
+}
+
+/* ── mere.run product pass ────────────────────────────────────────────
+   A sharper, output-first layer for the public runtime docs. The shared
+   primitives above remain useful to sibling docs hosts; these rules reset
+   the product masthead and tighten the long-form reading surface.
+   ───────────────────────────────────────────────────────────────────── */
+
+.VPNav {
+  background: color-mix(in srgb, var(--mere-canvas) 78%, transparent);
+  -webkit-backdrop-filter: blur(20px) saturate(1.7);
+  backdrop-filter: blur(20px) saturate(1.7);
+}
+
+.VPNavBarTitle .title {
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: -0.035em;
+}
+
+.VPNavBarMenuLink,
+.VPNavBarMenuGroup .button {
+  font-size: 13px;
+  font-weight: 600;
+}
+
+.VPNavBarMenuLink.active {
+  color: var(--mere-accent);
+}
+
+.VPNavBarSearch .DocSearch-Button {
+  border-color: var(--mere-line-soft);
+  border-radius: 10px;
+  background: color-mix(in oklch, var(--mere-paper) 72%, transparent);
+}
+
+.VPSidebar {
+  border-right-color: var(--mere-line-soft);
+  background: var(--vp-sidebar-bg-color);
+}
+
+.VPSidebarItem.level-0 > .item > .link > .text,
+.VPSidebarItem.level-0 > .item > .text {
+  color: var(--mere-ink-muted);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+}
+
+.VPSidebarItem:not(.level-0) .link > .text {
+  font-size: 13px;
+  font-weight: 520;
+}
+
+.VPSidebarItem.is-active > .item > .link {
+  border-radius: 4px;
+  background: transparent;
+  box-shadow: inset 2px 0 0 var(--mere-accent);
+}
+
+.VPDoc {
+  padding-top: 48px;
+}
+
+.vp-doc {
+  max-width: 80ch;
+}
+
+.vp-doc h1 {
+  max-width: 18ch;
+  font-size: clamp(38px, 4vw, 50px);
+  font-weight: 700;
+  letter-spacing: -0.045em;
+  line-height: 1.02;
+}
+
+.vp-doc h2 {
+  margin-top: 64px;
+  border-top: 0;
+  padding-top: 0;
+  font-size: 26px;
+  font-weight: 700;
+  letter-spacing: -0.03em;
+}
+
+.vp-doc > div > h2::before {
+  display: none;
+  content: none;
+}
+
+.vp-doc h3 {
+  margin-top: 38px;
+  font-size: 19px;
+  font-weight: 680;
+  letter-spacing: -0.018em;
+}
+
+.vp-doc p,
+.vp-doc li {
+  font-size: 15.5px;
+  line-height: 1.72;
+}
+
+.vp-doc div[class*='language-'] {
+  border-radius: 12px;
+  box-shadow: 0 18px 44px -30px #000;
+}
+
+.mere-doc-signal {
+  align-items: center;
+  margin-bottom: 40px;
+  border: 1px solid var(--mere-line-soft);
+  border-radius: 12px;
+  padding: 12px 14px;
+  background: color-mix(in oklch, var(--mere-paper) 72%, transparent);
+}
+
+.mere-doc-signal-label {
+  margin-bottom: 1px;
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+}
+
+.mere-doc-signal p {
+  font-size: 12.5px;
+}
+
+.mere-doc-signal-links a,
+.mere-doc-signal-links span {
+  font-size: 12px;
+}
+
+/* Home canvas */
+.VPHome {
+  position: relative;
+  isolation: isolate;
+}
+
+.VPHome::before {
+  position: absolute;
+  z-index: -1;
+  inset: 0 0 auto;
+  height: 820px;
+  background:
+    linear-gradient(color-mix(in oklch, var(--mere-line) 36%, transparent) 1px, transparent 1px),
+    linear-gradient(90deg, color-mix(in oklch, var(--mere-line) 36%, transparent) 1px, transparent 1px),
+    radial-gradient(circle at 76% 18%, color-mix(in oklch, var(--mere-accent) 18%, transparent), transparent 30%),
+    radial-gradient(circle at 18% 6%, color-mix(in oklch, #5DE7A5 12%, transparent), transparent 24%);
+  background-size: 48px 48px, 48px 48px, auto, auto;
+  -webkit-mask-image: linear-gradient(to bottom, #000 56%, transparent 100%);
+  mask-image: linear-gradient(to bottom, #000 56%, transparent 100%);
+  content: '';
+  pointer-events: none;
+}
+
+.VPHero {
+  padding: 88px 32px 50px;
+}
+
+.VPHero .container {
+  max-width: 1380px;
+  gap: 72px;
+}
+
+.VPHero .main {
+  max-width: 620px;
+}
+
+.VPHero .name {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  margin-bottom: 20px;
+  border: 1px solid color-mix(in oklch, var(--mere-accent) 32%, var(--mere-line));
+  border-radius: 999px;
+  padding: 6px 10px;
+  background: color-mix(in oklch, var(--mere-accent) 8%, var(--mere-paper));
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+}
+
+.VPHero .name::before {
+  width: 6px;
+  height: 6px;
+  margin-right: 8px;
+  border-radius: 50%;
+  background: #32D583;
+  box-shadow: 0 0 0 4px color-mix(in oklch, #32D583 16%, transparent);
+  content: '';
+}
+
+.VPHero .text {
+  max-width: 11ch;
+  font-size: clamp(56px, 6vw, 82px);
+  font-weight: 700;
+  letter-spacing: -0.065em;
+  line-height: 0.96;
+  text-wrap: balance;
+}
+
+.VPHero .tagline {
+  max-width: 54ch;
+  margin-top: 24px;
+  font-size: 18px;
+  font-weight: 470;
+  line-height: 1.58;
+}
+
+.VPHero .actions {
+  gap: 12px;
+  margin-top: 32px;
+}
+
+.VPHero .VPButton {
+  min-height: 46px;
+  border-radius: 10px !important;
+  padding: 0 20px;
+  font-size: 14px;
+  font-weight: 650 !important;
+}
+
+.VPHero .VPButton.brand {
+  border-color: var(--mere-ink) !important;
+  background: var(--mere-ink) !important;
+  color: var(--mere-canvas) !important;
+  box-shadow: 0 10px 28px color-mix(in oklch, var(--mere-ink) 18%, transparent);
+}
+
+.VPHero .VPButton.brand:hover {
+  border-color: var(--mere-accent) !important;
+  background: var(--mere-accent) !important;
+  color: #fff !important;
+}
+
+.VPHero .VPButton.alt {
+  border-color: var(--mere-line-strong) !important;
+  background: color-mix(in oklch, var(--mere-paper) 62%, transparent) !important;
+  -webkit-backdrop-filter: blur(10px);
+  backdrop-filter: blur(10px);
+}
+
+/* Output-first hero proof */
+.mere-launch-stage {
+  width: min(690px, 100%);
+}
+
+.mere-launch-frame {
+  overflow: hidden;
+  border: 1px solid #2D3442;
+  border-radius: 18px;
+  background: #0A0D12;
+  box-shadow:
+    0 0 0 1px rgb(255 255 255 / 0.05) inset,
+    0 38px 90px -34px rgb(4 7 14 / 0.72),
+    0 0 80px color-mix(in oklch, var(--mere-accent) 10%, transparent);
+  color: #F0F3F8;
+  transform: perspective(1500px) rotateY(-2deg) rotateX(1deg);
+  transform-origin: center left;
+}
+
+.mere-launch-topline {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  min-height: 44px;
+  border-bottom: 1px solid rgb(255 255 255 / 0.08);
+  padding: 0 15px;
+  background: #11151C;
+  color: #8D97A8;
+  font-family: var(--vp-font-family-mono);
+  font-size: 9.5px;
+  font-weight: 600;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.mere-window-controls {
+  display: flex;
+  gap: 6px;
+}
+
+.mere-window-controls span {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #343B48;
+}
+
+.mere-window-controls span:nth-child(1) { background: #FF6258; }
+.mere-window-controls span:nth-child(2) { background: #FFBF38; }
+.mere-window-controls span:nth-child(3) { background: #28C840; }
+
+.mere-launch-status {
+  justify-self: end;
+  color: #77E5A5;
+}
+
+.mere-launch-status::before {
+  display: inline-block;
+  width: 6px;
+  height: 6px;
+  margin-right: 7px;
+  border-radius: 50%;
+  background: currentColor;
+  box-shadow: 0 0 12px currentColor;
+  content: '';
+  animation: mere-live 2.8s ease-in-out infinite;
+}
+
+.mere-launch-media {
+  position: relative;
+  overflow: hidden;
+  background:
+    radial-gradient(circle at 50% 0, rgb(70 88 232 / 0.18), transparent 42%),
+    #080B0F;
+}
+
+.mere-launch-media::after {
+  position: absolute;
+  inset: 0;
+  border: 1px solid rgb(255 255 255 / 0.035);
+  background: linear-gradient(transparent 50%, rgb(0 0 0 / 0.08) 50%);
+  background-size: 100% 4px;
+  content: '';
+  opacity: 0.35;
+  pointer-events: none;
+}
+
+.mere-launch-media img {
+  display: block;
+  width: 100%;
+  height: auto;
+  aspect-ratio: 10 / 7;
+  object-fit: cover;
+}
+
+.mere-proof-label {
+  position: absolute;
+  z-index: 1;
+  right: 14px;
+  bottom: 14px;
+  border: 1px solid rgb(255 255 255 / 0.14);
+  border-radius: 999px;
+  padding: 6px 9px;
+  background: rgb(5 8 12 / 0.78);
+  color: #D7DCE5;
+  font-family: var(--vp-font-family-mono);
+  font-size: 9px;
+  font-weight: 650;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  -webkit-backdrop-filter: blur(10px);
+  backdrop-filter: blur(10px);
+}
+
+.mere-launch-command {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 10px;
+  min-height: 54px;
+  border-top: 1px solid rgb(255 255 255 / 0.08);
+  padding: 0 16px;
+  color: #66E59C;
+  font-family: var(--vp-font-family-mono);
+  font-size: 11px;
+}
+
+.mere-launch-command code {
+  overflow: hidden;
+  color: #D6DBE4;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.mere-launch-command a {
+  color: #9BA8FF;
+  font-family: var(--vp-font-family-base);
+  font-size: 11px;
+  font-weight: 620;
+  text-decoration: none;
+  white-space: nowrap;
+}
+
+/* Intent cards */
+.VPFeatures {
+  padding: 0 32px 76px;
+}
+
+.VPFeatures .container {
+  max-width: 1380px;
+}
+
+.VPFeatures .items {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 14px;
+  margin: 0;
+}
+
+.VPFeatures .item {
+  width: auto !important;
+  padding: 0 !important;
+}
+
+.VPFeature,
+.VPLink.VPFeature {
+  position: relative;
+  min-height: 188px;
+  overflow: hidden;
+  border: 1px solid var(--mere-line-soft);
+  border-radius: 14px !important;
+  padding: 56px 22px 22px;
+  background: color-mix(in oklch, var(--mere-paper) 78%, transparent) !important;
+  box-shadow: 0 18px 46px -42px var(--mere-ink) !important;
+  -webkit-backdrop-filter: blur(12px);
+  backdrop-filter: blur(12px);
+  transition: border-color 180ms ease, transform 180ms ease, box-shadow 180ms ease !important;
+}
+
+.VPFeature .icon {
+  position: absolute;
+  top: 18px;
+  left: 22px;
+  display: block;
+  width: auto;
+  height: auto;
+  border-radius: 0;
+  background: transparent;
+  color: var(--mere-accent);
+  font-family: var(--vp-font-family-mono);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.1em;
+}
+
+.VPFeature:hover,
+.VPLink.VPFeature:hover {
+  border-color: color-mix(in oklch, var(--mere-accent) 48%, var(--mere-line));
+  box-shadow: 0 24px 54px -38px color-mix(in oklch, var(--mere-accent) 48%, var(--mere-ink)) !important;
+  transform: translateY(-3px);
+}
+
+.VPFeature .title {
+  font-size: 21px;
+  font-weight: 700;
+  letter-spacing: -0.035em;
+}
+
+.VPFeature .details {
+  margin-top: 9px;
+  font-size: 13.5px;
+  line-height: 1.56;
+}
+
+.VPHomeContent {
+  border-top: 1px solid var(--mere-line-soft);
+  padding-top: 74px;
+  background: color-mix(in oklch, var(--mere-paper) 42%, transparent);
+}
+
+.VPHomeContent .container {
+  max-width: 1180px;
+}
+
+.VPHomeContent .vp-doc h2 {
+  font-size: 31px;
+}
+
+@media (max-width: 1100px) {
+  .VPHero {
+    padding-top: 68px;
+  }
+
+  .VPHero .container {
+    gap: 38px;
+  }
+
+  .VPHero .text {
+    font-size: clamp(52px, 6vw, 68px);
+  }
+
+  .mere-launch-frame {
+    transform: none;
+  }
+
+  .VPFeatures .items {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media (max-width: 960px) {
+  .VPHero.has-image .container {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .VPHero.has-image .main {
+    order: 1;
+    max-width: 720px;
+  }
+
+  .VPHero.has-image .image {
+    order: 2;
+    width: 100% !important;
+    height: auto !important;
+    margin: 8px 0 0 !important;
+  }
+
+  .VPHero.has-image .image-container {
+    position: relative !important;
+    inset: auto !important;
+    width: 100% !important;
+    height: auto !important;
+    transform: none !important;
+  }
+
+  .mere-launch-stage {
+    width: 100%;
+    max-width: 760px;
+  }
+
+  .mere-doc-signal {
+    align-items: flex-start;
+  }
+}
+
+@media (max-width: 640px) {
+  .VPHero {
+    padding: 44px 20px 30px;
+  }
+
+  .VPHero .container {
+    gap: 34px;
+  }
+
+  .VPHero .name {
+    margin-bottom: 16px;
+  }
+
+  .VPHero .text {
+    max-width: 11ch;
+    font-size: 43px;
+    letter-spacing: -0.055em;
+  }
+
+  .VPHero .tagline {
+    margin-top: 18px;
+    font-size: 15.5px;
+  }
+
+  .VPHero .actions {
+    margin-top: 24px;
+  }
+
+  .VPHero .actions .VPButton {
+    min-height: 44px;
+  }
+
+  .mere-launch-frame {
+    border-radius: 13px;
+  }
+
+  .mere-launch-topline {
+    grid-template-columns: auto 1fr auto;
+    min-height: 38px;
+    padding: 0 10px;
+    font-size: 8px;
+  }
+
+  .mere-launch-title {
+    justify-self: center;
+  }
+
+  .mere-window-controls {
+    gap: 4px;
+  }
+
+  .mere-window-controls span {
+    width: 6px;
+    height: 6px;
+  }
+
+  .mere-proof-label {
+    right: 9px;
+    bottom: 9px;
+    font-size: 8px;
+  }
+
+  .mere-launch-command {
+    min-height: 45px;
+    padding: 0 11px;
+    font-size: 9px;
+  }
+
+  .mere-launch-command a {
+    display: none;
+  }
+
+  .VPFeatures {
+    padding: 0 20px 54px;
+  }
+
+  .VPFeatures .items {
+    grid-template-columns: 1fr;
+    gap: 10px;
+  }
+
+  .VPFeature,
+  .VPLink.VPFeature {
+    min-height: 0;
+    padding: 50px 18px 18px;
+  }
+
+  .VPFeature .icon {
+    top: 16px;
+    left: 18px;
+  }
+
+  .VPHomeContent {
+    padding-top: 50px;
+  }
+
+  .VPHomeContent .vp-doc h2 {
+    font-size: 26px;
+  }
+
+  .VPDoc {
+    padding-top: 30px;
+  }
+
+  .vp-doc h1 {
+    font-size: 37px;
+  }
+
+  .mere-doc-signal {
+    margin-bottom: 30px;
+    border-right: 0;
+    border-left: 0;
+    border-radius: 0;
+    padding-right: 0;
+    padding-left: 0;
+    background: transparent;
   }
 }
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,35 +3,33 @@ layout: home
 
 hero:
   name: mere.run
-  text: Create anything. Locally.
-  tagline: Image, text, video, music, sound, speech, vision, 3D, and persistent worlds in one Swift CLI, on hardware you already own. No inference API key. No upload. No venv.
+  text: Your machine can make anything.
+  tagline: One native CLI for images, text, video, music, speech, vision, 3D, and persistent worlds. Your weights. Your files. Nothing leaves unless you tell it to.
   actions:
     - theme: brand
-      text: Get Started
+      text: Install and run
       link: /getting-started
     - theme: alt
-      text: CLI Reference
-      link: /cli
-    - theme: alt
-      text: Portable Workflows
-      link: /workflows
-    - theme: alt
-      text: Linux QuickStart
-      link: /linux-quickstart
+      text: Explore capabilities
+      link: /runtime/image
 
 features:
-  - title: Everything. Actually everything.
-    details: Score a track. With a unified A/V model, render a clip and its soundtrack in the same pass. Clone a voice. Follow an object through a video. Turn a photo into a textured mesh. Same CLI, same afternoon.
-  - title: No venv. Ever.
-    details: Core model paths run through Swift and MLX, with llama.cpp for explicit GGUF models — no Python worker, torch install, wheels to resolve, or environment to activate. Clone it and swift build.
-  - title: Nothing leaves
-    details: Weights live in a store you control. During local inference, prompts, photos, and audio stay on your disk. Nothing is metered or uploaded unless you explicitly use a networked action.
-  - title: Workflow runs keep their receipts
-    details: Portable workflow runs write a durable directory — plan, events, artifacts, SHA-256 manifests. Kill one halfway and resume it. Hand the immutable bundle to another executor with the same resolved inputs and fingerprints.
-  - title: Already speaks OpenAI
-    details: Serve chat, embeddings, images, speech, and transcription on localhost. Point your editor, your scripts, or Open WebUI at it. Change the base URL; change nothing else.
-  - title: One laptop now, a fleet later
-    details: The same immutable bundle runs here, over SSH to a GPU box, or across a relay fleet — with the same resolved seeds, fingerprints, and validation contract.
+  - icon: 01 / CREATE
+    title: Make
+    details: Generate images, synchronized video and audio, music, speech, sound effects, 3D assets, and persistent worlds from one executable.
+    link: /runtime/image
+  - icon: 02 / UNDERSTAND
+    title: Understand
+    details: Caption, ground, segment, track, transcribe, diarize, inspect, and embed media without uploading the source.
+    link: /runtime/vision
+  - icon: 03 / AUTOMATE
+    title: Automate
+    details: Build typed workflow graphs with resumable runs, immutable inputs, events, artifacts, and SHA-256 receipts.
+    link: /workflows
+  - icon: 04 / SERVE
+    title: Serve
+    details: Expose local chat, embeddings, images, speech, and transcription through OpenAI-compatible endpoints.
+    link: /runtime/api-server
 ---
 
 ## Six commands, six kinds of thing


### PR DESCRIPTION
## What changed
- recompose the docs homepage around a real `mere.run` M4 Max session
- replace the warm editorial treatment with a sharper light/dark product system
- organize top-level navigation and capability cards around Create, Understand, Automate, Serve, and Reference
- modernize article typography, sidebars, section signals, code panels, and responsive behavior
- preserve the reusable atlas hero as the default for sibling Mere docs while opting `mere.run` into the new proof hero

## Why
The existing theme was polished but communicated a literary/reference site more than a broad local multimodal runtime. The redesign makes actual product output central and gives long-form docs a faster, more contemporary reading hierarchy.

## Impact
Visitors get one clear installation action, real output evidence above the fold, intent-based navigation, stronger dark mode, and a mobile layout verified at 390×844. Sibling docs that reuse the theme retain the existing atlas default.

## Validation
- `./scripts/check.sh`
- `pnpm docs:build`
- production VitePress preview in light and dark modes
- desktop homepage and Getting Started article at 1440×900
- mobile homepage at 390×844
- bundled proof GIF verified at 900×630 with no horizontal overflow or production browser errors