### PR TITLE
Harden Qwen3.8 runtime and Pi integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,38 @@ The format is based on Keep a Changelog.
   verified artifact fetch) built on `MereRunRelayKit`, with the architecture
   and phasing documented in `docs/ios-studio.md`.
 
+### Agents and Qwen3.8
+
+- exposed Qwen3.8's native `low`, `medium`, and `xhigh` reasoning-effort
+  profile through Pi, `text chat`, and the OpenAI-compatible API, including
+  stable aliases for Pi's broader effort vocabulary.
+- replaced delimiter/regex early stopping for Qwen XML tool calls with a
+  bounded structural streaming parser. Literal closing-tag text inside
+  parameter values no longer truncates a call, and adversarial streams cannot
+  trigger unbounded reparsing.
+
+### Qwen-family acceleration and serving
+
+- added a macOS BF16 Metal kernel for the Qwen3.8 gated-delta prework used by
+  MTP target verification. It is explicitly gated to target-verification
+  forwards and sequence widths 3–9; decode and prefill retain the composed
+  path. GPU parity is bit-exact at every claimed width.
+- made Qwen-family decode routing request-aware: an eligible uncontended
+  request may use MTP, while a request admitted alongside a waiting, running,
+  or prefilling peer stays on continuous batching.
+- made Qwen3.8 prefill live-headroom aware instead of selecting a wide chunk
+  from total physical RAM. It retains the 1,024-token default and caps chunks
+  at 512 below 16 GiB of reclaimable memory or under request contention; the
+  explicit environment value remains a pressure-capped upper bound.
+- made reusable MLX-buffer reclamation pressure-gated. Prefill clears only
+  after a reclaimable cache crosses 90% of the MLX memory limit, and the API
+  runtime clears reusable buffers before evicting a resident model.
+
+### Attribution
+
+- documented the Apache-2.0 provenance of the adapted Qwen GDN verification
+  kernel in `THIRD_PARTY_NOTICES.md`.
+
 ## 0.40.1 - 2026-08-16
 
 This patch release makes model health and discovery fast even when checkpoints

--- a/Sources/MereRunCLI/Commands/APIServeCommand.swift
+++ b/Sources/MereRunCLI/Commands/APIServeCommand.swift
@@ -2555,7 +2555,8 @@ enum APIServerContract {
             reasoningEffort: reasoningEffort,
             showThinking: requiresJSON
                 ? false
-                : resolvedAPIProfile?.thinkingLevels == [.high],
+                : Q35Resources.thinkingDefault(forModelId: laneModelID)
+                    || resolvedAPIProfile?.thinkingLevels == [.high],
             lora: lora,
             requiresJSON: requiresJSON,
             tools: tools,

--- a/Sources/MereRunCLI/Commands/TextChatCommand.swift
+++ b/Sources/MereRunCLI/Commands/TextChatCommand.swift
@@ -85,7 +85,7 @@ struct TextChat: AsyncParsableCommand {
 
     @Option(
         name: [.customLong("reasoning-effort")],
-        help: "Inkling-Small reasoning effort from 0 through 0.99. Default: 0.9."
+        help: "Reasoning effort from 0 through 1 for Qwen3.8, or 0 through 0.99 for Inkling-Small and Muse Glimmer."
     )
     var reasoningEffort: Double?
 
@@ -705,8 +705,11 @@ struct TextChat: AsyncParsableCommand {
     static func validateReasoningEffort(_ value: Double?, modelID: String) throws {
         guard let value else { return }
         guard InklingResources.handles(modelSpec: modelID)
-                || MuseGlimmerResources.handles(modelSpec: modelID) else {
-            throw ValidationError("--reasoning-effort is supported only for Inkling-Small and Muse Glimmer.")
+                || MuseGlimmerResources.handles(modelSpec: modelID)
+                || Q35Resources.isQ38ModelId(modelID) else {
+            throw ValidationError(
+                "--reasoning-effort is supported only for Qwen3.8, Inkling-Small, and Muse Glimmer."
+            )
         }
         let allowed = InklingResources.handles(modelSpec: modelID)
             ? (0...0.99).contains(value)

--- a/Sources/MereRunCLI/Support/PiAgentIntegration.swift
+++ b/Sources/MereRunCLI/Support/PiAgentIntegration.swift
@@ -72,13 +72,13 @@ struct PiProviderModel {
         let supportedThinkingLevels = Set(profile.thinkingLevels)
         let thinkingLevelMap = profile.reasoning
             ? ManagedModelThinkingLevel.allCases.compactMap { level -> (key: String, value: String?)? in
+                if let mapped = profile.thinkingLevelMap[level] {
+                    return (level.rawValue, mapped.rawValue)
+                }
                 guard supportedThinkingLevels.contains(level) else {
                     return (level.rawValue, nil)
                 }
-                guard let mapped = profile.thinkingLevelMap[level] else {
-                    return nil
-                }
-                return (level.rawValue, mapped.rawValue)
+                return nil
             }
             : nil
         let compatibility = profile.compatibility

--- a/Sources/MereRunCLI/Support/RuntimeModelPool.swift
+++ b/Sources/MereRunCLI/Support/RuntimeModelPool.swift
@@ -1,4 +1,5 @@
 import Foundation
+import MLX
 import MereRunCore
 #if canImport(Darwin)
 import Darwin
@@ -930,6 +931,7 @@ actor RuntimeModelPool {
     private let ensureMLXAvailable: @Sendable () throws -> Void
     private let prepareLoadedModel: @Sendable (RuntimeLoadedModel) async throws -> Void
     private let unloadLoadedModel: @Sendable (RuntimeLoadedModel) async -> Void
+    private let clearMLXCache: @Sendable () -> Void
 
     private var loadedModels: [String: RuntimeLoadedModel] = [:]
     private var loadedModelTokens: [String: UUID] = [:]
@@ -966,6 +968,9 @@ actor RuntimeModelPool {
         },
         unloadLoadedModel: @escaping @Sendable (RuntimeLoadedModel) async -> Void = { loaded in
             await loaded.unload()
+        },
+        clearMLXCache: @escaping @Sendable () -> Void = {
+            Memory.clearCache()
         }
     ) {
         self.defaultModelID = defaultModelID
@@ -986,6 +991,7 @@ actor RuntimeModelPool {
         self.ensureMLXAvailable = ensureMLXAvailable
         self.prepareLoadedModel = prepareLoadedModel
         self.unloadLoadedModel = unloadLoadedModel
+        self.clearMLXCache = clearMLXCache
     }
 
     func preloadDefault() async throws {
@@ -1176,6 +1182,7 @@ actor RuntimeModelPool {
             protectedIDs.insert(defaultModelID)
         }
         var evicted: [String] = []
+        var clearedReusableBuffers = false
         while true {
             let pressure = memoryPressurePolicy.pressure(for: currentMemorySample())
             switch pressure {
@@ -1183,6 +1190,12 @@ actor RuntimeModelPool {
                 return evicted.sorted()
             case .elevated, .critical:
                 break
+            }
+            if !clearedReusableBuffers {
+                clearMLXCache()
+                clearedReusableBuffers = true
+                await Task.yield()
+                continue
             }
             guard let id = await evictOldestIdleUnpinnedModel(excluding: protectedIDs) else {
                 return evicted.sorted()
@@ -1324,8 +1337,15 @@ actor RuntimeModelPool {
         sample: RuntimeMemorySample? = nil,
         excluding excludedIDs: Set<String> = []
     ) async -> [String] {
-        let memorySample = sample ?? currentMemorySample()
-        let pressure = memoryPressurePolicy.pressure(for: memorySample)
+        var memorySample = sample ?? currentMemorySample()
+        var pressure = memoryPressurePolicy.pressure(for: memorySample)
+        if pressure == .elevated || pressure == .critical {
+            clearMLXCache()
+            if sample == nil {
+                memorySample = currentMemorySample()
+                pressure = memoryPressurePolicy.pressure(for: memorySample)
+            }
+        }
         let evictionLimit: Int?
         switch pressure {
         case .disabled, .unknown, .nominal:

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -236,6 +236,30 @@ public extension ManagedModelAPIProfile {
         )
     }
 
+    static func q38(contextWindow: Int) -> ManagedModelAPIProfile {
+        chat(
+            servingEngine: .textChatQ36,
+            inputModalities: [.text, .image],
+            contextWindow: contextWindow,
+            maximumOutputTokens: 4_096,
+            thinkingLevels: [.low, .medium, .xhigh],
+            thinkingLevelMap: [.minimal: .low, .high: .xhigh, .max: .xhigh],
+            reasoningEffortStrengths: [
+                .minimal: 0.2,
+                .low: 0.2,
+                .medium: 0.5,
+                .high: 1,
+                .xhigh: 1,
+                .max: 1,
+            ],
+            toolCall: true,
+            structuredOutput: true,
+            compatibility: ManagedModelOpenAICompatibilityProfile(
+                supportsReasoningEffort: true
+            )
+        )
+    }
+
     static func lfm2(
         inputModalities: [ManagedModelAPIModality] = [.text],
         contextWindow: Int = LFM2Resources.defaultContextLength
@@ -1669,7 +1693,7 @@ public enum ManagedModelCatalog {
                 "model benchmark code",
                 "model benchmark vlm",
             ],
-            apiProfile: .q36(contextWindow: Q35Resources.q38TwentySevenBContextLength)
+            apiProfile: .q38(contextWindow: Q35Resources.q38TwentySevenBContextLength)
         ),
         ManagedModelSpec(
             id: Q35Resources.q38TwentySevenB4BitModelId,
@@ -1708,7 +1732,7 @@ public enum ManagedModelCatalog {
                 "model benchmark code",
                 "model benchmark vlm",
             ],
-            apiProfile: .q36(contextWindow: Q35Resources.q38TwentySevenBContextLength)
+            apiProfile: .q38(contextWindow: Q35Resources.q38TwentySevenBContextLength)
         ),
         ManagedModelSpec(
             id: Q35Resources.bonsai27B1BitModelId,

--- a/Sources/MereRunCore/Q35/Q35Generator.swift
+++ b/Sources/MereRunCore/Q35/Q35Generator.swift
@@ -1,6 +1,9 @@
 import Foundation
 import MediaIO
 import MLX
+#if canImport(Darwin)
+import Darwin
+#endif
 
 public typealias Q35ContinuousBatchingStats = RuntimeDecodeBatchingStats
 
@@ -118,18 +121,9 @@ private final class Q35BatchedDecodeRow: @unchecked Sendable {
 }
 
 public actor Q35Generator: ChatGenerator {
-    /// MERERUN_Q35_PREFILL_CHUNK_TOKENS overrides the prefill chunk length.
-    /// Larger chunks batch more routed-expert rows per gather matmul: on
-    /// Ornith 35B (M4 Max) a 6.8K-token prefill runs 1116 tok/s at 512,
-    /// 1238 tok/s at 1024, and regresses at 2048; outputs are byte-identical
-    /// across chunk sizes (causal chunking is exact).
-    private static let prefillChunkSize: Int = {
-        if let raw = ProcessInfo.processInfo.environment["MERERUN_Q35_PREFILL_CHUNK_TOKENS"],
-           let value = Int(raw), (64...8192).contains(value) {
-            return value
-        }
-        return 1024
-    }()
+    private static let contendedPrefillChunkSize = 512
+    private static let q38LowPrefillHeadroomBytes = UInt64(16) * 1_024 * 1_024 * 1_024
+    private static let minimumReclaimableCacheBytes = 256 * 1_024 * 1_024
     private static let prefixKVCacheMaxEntries = 4
     private static let defaultMTPBlockSize = 4
     private static let mtpPromptHistoryLimit = 4_096
@@ -171,6 +165,7 @@ public actor Q35Generator: ChatGenerator {
     private var decodeQueue: [Q35BatchedDecodeRow] = []
     private var activeDecodeRows: [Q35BatchedDecodeRow] = []
     private var decodeLoopRunning = false
+    private var activeChatRequestCount = 0
     private var batchedDecodeSteps = 0
     private var samePositionBatchedSteps = 0
     private var variablePositionBatchedSteps = 0
@@ -191,6 +186,77 @@ public actor Q35Generator: ChatGenerator {
         self.continuousBatchingEnabled = continuousBatchingEnabled
         self.visionMinPixels = visionMinPixels ?? visionPixelBounds.minimum
         self.visionMaxPixels = visionMaxPixels ?? visionPixelBounds.maximum
+    }
+
+    /// Select a prefill width from the model, live machine headroom, and current
+    /// scheduler contention. Q38's dense BF16 path must not infer activation
+    /// headroom from total physical memory: model residency and concurrent work
+    /// can consume most unified memory before prefill starts. The environment
+    /// override remains an upper bound, not permission to ignore live pressure.
+    static func prefillChunkSize(
+        modelId: String,
+        availableMemory: UInt64? = currentHostAvailableMemoryBytes(),
+        activeRequestCount: Int = 1,
+        environment: [String: String] = ProcessInfo.processInfo.environment
+    ) -> Int {
+        let configured = environment["MERERUN_Q35_PREFILL_CHUNK_TOKENS"]
+            .flatMap(Int.init)
+            .flatMap { (64...8192).contains($0) ? $0 : nil }
+        let base = configured ?? 1_024
+        if activeRequestCount > 1 {
+            return min(base, contendedPrefillChunkSize)
+        }
+        if Q35Resources.isQ38ModelId(modelId),
+           let availableMemory,
+           availableMemory < q38LowPrefillHeadroomBytes {
+            return min(base, contendedPrefillChunkSize)
+        }
+        return base
+    }
+
+    static func currentHostAvailableMemoryBytes() -> UInt64? {
+        #if canImport(Darwin)
+        var stats = vm_statistics64()
+        var count = mach_msg_type_number_t(MemoryLayout<vm_statistics64>.size) / 4
+        let result = withUnsafeMutablePointer(to: &stats) { pointer in
+            pointer.withMemoryRebound(to: integer_t.self, capacity: Int(count)) { rebound in
+                host_statistics64(mach_host_self(), HOST_VM_INFO64, rebound, &count)
+            }
+        }
+        guard result == KERN_SUCCESS else { return nil }
+        let pageSize = UInt64(getpagesize())
+        let availablePages = UInt64(stats.free_count) + UInt64(stats.inactive_count)
+        let availableBytes = availablePages.multipliedReportingOverflow(by: pageSize)
+        return availableBytes.overflow ? UInt64.max : availableBytes.partialValue
+        #else
+        return nil
+        #endif
+    }
+
+    static func shouldClearMLXCache(
+        activeMemory: Int,
+        cacheMemory: Int,
+        memoryLimit: Int
+    ) -> Bool {
+        guard activeMemory >= 0,
+              cacheMemory >= minimumReclaimableCacheBytes,
+              memoryLimit > 0 else {
+            return false
+        }
+        let total = activeMemory.addingReportingOverflow(cacheMemory)
+        guard !total.overflow else { return true }
+        return total.partialValue >= memoryLimit * 9 / 10
+    }
+
+    private func clearMLXCacheUnderPressureIfNeeded() {
+        let snapshot = Memory.snapshot()
+        if Self.shouldClearMLXCache(
+            activeMemory: snapshot.activeMemory,
+            cacheMemory: snapshot.cacheMemory,
+            memoryLimit: Memory.memoryLimit
+        ) {
+            Memory.clearCache()
+        }
     }
 
     static func qwen3VLTargetSize(
@@ -233,7 +299,9 @@ public actor Q35Generator: ChatGenerator {
         _ request: ChatRequest,
         progressHandler: (@Sendable (ChatProgress) -> Void)?
     ) async throws -> ChatResponse {
-        try await Stream.withNewDefaultStream {
+        activeChatRequestCount += 1
+        defer { activeChatRequestCount = max(0, activeChatRequestCount - 1) }
+        return try await Stream.withNewDefaultStream {
             let rootURL = try await resolveModelRoot(modelPath: nil, progressHandler: progressHandler)
             let loadStart = Date()
             try await ensureLoaded(rootURL: rootURL, progressHandler: progressHandler)
@@ -260,7 +328,9 @@ public actor Q35Generator: ChatGenerator {
         modelPath: String?,
         progressHandler: (@Sendable (ChatProgress) -> Void)?
     ) async throws -> ChatResponse {
-        try await Stream.withNewDefaultStream {
+        activeChatRequestCount += 1
+        defer { activeChatRequestCount = max(0, activeChatRequestCount - 1) }
+        return try await Stream.withNewDefaultStream {
             let rootURL = try await resolveModelRoot(modelPath: modelPath, progressHandler: progressHandler)
             let loadStart = Date()
             try await ensureLoaded(rootURL: rootURL, progressHandler: progressHandler)
@@ -434,6 +504,9 @@ public actor Q35Generator: ChatGenerator {
         let messages = request.messages
         let jsonConstrained = request.requiresJSON
         let includeThinking = request.showThinking && !jsonConstrained
+        let nativeReasoningEffort = Q35Resources.isQ38ModelId(modelId)
+            ? Q35Resources.q38ReasoningEffortLabel(for: request.reasoningEffort)
+            : nil
         let requestedContextLength = request.maxContextTokens ?? maxContextLength
         guard requestedContextLength > 0 else {
             throw Q35Error.generationFailed("maxContextTokens must be greater than zero.")
@@ -466,6 +539,7 @@ public actor Q35Generator: ChatGenerator {
             tools: request.tools,
             addGenerationPrompt: true,
             includeThinking: includeThinking,
+            reasoningEffort: nativeReasoningEffort,
             maxLength: effectiveContext,
             imageTokenCounts: visionReplacements.map { max(1, $0.embeddings.dim(0)) }
         )
@@ -528,6 +602,7 @@ public actor Q35Generator: ChatGenerator {
                 messages: messages,
                 tools: request.tools,
                 includeThinking: includeThinking,
+                reasoningEffort: nativeReasoningEffort,
                 promptTokens: promptTokens,
                 maxContextLength: effectiveContext
             )
@@ -671,10 +746,12 @@ public actor Q35Generator: ChatGenerator {
         jsonConstrained: Bool,
         continuousBatchingEnabled: Bool,
         mtpSpeculationEnabled: Bool,
+        schedulerContended: Bool = false,
         stopAtCompletedToolCall: Bool = false
     ) -> Q35DecodePath {
         if stopAtCompletedToolCall { return .pipelined }
         if jsonConstrained { return .jsonConstrainedSerial }
+        if mtpSpeculationEnabled, !schedulerContended { return .mtpSpeculativeSerial }
         if continuousBatchingEnabled { return .continuousBatched }
         if mtpSpeculationEnabled { return .mtpSpeculativeSerial }
         return .pipelined
@@ -772,6 +849,9 @@ public actor Q35Generator: ChatGenerator {
             jsonConstrained: jsonConstrained,
             continuousBatchingEnabled: continuousBatchingEnabled,
             mtpSpeculationEnabled: speculationMTP != nil,
+            schedulerContended: activeChatRequestCount > 1
+                || !decodeQueue.isEmpty
+                || !activeDecodeRows.isEmpty,
             stopAtCompletedToolCall: stopAtCompletedToolCall
         )
 
@@ -986,7 +1066,11 @@ public actor Q35Generator: ChatGenerator {
                         let candidateCaches = forkLayerCaches(layerCaches)
                         let candidateInput = MLXArray(([next] + draftTokens).map(Int32.init))
                             .reshaped(1, draftTokens.count + 1)
-                        let candidate = model.forward(candidateInput, cache: candidateCaches)
+                        let candidate = model.forward(
+                            candidateInput,
+                            cache: candidateCaches,
+                            targetVerify: true
+                        )
                         MLX.eval(candidate.logits)
                         MLX.eval(candidate.hidden)
                         mtpVerificationPasses += 1
@@ -1099,7 +1183,11 @@ public actor Q35Generator: ChatGenerator {
 
                     let candidateCaches = forkLayerCaches(layerCaches)
                     let candidateInput = MLXArray([Int32(next), Int32(draft)]).reshaped(1, 2)
-                    let candidate = model.forward(candidateInput, cache: candidateCaches)
+                    let candidate = model.forward(
+                        candidateInput,
+                        cache: candidateCaches,
+                        targetVerify: true
+                    )
                     MLX.eval(candidate.logits)
                     MLX.eval(candidate.hidden)
                     mtpVerificationPasses += 1
@@ -1216,7 +1304,7 @@ public actor Q35Generator: ChatGenerator {
 
         // Shared pipelined decode; mRoPE positions derive from the cache
         // offset, so the step closure computes them per forward.
-        var decodedToolCall = ""
+        var toolCallCompletionDetector = Q35ToolParser.StreamingCompletionDetector()
         let result = try AutoregressiveDecodeEngine.decode(
             AutoregressiveDecodeRequest(
                 initialLogits: initialLogits,
@@ -1239,8 +1327,7 @@ public actor Q35Generator: ChatGenerator {
             },
             shouldContinue: { _, piece in
                 guard stopAtCompletedToolCall else { return true }
-                decodedToolCall += piece
-                return !Q35ToolParser.containsCompletedToolCall(decodedToolCall)
+                return !toolCallCompletionDetector.feed(piece)
             },
             checkCancellation: { try Task.checkCancellation() }
         )
@@ -1658,13 +1745,17 @@ public actor Q35Generator: ChatGenerator {
         }
         while processed < promptTokens.count {
             try Task.checkCancellation()
+            let chunkSize = Self.prefillChunkSize(
+                modelId: modelId,
+                activeRequestCount: activeChatRequestCount
+            )
             let end = RuntimePrefillCheckpointPlanner.nextEnd(
                 processed: processed,
                 total: promptTokens.count,
-                chunkSize: Self.prefillChunkSize,
+                chunkSize: chunkSize,
                 checkpoints: checkpointTokenCounts
             )
-            if promptTokens.count > Self.prefillChunkSize {
+            if promptTokens.count > chunkSize {
                 progressHandler?(ChatProgress(stage: .encoding, message: "Prefilling \(end)/\(promptTokens.count) tokens"))
             }
             let chunk = MLXArray(promptTokens[processed..<end].map(Int32.init))
@@ -1699,6 +1790,7 @@ public actor Q35Generator: ChatGenerator {
                 logits = output.logits
                 hidden = nil
             }
+            clearMLXCacheUnderPressureIfNeeded()
             processed = end
             await Task.yield()
         }
@@ -1737,8 +1829,12 @@ public actor Q35Generator: ChatGenerator {
         var hidden: MLXArray?
         while processed < tokenCount {
             try Task.checkCancellation()
-            let end = min(processed + Self.prefillChunkSize, tokenCount)
-            if tokenCount > Self.prefillChunkSize {
+            let chunkSize = Self.prefillChunkSize(
+                modelId: modelId,
+                activeRequestCount: activeChatRequestCount
+            )
+            let end = min(processed + chunkSize, tokenCount)
+            if tokenCount > chunkSize {
                 progressHandler?(ChatProgress(stage: .encoding, message: "Prefilling \(end)/\(tokenCount) tokens"))
             }
             let chunkEmbeddings = inputEmbeddings[0..., processed..<end, 0...]
@@ -1766,6 +1862,7 @@ public actor Q35Generator: ChatGenerator {
                 logits = output.logits
                 hidden = nil
             }
+            clearMLXCacheUnderPressureIfNeeded()
             processed = end
             await Task.yield()
         }
@@ -1785,6 +1882,7 @@ public actor Q35Generator: ChatGenerator {
         messages: [ChatMessage],
         tools: [ToolDefinition]?,
         includeThinking: Bool,
+        reasoningEffort: String?,
         promptTokens: [Int],
         maxContextLength: Int
     ) -> Set<Int> {
@@ -1800,6 +1898,7 @@ public actor Q35Generator: ChatGenerator {
             tools: tools,
             addGenerationPrompt: false,
             includeThinking: includeThinking,
+            reasoningEffort: reasoningEffort,
             maxLength: maxContextLength
         ) else {
             return []
@@ -2006,7 +2105,7 @@ public actor Q35Generator: ChatGenerator {
         return index.weightMap.keys.contains { $0.hasPrefix("mtp.") }
     }
 
-    private static func mtpResources(primary resources: Q35Resources) -> Q35Resources? {
+    static func mtpResources(primary resources: Q35Resources) -> Q35Resources? {
         if hasMTPWeights(resources: resources) {
             return resources
         }

--- a/Sources/MereRunCore/Q35/Q35LinearAttention.swift
+++ b/Sources/MereRunCore/Q35/Q35LinearAttention.swift
@@ -32,18 +32,191 @@ private func q35Swiglu(_ gate: MLXArray, _ up: MLXArray) -> MLXArray {
     MLXNN.silu(gate) * up
 }
 
-private let q35RmsNormNoWeightCompiled = compile(shapeless: true) { x in
-    let squaredMean = (x * x).mean(axis: -1, keepDims: true)
-    return x * rsqrt(squaredMean + MLXArray(1e-6).asType(x.dtype))
+private func q35RmsNormNoWeight(
+    _ x: MLXArray,
+    weight: MLXArray? = nil,
+    eps: Float = 1e-6
+) -> MLXArray {
+    MLXFast.rmsNorm(
+        x,
+        weight: weight ?? MLXArray.ones([x.dim(x.ndim - 1)], dtype: x.dtype),
+        eps: eps
+    )
 }
 
-private func q35RmsNormNoWeight(_ x: MLXArray, eps: Float = 1e-6) -> MLXArray {
-    guard eps == 1e-6 else {
-        let squaredMean = (x * x).mean(axis: -1, keepDims: true)
-        return x * rsqrt(squaredMean + MLXArray(eps).asType(x.dtype))
-    }
-    return q35RmsNormNoWeightCompiled(x)
+struct Q35GDNPreworkOutput {
+    let q: MLXArray
+    let k: MLXArray
+    let v: MLXArray
+    let convState: MLXArray
 }
+
+func q35GDNPreworkOps(
+    qkv: MLXArray,
+    convState: MLXArray,
+    convWeight: MLXArray,
+    numKeyHeads: Int,
+    numValueHeads: Int,
+    keyHeadDim: Int,
+    valueHeadDim: Int,
+    rmsNormWeight: MLXArray? = nil
+) -> Q35GDNPreworkOutput {
+    let batch = qkv.dim(0)
+    let sequence = qkv.dim(1)
+    let convDim = qkv.dim(2)
+    let keep = convWeight.dim(1) - 1
+    let convInput = MLX.concatenated([convState, qkv], axis: 1)
+    let nextState = convInput[0..., (convInput.dim(1) - keep)..., 0...]
+    let convOut = MLXNN.silu(
+        MLX.conv1d(convInput, convWeight, groups: convDim)
+    )
+    let keyDim = numKeyHeads * keyHeadDim
+    let qConv = convOut[.ellipsis, 0..<keyDim]
+    let kConv = convOut[.ellipsis, keyDim..<(2 * keyDim)]
+    let vConv = convOut[.ellipsis, (2 * keyDim)...]
+
+    var q = qConv.reshaped(batch, sequence, numKeyHeads, keyHeadDim)
+    var k = kConv.reshaped(batch, sequence, numKeyHeads, keyHeadDim)
+    let v = vConv.reshaped(batch, sequence, numValueHeads, valueHeadDim)
+    let invScale = 1.0 / sqrt(Float(max(1, keyHeadDim)))
+    q = q35RmsNormNoWeight(q, weight: rmsNormWeight) * MLXArray(invScale * invScale).asType(q.dtype)
+    k = q35RmsNormNoWeight(k, weight: rmsNormWeight) * MLXArray(invScale).asType(k.dtype)
+
+    return Q35GDNPreworkOutput(q: q, k: k, v: v, convState: nextState)
+}
+
+#if os(macOS)
+private enum Q35GDNPreworkMetalKernel {
+    // Adapted under Apache-2.0 from the Qwen GDN verification prework source
+    // documented in THIRD_PARTY_NOTICES.md.
+    static let kernel = MLXFast.metalKernel(
+        name: "q35_gdn_verify_prework",
+        inputNames: ["qkv", "conv_state", "conv_w", "q_scale", "k_scale"],
+        outputNames: ["q_out", "k_out", "v_out", "conv_out"],
+        source: """
+            uint lane = thread_position_in_threadgroup.x;
+            uint row = threadgroup_position_in_grid.y;
+            uint logical_head = threadgroup_position_in_grid.z;
+            constexpr uint q_heads = uint(HK);
+            constexpr uint k_head_base = uint(HK);
+            constexpr uint v_head_base = 2 * uint(HK);
+            bool is_q = logical_head < q_heads;
+            bool is_k = logical_head >= k_head_base && logical_head < v_head_base;
+            uint head = is_q ? logical_head
+                       : (is_k ? logical_head - k_head_base : logical_head - v_head_base);
+            uint channel_base = is_q ? head * uint(DK)
+                               : (is_k ? uint(HK) * uint(DK) + head * uint(DK)
+                                       : 2 * uint(HK) * uint(DK) + head * uint(DV));
+            T activated[4];
+            float sumsq = 0.0f;
+            for (uint i = 0; i < 4; ++i) {
+                uint channel = channel_base + lane * 4 + i;
+                float acc = 0.0f;
+                for (uint tap = 0; tap < 4; ++tap) {
+                    uint input_row = row + tap;
+                    const T xv = input_row < uint(NKEEP)
+                        ? conv_state[input_row * uint(C) + channel]
+                        : qkv[(input_row - uint(NKEEP)) * uint(C) + channel];
+                    acc += float(xv) * float(conv_w[channel * 4 + tap]);
+                }
+                const T conv = T(acc);
+                T sy = T(1) / (T(1) + metal::exp(metal::abs(conv)));
+                const T act = conv * ((conv < T(0)) ? sy : T(1) - sy);
+                activated[i] = act;
+                float value = float(act);
+                sumsq += value * value;
+            }
+            if (is_q || is_k) {
+                sumsq = simd_sum(sumsq);
+                float inv = metal::precise::rsqrt(sumsq / float(DK) + 1e-6f);
+                const T scale = is_q ? q_scale : k_scale;
+                uint out_base = (row * uint(HK) + head) * uint(DK) + lane * 4;
+                for (uint i = 0; i < 4; ++i) {
+                    const T rms = T(1) * T(float(activated[i]) * inv);
+                    const T value = scale * rms;
+                    if (is_q) {
+                        q_out[out_base + i] = value;
+                    } else {
+                        k_out[out_base + i] = value;
+                    }
+                }
+            } else {
+                uint out_base = (row * uint(HV) + head) * uint(DV) + lane * 4;
+                for (uint i = 0; i < 4; ++i) {
+                    v_out[out_base + i] = activated[i];
+                }
+            }
+            if (row + uint(NKEEP) >= uint(S)) {
+                uint state_row = row + uint(NKEEP) - uint(S);
+                uint raw_base = row * uint(C) + channel_base + lane * 4;
+                uint state_base = state_row * uint(C) + channel_base + lane * 4;
+                for (uint i = 0; i < 4; ++i) {
+                    conv_out[state_base + i] = qkv[raw_base + i];
+                }
+            }
+            """
+    )
+}
+
+func q35GDNPreworkMetal(
+    qkv: MLXArray,
+    convState: MLXArray,
+    convWeight: MLXArray,
+    numKeyHeads: Int,
+    numValueHeads: Int,
+    keyHeadDim: Int,
+    valueHeadDim: Int
+) -> Q35GDNPreworkOutput? {
+    guard Device.defaultDevice().deviceType == .gpu,
+          qkv.ndim == 3,
+          qkv.dim(0) == 1,
+          (3...9).contains(qkv.dim(1)),
+          qkv.dtype == .bfloat16,
+          convState.shape == [1, 3, qkv.dim(2)],
+          convState.dtype == .bfloat16,
+          convWeight.shape == [qkv.dim(2), 4, 1],
+          convWeight.dtype == .bfloat16,
+          keyHeadDim == 128,
+          valueHeadDim == 128,
+          qkv.dim(2) == 2 * numKeyHeads * keyHeadDim + numValueHeads * valueHeadDim else {
+        return nil
+    }
+
+    let sequence = qkv.dim(1)
+    let convDim = qkv.dim(2)
+    let invScale = 1.0 / sqrt(Float(keyHeadDim))
+    let qScale = MLXArray(invScale * invScale).asType(.bfloat16)
+    let kScale = MLXArray(invScale).asType(.bfloat16)
+    let outputs = Q35GDNPreworkMetalKernel.kernel(
+        [qkv, convState, convWeight, qScale, kScale],
+        template: [
+            ("T", qkv.dtype),
+            ("HK", numKeyHeads),
+            ("HV", numValueHeads),
+            ("DK", keyHeadDim),
+            ("DV", valueHeadDim),
+            ("NKEEP", 3),
+            ("C", convDim),
+            ("S", sequence),
+        ],
+        grid: (32, sequence, 2 * numKeyHeads + numValueHeads),
+        threadGroup: (32, 1, 1),
+        outputShapes: [
+            [1, sequence, numKeyHeads, keyHeadDim],
+            [1, sequence, numKeyHeads, keyHeadDim],
+            [1, sequence, numValueHeads, valueHeadDim],
+            [1, 3, convDim],
+        ],
+        outputDTypes: Array(repeating: qkv.dtype, count: 4)
+    )
+    return Q35GDNPreworkOutput(
+        q: outputs[0],
+        k: outputs[1],
+        v: outputs[2],
+        convState: outputs[3]
+    )
+}
+#endif
 
 private func q35ConcatenatedOptional(_ lhs: MLXArray?, _ rhs: MLXArray?) -> MLXArray?? {
     switch (lhs, rhs) {
@@ -441,6 +614,7 @@ final class Q35LinearAttention: Module {
     private let valueDim: Int
     private let convDim: Int
     private let convKernelSize: Int
+    private let qkNormWeightBF16: MLXArray
     private var fusedInProjQKVZ: Linear?
     private var fusedInProjBA: Linear?
 
@@ -455,6 +629,7 @@ final class Q35LinearAttention: Module {
         self.valueDim = text.linearNumValueHeads * text.linearValueHeadDim
         self.convDim = self.keyDim * 2 + self.valueDim
         self.convKernelSize = max(1, text.linearConvKernelDim)
+        self.qkNormWeightBF16 = MLXArray.ones([self.keyHeadDim], dtype: .bfloat16)
 
         precondition(
             self.numValueHeads % max(1, self.numKeyHeads) == 0,
@@ -485,7 +660,8 @@ final class Q35LinearAttention: Module {
 
     func callAsFunction(
         _ x: MLXArray,
-        cache: Q35LinearCache?
+        cache: Q35LinearCache?,
+        targetVerify: Bool = false
     ) -> MLXArray {
         let batch = x.dim(0)
         let sequence = x.dim(1)
@@ -521,34 +697,51 @@ final class Q35LinearAttention: Module {
 
         let convState = cache?.convState
             ?? MLXArray.zeros([batch, keep, convDim], dtype: x.dtype)
-        let convInput = MLX.concatenated([convState, qkv], axis: 1)
-
-        if let cache {
-            if keep > 0 {
-                cache.convState = convInput[0..., (convInput.dim(1) - keep)..., 0...]
-            } else {
-                cache.convState = MLXArray.zeros([batch, 0, convDim], dtype: x.dtype)
-            }
+        let rmsNormWeight = qkv.dtype == .bfloat16 ? qkNormWeightBF16 : nil
+        let prework: Q35GDNPreworkOutput
+        #if os(macOS)
+        if targetVerify,
+           cache != nil,
+           let fused = q35GDNPreworkMetal(
+               qkv: qkv,
+               convState: convState,
+               convWeight: conv1d.weight,
+               numKeyHeads: numKeyHeads,
+               numValueHeads: numValueHeads,
+               keyHeadDim: keyHeadDim,
+               valueHeadDim: valueHeadDim
+           ) {
+            prework = fused
+        } else {
+            prework = q35GDNPreworkOps(
+                qkv: qkv,
+                convState: convState,
+                convWeight: conv1d.weight,
+                numKeyHeads: numKeyHeads,
+                numValueHeads: numValueHeads,
+                keyHeadDim: keyHeadDim,
+                valueHeadDim: valueHeadDim,
+                rmsNormWeight: rmsNormWeight
+            )
         }
-
-        let convOut = MLXNN.silu(conv1d(convInput))
-
-        let qConv = convOut[.ellipsis, 0..<keyDim]
-        let kConv = convOut[.ellipsis, keyDim..<(2 * keyDim)]
-        let vConv = convOut[.ellipsis, (2 * keyDim)...]
-
-        var q = qConv.reshaped(batch, sequence, numKeyHeads, keyHeadDim)
-        var k = kConv.reshaped(batch, sequence, numKeyHeads, keyHeadDim)
-        let v = vConv.reshaped(batch, sequence, numValueHeads, valueHeadDim)
-
-        let invScale = 1.0 / sqrt(Float(max(1, keyHeadDim)))
-        q = q35RmsNormNoWeight(q) * MLXArray(invScale * invScale).asType(q.dtype)
-        k = q35RmsNormNoWeight(k) * MLXArray(invScale).asType(k.dtype)
+        #else
+        prework = q35GDNPreworkOps(
+            qkv: qkv,
+            convState: convState,
+            convWeight: conv1d.weight,
+            numKeyHeads: numKeyHeads,
+            numValueHeads: numValueHeads,
+            keyHeadDim: keyHeadDim,
+            valueHeadDim: valueHeadDim,
+            rmsNormWeight: rmsNormWeight
+        )
+        #endif
+        cache?.convState = prework.convState
 
         let (updated, state) = q35GatedDeltaUpdate(
-            q: q,
-            k: k,
-            v: v,
+            q: prework.q,
+            k: prework.k,
+            v: prework.v,
             a: a,
             b: b,
             aLog: aLog,

--- a/Sources/MereRunCore/Q35/Q35Model.swift
+++ b/Sources/MereRunCore/Q35/Q35Model.swift
@@ -93,7 +93,8 @@ final class Q35DecoderLayer: Module {
         _ x: MLXArray,
         fullMask: MLXFast.ScaledDotProductAttentionMaskMode,
         cache: Q35LayerCache?,
-        positionIds: MLXArray? = nil
+        positionIds: MLXArray? = nil,
+        targetVerify: Bool = false
     ) -> MLXArray {
         var h = x
         if !isMLPOnly {
@@ -107,7 +108,11 @@ final class Q35DecoderLayer: Module {
                 } else {
                     linearCache = nil
                 }
-                attentionOut = linearAttention(normed, cache: linearCache)
+                attentionOut = linearAttention(
+                    normed,
+                    cache: linearCache,
+                    targetVerify: targetVerify
+                )
             case .full:
                 let fullCache: KVCache?
                 if case .full(let cache)? = cache {
@@ -165,7 +170,8 @@ final class Q35Transformer: Module {
         _ inputIds: MLXArray,
         cache: [Q35LayerCache?]?,
         inputEmbeddings: MLXArray? = nil,
-        positionIds: MLXArray? = nil
+        positionIds: MLXArray? = nil,
+        targetVerify: Bool = false
     ) -> MLXArray {
         var hidden = inputEmbeddings ?? embeddings(for: inputIds)
 
@@ -178,7 +184,8 @@ final class Q35Transformer: Module {
                 hidden,
                 fullMask: fullMask,
                 cache: layerCache,
-                positionIds: positionIds
+                positionIds: positionIds,
+                targetVerify: targetVerify
             )
             Q35DebugLayerDump.record(stage: "layer\(index)", hidden)
         }
@@ -418,13 +425,15 @@ public final class Q35Model: Module, @unchecked Sendable {
         _ inputIds: MLXArray,
         cache: [Q35LayerCache?]?,
         inputEmbeddings: MLXArray? = nil,
-        positionIds: MLXArray? = nil
+        positionIds: MLXArray? = nil,
+        targetVerify: Bool = false
     ) -> Q35ForwardOutput {
         let hidden = model(
             inputIds,
             cache: cache,
             inputEmbeddings: inputEmbeddings,
-            positionIds: positionIds
+            positionIds: positionIds,
+            targetVerify: targetVerify
         )
         return Q35ForwardOutput(hidden: hidden, logits: logits(from: hidden))
     }

--- a/Sources/MereRunCore/Q35/Q35Resources.swift
+++ b/Sources/MereRunCore/Q35/Q35Resources.swift
@@ -54,6 +54,15 @@ public struct Q35Resources: Sendable, Hashable {
         modelId == bonsai27B1BitModelId || modelId == bonsai27B2BitModelId
     }
 
+    /// Convert the public continuous reasoning control into the three native
+    /// levels accepted by the pinned Qwen3.8 chat template.
+    public static func q38ReasoningEffortLabel(for strength: Double?) -> String? {
+        guard let strength else { return nil }
+        if strength < 1.0 / 3.0 { return "low" }
+        if strength < 2.0 / 3.0 { return "medium" }
+        return "xhigh"
+    }
+
     public struct RecommendedSampling: Sendable, Hashable {
         public let temperature: Double
         public let topP: Double

--- a/Sources/MereRunCore/Q35/Q35TokenizerAndTemplate.swift
+++ b/Sources/MereRunCore/Q35/Q35TokenizerAndTemplate.swift
@@ -32,6 +32,7 @@ public struct Q35TokenizerAndTemplate {
         tools: [ToolDefinition]? = nil,
         addGenerationPrompt: Bool = true,
         includeThinking: Bool = true,
+        reasoningEffort: String? = nil,
         maxLength: Int,
         imageTokenCounts: [Int] = []
     ) throws -> [Int] {
@@ -41,6 +42,7 @@ public struct Q35TokenizerAndTemplate {
             tools: toolSpecs,
             addGenerationPrompt: addGenerationPrompt,
             includeThinking: includeThinking,
+            reasoningEffort: reasoningEffort,
             maxLength: tokenizer.maxLength
         )
         if !imageTokenCounts.isEmpty {

--- a/Sources/MereRunCore/Q35/Q35ToolParser.swift
+++ b/Sources/MereRunCore/Q35/Q35ToolParser.swift
@@ -16,43 +16,203 @@ import Foundation
 public enum Q35ToolParser {
     public static let closingTag = "</tool_call>"
 
-    private static let callPattern = #"(?s)<tool_call>\s*(.*?)\s*</tool_call>"#
-    private static let functionPattern = #"(?s)<function=([^>\r\n]+)>\s*(.*?)\s*</function>"#
-    private static let parameterPattern = #"(?s)<parameter=([^>\r\n]+)>\s*(.*?)\s*</parameter>"#
+    private static let openingTag = "<tool_call>"
+    private static let functionOpeningTag = "<function="
+    private static let functionClosingTag = "</function>"
+    private static let parameterOpeningTag = "<parameter="
+    private static let parameterClosingTag = "</parameter>"
+
+    /// Incremental completion detector for token streaming.
+    ///
+    /// Most tokens cannot complete a tool call, so structural parsing only runs
+    /// after a newly streamed closing marker. The number of reparses is bounded
+    /// to keep attacker-controlled output from creating quadratic work. If the
+    /// bound is exhausted, generation continues to EOS and the final response
+    /// still goes through the unbounded, linear structural parser.
+    public struct StreamingCompletionDetector: Sendable {
+        private static let maximumStructuralChecks = 64
+
+        private var bufferedText = ""
+        private var markerTail = ""
+        private var structuralChecks = 0
+
+        public init() {}
+
+        public mutating func feed(_ piece: String) -> Bool {
+            guard !piece.isEmpty else { return false }
+            bufferedText += piece
+
+            let markerWindow = markerTail + piece
+            let newMarkerCount = Q35ToolParser.occurrenceCount(
+                of: Q35ToolParser.closingTag,
+                in: markerWindow
+            )
+            markerTail = String(markerWindow.suffix(max(0, Q35ToolParser.closingTag.count - 1)))
+
+            guard newMarkerCount > 0,
+                  structuralChecks < Self.maximumStructuralChecks else {
+                return false
+            }
+            structuralChecks += newMarkerCount
+            return Q35ToolParser.containsCompletedToolCall(bufferedText)
+        }
+    }
 
     public static func parseToolCalls(_ text: String) -> [ToolCall] {
-        matches(pattern: callPattern, in: text).compactMap { call in
-            guard call.count == 2,
-                  let function = matches(pattern: functionPattern, in: call[1]).first,
-                  function.count == 3 else {
-                return nil
-            }
-
-            let name = function[1].trimmingCharacters(in: .whitespacesAndNewlines)
-            guard !name.isEmpty else { return nil }
-
-            var arguments: [String: String] = [:]
-            for parameter in matches(pattern: parameterPattern, in: function[2]) where parameter.count == 3 {
-                let key = parameter[1].trimmingCharacters(in: .whitespacesAndNewlines)
-                guard !key.isEmpty else { continue }
-                arguments[key] = parameter[2].trimmingCharacters(in: .whitespacesAndNewlines)
-            }
-            return ToolCall(name: name, arguments: arguments)
-        }
+        parsedEnvelopes(in: text).compactMap(\.toolCall)
     }
 
     public static func containsCompletedToolCall(_ text: String) -> Bool {
-        text.contains(closingTag)
+        firstParsedEnvelope(in: text, startingAt: text.startIndex) != nil
     }
 
-    private static func matches(pattern: String, in text: String) -> [[String]] {
-        guard let expression = try? NSRegularExpression(pattern: pattern) else { return [] }
-        let fullRange = NSRange(text.startIndex..<text.endIndex, in: text)
-        return expression.matches(in: text, range: fullRange).map { match in
-            (0..<match.numberOfRanges).map { index in
-                guard let range = Range(match.range(at: index), in: text) else { return "" }
-                return String(text[range])
+    private struct ParsedEnvelope {
+        let endIndex: String.Index
+        let toolCall: ToolCall?
+    }
+
+    private static func parsedEnvelopes(in text: String) -> [ParsedEnvelope] {
+        var parsed: [ParsedEnvelope] = []
+        var cursor = text.startIndex
+
+        while cursor < text.endIndex,
+              let openingRange = text.range(
+                  of: openingTag,
+                  range: cursor..<text.endIndex
+              ) {
+            if let envelope = parseEnvelope(in: text, openingRange: openingRange) {
+                parsed.append(envelope)
+                cursor = envelope.endIndex
+            } else {
+                cursor = openingRange.upperBound
             }
         }
+
+        return parsed
+    }
+
+    private static func firstParsedEnvelope(
+        in text: String,
+        startingAt cursor: String.Index
+    ) -> ParsedEnvelope? {
+        var searchCursor = cursor
+        while searchCursor < text.endIndex,
+              let openingRange = text.range(
+                  of: openingTag,
+                  range: searchCursor..<text.endIndex
+              ) {
+            if let envelope = parseEnvelope(in: text, openingRange: openingRange) {
+                return envelope
+            }
+            searchCursor = openingRange.upperBound
+        }
+        return nil
+    }
+
+    /// Parse one envelope by following sibling parameter elements. A parameter
+    /// close is structural only when the next non-space token is another
+    /// parameter or the enclosing function close. Marker-shaped text inside a
+    /// value is therefore preserved instead of truncating the call.
+    private static func parseEnvelope(
+        in text: String,
+        openingRange: Range<String.Index>
+    ) -> ParsedEnvelope? {
+        var cursor = skipWhitespace(in: text, from: openingRange.upperBound)
+        guard text[cursor...].hasPrefix(functionOpeningTag) else { return nil }
+
+        let nameStart = text.index(cursor, offsetBy: functionOpeningTag.count)
+        guard let nameEnd = elementOpeningTagEnd(in: text, from: nameStart) else {
+            return nil
+        }
+        let name = text[nameStart..<nameEnd]
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        cursor = text.index(after: nameEnd)
+
+        var arguments: [String: String] = [:]
+        while true {
+            cursor = skipWhitespace(in: text, from: cursor)
+
+            if text[cursor...].hasPrefix(functionClosingTag) {
+                let functionEnd = text.index(cursor, offsetBy: functionClosingTag.count)
+                let callClose = skipWhitespace(in: text, from: functionEnd)
+                guard text[callClose...].hasPrefix(closingTag) else { return nil }
+                let envelopeEnd = text.index(callClose, offsetBy: closingTag.count)
+                let toolCall = name.isEmpty ? nil : ToolCall(name: name, arguments: arguments)
+                return ParsedEnvelope(endIndex: envelopeEnd, toolCall: toolCall)
+            }
+
+            guard text[cursor...].hasPrefix(parameterOpeningTag) else { return nil }
+            let keyStart = text.index(cursor, offsetBy: parameterOpeningTag.count)
+            guard let keyEnd = elementOpeningTagEnd(in: text, from: keyStart) else {
+                return nil
+            }
+            let key = text[keyStart..<keyEnd]
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            let valueStart = text.index(after: keyEnd)
+            guard let valueClose = structuralParameterClose(
+                in: text,
+                valueStart: valueStart
+            ) else {
+                return nil
+            }
+
+            if !key.isEmpty {
+                arguments[key] = text[valueStart..<valueClose.lowerBound]
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+            }
+            cursor = valueClose.upperBound
+        }
+    }
+
+    private static func elementOpeningTagEnd(
+        in text: String,
+        from start: String.Index
+    ) -> String.Index? {
+        guard let end = text[start...].firstIndex(of: ">") else { return nil }
+        guard !text[start..<end].contains(where: { $0.isNewline }) else { return nil }
+        return end
+    }
+
+    private static func structuralParameterClose(
+        in text: String,
+        valueStart: String.Index
+    ) -> Range<String.Index>? {
+        var searchCursor = valueStart
+        while searchCursor < text.endIndex,
+              let closeRange = text.range(
+                  of: parameterClosingTag,
+                  range: searchCursor..<text.endIndex
+              ) {
+            let nextToken = skipWhitespace(in: text, from: closeRange.upperBound)
+            if text[nextToken...].hasPrefix(parameterOpeningTag)
+                || text[nextToken...].hasPrefix(functionClosingTag) {
+                return closeRange
+            }
+            searchCursor = closeRange.upperBound
+        }
+        return nil
+    }
+
+    private static func skipWhitespace(
+        in text: String,
+        from start: String.Index
+    ) -> String.Index {
+        var cursor = start
+        while cursor < text.endIndex, text[cursor].isWhitespace {
+            cursor = text.index(after: cursor)
+        }
+        return cursor
+    }
+
+    private static func occurrenceCount(of needle: String, in text: String) -> Int {
+        guard !needle.isEmpty else { return 0 }
+        var count = 0
+        var cursor = text.startIndex
+        while cursor < text.endIndex,
+              let range = text.range(of: needle, range: cursor..<text.endIndex) {
+            count += 1
+            cursor = range.upperBound
+        }
+        return count
     }
 }

--- a/Sources/MereRunCore/Q35/README.md
+++ b/Sources/MereRunCore/Q35/README.md
@@ -34,3 +34,17 @@ rows execute on a disposable fork. The exact target projection still verifies
 every emitted token. Per-request acceptance estimates adapt the draft depth and
 can fall back to target-only rounds when proposals stop paying for their repair
 cost. Sampled MTP keeps the full-vocabulary probability path.
+
+Qwen3.8 target verification marks its model forward explicitly. On macOS, only
+that marked path may use the fused BF16 GDN prework kernel, and only for batch
+one, a four-tap depthwise convolution, 128-wide key/value heads, and sequence
+widths 3–9. The kernel replaces convolution-state concatenation, depthwise
+Conv1d, SiLU, q/k/v preparation, RMS normalization, scaling, and next-state
+capture. Decode, prefill, unsupported shapes, and non-Metal platforms retain
+the composed operations. Metal tests require bit-exact parity for widths 3, 4,
+5, 7, and 9.
+
+The streaming tool-call parser walks the Qwen XML structure rather than using
+delimiter search. A closing tag is accepted only at its structural position,
+so strings containing tag-like text remain parameter data. Streaming reparses
+are bounded; EOS still receives a final structural parse.

--- a/Sources/MereRunCore/ZImageTurbo/Tokenizer/QwenTokenizer.swift
+++ b/Sources/MereRunCore/ZImageTurbo/Tokenizer/QwenTokenizer.swift
@@ -48,8 +48,15 @@ public final class QwenTokenizer {
     tools: [ToolSpec]? = nil,
     addGenerationPrompt: Bool = true,
     includeThinking: Bool = true,
+    reasoningEffort: String? = nil,
     maxLength: Int? = nil
   ) throws -> [Int] {
+    var additionalContext: [String: any Sendable] = [
+      "enable_thinking": includeThinking
+    ]
+    if let reasoningEffort {
+      additionalContext["reasoning_effort"] = reasoningEffort
+    }
     var encoded = try tokenizer.applyChatTemplate(
       messages: messages,
       chatTemplate: nil,
@@ -57,7 +64,7 @@ public final class QwenTokenizer {
       truncation: false,
       maxLength: nil,
       tools: tools,
-      additionalContext: ["enable_thinking": includeThinking]
+      additionalContext: additionalContext
     )
     let targetLength = min(maxLength ?? self.maxLength, self.maxLength)
     if encoded.count > targetLength {

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -301,6 +301,18 @@ SOFTWARE.
 
 ## Source-derived runtime implementations
 
+### Qwen3.5/3.6 GDN verification prework provenance
+
+- purpose: the macOS Metal kernel that fuses Qwen-family gated-delta
+  convolution, SiLU, q/k/v preparation, RMS normalization, scaling, and
+  convolution-state advance during MTP target verification
+- upstream project: [`jundot/omlx`](https://github.com/jundot/omlx), tag
+  `v0.6.1`, revision `b587575f3696fbc86c236b906684a48a92f8b118`
+- upstream file: `omlx/patches/qwen35_gdn_prework.py`
+- lineage noted by the upstream project: adapted from `mlx-serve`, itself a port of the
+  `mlxfast-challenge` Qwen3.5 packed GDN prework kernel
+- license: [Apache License 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+
 ### Poolside Laguna 2.1 native runtime
 
 - purpose: native Swift/MLX loading, attention, routed-MoE, tokenizer/template,

--- a/Tests/MereRunCLITests/APIServeCommandTests.swift
+++ b/Tests/MereRunCLITests/APIServeCommandTests.swift
@@ -2689,6 +2689,28 @@ final class APIServeCommandTests: XCTestCase {
         XCTAssertEqual(chatRequest.reasoningEffort, 0.8)
     }
 
+    func testQ38ReasoningAliasesMapToNativeXHighStrength() throws {
+        let profile = try XCTUnwrap(
+            ManagedModelCatalog.apiProfile(for: Q35Resources.q38TwentySevenB4BitModelId)
+        )
+        let request = OpenAIChatRequest(
+            model: Q35Resources.q38TwentySevenB4BitModelId,
+            messages: [OpenAIChatMessage(role: "user", content: "hello")],
+            reasoning_effort: "high"
+        )
+
+        let chatRequest = try APIServerContract.chatRequest(
+            from: request,
+            fallbackLoraPath: nil,
+            contextSize: 4_096,
+            capabilities: .catalog(profile),
+            servedModelID: Q35Resources.q38TwentySevenB4BitModelId
+        )
+
+        XCTAssertEqual(chatRequest.reasoningEffort, 1)
+        XCTAssertTrue(chatRequest.showThinking)
+    }
+
     func testStreamingUsageOptionHonorsCapabilities() throws {
         let request = OpenAIChatRequest(
             model: "mererun-test-model",

--- a/Tests/MereRunCLITests/RuntimeModelPoolTests.swift
+++ b/Tests/MereRunCLITests/RuntimeModelPoolTests.swift
@@ -822,6 +822,7 @@ final class RuntimeModelPoolTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: root) }
         let samples = RuntimeMemorySampleSequenceProbe([
             RuntimeMemorySample(physicalBytes: 100 * gib, residentBytes: 95 * gib),
+            RuntimeMemorySample(physicalBytes: 100 * gib, residentBytes: 95 * gib),
             RuntimeMemorySample(physicalBytes: 100 * gib, residentBytes: 10 * gib),
         ])
         let pool = RuntimeModelPool(
@@ -843,13 +844,43 @@ final class RuntimeModelPoolTests: XCTestCase {
         let evicted = await pool.relieveMemoryPressure()
 
         XCTAssertEqual(evicted, [Gemma4Resources.defaultModelId])
-        XCTAssertEqual(samples.readCount(), 2)
+        XCTAssertEqual(samples.readCount(), 3)
         let status = await pool.status()
         let gemma = try XCTUnwrap(status.models.first { $0.id == Gemma4Resources.defaultModelId })
         let q35 = try XCTUnwrap(status.models.first { $0.id == Q35Resources.defaultModelId })
         XCTAssertFalse(gemma.loaded)
         XCTAssertTrue(q35.loaded)
         XCTAssertEqual(q35.ready, true)
+    }
+
+    func testPressureReliefClearsReusableBuffersBeforeEvictingModels() async throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let samples = RuntimeMemorySampleSequenceProbe([
+            RuntimeMemorySample(physicalBytes: 100 * gib, residentBytes: 95 * gib),
+            RuntimeMemorySample(physicalBytes: 100 * gib, residentBytes: 10 * gib),
+        ])
+        let clears = RuntimeSynchronousCounterProbe()
+        let pool = RuntimeModelPool(
+            defaultModelID: "custom.gguf",
+            defaultEngine: .textCode,
+            startupModelPath: root.appendingPathComponent("custom.gguf").path,
+            settingsStore: RuntimeModelSettingsStore(modelsDir: root),
+            currentMemorySample: { samples.next() },
+            clearMLXCache: { clears.increment() }
+        )
+        await pool.seedLoadedModelForTesting(
+            id: Gemma4Resources.defaultModelId,
+            lastAccess: Date(timeIntervalSince1970: 10)
+        )
+
+        let evicted = await pool.relieveMemoryPressure()
+
+        XCTAssertTrue(evicted.isEmpty)
+        XCTAssertEqual(clears.value(), 1)
+        XCTAssertEqual(samples.readCount(), 2)
+        let status = await pool.status()
+        XCTAssertTrue(status.models.first { $0.id == Gemma4Resources.defaultModelId }?.loaded ?? false)
     }
 
     func testPressureReliefPreservesStartupDefaultByDefault() async throws {
@@ -888,6 +919,7 @@ final class RuntimeModelPoolTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: root) }
         let samples = RuntimeMemorySampleSequenceProbe([
             RuntimeMemorySample(physicalBytes: 100 * gib, residentBytes: 95 * gib),
+            RuntimeMemorySample(physicalBytes: 100 * gib, residentBytes: 95 * gib),
             RuntimeMemorySample(physicalBytes: 100 * gib, residentBytes: 10 * gib),
         ])
         let pool = RuntimeModelPool(
@@ -909,7 +941,7 @@ final class RuntimeModelPoolTests: XCTestCase {
         let evicted = await pool.relieveMemoryPressure(preserveDefault: false)
 
         XCTAssertEqual(evicted, ["custom.gguf"])
-        XCTAssertEqual(samples.readCount(), 2)
+        XCTAssertEqual(samples.readCount(), 3)
     }
 
     func testMemoryPressureLRUHonorsExcludedModel() async throws {
@@ -1471,5 +1503,22 @@ private final class RuntimeMemorySampleSequenceProbe: @unchecked Sendable {
         lock.lock()
         defer { lock.unlock() }
         return index
+    }
+}
+
+private final class RuntimeSynchronousCounterProbe: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+
+    func increment() {
+        lock.lock()
+        count += 1
+        lock.unlock()
+    }
+
+    func value() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return count
     }
 }

--- a/Tests/MereRunCLITests/SetupCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/SetupCommandParsingTests.swift
@@ -133,7 +133,17 @@ final class SetupCommandParsingTests: XCTestCase {
         XCTAssertEqual(providerModel.id, Q35Resources.q38TwentySevenBModelId)
         XCTAssertEqual(providerModel.contextWindow, Q35Resources.q38TwentySevenBContextLength)
         XCTAssertEqual(providerModel.maxTokens, 4_096)
+        XCTAssertTrue(providerModel.reasoning)
         XCTAssertTrue(providerModel.toolCall)
+        XCTAssertTrue(providerModel.supportsReasoningEffort)
+        XCTAssertEqual(
+            providerModel.thinkingLevelMap?.first { $0.key == "high" }?.value,
+            "xhigh"
+        )
+        XCTAssertEqual(
+            providerModel.thinkingLevelMap?.first { $0.key == "max" }?.value,
+            "xhigh"
+        )
         XCTAssertTrue(runtime.recommendation.isStartableByMereRun)
         XCTAssertEqual(runtime.recommendation.servingEngine, .textChatQ36)
     }

--- a/Tests/MereRunCLITests/TextChatCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/TextChatCommandParsingTests.swift
@@ -195,6 +195,21 @@ final class TextChatCommandParsingTests: XCTestCase {
         )
     }
 
+    func testQ38AcceptsContinuousReasoningEffort() throws {
+        XCTAssertNoThrow(
+            try TextChat.validateReasoningEffort(
+                0.5,
+                modelID: Q35Resources.q38TwentySevenB4BitModelId
+            )
+        )
+        XCTAssertThrowsError(
+            try TextChat.validateReasoningEffort(
+                1.1,
+                modelID: Q35Resources.q38TwentySevenBModelId
+            )
+        )
+    }
+
     func testMuseGlimmerDFlashStatsAreMachineScannable() {
         let formatted = TextChat.formatMuseDFlashStats(MuseGlimmerDFlashStats(
             enabled: true,

--- a/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
@@ -782,6 +782,9 @@ final class ManagedModelCatalogTests: XCTestCase {
         XCTAssertEqual(spec.hubFallback?.patterns.contains("generation_config.json"), true)
         XCTAssertEqual(spec.hubFallback?.patterns.contains("preprocessor_config.json"), true)
         XCTAssertEqual(spec.hubFallback?.patterns.contains("video_preprocessor_config.json"), true)
+        XCTAssertEqual(spec.apiProfile?.thinkingLevels, [.low, .medium, .xhigh])
+        XCTAssertEqual(spec.apiProfile?.thinkingLevelMap[.high], .xhigh)
+        XCTAssertEqual(spec.apiProfile?.compatibility.supportsReasoningEffort, true)
     }
 
     func testQ38TwentySevenB4BitUsesCrownedTargetAndQuantizedMTPHead() throws {
@@ -825,6 +828,9 @@ final class ManagedModelCatalogTests: XCTestCase {
         XCTAssertEqual(spec.estimatedDownloadBytes, 15_392_000_000)
         XCTAssertFalse(spec.runtimeAutoDownloadAllowed)
         XCTAssertTrue(spec.defaultCLICommands.contains("model benchmark code"))
+        XCTAssertEqual(spec.apiProfile?.thinkingLevels, [.low, .medium, .xhigh])
+        XCTAssertEqual(spec.apiProfile?.thinkingLevelMap[.minimal], .low)
+        XCTAssertEqual(spec.apiProfile?.thinkingLevelMap[.max], .xhigh)
     }
 
     func testQ38TwentySevenB4BitValidationRequiresMountedMTPFiles() throws {

--- a/Tests/MereRunCoreTests/Q35ConfigDecodingTests.swift
+++ b/Tests/MereRunCoreTests/Q35ConfigDecodingTests.swift
@@ -247,6 +247,157 @@ final class Q35ConfigDecodingTests: MereRunCoreTestCase {
         XCTAssertEqual(outputMaxDiff, 0, accuracy: 1e-5)
         XCTAssertEqual(stateMaxDiff, 0, accuracy: 1e-5)
     }
+
+    func testQ35GDNVerifyPreworkMetalIsBitExactAtClaimedWidths() throws {
+        guard Device.defaultDevice().deviceType == .gpu else {
+            throw XCTSkip("Q35 GDN prework Metal parity requires MERERUN_TEST_MLX_DEVICE=gpu.")
+        }
+
+        let numKeyHeads = 16
+        let numValueHeads = 48
+        let keyHeadDim = 128
+        let valueHeadDim = 128
+        let convDim = 2 * numKeyHeads * keyHeadDim + numValueHeads * valueHeadDim
+
+        for sequence in [3, 4, 5, 7, 9] {
+            MLXRandom.seed(11)
+            let qkv = MLXRandom.uniform(-0.5 ..< 0.5, [1, sequence, convDim]).asType(.bfloat16)
+            let state = MLXRandom.uniform(-0.5 ..< 0.5, [1, 3, convDim]).asType(.bfloat16)
+            let weight = MLXRandom.uniform(-0.2 ..< 0.2, [convDim, 4, 1]).asType(.bfloat16)
+            let reference = q35GDNPreworkOps(
+                qkv: qkv,
+                convState: state,
+                convWeight: weight,
+                numKeyHeads: numKeyHeads,
+                numValueHeads: numValueHeads,
+                keyHeadDim: keyHeadDim,
+                valueHeadDim: valueHeadDim
+            )
+            let fast = try XCTUnwrap(q35GDNPreworkMetal(
+                qkv: qkv,
+                convState: state,
+                convWeight: weight,
+                numKeyHeads: numKeyHeads,
+                numValueHeads: numValueHeads,
+                keyHeadDim: keyHeadDim,
+                valueHeadDim: valueHeadDim
+            ))
+
+            for (name, expected, actual) in [
+                ("q", reference.q, fast.q),
+                ("k", reference.k, fast.k),
+                ("v", reference.v, fast.v),
+                ("convState", reference.convState, fast.convState),
+            ] {
+                MLX.eval(expected, actual)
+                XCTAssertEqual(actual.shape, expected.shape, "\(name), S=\(sequence)")
+                XCTAssertTrue(
+                    MLX.allClose(expected, actual, rtol: 0, atol: 0).item(Bool.self),
+                    "\(name) was not bit-exact at S=\(sequence)"
+                )
+            }
+        }
+    }
+
+    func testQ35GDNVerifyPreworkBenchmarkWhenEnabled() throws {
+        guard ProcessInfo.processInfo.environment["MERERUN_TEST_Q35_GDN_BENCHMARK"] == "1" else {
+            throw XCTSkip("Set MERERUN_TEST_Q35_GDN_BENCHMARK=1 to measure fused GDN prework.")
+        }
+        guard Device.defaultDevice().deviceType == .gpu else {
+            throw XCTSkip("Q35 GDN prework benchmark requires MERERUN_TEST_MLX_DEVICE=gpu.")
+        }
+
+        let numKeyHeads = 16
+        let numValueHeads = 48
+        let keyHeadDim = 128
+        let valueHeadDim = 128
+        let convDim = 2 * numKeyHeads * keyHeadDim + numValueHeads * valueHeadDim
+        let iterations = 50
+        let rmsNormWeight = MLXArray.ones([keyHeadDim], dtype: .bfloat16)
+
+        for sequence in [4, 9] {
+            MLXRandom.seed(17)
+            let qkv = MLXRandom.uniform(-0.5 ..< 0.5, [1, sequence, convDim]).asType(.bfloat16)
+            let state = MLXRandom.uniform(-0.5 ..< 0.5, [1, 3, convDim]).asType(.bfloat16)
+            let weight = MLXRandom.uniform(-0.2 ..< 0.2, [convDim, 4, 1]).asType(.bfloat16)
+
+            func reference() -> Q35GDNPreworkOutput {
+                q35GDNPreworkOps(
+                    qkv: qkv,
+                    convState: state,
+                    convWeight: weight,
+                    numKeyHeads: numKeyHeads,
+                    numValueHeads: numValueHeads,
+                    keyHeadDim: keyHeadDim,
+                    valueHeadDim: valueHeadDim,
+                    rmsNormWeight: rmsNormWeight
+                )
+            }
+
+            func fused() throws -> Q35GDNPreworkOutput {
+                try XCTUnwrap(q35GDNPreworkMetal(
+                    qkv: qkv,
+                    convState: state,
+                    convWeight: weight,
+                    numKeyHeads: numKeyHeads,
+                    numValueHeads: numValueHeads,
+                    keyHeadDim: keyHeadDim,
+                    valueHeadDim: valueHeadDim
+                ))
+            }
+
+            func evaluate(_ output: Q35GDNPreworkOutput) {
+                MLX.eval(output.q, output.k, output.v, output.convState)
+            }
+
+            for _ in 0..<3 {
+                evaluate(reference())
+                evaluate(try fused())
+            }
+
+            let referenceStart = Date()
+            for _ in 0..<iterations {
+                evaluate(reference())
+            }
+            let referenceSeconds = Date().timeIntervalSince(referenceStart)
+
+            let fusedStart = Date()
+            for _ in 0..<iterations {
+                evaluate(try fused())
+            }
+            let fusedSeconds = Date().timeIntervalSince(fusedStart)
+            let referenceMilliseconds = referenceSeconds * 1_000 / Double(iterations)
+            let fusedMilliseconds = fusedSeconds * 1_000 / Double(iterations)
+            let speedup = referenceMilliseconds / fusedMilliseconds
+            print(String(
+                format: "q35_gdn_prework_benchmark sequence=%d iterations=%d reference_ms=%.4f fused_ms=%.4f speedup=%.3fx",
+                sequence,
+                iterations,
+                referenceMilliseconds,
+                fusedMilliseconds,
+                speedup
+            ))
+        }
+    }
+
+    func testQ35GDNVerifyPreworkRejectsDecodeWidth() throws {
+        guard Device.defaultDevice().deviceType == .gpu else {
+            throw XCTSkip("Q35 GDN prework eligibility requires MERERUN_TEST_MLX_DEVICE=gpu.")
+        }
+        let qkv = MLXArray.zeros([1, 1, 10_240], dtype: .bfloat16)
+        let state = MLXArray.zeros([1, 3, 10_240], dtype: .bfloat16)
+        let weight = MLXArray.zeros([10_240, 4, 1], dtype: .bfloat16)
+
+        XCTAssertNil(q35GDNPreworkMetal(
+            qkv: qkv,
+            convState: state,
+            convWeight: weight,
+            numKeyHeads: 16,
+            numValueHeads: 48,
+            keyHeadDim: 128,
+            valueHeadDim: 128
+        ))
+    }
     #endif
 
     func testQ35RMSNormOffsetConversionSkipsLinearAttentionGateNorm() {
@@ -371,6 +522,34 @@ final class Q35ConfigDecodingTests: MereRunCoreTestCase {
             "<|vision_start|><|image_pad|><|image_pad|><|image_pad|><|vision_end|>Read it."
         ))
         XCTAssertTrue(decoded.hasSuffix("<|im_start|>assistant\n<think>\n"))
+    }
+
+    func testQ38PinnedTokenizerRendersNativeReasoningEffortWhenAvailable() throws {
+        guard let rootPath = ProcessInfo.processInfo.environment["MERERUN_Q38_TOKENIZER_ROOT"] else {
+            throw XCTSkip("Set MERERUN_Q38_TOKENIZER_ROOT to run pinned Qwen3.8 tokenizer parity.")
+        }
+        let template = try Q35TokenizerAndTemplate.load(
+            from: URL(fileURLWithPath: rootPath),
+            maxLengthOverride: Q35Resources.q38TwentySevenBContextLength
+        )
+        let tokens = try template.encodeForGeneration(
+            messages: [ChatMessage(role: .user, content: "Answer directly.")],
+            addGenerationPrompt: true,
+            includeThinking: true,
+            reasoningEffort: "low",
+            maxLength: Q35Resources.q38TwentySevenBContextLength
+        )
+
+        XCTAssertTrue(template.decode(tokens: tokens).contains("Reasoning effort is set to low."))
+    }
+
+    func testQ38ContinuousReasoningEffortMapsToNativeLevels() {
+        XCTAssertNil(Q35Resources.q38ReasoningEffortLabel(for: nil))
+        XCTAssertEqual(Q35Resources.q38ReasoningEffortLabel(for: 0), "low")
+        XCTAssertEqual(Q35Resources.q38ReasoningEffortLabel(for: 0.2), "low")
+        XCTAssertEqual(Q35Resources.q38ReasoningEffortLabel(for: 0.5), "medium")
+        XCTAssertEqual(Q35Resources.q38ReasoningEffortLabel(for: 0.8), "xhigh")
+        XCTAssertEqual(Q35Resources.q38ReasoningEffortLabel(for: 1), "xhigh")
     }
 
     func testQ35TemplateLeavesThinkingOpenWhenRequested() {
@@ -548,6 +727,23 @@ final class Q35ConfigDecodingTests: MereRunCoreTestCase {
         ])
 
         XCTAssertEqual(shards, ["model-00017.safetensors", "model-00018.safetensors"])
+    }
+
+    func testQ38MountedMTPComponentIsDiscovered() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "q38-mtp-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        defer { try? FileManager.default.removeItem(at: root) }
+        let mtpRoot = root.appendingPathComponent(Q35Resources.q38MTPComponentPath, isDirectory: true)
+        try FileManager.default.createDirectory(at: mtpRoot, withIntermediateDirectories: true)
+        try Data().write(to: mtpRoot.appendingPathComponent("model.safetensors"))
+
+        let resources = try XCTUnwrap(
+            Q35Generator.mtpResources(primary: Q35Resources(rootURL: root))
+        )
+
+        XCTAssertEqual(resources.rootURL.standardizedFileURL, mtpRoot.standardizedFileURL)
     }
 
     func testQ35StandaloneMTPWeightMappingAcceptsBareHeadKeys() {
@@ -780,6 +976,15 @@ final class Q35ConfigDecodingTests: MereRunCoreTestCase {
                 continuousBatchingEnabled: true,
                 mtpSpeculationEnabled: true
             ),
+            .mtpSpeculativeSerial
+        )
+        XCTAssertEqual(
+            Q35Generator.decodePath(
+                jsonConstrained: false,
+                continuousBatchingEnabled: true,
+                mtpSpeculationEnabled: true,
+                schedulerContended: true
+            ),
             .continuousBatched
         )
         XCTAssertEqual(
@@ -798,6 +1003,98 @@ final class Q35ConfigDecodingTests: MereRunCoreTestCase {
             ),
             .pipelined
         )
+    }
+
+    func testQ38PrefillChunkUsesSafeDefaultAndShrinksWithLowLiveHeadroom() {
+        let gibibyte = UInt64(1_024 * 1_024 * 1_024)
+        XCTAssertEqual(
+            Q35Generator.prefillChunkSize(
+                modelId: Q35Resources.q38TwentySevenBModelId,
+                availableMemory: 64 * gibibyte,
+                environment: [:]
+            ),
+            1_024
+        )
+        XCTAssertEqual(
+            Q35Generator.prefillChunkSize(
+                modelId: Q35Resources.q38TwentySevenBModelId,
+                availableMemory: 16 * gibibyte - 1,
+                environment: [:]
+            ),
+            512
+        )
+        XCTAssertEqual(
+            Q35Generator.prefillChunkSize(
+                modelId: Q35Resources.defaultModelId,
+                availableMemory: 1,
+                environment: [:]
+            ),
+            1_024
+        )
+        XCTAssertEqual(
+            Q35Generator.prefillChunkSize(
+                modelId: Q35Resources.q38TwentySevenBModelId,
+                availableMemory: nil,
+                environment: [:]
+            ),
+            1_024
+        )
+    }
+
+    func testQ38PrefillChunkShrinksUnderContentionAndHonorsOverride() {
+        XCTAssertEqual(
+            Q35Generator.prefillChunkSize(
+                modelId: Q35Resources.q38TwentySevenBModelId,
+                availableMemory: UInt64.max,
+                activeRequestCount: 2,
+                environment: [:]
+            ),
+            512
+        )
+        XCTAssertEqual(
+            Q35Generator.prefillChunkSize(
+                modelId: Q35Resources.q38TwentySevenBModelId,
+                availableMemory: UInt64.max,
+                activeRequestCount: 2,
+                environment: ["MERERUN_Q35_PREFILL_CHUNK_TOKENS": "256"]
+            ),
+            256
+        )
+        XCTAssertEqual(
+            Q35Generator.prefillChunkSize(
+                modelId: Q35Resources.q38TwentySevenBModelId,
+                availableMemory: 1,
+                environment: ["MERERUN_Q35_PREFILL_CHUNK_TOKENS": "4096"]
+            ),
+            512
+        )
+        XCTAssertEqual(
+            Q35Generator.prefillChunkSize(
+                modelId: Q35Resources.q38TwentySevenBModelId,
+                availableMemory: UInt64.max,
+                environment: ["MERERUN_Q35_PREFILL_CHUNK_TOKENS": "4096"]
+            ),
+            4_096
+        )
+    }
+
+    func testQ35MLXCacheClearRequiresReclaimablePressure() {
+        let gib = 1_024 * 1_024 * 1_024
+        XCTAssertFalse(Q35Generator.shouldClearMLXCache(
+            activeMemory: 7 * gib,
+            cacheMemory: 128 * 1_024 * 1_024,
+            memoryLimit: 8 * gib
+        ))
+        XCTAssertFalse(Q35Generator.shouldClearMLXCache(
+            activeMemory: 5 * gib,
+            cacheMemory: 1 * gib,
+            memoryLimit: 8 * gib
+        ))
+        XCTAssertTrue(Q35Generator.shouldClearMLXCache(
+            activeMemory: 7 * gib,
+            cacheMemory: 1 * gib,
+            memoryLimit: 8 * gib
+        ))
     }
 
     func testQ35ToolCallsSelectEarlyStoppablePipelinedDecode() {

--- a/Tests/MereRunCoreTests/Q35ToolParserTests.swift
+++ b/Tests/MereRunCoreTests/Q35ToolParserTests.swift
@@ -64,6 +64,105 @@ final class Q35ToolParserTests: XCTestCase {
 
     func testCompletionDetectionRequiresClosingCheckpointTag() {
         XCTAssertFalse(Q35ToolParser.containsCompletedToolCall("<tool_call><function=film_status>"))
-        XCTAssertTrue(Q35ToolParser.containsCompletedToolCall("</function></tool_call>"))
+        XCTAssertTrue(
+            Q35ToolParser.containsCompletedToolCall(
+                "<tool_call><function=film_status></function></tool_call>"
+            )
+        )
+        XCTAssertFalse(Q35ToolParser.containsCompletedToolCall("literal </function></tool_call>"))
+    }
+
+    func testPreservesToolMarkersInsideParameterValues() {
+        let values = [
+            "text with a literal </tool_call> inside",
+            "text with a literal </parameter> inside",
+            "text with a literal </function> inside",
+            "text with a literal <parameter=nope> inside",
+            "evil </function>\n</tool_call> tail",
+        ]
+
+        for value in values {
+            let text = toolCall(body: value)
+            XCTAssertEqual(
+                Q35ToolParser.parseToolCalls(text),
+                [
+                    ToolCall(
+                        name: "note_write",
+                        arguments: ["title": "t", "body": value]
+                    ),
+                ],
+                "failed to preserve \(value)"
+            )
+        }
+    }
+
+    func testLiteralParameterOpenDoesNotCreateArgument() {
+        let calls = Q35ToolParser.parseToolCalls(
+            toolCall(body: "see <parameter=nope> here")
+        )
+
+        XCTAssertEqual(calls.first?.arguments.keys.sorted(), ["body", "title"])
+    }
+
+    func testStreamingCompletionIgnoresEmbeddedCloseMarkerAcrossChunkSizes() {
+        let text = toolCall(body: "text with a literal </tool_call> inside")
+
+        for chunkSize in [1, 2, 3, 7, 11, 64] {
+            var detector = Q35ToolParser.StreamingCompletionDetector()
+            var completionOffsets: [Int] = []
+            var offset = 0
+            while offset < text.count {
+                let end = min(text.count, offset + chunkSize)
+                let startIndex = text.index(text.startIndex, offsetBy: offset)
+                let endIndex = text.index(text.startIndex, offsetBy: end)
+                if detector.feed(String(text[startIndex..<endIndex])) {
+                    completionOffsets.append(end)
+                }
+                offset = end
+            }
+
+            XCTAssertEqual(completionOffsets, [text.count], "chunk size \(chunkSize)")
+        }
+    }
+
+    func testStreamingCompletionDoesNotTreatLiteralProseAsEnvelope() {
+        var detector = Q35ToolParser.StreamingCompletionDetector()
+
+        XCTAssertFalse(detector.feed("The marker </tool_"))
+        XCTAssertFalse(detector.feed("call> is documentation."))
+    }
+
+    func testStreamingCompletionBoundFallsBackToFinalStructuralParse() {
+        var detector = Q35ToolParser.StreamingCompletionDetector()
+        var completeText = ""
+        let malformed = "<tool_call><function=broken></tool_call>"
+
+        for _ in 0..<64 {
+            completeText += malformed
+            XCTAssertFalse(detector.feed(malformed))
+        }
+
+        let valid = "<tool_call><function=film_status></function></tool_call>"
+        completeText += valid
+        XCTAssertFalse(detector.feed(valid), "bounded streaming checks should remain exhausted")
+        XCTAssertEqual(
+            Q35ToolParser.parseToolCalls(completeText).last,
+            ToolCall(name: "film_status", arguments: [:])
+        )
+    }
+
+    private func toolCall(body: String) -> String {
+        """
+        <tool_call>
+        <function=note_write>
+        <parameter=title>
+        t
+        </parameter>
+        <parameter=body>
+        \(body)
+        </parameter>
+        </function>
+        </tool_call>
+        """
     }
 }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -2925,7 +2925,9 @@ native chat engine and DeepSeek V4 Flash uses the DS4-backed
 uses the best installed startable setup agent first, then a valid persisted Pi
 provider model, then the current machine's startable hardware tier. On 96 GB+
 Apple Silicon Macs, DeepSeek V4 Flash is the preferred setup-agent tier; smaller
-Qwen models are alternatives, not upgrades.
+Qwen models are alternatives, not upgrades. Qwen3.8 advertises its native
+`low`, `medium`, and `xhigh` reasoning levels to Pi; Pi's `minimal`, `high`, and
+`max` selections map to the nearest native level.
 
 ```bash
 swift run mere.run model pull text-agent-deepseek-v4-flash

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -290,12 +290,14 @@ Gemma case where the same fusion bought +17%.
 ### `MERERUN_Q35_PREFILL_CHUNK_TOKENS`
 
 Prefill chunk length for Qwen-family models, accepted range 64–8192, default
-1024. Larger chunks batch more routed-expert rows per gather matmul: on the
-Ornith 35B MoE (M4 Max) a 6.8K-token prefill measured 1116 tok/s at 512,
-1238 tok/s at 1024, and regressed at 2048. Chunked causal prefill is exact,
-so outputs are byte-identical across chunk sizes; the setting only trades
-throughput against progress-report granularity and per-chunk activation
-memory.
+1024. Qwen3.8 uses live host-memory headroom rather than total physical RAM: it
+caps the current chunk at 512 below 16 GiB of reclaimable headroom. The same cap
+applies when another request is admitted so a decoder is not stalled behind a
+wide prefill. An explicit value remains an upper bound and is still reduced
+under memory pressure or contention. On the Ornith 35B MoE (M4 Max), a
+6.8K-token prefill measured 1116 tok/s at 512, 1238 tok/s at 1024, and regressed
+at 2048. Chunked causal prefill is exact, so the setting trades throughput
+against progress-report granularity and per-chunk activation memory.
 
 ### `MERERUN_Q35_BATCHED_GPU_SAMPLING`
 
@@ -469,7 +471,10 @@ value, including unset, uses the model-specific policy. Qwen3.8's dense head is
 embedded in the BF16 checkpoint; `vision-chat-q38-27b-4bit` mounts the matching
 4-bit/group-64 MLX Fast proposal head. Both are opt-in because multi-token
 verification can diverge from serial greedy decode; Qwen3.6 hybrid MoE retains
-its adaptive default.
+its adaptive default. When continuous batching is enabled, an eligible MTP
+request takes the speculative lane only if no peer is already admitted. A
+contended request uses ordinary continuous batching; a late peer does not
+migrate an MTP request that is already running.
 
 The `Q35` name is an internal compatibility prefix for the Qwen-family runtime;
 the public managed model ids retain their Qwen release names.

--- a/docs/internals/guarded-acceleration.md
+++ b/docs/internals/guarded-acceleration.md
@@ -235,6 +235,49 @@ numerically equivalent for per-row affine quantization, but retains a second
 gate/up weight copy, so it is opt-in until a real checkpoint shows a worthwhile
 end-to-end gain.
 
+### Qwen3.8 runtime applicability review
+
+The relevant Qwen3.8 runtime techniques were reviewed against the native Swift
+implementation:
+
+| Technique | mere.run disposition |
+| --- | --- |
+| Structural streamed XML tool parsing | Adopted with bounded reparsing and adversarial literal-tag tests. |
+| Native Qwen3.8 reasoning effort | Adopted as `low`, `medium`, and `xhigh`, with explicit Pi aliases. |
+| GDN target-verification prework | Ported to a macOS BF16 Metal kernel, explicitly marked by the verifier and bit-exact at sequence widths 3, 4, 5, 7, and 9. |
+| 4096-token Qwen hybrid prefill floor | Not auto-promoted. Qwen3.8 retains 1024 and shrinks to 512 under low live headroom or contention; a configured wider value remains a pressure-capped upper bound. |
+| MTP versus batching admission | Adopted: MTP is selected only without an admitted peer; contended requests remain batchable. |
+| Conv3d vision weight conversion | Already present for both MLX and PyTorch layouts. |
+| Embedded and mounted MTP weights | Already present for official `mtp.*` shards and the managed `mtp/model.safetensors` component. |
+| One-block scaled dot-product attention | Already present through one `MLXFast.scaledDotProductAttention` call per full-attention layer. |
+| Private ANE/GPU hybrid prefill | Research only. It depends on a private fixed-shape ANE runtime and a separate native extension, so production mere.run does not depend on or advertise it. |
+
+The ANE path may be reconsidered only with a public supported runtime contract,
+fixed-shape parity, failure fallback, and matched end-to-end measurements. Its
+existence upstream is not production evidence here.
+
+The fused GDN prework has an opt-in, post-warmup GPU microbenchmark:
+
+```bash
+MERERUN_TEST_MLX_DEVICE=gpu \
+MERERUN_TEST_Q35_GDN_BENCHMARK=1 \
+  swift test --filter Q35ConfigDecodingTests/testQ35GDNVerifyPreworkBenchmarkWhenEnabled
+```
+
+On an M4 Max, 50 iterations per width measured 0.4106 ms composed versus
+0.2406 ms fused at width 4 (1.706x), and 0.3954 ms versus 0.2221 ms at width 9
+(1.780x). The separate GPU parity gate remained bit-exact at every claimed
+width.
+
+The installed Qwen3.8 BF16 long-context safety gate did not justify the wider
+default. With MTP disabled, the deterministic 6,463-token / one-output-token
+baseline at a 1,024-token chunk completed with `load=0.60s`,
+`prefill=551.41s`, and `time=552.25s`, returning `READY`. The matched 4,096
+attempt reached the final prefill checkpoint but destabilized an already busy
+host before returning a stats line. That attempt is a failed safety gate, not a
+performance result; no speedup is claimed. A clean post-reboot rerun is required
+before any automatic wide-chunk promotion.
+
 ## Already covered
 
 - Gemma4 12B uses a managed verifier-compatible MTP assistant and falls back to

--- a/docs/runtime/api-server.md
+++ b/docs/runtime/api-server.md
@@ -313,7 +313,9 @@ swift run mere.run api serve \
   weighted machine reservation
 - Gemma4, Qwen-family, and LFM2 prefills are chunked with cancellation and
   progress checkpoints before decode; this is cooperative single-request
-  prefill, not continuous batching
+  prefill, not continuous batching. Qwen3.8 defaults to 1,024-token chunks and
+  caps them at 512 when live reclaimable memory falls below 16 GiB or a peer is
+  admitted, so a live decoder is not held behind a pressure-heavy prefill
 - Gemma4 uses in-memory prefix KV reuse by default in `api serve`; set
   `MERERUN_GEMMA4_PREFIX_KV_CACHE=0` for a baseline. `/runtime/status` reports
   cache entries, hits, and reused tokens when the Gemma4 model is loaded; the
@@ -338,7 +340,10 @@ swift run mere.run api serve \
   `--max-active-requests` is above `1`. Their engine-specific continuous-batching
   variables can force the implementation on or force the serial path, and
   `/runtime/status` reports actual batched decode steps instead of assuming the
-  scheduler is active. Gemma4 full-attention rows remain same-position because
+  scheduler is active. An eligible Qwen MTP request takes its speculative lane
+  only when no peer is already admitted; contended arrivals use ordinary
+  batching, and a late arrival does not migrate an MTP request already in
+  progress. Gemma4 full-attention rows remain same-position because
   that engine still uses scalar RoPE/cache offsets. Qwen-family and LFM2
   full-attention rows use row-offset-aware ragged KV caches; Qwen-family linear
   attention and LFM2 short-convolution layers use typed recurrent state, so

--- a/docs/runtime/text.md
+++ b/docs/runtime/text.md
@@ -276,13 +276,25 @@ swift run mere.run text chat \
 
 The lane uses the published 262,144-token context, thinking default,
 temperature 1.0, top-p 0.95, top-k 20, both generation stop tokens, and the
-Qwen3.8 image sizing floor. The checkpoint also contains video understanding
-weights, but the current native command accepts text and local images only. Its
-embedded dense MTP head can be loaded from the official shards with
+Qwen3.8 image sizing floor. Its native reasoning-effort values are `low`,
+`medium`, and `xhigh`; Pi's `minimal`, `high`, and `max` aliases map to those
+native values without inventing unsupported template labels. Tool calls use a
+streaming structural Qwen XML parser, including when parameter strings contain
+tag-like text. The checkpoint also contains video understanding weights, but
+the current native command accepts text and local images only. Its embedded
+dense MTP head can be loaded from the official shards with
 `MERERUN_Q35_MTP_SPECULATION=1`. This materially accelerates greedy decode, but
 is experimental: BF16 multi-token verification can choose a different greedy
 path from serial target decode. The default, sampled, and JSON-constrained paths
-retain target-only decode.
+retain target-only decode. With API concurrency enabled, an eligible MTP request
+uses speculation only while uncontended; peers use the continuous-batching lane.
+
+Qwen3.8 prefill defaults to 1,024-token chunks. Live reclaimable host-memory
+headroom below 16 GiB, or an admitted peer, caps a chunk at 512 tokens. This
+uses current pressure rather than total physical RAM because the dense BF16
+checkpoint and concurrent workloads can consume most unified memory before
+prefill begins. `MERERUN_Q35_PREFILL_CHUNK_TOKENS` remains an explicit upper
+bound and is still pressure-capped.
 
 For the lower-residency lane, pull the separate 4-bit model ID:
 


### PR DESCRIPTION
## Summary

- expose Qwen3.8's native `low`, `medium`, and `xhigh` reasoning-effort profile through Pi, `text chat`, and the OpenAI-compatible API
- replace delimiter/regex tool-call stopping with a bounded structural streaming parser and adversarial literal-tag coverage
- add a bit-exact macOS BF16 Metal kernel for GDN target-verification prework, request-aware MTP versus continuous-batching admission, and pressure-gated MLX cache reclamation
- keep Qwen3.8 prefill conservative: 1,024 tokens by default, 512 under low live headroom or contention, with wider configured values still pressure-capped
- verify the existing vision Conv3d layouts, embedded and mounted MTP weights, and one-block SDPA path; document the decisions and third-party kernel provenance

## Validation

- `./scripts/check.sh`
  - strict lint, build, CLI help sweep, and hygiene checks passed
  - 2,929 XCTest cases executed, 215 fixture-dependent skips, 0 failures
  - 30 Swift Testing cases passed, 0 failures
- focused GPU parity and benchmark suite:
  - GDN prework bit-exact at sequence widths 3, 4, 5, 7, and 9
  - width 4: 0.4106 ms composed, 0.2406 ms fused, 1.706x
  - width 9: 0.3954 ms composed, 0.2221 ms fused, 1.780x
- structural tool parser, reasoning profile, request routing, pressure gates, cache behavior, vision layout, and MTP resource tests passed

## Safety decision

A real 6,463-token Qwen3.8 BF16 prompt completed with the 1,024-token chunk. A matched 4,096-token experiment on an already-loaded host destabilized the machine before returning statistics. This PR therefore does not auto-promote 4,096, makes no end-to-end speed claim for that experiment, and retains the conservative live-headroom policy.
