### PR TITLE
Isolate video preflight adapter roots

### DIFF
--- a/Sources/MereRunCLI/Commands/VideoCommand.swift
+++ b/Sources/MereRunCLI/Commands/VideoCommand.swift
@@ -2491,6 +2491,7 @@ struct VideoGenerate: AsyncParsableCommand {
     func makePreflightEnvelope(
         outputURL: URL,
         fileManager: FileManager = .default,
+        adaptersRoot: URL = MereRunModelPaths.adaptersDir,
         now: @escaping () -> Date = Date.init
     ) -> VideoGenerationPreflightEnvelope {
         let input = VideoGenerationPreflightInput(
@@ -2587,6 +2588,7 @@ struct VideoGenerate: AsyncParsableCommand {
         return VideoGenerationPreflightAnalyzer(
             input: input,
             fileManager: fileManager,
+            adaptersRoot: adaptersRoot,
             now: now
         ).envelope()
     }

--- a/Sources/MereRunCLI/Support/VideoGenerationPreflight.swift
+++ b/Sources/MereRunCLI/Support/VideoGenerationPreflight.swift
@@ -446,15 +446,18 @@ typealias VideoGenerationPreflightEnvelope = StructuredRunEnvelope<
 struct VideoGenerationPreflightAnalyzer {
     let input: VideoGenerationPreflightInput
     let fileManager: FileManager
+    let adaptersRoot: URL
     let now: () -> Date
 
     init(
         input: VideoGenerationPreflightInput,
         fileManager: FileManager = .default,
+        adaptersRoot: URL = MereRunModelPaths.adaptersDir,
         now: @escaping () -> Date = Date.init
     ) {
         self.input = input
         self.fileManager = fileManager
+        self.adaptersRoot = adaptersRoot
         self.now = now
     }
 
@@ -1481,7 +1484,8 @@ struct VideoGenerationPreflightAnalyzer {
             return pathSummary(requested: path)
         }
         let adapter = input.h3Adapter.map { reference -> VideoGenerationPathPreflightSummary in
-            let path = ManagedAdapterCatalog.spec(for: reference)?.installedFileURL().path ?? reference
+            let path = ManagedAdapterCatalog.spec(for: reference)?
+                .installedFileURL(adaptersRoot: adaptersRoot).path ?? reference
             return pathSummary(requested: reference, resolvedPath: path)
         }
         func loraReference(_ raw: String) -> String {
@@ -1491,7 +1495,8 @@ struct VideoGenerationPreflightAnalyzer {
         }
         func adapterPathSummary(_ raw: String) -> VideoGenerationPathPreflightSummary {
             let reference = loraReference(raw)
-            let resolved = ManagedAdapterCatalog.spec(for: reference)?.installedFileURL().path
+            let resolved = ManagedAdapterCatalog.spec(for: reference)?
+                .installedFileURL(adaptersRoot: adaptersRoot).path
                 ?? reference
             return pathSummary(requested: reference, resolvedPath: resolved)
         }

--- a/Tests/MereRunCLITests/VideoCommandTests.swift
+++ b/Tests/MereRunCLITests/VideoCommandTests.swift
@@ -1248,6 +1248,7 @@ final class VideoCommandTests: XCTestCase {
     func testVideoGeneratePreflightResolvesManagedLTX25Detailer() throws {
         let modelRoot = try makeValidLTX25FullModelRoot()
         let output = makeTempOutput(name: "dfr-managed-detailer.mp4")
+        let adaptersRoot = try makeTempDirectory()
         let command = try VideoGenerate.parse([
             "a detailed shoreline",
             "--model-root", modelRoot.path,
@@ -1258,17 +1259,17 @@ final class VideoCommandTests: XCTestCase {
             "--json",
         ])
 
-        let envelope = command.makePreflightEnvelope(outputURL: output)
+        let envelope = command.makePreflightEnvelope(
+            outputURL: output,
+            adaptersRoot: adaptersRoot
+        )
         let summary = try XCTUnwrap(envelope.result.inputs.detailingLoRAs?.first)
         XCTAssertEqual(summary.requested, ManagedAdapterCatalog.ltx25PixelSpatialUpscalerID)
         let installedFile = try XCTUnwrap(
             ManagedAdapterCatalog.spec(for: ManagedAdapterCatalog.ltx25PixelSpatialUpscalerID)
-        ).installedFileURL()
+        ).installedFileURL(adaptersRoot: adaptersRoot)
         XCTAssertEqual(summary.path, installedFile.path)
-        XCTAssertEqual(
-            envelope.diagnostics.contains { $0.id == "detailing_lora_0_missing" },
-            !FileManager.default.fileExists(atPath: installedFile.path)
-        )
+        XCTAssertTrue(envelope.diagnostics.contains { $0.id == "detailing_lora_0_missing" })
     }
 
     func testLTX25SpecificControlsSelectTheDistilledCatalogModel() throws {


### PR DESCRIPTION
## Summary
- inject the managed-adapter root into video preflight analysis
- resolve catalog adapter paths against that explicit root
- make the LTX-2.5 managed-detailer test independent of machine-installed adapters

## Validation
- swift test --filter VideoCommandTests.testVideoGeneratePreflightResolvesManagedLTX25Detailer
- ./scripts/check.sh
  - SwiftLint: 0 violations across 1,237 files
  - XCTest: 2,862 tests, 207 skipped, 0 failures
  - Swift Testing: 30 tests, 0 failures
  - build, CLI help sweep, and hygiene scans passed

## Provenance
This is the only behavior from the preserved legacy film-studio host patch that is not already superseded by PR #306. The original patch remains recoverable on codex/film-studio-agent-host at 1d631beb.