### PR TITLE
Add Qwen3.8 to the Pi agent catalog

### DIFF
--- a/Sources/MereRunCore/AgentModelResources.swift
+++ b/Sources/MereRunCore/AgentModelResources.swift
@@ -194,6 +194,8 @@ public enum MereRunAgentModelCatalog {
             ornith35B(),
             ornith35BMLX(),
             q36Nano(),
+            q38TwentySevenB4Bit(),
+            q38TwentySevenB(),
             qwen3CoderNext(),
             deepseekV4Flash(),
         ].filter { machine.isSupportedRuntime && machine.unifiedMemoryGB >= $0.minimumUnifiedMemoryGB }
@@ -220,6 +222,30 @@ public enum MereRunAgentModelCatalog {
             recommendedUnifiedMemoryGB: 32,
             servingEngine: .textChatQ36,
             managedModelID: Q35Resources.q36NanoModelId
+        )
+    }
+
+    private static func q38TwentySevenB4Bit() -> MereRunAgentModelRecommendation {
+        MereRunAgentModelRecommendation(
+            id: Q35Resources.q38TwentySevenB4BitModelId,
+            displayName: "Qwen3.8 27B MLX 4-bit",
+            summary: "Efficient Qwen3.8 multimodal reasoning agent for Pi and local tool workflows.",
+            minimumUnifiedMemoryGB: 32,
+            recommendedUnifiedMemoryGB: 48,
+            servingEngine: .textChatQ36,
+            managedModelID: Q35Resources.q38TwentySevenB4BitModelId
+        )
+    }
+
+    private static func q38TwentySevenB() -> MereRunAgentModelRecommendation {
+        MereRunAgentModelRecommendation(
+            id: Q35Resources.q38TwentySevenBModelId,
+            displayName: "Qwen3.8 27B BF16",
+            summary: "Full-precision Qwen3.8 multimodal reasoning agent for Pi and demanding local tool workflows.",
+            minimumUnifiedMemoryGB: 64,
+            recommendedUnifiedMemoryGB: 96,
+            servingEngine: .textChatQ36,
+            managedModelID: Q35Resources.q38TwentySevenBModelId
         )
     }
 

--- a/Tests/MereRunCLITests/SetupCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/SetupCommandParsingTests.swift
@@ -123,6 +123,21 @@ final class SetupCommandParsingTests: XCTestCase {
         XCTAssertEqual(recommendation.servingEngine, .textChatGemma4)
     }
 
+    func testQ38ProviderUsesNativeQwenRuntime() throws {
+        let runtime = try SetupAgentRuntime.runtime(
+            forManagedModelID: Q35Resources.q38TwentySevenBModelId
+        )
+        let providerModel = runtime.providerModel
+
+        XCTAssertEqual(runtime.engine, .textChatQ36)
+        XCTAssertEqual(providerModel.id, Q35Resources.q38TwentySevenBModelId)
+        XCTAssertEqual(providerModel.contextWindow, Q35Resources.q38TwentySevenBContextLength)
+        XCTAssertEqual(providerModel.maxTokens, 4_096)
+        XCTAssertTrue(providerModel.toolCall)
+        XCTAssertTrue(runtime.recommendation.isStartableByMereRun)
+        XCTAssertEqual(runtime.recommendation.servingEngine, .textChatQ36)
+    }
+
     func testOrnith35BProviderUsesNativeManagedModelID() throws {
         let recommendation = try XCTUnwrap(
             MereRunAgentModelCatalog

--- a/Tests/MereRunCoreTests/ManagedModelSupportTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelSupportTests.swift
@@ -639,6 +639,8 @@ final class ManagedModelSupportTests: XCTestCase {
         XCTAssertFalse(recommendations.contains { $0.id == "text-chat-q35" })
         XCTAssertFalse(recommendations.contains { $0.id == "text-chat-q35-nano" })
         XCTAssertTrue(recommendations.contains { $0.id == Q35Resources.q36NanoModelId })
+        XCTAssertTrue(recommendations.contains { $0.id == Q35Resources.q38TwentySevenBModelId })
+        XCTAssertTrue(recommendations.contains { $0.id == Q35Resources.q38TwentySevenB4BitModelId })
     }
 
     func testAgentRecommendationRejectsNonAppleSilicon() {


### PR DESCRIPTION
## Summary

- register the Qwen3.8 27B BF16 and MLX 4-bit lanes in the Pi agent catalog
- route both through the existing native `text-chat-q36` engine and tool-capable provider profile
- make an installed Qwen3.8 checkpoint visible and startable through `mere.run agent`, including Film Studio model selection

## Validation

- [x] `./scripts/check.sh`
- [x] focused agent runtime and managed-model catalog tests
- [x] built `agent status --json` reports installed `vision-chat-q38-27b` with `startableByMereRun: true`
- [x] docs reviewed; existing agent model-selection docs remain accurate
- [x] no vendored artifacts or package pins changed; `THIRD_PARTY_NOTICES.md` unchanged

## Runtime proof

The installed Qwen3.8 BF16 checkpoint also completed a real local generation through the released v0.38.0 helper, returning the requested exact response. This PR adds the missing Pi catalog bridge; it does not change the underlying Qwen runtime.