### PR TITLE
Release v0.40.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+## 0.40.1 - 2026-08-16
+
+This patch release makes model health and discovery fast even when checkpoints
+live in large or external stores. It separates availability from exact storage
+accounting and keeps verification explicit.
+
 ### Model inventory
 
 - split fast model availability from recursive storage accounting. `status` and
@@ -13,6 +19,10 @@ The format is based on Keep a Changelog.
   completeness, duration, and verification state in status JSON, and reserve
   recursive referenced-size scans for `model list --measure-sizes` and the
   dedicated storage commands.
+
+### Included pull requests
+
+- exact release range: [#314](https://github.com/sawfwair/mere-run/pull/314).
 
 ## 0.40.0 - 2026-08-16
 

--- a/Sources/MereRunCLI/Support/MereRunCLIVersion.swift
+++ b/Sources/MereRunCLI/Support/MereRunCLIVersion.swift
@@ -1,3 +1,3 @@
 enum MereRunCLIVersion {
-    static let current = "0.40.0"
+    static let current = "0.40.1"
 }

--- a/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
+++ b/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
@@ -129,7 +129,7 @@ final class CLIModelStoreBootstrapTests: XCTestCase {
     }
 
     func testMereRunCLIExposesReleaseVersion() {
-        XCTAssertEqual(MereRunCLIVersion.current, "0.40.0")
+        XCTAssertEqual(MereRunCLIVersion.current, "0.40.1")
         XCTAssertEqual(MereRunCLI.configuration.version, MereRunCLIVersion.current)
     }
 

--- a/scripts/build_mere_run_app.sh
+++ b/scripts/build_mere_run_app.sh
@@ -15,7 +15,7 @@ cd "$repo_root"
 
 # Version/build derive from git when not provided, so the bundle has a single source of
 # truth in CI. Fall back to a pinned value when git metadata is unavailable.
-default_version="0.40.0"
+default_version="0.40.1"
 if git_version="$(git describe --tags --exact-match 2>/dev/null)"; then
   default_version="${git_version#v}"
 fi


### PR DESCRIPTION
## Summary
- cut v0.40.1 for the fast model-inventory changes merged in #314
- move the inventory notes from Unreleased into the dated release section
- bump the CLI, app fallback, and version assertion to 0.40.1

## Validation
- `git diff --check origin/main...HEAD`
- #314 passed the full macOS Swift, Linux CLI, app-bundle, docs, dependency-review, and secret-scan gates
- final signed/notarized macOS and tensor.local x86_64 CUDA packages will be built from the annotated release tag