### PR TITLE
Release v0.39.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,41 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+## 0.39.0 - 2026-08-15
+
+This release completes Qwen3.8's native Pi-agent path, adds an inline Pi harness
+for native hosts, and makes video preflight resolve managed adapters against an
+explicit root. Together these changes make installed Qwen3.8 checkpoints
+directly usable by `mere.run agent`, preserve typed tool calls end to end, and
+keep packaged native-host lifecycles and adapter discovery deterministic.
+
+### Agents and API
+
+- registered the Qwen3.8 27B BF16 and MLX 4-bit lanes in the Pi agent catalog,
+  using the native Qwen runtime and the existing tool-capable provider profile.
+- added inline Pi launch, explicit working-directory selection, repeatable
+  forwarded arguments, and native-host lifecycle handling. The harness registers
+  the selected model directly, avoids catalog probes during startup, waits for
+  actual admission before applying load timeouts, and terminates its API child
+  when the parent exits.
+- added native Qwen3.5/Qwen3.8 XML tool-call parsing with schema-aware JSON
+  restoration for strings, arrays, booleans, numbers, and objects, plus early
+  decode termination once a complete tool call is available.
+- prevented parent and child agent/API commands from deadlocking on the same
+  machine-inference admission permits.
+
+### Video
+
+- injected the managed-adapter root into video preflight analysis and resolved
+  catalog adapter paths against that explicit root, including LTX 2.5 managed
+  detailers.
+
+### Included pull requests
+
+- exact release range: [#305](https://github.com/sawfwair/mere-run/pull/305),
+  [#306](https://github.com/sawfwair/mere-run/pull/306), and
+  [#307](https://github.com/sawfwair/mere-run/pull/307).
+
 ## 0.38.0 - 2026-08-14
 
 This release adds native Qwen3.8 27B vision, reasoning, coding, and experimental

--- a/Sources/MereRunCLI/Support/MereRunCLIVersion.swift
+++ b/Sources/MereRunCLI/Support/MereRunCLIVersion.swift
@@ -1,3 +1,3 @@
 enum MereRunCLIVersion {
-    static let current = "0.38.0"
+    static let current = "0.39.0"
 }

--- a/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
+++ b/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
@@ -129,7 +129,7 @@ final class CLIModelStoreBootstrapTests: XCTestCase {
     }
 
     func testMereRunCLIExposesReleaseVersion() {
-        XCTAssertEqual(MereRunCLIVersion.current, "0.38.0")
+        XCTAssertEqual(MereRunCLIVersion.current, "0.39.0")
         XCTAssertEqual(MereRunCLI.configuration.version, MereRunCLIVersion.current)
     }
 

--- a/scripts/build_mere_run_app.sh
+++ b/scripts/build_mere_run_app.sh
@@ -15,7 +15,7 @@ cd "$repo_root"
 
 # Version/build derive from git when not provided, so the bundle has a single source of
 # truth in CI. Fall back to a pinned value when git metadata is unavailable.
-default_version="0.38.0"
+default_version="0.39.0"
 if git_version="$(git describe --tags --exact-match 2>/dev/null)"; then
   default_version="${git_version#v}"
 fi


### PR DESCRIPTION
## Summary

- bump the CLI and packaged-app fallback version to 0.39.0
- document the Qwen3.8 Pi catalog bridge and inline native-host harness
- document deterministic managed-adapter root resolution for video preflight
- record the exact release range: #305, #306, and #307

The stars aligned so perfectly that our v0.38.0 was also the Qwen3.8 release. Apparently celestial semantic versioning is real; v0.39.0 now brings the agent harness home. ✨

## Validation

- `./scripts/check.sh`
  - strict SwiftLint passed across 1,239 files
  - build passed
  - XCTest: 2,875 tests, 207 expected skips, 0 failures
  - Swift Testing: 30 tests, 0 failures
  - CLI help sweep and hygiene scans passed

## Release scope

This PR changes release metadata and notes only. Runtime behavior is already merged in #305, #306, and #307.