### PR TITLE
iOS Studio: browser sign-in with PKCE and Keychain, and a full on-device lineup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,17 +12,6 @@ The format is based on Keep a Changelog.
   generation through `text chat` with prompt, optional system prompt,
   model, and sampling controls, returning the reply as a typed string
   output readable from the run manifest without artifact fetch.
-
-### Relay client and iOS
-
-- `RelayWorkflowExecutor` gains a public `manifest(jobID:)` accessor for
-  run manifests, and the iOS app adds a Chat tab: multi-turn
-  conversations threaded through stateless `text.generate` jobs with the
-  same transcript rendering, character budgeting, and think-tag
-  stripping as the macOS Studio.
-
-### Workflow graphs
-
 - grew the built-in workflow node catalog across the batch-shaped command
   surface: `music.generate`, `sfx.generate`, `speech.synthesize`,
   `speech.transcribe`, `music.separate`, `music.transcribe`,
@@ -37,6 +26,11 @@ The format is based on Keep a Changelog.
 
 ### Relay client and iOS
 
+- `RelayWorkflowExecutor` gains a public `manifest(jobID:)` accessor for
+  run manifests, and the iOS app adds a Chat tab: multi-turn
+  conversations threaded through stateless `text.generate` jobs with the
+  same transcript rendering, character budgeting, and think-tag
+  stripping as the macOS Studio.
 - extracted the relay client into a new `MereRunRelayKit` library target:
   executor profiles and references, OAuth device-grant authentication, the
   relay graph-job and fleet HTTP client with digest-verified artifact fetch,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on Keep a Changelog.
 
 ### Workflow graphs
 
+- workers now stream generation for `text.generate`: the node runs
+  `text chat --stream` and emits throttled `node_output_delta` events whose
+  message carries the accumulated text so far (added to the graph-event-v1
+  schema), with reasoning stripped from the stored value to match the
+  non-streamed contract. Serial execution only; deltas coalesce to the
+  latest per node downstream.
 - added `text.generate` to the built-in node catalog: single-turn text
   generation through `text chat` with prompt, optional system prompt,
   model, and sampling controls, returning the reply as a typed string
@@ -24,8 +30,27 @@ The format is based on Keep a Changelog.
   Interactive and resident surfaces (chat sessions, realtime music, live
   tracking, serving) stay outside the job vocabulary by design.
 
+### iOS runtime enablement
+
+- `MereRunCore` now builds for iOS: platform conditions gate the
+  macOS-only Magenta RT2 binary and IOKit linkage, process-spawning paths
+  (ffmpeg tools, the DS4 sidecar) compile out on iOS, the physical-footprint
+  probe is scoped to macOS libproc, and the pinned mlx-swift revision
+  advances to carry an iOS guard around the CPU JIT toolchain probe (Metal
+  kernel sources unchanged; the vendored metallib stamp advances with the
+  pin).
+
 ### Relay client and iOS
 
+- artifact fetch streams downloads straight to disk on Darwin with
+  post-transfer digest verification instead of buffering whole artifacts
+  in memory.
+- the iOS app renders generation live in Chat and run detail, starts a
+  Live Activity for every submitted job (Dynamic Island progress,
+  app-driven updates; push updates await relay APNs support), plays audio
+  artifacts inline, speaks app-voice error copy, and gains an experimental
+  on-device lane: FLUX.2 Klein nano installs through the managed store
+  into the app sandbox and generates entirely on the phone.
 - `RelayWorkflowExecutor` gains a public `manifest(jobID:)` accessor for
   run manifests, and the iOS app adds a Chat tab: multi-turn
   conversations threaded through stateless `text.generate` jobs with the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,22 @@ The format is based on Keep a Changelog.
 
 ### Relay client and iOS
 
+- the iOS app signs in with the browser: Authorization Code + PKCE
+  through `ASWebAuthenticationSession` against the broker's advertised
+  `authorization_endpoint`, returning over an `https://mere.world`
+  universal link, with tokens in the device Keychain
+  (after-first-unlock, this-device-only) and a silent migration for
+  existing file-stored device-grant credentials. The device-code flow
+  stays available behind a footnote for browserless pairing.
+  `MereRunRelayKit` gains `RelayAuthorizationCodeFlow`,
+  a `RelayCredentialStorage` protocol with file and Keychain backends,
+  and executor-level storage injection so refreshed tokens persist
+  wherever the credential came from.
+- the on-device lane grows into a lineup: Bonsai 1-bit and Bonsai
+  ternary image models join Klein nano behind a model picker in Create,
+  and Chat gains a fully on-device option running Bonsai 27B 1-bit with
+  streamed token deltas — download once, then prompts never leave the
+  phone.
 - artifact fetch streams downloads straight to disk on Darwin with
   post-transfer digest verification instead of buffering whole artifacts
   in memory.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ The format is based on Keep a Changelog.
 
 ### Workflow graphs
 
+- added `text.generate` to the built-in node catalog: single-turn text
+  generation through `text chat` with prompt, optional system prompt,
+  model, and sampling controls, returning the reply as a typed string
+  output readable from the run manifest without artifact fetch.
+
+### Relay client and iOS
+
+- `RelayWorkflowExecutor` gains a public `manifest(jobID:)` accessor for
+  run manifests, and the iOS app adds a Chat tab: multi-turn
+  conversations threaded through stateless `text.generate` jobs with the
+  same transcript rendering, character budgeting, and think-tag
+  stripping as the macOS Studio.
+
+### Workflow graphs
+
 - grew the built-in workflow node catalog across the batch-shaped command
   surface: `music.generate`, `sfx.generate`, `speech.synthesize`,
   `speech.transcribe`, `music.separate`, `music.transcribe`,

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "3c37bc1e7e3ec1a0e3a286cf5bf0f62289add03ddf860edb4d8b94f84a1bcfdb",
+  "originHash" : "7912f84701402566a75a301de11864f91f792625c61b28f258704fb4d46e4d71",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -33,7 +33,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sawfwair/mlx-swift",
       "state" : {
-        "revision" : "5bf3e46fecfb69cd3b559025fa99885ddd188731"
+        "revision" : "30be5d59f194d5f7c67500509bf13bdfa1f26b3b"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -220,7 +220,9 @@ if hasMagentaRT2Binary {
       path: "vendor/magentart.xcframework"
     )
   )
-  mereRunCoreDependencies.append(.target(name: "magentart"))
+  // The Magenta RT2 binary ships macOS slices only; iOS builds of the core
+  // exclude realtime music.
+  mereRunCoreDependencies.append(.target(name: "magentart", condition: .when(platforms: [.macOS])))
 }
 if !isLinuxPackage {
   targets.append(
@@ -254,7 +256,8 @@ if !isLinuxPackage {
   mereRunCoreLinkerSettings.append(.linkedFramework("Vision"))
   mereRunCoreLinkerSettings.append(.linkedFramework("ImageIO"))
   mereRunCoreLinkerSettings.append(.linkedFramework("CoreVideo"))
-  mereRunCoreLinkerSettings.append(.linkedFramework("IOKit"))
+  // IOKit does not exist on iOS.
+  mereRunCoreLinkerSettings.append(.linkedFramework("IOKit", .when(platforms: [.macOS])))
 }
 
 var audioCodecsDependencies: [Target.Dependency] = mlxDependency("MLX")
@@ -527,7 +530,7 @@ if !isLinuxPackage {
 var packageDependencies: [Package.Dependency] = (useLinuxPrebuiltMLX ? [] : [
   .package(
     url: "https://github.com/sawfwair/mlx-swift",
-    revision: "5bf3e46fecfb69cd3b559025fa99885ddd188731"
+    revision: "30be5d59f194d5f7c67500509bf13bdfa1f26b3b"
   )
 ]) + [
   .package(

--- a/Sources/MediaIO/FFmpegProcess.swift
+++ b/Sources/MediaIO/FFmpegProcess.swift
@@ -9,6 +9,25 @@ enum FFmpegProcess {
         let stderr: String
     }
 
+    #if os(iOS)
+    // ffmpeg tool spawning needs child processes, which iOS forbids; media
+    // conversion happens on nodes, never on the phone.
+    static func run(
+        tool: String,
+        arguments: [String],
+        stdin: Data? = nil
+    ) throws -> Result {
+        throw FFmpegProcessUnavailableError()
+    }
+
+    static func runStreamingInput(
+        tool: String,
+        arguments: [String],
+        writeInput: (FileHandle) throws -> Void
+    ) throws -> Result {
+        throw FFmpegProcessUnavailableError()
+    }
+    #else
     static func run(
         tool: String,
         arguments: [String],
@@ -184,4 +203,7 @@ enum FFmpegProcess {
     private static func shellQuote(_ value: String) -> String {
         "'\(value.replacingOccurrences(of: "'", with: "'\\''"))'"
     }
+    #endif
 }
+
+struct FFmpegProcessUnavailableError: Error {}

--- a/Sources/MereRunCLI/Support/MLXBundleSupport.swift
+++ b/Sources/MereRunCLI/Support/MLXBundleSupport.swift
@@ -27,7 +27,7 @@ enum MLXBundleSupport {
 
     static let expectedProvenance = MetallibProvenance(
       coreVersion: "0.32.1",
-      swiftRevision: "5bf3e46fecfb69cd3b559025fa99885ddd188731",
+      swiftRevision: "30be5d59f194d5f7c67500509bf13bdfa1f26b3b",
       kernelSourcesSHA256: "b791ce523bec5e6612766d9b00004fa66d3f3b1dbbbabd725b5d3c36cefbce41"
     )
 

--- a/Sources/MereRunCLI/Support/WorkflowJobBundle.swift
+++ b/Sources/MereRunCLI/Support/WorkflowJobBundle.swift
@@ -117,6 +117,7 @@ struct WorkflowNodeInvocation: Equatable {
     let streamsEvents: Bool
     let intrinsic: WorkflowIntrinsicInvocation?
     let stdoutOutputName: String?
+    let streamsStdoutDeltas: Bool
 
     init(
         command: [String],
@@ -126,7 +127,8 @@ struct WorkflowNodeInvocation: Equatable {
         outputs: [String: WorkflowInvocationOutput],
         streamsEvents: Bool,
         intrinsic: WorkflowIntrinsicInvocation? = nil,
-        stdoutOutputName: String? = nil
+        stdoutOutputName: String? = nil,
+        streamsStdoutDeltas: Bool = false
     ) {
         self.command = command
         self.executable = executable
@@ -136,6 +138,7 @@ struct WorkflowNodeInvocation: Equatable {
         self.streamsEvents = streamsEvents
         self.intrinsic = intrinsic
         self.stdoutOutputName = stdoutOutputName
+        self.streamsStdoutDeltas = streamsStdoutDeltas
     }
 }
 
@@ -682,10 +685,11 @@ enum WorkflowNodeCommandBuilder {
                 command: ["text", "chat"],
                 executable: CurrentExecutable.url(),
                 preflightArguments: args + ["--preflight", "--json"],
-                runArguments: args,
+                runArguments: args + ["--stream"],
                 outputs: ["text": valueOutput(.string)],
                 streamsEvents: false,
-                stdoutOutputName: "text"
+                stdoutOutputName: "text",
+                streamsStdoutDeltas: true
             )
         case "text.embed":
             let output = artifacts.appendingPathComponent("embeddings.json")

--- a/Sources/MereRunCLI/Support/WorkflowJobBundle.swift
+++ b/Sources/MereRunCLI/Support/WorkflowJobBundle.swift
@@ -668,6 +668,25 @@ enum WorkflowNodeCommandBuilder {
                 ],
                 streamsEvents: false
             )
+        case "text.generate":
+            var args = [
+                "text", "chat",
+                "--prompt", try requiredString("prompt", in: arguments),
+            ]
+            appendString("model", flag: "--model", from: arguments, to: &args)
+            appendString("system", flag: "--system", from: arguments, to: &args)
+            appendInteger("max_tokens", flag: "--max-tokens", from: arguments, to: &args)
+            appendNumber("temperature", flag: "--temperature", from: arguments, to: &args)
+            args += ["--require-installed", "--quiet"]
+            return .init(
+                command: ["text", "chat"],
+                executable: CurrentExecutable.url(),
+                preflightArguments: args + ["--preflight", "--json"],
+                runArguments: args,
+                outputs: ["text": valueOutput(.string)],
+                streamsEvents: false,
+                stdoutOutputName: "text"
+            )
         case "text.embed":
             let output = artifacts.appendingPathComponent("embeddings.json")
             var args = ["text", "embed", try requiredString("text", in: arguments), "--output", output.path]

--- a/Sources/MereRunCLI/Support/WorkflowRunner.swift
+++ b/Sources/MereRunCLI/Support/WorkflowRunner.swift
@@ -286,6 +286,36 @@ protocol WorkflowStreamingProcessRunning {
         timeoutSeconds: Int?,
         stdoutLineHandler: ((String) throws -> Void)?
     ) throws -> WorkflowProcessResult
+
+    func run(
+        executable: URL,
+        arguments: [String],
+        currentDirectory: URL,
+        timeoutSeconds: Int?,
+        stdoutLineHandler: ((String) throws -> Void)?,
+        stdoutChunkHandler: ((Data) throws -> Void)?
+    ) throws -> WorkflowProcessResult
+}
+
+extension WorkflowStreamingProcessRunning {
+    // Chunk delivery is opt-in for runners that support it; others keep
+    // line-based behavior and ignore raw chunks.
+    func run(
+        executable: URL,
+        arguments: [String],
+        currentDirectory: URL,
+        timeoutSeconds: Int?,
+        stdoutLineHandler: ((String) throws -> Void)?,
+        stdoutChunkHandler: ((Data) throws -> Void)?
+    ) throws -> WorkflowProcessResult {
+        try run(
+            executable: executable,
+            arguments: arguments,
+            currentDirectory: currentDirectory,
+            timeoutSeconds: timeoutSeconds,
+            stdoutLineHandler: stdoutLineHandler
+        )
+    }
 }
 
 struct WorkflowProcessRunner: WorkflowProcessRunning, WorkflowStreamingProcessRunning {
@@ -309,6 +339,24 @@ struct WorkflowProcessRunner: WorkflowProcessRunning, WorkflowStreamingProcessRu
         currentDirectory: URL,
         timeoutSeconds: Int?,
         stdoutLineHandler: ((String) throws -> Void)?
+    ) throws -> WorkflowProcessResult {
+        try run(
+            executable: executable,
+            arguments: arguments,
+            currentDirectory: currentDirectory,
+            timeoutSeconds: timeoutSeconds,
+            stdoutLineHandler: stdoutLineHandler,
+            stdoutChunkHandler: nil
+        )
+    }
+
+    func run(
+        executable: URL,
+        arguments: [String],
+        currentDirectory: URL,
+        timeoutSeconds: Int?,
+        stdoutLineHandler: ((String) throws -> Void)?,
+        stdoutChunkHandler: ((Data) throws -> Void)?
     ) throws -> WorkflowProcessResult {
         let process = Process()
         process.executableURL = executable
@@ -368,6 +416,7 @@ struct WorkflowProcessRunner: WorkflowProcessRunning, WorkflowStreamingProcessRu
             let data = stdout.fileHandleForReading.availableData
             if data.isEmpty { break }
             captured.append(data)
+            try stdoutChunkHandler?(data)
             guard stdoutLineHandler != nil else { continue }
             pending.append(data)
             while let newline = pending.firstIndex(of: 0x0A) {
@@ -682,6 +731,8 @@ struct WorkflowRunner: @unchecked Sendable {
                     do {
                         var providerOutputs: [String: WorkflowValue]?
                         var providerSequence = -1
+                        var deltaBytes = Data()
+                        var lastDeltaAt = Date.distantPast
                         let execution = try executeInvocation(
                             invocation,
                             currentDirectory: nodeDirectory,
@@ -720,6 +771,24 @@ struct WorkflowRunner: @unchecked Sendable {
                                     ))
                                     sequence += 1
                                 }
+                            } : nil,
+                            stdoutChunkHandler: invocation.streamsStdoutDeltas ? { chunk in
+                                // Each delta carries the accumulated text so far, so
+                                // downstream retention can coalesce to the latest
+                                // event without losing content.
+                                deltaBytes.append(chunk)
+                                let stamp = now()
+                                guard stamp.timeIntervalSince(lastDeltaAt) >= 0.3 else { return }
+                                lastDeltaAt = stamp
+                                try record(.init(
+                                    sequence: sequence,
+                                    createdAt: stamp,
+                                    type: "node_output_delta",
+                                    state: .running,
+                                    nodeID: nodeID,
+                                    message: String(decoding: deltaBytes, as: UTF8.self)
+                                ))
+                                sequence += 1
                             } : nil
                         )
                         let result = execution.result
@@ -1319,7 +1388,8 @@ struct WorkflowRunner: @unchecked Sendable {
         _ invocation: WorkflowNodeInvocation,
         currentDirectory: URL,
         timeoutSeconds: Int?,
-        stdoutLineHandler: ((String) throws -> Void)?
+        stdoutLineHandler: ((String) throws -> Void)?,
+        stdoutChunkHandler: ((Data) throws -> Void)? = nil
     ) throws -> (result: WorkflowProcessResult, outputs: [String: WorkflowValue]?) {
         if let intrinsic = invocation.intrinsic {
             try throwIfCancellationRequested()
@@ -1335,12 +1405,18 @@ struct WorkflowRunner: @unchecked Sendable {
             arguments: invocation.runArguments,
             currentDirectory: currentDirectory,
             timeoutSeconds: timeoutSeconds,
-            stdoutLineHandler: stdoutLineHandler
+            stdoutLineHandler: stdoutLineHandler,
+            stdoutChunkHandler: stdoutChunkHandler
         )
         guard result.status == 0, let outputName = invocation.stdoutOutputName else {
             return (result, nil)
         }
         var scalar = result.stdout
+        if invocation.streamsStdoutDeltas {
+            // Streamed generation emits reasoning inline; the stored value is
+            // the clean reply, matching the non-streamed path's contract.
+            scalar = GeneratedTextFilters.strippingThinking(scalar)
+        }
         if scalar.hasSuffix("\r\n") {
             scalar.removeLast(2)
         } else if scalar.hasSuffix("\n") {
@@ -1354,7 +1430,8 @@ struct WorkflowRunner: @unchecked Sendable {
         arguments: [String],
         currentDirectory: URL,
         timeoutSeconds: Int?,
-        stdoutLineHandler: ((String) throws -> Void)?
+        stdoutLineHandler: ((String) throws -> Void)?,
+        stdoutChunkHandler: ((Data) throws -> Void)? = nil
     ) throws -> WorkflowProcessResult {
         if let streamingRunner = processRunner as? any WorkflowStreamingProcessRunning {
             return try streamingRunner.run(
@@ -1362,7 +1439,8 @@ struct WorkflowRunner: @unchecked Sendable {
                 arguments: arguments,
                 currentDirectory: currentDirectory,
                 timeoutSeconds: timeoutSeconds,
-                stdoutLineHandler: stdoutLineHandler
+                stdoutLineHandler: stdoutLineHandler,
+                stdoutChunkHandler: stdoutChunkHandler
             )
         }
         if timeoutSeconds != nil {

--- a/Sources/MereRunCore/DeepseekV4Flash/DeepseekV4FlashGenerator.swift
+++ b/Sources/MereRunCore/DeepseekV4Flash/DeepseekV4FlashGenerator.swift
@@ -1,3 +1,6 @@
+// The DS4 engine is a macOS/Linux sidecar process; iOS builds of the
+// core exclude it (phones reach premier-tier agents through the fleet).
+#if !os(iOS)
 import Foundation
 #if canImport(FoundationNetworking)
 import FoundationNetworking
@@ -485,3 +488,4 @@ public actor DeepseekV4FlashGenerator: ChatGenerator {
 
 // Wire types `OpenAIChatRequest`, `OpenAIChatMessage`, and `OpenAIChatResponse`
 // are defined in `MereRunCore/CodeGen/OpenAITypes.swift` and reused here.
+#endif

--- a/Sources/MereRunCore/LoRA/LoRATrainingEnvironment.swift
+++ b/Sources/MereRunCore/LoRA/LoRATrainingEnvironment.swift
@@ -74,7 +74,8 @@ public enum LoRATrainingEnvironment {
     /// Physical memory footprint (the metric jetsam actually enforces —
     /// resident plus compressed), in gigabytes.
     public static func currentPhysicalFootprintGB() -> Double? {
-        #if canImport(Darwin)
+        // proc_pid_rusage is libproc, which iOS does not expose.
+        #if os(macOS)
         var usage = rusage_info_current()
         let status = withUnsafeMutablePointer(to: &usage) { pointer in
             pointer.withMemoryRebound(to: (rusage_info_t?).self, capacity: 1) { reboundPointer in

--- a/Sources/MereRunRelayKit/RelayAuthentication.swift
+++ b/Sources/MereRunRelayKit/RelayAuthentication.swift
@@ -32,6 +32,7 @@ public struct RelayAuthConfiguration: Codable, Equatable, Sendable {
     public let tokenEndpoint: String
     public let clientID: String
     public let scope: String
+    public let authorizationEndpoint: String?
 
     enum CodingKeys: String, CodingKey {
         case issuer
@@ -39,6 +40,7 @@ public struct RelayAuthConfiguration: Codable, Equatable, Sendable {
         case tokenEndpoint = "token_endpoint"
         case clientID = "client_id"
         case scope
+        case authorizationEndpoint = "authorization_endpoint"
     }
 
     public init(
@@ -46,13 +48,15 @@ public struct RelayAuthConfiguration: Codable, Equatable, Sendable {
         deviceAuthorizationEndpoint: String,
         tokenEndpoint: String,
         clientID: String,
-        scope: String
+        scope: String,
+        authorizationEndpoint: String? = nil
     ) {
         self.issuer = issuer
         self.deviceAuthorizationEndpoint = deviceAuthorizationEndpoint
         self.tokenEndpoint = tokenEndpoint
         self.clientID = clientID
         self.scope = scope
+        self.authorizationEndpoint = authorizationEndpoint
     }
 }
 
@@ -578,6 +582,34 @@ public enum RelayAuthentication {
         throw RelayClientError("Relay device sign-in expired before approval.")
     }
 
+    /// Storage-backed resolution for app clients: loads from the supplied
+    /// storage, refreshing (and saving back) when stale.
+    public static func resolveCredential(
+        profile: WorkflowExecutorProfile,
+        storage: any RelayCredentialStorage,
+        forceRefresh: Bool = false,
+        now: @Sendable () -> Int64 = currentEpochSeconds,
+        requester: HTTPRequester = send
+    ) async throws -> RelayResolvedCredential {
+        guard let current = try storage.load() else {
+            throw RelayClientError("No saved relay credential. Sign in again.")
+        }
+        if !forceRefresh, current.isFresh(now: now()) {
+            return RelayResolvedCredential(
+                accessToken: current.accessToken,
+                refreshable: current.refreshToken?.isEmpty == false
+            )
+        }
+        let refreshed = try await refreshedTokenSet(
+            current: current,
+            profile: profile,
+            now: now,
+            requester: requester
+        )
+        try storage.save(refreshed)
+        return RelayResolvedCredential(accessToken: refreshed.accessToken, refreshable: true)
+    }
+
     private static func refreshLocked(
         tokenFile: URL,
         profile: WorkflowExecutorProfile,
@@ -597,6 +629,22 @@ public enum RelayAuthentication {
                 refreshable: current.refreshToken?.isEmpty == false
             )
         }
+        let refreshed = try await refreshedTokenSet(
+            current: current,
+            profile: profile,
+            now: now,
+            requester: requester
+        )
+        try save(refreshed, to: tokenFile)
+        return RelayResolvedCredential(accessToken: refreshed.accessToken, refreshable: true)
+    }
+
+    private static func refreshedTokenSet(
+        current: RelayOAuthTokenSet,
+        profile: WorkflowExecutorProfile,
+        now: @Sendable () -> Int64,
+        requester: HTTPRequester
+    ) async throws -> RelayOAuthTokenSet {
         guard let refreshToken = current.refreshToken, !refreshToken.isEmpty else {
             throw RelayClientError("Relay session expired. Run `mere.run executor login relay:\(profile.name)`." )
         }
@@ -633,7 +681,7 @@ public enum RelayAuthentication {
         guard let accessToken = payload.accessToken else {
             throw tokenError(payload, status: response.statusCode)
         }
-        let refreshed = RelayOAuthTokenSet(
+        return RelayOAuthTokenSet(
             accessToken: accessToken,
             refreshToken: payload.refreshToken ?? refreshToken,
             tokenType: payload.tokenType ?? current.tokenType,
@@ -644,8 +692,6 @@ public enum RelayAuthentication {
             clientID: configuration.clientID,
             scope: configuration.scope
         )
-        try save(refreshed, to: tokenFile)
-        return RelayResolvedCredential(accessToken: accessToken, refreshable: true)
     }
 
     private static func requestToken(

--- a/Sources/MereRunRelayKit/RelayAuthorizationCode.swift
+++ b/Sources/MereRunRelayKit/RelayAuthorizationCode.swift
@@ -1,0 +1,144 @@
+import Crypto
+import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
+
+/// Authorization Code + PKCE for native clients. The relay's discovery
+/// document advertises `authorization_endpoint` when its broker supports the
+/// flow; clients fall back to the device grant when it is absent.
+public enum RelayAuthorizationCodeFlow {
+    public struct Started: Sendable {
+        public let authorizationURL: URL
+        public let codeVerifier: String
+        public let state: String
+    }
+
+    /// Builds the authorize URL with an S256 challenge and CSRF state.
+    public static func begin(
+        configuration: RelayAuthConfiguration,
+        clientID: String,
+        redirectURI: String
+    ) throws -> Started {
+        guard let endpoint = configuration.authorizationEndpoint,
+              var components = URLComponents(string: endpoint) else {
+            throw RelayClientError("The relay's broker does not offer browser sign-in; use the device code instead.")
+        }
+        let verifier = randomURLSafeToken(bytes: 48)
+        let challenge = Data(SHA256.hash(data: Data(verifier.utf8))).base64URLEncoded()
+        let state = randomURLSafeToken(bytes: 24)
+        components.queryItems = (components.queryItems ?? []) + [
+            URLQueryItem(name: "response_type", value: "code"),
+            URLQueryItem(name: "client_id", value: clientID),
+            URLQueryItem(name: "redirect_uri", value: redirectURI),
+            URLQueryItem(name: "scope", value: configuration.scope),
+            URLQueryItem(name: "state", value: state),
+            URLQueryItem(name: "code_challenge", value: challenge),
+            URLQueryItem(name: "code_challenge_method", value: "S256"),
+        ]
+        guard let url = components.url else {
+            throw RelayClientError("Relay authorization endpoint is invalid.")
+        }
+        return Started(authorizationURL: url, codeVerifier: verifier, state: state)
+    }
+
+    /// Validates the callback against the started flow and returns the code.
+    public static func code(
+        fromCallback callback: URL,
+        started: Started
+    ) throws -> String {
+        let items = URLComponents(url: callback, resolvingAgainstBaseURL: false)?.queryItems ?? []
+        guard items.first(where: { $0.name == "state" })?.value == started.state else {
+            throw RelayClientError("Sign-in was interrupted; try again.")
+        }
+        if let error = items.first(where: { $0.name == "error" })?.value {
+            throw RelayClientError("Sign-in was refused: \(error)")
+        }
+        guard let code = items.first(where: { $0.name == "code" })?.value, !code.isEmpty else {
+            throw RelayClientError("Sign-in did not return an authorization code.")
+        }
+        return code
+    }
+
+    /// Exchanges the code + verifier for a token set at the broker.
+    public static func exchange(
+        code: String,
+        started: Started,
+        configuration: RelayAuthConfiguration,
+        clientID: String,
+        redirectURI: String,
+        requester: RelayAuthentication.HTTPRequester = RelayAuthentication.send,
+        now: @Sendable () -> Int64 = RelayAuthentication.currentEpochSeconds
+    ) async throws -> RelayOAuthTokenSet {
+        guard let url = URL(string: configuration.tokenEndpoint) else {
+            throw RelayClientError("Relay token endpoint is invalid.")
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.timeoutInterval = 30
+        request.setValue("application/x-www-form-urlencoded", forHTTPHeaderField: "Content-Type")
+        request.setValue(configuration.issuer, forHTTPHeaderField: "Origin")
+        request.httpBody = Data(
+            formEncoded([
+                ("grant_type", "authorization_code"),
+                ("code", code),
+                ("redirect_uri", redirectURI),
+                ("client_id", clientID),
+                ("code_verifier", started.codeVerifier),
+            ]).utf8
+        )
+        let (data, response) = try await requester(request)
+        guard (200..<300).contains(response.statusCode) else {
+            throw RelayClientError("Sign-in failed with HTTP \(response.statusCode).")
+        }
+        struct TokenResponse: Decodable {
+            let accessToken: String
+            let refreshToken: String?
+            let tokenType: String?
+            let expiresIn: Int64?
+
+            enum CodingKeys: String, CodingKey {
+                case accessToken = "access_token"
+                case refreshToken = "refresh_token"
+                case tokenType = "token_type"
+                case expiresIn = "expires_in"
+            }
+        }
+        let token = try WorkflowBundleCodec.decoder().decode(TokenResponse.self, from: data)
+        return RelayOAuthTokenSet(
+            accessToken: token.accessToken,
+            refreshToken: token.refreshToken,
+            tokenType: token.tokenType,
+            expiresIn: token.expiresIn,
+            obtainedAtEpochSeconds: now(),
+            issuer: configuration.issuer,
+            tokenEndpoint: configuration.tokenEndpoint,
+            clientID: clientID,
+            scope: configuration.scope
+        )
+    }
+
+    private static func randomURLSafeToken(bytes count: Int) -> String {
+        var generator = SystemRandomNumberGenerator()
+        let bytes = (0..<count).map { _ in UInt8.random(in: .min ... .max, using: &generator) }
+        return Data(bytes).base64URLEncoded()
+    }
+
+    private static func formEncoded(_ pairs: [(String, String)]) -> String {
+        var allowed = CharacterSet.alphanumerics
+        allowed.insert(charactersIn: "-._~")
+        return pairs.map { name, value in
+            let encoded = value.addingPercentEncoding(withAllowedCharacters: allowed) ?? value
+            return "\(name)=\(encoded)"
+        }.joined(separator: "&")
+    }
+}
+
+extension Data {
+    func base64URLEncoded() -> String {
+        base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+    }
+}

--- a/Sources/MereRunRelayKit/RelayClient.swift
+++ b/Sources/MereRunRelayKit/RelayClient.swift
@@ -52,6 +52,17 @@ public struct RelayWorkflowExecutor: Sendable {
             .remoteJob(profile: profile.name, localRunDirectory: nil)
     }
 
+    /// The run manifest for a job: states, per-node records, and node output
+    /// values — the way text-valued results come back without artifact fetch.
+    public func manifest(jobID: String) async throws -> GraphRunManifest {
+        let data = try await request(path: "/api/graph-jobs/\(jobID)/run-manifest", method: "GET")
+        let manifest = try WorkflowBundleCodec.decoder().decode(GraphRunManifest.self, from: data)
+        guard manifest.jobID == jobID else {
+            throw RelayClientError("Relay returned a run manifest for a different job.")
+        }
+        return manifest
+    }
+
     public func events(jobID: String) async throws -> String {
         let data = try await request(path: "/api/graph-jobs/\(jobID)/events", method: "GET")
         return String(decoding: data, as: UTF8.self)
@@ -92,11 +103,7 @@ public struct RelayWorkflowExecutor: Sendable {
             throw RelayClientError("Relay job \(jobID) is not finished.")
         }
         try prepareFetchDestination(destination, expectedJobID: jobID)
-        let manifestData = try await request(path: "/api/graph-jobs/\(jobID)/run-manifest", method: "GET")
-        var manifest = try WorkflowBundleCodec.decoder().decode(GraphRunManifest.self, from: manifestData)
-        guard manifest.jobID == jobID else {
-            throw RelayClientError("Relay returned a run manifest for a different job.")
-        }
+        var manifest = try await manifest(jobID: jobID)
         manifest.executor = .init(
             kind: "relay",
             profile: profile.name,

--- a/Sources/MereRunRelayKit/RelayClient.swift
+++ b/Sources/MereRunRelayKit/RelayClient.swift
@@ -10,9 +10,22 @@ import FoundationNetworking
 /// verified artifact fetch — lives here and needs no local runtime.
 public struct RelayWorkflowExecutor: Sendable {
     public let profile: WorkflowExecutorProfile
+    public let credentialStorage: (any RelayCredentialStorage)?
 
-    public init(profile: WorkflowExecutorProfile) {
+    public init(profile: WorkflowExecutorProfile, credentialStorage: (any RelayCredentialStorage)? = nil) {
         self.profile = profile
+        self.credentialStorage = credentialStorage
+    }
+
+    private func resolveCredential(forceRefresh: Bool = false) async throws -> RelayResolvedCredential {
+        if let credentialStorage {
+            return try await RelayAuthentication.resolveCredential(
+                profile: profile,
+                storage: credentialStorage,
+                forceRefresh: forceRefresh
+            )
+        }
+        return try await RelayAuthentication.resolveCredential(profile: profile, forceRefresh: forceRefresh)
     }
 
     public func probe() async throws -> WorkflowExecutorProbe {
@@ -161,7 +174,7 @@ public struct RelayWorkflowExecutor: Sendable {
         guard let baseURL = profile.url, let url = URL(string: "\(baseURL)\(path)") else {
             throw RelayClientError("Relay executor profile has an invalid URL.")
         }
-        let credential = authorize ? try await RelayAuthentication.resolveCredential(profile: profile) : nil
+        let credential = authorize ? try await resolveCredential() : nil
         var result = try await Self.performWithTransientRetries(maximumAttempts: transientRetryAttempts) {
             try await performRequest(
                 url: url,
@@ -172,7 +185,7 @@ public struct RelayWorkflowExecutor: Sendable {
             )
         }
         if result.response.statusCode == 401, credential?.refreshable == true {
-            let refreshed = try await RelayAuthentication.resolveCredential(profile: profile, forceRefresh: true)
+            let refreshed = try await resolveCredential(forceRefresh: true)
             result = try await Self.performWithTransientRetries(maximumAttempts: transientRetryAttempts) {
                 try await performRequest(
                     url: url,

--- a/Sources/MereRunRelayKit/RelayClient.swift
+++ b/Sources/MereRunRelayKit/RelayClient.swift
@@ -118,17 +118,16 @@ public struct RelayWorkflowExecutor: Sendable {
             let url = try confinedFetchURL(root: destination, relativePath: artifact.path)
             if try verifiedExistingArtifact(artifact, at: url) { continue }
             let encodedName = try encodedPathSegment(artifact.name)
-            let data = try await request(
+            try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+            try await downloadArtifact(
                 path: "/api/graph-jobs/\(jobID)/artifacts/\(encodedName)",
-                method: "GET",
-                authorize: true
+                to: url
             )
-            guard Int64(data.count) == artifact.sizeBytes,
-                  ModelArtifactPinDigest.sha256(data) == artifact.sha256 else {
+            guard try ModelArtifactPinDigest.fileByteCount(url) == artifact.sizeBytes,
+                  try ModelArtifactPinDigest.fileSHA256(url) == artifact.sha256 else {
+                try? FileManager.default.removeItem(at: url)
                 throw RelayClientError("Fetched relay artifact failed verification: \(artifact.name)")
             }
-            try FileManager.default.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
-            try data.write(to: url, options: .atomic)
         }
         try WorkflowBundleCodec.write(manifest, to: destination.appendingPathComponent(GraphRunManifest.filename))
         let fetchedOutputs = manifest.outputs.filter { output in
@@ -214,6 +213,48 @@ public struct RelayWorkflowExecutor: Sendable {
 
     private static func isTransientHTTPStatus(_ statusCode: Int) -> Bool {
         statusCode == 408 || statusCode == 429 || (500...599).contains(statusCode)
+    }
+
+    /// Streams a GET straight to disk. On Darwin the transfer never buffers
+    /// the artifact in memory (video and 3D outputs can be large); platforms
+    /// without URLSession's async download fall back to a buffered fetch.
+    private func downloadArtifact(path: String, to fileURL: URL) async throws {
+        #if canImport(FoundationNetworking)
+        let data = try await request(path: path, method: "GET", authorize: true)
+        try data.write(to: fileURL, options: .atomic)
+        #else
+        guard let baseURL = profile.url, let url = URL(string: "\(baseURL)\(path)") else {
+            throw RelayClientError("Relay executor profile has an invalid URL.")
+        }
+        var credential = try await RelayAuthentication.resolveCredential(profile: profile)
+        var attempt = 0
+        while true {
+            attempt += 1
+            var request = URLRequest(url: url)
+            request.httpMethod = "GET"
+            request.timeoutInterval = 300
+            request.setValue("Bearer \(credential.accessToken)", forHTTPHeaderField: "Authorization")
+            let (temporary, response) = try await URLSession.shared.download(for: request)
+            guard let http = response as? HTTPURLResponse else {
+                try? FileManager.default.removeItem(at: temporary)
+                throw RelayClientError("Relay returned a non-HTTP response.")
+            }
+            if http.statusCode == 401, credential.refreshable, attempt == 1 {
+                try? FileManager.default.removeItem(at: temporary)
+                credential = try await RelayAuthentication.resolveCredential(profile: profile, forceRefresh: true)
+                continue
+            }
+            guard (200..<300).contains(http.statusCode) else {
+                try? FileManager.default.removeItem(at: temporary)
+                throw RelayClientError("Relay request failed with HTTP \(http.statusCode).")
+            }
+            if FileManager.default.fileExists(atPath: fileURL.path) {
+                try FileManager.default.removeItem(at: fileURL)
+            }
+            try FileManager.default.moveItem(at: temporary, to: fileURL)
+            return
+        }
+        #endif
     }
 
     private func performRequest(

--- a/Sources/MereRunRelayKit/RelayCredentialStorage.swift
+++ b/Sources/MereRunRelayKit/RelayCredentialStorage.swift
@@ -1,0 +1,97 @@
+import Foundation
+#if canImport(Security)
+import Security
+#endif
+
+/// Where a relay credential lives. The CLI keeps the 0600 token file so
+/// profiles stay shareable with the node app; the iOS app stores the token
+/// set in the Keychain.
+public protocol RelayCredentialStorage: Sendable {
+    func load() throws -> RelayOAuthTokenSet?
+    func save(_ tokenSet: RelayOAuthTokenSet) throws
+    func clear() throws
+}
+
+public struct FileCredentialStorage: RelayCredentialStorage {
+    public let url: URL
+
+    public init(url: URL) {
+        self.url = url
+    }
+
+    public func load() throws -> RelayOAuthTokenSet? {
+        guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+        return try? WorkflowBundleCodec.decoder().decode(RelayOAuthTokenSet.self, from: Data(contentsOf: url))
+    }
+
+    public func save(_ tokenSet: RelayOAuthTokenSet) throws {
+        try RelayAuthentication.save(tokenSet, to: url)
+    }
+
+    public func clear() throws {
+        if FileManager.default.fileExists(atPath: url.path) {
+            try FileManager.default.removeItem(at: url)
+        }
+    }
+}
+
+#if canImport(Security) && !os(Linux)
+/// Keychain-backed storage: device-only, available after first unlock, never
+/// migrated to other devices or backups.
+public struct KeychainCredentialStorage: RelayCredentialStorage {
+    public let service: String
+    public let account: String
+
+    public init(service: String, account: String) {
+        self.service = service
+        self.account = account
+    }
+
+    private var query: [String: Any] {
+        [
+            kSecClass as String: kSecClassGenericPassword,
+            kSecAttrService as String: service,
+            kSecAttrAccount as String: account,
+        ]
+    }
+
+    public func load() throws -> RelayOAuthTokenSet? {
+        var lookup = query
+        lookup[kSecReturnData as String] = true
+        lookup[kSecMatchLimit as String] = kSecMatchLimitOne
+        var result: CFTypeRef?
+        let status = SecItemCopyMatching(lookup as CFDictionary, &result)
+        guard status != errSecItemNotFound else { return nil }
+        guard status == errSecSuccess, let data = result as? Data else {
+            throw RelayClientError("Could not read the saved relay credential (\(status)).")
+        }
+        return try? WorkflowBundleCodec.decoder().decode(RelayOAuthTokenSet.self, from: data)
+    }
+
+    public func save(_ tokenSet: RelayOAuthTokenSet) throws {
+        let data = try WorkflowBundleCodec.encoder().encode(tokenSet)
+        var attributes = query
+        attributes[kSecValueData as String] = data
+        attributes[kSecAttrAccessible as String] = kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly
+        let status = SecItemAdd(attributes as CFDictionary, nil)
+        if status == errSecDuplicateItem {
+            let update = [kSecValueData as String: data] as CFDictionary
+            let updateStatus = SecItemUpdate(query as CFDictionary, update)
+            guard updateStatus == errSecSuccess else {
+                throw RelayClientError("Could not update the saved relay credential (\(updateStatus)).")
+            }
+            return
+        }
+        guard status == errSecSuccess else {
+            throw RelayClientError("Could not save the relay credential (\(status)).")
+        }
+    }
+
+    public func clear() throws {
+        let status = SecItemDelete(query as CFDictionary)
+        guard status == errSecSuccess || status == errSecItemNotFound else {
+            throw RelayClientError("Could not remove the saved relay credential (\(status)).")
+        }
+    }
+}
+#endif

--- a/Sources/MereRunRelayKit/RelayEventText.swift
+++ b/Sources/MereRunRelayKit/RelayEventText.swift
@@ -32,3 +32,29 @@ public enum RelayEventText {
         }
     }
 }
+
+/// Removes model reasoning blocks from generated text. Complete
+/// `<think>…</think>` blocks are always removed, as is a leading orphan
+/// close tag (some models pre-fill the opening tag). A trailing unclosed
+/// block is stripped only while `streaming` — at finalize it is kept, since
+/// a completed reply's leftover tag is almost certainly literal content.
+public enum GeneratedTextFilters {
+    public static func strippingThinking(_ text: String, streaming: Bool = false) -> String {
+        var result = text.replacingOccurrences(
+            of: "<think>[\\s\\S]*?</think>",
+            with: "",
+            options: .regularExpression
+        )
+        if !result.contains("<think>"), let close = result.range(of: "</think>") {
+            result = String(result[close.upperBound...])
+        }
+        if streaming {
+            result = result.replacingOccurrences(
+                of: "<think>[\\s\\S]*$",
+                with: "",
+                options: .regularExpression
+            )
+        }
+        return result.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}

--- a/Sources/MereRunRelayKit/WorkflowGraphDocuments.swift
+++ b/Sources/MereRunRelayKit/WorkflowGraphDocuments.swift
@@ -1142,6 +1142,24 @@ public enum WorkflowNodeRegistry {
             )
         ),
         WorkflowNodeCatalogEntry(
+            kind: "text.generate",
+            title: "Generate text",
+            category: "text",
+            inputs: [
+                .init(name: "prompt", type: .string, required: true, multiline: true),
+                .init(name: "model", type: .string, required: false),
+                .init(name: "system", type: .string, required: false, multiline: true),
+                .init(name: "max_tokens", type: .integer, required: false),
+                .init(name: "temperature", type: .number, required: false),
+            ],
+            outputs: [.init(name: "text", type: .string)],
+            requirements: .init(
+                modelIDs: [],
+                acceleratorBackends: ["metal", "cuda"],
+                minimumAcceleratorMemoryBytes: nil
+            )
+        ),
+        WorkflowNodeCatalogEntry(
             kind: "text.embed",
             title: "Embed text",
             category: "text",

--- a/Tests/MereRunCLITests/WorkflowGraphTests.swift
+++ b/Tests/MereRunCLITests/WorkflowGraphTests.swift
@@ -243,6 +243,45 @@ final class WorkflowGraphTests: XCTestCase {
         XCTAssertEqual(invocation.stdoutOutputName, "text")
     }
 
+    func testTextGenerateBuildsInstalledTextChatValueInvocation() throws {
+        let root = try temporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let node = WorkflowNode(
+            id: "reply",
+            kind: "text.generate",
+            arguments: [
+                "prompt": .string("Answer briefly."),
+                "system": .string("Be precise."),
+                "model": .string("text-chat-qwen38-27b-4bit"),
+                "max_tokens": .integer(256),
+                "temperature": .number(0.25),
+            ],
+            dependsOn: nil
+        )
+        let invocation = try WorkflowNodeCommandBuilder.invocation(
+            node: node,
+            arguments: node.arguments,
+            nodeDirectory: root
+        )
+        let runArguments = [
+            "text", "chat",
+            "--prompt", "Answer briefly.",
+            "--model", "text-chat-qwen38-27b-4bit",
+            "--system", "Be precise.",
+            "--max-tokens", "256",
+            "--temperature", "0.25",
+            "--require-installed", "--quiet",
+        ]
+
+        XCTAssertEqual(invocation.command, ["text", "chat"])
+        XCTAssertEqual(invocation.runArguments, runArguments)
+        XCTAssertEqual(invocation.preflightArguments, runArguments + ["--preflight", "--json"])
+        XCTAssertEqual(invocation.outputs["text"]?.type, .string)
+        XCTAssertNil(invocation.outputs["text"]?.path)
+        XCTAssertEqual(invocation.stdoutOutputName, "text")
+        XCTAssertFalse(invocation.streamsEvents)
+    }
+
     func testVisionGroundBuildsPreflightAndArtifactInvocation() throws {
         let root = try temporaryDirectory()
         defer { try? FileManager.default.removeItem(at: root) }

--- a/Tests/MereRunCLITests/WorkflowGraphTests.swift
+++ b/Tests/MereRunCLITests/WorkflowGraphTests.swift
@@ -274,12 +274,13 @@ final class WorkflowGraphTests: XCTestCase {
         ]
 
         XCTAssertEqual(invocation.command, ["text", "chat"])
-        XCTAssertEqual(invocation.runArguments, runArguments)
+        XCTAssertEqual(invocation.runArguments, runArguments + ["--stream"])
         XCTAssertEqual(invocation.preflightArguments, runArguments + ["--preflight", "--json"])
         XCTAssertEqual(invocation.outputs["text"]?.type, .string)
         XCTAssertNil(invocation.outputs["text"]?.path)
         XCTAssertEqual(invocation.stdoutOutputName, "text")
         XCTAssertFalse(invocation.streamsEvents)
+        XCTAssertTrue(invocation.streamsStdoutDeltas)
     }
 
     func testVisionGroundBuildsPreflightAndArtifactInvocation() throws {
@@ -1074,6 +1075,21 @@ final class WorkflowGraphTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: root) }
         let nodeDirectory = root.appendingPathComponent("run/nodes/000-fixture", isDirectory: true)
         try FileManager.default.createDirectory(at: nodeDirectory, withIntermediateDirectories: true)
+
+        var chunks: [String] = []
+        let streamed = try WorkflowProcessRunner().run(
+            executable: URL(fileURLWithPath: "/bin/sh"),
+            arguments: ["-c", "printf 'hello '; sleep 0.2; printf 'world'"],
+            currentDirectory: nodeDirectory,
+            timeoutSeconds: nil,
+            stdoutLineHandler: nil,
+            stdoutChunkHandler: { chunk in
+                chunks.append(String(decoding: chunk, as: UTF8.self))
+            }
+        )
+        XCTAssertEqual(streamed.stdout, "hello world")
+        XCTAssertGreaterThanOrEqual(chunks.count, 2)
+        XCTAssertEqual(chunks.joined(), "hello world")
 
         let result = try WorkflowProcessRunner().run(
             executable: URL(fileURLWithPath: "/bin/sh"),

--- a/Tests/MereRunRelayKitTests/RelayEventTextTests.swift
+++ b/Tests/MereRunRelayKitTests/RelayEventTextTests.swift
@@ -56,3 +56,34 @@ final class RelayEventTextTests: XCTestCase {
         XCTAssertEqual(try ModelArtifactPinDigest.fileByteCount(url), Int64(payload.count))
     }
 }
+
+final class GeneratedTextFiltersTests: XCTestCase {
+    func testCompleteThinkingBlocksAreRemoved() {
+        XCTAssertEqual(
+            GeneratedTextFilters.strippingThinking("<think>plan</think>Hello."),
+            "Hello."
+        )
+    }
+
+    func testLeadingOrphanCloseTagIsRemoved() {
+        XCTAssertEqual(
+            GeneratedTextFiltersTests.strip("reasoning</think>Answer."),
+            "Answer."
+        )
+    }
+
+    func testTrailingUnclosedBlockIsStrippedOnlyWhileStreaming() {
+        XCTAssertEqual(
+            GeneratedTextFilters.strippingThinking("Partial <think>still going", streaming: true),
+            "Partial"
+        )
+        XCTAssertEqual(
+            GeneratedTextFilters.strippingThinking("Done. <think>literal tag talk"),
+            "Done. <think>literal tag talk"
+        )
+    }
+
+    private static func strip(_ text: String) -> String {
+        GeneratedTextFilters.strippingThinking(text)
+    }
+}

--- a/docs/ios-studio.md
+++ b/docs/ios-studio.md
@@ -70,8 +70,10 @@ covers building.
 ## iOS-specific follow-ups
 
 - Keychain-backed credential storage and Authorization Code + PKCE sign-in
-  (hosted Studio's flow; a phone has a browser, so the device grant is a
-  working but non-idiomatic first step).
+  (done: `ASWebAuthenticationSession` over the broker's advertised
+  `authorization_endpoint`, universal-link callback on `mere.world`,
+  tokens in the Keychain with file→Keychain migration; the device grant
+  remains as the browserless fallback).
 - Artifact downloads stream to disk with digest verification (done);
   incremental in-flight hashing remains a refinement.
 - Live Activities ship with app-driven updates; completion pushes and

--- a/docs/ios-studio.md
+++ b/docs/ios-studio.md
@@ -14,7 +14,12 @@ covers building.
    hosted-Studio pattern — never from local discovery, which needs process
    spawning that iOS forbids), and reads the same `graph-event-v1` /
    `graph-run-v1` documents published in `docs/public/schemas/`.
-2. **On-device lane (later).** Small models genuinely fit Pro-class devices:
+2. **On-device lane (experimental, landed).** `MereRunCore` builds for
+   iOS; the app's image mode offers "This iPhone" alongside the fleet,
+   installing FLUX.2 Klein nano through the managed store into the app
+   sandbox and generating through the memory-optimized iOS pipeline. First
+   on-device generation still needs real-device validation of the MLX Metal
+   kernel path. The original sizing notes: Small models genuinely fit Pro-class devices:
    the Bonsai image binary (4B, 1-bit, ~3.4 GB) runs through the same FLUX.2
    Klein pipeline that already has a memory-constrained iOS generator in
    `MereRunCore` (`Flux2KleinGeneratoriOS`, ~2 GB peak via sequential

--- a/docs/ios-studio.md
+++ b/docs/ios-studio.md
@@ -19,7 +19,7 @@ covers building.
    installing FLUX.2 Klein nano through the managed store into the app
    sandbox and generating through the memory-optimized iOS pipeline. First
    on-device generation still needs real-device validation of the MLX Metal
-   kernel path. The original sizing notes: Small models genuinely fit Pro-class devices:
+   kernel path. Sizing: small models genuinely fit Pro-class devices —
    the Bonsai image binary (4B, 1-bit, ~3.4 GB) runs through the same FLUX.2
    Klein pipeline that already has a memory-constrained iOS generator in
    `MereRunCore` (`Flux2KleinGeneratoriOS`, ~2 GB peak via sequential
@@ -72,12 +72,10 @@ covers building.
 - Keychain-backed credential storage and Authorization Code + PKCE sign-in
   (hosted Studio's flow; a phone has a browser, so the device grant is a
   working but non-idiomatic first step).
-- Streaming artifact downloads (`URLSession.downloadTask` with incremental
-  SHA-256) before video/3D outputs; the current fetch buffers whole
-  artifacts in memory.
-- Completion pushes and Live Activities for long renders need APNs support
-  in the relay repository; until then the app polls in the foreground and
-  can adopt background refresh.
+- Artifact downloads stream to disk with digest verification (done);
+  incremental in-flight hashing remains a refinement.
+- Live Activities ship with app-driven updates; completion pushes and
+  push-updated activities need APNs support in the relay repository.
 
 ## Boundaries
 

--- a/docs/public/schemas/graph-event-v1.schema.json
+++ b/docs/public/schemas/graph-event-v1.schema.json
@@ -1,80 +1,161 @@
 {
-  "$schema": "https://json-schema.org/draft/2020-12/schema",
-  "$id": "https://mere.run/schemas/graph-event-v1.schema.json",
-  "title": "mere.run Graph Event V1",
-  "type": "object",
-  "additionalProperties": false,
-  "required": ["sequence", "created_at", "type", "state"],
-  "properties": {
-    "sequence": { "type": "integer", "minimum": 0 },
-    "created_at": { "type": "string", "format": "date-time" },
-    "type": {
-      "enum": [
-        "run_started",
-        "node_preflight_started",
-        "node_started",
-        "node_progress",
-        "preview_ready",
-        "artifact_ready",
-        "node_diagnostic",
-        "node_metric",
-        "node_heartbeat",
-        "node_resumed",
-        "node_finished",
-        "run_finished",
-        "run_failed",
-        "run_cancelled"
-      ]
+ "$schema": "https://json-schema.org/draft/2020-12/schema",
+ "$id": "https://mere.run/schemas/graph-event-v1.schema.json",
+ "title": "mere.run Graph Event V1",
+ "type": "object",
+ "additionalProperties": false,
+ "required": [
+  "sequence",
+  "created_at",
+  "type",
+  "state"
+ ],
+ "properties": {
+  "sequence": {
+   "type": "integer",
+   "minimum": 0
+  },
+  "created_at": {
+   "type": "string",
+   "format": "date-time"
+  },
+  "type": {
+   "enum": [
+    "run_started",
+    "node_preflight_started",
+    "node_started",
+    "node_progress",
+    "node_output_delta",
+    "preview_ready",
+    "artifact_ready",
+    "node_diagnostic",
+    "node_metric",
+    "node_heartbeat",
+    "node_resumed",
+    "node_finished",
+    "run_finished",
+    "run_failed",
+    "run_cancelled"
+   ]
+  },
+  "state": {
+   "enum": [
+    "planned",
+    "preflighting",
+    "queued",
+    "assigned",
+    "running",
+    "finished",
+    "failed",
+    "cancelled"
+   ]
+  },
+  "node_id": {
+   "type": [
+    "string",
+    "null"
+   ],
+   "pattern": "^[a-z][a-z0-9-]{0,63}$"
+  },
+  "message": {
+   "type": [
+    "string",
+    "null"
+   ]
+  },
+  "progress": {
+   "type": "object",
+   "additionalProperties": false,
+   "properties": {
+    "phase": {
+     "type": "string"
     },
-    "state": {
-      "enum": ["planned", "preflighting", "queued", "assigned", "running", "finished", "failed", "cancelled"]
+    "current": {
+     "type": "number",
+     "minimum": 0
     },
-    "node_id": {
-      "type": ["string", "null"],
-      "pattern": "^[a-z][a-z0-9-]{0,63}$"
+    "total": {
+     "type": "number",
+     "exclusiveMinimum": 0
     },
-    "message": { "type": ["string", "null"] },
-    "progress": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "phase": { "type": "string" },
-        "current": { "type": "number", "minimum": 0 },
-        "total": { "type": "number", "exclusiveMinimum": 0 },
-        "fraction": { "type": "number", "minimum": 0, "maximum": 1 },
-        "unit": { "type": "string" }
-      }
+    "fraction": {
+     "type": "number",
+     "minimum": 0,
+     "maximum": 1
     },
-    "artifact": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["name", "path", "content_type"],
-      "properties": {
-        "name": { "type": "string" },
-        "path": { "type": "string", "pattern": "^(?!/)(?!.*(?:^|/)\\.\\.(?:/|$)).+$" },
-        "content_type": { "type": "string", "minLength": 1 }
-      }
-    },
-    "diagnostic": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["id", "severity", "title", "message"],
-      "properties": {
-        "id": { "type": "string" },
-        "severity": { "enum": ["info", "warning", "blocker"] },
-        "title": { "type": "string" },
-        "message": { "type": "string" }
-      }
-    },
-    "metric": {
-      "type": "object",
-      "additionalProperties": false,
-      "required": ["name", "value"],
-      "properties": {
-        "name": { "type": "string" },
-        "value": { "type": "number" },
-        "unit": { "type": "string" }
-      }
+    "unit": {
+     "type": "string"
     }
+   }
+  },
+  "artifact": {
+   "type": "object",
+   "additionalProperties": false,
+   "required": [
+    "name",
+    "path",
+    "content_type"
+   ],
+   "properties": {
+    "name": {
+     "type": "string"
+    },
+    "path": {
+     "type": "string",
+     "pattern": "^(?!/)(?!.*(?:^|/)\\.\\.(?:/|$)).+$"
+    },
+    "content_type": {
+     "type": "string",
+     "minLength": 1
+    }
+   }
+  },
+  "diagnostic": {
+   "type": "object",
+   "additionalProperties": false,
+   "required": [
+    "id",
+    "severity",
+    "title",
+    "message"
+   ],
+   "properties": {
+    "id": {
+     "type": "string"
+    },
+    "severity": {
+     "enum": [
+      "info",
+      "warning",
+      "blocker"
+     ]
+    },
+    "title": {
+     "type": "string"
+    },
+    "message": {
+     "type": "string"
+    }
+   }
+  },
+  "metric": {
+   "type": "object",
+   "additionalProperties": false,
+   "required": [
+    "name",
+    "value"
+   ],
+   "properties": {
+    "name": {
+     "type": "string"
+    },
+    "value": {
+     "type": "number"
+    },
+    "unit": {
+     "type": "string"
+    }
+   }
   }
+ }
 }

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -59,7 +59,7 @@ The V1 node catalog contains:
 - `speech.synthesize`, `speech.transcribe`, `speech.diarize`
 - `vision.caption`, `vision.ocr`, `vision.geometry`, `vision.image-to-3d`
 - `audio.enhance`
-- `text.embed`, `text.anonymize`
+- `text.generate`, `text.embed`, `text.anonymize`
 
 The value and text nodes make authored creative material reusable without
 turning it into a runtime graph input. Literal values, seeds, joins, and

--- a/ios/MereRunStudio/App/ChatStore.swift
+++ b/ios/MereRunStudio/App/ChatStore.swift
@@ -1,0 +1,157 @@
+import Foundation
+import MereRunRelayKit
+
+/// A chat thread carried over stateless `text.generate` jobs: history lives
+/// on the phone, each turn renders the transcript into one prompt and runs it
+/// on the fleet. Rendering, budgeting, and think-tag stripping mirror the
+/// macOS Studio's `ConversationTranscript` so both shells produce identical
+/// prompts for identical threads (a shared home in RelayKit is a follow-up).
+@MainActor
+final class ChatStore: ObservableObject {
+    struct Message: Identifiable, Codable, Equatable {
+        enum Role: String, Codable {
+            case user
+            case assistant
+        }
+
+        let id: UUID
+        let role: Role
+        var content: String
+        var failed: Bool
+
+        init(role: Role, content: String, failed: Bool = false) {
+            self.id = UUID()
+            self.role = role
+            self.content = content
+            self.failed = failed
+        }
+    }
+
+    static let budgetChars = 48_000
+
+    @Published private(set) var messages: [Message] = []
+    @Published private(set) var awaitingReply = false
+    @Published var model = ""
+    @Published private(set) var errorMessage: String?
+
+    private let store: RelayStore
+    private let threadURL: URL
+
+    init(relay: RelayStore) {
+        store = relay
+        threadURL = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("MereRun", isDirectory: true)
+            .appendingPathComponent("chat-thread.json")
+        if let data = try? Data(contentsOf: threadURL),
+           let saved = try? JSONDecoder().decode([Message].self, from: data) {
+            messages = saved
+        }
+    }
+
+    func newChat() {
+        messages = []
+        errorMessage = nil
+        persist()
+    }
+
+    func send(_ text: String) async {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty, !awaitingReply else { return }
+        messages.append(Message(role: .user, content: trimmed))
+        persist()
+        awaitingReply = true
+        errorMessage = nil
+        defer { awaitingReply = false }
+        do {
+            let prompt = renderTranscript()
+            var arguments: [String: WorkflowValue] = ["prompt": .string(prompt)]
+            if !model.isEmpty {
+                arguments["model"] = .string(model)
+            }
+            let job = try await store.submit(kind: "text.generate", arguments: arguments)
+            let reply = try await awaitReply(jobID: job.jobID)
+            messages.append(Message(role: .assistant, content: reply))
+        } catch let error as RelayClientError {
+            errorMessage = error.message
+            messages.append(Message(role: .assistant, content: error.message, failed: true))
+        } catch {
+            errorMessage = error.localizedDescription
+            messages.append(Message(role: .assistant, content: error.localizedDescription, failed: true))
+        }
+        persist()
+    }
+
+    private func awaitReply(jobID: String) async throws -> String {
+        guard let client = store.client else {
+            throw RelayClientError("Pair with a relay before chatting.")
+        }
+        while true {
+            let job = try await client.inspect(jobID: jobID)
+            switch job.state {
+            case .finished:
+                let manifest = try await client.manifest(jobID: jobID)
+                guard let value = manifest.nodes
+                    .flatMap(\.outputs)
+                    .first(where: { $0.name == "text" })?
+                    .value?.stringValue else {
+                    throw RelayClientError("The reply did not include a text output.")
+                }
+                let cleaned = Self.stripThinkTags(value)
+                guard !cleaned.isEmpty else {
+                    throw RelayClientError("The model returned an empty reply.")
+                }
+                return cleaned
+            case .failed:
+                throw RelayClientError(job.error ?? "The chat run failed on the node.")
+            case .cancelled:
+                throw RelayClientError("The chat run was cancelled.")
+            default:
+                try await Task.sleep(for: .seconds(1))
+            }
+        }
+    }
+
+    /// Oldest messages are dropped from what is sent (never from the thread)
+    /// when the character budget is exceeded; a lone first turn renders
+    /// verbatim so it is byte-identical to a single-shot run.
+    private func renderTranscript() -> String {
+        let usable = messages.filter { !$0.failed }
+        var included: [Message] = []
+        var used = 0
+        for message in usable.reversed() {
+            let cost = message.content.count + 12
+            if included.isEmpty || used + cost <= Self.budgetChars {
+                included.append(message)
+                used += cost
+            } else {
+                break
+            }
+        }
+        included.reverse()
+        if included.count == 1, let only = included.first, only.role == .user {
+            return only.content
+        }
+        return included.map { message in
+            switch message.role {
+            case .user: "User: \(message.content)"
+            case .assistant: "Assistant: \(message.content)"
+            }
+        }.joined(separator: "\n\n")
+    }
+
+    static func stripThinkTags(_ text: String) -> String {
+        var result = text.replacingOccurrences(
+            of: "<think>[\\s\\S]*?</think>",
+            with: "",
+            options: .regularExpression
+        )
+        if !result.contains("<think>"), let close = result.range(of: "</think>") {
+            result = String(result[close.upperBound...])
+        }
+        return result.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    private func persist() {
+        try? JSONEncoder().encode(messages).write(to: threadURL, options: .atomic)
+    }
+}

--- a/ios/MereRunStudio/App/ChatStore.swift
+++ b/ios/MereRunStudio/App/ChatStore.swift
@@ -1,4 +1,5 @@
 import Foundation
+import MereRunCore
 import MereRunRelayKit
 
 /// A chat thread carried over stateless `text.generate` jobs: history lives
@@ -33,6 +34,7 @@ final class ChatStore: ObservableObject {
     @Published private(set) var awaitingReply = false
     @Published private(set) var streamingReply: String?
     @Published var model = ""
+    @Published var runLocally = false
     @Published private(set) var errorMessage: String?
 
     private let store: RelayStore
@@ -67,14 +69,24 @@ final class ChatStore: ObservableObject {
             streamingReply = nil
         }
         do {
-            let prompt = renderTranscript()
-            var arguments: [String: WorkflowValue] = ["prompt": .string(prompt)]
-            if !model.isEmpty {
-                arguments["model"] = .string(model)
+            if runLocally {
+                let reply = try await LocalEngine.shared.chat(
+                    messages: nativeMessages(),
+                    onDelta: { [weak self] partial in
+                        self?.streamingReply = partial
+                    }
+                )
+                messages.append(Message(role: .assistant, content: reply))
+            } else {
+                let prompt = renderTranscript()
+                var arguments: [String: WorkflowValue] = ["prompt": .string(prompt)]
+                if !model.isEmpty {
+                    arguments["model"] = .string(model)
+                }
+                let job = try await store.submit(kind: "text.generate", arguments: arguments)
+                let reply = try await awaitReply(jobID: job.jobID)
+                messages.append(Message(role: .assistant, content: reply))
             }
-            let job = try await store.submit(kind: "text.generate", arguments: arguments)
-            let reply = try await awaitReply(jobID: job.jobID)
-            messages.append(Message(role: .assistant, content: reply))
         } catch let error as RelayClientError {
             let text = AppErrorText.presentable(error.message)
             errorMessage = text
@@ -126,6 +138,30 @@ final class ChatStore: ObservableObject {
             default:
                 try await Task.sleep(for: .seconds(1))
             }
+        }
+    }
+
+    /// The thread as native chat messages for the on-device engine, budgeted
+    /// the same way as the rendered transcript: oldest turns drop first.
+    private func nativeMessages() -> [ChatMessage] {
+        let usable = messages.filter { !$0.failed }
+        var included: [Message] = []
+        var used = 0
+        for message in usable.reversed() {
+            let cost = message.content.count + 12
+            if included.isEmpty || used + cost <= Self.budgetChars {
+                included.append(message)
+                used += cost
+            } else {
+                break
+            }
+        }
+        included.reverse()
+        return included.map { message in
+            ChatMessage(
+                role: message.role == .user ? .user : .assistant,
+                content: message.content
+            )
         }
     }
 

--- a/ios/MereRunStudio/App/ChatStore.swift
+++ b/ios/MereRunStudio/App/ChatStore.swift
@@ -31,6 +31,7 @@ final class ChatStore: ObservableObject {
 
     @Published private(set) var messages: [Message] = []
     @Published private(set) var awaitingReply = false
+    @Published private(set) var streamingReply: String?
     @Published var model = ""
     @Published private(set) var errorMessage: String?
 
@@ -61,7 +62,10 @@ final class ChatStore: ObservableObject {
         persist()
         awaitingReply = true
         errorMessage = nil
-        defer { awaitingReply = false }
+        defer {
+            awaitingReply = false
+            streamingReply = nil
+        }
         do {
             let prompt = renderTranscript()
             var arguments: [String: WorkflowValue] = ["prompt": .string(prompt)]
@@ -72,8 +76,9 @@ final class ChatStore: ObservableObject {
             let reply = try await awaitReply(jobID: job.jobID)
             messages.append(Message(role: .assistant, content: reply))
         } catch let error as RelayClientError {
-            errorMessage = error.message
-            messages.append(Message(role: .assistant, content: error.message, failed: true))
+            let text = AppErrorText.presentable(error.message)
+            errorMessage = text
+            messages.append(Message(role: .assistant, content: text, failed: true))
         } catch {
             errorMessage = error.localizedDescription
             messages.append(Message(role: .assistant, content: error.localizedDescription, failed: true))
@@ -87,6 +92,19 @@ final class ChatStore: ObservableObject {
         }
         while true {
             let job = try await client.inspect(jobID: jobID)
+            if job.state == .running || job.state == .assigned {
+                // The worker streams node_output_delta events whose message is
+                // the accumulated text so far; render it as it grows.
+                if let raw = try? await client.events(jobID: jobID) {
+                    let delta = RelayEventText.decodedEvents(raw)
+                        .last(where: { $0.type == "node_output_delta" })?
+                        .message
+                    if let delta, !delta.isEmpty {
+                        let visible = GeneratedTextFilters.strippingThinking(delta, streaming: true)
+                        if !visible.isEmpty { streamingReply = visible }
+                    }
+                }
+            }
             switch job.state {
             case .finished:
                 let manifest = try await client.manifest(jobID: jobID)
@@ -96,7 +114,7 @@ final class ChatStore: ObservableObject {
                     .value?.stringValue else {
                     throw RelayClientError("The reply did not include a text output.")
                 }
-                let cleaned = Self.stripThinkTags(value)
+                let cleaned = GeneratedTextFilters.strippingThinking(value)
                 guard !cleaned.isEmpty else {
                     throw RelayClientError("The model returned an empty reply.")
                 }
@@ -139,17 +157,6 @@ final class ChatStore: ObservableObject {
         }.joined(separator: "\n\n")
     }
 
-    static func stripThinkTags(_ text: String) -> String {
-        var result = text.replacingOccurrences(
-            of: "<think>[\\s\\S]*?</think>",
-            with: "",
-            options: .regularExpression
-        )
-        if !result.contains("<think>"), let close = result.range(of: "</think>") {
-            result = String(result[close.upperBound...])
-        }
-        return result.trimmingCharacters(in: .whitespacesAndNewlines)
-    }
 
     private func persist() {
         try? JSONEncoder().encode(messages).write(to: threadURL, options: .atomic)

--- a/ios/MereRunStudio/App/LocalEngine.swift
+++ b/ios/MereRunStudio/App/LocalEngine.swift
@@ -1,0 +1,89 @@
+import Foundation
+import MereRunCore
+import UIKit
+
+/// The on-device lane: FLUX.2 Klein nano running natively on this iPhone
+/// through the memory-optimized iOS generator. The model installs into the
+/// app sandbox through the same managed store, catalog pins, and verified
+/// snapshots as every other mere.run install. Experimental: first-run
+/// generation exercises MLX Metal on the device.
+@MainActor
+final class LocalEngine: ObservableObject {
+    static let modelID = "image-klein-nano"
+
+    enum State: Equatable {
+        case checking
+        case notInstalled
+        case downloading(String)
+        case ready
+        case generating
+        case failed(String)
+    }
+
+    @Published private(set) var state: State = .checking
+    @Published private(set) var lastImage: UIImage?
+
+    private let generator = Flux2KleinGeneratoriOS()
+
+    init() {
+        refresh()
+    }
+
+    func refresh() {
+        state = ManagedModelResolver.resolveInstalledModel(id: Self.modelID) != nil
+            ? .ready
+            : .notInstalled
+    }
+
+    func download() async {
+        state = .downloading("Starting…")
+        do {
+            _ = try await ManagedModelResolver.installManagedModel(
+                id: Self.modelID,
+                progress: { [weak self] progress in
+                    let label: String
+                    switch progress {
+                    case .downloadingBytes(let completed, let total):
+                        if let total, total > 0 {
+                            label = "\(Int(Double(completed) / Double(total) * 100))% of \(total / 1_048_576) MB"
+                        } else {
+                            label = "\(completed / 1_048_576) MB"
+                        }
+                    case .downloadingPercent(let percent, _):
+                        label = "\(percent)%"
+                    case .extracting:
+                        label = "Preparing…"
+                    }
+                    Task { @MainActor [weak self] in
+                        self?.state = .downloading(label)
+                    }
+                }
+            )
+            state = .ready
+        } catch {
+            state = .failed(error.localizedDescription)
+        }
+    }
+
+    func generate(prompt: String, width: Int = 512, height: Int = 512, steps: Int = 4) async {
+        guard state == .ready else { return }
+        state = .generating
+        let output = FileManager.default.temporaryDirectory
+            .appendingPathComponent("local-\(UUID().uuidString).png")
+        let request = GenerationRequest(
+            prompt: prompt,
+            width: width,
+            height: height,
+            steps: steps,
+            outputURL: output,
+            model: Self.modelID
+        )
+        do {
+            let result = try await generator.generate(request, progressHandler: nil)
+            lastImage = UIImage(contentsOfFile: result.outputURL.path)
+            state = .ready
+        } catch {
+            state = .failed(error.localizedDescription)
+        }
+    }
+}

--- a/ios/MereRunStudio/App/LocalEngine.swift
+++ b/ios/MereRunStudio/App/LocalEngine.swift
@@ -1,46 +1,111 @@
 import Foundation
 import MereRunCore
+import MereRunRelayKit
 import UIKit
 
-/// The on-device lane: FLUX.2 Klein nano running natively on this iPhone
-/// through the memory-optimized iOS generator. The model installs into the
-/// app sandbox through the same managed store, catalog pins, and verified
+/// The on-device lane: small models running natively on this iPhone through
+/// MereRunCore's memory-optimized iOS generators. Models install into the app
+/// sandbox through the same managed store, catalog pins, and verified
 /// snapshots as every other mere.run install. Experimental: first-run
 /// generation exercises MLX Metal on the device.
 @MainActor
 final class LocalEngine: ObservableObject {
-    static let modelID = "image-klein-nano"
+    /// One shared engine so Create and Chat agree on what is installed.
+    static let shared = LocalEngine()
 
-    enum State: Equatable {
-        case checking
+    struct Model: Identifiable, Equatable {
+        enum Kind { case image, chat }
+
+        let id: String
+        let kind: Kind
+        let title: String
+        let detail: String
+
+        var sizeLabel: String {
+            guard let bytes = ManagedModelCatalog.spec(for: id)?.estimatedDownloadBytes else {
+                return ""
+            }
+            return String(format: "%.1f GB", Double(bytes) / 1_073_741_824)
+        }
+    }
+
+    static let imageModels: [Model] = [
+        Model(
+            id: "image-klein-nano",
+            kind: .image,
+            title: "Klein nano",
+            detail: "FLUX.2 Klein distilled to nano. The fastest local option."
+        ),
+        Model(
+            id: "image-bonsai-binary",
+            kind: .image,
+            title: "Bonsai 1-bit",
+            detail: "Bonsai 4B with binary weights. Small download, full pipeline."
+        ),
+        Model(
+            id: "image-bonsai-ternary",
+            kind: .image,
+            title: "Bonsai ternary",
+            detail: "Bonsai 4B with ternary weights. A quality step up from 1-bit."
+        ),
+    ]
+
+    static let chatModel = Model(
+        id: "text-chat-bonsai-27b-1bit",
+        kind: .chat,
+        title: "Bonsai 27B 1-bit",
+        detail: "A 27B chat model in binary weights, running entirely on this iPhone."
+    )
+
+    enum ModelState: Equatable {
         case notInstalled
         case downloading(String)
         case ready
-        case generating
-        case failed(String)
     }
 
-    @Published private(set) var state: State = .checking
-    @Published private(set) var lastImage: UIImage?
+    enum Activity: Equatable {
+        case idle
+        case generatingImage
+        case chatting
+    }
 
-    private let generator = Flux2KleinGeneratoriOS()
+    @Published private(set) var states: [String: ModelState] = [:]
+    @Published private(set) var activity: Activity = .idle
+    @Published private(set) var lastImage: UIImage?
+    @Published var selectedImageModelID = LocalEngine.imageModels[0].id
+    @Published private(set) var lastError: String?
+
+    private let imageGenerator = Flux2KleinGeneratoriOS()
+    private var chatGenerator: Q35Generator?
 
     init() {
         refresh()
     }
 
     func refresh() {
-        state = ManagedModelResolver.resolveInstalledModel(id: Self.modelID) != nil
-            ? .ready
-            : .notInstalled
+        for model in Self.imageModels + [Self.chatModel] {
+            if case .downloading = states[model.id] { continue }
+            states[model.id] = ManagedModelResolver.resolveInstalledModel(id: model.id) != nil
+                ? .ready
+                : .notInstalled
+        }
+        if states[selectedImageModelID] != .ready,
+           let installed = Self.imageModels.first(where: { states[$0.id] == .ready }) {
+            selectedImageModelID = installed.id
+        }
     }
 
-    func download() async {
-        state = .downloading("Starting…")
+    func state(of modelID: String) -> ModelState {
+        states[modelID] ?? .notInstalled
+    }
+
+    func download(_ modelID: String) async {
+        states[modelID] = .downloading("Starting…")
+        lastError = nil
         do {
             _ = try await ManagedModelResolver.installManagedModel(
-                id: Self.modelID,
-                progress: { [weak self] progress in
+                id: modelID,
+                progress: { progress in
                     let label: String
                     switch progress {
                     case .downloadingBytes(let completed, let total):
@@ -54,20 +119,24 @@ final class LocalEngine: ObservableObject {
                     case .extracting:
                         label = "Preparing…"
                     }
-                    Task { @MainActor [weak self] in
-                        self?.state = .downloading(label)
+                    Task { @MainActor in
+                        LocalEngine.shared.states[modelID] = .downloading(label)
                     }
                 }
             )
-            state = .ready
+            states[modelID] = .ready
         } catch {
-            state = .failed(error.localizedDescription)
+            states[modelID] = .notInstalled
+            lastError = error.localizedDescription
         }
     }
 
-    func generate(prompt: String, width: Int = 512, height: Int = 512, steps: Int = 4) async {
-        guard state == .ready else { return }
-        state = .generating
+    func generateImage(prompt: String, width: Int = 512, height: Int = 512, steps: Int = 4) async {
+        let modelID = selectedImageModelID
+        guard state(of: modelID) == .ready, activity == .idle else { return }
+        activity = .generatingImage
+        lastError = nil
+        defer { activity = .idle }
         let output = FileManager.default.temporaryDirectory
             .appendingPathComponent("local-\(UUID().uuidString).png")
         let request = GenerationRequest(
@@ -76,14 +145,83 @@ final class LocalEngine: ObservableObject {
             height: height,
             steps: steps,
             outputURL: output,
-            model: Self.modelID
+            model: modelID
         )
         do {
-            let result = try await generator.generate(request, progressHandler: nil)
+            let result = try await imageGenerator.generate(request, progressHandler: nil)
             lastImage = UIImage(contentsOfFile: result.outputURL.path)
-            state = .ready
         } catch {
-            state = .failed(error.localizedDescription)
+            lastError = error.localizedDescription
         }
     }
+
+    /// Runs one chat turn on-device, streaming visible token deltas to
+    /// `onDelta` as the accumulated reply so far.
+    func chat(
+        messages: [ChatMessage],
+        onDelta: @escaping @MainActor (String) -> Void
+    ) async throws -> String {
+        let model = Self.chatModel
+        guard let root = ManagedModelResolver.resolveInstalledModel(id: model.id) else {
+            throw RelayAppError("Download \(model.title) before chatting on-device.")
+        }
+        guard activity == .idle else {
+            throw RelayAppError("The on-device engine is busy with another run.")
+        }
+        activity = .chatting
+        defer { activity = .idle }
+
+        let generator = chatGenerator ?? Q35Generator(modelId: model.id)
+        chatGenerator = generator
+
+        let sampling = Q35Resources.recommendedSampling(forModelId: model.id)
+        let request = ChatRequest(
+            messages: messages,
+            maxTokens: 1024,
+            temperature: sampling?.temperature ?? 0.7,
+            topP: sampling?.topP ?? 0.9,
+            showThinking: false
+        )
+
+        let accumulated = StreamedText()
+        let response = try await generator.chat(
+            request,
+            modelPath: root.path,
+            progressHandler: { progress in
+                guard progress.stage == .generating,
+                      let piece = progress.message, !piece.isEmpty else { return }
+                Task { @MainActor in
+                    let text = accumulated.append(piece)
+                    let visible = GeneratedTextFilters.strippingThinking(text, streaming: true)
+                    if !visible.isEmpty { onDelta(visible) }
+                }
+            }
+        )
+        let cleaned = GeneratedTextFilters.strippingThinking(response.response)
+        guard !cleaned.isEmpty else {
+            throw RelayAppError("The model returned an empty reply.")
+        }
+        return cleaned
+    }
+}
+
+/// Accumulates streamed pieces on the main actor.
+@MainActor
+private final class StreamedText {
+    private var text = ""
+
+    func append(_ piece: String) -> String {
+        text += piece
+        return text
+    }
+}
+
+struct RelayAppError: LocalizedError {
+    let message: String
+
+    init(_ message: String) {
+        self.message = message
+    }
+
+    var errorDescription: String? { message }
 }

--- a/ios/MereRunStudio/App/MereRunStudioApp.swift
+++ b/ios/MereRunStudio/App/MereRunStudioApp.swift
@@ -21,6 +21,8 @@ struct RootView: View {
             TabView {
                 CreateView()
                     .tabItem { Label("Create", systemImage: "sparkles") }
+                ChatView(relay: relay)
+                    .tabItem { Label("Chat", systemImage: "bubble.left.and.bubble.right") }
                 RunsView()
                     .tabItem { Label("Runs", systemImage: "tray.full") }
                 FleetView()

--- a/ios/MereRunStudio/App/RelayStore.swift
+++ b/ios/MereRunStudio/App/RelayStore.swift
@@ -1,3 +1,4 @@
+import AuthenticationServices
 import Foundation
 import MereRunRelayKit
 
@@ -19,8 +20,17 @@ final class RelayStore: ObservableObject {
     @Published private(set) var pairing: PairingState = .unpaired
     @Published private(set) var authStatus: RelayAuthStatusResult?
 
+    static let iosClientID = "mererun-ios"
+    static let iosRedirectURI = "https://mere.world/oauth/ios-done"
+
     private let supportBase: URL
     private var profilesURL: URL { supportBase.appendingPathComponent("executors.json") }
+
+    /// Keychain is the credential's home on iOS; the legacy protected file
+    /// migrates in on first load and is removed.
+    private func keychain(for profileName: String) -> KeychainCredentialStorage {
+        KeychainCredentialStorage(service: "run.mere.studio.relay", account: profileName)
+    }
 
     init() {
         let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
@@ -51,6 +61,12 @@ final class RelayStore: ObservableObject {
                 url: stored.url,
                 tokenFile: tokenFile.path
             )
+            let storage = keychain(for: stored.name)
+            if (try? storage.load()) == nil,
+               let legacy = try? FileCredentialStorage(url: tokenFile).load() {
+                try? storage.save(legacy)
+                try? FileCredentialStorage(url: tokenFile).clear()
+            }
             pairing = .paired
             refreshAuthStatus()
         }
@@ -64,20 +80,88 @@ final class RelayStore: ObservableObject {
     }
 
     var client: RelayWorkflowExecutor? {
-        profile.map(RelayWorkflowExecutor.init(profile:))
+        profile.map { RelayWorkflowExecutor(profile: $0, credentialStorage: keychain(for: $0.name)) }
     }
 
     func refreshAuthStatus() {
         guard let profile else { return }
+        if let tokenSet = try? keychain(for: profile.name).load() {
+            authStatus = RelayAuthStatusResult(
+                executor: "relay:\(profile.name)",
+                credentialKind: "keychain-token-set",
+                authenticated: tokenSet.isFresh(now: Int64(Date().timeIntervalSince1970), skewSeconds: 0),
+                refreshable: tokenSet.refreshToken?.isEmpty == false,
+                expiresAtEpochSeconds: tokenSet.expiresAtEpochSeconds(),
+                tokenFile: nil
+            )
+            return
+        }
         authStatus = RelayAuthentication.status(profile: profile)
+    }
+
+    /// Browser sign-in: Authorization Code + PKCE through an in-app sheet,
+    /// intercepted at the universal-link callback. Falls back to the device
+    /// grant when the relay's broker does not advertise an authorize URL.
+    func signIn(urlString: String, profileName: String = "phone") async {
+        let trimmed = urlString.trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        guard let parsed = URL(string: trimmed), parsed.scheme == "https" || isLoopback(parsed) else {
+            pairing = .failed("Relay URL must use HTTPS.")
+            return
+        }
+        let candidate = WorkflowExecutorProfile(
+            name: profileName,
+            kind: .relay,
+            destination: nil,
+            remoteRoot: nil,
+            port: nil,
+            identityFile: nil,
+            mereRunPath: nil,
+            url: trimmed,
+            tokenFile: nil
+        )
+        pairing = .discovering
+        do {
+            let configuration = try await RelayAuthentication.discover(profile: candidate)
+            guard configuration.authorizationEndpoint != nil else {
+                await pair(urlString: urlString, profileName: profileName)
+                return
+            }
+            let started = try RelayAuthorizationCodeFlow.begin(
+                configuration: configuration,
+                clientID: Self.iosClientID,
+                redirectURI: Self.iosRedirectURI
+            )
+            let callback = try await WebSignIn.present(url: started.authorizationURL)
+            let code = try RelayAuthorizationCodeFlow.code(fromCallback: callback, started: started)
+            let tokenSet = try await RelayAuthorizationCodeFlow.exchange(
+                code: code,
+                started: started,
+                configuration: configuration,
+                clientID: Self.iosClientID,
+                redirectURI: Self.iosRedirectURI
+            )
+            try keychain(for: profileName).save(tokenSet)
+            try WorkflowExecutorProfileStore.save(
+                WorkflowExecutorProfiles(schemaVersion: 1, profiles: [candidate]),
+                to: profilesURL
+            )
+            profile = candidate
+            pairing = .paired
+            refreshAuthStatus()
+        } catch let error as RelayClientError {
+            pairing = .failed(AppErrorText.presentable(error.message))
+        } catch let error as ASWebAuthenticationSessionError where error.code == .canceledLogin {
+            pairing = .unpaired
+        } catch {
+            pairing = .failed(error.localizedDescription)
+        }
     }
 
     /// The mere.world account this pairing belongs to, from the token's
     /// email claim. Fleet visibility is scoped by account.
     var accountEmail: String? {
-        guard let tokenFile = profile?.tokenFile,
-              let data = try? Data(contentsOf: URL(fileURLWithPath: tokenFile)),
-              let tokenSet = try? WorkflowBundleCodec.decoder().decode(RelayOAuthTokenSet.self, from: data) else {
+        guard let name = profile?.name, let tokenSet = try? keychain(for: name).load() else {
             return nil
         }
         return tokenSet.accountEmail
@@ -195,8 +279,11 @@ final class RelayStore: ObservableObject {
     }
 
     func unpair() {
-        if let tokenFile = profile?.tokenFile {
-            try? FileManager.default.removeItem(atPath: tokenFile)
+        if let profile {
+            try? keychain(for: profile.name).clear()
+            if let tokenFile = profile.tokenFile {
+                try? FileManager.default.removeItem(atPath: tokenFile)
+            }
         }
         try? FileManager.default.removeItem(at: profilesURL)
         profile = nil
@@ -206,5 +293,37 @@ final class RelayStore: ObservableObject {
 
     private func isLoopback(_ url: URL) -> Bool {
         url.scheme == "http" && ["127.0.0.1", "localhost", "::1"].contains(url.host ?? "")
+    }
+}
+
+/// Presents the broker sign-in sheet and resolves with the intercepted
+/// universal-link callback.
+@MainActor
+enum WebSignIn {
+    private final class ContextProvider: NSObject, ASWebAuthenticationPresentationContextProviding {
+        func presentationAnchor(for session: ASWebAuthenticationSession) -> ASPresentationAnchor {
+            ASPresentationAnchor()
+        }
+    }
+
+    private static let contextProvider = ContextProvider()
+
+    static func present(url: URL) async throws -> URL {
+        try await withCheckedThrowingContinuation { continuation in
+            let session = ASWebAuthenticationSession(
+                url: url,
+                callback: .https(host: "mere.world", path: "/oauth/ios-done")
+            ) { callbackURL, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                } else if let callbackURL {
+                    continuation.resume(returning: callbackURL)
+                } else {
+                    continuation.resume(throwing: RelayClientError("Sign-in did not complete."))
+                }
+            }
+            session.presentationContextProvider = contextProvider
+            session.start()
+        }
     }
 }

--- a/ios/MereRunStudio/App/RelayStore.swift
+++ b/ios/MereRunStudio/App/RelayStore.swift
@@ -187,11 +187,15 @@ final class RelayStore: ObservableObject {
             .appendingPathComponent(bundle.job.jobID, isDirectory: true)
         try FileManager.default.createDirectory(at: runDirectory, withIntermediateDirectories: true)
         defer { try? FileManager.default.removeItem(at: scratch) }
-        return try await client.submit(
+        let job = try await client.submit(
             bundleDirectory: bundle.directory,
             localRunDirectory: runDirectory,
             pluginNodes: []
         )
+        #if canImport(ActivityKit)
+        RunActivityTracker.track(job: job, title: entry.title, client: client)
+        #endif
+        return job
     }
 
     func unpair() {
@@ -206,5 +210,25 @@ final class RelayStore: ObservableObject {
 
     private func isLoopback(_ url: URL) -> Bool {
         url.scheme == "http" && ["127.0.0.1", "localhost", "::1"].contains(url.host ?? "")
+    }
+}
+
+/// Translates client errors into the app's voice. RelayKit speaks the CLI's
+/// language ("executor login", flag names); the phone never should.
+enum AppErrorText {
+    static func presentable(_ message: String) -> String {
+        if message.contains("executor login") || message.contains("MERERUN_RELAY_TOKEN") {
+            return "Your session expired. Sign out in Settings and pair again."
+        }
+        if message.contains("Relay session expired") {
+            return "Your session expired. Sign out in Settings and pair again."
+        }
+        if message.contains("missing node kinds") {
+            return "Your fleet's nodes don't support this yet. Update mere.run on your nodes."
+        }
+        if message.contains("missing models") {
+            return "The selected model isn't installed on any online node."
+        }
+        return message
     }
 }

--- a/ios/MereRunStudio/App/RunActivityTracker.swift
+++ b/ios/MereRunStudio/App/RunActivityTracker.swift
@@ -1,0 +1,68 @@
+#if canImport(ActivityKit)
+import ActivityKit
+import Foundation
+import MereRunRelayKit
+
+/// Starts a Live Activity for a submitted job and follows it to a terminal
+/// state, updating progress from the worker's event stream. Updates are
+/// app-driven for now; push-updated activities need APNs support in the
+/// relay and are a documented follow-up.
+enum RunActivityTracker {
+    static func track(job: WorkflowRemoteJob, title: String, client: RelayWorkflowExecutor) {
+        guard ActivityAuthorizationInfo().areActivitiesEnabled else { return }
+        let attributes = RunActivityAttributes(jobID: job.jobID, title: title)
+        let initial = RunActivityAttributes.ContentState(
+            stateLabel: job.state.rawValue,
+            fraction: nil,
+            detail: "Queued on your fleet"
+        )
+        let jobID = job.jobID
+        let startLabel = job.state.rawValue
+        // The Activity handle is not Sendable; confining its whole lifetime to
+        // one detached task keeps request, update, and end in a single region.
+        Task.detached {
+            guard let activity = try? Activity.request(
+                attributes: attributes,
+                content: .init(state: initial, staleDate: nil)
+            ) else { return }
+            var lastLabel = startLabel
+            while true {
+                try? await Task.sleep(for: .seconds(2))
+                guard let current = try? await client.inspect(jobID: jobID) else { continue }
+                var fraction: Double?
+                var detail: String?
+                if let raw = try? await client.events(jobID: jobID) {
+                    let events = RelayEventText.decodedEvents(raw)
+                    if let progress = events.last(where: { $0.progress?.fraction != nil })?.progress {
+                        fraction = progress.fraction
+                        detail = progress.phase
+                    }
+                    if let delta = events.last(where: { $0.type == "node_output_delta" })?.message {
+                        let visible = GeneratedTextFilters.strippingThinking(delta, streaming: true)
+                        if !visible.isEmpty { detail = String(visible.suffix(80)) }
+                    }
+                }
+                lastLabel = current.state.rawValue
+                let state = RunActivityAttributes.ContentState(
+                    stateLabel: lastLabel,
+                    fraction: fraction,
+                    detail: detail
+                )
+                if current.state == .finished || current.state == .failed || current.state == .cancelled {
+                    let final = RunActivityAttributes.ContentState(
+                        stateLabel: lastLabel,
+                        fraction: current.state == .finished ? 1 : fraction,
+                        detail: current.state == .finished ? "Done — open mere.run to fetch" : current.error
+                    )
+                    await activity.end(
+                        .init(state: final, staleDate: nil),
+                        dismissalPolicy: .after(.now + 12)
+                    )
+                    return
+                }
+                await activity.update(.init(state: state, staleDate: nil))
+            }
+        }
+    }
+}
+#endif

--- a/ios/MereRunStudio/Shared/RunActivityAttributes.swift
+++ b/ios/MereRunStudio/Shared/RunActivityAttributes.swift
@@ -1,0 +1,25 @@
+#if canImport(ActivityKit)
+import ActivityKit
+import SwiftUI
+
+/// Shared between the app (which starts and updates activities) and the
+/// widget extension (which renders them).
+struct RunActivityAttributes: ActivityAttributes {
+    struct ContentState: Codable, Hashable {
+        var stateLabel: String
+        var fraction: Double?
+        var detail: String?
+    }
+
+    var jobID: String
+    var title: String
+}
+
+/// The bronze accent, duplicated here because the widget extension does not
+/// compile the app's theme. Keep in sync with MereTheme.accent.
+enum RunActivityPalette {
+    static var accent: Color {
+        Color(red: 0x9C / 255, green: 0x7A / 255, blue: 0x2E / 255)
+    }
+}
+#endif

--- a/ios/MereRunStudio/Views/ChatView.swift
+++ b/ios/MereRunStudio/Views/ChatView.swift
@@ -1,0 +1,170 @@
+import SwiftUI
+import MereRunRelayKit
+
+/// Multi-turn chat over the fleet: bubbles on paper, the composer pinned to
+/// the bottom, the model as a quiet chip. Each turn is a stateless
+/// `text.generate` job; the thread lives on the phone.
+struct ChatView: View {
+    @EnvironmentObject private var relay: RelayStore
+    @StateObject private var chat: ChatStore
+    @State private var draft = ""
+
+    init(relay: RelayStore) {
+        _chat = StateObject(wrappedValue: ChatStore(relay: relay))
+    }
+
+    private var chatModels: [String] {
+        (relay.workerProbe?.installedModelIDs ?? []).filter {
+            $0.hasPrefix("text-chat-") || $0.hasPrefix("text-agent-")
+        }
+    }
+
+    private var fleetOffersChat: Bool {
+        relay.workerProbe.map { $0.nodeKinds.contains("text.generate") } ?? true
+    }
+
+    var body: some View {
+        NavigationStack {
+            VStack(spacing: 0) {
+                ScrollViewReader { proxy in
+                    ScrollView {
+                        LazyVStack(alignment: .leading, spacing: MereTheme.Spacing.m) {
+                            if chat.messages.isEmpty {
+                                emptyState
+                            }
+                            ForEach(chat.messages) { message in
+                                bubble(message)
+                                    .id(message.id)
+                            }
+                            if chat.awaitingReply {
+                                HStack(spacing: MereTheme.Spacing.s) {
+                                    ProgressView()
+                                    Text("Running on your fleet…")
+                                        .font(.footnote)
+                                        .foregroundStyle(MereTheme.textMuted)
+                                }
+                                .id("pending")
+                            }
+                        }
+                        .padding(MereTheme.Spacing.l)
+                    }
+                    .defaultScrollAnchor(.bottom)
+                    .onChange(of: chat.messages.count) {
+                        if let last = chat.messages.last?.id {
+                            withAnimation { proxy.scrollTo(last, anchor: .bottom) }
+                        }
+                    }
+                }
+
+                if !fleetOffersChat {
+                    MereBannerView(
+                        text: "Your fleet's nodes don't offer text generation yet. Update mere.run on your nodes to add it.",
+                        color: MereTheme.caution
+                    )
+                    .padding(.horizontal, MereTheme.Spacing.l)
+                    .padding(.bottom, MereTheme.Spacing.s)
+                }
+
+                composer
+            }
+            .background(MereTheme.background.ignoresSafeArea())
+            .navigationTitle("Chat")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .primaryAction) {
+                    Button("New chat") { chat.newChat() }
+                        .disabled(chat.messages.isEmpty || chat.awaitingReply)
+                }
+            }
+            .task { await relay.refreshWorkerProbe() }
+        }
+    }
+
+    private var emptyState: some View {
+        VStack(alignment: .leading, spacing: MereTheme.Spacing.s) {
+            Text("Think it through.")
+                .font(.system(.largeTitle, design: .serif))
+                .foregroundStyle(MereTheme.textPrimary)
+            Text("Your words go to your machines and nowhere else.")
+                .font(.callout)
+                .foregroundStyle(MereTheme.textSecondary)
+        }
+        .padding(.top, MereTheme.Spacing.xxl)
+    }
+
+    private func bubble(_ message: ChatStore.Message) -> some View {
+        HStack {
+            if message.role == .user { Spacer(minLength: 40) }
+            Text(message.content)
+                .font(.body)
+                .foregroundStyle(message.failed ? MereTheme.failure : MereTheme.textPrimary)
+                .textSelection(.enabled)
+                .padding(MereTheme.Spacing.m)
+                .background(
+                    RoundedRectangle(cornerRadius: MereTheme.Radius.panel)
+                        .fill(message.role == .user ? MereTheme.accent.opacity(0.14) : MereTheme.surface)
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: MereTheme.Radius.panel)
+                        .stroke(
+                            message.role == .user
+                                ? MereTheme.accent.opacity(0.35)
+                                : MereTheme.border.opacity(0.6),
+                            lineWidth: 1
+                        )
+                )
+            if message.role == .assistant { Spacer(minLength: 40) }
+        }
+    }
+
+    private var composer: some View {
+        VStack(spacing: MereTheme.Spacing.s) {
+            HStack(alignment: .bottom, spacing: MereTheme.Spacing.s) {
+                TextField(
+                    "",
+                    text: $draft,
+                    prompt: Text("Ask your fleet…").foregroundColor(MereTheme.textMuted),
+                    axis: .vertical
+                )
+                .lineLimit(1...5)
+                .font(.body)
+                .foregroundStyle(MereTheme.textPrimary)
+                .padding(MereTheme.Spacing.m)
+                .merePanel()
+                Button {
+                    let text = draft
+                    draft = ""
+                    Task { await chat.send(text) }
+                } label: {
+                    Image(systemName: "arrow.up.circle.fill")
+                        .font(.system(size: 30))
+                }
+                .disabled(
+                    draft.trimmingCharacters(in: .whitespaces).isEmpty
+                        || chat.awaitingReply
+                        || !fleetOffersChat
+                )
+                .accessibilityLabel("Send")
+            }
+            HStack {
+                Menu {
+                    Button("Fleet default") { chat.model = "" }
+                    ForEach(chatModels, id: \.self) { id in
+                        Button(id) { chat.model = id }
+                    }
+                } label: {
+                    HStack(spacing: 5) {
+                        Image(systemName: "cpu")
+                        Text(chat.model.isEmpty ? "Fleet default" : chat.model)
+                            .lineLimit(1)
+                    }
+                    .font(.footnote)
+                    .foregroundStyle(MereTheme.textSecondary)
+                }
+                Spacer()
+            }
+        }
+        .padding(.horizontal, MereTheme.Spacing.l)
+        .padding(.bottom, MereTheme.Spacing.s)
+    }
+}

--- a/ios/MereRunStudio/Views/ChatView.swift
+++ b/ios/MereRunStudio/Views/ChatView.swift
@@ -7,6 +7,7 @@ import MereRunRelayKit
 struct ChatView: View {
     @EnvironmentObject private var relay: RelayStore
     @StateObject private var chat: ChatStore
+    @ObservedObject private var local = LocalEngine.shared
     @State private var draft = ""
 
     init(relay: RelayStore) {
@@ -21,6 +22,14 @@ struct ChatView: View {
 
     private var fleetOffersChat: Bool {
         relay.workerProbe.map { $0.nodeKinds.contains("text.generate") } ?? true
+    }
+
+    private var localChatReady: Bool {
+        local.state(of: LocalEngine.chatModel.id) == .ready
+    }
+
+    private var canSend: Bool {
+        chat.runLocally ? localChatReady : fleetOffersChat
     }
 
     var body: some View {
@@ -57,7 +66,9 @@ struct ChatView: View {
                                 } else {
                                     HStack(spacing: MereTheme.Spacing.s) {
                                         ProgressView()
-                                        Text("Running on your fleet…")
+                                        Text(chat.runLocally
+                                            ? "Thinking on this iPhone…"
+                                            : "Running on your fleet…")
                                             .font(.footnote)
                                             .foregroundStyle(MereTheme.textMuted)
                                     }
@@ -80,13 +91,19 @@ struct ChatView: View {
                     }
                 }
 
-                if !fleetOffersChat {
+                if !chat.runLocally, !fleetOffersChat {
                     MereBannerView(
                         text: "Your fleet's nodes don't offer text generation yet. Update mere.run on your nodes to add it.",
                         color: MereTheme.caution
                     )
                     .padding(.horizontal, MereTheme.Spacing.l)
                     .padding(.bottom, MereTheme.Spacing.s)
+                }
+
+                if chat.runLocally, !localChatReady {
+                    localChatSetup
+                        .padding(.horizontal, MereTheme.Spacing.l)
+                        .padding(.bottom, MereTheme.Spacing.s)
                 }
 
                 composer
@@ -101,6 +118,34 @@ struct ChatView: View {
                 }
             }
             .task { await relay.refreshWorkerProbe() }
+        }
+    }
+
+    @ViewBuilder
+    private var localChatSetup: some View {
+        switch local.state(of: LocalEngine.chatModel.id) {
+        case .notInstalled:
+            VStack(alignment: .leading, spacing: MereTheme.Spacing.s) {
+                MereBannerView(
+                    text: "\(LocalEngine.chatModel.title) (\(LocalEngine.chatModel.sizeLabel)) chats entirely on this iPhone. Download once over Wi-Fi; it stays in this app's storage.",
+                    color: MereTheme.accent
+                )
+                Button {
+                    Task { await local.download(LocalEngine.chatModel.id) }
+                } label: {
+                    Text("Download \(LocalEngine.chatModel.title)").frame(maxWidth: .infinity)
+                }
+                .buttonStyle(.bordered)
+            }
+        case .downloading(let label):
+            HStack(spacing: MereTheme.Spacing.s) {
+                ProgressView()
+                Text("Downloading — \(label)")
+                    .font(.footnote)
+                    .foregroundStyle(MereTheme.textSecondary)
+            }
+        case .ready:
+            EmptyView()
         }
     }
 
@@ -147,7 +192,8 @@ struct ChatView: View {
                 TextField(
                     "",
                     text: $draft,
-                    prompt: Text("Ask your fleet…").foregroundColor(MereTheme.textMuted),
+                    prompt: Text(chat.runLocally ? "Ask this iPhone…" : "Ask your fleet…")
+                        .foregroundColor(MereTheme.textMuted),
                     axis: .vertical
                 )
                 .lineLimit(1...5)
@@ -166,20 +212,35 @@ struct ChatView: View {
                 .disabled(
                     draft.trimmingCharacters(in: .whitespaces).isEmpty
                         || chat.awaitingReply
-                        || !fleetOffersChat
+                        || !canSend
                 )
                 .accessibilityLabel("Send")
             }
             HStack {
                 Menu {
-                    Button("Fleet default") { chat.model = "" }
-                    ForEach(chatModels, id: \.self) { id in
-                        Button(id) { chat.model = id }
+                    Section("Your fleet") {
+                        Button("Fleet default") {
+                            chat.runLocally = false
+                            chat.model = ""
+                        }
+                        ForEach(chatModels, id: \.self) { id in
+                            Button(id) {
+                                chat.runLocally = false
+                                chat.model = id
+                            }
+                        }
+                    }
+                    Section("This iPhone") {
+                        Button("\(LocalEngine.chatModel.title) — on device") {
+                            chat.runLocally = true
+                        }
                     }
                 } label: {
                     HStack(spacing: 5) {
-                        Image(systemName: "cpu")
-                        Text(chat.model.isEmpty ? "Fleet default" : chat.model)
+                        Image(systemName: chat.runLocally ? "iphone" : "cpu")
+                        Text(chat.runLocally
+                            ? "\(LocalEngine.chatModel.title) — on device"
+                            : (chat.model.isEmpty ? "Fleet default" : chat.model))
                             .lineLimit(1)
                     }
                     .font(.footnote)

--- a/ios/MereRunStudio/Views/ChatView.swift
+++ b/ios/MereRunStudio/Views/ChatView.swift
@@ -37,13 +37,32 @@ struct ChatView: View {
                                     .id(message.id)
                             }
                             if chat.awaitingReply {
-                                HStack(spacing: MereTheme.Spacing.s) {
-                                    ProgressView()
-                                    Text("Running on your fleet…")
-                                        .font(.footnote)
-                                        .foregroundStyle(MereTheme.textMuted)
+                                if let partial = chat.streamingReply {
+                                    HStack {
+                                        Text(partial)
+                                            .font(.body)
+                                            .foregroundStyle(MereTheme.textPrimary)
+                                            .padding(MereTheme.Spacing.m)
+                                            .background(
+                                                RoundedRectangle(cornerRadius: MereTheme.Radius.panel)
+                                                    .fill(MereTheme.surface)
+                                            )
+                                            .overlay(
+                                                RoundedRectangle(cornerRadius: MereTheme.Radius.panel)
+                                                    .stroke(MereTheme.accent.opacity(0.35), lineWidth: 1)
+                                            )
+                                        Spacer(minLength: 40)
+                                    }
+                                    .id("pending")
+                                } else {
+                                    HStack(spacing: MereTheme.Spacing.s) {
+                                        ProgressView()
+                                        Text("Running on your fleet…")
+                                            .font(.footnote)
+                                            .foregroundStyle(MereTheme.textMuted)
+                                    }
+                                    .id("pending")
                                 }
-                                .id("pending")
                             }
                         }
                         .padding(MereTheme.Spacing.l)
@@ -52,6 +71,11 @@ struct ChatView: View {
                     .onChange(of: chat.messages.count) {
                         if let last = chat.messages.last?.id {
                             withAnimation { proxy.scrollTo(last, anchor: .bottom) }
+                        }
+                    }
+                    .onChange(of: chat.streamingReply) {
+                        if chat.streamingReply != nil {
+                            proxy.scrollTo("pending", anchor: .bottom)
                         }
                     }
                 }

--- a/ios/MereRunStudio/Views/CreateView.swift
+++ b/ios/MereRunStudio/Views/CreateView.swift
@@ -168,6 +168,8 @@ struct CreateView: View {
     ]
 
     @EnvironmentObject private var relay: RelayStore
+    @StateObject private var local = LocalEngine()
+    @State private var runLocally = false
     @State private var selected = Self.modes[0]
     @State private var prompt = ""
     @State private var model = ""
@@ -228,7 +230,16 @@ struct CreateView: View {
                         .animation(nil, value: selected.kind)
 
                     modeRail
+
+                    if selected.kind == "image.generate" {
+                        destinationToggle
+                    }
+
                     composer
+
+                    if runLocally, selected.kind == "image.generate" {
+                        localLane
+                    }
 
                     if !isAvailable(selected) {
                         MereBannerView(
@@ -409,15 +420,70 @@ struct CreateView: View {
     }
 
 
+    private var destinationToggle: some View {
+        Picker("Runs on", selection: $runLocally) {
+            Text("Your fleet").tag(false)
+            Text("This iPhone").tag(true)
+        }
+        .pickerStyle(.segmented)
+    }
+
+    @ViewBuilder
+    private var localLane: some View {
+        switch local.state {
+        case .checking:
+            EmptyView()
+        case .notInstalled:
+            MereBannerView(
+                text: "Klein nano (about 2 GB) runs entirely on this iPhone. Download once over Wi-Fi; it stays in this app's storage.",
+                color: MereTheme.accent
+            )
+            Button {
+                Task { await local.download() }
+            } label: {
+                Text("Download Klein nano").frame(maxWidth: .infinity)
+            }
+            .buttonStyle(.bordered)
+        case .downloading(let label):
+            HStack(spacing: MereTheme.Spacing.s) {
+                ProgressView()
+                Text("Downloading — \(label)")
+                    .font(.footnote)
+                    .foregroundStyle(MereTheme.textSecondary)
+            }
+        case .failed(let message):
+            MereBannerView(text: message, color: MereTheme.failure)
+        case .ready, .generating:
+            if let image = local.lastImage {
+                Image(uiImage: image)
+                    .resizable()
+                    .scaledToFit()
+                    .clipShape(RoundedRectangle(cornerRadius: MereTheme.Radius.panel))
+            }
+            if local.state == .generating {
+                HStack(spacing: MereTheme.Spacing.s) {
+                    ProgressView()
+                    Text("Generating on this iPhone…")
+                        .font(.footnote)
+                        .foregroundStyle(MereTheme.textSecondary)
+                }
+            }
+        }
+    }
+
     private var runButton: some View {
         Button {
-            Task { await submit() }
+            if runLocally, selected.kind == "image.generate" {
+                Task { await local.generate(prompt: prompt) }
+            } else {
+                Task { await submit() }
+            }
         } label: {
             Group {
-                if submitting {
+                if submitting || local.state == .generating {
                     ProgressView().tint(.white)
                 } else {
-                    Text("Run on your fleet")
+                    Text(runLocally && selected.kind == "image.generate" ? "Run on this iPhone" : "Run on your fleet")
                         .font(.body.weight(.semibold))
                 }
             }
@@ -425,7 +491,9 @@ struct CreateView: View {
             .padding(.vertical, 6)
         }
         .buttonStyle(.borderedProminent)
-        .disabled(!canRun)
+        .disabled(runLocally && selected.kind == "image.generate"
+            ? (prompt.isEmpty || local.state != .ready)
+            : !canRun)
     }
 
     private var optionsSheet: some View {
@@ -599,7 +667,7 @@ struct CreateView: View {
             errorMessage = nil
             submittedJobID = job.jobID
         } catch let error as RelayClientError {
-            errorMessage = error.message
+            errorMessage = AppErrorText.presentable(error.message)
         } catch {
             errorMessage = error.localizedDescription
         }

--- a/ios/MereRunStudio/Views/CreateView.swift
+++ b/ios/MereRunStudio/Views/CreateView.swift
@@ -168,7 +168,7 @@ struct CreateView: View {
     ]
 
     @EnvironmentObject private var relay: RelayStore
-    @StateObject private var local = LocalEngine()
+    @ObservedObject private var local = LocalEngine.shared
     @State private var runLocally = false
     @State private var selected = Self.modes[0]
     @State private var prompt = ""
@@ -430,37 +430,22 @@ struct CreateView: View {
 
     @ViewBuilder
     private var localLane: some View {
-        switch local.state {
-        case .checking:
-            EmptyView()
-        case .notInstalled:
-            MereBannerView(
-                text: "Klein nano (about 2 GB) runs entirely on this iPhone. Download once over Wi-Fi; it stays in this app's storage.",
-                color: MereTheme.accent
-            )
-            Button {
-                Task { await local.download() }
-            } label: {
-                Text("Download Klein nano").frame(maxWidth: .infinity)
+        VStack(alignment: .leading, spacing: MereTheme.Spacing.m) {
+            ForEach(LocalEngine.imageModels) { candidate in
+                localModelRow(candidate)
             }
-            .buttonStyle(.bordered)
-        case .downloading(let label):
-            HStack(spacing: MereTheme.Spacing.s) {
-                ProgressView()
-                Text("Downloading — \(label)")
-                    .font(.footnote)
-                    .foregroundStyle(MereTheme.textSecondary)
+
+            if let message = local.lastError {
+                MereBannerView(text: message, color: MereTheme.failure)
             }
-        case .failed(let message):
-            MereBannerView(text: message, color: MereTheme.failure)
-        case .ready, .generating:
+
             if let image = local.lastImage {
                 Image(uiImage: image)
                     .resizable()
                     .scaledToFit()
                     .clipShape(RoundedRectangle(cornerRadius: MereTheme.Radius.panel))
             }
-            if local.state == .generating {
+            if local.activity == .generatingImage {
                 HStack(spacing: MereTheme.Spacing.s) {
                     ProgressView()
                     Text("Generating on this iPhone…")
@@ -471,16 +456,62 @@ struct CreateView: View {
         }
     }
 
+    @ViewBuilder
+    private func localModelRow(_ candidate: LocalEngine.Model) -> some View {
+        let state = local.state(of: candidate.id)
+        HStack(spacing: MereTheme.Spacing.m) {
+            Image(systemName: local.selectedImageModelID == candidate.id
+                ? "largecircle.fill.circle"
+                : "circle")
+                .foregroundStyle(local.selectedImageModelID == candidate.id
+                    ? MereTheme.accent
+                    : MereTheme.textMuted)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(candidate.title)
+                    .font(.subheadline.weight(.medium))
+                    .foregroundStyle(MereTheme.textPrimary)
+                Text(candidate.detail)
+                    .font(.caption)
+                    .foregroundStyle(MereTheme.textMuted)
+            }
+            Spacer()
+            switch state {
+            case .notInstalled:
+                Button("Get \(candidate.sizeLabel)") {
+                    Task { await local.download(candidate.id) }
+                }
+                .font(.caption.weight(.semibold))
+                .buttonStyle(.bordered)
+            case .downloading(let label):
+                HStack(spacing: MereTheme.Spacing.xs) {
+                    ProgressView().controlSize(.small)
+                    Text(label)
+                        .font(.caption2)
+                        .foregroundStyle(MereTheme.textSecondary)
+                }
+            case .ready:
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundStyle(MereTheme.success)
+            }
+        }
+        .contentShape(Rectangle())
+        .onTapGesture {
+            if state == .ready {
+                local.selectedImageModelID = candidate.id
+            }
+        }
+    }
+
     private var runButton: some View {
         Button {
             if runLocally, selected.kind == "image.generate" {
-                Task { await local.generate(prompt: prompt) }
+                Task { await local.generateImage(prompt: prompt) }
             } else {
                 Task { await submit() }
             }
         } label: {
             Group {
-                if submitting || local.state == .generating {
+                if submitting || local.activity == .generatingImage {
                     ProgressView().tint(.white)
                 } else {
                     Text(runLocally && selected.kind == "image.generate" ? "Run on this iPhone" : "Run on your fleet")
@@ -492,7 +523,9 @@ struct CreateView: View {
         }
         .buttonStyle(.borderedProminent)
         .disabled(runLocally && selected.kind == "image.generate"
-            ? (prompt.isEmpty || local.state != .ready)
+            ? (prompt.isEmpty
+                || local.state(of: local.selectedImageModelID) != .ready
+                || local.activity != .idle)
             : !canRun)
     }
 

--- a/ios/MereRunStudio/Views/FleetView.swift
+++ b/ios/MereRunStudio/Views/FleetView.swift
@@ -104,7 +104,7 @@ struct FleetView: View {
             snapshot = try await client.fleet()
             errorMessage = nil
         } catch let error as RelayClientError {
-            errorMessage = error.message
+            errorMessage = AppErrorText.presentable(error.message)
         } catch {
             errorMessage = error.localizedDescription
         }

--- a/ios/MereRunStudio/Views/PairingView.swift
+++ b/ios/MereRunStudio/Views/PairingView.swift
@@ -52,19 +52,25 @@ struct PairingView: View {
                     }
                     Button {
                         let url = pairingURL
-                        Task { await relay.pair(urlString: url) }
+                        Task { await relay.signIn(urlString: url) }
                     } label: {
                         if relay.pairing == .discovering {
                             ProgressView().frame(maxWidth: .infinity)
                         } else {
-                            Text(customRelay ? "Pair" : "Pair with relay.mere.run")
+                            Text(customRelay ? "Sign in" : "Sign in with mere.world")
                                 .frame(maxWidth: .infinity)
                         }
                     }
                     .buttonStyle(.borderedProminent)
                     .disabled(pairingURL.isEmpty || relay.pairing == .discovering)
-                    Button(customRelay ? "Use relay.mere.run" : "Use a different relay") {
-                        customRelay.toggle()
+                    HStack(spacing: MereTheme.Spacing.l) {
+                        Button(customRelay ? "Use relay.mere.run" : "Use a different relay") {
+                            customRelay.toggle()
+                        }
+                        Button("Use a device code") {
+                            let url = pairingURL
+                            Task { await relay.pair(urlString: url) }
+                        }
                     }
                     .font(.footnote)
                     .foregroundStyle(MereTheme.textMuted)

--- a/ios/MereRunStudio/Views/RunDetailView.swift
+++ b/ios/MereRunStudio/Views/RunDetailView.swift
@@ -1,3 +1,4 @@
+import AVFoundation
 import SwiftUI
 import MereRunRelayKit
 import UIKit
@@ -41,6 +42,15 @@ struct RunDetailView: View {
                     Text(placement.diagnostic ?? "No eligible nodes for this job.")
                         .font(.footnote)
                         .foregroundStyle(MereTheme.caution)
+                }
+            }
+
+            if isActive, let live = liveOutput {
+                Section("Live output") {
+                    Text(live)
+                        .font(.body)
+                        .foregroundStyle(MereTheme.textPrimary)
+                        .textSelection(.enabled)
                 }
             }
 
@@ -99,6 +109,9 @@ struct RunDetailView: View {
                                     .frame(maxHeight: 320)
                                     .clipShape(RoundedRectangle(cornerRadius: MereTheme.Radius.panel))
                             }
+                            if ["wav", "mp3", "m4a", "aiff"].contains(file.pathExtension.lowercased()) {
+                                ArtifactAudioPlayer(url: file)
+                            }
                             ShareLink(item: file) {
                                 Label(file.lastPathComponent, systemImage: "square.and.arrow.up")
                             }
@@ -145,6 +158,14 @@ struct RunDetailView: View {
         events.last { $0.progress != nil }
     }
 
+    private var liveOutput: String? {
+        guard let message = events.last(where: { $0.type == "node_output_delta" })?.message else {
+            return nil
+        }
+        let visible = GeneratedTextFilters.strippingThinking(message, streaming: true)
+        return visible.isEmpty ? nil : visible
+    }
+
     private func progressLine(_ event: GraphRunEvent) -> String {
         let phase = event.progress?.phase ?? event.type
         guard let current = event.progress?.current, let total = event.progress?.total else {
@@ -162,7 +183,7 @@ struct RunDetailView: View {
                 events = RelayEventText.decodedEvents(try await client.events(jobID: jobID))
                 errorMessage = nil
             } catch let error as RelayClientError {
-                errorMessage = error.message
+                errorMessage = AppErrorText.presentable(error.message)
             } catch {
                 errorMessage = error.localizedDescription
             }
@@ -178,7 +199,7 @@ struct RunDetailView: View {
         do {
             job = try await client.cancel(jobID: jobID)
         } catch let error as RelayClientError {
-            errorMessage = error.message
+            errorMessage = AppErrorText.presentable(error.message)
         } catch {
             errorMessage = error.localizedDescription
         }
@@ -191,7 +212,7 @@ struct RunDetailView: View {
         do {
             job = try await client.retry(jobID: jobID)
         } catch let error as RelayClientError {
-            errorMessage = error.message
+            errorMessage = AppErrorText.presentable(error.message)
         } catch {
             errorMessage = error.localizedDescription
         }
@@ -214,9 +235,55 @@ struct RunDetailView: View {
                 return FileManager.default.fileExists(atPath: url.path) ? url : nil
             }
         } catch let error as RelayClientError {
-            errorMessage = error.message
+            errorMessage = AppErrorText.presentable(error.message)
         } catch {
             errorMessage = error.localizedDescription
         }
+    }
+}
+
+
+/// Minimal transport for audio artifacts: play/pause and elapsed time.
+struct ArtifactAudioPlayer: View {
+    let url: URL
+
+    @State private var player: AVAudioPlayer?
+    @State private var playing = false
+
+    var body: some View {
+        HStack(spacing: MereTheme.Spacing.m) {
+            Button {
+                toggle()
+            } label: {
+                Image(systemName: playing ? "pause.circle.fill" : "play.circle.fill")
+                    .font(.system(size: 34))
+                    .foregroundStyle(MereTheme.accent)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(playing ? "Pause" : "Play")
+            Text(url.lastPathComponent)
+                .font(.footnote)
+                .foregroundStyle(MereTheme.textSecondary)
+                .lineLimit(1)
+            Spacer()
+        }
+        .onDisappear {
+            player?.stop()
+        }
+    }
+
+    private func toggle() {
+        if playing {
+            player?.pause()
+            playing = false
+            return
+        }
+        if player == nil {
+            try? AVAudioSession.sharedInstance().setCategory(.playback)
+            try? AVAudioSession.sharedInstance().setActive(true)
+            player = try? AVAudioPlayer(contentsOf: url)
+        }
+        player?.play()
+        playing = true
     }
 }

--- a/ios/MereRunStudio/Views/RunsView.swift
+++ b/ios/MereRunStudio/Views/RunsView.swift
@@ -60,7 +60,7 @@ struct RunsView: View {
             jobs = try await client.list(limit: 50)
             errorMessage = nil
         } catch let error as RelayClientError {
-            errorMessage = error.message
+            errorMessage = AppErrorText.presentable(error.message)
         } catch {
             errorMessage = error.localizedDescription
         }

--- a/ios/MereRunWidgets/Info.plist
+++ b/ios/MereRunWidgets/Info.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleDisplayName</key>
+	<string>mere.run</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>XPC!</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.widgetkit-extension</string>
+	</dict>
+</dict>
+</plist>

--- a/ios/MereRunWidgets/MereRunWidgets.swift
+++ b/ios/MereRunWidgets/MereRunWidgets.swift
@@ -1,0 +1,74 @@
+import ActivityKit
+import SwiftUI
+import WidgetKit
+
+@main
+struct MereRunWidgetsBundle: WidgetBundle {
+    var body: some Widget {
+        RunActivityWidget()
+    }
+}
+
+/// Live Activity for a fleet run: lock-screen banner and Dynamic Island.
+struct RunActivityWidget: Widget {
+    var body: some WidgetConfiguration {
+        ActivityConfiguration(for: RunActivityAttributes.self) { context in
+            HStack(spacing: 10) {
+                Image(systemName: "sparkles")
+                    .foregroundStyle(RunActivityPalette.accent)
+                VStack(alignment: .leading, spacing: 3) {
+                    Text(context.attributes.title)
+                        .font(.subheadline.weight(.semibold))
+                    if let fraction = context.state.fraction {
+                        ProgressView(value: fraction)
+                            .tint(RunActivityPalette.accent)
+                    }
+                    Text(context.state.detail ?? context.state.stateLabel)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+                Spacer()
+            }
+            .padding(12)
+            .activityBackgroundTint(Color(red: 0xFA / 255, green: 0xF8 / 255, blue: 0xF3 / 255))
+        } dynamicIsland: { context in
+            DynamicIsland {
+                DynamicIslandExpandedRegion(.leading) {
+                    Image(systemName: "sparkles")
+                        .foregroundStyle(RunActivityPalette.accent)
+                }
+                DynamicIslandExpandedRegion(.center) {
+                    VStack(alignment: .leading, spacing: 3) {
+                        Text(context.attributes.title)
+                            .font(.subheadline.weight(.semibold))
+                        if let fraction = context.state.fraction {
+                            ProgressView(value: fraction)
+                                .tint(RunActivityPalette.accent)
+                        }
+                    }
+                }
+                DynamicIslandExpandedRegion(.bottom) {
+                    Text(context.state.detail ?? context.state.stateLabel)
+                        .font(.footnote)
+                        .foregroundStyle(.secondary)
+                        .lineLimit(1)
+                }
+            } compactLeading: {
+                Image(systemName: "sparkles")
+                    .foregroundStyle(RunActivityPalette.accent)
+            } compactTrailing: {
+                if let fraction = context.state.fraction {
+                    Text("\(Int(fraction * 100))%")
+                        .font(.caption2.monospacedDigit())
+                        .foregroundStyle(RunActivityPalette.accent)
+                } else {
+                    ProgressView()
+                }
+            } minimal: {
+                Image(systemName: "sparkles")
+                    .foregroundStyle(RunActivityPalette.accent)
+            }
+        }
+    }
+}

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -20,6 +20,9 @@ targets:
     dependencies:
       - package: MereRun
         product: MereRunRelayKit
+      - package: MereRun
+        product: MereRunCore
+      - target: MereRunWidgets
     settings:
       base:
         PRODUCT_NAME: mere.run
@@ -28,12 +31,36 @@ targets:
         CURRENT_PROJECT_VERSION: 1
         MARKETING_VERSION: 0.1.0
         INFOPLIST_KEY_UILaunchScreen_Generation: YES
+        INFOPLIST_KEY_NSSupportsLiveActivities: YES
         INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone: UIInterfaceOrientationPortrait
         INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad: UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight
         INFOPLIST_KEY_CFBundleDisplayName: mere.run
         SWIFT_VERSION: "6.0"
+        # MereRunCore builds with C++ interoperability; importers must match.
+        OTHER_SWIFT_FLAGS: -cxx-interoperability-mode=default
         ENABLE_USER_SCRIPT_SANDBOXING: YES
         CODE_SIGN_STYLE: Automatic
         # Set for device builds: MERERUN_IOS_TEAM=<team id> xcodegen generate
         # Simulator builds need no team.
         DEVELOPMENT_TEAM: ${MERERUN_IOS_TEAM}
+  MereRunWidgets:
+    type: app-extension
+    platform: iOS
+    sources:
+      - MereRunWidgets
+      - MereRunStudio/Shared
+    info:
+      path: MereRunWidgets/Info.plist
+      properties:
+        CFBundleDisplayName: mere.run
+        NSExtension:
+          NSExtensionPointIdentifier: com.apple.widgetkit-extension
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: run.mere.studio.ios.widgets
+        SWIFT_VERSION: "6.0"
+        CURRENT_PROJECT_VERSION: 1
+        MARKETING_VERSION: 0.1.0
+        CODE_SIGN_STYLE: Automatic
+        DEVELOPMENT_TEAM: ${MERERUN_IOS_TEAM}
+        SKIP_INSTALL: YES

--- a/scripts/agent_readiness_check.sh
+++ b/scripts/agent_readiness_check.sh
@@ -123,6 +123,7 @@ dynamic_boundary_files=(
   "Sources/MereRunCore/ZImageTurbo/Model/TextEncoder/LLMGeneration/QwenGeneration.swift"
   "Sources/MereRunCore/ZImageTurbo/Tokenizer/QwenTokenizer.swift"
   "Sources/MereRunCore/ZImageTurbo/ZImageTurboGenerator.swift"
+  "Sources/MereRunRelayKit/RelayCredentialStorage.swift"
 )
 
 is_dynamic_boundary_file() {

--- a/vendor/mlx-swift_Cmlx.bundle/Contents/Resources/default.metallib.version
+++ b/vendor/mlx-swift_Cmlx.bundle/Contents/Resources/default.metallib.version
@@ -1,6 +1,6 @@
 mlx-core-version: 0.32.1
 mlx-swift-version: unknown
-mlx-swift-revision: 5bf3e46fecfb69cd3b559025fa99885ddd188731
+mlx-swift-revision: 30be5d59f194d5f7c67500509bf13bdfa1f26b3b
 kernel-sources-sha256: b791ce523bec5e6612766d9b00004fa66d3f3b1dbbbabd725b5d3c36cefbce41
-built-at: 2026-08-16T02:29:50Z
+built-at: 2026-08-18T00:18:56Z
 metal-compiler: Apple metal version 32023.883 (metalfe-32023.883)


### PR DESCRIPTION
## What this is

The sign-in and on-device tranche for the iOS Studio, plus recovery of the commits that kept advancing after #318 merged mid-branch.

### Browser sign-in (best-in-breed path)

- **Authorization Code + PKCE** through `ASWebAuthenticationSession`, driven by the relay's advertised `authorization_endpoint` (relay-mere-run#42, deployed). One tap, Face ID via passkey on mere.world, done.
- **Universal-link callback** on `https://mere.world/oauth/ios-done` (iOS 17.4+ `.https` callback; associated-domains entitlement for `applinks:` + `webcredentials:` so passkey autofill binds to the domain). Registered as the trusted public `mererun-ios` client in mere-world#76 (merged; deploy pending).
- **Keychain credential storage** (`kSecAttrAccessibleAfterFirstUnlockThisDeviceOnly`), with silent migration of existing file-stored device-grant credentials and executor-level storage injection in RelayKit so refreshed tokens persist wherever the credential came from.
- The device-code flow stays one tap away for browserless pairing.

### On-device lineup

- **Create:** Bonsai 1-bit (3.2 GB) and Bonsai ternary (3.6 GB) join Klein nano behind a model picker — same managed store, catalog pins, verified snapshots, and the same sequential-loading `Flux2KleinGeneratoriOS` (their packed transformers are single-file safetensors, which is exactly what the iOS loader wants).
- **Chat:** a fully on-device option running **Bonsai 27B 1-bit** through `Q35Generator`, streaming visible token deltas into the same live bubble the relay path uses. Download once over Wi-Fi; prompts never leave the phone. (The increased-memory entitlement is already declared.)

### Recovered post-#318 tail

#318 was merged at its second commit while the branch kept advancing; this PR merges the tail: relay token streaming end to end (`node_output_delta`), Live Activities with Dynamic Island progress, inline audio artifact playback, app-voice error copy, and the MereRunCore iOS enablement.

## Gates

- `swift build` clean, `swift test`: **2933 tests, 0 failures**, swiftlint clean
- iOS simulator + device builds green; installed and verified on an iPhone 16 Pro Max
- Note: GitHub Actions on this account is currently failing at startup ("recent account payments have failed or your spending limit needs to be increased") — checks here will not run until billing is fixed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013q8wQ4W7gnGK2US6fA4Ki2