### PR TITLE
Make model inventory fast by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+### Model inventory
+
+- split fast model availability from recursive storage accounting. `status` and
+  `model list` now avoid referenced-size traversal by default, expose inventory
+  completeness, duration, and verification state in status JSON, and reserve
+  recursive referenced-size scans for `model list --measure-sizes` and the
+  dedicated storage commands.
+
 ## 0.40.0 - 2026-08-16
 
 This release adds bounded native Falcon Perception batching, promotes the

--- a/Sources/MereRunCLI/Commands/ExecutorCommand.swift
+++ b/Sources/MereRunCLI/Commands/ExecutorCommand.swift
@@ -275,7 +275,10 @@ struct WorkflowExecutorProbe: Codable, Equatable, Sendable {
             nodeKinds: Array(Set(
                 WorkflowNodeRegistry.entries.map(\.kind) + graphProviders.flatMap { $0.nodes.map(\.kind) }
             )).sorted(),
-            installedModelIDs: ModelInventory.rows(fileManager: fileManager).filter(\.isInstalled).map(\.id).sorted(),
+            installedModelIDs: ModelInventory.snapshot(
+                mode: .verified,
+                fileManager: fileManager
+            ).rows.filter(\.isInstalled).map(\.id).sorted(),
             availableSecretNames: availableWorkflowSecretNames(),
             providers: graphProviders.map(\.requirement)
         )

--- a/Sources/MereRunCLI/Commands/GateCommand.swift
+++ b/Sources/MereRunCLI/Commands/GateCommand.swift
@@ -95,7 +95,7 @@ struct Gate: AsyncParsableCommand {
         let checks: [GateCheck]
         if allInstalled {
             let installedIDs = Set(
-                ModelInventory.rows()
+                ModelInventory.snapshot(mode: .verified).rows
                     .filter(\.isInstalled)
                     .map(\.id)
             )

--- a/Sources/MereRunCLI/Commands/ModelListCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelListCommand.swift
@@ -8,14 +8,22 @@ struct ModelList: ParsableCommand {
         abstract: "List all known models with install status."
     )
 
+    @Flag(
+        name: [.long],
+        help: "Measure referenced payload sizes (slower; follows model-store symlinks)."
+    )
+    var measureSizes = false
+
     func run() throws {
-        let rows = ModelInventory.rows()
+        let mode: ModelInventoryMode = measureSizes ? .measured : .fast
+        let rows = ModelInventory.snapshot(mode: mode).rows
 
         let widths = ModelListColumnWidths(rows: rows)
         printRow("ID", "Category", "Status", "Referenced", widths: widths)
         print(String(repeating: "-", count: widths.totalWidth))
         for row in rows {
-            printRow(row.id, row.category, row.status, row.size, widths: widths)
+            let size = row.size ?? (row.isInstalled ? "not measured" : "—")
+            printRow(row.id, row.category, row.status, size, widths: widths)
         }
         for line in Self.usageRestrictionLines() {
             print("\n\(line)")

--- a/Sources/MereRunCLI/Commands/StatusCommand.swift
+++ b/Sources/MereRunCLI/Commands/StatusCommand.swift
@@ -79,6 +79,9 @@ struct StatusSnapshot: Codable, Equatable {
     let modelStore: StatusModelStoreSnapshot
     let knownModelCount: Int
     let installedModels: [StatusInstalledModelSnapshot]
+    var inventoryMode: ModelInventoryMode = .fast
+    var inventoryComplete: Bool = true
+    var inventoryDurationMs: Int = 0
     var capabilities: StatusCapabilitiesSnapshot = .current
     var machineAdmission: MachineInferenceAdmissionSnapshot? = nil
     var machineAdmissionDetail: String? = nil
@@ -116,7 +119,10 @@ struct StatusModelStoreSnapshot: Codable, Equatable {
 struct StatusInstalledModelSnapshot: Codable, Equatable {
     let id: String
     let category: String
-    let size: String
+    let size: String?
+    var manifestPresent: Bool = false
+    var runtimeAvailable: Bool? = nil
+    var verification: ModelInventoryVerification = .notChecked
 }
 
 struct StatusSnapshotBuilder {
@@ -126,14 +132,18 @@ struct StatusSnapshotBuilder {
     let timeoutSeconds: Double
 
     func snapshot() async -> StatusSnapshot {
-        let inventoryRows = ModelInventory.rows()
+        let inventory = ModelInventory.snapshot(mode: .fast)
+        let inventoryRows = inventory.rows
         let installedModels = inventoryRows
             .filter(\.isInstalled)
             .map {
                 StatusInstalledModelSnapshot(
                     id: $0.id,
                     category: $0.category,
-                    size: $0.size
+                    size: $0.size,
+                    manifestPresent: $0.manifestPresent,
+                    runtimeAvailable: $0.runtimeAvailable,
+                    verification: $0.verification
                 )
             }
         let modelStore = MereRunModelPaths.modelStoreResolution()
@@ -158,6 +168,9 @@ struct StatusSnapshotBuilder {
             ),
             knownModelCount: inventoryRows.count,
             installedModels: installedModels,
+            inventoryMode: inventory.mode,
+            inventoryComplete: inventory.complete,
+            inventoryDurationMs: inventory.durationMs,
             machineAdmission: machineAdmission,
             machineAdmissionDetail: machineAdmissionDetail
         )
@@ -404,12 +417,21 @@ enum StatusFormatter {
             lines.append("  runtime settings: unavailable (\(detail))")
         }
         lines.append("  installed models: \(snapshot.installedModels.count)/\(snapshot.knownModelCount)")
+        let completeness = snapshot.inventoryComplete ? "complete" : "incomplete"
+        lines.append(
+            "  model inventory: \(snapshot.inventoryMode.rawValue), \(completeness), "
+                + "\(snapshot.inventoryDurationMs) ms"
+        )
 
         if snapshot.installedModels.isEmpty {
             lines.append("    none")
         } else {
             for model in snapshot.installedModels {
-                lines.append("    - \(model.id) (\(model.category), \(model.size))")
+                let size = model.size ?? "size not measured"
+                lines.append(
+                    "    - \(model.id) (\(model.category), \(size), "
+                        + "verification \(model.verification.rawValue))"
+                )
             }
         }
 

--- a/Sources/MereRunCLI/Guides/model-list.md
+++ b/Sources/MereRunCLI/Guides/model-list.md
@@ -2,8 +2,8 @@
 
 ## Purpose
 
-Show all known managed model ids, categories, install status, and resolved local
-referenced payload size. Use this before pulling or running models.
+Show all known managed model ids, categories, and shallow availability without
+recursively measuring model payloads. Use this before pulling or running models.
 Use `mere.run status` when you also need the active API server and currently
 served model.
 
@@ -15,13 +15,15 @@ No model is required.
 
 ```bash
 mere.run model list
+mere.run model list --measure-sizes
 mere.run status
 mere.run guide model list
 ```
 
 ## Parameters
 
-This command has no flags. It reads the configured model store.
+- `--measure-sizes`: recursively measure referenced payloads. This is slower
+  and follows model-store symlinks, including external stores.
 
 ## Usage Patterns
 
@@ -44,8 +46,10 @@ MERERUN_MODELS_DIR=/Volumes/Models/mere.run mere.run model list
 ## Iteration Tips
 
 - Look for `missing` vs `installed`, not just whether the id exists.
-- Referenced sizes follow symlinked payloads and are not additive when models
-  share files. Use `model storage` for physical and reclaimable byte counts.
+- The default `not measured` value keeps availability checks fast.
+- With `--measure-sizes`, referenced sizes follow symlinked payloads and are
+  not additive when models share files. Use `model storage` for physical and
+  reclaimable byte counts.
 - If validation looks wrong, inspect with `model info` or repair manifests.
 
 ## Troubleshooting

--- a/Sources/MereRunCLI/Guides/status.md
+++ b/Sources/MereRunCLI/Guides/status.md
@@ -39,6 +39,12 @@ mere.run guide status
 - `--timeout-seconds`: network probe timeout, default `1.0`.
 - `--json`: emit a structured snapshot.
 
+Installed-model inventory is shallow and does not recursively measure payload
+sizes. JSON includes `inventoryMode`, `inventoryComplete`,
+`inventoryDurationMs`, and per-model `verification`. A `not_checked` value
+means `runtimeAvailable` reflects a reachable model root without full runtime
+validation.
+
 ## Usage Patterns
 
 - Run before connecting an editor, agent, or local integration to the API server.
@@ -106,6 +112,8 @@ MERERUN_API_KEY=change-me mere.run status --json
   state rather than treating residency alone as request readiness.
 - The installed model list follows the same shared inventory path as
   `mere.run model list`.
+- Use `model list --measure-sizes` or `model storage` when byte accounting is
+  required; `status` deliberately stays on the startup-safe fast path.
 - `runtime settings` points at
   `<active model store>/.mere-run/runtime-model-settings.json`.
 

--- a/Sources/MereRunCLI/Support/ModelInventory.swift
+++ b/Sources/MereRunCLI/Support/ModelInventory.swift
@@ -185,7 +185,11 @@ enum ModelInventory {
         let registeredBindings = (modelID.map { resolver.locationCandidates(for: $0) } ?? [])
             .filter { $0.kind == .registeredBinding }
 
-        let flatDir = MereRunModelPaths.modelDir(id)
+        let flatDir = modelID.flatMap { modelID in
+            resolver.locationCandidates(for: modelID)
+                .first { $0.kind == .primaryStore }?
+                .rootURL
+        } ?? MereRunModelPaths.modelDir(id)
         let flatInstalled = isNonEmptyDirectory(flatDir, fileManager: fileManager)
         let hasManagedManifest = fileManager.fileExists(
             atPath: flatDir.appendingPathComponent(MereRunModelManifest.filename).path

--- a/Sources/MereRunCLI/Support/ModelInventory.swift
+++ b/Sources/MereRunCLI/Support/ModelInventory.swift
@@ -1,11 +1,32 @@
 import Foundation
 import MereRunCore
 
+enum ModelInventoryMode: String, Codable, Equatable {
+    case fast
+    case verified
+    case measured
+}
+
+enum ModelInventoryVerification: String, Codable, Equatable {
+    case checked
+    case notChecked = "not_checked"
+}
+
+struct ModelInventorySnapshot: Equatable {
+    let rows: [ModelInventoryRow]
+    let mode: ModelInventoryMode
+    let complete: Bool
+    let durationMs: Int
+}
+
 struct ModelInventoryRow: Equatable {
     let id: String
     let category: String
     let status: String
-    let size: String
+    let size: String?
+    let manifestPresent: Bool
+    let runtimeAvailable: Bool?
+    let verification: ModelInventoryVerification
 
     var isInstalled: Bool {
         status == "installed"
@@ -13,105 +34,262 @@ struct ModelInventoryRow: Equatable {
 }
 
 enum ModelInventory {
+    /// Compatibility entry point for callers that explicitly expect measured sizes.
     static func rows(fileManager: FileManager = .default) -> [ModelInventoryRow] {
-        let resolver = ModelResolver(fileManager: fileManager)
+        snapshot(mode: .measured, fileManager: fileManager).rows
+    }
+
+    static func snapshot(
+        mode: ModelInventoryMode,
+        fileManager: FileManager = .default,
+        locations: ModelLocationSnapshot? = nil
+    ) -> ModelInventorySnapshot {
+        let startedAt = Date()
+        let resolver = ModelResolver(fileManager: fileManager, locations: locations)
         let specs = ManagedModelCatalog.allSpecs
         let knownSpecs = Dictionary(uniqueKeysWithValues: specs.map { ($0.id, $0) })
         let idsInOrder = specs.map(\.id)
+        var complete = true
 
-        return idsInOrder.map { id in
+        let rows = idsInOrder.map { id in
             let spec = knownSpecs[id]
-            let status: String
-            let size: String
-
-            let modelID = ModelResolver.ModelID(rawValue: id)
-            let resolvedViaResolver = modelID.flatMap { resolver.resolveIfPresent($0) }
-            let registeredBindings = (modelID.map { resolver.locationCandidates(for: $0) } ?? [])
-                .filter { $0.kind == .registeredBinding }
-
-            let flatDir = MereRunModelPaths.modelDir(id)
-            let flatInstalled = isNonEmptyDirectory(flatDir, fileManager: fileManager)
-            let hasManagedManifest = fileManager.fileExists(
-                atPath: flatDir.appendingPathComponent(MereRunModelManifest.filename).path
+            if mode == .fast {
+                let result = fastRow(
+                    id: id,
+                    spec: spec,
+                    resolver: resolver,
+                    fileManager: fileManager
+                )
+                complete = complete && result.complete
+                return result.row
+            }
+            return checkedRow(
+                id: id,
+                spec: spec,
+                resolver: resolver,
+                measureSize: mode == .measured,
+                fileManager: fileManager
             )
-            let gemmaAliasInstall = gemmaAliasInstallURL(for: id, fileManager: fileManager)
+        }
 
-            if let spec, spec.usesPinnedGeometryArtifacts {
-                if let resolution = resolvedViaResolver {
-                    status = "installed"
-                    let bytes = FileSystemHelper.directorySize(at: resolution.rootURL)
-                    size = ByteCountFormatter.string(fromByteCount: bytes, countStyle: .file)
-                } else if spec.requiresManagedConversion,
-                          ManagedModelResolver.isManagedInstallComplete(
-                              spec: spec,
-                              at: flatDir,
-                              fileManager: fileManager
-                          ) {
-                    status = "conversion-required"
-                    let bytes = FileSystemHelper.directorySize(at: flatDir)
-                    size = ByteCountFormatter.string(fromByteCount: bytes, countStyle: .file)
-                } else if flatInstalled {
-                    status = "invalid"
-                    let bytes = FileSystemHelper.directorySize(at: flatDir)
-                    size = ByteCountFormatter.string(fromByteCount: bytes, countStyle: .file)
-                } else {
-                    status = "missing"
-                    size = "—"
+        let durationMs = max(0, Int(Date().timeIntervalSince(startedAt) * 1_000))
+        return ModelInventorySnapshot(
+            rows: rows,
+            mode: mode,
+            complete: complete,
+            durationMs: durationMs
+        )
+    }
+
+    private static func fastRow(
+        id: String,
+        spec: ManagedModelSpec?,
+        resolver: ModelResolver,
+        fileManager: FileManager
+    ) -> (row: ModelInventoryRow, complete: Bool) {
+        let candidateIDs = [id] + (spec?.resolutionFallbackIDs ?? [])
+        var foundInvalid = false
+        var foundManifest = false
+        var complete = true
+        var registeredBindingExists = false
+
+        for candidateID in candidateIDs {
+            guard let modelID = ModelResolver.ModelID(rawValue: candidateID) else { continue }
+            for candidate in resolver.locationCandidates(for: modelID) {
+                if candidate.kind == .registeredBinding {
+                    registeredBindingExists = true
                 }
-            } else if let resolution = resolvedViaResolver {
+
+                switch shallowDirectoryState(candidate.rootURL, fileManager: fileManager) {
+                case .missing, .empty:
+                    continue
+                case .unavailable:
+                    complete = false
+                    continue
+                case .available:
+                    break
+                }
+
+                let manifestURL = candidate.rootURL.appendingPathComponent(MereRunModelManifest.filename)
+                let manifestPresent = fileManager.fileExists(atPath: manifestURL.path)
+                foundManifest = foundManifest || manifestPresent
+
+                if manifestPresent {
+                    guard let manifest = try? MereRunModelManifest.loadIfPresent(
+                        from: candidate.rootURL,
+                        fileManager: fileManager
+                    ), manifest.id == candidateID else {
+                        foundInvalid = true
+                        continue
+                    }
+                } else if candidate.kind == .registeredSearchRoot {
+                    continue
+                }
+
+                if candidate.kind.isExternallyManaged,
+                   spec?.usageRestriction != nil,
+                   !candidate.usageTermsAcknowledged {
+                    foundInvalid = true
+                    continue
+                }
+
+                return (
+                    row: ModelInventoryRow(
+                        id: id,
+                        category: spec?.category.rawValue ?? inferCategory(for: id),
+                        status: "installed",
+                        size: nil,
+                        manifestPresent: manifestPresent,
+                        runtimeAvailable: true,
+                        verification: .notChecked
+                    ),
+                    complete: complete
+                )
+            }
+        }
+
+        let status: String
+        if foundInvalid {
+            status = "invalid"
+        } else if registeredBindingExists {
+            status = "offline"
+        } else {
+            status = "missing"
+        }
+        return (
+            row: ModelInventoryRow(
+                id: id,
+                category: spec?.category.rawValue ?? inferCategory(for: id),
+                status: status,
+                size: nil,
+                manifestPresent: foundManifest,
+                runtimeAvailable: false,
+                verification: .notChecked
+            ),
+            complete: complete
+        )
+    }
+
+    private static func checkedRow(
+        id: String,
+        spec: ManagedModelSpec?,
+        resolver: ModelResolver,
+        measureSize: Bool,
+        fileManager: FileManager
+    ) -> ModelInventoryRow {
+        let status: String
+        let measuredRoot: URL?
+
+        let modelID = ModelResolver.ModelID(rawValue: id)
+        let resolvedViaResolver = modelID.flatMap { resolver.resolveIfPresent($0) }
+        let registeredBindings = (modelID.map { resolver.locationCandidates(for: $0) } ?? [])
+            .filter { $0.kind == .registeredBinding }
+
+        let flatDir = MereRunModelPaths.modelDir(id)
+        let flatInstalled = isNonEmptyDirectory(flatDir, fileManager: fileManager)
+        let hasManagedManifest = fileManager.fileExists(
+            atPath: flatDir.appendingPathComponent(MereRunModelManifest.filename).path
+        )
+        let gemmaAliasInstall = gemmaAliasInstallURL(for: id, fileManager: fileManager)
+
+        if let spec, spec.usesPinnedGeometryArtifacts {
+            if let resolution = resolvedViaResolver {
                 status = "installed"
-                let bytes = FileSystemHelper.directorySize(at: resolution.rootURL)
-                size = ByteCountFormatter.string(fromByteCount: bytes, countStyle: .file)
-            } else if let gemmaAliasInstall {
-                status = "installed"
-                let bytes = FileSystemHelper.directorySize(at: gemmaAliasInstall)
-                size = ByteCountFormatter.string(fromByteCount: bytes, countStyle: .file)
-            } else if let spec,
+                measuredRoot = resolution.rootURL
+            } else if spec.requiresManagedConversion,
                       ManagedModelResolver.isManagedInstallComplete(
                           spec: spec,
                           at: flatDir,
                           fileManager: fileManager
-                      ) || spec.managedRuntimeURL(fileManager: fileManager) != nil {
-                status = "installed"
-                let bytes = FileSystemHelper.directorySize(at: flatDir)
-                size = ByteCountFormatter.string(fromByteCount: bytes, countStyle: .file)
+                      ) {
+                status = "conversion-required"
+                measuredRoot = flatDir
             } else if flatInstalled {
-                // Preserve manifest-less legacy roots, but never let a managed
-                // manifest paper over broken links or missing runtime assets.
-                status = hasManagedManifest ? "invalid" : "installed"
-                let bytes = FileSystemHelper.directorySize(at: flatDir)
-                size = ByteCountFormatter.string(fromByteCount: bytes, countStyle: .file)
-            } else if !registeredBindings.isEmpty {
-                let availableBinding = registeredBindings.first {
-                    isNonEmptyDirectory($0.rootURL, fileManager: fileManager)
-                }
-                status = availableBinding == nil ? "offline" : "invalid"
-                if let availableBinding {
-                    let bytes = FileSystemHelper.directorySize(at: availableBinding.rootURL)
-                    size = ByteCountFormatter.string(fromByteCount: bytes, countStyle: .file)
-                } else {
-                    size = "—"
-                }
+                status = "invalid"
+                measuredRoot = flatDir
             } else {
                 status = "missing"
-                size = "—"
+                measuredRoot = nil
             }
+        } else if let resolution = resolvedViaResolver {
+            status = "installed"
+            measuredRoot = resolution.rootURL
+        } else if let gemmaAliasInstall {
+            status = "installed"
+            measuredRoot = gemmaAliasInstall
+        } else if let spec,
+                  ManagedModelResolver.isManagedInstallComplete(
+                      spec: spec,
+                      at: flatDir,
+                      fileManager: fileManager
+                  ) || spec.managedRuntimeURL(fileManager: fileManager) != nil {
+            status = "installed"
+            measuredRoot = flatDir
+        } else if flatInstalled {
+            // Preserve manifest-less legacy roots, but never let a managed
+            // manifest paper over broken links or missing runtime assets.
+            status = hasManagedManifest ? "invalid" : "installed"
+            measuredRoot = flatDir
+        } else if !registeredBindings.isEmpty {
+            let availableBinding = registeredBindings.first {
+                isNonEmptyDirectory($0.rootURL, fileManager: fileManager)
+            }
+            status = availableBinding == nil ? "offline" : "invalid"
+            measuredRoot = availableBinding?.rootURL
+        } else {
+            status = "missing"
+            measuredRoot = nil
+        }
 
-            return ModelInventoryRow(
-                id: id,
-                category: spec?.category.rawValue ?? inferCategory(for: id),
-                status: status,
-                size: size
+        let size = measureSize ? formattedSize(of: measuredRoot) : nil
+        let manifestRoot = resolvedViaResolver?.rootURL ?? measuredRoot
+        let manifestPresent = manifestRoot.map {
+            fileManager.fileExists(
+                atPath: $0.appendingPathComponent(MereRunModelManifest.filename).path
             )
+        } ?? false
+        return ModelInventoryRow(
+            id: id,
+            category: spec?.category.rawValue ?? inferCategory(for: id),
+            status: status,
+            size: size,
+            manifestPresent: manifestPresent,
+            runtimeAvailable: status == "installed",
+            verification: .checked
+        )
+    }
+
+    private static func formattedSize(of url: URL?) -> String? {
+        guard let url else { return nil }
+        let bytes = FileSystemHelper.directorySize(at: url)
+        return ByteCountFormatter.string(fromByteCount: bytes, countStyle: .file)
+    }
+
+    private enum ShallowDirectoryState {
+        case missing
+        case empty
+        case available
+        case unavailable
+    }
+
+    private static func shallowDirectoryState(
+        _ url: URL,
+        fileManager: FileManager
+    ) -> ShallowDirectoryState {
+        var isDir: ObjCBool = false
+        guard fileManager.fileExists(atPath: url.path, isDirectory: &isDir), isDir.boolValue else {
+            return .missing
+        }
+        do {
+            let contents = try fileManager.contentsOfDirectoryResolvingSymlinks(at: url)
+            return contents.isEmpty ? .empty : .available
+        } catch {
+            return .unavailable
         }
     }
 
     private static func isNonEmptyDirectory(_ url: URL, fileManager: FileManager) -> Bool {
-        var isDir: ObjCBool = false
-        guard fileManager.fileExists(atPath: url.path, isDirectory: &isDir), isDir.boolValue else {
-            return false
-        }
-        return (try? fileManager.contentsOfDirectoryResolvingSymlinks(at: url))?.isEmpty == false
+        shallowDirectoryState(url, fileManager: fileManager) == .available
     }
 
     private static func gemmaAliasInstallURL(for id: String, fileManager: FileManager) -> URL? {

--- a/Tests/MereRunCLITests/ModelInventoryTests.swift
+++ b/Tests/MereRunCLITests/ModelInventoryTests.swift
@@ -1,0 +1,79 @@
+import XCTest
+import MereRunCore
+@testable import MereRunCLI
+
+final class ModelInventoryTests: XCTestCase {
+    func testFastInventoryDoesNotMeasureReferencedPayloads() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mere-run-fast-inventory-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let modelID = ModelResolver.ModelID.ornith35BMLX
+        let modelRoot = root.appendingPathComponent(modelID.rawValue, isDirectory: true)
+        let nested = modelRoot.appendingPathComponent("nested", isDirectory: true)
+        try FileManager.default.createDirectory(at: nested, withIntermediateDirectories: true)
+        try Data(repeating: 1, count: 29).write(to: nested.appendingPathComponent("payload.bin"))
+        try MereRunModelManifest.template(for: modelID, createdAt: Date(timeIntervalSince1970: 0))
+            .write(to: modelRoot)
+
+        let snapshot = ModelInventory.snapshot(
+            mode: .fast,
+            locations: ModelLocationSnapshot(primaryRoot: root)
+        )
+        let row = try XCTUnwrap(snapshot.rows.first { $0.id == modelID.rawValue })
+
+        XCTAssertEqual(snapshot.mode, .fast)
+        XCTAssertTrue(snapshot.complete)
+        XCTAssertGreaterThanOrEqual(snapshot.durationMs, 0)
+        XCTAssertEqual(row.status, "installed")
+        XCTAssertNil(row.size)
+        XCTAssertTrue(row.manifestPresent)
+        XCTAssertEqual(row.runtimeAvailable, true)
+        XCTAssertEqual(row.verification, .notChecked)
+    }
+
+    func testVerifiedInventoryChecksRuntimeWithoutMeasuringSize() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mere-run-verified-inventory-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let modelID = ModelResolver.ModelID.ornith35BMLX
+        let modelRoot = root.appendingPathComponent(modelID.rawValue, isDirectory: true)
+        try FileManager.default.createDirectory(at: modelRoot, withIntermediateDirectories: true)
+        try MereRunModelManifest.template(for: modelID, createdAt: Date(timeIntervalSince1970: 0))
+            .write(to: modelRoot)
+
+        let snapshot = ModelInventory.snapshot(
+            mode: .verified,
+            locations: ModelLocationSnapshot(primaryRoot: root)
+        )
+        let row = try XCTUnwrap(snapshot.rows.first { $0.id == modelID.rawValue })
+
+        XCTAssertEqual(row.status, "invalid")
+        XCTAssertNil(row.size)
+        XCTAssertEqual(row.runtimeAvailable, false)
+        XCTAssertEqual(row.verification, .checked)
+    }
+
+    func testFastInventoryReportsConfiguredMissingBindingOffline() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mere-run-offline-inventory-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let modelID = ModelResolver.ModelID.ornith35BMLX
+        let locations = ModelLocationSnapshot(
+            primaryRoot: root,
+            bindings: [
+                ModelLocationRegistry.Binding(
+                    modelID: modelID.rawValue,
+                    path: root.appendingPathComponent("offline-model").path
+                ),
+            ]
+        )
+        let snapshot = ModelInventory.snapshot(mode: .fast, locations: locations)
+        let row = try XCTUnwrap(snapshot.rows.first { $0.id == modelID.rawValue })
+
+        XCTAssertEqual(row.status, "offline")
+        XCTAssertEqual(row.verification, .notChecked)
+    }
+}

--- a/Tests/MereRunCLITests/StatusCommandTests.swift
+++ b/Tests/MereRunCLITests/StatusCommandTests.swift
@@ -34,6 +34,11 @@ final class StatusCommandTests: XCTestCase {
         XCTAssertTrue(cmd.json)
     }
 
+    func testModelListMeasuresSizesOnlyWhenRequested() throws {
+        XCTAssertFalse(try ModelList.parse([]).measureSizes)
+        XCTAssertTrue(try ModelList.parse(["--measure-sizes"]).measureSizes)
+    }
+
     func testStatusAdvertisesLiveASRProtocol() {
         XCTAssertEqual(StatusCapabilitiesSnapshot.current.asrStreamingProtocols, [1])
         XCTAssertEqual(StatusCapabilitiesSnapshot.current.asrStreamingBackends, ["parakeet", "qwen"])
@@ -72,7 +77,54 @@ final class StatusCommandTests: XCTestCase {
         XCTAssertTrue(output.contains("server: up (http://127.0.0.1:8080)"))
         XCTAssertTrue(output.contains("loaded models: text-chat-gemma4"))
         XCTAssertTrue(output.contains("installed models: 1/2"))
-        XCTAssertTrue(output.contains("text-chat-gemma4 (text-chat, 12 GB)"))
+        XCTAssertTrue(output.contains("text-chat-gemma4 (text-chat, 12 GB, verification not_checked)"))
+        XCTAssertTrue(output.contains("model inventory: fast, complete, 0 ms"))
+    }
+
+    func testJSONDescribesFastUnmeasuredInventory() throws {
+        let snapshot = StatusSnapshot(
+            server: StatusServerSnapshot(
+                url: "http://127.0.0.1:8080",
+                health: "down",
+                detail: nil,
+                loadedModels: [],
+                modelsDetail: nil,
+                runtime: nil,
+                runtimeDetail: nil
+            ),
+            modelStore: StatusModelStoreSnapshot(
+                path: "/tmp/models",
+                source: "default",
+                configuredPath: nil,
+                isFallbackToDefault: false
+            ),
+            knownModelCount: 1,
+            installedModels: [
+                StatusInstalledModelSnapshot(
+                    id: "text-chat-ornith-3.5b-mlx",
+                    category: "text-chat",
+                    size: nil,
+                    manifestPresent: true,
+                    runtimeAvailable: true,
+                    verification: .notChecked
+                ),
+            ],
+            inventoryMode: .fast,
+            inventoryComplete: true,
+            inventoryDurationMs: 12
+        )
+
+        let data = try JSONEncoder().encode(snapshot)
+        let object = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        let installed = try XCTUnwrap((object["installedModels"] as? [[String: Any]])?.first)
+
+        XCTAssertEqual(object["inventoryMode"] as? String, "fast")
+        XCTAssertEqual(object["inventoryComplete"] as? Bool, true)
+        XCTAssertEqual(object["inventoryDurationMs"] as? Int, 12)
+        XCTAssertEqual(installed["verification"] as? String, "not_checked")
+        XCTAssertEqual(installed["manifestPresent"] as? Bool, true)
+        XCTAssertNil(installed["size"])
+        XCTAssertEqual(installed["runtimeAvailable"] as? Bool, true)
     }
 
     func testFormatterShowsUnavailableLoadedModels() {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -2117,12 +2117,13 @@ swift run mere.run video export-latents \
 
 ### `mere.run model list`
 
-List all managed model IDs, whether they are installed, and their referenced
-payload size. Referenced sizes follow symlinks and are not additive when models
-share payloads.
+List all managed model IDs and their shallow availability without recursively
+scanning payloads. Pass `--measure-sizes` to calculate referenced sizes; those
+values follow symlinks and are not additive when models share payloads.
 
 ```bash
 swift run mere.run model list
+swift run mere.run model list --measure-sizes
 ```
 
 ### `mere.run model storage` and `mere.run model gc`

--- a/docs/runtime/model-management.md
+++ b/docs/runtime/model-management.md
@@ -126,8 +126,10 @@ the canonical names shown by `mere.run model list`.
 
 ### `mere.run model list`
 
-Shows the canonical managed model table, installed status, and referenced size.
-Referenced sizes are not additive because multiple models can share payload files.
+Shows the canonical managed model table and shallow availability without
+recursively scanning payload files. Pass `--measure-sizes` when referenced
+sizes are needed; those values follow symlinks and are not additive because
+multiple models can share payload files.
 
 ### `mere.run model storage`
 


### PR DESCRIPTION
## Summary
- split fast availability inventory from verified and measured storage accounting
- make `status` and default `model list` avoid recursive size traversal
- add explicit inventory completeness, duration, runtime availability, and verification metadata
- retain exact size scans behind `model list --measure-sizes` and storage commands

## Measured result
- old installed `status` exceeded 6.87 seconds and was interrupted
- new inventory completed in 27 ms; complete status returned in 1.45 seconds
- default model list returned in 0.13 seconds

## Validation
- `./scripts/check.sh`
- 2,908 XCTest cases, 211 skipped, 0 failures
- Swift Testing suites passed
- live installed-model status/list timing
- `git diff --check`