### PR TITLE
Add the direct lane: mere.run relay serve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,17 @@ The format is based on Keep a Changelog.
 
 ### Relay client and iOS
 
+- added the direct lane: `mere.run relay serve` hosts the client-facing
+  relay graph-job HTTP surface on the machine itself and runs submitted
+  jobs there through the same worker runner — no broker, no cloud hop.
+  Devices pair with a short-lived terminal code (bounded window, attempt
+  limit, hashed token storage that survives restarts), jobs validate
+  against the live capability probe at commit, and events, run manifests,
+  and digest-verified artifacts serve from the run directory. The API is
+  byte-identical to the hosted relay's, so `graph submit`, fetch, and the
+  iOS app work unchanged over the LAN or a tailnet; the phone pairs
+  through a new "Connect to a machine" lane and stores the bearer token
+  in the Keychain.
 - the iOS app signs in with the browser: Authorization Code + PKCE
   through `ASWebAuthenticationSession` against the broker's advertised
   `authorization_endpoint`, returning over an `https://mere.world`

--- a/Sources/MereRunCLI/Commands/RelayCommand.swift
+++ b/Sources/MereRunCLI/Commands/RelayCommand.swift
@@ -1,0 +1,367 @@
+import ArgumentParser
+import Foundation
+import Hummingbird
+import MereRunCore
+import MereRunRelayKit
+import NIOCore
+
+struct Relay: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "relay",
+        abstract: "Host the relay API surface directly on this machine.",
+        subcommands: [RelayServe.self]
+    )
+}
+
+/// The direct lane: serves the same graph-job HTTP surface as the hosted
+/// relay, executes jobs on this machine, and pairs clients with a short
+/// code shown in the terminal — no broker, no cloud hop. Reachable over the
+/// LAN or a tailnet; prompts and outputs never leave your machines.
+struct RelayServe: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "serve",
+        abstract: "Serve the relay graph-job API from this machine and run submitted jobs locally."
+    )
+
+    @Option(name: [.long], help: "Interface to bind.")
+    var host = "0.0.0.0"
+
+    @Option(name: [.long], help: "Port to listen on.")
+    var port = 6373
+
+    @Option(name: [.long], help: "Display name for this relay (defaults to the machine's hostname).")
+    var name: String?
+
+    @Option(name: [.customLong("pairing-window")], help: "Minutes after startup during which new devices can pair.")
+    var pairingWindowMinutes = 15
+
+    @Option(name: [.customLong("state-dir")], help: ArgumentHelp("Override the spool directory.", visibility: .hidden))
+    var stateDirectory: String?
+
+    func run() async throws {
+        let relayName = name ?? ProcessInfo.processInfo.hostName
+        let root = stateDirectory.map { URL(fileURLWithPath: $0).standardizedFileURL }
+            ?? MereRunModelPaths.applicationSupportBase.appendingPathComponent("local-relay", isDirectory: true)
+        var generator = SystemRandomNumberGenerator()
+        let pairingCode = String(format: "%06d", Int.random(in: 0...999_999, using: &generator))
+        let state = try await LocalRelayState(
+            rootDirectory: root,
+            relayName: relayName,
+            pairingCode: pairingCode,
+            pairingWindowMinutes: pairingWindowMinutes
+        )
+
+        let router = Self.buildRouter(state: state)
+        let app = Application(
+            router: router,
+            configuration: .init(address: .hostname(host, port: port))
+        )
+
+        let pairedCount = await state.pairedDeviceCount
+        let displayCode = "\(pairingCode.prefix(3))-\(pairingCode.suffix(3))"
+        print("mere.run direct relay \"\(relayName)\"")
+        print("Listening on http://\(host):\(port)")
+        print("Reach it from your phone at http://\(ProcessInfo.processInfo.hostName):\(port)")
+        print("or over Tailscale at this machine's tailnet address (use `tailscale serve` for HTTPS).")
+        print("")
+        print("Pairing code: \(displayCode)  (valid for \(pairingWindowMinutes) minutes; restart to reopen pairing)")
+        if pairedCount > 0 {
+            print("\(pairedCount) device\(pairedCount == 1 ? "" : "s") already paired.")
+        }
+        print("Press Ctrl+C to stop.")
+        fflush(stdout)
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            group.addTask {
+                try await app.runService()
+            }
+            group.addTask {
+                let queue = await state.makeQueue()
+                for await jobID in queue {
+                    await Self.runJob(jobID: jobID, state: state)
+                }
+            }
+            try await group.next()
+            group.cancelAll()
+        }
+    }
+
+    // MARK: - Job execution
+
+    private static let executionQueue = DispatchQueue(label: "run.mere.local-relay.execute", qos: .userInitiated)
+
+    private static func runJob(jobID: String, state: LocalRelayState) async {
+        guard await state.beginRun(jobID: jobID) else { return }
+        let bundleDir = await state.bundleDirectory(jobID: jobID)
+        let runDir = await state.runDirectory(jobID: jobID)
+        do {
+            // WorkflowRunner owns run-directory creation and refuses an
+            // existing one without resume; retry already cleared it.
+            let outcome: WorkflowRunOutcome = try await withCheckedThrowingContinuation { continuation in
+                executionQueue.async {
+                    do {
+                        let runner = try WorkflowRunner(
+                            bundleDirectory: bundleDir,
+                            runDirectory: runDir,
+                            resume: false,
+                            executor: .init(kind: "worker", profile: nil, jobReference: nil),
+                            eventHandler: nil
+                        )
+                        continuation.resume(returning: try runner.execute())
+                    } catch {
+                        continuation.resume(throwing: error)
+                    }
+                }
+            }
+            let manifestError = (try? WorkflowBundleCodec.decoder().decode(
+                GraphRunManifest.self,
+                from: Data(contentsOf: runDir.appendingPathComponent(GraphRunManifest.filename))
+            ))?.error
+            await state.finishRun(jobID: jobID, state: outcome.state, error: manifestError)
+        } catch let error as RelayClientError {
+            await state.finishRun(jobID: jobID, state: .failed, error: error.message)
+        } catch let error as ValidationError {
+            await state.finishRun(jobID: jobID, state: .failed, error: error.message)
+        } catch {
+            await state.finishRun(jobID: jobID, state: .failed, error: String(describing: error))
+        }
+    }
+
+    // MARK: - Router
+
+    static func buildRouter(state: LocalRelayState) -> Router<BasicRequestContext> {
+        let router = Router(context: BasicRequestContext.self)
+
+        router.get("/.well-known/mere-run-relay") { _, _ in
+            try jsonResponse(LocalRelayDiscoveryDocument(
+                schemaVersion: 1,
+                kind: LocalRelayDiscoveryDocument.kind,
+                authMode: LocalRelayDiscoveryDocument.authMode,
+                relayName: state.relayName,
+                contractVersions: [WorkflowJobManifest.contractVersion]
+            ))
+        }
+
+        router.post("/api/pair") { request, _ in
+            let body = try await request.body.collect(upTo: 1 << 16)
+            guard let pairRequest = try? WorkflowBundleCodec.decoder().decode(
+                LocalRelayPairRequest.self,
+                from: Data(body.readableBytesView)
+            ) else {
+                return errorResponse(.badRequest, "Pairing needs a JSON body with `code` and `device_name`.")
+            }
+            switch try await state.pair(code: pairRequest.code, deviceName: pairRequest.deviceName) {
+            case .paired(let token):
+                return try jsonResponse(LocalRelayPairResponse(token: token, relayName: state.relayName))
+            case .rejected:
+                return errorResponse(.unauthorized, "The pairing code did not match.")
+            case .closed:
+                return errorResponse(.forbidden, "Pairing is closed. Restart `mere.run relay serve` to reopen it.")
+            }
+        }
+
+        router.get("/api/graph-jobs/capabilities") { request, _ in
+            try await requireAuth(request, state: state)
+            return try jsonResponse(await state.probe())
+        }
+
+        router.get("/api/fleet") { request, _ in
+            try await requireAuth(request, state: state)
+            return try jsonResponse(await state.fleetSnapshot())
+        }
+
+        router.post("/api/fleet/nodes/{id}/refresh") { request, context in
+            try await requireAuth(request, state: state)
+            let deviceID = context.parameters.get("id", as: String.self) ?? "local"
+            return try jsonResponse(RelayFleetRefreshResult(deviceID: deviceID, requested: true))
+        }
+
+        router.post("/api/graph-jobs") { request, _ in
+            try await requireAuth(request, state: state)
+            return try await handle {
+                let body = try await request.body.collect(upTo: 64 << 20)
+                let createRequest = try WorkflowBundleCodec.decoder().decode(
+                    RelayGraphCreateRequest.self,
+                    from: Data(body.readableBytesView)
+                )
+                return try jsonResponse(await state.create(request: createRequest))
+            }
+        }
+
+        router.put("/api/graph-jobs/{id}/assets/{digest}") { request, context in
+            try await requireAuth(request, state: state)
+            let jobID = try requireParameter(context, "id")
+            let digest = try requireParameter(context, "digest")
+            let body = try await request.body.collect(upTo: 256 << 20)
+            return try await handle {
+                try await state.storeAsset(jobID: jobID, digest: digest, data: Data(body.readableBytesView))
+                return try jsonResponse(["stored": digest])
+            }
+        }
+
+        router.post("/api/graph-jobs/{id}/commit") { request, context in
+            try await requireAuth(request, state: state)
+            let jobID = try requireParameter(context, "id")
+            return try await handle {
+                let record = try await state.commit(jobID: jobID)
+                return try jsonResponse(record.response(artifacts: []))
+            }
+        }
+
+        router.get("/api/graph-jobs") { request, _ in
+            try await requireAuth(request, state: state)
+            let limit = request.uri.queryParameters["limit"].flatMap { Int($0) } ?? 20
+            let records = await state.list(limit: limit)
+            var responses: [RelayGraphJobResponse] = []
+            for record in records {
+                responses.append(record.response(artifacts: await state.artifacts(jobID: record.jobID)))
+            }
+            return try jsonResponse(RelayGraphJobListResponse(jobs: responses))
+        }
+
+        router.get("/api/graph-jobs/{id}") { request, context in
+            try await requireAuth(request, state: state)
+            let jobID = try requireParameter(context, "id")
+            guard let record = await state.record(jobID: jobID) else {
+                return errorResponse(.notFound, "Unknown job \(jobID).")
+            }
+            return try jsonResponse(record.response(artifacts: await state.artifacts(jobID: jobID)))
+        }
+
+        router.delete("/api/graph-jobs/{id}") { request, context in
+            try await requireAuth(request, state: state)
+            let jobID = try requireParameter(context, "id")
+            return try await handle {
+                let record = try await state.cancel(jobID: jobID)
+                return try jsonResponse(record.response(artifacts: await state.artifacts(jobID: jobID)))
+            }
+        }
+
+        router.post("/api/graph-jobs/{id}/retry") { request, context in
+            try await requireAuth(request, state: state)
+            let jobID = try requireParameter(context, "id")
+            return try await handle {
+                let record = try await state.retry(jobID: jobID)
+                return try jsonResponse(record.response(artifacts: []))
+            }
+        }
+
+        router.get("/api/graph-jobs/{id}/run-manifest") { request, context in
+            try await requireAuth(request, state: state)
+            let jobID = try requireParameter(context, "id")
+            guard let data = await state.manifestData(jobID: jobID) else {
+                return errorResponse(.notFound, "Job \(jobID) has no run manifest yet.")
+            }
+            return Response(
+                status: .ok,
+                headers: [.contentType: "application/json"],
+                body: .init(byteBuffer: ByteBuffer(bytes: data))
+            )
+        }
+
+        router.get("/api/graph-jobs/{id}/events") { request, context in
+            try await requireAuth(request, state: state)
+            let jobID = try requireParameter(context, "id")
+            let text = await state.eventsText(jobID: jobID)
+            return Response(
+                status: .ok,
+                headers: [.contentType: "text/plain; charset=utf-8"],
+                body: .init(byteBuffer: ByteBuffer(string: text))
+            )
+        }
+
+        router.get("/api/graph-jobs/{id}/artifacts/{name}") { request, context in
+            try await requireAuth(request, state: state)
+            let jobID = try requireParameter(context, "id")
+            let name = try requireParameter(context, "name")
+            return try await handle {
+                let (url, artifact) = try await state.artifactURL(jobID: jobID, name: name)
+                guard let fileHandle = FileHandle(forReadingAtPath: url.path) else {
+                    return errorResponse(.notFound, "Artifact \(name) is missing from the run directory.")
+                }
+                var headers = HTTPFields()
+                headers[.contentType] = artifact.contentType
+                headers[.contentLength] = String(artifact.sizeBytes)
+                return Response(
+                    status: .ok,
+                    headers: headers,
+                    body: .init(asyncSequence: FileChunkSequence(handle: fileHandle))
+                )
+            }
+        }
+
+        return router
+    }
+
+    // MARK: - Helpers
+
+    /// Client-meaningful failures travel as 400s with the message in the
+    /// body, the way the hosted relay reports them; everything else stays a
+    /// 500 through Hummingbird's default handling.
+    private static func handle(_ body: () async throws -> Response) async throws -> Response {
+        do {
+            return try await body()
+        } catch let error as RelayClientError {
+            return errorResponse(.badRequest, error.message)
+        }
+    }
+
+    private static func requireAuth(_ request: Request, state: LocalRelayState) async throws {
+        let header = request.headers[.authorization] ?? ""
+        let token = header.hasPrefix("Bearer ") ? String(header.dropFirst("Bearer ".count)) : ""
+        guard await state.authorized(bearerToken: token) else {
+            throw HTTPError(.unauthorized, message: "Pair with this relay before calling its API.")
+        }
+    }
+
+    private static func requireParameter(_ context: BasicRequestContext, _ name: String) throws -> String {
+        guard let value = context.parameters.get(name, as: String.self), !value.isEmpty else {
+            throw HTTPError(.badRequest, message: "Missing path parameter \(name).")
+        }
+        return value
+    }
+
+    private static func jsonResponse(_ value: some Encodable) throws -> Response {
+        let data = try WorkflowBundleCodec.encoder().encode(value)
+        return Response(
+            status: .ok,
+            headers: [.contentType: "application/json"],
+            body: .init(byteBuffer: ByteBuffer(bytes: data))
+        )
+    }
+
+    private static func errorResponse(_ status: HTTPResponse.Status, _ message: String) -> Response {
+        let payload = (try? JSONEncoder().encode(["error": message])) ?? Data()
+        return Response(
+            status: status,
+            headers: [.contentType: "application/json"],
+            body: .init(byteBuffer: ByteBuffer(bytes: payload))
+        )
+    }
+}
+
+/// Pull-based file reader so large artifacts stream with backpressure
+/// instead of buffering in memory. FileHandle is class-bound but this
+/// sequence is consumed by exactly one response writer.
+struct FileChunkSequence: AsyncSequence, @unchecked Sendable {
+    typealias Element = ByteBuffer
+
+    let handle: FileHandle
+
+    struct AsyncIterator: AsyncIteratorProtocol {
+        let handle: FileHandle
+
+        mutating func next() async throws -> ByteBuffer? {
+            let chunk = try handle.read(upToCount: 1 << 20)
+            guard let chunk, !chunk.isEmpty else {
+                try? handle.close()
+                return nil
+            }
+            return ByteBuffer(bytes: chunk)
+        }
+    }
+
+    func makeAsyncIterator() -> AsyncIterator {
+        AsyncIterator(handle: handle)
+    }
+}

--- a/Sources/MereRunCLI/Commands/RelayCommand.swift
+++ b/Sources/MereRunCLI/Commands/RelayCommand.swift
@@ -69,7 +69,7 @@ struct RelayServe: AsyncParsableCommand {
             print("\(pairedCount) device\(pairedCount == 1 ? "" : "s") already paired.")
         }
         print("Press Ctrl+C to stop.")
-        fflush(stdout)
+        fflush(nil)
 
         try await withThrowingTaskGroup(of: Void.self) { group in
             group.addTask {

--- a/Sources/MereRunCLI/MereRunCLI.swift
+++ b/Sources/MereRunCLI/MereRunCLI.swift
@@ -41,6 +41,7 @@ struct MereRunCLI: AsyncParsableCommand {
             World.self,
             Graph.self,
             Executor.self,
+            Relay.self,
             Run.self,
             Model.self,
             Adapter.self,

--- a/Sources/MereRunCLI/Support/LocalRelayServer.swift
+++ b/Sources/MereRunCLI/Support/LocalRelayServer.swift
@@ -1,0 +1,485 @@
+import Foundation
+import MereRunRelayKit
+
+/// State machine behind `mere.run relay serve`: paired-device tokens, the
+/// pairing window, the job spool, and a serial execution queue. The HTTP
+/// layer in `RelayCommand` is a thin translation onto this actor; every
+/// response it sends uses the same wire types the hosted relay serves, so
+/// `RelayWorkflowExecutor` clients cannot tell the two apart.
+actor LocalRelayState {
+    struct JobRecord {
+        let jobID: String
+        var state: GraphRunState
+        let createdAt: Date
+        var updatedAt: Date
+        var error: String?
+        var graphName: String
+        var expectedAssetDigests: Set<String>
+    }
+
+    struct DeviceRecord: Codable, Equatable {
+        let name: String
+        let tokenSHA256: String
+        let createdAt: Date
+
+        enum CodingKeys: String, CodingKey {
+            case name
+            case tokenSHA256 = "token_sha256"
+            case createdAt = "created_at"
+        }
+    }
+
+    struct DeviceFile: Codable {
+        var schemaVersion: Int
+        var devices: [DeviceRecord]
+
+        enum CodingKeys: String, CodingKey {
+            case schemaVersion = "schema_version"
+            case devices
+        }
+    }
+
+    enum PairingOutcome {
+        case paired(token: String)
+        case rejected
+        case closed
+    }
+
+    static let pairingAttemptLimit = 10
+
+    let rootDirectory: URL
+    let relayName: String
+    private let pairingCode: String
+    private let pairingDeadline: Date
+    private var pairingAttempts = 0
+    private var devices: [DeviceRecord]
+    private var jobs: [String: JobRecord] = [:]
+    private var queueContinuation: AsyncStream<String>.Continuation?
+    private var runningJobID: String?
+    private var cachedProbe: (probe: WorkflowExecutorProbe, at: Date)?
+    private let probeProvider: @Sendable () -> WorkflowExecutorProbe
+
+    init(
+        rootDirectory: URL,
+        relayName: String,
+        pairingCode: String,
+        pairingWindowMinutes: Int,
+        probeProvider: @escaping @Sendable () -> WorkflowExecutorProbe = { WorkflowExecutorProbe.local() }
+    ) throws {
+        self.rootDirectory = rootDirectory
+        self.relayName = relayName
+        self.pairingCode = pairingCode
+        self.probeProvider = probeProvider
+        self.pairingDeadline = Date().addingTimeInterval(TimeInterval(pairingWindowMinutes) * 60)
+        try FileManager.default.createDirectory(
+            at: rootDirectory.appendingPathComponent("jobs", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        let deviceURL = rootDirectory.appendingPathComponent("devices.json")
+        if let data = try? Data(contentsOf: deviceURL),
+           let file = try? WorkflowBundleCodec.decoder().decode(DeviceFile.self, from: data) {
+            self.devices = file.devices
+        } else {
+            self.devices = []
+        }
+        self.jobs = Self.recoverSpooledJobs(rootDirectory: rootDirectory)
+    }
+
+    // MARK: - Pairing and authentication
+
+    func pair(code: String, deviceName: String) throws -> PairingOutcome {
+        guard Date() < pairingDeadline, pairingAttempts < Self.pairingAttemptLimit else {
+            return .closed
+        }
+        let normalized = code.replacingOccurrences(of: "-", with: "").trimmingCharacters(in: .whitespaces)
+        guard normalized == pairingCode else {
+            pairingAttempts += 1
+            return .rejected
+        }
+        var tokenBytes = [UInt8](repeating: 0, count: 32)
+        var generator = SystemRandomNumberGenerator()
+        for index in tokenBytes.indices {
+            tokenBytes[index] = UInt8.random(in: .min ... .max, using: &generator)
+        }
+        let token = Data(tokenBytes).base64EncodedString()
+            .replacingOccurrences(of: "+", with: "-")
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: "=", with: "")
+        let record = DeviceRecord(
+            name: deviceName.isEmpty ? "device" : deviceName,
+            tokenSHA256: ModelArtifactPinDigest.sha256(Data(token.utf8)),
+            createdAt: Date()
+        )
+        devices.append(record)
+        try persistDevices()
+        return .paired(token: token)
+    }
+
+    func authorized(bearerToken: String?) -> Bool {
+        guard let bearerToken, !bearerToken.isEmpty else { return false }
+        let digest = ModelArtifactPinDigest.sha256(Data(bearerToken.utf8))
+        return devices.contains { $0.tokenSHA256 == digest }
+    }
+
+    var pairedDeviceCount: Int { devices.count }
+
+    private func persistDevices() throws {
+        let file = DeviceFile(schemaVersion: 1, devices: devices)
+        try WorkflowBundleCodec.write(file, to: rootDirectory.appendingPathComponent("devices.json"))
+    }
+
+    // MARK: - Probe
+
+    func probe() -> WorkflowExecutorProbe {
+        if let cachedProbe, Date().timeIntervalSince(cachedProbe.at) < 10 {
+            return cachedProbe.probe
+        }
+        let fresh = probeProvider()
+        cachedProbe = (fresh, Date())
+        return fresh
+    }
+
+    // MARK: - Job lifecycle
+
+    func bundleDirectory(jobID: String) -> URL {
+        rootDirectory
+            .appendingPathComponent("jobs", isDirectory: true)
+            .appendingPathComponent(jobID, isDirectory: true)
+            .appendingPathComponent("bundle", isDirectory: true)
+    }
+
+    func runDirectory(jobID: String) -> URL {
+        rootDirectory
+            .appendingPathComponent("jobs", isDirectory: true)
+            .appendingPathComponent(jobID, isDirectory: true)
+            .appendingPathComponent("run", isDirectory: true)
+    }
+
+    func create(request: RelayGraphCreateRequest) throws -> RelayGraphCreateResponse {
+        let jobID = request.job.jobID
+        guard jobs[jobID] == nil else {
+            throw RelayClientError("A job with ID \(jobID) already exists on this relay.")
+        }
+        let bundleDir = bundleDirectory(jobID: jobID)
+        try FileManager.default.createDirectory(at: bundleDir, withIntermediateDirectories: true)
+        for (name, contents) in request.bundleDocuments {
+            guard !name.contains("/"), !name.contains("..") else {
+                throw RelayClientError("Bundle document names must be plain filenames: \(name)")
+            }
+            try contents.write(to: bundleDir.appendingPathComponent(name), options: .atomic)
+        }
+        let digests = Set(request.assets.groups.flatMap(\.entries).map(\.digest))
+        jobs[jobID] = JobRecord(
+            jobID: jobID,
+            state: .planned,
+            createdAt: Date(),
+            updatedAt: Date(),
+            error: nil,
+            graphName: request.graph.name,
+            expectedAssetDigests: digests
+        )
+        return RelayGraphCreateResponse(jobID: jobID, state: .planned, missingAssetDigests: digests.sorted())
+    }
+
+    func storeAsset(jobID: String, digest: String, data: Data) throws {
+        guard let record = jobs[jobID], record.state == .planned else {
+            throw RelayClientError("Job \(jobID) is not accepting assets.")
+        }
+        guard record.expectedAssetDigests.contains(digest) else {
+            throw RelayClientError("Job \(jobID) does not expect asset \(digest).")
+        }
+        guard ModelArtifactPinDigest.sha256(data) == digest else {
+            throw RelayClientError("Uploaded asset does not match digest \(digest).")
+        }
+        let assetDir = bundleDirectory(jobID: jobID)
+            .appendingPathComponent("assets", isDirectory: true)
+            .appendingPathComponent("sha256", isDirectory: true)
+        try FileManager.default.createDirectory(at: assetDir, withIntermediateDirectories: true)
+        try data.write(to: assetDir.appendingPathComponent(digest), options: .atomic)
+    }
+
+    func commit(jobID: String) throws -> JobRecord {
+        guard var record = jobs[jobID] else {
+            throw RelayClientError("Unknown job \(jobID).")
+        }
+        guard record.state == .planned else {
+            throw RelayClientError("Job \(jobID) was already committed.")
+        }
+        let assetDir = bundleDirectory(jobID: jobID)
+            .appendingPathComponent("assets", isDirectory: true)
+            .appendingPathComponent("sha256", isDirectory: true)
+        for digest in record.expectedAssetDigests {
+            guard FileManager.default.fileExists(atPath: assetDir.appendingPathComponent(digest).path) else {
+                throw RelayClientError("Job \(jobID) is missing asset \(digest); upload it before committing.")
+            }
+        }
+        let job = try WorkflowBundleCodec.decoder().decode(
+            WorkflowJobManifest.self,
+            from: Data(contentsOf: bundleDirectory(jobID: jobID).appendingPathComponent(WorkflowJobManifest.filename))
+        )
+        try validateWorker(probe(), for: job, executor: "relay:\(relayName)", allowMixedBackend: true)
+        record.state = .queued
+        record.updatedAt = Date()
+        jobs[jobID] = record
+        queueContinuation?.yield(jobID)
+        return record
+    }
+
+    func record(jobID: String) -> JobRecord? {
+        jobs[jobID]
+    }
+
+    func list(limit: Int) -> [JobRecord] {
+        Array(jobs.values.sorted { $0.createdAt > $1.createdAt }.prefix(max(1, limit)))
+    }
+
+    func cancel(jobID: String) throws -> JobRecord {
+        guard var record = jobs[jobID] else {
+            throw RelayClientError("Unknown job \(jobID).")
+        }
+        switch record.state {
+        case .planned, .queued, .preflighting:
+            record.state = .cancelled
+            record.updatedAt = Date()
+            jobs[jobID] = record
+        case .running, .assigned:
+            let runDir = runDirectory(jobID: jobID)
+            try? Data(Date().ISO8601Format().utf8).write(
+                to: runDir.appendingPathComponent("cancel.request"),
+                options: .atomic
+            )
+            WorkflowChildProcessRegistry.terminateAll(in: runDir)
+        case .finished, .failed, .cancelled:
+            break
+        }
+        return jobs[jobID] ?? record
+    }
+
+    func retry(jobID: String) throws -> JobRecord {
+        guard var record = jobs[jobID] else {
+            throw RelayClientError("Unknown job \(jobID).")
+        }
+        guard record.state == .failed || record.state == .cancelled else {
+            throw RelayClientError("Job \(jobID) is \(record.state.rawValue); only failed or cancelled jobs retry.")
+        }
+        try? FileManager.default.removeItem(at: runDirectory(jobID: jobID))
+        record.state = .queued
+        record.error = nil
+        record.updatedAt = Date()
+        jobs[jobID] = record
+        queueContinuation?.yield(jobID)
+        return record
+    }
+
+    /// The manifest served to clients, when the run has produced one.
+    func manifestData(jobID: String) -> Data? {
+        try? Data(contentsOf: runDirectory(jobID: jobID).appendingPathComponent(GraphRunManifest.filename))
+    }
+
+    func eventsText(jobID: String) -> String {
+        guard let data = try? Data(contentsOf: runDirectory(jobID: jobID).appendingPathComponent("events.jsonl")) else {
+            return ""
+        }
+        return String(decoding: data, as: UTF8.self)
+    }
+
+    func artifactURL(jobID: String, name: String) throws -> (url: URL, artifact: GraphRunArtifact) {
+        guard let record = jobs[jobID], record.state == .finished else {
+            throw RelayClientError("Job \(jobID) is not finished.")
+        }
+        guard let data = manifestData(jobID: jobID),
+              let manifest = try? WorkflowBundleCodec.decoder().decode(GraphRunManifest.self, from: data),
+              let artifact = manifest.outputs.first(where: { $0.name == name }) else {
+            throw RelayClientError("Job \(jobID) has no artifact named \(name).")
+        }
+        let root = runDirectory(jobID: jobID).standardizedFileURL
+        let candidate = root.appendingPathComponent(artifact.path).standardizedFileURL
+        guard candidate.path.hasPrefix(root.path + "/") else {
+            throw RelayClientError("Artifact path escapes the run directory.")
+        }
+        return (candidate, artifact)
+    }
+
+    func artifacts(jobID: String) -> [GraphRunArtifact] {
+        guard let record = jobs[jobID], record.state == .finished,
+              let data = manifestData(jobID: jobID),
+              let manifest = try? WorkflowBundleCodec.decoder().decode(GraphRunManifest.self, from: data) else {
+            return []
+        }
+        return manifest.outputs
+    }
+
+    // MARK: - Fleet
+
+    func fleetSnapshot() -> RelayFleetSnapshot {
+        let probe = probe()
+        let busy = runningJobID != nil
+        let queueDepth = jobs.values.filter { $0.state == .queued }.count
+        let hostName = ProcessInfo.processInfo.hostName
+        let node = RelayFleetNode(
+            agentID: "local",
+            deviceID: "local",
+            deviceName: hostName,
+            reportedName: hostName,
+            version: probe.workerVersion,
+            status: busy ? "busy" : "online",
+            currentJobID: runningJobID,
+            lastSeen: Date().ISO8601Format(),
+            capabilities: RelayFleetCapabilities(
+                models: probe.installedModelIDs,
+                graphWorker: RelayFleetGraphWorker(
+                    workerVersion: probe.workerVersion,
+                    contractVersions: probe.contractVersions,
+                    acceleratorBackend: probe.acceleratorBackend,
+                    memoryBytes: probe.memoryBytes,
+                    availableDiskBytes: probe.availableDiskBytes,
+                    nodeKinds: probe.nodeKinds,
+                    installedModelIDs: probe.installedModelIDs
+                )
+            ),
+            runtime: RelayFleetRuntime(
+                mereRunVersion: probe.workerVersion,
+                installedModels: probe.installedModelIDs
+            ),
+            policy: RelayFleetPolicy(
+                enabled: true,
+                draining: false,
+                revoked: false,
+                priority: 0,
+                preferredModels: [],
+                displayName: relayName
+            )
+        )
+        let activity = list(limit: 20).map { record in
+            RelayFleetActivity(
+                id: record.jobID,
+                kind: "graph",
+                status: record.state.rawValue,
+                agentID: "local",
+                model: nil,
+                label: record.graphName,
+                createdAt: record.createdAt.ISO8601Format(),
+                durationMilliseconds: record.state == .finished || record.state == .failed
+                    ? Int(record.updatedAt.timeIntervalSince(record.createdAt) * 1000)
+                    : nil,
+                error: record.error
+            )
+        }
+        return RelayFleetSnapshot(
+            generatedAt: Date().ISO8601Format(),
+            summary: RelayFleetSummary(
+                totalNodes: 1,
+                onlineNodes: 1,
+                busyNodes: busy ? 1 : 0,
+                availableNodes: busy ? 0 : 1,
+                queueDepth: queueDepth,
+                installedModels: probe.installedModelIDs.count,
+                routableModels: probe.installedModelIDs.count
+            ),
+            nodes: [node],
+            activity: activity
+        )
+    }
+
+    // MARK: - Execution queue
+
+    /// One stream of committed job IDs; the serve command's run loop consumes
+    /// it and executes strictly serially — the local lane models one machine.
+    func makeQueue() -> AsyncStream<String> {
+        AsyncStream { continuation in
+            self.queueContinuation = continuation
+            for record in jobs.values.sorted(by: { $0.createdAt < $1.createdAt }) where record.state == .queued {
+                continuation.yield(record.jobID)
+            }
+        }
+    }
+
+    func beginRun(jobID: String) -> Bool {
+        guard var record = jobs[jobID], record.state == .queued else { return false }
+        record.state = .running
+        record.updatedAt = Date()
+        jobs[jobID] = record
+        runningJobID = jobID
+        return true
+    }
+
+    func finishRun(jobID: String, state: GraphRunState, error: String?) {
+        guard var record = jobs[jobID] else { return }
+        record.state = state
+        record.error = error
+        record.updatedAt = Date()
+        jobs[jobID] = record
+        runningJobID = nil
+    }
+
+    // MARK: - Startup recovery
+
+    /// Jobs already on disk come back with the state their run manifest
+    /// recorded; anything the previous process left mid-flight is failed
+    /// honestly rather than silently re-run.
+    private static func recoverSpooledJobs(rootDirectory: URL) -> [String: JobRecord] {
+        var jobs: [String: JobRecord] = [:]
+        let jobsDir = rootDirectory.appendingPathComponent("jobs", isDirectory: true)
+        guard let entries = try? FileManager.default.contentsOfDirectory(
+            at: jobsDir,
+            includingPropertiesForKeys: [.creationDateKey]
+        ) else { return jobs }
+        for entry in entries {
+            let jobID = entry.lastPathComponent
+            let manifestURL = entry
+                .appendingPathComponent("run", isDirectory: true)
+                .appendingPathComponent(GraphRunManifest.filename)
+            let bundleJobURL = entry
+                .appendingPathComponent("bundle", isDirectory: true)
+                .appendingPathComponent(WorkflowJobManifest.filename)
+            var graphName = jobID
+            if let graph = try? WorkflowGraphDocument.load(
+                from: entry.appendingPathComponent("bundle", isDirectory: true).appendingPathComponent("graph.json")
+            ) {
+                graphName = graph.name
+            }
+            let createdAt = (try? entry.resourceValues(forKeys: [.creationDateKey]).creationDate) ?? Date()
+            if let data = try? Data(contentsOf: manifestURL),
+               let manifest = try? WorkflowBundleCodec.decoder().decode(GraphRunManifest.self, from: data) {
+                let interrupted = !(manifest.state == .finished || manifest.state == .failed || manifest.state == .cancelled)
+                jobs[jobID] = JobRecord(
+                    jobID: jobID,
+                    state: interrupted ? .failed : manifest.state,
+                    createdAt: manifest.createdAt,
+                    updatedAt: manifest.updatedAt,
+                    error: interrupted
+                        ? "The local relay stopped before this job completed. Retry to run it again."
+                        : manifest.error,
+                    graphName: manifest.graphName,
+                    expectedAssetDigests: []
+                )
+            } else if FileManager.default.fileExists(atPath: bundleJobURL.path) {
+                jobs[jobID] = JobRecord(
+                    jobID: jobID,
+                    state: .failed,
+                    createdAt: createdAt,
+                    updatedAt: createdAt,
+                    error: "The local relay stopped before this job started. Retry to run it again.",
+                    graphName: graphName,
+                    expectedAssetDigests: []
+                )
+            }
+        }
+        return jobs
+    }
+}
+
+extension LocalRelayState.JobRecord {
+    func response(artifacts: [GraphRunArtifact]) -> RelayGraphJobResponse {
+        RelayGraphJobResponse(
+            jobID: jobID,
+            state: state,
+            createdAt: createdAt,
+            updatedAt: updatedAt,
+            artifacts: artifacts,
+            error: error,
+            placement: nil,
+            metrics: nil
+        )
+    }
+}

--- a/Sources/MereRunRelayKit/LocalRelayWireTypes.swift
+++ b/Sources/MereRunRelayKit/LocalRelayWireTypes.swift
@@ -1,0 +1,118 @@
+import Foundation
+
+/// Wire types for the direct lane: `mere.run relay serve` hosts the relay
+/// HTTP surface on the machine itself, and a client pairs straight to it over
+/// the LAN or a tailnet with a locally issued bearer token — no broker, no
+/// cloud hop. The job API is byte-identical to the hosted relay's; only
+/// discovery and pairing differ.
+public struct LocalRelayDiscoveryDocument: Codable, Equatable, Sendable {
+    public static let kind = "mere.run/relay"
+    public static let authMode = "local-pair"
+
+    public let schemaVersion: Int
+    public let kind: String
+    public let authMode: String
+    public let relayName: String
+    public let contractVersions: [String]
+
+    enum CodingKeys: String, CodingKey {
+        case schemaVersion = "schema_version"
+        case kind
+        case authMode = "auth_mode"
+        case relayName = "relay_name"
+        case contractVersions = "graph_contract_versions"
+    }
+
+    public init(schemaVersion: Int, kind: String, authMode: String, relayName: String, contractVersions: [String]) {
+        self.schemaVersion = schemaVersion
+        self.kind = kind
+        self.authMode = authMode
+        self.relayName = relayName
+        self.contractVersions = contractVersions
+    }
+}
+
+public struct LocalRelayPairRequest: Codable, Equatable, Sendable {
+    public let code: String
+    public let deviceName: String
+
+    enum CodingKeys: String, CodingKey {
+        case code
+        case deviceName = "device_name"
+    }
+
+    public init(code: String, deviceName: String) {
+        self.code = code
+        self.deviceName = deviceName
+    }
+}
+
+public struct LocalRelayPairResponse: Codable, Equatable, Sendable {
+    public let token: String
+    public let relayName: String
+
+    enum CodingKeys: String, CodingKey {
+        case token
+        case relayName = "relay_name"
+    }
+
+    public init(token: String, relayName: String) {
+        self.token = token
+        self.relayName = relayName
+    }
+}
+
+extension RelayAuthentication {
+    /// Fetches direct-lane discovery from a `relay serve` host and verifies
+    /// the document identifies a local-pairing relay.
+    public static func discoverLocalRelay(
+        url baseURL: String,
+        requester: HTTPRequester = send
+    ) async throws -> LocalRelayDiscoveryDocument {
+        guard let url = URL(string: "\(baseURL)/.well-known/mere-run-relay") else {
+            throw RelayClientError("The relay address is not a valid URL.")
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        let (data, response) = try await requester(request)
+        guard response.statusCode == 200 else {
+            throw RelayClientError("The relay did not answer discovery (HTTP \(response.statusCode)).")
+        }
+        guard let document = try? WorkflowBundleCodec.decoder().decode(LocalRelayDiscoveryDocument.self, from: data),
+              document.kind == LocalRelayDiscoveryDocument.kind,
+              document.authMode == LocalRelayDiscoveryDocument.authMode else {
+            throw RelayClientError(
+                "That address is not a direct mere.run relay. For a hosted relay, use the sign-in flow instead."
+            )
+        }
+        return document
+    }
+
+    /// Exchanges a pairing code shown by `mere.run relay serve` for a
+    /// long-lived bearer token.
+    public static func pairLocalRelay(
+        url baseURL: String,
+        code: String,
+        deviceName: String,
+        requester: HTTPRequester = send
+    ) async throws -> LocalRelayPairResponse {
+        guard let url = URL(string: "\(baseURL)/api/pair") else {
+            throw RelayClientError("The relay address is not a valid URL.")
+        }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        request.httpBody = try WorkflowBundleCodec.encoder().encode(
+            LocalRelayPairRequest(code: code, deviceName: deviceName)
+        )
+        let (data, response) = try await requester(request)
+        guard response.statusCode == 200 else {
+            let detail = String(decoding: data, as: UTF8.self)
+            if response.statusCode == 401 || response.statusCode == 403 {
+                throw RelayClientError("The pairing code was not accepted. Check the code shown in the terminal.")
+            }
+            throw RelayClientError("Pairing failed (HTTP \(response.statusCode)): \(detail)")
+        }
+        return try WorkflowBundleCodec.decoder().decode(LocalRelayPairResponse.self, from: data)
+    }
+}

--- a/Sources/MereRunRelayKit/LocalRelayWireTypes.swift
+++ b/Sources/MereRunRelayKit/LocalRelayWireTypes.swift
@@ -1,4 +1,7 @@
 import Foundation
+#if canImport(FoundationNetworking)
+import FoundationNetworking
+#endif
 
 /// Wire types for the direct lane: `mere.run relay serve` hosts the relay
 /// HTTP surface on the machine itself, and a client pairs straight to it over

--- a/Sources/MereRunRelayKit/RelayClient.swift
+++ b/Sources/MereRunRelayKit/RelayClient.swift
@@ -303,6 +303,12 @@ package struct RelayGraphCreateResponse: Codable {
         case state
         case missingAssetDigests = "missing_asset_digests"
     }
+
+    package init(jobID: String, state: GraphRunState, missingAssetDigests: [String]) {
+        self.jobID = jobID
+        self.state = state
+        self.missingAssetDigests = missingAssetDigests
+    }
 }
 
 package struct RelayGraphJobResponse: Codable {
@@ -326,6 +332,26 @@ package struct RelayGraphJobResponse: Codable {
         case metrics
     }
 
+    package init(
+        jobID: String,
+        state: GraphRunState,
+        createdAt: Date?,
+        updatedAt: Date?,
+        artifacts: [GraphRunArtifact],
+        error: String?,
+        placement: WorkflowGraphPlacement?,
+        metrics: WorkflowGraphExecutionMetrics?
+    ) {
+        self.jobID = jobID
+        self.state = state
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.artifacts = artifacts
+        self.error = error
+        self.placement = placement
+        self.metrics = metrics
+    }
+
     package func remoteJob(profile: String, localRunDirectory: String?) -> WorkflowRemoteJob {
         WorkflowRemoteJob(
             jobID: jobID,
@@ -345,6 +371,10 @@ package struct RelayGraphJobResponse: Codable {
 
 package struct RelayGraphJobListResponse: Codable {
     package let jobs: [RelayGraphJobResponse]
+
+    package init(jobs: [RelayGraphJobResponse]) {
+        self.jobs = jobs
+    }
 }
 
 package func prepareFetchDestination(_ destination: URL, expectedJobID: String) throws {
@@ -497,11 +527,11 @@ public extension RelayWorkflowExecutor {
 }
 
 package struct RelayGraphCreateRequest: Codable {
-    let job: WorkflowJobManifest
-    let graph: WorkflowGraphDocument
-    let inputs: WorkflowInputsDocument
-    let assets: WorkflowAssetManifest
-    let bundleDocuments: [String: Data]
+    package let job: WorkflowJobManifest
+    package let graph: WorkflowGraphDocument
+    package let inputs: WorkflowInputsDocument
+    package let assets: WorkflowAssetManifest
+    package let bundleDocuments: [String: Data]
 
     enum CodingKeys: String, CodingKey {
         case job
@@ -509,6 +539,20 @@ package struct RelayGraphCreateRequest: Codable {
         case inputs
         case assets
         case bundleDocuments = "bundle_documents"
+    }
+
+    package init(
+        job: WorkflowJobManifest,
+        graph: WorkflowGraphDocument,
+        inputs: WorkflowInputsDocument,
+        assets: WorkflowAssetManifest,
+        bundleDocuments: [String: Data]
+    ) {
+        self.job = job
+        self.graph = graph
+        self.inputs = inputs
+        self.assets = assets
+        self.bundleDocuments = bundleDocuments
     }
 }
 

--- a/Tests/MereRunCLITests/LocalRelayServerTests.swift
+++ b/Tests/MereRunCLITests/LocalRelayServerTests.swift
@@ -1,0 +1,307 @@
+import Foundation
+import MereRunRelayKit
+import XCTest
+
+@testable import MereRunCLI
+
+/// The direct lane's state machine: pairing, the auth gate, the job spool
+/// lifecycle, and restart recovery. The HTTP layer is a thin translation on
+/// top of this actor, and the full client round trip is exercised against a
+/// live `relay serve` in development.
+final class LocalRelayServerTests: XCTestCase {
+    private var root: URL!
+
+    override func setUpWithError() throws {
+        root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("local-relay-tests-\(UUID().uuidString)", isDirectory: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: root)
+    }
+
+    private func makeState(pairingWindowMinutes: Int = 15) async throws -> LocalRelayState {
+        try await LocalRelayState(
+            rootDirectory: root,
+            relayName: "test-relay",
+            pairingCode: "123456",
+            pairingWindowMinutes: pairingWindowMinutes,
+            probeProvider: {
+                WorkflowExecutorProbe(
+                    schemaVersion: 1,
+                    workerVersion: MereRunCLIVersion.current,
+                    contractVersions: [WorkflowJobManifest.contractVersion],
+                    platform: "macos",
+                    architecture: "arm64",
+                    acceleratorBackend: "metal",
+                    memoryBytes: 8 << 30,
+                    systemMemoryBytes: 8 << 30,
+                    logicalCPUCores: 8,
+                    availableDiskBytes: 100 << 30,
+                    networkAccess: true,
+                    nodeKinds: ["boolean.value"],
+                    installedModelIDs: [],
+                    availableSecretNames: [],
+                    providers: []
+                )
+            }
+        )
+    }
+
+    // MARK: - Pairing
+
+    func testPairingRejectsWrongCodeAndIssuesTokenForRightCode() async throws {
+        let state = try await makeState()
+
+        guard case .rejected = try await state.pair(code: "000000", deviceName: "bad") else {
+            return XCTFail("A wrong code must be rejected.")
+        }
+        let authorizedBefore = await state.authorized(bearerToken: "anything")
+        XCTAssertFalse(authorizedBefore)
+
+        guard case .paired(let token) = try await state.pair(code: "123-456", deviceName: "phone") else {
+            return XCTFail("The dashed form of the right code must pair.")
+        }
+        XCTAssertGreaterThanOrEqual(token.count, 40)
+        let authorized = await state.authorized(bearerToken: token)
+        XCTAssertTrue(authorized)
+        let stillRejectsGarbage = await state.authorized(bearerToken: String(token.dropLast()))
+        XCTAssertFalse(stillRejectsGarbage)
+    }
+
+    func testPairingClosesAfterWindowExpires() async throws {
+        let state = try await makeState(pairingWindowMinutes: 0)
+        guard case .closed = try await state.pair(code: "123456", deviceName: "late") else {
+            return XCTFail("An expired window must refuse pairing.")
+        }
+    }
+
+    func testPairingClosesAfterAttemptLimit() async throws {
+        let state = try await makeState()
+        for _ in 0..<LocalRelayState.pairingAttemptLimit {
+            _ = try await state.pair(code: "999999", deviceName: "guess")
+        }
+        guard case .closed = try await state.pair(code: "123456", deviceName: "brute") else {
+            return XCTFail("The right code after too many failures must find pairing closed.")
+        }
+    }
+
+    func testPairedDevicesSurviveRestart() async throws {
+        var token = ""
+        do {
+            let state = try await makeState()
+            guard case .paired(let issued) = try await state.pair(code: "123456", deviceName: "phone") else {
+                return XCTFail("Pairing must succeed.")
+            }
+            token = issued
+        }
+        let restarted = try await makeState()
+        let authorized = await restarted.authorized(bearerToken: token)
+        XCTAssertTrue(authorized, "Tokens must survive a server restart.")
+    }
+
+    // MARK: - Job lifecycle
+
+    private func makeCreateRequest(jobID: String = UUID().uuidString) throws -> RelayGraphCreateRequest {
+        let graph = WorkflowGraphDocument(
+            schemaVersion: WorkflowGraphDocument.schemaVersion,
+            kind: WorkflowGraphDocument.kind,
+            name: "test-graph",
+            inputs: [:],
+            nodes: [WorkflowNode(id: "flag", kind: "boolean.value", arguments: ["value": .boolean(true)], dependsOn: nil)],
+            outputs: ["value": .reference("nodes.flag.outputs.value")],
+            metadata: nil
+        )
+        let inputs = WorkflowInputsDocument(values: [:])
+        let assets = WorkflowAssetManifest(schemaVersion: 1, groups: [])
+        let job = WorkflowJobManifest(
+            contractVersion: WorkflowJobManifest.contractVersion,
+            jobID: jobID,
+            createdAt: Date(),
+            graphFingerprint: "test",
+            inputFingerprint: "test",
+            requirements: WorkflowJobRequirements(
+                minimumMereRunVersion: "0.1.0",
+                nodeKinds: ["boolean.value"],
+                modelIDs: [],
+                acceleratorBackends: ["cpu", "metal", "cuda", "rocm"],
+                minimumAcceleratorMemoryBytes: nil
+            ),
+            outputs: []
+        )
+        let encoder = WorkflowBundleCodec.encoder()
+        return RelayGraphCreateRequest(
+            job: job,
+            graph: graph,
+            inputs: inputs,
+            assets: assets,
+            bundleDocuments: [
+                WorkflowJobManifest.filename: try encoder.encode(job),
+                "graph.json": try encoder.encode(graph),
+                "inputs.json": try encoder.encode(inputs),
+                WorkflowAssetManifest.filename: try encoder.encode(assets),
+            ]
+        )
+    }
+
+    func testCreateCommitAndQueueFlow() async throws {
+        let state = try await makeState()
+        let request = try makeCreateRequest()
+        let created = try await state.create(request: request)
+        XCTAssertEqual(created.state, .planned)
+        XCTAssertTrue(created.missingAssetDigests.isEmpty)
+
+        let bundleDir = await state.bundleDirectory(jobID: created.jobID)
+        XCTAssertTrue(FileManager.default.fileExists(
+            atPath: bundleDir.appendingPathComponent("graph.json").path
+        ))
+
+        let queue = await state.makeQueue()
+        let committed = try await state.commit(jobID: created.jobID)
+        XCTAssertEqual(committed.state, .queued)
+
+        var iterator = queue.makeAsyncIterator()
+        let queuedID = await iterator.next()
+        XCTAssertEqual(queuedID, created.jobID)
+
+        let began = await state.beginRun(jobID: created.jobID)
+        XCTAssertTrue(began)
+        await state.finishRun(jobID: created.jobID, state: .finished, error: nil)
+        let record = await state.record(jobID: created.jobID)
+        XCTAssertEqual(record?.state, .finished)
+    }
+
+    func testCommitRefusesMissingAssets() async throws {
+        let state = try await makeState()
+        var request = try makeCreateRequest()
+        let payload = Data("hello".utf8)
+        let digest = ModelArtifactPinDigest.sha256(payload)
+        let assets = WorkflowAssetManifest(
+            schemaVersion: 1,
+            groups: [WorkflowAssetGroup(
+                name: "photo",
+                kind: .asset,
+                entries: [WorkflowAssetEntry(
+                    path: "assets/sha256/\(digest)",
+                    digest: digest,
+                    sizeBytes: Int64(payload.count),
+                    contentType: "application/octet-stream"
+                )]
+            )]
+        )
+        request = RelayGraphCreateRequest(
+            job: request.job,
+            graph: request.graph,
+            inputs: request.inputs,
+            assets: assets,
+            bundleDocuments: request.bundleDocuments
+        )
+        let created = try await state.create(request: request)
+        XCTAssertEqual(created.missingAssetDigests, [digest])
+
+        do {
+            _ = try await state.commit(jobID: created.jobID)
+            XCTFail("Commit must refuse while assets are missing.")
+        } catch let error as RelayClientError {
+            XCTAssertTrue(error.message.contains("missing asset"))
+        }
+
+        do {
+            try await state.storeAsset(jobID: created.jobID, digest: digest, data: Data("tampered".utf8))
+            XCTFail("A digest mismatch must be refused.")
+        } catch let error as RelayClientError {
+            XCTAssertTrue(error.message.contains("does not match digest"))
+        }
+
+        try await state.storeAsset(jobID: created.jobID, digest: digest, data: payload)
+        let committed = try await state.commit(jobID: created.jobID)
+        XCTAssertEqual(committed.state, .queued)
+    }
+
+    func testCancelQueuedJobAndRetry() async throws {
+        let state = try await makeState()
+        let created = try await state.create(request: try makeCreateRequest())
+        _ = try await state.commit(jobID: created.jobID)
+
+        let cancelled = try await state.cancel(jobID: created.jobID)
+        XCTAssertEqual(cancelled.state, .cancelled)
+
+        let retried = try await state.retry(jobID: created.jobID)
+        XCTAssertEqual(retried.state, .queued)
+
+        let finishedRecord = await state.record(jobID: created.jobID)
+        XCTAssertNil(finishedRecord?.error)
+    }
+
+    func testRetryRefusesTerminalSuccess() async throws {
+        let state = try await makeState()
+        let created = try await state.create(request: try makeCreateRequest())
+        _ = try await state.commit(jobID: created.jobID)
+        _ = await state.beginRun(jobID: created.jobID)
+        await state.finishRun(jobID: created.jobID, state: .finished, error: nil)
+
+        do {
+            _ = try await state.retry(jobID: created.jobID)
+            XCTFail("A finished job must not retry.")
+        } catch let error as RelayClientError {
+            XCTAssertTrue(error.message.contains("only failed or cancelled"))
+        }
+    }
+
+    func testInterruptedJobRecoversAsFailed() async throws {
+        var jobID = ""
+        do {
+            let state = try await makeState()
+            let created = try await state.create(request: try makeCreateRequest())
+            jobID = created.jobID
+            _ = try await state.commit(jobID: jobID)
+        }
+        let restarted = try await makeState()
+        let record = await restarted.record(jobID: jobID)
+        XCTAssertEqual(record?.state, .failed)
+        XCTAssertTrue(record?.error?.contains("stopped before") == true)
+        let retried = try await restarted.retry(jobID: jobID)
+        XCTAssertEqual(retried.state, .queued)
+    }
+
+    // MARK: - Fleet
+
+    func testFleetSnapshotDescribesThisMachine() async throws {
+        let state = try await makeState()
+        let snapshot = await state.fleetSnapshot()
+        XCTAssertEqual(snapshot.summary.totalNodes, 1)
+        XCTAssertEqual(snapshot.summary.onlineNodes, 1)
+        XCTAssertEqual(snapshot.nodes.first?.status, "online")
+        XCTAssertEqual(snapshot.nodes.first?.policy.displayName, "test-relay")
+        XCTAssertFalse(snapshot.nodes.first?.capabilities.graphWorker?.nodeKinds.isEmpty ?? true)
+    }
+
+    // MARK: - Wire types
+
+    func testDiscoveryDocumentRoundTrips() throws {
+        let document = LocalRelayDiscoveryDocument(
+            schemaVersion: 1,
+            kind: LocalRelayDiscoveryDocument.kind,
+            authMode: LocalRelayDiscoveryDocument.authMode,
+            relayName: "lab",
+            contractVersions: [WorkflowJobManifest.contractVersion]
+        )
+        let data = try WorkflowBundleCodec.encoder().encode(document)
+        let text = String(decoding: data, as: UTF8.self)
+        XCTAssertTrue(text.contains("\"auth_mode\""))
+        XCTAssertTrue(text.contains("\"graph_contract_versions\""))
+        let decoded = try WorkflowBundleCodec.decoder().decode(LocalRelayDiscoveryDocument.self, from: data)
+        XCTAssertEqual(decoded, document)
+    }
+
+    func testLocallyIssuedTokenSetNeverExpires() {
+        let tokenSet = RelayOAuthTokenSet(
+            accessToken: "opaque-not-a-jwt",
+            refreshToken: nil,
+            tokenType: "Bearer",
+            expiresIn: nil,
+            obtainedAtEpochSeconds: Int64(Date().timeIntervalSince1970)
+        )
+        XCTAssertTrue(tokenSet.isFresh(now: Int64(Date().timeIntervalSince1970) + 10_000_000))
+    }
+}

--- a/Tests/MereRunCLITests/SpeechTranscribeCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/SpeechTranscribeCommandParsingTests.swift
@@ -125,6 +125,7 @@ final class SpeechTranscribeCommandParsingTests: XCTestCase {
             "geo",
             "graph",
             "executor",
+            "relay",
             "run",
             "model",
             "adapter",

--- a/docs/.vitepress/command-pages.tsv
+++ b/docs/.vitepress/command-pages.tsv
@@ -14,6 +14,7 @@ video	/runtime/video
 world	/runtime/world
 graph	/workflows
 executor	/workflows#executor-profiles
+relay	/workflows#direct-relay-relay-serve
 run	/workflows#run-directories
 model	/runtime/model-management
 adapter	/runtime/model-management

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -140,6 +140,8 @@ Public tree:
   - `mere.run executor node-refresh` — Ask a connected relay node to rescan its capabilities and installed models.
   - `mere.run executor node-configure` — Update relay scheduling policy for a fleet node.
   - `mere.run executor remove` — Remove an executor profile.
+- [`mere.run relay`](/workflows#direct-relay-relay-serve) — Host the relay API surface directly on this machine.
+  - `mere.run relay serve` — Serve the relay graph-job API from this machine and run submitted jobs locally.
 - [`mere.run run`](/workflows#run-directories) — Inspect durable mere.run workflow reports and run directories.
   - `mere.run run list` — Find durable run directories, structured reports, and run plans under a root.
   - `mere.run run inspect` — Inspect a run directory, structured report, or run plan.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -154,6 +154,7 @@ itself, so it always matches the binary you just built:
 | [`mere.run world`](/runtime/world) | Run persistent local conditioned-video world sessions. |
 | [`mere.run graph`](/workflows) | Validate, materialize, run, and submit portable workflow graphs. |
 | [`mere.run executor`](/workflows#executor-profiles) | Manage local, SSH, and relay workflow executors. |
+| [`mere.run relay`](/workflows#direct-relay-relay-serve) | Host the relay API surface directly on this machine. |
 | [`mere.run run`](/workflows#run-directories) | Inspect durable mere.run workflow reports and run directories. |
 | [`mere.run model`](/runtime/model-management) | List, pull, locate, remove, inspect, optimize, and clean up models. |
 | [`mere.run adapter`](/runtime/model-management) | List and pull verified LoRA adapters. |

--- a/docs/index.md
+++ b/docs/index.md
@@ -75,6 +75,7 @@ links to the page that owns that command.
 | [`mere.run world`](/runtime/world) | Run persistent local conditioned-video world sessions. |
 | [`mere.run graph`](/workflows) | Validate, materialize, run, and submit portable workflow graphs. |
 | [`mere.run executor`](/workflows#executor-profiles) | Manage local, SSH, and relay workflow executors. |
+| [`mere.run relay`](/workflows#direct-relay-relay-serve) | Host the relay API surface directly on this machine. |
 | [`mere.run run`](/workflows#run-directories) | Inspect durable mere.run workflow reports and run directories. |
 | [`mere.run model`](/runtime/model-management) | List, pull, locate, remove, inspect, optimize, and clean up models. |
 | [`mere.run adapter`](/runtime/model-management) | List and pull verified LoRA adapters. |

--- a/docs/ios-studio.md
+++ b/docs/ios-studio.md
@@ -56,8 +56,11 @@ covers building.
   Provider-qualified nodes stay excluded on iOS, and modes whose required
   inputs are assets wait for the photo/file picker step.
 - **Phase B — chat.** Route chat to the best available transport: on-device
-  small models when present, a Mac's `api serve` over the LAN when reachable
-  (real SSE token streaming today), relay jobs otherwise. Token streaming
+  small models when present, a machine reached directly when paired (the
+  `mere.run relay serve` direct lane — the app's "Connect to a machine"
+  pairing serves the full job vocabulary over the LAN or a tailnet with no
+  cloud hop, superseding the earlier `api serve`-over-LAN idea), relay jobs
+  otherwise. Token streaming
   *through relay* is an additive event-type revision, not an architecture
   change: the node→relay leg is a persistent WebSocket, relay serves
   `/events` SSE-framed, and the event `type` is an open string in the

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -401,6 +401,44 @@ Interrupted multipart uploads resume from relay-verified parts after retry.
 Each job reports download, execution, upload, total timing, transferred bytes,
 and reused bytes and parts.
 
+## Direct relay (`relay serve`)
+
+`mere.run relay serve` hosts the same client-facing graph-job HTTP surface
+directly on a machine and runs submitted jobs there — no broker, no cloud
+hop. It is the single-machine, self-sovereign lane: reach it over the LAN or
+a tailnet (Tailscale users can front it with `tailscale serve` for HTTPS),
+and prompts, inputs, and outputs never leave your network.
+
+```bash
+# On the machine that will run the work:
+mere.run relay serve
+# → prints the address and a six-digit pairing code
+
+# On any other machine, exchange the code for a bearer token:
+curl -X POST http://lab.local:6373/api/pair \
+  -H 'Content-Type: application/json' \
+  -d '{"code": "123-456", "device_name": "laptop"}'
+
+# Save the token and add a normal relay executor profile:
+mere.run executor add relay lab --url http://lab.local:6373 --token-file ./lab-token
+mere.run graph submit workflow.json --executor relay:lab --run-dir ./runs/job
+```
+
+The iOS app pairs through **Connect to a machine** on its pairing screen.
+Because the API is byte-identical to the hosted relay's, every client —
+`graph submit`, fetch, events polling, the phone — works unchanged against
+either.
+
+Pairing accepts new devices for a bounded window after startup (default 15
+minutes, `--pairing-window`) and locks after ten failed codes; issued tokens
+are stored hashed in the spool directory and survive restarts. Jobs are
+validated against the machine's live capability probe at commit, execute
+strictly serially through the same `WorkflowRunner` as every other lane
+(events stream through `events.jsonl`, including `node_output_delta` for
+`text.generate`), and artifacts are served with digest verification from the
+run directory. Jobs interrupted by a shutdown come back as failed with an
+explanatory error and can be retried.
+
 ## Remote lifecycle
 
 ```bash

--- a/ios/MereRunStudio/App/RelayStore.swift
+++ b/ios/MereRunStudio/App/RelayStore.swift
@@ -1,6 +1,7 @@
 import AuthenticationServices
 import Foundation
 import MereRunRelayKit
+import UIKit
 
 /// Owns the relay profile, authentication state, and client access for the
 /// app. Storage mirrors the CLI's JSON shapes inside the app sandbox's
@@ -97,6 +98,61 @@ final class RelayStore: ObservableObject {
             return
         }
         authStatus = RelayAuthentication.status(profile: profile)
+    }
+
+    /// The direct lane: pair straight to a machine running
+    /// `mere.run relay serve` over the LAN or a tailnet, exchanging the
+    /// terminal's pairing code for a long-lived bearer token in the Keychain.
+    /// No broker, no cloud hop — prompts and outputs stay on your network.
+    func pairDirect(urlString: String, code: String, profileName: String = "direct") async {
+        var trimmed = urlString.trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "/"))
+        if !trimmed.contains("://") {
+            trimmed = "http://\(trimmed)"
+        }
+        guard let parsed = URL(string: trimmed), parsed.scheme == "http" || parsed.scheme == "https" else {
+            pairing = .failed("Enter the machine's address, like lab.local:6373 or a tailnet name.")
+            return
+        }
+        pairing = .discovering
+        do {
+            _ = try await RelayAuthentication.discoverLocalRelay(url: trimmed)
+            let paired = try await RelayAuthentication.pairLocalRelay(
+                url: trimmed,
+                code: code,
+                deviceName: UIDevice.current.name
+            )
+            let tokenSet = RelayOAuthTokenSet(
+                accessToken: paired.token,
+                refreshToken: nil,
+                tokenType: "Bearer",
+                expiresIn: nil,
+                obtainedAtEpochSeconds: Int64(Date().timeIntervalSince1970)
+            )
+            let candidate = WorkflowExecutorProfile(
+                name: profileName,
+                kind: .relay,
+                destination: nil,
+                remoteRoot: nil,
+                port: nil,
+                identityFile: nil,
+                mereRunPath: nil,
+                url: trimmed,
+                tokenFile: nil
+            )
+            try keychain(for: profileName).save(tokenSet)
+            try WorkflowExecutorProfileStore.save(
+                WorkflowExecutorProfiles(schemaVersion: 1, profiles: [candidate]),
+                to: profilesURL
+            )
+            profile = candidate
+            pairing = .paired
+            refreshAuthStatus()
+        } catch let error as RelayClientError {
+            pairing = .failed(AppErrorText.presentable(error.message))
+        } catch {
+            pairing = .failed(error.localizedDescription)
+        }
     }
 
     /// Browser sign-in: Authorization Code + PKCE through an in-app sheet,

--- a/ios/MereRunStudio/Info.plist
+++ b/ios/MereRunStudio/Info.plist
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>$(DEVELOPMENT_LANGUAGE)</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>NSAppTransportSecurity</key>
+	<dict>
+		<key>NSAllowsLocalNetworking</key>
+		<true/>
+	</dict>
+	<key>NSLocalNetworkUsageDescription</key>
+	<string>mere.run connects to your own machines on your network to run the work you submit.</string>
+</dict>
+</plist>

--- a/ios/MereRunStudio/Views/PairingView.swift
+++ b/ios/MereRunStudio/Views/PairingView.swift
@@ -10,10 +10,12 @@ struct PairingView: View {
 
     @EnvironmentObject private var relay: RelayStore
     @State private var customRelay = false
+    @State private var directConnect = false
     @State private var urlString = ""
+    @State private var pairCode = ""
 
     private var pairingURL: String {
-        customRelay ? urlString : Self.defaultRelayURL
+        customRelay || directConnect ? urlString : Self.defaultRelayURL
     }
 
     var body: some View {
@@ -31,16 +33,28 @@ struct PairingView: View {
             switch relay.pairing {
             case .unpaired, .failed, .discovering:
                 VStack(spacing: MereTheme.Spacing.m) {
-                    if customRelay {
+                    if customRelay || directConnect {
                         TextField(
                             "",
                             text: $urlString,
-                            prompt: Text("Your relay address").foregroundColor(MereTheme.textMuted)
+                            prompt: Text(directConnect ? "Machine address, like lab.local:6373" : "Your relay address")
+                                .foregroundColor(MereTheme.textMuted)
                         )
                         .foregroundStyle(MereTheme.textPrimary)
                         .textInputAutocapitalization(.never)
                         .autocorrectionDisabled()
                         .keyboardType(.URL)
+                        .padding(MereTheme.Spacing.m)
+                        .merePanel()
+                    }
+                    if directConnect {
+                        TextField(
+                            "",
+                            text: $pairCode,
+                            prompt: Text("Pairing code from the terminal").foregroundColor(MereTheme.textMuted)
+                        )
+                        .foregroundStyle(MereTheme.textPrimary)
+                        .keyboardType(.numbersAndPunctuation)
                         .padding(MereTheme.Spacing.m)
                         .merePanel()
                     }
@@ -52,29 +66,53 @@ struct PairingView: View {
                     }
                     Button {
                         let url = pairingURL
-                        Task { await relay.signIn(urlString: url) }
+                        if directConnect {
+                            let code = pairCode
+                            Task { await relay.pairDirect(urlString: url, code: code) }
+                        } else {
+                            Task { await relay.signIn(urlString: url) }
+                        }
                     } label: {
                         if relay.pairing == .discovering {
                             ProgressView().frame(maxWidth: .infinity)
                         } else {
-                            Text(customRelay ? "Sign in" : "Sign in with mere.world")
+                            Text(directConnect
+                                ? "Connect"
+                                : (customRelay ? "Sign in" : "Sign in with mere.world"))
                                 .frame(maxWidth: .infinity)
                         }
                     }
                     .buttonStyle(.borderedProminent)
-                    .disabled(pairingURL.isEmpty || relay.pairing == .discovering)
+                    .disabled(
+                        pairingURL.isEmpty
+                            || relay.pairing == .discovering
+                            || (directConnect && pairCode.isEmpty)
+                    )
                     HStack(spacing: MereTheme.Spacing.l) {
                         Button(customRelay ? "Use relay.mere.run" : "Use a different relay") {
                             customRelay.toggle()
+                            directConnect = false
                         }
-                        Button("Use a device code") {
-                            let url = pairingURL
-                            Task { await relay.pair(urlString: url) }
+                        Button(directConnect ? "Use a hosted relay" : "Connect to a machine") {
+                            directConnect.toggle()
+                            customRelay = false
+                        }
+                        if !directConnect {
+                            Button("Use a device code") {
+                                let url = pairingURL
+                                Task { await relay.pair(urlString: url) }
+                            }
                         }
                     }
                     .font(.footnote)
                     .foregroundStyle(MereTheme.textMuted)
                     .disabled(relay.pairing == .discovering)
+                    if directConnect {
+                        Text("Run `mere.run relay serve` on your machine, then enter its address and the code it prints. Works over your network or Tailscale.")
+                            .font(.caption)
+                            .foregroundStyle(MereTheme.textMuted)
+                            .multilineTextAlignment(.center)
+                    }
                 }
             case .awaitingApproval(let verificationURL, let userCode):
                 VStack(spacing: MereTheme.Spacing.m) {

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -23,6 +23,12 @@ targets:
       - package: MereRun
         product: MereRunCore
       - target: MereRunWidgets
+    info:
+      path: MereRunStudio/Info.plist
+      properties:
+        NSLocalNetworkUsageDescription: mere.run connects to your own machines on your network to run the work you submit.
+        NSAppTransportSecurity:
+          NSAllowsLocalNetworking: true
     settings:
       base:
         PRODUCT_NAME: mere.run


### PR DESCRIPTION
## What this is

The third transport in the ladder: **hosted relay** for fleets, **direct** for the self-sovereign single-machine case, **on-device** for airplane mode. `mere.run relay serve` hosts the relay's client-facing graph-job HTTP surface on the machine itself and runs submitted jobs there — no broker, no cloud hop, prompts and outputs never leave your network.

### Server (`relay serve`)

- Hummingbird router over a new `LocalRelayState` actor: pairing, auth gate, job spool, serial execution queue.
- **Pairing**: six-digit code printed at startup; bounded window (default 15 min, `--pairing-window`), ten-attempt limit, tokens issued as 256-bit bearer secrets stored **hashed** in the spool — they survive restarts.
- **Jobs**: the same two-phase create → upload-missing-assets (digest-verified) → commit contract as the hosted relay; commit validates against the machine's live capability probe; execution runs strictly serially through the same `WorkflowRunner` as every other lane, so `events.jsonl` (including `node_output_delta` streaming), run manifests, and digest-verified artifact serving all come for free. Interrupted jobs recover as failed-with-explanation and can be retried.
- **API parity**: responses are encoded from the same `package` wire types `RelayWorkflowExecutor` decodes, so every existing client works unchanged.

### Clients

- **CLI**: zero changes needed — `executor add relay lab --url http://lab.local:6373 --token-file ./token` then `graph submit --executor relay:lab`. Verified live end to end: pair → probe → submit → serial run → events → typed output in the run manifest → list/fleet.
- **iOS**: a "Connect to a machine" pairing lane (address + terminal code → Keychain token; locally issued token sets never expire and never try to refresh). Plus `NSAllowsLocalNetworking` and the local-network usage description. Works against Tailscale IPs and `tailscale serve` HTTPS names.

### Gates

- 2967 tests, 0 failures (12 new `LocalRelayServerTests` covering pairing, auth, spool lifecycle, recovery); swiftlint clean; docs contract tests updated for the new top-level command (`docs/workflows.md` gains a Direct relay section, inventories regenerated).
- iOS simulator + device builds green; app installed on an iPhone 16 Pro Max.
- Live smoke test: discovery ✓, wrong-code 401 ✓, unauthenticated 401 ✓, pair ✓, submit→finished with `value: true` output ✓, fleet snapshot ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013q8wQ4W7gnGK2US6fA4Ki2