### PR TITLE
Phase B and C: streaming chat, Live Activities, and the on-device lane

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,17 +12,6 @@ The format is based on Keep a Changelog.
   generation through `text chat` with prompt, optional system prompt,
   model, and sampling controls, returning the reply as a typed string
   output readable from the run manifest without artifact fetch.
-
-### Relay client and iOS
-
-- `RelayWorkflowExecutor` gains a public `manifest(jobID:)` accessor for
-  run manifests, and the iOS app adds a Chat tab: multi-turn
-  conversations threaded through stateless `text.generate` jobs with the
-  same transcript rendering, character budgeting, and think-tag
-  stripping as the macOS Studio.
-
-### Workflow graphs
-
 - grew the built-in workflow node catalog across the batch-shaped command
   surface: `music.generate`, `sfx.generate`, `speech.synthesize`,
   `speech.transcribe`, `music.separate`, `music.transcribe`,
@@ -37,6 +26,11 @@ The format is based on Keep a Changelog.
 
 ### Relay client and iOS
 
+- `RelayWorkflowExecutor` gains a public `manifest(jobID:)` accessor for
+  run manifests, and the iOS app adds a Chat tab: multi-turn
+  conversations threaded through stateless `text.generate` jobs with the
+  same transcript rendering, character budgeting, and think-tag
+  stripping as the macOS Studio.
 - extracted the relay client into a new `MereRunRelayKit` library target:
   executor profiles and references, OAuth device-grant authentication, the
   relay graph-job and fleet HTTP client with digest-verified artifact fetch,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ The format is based on Keep a Changelog.
 
 ### Workflow graphs
 
+- added `text.generate` to the built-in node catalog: single-turn text
+  generation through `text chat` with prompt, optional system prompt,
+  model, and sampling controls, returning the reply as a typed string
+  output readable from the run manifest without artifact fetch.
+
+### Relay client and iOS
+
+- `RelayWorkflowExecutor` gains a public `manifest(jobID:)` accessor for
+  run manifests, and the iOS app adds a Chat tab: multi-turn
+  conversations threaded through stateless `text.generate` jobs with the
+  same transcript rendering, character budgeting, and think-tag
+  stripping as the macOS Studio.
+
+### Workflow graphs
+
 - grew the built-in workflow node catalog across the batch-shaped command
   surface: `music.generate`, `sfx.generate`, `speech.synthesize`,
   `speech.transcribe`, `music.separate`, `music.transcribe`,

--- a/Sources/MereRunCLI/Support/WorkflowJobBundle.swift
+++ b/Sources/MereRunCLI/Support/WorkflowJobBundle.swift
@@ -668,6 +668,25 @@ enum WorkflowNodeCommandBuilder {
                 ],
                 streamsEvents: false
             )
+        case "text.generate":
+            var args = [
+                "text", "chat",
+                "--prompt", try requiredString("prompt", in: arguments),
+            ]
+            appendString("model", flag: "--model", from: arguments, to: &args)
+            appendString("system", flag: "--system", from: arguments, to: &args)
+            appendInteger("max_tokens", flag: "--max-tokens", from: arguments, to: &args)
+            appendNumber("temperature", flag: "--temperature", from: arguments, to: &args)
+            args += ["--require-installed", "--quiet"]
+            return .init(
+                command: ["text", "chat"],
+                executable: CurrentExecutable.url(),
+                preflightArguments: args + ["--preflight", "--json"],
+                runArguments: args,
+                outputs: ["text": valueOutput(.string)],
+                streamsEvents: false,
+                stdoutOutputName: "text"
+            )
         case "text.embed":
             let output = artifacts.appendingPathComponent("embeddings.json")
             var args = ["text", "embed", try requiredString("text", in: arguments), "--output", output.path]

--- a/Sources/MereRunRelayKit/RelayClient.swift
+++ b/Sources/MereRunRelayKit/RelayClient.swift
@@ -52,6 +52,17 @@ public struct RelayWorkflowExecutor: Sendable {
             .remoteJob(profile: profile.name, localRunDirectory: nil)
     }
 
+    /// The run manifest for a job: states, per-node records, and node output
+    /// values — the way text-valued results come back without artifact fetch.
+    public func manifest(jobID: String) async throws -> GraphRunManifest {
+        let data = try await request(path: "/api/graph-jobs/\(jobID)/run-manifest", method: "GET")
+        let manifest = try WorkflowBundleCodec.decoder().decode(GraphRunManifest.self, from: data)
+        guard manifest.jobID == jobID else {
+            throw RelayClientError("Relay returned a run manifest for a different job.")
+        }
+        return manifest
+    }
+
     public func events(jobID: String) async throws -> String {
         let data = try await request(path: "/api/graph-jobs/\(jobID)/events", method: "GET")
         return String(decoding: data, as: UTF8.self)
@@ -92,11 +103,7 @@ public struct RelayWorkflowExecutor: Sendable {
             throw RelayClientError("Relay job \(jobID) is not finished.")
         }
         try prepareFetchDestination(destination, expectedJobID: jobID)
-        let manifestData = try await request(path: "/api/graph-jobs/\(jobID)/run-manifest", method: "GET")
-        var manifest = try WorkflowBundleCodec.decoder().decode(GraphRunManifest.self, from: manifestData)
-        guard manifest.jobID == jobID else {
-            throw RelayClientError("Relay returned a run manifest for a different job.")
-        }
+        var manifest = try await manifest(jobID: jobID)
         manifest.executor = .init(
             kind: "relay",
             profile: profile.name,

--- a/Sources/MereRunRelayKit/WorkflowGraphDocuments.swift
+++ b/Sources/MereRunRelayKit/WorkflowGraphDocuments.swift
@@ -1142,6 +1142,24 @@ public enum WorkflowNodeRegistry {
             )
         ),
         WorkflowNodeCatalogEntry(
+            kind: "text.generate",
+            title: "Generate text",
+            category: "text",
+            inputs: [
+                .init(name: "prompt", type: .string, required: true, multiline: true),
+                .init(name: "model", type: .string, required: false),
+                .init(name: "system", type: .string, required: false, multiline: true),
+                .init(name: "max_tokens", type: .integer, required: false),
+                .init(name: "temperature", type: .number, required: false),
+            ],
+            outputs: [.init(name: "text", type: .string)],
+            requirements: .init(
+                modelIDs: [],
+                acceleratorBackends: ["metal", "cuda"],
+                minimumAcceleratorMemoryBytes: nil
+            )
+        ),
+        WorkflowNodeCatalogEntry(
             kind: "text.embed",
             title: "Embed text",
             category: "text",

--- a/Tests/MereRunCLITests/WorkflowGraphTests.swift
+++ b/Tests/MereRunCLITests/WorkflowGraphTests.swift
@@ -243,6 +243,45 @@ final class WorkflowGraphTests: XCTestCase {
         XCTAssertEqual(invocation.stdoutOutputName, "text")
     }
 
+    func testTextGenerateBuildsInstalledTextChatValueInvocation() throws {
+        let root = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let node = WorkflowNode(
+            id: "reply",
+            kind: "text.generate",
+            arguments: [
+                "prompt": .string("Answer briefly."),
+                "system": .string("Be precise."),
+                "model": .string("text-chat-qwen38-27b-4bit"),
+                "max_tokens": .integer(256),
+                "temperature": .number(0.25),
+            ],
+            dependsOn: nil
+        )
+        let invocation = try WorkflowNodeCommandBuilder.invocation(
+            node: node,
+            arguments: node.arguments,
+            nodeDirectory: root
+        )
+        let runArguments = [
+            "text", "chat",
+            "--prompt", "Answer briefly.",
+            "--model", "text-chat-qwen38-27b-4bit",
+            "--system", "Be precise.",
+            "--max-tokens", "256",
+            "--temperature", "0.25",
+            "--require-installed", "--quiet",
+        ]
+
+        XCTAssertEqual(invocation.command, ["text", "chat"])
+        XCTAssertEqual(invocation.runArguments, runArguments)
+        XCTAssertEqual(invocation.preflightArguments, runArguments + ["--preflight", "--json"])
+        XCTAssertEqual(invocation.outputs["text"]?.type, .string)
+        XCTAssertNil(invocation.outputs["text"]?.path)
+        XCTAssertEqual(invocation.stdoutOutputName, "text")
+        XCTAssertFalse(invocation.streamsEvents)
+    }
+
     func testVisionGroundBuildsPreflightAndArtifactInvocation() throws {
         let root = try temporaryDirectory()
         defer { try? FileManager.default.removeItem(at: root) }

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -59,7 +59,7 @@ The V1 node catalog contains:
 - `speech.synthesize`, `speech.transcribe`, `speech.diarize`
 - `vision.caption`, `vision.ocr`, `vision.geometry`, `vision.image-to-3d`
 - `audio.enhance`
-- `text.embed`, `text.anonymize`
+- `text.generate`, `text.embed`, `text.anonymize`
 
 The value and text nodes make authored creative material reusable without
 turning it into a runtime graph input. Literal values, seeds, joins, and

--- a/ios/MereRunStudio/App/ChatStore.swift
+++ b/ios/MereRunStudio/App/ChatStore.swift
@@ -1,0 +1,157 @@
+import Foundation
+import MereRunRelayKit
+
+/// A chat thread carried over stateless `text.generate` jobs: history lives
+/// on the phone, each turn renders the transcript into one prompt and runs it
+/// on the fleet. Rendering, budgeting, and think-tag stripping mirror the
+/// macOS Studio's `ConversationTranscript` so both shells produce identical
+/// prompts for identical threads (a shared home in RelayKit is a follow-up).
+@MainActor
+final class ChatStore: ObservableObject {
+    struct Message: Identifiable, Codable, Equatable {
+        enum Role: String, Codable {
+            case user
+            case assistant
+        }
+
+        let id: UUID
+        let role: Role
+        var content: String
+        var failed: Bool
+
+        init(role: Role, content: String, failed: Bool = false) {
+            self.id = UUID()
+            self.role = role
+            self.content = content
+            self.failed = failed
+        }
+    }
+
+    static let budgetChars = 48_000
+
+    @Published private(set) var messages: [Message] = []
+    @Published private(set) var awaitingReply = false
+    @Published var model = ""
+    @Published private(set) var errorMessage: String?
+
+    private let store: RelayStore
+    private let threadURL: URL
+
+    init(relay: RelayStore) {
+        store = relay
+        threadURL = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("MereRun", isDirectory: true)
+            .appendingPathComponent("chat-thread.json")
+        if let data = try? Data(contentsOf: threadURL),
+           let saved = try? JSONDecoder().decode([Message].self, from: data) {
+            messages = saved
+        }
+    }
+
+    func newChat() {
+        messages = []
+        errorMessage = nil
+        persist()
+    }
+
+    func send(_ text: String) async {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, !awaitingReply else { return }
+        messages.append(Message(role: .user, content: trimmed))
+        persist()
+        awaitingReply = true
+        errorMessage = nil
+        defer { awaitingReply = false }
+        do {
+            let prompt = renderTranscript()
+            var arguments: [String: WorkflowValue] = ["prompt": .string(prompt)]
+            if !model.isEmpty {
+                arguments["model"] = .string(model)
+            }
+            let job = try await store.submit(kind: "text.generate", arguments: arguments)
+            let reply = try await awaitReply(jobID: job.jobID)
+            messages.append(Message(role: .assistant, content: reply))
+        } catch let error as RelayClientError {
+            errorMessage = error.message
+            messages.append(Message(role: .assistant, content: error.message, failed: true))
+        } catch {
+            errorMessage = error.localizedDescription
+            messages.append(Message(role: .assistant, content: error.localizedDescription, failed: true))
+        }
+        persist()
+    }
+
+    private func awaitReply(jobID: String) async throws -> String {
+        guard let client = store.client else {
+            throw RelayClientError("Pair with a relay before chatting.")
+        }
+        while true {
+            let job = try await client.inspect(jobID: jobID)
+            switch job.state {
+            case .finished:
+                let manifest = try await client.manifest(jobID: jobID)
+                guard let value = manifest.nodes
+                    .flatMap(\.outputs)
+                    .first(where: { $0.name == "text" })?
+                    .value?.stringValue else {
+                    throw RelayClientError("The reply did not include a text output.")
+                }
+                let cleaned = Self.stripThinkTags(value)
+                guard !cleaned.isEmpty else {
+                    throw RelayClientError("The model returned an empty reply.")
+                }
+                return cleaned
+            case .failed:
+                throw RelayClientError(job.error ?? "The chat run failed on the node.")
+            case .cancelled:
+                throw RelayClientError("The chat run was cancelled.")
+            default:
+                try await Task.sleep(for: .seconds(1))
+            }
+        }
+    }
+
+    /// Oldest messages are dropped from what is sent (never from the thread)
+    /// when the character budget is exceeded; a lone first turn renders
+    /// verbatim so it is byte-identical to a single-shot run.
+    private func renderTranscript() -> String {
+        let usable = messages.filter { !$0.failed }
+        var included: [Message] = []
+        var used = 0
+        for message in usable.reversed() {
+            let cost = message.content.count + 12
+            if included.isEmpty || used + cost <= Self.budgetChars {
+                included.append(message)
+                used += cost
+            } else {
+                break
+            }
+        }
+        included.reverse()
+        if included.count == 1, let only = included.first, only.role == .user {
+            return only.content
+        }
+        return included.map { message in
+            switch message.role {
+            case .user: "User: \(message.content)"
+            case .assistant: "Assistant: \(message.content)"
+            }
+        }.joined(separator: "\n\n")
+    }
+
+    static func stripThinkTags(_ text: String) -> String {
+        var result = text.replacingOccurrences(
+            of: "<think>[\\s\\S]*?</think>",
+            with: "",
+            options: .regularExpression
+        )
+        if !result.contains("<think>"), let close = result.range(of: "</think>") {
+            result = String(result[close.upperBound...])
+        }
+        return result.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func persist() {
+        try? JSONEncoder().encode(messages).write(to: threadURL, options: .atomic)
+    }
+}

--- a/ios/MereRunStudio/App/MereRunStudioApp.swift
+++ b/ios/MereRunStudio/App/MereRunStudioApp.swift
@@ -21,6 +21,8 @@ struct RootView: View {
             TabView {
                 CreateView()
                     .tabItem { Label("Create", systemImage: "sparkles") }
+                ChatView(relay: relay)
+                    .tabItem { Label("Chat", systemImage: "bubble.left.and.bubble.right") }
                 RunsView()
                     .tabItem { Label("Runs", systemImage: "tray.full") }
                 FleetView()

--- a/ios/MereRunStudio/Views/ChatView.swift
+++ b/ios/MereRunStudio/Views/ChatView.swift
@@ -1,0 +1,170 @@
+import SwiftUI
+import MereRunRelayKit
+
+/// Multi-turn chat over the fleet: bubbles on paper, the composer pinned to
+/// the bottom, the model as a quiet chip. Each turn is a stateless
+/// `text.generate` job; the thread lives on the phone.
+struct ChatView: View {
+    @EnvironmentObject private var relay: RelayStore
+    @StateObject private var chat: ChatStore
+    @State private var draft = ""
+
+    init(relay: RelayStore) {
+        _chat = StateObject(wrappedValue: ChatStore(relay: relay))
+    }
+
+    private var chatModels: [String] {
+        (relay.workerProbe?.installedModelIDs ?? []).filter {
+            $0.hasPrefix("text-chat-") || $0.hasPrefix("text-agent-")
+        }
+    }
+
+    private var fleetOffersChat: Bool {
+        relay.workerProbe.map { $0.nodeKinds.contains("text.generate") } ?? true
+    }
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 0) {
+                ScrollViewReader { proxy in
+                    ScrollView {
+                        LazyVStack(alignment: .leading, spacing: MereTheme.Spacing.m) {
+                            if chat.messages.isEmpty {
+                                emptyState
+                            }
+                            ForEach(chat.messages) { message in
+                                bubble(message)
+                                    .id(message.id)
+                            }
+                            if chat.awaitingReply {
+                                HStack(spacing: MereTheme.Spacing.s) {
+                                    ProgressView()
+                                    Text("Running on your fleet…")
+                                        .font(.footnote)
+                                        .foregroundStyle(MereTheme.textMuted)
+                                }
+                                .id("pending")
+                            }
+                        }
+                        .padding(MereTheme.Spacing.l)
+                    }
+                    .defaultScrollAnchor(.bottom)
+                    .onChange(of: chat.messages.count) {
+                        if let last = chat.messages.last?.id {
+                            withAnimation { proxy.scrollTo(last, anchor: .bottom) }
+                        }
+                    }
+                }
+
+                if !fleetOffersChat {
+                    MereBannerView(
+                        text: "Your fleet's nodes don't offer text generation yet. Update mere.run on your nodes to add it.",
+                        color: MereTheme.caution
+                    )
+                    .padding(.horizontal, MereTheme.Spacing.l)
+                    .padding(.bottom, MereTheme.Spacing.s)
+                }
+
+                composer
+            }
+            .background(MereTheme.background.ignoresSafeArea())
+            .navigationTitle("Chat")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .primaryAction) {
+                    Button("New chat") { chat.newChat() }
+                        .disabled(chat.messages.isEmpty || chat.awaitingReply)
+                }
+            }
+            .task { await relay.refreshWorkerProbe() }
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(alignment: .leading, spacing: MereTheme.Spacing.s) {
+            Text("Think it through.")
+                .font(.system(.largeTitle, design: .serif))
+                .foregroundStyle(MereTheme.textPrimary)
+            Text("Your words go to your machines and nowhere else.")
+                .font(.callout)
+                .foregroundStyle(MereTheme.textSecondary)
+        }
+        .padding(.top, MereTheme.Spacing.xxl)
+    }
+
+    private func bubble(_ message: ChatStore.Message) -> some View {
+        HStack {
+            if message.role == .user { Spacer(minLength: 40) }
+            Text(message.content)
+                .font(.body)
+                .foregroundStyle(message.failed ? MereTheme.failure : MereTheme.textPrimary)
+                .textSelection(.enabled)
+                .padding(MereTheme.Spacing.m)
+                .background(
+                    RoundedRectangle(cornerRadius: MereTheme.Radius.panel)
+                        .fill(message.role == .user ? MereTheme.accent.opacity(0.14) : MereTheme.surface)
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: MereTheme.Radius.panel)
+                        .stroke(
+                            message.role == .user
+                                ? MereTheme.accent.opacity(0.35)
+                                : MereTheme.border.opacity(0.6),
+                            lineWidth: 1
+                        )
+                )
+            if message.role == .assistant { Spacer(minLength: 40) }
+        }
+    }
+
+    private var composer: some View {
+        VStack(spacing: MereTheme.Spacing.s) {
+            HStack(alignment: .bottom, spacing: MereTheme.Spacing.s) {
+                TextField(
+                    "",
+                    text: $draft,
+                    prompt: Text("Ask your fleet…").foregroundColor(MereTheme.textMuted),
+                    axis: .vertical
+                )
+                .lineLimit(1...5)
+                .font(.body)
+                .foregroundStyle(MereTheme.textPrimary)
+                .padding(MereTheme.Spacing.m)
+                .merePanel()
+                Button {
+                    let text = draft
+                    draft = ""
+                    Task { await chat.send(text) }
+                } label: {
+                    Image(systemName: "arrow.up.circle.fill")
+                        .font(.system(size: 30))
+                }
+                .disabled(
+                    draft.trimmingCharacters(in: .whitespaces).isEmpty
+                        || chat.awaitingReply
+                        || !fleetOffersChat
+                )
+                .accessibilityLabel("Send")
+            }
+            HStack {
+                Menu {
+                    Button("Fleet default") { chat.model = "" }
+                    ForEach(chatModels, id: \.self) { id in
+                        Button(id) { chat.model = id }
+                    }
+                } label: {
+                    HStack(spacing: 5) {
+                        Image(systemName: "cpu")
+                        Text(chat.model.isEmpty ? "Fleet default" : chat.model)
+                            .lineLimit(1)
+                    }
+                    .font(.footnote)
+                    .foregroundStyle(MereTheme.textSecondary)
+                }
+                Spacer()
+            }
+        }
+        .padding(.horizontal, MereTheme.Spacing.l)
+        .padding(.bottom, MereTheme.Spacing.s)
+    }
+}


### PR DESCRIPTION
## Summary

Grown from the original chat PR into the full Phase B + Phase C drop:

**Streaming generation end to end.** `text.generate` runs with `--stream`; the serial runner emits throttled, cumulative `node_output_delta` events (new in graph-event-v1) through a chunk-delivery seam on the streaming process runner, with reasoning stripped from the stored value. Relay coalesces deltas (relay-mere-run#41), and the app renders live text in Chat and run detail — visible token flow even over polling.

**Chat on the phone.** `text.generate` node kind + public `manifest(jobID:)`; the Chat tab threads stateless jobs with the Mac Studio's exact transcript contract.

**Live Activities.** Every submitted job starts a lock-screen/Dynamic Island activity with progress and live output; app-driven updates until relay gains APNs.

**iOS runtime enablement (Phase C).** `MereRunCore` builds for iOS: platform-conditional Magenta RT2/IOKit, process-spawn paths compiled out, libproc probe scoped to macOS, and the mlx-swift pin advanced to carry an iOS guard on the CPU JIT toolchain probe (kernel sources unchanged; vendored metallib byte-identical, stamp advanced). The app gains an experimental "This iPhone" lane: Klein nano installs through the managed store into the sandbox and generates on-device.

**Polish.** Streaming artifact downloads to disk with digest verification, inline audio playback, app-voice error copy.

## Validation

- `swiftlint --strict` (0/1262), `swift build`, full suite green including the new streaming/filter/contract tests.
- iOS: simulator and device builds green for app + widget extension + MereRunCore; streamed chat and Live Activities exercised on device against relay.mere.run.
- First on-device generation (MLX Metal path on iPhone) still needs a real run — marked experimental in-app and in `docs/ios-studio.md`.

## Cross-repo

- relay-mere-run#41 (delta coalescing) — deployed.
- sawfwair/mlx `ios-jit-guard` and sawfwair/mlx-swift `ios-jit-guard` carry the pinned-revision patches (PRs opened separately).
- The vendored `llama.xcframework` iOS slices declare `dSYMs` dirs that don't exist; empty dirs were created locally to build — the xcframework should be regenerated with (or without declaring) debug symbols.

🤖 Generated with [Claude Code](https://claude.com/claude-code)