### PR TITLE
Port promoted Qwen3.8 MTP crown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+### Runtime
+
+- accelerated opt-in Qwen3.8 greedy MTP with committed target-history priming,
+  a proposal-only compact vocabulary, fused draft-token selection, and
+  acceptance-adaptive draft depth. Target logits remain authoritative for every
+  emitted token, and sampled MTP retains its full-vocabulary probability path.
+- aligned the managed Qwen3.8 27B 4-bit lane with the pinned MLX Fast reference
+  target and its 4-bit/group-64 MTP head, while retaining Qwen's official
+  Apache-2.0 license. Standalone bare-name MTP weights now load and normalize
+  correctly instead of leaving an uninitialized proposal head.
+
 ## 0.39.0 - 2026-08-15
 
 This release completes Qwen3.8's native Pi-agent path, adds an inline Pi harness

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -1682,9 +1682,17 @@ public enum ManagedModelCatalog {
                 MountedHubFallbackConfig(
                     destinationPath: Q35Resources.q38MTPComponentPath,
                     hubFallback: HubFallbackConfig(
+                        repoId: Q35Resources.q38MTP4BitUpstreamRepoId,
+                        revision: Q35Resources.q38MTP4BitUpstreamRevision,
+                        patterns: Q35Resources.q38MTPComponentSnapshotPatterns
+                    )
+                ),
+                MountedHubFallbackConfig(
+                    destinationPath: Q35Resources.q38LicenseComponentPath,
+                    hubFallback: HubFallbackConfig(
                         repoId: Q35Resources.q38TwentySevenBUpstreamRepoId,
                         revision: Q35Resources.q38TwentySevenBUpstreamRevision,
-                        patterns: Q35Resources.q38MTPComponentSnapshotPatterns
+                        patterns: Q35Resources.q38LicenseComponentSnapshotPatterns
                     )
                 ),
             ],

--- a/Sources/MereRunCore/Q35/Q35Generator.swift
+++ b/Sources/MereRunCore/Q35/Q35Generator.swift
@@ -21,6 +21,7 @@ private struct Q35PrefixKVCacheEntry {
 private struct Q35PrefillOutput {
     let logits: MLXArray
     let hidden: MLXArray?
+    let mtpHistoryHidden: MLXArray?
 }
 
 private struct Q35BatchedDecodeResult {
@@ -131,6 +132,7 @@ public actor Q35Generator: ChatGenerator {
     }()
     private static let prefixKVCacheMaxEntries = 4
     private static let defaultMTPBlockSize = 4
+    private static let mtpPromptHistoryLimit = 4_096
 
     /// Continuous-batching decode samples every row on GPU (the same sampler
     /// the serial pipelined path uses) and reads the whole batch back in one
@@ -402,6 +404,8 @@ public actor Q35Generator: ChatGenerator {
                 bits: bits
             )
             loadedMTP = mtp
+            progressHandler?(ChatProgress(stage: .loadingModel, message: "Preparing Qwen-family MTP drafting"))
+            q35Model.prepareGreedyMTPDrafting()
         } else {
             loadedMTP = nil
         }
@@ -487,11 +491,15 @@ public actor Q35Generator: ChatGenerator {
             repetitionPenalty: nil,
             repetitionContextSize: 64
         )
-        let retainPrefillHidden =
-            prefixKVCacheEnabled
-            || (!jsonConstrained
-                && Self.shouldSpeculate(promptTokenCount: promptTokens.count, maxContextTokens: effectiveContext)
-                && mtpModel != nil)
+        let mtpSpeculationEligible = !jsonConstrained
+            && request.tools?.isEmpty != false
+            && imageURLs.isEmpty
+            && Self.shouldSpeculate(promptTokenCount: promptTokens.count, maxContextTokens: effectiveContext)
+            && mtpModel != nil
+        let retainMTPPromptHistory = mtpSpeculationEligible
+            && !loadedConfig.textConfig.usesMoE
+            && promptTokens.count <= Self.mtpPromptHistoryLimit
+        let retainPrefillHidden = prefixKVCacheEnabled || mtpSpeculationEligible
         let effectiveKVCacheMode: RuntimeKVCacheMode
         switch request.kvCacheMode {
         case .affine4:
@@ -510,7 +518,7 @@ public actor Q35Generator: ChatGenerator {
         var mropeRopeDelta: Int?
 
         if imageURLs.isEmpty {
-            let prefixSeed = prefixKVCacheSeed(
+            let prefixSeed = retainMTPPromptHistory ? nil : prefixKVCacheSeed(
                 modelPath: loadedModelPath ?? "",
                 promptTokens: promptTokens,
                 cacheMode: effectiveKVCacheMode
@@ -536,6 +544,7 @@ public actor Q35Generator: ChatGenerator {
                 modelPath: loadedModelPath ?? "",
                 checkpointTokenCounts: prefixCheckpoints,
                 retainHidden: retainPrefillHidden,
+                retainMTPHistory: retainMTPPromptHistory,
                 progressHandler: progressHandler
             )
         } else {
@@ -602,6 +611,7 @@ public actor Q35Generator: ChatGenerator {
             tokenizerAndTemplate: tokenizerAndTemplate,
             initialLogits: prefillOutput.logits,
             initialHidden: prefillOutput.hidden,
+            prefillMTPHidden: prefillOutput.mtpHistoryHidden,
             layerCaches: layerCaches,
             eosSet: eosSet,
             generationConfig: generationConfig,
@@ -736,6 +746,7 @@ public actor Q35Generator: ChatGenerator {
         tokenizerAndTemplate: Q35TokenizerAndTemplate,
         initialLogits: MLXArray,
         initialHidden: MLXArray?,
+        prefillMTPHidden: MLXArray?,
         layerCaches: [Q35LayerCache?],
         eosSet: Set<Int>,
         generationConfig: GenerationConfig,
@@ -773,6 +784,7 @@ public actor Q35Generator: ChatGenerator {
                 tokenizerAndTemplate: tokenizerAndTemplate,
                 initialLogits: initialLogits,
                 initialHidden: initialHidden,
+                prefillMTPHidden: prefillMTPHidden,
                 mtpModel: decodePath == .mtpSpeculativeSerial ? speculationMTP : nil,
                 layerCaches: layerCaches,
                 eosSet: eosSet,
@@ -819,6 +831,7 @@ public actor Q35Generator: ChatGenerator {
         tokenizerAndTemplate: Q35TokenizerAndTemplate,
         initialLogits: MLXArray,
         initialHidden: MLXArray?,
+        prefillMTPHidden: MLXArray?,
         mtpModel: Q35MTPModel?,
         layerCaches: [Q35LayerCache?],
         eosSet: Set<Int>,
@@ -862,6 +875,13 @@ public actor Q35Generator: ChatGenerator {
         var mtpAcceptedTokens = 0
         var mtpVerificationPasses = 0
         var mtpReplacementPasses = 0
+        var mtpNonDraftingRounds = 0
+        let mtpBlockSize = Self.mtpBlockSize()
+        var mtpAdaptivePolicy = Q35MTPAdaptivePolicy(maxDraftDepth: mtpBlockSize - 1)
+        let mtpDraftSession = Q35MTPDraftSession(
+            promptTokens: promptTokens,
+            promptHidden: prefillMTPHidden
+        )
         let decodeStart = Date()
 
         func emit(_ token: Int) {
@@ -948,90 +968,174 @@ public actor Q35Generator: ChatGenerator {
             if let mtpModel, let hidden = previousHidden {
                 let positionOffset = prefillTokenCount + generated.count - 1
                 if generationConfig.temperature == 0 {
-                    let blockSize = min(
-                        Self.mtpBlockSize(),
-                        max(2, tokenBudget - generated.count + 1)
+                    let offeredDepth = min(
+                        mtpBlockSize - 1,
+                        tokenBudget - generated.count
                     )
-                    let draftTokens = mtpModel.draftBlock(
-                        lastToken: next,
-                        hidden: hidden,
-                        positionOffset: positionOffset,
-                        blockSize: blockSize,
-                        baseModel: model
-                    )
-                    guard !draftTokens.isEmpty else {
-                        continue
-                    }
-                    mtpDraftedTokens += draftTokens.count
-
-                    let candidateCaches = forkLayerCaches(layerCaches)
-                    let candidateInput = MLXArray(([next] + draftTokens).map(Int32.init))
-                        .reshaped(1, draftTokens.count + 1)
-                    let candidate = model.forward(candidateInput, cache: candidateCaches)
-                    MLX.eval(candidate.logits)
-                    MLX.eval(candidate.hidden)
-                    mtpVerificationPasses += 1
-
-                    var accepted = 0
-                    var verificationHistory = repetitionHistory
-                    var replacement: Int?
-                    for (index, draftToken) in draftTokens.enumerated() {
-                        let targetToken = sampleToken(
-                            logits: candidate.logits[0, index, 0...],
-                            config: generationConfig,
-                            previousTokens: verificationHistory
+                    let draftDepth = mtpAdaptivePolicy.draftDepth(offeredDepth: offeredDepth)
+                    if draftDepth > 0 {
+                        let draftTokens = mtpModel.draftBlock(
+                            lastToken: next,
+                            hidden: hidden,
+                            blockSize: draftDepth + 1,
+                            session: mtpDraftSession,
+                            baseModel: model
                         )
-                        guard targetToken == draftToken else {
-                            replacement = targetToken
-                            break
-                        }
-                        accepted += 1
-                        verificationHistory.append(draftToken)
-                    }
+                        mtpDraftedTokens += draftTokens.count
 
-                    if accepted == draftTokens.count {
+                        let candidateCaches = forkLayerCaches(layerCaches)
+                        let candidateInput = MLXArray(([next] + draftTokens).map(Int32.init))
+                            .reshaped(1, draftTokens.count + 1)
+                        let candidate = model.forward(candidateInput, cache: candidateCaches)
+                        MLX.eval(candidate.logits)
+                        MLX.eval(candidate.hidden)
+                        mtpVerificationPasses += 1
+
+                        var accepted = 0
+                        var verificationHistory = repetitionHistory
+                        var replacement: Int?
+                        for (index, draftToken) in draftTokens.enumerated() {
+                            let targetToken = sampleToken(
+                                logits: candidate.logits[0, index, 0...],
+                                config: generationConfig,
+                                previousTokens: verificationHistory
+                            )
+                            guard targetToken == draftToken else {
+                                replacement = targetToken
+                                break
+                            }
+                            accepted += 1
+                            verificationHistory.append(draftToken)
+                        }
+                        mtpAdaptivePolicy.record(
+                            acceptedDrafts: accepted,
+                            drafted: draftTokens.count
+                        )
+
+                        if accepted == draftTokens.count {
+                            mtpAcceptedTokens += accepted
+                            mtpDraftSession.recordCommittedTransitions(
+                                hiddenStates: candidate.hidden,
+                                nextTokens: draftTokens
+                            )
+                            var hitEOS = false
+                            for token in draftTokens {
+                                if eosSet.contains(token) {
+                                    hitEOS = true
+                                    break
+                                }
+                                emit(token)
+                            }
+                            layerCaches = candidateCaches
+                            logits = lastTokenLogits(candidate.logits)
+                            previousHidden = lastTokenHidden(candidate.hidden)
+                            if hitEOS || generated.count >= tokenBudget {
+                                break
+                            }
+                            continue
+                        }
+
+                        let acceptedPrefix = Array(draftTokens.prefix(accepted))
                         mtpAcceptedTokens += accepted
                         var hitEOS = false
-                        for token in draftTokens {
+                        for token in acceptedPrefix {
                             if eosSet.contains(token) {
                                 hitEOS = true
                                 break
                             }
                             emit(token)
                         }
-                        layerCaches = candidateCaches
-                        logits = lastTokenLogits(candidate.logits)
-                        previousHidden = lastTokenHidden(candidate.hidden)
                         if hitEOS || generated.count >= tokenBudget {
                             break
                         }
-                        continue
-                    }
 
-                    let acceptedPrefix = Array(draftTokens.prefix(accepted))
-                    mtpAcceptedTokens += accepted
-                    var hitEOS = false
-                    for token in acceptedPrefix {
-                        if eosSet.contains(token) {
-                            hitEOS = true
+                        guard let replacement else {
+                            continue
+                        }
+                        if eosSet.contains(replacement) {
                             break
                         }
-                        emit(token)
-                    }
-                    if hitEOS || generated.count >= tokenBudget {
-                        break
-                    }
 
-                    guard let replacement else {
+                        let replacementCaches = forkLayerCaches(layerCaches)
+                        let replacementInput = MLXArray(
+                            ([next] + acceptedPrefix + [replacement]).map(Int32.init)
+                        ).reshaped(1, acceptedPrefix.count + 2)
+                        let replacementForward = model.forward(replacementInput, cache: replacementCaches)
+                        MLX.eval(replacementForward.logits)
+                        MLX.eval(replacementForward.hidden)
+                        mtpReplacementPasses += 1
+                        mtpDraftSession.recordCommittedTransitions(
+                            hiddenStates: replacementForward.hidden,
+                            nextTokens: acceptedPrefix + [replacement]
+                        )
+                        emit(replacement)
+                        layerCaches = replacementCaches
+                        logits = lastTokenLogits(replacementForward.logits)
+                        previousHidden = lastTokenHidden(replacementForward.hidden)
                         continue
                     }
+
+                    mtpNonDraftingRounds += 1
+                    mtpDraftSession.recordCommittedTransitions(
+                        hiddenStates: hidden,
+                        nextTokens: [next]
+                    )
+                } else {
+                    let draftLogits = mtpModel.draftLogits(
+                        token: next,
+                        previousHidden: hidden,
+                        positionOffset: positionOffset,
+                        baseModel: model
+                    )
+                    MLX.eval(draftLogits)
+                    mtpDraftedTokens += 1
+
+                    let draftProbs = samplingProbabilities(
+                        logits: draftLogits[0, -1, 0...],
+                        config: generationConfig,
+                        previousTokens: repetitionHistory
+                    )
+                    let draft = sampleToken(probabilities: draftProbs)
+
+                    let candidateCaches = forkLayerCaches(layerCaches)
+                    let candidateInput = MLXArray([Int32(next), Int32(draft)]).reshaped(1, 2)
+                    let candidate = model.forward(candidateInput, cache: candidateCaches)
+                    MLX.eval(candidate.logits)
+                    MLX.eval(candidate.hidden)
+                    mtpVerificationPasses += 1
+
+                    let targetProbs = samplingProbabilities(
+                        logits: candidate.logits[0, 0, 0...],
+                        config: generationConfig,
+                        previousTokens: repetitionHistory
+                    )
+                    let draftProb = max(draftProbs[draft].item(Float.self), Float.leastNonzeroMagnitude)
+                    let targetProb = targetProbs[draft].item(Float.self)
+                    let acceptProbability = min(1.0, targetProb / draftProb)
+
+                    if Float.random(in: 0..<1) <= acceptProbability {
+                        mtpAcceptedTokens += 1
+                        if eosSet.contains(draft) {
+                            break
+                        }
+                        emit(draft)
+                        layerCaches = candidateCaches
+                        logits = lastTokenLogits(candidate.logits)
+                        previousHidden = lastTokenHidden(candidate.hidden)
+                        continue
+                    }
+
+                    let residualProbs = MLX.maximum(targetProbs - draftProbs, MLXArray(0.0))
+                    let residualMass = residualProbs.sum().item(Float.self)
+                    let replacement = residualMass > 1e-6
+                        ? sampleToken(probabilities: residualProbs / residualProbs.sum())
+                        : sampleToken(probabilities: targetProbs)
                     if eosSet.contains(replacement) {
                         break
                     }
 
                     let replacementCaches = forkLayerCaches(layerCaches)
-                    let replacementInput = MLXArray(([next] + acceptedPrefix + [replacement]).map(Int32.init))
-                        .reshaped(1, acceptedPrefix.count + 2)
+                    let replacementInput = MLXArray([Int32(next), Int32(replacement)]).reshaped(1, 2)
                     let replacementForward = model.forward(replacementInput, cache: replacementCaches)
                     MLX.eval(replacementForward.logits)
                     MLX.eval(replacementForward.hidden)
@@ -1042,71 +1146,6 @@ public actor Q35Generator: ChatGenerator {
                     previousHidden = lastTokenHidden(replacementForward.hidden)
                     continue
                 }
-
-                let draftLogits = mtpModel.draftLogits(
-                    token: next,
-                    previousHidden: hidden,
-                    positionOffset: positionOffset,
-                    baseModel: model
-                )
-                MLX.eval(draftLogits)
-                mtpDraftedTokens += 1
-
-                let draftProbs = samplingProbabilities(
-                    logits: draftLogits[0, -1, 0...],
-                    config: generationConfig,
-                    previousTokens: repetitionHistory
-                )
-                let draft = sampleToken(probabilities: draftProbs)
-
-                let candidateCaches = forkLayerCaches(layerCaches)
-                let candidateInput = MLXArray([Int32(next), Int32(draft)]).reshaped(1, 2)
-                let candidate = model.forward(candidateInput, cache: candidateCaches)
-                MLX.eval(candidate.logits)
-                MLX.eval(candidate.hidden)
-                mtpVerificationPasses += 1
-
-                let targetProbs = samplingProbabilities(
-                    logits: candidate.logits[0, 0, 0...],
-                    config: generationConfig,
-                    previousTokens: repetitionHistory
-                )
-                let draftProb = max(draftProbs[draft].item(Float.self), Float.leastNonzeroMagnitude)
-                let targetProb = targetProbs[draft].item(Float.self)
-                let acceptProbability = min(1.0, targetProb / draftProb)
-
-                if Float.random(in: 0..<1) <= acceptProbability {
-                    mtpAcceptedTokens += 1
-                    if eosSet.contains(draft) {
-                        break
-                    }
-                    emit(draft)
-                    layerCaches = candidateCaches
-                    logits = lastTokenLogits(candidate.logits)
-                    previousHidden = lastTokenHidden(candidate.hidden)
-                    continue
-                }
-
-                let residualProbs = MLX.maximum(targetProbs - draftProbs, MLXArray(0.0))
-                let residualMass = residualProbs.sum().item(Float.self)
-                let replacement = residualMass > 1e-6
-                    ? sampleToken(probabilities: residualProbs / residualProbs.sum())
-                    : sampleToken(probabilities: targetProbs)
-                if eosSet.contains(replacement) {
-                    break
-                }
-
-                let replacementCaches = forkLayerCaches(layerCaches)
-                let replacementInput = MLXArray([Int32(next), Int32(replacement)]).reshaped(1, 2)
-                let replacementForward = model.forward(replacementInput, cache: replacementCaches)
-                MLX.eval(replacementForward.logits)
-                MLX.eval(replacementForward.hidden)
-                mtpReplacementPasses += 1
-                emit(replacement)
-                layerCaches = replacementCaches
-                logits = lastTokenLogits(replacementForward.logits)
-                previousHidden = lastTokenHidden(replacementForward.hidden)
-                continue
             }
 
             let nextInput = MLXArray([Int32(next)]).reshaped(1, 1)
@@ -1137,13 +1176,14 @@ public actor Q35Generator: ChatGenerator {
                 ? Double(mtpAcceptedTokens) / Double(mtpDraftedTokens) * 100
                 : 0
             Gemma4DecodeTrace.emit(String(
-                format: "[q35-decode-trace] mode=mtp tokens=%d drafted=%d accepted=%d acceptance=%.1f%% verify=%d replacement=%d wall=%.2fms/tok",
+                format: "[q35-decode-trace] mode=mtp tokens=%d drafted=%d accepted=%d acceptance=%.1f%% verify=%d replacement=%d serial=%d wall=%.2fms/tok",
                 generated.count,
                 mtpDraftedTokens,
                 mtpAcceptedTokens,
                 acceptance,
                 mtpVerificationPasses,
                 mtpReplacementPasses,
+                mtpNonDraftingRounds,
                 decodeSeconds / Double(max(1, generated.count)) * 1000
             ))
         }
@@ -1602,6 +1642,7 @@ public actor Q35Generator: ChatGenerator {
         modelPath: String? = nil,
         checkpointTokenCounts: Set<Int> = [],
         retainHidden: Bool = true,
+        retainMTPHistory: Bool = false,
         progressHandler: (@Sendable (ChatProgress) -> Void)?
     ) async throws -> Q35PrefillOutput {
         guard !promptTokens.isEmpty else {
@@ -1611,6 +1652,7 @@ public actor Q35Generator: ChatGenerator {
         var processed = startIndex
         var logits = existingLogits
         var hidden = existingHidden
+        var mtpHistoryChunks: [MLXArray] = []
         if processed > 0, processed < promptTokens.count {
             progressHandler?(ChatProgress(stage: .encoding, message: "Reusing \(processed) prompt KV tokens"))
         }
@@ -1628,11 +1670,18 @@ public actor Q35Generator: ChatGenerator {
             let chunk = MLXArray(promptTokens[processed..<end].map(Int32.init))
                 .reshaped(1, end - processed)
             if retainHidden {
-                let output = model.forwardPrefill(chunk, cache: cache)
+                let output = model.forwardPrefill(
+                    chunk,
+                    cache: cache,
+                    retainAllHidden: retainMTPHistory
+                )
                 MLX.eval(output.logits)
                 MLX.eval(output.hidden)
                 logits = output.logits
-                hidden = output.hidden
+                hidden = lastTokenHidden(output.hidden)
+                if retainMTPHistory {
+                    mtpHistoryChunks.append(output.hidden)
+                }
                 if let modelPath {
                     storePrefixKVCache(
                         modelPath: modelPath,
@@ -1640,7 +1689,7 @@ public actor Q35Generator: ChatGenerator {
                         tokenCount: end,
                         cache: cache,
                         logits: output.logits,
-                        hidden: output.hidden,
+                        hidden: lastTokenHidden(output.hidden),
                         priority: checkpointTokenCounts.contains(end) ? .semantic : .chunk
                     )
                 }
@@ -1657,7 +1706,17 @@ public actor Q35Generator: ChatGenerator {
         guard let logits else {
             throw Q35Error.generationFailed("Prefill did not produce logits.")
         }
-        return Q35PrefillOutput(logits: logits, hidden: hidden)
+        let mtpHistoryHidden = mtpHistoryChunks.isEmpty
+            ? nil
+            : MLX.concatenated(mtpHistoryChunks, axis: 1)
+        if let mtpHistoryHidden {
+            MLX.eval(mtpHistoryHidden)
+        }
+        return Q35PrefillOutput(
+            logits: logits,
+            hidden: hidden,
+            mtpHistoryHidden: mtpHistoryHidden
+        )
     }
 
     private func chunkedPrefillEmbeddings(
@@ -1714,7 +1773,11 @@ public actor Q35Generator: ChatGenerator {
         guard let logits else {
             throw Q35Error.generationFailed("Prefill did not produce logits.")
         }
-        return Q35PrefillOutput(logits: logits, hidden: hidden)
+        return Q35PrefillOutput(
+            logits: logits,
+            hidden: hidden,
+            mtpHistoryHidden: nil
+        )
     }
 
     private func semanticPrefixCheckpoints(
@@ -1932,8 +1995,7 @@ public actor Q35Generator: ChatGenerator {
     }
 
     private static func hasMTPWeights(resources: Q35Resources) -> Bool {
-        let standalone = resources.rootURL.appendingPathComponent("mtp.safetensors")
-        if FileManager.default.fileExists(atPath: standalone.path) {
+        if standaloneMTPWeightsURL(resources: resources) != nil {
             return true
         }
         guard FileManager.default.fileExists(atPath: resources.modelIndexURL.path),
@@ -1957,14 +2019,25 @@ public actor Q35Generator: ChatGenerator {
         return hasMTPWeights(resources: mounted) ? mounted : nil
     }
 
+    private static func standaloneMTPWeightsURL(resources: Q35Resources) -> URL? {
+        let explicit = resources.rootURL.appendingPathComponent("mtp.safetensors")
+        if FileManager.default.fileExists(atPath: explicit.path) {
+            return explicit
+        }
+        guard resources.rootURL.lastPathComponent == Q35Resources.q38MTPComponentPath,
+              FileManager.default.fileExists(atPath: resources.modelWeightsURL.path) else {
+            return nil
+        }
+        return resources.modelWeightsURL
+    }
+
     private func loadMTPWeights(
         into mtp: Q35MTPModel,
         from resources: Q35Resources,
         groupSize: Int,
         bits: Int
     ) throws {
-        let standalone = resources.rootURL.appendingPathComponent("mtp.safetensors")
-        if FileManager.default.fileExists(atPath: standalone.path) {
+        if let standalone = Self.standaloneMTPWeightsURL(resources: resources) {
             let metadata = try SafetensorsStreamingLoader.metadata(url: standalone)
             if metadata.keys.contains(where: { $0.hasSuffix(".scales") }) {
                 let arrays = try MLX.loadArrays(url: standalone)
@@ -1974,8 +2047,9 @@ public actor Q35Generator: ChatGenerator {
                     groupSize: groupSize,
                     bits: bits,
                     keyMapper: { key in
-                        Self.mapMTPWeightKey(key) ?? "__unused__.\(key)"
-                    }
+                        Self.mapMTPWeightKey(key, standalone: true) ?? "__unused__.\(key)"
+                    },
+                    mapper: Self.mapMTPWeight
                 )
             } else {
                 try SafetensorsStreamingLoader.applyWeightsStreaming(
@@ -1983,10 +2057,10 @@ public actor Q35Generator: ChatGenerator {
                     to: mtp,
                     dtype: .bfloat16,
                     verify: .none,
-                    include: { Self.mapMTPWeightKey($0) != nil },
+                    include: { Self.mapMTPWeightKey($0, standalone: true) != nil },
                     mapper: { key, value in
-                        guard let mapped = Self.mapMTPWeightKey(key) else { return [] }
-                        return [(mapped, value)]
+                        guard let mapped = Self.mapMTPWeightKey(key, standalone: true) else { return [] }
+                        return Self.mapMTPWeight(mapped, value)
                     },
                     batchSize: 32
                 )
@@ -2005,7 +2079,7 @@ public actor Q35Generator: ChatGenerator {
                 verify: .none,
                 mapper: { key, value in
                     guard let mapped = Self.mapMTPWeightKey(key) else { return [] }
-                    return [(mapped, value)]
+                    return Self.mapMTPWeight(mapped, value)
                 }
             )
         }
@@ -2017,9 +2091,37 @@ public actor Q35Generator: ChatGenerator {
         })).sorted()
     }
 
-    private static func mapMTPWeightKey(_ key: String) -> String? {
-        guard key.hasPrefix("mtp.") else { return nil }
-        return String(key.dropFirst("mtp.".count))
+    static func mapMTPWeightKey(_ key: String, standalone: Bool = false) -> String? {
+        if key.hasPrefix("mtp.") {
+            return String(key.dropFirst("mtp.".count))
+        }
+        guard standalone else { return nil }
+        let barePrefixes = [
+            "fc.",
+            "layers.",
+            "norm.",
+            "pre_fc_norm_embedding.",
+            "pre_fc_norm_hidden.",
+        ]
+        return barePrefixes.contains(where: { key.hasPrefix($0) }) ? key : nil
+    }
+
+    static func isMTPRMSNormWeight(_ key: String) -> Bool {
+        key == "norm.weight"
+            || key == "pre_fc_norm_embedding.weight"
+            || key == "pre_fc_norm_hidden.weight"
+            || key.hasSuffix(".input_layernorm.weight")
+            || key.hasSuffix(".post_attention_layernorm.weight")
+            || key.hasSuffix(".self_attn.q_norm.weight")
+            || key.hasSuffix(".self_attn.k_norm.weight")
+    }
+
+    private static func mapMTPWeight(_ key: String, _ value: MLXArray) -> [(String, MLXArray)] {
+        guard !key.hasPrefix("__unused__.") else { return [] }
+        if isMTPRMSNormWeight(key) {
+            return [(key, value - MLXArray(1.0).asType(value.dtype))]
+        }
+        return [(key, value)]
     }
 
     private static func mapTextWeightKey(_ key: String) -> String? {

--- a/Sources/MereRunCore/Q35/Q35MTP.swift
+++ b/Sources/MereRunCore/Q35/Q35MTP.swift
@@ -195,14 +195,13 @@ final class Q35MTPModel: Module {
     func callAsFunction(
         inputEmbeddings: MLXArray,
         hiddenStates: MLXArray,
-        positionOffset: Int
+        cache: KVCache
     ) -> MLXArray {
         let normalizedEmbeddings = preFCNormEmbedding(inputEmbeddings)
         let normalizedHidden = preFCNormHidden(hiddenStates)
         var hidden = MLX.concatenated([normalizedEmbeddings, normalizedHidden], axis: -1)
         hidden = fc(hidden)
 
-        let cache = Q35MTPPositionCache(offset: positionOffset)
         let mask = cache.makeMask(n: hidden.dim(1))
         for layer in layers {
             hidden = layer(hidden, mask: mask, cache: cache)
@@ -218,10 +217,11 @@ final class Q35MTPModel: Module {
     ) -> MLXArray {
         let inputIds = MLXArray([Int32(token)]).reshaped(1, 1)
         let embeddings = baseModel.embeddings(for: inputIds)
+        let cache = Q35MTPPositionCache(offset: positionOffset)
         let hidden = self(
             inputEmbeddings: embeddings,
             hiddenStates: previousHidden,
-            positionOffset: positionOffset
+            cache: cache
         )
         return baseModel.logits(from: hidden)
     }
@@ -229,29 +229,96 @@ final class Q35MTPModel: Module {
     func draftBlock(
         lastToken: Int,
         hidden: MLXArray,
-        positionOffset: Int,
         blockSize: Int,
+        session: Q35MTPDraftSession,
+        baseModel: Q35Model
+    ) -> [Int] {
+        session.draftBlock(
+            lastToken: lastToken,
+            hidden: hidden,
+            blockSize: blockSize,
+            mtpModel: self,
+            baseModel: baseModel
+        )
+    }
+}
+
+/// Request-local committed-history cache for greedy MTP proposals.
+///
+/// The persistent cache contains only target-confirmed transitions. Draft-only
+/// rows run on a fork and are discarded after the round, so proposal history
+/// can improve acceptance without becoming an output authority.
+final class Q35MTPDraftSession {
+    private let historyCache = KVCacheSimple(step: 256)
+    private var backlogHidden: [MLXArray] = []
+    private var backlogTokens: [Int] = []
+
+    init(promptTokens: [Int] = [], promptHidden: MLXArray? = nil) {
+        guard let promptHidden,
+              promptTokens.count > 1,
+              promptHidden.dim(1) == promptTokens.count else {
+            return
+        }
+        backlogHidden.append(promptHidden[0..., 0..<(promptTokens.count - 1), 0...])
+        backlogTokens.append(contentsOf: promptTokens.dropFirst())
+    }
+
+    var committedHistoryCount: Int {
+        historyCache.offset + backlogTokens.count
+    }
+
+    func recordCommittedTransitions(hiddenStates: MLXArray, nextTokens: [Int]) {
+        guard !nextTokens.isEmpty,
+              hiddenStates.dim(1) >= nextTokens.count else {
+            return
+        }
+        backlogHidden.append(hiddenStates[0..., 0..<nextTokens.count, 0...])
+        backlogTokens.append(contentsOf: nextTokens)
+    }
+
+    func draftBlock(
+        lastToken: Int,
+        hidden: MLXArray,
+        blockSize: Int,
+        mtpModel: Q35MTPModel,
         baseModel: Q35Model
     ) -> [Int] {
         let total = max(1, blockSize) - 1
-        guard total > 0 else {
-            return []
-        }
+        guard total > 0 else { return [] }
 
-        var tokenArray = MLXArray([Int32(lastToken)]).reshaped(1, 1)
-        var previousHidden = hidden
-        var tokenArrays: [MLXArray] = []
+        backlogHidden.append(hidden)
+        backlogTokens.append(lastToken)
+        let flushHidden = backlogHidden.count == 1
+            ? backlogHidden[0]
+            : MLX.concatenated(backlogHidden, axis: 1)
+        let flushTokens = MLXArray(backlogTokens.map(Int32.init))
+            .reshaped(1, backlogTokens.count)
+        backlogHidden.removeAll(keepingCapacity: true)
+        backlogTokens.removeAll(keepingCapacity: true)
+
+        let flushEmbeddings = baseModel.embeddings(for: flushTokens)
+        let flushed = mtpModel(
+            inputEmbeddings: flushEmbeddings,
+            hiddenStates: flushHidden,
+            cache: historyCache
+        )
+        var previousHidden = flushed[0..., (flushed.dim(1) - 1)..., 0...]
+        var tokenArray = baseModel.greedyDraftToken(from: previousHidden)
+        var tokenArrays = [tokenArray]
         tokenArrays.reserveCapacity(total)
-        for index in 0..<total {
-            let embeddings = baseModel.embeddings(for: tokenArray)
-            previousHidden = self(
-                inputEmbeddings: embeddings,
-                hiddenStates: previousHidden,
-                positionOffset: positionOffset + index
-            )
-            let draftLogits = baseModel.logits(from: previousHidden)[0, -1, 0...]
-            tokenArray = argMax(draftLogits, axis: -1).asType(.int32).reshaped(1, 1)
-            tokenArrays.append(tokenArray)
+
+        if total > 1 {
+            let speculativeCache = historyCache.fork()
+            for _ in 1..<total {
+                let embeddings = baseModel.embeddings(for: tokenArray)
+                previousHidden = mtpModel(
+                    inputEmbeddings: embeddings,
+                    hiddenStates: previousHidden,
+                    cache: speculativeCache
+                )
+                tokenArray = baseModel.greedyDraftToken(from: previousHidden)
+                tokenArrays.append(tokenArray)
+            }
         }
 
         let draftTokens = MLX.concatenated(tokenArrays, axis: 1)

--- a/Sources/MereRunCore/Q35/Q35MTPAdaptivePolicy.swift
+++ b/Sources/MereRunCore/Q35/Q35MTPAdaptivePolicy.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+/// Chooses a greedy MTP draft depth from the acceptance observed in this request.
+///
+/// The MTP head only proposes. A deeper round is useful while the probability of
+/// reaching its next draft outweighs the marginal head work and the repair work
+/// paid after a rejection. The target still verifies every proposed token.
+struct Q35MTPAdaptivePolicy {
+    private static let acceptanceAlpha = 0.15
+    private static let inferredAcceptanceCeiling = 0.95
+
+    /// Unlike the MLX Fast crown's checkpointed rollback path, mere.run repairs
+    /// a rejected prefix with a target forward. Use the MTPLX-style cost ratio
+    /// that prices that repair instead of the crown's lower rollback-only fit.
+    private static let headStepCostRatio = 0.43
+
+    private var positionAcceptance: [Double]
+
+    init(maxDraftDepth: Int) {
+        positionAcceptance = (0..<max(0, maxDraftDepth)).map { index in
+            0.85 * pow(0.98, Double(index))
+        }
+    }
+
+    func draftDepth(offeredDepth: Int) -> Int {
+        let cap = min(max(0, offeredDepth), positionAcceptance.count)
+        guard cap > 0 else { return 0 }
+
+        let cost = Self.headStepCostRatio
+        var reach = 1.0
+        var expectedAccepted = 0.0
+        var depth = 0
+        while depth < cap {
+            reach *= positionAcceptance[depth]
+            let threshold = cost * (1.0 + expectedAccepted) / (1.0 + Double(depth) * cost)
+            guard reach > threshold else { break }
+            expectedAccepted += reach
+            depth += 1
+        }
+        return depth
+    }
+
+    mutating func record(acceptedDrafts: Int, drafted: Int) {
+        let observedDrafts = min(max(0, drafted), positionAcceptance.count)
+        guard observedDrafts > 0 else { return }
+
+        let accepted = min(max(0, acceptedDrafts), observedDrafts)
+        let alpha = Self.acceptanceAlpha
+        for index in 0..<accepted {
+            positionAcceptance[index] += alpha * (1.0 - positionAcceptance[index])
+        }
+
+        if accepted < observedDrafts {
+            positionAcceptance[accepted] += alpha * (0.0 - positionAcceptance[accepted])
+        } else if accepted < positionAcceptance.count,
+                  positionAcceptance[accepted] < Self.inferredAcceptanceCeiling {
+            // A fully accepted round is weak evidence that the next position is
+            // worth trying. Cap transferred optimism because it was not observed.
+            positionAcceptance[accepted] += alpha * (
+                Self.inferredAcceptanceCeiling - positionAcceptance[accepted]
+            )
+        }
+    }
+}

--- a/Sources/MereRunCore/Q35/Q35Model.swift
+++ b/Sources/MereRunCore/Q35/Q35Model.swift
@@ -195,11 +195,100 @@ struct Q35ForwardOutput {
     let logits: MLXArray
 }
 
+#if os(macOS) || os(iOS)
+private let q35CompactDraftSelectKernel = MLXFast.metalKernel(
+    name: "q35_compact_draft_select",
+    inputNames: ["logits"],
+    outputNames: ["token_id"],
+    source: """
+        uint lane = thread_position_in_threadgroup.x;
+        float best_value = 0.0f;
+        uint best_id = 0;
+        bool have = false;
+
+        for (uint index = lane; index < REAL_COUNT; index += TG_SIZE) {
+            float value = float(logits[index]);
+            bool value_nan = isnan(value);
+            bool take;
+            if (!have) {
+                take = true;
+            } else if (value_nan != isnan(best_value)) {
+                take = !value_nan;
+            } else if (value > best_value) {
+                take = true;
+            } else if (value < best_value) {
+                take = false;
+            } else {
+                take = index < best_id;
+            }
+            if (take) {
+                best_value = value;
+                best_id = index;
+                have = true;
+            }
+        }
+
+        threadgroup float scratch_value[TG_SIZE];
+        threadgroup uint scratch_id[TG_SIZE];
+        scratch_value[lane] = have ? best_value : NAN;
+        scratch_id[lane] = have ? best_id : 0xFFFFFFFFu;
+        threadgroup_barrier(mem_flags::mem_threadgroup);
+
+        for (uint stride = TG_SIZE / 2; stride > 0; stride >>= 1) {
+            if (lane < stride) {
+                float lhs_value = scratch_value[lane];
+                float rhs_value = scratch_value[lane + stride];
+                uint lhs_id = scratch_id[lane];
+                uint rhs_id = scratch_id[lane + stride];
+                bool lhs_empty = lhs_id == 0xFFFFFFFFu;
+                bool rhs_empty = rhs_id == 0xFFFFFFFFu;
+                bool take_rhs;
+                if (rhs_empty) {
+                    take_rhs = false;
+                } else if (lhs_empty) {
+                    take_rhs = true;
+                } else if (isnan(rhs_value) != isnan(lhs_value)) {
+                    take_rhs = !isnan(rhs_value);
+                } else if (rhs_value > lhs_value) {
+                    take_rhs = true;
+                } else if (rhs_value < lhs_value) {
+                    take_rhs = false;
+                } else {
+                    take_rhs = rhs_id < lhs_id;
+                }
+                if (take_rhs) {
+                    scratch_value[lane] = rhs_value;
+                    scratch_id[lane] = rhs_id;
+                }
+            }
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+        }
+
+        if (lane == 0) {
+            uint id = scratch_id[0];
+            token_id[0] = int(id < PREFIX_COUNT ? id : id + CONTROL_OFFSET);
+        }
+    """,
+    header: "",
+    ensureRowContiguous: false
+)
+#endif
+
 public final class Q35Model: Module, @unchecked Sendable {
     @ModuleInfo(key: "model") var model: Q35Transformer
     @ModuleInfo(key: "lm_head") var lmHead: Linear?
 
     public let config: Q35Config
+
+    private var compactDraftHead: Linear?
+    private var compactDraftHeadSource: ObjectIdentifier?
+
+    static let compactDraftPrefixCount = 98_304
+    static let compactDraftControlStart = 248_044
+    static let compactDraftControlEnd = 248_070
+    static let compactDraftRealCount = compactDraftPrefixCount
+        + compactDraftControlEnd - compactDraftControlStart
+    static let compactDraftPaddedCount = 98_336
 
     public init(config: Q35Config) {
         self.config = config
@@ -220,6 +309,109 @@ public final class Q35Model: Module, @unchecked Sendable {
 
     func logits(from hidden: MLXArray) -> MLXArray {
         lmHead?(hidden) ?? model.embedTokens.asLinear(hidden)
+    }
+
+    /// Prepare the proposal-only compact projection after the exact target
+    /// weights have loaded. This is called only when an MTP head is admitted.
+    func prepareGreedyMTPDrafting() {
+        guard let head = resolvedCompactDraftHead() else { return }
+        MLX.eval(head.weight)
+        if let quantized = head as? PortableQuantizedLinear {
+            MLX.eval(quantized.scales)
+            if let biases = quantized.biases { MLX.eval(biases) }
+        }
+
+        let hidden = MLXArray.zeros(
+            [1, 1, config.textConfig.hiddenSize],
+            dtype: .bfloat16
+        )
+        MLX.eval(greedyDraftToken(from: hidden))
+    }
+
+    /// Proposal-only greedy token selection. Target verification remains the
+    /// sole authority for emitted tokens.
+    func greedyDraftToken(from hidden: MLXArray) -> MLXArray {
+        guard let head = resolvedCompactDraftHead() else {
+            return argMax(logits(from: hidden), axis: -1).asType(.int32).reshaped(1, 1)
+        }
+        return Self.compactDraftTokenID(from: head(hidden))
+    }
+
+    static func compactDraftRows(_ array: MLXArray) -> MLXArray {
+        let prefix = array[0..<compactDraftPrefixCount]
+        let controls = array[compactDraftControlStart..<compactDraftControlEnd]
+        let paddingCount = compactDraftPaddedCount - compactDraftRealCount
+        let padding = array[0..<paddingCount]
+        return MLX.concatenated([prefix, controls, padding], axis: 0)
+    }
+
+    static func compactDraftTokenID(from paddedLogits: MLXArray) -> MLXArray {
+        #if os(macOS) || os(iOS)
+        if Device.defaultDevice().deviceType == .gpu {
+            let threadGroupSize = 1_024
+            return q35CompactDraftSelectKernel(
+                [paddedLogits.reshaped([compactDraftPaddedCount])],
+                template: [
+                    ("REAL_COUNT", compactDraftRealCount),
+                    ("PREFIX_COUNT", compactDraftPrefixCount),
+                    ("CONTROL_OFFSET", compactDraftControlStart - compactDraftPrefixCount),
+                    ("TG_SIZE", threadGroupSize),
+                ],
+                grid: (threadGroupSize, 1, 1),
+                threadGroup: (threadGroupSize, 1, 1),
+                outputShapes: [[1, 1]],
+                outputDTypes: [.int32]
+            )[0]
+        }
+        #endif
+
+        let compactID = argMax(
+            paddedLogits[0..., 0..., 0..<compactDraftRealCount],
+            axis: -1
+        ).asType(.int32)
+        return MLX.which(
+            compactID .< compactDraftPrefixCount,
+            compactID,
+            compactID + (compactDraftControlStart - compactDraftPrefixCount)
+        )
+    }
+
+    private func resolvedCompactDraftHead() -> Linear? {
+        guard config.textConfig.vocabSize == 248_320,
+              let fullHead = lmHead else {
+            return nil
+        }
+
+        let source = ObjectIdentifier(fullHead)
+        if compactDraftHeadSource == source {
+            return compactDraftHead
+        }
+
+        let resolved: Linear?
+        if let quantized = fullHead as? PortableQuantizedLinear {
+            resolved = PortableQuantizedLinear(
+                weight: Self.compactDraftRows(quantized.weight),
+                bias: quantized.bias.map(Self.compactDraftRows),
+                scales: Self.compactDraftRows(quantized.scales),
+                biases: quantized.biases.map(Self.compactDraftRows),
+                groupSize: quantized.groupSize,
+                bits: quantized.bits,
+                mode: quantized.mode
+            )
+        } else if type(of: fullHead) == Linear.self {
+            resolved = Linear(
+                weight: Self.compactDraftRows(fullHead.weight),
+                bias: fullHead.bias.map(Self.compactDraftRows)
+            )
+        } else {
+            // Wrapped or corrected projections may carry behavior that cannot
+            // be represented by slicing their stored base arrays.
+            resolved = nil
+        }
+
+        compactDraftHead = resolved
+        compactDraftHeadSource = source
+        return resolved
     }
 
     func forward(
@@ -248,19 +440,26 @@ public final class Q35Model: Module, @unchecked Sendable {
         _ inputIds: MLXArray,
         cache: [Q35LayerCache?]?,
         inputEmbeddings: MLXArray? = nil,
-        positionIds: MLXArray? = nil
+        positionIds: MLXArray? = nil,
+        retainAllHidden: Bool = false
     ) -> Q35ForwardOutput {
-        var hidden = model(
+        let hidden = model(
             inputIds,
             cache: cache,
             inputEmbeddings: inputEmbeddings,
             positionIds: positionIds
         )
         let sequenceLength = hidden.dim(1)
+        let lastHidden: MLXArray
         if sequenceLength > 1 {
-            hidden = hidden[0..., (sequenceLength - 1)..., 0...]
+            lastHidden = hidden[0..., (sequenceLength - 1)..., 0...]
+        } else {
+            lastHidden = hidden
         }
-        return Q35ForwardOutput(hidden: hidden, logits: logits(from: hidden))
+        return Q35ForwardOutput(
+            hidden: retainAllHidden ? hidden : lastHidden,
+            logits: logits(from: lastHidden)
+        )
     }
 
     public func callAsFunction(

--- a/Sources/MereRunCore/Q35/Q35Resources.swift
+++ b/Sources/MereRunCore/Q35/Q35Resources.swift
@@ -86,15 +86,15 @@ public struct Q35Resources: Sendable, Hashable {
     public static let q38TwentySevenBUpstreamRepoId = "Qwen/Qwen3.8-27B"
     public static let q38TwentySevenBUpstreamRevision = "1d4bf0f2ff6012fd82039f2fa52739d0dd7c60c0"
     public static let q38TwentySevenBEstimatedDownloadBytes: Int64 = 55_586_114_863
-    public static let q38TwentySevenB4BitUpstreamRepoId = "lmstudio-community/Qwen3.8-27B-MLX-4bit"
-    public static let q38TwentySevenB4BitUpstreamRevision = "6067b15cf581666a4aecf6af3afaba4bb5efc20c"
-    public static let q38TwentySevenB4BitEstimatedDownloadBytes: Int64 = 19_473_823_081
+    public static let q38TwentySevenB4BitUpstreamRepoId = "EigenLabs/Qwen3.8-27B-4bit"
+    public static let q38TwentySevenB4BitUpstreamRevision = "eda45ab47f465d08d6558f0353a2346e2eb9d5b3"
+    public static let q38TwentySevenB4BitEstimatedDownloadBytes: Int64 = 15_392_000_000
     public static let q38MTPComponentPath = "mtp"
-    public static let q38MTPComponentSnapshotPatterns = [
-        "LICENSE",
-        "model.safetensors.index.json",
-        "model-00018-of-00018.safetensors",
-    ]
+    public static let q38MTP4BitUpstreamRepoId = "lowskillcoding/qwen38-mtp-head-4bit-g64"
+    public static let q38MTP4BitUpstreamRevision = "0966ddaff972fd3ca2be08f3640603b47e9ce70a"
+    public static let q38MTPComponentSnapshotPatterns = ["model.safetensors"]
+    public static let q38LicenseComponentPath = "licenses/qwen3.8"
+    public static let q38LicenseComponentSnapshotPatterns = ["LICENSE"]
     public static let q38TwentySevenBContextLength = 262_144
     public static let q38TwentySevenBVisionMinPixels = 65_536
     public static let q38TwentySevenBVisionMaxPixels = 16_777_216

--- a/Sources/MereRunCore/Q35/README.md
+++ b/Sources/MereRunCore/Q35/README.md
@@ -18,8 +18,19 @@ both conventions compatible with the native offset RMSNorm module.
 
 The official Qwen3.8 27B shards embed a dense one-layer MTP head. The loader
 reads only the shards that contain `mtp.*` tensors, maps its dense SwiGLU layout,
-and also discovers the same pinned official shard under `mtp/` beside the
-managed 4-bit target. `MERERUN_Q35_MTP_SPECULATION=1` enables greedy speculation
-from short prompts. It stays opt-in because multi-token target verification can
-choose a different greedy path from serial target decode. Hybrid MoE Qwen models
-keep the existing adaptive long-context threshold.
+and also discovers a bare `model.safetensors` MTP component under `mtp/`. The
+managed 4-bit lane pairs the MLX Fast reference target with a matching
+4-bit/group-64 proposal head. `MERERUN_Q35_MTP_SPECULATION=1` enables greedy
+speculation from short prompts. It stays opt-in because multi-token target
+verification can choose a different greedy path from serial target decode.
+Hybrid MoE Qwen models keep the existing adaptive long-context threshold.
+
+Greedy Qwen3.8 MTP uses a proposal-only compact vocabulary projection containing
+the first 98,304 tokenizer rows and the official control-token rows. A fused
+Metal reduction maps its argmax back to the full tokenizer without materializing
+the unused vocabulary tail. A request-local MTP cache is primed from up to 4,096
+prompt hidden states and retains only target-confirmed transitions; speculative
+rows execute on a disposable fork. The exact target projection still verifies
+every emitted token. Per-request acceptance estimates adapt the draft depth and
+can fall back to target-only rounds when proposals stop paying for their repair
+cost. Sampled MTP keeps the full-vocabulary probability path.

--- a/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
@@ -784,7 +784,7 @@ final class ManagedModelCatalogTests: XCTestCase {
         XCTAssertEqual(spec.hubFallback?.patterns.contains("video_preprocessor_config.json"), true)
     }
 
-    func testQ38TwentySevenB4BitUsesPinnedConversionAndOfficialMTPShard() throws {
+    func testQ38TwentySevenB4BitUsesCrownedTargetAndQuantizedMTPHead() throws {
         let spec = try XCTUnwrap(
             ManagedModelCatalog.spec(for: Q35Resources.q38TwentySevenB4BitModelId)
         )
@@ -794,23 +794,35 @@ final class ManagedModelCatalogTests: XCTestCase {
         XCTAssertEqual(spec.installShape, .directoryRoot)
         XCTAssertEqual(spec.hubFallback?.repoId, Q35Resources.q38TwentySevenB4BitUpstreamRepoId)
         XCTAssertEqual(spec.hubFallback?.revision, Q35Resources.q38TwentySevenB4BitUpstreamRevision)
-        XCTAssertEqual(spec.mountedHubFallbacks.count, 1)
+        XCTAssertEqual(spec.mountedHubFallbacks.count, 2)
         XCTAssertEqual(spec.mountedHubFallbacks.first?.destinationPath, Q35Resources.q38MTPComponentPath)
         XCTAssertEqual(
             spec.mountedHubFallbacks.first?.hubFallback.repoId,
-            Q35Resources.q38TwentySevenBUpstreamRepoId
+            Q35Resources.q38MTP4BitUpstreamRepoId
         )
         XCTAssertEqual(
             spec.mountedHubFallbacks.first?.hubFallback.revision,
-            Q35Resources.q38TwentySevenBUpstreamRevision
+            Q35Resources.q38MTP4BitUpstreamRevision
         )
         XCTAssertEqual(
             spec.mountedHubFallbacks.first?.hubFallback.patterns,
             Q35Resources.q38MTPComponentSnapshotPatterns
         )
+        XCTAssertEqual(
+            spec.mountedHubFallbacks.last?.destinationPath,
+            Q35Resources.q38LicenseComponentPath
+        )
+        XCTAssertEqual(
+            spec.mountedHubFallbacks.last?.hubFallback.repoId,
+            Q35Resources.q38TwentySevenBUpstreamRepoId
+        )
+        XCTAssertEqual(
+            spec.mountedHubFallbacks.last?.hubFallback.patterns,
+            Q35Resources.q38LicenseComponentSnapshotPatterns
+        )
         XCTAssertEqual(spec.validationKind, .q35)
         XCTAssertEqual(spec.defaultRuntimeServingEngine, .textChatQ36)
-        XCTAssertEqual(spec.estimatedDownloadBytes, 19_473_823_081)
+        XCTAssertEqual(spec.estimatedDownloadBytes, 15_392_000_000)
         XCTAssertFalse(spec.runtimeAutoDownloadAllowed)
         XCTAssertTrue(spec.defaultCLICommands.contains("model benchmark code"))
     }
@@ -834,6 +846,14 @@ final class ManagedModelCatalogTests: XCTestCase {
         try FileManager.default.createDirectory(at: mtpRoot, withIntermediateDirectories: true)
         for filename in Q35Resources.q38MTPComponentSnapshotPatterns {
             try Data().write(to: mtpRoot.appendingPathComponent(filename))
+        }
+        let licenseRoot = root.appendingPathComponent(
+            Q35Resources.q38LicenseComponentPath,
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: licenseRoot, withIntermediateDirectories: true)
+        for filename in Q35Resources.q38LicenseComponentSnapshotPatterns {
+            try Data().write(to: licenseRoot.appendingPathComponent(filename))
         }
         XCTAssertTrue(spec.missingPaths(in: root).isEmpty)
     }

--- a/Tests/MereRunCoreTests/MereRunModelManifestTests.swift
+++ b/Tests/MereRunCoreTests/MereRunModelManifestTests.swift
@@ -252,12 +252,15 @@ final class MereRunModelManifestTests: MereRunCoreTestCase {
             "\(Q35Resources.q38TwentySevenB4BitUpstreamRepoId)"
                 + "@\(Q35Resources.q38TwentySevenB4BitUpstreamRevision)"
         )
-        XCTAssertEqual(manifest.sources?.count, 2)
+        XCTAssertEqual(manifest.sources?.count, 3)
         XCTAssertEqual(manifest.sources?.first?.role, "primary")
         XCTAssertEqual(manifest.sources?.first?.repository, Q35Resources.q38TwentySevenB4BitUpstreamRepoId)
+        XCTAssertEqual(manifest.sources?[1].role, "component")
+        XCTAssertEqual(manifest.sources?[1].repository, Q35Resources.q38MTP4BitUpstreamRepoId)
+        XCTAssertEqual(manifest.sources?[1].destinationPath, Q35Resources.q38MTPComponentPath)
         XCTAssertEqual(manifest.sources?.last?.role, "component")
         XCTAssertEqual(manifest.sources?.last?.repository, Q35Resources.q38TwentySevenBUpstreamRepoId)
-        XCTAssertEqual(manifest.sources?.last?.destinationPath, Q35Resources.q38MTPComponentPath)
+        XCTAssertEqual(manifest.sources?.last?.destinationPath, Q35Resources.q38LicenseComponentPath)
     }
 
     func testFalconPerceptionTemplateHasExpectedMetadata() throws {

--- a/Tests/MereRunCoreTests/Q35ConfigDecodingTests.swift
+++ b/Tests/MereRunCoreTests/Q35ConfigDecodingTests.swift
@@ -550,6 +550,30 @@ final class Q35ConfigDecodingTests: MereRunCoreTestCase {
         XCTAssertEqual(shards, ["model-00017.safetensors", "model-00018.safetensors"])
     }
 
+    func testQ35StandaloneMTPWeightMappingAcceptsBareHeadKeys() {
+        XCTAssertEqual(
+            Q35Generator.mapMTPWeightKey("layers.0.self_attn.q_proj.weight", standalone: true),
+            "layers.0.self_attn.q_proj.weight"
+        )
+        XCTAssertEqual(
+            Q35Generator.mapMTPWeightKey("mtp.layers.0.self_attn.q_proj.weight", standalone: true),
+            "layers.0.self_attn.q_proj.weight"
+        )
+        XCTAssertNil(Q35Generator.mapMTPWeightKey("lm_head.weight", standalone: true))
+        XCTAssertNil(Q35Generator.mapMTPWeightKey("layers.0.self_attn.q_proj.weight"))
+    }
+
+    func testQ35MTPRMSNormWeightInventoryMatchesHeadArchitecture() {
+        XCTAssertTrue(Q35Generator.isMTPRMSNormWeight("norm.weight"))
+        XCTAssertTrue(Q35Generator.isMTPRMSNormWeight("pre_fc_norm_embedding.weight"))
+        XCTAssertTrue(Q35Generator.isMTPRMSNormWeight("pre_fc_norm_hidden.weight"))
+        XCTAssertTrue(Q35Generator.isMTPRMSNormWeight("layers.0.input_layernorm.weight"))
+        XCTAssertTrue(Q35Generator.isMTPRMSNormWeight("layers.0.post_attention_layernorm.weight"))
+        XCTAssertTrue(Q35Generator.isMTPRMSNormWeight("layers.0.self_attn.q_norm.weight"))
+        XCTAssertTrue(Q35Generator.isMTPRMSNormWeight("layers.0.self_attn.k_norm.weight"))
+        XCTAssertFalse(Q35Generator.isMTPRMSNormWeight("layers.0.self_attn.q_proj.weight"))
+    }
+
     func testQ35MTPDraftBlockReturnsRequestedGreedyTokens() throws {
         MLXRandom.seed(40)
         let config = try decodeConfig(makeTinyRuntimeConfig(layerTypes: ["full_attention"]))
@@ -563,16 +587,116 @@ final class Q35ConfigDecodingTests: MereRunCoreTestCase {
 
         let lastIndex = output.hidden.dim(1) - 1
         let previousHidden = output.hidden[0..., lastIndex..<(lastIndex + 1), 0...]
+        let session = Q35MTPDraftSession()
         let draftTokens = mtp.draftBlock(
             lastToken: 4,
             hidden: previousHidden,
-            positionOffset: tokens.count,
             blockSize: 4,
+            session: session,
             baseModel: model
         )
 
         XCTAssertEqual(draftTokens.count, 3)
         XCTAssertTrue(draftTokens.allSatisfy { $0 >= 0 && $0 < config.textConfig.vocabSize })
+        XCTAssertEqual(session.committedHistoryCount, 1)
+    }
+
+    func testQ35MTPDraftSessionFlushesOnlyCommittedHistory() throws {
+        MLXRandom.seed(41)
+        let config = try decodeConfig(makeTinyRuntimeConfig(layerTypes: ["full_attention"]))
+        let model = Q35Model(config: config)
+        let mtp = Q35MTPModel(config: config)
+        let session = Q35MTPDraftSession()
+        let firstHidden = MLXRandom.uniform(-0.1..<0.1, [1, 1, config.textConfig.hiddenSize])
+
+        _ = mtp.draftBlock(
+            lastToken: 4,
+            hidden: firstHidden,
+            blockSize: 4,
+            session: session,
+            baseModel: model
+        )
+        XCTAssertEqual(session.committedHistoryCount, 1)
+
+        let committedHidden = MLXRandom.uniform(-0.1..<0.1, [1, 1, config.textConfig.hiddenSize])
+        session.recordCommittedTransitions(hiddenStates: committedHidden, nextTokens: [5])
+        XCTAssertEqual(session.committedHistoryCount, 2)
+
+        _ = mtp.draftBlock(
+            lastToken: 6,
+            hidden: committedHidden,
+            blockSize: 2,
+            session: session,
+            baseModel: model
+        )
+        XCTAssertEqual(session.committedHistoryCount, 3)
+    }
+
+    func testQ35MTPAdaptivePolicyRampsAfterFullAcceptance() {
+        var policy = Q35MTPAdaptivePolicy(maxDraftDepth: 3)
+
+        XCTAssertEqual(policy.draftDepth(offeredDepth: 3), 2)
+        policy.record(acceptedDrafts: 2, drafted: 2)
+        XCTAssertEqual(policy.draftDepth(offeredDepth: 3), 3)
+    }
+
+    func testQ35MTPAdaptivePolicyFallsBackAfterRepeatedRejection() {
+        var policy = Q35MTPAdaptivePolicy(maxDraftDepth: 3)
+
+        for _ in 0..<8 {
+            let depth = policy.draftDepth(offeredDepth: 3)
+            guard depth > 0 else { break }
+            policy.record(acceptedDrafts: 0, drafted: depth)
+        }
+
+        XCTAssertEqual(policy.draftDepth(offeredDepth: 3), 0)
+    }
+
+    func testQ35CompactDraftRowsKeepPrefixControlsAndPadding() {
+        let rows = MLXArray(
+            (0..<Q35Model.compactDraftControlEnd).map(Float.init)
+        ).reshaped(Q35Model.compactDraftControlEnd, 1)
+
+        let compact = Q35Model.compactDraftRows(rows)
+        MLX.eval(compact)
+
+        XCTAssertEqual(compact.shape, [Q35Model.compactDraftPaddedCount, 1])
+        XCTAssertEqual(
+            compact[Q35Model.compactDraftPrefixCount - 1, 0].item(Float.self),
+            Float(Q35Model.compactDraftPrefixCount - 1)
+        )
+        XCTAssertEqual(
+            compact[Q35Model.compactDraftPrefixCount, 0].item(Float.self),
+            Float(Q35Model.compactDraftControlStart)
+        )
+        XCTAssertEqual(
+            compact[Q35Model.compactDraftRealCount - 1, 0].item(Float.self),
+            Float(Q35Model.compactDraftControlEnd - 1)
+        )
+        XCTAssertEqual(compact[Q35Model.compactDraftRealCount, 0].item(Float.self), 0)
+    }
+
+    func testQ35CompactDraftSelectionMapsControlToken() {
+        var values = Array(repeating: Float(0), count: Q35Model.compactDraftPaddedCount)
+        values[Q35Model.compactDraftPrefixCount + 2] = 5
+        let logits = MLXArray(values).reshaped(1, 1, values.count)
+
+        let token = Q35Model.compactDraftTokenID(from: logits)
+        MLX.eval(token)
+
+        XCTAssertEqual(token.item(Int32.self), Int32(Q35Model.compactDraftControlStart + 2))
+    }
+
+    func testQ35CompactDraftSelectionUsesLowerIDForTie() {
+        var values = Array(repeating: Float(0), count: Q35Model.compactDraftPaddedCount)
+        values[7] = 5
+        values[9] = 5
+        let logits = MLXArray(values).reshaped(1, 1, values.count)
+
+        let token = Q35Model.compactDraftTokenID(from: logits)
+        MLX.eval(token)
+
+        XCTAssertEqual(token.item(Int32.self), 7)
     }
 
     func testQ35MTPSpeculationRequiresAdaptiveContextWindow() {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -466,10 +466,10 @@ the `vision-chat-q38-27b` BF16 and 4-bit lanes. Set this to
 `1`, `true`, `yes`, or `on` to force consideration when the effective context
 window is large enough; set it to `0`, `false`, or `no` to disable MTP. Any other
 value, including unset, uses the model-specific policy. Qwen3.8's dense head is
-embedded in the BF16 checkpoint and mounted from the pinned official final shard
-for `vision-chat-q38-27b-4bit`. Both are opt-in because multi-token verification
-can diverge from serial greedy decode; Qwen3.6 hybrid MoE retains its adaptive
-default.
+embedded in the BF16 checkpoint; `vision-chat-q38-27b-4bit` mounts the matching
+4-bit/group-64 MLX Fast proposal head. Both are opt-in because multi-token
+verification can diverge from serial greedy decode; Qwen3.6 hybrid MoE retains
+its adaptive default.
 
 The `Q35` name is an internal compatibility prefix for the Qwen-family runtime;
 the public managed model ids retain their Qwen release names.

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -329,13 +329,15 @@ explicit `model pull`, and is cataloged for 64 GB unified memory minimum with
 metadata as well as the license.
 
 `vision-chat-q38-27b-4bit` installs
-`lmstudio-community/Qwen3.8-27B-MLX-4bit` at immutable revision
-`6067b15cf581666a4aecf6af3afaba4bb5efc20c`. The target uses 4-bit/group-64
-MLX affine weights and retains the same Qwen3.8 text, code, image, context, and
-sampling contracts. The managed pull also mounts Qwen's official final BF16
-shard at revision `1d4bf0f2ff6012fd82039f2fa52739d0dd7c60c0` under `mtp/`;
-that shard contains the 15 published MTP tensors and the Apache-2.0 license.
-The two pinned sources total 19.47 GB. The MTP component is loaded only when
+`EigenLabs/Qwen3.8-27B-4bit` at immutable revision
+`eda45ab47f465d08d6558f0353a2346e2eb9d5b3`. This is the independently
+reconverted 4-bit/group-64 MLX affine target pinned by the Qwen MLX Fast track.
+It retains the same Qwen3.8 text, code, image, context, and sampling contracts.
+The managed pull mounts the track's matching proposal-only 4-bit/group-64 head,
+`lowskillcoding/qwen38-mtp-head-4bit-g64` at revision
+`0966ddaff972fd3ca2be08f3640603b47e9ce70a`, under `mtp/`. Qwen's official
+Apache-2.0 license is retained separately from the official pinned revision.
+The sources total about 15.39 GB. The MTP component is loaded only when
 `MERERUN_Q35_MTP_SPECULATION=1`; default decode remains target-only because
 greedy speculative verification is not bit-exact with serial decode.
 

--- a/docs/runtime/text.md
+++ b/docs/runtime/text.md
@@ -293,8 +293,10 @@ swift run mere.run text chat \
   --prompt "Implement a bounded async work queue in Swift."
 ```
 
-This installs a pinned 4-bit/group-64 MLX target and Qwen's pinned final BF16
-shard under `mtp/`, totaling 19.47 GB. On the measured M4 Max coding slice,
+This installs the pinned MLX Fast 4-bit/group-64 target and its matching
+proposal-only 4-bit/group-64 MTP head under `mtp/`, totaling about 15.39 GB;
+the managed install also retains Qwen's official Apache-2.0 license. On the
+measured M4 Max coding slice,
 target-only warm decode reached about 26.5 tok/s versus 8.8 tok/s for BF16;
 explicit MTP reached 37.8–43.8 tok/s across the three short cases. All cases
 passed. On a deterministic 24-task stride through the official HumanEval set,


### PR DESCRIPTION
## Summary

- port the promoted Qwen3.8 MLX Fast MTP crown into the native Q35 runtime
- retain target-confirmed MTP history and adapt draft depth from per-position acceptance
- shrink proposal-only projection work with a compact vocabulary and fused Metal selection/remapping
- pin the matching 4-bit target and MTP head as immutable managed-model components
- repair standalone MTP tensor-name and RMSNorm conversion so the quantized head loads correctly

## Optimization boundary

Target logits remain authoritative for every emitted token. Draft-only transitions are discarded, sampled decoding keeps the full target vocabulary, and repeated rejection falls back to exact serial target decoding.

This ports the promoted `2.7966846733864905x` MLX Fast crown. It intentionally excludes the later 64K-vocabulary experiment and vendored MLX affine-kernel patch because neither has a promoted timing/score receipt; this PR does not modify `vendor/`.

## Model provenance

- target: `EigenLabs/Qwen3.8-27B-4bit@eda45ab47f465d08d6558f0353a2346e2eb9d5b3`
- MTP head: `lowskillcoding/qwen38-mtp-head-4bit-g64@0966ddaff972fd3ca2be08f3640603b47e9ce70a`
- Qwen license: mounted separately from `Qwen/Qwen3.8-27B@1d4bf0f2ff6012fd82039f2fa52739d0dd7c60c0`
- exact managed install: 15.39 GB

## Validation after MLX refresh

Rebased onto `fd526b9eb14786cbf112229a595990f97043f5d7`, the merge of #310.

- `./scripts/check.sh`
  - SwiftLint: 1,242 files, zero violations
  - XCTest: 2,886 executed, 209 expected skips, zero failures
  - Swift Testing: 30 tests, zero failures
  - build, CLI help sweep, and hygiene scans passed
- `swift build -c release` passed
- `pnpm docs:build` passed
- exact managed pull passed with the production release binary
- `model info` reports `isValid: true` and the three immutable sources above
- real 27B 4-bit managed inference passed on native MLX/Metal
- temperature-zero serial and MTP runs produced identical visible output through 256 generated tokens

Matched warm 256-token decode receipt (`--no-thinking`, temperature zero, same Swift coding prompt):

- serial: 26.81 tok/s, 9.55 s decode
- MTP: 43.69 tok/s, 5.86 s decode (`1.63x`)
- MTP acceptance: 151/195 draft tokens (`77.4%`), 80 verification passes, 25 replacement passes, zero serial fallback rounds

A 64-token pair measured 27.03 tok/s serial versus 26.55 tok/s MTP; at that size MTP setup does not amortize. The longer receipt is the representative decode-tail result.

These are local decode measurements, not an official mere.run benchmark score. Load time, prefill, TTFT, and decode are kept distinct; the promoted `2.7967x` number is the upstream official MLX Fast score.
