### PR TITLE
Add bounded Falcon vision batching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on Keep a Changelog.
 
 ### Runtime
 
+- added bounded dense batching to the resident Falcon Perception vision
+  service. The new endpoint performs one native MLX prefill/decode pass for up
+  to 32 image-query pairs, returns ordered per-image hashes and detections, and
+  preserves task-scoped CPU/GPU streams across asynchronous executor hops.
 - accelerated opt-in Qwen3.8 greedy MTP with committed target-history priming,
   a proposal-only compact vocabulary, fused draft-token selection, and
   acceptance-adaptive draft depth. Target logits remain authoritative for every

--- a/Sources/MereRunCLI/Commands/VisionServeCommand.swift
+++ b/Sources/MereRunCLI/Commands/VisionServeCommand.swift
@@ -2,6 +2,7 @@ import ArgumentParser
 import Crypto
 import Foundation
 import Hummingbird
+import MLX
 import MereRunCore
 import NIOCore
 
@@ -12,7 +13,8 @@ struct VisionServe: AsyncParsableCommand {
         discussion: """
         Starts a generic HTTP service backed by the native Falcon Perception runtime.
         The model remains resident across requests. Clients send image bytes and one or
-        more text queries as multipart/form-data to POST /v1/vision/ground.
+        more text queries as multipart/form-data to POST /v1/vision/ground, or
+        a bounded set of images to POST /v1/vision/ground-batch.
 
         The service is loopback-only by default. Non-loopback binds require --api-key.
         """
@@ -33,6 +35,15 @@ struct VisionServe: AsyncParsableCommand {
     @Option(name: [.customLong("max-frame-bytes")], help: "Maximum encoded image upload size.")
     var maxFrameBytes: Int = 16 * 1_024 * 1_024
 
+    @Option(
+        name: [.customLong("max-batch-size")],
+        help: "Maximum image-query pairs accepted by one batch request."
+    )
+    var maxBatchSize: Int = 8
+
+    @Option(name: [.customLong("max-batch-bytes")], help: "Maximum combined encoded image bytes in one batch.")
+    var maxBatchBytes: Int = 64 * 1_024 * 1_024
+
     @Flag(name: [.customLong("preflight")], help: "Validate configuration without starting the server.")
     var preflight: Bool = false
 
@@ -45,6 +56,12 @@ struct VisionServe: AsyncParsableCommand {
         }
         guard maxFrameBytes > 0 else {
             throw ValidationError("--max-frame-bytes must be greater than zero.")
+        }
+        guard (1...32).contains(maxBatchSize) else {
+            throw ValidationError("--max-batch-size must be between 1 and 32.")
+        }
+        guard maxBatchBytes > 0, maxBatchBytes <= Int.max - 1_048_576 else {
+            throw ValidationError("--max-batch-bytes is outside the supported range.")
         }
         if json && !preflight {
             throw ValidationError("--json is only supported with --preflight for vision serve.")
@@ -66,6 +83,8 @@ struct VisionServe: AsyncParsableCommand {
                 host: host,
                 port: port,
                 maximumFrameBytes: maxFrameBytes,
+                maximumBatchSize: maxBatchSize,
+                maximumBatchBytes: maxBatchBytes,
                 authenticationRequired: apiKey?.isEmpty == false
             )
             if json {
@@ -75,7 +94,10 @@ struct VisionServe: AsyncParsableCommand {
             } else {
                 print("Ready: \(report.capability) with \(report.modelID)")
                 print("Endpoint: http://\(report.host):\(report.port)/v1/vision/ground")
+                print("Batch endpoint: http://\(report.host):\(report.port)/v1/vision/ground-batch")
                 print("Maximum frame bytes: \(report.maximumFrameBytes)")
+                print("Maximum batch size: \(report.maximumBatchSize)")
+                print("Maximum batch bytes: \(report.maximumBatchBytes)")
             }
             return
         }
@@ -85,7 +107,9 @@ struct VisionServe: AsyncParsableCommand {
         let server = VisionGroundingServer(
             runtime: runtime,
             apiKey: apiKey,
-            maximumFrameBytes: maxFrameBytes
+            maximumFrameBytes: maxFrameBytes,
+            maximumBatchSize: maxBatchSize,
+            maximumBatchBytes: maxBatchBytes
         )
         try await server.run(host: host, port: port)
     }
@@ -99,6 +123,8 @@ struct VisionServePreflightReport: Codable, Equatable, Sendable {
     let host: String
     let port: Int
     let maximumFrameBytes: Int
+    let maximumBatchSize: Int
+    let maximumBatchBytes: Int
     let authenticationRequired: Bool
 
     enum CodingKeys: String, CodingKey {
@@ -109,6 +135,8 @@ struct VisionServePreflightReport: Codable, Equatable, Sendable {
         case host
         case port
         case maximumFrameBytes = "maximum_frame_bytes"
+        case maximumBatchSize = "maximum_batch_size"
+        case maximumBatchBytes = "maximum_batch_bytes"
         case authenticationRequired = "authentication_required"
     }
 }
@@ -120,6 +148,14 @@ struct VisionGroundingRequestPlan: Equatable, Sendable {
     let capturedAt: String?
     let maxNewTokens: Int
     let segmentationThreshold: Float
+}
+
+struct VisionGroundingBatchRequestPlan: Equatable, Sendable {
+    let queries: [String]
+    let streamID: String?
+    let frameIDs: [String]
+    let capturedAt: String?
+    let maxNewTokens: Int
 }
 
 struct VisionGroundingDetectionResponse: Codable, Equatable, Sendable {
@@ -167,6 +203,42 @@ struct VisionGroundingResponse: Codable, Equatable, Sendable {
     }
 }
 
+struct VisionGroundingBatchItemResponse: Codable, Equatable, Sendable {
+    let index: Int
+    let frameID: String?
+    let imageSHA256: String
+    let queries: [String]
+    let detections: [VisionGroundingDetectionResponse]
+
+    enum CodingKeys: String, CodingKey {
+        case index
+        case frameID = "frame_id"
+        case imageSHA256 = "image_sha256"
+        case queries
+        case detections
+    }
+}
+
+struct VisionGroundingBatchResponse: Codable, Equatable, Sendable {
+    let created: Int
+    let object: String
+    let model: String
+    let streamID: String?
+    let capturedAt: String?
+    let items: [VisionGroundingBatchItemResponse]
+    let timing: VisionGroundingTimingResponse
+
+    enum CodingKeys: String, CodingKey {
+        case created
+        case object
+        case model
+        case streamID = "stream_id"
+        case capturedAt = "captured_at"
+        case items
+        case timing
+    }
+}
+
 enum VisionGroundingServerError: LocalizedError, Equatable {
     case invalidField(String, String)
     case unsupportedMediaType
@@ -194,6 +266,21 @@ protocol VisionGroundingRuntime: Sendable {
         maxNewTokens: Int,
         segmentationThreshold: Float
     ) async throws -> FalconPerceptionGroundingRun
+
+    func groundBatch(
+        inputs: [VisionGroundingRuntimeInput],
+        maxNewTokens: Int
+    ) async throws -> [VisionGroundingRuntimeResult]
+}
+
+struct VisionGroundingRuntimeInput: Hashable, Sendable {
+    let imageURL: URL
+    let queries: [String]
+}
+
+struct VisionGroundingRuntimeResult: Hashable, Sendable {
+    let queries: [String]
+    let detections: [FalconPerceptionDetection]
 }
 
 actor ResidentFalconGroundingRuntime: VisionGroundingRuntime {
@@ -218,15 +305,45 @@ actor ResidentFalconGroundingRuntime: VisionGroundingRuntime {
         outputDirectoryURL: URL,
         maxNewTokens: Int,
         segmentationThreshold: Float
-    ) throws -> FalconPerceptionGroundingRun {
-        try grounder.ground(
-            imageURL: imageURL,
-            queries: queries,
-            annotatedImageURL: outputDirectoryURL.appendingPathComponent("annotated.png"),
-            jsonOutputURL: outputDirectoryURL.appendingPathComponent("detections.json"),
-            maxNewTokens: maxNewTokens,
-            segmentationThreshold: segmentationThreshold
-        )
+    ) async throws -> FalconPerceptionGroundingRun {
+        try await Stream.withNewDefaultStream {
+            await Task.yield()
+            return try grounder.ground(
+                imageURL: imageURL,
+                queries: queries,
+                annotatedImageURL: outputDirectoryURL.appendingPathComponent("annotated.png"),
+                jsonOutputURL: outputDirectoryURL.appendingPathComponent("detections.json"),
+                maxNewTokens: maxNewTokens,
+                segmentationThreshold: segmentationThreshold
+            )
+        }
+    }
+
+    func groundBatch(
+        inputs: [VisionGroundingRuntimeInput],
+        maxNewTokens: Int
+    ) async throws -> [VisionGroundingRuntimeResult] {
+        try await Stream.withNewDefaultStream {
+            await Task.yield()
+            let flattenedInputs = inputs.flatMap { input in
+                input.queries.map {
+                    FalconPerceptionBatchInput(imageURL: input.imageURL, query: $0)
+                }
+            }
+            let flattenedResults = try grounder.groundBatch(
+                inputs: flattenedInputs,
+                maxNewTokens: maxNewTokens
+            )
+            var resultIndex = 0
+            return inputs.map { input in
+                let itemResults = Array(flattenedResults[resultIndex..<(resultIndex + input.queries.count)])
+                resultIndex += input.queries.count
+                return VisionGroundingRuntimeResult(
+                    queries: input.queries,
+                    detections: itemResults.flatMap(\.detections)
+                )
+            }
+        }
     }
 }
 
@@ -234,17 +351,23 @@ final class VisionGroundingServer: @unchecked Sendable {
     private let runtime: any VisionGroundingRuntime
     private let apiKey: String?
     private let maximumFrameBytes: Int
+    private let maximumBatchSize: Int
+    private let maximumBatchBytes: Int
     private let fileManager: FileManager
 
     init(
         runtime: any VisionGroundingRuntime,
         apiKey: String?,
         maximumFrameBytes: Int,
+        maximumBatchSize: Int,
+        maximumBatchBytes: Int,
         fileManager: FileManager = .default
     ) {
         self.runtime = runtime
         self.apiKey = apiKey?.trimmingCharacters(in: .whitespacesAndNewlines)
         self.maximumFrameBytes = maximumFrameBytes
+        self.maximumBatchSize = maximumBatchSize
+        self.maximumBatchBytes = maximumBatchBytes
         self.fileManager = fileManager
     }
 
@@ -254,6 +377,7 @@ final class VisionGroundingServer: @unchecked Sendable {
             configuration: .init(address: .hostname(host, port: port))
         )
         CLIStderr.write("Resident vision service: http://\(host):\(port)/v1/vision/ground\n")
+        CLIStderr.write("Resident vision batch service: http://\(host):\(port)/v1/vision/ground-batch\n")
         CLIStderr.write("Model: \(runtime.modelID)\n")
         try await app.runService()
     }
@@ -272,6 +396,9 @@ final class VisionGroundingServer: @unchecked Sendable {
         }
         router.post("/v1/vision/ground") { [self] request, _ in
             await handleGrounding(request)
+        }
+        router.post("/v1/vision/ground-batch") { [self] request, _ in
+            await handleBatchGrounding(request)
         }
         return router
     }
@@ -313,6 +440,60 @@ final class VisionGroundingServer: @unchecked Sendable {
         )
     }
 
+    static func batchRequestPlan(from form: MultipartFormData) throws -> VisionGroundingBatchRequestPlan {
+        let queries = form.parts
+            .filter { ($0.name == "query" || $0.name == "query[]") && $0.filename == nil }
+            .compactMap { String(data: $0.body, encoding: .utf8) }
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        guard !queries.isEmpty else {
+            throw VisionGroundingServerError.invalidField(
+                "query",
+                "at least one non-empty query or query[] field is required"
+            )
+        }
+        guard queries.count <= 32 else {
+            throw VisionGroundingServerError.invalidField("query", "at most 32 queries are allowed")
+        }
+        let frameIDs = try form.parts
+            .filter { ($0.name == "frame_id" || $0.name == "frame_id[]") && $0.filename == nil }
+            .compactMap { String(data: $0.body, encoding: .utf8) }
+            .map { try identifierField($0, name: "frame_id") }
+            .compactMap { $0 }
+        return VisionGroundingBatchRequestPlan(
+            queries: queries,
+            streamID: try identifierField(form.field("stream_id"), name: "stream_id"),
+            frameIDs: frameIDs,
+            capturedAt: normalizedOptional(form.field("captured_at")),
+            maxNewTokens: try integerField(
+                form.field("max_new_tokens"),
+                name: "max_new_tokens",
+                defaultValue: 512,
+                range: 1...2_048
+            )
+        )
+    }
+
+    static func validateBatchCardinality(
+        imageCount: Int,
+        queryCount: Int,
+        maximumBatchSize: Int
+    ) throws {
+        guard imageCount > 0, imageCount <= maximumBatchSize else {
+            throw VisionGroundingServerError.invalidField(
+                "image[]",
+                "batch must contain 1...\(maximumBatchSize) image files"
+            )
+        }
+        let pairCount = imageCount.multipliedReportingOverflow(by: queryCount)
+        guard !pairCount.overflow, pairCount.partialValue <= maximumBatchSize else {
+            throw VisionGroundingServerError.invalidField(
+                "image[]",
+                "batch must not exceed \(maximumBatchSize) image-query pairs"
+            )
+        }
+    }
+
     static func response(
         from run: FalconPerceptionGroundingRun,
         plan: VisionGroundingRequestPlan,
@@ -338,6 +519,46 @@ final class VisionGroundingServer: @unchecked Sendable {
                     center: detection.xy,
                     size: detection.hw,
                     box: detection.box
+                )
+            },
+            timing: VisionGroundingTimingResponse(
+                inferenceSeconds: finishedAt.timeIntervalSince(inferenceStartedAt),
+                totalSeconds: finishedAt.timeIntervalSince(startedAt)
+            )
+        )
+    }
+
+    static func batchResponse(
+        modelID: String,
+        plan: VisionGroundingBatchRequestPlan,
+        results: [VisionGroundingRuntimeResult],
+        imageSHA256s: [String],
+        startedAt: Date,
+        inferenceStartedAt: Date,
+        finishedAt: Date
+    ) -> VisionGroundingBatchResponse {
+        VisionGroundingBatchResponse(
+            created: Int(finishedAt.timeIntervalSince1970),
+            object: "vision.grounding.batch",
+            model: modelID,
+            streamID: plan.streamID,
+            capturedAt: plan.capturedAt,
+            items: results.enumerated().map { itemIndex, result in
+                VisionGroundingBatchItemResponse(
+                    index: itemIndex,
+                    frameID: plan.frameIDs.isEmpty ? nil : plan.frameIDs[itemIndex],
+                    imageSHA256: imageSHA256s[itemIndex],
+                    queries: result.queries,
+                    detections: result.detections.enumerated().map { detectionIndex, detection in
+                        VisionGroundingDetectionResponse(
+                            index: detectionIndex,
+                            label: detection.label,
+                            score: detection.score,
+                            center: detection.xy,
+                            size: detection.hw,
+                            box: detection.box
+                        )
+                    }
                 )
             },
             timing: VisionGroundingTimingResponse(
@@ -396,6 +617,111 @@ final class VisionGroundingServer: @unchecked Sendable {
                     from: run,
                     plan: plan,
                     imageSHA256: digest,
+                    startedAt: startedAt,
+                    inferenceStartedAt: inferenceStartedAt,
+                    finishedAt: finishedAt
+                )
+            )
+        } catch {
+            return errorResponse(
+                status: error is VisionGroundingServerError || error is MultipartFormData.ParseError
+                    ? .badRequest
+                    : .internalServerError,
+                message: error.localizedDescription
+            )
+        }
+    }
+
+    private func handleBatchGrounding(_ request: Request) async -> Response {
+        guard isAuthorized(request) else {
+            return errorResponse(status: .unauthorized, message: "Invalid API key.")
+        }
+        let startedAt = Date()
+        do {
+            guard let boundary = APIServerContract.multipartBoundary(from: request.headers[.contentType]) else {
+                throw VisionGroundingServerError.unsupportedMediaType
+            }
+            let body = try await request.body.collect(upTo: maximumBatchBytes + 1_024 * 1_024)
+            let form = try MultipartFormData.parse(
+                body: Data(body.readableBytesView),
+                boundary: boundary
+            )
+            let plan = try Self.batchRequestPlan(from: form)
+            let images = form.parts.filter {
+                ["image", "image[]", "frame", "frame[]"].contains($0.name) && $0.filename != nil
+            }
+            try Self.validateBatchCardinality(
+                imageCount: images.count,
+                queryCount: plan.queries.count,
+                maximumBatchSize: maximumBatchSize
+            )
+            if !plan.frameIDs.isEmpty, plan.frameIDs.count != images.count {
+                throw VisionGroundingServerError.invalidField(
+                    "frame_id[]",
+                    "must be omitted or contain exactly one identifier per image"
+                )
+            }
+
+            var totalEncodedBytes = 0
+            for image in images {
+                guard !image.body.isEmpty, image.body.count <= maximumFrameBytes else {
+                    throw VisionGroundingServerError.invalidField(
+                        "image[]",
+                        "every encoded image must contain 1...\(maximumFrameBytes) bytes"
+                    )
+                }
+                let addition = totalEncodedBytes.addingReportingOverflow(image.body.count)
+                guard !addition.overflow, addition.partialValue <= maximumBatchBytes else {
+                    throw VisionGroundingServerError.invalidField(
+                        "image[]",
+                        "combined encoded image bytes must not exceed \(maximumBatchBytes)"
+                    )
+                }
+                totalEncodedBytes = addition.partialValue
+            }
+
+            let requestDirectory = fileManager.temporaryDirectory
+                .appendingPathComponent("mere-run-vision-serve", isDirectory: true)
+                .appendingPathComponent(UUID().uuidString, isDirectory: true)
+            try fileManager.createDirectory(at: requestDirectory, withIntermediateDirectories: true)
+            defer { try? fileManager.removeItem(at: requestDirectory) }
+
+            var runtimeInputs = [VisionGroundingRuntimeInput]()
+            var imageSHA256s = [String]()
+            runtimeInputs.reserveCapacity(images.count)
+            imageSHA256s.reserveCapacity(images.count)
+            for (index, image) in images.enumerated() {
+                let fileExtension = try Self.imageExtension(for: image)
+                let imageURL = requestDirectory
+                    .appendingPathComponent("frame-\(index)")
+                    .appendingPathExtension(fileExtension)
+                try image.body.write(to: imageURL, options: [.atomic])
+                runtimeInputs.append(VisionGroundingRuntimeInput(imageURL: imageURL, queries: plan.queries))
+                imageSHA256s.append(
+                    SHA256.hash(data: image.body)
+                        .map { String(format: "%02x", $0) }
+                        .joined()
+                )
+            }
+
+            let inferenceStartedAt = Date()
+            let results = try await runtime.groundBatch(
+                inputs: runtimeInputs,
+                maxNewTokens: plan.maxNewTokens
+            )
+            guard results.count == images.count else {
+                throw VisionGroundingServerError.invalidField(
+                    "image[]",
+                    "runtime returned \(results.count) results for \(images.count) images"
+                )
+            }
+            let finishedAt = Date()
+            return try jsonResponse(
+                Self.batchResponse(
+                    modelID: runtime.modelID,
+                    plan: plan,
+                    results: results,
+                    imageSHA256s: imageSHA256s,
                     startedAt: startedAt,
                     inferenceStartedAt: inferenceStartedAt,
                     finishedAt: finishedAt

--- a/Sources/MereRunCore/FalconPerception/FalconPerceptionGrounder.swift
+++ b/Sources/MereRunCore/FalconPerception/FalconPerceptionGrounder.swift
@@ -70,6 +70,35 @@ public struct FalconPerceptionGroundingRun: Hashable, Sendable {
     public let metadata: FalconPerceptionGroundingMetadata
 }
 
+public struct FalconPerceptionBatchInput: Hashable, Sendable {
+    public let imageURL: URL
+    public let query: String
+
+    public init(imageURL: URL, query: String) {
+        self.imageURL = imageURL
+        self.query = query
+    }
+}
+
+public struct FalconPerceptionBatchResult: Hashable, Sendable {
+    public let modelID: String
+    public let imageURL: URL
+    public let query: String
+    public let detections: [FalconPerceptionDetection]
+
+    public init(
+        modelID: String,
+        imageURL: URL,
+        query: String,
+        detections: [FalconPerceptionDetection]
+    ) {
+        self.modelID = modelID
+        self.imageURL = imageURL
+        self.query = query
+        self.detections = detections
+    }
+}
+
 public final class FalconPerceptionGrounder: @unchecked Sendable {
     public enum GrounderError: LocalizedError, Sendable {
         case invalidModelRoot(URL, details: [String])
@@ -309,6 +338,228 @@ public final class FalconPerceptionGrounder: @unchecked Sendable {
             detections: detections,
             metadata: metadata
         )
+    }
+
+    public func groundBatch(
+        inputs: [FalconPerceptionBatchInput],
+        maxNewTokens: Int = 512
+    ) throws -> [FalconPerceptionBatchResult] {
+        guard !inputs.isEmpty else {
+            throw GrounderError.failedToEncodeMetadata("At least one batch input is required.")
+        }
+        let normalizedInputs = try inputs.map { input in
+            let query = input.query.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !query.isEmpty else {
+                throw GrounderError.failedToEncodeMetadata("Every batch input requires a non-empty query.")
+            }
+            return FalconPerceptionBatchInput(imageURL: input.imageURL, query: query)
+        }
+        guard maxNewTokens > 0 else {
+            throw GrounderError.failedToEncodeMetadata("maxNewTokens must be greater than zero.")
+        }
+        defer { clearCache() }
+
+        let state = try ensureLoaded()
+        let processed = try state.processor.processBatch(normalizedInputs)
+        let model = state.model
+        let config = state.config
+        let batchSize = normalizedInputs.count
+        model.resetGroundingState()
+        defer { model.resetGroundingState() }
+
+        let positionData = FalconPerceptionModel.computeBatchPositionData(
+            inputIDs: processed.inputIDs,
+            config: config,
+            imageGridHW: processed.imageGridHW,
+            padTokenID: state.tokenizer.padTokenID
+        )
+        let caches = model.makeCaches()
+        let inputsEmbeds = model.makeInputEmbeddings(
+            inputIDs: processed.inputIDs,
+            pixelValues: processed.pixelValues,
+            imageGridHW: processed.imageGridHW
+        )
+        var logits = model.forward(
+            inputIDs: processed.inputIDs,
+            inputsEmbeds: inputsEmbeds,
+            mask: positionData.attentionMask,
+            caches: caches,
+            positionIDs: positionData.positionIDs,
+            posHW: positionData.posHW,
+            lastPositionOnly: true
+        )
+        MLX.eval(logits)
+
+        var preparedDetections = Array(repeating: [PreparedDetection](), count: batchSize)
+        var currentXY = [FalconPerceptionCenter?](repeating: nil, count: batchSize)
+        var currentHW = [FalconPerceptionSize?](repeating: nil, count: batchSize)
+        var stopped = [Bool](repeating: false, count: batchSize)
+
+        for _ in 0..<maxNewTokens where stopped.contains(false) {
+            let lastLogits = logits[0..., logits.dim(1) - 1, 0...]
+            var tokenIDs = MLX.argMax(lastLogits, axis: -1).asArray(Int32.self).map(Int.init)
+            guard tokenIDs.count == batchSize else {
+                throw GrounderError.failedToEncodeMetadata("Falcon batch decode returned an invalid token batch.")
+            }
+
+            let needsCoordinates = tokenIDs.contains(config.coordTokenID)
+            let needsSizes = tokenIDs.contains(config.sizeTokenID)
+            let hiddenLast: MLXArray?
+            if needsCoordinates || needsSizes {
+                guard let hiddenState = model.lastHiddenState else {
+                    throw GrounderError.failedToEncodeMetadata("Falcon batch decode did not expose hidden state.")
+                }
+                hiddenLast = hiddenState[0..., hiddenState.dim(1) - 1, 0...]
+            } else {
+                hiddenLast = nil
+            }
+            let coordLogits = needsCoordinates ? hiddenLast.map(model.decodeCoordinates) : nil
+            let coordBins = coordLogits.map {
+                MLX.argMax($0, axis: -1).asArray(Int32.self).map(Int.init)
+            } ?? []
+            let coordBinCount = max(1, (coordLogits?.dim(-1) ?? 1) - 1)
+            let sizeValues = needsSizes
+                ? hiddenLast.map { model.processSizes(model.decodeSizes(from: $0)).asArray(Float.self) } ?? []
+                : []
+
+            var encodedCoordinates = [Float](repeating: 0, count: batchSize * 2)
+            var encodedSizes = [Float](repeating: 0, count: batchSize * 2)
+            for batchIndex in 0..<batchSize {
+                if stopped[batchIndex] {
+                    tokenIDs[batchIndex] = state.tokenizer.padTokenID
+                    continue
+                }
+                let tokenID = tokenIDs[batchIndex]
+                if tokenID == config.eosID {
+                    stopped[batchIndex] = true
+                    tokenIDs[batchIndex] = state.tokenizer.padTokenID
+                    continue
+                }
+
+                if tokenID == config.coordTokenID {
+                    if let xy = currentXY[batchIndex], let hw = currentHW[batchIndex] {
+                        preparedDetections[batchIndex].append(
+                            PreparedDetection(
+                                label: normalizedInputs[batchIndex].query,
+                                xy: xy,
+                                hw: hw,
+                                box: Self.boundingBox(xy: xy, hw: hw),
+                                score: nil,
+                                binaryMask: nil,
+                                maskPath: nil
+                            )
+                        )
+                    }
+                    let valueOffset = batchIndex * 2
+                    let xy = FalconPerceptionCenter(
+                        x: Float(coordBins[valueOffset]) / Float(coordBinCount),
+                        y: Float(coordBins[valueOffset + 1]) / Float(coordBinCount)
+                    )
+                    currentXY[batchIndex] = xy
+                    currentHW[batchIndex] = nil
+                    encodedCoordinates[valueOffset] = xy.x
+                    encodedCoordinates[valueOffset + 1] = xy.y
+                } else if tokenID == config.sizeTokenID {
+                    let valueOffset = batchIndex * 2
+                    let hw = FalconPerceptionSize(
+                        h: sizeValues[valueOffset],
+                        w: sizeValues[valueOffset + 1]
+                    )
+                    currentHW[batchIndex] = hw
+                    encodedSizes[valueOffset] = hw.h
+                    encodedSizes[valueOffset + 1] = hw.w
+                } else if tokenID == config.segTokenID {
+                    if let xy = currentXY[batchIndex], let hw = currentHW[batchIndex] {
+                        preparedDetections[batchIndex].append(
+                            PreparedDetection(
+                                label: normalizedInputs[batchIndex].query,
+                                xy: xy,
+                                hw: hw,
+                                box: Self.boundingBox(xy: xy, hw: hw),
+                                score: nil,
+                                binaryMask: nil,
+                                maskPath: nil
+                            )
+                        )
+                    }
+                    currentXY[batchIndex] = nil
+                    currentHW[batchIndex] = nil
+                }
+            }
+
+            if stopped.allSatisfy({ $0 }) {
+                break
+            }
+
+            let tokenArray = MLXArray(tokenIDs.map(Int32.init), [batchSize, 1])
+            var tokenEmbeds = model.embedTokens(tokenArray)
+            if needsCoordinates {
+                tokenEmbeds = model.encodeCoordinates(
+                    into: tokenEmbeds,
+                    inputIDs: tokenArray,
+                    coordXY: MLXArray(encodedCoordinates, [batchSize, 2])
+                )
+            }
+            if needsSizes {
+                tokenEmbeds = model.encodeSizes(
+                    into: tokenEmbeds,
+                    inputIDs: tokenArray,
+                    sizeHW: MLXArray(encodedSizes, [batchSize, 2])
+                )
+            }
+
+            let cacheOffset = caches.first??.offset ?? 0
+            let decodePositions = positionData.ropeDeltas.map { Int32(cacheOffset + $0) }
+            let totalKeys = cacheOffset + 1
+            var decodeMask = [Bool]()
+            decodeMask.reserveCapacity(batchSize * totalKeys)
+            for batchIndex in 0..<batchSize {
+                for keyIndex in 0..<totalKeys {
+                    decodeMask.append(keyIndex >= positionData.padCounts[batchIndex])
+                }
+            }
+            logits = model.forward(
+                inputIDs: tokenArray,
+                inputsEmbeds: tokenEmbeds,
+                mask: MLXArray(decodeMask, [batchSize, 1, 1, totalKeys]),
+                caches: caches,
+                positionIDs: MLXArray(decodePositions, [batchSize, 1]),
+                posHW: MLX.zeros([batchSize, 1, 2], dtype: .float32),
+                lastPositionOnly: true
+            )
+            MLX.eval(logits)
+        }
+
+        return normalizedInputs.enumerated().map { batchIndex, input in
+            if let xy = currentXY[batchIndex], let hw = currentHW[batchIndex] {
+                preparedDetections[batchIndex].append(
+                    PreparedDetection(
+                        label: input.query,
+                        xy: xy,
+                        hw: hw,
+                        box: Self.boundingBox(xy: xy, hw: hw),
+                        score: nil,
+                        binaryMask: nil,
+                        maskPath: nil
+                    )
+                )
+            }
+            return FalconPerceptionBatchResult(
+                modelID: modelID,
+                imageURL: input.imageURL.standardizedFileURL,
+                query: input.query,
+                detections: preparedDetections[batchIndex].map {
+                    FalconPerceptionDetection(
+                        label: $0.label,
+                        xy: $0.xy,
+                        hw: $0.hw,
+                        box: $0.box,
+                        score: $0.score,
+                        maskPath: nil
+                    )
+                }
+            )
+        }
     }
 
     private func createParentDirectoryIfNeeded(for url: URL) throws {

--- a/Sources/MereRunCore/FalconPerception/FalconPerceptionModel.swift
+++ b/Sources/MereRunCore/FalconPerception/FalconPerceptionModel.swift
@@ -668,6 +668,14 @@ final class FalconPerceptionLanguageModel: Module {
     }
 }
 
+struct FalconPerceptionBatchPositionData {
+    let positionIDs: MLXArray
+    let posHW: MLXArray
+    let ropeDeltas: [Int]
+    let attentionMask: MLXArray
+    let padCounts: [Int]
+}
+
 public final class FalconPerceptionModel: Module, @unchecked Sendable {
     @ModuleInfo(key: "language_model") var languageModel: FalconPerceptionLanguageModel
     @ModuleInfo(key: "coord_encoder") var coordEncoder: FalconPerceptionFourierEncoder
@@ -769,7 +777,12 @@ public final class FalconPerceptionModel: Module, @unchecked Sendable {
             imageTokenID: config.imgID,
             imageFeatures: hiddenStates,
             inputsEmbeds: inputsEmbeds,
-            inputIDs: inputIDs
+            inputIDs: inputIDs,
+            imageGridHW: imageGridHW,
+            paddedGridHW: (
+                pixelValues.dim(1) / max(1, config.visionConfig.spatialPatchSize),
+                pixelValues.dim(2) / max(1, config.visionConfig.spatialPatchSize)
+            )
         )
     }
 
@@ -777,11 +790,15 @@ public final class FalconPerceptionModel: Module, @unchecked Sendable {
         guard let coordXY else { return embeds }
         let ids = inputIDs.asArray(Int32.self).map(Int.init)
         guard ids.contains(config.coordTokenID) else { return embeds }
-        let encoded = coordEncoder(coordXY.reshaped(-1, 2)).reshaped(1, -1, embeds.dim(-1))
+        let batchSize = inputIDs.dim(0)
+        let sequenceLength = inputIDs.dim(1)
+        let encoded = coordEncoder(coordXY.reshaped(batchSize, 2)).reshaped(batchSize, embeds.dim(-1))
         let output = embeds
-        let sequenceLength = min(ids.count, output.dim(1))
-        for index in 0..<sequenceLength where ids[index] == config.coordTokenID {
-            output[0, index] = encoded[0, 0]
+        for batchIndex in 0..<batchSize {
+            for index in 0..<sequenceLength
+            where ids[(batchIndex * sequenceLength) + index] == config.coordTokenID {
+                output[batchIndex, index] = encoded[batchIndex]
+            }
         }
         return output
     }
@@ -790,11 +807,15 @@ public final class FalconPerceptionModel: Module, @unchecked Sendable {
         guard let sizeHW else { return embeds }
         let ids = inputIDs.asArray(Int32.self).map(Int.init)
         guard ids.contains(config.sizeTokenID) else { return embeds }
-        let encoded = sizeEncoder(sizeHW.reshaped(-1, 2)).reshaped(1, -1, embeds.dim(-1))
+        let batchSize = inputIDs.dim(0)
+        let sequenceLength = inputIDs.dim(1)
+        let encoded = sizeEncoder(sizeHW.reshaped(batchSize, 2)).reshaped(batchSize, embeds.dim(-1))
         let output = embeds
-        let sequenceLength = min(ids.count, output.dim(1))
-        for index in 0..<sequenceLength where ids[index] == config.sizeTokenID {
-            output[0, index] = encoded[0, 0]
+        for batchIndex in 0..<batchSize {
+            for index in 0..<sequenceLength
+            where ids[(batchIndex * sequenceLength) + index] == config.sizeTokenID {
+                output[batchIndex, index] = encoded[batchIndex]
+            }
         }
         return output
     }
@@ -945,17 +966,135 @@ public final class FalconPerceptionModel: Module, @unchecked Sendable {
         imageTokenID: Int,
         imageFeatures: MLXArray,
         inputsEmbeds: MLXArray,
-        inputIDs: MLXArray
+        inputIDs: MLXArray,
+        imageGridHW: MLXArray,
+        paddedGridHW: (Int, Int)
     ) -> MLXArray {
         let ids = inputIDs.asArray(Int32.self).map(Int.init)
-        let positions = ids.enumerated().compactMap { index, value in
-            value == imageTokenID ? index : nil
-        }
+        let gridValues = imageGridHW.asArray(Int32.self).map(Int.init)
+        let batchSize = inputIDs.dim(0)
+        let sequenceLength = inputIDs.dim(1)
+        let hiddenSize = inputsEmbeds.dim(-1)
+        let paddedGridH = paddedGridHW.0
+        let paddedGridW = paddedGridHW.1
+        let features = imageFeatures.reshaped(batchSize, paddedGridH, paddedGridW, hiddenSize)
         let output = inputsEmbeds
-        for (featureIndex, position) in positions.enumerated() where featureIndex < imageFeatures.dim(0) {
-            output[0, position] = imageFeatures[featureIndex]
+
+        for batchIndex in 0..<batchSize {
+            let rowStart = batchIndex * sequenceLength
+            let positions = (0..<sequenceLength).filter {
+                ids[rowStart + $0] == imageTokenID
+            }
+            let gridH = min(paddedGridH, gridValues[batchIndex * 2])
+            let gridW = min(paddedGridW, gridValues[(batchIndex * 2) + 1])
+            var featureIndex = 0
+            for hIndex in 0..<gridH {
+                for wIndex in 0..<gridW where featureIndex < positions.count {
+                    output[batchIndex, positions[featureIndex]] = features[batchIndex, hIndex, wIndex]
+                    featureIndex += 1
+                }
+            }
         }
         return output
+    }
+
+    static func computeBatchPositionData(
+        inputIDs: MLXArray,
+        config: FalconPerceptionModelConfig,
+        imageGridHW: MLXArray,
+        padTokenID: Int
+    ) -> FalconPerceptionBatchPositionData {
+        precondition(inputIDs.ndim == 2, "Falcon batch input IDs must have shape [batch, sequence].")
+        precondition(imageGridHW.ndim == 2 && imageGridHW.dim(1) == 2)
+        let batchSize = inputIDs.dim(0)
+        let sequenceLength = inputIDs.dim(1)
+        let ids = inputIDs.asArray(Int32.self).map(Int.init)
+        let grids = imageGridHW.asArray(Int32.self).map(Int.init)
+
+        var allPositions = [Int32]()
+        var allPosHW = [Float]()
+        var allMask = [Bool]()
+        var ropeDeltas = [Int]()
+        var padCounts = [Int]()
+        allPositions.reserveCapacity(batchSize * sequenceLength)
+        allPosHW.reserveCapacity(batchSize * sequenceLength * 2)
+        allMask.reserveCapacity(batchSize * sequenceLength * sequenceLength)
+
+        for batchIndex in 0..<batchSize {
+            let rowStart = batchIndex * sequenceLength
+            let row = Array(ids[rowStart..<(rowStart + sequenceLength)])
+            let padCount = row.prefix { $0 == padTokenID }.count
+            padCounts.append(padCount)
+
+            var positions = [Int32](repeating: 0, count: sequenceLength)
+            var inImage = false
+            var nextPosition = 0
+            for index in padCount..<sequenceLength {
+                let token = row[index]
+                if token == config.imageCLSTokenID && !inImage {
+                    inImage = true
+                }
+                positions[index] = Int32(nextPosition)
+                if !inImage {
+                    nextPosition += 1
+                }
+                if token == config.imgEndID && inImage {
+                    inImage = false
+                    nextPosition += 1
+                }
+            }
+            allPositions.append(contentsOf: positions)
+            let maxPosition = padCount < sequenceLength
+                ? positions[padCount...].map(Int.init).max() ?? 0
+                : 0
+            ropeDeltas.append(maxPosition + 1 - sequenceLength)
+
+            let posHW = computePosHW(
+                tokenIDs: row,
+                imageTokenID: config.imgID,
+                imageGridHWS: [(grids[batchIndex * 2], grids[(batchIndex * 2) + 1])]
+            )
+            allPosHW.append(contentsOf: posHW.asArray(Float.self))
+
+            var blockIDs = [Int](repeating: 0, count: sequenceLength)
+            inImage = false
+            var block = 0
+            for index in padCount..<sequenceLength {
+                let token = row[index]
+                if token == config.imageCLSTokenID && !inImage {
+                    inImage = true
+                    block += 1
+                }
+                if inImage && token != config.imgEndID {
+                    blockIDs[index] = block
+                }
+                if token == config.imgEndID && inImage {
+                    inImage = false
+                }
+            }
+            for queryIndex in 0..<sequenceLength {
+                for keyIndex in 0..<sequenceLength {
+                    if queryIndex < padCount {
+                        allMask.append(queryIndex == keyIndex)
+                    } else if keyIndex < padCount {
+                        allMask.append(false)
+                    } else {
+                        let causal = queryIndex >= keyIndex
+                        let sameImage = blockIDs[queryIndex] > 0
+                            && blockIDs[queryIndex] == blockIDs[keyIndex]
+                        allMask.append(causal || sameImage)
+                    }
+                }
+            }
+        }
+
+        return FalconPerceptionBatchPositionData(
+            positionIDs: MLXArray(allPositions, [batchSize, sequenceLength]),
+            posHW: MLXArray(allPosHW, [batchSize, sequenceLength, 2]),
+            ropeDeltas: ropeDeltas,
+            attentionMask: MLXArray(allMask, [batchSize, 1, sequenceLength, sequenceLength]),
+            padCounts: padCounts
+        )
     }
 
     public static func computePositionData(
@@ -1071,15 +1210,17 @@ public final class FalconPerceptionModel: Module, @unchecked Sendable {
     }
 
     static func computeGoldenFrequencies(freqsGolden: MLXArray, posHW: MLXArray) -> (MLXArray, MLXArray) {
+        precondition(posHW.ndim == 3 && posHW.dim(2) == 2)
+        let batchSize = posHW.dim(0)
         let heads = freqsGolden.dim(0)
         let frequencyCount = freqsGolden.dim(1)
         let tokenCount = posHW.dim(1)
-        let positions = posHW[0].asType(.float32).reshaped(tokenCount, 1, 1, 2)
-        let frequencies = freqsGolden.asType(.float32).reshaped(1, heads, frequencyCount, 2)
+        let positions = posHW.asType(.float32).reshaped(batchSize, tokenCount, 1, 1, 2)
+        let frequencies = freqsGolden.asType(.float32).reshaped(1, 1, heads, frequencyCount, 2)
         let angles = MLX.sum(positions * frequencies, axis: -1)
         return (
-            MLX.cos(angles).reshaped(1, tokenCount, heads, frequencyCount),
-            MLX.sin(angles).reshaped(1, tokenCount, heads, frequencyCount)
+            MLX.cos(angles).reshaped(batchSize, tokenCount, heads, frequencyCount),
+            MLX.sin(angles).reshaped(batchSize, tokenCount, heads, frequencyCount)
         )
     }
 
@@ -1140,8 +1281,12 @@ public final class FalconPerceptionModel: Module, @unchecked Sendable {
         let kEven = kReshaped[.ellipsis, 0]
         let kOdd = kReshaped[.ellipsis, 1]
 
-        let cosExpanded = cos.reshaped(1, 1, cos.dim(0), cos.dim(1))
-        let sinExpanded = sin.reshaped(1, 1, sin.dim(0), sin.dim(1))
+        let cosExpanded = cos.ndim == 2
+            ? cos.reshaped(1, 1, cos.dim(0), cos.dim(1))
+            : cos.reshaped(cos.dim(0), 1, cos.dim(1), cos.dim(2))
+        let sinExpanded = sin.ndim == 2
+            ? sin.reshaped(1, 1, sin.dim(0), sin.dim(1))
+            : sin.reshaped(sin.dim(0), 1, sin.dim(1), sin.dim(2))
 
         let qOutEven = qEven * cosExpanded - qOdd * sinExpanded
         let qOutOdd = qEven * sinExpanded + qOdd * cosExpanded

--- a/Sources/MereRunCore/FalconPerception/FalconPerceptionProcessor.swift
+++ b/Sources/MereRunCore/FalconPerception/FalconPerceptionProcessor.swift
@@ -21,6 +21,13 @@ public struct FalconPerceptionProcessedInput: @unchecked Sendable {
     }
 }
 
+struct FalconPerceptionProcessedBatch: @unchecked Sendable {
+    let inputIDs: MLXArray
+    let pixelValues: MLXArray
+    let imageGridHW: MLXArray
+    let processedSizes: [(width: Int, height: Int)]
+}
+
 public enum FalconPerceptionProcessorError: LocalizedError {
     case unsupportedPlatform
     case invalidImage(URL)
@@ -59,6 +66,51 @@ public struct FalconPerceptionProcessor: @unchecked Sendable {
             throw FalconPerceptionProcessorError.invalidImage(imageURL)
         }
         return process(imageRGBA: image, query: query)
+    }
+
+    func processBatch(_ inputs: [FalconPerceptionBatchInput]) throws -> FalconPerceptionProcessedBatch {
+        precondition(!inputs.isEmpty, "Falcon batch preprocessing requires at least one input.")
+        let processed = try inputs.map { try process(imageURL: $0.imageURL, query: $0.query) }
+        let maximumSequenceLength = processed.map { $0.inputIDs.dim(1) }.max() ?? 0
+        let maximumHeight = processed.map { $0.pixelValues.dim(1) }.max() ?? 0
+        let maximumWidth = processed.map { $0.pixelValues.dim(2) }.max() ?? 0
+
+        var tokenValues = [Int32]()
+        var pixelRows = [MLXArray]()
+        var gridValues = [Int32]()
+        var processedSizes = [(width: Int, height: Int)]()
+        tokenValues.reserveCapacity(inputs.count * maximumSequenceLength)
+        pixelRows.reserveCapacity(inputs.count)
+        gridValues.reserveCapacity(inputs.count * 2)
+        processedSizes.reserveCapacity(inputs.count)
+
+        for item in processed {
+            let ids = item.inputIDs.asArray(Int32.self)
+            tokenValues.append(
+                contentsOf: Array(repeating: Int32(tokenizer.padTokenID), count: maximumSequenceLength - ids.count)
+            )
+            tokenValues.append(contentsOf: ids)
+            pixelRows.append(
+                padded(
+                    item.pixelValues,
+                    widths: [
+                        [0, 0],
+                        [0, maximumHeight - item.pixelValues.dim(1)],
+                        [0, maximumWidth - item.pixelValues.dim(2)],
+                        [0, 0],
+                    ]
+                )
+            )
+            gridValues.append(contentsOf: item.imageGridHW.asArray(Int32.self))
+            processedSizes.append(item.processedSize)
+        }
+
+        return FalconPerceptionProcessedBatch(
+            inputIDs: MLXArray(tokenValues, [inputs.count, maximumSequenceLength]),
+            pixelValues: concatenated(pixelRows, axis: 0),
+            imageGridHW: MLXArray(gridValues, [inputs.count, 2]),
+            processedSizes: processedSizes
+        )
     }
 
     public func process(imageRGBA: MediaImage, query: String) -> FalconPerceptionProcessedInput {

--- a/Tests/MereRunCLITests/VisionServeCommandTests.swift
+++ b/Tests/MereRunCLITests/VisionServeCommandTests.swift
@@ -10,12 +10,16 @@ final class VisionServeCommandTests: XCTestCase {
             "--port", "9091",
             "--model", "vision-ground-falcon-perception",
             "--max-frame-bytes", "4194304",
+            "--max-batch-size", "6",
+            "--max-batch-bytes", "25165824",
         ])
 
         XCTAssertEqual(command.host, "127.0.0.1")
         XCTAssertEqual(command.port, 9_091)
         XCTAssertEqual(command.model, "vision-ground-falcon-perception")
         XCTAssertEqual(command.maxFrameBytes, 4_194_304)
+        XCTAssertEqual(command.maxBatchSize, 6)
+        XCTAssertEqual(command.maxBatchBytes, 25_165_824)
     }
 
     func testRejectsNonLoopbackServerWithoutAPIKey() {
@@ -51,6 +55,46 @@ final class VisionServeCommandTests: XCTestCase {
     func testRequiresAtLeastOneQuery() {
         let form = MultipartFormData(parts: [])
         XCTAssertThrowsError(try VisionGroundingServer.requestPlan(from: form))
+    }
+
+    func testBuildsBatchRequestPlanWithPerFrameIdentifiers() throws {
+        let form = MultipartFormData(parts: [
+            .init(name: "query", filename: nil, contentType: nil, body: Data("target".utf8)),
+            .init(name: "frame_id[]", filename: nil, contentType: nil, body: Data("frame-1".utf8)),
+            .init(name: "frame_id[]", filename: nil, contentType: nil, body: Data("frame-2".utf8)),
+            .init(name: "stream_id", filename: nil, contentType: nil, body: Data("camera-7".utf8)),
+            .init(name: "max_new_tokens", filename: nil, contentType: nil, body: Data("128".utf8)),
+        ])
+
+        let plan = try VisionGroundingServer.batchRequestPlan(from: form)
+        XCTAssertEqual(plan.queries, ["target"])
+        XCTAssertEqual(plan.frameIDs, ["frame-1", "frame-2"])
+        XCTAssertEqual(plan.streamID, "camera-7")
+        XCTAssertEqual(plan.maxNewTokens, 128)
+    }
+
+    func testRejectsInvalidBatchLimits() {
+        XCTAssertThrowsError(try VisionServe.parse(["--max-batch-size", "0"]))
+        XCTAssertThrowsError(try VisionServe.parse(["--max-batch-size", "33"]))
+        XCTAssertThrowsError(try VisionServe.parse(["--max-batch-bytes", "0"]))
+        XCTAssertThrowsError(try VisionServe.parse(["--max-batch-bytes", String(Int.max)]))
+    }
+
+    func testBatchLimitCountsImageQueryPairs() throws {
+        XCTAssertNoThrow(
+            try VisionGroundingServer.validateBatchCardinality(
+                imageCount: 4,
+                queryCount: 2,
+                maximumBatchSize: 8
+            )
+        )
+        XCTAssertThrowsError(
+            try VisionGroundingServer.validateBatchCardinality(
+                imageCount: 5,
+                queryCount: 2,
+                maximumBatchSize: 8
+            )
+        )
     }
 
     func testResponseDoesNotExposeServerLocalPaths() throws {

--- a/Tests/MereRunCoreTests/FalconPerceptionProcessorTests.swift
+++ b/Tests/MereRunCoreTests/FalconPerceptionProcessorTests.swift
@@ -273,6 +273,154 @@ final class FalconPerceptionProcessorTests: MereRunCoreTestCase {
         XCTAssertEqual(selected.1?.asArray(Float.self), [14, 15, 10, 11, 16, 17])
     }
 
+    func testFalconBatchPositionDataLeftPadsWithoutExposingPaddingKeys() {
+        let config = FalconPerceptionModelConfig()
+        let padID = 0
+        let first = [
+            padID,
+            padID,
+            17,
+            config.imageCLSTokenID,
+            config.imageReg1TokenID,
+            config.imageReg2TokenID,
+            config.imageReg3TokenID,
+            config.imageReg4TokenID,
+            config.imgID,
+            config.imgEndID,
+            23,
+        ]
+        let second = [
+            19,
+            config.imageCLSTokenID,
+            config.imageReg1TokenID,
+            config.imageReg2TokenID,
+            config.imageReg3TokenID,
+            config.imageReg4TokenID,
+            config.imgID,
+            config.imgID,
+            config.imgID,
+            config.imgEndID,
+            29,
+        ]
+        let inputIDs = MLXArray((first + second).map(Int32.init), [2, first.count])
+        let imageGridHW = MLXArray([
+            Int32(1), Int32(1),
+            Int32(1), Int32(3),
+        ], [2, 2])
+
+        let result = FalconPerceptionModel.computeBatchPositionData(
+            inputIDs: inputIDs,
+            config: config,
+            imageGridHW: imageGridHW,
+            padTokenID: padID
+        )
+
+        XCTAssertEqual(result.positionIDs.shape, [2, first.count])
+        XCTAssertEqual(result.posHW.shape, [2, first.count, 2])
+        XCTAssertEqual(result.attentionMask.shape, [2, 1, first.count, first.count])
+        XCTAssertEqual(result.padCounts, [2, 0])
+        XCTAssertEqual(result.ropeDeltas.count, 2)
+
+        let mask = result.attentionMask.asArray(Bool.self)
+        let side = first.count
+        func value(batch: Int, query: Int, key: Int) -> Bool {
+            mask[(batch * side * side) + (query * side) + key]
+        }
+        XCTAssertFalse(value(batch: 0, query: side - 1, key: 0))
+        XCTAssertFalse(value(batch: 0, query: side - 1, key: 1))
+        XCTAssertTrue(value(batch: 0, query: side - 1, key: 2))
+        XCTAssertTrue(value(batch: 1, query: side - 1, key: 0))
+    }
+
+    func testFalconBatchRotaryTablesPreserveBatchDimension() {
+        let frequencies = MLXArray([
+            Float(1), 0, 0, 1,
+            0.5, 0.25, -1, 1,
+        ], [2, 2, 2])
+        let positions = MLXArray([
+            Float(1), 2,
+            -1, 0.5,
+            0.25, -0.75,
+            2, 1,
+        ], [2, 2, 2])
+
+        let (cosines, sines) = FalconPerceptionModel.computeGoldenFrequencies(
+            freqsGolden: frequencies,
+            posHW: positions
+        )
+        MLX.eval(cosines, sines)
+
+        XCTAssertEqual(cosines.shape, [2, 2, 2, 2])
+        XCTAssertEqual(sines.shape, [2, 2, 2, 2])
+
+        let cosineTable = MLXArray((0..<10).map(Float.init), [5, 2])
+        let selected = FalconPerceptionModel.selectCosSinTables(
+            positionIDs: MLXArray([Int32(2), 0, 3, 1], [2, 2]),
+            cosTable: cosineTable,
+            sinTable: cosineTable + 10
+        )
+        XCTAssertEqual(selected.0?.shape, [2, 2, 2])
+        XCTAssertEqual(selected.0?.asArray(Float.self), [4, 5, 0, 1, 6, 7, 2, 3])
+    }
+
+    func testFalconMergeImageFeaturesKeepsPaddedBatchPatchesOutOfOtherRows() {
+        let config = FalconPerceptionModelConfig(
+            textConfig: FalconPerceptionTextConfig(
+                hiddenSize: 2,
+                numHiddenLayers: 1,
+                numAttentionHeads: 1,
+                headDim: 2,
+                numKeyValueHeads: 1,
+                vocabSize: 512,
+                intermediateSize: 4,
+                maxPositionEmbeddings: 32
+            ),
+            visionConfig: FalconPerceptionVisionConfig(
+                spatialPatchSize: 1,
+                temporalPatchSize: 1,
+                channelSize: 3
+            ),
+            vocabSize: 512,
+            coordEncDim: 2,
+            coordDecDim: 2,
+            coordOutDim: 4,
+            sizeEncDim: 2,
+            sizeDecDim: 2,
+            sizeOutDim: 4
+        )
+        let model = FalconPerceptionModel(config: config)
+        let inputIDs = MLXArray([
+            Int32(config.imgID), Int32(config.imgID), 9, 9,
+            Int32(config.imgID), 9, 9, 9,
+        ], [2, 4])
+        let inputEmbeds = MLX.zeros([2, 4, 2], dtype: .float32)
+        let imageFeatures = MLXArray([
+            Float(1), 2,
+            3, 4,
+            5, 6,
+            7, 8,
+        ], [4, 2])
+        let imageGridHW = MLXArray([
+            Int32(1), Int32(2),
+            Int32(1), Int32(1),
+        ], [2, 2])
+
+        let merged = model.mergeImageFeatures(
+            imageTokenID: config.imgID,
+            imageFeatures: imageFeatures,
+            inputsEmbeds: inputEmbeds,
+            inputIDs: inputIDs,
+            imageGridHW: imageGridHW,
+            paddedGridHW: (1, 2)
+        )
+        MLX.eval(merged)
+
+        XCTAssertEqual(merged[0, 0].asArray(Float.self), [1, 2])
+        XCTAssertEqual(merged[0, 1].asArray(Float.self), [3, 4])
+        XCTAssertEqual(merged[1, 0].asArray(Float.self), [5, 6])
+        XCTAssertEqual(merged[1, 1].asArray(Float.self), [0, 0])
+    }
+
     func testCachedDecodeMatchesFullForwardForPresenceStep() {
         let config = FalconPerceptionModelConfig(
             textConfig: FalconPerceptionTextConfig(

--- a/docs/runtime/vision.md
+++ b/docs/runtime/vision.md
@@ -235,6 +235,27 @@ assign application semantics or preserve application-specific state; clients
 own cadence, temporal association, and policy. Loopback is the default, and
 non-loopback binds require `--api-key`.
 
+Use the bounded batch endpoint to ground several images in one native MLX
+prefill/decode pass:
+
+```bash
+curl http://127.0.0.1:8091/v1/vision/ground-batch \
+  -F 'stream_id=batch-0001' \
+  -F 'frame_id[]=frame-000042' \
+  -F 'frame_id[]=frame-000043' \
+  -F 'query=target' \
+  -F 'image[]=@frame-000042.webp;type=image/webp' \
+  -F 'image[]=@frame-000043.webp;type=image/webp'
+```
+
+`frame_id[]` is optional; when present it must provide one identifier per
+image. Every query applies to every image, and `--max-batch-size` limits the
+flattened number of image-query pairs (8 by default, at most 32). Individual
+images remain subject to `--max-frame-bytes`; their combined encoded bytes are
+bounded by `--max-batch-bytes`. The batch response contains ordered per-image
+hashes and normalized detections. It intentionally omits masks and annotated
+images; use the single-image endpoint when those artifacts are required.
+
 ### Track objects through a video
 
 ```bash


### PR DESCRIPTION
## Summary

- add a bounded `POST /v1/vision/ground-batch` endpoint to the resident Falcon Perception service
- preprocess, prefill, and decode image-query samples as one native MLX batch with row-safe padding, attention masks, rotary positions, image features, and KV state
- preserve task-scoped MLX CPU/GPU streams across asynchronous executor hops
- enforce per-image bytes, aggregate bytes, and total image-query-pair limits; return ordered per-image hashes and typed detections

## Compatibility and limits

- the existing single-image endpoint is unchanged
- batch responses are detection-only; callers that require masks or annotated images should use the single-image endpoint
- `--max-batch-size` defaults to 8 and is capped at 32 image-query pairs
- loopback and API-key binding policy is unchanged

## Validation

- `./scripts/check.sh`
  - SwiftLint: 1,247 files, 0 violations
  - XCTest: 2,903 tests, 211 expected skips, 0 failures
  - Swift Testing: 30 tests, 0 failures
- focused Falcon tensor/batch tests: 21 passed
- focused vision-service contract tests: 9 passed
- installed-model resident smoke completed at batch sizes 1, 2, 4, and 8 without a stream failure; the two-sample run preserved the expected ordered outputs

Local M4 Max / 128 GB warm measurements on one fixed two-image grounding corpus:

| Batch samples | Total wall time | Wall time per sample |
| ---: | ---: | ---: |
| 1 | 4.51-4.67 s | 4.51-4.67 s |
| 2 | 8.11 s | 4.05 s |
| 4 | 14.91 s | 3.73 s |
| 8 | 29.05 s | 3.63 s |

The two matched one-sample requests took 9.18 s combined versus 8.11 s for the two-sample batch. These are local, corpus-specific throughput measurements, not a universal latency guarantee.
