### PR TITLE
Speed up pull request checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,16 +2,78 @@ name: ci
 
 on:
   push:
+    branches: [main]
   pull_request:
 
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
-  swift:
-    runs-on: macos-26
+  changes:
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
     steps:
       - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Detect changes that require native builds
+        id: filter
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD_SHA: ${{ github.sha }}
+        run: |
+          set -euo pipefail
+
+          code_required=true
+          if [[ -n "$BASE_SHA" && ! "$BASE_SHA" =~ ^0+$ ]] \
+              && git cat-file -e "${BASE_SHA}^{commit}"; then
+            mapfile -t changed_files < <(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
+            if (( ${#changed_files[@]} > 0 )); then
+              code_required=false
+              for path in "${changed_files[@]}"; do
+                case "$path" in
+                  docs/*|README.md|CHANGELOG.md|CODEBASE.md|CONTRIBUTING.md|SECURITY.md|LICENSE|package.json|pnpm-lock.yaml|pnpm-workspace.yaml|.github/workflows/docs.yml)
+                    ;;
+                  *)
+                    code_required=true
+                    break
+                    ;;
+                esac
+              done
+            fi
+          fi
+
+          echo "code=$code_required" >>"$GITHUB_OUTPUT"
+          printf 'Native builds required: %s\n' "$code_required"
+
+  swift:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: macos-26
+    env:
+      MERERUN_SWIFT_DISABLE_INDEX_STORE: '1'
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: '26.4'
+      - name: Restore SwiftPM dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/Library/Caches/org.swift.swiftpm
+            .build/artifacts
+            .build/checkouts
+            .build/repositories
+          key: swiftpm-${{ runner.os }}-${{ runner.arch }}-xcode-26.4-${{ hashFiles('Package.swift', 'Package.resolved') }}
       - name: Install check dependencies
         run: |
           # macos-26 currently carries an untrusted aws/tap that causes every
@@ -20,20 +82,12 @@ jobs:
           brew install swiftlint ripgrep
       - name: Run package checks
         run: ./scripts/check.sh
-
-  macos-app-bundle:
-    runs-on: macos-26
-    steps:
-      - uses: actions/checkout@v7
-      - uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: '26.4'
       - name: Build app bundle (ad-hoc)
         run: ./scripts/build_mere_run_app.sh debug
       - name: Verify bundle structure
         run: |
           set -euo pipefail
-          bundle="$(swift build --show-bin-path)/MereRun.app"
+          bundle="$(swift build --disable-index-store --show-bin-path)/MereRun.app"
           test -x "${bundle}/Contents/MacOS/mere.run.app"
           test -x "${bundle}/Contents/Helpers/mere.run"
           find "${bundle}/Contents/Helpers" -maxdepth 1 -name 'libonnxruntime*.dylib' -print -quit | grep -q .
@@ -53,10 +107,52 @@ jobs:
             | grep -q 'com.apple.security.device.audio-input'
           codesign --verify --strict --verbose=2 "$bundle"
 
-  linux-cli-compatibility-docs:
+  # Keep the existing protected-check context while the real bundle build and
+  # verification share the warm SwiftPM build directory in the swift job.
+  macos-app-bundle:
+    needs: [changes, swift]
+    if: always()
     runs-on: ubuntu-latest
     steps:
+      - name: Verify macOS bundle gate
+        env:
+          CHANGE_DETECTION_RESULT: ${{ needs.changes.result }}
+          CODE_REQUIRED: ${{ needs.changes.outputs.code }}
+          SWIFT_RESULT: ${{ needs.swift.result }}
+        run: |
+          set -euo pipefail
+
+          if [[ "$CHANGE_DETECTION_RESULT" != "success" ]]; then
+            echo "Change detection did not succeed: $CHANGE_DETECTION_RESULT" >&2
+            exit 1
+          fi
+          if [[ "$CODE_REQUIRED" == "true" && "$SWIFT_RESULT" != "success" ]]; then
+            echo "macOS package and bundle checks did not succeed: $SWIFT_RESULT" >&2
+            exit 1
+          fi
+          if [[ "$CODE_REQUIRED" != "true" && "$CODE_REQUIRED" != "false" ]]; then
+            echo "Change detection returned an invalid code result: $CODE_REQUIRED" >&2
+            exit 1
+          fi
+
+          echo "macOS bundle gate satisfied (code required: $CODE_REQUIRED; swift: $SWIFT_RESULT)."
+
+  linux-cli-compatibility-docs:
+    needs: changes
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - name: Verify change detection
+        env:
+          CHANGE_DETECTION_RESULT: ${{ needs.changes.result }}
+        run: |
+          if [[ "$CHANGE_DETECTION_RESULT" != "success" ]]; then
+            echo "Change detection did not succeed: $CHANGE_DETECTION_RESULT" >&2
+            exit 1
+          fi
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Verify Linux CLI compatibility documentation
         run: |
           set -euo pipefail
@@ -69,10 +165,14 @@ jobs:
           grep -R "macOS-only" README.md docs/getting-started.md docs/repository-tour.md docs/internals/source-layout.md >/dev/null
 
   linux-cli:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-22.04
     container: swift:6.0-jammy
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Install Linux check dependencies
         run: |
           apt-get update
@@ -94,6 +194,16 @@ jobs:
             ripgrep \
             unzip \
             zip \
-            zlib1g-dev
+            zlib1g-dev \
+            zstd
+      - name: Restore SwiftPM and Linux native dependencies
+        uses: actions/cache@v4
+        with:
+          path: |
+            .build/artifacts
+            .build/checkouts
+            .build/native/linux-x86_64
+            .build/repositories
+          key: swiftpm-${{ runner.os }}-${{ runner.arch }}-swift-6.0-${{ hashFiles('Package.swift', 'Package.resolved', 'scripts/prepare-linux-native.sh', 'scripts/linux-arm64-bf16-toolchain.sh') }}
       - name: Run Linux CLI compatibility gate
         run: ./scripts/check-linux.sh

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,8 +24,8 @@ permissions:
   contents: read
 
 concurrency:
-  group: docs-pages
-  cancel-in-progress: false
+  group: docs-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   build:

--- a/scripts/build_mere_run_app.sh
+++ b/scripts/build_mere_run_app.sh
@@ -39,6 +39,11 @@ fi
 swift_app_args=(build --product mere.run.app)
 swift_cli_args=(build --product mere.run)
 swift_bin_path_args=(build --show-bin-path)
+if [[ "${MERERUN_SWIFT_DISABLE_INDEX_STORE:-0}" == "1" ]]; then
+  swift_app_args+=(--disable-index-store)
+  swift_cli_args+=(--disable-index-store)
+  swift_bin_path_args+=(--disable-index-store)
+fi
 if [[ "$configuration" == "release" ]]; then
   swift_app_args+=(--configuration release)
   swift_cli_args+=(--configuration release)

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -34,10 +34,20 @@ fi
 
 swiftlint --strict --cache-path .build/swiftlint.cache
 bash ./scripts/agent_readiness_check.sh
-swift build
+swiftpm() {
+  local subcommand="$1"
+  shift
+  if [[ "${MERERUN_SWIFT_DISABLE_INDEX_STORE:-0}" == "1" ]]; then
+    swift "$subcommand" --disable-index-store "$@"
+  else
+    swift "$subcommand" "$@"
+  fi
+}
+
+swiftpm build
 ./scripts/build_mlx_metallib.sh \
   --verify-only vendor/mlx-swift_Cmlx.bundle
-swift test
+swiftpm test
 mere_run_bin=".build/debug/mere.run"
 if [[ ! -x "$mere_run_bin" ]]; then
   echo "Expected built executable at $mere_run_bin after swift build." >&2


### PR DESCRIPTION
## Summary

- run the full CI workflow only for pull requests and pushes to `main`, with stale PR runs cancelled
- skip macOS and Linux native builds for docs-only changes while preserving every protected check context
- reuse the main macOS SwiftPM build for app packaging instead of cold-building the package in a second macOS job
- cache SwiftPM dependencies and prepared Linux native dependencies
- disable Swift index-store generation in CI and keep the app-bundle build on the same SwiftPM flags
- isolate docs concurrency per PR while keeping main deployments serialized

## Why

Feature-branch pushes and pull-request events were launching duplicate full workflows for the same commit. The app-bundle job also repeated a cold macOS package build, docs-only PRs paid for both native platforms, stale runs continued after new pushes, and docs PRs shared one global queue.

## Impact

Code PRs retain the existing macOS, Linux, app-bundle, dependency-review, and secret-scan gates. Documentation-only PRs use lightweight gate jobs plus the docs build. Unknown change-detection states fail safe and run native checks.

Local validation confirmed that app packaging reuses the warm CI-mode build and completed in 27.24 seconds rather than starting another cold compile. Remote cache-hit rates and end-to-end timing should be measured from this PR.

## Validation

- `./scripts/check.sh`
  - 2,825 XCTest cases passed, 206 skipped, 0 failures
  - 30 Swift Testing cases passed
- `MERERUN_SWIFT_DISABLE_INDEX_STORE=1 ./scripts/check.sh`
  - passed in 7m04s locally
- `MERERUN_SWIFT_DISABLE_INDEX_STORE=1 ./scripts/build_mere_run_app.sh debug`
  - bundle built, signed, and verified in 27.24s
- exact workflow bundle assertions passed
- `actionlint .github/workflows/*.yml`
- `bash -n scripts/check.sh scripts/build_mere_run_app.sh`
- `git diff --check`
- live branch-protection readback confirmed all six required contexts are preserved
