### PR TITLE
Optimize MiniMax Music 3 inference on Apple Silicon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,31 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+### Music
+
+- accelerated MiniMax Music 3 on Apple Silicon with a reachable 16,385-row
+  semantic head, fused QKV and gate/up projections, incremental residual-depth
+  KV caches, cached rotary/zero conditioning, batched flow guidance, and fewer
+  forced evaluations. The exact upstream graph remains available through
+  `--performance-mode reference`; optimized BF16 is the default.
+- added opt-in `q8` and `q4` group-64 affine turbo modes across the language
+  and depth transformers. On an M4 Max, a matched 250-frame/30-step staged
+  render measured 143.29 s in the 0.37.0 reference runtime, 105.46 s in optimized
+  BF16 before the duration-floor correction, 52.66 s in Q8, and 51.40 s in Q4.
+  A checkpoint gate measured Q8/Q4 semantic-logit cosine 0.99985/0.99166 and
+  top-100 overlap 98/80 against optimized BF16. Whole-flow compilation and
+  affine flow quantization were measured and rejected because both regressed;
+  batched flow CFG beat the serial alternative by 6.0% on a matched probe. A
+  strict three-minute Q8 render completed in 1,413.81 s with 4.50 GB maximum
+  resident memory and decoded to 180.268 s.
+- verified `--performance-mode reference` end to end against a clean 0.37.0
+  executable: matched 250-frame renders were byte-identical after PCM24 export,
+  including deterministic dither.
+- added `--minimum-duration` and `--min-frames` plus speech-request
+  `minimum_audio_duration` and `min_new_tokens`. EOS remains masked through the
+  requested floor, and second-based floors account for whole vocoder hops so a
+  nominal 10-second request no longer decodes to 9.996 seconds.
+
 ## 0.37.0 - 2026-08-13
 
 This release adds two substantial native Apple Silicon runtimes: LiquidAI's

--- a/README.md
+++ b/README.md
@@ -606,15 +606,18 @@ swift run mere.run music generate \
   --model music-minimax-music3 \
   --lyrics-file ./lyrics.txt \
   --duration 30 \
+  --minimum-duration 30 \
   --steps 30 \
   --seed 7 \
   --memory-mode staged \
+  --performance-mode q8 \
   --output ./minimax-song.wav
 
 # Keep MiniMax Music 3 warm behind its speech-compatible HTTP route
 swift run mere.run music serve \
   --model music-minimax-music3 \
   --memory-mode resident \
+  --performance-mode q8 \
   --port 8080
 
 # Generate with ACE-Step XL Turbo on larger Macs

--- a/Sources/MereRunCLI/Commands/MiniMaxMusic3Serve.swift
+++ b/Sources/MereRunCLI/Commands/MiniMaxMusic3Serve.swift
@@ -13,6 +13,8 @@ struct MiniMaxMusic3SpeechRequest: Codable, Sendable {
     var maxNewTokens: Int?
     var stream: Bool?
     var audioDuration: Float?
+    var minimumAudioDuration: Float?
+    var minNewTokens: Int?
     var numInferenceSteps: Int?
     var guidanceScale: Float?
     var sampleRate: Int?
@@ -26,6 +28,8 @@ struct MiniMaxMusic3SpeechRequest: Codable, Sendable {
         case maxNewTokens = "max_new_tokens"
         case stream
         case audioDuration = "audio_duration"
+        case minimumAudioDuration = "minimum_audio_duration"
+        case minNewTokens = "min_new_tokens"
         case numInferenceSteps = "num_inference_steps"
         case guidanceScale = "guidance_scale"
         case sampleRate = "sample_rate"
@@ -37,6 +41,7 @@ private struct MiniMaxMusic3HealthResponse: Codable {
     var model: String
     var resident: Bool
     var memoryMode: MiniMaxMusic3LoadingStrategy
+    var performanceMode: MiniMaxMusic3PerformanceMode
     var nativeSampleRate: Int
     var speechSampleRate: Int
 
@@ -45,6 +50,7 @@ private struct MiniMaxMusic3HealthResponse: Codable {
         case model
         case resident
         case memoryMode = "memory_mode"
+        case performanceMode = "performance_mode"
         case nativeSampleRate = "native_sample_rate"
         case speechSampleRate = "speech_sample_rate"
     }
@@ -55,11 +61,13 @@ private actor MiniMaxMusic3ServerSession {
 
     init(
         resources: MiniMaxMusic3Resources,
-        loadingStrategy: MiniMaxMusic3LoadingStrategy
+        loadingStrategy: MiniMaxMusic3LoadingStrategy,
+        performanceMode: MiniMaxMusic3PerformanceMode
     ) throws {
         self.pipeline = try MiniMaxMusic3Pipeline(
             resources: resources,
-            loadingStrategy: loadingStrategy
+            loadingStrategy: loadingStrategy,
+            performanceMode: performanceMode
         )
     }
 
@@ -119,7 +127,14 @@ private actor MiniMaxMusic3ServerSession {
             throw ValidationError("audio_duration must be greater than 0 and at most 360 seconds.")
         }
         let durationFrames = Int(duration * Float(MiniMaxMusic3Prompt.frameRate))
-        let maximumFrames = request.maxNewTokens ?? durationFrames
+        let durationFloorFrames = request.minimumAudioDuration.map {
+            MiniMaxMusic3Prompt.minimumFrameCount(forDurationSeconds: $0)
+        }
+        let minimumFrames = request.minNewTokens ?? durationFloorFrames
+        let maximumFrames = request.maxNewTokens
+            ?? (request.minimumAudioDuration == nil
+                ? durationFrames
+                : max(durationFrames, minimumFrames ?? 0))
         guard (1...MiniMaxMusic3Prompt.maxAudioFrames).contains(maximumFrames) else {
             throw ValidationError("max_new_tokens must be between 1 and 9000.")
         }
@@ -130,6 +145,36 @@ private actor MiniMaxMusic3ServerSession {
             throw ValidationError(
                 "audio_duration and max_new_tokens must describe the same 25 Hz frame limit."
             )
+        }
+        if let minimumAudioDuration = request.minimumAudioDuration,
+           minimumAudioDuration <= 0 || minimumAudioDuration > 360
+        {
+            throw ValidationError(
+                "minimum_audio_duration must be greater than 0 and at most 360 seconds."
+            )
+        }
+        if request.audioDuration != nil,
+           let minimumAudioDuration = request.minimumAudioDuration,
+           minimumAudioDuration > duration
+        {
+            throw ValidationError(
+                "minimum_audio_duration cannot exceed audio_duration."
+            )
+        }
+        if let minimumFrames,
+           !(1...MiniMaxMusic3Prompt.maxAudioFrames).contains(minimumFrames)
+        {
+            throw ValidationError("min_new_tokens must be between 1 and 9000.")
+        }
+        if let durationFloorFrames, let requestedMinimum = request.minNewTokens,
+           durationFloorFrames != requestedMinimum
+        {
+            throw ValidationError(
+                "minimum_audio_duration and min_new_tokens must describe the same 25 Hz frame floor."
+            )
+        }
+        if let minimumFrames, minimumFrames > maximumFrames {
+            throw ValidationError("The requested duration floor cannot exceed the output upper bound.")
         }
         let steps = request.numInferenceSteps ?? 30
         guard steps > 0 else {
@@ -148,6 +193,7 @@ private actor MiniMaxMusic3ServerSession {
                 caption: caption,
                 lyrics: lyrics,
                 durationSeconds: duration,
+                minimumFrames: minimumFrames,
                 maximumFrames: maximumFrames,
                 inferenceSteps: steps,
                 seed: request.seed ?? 0,
@@ -162,20 +208,24 @@ final class MiniMaxMusic3APIServer: @unchecked Sendable {
     private let session: MiniMaxMusic3ServerSession
     private let modelID: String
     private let loadingStrategy: MiniMaxMusic3LoadingStrategy
+    private let performanceMode: MiniMaxMusic3PerformanceMode
     private let apiKey: String?
 
     init(
         resources: MiniMaxMusic3Resources,
         modelID: String,
         loadingStrategy: MiniMaxMusic3LoadingStrategy,
+        performanceMode: MiniMaxMusic3PerformanceMode,
         apiKey: String?
     ) throws {
         self.session = try MiniMaxMusic3ServerSession(
             resources: resources,
-            loadingStrategy: loadingStrategy
+            loadingStrategy: loadingStrategy,
+            performanceMode: performanceMode
         )
         self.modelID = modelID
         self.loadingStrategy = loadingStrategy
+        self.performanceMode = performanceMode
         self.apiKey = apiKey
     }
 
@@ -203,6 +253,7 @@ final class MiniMaxMusic3APIServer: @unchecked Sendable {
                     model: modelID,
                     resident: loadingStrategy == .resident,
                     memoryMode: loadingStrategy,
+                    performanceMode: performanceMode,
                     nativeSampleRate: 44_100,
                     speechSampleRate: 32_000
                 )

--- a/Sources/MereRunCLI/Commands/MusicGenerateCommand.swift
+++ b/Sources/MereRunCLI/Commands/MusicGenerateCommand.swift
@@ -157,6 +157,18 @@ struct MusicGenerate: AsyncParsableCommand {
     var durationSeconds: Float?
 
     @Option(
+        name: [.customLong("minimum-duration")],
+        help: "MiniMax Music 3 minimum output duration in seconds; EOS is masked until this floor."
+    )
+    var miniMaxMinimumDurationSeconds: Float?
+
+    @Option(
+        name: [.customLong("min-frames")],
+        help: "MiniMax Music 3 minimum 25 Hz acoustic frames (1...9000); must agree with --minimum-duration."
+    )
+    var miniMaxMinimumFrames: Int?
+
+    @Option(
         name: [.customLong("max-frames")],
         help: "MiniMax Music 3 exact 25 Hz acoustic-frame limit (1...9000); must agree with --duration when both are set."
     )
@@ -173,6 +185,12 @@ struct MusicGenerate: AsyncParsableCommand {
         help: "MiniMax Music 3 loading: staged releases each model stage before loading the next; resident keeps all weights loaded."
     )
     var miniMaxLoadingStrategy: MiniMaxMusic3LoadingStrategy?
+
+    @Option(
+        name: [.customLong("performance-mode")],
+        help: "MiniMax Music 3 execution: reference, optimized (default), q8, or q4."
+    )
+    var miniMaxPerformanceMode: MiniMaxMusic3PerformanceMode?
 
     @Option(name: [.customLong("quality")], help: "Adaptive ACE-Step quality: draft, song, final, or edit.")
     var quality: ACEStepQualityPreset?
@@ -509,11 +527,14 @@ struct MusicGenerate: AsyncParsableCommand {
         }
 
         if miniMaxMaximumFrames != nil
+            || miniMaxMinimumFrames != nil
+            || miniMaxMinimumDurationSeconds != nil
             || miniMaxOutputSampleRate != nil
             || miniMaxLoadingStrategy != nil
+            || miniMaxPerformanceMode != nil
         {
             throw ValidationError(
-                "--max-frames, --sample-rate, and --memory-mode require MiniMax Music 3."
+                "MiniMax duration-frame, sample-rate, memory-mode, and performance-mode options require MiniMax Music 3."
             )
         }
 
@@ -1159,20 +1180,30 @@ struct MusicGenerate: AsyncParsableCommand {
         if !quiet {
             CLIStderr.write("MiniMax memory mode: \(loadingStrategy.rawValue)\n")
         }
+        let performanceMode = miniMaxPerformanceMode ?? .optimized
+        if !quiet {
+            CLIStderr.write("MiniMax performance mode: \(performanceMode.rawValue)\n")
+        }
         let pipeline = try MiniMaxMusic3Pipeline(
             resources: resources,
-            loadingStrategy: loadingStrategy
+            loadingStrategy: loadingStrategy,
+            performanceMode: performanceMode
         )
         let requestedDuration = explicitDurationSeconds
             ?? miniMaxMaximumFrames.map {
                 Float($0) / Float(MiniMaxMusic3Prompt.frameRate)
             }
             ?? 60
+        let requestedMinimumFrames = miniMaxMinimumFrames
+            ?? miniMaxMinimumDurationSeconds.map {
+                MiniMaxMusic3Prompt.minimumFrameCount(forDurationSeconds: $0)
+            }
         let result = try pipeline.generate(
             options: MiniMaxMusic3GenerationOptions(
                 caption: caption,
                 lyrics: resolvedLyrics,
                 durationSeconds: requestedDuration,
+                minimumFrames: requestedMinimumFrames,
                 maximumFrames: miniMaxMaximumFrames,
                 inferenceSteps: steps ?? 30,
                 seed: seed ?? 0,
@@ -1228,6 +1259,7 @@ struct MusicGenerate: AsyncParsableCommand {
                 caption: caption,
                 lyrics: resolvedLyrics,
                 durationSeconds: requestedDuration,
+                requestedMinimumFrames: requestedMinimumFrames,
                 requestedMaximumFrames: miniMaxMaximumFrames,
                 generatedFrameCount: result.frameCount,
                 inferenceSteps: steps ?? 30,
@@ -1236,6 +1268,7 @@ struct MusicGenerate: AsyncParsableCommand {
                 nativeSampleRate: result.sampleRate,
                 outputSampleRate: outputSampleRate,
                 loadingStrategy: loadingStrategy,
+                performanceMode: performanceMode,
                 export: exportOptions,
                 outputFilename: outputURL.lastPathComponent,
                 outputSHA256: try ModelArtifactPin.fileSHA256(outputURL)
@@ -1255,6 +1288,26 @@ struct MusicGenerate: AsyncParsableCommand {
     }
 
     func validateMiniMaxMusic3Options(explicitDurationSeconds: Float?) throws {
+        if let miniMaxMinimumDurationSeconds,
+           miniMaxMinimumDurationSeconds <= 0 || miniMaxMinimumDurationSeconds > 360
+        {
+            throw ValidationError("--minimum-duration must be greater than 0 and at most 360 seconds.")
+        }
+        if let miniMaxMinimumFrames,
+           !(1...MiniMaxMusic3Prompt.maxAudioFrames).contains(miniMaxMinimumFrames)
+        {
+            throw ValidationError("--min-frames must be between 1 and 9000.")
+        }
+        if let miniMaxMinimumDurationSeconds, let miniMaxMinimumFrames,
+           MiniMaxMusic3Prompt.minimumFrameCount(
+            forDurationSeconds: miniMaxMinimumDurationSeconds
+           )
+            != miniMaxMinimumFrames
+        {
+            throw ValidationError(
+                "--minimum-duration and --min-frames must describe the same 25 Hz frame floor."
+            )
+        }
         if let miniMaxMaximumFrames,
            !(1...MiniMaxMusic3Prompt.maxAudioFrames).contains(miniMaxMaximumFrames)
         {
@@ -1275,6 +1328,32 @@ struct MusicGenerate: AsyncParsableCommand {
         }
         if let explicitDurationSeconds, explicitDurationSeconds > 360 {
             throw ValidationError("MiniMax Music 3 supports at most 360 seconds (9,000 frames at 25 Hz).")
+        }
+        if let explicitDurationSeconds, let miniMaxMinimumDurationSeconds,
+           miniMaxMinimumDurationSeconds > explicitDurationSeconds
+        {
+            throw ValidationError("MiniMax Music 3 minimum duration cannot exceed its output upper bound.")
+        }
+        let resolvedMinimumFrames = miniMaxMinimumFrames
+            ?? miniMaxMinimumDurationSeconds.map {
+                MiniMaxMusic3Prompt.minimumFrameCount(forDurationSeconds: $0)
+            }
+        if let resolvedMinimumFrames,
+           resolvedMinimumFrames > MiniMaxMusic3Prompt.maxAudioFrames
+        {
+            throw ValidationError(
+                "MiniMax Music 3 minimum duration exceeds the decoded duration available from 9,000 frames."
+            )
+        }
+        let durationFrames = explicitDurationSeconds.map {
+            Int($0 * Float(MiniMaxMusic3Prompt.frameRate))
+        } ?? 60 * MiniMaxMusic3Prompt.frameRate
+        let resolvedMaximumFrames = miniMaxMaximumFrames
+            ?? (miniMaxMinimumDurationSeconds == nil
+                ? durationFrames
+                : max(durationFrames, resolvedMinimumFrames ?? 0))
+        if let resolvedMinimumFrames, resolvedMinimumFrames > resolvedMaximumFrames {
+            throw ValidationError("MiniMax Music 3 minimum duration cannot exceed its output upper bound.")
         }
         if useLM || noLM || analyzeSourceAudio || lmModel != nil || lmSubdirectory != nil {
             throw ValidationError("MiniMax Music 3 uses its built-in autoregressive stage; ACE-Step LM options do not apply.")

--- a/Sources/MereRunCLI/Commands/MusicServeCommand.swift
+++ b/Sources/MereRunCLI/Commands/MusicServeCommand.swift
@@ -25,6 +25,12 @@ struct MusicServe: AsyncParsableCommand {
     )
     var miniMaxLoadingStrategy: MiniMaxMusic3LoadingStrategy?
 
+    @Option(
+        name: [.customLong("performance-mode")],
+        help: "MiniMax Music 3 execution: reference, optimized (default), q8, or q4."
+    )
+    var miniMaxPerformanceMode: MiniMaxMusic3PerformanceMode?
+
     @Option(name: [.customLong("checkpoints-root")], help: "Root containing ACE-Step checkpoint directories.")
     var checkpointsRoot: String?
 
@@ -82,8 +88,8 @@ struct MusicServe: AsyncParsableCommand {
             try await runMiniMaxMusic3(apiKey: resolvedAPIKey)
             return
         }
-        if miniMaxLoadingStrategy != nil {
-            throw ValidationError("--memory-mode requires MiniMax Music 3.")
+        if miniMaxLoadingStrategy != nil || miniMaxPerformanceMode != nil {
+            throw ValidationError("--memory-mode and --performance-mode require MiniMax Music 3.")
         }
 
         let root = try await ACEStepCLIHelper.resolveCheckpointsRoot(
@@ -192,13 +198,16 @@ struct MusicServe: AsyncParsableCommand {
             )
         }
         let loadingStrategy = miniMaxLoadingStrategy ?? .resident
+        let performanceMode = miniMaxPerformanceMode ?? .optimized
         CLIStderr.write(
-            "Loading MiniMax Music 3 server in \(loadingStrategy.rawValue) memory mode\n"
+            "Loading MiniMax Music 3 server in \(loadingStrategy.rawValue) memory mode "
+                + "with \(performanceMode.rawValue) execution\n"
         )
         let server = try MiniMaxMusic3APIServer(
             resources: resources,
             modelID: ModelResolver.ModelID.miniMaxMusic3.rawValue,
             loadingStrategy: loadingStrategy,
+            performanceMode: performanceMode,
             apiKey: apiKey
         )
         try await server.run(host: host, port: port)

--- a/Sources/MereRunCLI/Guides/music-generate-minimax-music3.md
+++ b/Sources/MereRunCLI/Guides/music-generate-minimax-music3.md
@@ -27,17 +27,31 @@ MiniMax Music 3 consumes only these model inputs:
   arrangement, and production profile
 - `--lyrics`, `--lyrics-file`, `--lrc-file`, or `--instrumental`
 - `--duration`: upper-bound seconds; defaults to 60
+- `--minimum-duration`: decoded-audio duration floor. The runtime rounds up to
+  the first 25 Hz frame whose whole 512-sample vocoder hops meet the request.
+- `--min-frames`: exact acoustic-frame floor; 1 through 9000
 - `--max-frames`: exact 25 Hz acoustic-frame upper bound; 1 through 9000
 - `--steps`: flow-Euler steps per chunk; defaults to 30
 - `--seed`: deterministic MLX seed; defaults to 0
 - `--guidance-scale`: flow classifier-free guidance; defaults to 1.7
 - `--memory-mode staged|resident`: staged loads and releases the autoregressive,
   flow, and vocoder stages separately; resident keeps every component loaded
+- `--performance-mode reference|optimized|q8|q4`: exact upstream graph,
+  parity-safe BF16 acceleration (default), recommended affine Q8 turbo, or
+  maximum-compression affine Q4 turbo
 - `--sample-rate 44100|32000`: native Diffusers output or SGLang-compatible WAV
 
 When both `--duration` and `--max-frames` are provided, they must describe the
 same limit. The checkpoint hard cap is 9000 frames (360 seconds), while the
 official supported-quality claim is songs up to five minutes.
+
+`optimized` keeps BF16 weights while reducing launch and memory traffic with a
+compact reachable-token head, fused projections, incremental depth KV caches,
+and batched flow guidance. `q8` additionally quantizes the autoregressive
+language and depth transformers with group-64 affine weights; `q4` applies the
+same path at four bits. Quantization changes the sampled composition, so use `reference` or
+`optimized` for upstream-parity investigations and `q8` for the normal turbo
+tradeoff.
 
 Incompatible ACE-Step cover, editing, LM-planner, adapter, VAE,
 candidate-ranking, stem, and DAW settings fail explicitly for this model.
@@ -50,6 +64,9 @@ Magenta RT2 settings also fail instead of being silently ignored.
 | `prompt` | positional caption |
 | `lyrics` | `--lyrics`, `--lyrics-file`, `--lrc-file`, or `--instrumental` |
 | `audio_duration` | `--duration` |
+| `minimum_audio_duration` | `--minimum-duration` |
+| `min_new_tokens` | `--min-frames` |
+| `max_new_tokens` | `--max-frames` |
 | `generator` | `--seed` |
 | `num_inference_steps` | `--steps` |
 | `output_type=np|pt` | `--export-format float32` with mastering disabled as shown below |
@@ -58,7 +75,9 @@ The released autoregressive CFG (`1.5`) and top-k (`50`) remain fixed because
 they are checkpoint behavior, not pipeline inputs. Flow guidance defaults to
 the released `1.7` and is available as `--guidance-scale`. The speech route
 maps upstream `max_new_tokens` to the same frame limit exposed by
-`--max-frames`, accepts only `response_format=wav`, and requires
+`--max-frames`; native `minimum_audio_duration` and `min_new_tokens` map to the
+same duration floor exposed by `--minimum-duration` and `--min-frames`. It
+accepts only `response_format=wav`, and requires
 `stream=false`. Both upstream paths are single-sample, so mere.run does not
 invent a batch parameter.
 
@@ -74,6 +93,8 @@ mere.run music generate \
   --model music-minimax-music3 \
   --lyrics-file ./lyrics.txt \
   --duration 60 \
+  --minimum-duration 60 \
+  --performance-mode q8 \
   --steps 30 \
   --seed 7 \
   --output ./song.wav
@@ -117,6 +138,7 @@ Start the SGLang-compatible speech route with all weights warm:
 mere.run music serve \
   --model music-minimax-music3 \
   --memory-mode resident \
+  --performance-mode q8 \
   --port 8081
 ```
 
@@ -132,6 +154,7 @@ curl http://127.0.0.1:8081/v1/audio/speech \
     "response_format": "wav",
     "seed": 7,
     "max_new_tokens": 750,
+    "min_new_tokens": 750,
     "stream": false
   }' \
   --output song.wav

--- a/Sources/MereRunCLI/Guides/music-generate.md
+++ b/Sources/MereRunCLI/Guides/music-generate.md
@@ -77,6 +77,10 @@ mere.run guide music generate --model music-magenta-rt2-small
 - `--use-lm`: enable 5 Hz constrained LM for supported text-to-music tasks.
 - `--lm-model music-acestep-lm-4b`: explicitly select the optional 4B planner.
 - `--duration`: output seconds.
+- `--minimum-duration`: MiniMax Music 3 decoded-audio duration floor.
+- `--min-frames`, `--max-frames`: MiniMax Music 3 exact 25 Hz floor and limit.
+- `--performance-mode reference|optimized|q8|q4`: MiniMax Music 3 execution tier;
+  `optimized` is the BF16 default and `q8` is the recommended turbo tier.
 - `--steps`, `-s`: denoise steps; MiniMax Music 3 defaults to `30`.
 - `--shift`: turbo scheduler shift; ACE-Step CLI default is `3.0`, matching upstream.
 - `--seed`: deterministic generation.
@@ -147,8 +151,13 @@ mere.run guide music generate --model music-magenta-rt2-small
 MiniMax Music 3 requires `--lyrics`, `--lyrics-file`, `--lrc-file`, or
 `--instrumental`. Its native staged runtime autoregressively generates 25 Hz
 semantic and residual codes, conditions a flow transformer, and decodes stereo
-audio without a Python process. `--duration` accepts up to 360 seconds and
-`--guidance-scale` defaults to `1.7`. ACE-Step source audio, adapters, ranked
+audio without a Python process. `--duration` accepts up to 360 seconds;
+`--minimum-duration` prevents semantic EOS and rounds for the vocoder hop so
+the decoded WAV meets the requested floor. `--guidance-scale` defaults to `1.7`.
+The default `--performance-mode optimized` keeps BF16 quality while using
+compact/fused projections, cached depth decode, and batched flow guidance;
+`q8` is the recommended quantized turbo tier, with `q4` available for maximum
+memory reduction. ACE-Step source audio, adapters, ranked
 candidates, stems, DAW bundles, and LRC export do not apply to this model. A
 reproducibility recipe is written beside the WAV unless `--no-recipe` is used.
 The selective managed download is approximately 26.6 GiB and requires

--- a/Sources/MereRunCLI/Support/MiniMaxMusic3CLIOptions.swift
+++ b/Sources/MereRunCLI/Support/MiniMaxMusic3CLIOptions.swift
@@ -2,3 +2,4 @@ import ArgumentParser
 import MereRunCore
 
 extension MiniMaxMusic3LoadingStrategy: ExpressibleByArgument {}
+extension MiniMaxMusic3PerformanceMode: ExpressibleByArgument {}

--- a/Sources/MereRunCLI/Support/MiniMaxMusic3GenerationArtifacts.swift
+++ b/Sources/MereRunCLI/Support/MiniMaxMusic3GenerationArtifacts.swift
@@ -2,7 +2,7 @@ import Foundation
 import MereRunCore
 
 struct MiniMaxMusic3GenerationRecipe: Codable {
-    static let currentSchemaVersion = 2
+    static let currentSchemaVersion = 3
 
     var schemaVersion: Int
     var createdAt: Date
@@ -12,6 +12,7 @@ struct MiniMaxMusic3GenerationRecipe: Codable {
     var caption: String
     var lyrics: String
     var durationSeconds: Float
+    var requestedMinimumFrames: Int?
     var requestedMaximumFrames: Int?
     var generatedFrameCount: Int
     var inferenceSteps: Int
@@ -20,6 +21,7 @@ struct MiniMaxMusic3GenerationRecipe: Codable {
     var nativeSampleRate: Int
     var outputSampleRate: Int
     var loadingStrategy: MiniMaxMusic3LoadingStrategy
+    var performanceMode: MiniMaxMusic3PerformanceMode
     var export: ACEStepAudioExportOptions
     var outputFilename: String
     var outputSHA256: String
@@ -33,6 +35,7 @@ struct MiniMaxMusic3GenerationRecipe: Codable {
         case caption
         case lyrics
         case durationSeconds = "duration_seconds"
+        case requestedMinimumFrames = "requested_minimum_frames"
         case requestedMaximumFrames = "requested_maximum_frames"
         case generatedFrameCount = "generated_frame_count"
         case inferenceSteps = "inference_steps"
@@ -41,6 +44,7 @@ struct MiniMaxMusic3GenerationRecipe: Codable {
         case nativeSampleRate = "native_sample_rate"
         case outputSampleRate = "output_sample_rate"
         case loadingStrategy = "loading_strategy"
+        case performanceMode = "performance_mode"
         case export
         case outputFilename = "output_filename"
         case outputSHA256 = "output_sha256"

--- a/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3DepthDecoder.swift
+++ b/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3DepthDecoder.swift
@@ -11,6 +11,8 @@ final class MiniMaxMusic3DepthAttention: Module {
     @ModuleInfo(key: "to_v") var value: Linear
     @ModuleInfo(key: "to_out") var output: Linear
 
+    private var usesFusedProjections = false
+
     init(dimensions: Int, heads: Int) {
         self.heads = heads
         self.headDimension = dimensions / heads
@@ -20,12 +22,48 @@ final class MiniMaxMusic3DepthAttention: Module {
         self._output.wrappedValue = Linear(dimensions, dimensions, bias: false)
     }
 
-    func callAsFunction(_ hidden: MLXArray) -> MLXArray {
+    func callAsFunction(_ hidden: MLXArray, cache: KVCache? = nil) -> MLXArray {
+        if cache == nil, !usesFusedProjections {
+            return reference(hidden)
+        }
         let batch = hidden.dim(0)
         let length = hidden.dim(1)
-        let q = query(hidden).reshaped(batch, length, heads, headDimension).transposed(0, 2, 1, 3)
-        let k = key(hidden).reshaped(batch, length, heads, headDimension).transposed(0, 2, 1, 3)
-        let v = value(hidden).reshaped(batch, length, heads, headDimension).transposed(0, 2, 1, 3)
+        let projections: [MLXArray]
+        if usesFusedProjections {
+            projections = MLX.split(query(hidden), parts: 3, axis: -1)
+        } else {
+            projections = [query(hidden), key(hidden), value(hidden)]
+        }
+        let q = projections[0].reshaped(batch, length, heads, headDimension)
+            .transposed(0, 2, 1, 3)
+        let k = projections[1].reshaped(batch, length, heads, headDimension)
+            .transposed(0, 2, 1, 3)
+        let v = projections[2].reshaped(batch, length, heads, headDimension)
+            .transposed(0, 2, 1, 3)
+        var attendedKeys = k
+        var attendedValues = v
+        if let cache {
+            (attendedKeys, attendedValues) = cache.update(keys: k, values: v)
+        }
+        let attended = MLXFast.scaledDotProductAttention(
+            queries: q.asType(.float32),
+            keys: attendedKeys.asType(.float32),
+            values: attendedValues.asType(.float32),
+            scale: 1 / Float(headDimension).squareRoot(),
+            mask: cache?.makeMask(n: length) ?? .causal
+        )
+        return output(attended.asType(q.dtype).transposed(0, 2, 1, 3).reshaped(batch, length, -1))
+    }
+
+    private func reference(_ hidden: MLXArray) -> MLXArray {
+        let batch = hidden.dim(0)
+        let length = hidden.dim(1)
+        let q = query(hidden).reshaped(batch, length, heads, headDimension)
+            .transposed(0, 2, 1, 3)
+        let k = key(hidden).reshaped(batch, length, heads, headDimension)
+            .transposed(0, 2, 1, 3)
+        let v = value(hidden).reshaped(batch, length, heads, headDimension)
+            .transposed(0, 2, 1, 3)
         let attended = MLXFast.scaledDotProductAttention(
             queries: q.asType(.float32),
             keys: k.asType(.float32),
@@ -33,7 +71,22 @@ final class MiniMaxMusic3DepthAttention: Module {
             scale: 1 / Float(headDimension).squareRoot(),
             mask: .causal
         )
-        return output(attended.asType(q.dtype).transposed(0, 2, 1, 3).reshaped(batch, length, -1))
+        return output(
+            attended.asType(q.dtype).transposed(0, 2, 1, 3).reshaped(batch, length, -1)
+        )
+    }
+
+    func prepareFusedProjections() {
+        guard !usesFusedProjections else { return }
+        let fused = MLX.concatenated([query.weight, key.weight, value.weight], axis: 0)
+        MLX.eval(fused)
+        let placeholder = Linear(weight: MLXArray.zeros([1, 1], dtype: fused.dtype), bias: nil)
+        update(modules: ModuleChildren.unflattened([
+            ("to_q", Linear(weight: fused, bias: nil)),
+            ("to_k", placeholder),
+            ("to_v", Linear(weight: placeholder.weight, bias: nil)),
+        ]))
+        usesFusedProjections = true
     }
 }
 
@@ -45,6 +98,8 @@ final class MiniMaxMusic3DepthBlock: Module {
     @ModuleInfo(key: "up_proj") var upProjection: Linear
     @ModuleInfo(key: "down_proj") var downProjection: Linear
 
+    private var usesFusedFeedForward = false
+
     init(dimensions: Int, heads: Int, intermediateSize: Int) {
         self._inputLayerNorm.wrappedValue = RMSNorm(dimensions: dimensions, eps: 1e-6)
         self._attention.wrappedValue = MiniMaxMusic3DepthAttention(dimensions: dimensions, heads: heads)
@@ -54,10 +109,39 @@ final class MiniMaxMusic3DepthBlock: Module {
         self._downProjection.wrappedValue = Linear(intermediateSize, dimensions, bias: false)
     }
 
-    func callAsFunction(_ input: MLXArray) -> MLXArray {
-        let attended = input + attention(inputLayerNorm(input))
+    func callAsFunction(_ input: MLXArray, cache: KVCache? = nil) -> MLXArray {
+        if cache == nil, !usesFusedFeedForward {
+            let attended = input + attention(inputLayerNorm(input))
+            let normalized = postAttentionLayerNorm(attended)
+            return attended + downProjection(
+                MLXNN.silu(gateProjection(normalized)) * upProjection(normalized)
+            )
+        }
+        let attended = input + attention(inputLayerNorm(input), cache: cache)
         let normalized = postAttentionLayerNorm(attended)
-        return attended + downProjection(MLXNN.silu(gateProjection(normalized)) * upProjection(normalized))
+        let gate: MLXArray
+        let up: MLXArray
+        if usesFusedFeedForward {
+            let parts = MLX.split(gateProjection(normalized), parts: 2, axis: -1)
+            gate = parts[0]
+            up = parts[1]
+        } else {
+            gate = gateProjection(normalized)
+            up = upProjection(normalized)
+        }
+        return attended + downProjection(MLXNN.silu(gate) * up)
+    }
+
+    func prepareFusedProjections() {
+        attention.prepareFusedProjections()
+        guard !usesFusedFeedForward else { return }
+        let fused = MLX.concatenated([gateProjection.weight, upProjection.weight], axis: 0)
+        MLX.eval(fused)
+        update(modules: ModuleChildren.unflattened([
+            ("gate_proj", Linear(weight: fused, bias: nil)),
+            ("up_proj", Linear(weight: MLXArray.zeros([1, 1], dtype: fused.dtype), bias: nil)),
+        ]))
+        usesFusedFeedForward = true
     }
 }
 
@@ -95,13 +179,44 @@ public final class MiniMaxMusic3DepthDecoder: Module {
         }
     }
 
-    public func callAsFunction(_ inputEmbeddings: MLXArray) -> MLXArray {
-        let positions = MLXArray((0..<inputEmbeddings.dim(1)).map(Int32.init))
+    public func callAsFunction(
+        _ inputEmbeddings: MLXArray,
+        cache: [KVCache]? = nil
+    ) -> MLXArray {
+        let positions: MLXArray
+        if let cache {
+            let offset = cache.first?.offset ?? 0
+            positions = MLX.arange(
+                offset,
+                offset + inputEmbeddings.dim(1),
+                dtype: .int32
+            )
+        } else {
+            positions = MLXArray((0..<inputEmbeddings.dim(1)).map(Int32.init))
+        }
         var hidden = inputEmbeddings + positionEmbedding(positions).expandedDimensions(axis: 0)
-        for layer in layers {
-            hidden = layer(hidden)
+        if let cache {
+            precondition(cache.count == layers.count)
+            for (layer, layerCache) in zip(layers, cache) {
+                hidden = layer(hidden, cache: layerCache)
+            }
+        } else {
+            for layer in layers {
+                hidden = layer(hidden)
+            }
         }
         return norm(hidden)
+    }
+
+    public func makeCache() -> [KVCache] {
+        (0..<configuration.numLayers).map { _ in KVCacheSimple(step: 8) }
+    }
+
+    public func prepareFusedProjections() {
+        for layer in layers {
+            layer.prepareFusedProjections()
+        }
+        MLX.Memory.clearCache()
     }
 
     public func embedResidualCodes(_ codes: MLXArray, codebookIndex: Int) -> MLXArray {

--- a/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3LanguageModel.swift
+++ b/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3LanguageModel.swift
@@ -7,6 +7,8 @@ public final class MiniMaxMusic3LanguageModel: Module {
     @ModuleInfo(key: "model") var model: QwenEncoder
     @ModuleInfo(key: "lm_head") var languageModelHead: Linear
 
+    public private(set) var usesCompactSemanticHead = false
+
     public init(configuration: MiniMaxMusic3LanguageConfiguration) {
         self.configuration = configuration
         let qwenConfiguration = QwenTextEncoderConfiguration(
@@ -52,5 +54,35 @@ public final class MiniMaxMusic3LanguageModel: Module {
 
     public func logits(_ hidden: MLXArray) -> MLXArray {
         languageModelHead(hidden)
+    }
+
+    public func prepareFusedProjections() {
+        model.prepareFusedProjections()
+        MLX.Memory.clearCache()
+    }
+
+    /// The autoregressive sampler can emit only EOS or one of the checkpoint's
+    /// semantic audio tokens. Projecting all 200,000 vocabulary rows streams a
+    /// 1.64 GB BF16 head on every 25 Hz frame, so the optimized runtime retains
+    /// only the 16,385 reachable rows after checkpoint loading.
+    public func prepareCompactSemanticHead() {
+        guard !usesCompactSemanticHead else { return }
+        let end = languageModelHead.weight[
+            MiniMaxMusic3Prompt.audioEndTokenID..<(MiniMaxMusic3Prompt.audioEndTokenID + 1),
+            0...
+        ]
+        let semanticEnd = MiniMaxMusic3Prompt.audioCodeOffset
+            + MiniMaxMusic3Prompt.semanticVocabularySize
+        let semantic = languageModelHead.weight[
+            MiniMaxMusic3Prompt.audioCodeOffset..<semanticEnd,
+            0...
+        ]
+        let compact = MLX.concatenated([end, semantic], axis: 0)
+        MLX.eval(compact)
+        update(modules: ModuleChildren.unflattened([
+            ("lm_head", Linear(weight: compact, bias: nil)),
+        ]))
+        usesCompactSemanticHead = true
+        MLX.Memory.clearCache()
     }
 }

--- a/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3ModelLoader.swift
+++ b/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3ModelLoader.swift
@@ -27,11 +27,43 @@ public enum MiniMaxMusic3LoadingStrategy: String, CaseIterable, Codable, Sendabl
     case resident
 }
 
+public enum MiniMaxMusic3PerformanceMode: String, CaseIterable, Codable, Sendable {
+    /// Original upstream-equivalent graph, retained as an A/B and recovery path.
+    case reference
+    /// BF16 graph optimizations that preserve the model's sampling distribution.
+    case optimized
+    /// Optimized graph with affine 8-bit autoregressive weights.
+    case q8
+    /// Optimized graph with affine 4-bit autoregressive weights.
+    case q4
+
+    var quantizationBits: Int? {
+        switch self {
+        case .reference, .optimized:
+            nil
+        case .q8:
+            8
+        case .q4:
+            4
+        }
+    }
+
+    var usesOptimizedGraph: Bool {
+        self != .reference
+    }
+}
+
 public enum MiniMaxMusic3ModelLoader {
-    public static func load(from resources: MiniMaxMusic3Resources) throws -> MiniMaxMusic3Models {
+    public static func load(
+        from resources: MiniMaxMusic3Resources,
+        performanceMode: MiniMaxMusic3PerformanceMode = .optimized
+    ) throws -> MiniMaxMusic3Models {
         try validate(resources)
-        let autoregressive = try loadAutoregressive(from: resources)
-        let flow = try loadFlow(from: resources)
+        let autoregressive = try loadAutoregressive(
+            from: resources,
+            performanceMode: performanceMode
+        )
+        let flow = try loadFlow(from: resources, performanceMode: performanceMode)
         let vocoder = try loadVocoder(from: resources)
         MLX.eval(
             autoregressive.languageModel.parameters(),
@@ -51,7 +83,8 @@ public enum MiniMaxMusic3ModelLoader {
     }
 
     public static func loadAutoregressive(
-        from resources: MiniMaxMusic3Resources
+        from resources: MiniMaxMusic3Resources,
+        performanceMode: MiniMaxMusic3PerformanceMode = .optimized
     ) throws -> MiniMaxMusic3AutoregressiveModels {
         try validate(resources)
         let languageModel = MiniMaxMusic3LanguageModel(
@@ -70,6 +103,18 @@ public enum MiniMaxMusic3ModelLoader {
             directory: resources.depthDecoderURL,
             into: depthDecoder
         )
+        if performanceMode.usesOptimizedGraph {
+            languageModel.prepareCompactSemanticHead()
+            languageModel.prepareFusedProjections()
+            depthDecoder.prepareFusedProjections()
+        }
+        if let bits = performanceMode.quantizationBits {
+            quantizeAutoregressive(
+                languageModel: languageModel,
+                depthDecoder: depthDecoder,
+                bits: bits
+            )
+        }
         let tokenizer = try ACEStep5HzLMTokenizer.load(
             from: resources.tokenizerURL,
             requireAudioCodeTokens: false
@@ -83,7 +128,8 @@ public enum MiniMaxMusic3ModelLoader {
     }
 
     public static func loadFlow(
-        from resources: MiniMaxMusic3Resources
+        from resources: MiniMaxMusic3Resources,
+        performanceMode: MiniMaxMusic3PerformanceMode = .optimized
     ) throws -> MiniMaxMusic3FlowModels {
         try validate(resources)
         let conditionEncoder = MiniMaxMusic3ConditionEncoder(
@@ -102,11 +148,38 @@ public enum MiniMaxMusic3ModelLoader {
             into: transformer,
             mapper: MiniMaxMusic3Transformer.mapWeight
         )
+        if performanceMode.usesOptimizedGraph {
+            transformer.prepareFusedProjections()
+        }
         MLX.eval(conditionEncoder.parameters(), transformer.parameters())
         return MiniMaxMusic3FlowModels(
             conditionEncoder: conditionEncoder,
             transformer: transformer
         )
+    }
+
+    private static func quantizeAutoregressive(
+        languageModel: MiniMaxMusic3LanguageModel,
+        depthDecoder: MiniMaxMusic3DepthDecoder,
+        bits: Int
+    ) {
+        for model in [languageModel as Module, depthDecoder as Module] {
+            quantize(model: model, bits: bits)
+        }
+        MLX.eval(languageModel.parameters(), depthDecoder.parameters())
+        MLX.Memory.clearCache()
+    }
+
+    private static func quantize(model: Module, bits: Int) {
+        MLXNN.quantize(model: model, groupSize: 64, bits: bits) { _, module in
+            if let linear = module as? Linear {
+                return linear.shape.1 % 64 == 0
+            }
+            if let embedding = module as? Embedding {
+                return embedding.shape.1 % 64 == 0
+            }
+            return false
+        }
     }
 
     public static func loadVocoder(

--- a/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3Pipeline.swift
+++ b/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3Pipeline.swift
@@ -6,6 +6,7 @@ public struct MiniMaxMusic3GenerationOptions: Sendable {
     public var caption: String
     public var lyrics: String
     public var durationSeconds: Float
+    public var minimumFrames: Int?
     public var maximumFrames: Int?
     public var inferenceSteps: Int
     public var seed: UInt64
@@ -15,6 +16,7 @@ public struct MiniMaxMusic3GenerationOptions: Sendable {
         caption: String,
         lyrics: String,
         durationSeconds: Float = 60,
+        minimumFrames: Int? = nil,
         maximumFrames: Int? = nil,
         inferenceSteps: Int = 30,
         seed: UInt64 = 0,
@@ -23,6 +25,7 @@ public struct MiniMaxMusic3GenerationOptions: Sendable {
         self.caption = caption
         self.lyrics = lyrics
         self.durationSeconds = durationSeconds
+        self.minimumFrames = minimumFrames
         self.maximumFrames = maximumFrames
         self.inferenceSteps = inferenceSteps
         self.seed = seed
@@ -46,16 +49,19 @@ public final class MiniMaxMusic3Pipeline {
     private let residentModels: MiniMaxMusic3Models?
     private let resources: MiniMaxMusic3Resources?
     public let loadingStrategy: MiniMaxMusic3LoadingStrategy
+    public let performanceMode: MiniMaxMusic3PerformanceMode
 
     public init(models: MiniMaxMusic3Models) {
         self.residentModels = models
         self.resources = nil
         self.loadingStrategy = .resident
+        self.performanceMode = .reference
     }
 
     public init(
         resources: MiniMaxMusic3Resources,
-        loadingStrategy: MiniMaxMusic3LoadingStrategy = .staged
+        loadingStrategy: MiniMaxMusic3LoadingStrategy = .staged,
+        performanceMode: MiniMaxMusic3PerformanceMode = .optimized
     ) throws {
         let missing = resources.validate()
         guard missing.isEmpty else {
@@ -63,8 +69,12 @@ public final class MiniMaxMusic3Pipeline {
         }
         self.resources = resources
         self.loadingStrategy = loadingStrategy
+        self.performanceMode = performanceMode
         self.residentModels = loadingStrategy == .resident
-            ? try MiniMaxMusic3ModelLoader.load(from: resources)
+            ? try MiniMaxMusic3ModelLoader.load(
+                from: resources,
+                performanceMode: performanceMode
+            )
             : nil
     }
 
@@ -89,6 +99,21 @@ public final class MiniMaxMusic3Pipeline {
         {
             throw MiniMaxMusic3Error.invalidPrompt(
                 "maximum frames must be between 1 and \(MiniMaxMusic3Prompt.maxAudioFrames)"
+            )
+        }
+        if let minimumFrames = options.minimumFrames,
+           !(1...MiniMaxMusic3Prompt.maxAudioFrames).contains(minimumFrames)
+        {
+            throw MiniMaxMusic3Error.invalidPrompt(
+                "minimum frames must be between 1 and \(MiniMaxMusic3Prompt.maxAudioFrames)"
+            )
+        }
+        if let minimumFrames = options.minimumFrames,
+           let maximumFrames = options.maximumFrames,
+           minimumFrames > maximumFrames
+        {
+            throw MiniMaxMusic3Error.invalidPrompt(
+                "minimum frames cannot exceed maximum frames"
             )
         }
 
@@ -135,7 +160,10 @@ public final class MiniMaxMusic3Pipeline {
                 depthDecoder: $0.depthDecoder,
                 tokenizer: $0.tokenizer
             )
-        } ?? MiniMaxMusic3ModelLoader.loadAutoregressive(from: requiredResources())
+        } ?? MiniMaxMusic3ModelLoader.loadAutoregressive(
+            from: requiredResources(),
+            performanceMode: performanceMode
+        )
         let tokenIDs = try promptTokenIDs(
             caption: options.caption,
             lyrics: options.lyrics,
@@ -144,6 +172,7 @@ public final class MiniMaxMusic3Pipeline {
         let frameHiddens = try generateSemanticFrames(
             textIDs: tokenIDs,
             durationSeconds: options.durationSeconds,
+            minimumFrames: options.minimumFrames,
             maximumFrames: options.maximumFrames,
             languageModel: models.languageModel,
             depthDecoder: models.depthDecoder,
@@ -166,7 +195,10 @@ public final class MiniMaxMusic3Pipeline {
                 conditionEncoder: $0.conditionEncoder,
                 transformer: $0.transformer
             )
-        } ?? MiniMaxMusic3ModelLoader.loadFlow(from: requiredResources())
+        } ?? MiniMaxMusic3ModelLoader.loadFlow(
+            from: requiredResources(),
+            performanceMode: performanceMode
+        )
         let chunks = denoise(
             frameHiddens: frameHiddens,
             steps: steps,
@@ -222,6 +254,7 @@ public final class MiniMaxMusic3Pipeline {
     private func generateSemanticFrames(
         textIDs: MLXArray,
         durationSeconds: Float,
+        minimumFrames explicitMinimumFrames: Int?,
         maximumFrames explicitMaximumFrames: Int?,
         languageModel: MiniMaxMusic3LanguageModel,
         depthDecoder: MiniMaxMusic3DepthDecoder,
@@ -235,20 +268,33 @@ public final class MiniMaxMusic3Pipeline {
             cache: caches,
             lastPositionOnly: true
         ).squeezed(axis: 1)
+        let minimumFrames = explicitMinimumFrames ?? 0
+        let durationFrames = Int(durationSeconds * Float(MiniMaxMusic3Prompt.frameRate))
         let requestedFrames = explicitMaximumFrames
-            ?? Int(durationSeconds * Float(MiniMaxMusic3Prompt.frameRate))
+            ?? max(durationFrames, minimumFrames)
         let maximumFrames = min(requestedFrames, MiniMaxMusic3Prompt.maxAudioFrames)
         guard maximumFrames > 0 else {
             throw MiniMaxMusic3Error.invalidPrompt("duration is shorter than one 25 Hz audio frame")
+        }
+        guard minimumFrames <= maximumFrames else {
+            throw MiniMaxMusic3Error.invalidPrompt(
+                "minimum duration requires more than \(maximumFrames) audio frames"
+            )
         }
 
         var frameHiddens: [MLXArray] = []
         frameHiddens.reserveCapacity(maximumFrames)
         for frameIndex in 0...maximumFrames {
-            let sampled = sampleSemantic(
-                logits: languageModel.logits(lastHidden),
-                generator: generator
-            )
+            let logits = languageModel.logits(lastHidden)
+            let allowEnd = frameHiddens.count >= minimumFrames
+            let sampled = performanceMode == .reference
+                ? sampleSemanticReference(logits: logits, allowEnd: allowEnd, generator: generator)
+                : sampleSemantic(
+                    logits: logits,
+                    compactHead: languageModel.usesCompactSemanticHead,
+                    allowEnd: allowEnd,
+                    generator: generator
+                )
             let sampledID = sampled.item(Int.self)
             if sampledID == MiniMaxMusic3Prompt.audioEndTokenID {
                 break
@@ -263,12 +309,20 @@ public final class MiniMaxMusic3Pipeline {
                 depthDecoder: depthDecoder,
                 generator: generator
             )
+            var conditioningToEvaluate: MLXArray?
             if frameIndex > 0 {
                 let conditioning = MLX.concatenated([lastHidden[0..<1], depth.hidden], axis: -1)
-                MLX.eval(conditioning)
+                if performanceMode == .reference {
+                    MLX.eval(conditioning)
+                } else {
+                    conditioningToEvaluate = conditioning
+                }
                 frameHiddens.append(conditioning)
                 progress?(.semantic(frame: frameHiddens.count, maximum: maximumFrames))
                 if frameHiddens.count >= maximumFrames {
+                    if performanceMode != .reference {
+                        MLX.eval(conditioning)
+                    }
                     break
                 }
             }
@@ -283,7 +337,13 @@ public final class MiniMaxMusic3Pipeline {
                 cache: caches,
                 lastPositionOnly: true
             ).squeezed(axis: 1)
-            MLX.eval(lastHidden)
+            if performanceMode == .reference {
+                MLX.eval(lastHidden)
+            } else if let conditioningToEvaluate {
+                MLX.eval(lastHidden, conditioningToEvaluate)
+            } else {
+                MLX.eval(lastHidden)
+            }
         }
 
         guard !frameHiddens.isEmpty else {
@@ -292,15 +352,21 @@ public final class MiniMaxMusic3Pipeline {
         return MLX.stacked(frameHiddens, axis: 1)
     }
 
-    private func sampleSemantic(
+    private func sampleSemanticReference(
         logits: MLXArray,
+        allowEnd: Bool,
         generator: MLXRandom.RandomState
     ) -> MLXArray {
-        let guided = Self.guidedSemanticLogits(logits)
+        let guided = allowEnd
+            ? Self.guidedSemanticLogitsReference(logits)
+            : Self.guidedSemanticLogits(logits, allowEnd: false)
         return sampleTopK(guided[0], generator: generator)
     }
 
-    static func guidedSemanticLogits(_ logits: MLXArray) -> MLXArray {
+    /// Keep the released full-vocabulary graph byte-for-byte available for
+    /// seeded parity checks. Even graph-equivalent mask construction can alter
+    /// lazy evaluation and therefore the autoregressive sampling trajectory.
+    private static func guidedSemanticLogitsReference(_ logits: MLXArray) -> MLXArray {
         let vocabulary = logits.dim(-1)
         let tokenIndices = MLXArray((0..<vocabulary).map(Int32.init)).reshaped(1, vocabulary)
         let semanticStart = MLXArray(Int32(MiniMaxMusic3Prompt.audioCodeOffset))
@@ -310,18 +376,92 @@ public final class MiniMaxMusic3Pipeline {
         let allowedSemantic = (tokenIndices .>= semanticStart) .&& (tokenIndices .< semanticEnd)
         let allowedEnd = tokenIndices .== MLXArray(Int32(MiniMaxMusic3Prompt.audioEndTokenID))
         let allowed = allowedSemantic .|| allowedEnd
-
-        // MiniMax masks the language-model vocabulary before choosing the
-        // conditional branch's top candidates. Text-token logits must never
-        // influence the audio-code threshold.
         let masked = MLX.where(allowed, logits.asType(.float32), MLXArray(-Float.infinity))
         let conditional = masked[0..<1]
         let unconditional = masked[1..<2]
         var guided = unconditional + (conditional - unconditional) * MLXArray(Float(1.5))
         let firstTopIndex = vocabulary - min(50, vocabulary)
+        let topIndices = MLX.argPartition(
+            conditional,
+            kth: firstTopIndex,
+            axis: -1
+        )[0, firstTopIndex...]
+        let threshold = conditional[0].take(topIndices, axis: -1).min()
+        guided = MLX.where(conditional .< threshold, MLXArray(-Float.infinity), guided)
+        return MLX.where(allowed, guided, MLXArray(-Float.infinity))
+    }
+
+    private func sampleSemantic(
+        logits: MLXArray,
+        compactHead: Bool,
+        allowEnd: Bool,
+        generator: MLXRandom.RandomState
+    ) -> MLXArray {
+        let guided = Self.guidedSemanticLogits(logits, allowEnd: allowEnd)
+        let sampled = sampleTopK(guided[0], generator: generator)
+        guard compactHead else { return sampled }
+        return MLX.where(
+            sampled .== MLXArray(Int32(0)),
+            MLXArray(Int32(MiniMaxMusic3Prompt.audioEndTokenID)),
+            sampled + MLXArray(Int32(MiniMaxMusic3Prompt.audioCodeOffset - 1))
+        ).asType(.int32)
+    }
+
+    static func guidedSemanticLogits(
+        _ logits: MLXArray,
+        allowEnd: Bool = true
+    ) -> MLXArray {
+        let vocabulary = logits.dim(-1)
+        if vocabulary == MiniMaxMusic3Prompt.semanticVocabularySize + 1 {
+            let eligible: MLXArray
+            if allowEnd {
+                eligible = logits.asType(.float32)
+            } else {
+                eligible = MLX.concatenated(
+                    [
+                        MLXArray.full(
+                            [logits.dim(0), 1],
+                            values: MLXArray(-Float.infinity)
+                        ),
+                        logits[0..., 1...].asType(.float32),
+                    ],
+                    axis: -1
+                )
+            }
+            return guidedTopK(eligible)
+        }
+
+        let tokenIndices = MLX.arange(vocabulary, dtype: .int32).reshaped(1, vocabulary)
+        let semanticStart = MLXArray(Int32(MiniMaxMusic3Prompt.audioCodeOffset))
+        let semanticEnd = MLXArray(Int32(
+            MiniMaxMusic3Prompt.audioCodeOffset + MiniMaxMusic3Prompt.semanticVocabularySize
+        ))
+        let allowedSemantic = (tokenIndices .>= semanticStart) .&& (tokenIndices .< semanticEnd)
+        let allowedEnd = allowEnd
+            ? tokenIndices .== MLXArray(Int32(MiniMaxMusic3Prompt.audioEndTokenID))
+            : MLXArray.zeros(tokenIndices.shape, dtype: .bool)
+        let allowed = allowedSemantic .|| allowedEnd
+
+        // MiniMax masks the language-model vocabulary before choosing the
+        // conditional branch's top candidates. Text-token logits must never
+        // influence the audio-code threshold.
+        let masked = MLX.where(allowed, logits.asType(.float32), MLXArray(-Float.infinity))
+        return guidedTopK(masked, allowed: allowed)
+    }
+
+    private static func guidedTopK(
+        _ logits: MLXArray,
+        allowed: MLXArray? = nil
+    ) -> MLXArray {
+        let vocabulary = logits.dim(-1)
+        let conditional = logits[0..<1]
+        let unconditional = logits[1..<2]
+        var guided = unconditional + (conditional - unconditional) * MLXArray(Float(1.5))
+        let firstTopIndex = vocabulary - min(50, vocabulary)
         let topIndices = MLX.argPartition(conditional, kth: firstTopIndex, axis: -1)[0, firstTopIndex...]
         let threshold = conditional[0].take(topIndices, axis: -1).min()
         guided = MLX.where(conditional .< threshold, MLXArray(-Float.infinity), guided)
+        guard let allowed else { return guided }
         return MLX.where(allowed, guided, MLXArray(-Float.infinity))
     }
 
@@ -339,8 +479,16 @@ public final class MiniMaxMusic3Pipeline {
         sequence.append(depthDecoder.projection(semanticEmbedding).expandedDimensions(axis: 1))
         var codes = [semanticCode]
         var hiddenParts: [MLXArray] = []
+        let caches = performanceMode.usesOptimizedGraph
+            ? depthDecoder.makeCache()
+            : nil
         for codebook in 1..<depthDecoder.configuration.numCodebooks {
-            let hidden = depthDecoder(MLX.concatenated(sequence, axis: 1))[0..., -1, 0...]
+            let input = if caches == nil || codebook == 1 {
+                MLX.concatenated(sequence, axis: 1)
+            } else {
+                sequence[sequence.count - 1]
+            }
+            let hidden = depthDecoder(input, cache: caches)[0..., -1, 0...]
             hiddenParts.append(hidden[0..<1])
             let logits = depthDecoder.logits(hidden, codebookIndex: codebook - 1)
             let conditional = logits[0..<1].asType(.float32)
@@ -398,6 +546,105 @@ public final class MiniMaxMusic3Pipeline {
     }
 
     private func denoise(
+        frameHiddens: MLXArray,
+        steps: Int,
+        guidanceScale: Float,
+        conditionEncoder: MiniMaxMusic3ConditionEncoder,
+        transformer: MiniMaxMusic3Transformer,
+        generator: MLXRandom.RandomState,
+        progress: (@Sendable (MiniMaxMusic3Progress) -> Void)?
+    ) -> [MLXArray] {
+        if performanceMode == .reference {
+            return denoiseReference(
+                frameHiddens: frameHiddens,
+                steps: steps,
+                guidanceScale: guidanceScale,
+                conditionEncoder: conditionEncoder,
+                transformer: transformer,
+                generator: generator,
+                progress: progress
+            )
+        }
+        let starts = MiniMaxMusic3Prompt.chunkStarts(frameCount: frameHiddens.dim(1))
+        var previousLatent: MLXArray?
+        var previousCondition: MLXArray?
+        var chunks: [MLXArray] = []
+        chunks.reserveCapacity(starts.count)
+
+        for (chunkIndex, start) in starts.enumerated() {
+            let end = min(start + 200, frameHiddens.dim(1))
+            var condition = conditionEncoder(frameHiddens[0..., start..<end, 0...])
+                .asType(.bfloat16)
+            let overlap = min(previousLatent?.dim(2) ?? 0, condition.dim(1))
+            if overlap > 0, let previousCondition {
+                condition = MLX.concatenated(
+                    [previousCondition[0..., 0..<overlap, 0...], condition[0..., overlap..., 0...]],
+                    axis: 1
+                )
+            }
+            var latents = MLXRandom.normal([
+                1,
+                transformer.configuration.inChannels,
+                condition.dim(1),
+            ], key: generator).asType(condition.dtype)
+            let noisePrompt = overlap > 0 ? latents[0..., 0..., 0..<overlap] : nil
+            let zeroCondition = MLXArray.zeros(condition.shape, dtype: condition.dtype)
+            let rotary = transformer.rotaryCache(
+                latentLength: condition.dim(1),
+                dtype: condition.dtype
+            )
+            let stepSize = MLXArray(1 / Float(steps)).asType(condition.dtype)
+
+            for step in 0..<steps {
+                let time = Float(step) / Float(steps)
+                if overlap > 0, let previousLatent, let noisePrompt {
+                    let blended = (1 - (1 - 1e-6) * time) * noisePrompt
+                        + time * previousLatent[0..., 0..., 0..<overlap]
+                    latents = MLX.concatenated(
+                        [blended, latents[0..., 0..., overlap...]],
+                        axis: 2
+                    )
+                }
+                let timestep = MLXArray([time]).asType(latents.dtype)
+                let batchedLatents = MLX.concatenated([latents, latents], axis: 0)
+                let batchedTimestep = MLX.repeated(timestep, count: 2, axis: 0)
+                let batchedCondition = MLX.concatenated([condition, zeroCondition], axis: 0)
+                let velocities = transformer(
+                    latents: batchedLatents,
+                    timestep: batchedTimestep,
+                    condition: batchedCondition,
+                    rotary: rotary
+                )
+                let conditional = velocities[0..<1]
+                let unconditional = velocities[1..<2]
+                let velocity = unconditional + (conditional - unconditional) * MLXArray(guidanceScale)
+                latents = latents + velocity * stepSize
+                MLX.eval(latents)
+                progress?(.denoise(
+                    chunk: chunkIndex + 1,
+                    chunkCount: starts.count,
+                    step: step + 1,
+                    stepCount: steps
+                ))
+            }
+            if overlap > 0, let previousLatent {
+                latents = MLX.concatenated(
+                    [previousLatent[0..., 0..., 0..<overlap], latents[0..., 0..., overlap...]],
+                    axis: 2
+                )
+            }
+            let overlapStart = max(0, latents.dim(2) - 344)
+            let overlapEnd = max(overlapStart, latents.dim(2) - 172)
+            previousLatent = latents[0..., 0..., overlapStart..<overlapEnd]
+            previousCondition = condition[0..., overlapStart..<overlapEnd, 0...]
+            MLX.eval(latents, previousLatent!, previousCondition!)
+            chunks.append(latents)
+            MLX.Memory.clearCache()
+        }
+        return chunks
+    }
+
+    private func denoiseReference(
         frameHiddens: MLXArray,
         steps: Int,
         guidanceScale: Float,

--- a/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3Prompt.swift
+++ b/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3Prompt.swift
@@ -104,4 +104,34 @@ public enum MiniMaxMusic3Prompt {
     ) -> Int {
         max(1, frameCount * outputSamplingRate * inputHopLength / inputSamplingRate / outputHopLength)
     }
+
+    public static func decodedSampleCount(
+        frameCount: Int,
+        inputSamplingRate: Int = 24_000,
+        inputHopLength: Int = 960,
+        outputSamplingRate: Int = 44_100,
+        outputHopLength: Int = 512
+    ) -> Int {
+        latentLength(
+            frameCount: frameCount,
+            inputSamplingRate: inputSamplingRate,
+            inputHopLength: inputHopLength,
+            outputSamplingRate: outputSamplingRate,
+            outputHopLength: outputHopLength
+        ) * outputHopLength
+    }
+
+    /// Returns the first semantic frame count whose decoded waveform is at
+    /// least the requested duration. The vocoder emits whole 512-sample latent
+    /// hops, so `duration * 25` can otherwise undershoot by a fraction of a hop.
+    public static func minimumFrameCount(forDurationSeconds durationSeconds: Float) -> Int {
+        let minimumSamples = Int(
+            Foundation.ceil(Double(durationSeconds) * 44_100)
+        )
+        var frames = max(1, Int(Foundation.ceil(Double(durationSeconds) * Double(frameRate))))
+        while decodedSampleCount(frameCount: frames) < minimumSamples {
+            frames += 1
+        }
+        return frames
+    }
 }

--- a/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3Transformer.swift
+++ b/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3Transformer.swift
@@ -68,6 +68,8 @@ final class MiniMaxMusic3FlowAttention: Module {
     @ModuleInfo(key: "to_v") var value: Linear
     @ModuleInfo(key: "to_out") var output: [Linear]
 
+    private var usesFusedProjections = false
+
     init(dimensions: Int, heads: Int, headDimension: Int, rotaryDimension: Int) {
         self.heads = heads
         self.headDimension = headDimension
@@ -80,11 +82,20 @@ final class MiniMaxMusic3FlowAttention: Module {
     }
 
     func callAsFunction(_ hidden: MLXArray, rotary: (MLXArray, MLXArray)) -> MLXArray {
+        if !usesFusedProjections {
+            return reference(hidden, rotary: rotary)
+        }
         let batch = hidden.dim(0)
         let length = hidden.dim(1)
-        var q = query(hidden).reshaped(batch, length, heads, headDimension)
-        var k = key(hidden).reshaped(batch, length, heads, headDimension)
-        let v = value(hidden).reshaped(batch, length, heads, headDimension)
+        let projections: [MLXArray]
+        if usesFusedProjections {
+            projections = MLX.split(query(hidden), parts: 3, axis: -1)
+        } else {
+            projections = [query(hidden), key(hidden), value(hidden)]
+        }
+        var q = projections[0].reshaped(batch, length, heads, headDimension)
+        var k = projections[1].reshaped(batch, length, heads, headDimension)
+        let v = projections[2].reshaped(batch, length, heads, headDimension)
         q = MiniMaxMusic3RotaryEmbedding.apply(q, cos: rotary.0, sin: rotary.1, dimensions: rotaryDimension)
         k = MiniMaxMusic3RotaryEmbedding.apply(k, cos: rotary.0, sin: rotary.1, dimensions: rotaryDimension)
         let attended = MLXFast.scaledDotProductAttention(
@@ -96,6 +107,51 @@ final class MiniMaxMusic3FlowAttention: Module {
         )
         let merged = attended.asType(q.dtype).transposed(0, 2, 1, 3).reshaped(batch, length, -1)
         return output[0](merged)
+    }
+
+    private func reference(
+        _ hidden: MLXArray,
+        rotary: (MLXArray, MLXArray)
+    ) -> MLXArray {
+        let batch = hidden.dim(0)
+        let length = hidden.dim(1)
+        var q = query(hidden).reshaped(batch, length, heads, headDimension)
+        var k = key(hidden).reshaped(batch, length, heads, headDimension)
+        let v = value(hidden).reshaped(batch, length, heads, headDimension)
+        q = MiniMaxMusic3RotaryEmbedding.apply(
+            q,
+            cos: rotary.0,
+            sin: rotary.1,
+            dimensions: rotaryDimension
+        )
+        k = MiniMaxMusic3RotaryEmbedding.apply(
+            k,
+            cos: rotary.0,
+            sin: rotary.1,
+            dimensions: rotaryDimension
+        )
+        let attended = MLXFast.scaledDotProductAttention(
+            queries: q.transposed(0, 2, 1, 3).asType(.float32),
+            keys: k.transposed(0, 2, 1, 3).asType(.float32),
+            values: v.transposed(0, 2, 1, 3).asType(.float32),
+            scale: 1 / Float(headDimension).squareRoot(),
+            mask: .none
+        )
+        let merged = attended.asType(q.dtype).transposed(0, 2, 1, 3)
+            .reshaped(batch, length, -1)
+        return output[0](merged)
+    }
+
+    func prepareFusedProjections() {
+        guard !usesFusedProjections else { return }
+        let fused = MLX.concatenated([query.weight, key.weight, value.weight], axis: 0)
+        MLX.eval(fused)
+        update(modules: ModuleChildren.unflattened([
+            ("to_q", Linear(weight: fused, bias: nil)),
+            ("to_k", Linear(weight: MLXArray.zeros([1, 1], dtype: fused.dtype), bias: nil)),
+            ("to_v", Linear(weight: MLXArray.zeros([1, 1], dtype: fused.dtype), bias: nil)),
+        ]))
+        usesFusedProjections = true
     }
 }
 
@@ -124,6 +180,10 @@ final class MiniMaxMusic3TransformerBlock: Module {
         let attended = input + attention(norm1(input), rotary: rotary)
         let parts = MLX.split(feedForwardInput(norm2(attended)), parts: 2, axis: -1)
         return attended + feedForwardOutput(parts[0] * MLXNN.silu(parts[1]))
+    }
+
+    func prepareFusedProjections() {
+        attention.prepareFusedProjections()
     }
 }
 
@@ -192,6 +252,46 @@ public final class MiniMaxMusic3Transformer: Module {
         hidden = outputProjection(hidden[0..., 1..., 0...])
         let postprocessed = postprocessConvolution(hidden) + hidden
         return postprocessed.transposed(0, 2, 1)
+    }
+
+    func rotaryCache(
+        latentLength: Int,
+        dtype: DType
+    ) -> (MLXArray, MLXArray) {
+        MiniMaxMusic3RotaryEmbedding.cache(
+            length: latentLength + 1,
+            dimensions: configuration.rotaryDim,
+            theta: 10_000,
+            dtype: dtype
+        )
+    }
+
+    func callAsFunction(
+        latents: MLXArray,
+        timestep: MLXArray,
+        condition: MLXArray,
+        rotary: (MLXArray, MLXArray)
+    ) -> MLXArray {
+        let latentNLC = latents.transposed(0, 2, 1)
+        let zeros = MLXArray.zeros(latentNLC.shape, dtype: latentNLC.dtype)
+        var hidden = MLX.concatenated([latentNLC, zeros, condition], axis: -1)
+        hidden = preprocessConvolution(hidden) + hidden
+        hidden = inputProjection(hidden)
+        let time = timeEmbedding(timeProjection(timestep)).expandedDimensions(axis: 1)
+        hidden = MLX.concatenated([time, hidden], axis: 1)
+        for block in blocks {
+            hidden = block(hidden, rotary: rotary)
+        }
+        hidden = outputProjection(hidden[0..., 1..., 0...])
+        let postprocessed = postprocessConvolution(hidden) + hidden
+        return postprocessed.transposed(0, 2, 1)
+    }
+
+    public func prepareFusedProjections() {
+        for block in blocks {
+            block.prepareFusedProjections()
+        }
+        MLX.Memory.clearCache()
     }
 
     static func mapWeight(key: String, value: MLXArray) -> [(String, MLXArray)] {

--- a/Sources/MereRunCore/ZImageTurbo/Model/TextEncoder/TextEncoder+Blocks.swift
+++ b/Sources/MereRunCore/ZImageTurbo/Model/TextEncoder/TextEncoder+Blocks.swift
@@ -23,6 +23,8 @@ public final class QwenAttention: Module {
   @ModuleInfo(key: "q_norm") var qNorm: RMSNorm
   @ModuleInfo(key: "k_norm") var kNorm: RMSNorm
 
+  private var usesFusedProjections = false
+
   let rotaryEmb: Qwen3VLRotaryEmbedding?
   let legacyRotaryEmb: Qwen2VLRotaryEmbedding?
   let mropeSection: [Int]?
@@ -83,9 +85,25 @@ public final class QwenAttention: Module {
     let B = x.dim(0)
     let L = x.dim(1)
 
-    var queries = qProj(x)
-    var keys = kProj(x)
-    var values = vProj(x)
+    var queries: MLXArray
+    var keys: MLXArray
+    var values: MLXArray
+    if usesFusedProjections {
+      let queryRows = numAttentionHeads * headDim
+      let keyRows = numKeyValueHeads * headDim
+      let projections = MLX.split(
+        qProj(x),
+        indices: [queryRows, queryRows + keyRows],
+        axis: -1
+      )
+      queries = projections[0]
+      keys = projections[1]
+      values = projections[2]
+    } else {
+      queries = qProj(x)
+      keys = kProj(x)
+      values = vProj(x)
+    }
 
     if debug {
         eval(queries, keys, values)
@@ -191,12 +209,26 @@ public final class QwenAttention: Module {
     let shape = x.shape
     return expanded.reshaped(shape[0], shape[1] * repeats, shape[2], shape[3])
   }
+
+  func prepareFusedProjections() {
+    guard !usesFusedProjections else { return }
+    let fused = MLX.concatenated([qProj.weight, kProj.weight, vProj.weight], axis: 0)
+    MLX.eval(fused)
+    update(modules: ModuleChildren.unflattened([
+      ("q_proj", Linear(weight: fused, bias: nil)),
+      ("k_proj", Linear(weight: MLXArray.zeros([1, 1], dtype: fused.dtype), bias: nil)),
+      ("v_proj", Linear(weight: MLXArray.zeros([1, 1], dtype: fused.dtype), bias: nil)),
+    ]))
+    usesFusedProjections = true
+  }
 }
 
 public final class QwenMLP: Module {
   @ModuleInfo(key: "gate_proj") var gateProj: Linear
   @ModuleInfo(key: "down_proj") var downProj: Linear
   @ModuleInfo(key: "up_proj") var upProj: Linear
+
+  private var usesFusedProjections = false
 
   init(dimensions: Int, hiddenDimensions: Int) {
     self._gateProj.wrappedValue = Linear(dimensions, hiddenDimensions, bias: false)
@@ -209,8 +241,16 @@ public final class QwenMLP: Module {
         eval(x)
         print("[MLP] Input x: std=\(MLX.std(x.asType(.float32)).item(Float.self)), mean=\(MLX.mean(x.asType(.float32)).item(Float.self)), max=\(MLX.max(x).item(Float.self)), min=\(MLX.min(x).item(Float.self))")
     }
-    let gate = gateProj(x)
-    let up = upProj(x)
+    let gate: MLXArray
+    let up: MLXArray
+    if usesFusedProjections {
+      let parts = MLX.split(gateProj(x), parts: 2, axis: -1)
+      gate = parts[0]
+      up = parts[1]
+    } else {
+      gate = gateProj(x)
+      up = upProj(x)
+    }
     if debug {
         eval(gate, up)
         print("[MLP] gate dtype: \(gate.dtype), x dtype: \(x.dtype)")
@@ -234,6 +274,17 @@ public final class QwenMLP: Module {
         print("[MLP] After down_proj: std=\(MLX.std(out.asType(.float32)).item(Float.self))")
     }
     return out
+  }
+
+  func prepareFusedProjections() {
+    guard !usesFusedProjections else { return }
+    let fused = MLX.concatenated([gateProj.weight, upProj.weight], axis: 0)
+    MLX.eval(fused)
+    update(modules: ModuleChildren.unflattened([
+      ("gate_proj", Linear(weight: fused, bias: nil)),
+      ("up_proj", Linear(weight: MLXArray.zeros([1, 1], dtype: fused.dtype), bias: nil)),
+    ]))
+    usesFusedProjections = true
   }
 }
 
@@ -313,6 +364,14 @@ public final class QwenEncoder: Module {
     }
     self._norm.wrappedValue = RMSNorm(
       dimensions: configuration.hiddenSize, eps: configuration.rmsNormEps)
+  }
+
+  public func prepareFusedProjections() {
+    for layer in layers {
+      layer.selfAttention.prepareFusedProjections()
+      layer.mlp.prepareFusedProjections()
+    }
+    MLX.Memory.clearCache()
   }
 
   public func callAsFunction(

--- a/Tests/MereRunCLITests/MusicGenerateCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/MusicGenerateCommandParsingTests.swift
@@ -78,23 +78,77 @@ final class MusicGenerateCommandParsingTests: XCTestCase {
             "--model", MiniMaxMusic3Resources.modelID,
             "--lyrics", "[verse]\nwe glow",
             "--duration", "30",
+            "--minimum-duration", "20",
+            "--min-frames", "500",
             "--max-frames", "750",
             "--steps", "24",
             "--seed", "7",
             "--guidance-scale", "1.7",
             "--sample-rate", "32000",
             "--memory-mode", "staged",
+            "--performance-mode", "q8",
         ])
 
         XCTAssertEqual(command.model, MiniMaxMusic3Resources.modelID)
         XCTAssertEqual(command.lyrics, "[verse]\nwe glow")
         XCTAssertEqual(command.durationSeconds, 30)
+        XCTAssertEqual(command.miniMaxMinimumDurationSeconds, 20)
+        XCTAssertEqual(command.miniMaxMinimumFrames, 500)
         XCTAssertEqual(command.miniMaxMaximumFrames, 750)
         XCTAssertEqual(command.steps, 24)
         XCTAssertEqual(command.seed, 7)
         XCTAssertEqual(command.guidanceScale, 1.7)
         XCTAssertEqual(command.miniMaxOutputSampleRate, 32_000)
         XCTAssertEqual(command.miniMaxLoadingStrategy, .staged)
+        XCTAssertEqual(command.miniMaxPerformanceMode, .q8)
+    }
+
+    func testMiniMaxValidatesDurationFloorAgainstUpperBound() throws {
+        let valid = try MusicGenerate.parse([
+            "deep house",
+            "--model", MiniMaxMusic3Resources.modelID,
+            "--instrumental",
+            "--duration", "30",
+            "--minimum-duration", "20",
+        ])
+        XCTAssertNoThrow(
+            try valid.validateMiniMaxMusic3Options(explicitDurationSeconds: 30)
+        )
+
+        let hopRounded = try MusicGenerate.parse([
+            "deep house",
+            "--model", MiniMaxMusic3Resources.modelID,
+            "--instrumental",
+            "--duration", "10",
+            "--minimum-duration", "10",
+        ])
+        XCTAssertNoThrow(
+            try hopRounded.validateMiniMaxMusic3Options(explicitDurationSeconds: 10)
+        )
+
+        let invalid = try MusicGenerate.parse([
+            "deep house",
+            "--model", MiniMaxMusic3Resources.modelID,
+            "--instrumental",
+            "--duration", "10",
+            "--minimum-duration", "20",
+        ])
+        XCTAssertThrowsError(
+            try invalid.validateMiniMaxMusic3Options(explicitDurationSeconds: 10)
+        )
+
+        let beyondHopLimitedMaximum = try MusicGenerate.parse([
+            "deep house",
+            "--model", MiniMaxMusic3Resources.modelID,
+            "--instrumental",
+            "--duration", "360",
+            "--minimum-duration", "360",
+        ])
+        XCTAssertThrowsError(
+            try beyondHopLimitedMaximum.validateMiniMaxMusic3Options(
+                explicitDurationSeconds: 360
+            )
+        )
     }
 
     func testMiniMaxRejectsSharedControlsInsteadOfIgnoringThem() throws {

--- a/Tests/MereRunCLITests/MusicServeAndExportTests.swift
+++ b/Tests/MereRunCLITests/MusicServeAndExportTests.swift
@@ -33,11 +33,13 @@ final class MusicServeAndExportTests: XCTestCase {
         let command = try MusicServe.parse([
             "--model", MiniMaxMusic3Resources.modelID,
             "--memory-mode", "resident",
+            "--performance-mode", "q4",
             "--port", "8091",
         ])
 
         XCTAssertEqual(command.model, MiniMaxMusic3Resources.modelID)
         XCTAssertEqual(command.miniMaxLoadingStrategy, .resident)
+        XCTAssertEqual(command.miniMaxPerformanceMode, .q4)
         XCTAssertEqual(command.port, 8_091)
     }
 
@@ -53,8 +55,10 @@ final class MusicServeAndExportTests: XCTestCase {
                   "response_format": "wav",
                   "seed": 7,
                   "max_new_tokens": 750,
+                  "min_new_tokens": 500,
                   "stream": false,
                   "audio_duration": 30,
+                  "minimum_audio_duration": 20,
                   "num_inference_steps": 24,
                   "guidance_scale": 1.7,
                   "sample_rate": 44100
@@ -64,7 +68,9 @@ final class MusicServeAndExportTests: XCTestCase {
         )
 
         XCTAssertEqual(request.maxNewTokens, 750)
+        XCTAssertEqual(request.minNewTokens, 500)
         XCTAssertEqual(request.audioDuration, 30)
+        XCTAssertEqual(request.minimumAudioDuration, 20)
         XCTAssertEqual(request.numInferenceSteps, 24)
         XCTAssertEqual(request.guidanceScale, 1.7)
         XCTAssertEqual(request.sampleRate, 44_100)

--- a/Tests/MereRunCoreTests/MiniMaxMusic3Tests.swift
+++ b/Tests/MereRunCoreTests/MiniMaxMusic3Tests.swift
@@ -3,6 +3,82 @@ import XCTest
 @testable import MereRunCore
 
 final class MiniMaxMusic3Tests: MereRunCoreTestCase {
+    func testInstalledQuantizedSemanticLogitQuality() throws {
+        let environment = ProcessInfo.processInfo.environment
+        guard environment["MERERUN_MINIMAX_MUSIC3_QUANTIZATION_E2E"] == "1",
+              let root = environment["MERERUN_MINIMAX_MUSIC3_MODEL_ROOT"]
+        else {
+            throw XCTSkip("set the MiniMax Music 3 model root and quantization E2E flag")
+        }
+        let resources = MiniMaxMusic3Resources(rootURL: URL(fileURLWithPath: root))
+        let prompt = MiniMaxMusic3Prompt.assemble(
+            caption: "128 BPM progressive deep house, rubbery sub bass, shuffled hats, glassy minor-seventh stabs.",
+            lyrics: "[Instrumental]"
+        )
+
+        func semanticLogits(_ mode: MiniMaxMusic3PerformanceMode) throws -> [Float] {
+            let models = try MiniMaxMusic3ModelLoader.loadAutoregressive(
+                from: resources,
+                performanceMode: mode
+            )
+            let conditional = models.tokenizer.encode(prompt, addSpecialTokens: false)
+            var unconditional = conditional
+            for index in 1..<(unconditional.count - 2) {
+                unconditional[index] = MiniMaxMusic3Prompt.audioCFGTokenID
+            }
+            let ids = MLXArray((conditional + unconditional).map(Int32.init))
+                .reshaped(2, conditional.count)
+            let hidden = models.languageModel.hidden(
+                embeddings: models.languageModel.embed(tokenIDs: ids),
+                cache: models.languageModel.makeCache(),
+                lastPositionOnly: true
+            ).squeezed(axis: 1)
+            let logits = models.languageModel.logits(hidden).asType(.float32)
+            MLX.eval(logits)
+            return logits.asArray(Float.self)
+        }
+
+        let reference = try semanticLogits(.optimized)
+        MLX.Memory.clearCache()
+        let q8 = try semanticLogits(.q8)
+        MLX.Memory.clearCache()
+        let q4 = try semanticLogits(.q4)
+        MLX.Memory.clearCache()
+
+        func cosine(_ lhs: [Float], _ rhs: [Float]) -> Double {
+            var dot = 0.0
+            var lhsSquared = 0.0
+            var rhsSquared = 0.0
+            for (left, right) in zip(lhs, rhs) {
+                let left = Double(left)
+                let right = Double(right)
+                dot += left * right
+                lhsSquared += left * left
+                rhsSquared += right * right
+            }
+            return dot / (lhsSquared.squareRoot() * rhsSquared.squareRoot())
+        }
+
+        func topIndices(_ values: [Float], count: Int) -> Set<Int> {
+            Set(values.indices.sorted { values[$0] > values[$1] }.prefix(count))
+        }
+
+        let referenceTop = topIndices(reference, count: 100)
+        let q8Cosine = cosine(reference, q8)
+        let q4Cosine = cosine(reference, q4)
+        let q8Overlap = referenceTop.intersection(topIndices(q8, count: 100)).count
+        let q4Overlap = referenceTop.intersection(topIndices(q4, count: 100)).count
+        print(
+            "[minimax-music3-q] q8 cosine=\(q8Cosine) top100=\(q8Overlap) "
+                + "q4 cosine=\(q4Cosine) top100=\(q4Overlap)"
+        )
+
+        XCTAssertGreaterThan(q8Cosine, 0.95)
+        XCTAssertGreaterThanOrEqual(q8Overlap, 80)
+        XCTAssertGreaterThan(q4Cosine, 0.80)
+        XCTAssertGreaterThanOrEqual(q4Overlap, 50)
+    }
+
     func testInstalledStagedAndResidentGenerationAreSeedEquivalent() throws {
         let environment = ProcessInfo.processInfo.environment
         guard environment["MERERUN_MINIMAX_MUSIC3_E2E"] == "1",
@@ -353,6 +429,13 @@ final class MiniMaxMusic3Tests: MereRunCoreTestCase {
         XCTAssertEqual(MiniMaxMusic3Prompt.chunkStarts(frameCount: 300), [0, 100])
         XCTAssertEqual(MiniMaxMusic3Prompt.latentLength(frameCount: 200), 689)
         XCTAssertEqual(MiniMaxMusic3Prompt.latentLength(frameCount: 100), 344)
+        XCTAssertEqual(MiniMaxMusic3Prompt.decodedSampleCount(frameCount: 250), 440_832)
+        XCTAssertEqual(MiniMaxMusic3Prompt.minimumFrameCount(forDurationSeconds: 10), 251)
+        XCTAssertLessThan(MiniMaxMusic3Prompt.decodedSampleCount(frameCount: 250), 441_000)
+        XCTAssertGreaterThanOrEqual(
+            MiniMaxMusic3Prompt.decodedSampleCount(frameCount: 251),
+            441_000
+        )
     }
 
     func testConditionEncoderProducesLatentAlignedShape() {
@@ -388,6 +471,51 @@ final class MiniMaxMusic3Tests: MereRunCoreTestCase {
         XCTAssertEqual(model.logits(output[0..., -1, 0...], codebookIndex: 0).shape, [2, 16])
     }
 
+    func testDepthDecoderIncrementalCacheMatchesFullPrefix() {
+        let configuration = MiniMaxMusic3DepthConfiguration(
+            hiddenSize: 8,
+            numLayers: 2,
+            numAttentionHeads: 2,
+            intermediateSize: 16,
+            audioVocabSize: 16,
+            numCodebooks: 4,
+            maxPositionEmbeddings: 8
+        )
+        let model = MiniMaxMusic3DepthDecoder(configuration: configuration)
+        let input = MLXArray((0..<(2 * 5 * 8)).map { Float($0) / 100 }).reshaped(2, 5, 8)
+        let full = model(input)
+        let cache = model.makeCache()
+        let prefix = model(input[0..., 0..<2, 0...], cache: cache)
+        let third = model(input[0..., 2..<3, 0...], cache: cache)
+        let fourth = model(input[0..., 3..<4, 0...], cache: cache)
+        let fifth = model(input[0..., 4..<5, 0...], cache: cache)
+        let incremental = MLX.concatenated([prefix, third, fourth, fifth], axis: 1)
+        MLX.eval(full, incremental)
+
+        XCTAssertTrue(MLX.allClose(full, incremental, rtol: 1e-5, atol: 1e-5).item(Bool.self))
+    }
+
+    func testDepthDecoderFusedProjectionsMatchSeparateProjections() {
+        let configuration = MiniMaxMusic3DepthConfiguration(
+            hiddenSize: 8,
+            numLayers: 2,
+            numAttentionHeads: 2,
+            intermediateSize: 16,
+            audioVocabSize: 16,
+            numCodebooks: 4,
+            maxPositionEmbeddings: 8
+        )
+        let model = MiniMaxMusic3DepthDecoder(configuration: configuration)
+        let input = MLXArray((0..<(2 * 5 * 8)).map { Float($0) / 100 }).reshaped(2, 5, 8)
+        let separate = model(input)
+        MLX.eval(separate)
+        model.prepareFusedProjections()
+        let fused = model(input)
+        MLX.eval(fused)
+
+        XCTAssertTrue(MLX.allClose(separate, fused, rtol: 1e-5, atol: 1e-5).item(Bool.self))
+    }
+
     func testFlowTransformerTinyConfigurationPreservesLatentShape() {
         let configuration = MiniMaxMusic3TransformerConfiguration(
             inChannels: 2,
@@ -407,6 +535,128 @@ final class MiniMaxMusic3Tests: MereRunCoreTestCase {
         )
         MLX.eval(output)
         XCTAssertEqual(output.shape, [1, 2, 7])
+    }
+
+    func testFlowTransformerBatchedGuidanceMatchesSerialPasses() {
+        let configuration = MiniMaxMusic3TransformerConfiguration(
+            inChannels: 2,
+            conditionDim: 4,
+            numLayers: 1,
+            numAttentionHeads: 2,
+            attentionHeadDim: 4,
+            ffInnerDim: 16,
+            rotaryDim: 2,
+            fourierEmbeddingDim: 4
+        )
+        let model = MiniMaxMusic3Transformer(configuration: configuration)
+        let latents = MLXArray((0..<(2 * 7)).map { Float($0) / 20 }).reshaped(1, 2, 7)
+        let condition = MLXArray((0..<(7 * 4)).map { Float($0) / 30 }).reshaped(1, 7, 4)
+        let zeros = MLXArray.zeros(condition.shape)
+        let timestep = MLXArray([Float(0.5)])
+        let rotary = model.rotaryCache(latentLength: 7, dtype: condition.dtype)
+        let conditional = model(
+            latents: latents,
+            timestep: timestep,
+            condition: condition,
+            rotary: rotary
+        )
+        let unconditional = model(
+            latents: latents,
+            timestep: timestep,
+            condition: zeros,
+            rotary: rotary
+        )
+        let batched = model(
+            latents: MLX.concatenated([latents, latents], axis: 0),
+            timestep: MLX.repeated(timestep, count: 2, axis: 0),
+            condition: MLX.concatenated([condition, zeros], axis: 0),
+            rotary: rotary
+        )
+        MLX.eval(conditional, unconditional, batched)
+
+        XCTAssertTrue(
+            MLX.allClose(conditional, batched[0..<1], rtol: 1e-5, atol: 1e-5).item(Bool.self)
+        )
+        XCTAssertTrue(
+            MLX.allClose(unconditional, batched[1..<2], rtol: 1e-5, atol: 1e-5).item(Bool.self)
+        )
+
+        model.prepareFusedProjections()
+        let fused = model(
+            latents: MLX.concatenated([latents, latents], axis: 0),
+            timestep: MLX.repeated(timestep, count: 2, axis: 0),
+            condition: MLX.concatenated([condition, zeros], axis: 0),
+            rotary: rotary
+        )
+        MLX.eval(fused)
+        XCTAssertTrue(MLX.allClose(batched, fused, rtol: 1e-5, atol: 1e-5).item(Bool.self))
+    }
+
+    func testLanguageModelFusedProjectionsMatchSeparateProjections() {
+        let configuration = MiniMaxMusic3LanguageConfiguration(
+            vocabSize: 32,
+            hiddenSize: 8,
+            intermediateSize: 16,
+            numHiddenLayers: 2,
+            numAttentionHeads: 2,
+            numKeyValueHeads: 1,
+            headDim: 4,
+            maxPositionEmbeddings: 16,
+            rmsNormEps: 1e-6,
+            ropeParameters: .init(ropeTheta: 10_000)
+        )
+        let model = MiniMaxMusic3LanguageModel(configuration: configuration)
+        let embeddings = model.embed(tokenIDs: MLXArray([Int32(1), 2, 3]).reshaped(1, 3))
+        let separate = model.hidden(
+            embeddings: embeddings,
+            cache: model.makeCache(),
+            lastPositionOnly: false
+        )
+        MLX.eval(separate)
+        model.prepareFusedProjections()
+        let fused = model.hidden(
+            embeddings: embeddings,
+            cache: model.makeCache(),
+            lastPositionOnly: false
+        )
+        MLX.eval(fused)
+
+        XCTAssertTrue(MLX.allClose(separate, fused, rtol: 1e-5, atol: 1e-5).item(Bool.self))
+    }
+
+    func testCompactSemanticHeadMatchesReachableFullVocabularyRows() {
+        let configuration = MiniMaxMusic3LanguageConfiguration(
+            vocabSize: MiniMaxMusic3Prompt.audioCodeOffset
+                + MiniMaxMusic3Prompt.semanticVocabularySize + 8,
+            hiddenSize: 8,
+            intermediateSize: 16,
+            numHiddenLayers: 1,
+            numAttentionHeads: 2,
+            numKeyValueHeads: 1,
+            headDim: 4,
+            maxPositionEmbeddings: 16,
+            rmsNormEps: 1e-6,
+            ropeParameters: .init(ropeTheta: 10_000)
+        )
+        let model = MiniMaxMusic3LanguageModel(configuration: configuration)
+        let hidden = MLXArray((0..<16).map { Float($0) / 10 }).reshaped(2, 8)
+        let full = model.logits(hidden)
+        let semanticEnd = MiniMaxMusic3Prompt.audioCodeOffset
+            + MiniMaxMusic3Prompt.semanticVocabularySize
+        let expected = MLX.concatenated(
+            [
+                full[0..., MiniMaxMusic3Prompt.audioEndTokenID..<(MiniMaxMusic3Prompt.audioEndTokenID + 1)],
+                full[0..., MiniMaxMusic3Prompt.audioCodeOffset..<semanticEnd],
+            ],
+            axis: -1
+        )
+        model.prepareCompactSemanticHead()
+        let compact = model.logits(hidden)
+        MLX.eval(expected, compact)
+
+        XCTAssertTrue(model.usesCompactSemanticHead)
+        XCTAssertEqual(compact.shape, [2, MiniMaxMusic3Prompt.semanticVocabularySize + 1])
+        XCTAssertTrue(MLX.allClose(expected, compact, rtol: 1e-5, atol: 1e-5).item(Bool.self))
     }
 
     func testSemanticTopKIgnoresTextVocabularyLogits() {
@@ -430,6 +680,28 @@ final class MiniMaxMusic3Tests: MereRunCoreTestCase {
 
         XCTAssertTrue(guided[0, MiniMaxMusic3Prompt.audioCodeOffset].item(Float.self).isFinite)
         XCTAssertFalse(guided[0, 0].item(Float.self).isFinite)
+    }
+
+    func testSemanticEndTokenCanBeMaskedUntilDurationFloor() {
+        var values = [Float](
+            repeating: -10,
+            count: 2 * (MiniMaxMusic3Prompt.semanticVocabularySize + 1)
+        )
+        values[0] = 100
+        values[MiniMaxMusic3Prompt.semanticVocabularySize + 1] = 100
+        values[1] = 10
+        values[MiniMaxMusic3Prompt.semanticVocabularySize + 2] = 10
+        let logits = MLXArray(values).reshaped(
+            2,
+            MiniMaxMusic3Prompt.semanticVocabularySize + 1
+        )
+        let masked = MiniMaxMusic3Pipeline.guidedSemanticLogits(logits, allowEnd: false)
+        let allowed = MiniMaxMusic3Pipeline.guidedSemanticLogits(logits, allowEnd: true)
+        MLX.eval(masked, allowed)
+
+        XCTAssertFalse(masked[0, 0].item(Float.self).isFinite)
+        XCTAssertTrue(masked[0, 1].item(Float.self).isFinite)
+        XCTAssertTrue(allowed[0, 0].item(Float.self).isFinite)
     }
 
     func testManagedCatalogPinsSelectiveRestrictedSnapshot() throws {

--- a/docs/benchmarks/minimax-music3-m4-max.md
+++ b/docs/benchmarks/minimax-music3-m4-max.md
@@ -1,0 +1,109 @@
+# MiniMax Music 3 on M4 Max
+
+This receipt records installed-checkpoint MiniMax Music 3 performance work on a
+16-core CPU / 40-core GPU M4 Max MacBook Pro with 128 GB unified memory. Tests
+used the immutable managed `MiniMaxAI/MiniMax-Music3` snapshot, staged loading,
+44.1 kHz stereo PCM24 export, seed 37, guidance 1.7, and 30 flow steps unless a
+row says otherwise.
+
+## Matched 250-frame result
+
+| Runtime | Wall time | Max resident | Relative speed |
+| --- | ---: | ---: | ---: |
+| mere.run 0.37.0 reference | 143.29 s | 18.67 GB | 1.00x |
+| optimized BF16 | 105.46 s | 7.14 GB | 1.36x |
+| Q8 autoregressive turbo | 52.66 s | 4.36 GB | 2.72x |
+| Q4 autoregressive turbo | 51.40 s | 3.19 GB | 2.79x |
+
+Q8 is the recommended turbo tier. Its first-step installed-checkpoint semantic
+logits measured cosine similarity 0.99985 and retained 98 of the BF16 top 100
+candidates. Q4 measured 0.99166 and retained 80 of 100; its small additional
+speedup comes with a larger sampling-distribution change.
+
+The BF16 optimized graph uses a 16,385-row reachable semantic head instead of
+projecting the full 200,000-token vocabulary at every 25 Hz frame, fused QKV
+and gate/up projections, incremental residual-depth KV caches, cached rotary
+and zero conditioning, batched conditional/unconditional flow evaluation, and
+fewer forced graph evaluations. `--performance-mode reference` preserves the
+released graph for parity investigations.
+
+The finished reference path was also rendered from the optimized release
+binary and compared with a clean 0.37.0 build. Both 250-frame PCM24 files had
+the identical SHA-256
+`6aee35f704ae5621f3bbc9b4b2ec04080931f8ec4a7db1e9099cf4ac4aaf5890`.
+This comparison covers the seeded autoregressive trajectory, serial flow
+guidance, vocoder, normalization, fade, and deterministic dither—not only
+isolated tensor fixtures.
+
+## Rejected experiments
+
+- Whole-flow MLX compilation was waveform-identical but took 37.92 s versus
+  35.63 s eager on a 100-frame, one-chunk, 30-step run: a 6.4% regression.
+- Affine Q8 flow weights retained 0.99941 cosine on a fixed transformer fixture
+  but increased a 251-frame end-to-end run to 60.10 s and did not reduce the
+  run's peak resident memory. The production turbo modes therefore keep flow
+  BF16.
+- Serial flow CFG took 18.43 s versus 17.38 s for batched CFG on a matched
+  100-frame, one-chunk, 30-step Q8 run. Batched CFG stays as the default.
+
+## Duration-floor correction
+
+The model emits semantic frames at 25 Hz, but the vocoder emits whole
+512-sample hops. At 44.1 kHz, 250 semantic frames decode to 440,832 samples, or
+9.99619 seconds. A requested 10-second minimum now selects 251 frames and
+decodes to 10.04263 seconds. This is why second-based floors must not use only
+`duration * 25` truncation.
+
+Long-form Q8 floor runs from the same release binary confirm both the corrected
+duration contract and approximately linear scaling:
+
+| Requested minimum | Frames / flow chunks | Wall time | Max resident | Peak footprint | Decoded duration |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| 60 s | 1,501 / 15 | 457.54 s | 4.30 GB | 19.19 GB | 60.10485 s |
+| 180 s | 4,501 / 45 | 1,413.81 s | 4.50 GB | 41.64 GB | 180.26812 s |
+
+The 180-second receipt used native 44.1 kHz stereo PCM24 export. Its audio
+SHA-256 was
+`03726d0e39b0d6b36184d28862818a183cc80fddf1b5c7488bc81066a069289b`.
+
+## Physical limit
+
+The autoregressive stack emits one semantic frame plus seven residual codes per
+25 Hz output frame. It is serial across time, so a three-minute song requires
+at least 4,501 semantic iterations when a strict decoded-duration floor is
+requested. No kernel can parallelize those dependent iterations without
+changing the model.
+
+The original BF16 8B semantic stack is primarily memory-bandwidth bound. An
+idealized 26.2 GB of BF16 parameter traffic per output frame against the
+[M4 Max's 546 GB/s memory bandwidth](https://www.apple.com/macbook-pro/specs/)
+is already about 48 ms per frame before KV traffic, sampling, depth decode,
+synchronization, or flow matching. Q8 reduces the dominant autoregressive
+parameter traffic, after which the unquantized 4.86B flow transformer and its
+30 serial Euler evaluations per chunk become the main tail. Long-song latency
+therefore remains approximately linear in semantic frames and overlapping flow
+chunks even after launch overhead is reduced.
+
+## Reproduction
+
+```bash
+/usr/bin/time -lp mere.run music generate \
+  "128 BPM progressive deep-house instrumental, rubbery sub bass, shuffled hats, glassy minor-seventh stabs, hypnotic analog lead, polished club mix" \
+  --model music-minimax-music3 \
+  --instrumental \
+  --duration 10 \
+  --max-frames 250 \
+  --steps 30 \
+  --seed 37 \
+  --guidance-scale 1.7 \
+  --memory-mode staged \
+  --performance-mode q8 \
+  --sample-rate 44100 \
+  --export-format pcm24 \
+  --normalize peak \
+  --target-peak-db=-1.0 \
+  --output /tmp/minimax-music3-q8-10s.wav
+```
+
+Use `--minimum-duration 10` without `--max-frames` to benchmark the strict
+decoded-duration floor instead; that intentionally generates 251 frames.

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -713,6 +713,14 @@ upstream 1...9,000-frame contract directly, while `--duration` converts seconds
 at 25 Hz. The model card describes supported-quality generation through five
 minutes; 9,000 frames is the six-minute runtime hard limit.
 
+`--minimum-duration` and `--min-frames` add an EOS floor; duration floors round
+up across the vocoder's whole 512-sample hops so the decoded WAV does not
+undershoot. `--performance-mode optimized` is the BF16 default and uses compact
+semantic logits, fused projections, incremental depth caches, and batched flow
+guidance. The opt-in `q8` and `q4` modes apply group-64 affine quantization to
+the autoregressive transformers; `q8` is the recommended turbo tier. Flow stays
+BF16 because installed-checkpoint timing showed its quantized kernels regress.
+
 Generation defaults to `--memory-mode staged`, which releases the language,
 flow, and vocoder weights between stages. `--memory-mode resident` keeps the
 entire stack loaded for repeated work. Staged mode moves the catalog floor to

--- a/docs/runtime/music.md
+++ b/docs/runtime/music.md
@@ -87,14 +87,17 @@ swift run mere.run music generate \
   --model music-minimax-music3 \
   --lyrics-file ./lyrics.txt \
   --duration 30 \
+  --minimum-duration 30 \
   --steps 30 \
   --seed 7 \
   --memory-mode staged \
+  --performance-mode q8 \
   --output ./minimax-song.wav
 
 swift run mere.run music serve \
   --model music-minimax-music3 \
   --memory-mode resident \
+  --performance-mode q8 \
   --port 8080
 
 curl http://127.0.0.1:8080/v1/audio/speech \


### PR DESCRIPTION
## What changed

- optimize the native MiniMax Music 3 BF16 graph with a reachable 16,385-row semantic head, fused QKV and gate/up projections, incremental residual-depth KV caches, cached rotary and zero conditioning, batched flow CFG, and fewer forced evaluations
- add explicit `reference`, `optimized`, `q8`, and `q4` performance modes; optimized BF16 remains the default and Q8/Q4 quantize only the autoregressive language/depth stack
- add strict `--minimum-duration` / `--min-frames` controls plus matching speech API fields and schema-3 recipe metadata
- correct second-based duration floors for whole 512-sample vocoder hops
- document the controls, benchmark method, rejected experiments, and measured physical limit

## Why

The released graph preserved upstream behavior but left substantial Apple Silicon performance unused:

- the 25 Hz sampler projected a 200,000-token vocabulary even though only EOS plus 16,384 semantic codes are reachable
- attention and feed-forward projections launched separately
- residual depth decoding recomputed the full prefix for each codebook
- flow CFG repeated serial conditional/unconditional passes and rebuilt invariant tensors
- `duration * 25` could decode slightly short because the vocoder emits whole hops

The reference path retains the released operation ordering for exact recovery and A/B work.

## Measured impact

Matched 250-frame, 30-step staged runs on an M4 Max:

| Mode | Wall time | Speedup | Max resident |
| --- | ---: | ---: | ---: |
| 0.37.0 reference | 143.29 s | 1.00x | 18.67 GB |
| optimized BF16 | 105.46 s | 1.36x | 7.14 GB |
| Q8 turbo | 52.66 s | 2.72x | 4.36 GB |
| Q4 turbo | 51.40 s | 2.79x | 3.19 GB |

Installed-checkpoint semantic-logit gates:

- Q8: cosine 0.9998546, top-100 overlap 98/100
- Q4: cosine 0.9916618, top-100 overlap 80/100

A strict 180-second Q8 render completed in 1,413.81 seconds, used 4.50 GB maximum resident memory, and decoded to 180.268 seconds. A strict 60-second render decoded to 60.105 seconds.

The finished `reference` path produced a byte-identical 250-frame PCM24 render against clean 0.37.0: SHA-256 `6aee35f704ae5621f3bbc9b4b2ec04080931f8ec4a7db1e9099cf4ac4aaf5890`.

Whole-flow compilation, flow-weight quantization, and serial CFG were benchmarked and rejected because they regressed end-to-end performance. Flow therefore remains BF16.

## Validation

- `./scripts/check.sh` after rebasing onto current `origin/main`
- 2,823 XCTest cases: 0 failures, 206 checkpoint-gated skips
- 28 Swift Testing cases: passed
- strict SwiftLint, build, CLI help sweep, and hygiene scans: passed
- release `mere.run` product build: passed
- installed-checkpoint Q8/Q4 quality gate on Metal: passed
- exact reference waveform parity against clean 0.37.0: passed
- 10/60/180-second real model renders and WAV/recipe checksum validation: passed
