### PR TITLE
Optimize and harden MiniMax Music 3 long-form generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -115,6 +115,18 @@ Qwen3.8 MTP stays opt-in; target-only decode remains the default.
 
 ### Music
 
+- added an opt-in MiniMax Music 3 whole-song flow path that averages
+  overlapping window velocities at every Euler step, bounded long-latent DAV
+  decode, and a versioned stage-separated random recipe. Released sequential
+  windowing and shared-stream seeded output remain the defaults.
+- added mandatory MiniMax output-integrity validation for non-finite samples,
+  silence, implausible peaks, and stereo-channel collapse. Schema 5 recipes
+  record the measured peak, RMS, sample count, and collapse fraction.
+- bounded optimized MiniMax autoregressive allocator growth by returning
+  completed variable-length attention buffers every 64 frames. A matched
+  forced 120-second Q8/draft render reduced peak physical footprint from
+  110.20 GB to 23.78 GB with zero swaps and a byte-identical float32 WAV; the
+  autoregressive stage changed from 144.75 to 151.05 seconds.
 - accelerated MiniMax Music 3 on Apple Silicon with a reachable 16,385-row
   semantic head, fused QKV and gate/up projections, incremental residual-depth
   KV caches, cached rotary/zero conditioning, batched flow guidance, and fewer
@@ -128,8 +140,8 @@ Qwen3.8 MTP stays opt-in; target-only decode remains the default.
   top-100 overlap 98/80 against optimized BF16. Whole-flow compilation and
   affine flow quantization were measured and rejected because both regressed;
   batched flow CFG beat the serial alternative by 6.0% on a matched probe. A
-  strict three-minute Q8 render completed in 1,413.81 s with 4.50 GB maximum
-  resident memory and decoded to 180.268 s.
+  strict three-minute Q8 render completed in 1,413.81 s with 4.50 GB process
+  RSS (which excludes unified Metal footprint) and decoded to 180.268 s.
 - verified `--performance-mode reference` end to end against a clean 0.37.0
   executable: matched 250-frame renders were byte-identical after PCM24 export,
   including deterministic dither.

--- a/README.md
+++ b/README.md
@@ -611,7 +611,7 @@ swift run mere.run music generate \
   --lyrics-file ./lyrics.txt \
   --duration 30 \
   --minimum-duration 30 \
-  --steps 30 \
+  --sampling-tier fast \
   --seed 7 \
   --memory-mode staged \
   --performance-mode q8 \

--- a/README.md
+++ b/README.md
@@ -617,6 +617,16 @@ swift run mere.run music generate \
   --performance-mode q8 \
   --output ./minimax-song.wav
 
+# Compare the experimental whole-song flow windowing recipe without changing defaults
+swift run mere.run music generate \
+  "cinematic synth-pop, female lead, 118 bpm, wide guitars" \
+  --model music-minimax-music3 \
+  --lyrics-file ./lyrics.txt \
+  --duration 30 \
+  --flow-strategy overlap-average \
+  --seed-strategy stage-separated-v1 \
+  --output ./minimax-overlap-average.wav
+
 # Keep MiniMax Music 3 warm behind its speech-compatible HTTP route
 swift run mere.run music serve \
   --model music-minimax-music3 \

--- a/Sources/MereRunCLI/Commands/MiniMaxMusic3Serve.swift
+++ b/Sources/MereRunCLI/Commands/MiniMaxMusic3Serve.swift
@@ -16,6 +16,8 @@ struct MiniMaxMusic3SpeechRequest: Codable, Sendable {
     var minimumAudioDuration: Float?
     var minNewTokens: Int?
     var samplingTier: MiniMaxMusic3SamplingTier?
+    var flowStrategy: MiniMaxMusic3FlowStrategy?
+    var seedStrategy: MiniMaxMusic3SeedStrategy?
     var numInferenceSteps: Int?
     var guidanceScale: Float?
     var sampleRate: Int?
@@ -32,6 +34,8 @@ struct MiniMaxMusic3SpeechRequest: Codable, Sendable {
         case minimumAudioDuration = "minimum_audio_duration"
         case minNewTokens = "min_new_tokens"
         case samplingTier = "sampling_tier"
+        case flowStrategy = "flow_strategy"
+        case seedStrategy = "seed_strategy"
         case numInferenceSteps = "num_inference_steps"
         case guidanceScale = "guidance_scale"
         case sampleRate = "sample_rate"
@@ -201,7 +205,9 @@ private actor MiniMaxMusic3ServerSession {
                 maximumFrames: maximumFrames,
                 inferenceSteps: steps,
                 seed: request.seed ?? 0,
-                guidanceScale: guidanceScale
+                guidanceScale: guidanceScale,
+                flowStrategy: request.flowStrategy ?? .sequential,
+                seedStrategy: request.seedStrategy ?? .legacy
             ),
             sampleRate
         )

--- a/Sources/MereRunCLI/Commands/MiniMaxMusic3Serve.swift
+++ b/Sources/MereRunCLI/Commands/MiniMaxMusic3Serve.swift
@@ -15,6 +15,7 @@ struct MiniMaxMusic3SpeechRequest: Codable, Sendable {
     var audioDuration: Float?
     var minimumAudioDuration: Float?
     var minNewTokens: Int?
+    var samplingTier: MiniMaxMusic3SamplingTier?
     var numInferenceSteps: Int?
     var guidanceScale: Float?
     var sampleRate: Int?
@@ -30,6 +31,7 @@ struct MiniMaxMusic3SpeechRequest: Codable, Sendable {
         case audioDuration = "audio_duration"
         case minimumAudioDuration = "minimum_audio_duration"
         case minNewTokens = "min_new_tokens"
+        case samplingTier = "sampling_tier"
         case numInferenceSteps = "num_inference_steps"
         case guidanceScale = "guidance_scale"
         case sampleRate = "sample_rate"
@@ -176,7 +178,9 @@ private actor MiniMaxMusic3ServerSession {
         if let minimumFrames, minimumFrames > maximumFrames {
             throw ValidationError("The requested duration floor cannot exceed the output upper bound.")
         }
-        let steps = request.numInferenceSteps ?? 30
+        let steps = request.numInferenceSteps
+            ?? request.samplingTier?.inferenceSteps
+            ?? MiniMaxMusic3SamplingTier.quality.inferenceSteps
         guard steps > 0 else {
             throw ValidationError("num_inference_steps must be positive.")
         }

--- a/Sources/MereRunCLI/Commands/MusicGenerateCommand.swift
+++ b/Sources/MereRunCLI/Commands/MusicGenerateCommand.swift
@@ -199,6 +199,18 @@ struct MusicGenerate: AsyncParsableCommand {
     var miniMaxSamplingTier: MiniMaxMusic3SamplingTier?
 
     @Option(
+        name: [.customLong("flow-strategy")],
+        help: "MiniMax Music 3 long-form flow: sequential (default) or experimental overlap-average."
+    )
+    var miniMaxFlowStrategy: MiniMaxMusic3FlowStrategy?
+
+    @Option(
+        name: [.customLong("seed-strategy")],
+        help: "MiniMax Music 3 randomness: legacy (default) or stage-separated-v1."
+    )
+    var miniMaxSeedStrategy: MiniMaxMusic3SeedStrategy?
+
+    @Option(
         name: [.customLong("profile-output")],
         help: "Write detailed MiniMax Music 3 stage timings as JSON; profiling adds synchronization overhead."
     )
@@ -545,10 +557,12 @@ struct MusicGenerate: AsyncParsableCommand {
             || miniMaxLoadingStrategy != nil
             || miniMaxPerformanceMode != nil
             || miniMaxSamplingTier != nil
+            || miniMaxFlowStrategy != nil
+            || miniMaxSeedStrategy != nil
             || miniMaxProfileOutput != nil
         {
             throw ValidationError(
-                "MiniMax duration-frame, sample-rate, memory-mode, performance-mode, sampling-tier, and profiling options require MiniMax Music 3."
+                "MiniMax duration-frame, sample-rate, memory-mode, performance-mode, flow, seed, sampling-tier, and profiling options require MiniMax Music 3."
             )
         }
 
@@ -1199,6 +1213,12 @@ struct MusicGenerate: AsyncParsableCommand {
             CLIStderr.write("MiniMax performance mode: \(performanceMode.rawValue)\n")
         }
         let inferenceSteps = resolvedMiniMaxInferenceSteps
+        let flowStrategy = miniMaxFlowStrategy ?? .sequential
+        let seedStrategy = miniMaxSeedStrategy ?? .legacy
+        if !quiet {
+            CLIStderr.write("MiniMax flow strategy: \(flowStrategy.rawValue)\n")
+            CLIStderr.write("MiniMax seed strategy: \(seedStrategy.rawValue)\n")
+        }
         if !quiet {
             let samplingLabel = miniMaxSamplingTier?.rawValue ?? "quality"
             CLIStderr.write(
@@ -1229,7 +1249,9 @@ struct MusicGenerate: AsyncParsableCommand {
                 inferenceSteps: inferenceSteps,
                 seed: seed ?? 0,
                 guidanceScale: guidanceScale ?? 1.7,
-                profilingEnabled: miniMaxProfileOutput != nil
+                profilingEnabled: miniMaxProfileOutput != nil,
+                flowStrategy: flowStrategy,
+                seedStrategy: seedStrategy
             ),
             progress: { event in
                 guard !quiet else { return }
@@ -1308,6 +1330,9 @@ struct MusicGenerate: AsyncParsableCommand {
                 outputSampleRate: outputSampleRate,
                 loadingStrategy: loadingStrategy,
                 performanceMode: performanceMode,
+                flowStrategy: flowStrategy,
+                seedStrategy: seedStrategy,
+                audioHealth: result.audioHealth,
                 export: exportOptions,
                 outputFilename: outputURL.lastPathComponent,
                 outputSHA256: try ModelArtifactPin.fileSHA256(outputURL)

--- a/Sources/MereRunCLI/Commands/MusicGenerateCommand.swift
+++ b/Sources/MereRunCLI/Commands/MusicGenerateCommand.swift
@@ -192,6 +192,18 @@ struct MusicGenerate: AsyncParsableCommand {
     )
     var miniMaxPerformanceMode: MiniMaxMusic3PerformanceMode?
 
+    @Option(
+        name: [.customLong("sampling-tier")],
+        help: "MiniMax Music 3 flow sampling: quality (30 steps), fast (20), or draft (16); --steps overrides."
+    )
+    var miniMaxSamplingTier: MiniMaxMusic3SamplingTier?
+
+    @Option(
+        name: [.customLong("profile-output")],
+        help: "Write detailed MiniMax Music 3 stage timings as JSON; profiling adds synchronization overhead."
+    )
+    var miniMaxProfileOutput: String?
+
     @Option(name: [.customLong("quality")], help: "Adaptive ACE-Step quality: draft, song, final, or edit.")
     var quality: ACEStepQualityPreset?
 
@@ -532,9 +544,11 @@ struct MusicGenerate: AsyncParsableCommand {
             || miniMaxOutputSampleRate != nil
             || miniMaxLoadingStrategy != nil
             || miniMaxPerformanceMode != nil
+            || miniMaxSamplingTier != nil
+            || miniMaxProfileOutput != nil
         {
             throw ValidationError(
-                "MiniMax duration-frame, sample-rate, memory-mode, and performance-mode options require MiniMax Music 3."
+                "MiniMax duration-frame, sample-rate, memory-mode, performance-mode, sampling-tier, and profiling options require MiniMax Music 3."
             )
         }
 
@@ -1184,6 +1198,13 @@ struct MusicGenerate: AsyncParsableCommand {
         if !quiet {
             CLIStderr.write("MiniMax performance mode: \(performanceMode.rawValue)\n")
         }
+        let inferenceSteps = resolvedMiniMaxInferenceSteps
+        if !quiet {
+            let samplingLabel = miniMaxSamplingTier?.rawValue ?? "quality"
+            CLIStderr.write(
+                "MiniMax sampling tier: \(samplingLabel) (\(inferenceSteps) flow steps)\n"
+            )
+        }
         let pipeline = try MiniMaxMusic3Pipeline(
             resources: resources,
             loadingStrategy: loadingStrategy,
@@ -1205,9 +1226,10 @@ struct MusicGenerate: AsyncParsableCommand {
                 durationSeconds: requestedDuration,
                 minimumFrames: requestedMinimumFrames,
                 maximumFrames: miniMaxMaximumFrames,
-                inferenceSteps: steps ?? 30,
+                inferenceSteps: inferenceSteps,
                 seed: seed ?? 0,
-                guidanceScale: guidanceScale ?? 1.7
+                guidanceScale: guidanceScale ?? 1.7,
+                profilingEnabled: miniMaxProfileOutput != nil
             ),
             progress: { event in
                 guard !quiet else { return }
@@ -1227,6 +1249,22 @@ struct MusicGenerate: AsyncParsableCommand {
                 }
             }
         )
+        if let miniMaxProfileOutput {
+            guard let profile = result.profile else {
+                throw ValidationError("MiniMax Music 3 profiling did not produce a receipt.")
+            }
+            let profileURL = resolveUserPath(miniMaxProfileOutput)
+            try FileManager.default.createDirectory(
+                at: profileURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            let encoder = JSONEncoder()
+            encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+            try encoder.encode(profile).write(to: profileURL, options: .atomic)
+            if !quiet {
+                CLIStderr.write("Saved MiniMax profile: \(profileURL.path)\n")
+            }
+        }
         let exportOptions = ACEStepAudioExportOptions(
             format: exportFormat,
             normalization: normalization,
@@ -1262,7 +1300,8 @@ struct MusicGenerate: AsyncParsableCommand {
                 requestedMinimumFrames: requestedMinimumFrames,
                 requestedMaximumFrames: miniMaxMaximumFrames,
                 generatedFrameCount: result.frameCount,
-                inferenceSteps: steps ?? 30,
+                samplingTier: miniMaxSamplingTier,
+                inferenceSteps: inferenceSteps,
                 seed: seed ?? 0,
                 guidanceScale: guidanceScale ?? 1.7,
                 nativeSampleRate: result.sampleRate,
@@ -1285,6 +1324,10 @@ struct MusicGenerate: AsyncParsableCommand {
             CLIStderr.write("Saved audio: \(outputURL.path)\n")
         }
         print(outputURL.path)
+    }
+
+    var resolvedMiniMaxInferenceSteps: Int {
+        steps ?? miniMaxSamplingTier?.inferenceSteps ?? MiniMaxMusic3SamplingTier.quality.inferenceSteps
     }
 
     func validateMiniMaxMusic3Options(explicitDurationSeconds: Float?) throws {

--- a/Sources/MereRunCLI/Guides/music-generate-minimax-music3.md
+++ b/Sources/MereRunCLI/Guides/music-generate-minimax-music3.md
@@ -31,7 +31,11 @@ MiniMax Music 3 consumes only these model inputs:
   the first 25 Hz frame whose whole 512-sample vocoder hops meet the request.
 - `--min-frames`: exact acoustic-frame floor; 1 through 9000
 - `--max-frames`: exact 25 Hz acoustic-frame upper bound; 1 through 9000
-- `--steps`: flow-Euler steps per chunk; defaults to 30
+- `--sampling-tier quality|fast|draft`: named flow-Euler schedules with 30,
+  20, or 16 steps; defaults to `quality`
+- `--steps`: exact flow-Euler steps per chunk; overrides `--sampling-tier`
+- `--profile-output`: write synchronized stage timings as JSON; intended for
+  benchmarking because the extra evaluations can affect wall time
 - `--seed`: deterministic MLX seed; defaults to 0
 - `--guidance-scale`: flow classifier-free guidance; defaults to 1.7
 - `--memory-mode staged|resident`: staged loads and releases the autoregressive,
@@ -52,6 +56,10 @@ language and depth transformers with group-64 affine weights; `q4` applies the
 same path at four bits. Quantization changes the sampled composition, so use `reference` or
 `optimized` for upstream-parity investigations and `q8` for the normal turbo
 tradeoff.
+
+The `quality`, `fast`, and `draft` sampling tiers use the same model and fixed
+Euler schedule with 30, 20, and 16 evaluations respectively. Use `--steps`
+when you need an exact custom count; it takes precedence over the named tier.
 
 Incompatible ACE-Step cover, editing, LM-planner, adapter, VAE,
 candidate-ranking, stem, and DAW settings fail explicitly for this model.
@@ -155,6 +163,7 @@ curl http://127.0.0.1:8081/v1/audio/speech \
     "seed": 7,
     "max_new_tokens": 750,
     "min_new_tokens": 750,
+    "sampling_tier": "fast",
     "stream": false
   }' \
   --output song.wav

--- a/Sources/MereRunCLI/Guides/music-generate.md
+++ b/Sources/MereRunCLI/Guides/music-generate.md
@@ -81,7 +81,11 @@ mere.run guide music generate --model music-magenta-rt2-small
 - `--min-frames`, `--max-frames`: MiniMax Music 3 exact 25 Hz floor and limit.
 - `--performance-mode reference|optimized|q8|q4`: MiniMax Music 3 execution tier;
   `optimized` is the BF16 default and `q8` is the recommended turbo tier.
-- `--steps`, `-s`: denoise steps; MiniMax Music 3 defaults to `30`.
+- `--sampling-tier quality|fast|draft`: MiniMax Music 3 flow schedule with 30,
+  20, or 16 steps.
+- `--steps`, `-s`: exact denoise steps; overrides a MiniMax sampling tier.
+- `--profile-output`: MiniMax Music 3 synchronized stage-timing JSON for
+  benchmarks; profiling can affect wall time.
 - `--shift`: turbo scheduler shift; ACE-Step CLI default is `3.0`, matching upstream.
 - `--seed`: deterministic generation.
 - `--source-audio`: source song for ACE-Step cover, repaint, extract, lego, or

--- a/Sources/MereRunCLI/Support/MiniMaxMusic3CLIOptions.swift
+++ b/Sources/MereRunCLI/Support/MiniMaxMusic3CLIOptions.swift
@@ -4,3 +4,5 @@ import MereRunCore
 extension MiniMaxMusic3LoadingStrategy: ExpressibleByArgument {}
 extension MiniMaxMusic3PerformanceMode: ExpressibleByArgument {}
 extension MiniMaxMusic3SamplingTier: ExpressibleByArgument {}
+extension MiniMaxMusic3FlowStrategy: ExpressibleByArgument {}
+extension MiniMaxMusic3SeedStrategy: ExpressibleByArgument {}

--- a/Sources/MereRunCLI/Support/MiniMaxMusic3CLIOptions.swift
+++ b/Sources/MereRunCLI/Support/MiniMaxMusic3CLIOptions.swift
@@ -3,3 +3,4 @@ import MereRunCore
 
 extension MiniMaxMusic3LoadingStrategy: ExpressibleByArgument {}
 extension MiniMaxMusic3PerformanceMode: ExpressibleByArgument {}
+extension MiniMaxMusic3SamplingTier: ExpressibleByArgument {}

--- a/Sources/MereRunCLI/Support/MiniMaxMusic3GenerationArtifacts.swift
+++ b/Sources/MereRunCLI/Support/MiniMaxMusic3GenerationArtifacts.swift
@@ -2,7 +2,7 @@ import Foundation
 import MereRunCore
 
 struct MiniMaxMusic3GenerationRecipe: Codable {
-    static let currentSchemaVersion = 3
+    static let currentSchemaVersion = 4
 
     var schemaVersion: Int
     var createdAt: Date
@@ -15,6 +15,7 @@ struct MiniMaxMusic3GenerationRecipe: Codable {
     var requestedMinimumFrames: Int?
     var requestedMaximumFrames: Int?
     var generatedFrameCount: Int
+    var samplingTier: MiniMaxMusic3SamplingTier?
     var inferenceSteps: Int
     var seed: UInt64
     var guidanceScale: Float
@@ -38,6 +39,7 @@ struct MiniMaxMusic3GenerationRecipe: Codable {
         case requestedMinimumFrames = "requested_minimum_frames"
         case requestedMaximumFrames = "requested_maximum_frames"
         case generatedFrameCount = "generated_frame_count"
+        case samplingTier = "sampling_tier"
         case inferenceSteps = "inference_steps"
         case seed
         case guidanceScale = "guidance_scale"

--- a/Sources/MereRunCLI/Support/MiniMaxMusic3GenerationArtifacts.swift
+++ b/Sources/MereRunCLI/Support/MiniMaxMusic3GenerationArtifacts.swift
@@ -2,7 +2,7 @@ import Foundation
 import MereRunCore
 
 struct MiniMaxMusic3GenerationRecipe: Codable {
-    static let currentSchemaVersion = 4
+    static let currentSchemaVersion = 5
 
     var schemaVersion: Int
     var createdAt: Date
@@ -23,6 +23,9 @@ struct MiniMaxMusic3GenerationRecipe: Codable {
     var outputSampleRate: Int
     var loadingStrategy: MiniMaxMusic3LoadingStrategy
     var performanceMode: MiniMaxMusic3PerformanceMode
+    var flowStrategy: MiniMaxMusic3FlowStrategy
+    var seedStrategy: MiniMaxMusic3SeedStrategy
+    var audioHealth: MiniMaxMusic3AudioHealthReport
     var export: ACEStepAudioExportOptions
     var outputFilename: String
     var outputSHA256: String
@@ -47,6 +50,9 @@ struct MiniMaxMusic3GenerationRecipe: Codable {
         case outputSampleRate = "output_sample_rate"
         case loadingStrategy = "loading_strategy"
         case performanceMode = "performance_mode"
+        case flowStrategy = "flow_strategy"
+        case seedStrategy = "seed_strategy"
+        case audioHealth = "audio_health"
         case export
         case outputFilename = "output_filename"
         case outputSHA256 = "output_sha256"

--- a/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3DepthDecoder.swift
+++ b/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3DepthDecoder.swift
@@ -208,8 +208,13 @@ public final class MiniMaxMusic3DepthDecoder: Module {
         return norm(hidden)
     }
 
-    public func makeCache() -> [KVCache] {
-        (0..<configuration.numLayers).map { _ in KVCacheSimple(step: 8) }
+    public func makeCache(capacity: Int? = nil) -> [KVCache] {
+        (0..<configuration.numLayers).map { _ in
+            if let capacity {
+                return KVCacheStatic(capacity: capacity)
+            }
+            return KVCacheSimple(step: 8)
+        }
     }
 
     public func prepareFusedProjections() {

--- a/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3LanguageModel.swift
+++ b/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3LanguageModel.swift
@@ -32,8 +32,13 @@ public final class MiniMaxMusic3LanguageModel: Module {
         )
     }
 
-    public func makeCache() -> [KVCache] {
-        (0..<configuration.numHiddenLayers).map { _ in KVCacheSimple(step: 256) }
+    public func makeCache(capacity: Int? = nil) -> [KVCache] {
+        (0..<configuration.numHiddenLayers).map { _ in
+            if let capacity {
+                return KVCacheStatic(capacity: capacity)
+            }
+            return KVCacheSimple(step: 256)
+        }
     }
 
     public func embed(tokenIDs: MLXArray) -> MLXArray {

--- a/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3ModelLoader.swift
+++ b/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3ModelLoader.swift
@@ -226,6 +226,7 @@ public enum MiniMaxMusic3ModelLoader {
 public enum MiniMaxMusic3Error: LocalizedError {
     case missingResources([URL])
     case invalidPrompt(String)
+    case invalidAudio(String)
     case generatedNoFrames
 
     public var errorDescription: String? {
@@ -234,6 +235,8 @@ public enum MiniMaxMusic3Error: LocalizedError {
             return "MiniMax Music 3 is missing required files: \(urls.map(\.path).joined(separator: ", "))"
         case .invalidPrompt(let reason):
             return "Invalid MiniMax Music 3 prompt: \(reason)"
+        case .invalidAudio(let reason):
+            return "Invalid MiniMax Music 3 audio: \(reason)"
         case .generatedNoFrames:
             return "MiniMax Music 3 ended before generating an audio frame."
         }

--- a/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3Pipeline.swift
+++ b/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3Pipeline.swift
@@ -12,6 +12,8 @@ public struct MiniMaxMusic3GenerationOptions: Sendable {
     public var seed: UInt64
     public var guidanceScale: Float
     public var profilingEnabled: Bool
+    public var flowStrategy: MiniMaxMusic3FlowStrategy
+    public var seedStrategy: MiniMaxMusic3SeedStrategy
 
     public init(
         caption: String,
@@ -22,7 +24,9 @@ public struct MiniMaxMusic3GenerationOptions: Sendable {
         inferenceSteps: Int = 30,
         seed: UInt64 = 0,
         guidanceScale: Float = 1.7,
-        profilingEnabled: Bool = false
+        profilingEnabled: Bool = false,
+        flowStrategy: MiniMaxMusic3FlowStrategy = .sequential,
+        seedStrategy: MiniMaxMusic3SeedStrategy = .legacy
     ) {
         self.caption = caption
         self.lyrics = lyrics
@@ -33,6 +37,8 @@ public struct MiniMaxMusic3GenerationOptions: Sendable {
         self.seed = seed
         self.guidanceScale = guidanceScale
         self.profilingEnabled = profilingEnabled
+        self.flowStrategy = flowStrategy
+        self.seedStrategy = seedStrategy
     }
 }
 
@@ -41,6 +47,12 @@ public struct MiniMaxMusic3GenerationResult {
     public let sampleRate: Int
     public let frameCount: Int
     public let profile: MiniMaxMusic3GenerationProfile?
+    public let audioHealth: MiniMaxMusic3AudioHealthReport
+}
+
+private struct MiniMaxMusic3FlowResult {
+    let latents: [MLXArray]
+    let windowCount: Int
 }
 
 public enum MiniMaxMusic3Progress: Sendable, Equatable {
@@ -50,6 +62,8 @@ public enum MiniMaxMusic3Progress: Sendable, Equatable {
 }
 
 public final class MiniMaxMusic3Pipeline {
+    static let autoregressiveCacheClearInterval = 64
+
     private let residentModels: MiniMaxMusic3Models?
     private let resources: MiniMaxMusic3Resources?
     public let loadingStrategy: MiniMaxMusic3LoadingStrategy
@@ -123,11 +137,22 @@ public final class MiniMaxMusic3Pipeline {
 
         let totalStart = ContinuousClock.now
         let recorder = options.profilingEnabled ? MiniMaxMusic3ProfileRecorder() : nil
-        let generator = MLXRandom.RandomState(seed: options.seed)
+        let autoregressiveGenerator: MLXRandom.RandomState
+        let flowGenerator: MLXRandom.RandomState
+        switch options.seedStrategy {
+        case .legacy:
+            let sharedGenerator = MLXRandom.RandomState(seed: options.seed)
+            autoregressiveGenerator = sharedGenerator
+            flowGenerator = sharedGenerator
+        case .stageSeparatedV1:
+            let seeds = options.seedStrategy.stageSeeds(seed: options.seed)
+            autoregressiveGenerator = MLXRandom.RandomState(seed: seeds.autoregressive)
+            flowGenerator = MLXRandom.RandomState(seed: seeds.flow)
+        }
         let autoregressiveStart = ContinuousClock.now
         let frameHiddens = try autoregressiveStage(
             options: options,
-            generator: generator,
+            generator: autoregressiveGenerator,
             recorder: recorder,
             progress: progress
         )
@@ -136,11 +161,12 @@ public final class MiniMaxMusic3Pipeline {
             MLX.Memory.clearCache()
         }
         let flowStart = ContinuousClock.now
-        let chunks = try flowStage(
+        let flow = try flowStage(
             frameHiddens: frameHiddens,
             steps: options.inferenceSteps,
             guidanceScale: options.guidanceScale,
-            generator: generator,
+            strategy: options.flowStrategy,
+            generator: flowGenerator,
             recorder: recorder,
             progress: progress
         )
@@ -150,7 +176,8 @@ public final class MiniMaxMusic3Pipeline {
         }
         let vocoderStart = ContinuousClock.now
         let decoded = try vocoderStage(
-            chunks: chunks,
+            flow: flow,
+            strategy: options.flowStrategy,
             recorder: recorder,
             progress: progress
         )
@@ -158,12 +185,16 @@ public final class MiniMaxMusic3Pipeline {
         if loadingStrategy == .staged {
             MLX.Memory.clearCache()
         }
-        let waveform = decoded.waveform
+        let audioHealth = try MiniMaxMusic3AudioHealth.validate(
+            decoded.waveform,
+            sampleRate: decoded.sampleRate
+        )
+        let waveform = MLX.clip(decoded.waveform.asType(.float32), min: -1, max: 1)
         MLX.eval(waveform)
         let profile = recorder.map {
             MiniMaxMusic3GenerationProfile(
                 frameCount: frameHiddens.dim(1),
-                chunkCount: chunks.count,
+                chunkCount: flow.windowCount,
                 inferenceSteps: options.inferenceSteps,
                 totalSeconds: MiniMaxMusic3ProfileRecorder.seconds(since: totalStart),
                 recorder: $0
@@ -173,7 +204,8 @@ public final class MiniMaxMusic3Pipeline {
             waveform: waveform,
             sampleRate: decoded.sampleRate,
             frameCount: frameHiddens.dim(1),
-            profile: profile
+            profile: profile,
+            audioHealth: audioHealth
         )
     }
 
@@ -219,10 +251,11 @@ public final class MiniMaxMusic3Pipeline {
         frameHiddens: MLXArray,
         steps: Int,
         guidanceScale: Float,
+        strategy: MiniMaxMusic3FlowStrategy,
         generator: MLXRandom.RandomState,
         recorder: MiniMaxMusic3ProfileRecorder?,
         progress: (@Sendable (MiniMaxMusic3Progress) -> Void)?
-    ) throws -> [MLXArray] {
+    ) throws -> MiniMaxMusic3FlowResult {
         let loadStart = ContinuousClock.now
         let models = try residentModels.map {
             MiniMaxMusic3FlowModels(
@@ -238,6 +271,7 @@ public final class MiniMaxMusic3Pipeline {
             frameHiddens: frameHiddens,
             steps: steps,
             guidanceScale: guidanceScale,
+            strategy: strategy,
             conditionEncoder: models.conditionEncoder,
             transformer: models.transformer,
             generator: generator,
@@ -245,11 +279,18 @@ public final class MiniMaxMusic3Pipeline {
             progress: progress
         )
         MLX.eval(chunks)
-        return chunks
+        let windowCount = switch strategy {
+        case .sequential:
+            chunks.count
+        case .overlapAverage:
+            Self.overlapAverageStarts(latentLength: chunks[0].dim(2)).count
+        }
+        return MiniMaxMusic3FlowResult(latents: chunks, windowCount: windowCount)
     }
 
     private func vocoderStage(
-        chunks: [MLXArray],
+        flow: MiniMaxMusic3FlowResult,
+        strategy: MiniMaxMusic3FlowStrategy,
         recorder: MiniMaxMusic3ProfileRecorder?,
         progress: (@Sendable (MiniMaxMusic3Progress) -> Void)?
     ) throws -> (waveform: MLXArray, sampleRate: Int) {
@@ -257,12 +298,22 @@ public final class MiniMaxMusic3Pipeline {
         let vocoder = try residentModels?.vocoder
             ?? MiniMaxMusic3ModelLoader.loadVocoder(from: requiredResources())
         recorder?.record(.vocoderLoad, since: loadStart)
-        let waveform = decode(
-            chunks: chunks,
-            vocoder: vocoder,
-            recorder: recorder,
-            progress: progress
-        )
+        let waveform = switch strategy {
+        case .sequential:
+            decodeSequential(
+                chunks: flow.latents,
+                vocoder: vocoder,
+                recorder: recorder,
+                progress: progress
+            )
+        case .overlapAverage:
+            decodeWholeLatent(
+                flow.latents[0],
+                vocoder: vocoder,
+                recorder: recorder,
+                progress: progress
+            )
+        }
         MLX.eval(waveform)
         return (waveform, vocoder.configuration.samplingRate)
     }
@@ -407,12 +458,25 @@ public final class MiniMaxMusic3Pipeline {
                 MLX.eval(lastHidden)
             }
             recorder?.record(.autoregressiveFeedback, since: feedbackStart)
+            if performanceMode.usesOptimizedGraph,
+               Self.shouldClearAutoregressiveCache(generatedFrameCount: frameHiddens.count)
+            {
+                // Cached single-token attention changes shape as the prefix grows.
+                // Periodically return completed intermediate Metal buffers instead
+                // of retaining every prior sequence-length allocation for the full song.
+                MLX.Memory.clearCache()
+            }
         }
 
         guard !frameHiddens.isEmpty else {
             throw MiniMaxMusic3Error.generatedNoFrames
         }
         return MLX.stacked(frameHiddens, axis: 1)
+    }
+
+    static func shouldClearAutoregressiveCache(generatedFrameCount: Int) -> Bool {
+        generatedFrameCount > 0
+            && generatedFrameCount.isMultiple(of: autoregressiveCacheClearInterval)
     }
 
     private func sampleSemanticReference(
@@ -612,12 +676,25 @@ public final class MiniMaxMusic3Pipeline {
         frameHiddens: MLXArray,
         steps: Int,
         guidanceScale: Float,
+        strategy: MiniMaxMusic3FlowStrategy,
         conditionEncoder: MiniMaxMusic3ConditionEncoder,
         transformer: MiniMaxMusic3Transformer,
         generator: MLXRandom.RandomState,
         recorder: MiniMaxMusic3ProfileRecorder?,
         progress: (@Sendable (MiniMaxMusic3Progress) -> Void)?
     ) -> [MLXArray] {
+        if strategy == .overlapAverage {
+            return [denoiseOverlapAverage(
+                frameHiddens: frameHiddens,
+                steps: steps,
+                guidanceScale: guidanceScale,
+                conditionEncoder: conditionEncoder,
+                transformer: transformer,
+                generator: generator,
+                recorder: recorder,
+                progress: progress
+            )]
+        }
         if performanceMode == .reference {
             return denoiseReference(
                 frameHiddens: frameHiddens,
@@ -725,6 +802,130 @@ public final class MiniMaxMusic3Pipeline {
         return chunks
     }
 
+    private func denoiseOverlapAverage(
+        frameHiddens: MLXArray,
+        steps: Int,
+        guidanceScale: Float,
+        conditionEncoder: MiniMaxMusic3ConditionEncoder,
+        transformer: MiniMaxMusic3Transformer,
+        generator: MLXRandom.RandomState,
+        recorder: MiniMaxMusic3ProfileRecorder?,
+        progress: (@Sendable (MiniMaxMusic3Progress) -> Void)?
+    ) -> MLXArray {
+        let conditionStart = ContinuousClock.now
+        let condition = conditionEncoder(frameHiddens).asType(.bfloat16)
+        let uncondition = conditionEncoder(MLXArray.zeros(
+            frameHiddens.shape,
+            dtype: frameHiddens.dtype
+        )).asType(.bfloat16)
+        let batchedCondition = MLX.concatenated([condition, uncondition], axis: 0)
+        let preparedCondition = transformer.prepareConditionInput(batchedCondition)
+        if recorder != nil {
+            MLX.eval(condition, uncondition)
+            if let preparedCondition {
+                MLX.eval(preparedCondition)
+            }
+            recorder?.record(.conditionEncoding, since: conditionStart)
+        }
+
+        let latentLength = condition.dim(1)
+        let starts = Self.overlapAverageStarts(latentLength: latentLength)
+        let counts = MLXArray.zeros([1, 1, latentLength], dtype: condition.dtype)
+        let windowLength = MiniMaxMusic3Prompt.latentLength(frameCount: 200)
+        for start in starts {
+            let end = min(start + windowLength, latentLength)
+            counts[0..., 0..., start..<end] = counts[0..., 0..., start..<end] + 1
+        }
+        MLX.eval(counts)
+
+        var latents = MLXRandom.normal([
+            1,
+            transformer.configuration.inChannels,
+            latentLength,
+        ], key: generator).asType(condition.dtype)
+        let stepSize = MLXArray(1 / Float(steps)).asType(condition.dtype)
+        var rotaryCaches: [Int: (MLXArray, MLXArray)] = [:]
+
+        for step in 0..<steps {
+            let transformerStart = ContinuousClock.now
+            let timestep = MLXArray([Float(step) / Float(steps)]).asType(latents.dtype)
+            let batchedLatents = MLX.concatenated([latents, latents], axis: 0)
+            let batchedTimestep = MLX.repeated(timestep, count: 2, axis: 0)
+            let accumulated = MLXArray.zeros(
+                [2, transformer.configuration.inChannels, latentLength],
+                dtype: latents.dtype
+            )
+            var firstPendingProgressIndex = 0
+            for (windowIndex, start) in starts.enumerated() {
+                let end = min(start + windowLength, latentLength)
+                let length = end - start
+                let rotary = rotaryCaches[length] ?? transformer.rotaryCache(
+                    latentLength: length,
+                    dtype: latents.dtype
+                )
+                rotaryCaches[length] = rotary
+                let velocities = if let preparedCondition {
+                    transformer(
+                        latents: batchedLatents[0..., 0..., start..<end],
+                        timestep: batchedTimestep,
+                        preparedCondition: preparedCondition[0..., start..<end, 0...],
+                        rotary: rotary
+                    )
+                } else {
+                    transformer(
+                        latents: batchedLatents[0..., 0..., start..<end],
+                        timestep: batchedTimestep,
+                        condition: batchedCondition[0..., start..<end, 0...],
+                        rotary: rotary
+                    )
+                }
+                accumulated[0..., 0..., start..<end] =
+                    accumulated[0..., 0..., start..<end] + velocities
+                let completedBatch = (windowIndex + 1).isMultiple(of: 2)
+                    || windowIndex + 1 == starts.count
+                if completedBatch {
+                    // Keep the lazy MLX graph bounded. A complete long-song step can
+                    // contain dozens of transformer calls and otherwise retain their
+                    // intermediate activations until the final latent synchronization.
+                    MLX.eval(accumulated)
+                    for completedIndex in firstPendingProgressIndex...windowIndex {
+                        progress?(.denoise(
+                            chunk: completedIndex + 1,
+                            chunkCount: starts.count,
+                            step: step + 1,
+                            stepCount: steps
+                        ))
+                    }
+                    firstPendingProgressIndex = windowIndex + 1
+                }
+            }
+            let averaged = accumulated / counts
+            let conditional = averaged[0..<1]
+            let unconditional = averaged[1..<2]
+            let velocity = unconditional + (conditional - unconditional) * MLXArray(guidanceScale)
+            latents = latents + velocity * stepSize
+            MLX.eval(latents)
+            recorder?.record(.flowTransformer, since: transformerStart)
+        }
+        return latents
+    }
+
+    static func overlapAverageStarts(latentLength: Int) -> [Int] {
+        precondition(latentLength > 0)
+        let windowLength = MiniMaxMusic3Prompt.latentLength(frameCount: 200)
+        let hopLength = MiniMaxMusic3Prompt.latentLength(frameCount: 100)
+        guard latentLength > windowLength else { return [0] }
+        var starts: [Int] = []
+        var start = 0
+        while true {
+            starts.append(start)
+            if start + windowLength >= latentLength {
+                return starts
+            }
+            start += hopLength
+        }
+    }
+
     private func denoiseReference(
         frameHiddens: MLXArray,
         steps: Int,
@@ -806,7 +1007,7 @@ public final class MiniMaxMusic3Pipeline {
         return chunks
     }
 
-    private func decode(
+    private func decodeSequential(
         chunks: [MLXArray],
         vocoder: MiniMaxMusic3Vocoder,
         recorder: MiniMaxMusic3ProfileRecorder?,
@@ -826,6 +1027,31 @@ public final class MiniMaxMusic3Pipeline {
             waveforms.append(cropped)
             progress?(.decode(chunk: index + 1, chunkCount: chunks.count))
         }
-        return MLX.clip(MLX.concatenated(waveforms, axis: 2).asType(.float32), min: -1, max: 1)
+        return MLX.concatenated(waveforms, axis: 2).asType(.float32)
+    }
+
+    private func decodeWholeLatent(
+        _ latent: MLXArray,
+        vocoder: MiniMaxMusic3Vocoder,
+        recorder: MiniMaxMusic3ProfileRecorder?,
+        progress: (@Sendable (MiniMaxMusic3Progress) -> Void)?
+    ) -> MLXArray {
+        let slices = MiniMaxMusic3DAVDecodeSlice.plan(frameCount: latent.dim(2))
+        let upsample = vocoder.configuration.upsamplingRatios.reduce(1, *)
+        var waveforms: [MLXArray] = []
+        waveforms.reserveCapacity(slices.count)
+        for (index, slice) in slices.enumerated() {
+            let decodeStart = ContinuousClock.now
+            let waveform = vocoder(latent[0..., 0..., slice.context].asType(.bfloat16))
+            let retainedStart = slice.retained.lowerBound * upsample
+            let retainedEnd = slice.retained.upperBound * upsample
+            let retainedSamples = retainedStart..<retainedEnd
+            let cropped = waveform[0..., 0..., retainedSamples]
+            MLX.eval(cropped)
+            recorder?.record(.vocoderDecode, since: decodeStart)
+            waveforms.append(cropped)
+            progress?(.decode(chunk: index + 1, chunkCount: slices.count))
+        }
+        return MLX.concatenated(waveforms, axis: 2).asType(.float32)
     }
 }

--- a/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3Pipeline.swift
+++ b/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3Pipeline.swift
@@ -11,6 +11,7 @@ public struct MiniMaxMusic3GenerationOptions: Sendable {
     public var inferenceSteps: Int
     public var seed: UInt64
     public var guidanceScale: Float
+    public var profilingEnabled: Bool
 
     public init(
         caption: String,
@@ -20,7 +21,8 @@ public struct MiniMaxMusic3GenerationOptions: Sendable {
         maximumFrames: Int? = nil,
         inferenceSteps: Int = 30,
         seed: UInt64 = 0,
-        guidanceScale: Float = 1.7
+        guidanceScale: Float = 1.7,
+        profilingEnabled: Bool = false
     ) {
         self.caption = caption
         self.lyrics = lyrics
@@ -30,6 +32,7 @@ public struct MiniMaxMusic3GenerationOptions: Sendable {
         self.inferenceSteps = inferenceSteps
         self.seed = seed
         self.guidanceScale = guidanceScale
+        self.profilingEnabled = profilingEnabled
     }
 }
 
@@ -37,6 +40,7 @@ public struct MiniMaxMusic3GenerationResult {
     public let waveform: MLXArray
     public let sampleRate: Int
     public let frameCount: Int
+    public let profile: MiniMaxMusic3GenerationProfile?
 }
 
 public enum MiniMaxMusic3Progress: Sendable, Equatable {
@@ -117,43 +121,69 @@ public final class MiniMaxMusic3Pipeline {
             )
         }
 
+        let totalStart = ContinuousClock.now
+        let recorder = options.profilingEnabled ? MiniMaxMusic3ProfileRecorder() : nil
         let generator = MLXRandom.RandomState(seed: options.seed)
+        let autoregressiveStart = ContinuousClock.now
         let frameHiddens = try autoregressiveStage(
             options: options,
             generator: generator,
+            recorder: recorder,
             progress: progress
         )
+        recorder?.record(.autoregressive, since: autoregressiveStart)
         if loadingStrategy == .staged {
             MLX.Memory.clearCache()
         }
+        let flowStart = ContinuousClock.now
         let chunks = try flowStage(
             frameHiddens: frameHiddens,
             steps: options.inferenceSteps,
             guidanceScale: options.guidanceScale,
             generator: generator,
+            recorder: recorder,
             progress: progress
         )
+        recorder?.record(.flow, since: flowStart)
         if loadingStrategy == .staged {
             MLX.Memory.clearCache()
         }
-        let decoded = try vocoderStage(chunks: chunks, progress: progress)
+        let vocoderStart = ContinuousClock.now
+        let decoded = try vocoderStage(
+            chunks: chunks,
+            recorder: recorder,
+            progress: progress
+        )
+        recorder?.record(.vocoder, since: vocoderStart)
         if loadingStrategy == .staged {
             MLX.Memory.clearCache()
         }
         let waveform = decoded.waveform
         MLX.eval(waveform)
+        let profile = recorder.map {
+            MiniMaxMusic3GenerationProfile(
+                frameCount: frameHiddens.dim(1),
+                chunkCount: chunks.count,
+                inferenceSteps: options.inferenceSteps,
+                totalSeconds: MiniMaxMusic3ProfileRecorder.seconds(since: totalStart),
+                recorder: $0
+            )
+        }
         return MiniMaxMusic3GenerationResult(
             waveform: waveform,
             sampleRate: decoded.sampleRate,
-            frameCount: frameHiddens.dim(1)
+            frameCount: frameHiddens.dim(1),
+            profile: profile
         )
     }
 
     private func autoregressiveStage(
         options: MiniMaxMusic3GenerationOptions,
         generator: MLXRandom.RandomState,
+        recorder: MiniMaxMusic3ProfileRecorder?,
         progress: (@Sendable (MiniMaxMusic3Progress) -> Void)?
     ) throws -> MLXArray {
+        let loadStart = ContinuousClock.now
         let models = try residentModels.map {
             MiniMaxMusic3AutoregressiveModels(
                 languageModel: $0.languageModel,
@@ -164,6 +194,7 @@ public final class MiniMaxMusic3Pipeline {
             from: requiredResources(),
             performanceMode: performanceMode
         )
+        recorder?.record(.autoregressiveLoad, since: loadStart)
         let tokenIDs = try promptTokenIDs(
             caption: options.caption,
             lyrics: options.lyrics,
@@ -177,6 +208,7 @@ public final class MiniMaxMusic3Pipeline {
             languageModel: models.languageModel,
             depthDecoder: models.depthDecoder,
             generator: generator,
+            recorder: recorder,
             progress: progress
         )
         MLX.eval(frameHiddens)
@@ -188,8 +220,10 @@ public final class MiniMaxMusic3Pipeline {
         steps: Int,
         guidanceScale: Float,
         generator: MLXRandom.RandomState,
+        recorder: MiniMaxMusic3ProfileRecorder?,
         progress: (@Sendable (MiniMaxMusic3Progress) -> Void)?
     ) throws -> [MLXArray] {
+        let loadStart = ContinuousClock.now
         let models = try residentModels.map {
             MiniMaxMusic3FlowModels(
                 conditionEncoder: $0.conditionEncoder,
@@ -199,6 +233,7 @@ public final class MiniMaxMusic3Pipeline {
             from: requiredResources(),
             performanceMode: performanceMode
         )
+        recorder?.record(.flowLoad, since: loadStart)
         let chunks = denoise(
             frameHiddens: frameHiddens,
             steps: steps,
@@ -206,6 +241,7 @@ public final class MiniMaxMusic3Pipeline {
             conditionEncoder: models.conditionEncoder,
             transformer: models.transformer,
             generator: generator,
+            recorder: recorder,
             progress: progress
         )
         MLX.eval(chunks)
@@ -214,11 +250,19 @@ public final class MiniMaxMusic3Pipeline {
 
     private func vocoderStage(
         chunks: [MLXArray],
+        recorder: MiniMaxMusic3ProfileRecorder?,
         progress: (@Sendable (MiniMaxMusic3Progress) -> Void)?
     ) throws -> (waveform: MLXArray, sampleRate: Int) {
+        let loadStart = ContinuousClock.now
         let vocoder = try residentModels?.vocoder
             ?? MiniMaxMusic3ModelLoader.loadVocoder(from: requiredResources())
-        let waveform = decode(chunks: chunks, vocoder: vocoder, progress: progress)
+        recorder?.record(.vocoderLoad, since: loadStart)
+        let waveform = decode(
+            chunks: chunks,
+            vocoder: vocoder,
+            recorder: recorder,
+            progress: progress
+        )
         MLX.eval(waveform)
         return (waveform, vocoder.configuration.samplingRate)
     }
@@ -259,15 +303,9 @@ public final class MiniMaxMusic3Pipeline {
         languageModel: MiniMaxMusic3LanguageModel,
         depthDecoder: MiniMaxMusic3DepthDecoder,
         generator: MLXRandom.RandomState,
+        recorder: MiniMaxMusic3ProfileRecorder?,
         progress: (@Sendable (MiniMaxMusic3Progress) -> Void)?
     ) throws -> MLXArray {
-        let caches = languageModel.makeCache()
-        let textEmbeddings = languageModel.embed(tokenIDs: textIDs)
-        var lastHidden = languageModel.hidden(
-            embeddings: textEmbeddings,
-            cache: caches,
-            lastPositionOnly: true
-        ).squeezed(axis: 1)
         let minimumFrames = explicitMinimumFrames ?? 0
         let durationFrames = Int(durationSeconds * Float(MiniMaxMusic3Prompt.frameRate))
         let requestedFrames = explicitMaximumFrames
@@ -282,9 +320,26 @@ public final class MiniMaxMusic3Pipeline {
             )
         }
 
+        let cacheCapacity = textIDs.dim(1) + maximumFrames + 1
+        let caches = languageModel.makeCache(
+            capacity: performanceMode.usesOptimizedGraph ? cacheCapacity : nil
+        )
+        let prefillStart = ContinuousClock.now
+        let textEmbeddings = languageModel.embed(tokenIDs: textIDs)
+        var lastHidden = languageModel.hidden(
+            embeddings: textEmbeddings,
+            cache: caches,
+            lastPositionOnly: true
+        ).squeezed(axis: 1)
+        if recorder != nil {
+            MLX.eval(lastHidden)
+            recorder?.record(.promptPrefill, since: prefillStart)
+        }
+
         var frameHiddens: [MLXArray] = []
         frameHiddens.reserveCapacity(maximumFrames)
         for frameIndex in 0...maximumFrames {
+            let samplingStart = ContinuousClock.now
             let logits = languageModel.logits(lastHidden)
             let allowEnd = frameHiddens.count >= minimumFrames
             let sampled = performanceMode == .reference
@@ -296,12 +351,14 @@ public final class MiniMaxMusic3Pipeline {
                     generator: generator
                 )
             let sampledID = sampled.item(Int.self)
+            recorder?.record(.semanticSampling, since: samplingStart)
             if sampledID == MiniMaxMusic3Prompt.audioEndTokenID {
                 break
             }
 
             let semantic = sampled.asType(.int32) - MLXArray(Int32(MiniMaxMusic3Prompt.audioCodeOffset))
             let duplicatedSemantic = MLX.repeated(semantic.reshaped(1), count: 2, axis: 0)
+            let depthStart = ContinuousClock.now
             let depth = generateDepthCodes(
                 lastHidden: lastHidden,
                 semanticCode: duplicatedSemantic,
@@ -309,6 +366,10 @@ public final class MiniMaxMusic3Pipeline {
                 depthDecoder: depthDecoder,
                 generator: generator
             )
+            if recorder != nil {
+                MLX.eval(depth.codes, depth.hidden)
+                recorder?.record(.residualDepth, since: depthStart)
+            }
             var conditioningToEvaluate: MLXArray?
             if frameIndex > 0 {
                 let conditioning = MLX.concatenated([lastHidden[0..<1], depth.hidden], axis: -1)
@@ -327,6 +388,7 @@ public final class MiniMaxMusic3Pipeline {
                 }
             }
 
+            let feedbackStart = ContinuousClock.now
             let feedback = embedAudioFrame(
                 depth.codes,
                 languageModel: languageModel,
@@ -344,6 +406,7 @@ public final class MiniMaxMusic3Pipeline {
             } else {
                 MLX.eval(lastHidden)
             }
+            recorder?.record(.autoregressiveFeedback, since: feedbackStart)
         }
 
         guard !frameHiddens.isEmpty else {
@@ -480,7 +543,7 @@ public final class MiniMaxMusic3Pipeline {
         var codes = [semanticCode]
         var hiddenParts: [MLXArray] = []
         let caches = performanceMode.usesOptimizedGraph
-            ? depthDecoder.makeCache()
+            ? depthDecoder.makeCache(capacity: depthDecoder.configuration.numCodebooks)
             : nil
         for codebook in 1..<depthDecoder.configuration.numCodebooks {
             let input = if caches == nil || codebook == 1 {
@@ -552,6 +615,7 @@ public final class MiniMaxMusic3Pipeline {
         conditionEncoder: MiniMaxMusic3ConditionEncoder,
         transformer: MiniMaxMusic3Transformer,
         generator: MLXRandom.RandomState,
+        recorder: MiniMaxMusic3ProfileRecorder?,
         progress: (@Sendable (MiniMaxMusic3Progress) -> Void)?
     ) -> [MLXArray] {
         if performanceMode == .reference {
@@ -573,6 +637,7 @@ public final class MiniMaxMusic3Pipeline {
 
         for (chunkIndex, start) in starts.enumerated() {
             let end = min(start + 200, frameHiddens.dim(1))
+            let conditionStart = ContinuousClock.now
             var condition = conditionEncoder(frameHiddens[0..., start..<end, 0...])
                 .asType(.bfloat16)
             let overlap = min(previousLatent?.dim(2) ?? 0, condition.dim(1))
@@ -582,6 +647,10 @@ public final class MiniMaxMusic3Pipeline {
                     axis: 1
                 )
             }
+            if recorder != nil {
+                MLX.eval(condition)
+                recorder?.record(.conditionEncoding, since: conditionStart)
+            }
             var latents = MLXRandom.normal([
                 1,
                 transformer.configuration.inChannels,
@@ -589,6 +658,8 @@ public final class MiniMaxMusic3Pipeline {
             ], key: generator).asType(condition.dtype)
             let noisePrompt = overlap > 0 ? latents[0..., 0..., 0..<overlap] : nil
             let zeroCondition = MLXArray.zeros(condition.shape, dtype: condition.dtype)
+            let batchedCondition = MLX.concatenated([condition, zeroCondition], axis: 0)
+            let preparedCondition = transformer.prepareConditionInput(batchedCondition)
             let rotary = transformer.rotaryCache(
                 latentLength: condition.dim(1),
                 dtype: condition.dtype
@@ -596,6 +667,7 @@ public final class MiniMaxMusic3Pipeline {
             let stepSize = MLXArray(1 / Float(steps)).asType(condition.dtype)
 
             for step in 0..<steps {
+                let transformerStart = ContinuousClock.now
                 let time = Float(step) / Float(steps)
                 if overlap > 0, let previousLatent, let noisePrompt {
                     let blended = (1 - (1 - 1e-6) * time) * noisePrompt
@@ -608,18 +680,27 @@ public final class MiniMaxMusic3Pipeline {
                 let timestep = MLXArray([time]).asType(latents.dtype)
                 let batchedLatents = MLX.concatenated([latents, latents], axis: 0)
                 let batchedTimestep = MLX.repeated(timestep, count: 2, axis: 0)
-                let batchedCondition = MLX.concatenated([condition, zeroCondition], axis: 0)
-                let velocities = transformer(
-                    latents: batchedLatents,
-                    timestep: batchedTimestep,
-                    condition: batchedCondition,
-                    rotary: rotary
-                )
+                let velocities = if let preparedCondition {
+                    transformer(
+                        latents: batchedLatents,
+                        timestep: batchedTimestep,
+                        preparedCondition: preparedCondition,
+                        rotary: rotary
+                    )
+                } else {
+                    transformer(
+                        latents: batchedLatents,
+                        timestep: batchedTimestep,
+                        condition: batchedCondition,
+                        rotary: rotary
+                    )
+                }
                 let conditional = velocities[0..<1]
                 let unconditional = velocities[1..<2]
                 let velocity = unconditional + (conditional - unconditional) * MLXArray(guidanceScale)
                 latents = latents + velocity * stepSize
                 MLX.eval(latents)
+                recorder?.record(.flowTransformer, since: transformerStart)
                 progress?(.denoise(
                     chunk: chunkIndex + 1,
                     chunkCount: starts.count,
@@ -728,17 +809,20 @@ public final class MiniMaxMusic3Pipeline {
     private func decode(
         chunks: [MLXArray],
         vocoder: MiniMaxMusic3Vocoder,
+        recorder: MiniMaxMusic3ProfileRecorder?,
         progress: (@Sendable (MiniMaxMusic3Progress) -> Void)?
     ) -> MLXArray {
         var waveforms: [MLXArray] = []
         waveforms.reserveCapacity(chunks.count)
         for (index, chunk) in chunks.enumerated() {
+            let decodeStart = ContinuousClock.now
             let waveform = vocoder(chunk.asType(.bfloat16))
             let left = index == 0 ? 0 : 86 * 512
             let right = index == chunks.count - 1 ? 0 : 258 * 512
             let sampleEnd = waveform.dim(2) - right
             let cropped = waveform[0..., 0..., left..<sampleEnd]
             MLX.eval(cropped)
+            recorder?.record(.vocoderDecode, since: decodeStart)
             waveforms.append(cropped)
             progress?(.decode(chunk: index + 1, chunkCount: chunks.count))
         }

--- a/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3Profiler.swift
+++ b/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3Profiler.swift
@@ -1,0 +1,120 @@
+import Foundation
+
+public struct MiniMaxMusic3GenerationProfile: Codable, Sendable, Equatable {
+    public static let currentSchemaVersion = 1
+
+    public let schemaVersion: Int
+    public let frameCount: Int
+    public let chunkCount: Int
+    public let inferenceSteps: Int
+    public let totalSeconds: Double
+    public let autoregressiveStageSeconds: Double
+    public let autoregressiveLoadSeconds: Double
+    public let promptPrefillSeconds: Double
+    public let semanticSamplingSeconds: Double
+    public let residualDepthSeconds: Double
+    public let autoregressiveFeedbackSeconds: Double
+    public let flowStageSeconds: Double
+    public let flowLoadSeconds: Double
+    public let conditionEncodingSeconds: Double
+    public let flowTransformerSeconds: Double
+    public let vocoderStageSeconds: Double
+    public let vocoderLoadSeconds: Double
+    public let vocoderDecodeSeconds: Double
+
+    init(
+        frameCount: Int,
+        chunkCount: Int,
+        inferenceSteps: Int,
+        totalSeconds: Double,
+        recorder: MiniMaxMusic3ProfileRecorder
+    ) {
+        self.schemaVersion = Self.currentSchemaVersion
+        self.frameCount = frameCount
+        self.chunkCount = chunkCount
+        self.inferenceSteps = inferenceSteps
+        self.totalSeconds = totalSeconds
+        self.autoregressiveStageSeconds = recorder.autoregressiveStageSeconds
+        self.autoregressiveLoadSeconds = recorder.autoregressiveLoadSeconds
+        self.promptPrefillSeconds = recorder.promptPrefillSeconds
+        self.semanticSamplingSeconds = recorder.semanticSamplingSeconds
+        self.residualDepthSeconds = recorder.residualDepthSeconds
+        self.autoregressiveFeedbackSeconds = recorder.autoregressiveFeedbackSeconds
+        self.flowStageSeconds = recorder.flowStageSeconds
+        self.flowLoadSeconds = recorder.flowLoadSeconds
+        self.conditionEncodingSeconds = recorder.conditionEncodingSeconds
+        self.flowTransformerSeconds = recorder.flowTransformerSeconds
+        self.vocoderStageSeconds = recorder.vocoderStageSeconds
+        self.vocoderLoadSeconds = recorder.vocoderLoadSeconds
+        self.vocoderDecodeSeconds = recorder.vocoderDecodeSeconds
+    }
+}
+
+enum MiniMaxMusic3ProfileStage {
+    case autoregressive
+    case autoregressiveLoad
+    case promptPrefill
+    case semanticSampling
+    case residualDepth
+    case autoregressiveFeedback
+    case flow
+    case flowLoad
+    case conditionEncoding
+    case flowTransformer
+    case vocoder
+    case vocoderLoad
+    case vocoderDecode
+}
+
+final class MiniMaxMusic3ProfileRecorder {
+    private(set) var autoregressiveStageSeconds = 0.0
+    private(set) var autoregressiveLoadSeconds = 0.0
+    private(set) var promptPrefillSeconds = 0.0
+    private(set) var semanticSamplingSeconds = 0.0
+    private(set) var residualDepthSeconds = 0.0
+    private(set) var autoregressiveFeedbackSeconds = 0.0
+    private(set) var flowStageSeconds = 0.0
+    private(set) var flowLoadSeconds = 0.0
+    private(set) var conditionEncodingSeconds = 0.0
+    private(set) var flowTransformerSeconds = 0.0
+    private(set) var vocoderStageSeconds = 0.0
+    private(set) var vocoderLoadSeconds = 0.0
+    private(set) var vocoderDecodeSeconds = 0.0
+
+    func record(_ stage: MiniMaxMusic3ProfileStage, since start: ContinuousClock.Instant) {
+        let seconds = Self.seconds(since: start)
+        switch stage {
+        case .autoregressive:
+            autoregressiveStageSeconds += seconds
+        case .autoregressiveLoad:
+            autoregressiveLoadSeconds += seconds
+        case .promptPrefill:
+            promptPrefillSeconds += seconds
+        case .semanticSampling:
+            semanticSamplingSeconds += seconds
+        case .residualDepth:
+            residualDepthSeconds += seconds
+        case .autoregressiveFeedback:
+            autoregressiveFeedbackSeconds += seconds
+        case .flow:
+            flowStageSeconds += seconds
+        case .flowLoad:
+            flowLoadSeconds += seconds
+        case .conditionEncoding:
+            conditionEncodingSeconds += seconds
+        case .flowTransformer:
+            flowTransformerSeconds += seconds
+        case .vocoder:
+            vocoderStageSeconds += seconds
+        case .vocoderLoad:
+            vocoderLoadSeconds += seconds
+        case .vocoderDecode:
+            vocoderDecodeSeconds += seconds
+        }
+    }
+
+    static func seconds(since start: ContinuousClock.Instant) -> Double {
+        let components = start.duration(to: .now).components
+        return Double(components.seconds) + Double(components.attoseconds) / 1e18
+    }
+}

--- a/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3RuntimeOptions.swift
+++ b/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3RuntimeOptions.swift
@@ -1,0 +1,158 @@
+import Crypto
+import Foundation
+import MLX
+
+public enum MiniMaxMusic3FlowStrategy: String, CaseIterable, Codable, Sendable {
+    /// Denoise overlapping windows in sequence and carry the overlap forward.
+    case sequential
+    /// Denoise one song-length latent and average overlapping window velocities.
+    case overlapAverage = "overlap-average"
+}
+
+public enum MiniMaxMusic3SeedStrategy: String, CaseIterable, Codable, Sendable {
+    /// Preserve the released recipe: autoregressive sampling and flow noise share one stream.
+    case legacy
+    /// Give each model stage a stable, independently derived random stream.
+    case stageSeparatedV1 = "stage-separated-v1"
+
+    func stageSeeds(seed: UInt64) -> (autoregressive: UInt64, flow: UInt64) {
+        switch self {
+        case .legacy:
+            return (seed, seed)
+        case .stageSeparatedV1:
+            return (
+                Self.derive(seed: seed, domain: "autoregressive"),
+                Self.derive(seed: seed, domain: "flow")
+            )
+        }
+    }
+
+    private static func derive(seed: UInt64, domain: String) -> UInt64 {
+        var input = (0..<8).map { UInt8(truncatingIfNeeded: seed >> UInt64($0 * 8)) }
+        let domainBytes = Array(domain.utf8)
+        input.append(contentsOf: (0..<4).map {
+            UInt8(truncatingIfNeeded: UInt32(domainBytes.count) >> UInt32($0 * 8))
+        })
+        input.append(contentsOf: domainBytes)
+        let digest = SHA256.hash(data: Data(input))
+        return digest.prefix(8).enumerated().reduce(UInt64(0)) { value, element in
+            value | (UInt64(element.element) << UInt64(element.offset * 8))
+        }
+    }
+}
+
+public struct MiniMaxMusic3AudioHealthReport: Codable, Equatable, Sendable {
+    public let sampleCount: Int
+    public let peak: Float
+    public let rms: Float
+    public let stereoCollapseFraction: Float
+
+    public init(
+        sampleCount: Int,
+        peak: Float,
+        rms: Float,
+        stereoCollapseFraction: Float
+    ) {
+        self.sampleCount = sampleCount
+        self.peak = peak
+        self.rms = rms
+        self.stereoCollapseFraction = stereoCollapseFraction
+    }
+}
+
+public enum MiniMaxMusic3AudioHealth {
+    public static let silenceThreshold: Float = 1e-7
+    public static let implausiblePeakThreshold: Float = 8
+    public static let stereoCollapseThreshold: Float = 0.75
+
+    public static func validate(
+        _ waveform: MLXArray,
+        sampleRate: Int
+    ) throws -> MiniMaxMusic3AudioHealthReport {
+        guard waveform.ndim == 3, waveform.dim(0) == 1, waveform.dim(1) == 2,
+              waveform.dim(2) > 0, sampleRate > 0
+        else {
+            throw MiniMaxMusic3Error.invalidAudio(
+                "expected waveform shape [1, 2, samples] and a positive sample rate"
+            )
+        }
+        guard MLX.all(MLX.isFinite(waveform)).item(Bool.self) else {
+            throw MiniMaxMusic3Error.invalidAudio("the waveform contains non-finite samples")
+        }
+
+        let samples = waveform[0, 0..., 0...].asType(.float32)
+        let peak = MLX.max(MLX.abs(samples)).item(Float.self)
+        let rms = MLX.sqrt(MLX.mean(MLX.square(samples))).item(Float.self)
+        guard rms > silenceThreshold else {
+            throw MiniMaxMusic3Error.invalidAudio("the waveform is silent")
+        }
+        guard peak <= implausiblePeakThreshold else {
+            throw MiniMaxMusic3Error.invalidAudio(
+                String(format: "the waveform has an implausible %.3f peak", peak)
+            )
+        }
+
+        let blockCount = waveform.dim(2) / sampleRate
+        let collapseFraction: Float
+        if blockCount == 0 {
+            collapseFraction = 0
+        } else {
+            let framed = samples[0..., 0..<(blockCount * sampleRate)]
+                .reshaped(2, blockCount, sampleRate)
+            let blockRMS = MLX.sqrt(MLX.mean(MLX.square(framed), axis: 2))
+            let lower = MLX.min(blockRMS, axis: 0)
+            let upper = MLX.max(blockRMS, axis: 0)
+            let collapsed = MLX.logicalAnd(
+                upper .> MLXArray(silenceThreshold),
+                lower .< upper * MLXArray(Float(0.1))
+            )
+            collapseFraction = MLX.mean(collapsed.asType(.float32)).item(Float.self)
+        }
+        guard collapseFraction < stereoCollapseThreshold else {
+            throw MiniMaxMusic3Error.invalidAudio(
+                String(
+                    format: "the DAV decoder collapsed one stereo channel in %.0f%% of the audio",
+                    collapseFraction * 100
+                )
+            )
+        }
+        return MiniMaxMusic3AudioHealthReport(
+            sampleCount: waveform.dim(2),
+            peak: peak,
+            rms: rms,
+            stereoCollapseFraction: collapseFraction
+        )
+    }
+}
+
+struct MiniMaxMusic3DAVDecodeSlice: Equatable {
+    let context: Range<Int>
+    let retained: Range<Int>
+
+    static func plan(
+        frameCount: Int,
+        maximumChunkFrames: Int = 1_024,
+        overlapFrames: Int = 64
+    ) -> [Self] {
+        precondition(frameCount > 0)
+        precondition(overlapFrames >= 0 && maximumChunkFrames > 2 * overlapFrames)
+        guard frameCount > maximumChunkFrames else {
+            return [Self(context: 0..<frameCount, retained: 0..<frameCount)]
+        }
+        let retainedFrameCount = maximumChunkFrames - 2 * overlapFrames
+        var retainedStart = 0
+        var slices: [Self] = []
+        while retainedStart < frameCount {
+            let retainedEnd = min(frameCount, retainedStart + retainedFrameCount)
+            let contextStart = max(0, retainedStart - overlapFrames)
+            let contextEnd = min(frameCount, retainedEnd + overlapFrames)
+            let localStart = retainedStart - contextStart
+            slices.append(Self(
+                context: contextStart..<contextEnd,
+                retained: localStart..<(localStart + retainedEnd - retainedStart)
+            ))
+            retainedStart = retainedEnd
+        }
+        return slices
+    }
+}

--- a/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3SamplingTier.swift
+++ b/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3SamplingTier.swift
@@ -1,0 +1,18 @@
+import Foundation
+
+public enum MiniMaxMusic3SamplingTier: String, CaseIterable, Codable, Sendable {
+    case quality
+    case fast
+    case draft
+
+    public var inferenceSteps: Int {
+        switch self {
+        case .quality:
+            30
+        case .fast:
+            20
+        case .draft:
+            16
+        }
+    }
+}

--- a/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3Transformer.swift
+++ b/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3Transformer.swift
@@ -198,6 +198,9 @@ public final class MiniMaxMusic3Transformer: Module {
     @ModuleInfo(key: "proj_out") var outputProjection: Linear
     @ModuleInfo(key: "postprocess_conv") var postprocessConvolution: Conv1d
 
+    private var latentInputProjection: Linear?
+    private var conditionInputProjection: Linear?
+
     public init(configuration: MiniMaxMusic3TransformerConfiguration) {
         self.configuration = configuration
         let inner = configuration.numAttentionHeads * configuration.attentionHeadDim
@@ -273,10 +276,40 @@ public final class MiniMaxMusic3Transformer: Module {
         rotary: (MLXArray, MLXArray)
     ) -> MLXArray {
         let latentNLC = latents.transposed(0, 2, 1)
-        let zeros = MLXArray.zeros(latentNLC.shape, dtype: latentNLC.dtype)
-        var hidden = MLX.concatenated([latentNLC, zeros, condition], axis: -1)
-        hidden = preprocessConvolution(hidden) + hidden
-        hidden = inputProjection(hidden)
+        var hidden: MLXArray
+        if let latentInputProjection, let conditionInputProjection {
+            hidden = latentInputProjection(latentNLC) + conditionInputProjection(condition)
+        } else {
+            let zeros = MLXArray.zeros(latentNLC.shape, dtype: latentNLC.dtype)
+            hidden = MLX.concatenated([latentNLC, zeros, condition], axis: -1)
+            hidden = preprocessConvolution(hidden) + hidden
+            hidden = inputProjection(hidden)
+        }
+        let time = timeEmbedding(timeProjection(timestep)).expandedDimensions(axis: 1)
+        hidden = MLX.concatenated([time, hidden], axis: 1)
+        for block in blocks {
+            hidden = block(hidden, rotary: rotary)
+        }
+        hidden = outputProjection(hidden[0..., 1..., 0...])
+        let postprocessed = postprocessConvolution(hidden) + hidden
+        return postprocessed.transposed(0, 2, 1)
+    }
+
+    func prepareConditionInput(_ condition: MLXArray) -> MLXArray? {
+        conditionInputProjection?(condition)
+    }
+
+    func callAsFunction(
+        latents: MLXArray,
+        timestep: MLXArray,
+        preparedCondition: MLXArray,
+        rotary: (MLXArray, MLXArray)
+    ) -> MLXArray {
+        guard let latentInputProjection else {
+            preconditionFailure("prepared flow conditioning requires fused input projections")
+        }
+        let latentNLC = latents.transposed(0, 2, 1)
+        var hidden = latentInputProjection(latentNLC) + preparedCondition
         let time = timeEmbedding(timeProjection(timestep)).expandedDimensions(axis: 1)
         hidden = MLX.concatenated([time, hidden], axis: 1)
         for block in blocks {
@@ -288,10 +321,27 @@ public final class MiniMaxMusic3Transformer: Module {
     }
 
     public func prepareFusedProjections() {
+        prepareFusedInputProjection()
         for block in blocks {
             block.prepareFusedProjections()
         }
         MLX.Memory.clearCache()
+    }
+
+    private func prepareFusedInputProjection() {
+        guard latentInputProjection == nil, conditionInputProjection == nil else { return }
+        let convolution = preprocessConvolution.weight.squeezed(axis: 1)
+        let dimensions = convolution.dim(0)
+        let residualConvolution = convolution
+            + MLXArray.eye(dimensions, dtype: convolution.dtype)
+        let combined = MLX.matmul(inputProjection.weight, residualConvolution)
+        let latentChannels = configuration.inChannels
+        let conditionStart = 2 * latentChannels
+        let latentWeight = combined[0..., 0..<latentChannels]
+        let conditionWeight = combined[0..., conditionStart...]
+        MLX.eval(latentWeight, conditionWeight)
+        latentInputProjection = Linear(weight: latentWeight, bias: nil)
+        conditionInputProjection = Linear(weight: conditionWeight, bias: nil)
     }
 
     static func mapWeight(key: String, value: MLXArray) -> [(String, MLXArray)] {

--- a/Sources/MereRunCore/MiniMaxMusic3/README.md
+++ b/Sources/MereRunCore/MiniMaxMusic3/README.md
@@ -17,4 +17,41 @@ weight-name mapping in parity with the pinned upstream revision declared by
 The default `staged` loading strategy releases each stage before loading the
 next one and clears the MLX cache between stages. `resident` loads the complete
 stack once for lower repeated-request latency. Both strategies execute the same
-model math and generation schedule.
+model math and generation schedule. Optimized autoregressive generation also
+returns completed variable-length attention buffers to MLX every 64 frames;
+live model weights, KV state, and generated conditioning remain resident.
+
+The released flow and seed recipes remain `sequential` and `legacy`.
+`overlap-average` is an opt-in whole-song flow experiment that averages
+overlapping window velocities at each Euler step, then uses bounded DAV decode
+with retained-center stitching. `stage-separated-v1` independently derives the
+autoregressive and flow random streams. The pipeline validates finite output,
+signal level, peak, and stereo integrity before returning audio.
+
+On an M4 Max with 128 GB unified memory and MLX 0.32.1, the PocketAiHub-style
+direct INT8 ConvRot projection was slower than the converted BF16 dense path at
+every measured 2,048-by-2,048 shape: 0.757 vs 0.285 ms at 100 rows, 1.048 vs
+0.555 ms at 689 rows, and 1.772 vs 1.108 ms at 1,380 rows. Output cosine was
+0.999991 or better. ConvRot therefore remains a tested research oracle rather
+than a production execution path.
+
+A real 251-frame Q8/draft checkpoint run measured sequential flow/vocoder at
+48.08/4.91 seconds and overlap-average at 46.52/1.08 seconds. End-to-end totals
+were 82.14 and 86.67 seconds respectively because the second run's common
+autoregressive stage thermalized by roughly 10.5 seconds; compare isolated
+profile stages, not that single noisy total, when evaluating the flow strategy.
+
+A matched forced 3,001-frame (120-second) Q8/draft run measured sequential and
+overlap-average flow at 454.31 and 464.38 seconds respectively, so the
+whole-song experiment remains an opt-in continuity recipe rather than a speed
+default. Sequential and overlap-average decode took 15.95 and 9.43 seconds.
+Sample jumps at the exact flow and DAV boundaries stayed below each render's
+global 99.99th-percentile adjacent-sample difference.
+
+The same 3,001-frame sequential run exposed duration-scaled MLX buffer-cache
+growth that process RSS did not report: `/usr/bin/time -l` measured a 110.20 GB
+peak physical footprint. Returning completed autoregressive buffers every 64
+frames reduced the matched peak to 23.78 GB (a 78.4% reduction) with zero swaps. The
+autoregressive stage changed from 144.75 to 151.05 seconds, and the complete
+float32 WAV remained byte-identical at SHA-256
+`5ec23504131e7b74cef86f368d1a9164f9ac96d071d9c0f25615c5525fc559be`.

--- a/Sources/MereRunCore/ZImageTurbo/Model/TextEncoder/LLMGeneration/KVCache.swift
+++ b/Sources/MereRunCore/ZImageTurbo/Model/TextEncoder/LLMGeneration/KVCache.swift
@@ -179,6 +179,63 @@ public class KVCacheSimple: KVCache {
     }
 }
 
+/// A fixed-capacity cache for generation loops whose maximum sequence length
+/// is known before prefill. Unlike `KVCacheSimple`, it never concatenates a new
+/// backing allocation while decoding.
+public final class KVCacheStatic: KVCache {
+    public let capacity: Int
+    private var keys: MLXArray?
+    private var values: MLXArray?
+    public private(set) var offset = 0
+
+    public init(capacity: Int) {
+        precondition(capacity > 0)
+        self.capacity = capacity
+    }
+
+    public var supportsVariablePositionBatching: Bool {
+        true
+    }
+
+    public func update(keys newKeys: MLXArray, values newValues: MLXArray) -> (MLXArray, MLXArray) {
+        let nextOffset = offset + newKeys.dim(2)
+        precondition(
+            nextOffset <= capacity,
+            "KV cache capacity \(capacity) is smaller than required length \(nextOffset)"
+        )
+        if keys == nil {
+            keys = MLXArray.zeros(
+                [newKeys.dim(0), newKeys.dim(1), capacity, newKeys.dim(3)],
+                dtype: newKeys.dtype
+            )
+            values = MLXArray.zeros(
+                [newValues.dim(0), newValues.dim(1), capacity, newValues.dim(3)],
+                dtype: newValues.dtype
+            )
+        }
+
+        keys?[.ellipsis, offset..<nextOffset, 0...] = newKeys
+        values?[.ellipsis, offset..<nextOffset, 0...] = newValues
+        offset = nextOffset
+        return (
+            keys![.ellipsis, ..<offset, 0...],
+            values![.ellipsis, ..<offset, 0...]
+        )
+    }
+
+    public func makeMask(n: Int) -> MLXFast.ScaledDotProductAttentionMaskMode {
+        n == 1 ? .none : .causal
+    }
+
+    public func fork() -> KVCache {
+        let copy = KVCacheStatic(capacity: capacity)
+        copy.keys = keys.map { $0.asType($0.dtype) }
+        copy.values = values.map { $0.asType($0.dtype) }
+        copy.offset = offset
+        return copy
+    }
+}
+
 public final class KVRaggedBatchCache: KVCache {
     struct RowState {
         let keys: MLXArray

--- a/Tests/MereRunCLITests/MusicGenerateCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/MusicGenerateCommandParsingTests.swift
@@ -88,6 +88,8 @@ final class MusicGenerateCommandParsingTests: XCTestCase {
             "--memory-mode", "staged",
             "--performance-mode", "q8",
             "--sampling-tier", "fast",
+            "--flow-strategy", "overlap-average",
+            "--seed-strategy", "stage-separated-v1",
             "--profile-output", "/tmp/minimax-profile.json",
         ])
 
@@ -104,6 +106,8 @@ final class MusicGenerateCommandParsingTests: XCTestCase {
         XCTAssertEqual(command.miniMaxLoadingStrategy, .staged)
         XCTAssertEqual(command.miniMaxPerformanceMode, .q8)
         XCTAssertEqual(command.miniMaxSamplingTier, .fast)
+        XCTAssertEqual(command.miniMaxFlowStrategy, .overlapAverage)
+        XCTAssertEqual(command.miniMaxSeedStrategy, .stageSeparatedV1)
         XCTAssertEqual(command.resolvedMiniMaxInferenceSteps, 24)
         XCTAssertEqual(command.miniMaxProfileOutput, "/tmp/minimax-profile.json")
     }

--- a/Tests/MereRunCLITests/MusicGenerateCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/MusicGenerateCommandParsingTests.swift
@@ -87,6 +87,8 @@ final class MusicGenerateCommandParsingTests: XCTestCase {
             "--sample-rate", "32000",
             "--memory-mode", "staged",
             "--performance-mode", "q8",
+            "--sampling-tier", "fast",
+            "--profile-output", "/tmp/minimax-profile.json",
         ])
 
         XCTAssertEqual(command.model, MiniMaxMusic3Resources.modelID)
@@ -101,6 +103,25 @@ final class MusicGenerateCommandParsingTests: XCTestCase {
         XCTAssertEqual(command.miniMaxOutputSampleRate, 32_000)
         XCTAssertEqual(command.miniMaxLoadingStrategy, .staged)
         XCTAssertEqual(command.miniMaxPerformanceMode, .q8)
+        XCTAssertEqual(command.miniMaxSamplingTier, .fast)
+        XCTAssertEqual(command.resolvedMiniMaxInferenceSteps, 24)
+        XCTAssertEqual(command.miniMaxProfileOutput, "/tmp/minimax-profile.json")
+    }
+
+    func testMiniMaxSamplingTiersResolveDocumentedStepCounts() throws {
+        for (tier, expectedSteps) in [
+            ("quality", 30),
+            ("fast", 20),
+            ("draft", 16),
+        ] {
+            let command = try MusicGenerate.parse([
+                "deep house",
+                "--model", MiniMaxMusic3Resources.modelID,
+                "--instrumental",
+                "--sampling-tier", tier,
+            ])
+            XCTAssertEqual(command.resolvedMiniMaxInferenceSteps, expectedSteps)
+        }
     }
 
     func testMiniMaxValidatesDurationFloorAgainstUpperBound() throws {

--- a/Tests/MereRunCLITests/MusicServeAndExportTests.swift
+++ b/Tests/MereRunCLITests/MusicServeAndExportTests.swift
@@ -60,6 +60,8 @@ final class MusicServeAndExportTests: XCTestCase {
                   "audio_duration": 30,
                   "minimum_audio_duration": 20,
                   "sampling_tier": "draft",
+                  "flow_strategy": "overlap-average",
+                  "seed_strategy": "stage-separated-v1",
                   "num_inference_steps": 24,
                   "guidance_scale": 1.7,
                   "sample_rate": 44100
@@ -73,6 +75,8 @@ final class MusicServeAndExportTests: XCTestCase {
         XCTAssertEqual(request.audioDuration, 30)
         XCTAssertEqual(request.minimumAudioDuration, 20)
         XCTAssertEqual(request.samplingTier, .draft)
+        XCTAssertEqual(request.flowStrategy, .overlapAverage)
+        XCTAssertEqual(request.seedStrategy, .stageSeparatedV1)
         XCTAssertEqual(request.numInferenceSteps, 24)
         XCTAssertEqual(request.guidanceScale, 1.7)
         XCTAssertEqual(request.sampleRate, 44_100)

--- a/Tests/MereRunCLITests/MusicServeAndExportTests.swift
+++ b/Tests/MereRunCLITests/MusicServeAndExportTests.swift
@@ -59,6 +59,7 @@ final class MusicServeAndExportTests: XCTestCase {
                   "stream": false,
                   "audio_duration": 30,
                   "minimum_audio_duration": 20,
+                  "sampling_tier": "draft",
                   "num_inference_steps": 24,
                   "guidance_scale": 1.7,
                   "sample_rate": 44100
@@ -71,6 +72,7 @@ final class MusicServeAndExportTests: XCTestCase {
         XCTAssertEqual(request.minNewTokens, 500)
         XCTAssertEqual(request.audioDuration, 30)
         XCTAssertEqual(request.minimumAudioDuration, 20)
+        XCTAssertEqual(request.samplingTier, .draft)
         XCTAssertEqual(request.numInferenceSteps, 24)
         XCTAssertEqual(request.guidanceScale, 1.7)
         XCTAssertEqual(request.sampleRate, 44_100)

--- a/Tests/MereRunCoreTests/MiniMaxMusic3ConvRotWeightOnlyResearchTests.swift
+++ b/Tests/MereRunCoreTests/MiniMaxMusic3ConvRotWeightOnlyResearchTests.swift
@@ -1,0 +1,210 @@
+import Foundation
+import MLX
+import MLXNN
+import XCTest
+@testable import MereRunCore
+
+/// Weight-only ConvRot oracle matching PocketAiHub's direct MLX evaluation.
+///
+/// Run the production-width timing explicitly; set
+/// `MERERUN_MINIMAX_MUSIC3_CONVROT_ROWS` to change the default 100-row input:
+///
+///     MERERUN_MINIMAX_MUSIC3_CONVROT_WEIGHT_ONLY_E2E=1 \
+///       swift test --filter MiniMaxMusic3ConvRotWeightOnlyResearchTests/testProductionWidth
+final class MiniMaxMusic3ConvRotWeightOnlyResearchTests: MereRunCoreTestCase {
+    func testConvRotWeightOnlyProjectionMatchesDenseReference() throws {
+        let inputDimensions = 256
+        let outputDimensions = 8
+        let codes = MLXArray((0..<(outputDimensions * inputDimensions)).map {
+            Int8($0 % 31 - 15)
+        }).reshaped(outputDimensions, inputDimensions)
+        let rowScales = MLXArray((0..<outputDimensions).map {
+            Float($0 + 1) / 1_000
+        })
+        let input = MLXArray((0..<(3 * inputDimensions)).map {
+            Float($0 % 29 - 14) / 17
+        }).reshaped(3, inputDimensions).asType(.bfloat16)
+        let layer = try XCTUnwrap(MiniMaxMusic3ConvRotWeightOnlyLinear(
+            codes: codes,
+            rowScales: rowScales,
+            bias: nil
+        ))
+
+        let actual = layer(input).asType(.float32)
+        let denseWeight = layer.denseReferenceWeight(dtype: .bfloat16)
+        let expected = MLX.matmul(input, denseWeight.transposed()).asType(.float32)
+        MLX.eval(actual, expected)
+
+        XCTAssertTrue(MLX.allClose(actual, expected, rtol: 2e-2, atol: 2e-2).item(Bool.self))
+    }
+
+    func testProductionWidthConvRotWeightOnlyTiming() throws {
+        let environment = ProcessInfo.processInfo.environment
+        guard environment[
+            "MERERUN_MINIMAX_MUSIC3_CONVROT_WEIGHT_ONLY_E2E"
+        ] == "1" else {
+            throw XCTSkip("set the ConvRot weight-only E2E flag")
+        }
+        let rows = max(1, Int(environment["MERERUN_MINIMAX_MUSIC3_CONVROT_ROWS"] ?? "") ?? 100)
+        let inputDimensions = 2_048
+        let outputDimensions = 2_048
+        let codes = (MLX.sin(
+            MLX.arange(outputDimensions * inputDimensions, dtype: .float32) / 17
+        ) * 31).asType(.int8).reshaped(outputDimensions, inputDimensions)
+        let scales = (MLX.sin(
+            MLX.arange(outputDimensions, dtype: .float32) / 11
+        ) * 0.0008 + 0.001).asType(.float32)
+        let input = MLX.sin(
+            MLX.arange(rows * inputDimensions, dtype: .float32) / 23
+        ).reshaped(rows, inputDimensions).asType(.bfloat16)
+        Self.trace("fixtures declared")
+        let layer = try XCTUnwrap(MiniMaxMusic3ConvRotWeightOnlyLinear(
+            codes: codes,
+            rowScales: scales,
+            bias: nil
+        ))
+        Self.trace("ConvRot layer initialized")
+        let denseWeight = layer.denseReferenceWeight(dtype: .bfloat16)
+        Self.trace("dense oracle declared")
+        MLX.eval(layer(input), MLX.matmul(input, denseWeight.transposed()))
+        Self.trace("warmup complete")
+
+        let convRotMilliseconds = Self.bestMilliseconds { layer(input) }
+        let denseMilliseconds = Self.bestMilliseconds {
+            MLX.matmul(input, denseWeight.transposed())
+        }
+        let actual = layer(input).asType(.float32)
+        let expected = MLX.matmul(input, denseWeight.transposed()).asType(.float32)
+        MLX.eval(actual, expected)
+        let cosine = MLX.sum(actual * expected)
+            / MLX.sqrt(MLX.sum(MLX.square(actual)) * MLX.sum(MLX.square(expected)))
+
+        print(
+            "MiniMax Music 3 ConvRot weight-only: "
+                + String(format: "rows=%d convrot=%.3fms dense=%.3fms ratio=%.3fx cosine=%.7f",
+                    rows,
+                    convRotMilliseconds,
+                    denseMilliseconds,
+                    convRotMilliseconds / denseMilliseconds,
+                    cosine.item(Float.self))
+        )
+    }
+
+    private static func trace(_ message: String) {
+        FileHandle.standardError.write(Data("[convrot-benchmark] \(message)\n".utf8))
+    }
+
+    private static func bestMilliseconds(
+        rounds: Int = 5,
+        _ operation: () -> MLXArray
+    ) -> Double {
+        MLX.eval(operation())
+        var best = Double.greatestFiniteMagnitude
+        for _ in 0..<rounds {
+            let start = DispatchTime.now().uptimeNanoseconds
+            MLX.eval(operation())
+            let elapsed = DispatchTime.now().uptimeNanoseconds - start
+            best = min(best, Double(elapsed) / 1_000_000)
+        }
+        return best
+    }
+}
+
+private final class MiniMaxMusic3ConvRotWeightOnlyLinear: Linear {
+    let inputDimensions: Int
+    let outputDimensions: Int
+    let quantizationScales: MLXArray
+    let quantizationBiases: MLXArray
+    let rotation: MLXArray
+
+    override var shape: (Int, Int) {
+        (outputDimensions, inputDimensions)
+    }
+
+    init?(codes: MLXArray, rowScales: MLXArray, bias: MLXArray?) {
+        guard codes.ndim == 2,
+              codes.dtype == .int8,
+              codes.dim(1).isMultiple(of: 256),
+              rowScales.size == codes.dim(0)
+        else {
+            return nil
+        }
+        self.outputDimensions = codes.dim(0)
+        self.inputDimensions = codes.dim(1)
+        let scales = MLX.repeated(
+            rowScales.reshaped(outputDimensions, 1),
+            count: inputDimensions / 128,
+            axis: 1
+        )
+        self.quantizationScales = scales
+        self.quantizationBiases = scales * -128
+        self.rotation = miniMaxMusic3ConvRotH256()
+        let unsigned = (codes.asType(.int16) + 128).asType(.uint8).contiguous()
+        let packed = unsigned.view(dtype: .uint32).reshaped(outputDimensions, inputDimensions / 4)
+        super.init(weight: packed, bias: bias)
+        MLX.eval(weight, quantizationScales, quantizationBiases)
+        freeze()
+    }
+
+    override func callAsFunction(_ input: MLXArray) -> MLXArray {
+        let rotated = rotate(input)
+        var output = MLX.quantizedMM(
+            rotated,
+            weight,
+            scales: quantizationScales,
+            biases: quantizationBiases,
+            transpose: true,
+            groupSize: 128,
+            bits: 8,
+            mode: .affine
+        ).asType(input.dtype)
+        if let bias {
+            output = output + bias.asType(output.dtype)
+        }
+        return output
+    }
+
+    func denseReferenceWeight(dtype: DType) -> MLXArray {
+        let rowScales = quantizationScales[0..., 0..<1]
+        let signedCodes = weight.view(dtype: .uint8).asType(.int16) - 128
+        let rotatedWeight = signedCodes.asType(.float32) * rowScales.asType(.float32)
+        return MLX.matmul(
+            rotatedWeight.reshaped(-1, 256),
+            rotation.transposed()
+        ).reshaped(outputDimensions, inputDimensions).asType(dtype)
+    }
+
+    private func rotate(_ input: MLXArray) -> MLXArray {
+        let shape = input.shape
+        return MLX.matmul(
+            input.reshaped(-1, shape.last! / 256, 256),
+            rotation.asType(input.dtype)
+        ).reshaped(shape)
+    }
+}
+
+private func miniMaxMusic3ConvRotH256() -> MLXArray {
+    let h4: [[Float]] = [
+        [1, 1, 1, -1],
+        [1, 1, -1, 1],
+        [1, -1, 1, 1],
+        [-1, 1, 1, 1],
+    ]
+    let scale = Float(1 / Double(256).squareRoot())
+    var values: [Float] = []
+    values.reserveCapacity(256 * 256)
+    for row in 0..<256 {
+        for column in 0..<256 {
+            var value: Float = 1
+            var rowDigits = row
+            var columnDigits = column
+            for _ in 0..<4 {
+                value *= h4[rowDigits % 4][columnDigits % 4]
+                rowDigits /= 4
+                columnDigits /= 4
+            }
+            values.append(value * scale)
+        }
+    }
+    return MLXArray(values).reshaped(256, 256)
+}

--- a/Tests/MereRunCoreTests/MiniMaxMusic3Tests.swift
+++ b/Tests/MereRunCoreTests/MiniMaxMusic3Tests.swift
@@ -495,6 +495,36 @@ final class MiniMaxMusic3Tests: MereRunCoreTestCase {
         XCTAssertTrue(MLX.allClose(full, incremental, rtol: 1e-5, atol: 1e-5).item(Bool.self))
     }
 
+    func testDepthDecoderStaticCacheMatchesGrowingCache() {
+        let configuration = MiniMaxMusic3DepthConfiguration(
+            hiddenSize: 8,
+            numLayers: 2,
+            numAttentionHeads: 2,
+            intermediateSize: 16,
+            audioVocabSize: 16,
+            numCodebooks: 4,
+            maxPositionEmbeddings: 8
+        )
+        let model = MiniMaxMusic3DepthDecoder(configuration: configuration)
+        let input = MLXArray((0..<(2 * 4 * 8)).map { Float($0) / 100 }).reshaped(2, 4, 8)
+        let growingCache = model.makeCache()
+        let staticCache = model.makeCache(capacity: 4)
+        var growing: [MLXArray] = []
+        var fixed: [MLXArray] = []
+        for index in 0..<4 {
+            growing.append(model(input[0..., index..<(index + 1), 0...], cache: growingCache))
+            fixed.append(model(input[0..., index..<(index + 1), 0...], cache: staticCache))
+        }
+        let growingOutput = MLX.concatenated(growing, axis: 1)
+        let staticOutput = MLX.concatenated(fixed, axis: 1)
+        MLX.eval(growingOutput, staticOutput)
+
+        XCTAssertEqual(staticCache.first?.offset, 4)
+        XCTAssertTrue(
+            MLX.allClose(growingOutput, staticOutput, rtol: 1e-5, atol: 1e-5).item(Bool.self)
+        )
+    }
+
     func testDepthDecoderFusedProjectionsMatchSeparateProjections() {
         let configuration = MiniMaxMusic3DepthConfiguration(
             hiddenSize: 8,
@@ -537,7 +567,7 @@ final class MiniMaxMusic3Tests: MereRunCoreTestCase {
         XCTAssertEqual(output.shape, [1, 2, 7])
     }
 
-    func testFlowTransformerBatchedGuidanceMatchesSerialPasses() {
+    func testFlowTransformerBatchedGuidanceMatchesSerialPasses() throws {
         let configuration = MiniMaxMusic3TransformerConfiguration(
             inChannels: 2,
             conditionDim: 4,
@@ -590,6 +620,17 @@ final class MiniMaxMusic3Tests: MereRunCoreTestCase {
         )
         MLX.eval(fused)
         XCTAssertTrue(MLX.allClose(batched, fused, rtol: 1e-5, atol: 1e-5).item(Bool.self))
+
+        let batchedCondition = MLX.concatenated([condition, zeros], axis: 0)
+        let preparedCondition = try XCTUnwrap(model.prepareConditionInput(batchedCondition))
+        let prepared = model(
+            latents: MLX.concatenated([latents, latents], axis: 0),
+            timestep: MLX.repeated(timestep, count: 2, axis: 0),
+            preparedCondition: preparedCondition,
+            rotary: rotary
+        )
+        MLX.eval(prepared)
+        XCTAssertTrue(MLX.allClose(batched, prepared, rtol: 1e-5, atol: 1e-5).item(Bool.self))
     }
 
     func testLanguageModelFusedProjectionsMatchSeparateProjections() {

--- a/Tests/MereRunCoreTests/MiniMaxMusic3Tests.swift
+++ b/Tests/MereRunCoreTests/MiniMaxMusic3Tests.swift
@@ -3,6 +3,13 @@ import XCTest
 @testable import MereRunCore
 
 final class MiniMaxMusic3Tests: MereRunCoreTestCase {
+    func testAutoregressiveCacheClearingUsesBoundedIntervals() {
+        XCTAssertFalse(MiniMaxMusic3Pipeline.shouldClearAutoregressiveCache(generatedFrameCount: 0))
+        XCTAssertFalse(MiniMaxMusic3Pipeline.shouldClearAutoregressiveCache(generatedFrameCount: 63))
+        XCTAssertTrue(MiniMaxMusic3Pipeline.shouldClearAutoregressiveCache(generatedFrameCount: 64))
+        XCTAssertTrue(MiniMaxMusic3Pipeline.shouldClearAutoregressiveCache(generatedFrameCount: 128))
+    }
+
     func testInstalledQuantizedSemanticLogitQuality() throws {
         let environment = ProcessInfo.processInfo.environment
         guard environment["MERERUN_MINIMAX_MUSIC3_QUANTIZATION_E2E"] == "1",
@@ -436,6 +443,86 @@ final class MiniMaxMusic3Tests: MereRunCoreTestCase {
             MiniMaxMusic3Prompt.decodedSampleCount(frameCount: 251),
             441_000
         )
+    }
+
+    func testOverlapAverageWindowPlanCoversLongLatent() {
+        let window = MiniMaxMusic3Prompt.latentLength(frameCount: 200)
+        let hop = MiniMaxMusic3Prompt.latentLength(frameCount: 100)
+
+        XCTAssertEqual(MiniMaxMusic3Pipeline.overlapAverageStarts(latentLength: window), [0])
+        XCTAssertEqual(
+            MiniMaxMusic3Pipeline.overlapAverageStarts(latentLength: window + 1),
+            [0, hop]
+        )
+        let starts = MiniMaxMusic3Pipeline.overlapAverageStarts(latentLength: 2_500)
+        XCTAssertEqual(starts, [0, 344, 688, 1_032, 1_376, 1_720, 2_064])
+        XCTAssertGreaterThanOrEqual(starts.last! + window, 2_500)
+    }
+
+    func testDAVDecodePlanRetainsEveryLongLatentFrameOnce() {
+        let slices = MiniMaxMusic3DAVDecodeSlice.plan(frameCount: 2_500)
+
+        XCTAssertEqual(slices.count, 3)
+        XCTAssertEqual(slices[0], .init(context: 0..<960, retained: 0..<896))
+        XCTAssertEqual(slices[1], .init(context: 832..<1_856, retained: 64..<960))
+        XCTAssertEqual(slices[2], .init(context: 1_728..<2_500, retained: 64..<772))
+        XCTAssertEqual(slices.reduce(0) { $0 + $1.retained.count }, 2_500)
+        XCTAssertTrue(slices.allSatisfy { $0.context.count <= 1_024 })
+    }
+
+    func testAudioHealthAcceptsBalancedStereoAndReportsSignal() throws {
+        let waveform = MLXArray([
+            Float(0.2), -0.2, 0.1, -0.1, 0.3, -0.3, 0.2, -0.2,
+            Float(0.1), -0.1, 0.2, -0.2, 0.2, -0.2, 0.3, -0.3,
+        ]).reshaped(1, 2, 8)
+
+        let report = try MiniMaxMusic3AudioHealth.validate(waveform, sampleRate: 4)
+
+        XCTAssertEqual(report.sampleCount, 8)
+        XCTAssertEqual(report.peak, 0.3, accuracy: 1e-6)
+        XCTAssertGreaterThan(report.rms, 0.1)
+        XCTAssertEqual(report.stereoCollapseFraction, 0, accuracy: 1e-6)
+    }
+
+    func testAudioHealthRejectsSilentNonFinitePeakingAndCollapsedAudio() {
+        XCTAssertThrowsError(
+            try MiniMaxMusic3AudioHealth.validate(MLXArray.zeros([1, 2, 8]), sampleRate: 4)
+        )
+        XCTAssertThrowsError(
+            try MiniMaxMusic3AudioHealth.validate(
+                MLXArray([Float.nan, 0, 0, 0, 0, 0, 0, 0]).reshaped(1, 2, 4),
+                sampleRate: 4
+            )
+        )
+        XCTAssertThrowsError(
+            try MiniMaxMusic3AudioHealth.validate(
+                MLXArray([Float(9), 1, 1, 1, 1, 1, 1, 1]).reshaped(1, 2, 4),
+                sampleRate: 4
+            )
+        )
+        XCTAssertThrowsError(
+            try MiniMaxMusic3AudioHealth.validate(
+                MLXArray([
+                    Float(0.2), -0.2, 0.2, -0.2, 0.2, -0.2, 0.2, -0.2,
+                    Float(0), 0, 0, 0, 0, 0, 0, 0,
+                ]).reshaped(1, 2, 8),
+                sampleRate: 4
+            )
+        )
+    }
+
+    func testStageSeparatedSeedRecipeIsStableAndIndependent() {
+        let legacy = MiniMaxMusic3SeedStrategy.legacy.stageSeeds(seed: 37)
+        let first = MiniMaxMusic3SeedStrategy.stageSeparatedV1.stageSeeds(seed: 37)
+        let second = MiniMaxMusic3SeedStrategy.stageSeparatedV1.stageSeeds(seed: 37)
+
+        XCTAssertEqual(legacy.autoregressive, 37)
+        XCTAssertEqual(legacy.flow, 37)
+        XCTAssertEqual(first.autoregressive, second.autoregressive)
+        XCTAssertEqual(first.flow, second.flow)
+        XCTAssertNotEqual(first.autoregressive, first.flow)
+        XCTAssertNotEqual(first.autoregressive, 37)
+        XCTAssertNotEqual(first.flow, 37)
     }
 
     func testConditionEncoderProducesLatentAlignedShape() {

--- a/Tests/MereRunCoreTests/MiniMaxMusic3W8A8ResearchTests.swift
+++ b/Tests/MereRunCoreTests/MiniMaxMusic3W8A8ResearchTests.swift
@@ -1,0 +1,329 @@
+import Foundation
+import MLX
+import MLXFast
+import MLXRandom
+import XCTest
+@testable import MereRunCore
+
+/// Env-gated production-shape oracle for MiniMax Music 3 ConvRot W8A8.
+///
+/// This intentionally stays out of the runtime until the complete projection,
+/// including activation rotation and quantization, beats MLX's BF16 GEMM on a
+/// supported Apple GPU. Run with:
+///
+/// ```bash
+/// MERERUN_TEST_MLX_DEVICE=gpu MERERUN_MINIMAX_MUSIC3_W8A8_BENCH=1 \
+///   swift test -c release --filter MiniMaxMusic3W8A8ResearchTests
+/// ```
+final class MiniMaxMusic3W8A8ResearchTests: MereRunCoreTestCase {
+    func testConvRotW8A8ProjectionAtFlowShape() throws {
+        guard ProcessInfo.processInfo.environment["MERERUN_MINIMAX_MUSIC3_W8A8_BENCH"] == "1" else {
+            throw XCTSkip("Set MERERUN_MINIMAX_MUSIC3_W8A8_BENCH=1 to run the W8A8 research lane.")
+        }
+        guard Device.defaultDevice().deviceType == .gpu else {
+            throw XCTSkip("The W8A8 research lane requires MERERUN_TEST_MLX_DEVICE=gpu.")
+        }
+
+        let environment = ProcessInfo.processInfo.environment
+        let rows = max(1, Int(environment["MERERUN_MINIMAX_MUSIC3_W8A8_ROWS"] ?? "") ?? 690)
+        let outputs = max(
+            MiniMaxMusic3W8A8Oracle.outputsPerThreadgroup,
+            Int(environment["MERERUN_MINIMAX_MUSIC3_W8A8_OUTPUTS"] ?? "") ?? 16_384
+        )
+        let rounds = max(1, Int(environment["MERERUN_MINIMAX_MUSIC3_W8A8_ROUNDS"] ?? "") ?? 2)
+        let iterations = max(
+            1,
+            Int(environment["MERERUN_MINIMAX_MUSIC3_W8A8_ITERATIONS"] ?? "") ?? 2
+        )
+
+        MLXRandom.seed(8_803)
+        let input = MLXRandom.normal([rows, MiniMaxMusic3W8A8Oracle.inputWidth])
+            .asType(.bfloat16)
+        let weight = MLXRandom.normal([outputs, MiniMaxMusic3W8A8Oracle.inputWidth])
+            .asType(.bfloat16)
+        let preparedWeight = try XCTUnwrap(MiniMaxMusic3W8A8Oracle.rotateAndQuantize(weight))
+        MLX.eval(preparedWeight.values, preparedWeight.scales)
+
+        let reference = MLX.matmul(input, weight.transposed())
+        let candidate = try XCTUnwrap(
+            MiniMaxMusic3W8A8Oracle.project(input: input, weight: preparedWeight)
+        )
+        MLX.eval(reference, candidate)
+
+        let referenceF32 = reference.asType(.float32)
+        let candidateF32 = candidate.asType(.float32)
+        let error = candidateF32 - referenceF32
+        let cosine = (
+            MLX.sum(referenceF32 * candidateF32)
+                / MLX.sqrt(MLX.sum(referenceF32 * referenceF32)
+                    * MLX.sum(candidateF32 * candidateF32))
+        ).item(Float.self)
+        let relativeRMSE = (
+            MLX.sqrt(MLX.mean(error * error))
+                / MLX.sqrt(MLX.mean(referenceF32 * referenceF32))
+        ).item(Float.self)
+
+        XCTAssertGreaterThan(cosine, 0.999)
+        XCTAssertLessThan(relativeRMSE, 0.05)
+
+        let denseMilliseconds = benchmarkMilliseconds(
+            rounds: rounds,
+            iterations: iterations
+        ) {
+            MLX.matmul(input, weight.transposed())
+        }
+        let w8a8Milliseconds = benchmarkMilliseconds(
+            rounds: rounds,
+            iterations: iterations
+        ) {
+            MiniMaxMusic3W8A8Oracle.project(input: input, weight: preparedWeight)!
+        }
+        let report: [String: Any] = [
+            "candidate_ms": w8a8Milliseconds,
+            "cosine": cosine,
+            "dense_bf16_ms": denseMilliseconds,
+            "input_width": MiniMaxMusic3W8A8Oracle.inputWidth,
+            "output_width": outputs,
+            "relative_rmse": relativeRMSE,
+            "rows": rows,
+            "speedup": denseMilliseconds / w8a8Milliseconds,
+        ]
+        let data = try JSONSerialization.data(
+            withJSONObject: report,
+            options: [.prettyPrinted, .sortedKeys]
+        )
+        print(String(decoding: data, as: UTF8.self))
+    }
+
+    private func benchmarkMilliseconds(
+        rounds: Int,
+        iterations: Int,
+        _ body: () -> MLXArray
+    ) -> Double {
+        MLX.eval(body())
+        var best = Double.greatestFiniteMagnitude
+        for _ in 0..<rounds {
+            let start = DispatchTime.now().uptimeNanoseconds
+            for _ in 0..<iterations {
+                MLX.eval(body())
+            }
+            let elapsed = DispatchTime.now().uptimeNanoseconds - start
+            best = min(best, Double(elapsed) / 1_000_000 / Double(iterations))
+        }
+        return best
+    }
+}
+
+private struct MiniMaxMusic3W8A8Rows {
+    let values: MLXArray
+    let scales: MLXArray
+}
+
+private enum MiniMaxMusic3W8A8Oracle {
+    static let inputWidth = 2_048
+    static let convRotGroupSize = 64
+    static let threadCount = 256
+    static let outputsPerThreadgroup = 8
+
+    static func rotateAndQuantize(_ input: MLXArray) -> MiniMaxMusic3W8A8Rows? {
+        guard Device.defaultDevice().deviceType == .gpu,
+              input.dtype == .bfloat16,
+              input.ndim == 2,
+              input.dim(0) > 0,
+              input.dim(1) == inputWidth else {
+            return nil
+        }
+        let rows = input.dim(0)
+        let outputs = rotateAndQuantizeKernel(
+            [input],
+            grid: (threadCount, rows, 1),
+            threadGroup: (threadCount, 1, 1),
+            outputShapes: [input.shape, [rows]],
+            outputDTypes: [.int8, .float32]
+        )
+        return MiniMaxMusic3W8A8Rows(values: outputs[0], scales: outputs[1])
+    }
+
+    static func project(
+        input: MLXArray,
+        weight: MiniMaxMusic3W8A8Rows
+    ) -> MLXArray? {
+        guard let quantizedInput = rotateAndQuantize(input),
+              weight.values.dtype == .int8,
+              weight.values.ndim == 2,
+              weight.values.dim(1) == inputWidth,
+              weight.scales.shape == [weight.values.dim(0)] else {
+            return nil
+        }
+        let rows = input.dim(0)
+        let outputs = weight.values.dim(0)
+        let tiles = (outputs + outputsPerThreadgroup - 1) / outputsPerThreadgroup
+        return projectionKernel(
+            [
+                quantizedInput.values,
+                quantizedInput.scales,
+                weight.values,
+                weight.scales,
+            ],
+            grid: (tiles * 64, rows, 1),
+            threadGroup: (64, 1, 1),
+            outputShapes: [[rows, outputs]],
+            outputDTypes: [.bfloat16]
+        )[0]
+    }
+
+    /// Applies Comfy-Kitchen's normalized regular-Hadamard H64 independently
+    /// to every 64-value group, then uses one symmetric INT8 scale per row.
+    private static let rotateAndQuantizeKernel = MLXFast.metalKernel(
+        name: "mere_minimax_music3_convrot_h64_quantize_i8_h2048_v1",
+        inputNames: ["input"],
+        outputNames: ["quantized", "scales"],
+        source: """
+            constexpr uint input_width = 2048;
+            constexpr uint convrot_group_size = 64;
+            constexpr uint simd_width = 32;
+            constexpr float normalization = 0.125f;
+
+            uint row = threadgroup_position_in_grid.y;
+            uint tid = thread_index_in_threadgroup;
+            uint simd_lane = thread_index_in_simdgroup;
+            uint simd_group = simdgroup_index_in_threadgroup;
+            uint row_offset = row * input_width;
+            threadgroup float rotated[input_width];
+            threadgroup float partial_maxima[simd_width];
+            threadgroup float maximum[1];
+
+            for (uint dimension = tid; dimension < input_width;
+                 dimension += threads_per_threadgroup.x) {
+                rotated[dimension] = float(input[row_offset + dimension]);
+            }
+            threadgroup_barrier(metal::mem_flags::mem_threadgroup);
+
+            for (uint stride = 1; stride < convrot_group_size; stride *= 4) {
+                for (uint tuple = tid; tuple < input_width / 4;
+                     tuple += threads_per_threadgroup.x) {
+                    uint block = tuple / stride;
+                    uint offset = tuple - block * stride;
+                    uint base = block * 4 * stride + offset;
+                    float a = rotated[base];
+                    float b = rotated[base + stride];
+                    float c = rotated[base + 2 * stride];
+                    float d = rotated[base + 3 * stride];
+                    rotated[base] = a + b + c - d;
+                    rotated[base + stride] = a + b - c + d;
+                    rotated[base + 2 * stride] = a - b + c + d;
+                    rotated[base + 3 * stride] = -a + b + c + d;
+                }
+                threadgroup_barrier(metal::mem_flags::mem_threadgroup);
+            }
+
+            float local_max = 0.0f;
+            for (uint dimension = tid; dimension < input_width;
+                 dimension += threads_per_threadgroup.x) {
+                float value = rotated[dimension] * normalization;
+                rotated[dimension] = value;
+                local_max = metal::max(local_max, metal::fabs(value));
+            }
+            local_max = simd_max(local_max);
+            if (simd_group == 0) {
+                partial_maxima[simd_lane] = 0.0f;
+            }
+            threadgroup_barrier(metal::mem_flags::mem_threadgroup);
+            if (simd_lane == 0) {
+                partial_maxima[simd_group] = local_max;
+            }
+            threadgroup_barrier(metal::mem_flags::mem_threadgroup);
+            if (simd_group == 0) {
+                local_max = simd_max(partial_maxima[simd_lane]);
+                if (simd_lane == 0) {
+                    maximum[0] = local_max;
+                    scales[row] = local_max > 0.0f
+                        ? local_max / 127.0f
+                        : 1.0f / 127.0f;
+                }
+            }
+            threadgroup_barrier(metal::mem_flags::mem_threadgroup);
+
+            float quantize_scale = maximum[0] > 0.0f
+                ? 127.0f / maximum[0]
+                : 127.0f;
+            for (uint dimension = tid; dimension < input_width;
+                 dimension += threads_per_threadgroup.x) {
+                int value = int(rint(rotated[dimension] * quantize_scale));
+                quantized[row_offset + dimension] = int8_t(
+                    metal::clamp(value, -127, 127));
+            }
+        """,
+        ensureRowContiguous: true
+    )
+
+    /// Portable packed W8A8 oracle. Apple GPU generations without native INT8
+    /// matrix units execute these integer products in ordinary shader lanes;
+    /// that is precisely the physical-path question this benchmark answers.
+    private static let projectionKernel = MLXFast.metalKernel(
+        name: "mere_minimax_music3_convrot_w8a8_projection_h2048_v1",
+        inputNames: ["input", "input_scales", "weight", "weight_scales"],
+        outputNames: ["output"],
+        source: """
+            constexpr uint input_width = 2048;
+            constexpr uint values_per_thread = 8;
+            constexpr uint block_size = 256;
+            constexpr uint results_per_simdgroup = 4;
+            constexpr uint projection_simdgroups = 2;
+            constexpr uint outputs_per_threadgroup =
+                results_per_simdgroup * projection_simdgroups;
+
+            uint tile = threadgroup_position_in_grid.x;
+            uint row = threadgroup_position_in_grid.y;
+            uint simd_group = simdgroup_index_in_threadgroup;
+            uint lane = thread_index_in_simdgroup;
+            uint output_width = uint(weight_shape[0]);
+            uint output_row = tile * outputs_per_threadgroup
+                + simd_group * results_per_simdgroup;
+
+            const device int8_t* input_values = input
+                + row * input_width + lane * values_per_thread;
+            const device int8_t* weight_values = weight
+                + output_row * input_width + lane * values_per_thread;
+            float results[results_per_simdgroup] = {0.0f};
+
+            for (uint block = 0; block < input_width; block += block_size) {
+                int activation[values_per_thread];
+                for (uint index = 0; index < values_per_thread; ++index) {
+                    activation[index] = int(input_values[index]);
+                }
+                for (uint output_index = 0;
+                     output_index < results_per_simdgroup;
+                     ++output_index) {
+                    uint global_output = output_row + output_index;
+                    if (global_output < output_width) {
+                        const device int8_t* weight_row = weight_values
+                            + output_index * input_width;
+                        int dot = 0;
+                        for (uint index = 0; index < values_per_thread; ++index) {
+                            dot += activation[index] * int(weight_row[index]);
+                        }
+                        results[output_index] += float(dot);
+                    }
+                }
+                input_values += block_size;
+                weight_values += block_size;
+            }
+
+            float input_scale = input_scales[row];
+            for (uint output_index = 0;
+                 output_index < results_per_simdgroup;
+                 ++output_index) {
+                uint global_output = output_row + output_index;
+                if (global_output < output_width) {
+                    float sum = simd_sum(results[output_index]);
+                    if (lane == 0) {
+                        output[row * output_width + global_output] = bfloat16_t(
+                            sum * input_scale * weight_scales[global_output]);
+                    }
+                }
+            }
+        """,
+        ensureRowContiguous: true
+    )
+}

--- a/docs/benchmarks/minimax-music3-m4-max.md
+++ b/docs/benchmarks/minimax-music3-m4-max.md
@@ -27,6 +27,41 @@ and zero conditioning, batched conditional/unconditional flow evaluation, and
 fewer forced graph evaluations. `--performance-mode reference` preserves the
 released graph for parity investigations.
 
+## MLX 0.32.1 follow-on
+
+The next pass rebased onto mere.run PR #297 after it landed. The tested chain
+pins `mlx-swift` at `3e6df6d8163a8f212061d15739eeeec12d5b89e3`, its embedded
+MLX at `b57bd7640f3f7c743b76a58478faaf1e8ee084f2`, and MLX core 0.32.1.
+
+Stage profiling, a fixed-capacity autoregressive KV cache, and precomputed flow
+input projections were added independently. These matched 100-frame Q8 runs
+used the same prompt, checkpoint, seed, 30-step schedule, and one flow chunk:
+
+| Graph | Total | Autoregressive | Flow | Flow transformer | Change |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Refreshed dependency baseline | 30.90 s | 13.16 s | 16.88 s | 16.31 s | baseline |
+| Static KV cache | 22.21 s | 7.25 s | 14.61 s | 14.29 s | 28.1% less total |
+| Static KV + fused flow inputs | 19.24 s | 6.70 s | 12.21 s | 11.81 s | 37.7% less total |
+
+The baseline and static-cache WAVs were byte-identical. Combining the flow
+preprocess, residual, and input projections changes floating-point association;
+its comparison against the unfused path measured 59.77 dB waveform PSNR and
+0.999974 cosine similarity.
+
+The public `--sampling-tier` presets keep the model and Euler solver fixed while
+changing only the number of flow evaluations. `--steps` remains the exact
+override. A clean 100-frame series from the final graph measured:
+
+| Tier | Flow steps | Profiled total | Autoregressive | Flow | Wall time | Total speedup |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| `quality` | 30 | 20.03 s | 6.79 s | 12.89 s | 22.92 s | 1.00x |
+| `fast` | 20 | 15.04 s | 5.52 s | 9.19 s | 15.13 s | 1.33x |
+| `draft` | 16 | 13.41 s | 5.61 s | 7.47 s | 13.51 s | 1.49x |
+
+Profiler JSON is opt-in with `--profile-output`. It synchronizes stage
+boundaries so its internal totals are useful for hotspot attribution, while
+unprofiled `/usr/bin/time` remains the wall-clock authority.
+
 The finished reference path was also rendered from the optimized release
 binary and compared with a clean 0.37.0 build. Both 250-frame PCM24 files had
 the identical SHA-256
@@ -45,6 +80,41 @@ isolated tensor fixtures.
   BF16.
 - Serial flow CFG took 18.43 s versus 17.38 s for batched CFG on a matched
   100-frame, one-chunk, 30-step Q8 run. Batched CFG stays as the default.
+- Compiling only the residual-depth graph was waveform-identical, but an ABBA
+  series regressed from a 1.851 s eager median to a 2.157 s compiled median,
+  16.5% slower. The fixed-capacity cache remains eager.
+- A production-shape ConvRot W8A8 Metal oracle retained 0.999929 cosine and
+  0.01192 relative RMSE, but took 57.64 ms versus 3.47 ms for BF16 GEMM, 16.6x
+  slower on this M4 Max. The research test remains env-gated; the runtime does
+  not ship a slower W8A8 path.
+- A real, derived Q8 checkpoint repack occupied 9.01 GB and produced a
+  byte-identical seeded WAV, but its ABBA load median was 3.883 s versus
+  1.849 s from the released shards. Its first proof also reached 9.22 GB max
+  resident versus 4.36 GB. The derived artifact and public repack surface were
+  removed; source shards remain authoritative.
+
+## ComfyUI comparison
+
+The current ComfyUI implementation validates several architectural choices:
+its autoregressive model uses a fixed KV cache, prunes the semantic projection
+to 16,385 reachable rows, and has optional prefetch/graph support for the
+residual-depth blocks. Its flow transformer still constructs the aligned input
+inside each forward; mere.run now precomputes the invariant condition side and
+fuses the latent-side projections. See ComfyUI's pinned
+[autoregressive implementation](https://github.com/Comfy-Org/ComfyUI/blob/7fe8a6138504f90ff7be82f3babf416da32876b1/comfy/ldm/minimax_music/ar.py)
+and [flow transformer](https://github.com/Comfy-Org/ComfyUI/blob/7fe8a6138504f90ff7be82f3babf416da32876b1/comfy/ldm/minimax_music/dit.py).
+
+The public Comfy workflow offers pruned ConvRot INT8 checkpoints for the text
+encoder and either FP16 or INT8 ConvRot flow weights. That is weight
+quantization, not evidence that activation-quantized W8A8 is faster on M4-class
+Apple GPUs. See the pinned
+[workflow template](https://github.com/Comfy-Org/workflow_templates/blob/d9e66019b85da231b7c936ad9cb7ff08cec16557/templates/audio_minimax_music_3.json).
+
+A frequently cited public timing log is also easy to misread: it generates
+1,501 frames, approximately 60 seconds of audio, in about 170 seconds before
+decode on a 24 GB AMD/HIP GPU. It is not a three-minute output and it is not an
+MPS result. See the
+[full ComfyUI run log](https://github.com/OrsoEric/HOWTO-ComfyUI/blob/602c8ef74cc297e530d8b905389a7b58e4f05bd1/logs/2026-08-14a-minmax3-music.md).
 
 ## Duration-floor correction
 
@@ -84,6 +154,20 @@ parameter traffic, after which the unquantized 4.86B flow transformer and its
 therefore remains approximately linear in semantic frames and overlapping flow
 chunks even after launch overhead is reduced.
 
+For scale, halving that idealized autoregressive traffic for Q8 gives an
+optimistic bandwidth-only floor near 24 ms per frame, or about 108 seconds for
+4,501 frames. Streaming 4.86B BF16 flow parameters once per evaluation adds an
+idealized roughly 24 seconds for 30 steps across 45 chunks, or about 13 seconds
+at 16 steps. That places the absolute bandwidth-only floor around two minutes
+before KV traffic, activations, kernel inefficiency, loads, sampling, overlap,
+and vocoder work. It is a physical lower bound, not an achievable forecast.
+
+Applying the measured `draft` flow ratio to the installed 180-second quality
+receipt projects roughly 14–16 minutes on this machine. That projection is the
+remaining practical ceiling from schedule reduction alone; materially crossing
+it requires faster flow kernels or a changed/distilled model, not more launch
+cleanup.
+
 ## Reproduction
 
 ```bash
@@ -93,7 +177,7 @@ chunks even after launch overhead is reduced.
   --instrumental \
   --duration 10 \
   --max-frames 250 \
-  --steps 30 \
+  --sampling-tier quality \
   --seed 37 \
   --guidance-scale 1.7 \
   --memory-mode staged \
@@ -102,6 +186,7 @@ chunks even after launch overhead is reduced.
   --export-format pcm24 \
   --normalize peak \
   --target-peak-db=-1.0 \
+  --profile-output /tmp/minimax-music3-q8-profile.json \
   --output /tmp/minimax-music3-q8-10s.wav
 ```
 

--- a/docs/runtime/music.md
+++ b/docs/runtime/music.md
@@ -88,7 +88,7 @@ swift run mere.run music generate \
   --lyrics-file ./lyrics.txt \
   --duration 30 \
   --minimum-duration 30 \
-  --steps 30 \
+  --sampling-tier fast \
   --seed 7 \
   --memory-mode staged \
   --performance-mode q8 \
@@ -102,7 +102,7 @@ swift run mere.run music serve \
 
 curl http://127.0.0.1:8080/v1/audio/speech \
   -H 'Content-Type: application/json' \
-  -d '{"model":"music-minimax-music3","instructions":"cinematic synth-pop, female lead","input":"[Verse]\nNeon on the avenue","max_new_tokens":750,"seed":7}' \
+  -d '{"model":"music-minimax-music3","instructions":"cinematic synth-pop, female lead","input":"[Verse]\nNeon on the avenue","max_new_tokens":750,"sampling_tier":"fast","seed":7}' \
   --output ./minimax-speech-route.wav
 
 swift run mere.run music generate \

--- a/docs/runtime/music.md
+++ b/docs/runtime/music.md
@@ -94,6 +94,15 @@ swift run mere.run music generate \
   --performance-mode q8 \
   --output ./minimax-song.wav
 
+swift run mere.run music generate \
+  "cinematic synth-pop, female lead, 118 bpm, wide guitars" \
+  --model music-minimax-music3 \
+  --lyrics-file ./lyrics.txt \
+  --duration 30 \
+  --flow-strategy overlap-average \
+  --seed-strategy stage-separated-v1 \
+  --output ./minimax-overlap-average.wav
+
 swift run mere.run music serve \
   --model music-minimax-music3 \
   --memory-mode resident \
@@ -168,6 +177,35 @@ swift run mere.run music separate ./noisy.wav \
   --model music-separate-mel-roformer-denoise \
   --output-dir ./noise-restored
 ```
+
+MiniMax Music 3 keeps `--flow-strategy sequential` and
+`--seed-strategy legacy` as its released defaults. The experimental
+`overlap-average` strategy denoises one song-length latent and averages the
+velocities from overlapping flow windows at every Euler step; it then decodes
+the long latent in bounded DAV chunks. `stage-separated-v1` derives stable,
+independent autoregressive and flow random streams so changes in one stage do
+not perturb the other. Both choices are recorded in schema 5 recipe JSON.
+The speech-compatible HTTP route accepts the same choices as
+`flow_strategy` and `seed_strategy`.
+
+Optimized MiniMax modes periodically return completed autoregressive attention
+buffers to MLX while preserving live KV state. This bounds unified-memory use
+for long songs without changing seeded output. On an M4 Max, a matched forced
+120-second Q8/draft render dropped from 110.20 GB to 23.78 GB peak physical
+footprint with a byte-identical float32 WAV; its autoregressive stage changed
+from 144.75 to 151.05 seconds. Process RSS alone does not include this Metal
+footprint, so long-form memory validation must use the macOS physical-footprint
+counter.
+
+On the same 120-second fixture, sequential and overlap-average flow measured
+454.31 and 464.38 seconds. Keep `sequential` as the performance default;
+`overlap-average` is available for explicit continuity experiments rather than
+as an acceleration preset.
+
+Every MiniMax result is checked before export for non-finite samples, silence,
+implausible peaks, and a near-missing stereo channel. The recipe records RMS,
+peak, sample count, and stereo-collapse fraction. These checks fail generation
+instead of saving a corrupted long-form render.
 
 `music separate` decodes the source at 44.1 kHz stereo, runs the pinned ViperX
 1297 BS-RoFormer checkpoint, and writes `vocals.wav`, `instrumental.wav`, and


### PR DESCRIPTION
## Summary

- accelerate the native MiniMax Music 3 pipeline with a reachable semantic head, fused projections, incremental residual-depth KV caches, cached conditioning, batched flow guidance, profiling, and explicit performance tiers
- bound long-form MLX buffer-cache growth by clearing completed autoregressive workspaces every 64 frames while preserving live model, KV, and conditioning state
- decode long DAV latents in bounded overlapping slices and validate every result for finite samples, silence, implausible peaks, and stereo collapse
- expose versioned flow and seed recipes through the CLI, HTTP route, and schema 5 generation artifacts; released `sequential` flow and `legacy` seeding remain unchanged defaults
- retain `overlap-average` and direct INT8 ConvRot only as explicit research paths because measured runs did not establish either as a production speed win

## Measured results

- matched 100-frame Q8 generation: 30.90 s to 19.24 s, 37.7% faster
- matched forced 120-second Q8/draft generation: 110.20 GB to 23.78 GB peak physical footprint, 78.4% lower and 4.63x smaller, with zero swaps
- the bounded-cache 120-second float32 WAV is byte-identical to the unbounded baseline: `5ec23504131e7b74cef86f368d1a9164f9ac96d071d9c0f25615c5525fc559be`
- autoregressive time for that memory comparison: 144.75 s to 151.05 s, a 4.4% cost for bounded long-form memory
- bounded DAV decode on the 120-second fixture: 15.95 s to 9.43 s, 40.9% faster
- `overlap-average` flow measured 464.38 s versus 454.31 s sequential, so it remains opt-in and is not presented as an acceleration preset
- direct INT8 ConvRot was 1.60x to 2.66x slower than dense BF16 at measured production-width shapes, so no production dispatch uses it

The long-form runs used an M4 Max with 128 GB unified memory. The 23.78 GB peak makes 32 GB plausible, but this PR does not claim 32 GB support without an actual 32 GB hardware run.

## Post-restack MLX refresh receipt

The exact rebased head `5720cb7c1411f179af6398d874d6d35b590cf9d9` was replayed against the installed upstream checkpoint `MiniMaxAI/MiniMax-Music3@bd348f9c49ea3c1b39f33ace3436f8fad435f24e` after the MLX/mlx-swift refresh landed on `main`.

- exact deterministic recipe: 120 seconds, Q8, draft, staged loading, sequential flow, 16 steps, `stage-separated-v1`, seed `20260815`
- output: 3,001 frames, 44.1 kHz stereo Float32 WAV, 120.186 seconds
- output SHA-256: `5ec23504131e7b74cef86f368d1a9164f9ac96d071d9c0f25615c5525fc559be`, byte-identical to the pre-refresh bounded-cache receipt
- audio health: peak `1.0`, RMS `0.08406066`, stereo-collapse fraction `0`
- physical peak: 23.78 GB, zero swaps
- stage-timed inference: 725.42 s total (164.26 s autoregressive, 540.93 s flow, 20.01 s vocoder)
- the earlier bounded-cache profile was 679.50 s, so this replay was 6.8% slower; no performance win is claimed from the dependency refresh
- `/usr/bin/time` wall time included machine-admission queueing and is not used as an inference-performance result

## Validation

- [x] rebased directly onto current `main` at `22b35602059f2df6f5a169ad24e44d04b3e264dc`
- [x] `./scripts/check.sh`
  - strict SwiftLint: 0 violations across 1,247 Swift files
  - 2,897 XCTest cases, 211 expected skips, 0 failures
  - 30 Swift Testing cases passed
  - build, MLX metallib compatibility, CLI help sweep, and hygiene scans passed
- [x] `swift build -c release`
- [x] focused MiniMax unit, CLI parsing, HTTP, artifact, bounded-decode, audio-health, and opt-in research tests are included in the full gate
- [x] `pnpm docs:build`
- [x] README, runtime documentation, benchmark notes, and changelog updated
- [x] `git diff --check origin/main...HEAD`
- [x] exact installed-checkpoint Q8 long-form replay completed after the MLX refresh with byte-identical audio
- [x] all GitHub CI, Linux compatibility, macOS app-bundle, docs, dependency-review, and secret-scan checks passed on the exact head
- [x] `THIRD_PARTY_NOTICES.md` not applicable: no vendored artifacts or package pins changed
