### PR TITLE
Prepare mere.run 0.38.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,19 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+## 0.38.0 - 2026-08-14
+
+This release adds native Qwen3.8 27B vision, reasoning, coding, and experimental
+multi-token-prediction lanes; substantially accelerates MiniMax Music 3; and
+adds the published MiniMax-H3 Ref2VA Turbo adapter recipe. It also refreshes
+mere.run's owned MLX dependency chain, centralizes served-model capability
+metadata for the API and Pi agents, improves Studio model-download visibility,
+and ships a redesigned documentation experience.
+
+Large and restricted checkpoints remain explicit managed pulls with immutable
+upstream revisions, license gates, and machine-admission guidance. Experimental
+Qwen3.8 MTP stays opt-in; target-only decode remains the default.
+
 ### Studio
 
 - enriched the Models browser with estimated checkpoint size, minimum unified
@@ -86,6 +99,18 @@ The format is based on Keep a Changelog.
   four-evaluation, video/audio shift 12/3, alpha-8 recipe and fuses its 312
   PEFT pairs after the managed INT8 transformer is admitted and expanded to
   resident BF16.
+
+### Included pull requests
+
+- exact release range: [#293](https://github.com/sawfwair/mere-run/pull/293),
+  [#294](https://github.com/sawfwair/mere-run/pull/294),
+  [#295](https://github.com/sawfwair/mere-run/pull/295),
+  [#296](https://github.com/sawfwair/mere-run/pull/296),
+  [#297](https://github.com/sawfwair/mere-run/pull/297),
+  [#298](https://github.com/sawfwair/mere-run/pull/298),
+  [#299](https://github.com/sawfwair/mere-run/pull/299),
+  [#302](https://github.com/sawfwair/mere-run/pull/302), and
+  [#303](https://github.com/sawfwair/mere-run/pull/303).
 
 ## 0.37.0 - 2026-08-13
 

--- a/Sources/MereRunCLI/Support/MereRunCLIVersion.swift
+++ b/Sources/MereRunCLI/Support/MereRunCLIVersion.swift
@@ -1,3 +1,3 @@
 enum MereRunCLIVersion {
-    static let current = "0.37.0"
+    static let current = "0.38.0"
 }

--- a/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
+++ b/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
@@ -129,7 +129,7 @@ final class CLIModelStoreBootstrapTests: XCTestCase {
     }
 
     func testMereRunCLIExposesReleaseVersion() {
-        XCTAssertEqual(MereRunCLIVersion.current, "0.37.0")
+        XCTAssertEqual(MereRunCLIVersion.current, "0.38.0")
         XCTAssertEqual(MereRunCLI.configuration.version, MereRunCLIVersion.current)
     }
 

--- a/scripts/build_mere_run_app.sh
+++ b/scripts/build_mere_run_app.sh
@@ -15,7 +15,7 @@ cd "$repo_root"
 
 # Version/build derive from git when not provided, so the bundle has a single source of
 # truth in CI. Fall back to a pinned value when git metadata is unavailable.
-default_version="0.37.0"
+default_version="0.38.0"
 if git_version="$(git describe --tags --exact-match 2>/dev/null)"; then
   default_version="${git_version#v}"
 fi


### PR DESCRIPTION
## Summary

- bump the CLI, app fallback, and release contract test to 0.38.0
- move the completed Unreleased notes into the 0.38.0 changelog entry
- record the exact merged PR range (#293-#303)

Apparently the stars aligned: mere.run 0.38.0 is also the Qwen3.8 release. Versioning has achieved product-market fit. ✨

## Validation

- `./scripts/check.sh`
- 2,862 tests executed, 207 expected asset/GPU skips, 0 failures
- strict SwiftLint, build, CLI help sweep, and hygiene scans passed

## Release boundary

This PR prepares the source version and changelog only. The annotated `v0.38.0` tag will be created from the protected merge commit after exact-head CI and merge-tree verification.