### PR TITLE
Refresh MLX stack through v0.32.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+### MLX v0.32.1 runtime refresh
+
+- refreshed the maintained MLX and mlx-swift forks through upstream MLX
+  v0.32.1. The Swift bridge now follows MLX's thread-local compile-cache API,
+  preserves cross-executor compiled-function erasure, and no longer serializes
+  unrelated compiled calls behind a process-wide lock.
+- expanded the vendored Metal-library provenance contract to verify the exact
+  mlx-swift revision, MLX fork revision, upstream release tag and revision,
+  generated-kernel source digest, and bundled metallib digest before builds or
+  runtime startup.
+
 ### Fused model evaluation and logprobs
 
 - added versioned `model benchmark fused` Lite and Comprehensive suites. The

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "7912f84701402566a75a301de11864f91f792625c61b28f258704fb4d46e4d71",
+  "originHash" : "df7b39bd26e0a4063f3313cb47fbe8f4317cf7577dc00ec51720414b9f8797b2",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -33,7 +33,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sawfwair/mlx-swift",
       "state" : {
-        "revision" : "30be5d59f194d5f7c67500509bf13bdfa1f26b3b"
+        "revision" : "7558b9cff75746e3ce25802aecbdc498b240af7f"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -531,7 +531,7 @@ if !isLinuxPackage {
 var packageDependencies: [Package.Dependency] = (useLinuxPrebuiltMLX ? [] : [
   .package(
     url: "https://github.com/sawfwair/mlx-swift",
-    revision: "30be5d59f194d5f7c67500509bf13bdfa1f26b3b"
+    revision: "7558b9cff75746e3ce25802aecbdc498b240af7f"
   )
 ]) + [
   .package(

--- a/Sources/MereRunCLI/Support/MLXBundleSupport.swift
+++ b/Sources/MereRunCLI/Support/MLXBundleSupport.swift
@@ -15,6 +15,9 @@ enum MLXBundleSupport {
 
     struct MetallibProvenance: Equatable {
       let coreVersion: String
+      let coreRevision: String
+      let upstreamTag: String
+      let upstreamRevision: String
       let swiftRevision: String
       let kernelSourcesSHA256: String
     }
@@ -27,8 +30,11 @@ enum MLXBundleSupport {
 
     static let expectedProvenance = MetallibProvenance(
       coreVersion: "0.32.1",
-      swiftRevision: "30be5d59f194d5f7c67500509bf13bdfa1f26b3b",
-      kernelSourcesSHA256: "b791ce523bec5e6612766d9b00004fa66d3f3b1dbbbabd725b5d3c36cefbce41"
+      coreRevision: "11da2b33a51772c023e2f7d7bc4ba9b3ff7e03ef",
+      upstreamTag: "v0.32.1",
+      upstreamRevision: "3a6219917e4535575ce5bce2fc2ba27a483a709b",
+      swiftRevision: "7558b9cff75746e3ce25802aecbdc498b240af7f",
+      kernelSourcesSHA256: "acfb87b05e097f03cecffcd084b988d99fb0321ea923cd561a482d114d75a895"
     )
 
     /// Relationship between a bundle's metallib version stamp
@@ -267,6 +273,9 @@ enum MLXBundleSupport {
     static func stampStatus(contents: String) -> MetallibStamp {
       let fields = [
         ("mlx-core-version", stampField("mlx-core-version", in: contents)),
+        ("mlx-core-revision", stampField("mlx-core-revision", in: contents)),
+        ("mlx-upstream-tag", stampField("mlx-upstream-tag", in: contents)),
+        ("mlx-upstream-revision", stampField("mlx-upstream-revision", in: contents)),
         ("mlx-swift-revision", stampField("mlx-swift-revision", in: contents)),
         ("kernel-sources-sha256", stampField("kernel-sources-sha256", in: contents)),
       ]
@@ -275,20 +284,29 @@ enum MLXBundleSupport {
       }
       guard missingFields.isEmpty,
         let coreVersion = fields[0].1,
-        let swiftRevision = fields[1].1,
-        let kernelSourcesSHA256 = fields[2].1
+        let coreRevision = fields[1].1,
+        let upstreamTag = fields[2].1,
+        let upstreamRevision = fields[3].1,
+        let swiftRevision = fields[4].1,
+        let kernelSourcesSHA256 = fields[5].1
       else {
         return .unstamped(missingFields: missingFields)
       }
 
       let stamped = MetallibProvenance(
         coreVersion: coreVersion,
+        coreRevision: coreRevision,
+        upstreamTag: upstreamTag,
+        upstreamRevision: upstreamRevision,
         swiftRevision: swiftRevision,
         kernelSourcesSHA256: kernelSourcesSHA256
       )
       let expected = expectedProvenance
       let comparisons = [
         ("mlx-core-version", stamped.coreVersion, expected.coreVersion),
+        ("mlx-core-revision", stamped.coreRevision, expected.coreRevision),
+        ("mlx-upstream-tag", stamped.upstreamTag, expected.upstreamTag),
+        ("mlx-upstream-revision", stamped.upstreamRevision, expected.upstreamRevision),
         ("mlx-swift-revision", stamped.swiftRevision, expected.swiftRevision),
         ("kernel-sources-sha256", stamped.kernelSourcesSHA256, expected.kernelSourcesSHA256),
       ]

--- a/Sources/MereRunCore/Gemma4/Gemma4Generator.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4Generator.swift
@@ -1139,7 +1139,9 @@ public actor Gemma4Generator: ChatGenerator {
                     }
 
                     let replacementCaches = forkLayerCaches(baseCaches)
-                    let replacementInput = MLXArray(([next] + acceptedPrefix + [replacement]).map(Int32.init))
+                    let replacementTokens = [next] + acceptedPrefix + [replacement]
+                    let replacementInputValues = replacementTokens.map { Int32($0) }
+                    let replacementInput = MLXArray(replacementInputValues)
                         .reshaped(1, acceptedPrefix.count + 2)
                     let replacementForward = model.forwardForSpeculation(
                         inputIds: replacementInput,

--- a/Sources/MereRunCore/Q35/Q35Generator.swift
+++ b/Sources/MereRunCore/Q35/Q35Generator.swift
@@ -1158,9 +1158,10 @@ public actor Q35Generator: ChatGenerator {
                         }
 
                         let replacementCaches = forkLayerCaches(layerCaches)
-                        let replacementInput = MLXArray(
-                            ([next] + acceptedPrefix + [replacement]).map(Int32.init)
-                        ).reshaped(1, acceptedPrefix.count + 2)
+                        let replacementTokens = [next] + acceptedPrefix + [replacement]
+                        let replacementInputValues = replacementTokens.map { Int32($0) }
+                        let replacementInput = MLXArray(replacementInputValues)
+                            .reshaped(1, acceptedPrefix.count + 2)
                         let replacementForward = model.forward(replacementInput, cache: replacementCaches)
                         MLX.eval(replacementForward.logits)
                         MLX.eval(replacementForward.hidden)

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -753,10 +753,12 @@ limitations under the License.
 - source project: [`sawfwair/mlx-swift`](https://github.com/sawfwair/mlx-swift),
   based on upstream [`ml-explore/mlx-swift`](https://github.com/ml-explore/mlx-swift)
   0.32.1
-- pinned package revision: `5bf3e46fecfb69cd3b559025fa99885ddd188731`
-- embedded MLX revision: `31af89c4c21642236b8a2bc1358438512d9521e3`
+- pinned package revision: `7558b9cff75746e3ce25802aecbdc498b240af7f`
+- embedded MLX revision: `11da2b33a51772c023e2f7d7bc4ba9b3ff7e03ef`
+- incorporated upstream MLX v0.32.1 revision:
+  `3a6219917e4535575ce5bce2fc2ba27a483a709b`
 - generated-kernel source SHA-256:
-  `b791ce523bec5e6612766d9b00004fa66d3f3b1dbbbabd725b5d3c36cefbce41`
+  `acfb87b05e097f03cecffcd084b988d99fb0321ea923cd561a482d114d75a895`
 - license: MIT
 
 ```

--- a/Tests/MereRunCLITests/MLXBundleSupportTests.swift
+++ b/Tests/MereRunCLITests/MLXBundleSupportTests.swift
@@ -37,7 +37,13 @@ final class MLXBundleSupportTests: XCTestCase {
 
     XCTAssertEqual(
       status,
-      .unstamped(missingFields: ["mlx-swift-revision", "kernel-sources-sha256"])
+      .unstamped(missingFields: [
+        "mlx-core-revision",
+        "mlx-upstream-tag",
+        "mlx-upstream-revision",
+        "mlx-swift-revision",
+        "kernel-sources-sha256",
+      ])
     )
   }
 
@@ -46,6 +52,9 @@ final class MLXBundleSupportTests: XCTestCase {
     let status = MLXBundleSupport.stampStatus(
       contents: """
         mlx-core-version: \(expected.coreVersion)
+        mlx-core-revision: \(expected.coreRevision)
+        mlx-upstream-tag: \(expected.upstreamTag)
+        mlx-upstream-revision: \(expected.upstreamRevision)
         mlx-swift-revision: \(String(repeating: "0", count: 40))
         kernel-sources-sha256: \(expected.kernelSourcesSHA256)
         """
@@ -63,11 +72,42 @@ final class MLXBundleSupportTests: XCTestCase {
     )
   }
 
+  func testCoreAndUpstreamRevisionMismatchesAreRejected() {
+    let expected = MLXBundleSupport.expectedProvenance
+    let wrongCore = String(repeating: "1", count: 40)
+    let wrongUpstream = String(repeating: "2", count: 40)
+    let status = MLXBundleSupport.stampStatus(
+      contents: """
+        mlx-core-version: \(expected.coreVersion)
+        mlx-core-revision: \(wrongCore)
+        mlx-upstream-tag: \(expected.upstreamTag)
+        mlx-upstream-revision: \(wrongUpstream)
+        mlx-swift-revision: \(expected.swiftRevision)
+        kernel-sources-sha256: \(expected.kernelSourcesSHA256)
+        """
+    )
+
+    XCTAssertEqual(
+      status,
+      .mismatched([
+        .init(field: "mlx-core-revision", stamped: wrongCore, expected: expected.coreRevision),
+        .init(
+          field: "mlx-upstream-revision",
+          stamped: wrongUpstream,
+          expected: expected.upstreamRevision
+        ),
+      ])
+    )
+  }
+
   func testKernelSourceHashMismatchIsRejected() {
     let expected = MLXBundleSupport.expectedProvenance
     let status = MLXBundleSupport.stampStatus(
       contents: """
         mlx-core-version: \(expected.coreVersion)
+        mlx-core-revision: \(expected.coreRevision)
+        mlx-upstream-tag: \(expected.upstreamTag)
+        mlx-upstream-revision: \(expected.upstreamRevision)
         mlx-swift-revision: \(expected.swiftRevision)
         kernel-sources-sha256: \(String(repeating: "0", count: 64))
         """

--- a/Tests/MereRunCoreTests/MLXCompiledFunctionOverheadTests.swift
+++ b/Tests/MereRunCoreTests/MLXCompiledFunctionOverheadTests.swift
@@ -4,10 +4,8 @@ import MLX
 @testable import MereRunCore
 
 /// Micro-benchmark for the per-call cost of mlx-swift compiled functions,
-/// used to evaluate CompiledFunction.call patches (it rebuilds a closure
-/// trampoline and takes the global evalLock on every invocation in
-/// mlx-swift 0.31.4). Skipped unless explicitly requested — it prints timing,
-/// it does not assert performance.
+/// used to evaluate CompiledFunction.call patches. Skipped unless explicitly
+/// requested — it prints timing, it does not assert performance.
 final class MLXCompiledFunctionOverheadTests: MereRunCoreTestCase {
     func testCompiledCallOverheadMicrobench() throws {
         guard ProcessInfo.processInfo.environment["MERERUN_BENCHMARK_COMPILE_OVERHEAD"] == "1" else {

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -333,9 +333,10 @@ training) — enable explicitly for that scenario.
 ### `MERERUN_GEMMA4_COMPILED_SEGMENTS`
 
 Opt-in (`1`, `true`, or `on`) MLX-compiled per-layer decode segments. Off by
-default: with mlx-swift 0.31.4 every compiled call serializes on the global
-eval lock, which measured slower than the interpreted path at decode call
-rates. Kept for evaluation against future mlx-swift releases.
+default pending a full-model quality and throughput requalification. The pinned
+mlx-swift fork no longer serializes unrelated compiled functions on the global
+eval lock; its concurrency benchmark is documented in
+[`mlx-swift-fork.md`](./mlx-swift-fork.md).
 
 ### Magenta RT2 prompt swaps (no switch)
 

--- a/docs/mlx-swift-fork.md
+++ b/docs/mlx-swift-fork.md
@@ -1,17 +1,18 @@
 # mlx-swift fork policy and compiled-call overhead
 
 mere-run pins the public `sawfwair/mlx-swift` fork at
-`5bf3e46fecfb69cd3b559025fa99885ddd188731`. It is rebased onto upstream
-`mlx-swift` `da318704cc0e972b61dcca43c62cd15e545362ae`, including the upstream
-`MLXArray` finalizer fix and generated-source-list maintenance. The embedded
+`7558b9cff75746e3ce25802aecbdc498b240af7f`. It contains upstream
+`mlx-swift` through `97cf19efeaa4e929415e75982e999adb34f62c0d`. The embedded
 `sawfwair/mlx` revision is
-`31af89c4c21642236b8a2bc1358438512d9521e3`, based on upstream MLX
-`9ab977b5649154590d598ea5d545aa1b3c97f883` and retaining the 0.32.1 ABI.
+`11da2b33a51772c023e2f7d7bc4ba9b3ff7e03ef`, which contains the exact
+upstream MLX v0.32.1 release commit
+`3a6219917e4535575ce5bce2fc2ba27a483a709b`.
 
 The owned patch stack carries the Linux/CUDA package bridge, executor-safe
 Swift streams, native affine 1-bit CUDA quantize/dequantize/QMV execution, the
 Metal affine 1-bit path, custom quantized-kernel headers, NVFP4 staging, the
-generation-17 NAX correctness gate, and M4/H3 tuning. The obsolete unaligned
+generation-17 NAX correctness gate, M4/H3 tuning, and executor-safe compile
+cache bridging. The obsolete unaligned
 1-bit fast-kernel tail was not replayed because upstream now requires aligned
 fast dispatch; the fork instead tests matching host/kernel alignment directly.
 Changes stay scoped to their bit width, group size, quantization mode, and
@@ -44,8 +45,9 @@ order:
    mlx-swift and publish the reviewed Swift revision. Never make mere.run depend
    on an unpushed or floating dependency ref.
 5. Pin the immutable mlx-swift revision in `Package.swift` and
-   `Package.resolved`, rebuild the vendored Metal library, and update all three
-   provenance fields: Swift revision, core version, and generated-source hash.
+   `Package.resolved`, rebuild the vendored Metal library, and update its
+   enforced provenance: Swift revision, core version and revision, upstream
+   release tag and revision, and generated-source hash.
 6. Run `./scripts/check.sh`, followed by both supported runtime gates:
    `MERERUN_RUN_E2E=core ./scripts/check.sh` and
    `MERERUN_RUN_E2E=installed ./scripts/check.sh`. Include a real generation
@@ -58,9 +60,20 @@ order:
 Perform this audit at least once per upstream minor release, and sooner for a
 security fix or a correctness/performance change in a path mere.run owns.
 
-A separate measured one-line compiled-call optimization exists on staging
-branches but is **deliberately not included in the pin**. The rest of this
-document records why, and what a safe version of that fix requires.
+The previously staged compiled-call optimization is now included: MLX v0.32.1
+makes compile caches thread-local and cache erasure thread-safe, and the Swift
+bridge retains the originating cache identities across executors. With that
+core prerequisite in place, independent compiled functions no longer take the
+global Swift evaluation lock. The regression suite covers concurrent first
+traces, shape changes, numerical evaluation, and cross-thread cache erasure.
+
+An eight-worker, 2,000-call-per-worker A/B on the same machine isolates that
+lock change on the same v0.32.1 core. Across five alternating trials, median
+compiled graph-build wall time fell from 7.56 us/call to 1.38 us/call (5.5x
+higher concurrent call throughput); median build-plus-evaluation wall time fell
+from 13.53 us/call to 7.61 us/call. Reproduce it in mlx-swift with
+`MLX_SWIFT_BENCHMARK_COMPILE_CONCURRENCY=1 swift test --filter
+TransformTests.testConcurrentCompiledCallOverheadMicrobench`.
 
 ## The finding
 
@@ -78,7 +91,7 @@ Every MLXNN compiled activation (`geluApproximate`, swiglu helpers, …) pays
 this cost per call, not just explicit `compile(...)` users. Confirmed present
 through upstream v0.31.6 (the file is unchanged upstream since 2026-05-07).
 
-## Why the one-line fix is not shipped
+## Why the one-line fix was previously held back
 
 Removing the global lock is only proven safe for the paths our benchmarks
 exercised: repeated calls to already-traced functions from one generator at a
@@ -117,7 +130,8 @@ architecture exercises it" is past the threshold to hold it back.
    this class. Run it through Xcode, which builds the Metal shader bundle;
    command-line SwiftPM alone cannot build that bundle.
 
-Do **not** upstream or re-pin the lock removal alone.
+Do **not** replay the lock removal onto an older core without the cache-scoped
+erase bridge and the concurrency regressions.
 
 ## Staging branches (kept on the fork)
 
@@ -135,8 +149,9 @@ Do **not** upstream or re-pin the lock removal alone.
 - The Linux/CUDA prebuilt path builds the exact embedded MLX revision selected
   by this pin; do not replace it with a floating checkout.
 - The vendored Metal library is accepted only when its stamp matches the exact
-  mlx-swift revision, MLX core version, and generated-kernel source hash
-  compiled into `mere.run`. `scripts/check.sh` recomputes the same provenance
-  from the clean pinned checkout.
+  mlx-swift revision, MLX core version and revision, incorporated upstream
+  release, and generated-kernel source hash compiled into `mere.run`.
+  `scripts/check.sh` recomputes the same provenance and release ancestry from
+  the clean pinned checkout.
 - Never edit `.build/checkouts/` to change dependency behavior — checkout
   edits silently vanish on the next `swift package resolve/update`.

--- a/scripts/build_mlx_metallib.sh
+++ b/scripts/build_mlx_metallib.sh
@@ -13,9 +13,9 @@ set -euo pipefail
 # text model once the KV length crossed 1024 (2-pass SDPA kernel ABI change).
 #
 # The produced library is accompanied by a `default.metallib.version` sidecar
-# recording the mlx core version, the mlx-swift pin, and a hash of the kernel
-# sources. `mere.run` validates the sidecar at startup (MLXBundleSupport) and
-# refuses to run against a mismatched library.
+# recording the exact mlx-swift/core revisions, the incorporated upstream MLX
+# release, and a hash of the kernel sources. `mere.run` validates the sidecar
+# at startup (MLXBundleSupport) and refuses to run against a mismatched library.
 #
 # Usage:
 #   scripts/build_mlx_metallib.sh                       Build and install into
@@ -37,9 +37,12 @@ set -euo pipefail
 repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 checkout="${MERERUN_MLX_SWIFT_CHECKOUT:-$repo_root/.build/checkouts/mlx-swift}"
 gen_dir="$checkout/Source/Cmlx/mlx-generated/metal"
+core_checkout="$checkout/Source/Cmlx/mlx"
 version_header="$checkout/Source/Cmlx/mlx/mlx/version.h"
 resolved="$repo_root/Package.resolved"
 stamp_name="default.metallib.version"
+upstream_tag="v0.32.1"
+upstream_revision="3a6219917e4535575ce5bce2fc2ba27a483a709b"
 
 usage() {
   sed -n '3,36p' "${BASH_SOURCE[0]}" | sed 's/^# \{0,1\}//'
@@ -128,6 +131,16 @@ if [[ -n "$(git -C "$checkout" status --porcelain --untracked-files=no)" ]]; the
   exit 1
 fi
 
+core_revision="$(git -C "$core_checkout" rev-parse HEAD)"
+if [[ -n "$(git -C "$core_checkout" status --porcelain --untracked-files=no)" ]]; then
+  echo "error: MLX core checkout has tracked modifications; refusing to build unverifiable Metal kernels" >&2
+  exit 1
+fi
+if ! git -C "$core_checkout" merge-base --is-ancestor "$upstream_revision" "$core_revision"; then
+  echo "error: MLX core $core_revision does not contain upstream $upstream_tag ($upstream_revision)" >&2
+  exit 1
+fi
+
 # Fingerprint the clean tracked blobs instead of the checked-out bytes. Git may
 # represent those bytes differently across fresh CI checkouts (for example,
 # through platform line-ending settings), while the blobs still identify the
@@ -185,10 +198,16 @@ if [[ "$mode" == "verify" ]]; then
     exit 1
   fi
   stamped_core="$(stamp_field "mlx-core-version" "$sidecar")"
+  stamped_core_revision="$(stamp_field "mlx-core-revision" "$sidecar")"
+  stamped_upstream_tag="$(stamp_field "mlx-upstream-tag" "$sidecar")"
+  stamped_upstream_revision="$(stamp_field "mlx-upstream-revision" "$sidecar")"
   stamped_rev="$(stamp_field "mlx-swift-revision" "$sidecar")"
   stamped_hash="$(stamp_field "kernel-sources-sha256" "$sidecar")"
   status=0
   [[ "$stamped_core" == "$core_version" ]] || { echo "STALE: mlx core version $stamped_core != checkout $core_version" >&2; status=1; }
+  [[ "$stamped_core_revision" == "$core_revision" ]] || { echo "STALE: mlx core revision $stamped_core_revision != checkout $core_revision" >&2; status=1; }
+  [[ "$stamped_upstream_tag" == "$upstream_tag" ]] || { echo "STALE: upstream tag $stamped_upstream_tag != required $upstream_tag" >&2; status=1; }
+  [[ "$stamped_upstream_revision" == "$upstream_revision" ]] || { echo "STALE: upstream revision $stamped_upstream_revision != required $upstream_revision" >&2; status=1; }
   [[ "$stamped_rev" == "$swift_pin_revision" ]] || { echo "STALE: mlx-swift revision $stamped_rev != pinned $swift_pin_revision" >&2; status=1; }
   [[ "$stamped_hash" == "$sources_hash" ]] || { echo "STALE: kernel source hash mismatch" >&2; status=1; }
   if [[ $status -eq 0 ]]; then
@@ -236,6 +255,9 @@ xcrun -sdk macosx metallib "$workdir"/*.air -o "$workdir/default.metallib"
 metal_compiler="$(xcrun -sdk macosx metal --version 2>/dev/null | head -1 || echo unknown)"
 cat > "$workdir/$stamp_name" <<EOF
 mlx-core-version: $core_version
+mlx-core-revision: $core_revision
+mlx-upstream-tag: $upstream_tag
+mlx-upstream-revision: $upstream_revision
 mlx-swift-version: $swift_pin_version
 mlx-swift-revision: $swift_pin_revision
 kernel-sources-sha256: $sources_hash
@@ -309,7 +331,10 @@ if [[ -d "$vendor_bundle" ]]; then
   if [[ -f "$vendor_stamp" ]] \
     && [[ "$(stamp_field "kernel-sources-sha256" "$vendor_stamp")" == "$sources_hash" ]] \
     && [[ "$(stamp_field "mlx-swift-revision" "$vendor_stamp")" == "$swift_pin_revision" ]] \
-    && [[ "$(stamp_field "mlx-core-version" "$vendor_stamp")" == "$core_version" ]]; then
+    && [[ "$(stamp_field "mlx-core-version" "$vendor_stamp")" == "$core_version" ]] \
+    && [[ "$(stamp_field "mlx-core-revision" "$vendor_stamp")" == "$core_revision" ]] \
+    && [[ "$(stamp_field "mlx-upstream-tag" "$vendor_stamp")" == "$upstream_tag" ]] \
+    && [[ "$(stamp_field "mlx-upstream-revision" "$vendor_stamp")" == "$upstream_revision" ]]; then
     echo "[metallib] vendored $vendor_bundle already current; left untouched"
   else
     install_pair "$vendor_bundle/Contents/Resources"
@@ -318,4 +343,4 @@ if [[ -d "$vendor_bundle" ]]; then
   fi
 fi
 
-echo "[metallib] stamp: mlx core $core_version, mlx-swift $swift_pin_version ($swift_pin_revision)"
+echo "[metallib] stamp: mlx core $core_version ($core_revision), upstream $upstream_tag ($upstream_revision), mlx-swift $swift_pin_version ($swift_pin_revision)"

--- a/vendor/mlx-swift_Cmlx.bundle/Contents/Resources/default.metallib.version
+++ b/vendor/mlx-swift_Cmlx.bundle/Contents/Resources/default.metallib.version
@@ -1,6 +1,9 @@
 mlx-core-version: 0.32.1
+mlx-core-revision: 11da2b33a51772c023e2f7d7bc4ba9b3ff7e03ef
+mlx-upstream-tag: v0.32.1
+mlx-upstream-revision: 3a6219917e4535575ce5bce2fc2ba27a483a709b
 mlx-swift-version: unknown
-mlx-swift-revision: 30be5d59f194d5f7c67500509bf13bdfa1f26b3b
-kernel-sources-sha256: b791ce523bec5e6612766d9b00004fa66d3f3b1dbbbabd725b5d3c36cefbce41
-built-at: 2026-08-18T00:18:56Z
+mlx-swift-revision: 7558b9cff75746e3ce25802aecbdc498b240af7f
+kernel-sources-sha256: acfb87b05e097f03cecffcd084b988d99fb0321ea923cd561a482d114d75a895
+built-at: 2026-08-18T12:13:53Z
 metal-compiler: Apple metal version 32023.883 (metalfe-32023.883)


### PR DESCRIPTION
## Summary

- pin mere.run to sawfwair/mlx-swift#9, which carries the exact upstream mlx-swift head plus sawfwair/mlx#6 at upstream MLX v0.32.1
- adapt the Swift compile bridge to MLX v0.32.1 thread-local cache semantics and remove process-wide serialization of unrelated compiled calls
- verify the complete dependency ancestry and six-part runtime provenance chain: mlx-swift SHA, MLX fork SHA, upstream tag, upstream SHA, kernel-source digest, and metallib digest
- split two speculative token-input expressions into typed stages so the refreshed graph also builds under the Swift 6.0 Linux compiler
- update the vendored metallib receipt, fork documentation, third-party notice, and changelog

Depends on:

- sawfwair/mlx#6
- sawfwair/mlx-swift#9

## Performance

The same 8-worker x 2,000-call benchmark, on the same v0.32.1 core, measured median build-wall cost of 7.56 us/call with the prior global eval lock and 1.38 us/call with the new bridge across five alternating trials: 5.48x higher concurrent compiled-call throughput. Single-thread latency remained effectively unchanged.

## Validation

- rebased onto `origin/main` at `053e283153d3f5a80725a0fbbb557f5382e2be1f`
- `./scripts/check.sh`: 2,992 XCTest cases (219 skipped) plus all Swift Testing suites, 0 failures; lint, build, CLI help sweep, provenance, and hygiene checks passed
- `MERERUN_RUN_E2E=core ./scripts/check.sh`: 10 runtime/artifact passes, 0 failures, 1 unavailable-model skip
- `MERERUN_RUN_E2E=installed ./scripts/check.sh`: 14 runtime/artifact passes, 0 failures, 4 unavailable-model skips
- generated/validated speech, Parakeet and Qwen transcription, Z-Image, ACE-Step music, LightOn OCR, and Klein Nano image artifacts
- focused Q35/Gemma4 compatibility suite: 86 tests, 6 skipped, 0 failures
- GitHub: Swift package, Swift 6.0 Linux CLI, macOS app bundle, docs, dependency review, secret scan, and compatibility-doc checks all pass
- vendored metallib bytes remain unchanged (`8dcf3b0ef8de0f9ae00fe11c92e7ba6b7a2f345fe7501bff7970b9efd2d7c1a3`); regenerated kernel-source digest is `acfb87b05e097f03cecffcd084b988d99fb0321ea923cd561a482d114d75a895`

## Remaining model coverage

The installed store did not contain `text-chat-q36-nano`, `image-klein-max`, or `video-ltx-av`, so those paths were skipped and are not claimed as runtime proof.