### PR TITLE
Freeze fused benchmark fixtures and harden eval receipts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,22 @@ The format is based on Keep a Changelog.
   Reports expose lane, source, and capability breakdowns. A `fused-fixture`
   helper stamps and verifies canonical external-fixture hashes without loading
   a model.
+- added a deterministic, license-aware importer and immutable source lock for
+  the selected 35 HumanEval+, MBPP+, LiveCodeBench, BFCL, and LongBench cases.
+  Normalized fixtures retain exact upstream revisions and source hashes while
+  the datasets remain non-vendored. Typed scoring covers Plus tests,
+  stdin/functional code, parallel and zero-call tools, QA-F1, ROUGE-L, and
+  retrieval. Fixture work and fused dry-runs now bypass machine inference
+  admission because they cannot load a model.
+- made long fused runs interruption-safe: `--checkpoint` atomically records
+  each completed case-trial, `--resume` requires an exact plan and installed
+  model-manifest hash match, and `--case-trial-limit` yields cleanly after a
+  bounded slice. Fused evaluation now refuses missing models instead of
+  downloading them during a benchmark. Model preparation or generation
+  failures preserve prior rows but leave the current row pending for retry,
+  and reports expose explicit partial/complete progress. Receipt plans now bind
+  the exact runner executable, host identity, resolved Python binary and
+  sandbox backend, and preserve checkpoint creation/update timestamps.
 - added 10 deterministic generated PNG vision fixtures and wired their image
   paths through the managed chat plan into the runtime request. OCR, chart,
   spatial, counting, document-layout, negative-evidence, multi-panel,

--- a/Sources/MereRunCLI/BenchmarkSuites/mere-fused-sources-v1.json
+++ b/Sources/MereRunCLI/BenchmarkSuites/mere-fused-sources-v1.json
@@ -1,0 +1,67 @@
+{
+  "schemaVersion": 1,
+  "evalplus": {
+    "repositoryRevision": "26d6d00bb1fd0fa37f39c99d5290da67891d1c5e",
+    "humanEval": {
+      "version": "v0.1.10",
+      "url": "https://github.com/evalplus/humanevalplus_release/releases/download/v0.1.10/HumanEvalPlus.jsonl.gz",
+      "sha256": "272720b90ac375502c8ed23cd791c2a93dfb22a911641a494da74a426c09f101"
+    },
+    "mbpp": {
+      "version": "v0.2.0",
+      "url": "https://github.com/evalplus/mbppplus_release/releases/download/v0.2.0/MbppPlus.jsonl.gz",
+      "sha256": "af43697e8791c4c149bdfd6b489d8b5412507551ac20e28a439f650b8225db63"
+    }
+  },
+  "liveCodeBench": {
+    "repositoryRevision": "28fef95ea8c9f7a547c8329f2cd3d32b92c1fa24",
+    "datasetRevision": "0fe84c3912ea0c4d4a78037083943e8f0c4dd505",
+    "version": "release_v5",
+    "url": "https://huggingface.co/datasets/livecodebench/code_generation_lite/resolve/0fe84c3912ea0c4d4a78037083943e8f0c4dd505/test.jsonl",
+    "selectedRows": [
+      {"index": 0, "questionID": "1873_A", "fixtureID": "lcb.release-v5.stratum-0", "rawSHA256": "eba9fa95de36e7eb53bfb392826ea4d335a9b65347abeed1c5f6a034c0580b5d"},
+      {"index": 3, "questionID": "1883_B", "fixtureID": "lcb.release-v5.stratum-1", "rawSHA256": "5140d51e51553d947ed9f7131542042c73fa681a761458951f0d05e9c4d98740"},
+      {"index": 6, "questionID": "1899_B", "fixtureID": "lcb.release-v5.stratum-2", "rawSHA256": "7ea74a8879662bdc9658d48d7be67621d245d9a397bdd002508ceaaf14f68f5d"},
+      {"index": 9, "questionID": "2727", "fixtureID": "lcb.release-v5.stratum-3", "rawSHA256": "cc8db8ed098d199d78ac5be072be5bd5bf6e43f6b0b4f6811338226b1aaffc8a"},
+      {"index": 10, "questionID": "2728", "fixtureID": "lcb.release-v5.stratum-4", "rawSHA256": "6eabfaa2132f7f299653c53a593a91777f8e32b90e2e43fcbf3f8bd6a848fb31"},
+      {"index": 15, "questionID": "2757", "fixtureID": "lcb.release-v5.stratum-5", "rawSHA256": "c16b00fc43bb38983cd484fb65f4f2eb089963550b95814cbc3a66fe46397cbe"}
+    ]
+  },
+  "bfcl": {
+    "version": "v3",
+    "repositoryRevision": "ea13468e4423454d0c213704fb87cf7cb3990433",
+    "rawBaseURL": "https://raw.githubusercontent.com/ShishirPatil/gorilla/ea13468e4423454d0c213704fb87cf7cb3990433/berkeley-function-call-leaderboard/bfcl_eval/data/",
+    "resources": {
+      "BFCL_v3_simple.json": "fbc37b2ad252bf9af985582e0e07b456173fe627d957491472ea9cef5fb83158",
+      "possible_answer/BFCL_v3_simple.json": "2911a2bc00df82c4f999ffa64fedb0164cb88e96212ffa5972087eb91fd496ee",
+      "BFCL_v3_java.json": "261d327d50c1bb505614dd5f75a29167d5bd9f938e5cefefef989c325cb67848",
+      "possible_answer/BFCL_v3_java.json": "692c16dac988f24f41e26591b7c7ad9596d0d7f05d3c94d15dbf7de3f48025e5",
+      "BFCL_v3_parallel.json": "fad375d68295776efb63e5aa331dd884f8635e7bb50e05908113c74f14281c3c",
+      "possible_answer/BFCL_v3_parallel.json": "3af54bf04e5b7640b03a9b6a82440f52474feb24b398f94435fd2b155c7727de",
+      "BFCL_v3_multiple.json": "aef168155ebd74b7ac2401198b201343bc7d16d7a3d7e0d4e6d8ee82c6969b2a",
+      "possible_answer/BFCL_v3_multiple.json": "244e00ce9395df948bcafc7bee64e8f9c87ef70887587d83cae45b13699f3047",
+      "BFCL_v3_parallel_multiple.json": "8863ea8433239f55c5f016154cf0830853c89f693c6ea270396a2fa121960579",
+      "possible_answer/BFCL_v3_parallel_multiple.json": "5ebf24f458c1f16300c05505d83d6f0a1b68b79be273a033febd0d4f840507e3",
+      "BFCL_v3_irrelevance.json": "8237162db28f3cf2e3f7d0b0380333fdf829c2ff15234506b0f2205399c8c655",
+      "BFCL_v3_multi_turn_base.json": "fe5c442849bdb2c2cdedc91f377411ff7fc6cd11af299766f4554d71d3d40f98",
+      "possible_answer/BFCL_v3_multi_turn_base.json": "6ea6bf48a2fc6067b57a289d314e7dc0582b12e22be53c8f7681599fba84a028",
+      "BFCL_v3_multi_turn_miss_func.json": "4a3a862f3e897d121ad94aa2c3f29ea752b7f7ac4eac6a23c8d502d1143e3492",
+      "possible_answer/BFCL_v3_multi_turn_miss_func.json": "e47b7f29224e43b8991ef6f5e6e01a936a4dccad17d1484610e6a33f27998b34",
+      "BFCL_v3_multi_turn_miss_param.json": "25509d5c441017c51de784e7670647dbec11a22fe0640990b0dafabf32e8c8d1",
+      "possible_answer/BFCL_v3_multi_turn_miss_param.json": "585d97fd579965a14b63d09882a680bcfbd1826ccf3e3a5de6fa68363c98a704",
+      "BFCL_v3_multi_turn_long_context.json": "17898c71fc5ceca4538e812602bc0338efafe665594380094bd4288f10394f51",
+      "possible_answer/BFCL_v3_multi_turn_long_context.json": "387fae6ec3146c1fd4cce8b901a69b1ec7a0844aa211f425f79049d35dd0b433",
+      "multi_turn_func_doc/gorilla_file_system.json": "26c01bed25bf7affbc8d281cc8124ccdc220a64c374ac4a7a9181dea0a0468ee",
+      "multi_turn_func_doc/posting_api.json": "87f9fc404a06e4107d7c366f1399c596440e84c16cb119faf374b2f532d86e8b"
+    }
+  },
+  "longBench": {
+    "version": "v1",
+    "repositoryRevision": "2e00731f8d0bff23dc4325161044d0ed8af94c1e",
+    "datasetRevision": "5e628be450b7e67fb7ae6e201bd6d8f7056f7672",
+    "dataURL": "https://huggingface.co/datasets/THUDM/LongBench/resolve/5e628be450b7e67fb7ae6e201bd6d8f7056f7672/data.zip",
+    "dataSHA256": "cb45b11a4133c6bc1d6a44b0f8e701335ff1e543195db1103472e575857f7f64",
+    "promptURL": "https://raw.githubusercontent.com/THUDM/LongBench/2e00731f8d0bff23dc4325161044d0ed8af94c1e/LongBench/config/dataset2prompt.json",
+    "promptSHA256": "56d22ad4f382169c2b8a11ff4c982a4a1bea096c8152b0f0b85b64686b157c30"
+  }
+}

--- a/Sources/MereRunCLI/BenchmarkSuites/mere-fused-v1.json
+++ b/Sources/MereRunCLI/BenchmarkSuites/mere-fused-v1.json
@@ -1,7 +1,7 @@
 {
   "schemaVersion": 1,
   "id": "mere-fused-v1",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Mere-owned fused quality suite. Comprehensive is a balanced 100-plus-case evaluation across chat, code, tools, long context, and vision; Lite is a fixed stratified subset, never a random or easiest-case sample.",
   "defaultLiteTrials": 2,
   "defaultComprehensiveTrials": 5,
@@ -11,9 +11,9 @@
     {"id":"openai-humaneval","name":"OpenAI HumanEval","version":"v1","license":"MIT","sourceURL":"https://github.com/openai/human-eval","redistribution":"embedded-selected-cases"},
     {"id":"evalplus-humaneval-plus","name":"EvalPlus HumanEval+","version":"pinned-by-import","license":"Apache-2.0 AND MIT","sourceURL":"https://github.com/evalplus/evalplus","redistribution":"reference-only"},
     {"id":"evalplus-mbpp-plus","name":"EvalPlus MBPP+","version":"pinned-by-import","license":"Apache-2.0 AND MIT","sourceURL":"https://github.com/evalplus/evalplus","redistribution":"reference-only"},
-    {"id":"livecodebench","name":"LiveCodeBench","version":"release_v5","license":"MIT","sourceURL":"https://github.com/LiveCodeBench/LiveCodeBench","redistribution":"reference-only"},
+    {"id":"livecodebench","name":"LiveCodeBench","version":"release_v5","license":"MIT code; dataset card declares cc","sourceURL":"https://huggingface.co/datasets/livecodebench/code_generation_lite","redistribution":"reference-only"},
     {"id":"bfcl","name":"Berkeley Function Calling Leaderboard","version":"v3","license":"Apache-2.0","sourceURL":"https://github.com/ShishirPatil/gorilla","redistribution":"reference-only"},
-    {"id":"longbench","name":"LongBench","version":"v1","license":"MIT","sourceURL":"https://github.com/THUDM/LongBench","redistribution":"reference-only"},
+    {"id":"longbench","name":"LongBench","version":"v1","license":"MIT repository; constituent datasets retain their source terms","sourceURL":"https://huggingface.co/datasets/THUDM/LongBench","redistribution":"reference-only"},
     {"id":"mere-vision","name":"Mere authored local vision scenarios","version":"2026-08-17","license":"MIT","sourceURL":"https://github.com/sawfwair/mere-run","redistribution":"generated-fixtures"}
   ],
   "cases": [
@@ -99,12 +99,12 @@
     {"id":"mbpp-plus.7","sourceID":"evalplus-mbpp-plus","sourceCaseID":"Mbpp/7","adapter":"external-code","capabilityTags":["code","mbpp-plus","algorithms"],"difficulty":"hard","selectionRationale":"Adds a more algorithmic short-specification task.","lite":false},
     {"id":"mbpp-plus.56","sourceID":"evalplus-mbpp-plus","sourceCaseID":"Mbpp/56","adapter":"external-code","capabilityTags":["code","mbpp-plus","edge-cases"],"difficulty":"hard","selectionRationale":"Adds a distant edge-case stratum.","lite":false},
 
-    {"id":"lcb.release-v5.stratum-0","sourceID":"livecodebench","sourceCaseID":"release_v5:test:0","adapter":"external-code","capabilityTags":["code","livecodebench","generation","recent-problems"],"difficulty":"medium","selectionRationale":"Deterministic recent code-generation stratum selected by the importer.","lite":true},
-    {"id":"lcb.release-v5.stratum-1","sourceID":"livecodebench","sourceCaseID":"release_v5:test:1","adapter":"external-code","capabilityTags":["code","livecodebench","generation","recent-problems"],"difficulty":"hard","selectionRationale":"Second recent code-generation difficulty stratum.","lite":false},
-    {"id":"lcb.release-v5.stratum-2","sourceID":"livecodebench","sourceCaseID":"release_v5:test:2","adapter":"external-code","capabilityTags":["code","livecodebench","execution","recent-problems"],"difficulty":"medium","selectionRationale":"Recent code-execution reasoning stratum.","lite":false},
-    {"id":"lcb.release-v5.stratum-3","sourceID":"livecodebench","sourceCaseID":"release_v5:test:3","adapter":"external-code","capabilityTags":["code","livecodebench","execution","recent-problems"],"difficulty":"hard","selectionRationale":"Harder code-execution reasoning stratum.","lite":false},
-    {"id":"lcb.release-v5.stratum-4","sourceID":"livecodebench","sourceCaseID":"release_v5:test:4","adapter":"external-code","capabilityTags":["code","livecodebench","test-output","recent-problems"],"difficulty":"medium","selectionRationale":"Test-output prediction stratum distinct from generation.","lite":false},
-    {"id":"lcb.release-v5.stratum-5","sourceID":"livecodebench","sourceCaseID":"release_v5:test:5","adapter":"external-code","capabilityTags":["code","livecodebench","test-output","recent-problems"],"difficulty":"hard","selectionRationale":"Hard test-output prediction stratum.","lite":false},
+    {"id":"lcb.release-v5.stratum-0","sourceID":"livecodebench","sourceCaseID":"release_v5:test:1873_A","adapter":"external-code","capabilityTags":["code","livecodebench","generation","stdin","codeforces"],"difficulty":"easy","selectionRationale":"Pinned stdin-style Codeforces easy stratum from the cumulative release-v5 set.","lite":true},
+    {"id":"lcb.release-v5.stratum-1","sourceID":"livecodebench","sourceCaseID":"release_v5:test:1883_B","adapter":"external-code","capabilityTags":["code","livecodebench","generation","stdin","codeforces"],"difficulty":"medium","selectionRationale":"Pinned stdin-style Codeforces medium stratum.","lite":false},
+    {"id":"lcb.release-v5.stratum-2","sourceID":"livecodebench","sourceCaseID":"release_v5:test:1899_B","adapter":"external-code","capabilityTags":["code","livecodebench","generation","stdin","codeforces"],"difficulty":"hard","selectionRationale":"Pinned stdin-style Codeforces hard stratum.","lite":false},
+    {"id":"lcb.release-v5.stratum-3","sourceID":"livecodebench","sourceCaseID":"release_v5:test:2727","adapter":"external-code","capabilityTags":["code","livecodebench","generation","functional","leetcode"],"difficulty":"easy","selectionRationale":"Pinned functional LeetCode easy stratum with public and private tests.","lite":false},
+    {"id":"lcb.release-v5.stratum-4","sourceID":"livecodebench","sourceCaseID":"release_v5:test:2728","adapter":"external-code","capabilityTags":["code","livecodebench","generation","functional","leetcode"],"difficulty":"medium","selectionRationale":"Pinned functional LeetCode medium stratum with public and private tests.","lite":false},
+    {"id":"lcb.release-v5.stratum-5","sourceID":"livecodebench","sourceCaseID":"release_v5:test:2757","adapter":"external-code","capabilityTags":["code","livecodebench","generation","functional","leetcode"],"difficulty":"hard","selectionRationale":"Pinned functional LeetCode hard stratum with public and private tests.","lite":false},
 
     {"id":"bfcl.v3.simple-python-0","sourceID":"bfcl","sourceCaseID":"v3:simple_python:0","adapter":"external-tool","capabilityTags":["tools","bfcl","single-turn","python"],"difficulty":"medium","selectionRationale":"Simple Python function-selection stratum.","lite":true},
     {"id":"bfcl.v3.simple-java-0","sourceID":"bfcl","sourceCaseID":"v3:simple_java:0","adapter":"external-tool","capabilityTags":["tools","bfcl","single-turn","java"],"difficulty":"medium","selectionRationale":"Cross-language simple-call stratum.","lite":false},

--- a/Sources/MereRunCLI/Commands/ModelBenchmarkFusedCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelBenchmarkFusedCommand.swift
@@ -1,6 +1,7 @@
 import ArgumentParser
 import Foundation
 import MereRunCore
+import MereRunRelayKit
 
 enum FusedBenchmarkPerformanceLane: String, CaseIterable, ExpressibleByArgument, Codable {
     case none
@@ -70,6 +71,21 @@ struct ModelBenchmarkFused: AsyncParsableCommand {
     @Flag(name: [.long], help: "Print the complete plan without loading or running models.")
     var dryRun: Bool = false
 
+    @Option(
+        name: [.long],
+        help: "Atomically persist the run plan and every completed case-trial as JSON."
+    )
+    var checkpoint: String?
+
+    @Flag(name: [.long], help: "Resume a checkpoint whose complete run plan exactly matches this invocation.")
+    var resume: Bool = false
+
+    @Option(
+        name: [.customLong("case-trial-limit")],
+        help: "Stop cleanly after this many new case-trials; requires --checkpoint."
+    )
+    var caseTrialLimit: Int?
+
     @Flag(name: [.long], help: "Emit machine-readable JSON.")
     var json: Bool = false
 
@@ -88,6 +104,15 @@ struct ModelBenchmarkFused: AsyncParsableCommand {
         }
         guard executionTimeout > 0, executionTimeout.isFinite else {
             throw ValidationError("--execution-timeout must be a positive finite number.")
+        }
+        guard !resume || checkpoint != nil else {
+            throw ValidationError("--resume requires --checkpoint.")
+        }
+        guard caseTrialLimit == nil || caseTrialLimit! > 0 else {
+            throw ValidationError("--case-trial-limit must be greater than zero.")
+        }
+        guard caseTrialLimit == nil || checkpoint != nil else {
+            throw ValidationError("--case-trial-limit requires --checkpoint.")
         }
         let manifest = try loadedManifest()
         let selected = try selectedCases(in: manifest)
@@ -124,35 +149,101 @@ struct ModelBenchmarkFused: AsyncParsableCommand {
         }
         let repeatedTrials = trials ?? suiteManifest.defaultTrials(for: suite)
         let capture = logprobs.capture(topLogprobs: topLogprobs)
+        let runner = try FusedBenchmarkRunnerIdentity.current()
+        let host = FusedBenchmarkHost.current()
+        let includesExecutableCode = selected.contains { descriptor in
+            descriptor.adapter == .humanEval || descriptor.adapter == .externalCode
+        }
+        let codeRuntime = try includesExecutableCode && allowCodeExecution
+            ? FusedBenchmarkCodeRuntimeIdentity.resolve(python: python, sandbox: sandbox)
+            : nil
         let plan = FusedBenchmarkPlan(
+            runnerVersion: runner.version,
+            runnerExecutableByteCount: runner.executableByteCount,
+            runnerExecutableSHA256: runner.executableSHA256,
+            host: host,
             manifestID: suiteManifest.id,
             manifestVersion: suiteManifest.version,
             manifestSHA256: try suiteManifest.contentSHA256(),
             suite: suite.rawValue,
-            models: modelIDs.map { modelID in
-                FusedBenchmarkPlannedModel(
+            models: try modelIDs.map { modelID in
+                try FusedBenchmarkPlannedModel.resolve(
                     id: modelID,
-                    profiles: FusedBenchmarkSamplingProfile.nativeProfiles(
-                        modelID: modelID,
-                        suite: suite
-                    )
+                    suite: suite
                 )
             },
             trials: repeatedTrials,
             qualityLane: "sampled-final-target; exact-policy; logprobs=\(capture.mode.rawValue)",
             performanceLane: performanceLane.rawValue,
+            settings: FusedBenchmarkRunSettings(
+                maxTokensOverride: maxTokens,
+                contextSize: contextSize,
+                logprobs: logprobs.rawValue,
+                topLogprobs: topLogprobs,
+                executionTimeout: executionTimeout,
+                pythonExecutable: python,
+                pythonResolvedPath: codeRuntime?.pythonResolvedPath,
+                pythonExecutableSHA256: codeRuntime?.pythonExecutableSHA256,
+                sandbox: sandbox.rawValue,
+                sandboxBackend: codeRuntime?.sandboxBackend,
+                allowCodeExecution: allowCodeExecution,
+                logResponses: logResponses
+            ),
             cases: resolvedCases.map(\.plan),
             importedFixtureFiles: fixturePaths
         )
 
+        let checkpointStore = checkpoint.map {
+            FusedBenchmarkCheckpointStore(
+                url: URL(fileURLWithPath: $0).standardizedFileURL
+            )
+        }
+        var results: [FusedBenchmarkCaseResult]
+        if let checkpointStore {
+            if resume {
+                results = try checkpointStore.loadResults(validating: plan)
+            } else {
+                try checkpointStore.initialize(plan: plan)
+                results = []
+            }
+        } else {
+            results = []
+        }
+
         if dryRun {
-            try printReport(FusedBenchmarkReport(plan: plan, results: []), dryRun: true)
+            try printReport(FusedBenchmarkReport(plan: plan, results: results), dryRun: true)
             return
         }
 
+        var completedKeys = Set(results.map(\.key))
+        let expectedKeys = plan.expectedResultKeys
+        let pendingKeys = expectedKeys.subtracting(completedKeys)
+        if pendingKeys.isEmpty {
+            try printReport(FusedBenchmarkReport(plan: plan, results: results), dryRun: false)
+            return
+        }
+        let pendingModelIDs = Set(pendingKeys.map(\.model))
+        let unavailable = plan.models.filter {
+            pendingModelIDs.contains($0.id) && !$0.installed
+        }.map(\.id)
+        guard unavailable.isEmpty else {
+            throw ValidationError(
+                "Fused benchmarks never download models. Mount or install these models under the selected "
+                    + "--models-root before running: \(unavailable.joined(separator: ", "))."
+            )
+        }
+
         try MLXBundleSupport.ensureAvailable(quiet: json)
-        var results: [FusedBenchmarkCaseResult] = []
+        var completedThisInvocation = 0
+        var reachedCaseTrialLimit = false
         for modelID in modelIDs {
+            if reachedCaseTrialLimit {
+                break
+            }
+            let modelHasPendingResults = pendingKeys.contains { $0.model == modelID }
+            if !modelHasPendingResults {
+                continue
+            }
             if !json {
                 CLIStderr.write("Fused quality benchmark: \(modelID)\n")
             }
@@ -169,35 +260,90 @@ struct ModelBenchmarkFused: AsyncParsableCommand {
                 modelID: modelID,
                 suite: suite
             )
-            for profile in profiles {
-                for trial in 1...repeatedTrials {
-                    for benchmarkCase in resolvedCases {
-                        results.append(try await runCase(
-                            benchmarkCase,
-                            modelID: modelID,
-                            profile: profile,
-                            trial: trial,
-                            capture: capture,
-                            lane: "quality-final-target",
-                            scoreQuality: true,
-                            pool: pool
-                        ))
+            do {
+                profileLoop: for profile in profiles {
+                    for trial in 1...repeatedTrials {
+                        for benchmarkCase in resolvedCases {
+                            let key = FusedBenchmarkResultKey(
+                                lane: "quality-final-target",
+                                model: modelID,
+                                profile: profile.name,
+                                trial: trial,
+                                caseID: benchmarkCase.descriptor.id
+                            )
+                            if completedKeys.contains(key) {
+                                continue
+                            }
+                            let result = try await runCase(
+                                benchmarkCase,
+                                modelID: modelID,
+                                profile: profile,
+                                trial: trial,
+                                capture: capture,
+                                lane: "quality-final-target",
+                                scoreQuality: true,
+                                pool: pool
+                            )
+                            results.append(result)
+                            completedKeys.insert(result.key)
+                            completedThisInvocation += 1
+                            try checkpointStore?.write(plan: plan, results: results)
+                            if let checkpointStore {
+                                CLIStderr.write(
+                                    "Checkpointed \(results.count)/\(expectedKeys.count) case-trials at "
+                                        + "\(checkpointStore.url.path).\n"
+                                )
+                            }
+                            if let caseTrialLimit,
+                               completedThisInvocation >= caseTrialLimit {
+                                reachedCaseTrialLimit = true
+                                break profileLoop
+                            }
+                        }
+                    }
+                    if performanceLane == .native {
+                        for benchmarkCase in resolvedCases {
+                            let key = FusedBenchmarkResultKey(
+                                lane: "performance-native-runtime",
+                                model: modelID,
+                                profile: profile.name,
+                                trial: 1,
+                                caseID: benchmarkCase.descriptor.id
+                            )
+                            if completedKeys.contains(key) {
+                                continue
+                            }
+                            let result = try await runCase(
+                                benchmarkCase,
+                                modelID: modelID,
+                                profile: profile,
+                                trial: 1,
+                                capture: .none,
+                                lane: "performance-native-runtime",
+                                scoreQuality: false,
+                                pool: pool
+                            )
+                            results.append(result)
+                            completedKeys.insert(result.key)
+                            completedThisInvocation += 1
+                            try checkpointStore?.write(plan: plan, results: results)
+                            if let checkpointStore {
+                                CLIStderr.write(
+                                    "Checkpointed \(results.count)/\(expectedKeys.count) case-trials at "
+                                        + "\(checkpointStore.url.path).\n"
+                                )
+                            }
+                            if let caseTrialLimit,
+                               completedThisInvocation >= caseTrialLimit {
+                                reachedCaseTrialLimit = true
+                                break profileLoop
+                            }
+                        }
                     }
                 }
-                if performanceLane == .native {
-                    for benchmarkCase in resolvedCases {
-                        results.append(try await runCase(
-                            benchmarkCase,
-                            modelID: modelID,
-                            profile: profile,
-                            trial: 1,
-                            capture: .none,
-                            lane: "performance-native-runtime",
-                            scoreQuality: false,
-                            pool: pool
-                        ))
-                    }
-                }
+            } catch {
+                _ = try? await pool.unloadModel(idOrAlias: modelID)
+                throw error
             }
             _ = try? await pool.unloadModel(idOrAlias: modelID)
         }
@@ -259,12 +405,12 @@ struct ModelBenchmarkFused: AsyncParsableCommand {
                 serverContextSize: contextSize
             )
         } catch {
-            return benchmarkCase.failedResult(
+            throw FusedBenchmarkRuntimeError.modelPreparation(
                 model: modelID,
                 profile: profile.name,
                 trial: trial,
-                lane: lane,
-                error: String(describing: error)
+                caseID: benchmarkCase.descriptor.id,
+                detail: String(describing: error)
             )
         }
 
@@ -275,13 +421,12 @@ struct ModelBenchmarkFused: AsyncParsableCommand {
             await plan.lease.release()
         } catch {
             await plan.lease.release()
-            return benchmarkCase.failedResult(
+            throw FusedBenchmarkRuntimeError.generation(
                 model: modelID,
                 profile: profile.name,
                 trial: trial,
-                lane: lane,
-                error: String(describing: error),
-                generationSeconds: Date().timeIntervalSince(started)
+                caseID: benchmarkCase.descriptor.id,
+                detail: String(describing: error)
             )
         }
         let generationSeconds = Date().timeIntervalSince(started)
@@ -381,14 +526,54 @@ struct ModelBenchmarkFused: AsyncParsableCommand {
     }
 }
 
-private struct FusedBenchmarkScoring {
+struct FusedBenchmarkScoring {
     let passed: Bool?
     let score: Double?
     let executionSeconds: Double?
     let error: String?
 }
 
-private enum FusedResolvedBenchmarkPayload {
+enum FusedBenchmarkRuntimeError: LocalizedError {
+    case modelPreparation(model: String, profile: String, trial: Int, caseID: String, detail: String)
+    case generation(model: String, profile: String, trial: Int, caseID: String, detail: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .modelPreparation(let model, let profile, let trial, let caseID, let detail):
+            return Self.message(
+                stage: "model preparation",
+                model: model,
+                profile: profile,
+                trial: trial,
+                caseID: caseID,
+                detail: detail
+            )
+        case .generation(let model, let profile, let trial, let caseID, let detail):
+            return Self.message(
+                stage: "generation",
+                model: model,
+                profile: profile,
+                trial: trial,
+                caseID: caseID,
+                detail: detail
+            )
+        }
+    }
+
+    private static func message(
+        stage: String,
+        model: String,
+        profile: String,
+        trial: Int,
+        caseID: String,
+        detail: String
+    ) -> String {
+        "Fused benchmark \(stage) failed for \(model) [\(profile)] trial \(trial), case \(caseID); "
+            + "the row remains pending: \(detail)"
+    }
+}
+
+enum FusedResolvedBenchmarkPayload {
     case chat(ChatBenchmarkCase)
     case tool(ToolBenchmarkCase)
     case code(CodeBenchmarkTask)
@@ -396,7 +581,7 @@ private enum FusedResolvedBenchmarkPayload {
     case unresolved(String)
 }
 
-private struct FusedResolvedBenchmarkCase {
+struct FusedResolvedBenchmarkCase {
     let descriptor: FusedBenchmarkCaseDescriptor
     let provenance: FusedBenchmarkProvenance
     let payload: FusedResolvedBenchmarkPayload
@@ -485,13 +670,14 @@ private struct FusedResolvedBenchmarkCase {
                 contentSHA256: contentHash,
                 imageSHA256: imageSHA256,
                 sourceVersion: imported[descriptor.id]?.sourceVersion,
+                sourceRevision: imported[descriptor.id]?.sourceRevision,
                 originalID: imported[descriptor.id]?.originalID
             ),
             payload: payload
         )
     }
 
-    var plan: FusedBenchmarkPlannedCase {
+    fileprivate var plan: FusedBenchmarkPlannedCase {
         let resolved: Bool
         let reason: String?
         if case .unresolved(let detail) = payload {
@@ -549,7 +735,8 @@ private struct FusedResolvedBenchmarkCase {
         case .external(let benchmarkCase):
             messages = benchmarkCase.messages
             tools = benchmarkCase.tools
-            defaultBudget = benchmarkCase.kind == .code ? 1_024 : 256
+            defaultBudget = benchmarkCase.generationBudget
+                ?? (benchmarkCase.kind == .code ? 1_024 : 256)
             logprobRegionHint = benchmarkCase.kind == .code ? .code : .visible
         case .unresolved:
             return nil
@@ -655,26 +842,59 @@ private struct FusedResolvedBenchmarkCase {
     ) throws -> FusedBenchmarkScoring {
         switch benchmarkCase.kind {
         case .chat, .vision:
-            let normalized = visibleResponse.lowercased()
-            let required = benchmarkCase.requiredPhrases ?? []
-            let forbidden = benchmarkCase.forbiddenPhrases ?? []
-            let passedChecks = required.filter { normalized.contains($0.lowercased()) }.count
-                + forbidden.filter { !normalized.contains($0.lowercased()) }.count
-            let total = required.count + forbidden.count
+            let metric = benchmarkCase.textMetric ?? .phraseChecks
+            if metric != .phraseChecks {
+                let references = benchmarkCase.referenceAnswers ?? []
+                let score = references.map { reference in
+                    Self.textScore(metric: metric, prediction: visibleResponse, reference: reference)
+                }.max() ?? 0
+                let threshold = benchmarkCase.passThreshold ?? 1
+                let passed = score >= threshold
+                return FusedBenchmarkScoring(
+                    passed: passed,
+                    score: score,
+                    executionSeconds: nil,
+                    error: passed ? nil : "external text score was below \(threshold)"
+                )
+            }
+            let phraseResult = Self.phraseChecks(
+                response: visibleResponse,
+                required: benchmarkCase.requiredPhrases ?? [],
+                forbidden: benchmarkCase.forbiddenPhrases ?? []
+            )
             return FusedBenchmarkScoring(
-                passed: total > 0 ? passedChecks == total : nil,
-                score: total > 0 ? Double(passedChecks) / Double(total) : nil,
+                passed: phraseResult.total > 0 ? phraseResult.passed == phraseResult.total : nil,
+                score: phraseResult.total > 0
+                    ? Double(phraseResult.passed) / Double(phraseResult.total)
+                    : nil,
                 executionSeconds: nil,
-                error: total > 0 && passedChecks != total ? "external text checks failed" : nil
+                error: phraseResult.total > 0 && phraseResult.passed != phraseResult.total
+                    ? "external text checks failed"
+                    : nil
             )
         case .tool:
             let calls = response.toolCalls ?? []
-            let match = calls.first { $0.name == benchmarkCase.expectedToolName }
-            let argumentChecks = benchmarkCase.expectedArguments ?? [:]
-            let argumentsPassed = match.map { call in
-                argumentChecks.allSatisfy { call.arguments[$0.key] == $0.value }
-            } ?? false
-            let passed = match != nil && argumentsPassed
+            let phraseResult = Self.phraseChecks(
+                response: visibleResponse,
+                required: benchmarkCase.requiredPhrases ?? [],
+                forbidden: benchmarkCase.forbiddenPhrases ?? []
+            )
+            let phrasesPassed = phraseResult.passed == phraseResult.total
+            let expectedCalls: [FusedExternalToolExpectation]
+            if let declared = benchmarkCase.expectedToolCalls {
+                expectedCalls = declared
+            } else if let name = benchmarkCase.expectedToolName {
+                expectedCalls = [FusedExternalToolExpectation(
+                    name: name,
+                    arguments: (benchmarkCase.expectedArguments ?? [:]).mapValues { [$0] }
+                )]
+            } else {
+                expectedCalls = []
+            }
+            let callsPassed = benchmarkCase.expectsNoToolCalls == true
+                ? calls.isEmpty
+                : Self.toolCallsMatch(expected: expectedCalls, observed: calls)
+            let passed = callsPassed && phrasesPassed
             return FusedBenchmarkScoring(
                 passed: passed,
                 score: passed ? 1 : 0,
@@ -682,18 +902,45 @@ private struct FusedResolvedBenchmarkCase {
                 error: passed ? nil : "external tool expectation failed"
             )
         case .code:
-            guard allowCodeExecution,
-                  let entryPoint = benchmarkCase.entryPoint,
-                  let tests = benchmarkCase.tests else {
+            guard allowCodeExecution else {
                 return FusedBenchmarkScoring(
                     passed: nil,
                     score: nil,
                     executionSeconds: nil,
-                    error: "external code fixture is incomplete or execution was not authorized"
+                    error: "external code execution was not authorized"
                 )
             }
-            let code = Self.extractCode(visibleResponse, entryPoint: entryPoint)
-            let program = "\(code)\n\n\(tests)\n\ncheck(\(entryPoint))\n"
+            let code = Self.extractCode(visibleResponse)
+            let evaluation = benchmarkCase.codeEvaluation ?? .function
+            let program: String
+            switch evaluation {
+            case .function:
+                guard let entryPoint = benchmarkCase.entryPoint,
+                      let tests = benchmarkCase.tests else {
+                    return FusedBenchmarkScoring(
+                        passed: nil,
+                        score: nil,
+                        executionSeconds: nil,
+                        error: "external function fixture is incomplete"
+                    )
+                }
+                program = "\(code)\n\n_mere_candidate = \(entryPoint)\n\n\(tests)\n\ncheck(_mere_candidate)\n"
+            case .stdin, .functional:
+                guard let codeTests = benchmarkCase.codeTests else {
+                    return FusedBenchmarkScoring(
+                        passed: nil,
+                        score: nil,
+                        executionSeconds: nil,
+                        error: "external program fixture is incomplete"
+                    )
+                }
+                program = try Self.programHarness(
+                    candidate: code,
+                    evaluation: evaluation,
+                    entryPoint: benchmarkCase.entryPoint,
+                    tests: codeTests
+                )
+            }
             let execution = try CodeExecutionSandbox.runPython(
                 program: program,
                 python: python,
@@ -705,6 +952,197 @@ private struct FusedResolvedBenchmarkCase {
                 score: execution.passed ? 1 : 0,
                 executionSeconds: execution.seconds,
                 error: execution.errorSummary
+            )
+        }
+    }
+
+    private static func phraseChecks(
+        response: String,
+        required: [String],
+        forbidden: [String]
+    ) -> (passed: Int, total: Int) {
+        let normalized = response.lowercased()
+        let passed = required.filter { normalized.contains($0.lowercased()) }.count
+            + forbidden.filter { !normalized.contains($0.lowercased()) }.count
+        return (passed, required.count + forbidden.count)
+    }
+
+    private static func textScore(
+        metric: FusedExternalTextMetric,
+        prediction: String,
+        reference: String
+    ) -> Double {
+        switch metric {
+        case .phraseChecks:
+            return prediction.localizedCaseInsensitiveContains(reference) ? 1 : 0
+        case .qaF1:
+            let predicted = normalizedAnswerTokens(prediction)
+            let expected = normalizedAnswerTokens(reference)
+            guard !predicted.isEmpty, !expected.isEmpty else {
+                return predicted == expected ? 1 : 0
+            }
+            var remaining = Dictionary(grouping: expected, by: { $0 }).mapValues(\.count)
+            var overlap = 0
+            for token in predicted where remaining[token, default: 0] > 0 {
+                overlap += 1
+                remaining[token, default: 0] -= 1
+            }
+            guard overlap > 0 else { return 0 }
+            let precision = Double(overlap) / Double(predicted.count)
+            let recall = Double(overlap) / Double(expected.count)
+            return 2 * precision * recall / (precision + recall)
+        case .rougeL:
+            let predicted = normalizedAnswerTokens(prediction)
+            let expected = normalizedAnswerTokens(reference)
+            guard !predicted.isEmpty, !expected.isEmpty else { return 0 }
+            var previous = Array(repeating: 0, count: expected.count + 1)
+            for predictedToken in predicted {
+                var current = Array(repeating: 0, count: expected.count + 1)
+                for (index, expectedToken) in expected.enumerated() {
+                    current[index + 1] = predictedToken == expectedToken
+                        ? previous[index] + 1
+                        : max(previous[index + 1], current[index])
+                }
+                previous = current
+            }
+            let overlap = previous[expected.count]
+            let precision = Double(overlap) / Double(predicted.count)
+            let recall = Double(overlap) / Double(expected.count)
+            return overlap == 0 ? 0 : 2 * precision * recall / (precision + recall)
+        case .retrieval:
+            let expectedNumbers = numericTokens(reference)
+            guard let expected = expectedNumbers.first else { return 0 }
+            let predicted = numericTokens(prediction)
+            guard !predicted.isEmpty else { return 0 }
+            return Double(predicted.filter { $0 == expected }.count) / Double(predicted.count)
+        }
+    }
+
+    private static func normalizedAnswerTokens(_ text: String) -> [String] {
+        let lowered = text.lowercased()
+        let scalars = lowered.unicodeScalars.map { scalar -> Character in
+            CharacterSet.punctuationCharacters.contains(scalar) ? " " : Character(String(scalar))
+        }
+        return String(scalars).split(whereSeparator: { $0.isWhitespace }).map(String.init)
+            .filter { $0 != "a" && $0 != "an" && $0 != "the" }
+    }
+
+    private static func numericTokens(_ text: String) -> [String] {
+        text.components(separatedBy: CharacterSet.decimalDigits.inverted).filter { !$0.isEmpty }
+    }
+
+    private static func toolCallsMatch(
+        expected: [FusedExternalToolExpectation],
+        observed: [ToolCall]
+    ) -> Bool {
+        guard expected.count == observed.count else { return false }
+
+        func expectationMatches(
+            _ expectation: FusedExternalToolExpectation,
+            _ call: ToolCall
+        ) -> Bool {
+            guard expectation.name == call.name,
+                  call.arguments.keys.allSatisfy({ expectation.arguments[$0] != nil }) else {
+                return false
+            }
+            return expectation.arguments.allSatisfy { key, accepted in
+                guard let value = call.arguments[key] else { return accepted.contains("") }
+                let canonical = canonicalToolArgument(value)
+                return accepted.contains { canonicalToolArgument($0) == canonical }
+            }
+        }
+
+        func match(_ index: Int, remaining: [Int]) -> Bool {
+            guard index < expected.count else { return remaining.isEmpty }
+            for observedIndex in remaining where expectationMatches(expected[index], observed[observedIndex]) {
+                if match(index + 1, remaining: remaining.filter { $0 != observedIndex }) {
+                    return true
+                }
+            }
+            return false
+        }
+
+        return match(0, remaining: Array(observed.indices))
+    }
+
+    private static func canonicalToolArgument(_ value: String) -> String {
+        var trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.count >= 2,
+           (trimmed.hasPrefix("'") && trimmed.hasSuffix("'")) {
+            trimmed.removeFirst()
+            trimmed.removeLast()
+        }
+        guard let data = trimmed.data(using: .utf8),
+              let value = try? JSONDecoder().decode(OpenAIJSONValue.self, from: data) else {
+            return trimmed
+        }
+        if case .string(let string) = value {
+            return string
+        }
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        guard let canonical = try? encoder.encode(value) else { return trimmed }
+        return String(decoding: canonical, as: UTF8.self)
+    }
+
+    private static func programHarness(
+        candidate: String,
+        evaluation: FusedExternalCodeEvaluation,
+        entryPoint: String?,
+        tests: [FusedExternalCodeTest]
+    ) throws -> String {
+        let encodedCandidate = Data(candidate.utf8).base64EncodedString()
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        let encodedTests = (try encoder.encode(tests)).base64EncodedString()
+        switch evaluation {
+        case .stdin:
+            return """
+            import base64, contextlib, io, json, sys, typing
+            candidate_source = base64.b64decode(\"\(encodedCandidate)\").decode(\"utf-8\")
+            cases = json.loads(base64.b64decode(\"\(encodedTests)\").decode(\"utf-8\"))
+
+            def normalize_output(value):
+                return [line.rstrip().split() for line in value.strip().splitlines()]
+
+            for case in cases:
+                namespace = {\"__name__\": \"__main__\"}
+                namespace.update(vars(typing))
+                input_stream = io.StringIO(case[\"input\"])
+                output_stream = io.StringIO()
+                previous_stdin = sys.stdin
+                sys.stdin = input_stream
+                try:
+                    with contextlib.redirect_stdout(output_stream):
+                        exec(compile(candidate_source, \"candidate.py\", \"exec\"), namespace)
+                finally:
+                    sys.stdin = previous_stdin
+                assert normalize_output(output_stream.getvalue()) == normalize_output(case[\"output\"])
+            """
+        case .functional:
+            guard let entryPoint else {
+                throw FusedBenchmarkError.invalidExternalFixture(
+                    "functional code evaluation is missing its entry point"
+                )
+            }
+            let encodedEntryPoint = Data(entryPoint.utf8).base64EncodedString()
+            return """
+            import base64, json, typing
+            candidate_source = base64.b64decode(\"\(encodedCandidate)\").decode(\"utf-8\")
+            entry_point = base64.b64decode(\"\(encodedEntryPoint)\").decode(\"utf-8\")
+            cases = json.loads(base64.b64decode(\"\(encodedTests)\").decode(\"utf-8\"))
+            namespace = {\"__name__\": \"candidate\"}
+            namespace.update(vars(typing))
+            exec(compile(candidate_source, \"candidate.py\", \"exec\"), namespace)
+            for case in cases:
+                args = [json.loads(line) for line in case[\"input\"].splitlines()]
+                expected = json.loads(case[\"output\"])
+                actual = getattr(namespace[\"Solution\"](), entry_point)(*args)
+                assert actual == expected, (actual, expected)
+            """
+        case .function:
+            throw FusedBenchmarkError.invalidExternalFixture(
+                "function code evaluation does not use the program harness"
             )
         }
     }
@@ -766,34 +1204,7 @@ private struct FusedResolvedBenchmarkCase {
         )
     }
 
-    func failedResult(
-        model: String,
-        profile: String,
-        trial: Int,
-        lane: String,
-        error: String,
-        generationSeconds: Double? = nil
-    ) -> FusedBenchmarkCaseResult {
-        FusedBenchmarkCaseResult(
-            lane: lane,
-            model: model,
-            profile: profile,
-            trial: trial,
-            caseID: descriptor.id,
-            provenance: provenance,
-            passed: false,
-            score: 0,
-            generationSeconds: generationSeconds,
-            executionSeconds: nil,
-            tokensGenerated: nil,
-            logprobs: nil,
-            acceleration: nil,
-            response: nil,
-            error: error
-        )
-    }
-
-    private static func extractCode(_ response: String, entryPoint: String) -> String {
+    private static func extractCode(_ response: String) -> String {
         var text = response
         if let opening = text.range(of: "```") {
             let afterOpening = text[opening.upperBound...]
@@ -802,9 +1213,6 @@ private struct FusedResolvedBenchmarkCase {
             let tail = text[start...]
             text = tail.range(of: "```").map { String(tail[..<$0.lowerBound]) }
                 ?? String(tail)
-        }
-        if let definition = text.range(of: "def \(entryPoint)") {
-            text = String(text[definition.lowerBound...])
         }
         return text.trimmingCharacters(in: .whitespacesAndNewlines)
     }
@@ -832,12 +1240,60 @@ private extension JSONEncoder {
     }
 }
 
-private struct FusedBenchmarkPlannedModel: Codable {
+struct FusedBenchmarkPlannedModel: Codable, Hashable {
     let id: String
     let profiles: [FusedBenchmarkSamplingProfile]
+    let catalogRepository: String?
+    let catalogRevision: String?
+    let installed: Bool
+    let runtimeManifestID: String?
+    let runtimeManifestSchemaVersion: Int?
+    let runtimeManifestSHA256: String?
+    let runtimeManifestSources: [MereRunModelManifest.SourceProvenance]?
+
+    static func resolve(
+        id: String,
+        suite: FusedBenchmarkSuiteSelection,
+        fileManager: FileManager = .default
+    ) throws -> FusedBenchmarkPlannedModel {
+        let spec = ManagedModelCatalog.spec(for: id)
+        let runtimeRoot = ManagedModelResolver.resolveInstalledModel(
+            id: id,
+            fileManager: fileManager
+        )
+        let manifestURL = runtimeRoot.map(MereRunModelManifest.url(in:))
+        let manifestData: Data?
+        let manifest: MereRunModelManifest?
+        if let runtimeRoot,
+           let manifestURL,
+           fileManager.fileExists(atPath: manifestURL.path) {
+            manifestData = try Data(contentsOf: manifestURL)
+            manifest = try MereRunModelManifest.loadRequired(
+                from: runtimeRoot,
+                fileManager: fileManager
+            )
+        } else {
+            manifestData = nil
+            manifest = nil
+        }
+        return FusedBenchmarkPlannedModel(
+            id: id,
+            profiles: FusedBenchmarkSamplingProfile.nativeProfiles(
+                modelID: id,
+                suite: suite
+            ),
+            catalogRepository: spec?.upstreamRepoId,
+            catalogRevision: spec?.upstreamRevision,
+            installed: runtimeRoot != nil,
+            runtimeManifestID: manifest?.id,
+            runtimeManifestSchemaVersion: manifest?.schemaVersion,
+            runtimeManifestSHA256: manifestData.map(FusedBenchmarkHash.sha256),
+            runtimeManifestSources: manifest?.sources
+        )
+    }
 }
 
-private struct FusedBenchmarkPlannedCase: Codable {
+struct FusedBenchmarkPlannedCase: Codable, Hashable {
     let id: String
     let adapter: String
     let lane: String
@@ -846,7 +1302,72 @@ private struct FusedBenchmarkPlannedCase: Codable {
     let provenance: FusedBenchmarkProvenance
 }
 
-private struct FusedBenchmarkPlan: Codable {
+struct FusedBenchmarkRunnerIdentity: Codable, Hashable {
+    let version: String
+    let executableByteCount: Int64
+    let executableSHA256: String
+
+    static func current() throws -> FusedBenchmarkRunnerIdentity {
+        let executable = CurrentExecutable.url().standardizedFileURL.resolvingSymlinksInPath()
+        return FusedBenchmarkRunnerIdentity(
+            version: MereRunCLIVersion.current,
+            executableByteCount: try ModelArtifactPin.fileByteCount(executable),
+            executableSHA256: try ModelArtifactPin.fileSHA256(executable)
+        )
+    }
+}
+
+struct FusedBenchmarkHost: Codable, Hashable {
+    let processorName: String
+    let physicalMemoryBytes: UInt64
+    let architecture: String
+    let operatingSystemVersion: String
+    let logicalProcessorCount: Int
+
+    static func current(
+        machine: MereRunMachineProfile = .current,
+        processInfo: ProcessInfo = .processInfo
+    ) -> FusedBenchmarkHost {
+        #if arch(arm64)
+        let architecture = "arm64"
+        #elseif arch(x86_64)
+        let architecture = "x86_64"
+        #else
+        let architecture = "unknown"
+        #endif
+        return FusedBenchmarkHost(
+            processorName: machine.processorName,
+            physicalMemoryBytes: machine.physicalMemoryBytes,
+            architecture: architecture,
+            operatingSystemVersion: processInfo.operatingSystemVersionString,
+            logicalProcessorCount: processInfo.processorCount
+        )
+    }
+}
+
+struct FusedBenchmarkCodeRuntimeIdentity: Codable, Hashable {
+    let pythonResolvedPath: String
+    let pythonExecutableSHA256: String
+    let sandboxBackend: String
+
+    static func resolve(
+        python: String,
+        sandbox: CodeExecutionSandboxMode
+    ) throws -> FusedBenchmarkCodeRuntimeIdentity {
+        let executable = try CodeExecutionSandbox.resolvedPythonExecutable(python)
+        return FusedBenchmarkCodeRuntimeIdentity(
+            pythonResolvedPath: executable.path,
+            pythonExecutableSHA256: try ModelArtifactPin.fileSHA256(executable),
+            sandboxBackend: try CodeExecutionSandbox.resolvedBackend(mode: sandbox).rawValue
+        )
+    }
+}
+
+struct FusedBenchmarkPlan: Codable, Hashable {
+    let runnerVersion: String
+    let runnerExecutableByteCount: Int64
+    let runnerExecutableSHA256: String
+    let host: FusedBenchmarkHost
     let manifestID: String
     let manifestVersion: String
     let manifestSHA256: String
@@ -855,8 +1376,201 @@ private struct FusedBenchmarkPlan: Codable {
     let trials: Int
     let qualityLane: String
     let performanceLane: String
+    let settings: FusedBenchmarkRunSettings
     let cases: [FusedBenchmarkPlannedCase]
     let importedFixtureFiles: [String]
+
+    var expectedResultKeys: Set<FusedBenchmarkResultKey> {
+        var keys: Set<FusedBenchmarkResultKey> = []
+        for model in models {
+            for profile in model.profiles {
+                for trial in 1...trials {
+                    for benchmarkCase in cases {
+                        keys.insert(FusedBenchmarkResultKey(
+                            lane: "quality-final-target",
+                            model: model.id,
+                            profile: profile.name,
+                            trial: trial,
+                            caseID: benchmarkCase.id
+                        ))
+                    }
+                }
+                if performanceLane == FusedBenchmarkPerformanceLane.native.rawValue {
+                    for benchmarkCase in cases {
+                        keys.insert(FusedBenchmarkResultKey(
+                            lane: "performance-native-runtime",
+                            model: model.id,
+                            profile: profile.name,
+                            trial: 1,
+                            caseID: benchmarkCase.id
+                        ))
+                    }
+                }
+            }
+        }
+        return keys
+    }
+
+    func contentSHA256() throws -> String {
+        FusedBenchmarkHash.sha256(try JSONEncoder.sorted.encode(self))
+    }
+}
+
+struct FusedBenchmarkRunSettings: Codable, Hashable {
+    let maxTokensOverride: Int?
+    let contextSize: Int
+    let logprobs: String
+    let topLogprobs: Int
+    let executionTimeout: Double
+    let pythonExecutable: String
+    let pythonResolvedPath: String?
+    let pythonExecutableSHA256: String?
+    let sandbox: String
+    let sandboxBackend: String?
+    let allowCodeExecution: Bool
+    let logResponses: Bool
+}
+
+struct FusedBenchmarkResultKey: Codable, Hashable {
+    let lane: String
+    let model: String
+    let profile: String
+    let trial: Int
+    let caseID: String
+}
+
+extension FusedBenchmarkCaseResult {
+    var key: FusedBenchmarkResultKey {
+        FusedBenchmarkResultKey(
+            lane: lane,
+            model: model,
+            profile: profile,
+            trial: trial,
+            caseID: caseID
+        )
+    }
+}
+
+struct FusedBenchmarkCheckpoint: Codable {
+    static let currentSchemaVersion = 2
+
+    let schemaVersion: Int
+    let createdAt: Date
+    let updatedAt: Date
+    let planSHA256: String
+    let plan: FusedBenchmarkPlan
+    let results: [FusedBenchmarkCaseResult]
+
+    init(
+        plan: FusedBenchmarkPlan,
+        results: [FusedBenchmarkCaseResult],
+        createdAt: Date = Date(),
+        updatedAt: Date = Date()
+    ) throws {
+        self.schemaVersion = Self.currentSchemaVersion
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.planSHA256 = try plan.contentSHA256()
+        self.plan = plan
+        self.results = results
+    }
+
+    func validatedResults(for expectedPlan: FusedBenchmarkPlan) throws -> [FusedBenchmarkCaseResult] {
+        guard schemaVersion == Self.currentSchemaVersion else {
+            throw FusedBenchmarkCheckpointError.invalid(
+                "unsupported schema version \(schemaVersion)"
+            )
+        }
+        let storedPlanSHA256 = try plan.contentSHA256()
+        guard planSHA256 == storedPlanSHA256 else {
+            throw FusedBenchmarkCheckpointError.invalid(
+                "stored plan hash \(planSHA256) does not match its payload \(storedPlanSHA256)"
+            )
+        }
+        let expectedPlanSHA256 = try expectedPlan.contentSHA256()
+        guard planSHA256 == expectedPlanSHA256 else {
+            throw FusedBenchmarkCheckpointError.invalid(
+                "run plan changed (checkpoint \(planSHA256), invocation \(expectedPlanSHA256))"
+            )
+        }
+        let keys = results.map(\.key)
+        guard Set(keys).count == keys.count else {
+            throw FusedBenchmarkCheckpointError.invalid("duplicate completed case-trials")
+        }
+        let unexpected = Set(keys).subtracting(expectedPlan.expectedResultKeys)
+        guard unexpected.isEmpty else {
+            throw FusedBenchmarkCheckpointError.invalid(
+                "contains \(unexpected.count) result(s) outside the run plan"
+            )
+        }
+        return results
+    }
+}
+
+enum FusedBenchmarkCheckpointError: LocalizedError {
+    case invalid(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalid(let detail):
+            return "Invalid fused benchmark checkpoint: \(detail)."
+        }
+    }
+}
+
+struct FusedBenchmarkCheckpointStore {
+    let url: URL
+    private let fileManager: FileManager
+
+    init(url: URL, fileManager: FileManager = .default) {
+        self.url = url
+        self.fileManager = fileManager
+    }
+
+    func initialize(plan: FusedBenchmarkPlan) throws {
+        guard !fileManager.fileExists(atPath: url.path) else {
+            throw FusedBenchmarkCheckpointError.invalid(
+                "file already exists at \(url.path); use --resume or choose a new path"
+            )
+        }
+        try write(plan: plan, results: [])
+    }
+
+    func loadResults(validating plan: FusedBenchmarkPlan) throws -> [FusedBenchmarkCaseResult] {
+        guard fileManager.fileExists(atPath: url.path) else {
+            throw FusedBenchmarkCheckpointError.invalid("file does not exist at \(url.path)")
+        }
+        let checkpoint = try loadCheckpoint()
+        return try checkpoint.validatedResults(for: plan)
+    }
+
+    func write(plan: FusedBenchmarkPlan, results: [FusedBenchmarkCaseResult]) throws {
+        let now = Date()
+        let createdAt = if fileManager.fileExists(atPath: url.path) {
+            try loadCheckpoint().createdAt
+        } else {
+            now
+        }
+        let checkpoint = try FusedBenchmarkCheckpoint(
+            plan: plan,
+            results: results,
+            createdAt: createdAt,
+            updatedAt: now
+        )
+        let parent = url.deletingLastPathComponent()
+        try fileManager.createDirectory(at: parent, withIntermediateDirectories: true)
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        try encoder.encode(checkpoint).write(to: url, options: .atomic)
+    }
+
+    private func loadCheckpoint() throws -> FusedBenchmarkCheckpoint {
+        let data = try Data(contentsOf: url)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode(FusedBenchmarkCheckpoint.self, from: data)
+    }
 }
 
 private struct FusedBenchmarkBreakdown: Codable {
@@ -875,9 +1589,17 @@ private struct FusedBenchmarkCalibrationGroup: Codable {
     let calibration: FusedBenchmarkCalibration
 }
 
+private struct FusedBenchmarkProgress: Codable {
+    let expectedCaseTrials: Int
+    let completedCaseTrials: Int
+    let remainingCaseTrials: Int
+    let complete: Bool
+}
+
 private struct FusedBenchmarkReport: Codable {
     let plan: FusedBenchmarkPlan
     let results: [FusedBenchmarkCaseResult]
+    let progress: FusedBenchmarkProgress
     let calibrationByModelProfile: [FusedBenchmarkCalibrationGroup]
     let laneBreakdown: [FusedBenchmarkBreakdown]
     let capabilityBreakdown: [FusedBenchmarkBreakdown]
@@ -886,6 +1608,14 @@ private struct FusedBenchmarkReport: Codable {
     init(plan: FusedBenchmarkPlan, results: [FusedBenchmarkCaseResult]) {
         self.plan = plan
         self.results = results
+        let expected = plan.expectedResultKeys.count
+        let completed = Set(results.map(\.key)).intersection(plan.expectedResultKeys).count
+        self.progress = FusedBenchmarkProgress(
+            expectedCaseTrials: expected,
+            completedCaseTrials: completed,
+            remainingCaseTrials: max(0, expected - completed),
+            complete: completed == expected
+        )
         let quality = results.filter { $0.lane == "quality-final-target" }
         self.calibrationByModelProfile = Self.groups(in: quality).map { group in
             FusedBenchmarkCalibrationGroup(
@@ -929,6 +1659,10 @@ private struct FusedBenchmarkReport: Codable {
         }.joined(separator: ", ")
         var lines = [
             "Mere fused benchmark \(plan.manifestID)@\(plan.manifestVersion)",
+            "mere.run version: \(plan.runnerVersion)",
+            "runner executable sha256: \(plan.runnerExecutableSHA256)",
+            "host: \(plan.host.processorName), \(plan.host.physicalMemoryBytes) bytes, "
+                + "\(plan.host.architecture), \(plan.host.operatingSystemVersion)",
             "manifest sha256: \(plan.manifestSHA256)",
             "suite: \(plan.suite)",
             "models: \(plan.models.map(\.id).joined(separator: ", "))",
@@ -952,6 +1686,10 @@ private struct FusedBenchmarkReport: Codable {
             return lines.joined(separator: "\n")
         }
 
+        lines.append(
+            "progress: \(progress.completedCaseTrials)/\(progress.expectedCaseTrials) case-trials "
+                + "(\(progress.complete ? "complete" : "partial"))"
+        )
         let quality = results.filter { $0.lane == "quality-final-target" && $0.passed != nil }
         let passes = quality.filter { $0.passed == true }.count
         lines.append("quality: \(passes)/\(quality.count) case-trials passed")

--- a/Sources/MereRunCLI/Guides/model-benchmark.md
+++ b/Sources/MereRunCLI/Guides/model-benchmark.md
@@ -27,6 +27,45 @@ native non-greedy model profiles and repeated trials. `--performance-lane
 native` adds separately labeled timing rows with logprob capture off; those
 rows never contribute correctness scores.
 
+The upstream HumanEval+, MBPP+, LiveCodeBench, BFCL, and LongBench datasets are
+not vendored. Generate the pinned 35-case normalized selection from the
+hash-verified source lock, stamp it, and verify it before model loading:
+
+```bash
+python3 scripts/import-fused-benchmark-fixtures.py
+mere.run model benchmark fused-fixture \
+  .tmp/fused-benchmark-fixtures/unstamped.jsonl \
+  > .tmp/fused-benchmark-fixtures/selected.jsonl
+mere.run model benchmark fused-fixture \
+  .tmp/fused-benchmark-fixtures/selected.jsonl --check
+```
+
+Pass the frozen file to `fused` with `--external-cases`. The selection exercises
+Plus tests, LiveCodeBench public/private execution, BFCL multi-call and no-call
+semantics, and LongBench QA-F1, ROUGE-L, and retrieval scoring. It is a Mere
+subset with pinned provenance, not an upstream leaderboard reproduction.
+
+Fused runs never download missing models. For a long run, checkpoint every
+completed case-trial and yield cleanly after a bounded slice:
+
+```bash
+mere.run model benchmark fused \
+  --suite comprehensive \
+  --models vision-chat-q38-27b \
+  --external-cases .tmp/fused-benchmark-fixtures/selected.jsonl \
+  --allow-code-execution \
+  --checkpoint .tmp/fused-benchmark-results/qwen38.json \
+  --case-trial-limit 5 \
+  --json
+```
+
+Repeat the exact command with `--resume`. Resume verifies the complete plan and
+installed model-manifest hashes before skipping completed rows. The plan also
+binds the exact runner binary, host identity, resolved Python binary, and
+resolved sandbox backend. Model preparation or generation failures preserve
+prior rows but leave the current row pending for retry. `--dry-run` can create
+or validate an empty checkpoint without model loading or Metal work.
+
 ```bash
 mere.run model benchmark gemma4-kv \
   --model text-chat-gemma4-turbo \

--- a/Sources/MereRunCLI/Support/CodeExecutionSandbox.swift
+++ b/Sources/MereRunCLI/Support/CodeExecutionSandbox.swift
@@ -59,6 +59,24 @@ enum CodeExecutionSandbox {
         _ = try resolveBackend(mode: mode)
     }
 
+    static func resolvedBackend(mode: CodeExecutionSandboxMode) throws -> CodeExecutionSandboxBackend {
+        try resolveBackend(mode: mode)
+    }
+
+    static func resolvedPythonExecutable(_ python: String) throws -> URL {
+        if python.contains("/") {
+            let url = URL(fileURLWithPath: python).standardizedFileURL
+            guard executableExists(at: url.path) else {
+                throw ValidationError("Python executable not found or not executable: \(python).")
+            }
+            return url.resolvingSymlinksInPath()
+        }
+        guard let path = findExecutable(named: python) else {
+            throw ValidationError("Python executable not found on PATH: \(python).")
+        }
+        return URL(fileURLWithPath: path).standardizedFileURL.resolvingSymlinksInPath()
+    }
+
     static func runPython(
         program: String,
         python: String,

--- a/Sources/MereRunCLI/Support/FusedBenchmarkSuite.swift
+++ b/Sources/MereRunCLI/Support/FusedBenchmarkSuite.swift
@@ -192,6 +192,7 @@ struct FusedBenchmarkManifest: Codable {
 struct FusedBenchmarkProvenance: Codable, Hashable {
     let source: String
     let sourceVersion: String
+    let sourceRevision: String?
     let originalID: String
     let license: String
     let sourceURL: String
@@ -209,18 +210,20 @@ struct FusedBenchmarkProvenance: Codable, Hashable {
         contentSHA256: String?,
         imageSHA256: String? = nil,
         sourceVersion: String? = nil,
+        sourceRevision: String? = nil,
         originalID: String? = nil
     ) {
         let resolvedVersion = sourceVersion ?? source.version
         let resolvedOriginalID = originalID ?? descriptor.sourceCaseID
         self.source = source.name
         self.sourceVersion = resolvedVersion
+        self.sourceRevision = sourceRevision
         self.originalID = resolvedOriginalID
         self.license = source.license
         self.sourceURL = source.sourceURL
         self.redistribution = source.redistribution
         self.referenceSHA256 = FusedBenchmarkHash.sha256(
-            "\(source.id)|\(resolvedVersion)|\(resolvedOriginalID)|\(descriptor.adapter.rawValue)"
+            "\(source.id)|\(resolvedVersion)|\(sourceRevision ?? "")|\(resolvedOriginalID)|\(descriptor.adapter.rawValue)"
         )
         self.contentSHA256 = contentSHA256
         self.imageSHA256 = imageSHA256
@@ -228,6 +231,30 @@ struct FusedBenchmarkProvenance: Codable, Hashable {
         self.difficulty = descriptor.difficulty
         self.selectionRationale = descriptor.selectionRationale
     }
+}
+
+enum FusedExternalTextMetric: String, Codable {
+    case phraseChecks = "phrase-checks"
+    case qaF1 = "qa-f1"
+    case rougeL = "rouge-l"
+    case retrieval = "retrieval"
+}
+
+enum FusedExternalCodeEvaluation: String, Codable {
+    case function
+    case stdin
+    case functional
+}
+
+struct FusedExternalCodeTest: Codable, Hashable {
+    let input: String
+    let output: String
+}
+
+struct FusedExternalToolExpectation: Codable, Hashable {
+    let name: String
+    /// Accepted canonical string renderings for each required argument.
+    let arguments: [String: [String]]
 }
 
 struct FusedBenchmarkSamplingProfile: Codable, Hashable {
@@ -322,6 +349,7 @@ struct FusedExternalBenchmarkCase: Codable {
     let id: String
     let kind: Kind
     let sourceVersion: String
+    let sourceRevision: String?
     let originalID: String
     let messages: [ChatMessage]
     let tools: [ToolDefinition]?
@@ -332,7 +360,65 @@ struct FusedExternalBenchmarkCase: Codable {
     let entryPoint: String?
     let tests: String?
     let imageSHA256: String?
+    let textMetric: FusedExternalTextMetric?
+    let referenceAnswers: [String]?
+    let passThreshold: Double?
+    let expectedToolCalls: [FusedExternalToolExpectation]?
+    let expectsNoToolCalls: Bool?
+    let codeEvaluation: FusedExternalCodeEvaluation?
+    let codeTests: [FusedExternalCodeTest]?
+    let generationBudget: Int?
     let contentSHA256: String
+
+    init(
+        id: String,
+        kind: Kind,
+        sourceVersion: String,
+        originalID: String,
+        messages: [ChatMessage],
+        tools: [ToolDefinition]?,
+        requiredPhrases: [String]?,
+        forbiddenPhrases: [String]?,
+        expectedToolName: String?,
+        expectedArguments: [String: String]?,
+        entryPoint: String?,
+        tests: String?,
+        imageSHA256: String?,
+        contentSHA256: String,
+        sourceRevision: String? = nil,
+        textMetric: FusedExternalTextMetric? = nil,
+        referenceAnswers: [String]? = nil,
+        passThreshold: Double? = nil,
+        expectedToolCalls: [FusedExternalToolExpectation]? = nil,
+        expectsNoToolCalls: Bool? = nil,
+        codeEvaluation: FusedExternalCodeEvaluation? = nil,
+        codeTests: [FusedExternalCodeTest]? = nil,
+        generationBudget: Int? = nil
+    ) {
+        self.id = id
+        self.kind = kind
+        self.sourceVersion = sourceVersion
+        self.sourceRevision = sourceRevision
+        self.originalID = originalID
+        self.messages = messages
+        self.tools = tools
+        self.requiredPhrases = requiredPhrases
+        self.forbiddenPhrases = forbiddenPhrases
+        self.expectedToolName = expectedToolName
+        self.expectedArguments = expectedArguments
+        self.entryPoint = entryPoint
+        self.tests = tests
+        self.imageSHA256 = imageSHA256
+        self.textMetric = textMetric
+        self.referenceAnswers = referenceAnswers
+        self.passThreshold = passThreshold
+        self.expectedToolCalls = expectedToolCalls
+        self.expectsNoToolCalls = expectsNoToolCalls
+        self.codeEvaluation = codeEvaluation
+        self.codeTests = codeTests
+        self.generationBudget = generationBudget
+        self.contentSHA256 = contentSHA256
+    }
 
     func computedContentSHA256() throws -> String {
         let encoder = JSONEncoder()
@@ -341,6 +427,7 @@ struct FusedExternalBenchmarkCase: Codable {
             id: id,
             kind: kind,
             sourceVersion: sourceVersion,
+            sourceRevision: sourceRevision,
             originalID: originalID,
             messages: messages,
             tools: tools,
@@ -350,7 +437,15 @@ struct FusedExternalBenchmarkCase: Codable {
             expectedArguments: expectedArguments,
             entryPoint: entryPoint,
             tests: tests,
-            imageSHA256: imageSHA256
+            imageSHA256: imageSHA256,
+            textMetric: textMetric,
+            referenceAnswers: referenceAnswers,
+            passThreshold: passThreshold,
+            expectedToolCalls: expectedToolCalls,
+            expectsNoToolCalls: expectsNoToolCalls,
+            codeEvaluation: codeEvaluation,
+            codeTests: codeTests,
+            generationBudget: generationBudget
         )
         return FusedBenchmarkHash.sha256(try encoder.encode(payload))
     }
@@ -371,7 +466,16 @@ struct FusedExternalBenchmarkCase: Codable {
             entryPoint: entryPoint,
             tests: tests,
             imageSHA256: imageSHA256,
-            contentSHA256: ""
+            contentSHA256: "",
+            sourceRevision: sourceRevision,
+            textMetric: textMetric,
+            referenceAnswers: referenceAnswers,
+            passThreshold: passThreshold,
+            expectedToolCalls: expectedToolCalls,
+            expectsNoToolCalls: expectsNoToolCalls,
+            codeEvaluation: codeEvaluation,
+            codeTests: codeTests,
+            generationBudget: generationBudget
         )
         return FusedExternalBenchmarkCase(
             id: unstamped.id,
@@ -387,7 +491,16 @@ struct FusedExternalBenchmarkCase: Codable {
             entryPoint: unstamped.entryPoint,
             tests: unstamped.tests,
             imageSHA256: unstamped.imageSHA256,
-            contentSHA256: try unstamped.computedContentSHA256()
+            contentSHA256: try unstamped.computedContentSHA256(),
+            sourceRevision: unstamped.sourceRevision,
+            textMetric: unstamped.textMetric,
+            referenceAnswers: unstamped.referenceAnswers,
+            passThreshold: unstamped.passThreshold,
+            expectedToolCalls: unstamped.expectedToolCalls,
+            expectsNoToolCalls: unstamped.expectsNoToolCalls,
+            codeEvaluation: unstamped.codeEvaluation,
+            codeTests: unstamped.codeTests,
+            generationBudget: unstamped.generationBudget
         )
     }
 
@@ -426,6 +539,7 @@ private struct FusedExternalBenchmarkHashPayload: Codable {
     let id: String
     let kind: FusedExternalBenchmarkCase.Kind
     let sourceVersion: String
+    let sourceRevision: String?
     let originalID: String
     let messages: [ChatMessage]
     let tools: [ToolDefinition]?
@@ -436,6 +550,14 @@ private struct FusedExternalBenchmarkHashPayload: Codable {
     let entryPoint: String?
     let tests: String?
     let imageSHA256: String?
+    let textMetric: FusedExternalTextMetric?
+    let referenceAnswers: [String]?
+    let passThreshold: Double?
+    let expectedToolCalls: [FusedExternalToolExpectation]?
+    let expectsNoToolCalls: Bool?
+    let codeEvaluation: FusedExternalCodeEvaluation?
+    let codeTests: [FusedExternalCodeTest]?
+    let generationBudget: Int?
 }
 
 enum FusedExternalBenchmarkLoader {
@@ -515,6 +637,64 @@ enum FusedExternalBenchmarkContract {
             throw FusedBenchmarkError.invalidExternalFixture(
                 "\(descriptor.id) has source version \(benchmarkCase.sourceVersion); expected \(source.version)"
             )
+        }
+        guard let revision = benchmarkCase.sourceRevision,
+              !revision.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw FusedBenchmarkError.invalidExternalFixture(
+                "\(descriptor.id) must declare an immutable source revision"
+            )
+        }
+        if let generationBudget = benchmarkCase.generationBudget,
+           generationBudget <= 0 {
+            throw FusedBenchmarkError.invalidExternalFixture(
+                "\(descriptor.id) has a non-positive generation budget"
+            )
+        }
+        switch benchmarkCase.kind {
+        case .chat:
+            let metric = benchmarkCase.textMetric ?? .phraseChecks
+            if metric != .phraseChecks {
+                guard benchmarkCase.referenceAnswers?.isEmpty == false,
+                      let threshold = benchmarkCase.passThreshold,
+                      (0...1).contains(threshold) else {
+                    throw FusedBenchmarkError.invalidExternalFixture(
+                        "\(descriptor.id) text metric needs reference answers and a 0...1 pass threshold"
+                    )
+                }
+            }
+        case .tool:
+            let hasExpectedCalls = benchmarkCase.expectedToolCalls?.isEmpty == false
+                || benchmarkCase.expectedToolName != nil
+            let expectsNone = benchmarkCase.expectsNoToolCalls == true
+            guard hasExpectedCalls != expectsNone else {
+                throw FusedBenchmarkError.invalidExternalFixture(
+                    "\(descriptor.id) must declare expected tool calls or expectsNoToolCalls"
+                )
+            }
+        case .code:
+            switch benchmarkCase.codeEvaluation ?? .function {
+            case .function:
+                guard benchmarkCase.entryPoint?.isEmpty == false,
+                      benchmarkCase.tests?.isEmpty == false else {
+                    throw FusedBenchmarkError.invalidExternalFixture(
+                        "\(descriptor.id) function scoring needs an entry point and tests"
+                    )
+                }
+            case .stdin, .functional:
+                guard benchmarkCase.codeTests?.isEmpty == false else {
+                    throw FusedBenchmarkError.invalidExternalFixture(
+                        "\(descriptor.id) program scoring needs code tests"
+                    )
+                }
+                if benchmarkCase.codeEvaluation == .functional,
+                   benchmarkCase.entryPoint?.isEmpty != false {
+                    throw FusedBenchmarkError.invalidExternalFixture(
+                        "\(descriptor.id) functional scoring needs an entry point"
+                    )
+                }
+            }
+        case .vision:
+            break
         }
     }
 }

--- a/Sources/MereRunCLI/Support/MachineInferenceAdmission.swift
+++ b/Sources/MereRunCLI/Support/MachineInferenceAdmission.swift
@@ -570,6 +570,7 @@ enum CLIInferenceAdmissionClassifier {
         let commandTokens = commandPath(tokens)
         guard let topLevel = commandTokens.first else { return nil }
         let subcommand = commandTokens.dropFirst().first
+        let nestedSubcommand = commandTokens.dropFirst(2).first
         let label = [topLevel, subcommand].compactMap { $0 }.joined(separator: " ")
 
         // These orchestration commands either acquire a workload-specific
@@ -624,6 +625,9 @@ enum CLIInferenceAdmissionClassifier {
         case "geo":
             return MachineInferenceRequest(label: label, resourceClass: .large)
         case "model" where subcommand == "benchmark":
+            if nestedSubcommand == "fused-fixture" {
+                return nil
+            }
             return MachineInferenceRequest(label: label, resourceClass: .large)
         case "adapter" where subcommand != "list" && subcommand != "pull":
             return MachineInferenceRequest(label: label, resourceClass: .standard)
@@ -686,7 +690,7 @@ enum CLIInferenceAdmissionClassifier {
                 continue
             }
             result.append(token)
-            if result.count == 2 {
+            if result.count == 3 {
                 break
             }
         }

--- a/Tests/MereRunCLITests/FusedBenchmarkSuiteTests.swift
+++ b/Tests/MereRunCLITests/FusedBenchmarkSuiteTests.swift
@@ -2,20 +2,241 @@ import Foundation
 import XCTest
 @testable import MereRunCLI
 @testable import MereRunCore
+import MereRunRelayKit
 
 final class FusedBenchmarkSuiteTests: XCTestCase {
+    func testRuntimeInfrastructureFailureLeavesCaseTrialPending() {
+        let preparation = FusedBenchmarkRuntimeError.modelPreparation(
+            model: "test-model",
+            profile: "test-profile",
+            trial: 2,
+            caseID: "test-case",
+            detail: "model unavailable"
+        )
+        let generation = FusedBenchmarkRuntimeError.generation(
+            model: "test-model",
+            profile: "test-profile",
+            trial: 2,
+            caseID: "test-case",
+            detail: "runtime interrupted"
+        )
+
+        XCTAssertTrue(preparation.localizedDescription.contains("model preparation failed"))
+        XCTAssertTrue(preparation.localizedDescription.contains("the row remains pending"))
+        XCTAssertTrue(generation.localizedDescription.contains("generation failed"))
+        XCTAssertTrue(generation.localizedDescription.contains("the row remains pending"))
+    }
+
     func testBundledManifestIsVersionedAndLiteCoversEverySourceFamily() throws {
         let manifest = try FusedBenchmarkManifest.bundled()
         let comprehensive = manifest.selectedCases(for: .comprehensive)
         let lite = manifest.selectedCases(for: .lite)
 
         XCTAssertEqual(manifest.schemaVersion, 1)
-        XCTAssertEqual(manifest.version, "1.1.0")
+        XCTAssertEqual(manifest.version, "1.2.0")
         XCTAssertEqual(comprehensive.count, 110)
         XCTAssertEqual(lite.count, 24)
         XCTAssertEqual(Set(comprehensive.map(\.sourceID)), Set(lite.map(\.sourceID)))
         XCTAssertTrue(comprehensive.allSatisfy { !$0.capabilityTags.isEmpty })
         XCTAssertTrue(comprehensive.allSatisfy { !$0.selectionRationale.isEmpty })
+    }
+
+    func testCheckpointRequiresExactPlanAndRejectsDuplicateRows() throws {
+        let manifest = try FusedBenchmarkManifest.bundled()
+        let descriptor = try XCTUnwrap(manifest.selectedCases(for: .lite).first)
+        let source = try XCTUnwrap(manifest.source(id: descriptor.sourceID))
+        let provenance = FusedBenchmarkProvenance(
+            descriptor: descriptor,
+            source: source,
+            contentSHA256: nil
+        )
+        let profile = FusedBenchmarkSamplingProfile(
+            name: "test-native",
+            temperature: 1,
+            topP: 0.95,
+            topK: 20,
+            minP: 0,
+            reasoningEffort: nil,
+            reasoningTier: nil,
+            showThinking: false
+        )
+        let model = FusedBenchmarkPlannedModel(
+            id: "test-model",
+            profiles: [profile],
+            catalogRepository: "example/test-model",
+            catalogRevision: "0123456789abcdef",
+            installed: true,
+            runtimeManifestID: "test-model",
+            runtimeManifestSchemaVersion: 3,
+            runtimeManifestSHA256: String(repeating: "a", count: 64),
+            runtimeManifestSources: nil
+        )
+        let plannedCase = FusedBenchmarkPlannedCase(
+            id: descriptor.id,
+            adapter: descriptor.adapter.rawValue,
+            lane: descriptor.adapter.lane.rawValue,
+            resolved: true,
+            unresolvedReason: nil,
+            provenance: provenance
+        )
+        let plan = FusedBenchmarkPlan(
+            runnerVersion: MereRunCLIVersion.current,
+            runnerExecutableByteCount: 123,
+            runnerExecutableSHA256: String(repeating: "b", count: 64),
+            host: FusedBenchmarkHost(
+                processorName: "test-processor",
+                physicalMemoryBytes: 128 * 1_073_741_824,
+                architecture: "arm64",
+                operatingSystemVersion: "test-os",
+                logicalProcessorCount: 12
+            ),
+            manifestID: manifest.id,
+            manifestVersion: manifest.version,
+            manifestSHA256: try manifest.contentSHA256(),
+            suite: "lite",
+            models: [model],
+            trials: 1,
+            qualityLane: "sampled-final-target; exact-policy; logprobs=summary",
+            performanceLane: "none",
+            settings: FusedBenchmarkRunSettings(
+                maxTokensOverride: nil,
+                contextSize: 32_768,
+                logprobs: "summary",
+                topLogprobs: 5,
+                executionTimeout: 5,
+                pythonExecutable: "python3",
+                pythonResolvedPath: "/usr/bin/python3",
+                pythonExecutableSHA256: String(repeating: "c", count: 64),
+                sandbox: "auto",
+                sandboxBackend: "macos-sandbox-exec",
+                allowCodeExecution: true,
+                logResponses: false
+            ),
+            cases: [plannedCase],
+            importedFixtureFiles: []
+        )
+        let result = FusedBenchmarkCaseResult(
+            lane: "quality-final-target",
+            model: model.id,
+            profile: profile.name,
+            trial: 1,
+            caseID: descriptor.id,
+            provenance: provenance,
+            passed: true,
+            score: 1,
+            generationSeconds: 0.1,
+            executionSeconds: nil,
+            tokensGenerated: 3,
+            logprobs: nil,
+            acceleration: nil,
+            response: nil,
+            error: nil
+        )
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("fused-checkpoint-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = FusedBenchmarkCheckpointStore(
+            url: directory.appendingPathComponent("checkpoint.json")
+        )
+
+        try store.initialize(plan: plan)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let initialized = try decoder.decode(
+            FusedBenchmarkCheckpoint.self,
+            from: Data(contentsOf: store.url)
+        )
+        XCTAssertEqual(try store.loadResults(validating: plan), [])
+        try store.write(plan: plan, results: [result])
+        let updated = try decoder.decode(
+            FusedBenchmarkCheckpoint.self,
+            from: Data(contentsOf: store.url)
+        )
+        XCTAssertEqual(initialized.createdAt, updated.createdAt)
+        XCTAssertGreaterThanOrEqual(updated.updatedAt, initialized.updatedAt)
+        XCTAssertEqual(try store.loadResults(validating: plan), [result])
+        XCTAssertThrowsError(try store.initialize(plan: plan))
+
+        let changedPlan = FusedBenchmarkPlan(
+            runnerVersion: plan.runnerVersion,
+            runnerExecutableByteCount: plan.runnerExecutableByteCount,
+            runnerExecutableSHA256: plan.runnerExecutableSHA256,
+            host: plan.host,
+            manifestID: plan.manifestID,
+            manifestVersion: plan.manifestVersion,
+            manifestSHA256: plan.manifestSHA256,
+            suite: "comprehensive",
+            models: plan.models,
+            trials: plan.trials,
+            qualityLane: plan.qualityLane,
+            performanceLane: plan.performanceLane,
+            settings: plan.settings,
+            cases: plan.cases,
+            importedFixtureFiles: plan.importedFixtureFiles
+        )
+        XCTAssertThrowsError(try store.loadResults(validating: changedPlan)) { error in
+            XCTAssertTrue(error.localizedDescription.contains("run plan changed"))
+        }
+
+        let changedRunnerPlan = FusedBenchmarkPlan(
+            runnerVersion: plan.runnerVersion,
+            runnerExecutableByteCount: plan.runnerExecutableByteCount,
+            runnerExecutableSHA256: String(repeating: "d", count: 64),
+            host: plan.host,
+            manifestID: plan.manifestID,
+            manifestVersion: plan.manifestVersion,
+            manifestSHA256: plan.manifestSHA256,
+            suite: plan.suite,
+            models: plan.models,
+            trials: plan.trials,
+            qualityLane: plan.qualityLane,
+            performanceLane: plan.performanceLane,
+            settings: plan.settings,
+            cases: plan.cases,
+            importedFixtureFiles: plan.importedFixtureFiles
+        )
+        XCTAssertThrowsError(try store.loadResults(validating: changedRunnerPlan)) { error in
+            XCTAssertTrue(error.localizedDescription.contains("run plan changed"))
+        }
+
+        let changedSettingsPlan = FusedBenchmarkPlan(
+            runnerVersion: plan.runnerVersion,
+            runnerExecutableByteCount: plan.runnerExecutableByteCount,
+            runnerExecutableSHA256: plan.runnerExecutableSHA256,
+            host: plan.host,
+            manifestID: plan.manifestID,
+            manifestVersion: plan.manifestVersion,
+            manifestSHA256: plan.manifestSHA256,
+            suite: plan.suite,
+            models: plan.models,
+            trials: plan.trials,
+            qualityLane: plan.qualityLane,
+            performanceLane: plan.performanceLane,
+            settings: FusedBenchmarkRunSettings(
+                maxTokensOverride: plan.settings.maxTokensOverride,
+                contextSize: 4_096,
+                logprobs: plan.settings.logprobs,
+                topLogprobs: plan.settings.topLogprobs,
+                executionTimeout: plan.settings.executionTimeout,
+                pythonExecutable: plan.settings.pythonExecutable,
+                pythonResolvedPath: plan.settings.pythonResolvedPath,
+                pythonExecutableSHA256: plan.settings.pythonExecutableSHA256,
+                sandbox: plan.settings.sandbox,
+                sandboxBackend: plan.settings.sandboxBackend,
+                allowCodeExecution: plan.settings.allowCodeExecution,
+                logResponses: plan.settings.logResponses
+            ),
+            cases: plan.cases,
+            importedFixtureFiles: plan.importedFixtureFiles
+        )
+        XCTAssertThrowsError(try store.loadResults(validating: changedSettingsPlan)) { error in
+            XCTAssertTrue(error.localizedDescription.contains("run plan changed"))
+        }
+
+        let duplicate = try FusedBenchmarkCheckpoint(plan: plan, results: [result, result])
+        XCTAssertThrowsError(try duplicate.validatedResults(for: plan)) { error in
+            XCTAssertTrue(error.localizedDescription.contains("duplicate completed case-trials"))
+        }
     }
 
     func testComprehensiveHasBalancedLaneFloors() throws {
@@ -238,6 +459,209 @@ final class FusedBenchmarkSuiteTests: XCTestCase {
         )) { error in
             XCTAssertTrue(error.localizedDescription.contains("original id"))
         }
+    }
+
+    func testExternalLongBenchUsesQAF1InsteadOfPhrasePresence() throws {
+        let manifest = try FusedBenchmarkManifest.bundled()
+        let descriptor = try XCTUnwrap(
+            manifest.cases.first { $0.id == "longbench.hotpotqa-0" }
+        )
+        let fixture = try FusedExternalBenchmarkCase(
+            id: descriptor.id,
+            kind: .chat,
+            sourceVersion: "v1",
+            originalID: descriptor.sourceCaseID,
+            messages: [ChatMessage(role: .user, content: "Question")],
+            tools: nil,
+            requiredPhrases: nil,
+            forbiddenPhrases: nil,
+            expectedToolName: nil,
+            expectedArguments: nil,
+            entryPoint: nil,
+            tests: nil,
+            imageSHA256: nil,
+            contentSHA256: "",
+            sourceRevision: "dataset@0123456789abcdef",
+            textMetric: .qaF1,
+            referenceAnswers: ["Miller v. California"],
+            passThreshold: 0.5
+        ).stamped()
+        let resolved = try FusedResolvedBenchmarkCase.resolve(
+            descriptor: descriptor,
+            manifest: manifest,
+            imported: [fixture.id: fixture]
+        )
+        let scoring = try resolved.score(
+            response: ChatResponse(response: "Miller v California", tokensGenerated: 3),
+            visibleResponse: "Miller v California",
+            allowCodeExecution: false,
+            python: "python3",
+            sandbox: .none,
+            executionTimeout: 1
+        )
+
+        XCTAssertEqual(scoring.score, 1)
+        XCTAssertEqual(scoring.passed, true)
+    }
+
+    func testExternalBFCLRequiresEveryParallelCallWithoutExtras() throws {
+        let manifest = try FusedBenchmarkManifest.bundled()
+        let descriptor = try XCTUnwrap(
+            manifest.cases.first { $0.id == "bfcl.v3.parallel-0" }
+        )
+        let fixture = try FusedExternalBenchmarkCase(
+            id: descriptor.id,
+            kind: .tool,
+            sourceVersion: "v3",
+            originalID: descriptor.sourceCaseID,
+            messages: [ChatMessage(role: .user, content: "Play both artists")],
+            tools: nil,
+            requiredPhrases: nil,
+            forbiddenPhrases: nil,
+            expectedToolName: nil,
+            expectedArguments: nil,
+            entryPoint: nil,
+            tests: nil,
+            imageSHA256: nil,
+            contentSHA256: "",
+            sourceRevision: "ea13468e4423454d0c213704fb87cf7cb3990433",
+            expectedToolCalls: [
+                FusedExternalToolExpectation(
+                    name: "spotify.play",
+                    arguments: [
+                        "artist": ["Taylor Swift"],
+                        "duration": ["20"],
+                        "options": ["{\"fade\":true,\"volume\":0.5}"],
+                    ]
+                ),
+                FusedExternalToolExpectation(
+                    name: "spotify.play",
+                    arguments: ["artist": ["Maroon 5"], "duration": ["15"]]
+                ),
+            ]
+        ).stamped()
+        let resolved = try FusedResolvedBenchmarkCase.resolve(
+            descriptor: descriptor,
+            manifest: manifest,
+            imported: [fixture.id: fixture]
+        )
+        let response = ChatResponse(
+            response: "",
+            tokensGenerated: 2,
+            toolCalls: [
+                ToolCall(name: "spotify.play", arguments: ["artist": "Maroon 5", "duration": "15"]),
+                ToolCall(
+                    name: "spotify.play",
+                    arguments: [
+                        "artist": "Taylor Swift",
+                        "duration": "20",
+                        "options": "{\"volume\":0.5,\"fade\":true}",
+                    ]
+                ),
+            ]
+        )
+        let scoring = try resolved.score(
+            response: response,
+            visibleResponse: "",
+            allowCodeExecution: false,
+            python: "python3",
+            sandbox: .none,
+            executionTimeout: 1
+        )
+
+        XCTAssertEqual(scoring.passed, true)
+        XCTAssertEqual(scoring.score, 1)
+    }
+
+    func testExternalLiveCodeBenchStdinHarnessRunsEveryCase() throws {
+        let manifest = try FusedBenchmarkManifest.bundled()
+        let descriptor = try XCTUnwrap(
+            manifest.cases.first { $0.id == "lcb.release-v5.stratum-0" }
+        )
+        let fixture = try FusedExternalBenchmarkCase(
+            id: descriptor.id,
+            kind: .code,
+            sourceVersion: "release_v5",
+            originalID: descriptor.sourceCaseID,
+            messages: [ChatMessage(role: .user, content: "Echo uppercased input")],
+            tools: nil,
+            requiredPhrases: nil,
+            forbiddenPhrases: nil,
+            expectedToolName: nil,
+            expectedArguments: nil,
+            entryPoint: nil,
+            tests: nil,
+            imageSHA256: nil,
+            contentSHA256: "",
+            sourceRevision: "dataset@0fe84c3912ea0c4d4a78037083943e8f0c4dd505",
+            codeEvaluation: .stdin,
+            codeTests: [
+                FusedExternalCodeTest(input: "mere\n", output: "MERE\n"),
+                FusedExternalCodeTest(input: "run\n", output: "RUN\n"),
+            ]
+        ).stamped()
+        let resolved = try FusedResolvedBenchmarkCase.resolve(
+            descriptor: descriptor,
+            manifest: manifest,
+            imported: [fixture.id: fixture]
+        )
+        let source = "print(input().upper())"
+        let scoring = try resolved.score(
+            response: ChatResponse(response: source, tokensGenerated: 4),
+            visibleResponse: source,
+            allowCodeExecution: true,
+            python: "/usr/bin/python3",
+            sandbox: .none,
+            executionTimeout: 2
+        )
+
+        XCTAssertEqual(scoring.passed, true, scoring.error ?? "")
+        XCTAssertEqual(scoring.score, 1)
+    }
+
+    func testExternalFunctionHarnessPreservesCandidateNamedCheck() throws {
+        let manifest = try FusedBenchmarkManifest.bundled()
+        let descriptor = try XCTUnwrap(
+            manifest.cases.first { $0.id == "mbpp-plus.56" }
+        )
+        let fixture = try FusedExternalBenchmarkCase(
+            id: descriptor.id,
+            kind: .code,
+            sourceVersion: "v0.2.0",
+            originalID: descriptor.sourceCaseID,
+            messages: [ChatMessage(role: .user, content: "Implement check")],
+            tools: nil,
+            requiredPhrases: nil,
+            forbiddenPhrases: nil,
+            expectedToolName: nil,
+            expectedArguments: nil,
+            entryPoint: "check",
+            tests: "def check(candidate):\n    assert candidate(3) == 6",
+            imageSHA256: nil,
+            contentSHA256: "",
+            sourceRevision: "pinned",
+            codeEvaluation: .function
+        ).stamped()
+        let resolved = try FusedResolvedBenchmarkCase.resolve(
+            descriptor: descriptor,
+            manifest: manifest,
+            imported: [fixture.id: fixture]
+        )
+
+        let scoring = try resolved.score(
+            response: ChatResponse(
+                response: "def check(value):\n    return value * 2",
+                tokensGenerated: 8
+            ),
+            visibleResponse: "def check(value):\n    return value * 2",
+            allowCodeExecution: true,
+            python: "/usr/bin/python3",
+            sandbox: .none,
+            executionTimeout: 5
+        )
+
+        XCTAssertEqual(scoring.passed, true, scoring.error ?? "")
+        XCTAssertNil(scoring.error)
     }
 
     func testCalibrationSeparatesFragilePassesAndConfidentFailures() throws {

--- a/Tests/MereRunCLITests/MachineInferenceAdmissionTests.swift
+++ b/Tests/MereRunCLITests/MachineInferenceAdmissionTests.swift
@@ -346,6 +346,13 @@ final class MachineInferenceAdmissionTests: XCTestCase {
                 arguments: ["mere.run", "model", "benchmark", "fused", "--dry-run", "--json"]
             )
         )
+        XCTAssertNil(
+            CLIInferenceAdmissionClassifier.request(
+                arguments: [
+                    "mere.run", "model", "benchmark", "fused-fixture", "selected.jsonl", "--check",
+                ]
+            )
+        )
     }
 
     func testAPIServerKeepsInternalConcurrencyInsideWeightedReservation() {

--- a/Tests/MereRunCLITests/ModelBenchmarkCommandTests.swift
+++ b/Tests/MereRunCLITests/ModelBenchmarkCommandTests.swift
@@ -36,6 +36,32 @@ final class ModelBenchmarkCommandTests: XCTestCase {
         XCTAssertFalse(command.allowCodeExecution)
     }
 
+    func testFusedBenchmarkParsesCheckpointedBoundedResume() throws {
+        let command = try ModelBenchmarkFused.parse([
+            "--dry-run",
+            "--checkpoint", "/tmp/mere-fused-checkpoint.json",
+            "--resume",
+            "--case-trial-limit", "3",
+        ])
+
+        XCTAssertEqual(command.checkpoint, "/tmp/mere-fused-checkpoint.json")
+        XCTAssertTrue(command.resume)
+        XCTAssertEqual(command.caseTrialLimit, 3)
+    }
+
+    func testFusedBenchmarkRejectsUnboundedResumeControls() {
+        XCTAssertThrowsError(try ModelBenchmarkFused.parse(["--dry-run", "--resume"]))
+        XCTAssertThrowsError(try ModelBenchmarkFused.parse([
+            "--dry-run",
+            "--case-trial-limit", "1",
+        ]))
+        XCTAssertThrowsError(try ModelBenchmarkFused.parse([
+            "--dry-run",
+            "--checkpoint", "/tmp/mere-fused-checkpoint.json",
+            "--case-trial-limit", "0",
+        ]))
+    }
+
     func testBenchmarkCommandExposesToolCallsSubcommand() {
         let commandNames = Set(ModelBenchmark.configuration.subcommands.map { $0.configuration.commandName })
         XCTAssertTrue(commandNames.contains("tool-calls"))

--- a/docs/benchmark-fused.md
+++ b/docs/benchmark-fused.md
@@ -37,6 +37,15 @@ mere.run model benchmark fused --suite comprehensive --dry-run --json
 The default model matrix covers Qwen3.8 BF16 and 4-bit, Nemotron Lightning, and
 Laguna XS 2.1. Override it with `--models`.
 
+A real fused run never downloads a missing model. Every selected catalog id
+must already resolve under the active `--models-root`; otherwise the command
+stops before MLX initialization. The plan records the mere.run version and exact
+runner-executable SHA-256, host processor/memory/architecture/OS identity,
+catalog repository and revision, plus the installed `mererun_model.json` id,
+schema version, source pins, and exact manifest SHA-256. This makes a receipt
+identify the code, host, and checkpoint metadata that were actually visible to
+the runtime without recursively scanning model storage.
+
 ## Sampling contract
 
 The fused quality lane never uses temperature zero. It evaluates the models
@@ -120,18 +129,59 @@ are embedded. The 10 Mere vision cases materialize deterministic local PNG
 fixtures for OCR, charts, spatial reasoning, counting, document layout,
 negative evidence, multi-panel consistency, dense captioning, and action
 boundaries. Their exact image bytes are hashed into the receipt before a model
-can load. HumanEval+, MBPP+, LiveCodeBench, BFCL, and LongBench remain
-reference-only. This avoids silently vendoring changing public datasets or
-misrepresenting their licenses.
+can load.
 
-Normalize selected external cases to one JSON object per line and pass one or
-more files with `--external-cases`. The typed record contains:
+The upstream HumanEval+, MBPP+, LiveCodeBench, BFCL, and LongBench datasets are
+not vendored. Instead,
+`BenchmarkSuites/mere-fused-sources-v1.json` locks the exact repository or
+dataset revision, source URL, source-file SHA-256, license context, and selected
+upstream ids. `scripts/import-fused-benchmark-fixtures.py` verifies those locks
+and deterministically normalizes the selected 35 cases to local JSONL. This
+keeps upstream license terms visible without treating a changing remote dataset
+as part of the repository.
+
+Generate the selected cases, stamp their canonical content hashes, then verify
+the frozen result before running a model:
+
+```bash
+python3 scripts/import-fused-benchmark-fixtures.py
+.build/debug/mere.run model benchmark fused-fixture \
+  .tmp/fused-benchmark-fixtures/unstamped.jsonl \
+  > .tmp/fused-benchmark-fixtures/selected.jsonl
+.build/debug/mere.run model benchmark fused-fixture \
+  .tmp/fused-benchmark-fixtures/selected.jsonl --check
+```
+
+After one online import, `--offline` reproduces the same normalized fixtures
+using only the verified source cache. Generated source and fixture files remain
+under `.tmp/` and are not committed.
+
+The normalized selection contains:
+
+- six HumanEval+ and six MBPP+ tasks evaluated against every selected base and
+  Plus input;
+- six LiveCodeBench `release_v5` code-generation strata spanning Codeforces
+  stdin programs and LeetCode-style functional tasks, including public and
+  private tests;
+- ten BFCL v3 slices covering single, parallel, zero-call, and pinned
+  conversation-history tool-use cases;
+- seven LongBench v1 slices scored with task-appropriate QA-F1, ROUGE-L, or
+  retrieval metrics and explicit Mere thresholds.
+
+This is a pinned Mere subset, not a reproduction of any upstream leaderboard.
+BFCL conversation-history slices are not the complete BFCL executable-state
+runner, and the LongBench pass thresholds are Mere suite contracts.
+
+Pass the frozen file with `--external-cases`. The typed record includes an
+immutable source revision and the scoring contract needed to reproduce the
+case:
 
 ```json
 {
   "id": "humaneval-plus.0",
   "kind": "code",
-  "sourceVersion": "<pinned upstream revision>",
+  "sourceVersion": "v0.1.10",
+  "sourceRevision": "26d6d00...",
   "originalID": "HumanEval/0",
   "messages": [{"role":"user","content":"..."}],
   "entryPoint": "has_close_elements",
@@ -140,20 +190,77 @@ more files with `--external-cases`. The typed record contains:
 }
 ```
 
-Optional fields cover tools, required/forbidden phrases, expected tool name,
-expected arguments, and a single absolute `imageUrl` on a vision message. A
-vision record also carries `imageSHA256`. The fixture helper computes both the
-image-byte hash and the content hash over the sorted canonical payload excluding
-`contentSHA256`; an import is rejected before any model loads when either hash
-does not match. The importer-generated upstream id and resolved hashes become
-the run receipt.
+Optional typed fields cover text metrics and reference answers, one or more
+expected tool calls (including an explicit no-call expectation), function,
+stdin, and functional code tests, tools, phrase constraints, and a single
+absolute `imageUrl` on a vision message. A vision record also carries
+`imageSHA256`. The fixture helper computes both the image-byte hash and the
+content hash over the sorted canonical payload excluding `contentSHA256`; an
+import is rejected before any model loads when either hash does not match. The
+importer-generated upstream id, source revision, and resolved hashes become the
+run receipt.
 
-Stamp a normalized file to stdout, then verify the frozen result:
+Run the frozen selection with either suite:
 
 ```bash
-mere.run model benchmark fused-fixture unstamped.jsonl > selected.jsonl
-mere.run model benchmark fused-fixture selected.jsonl --check
+mere.run model benchmark fused \
+  --suite lite \
+  --external-cases .tmp/fused-benchmark-fixtures/selected.jsonl \
+  --allow-code-execution \
+  --sandbox auto \
+  --json
 ```
+
+Fixture stamping, verification, and `fused --dry-run` bypass machine inference
+admission because they cannot load a model. A non-dry fused run still uses the
+normal machine-wide admission controller.
+
+## Checkpointed and bounded runs
+
+Long fused runs can persist an atomic JSON checkpoint after every completed
+case-trial. `--resume` accepts that file only when the full plan hash still
+matches: exact runner executable and host identity, suite manifest, model order
+and profiles, installed model-manifest hashes, fixture paths and hashes, trials,
+cases, context and token limits, logprob settings, response capture, resolved
+Python executable and SHA-256, resolved code-sandbox backend, execution timeout,
+and performance lane. Duplicate or out-of-plan rows are rejected. Checkpoints
+also preserve ISO-8601 creation and last-update timestamps.
+
+Model preparation or generation failures abort the invocation without writing
+the current row. Rows checkpointed before the failure remain intact, and an
+exact `--resume` retries the pending row instead of recording infrastructure
+failure as model quality.
+
+Use `--case-trial-limit` to yield Metal cleanly after a small number of new
+rows. It requires a checkpoint; the next invocation resumes at the first
+unfinished row instead of repeating completed inference:
+
+```bash
+mere.run model benchmark fused \
+  --suite comprehensive \
+  --models vision-chat-q38-27b \
+  --external-cases .tmp/fused-benchmark-fixtures/selected.jsonl \
+  --allow-code-execution \
+  --checkpoint .tmp/fused-benchmark-results/qwen38.json \
+  --case-trial-limit 5 \
+  --json
+
+mere.run model benchmark fused \
+  --suite comprehensive \
+  --models vision-chat-q38-27b \
+  --external-cases .tmp/fused-benchmark-fixtures/selected.jsonl \
+  --allow-code-execution \
+  --checkpoint .tmp/fused-benchmark-results/qwen38.json \
+  --case-trial-limit 5 \
+  --resume \
+  --json
+```
+
+The checkpoint is also usable with `--dry-run`, which creates or validates the
+exact empty run plan without admission, model loading, generated-code
+execution, or Metal work. Run one model per checkpoint when installed models
+live under different mounted roots. Reports expose completed, remaining, and
+complete/partial case-trial counts.
 
 ## Code execution
 

--- a/docs/runtime/model-management.md
+++ b/docs/runtime/model-management.md
@@ -362,8 +362,10 @@ not part of the everyday inference workflow. Lanes:
   chat/code/tools/long-context/vision quality suite with native sampled
   profiles, repeated trials, provenance, and optional final-target logprob
   calibration diagnostics.
-- `fused-fixture` — stamps or verifies normalized reference-only fixture
-  content hashes without loading a model.
+- `fused-fixture` — stamps or verifies normalized pinned-fixture content hashes
+  without loading a model. The external source material remains non-vendored;
+  `scripts/import-fused-benchmark-fixtures.py` regenerates the selected cases
+  from the revision- and hash-locked source manifest.
 - `tool-calls` — runs a small tool-call selection eval against local chat models.
 - `tool-continuations` — evaluates Gemma 4 continuation after completed tool
   calls.

--- a/scripts/import-fused-benchmark-fixtures.py
+++ b/scripts/import-fused-benchmark-fixtures.py
@@ -1,0 +1,590 @@
+#!/usr/bin/env python3
+"""Import the pinned external cases selected by mere-fused-v1.
+
+The importer downloads only the version-locked source artifacts in
+mere-fused-sources-v1.json, verifies their bytes (or selected raw JSONL row),
+and writes normalized unstamped JSONL. Use `mere.run model benchmark
+fused-fixture` to stamp the canonical content hashes.
+"""
+
+import argparse
+import ast
+import base64
+import copy
+import gzip
+import hashlib
+import io
+import json
+import pathlib
+import pickle
+import re
+import sys
+import urllib.request
+import zipfile
+import zlib
+
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+DEFAULT_LOCK = (
+    REPO_ROOT
+    / "Sources"
+    / "MereRunCLI"
+    / "BenchmarkSuites"
+    / "mere-fused-sources-v1.json"
+)
+DEFAULT_OUTPUT = REPO_ROOT / ".tmp" / "fused-benchmark-fixtures" / "unstamped.jsonl"
+DEFAULT_CACHE = REPO_ROOT / ".tmp" / "fused-benchmark-sources"
+
+HUMANEVAL_IDS = ["HumanEval/0", "HumanEval/3", "HumanEval/8", "HumanEval/32", "HumanEval/53", "HumanEval/81"]
+MBPP_IDS = ["Mbpp/2", "Mbpp/3", "Mbpp/4", "Mbpp/6", "Mbpp/7", "Mbpp/56"]
+
+BFCL_SINGLE = [
+    ("bfcl.v3.simple-python-0", "v3:simple_python:0", "BFCL_v3_simple.json", True),
+    ("bfcl.v3.simple-java-0", "v3:simple_java:0", "BFCL_v3_java.json", True),
+    ("bfcl.v3.parallel-0", "v3:parallel:0", "BFCL_v3_parallel.json", True),
+    ("bfcl.v3.multiple-0", "v3:multiple:0", "BFCL_v3_multiple.json", True),
+    ("bfcl.v3.parallel-multiple-0", "v3:parallel_multiple:0", "BFCL_v3_parallel_multiple.json", True),
+    ("bfcl.v3.irrelevance-0", "v3:irrelevance:0", "BFCL_v3_irrelevance.json", False),
+]
+
+BFCL_MULTI = [
+    ("bfcl.v3.multi-turn-base-0", "v3:multi_turn_base:0", "BFCL_v3_multi_turn_base.json", 3),
+    ("bfcl.v3.multi-turn-miss-func-0", "v3:multi_turn_miss_func:0", "BFCL_v3_multi_turn_miss_func.json", 3),
+    ("bfcl.v3.multi-turn-miss-param-0", "v3:multi_turn_miss_param:0", "BFCL_v3_multi_turn_miss_param.json", 3),
+    ("bfcl.v3.multi-turn-long-context-0", "v3:multi_turn_long_context:0", "BFCL_v3_multi_turn_long_context.json", 3),
+]
+
+LONG_BENCH = [
+    ("longbench.hotpotqa-0", "hotpotqa", "hotpotqa:test:0", "qa-f1", 0.5, 128),
+    ("longbench.gov-report-0", "gov_report", "gov_report:test:0", "rouge-l", 0.2, 512),
+    ("longbench.qasper-0", "qasper", "qasper:test:0", "qa-f1", 0.5, 128),
+    ("longbench.2wikimqa-0", "2wikimqa", "2wikimqa:test:0", "qa-f1", 0.5, 128),
+    ("longbench.musique-0", "musique", "musique:test:0", "qa-f1", 0.5, 128),
+    ("longbench.multi-news-0", "multi_news", "multi_news:test:0", "rouge-l", 0.2, 512),
+    ("longbench.passage-retrieval-0", "passage_retrieval_en", "passage_retrieval_en:test:0", "retrieval", 1.0, 64),
+]
+
+
+def sha256(data):
+    return hashlib.sha256(data).hexdigest()
+
+
+def fetch_verified(url, destination, expected_sha, offline):
+    if destination.exists() and sha256(destination.read_bytes()) == expected_sha:
+        return destination.read_bytes()
+    if offline:
+        raise RuntimeError("missing or invalid offline source: %s" % destination)
+    destination.parent.mkdir(parents=True, exist_ok=True)
+    request = urllib.request.Request(url, headers={"User-Agent": "mere.run-fused-import/1"})
+    with urllib.request.urlopen(request, timeout=180) as response:
+        data = response.read()
+    actual = sha256(data)
+    if actual != expected_sha:
+        raise RuntimeError("SHA-256 mismatch for %s: got %s" % (url, actual))
+    temporary = destination.with_suffix(destination.suffix + ".download")
+    temporary.write_bytes(data)
+    temporary.replace(destination)
+    return data
+
+
+def read_jsonl(data):
+    return [json.loads(line) for line in data.decode("utf-8").splitlines() if line.strip()]
+
+
+def fixture_base(fixture_id, kind, source_version, source_revision, original_id, messages):
+    return {
+        "id": fixture_id,
+        "kind": kind,
+        "sourceVersion": source_version,
+        "sourceRevision": source_revision,
+        "originalID": original_id,
+        "messages": messages,
+        "contentSHA256": "",
+    }
+
+
+def code_messages(prompt):
+    return [
+        {
+            "role": "system",
+            "content": "Complete the Python task. Return only valid Python implementation code without Markdown or prose.",
+        },
+        {"role": "user", "content": prompt},
+    ]
+
+
+def reference_function(task):
+    entry = task["entry_point"]
+    if task["task_id"].startswith("HumanEval/"):
+        source = task["prompt"] + task["canonical_solution"]
+    else:
+        source = task["canonical_solution"]
+    return re.sub(r"\b%s\b" % re.escape(entry), "_mere_reference", source)
+
+
+def evalplus_test_code(task):
+    inputs = task["base_input"] + task["plus_input"]
+    deduplicated = []
+    seen = set()
+    for item in inputs:
+        key = repr(item)
+        if key not in seen:
+            seen.add(key)
+            deduplicated.append(item)
+    entry = task["entry_point"]
+    special_set = entry in {"similar_elements", "find_char_long"}
+    find_zero = entry == "find_zero"
+    return """\
+import copy as _mere_copy
+import math as _mere_math
+
+{reference}
+
+def _mere_poly(coefficients, value):
+    return sum(coefficient * _mere_math.pow(value, index) for index, coefficient in enumerate(coefficients))
+
+def _mere_equal(actual, expected):
+    if {special_set!r}:
+        return set(actual) == set(expected)
+    if isinstance(expected, float):
+        return abs(actual - expected) <= max({atol!r}, 1e-6)
+    return actual == expected
+
+def check(candidate):
+    inputs = {inputs!r}
+    for item in inputs:
+        candidate_input = _mere_copy.deepcopy(item)
+        if {find_zero!r}:
+            root = candidate(*candidate_input)
+            assert abs(_mere_poly(candidate_input[0], root)) <= {atol!r}
+        else:
+            expected = _mere_reference(*_mere_copy.deepcopy(item))
+            actual = candidate(*candidate_input)
+            assert _mere_equal(actual, expected), (item, actual, expected)
+""".format(
+        reference=reference_function(task),
+        special_set=special_set,
+        atol=task["atol"],
+        inputs=deduplicated,
+        find_zero=find_zero,
+    )
+
+
+def import_evalplus(lock, cache, offline):
+    source = lock["evalplus"]
+    revision = source["repositoryRevision"]
+    families = [
+        (source["humanEval"], HUMANEVAL_IDS, "humaneval-plus.", "HumanEval/"),
+        (source["mbpp"], MBPP_IDS, "mbpp-plus.", "Mbpp/"),
+    ]
+    fixtures = []
+    for resource, selected_ids, fixture_prefix, task_prefix in families:
+        compressed = fetch_verified(
+            resource["url"],
+            cache / pathlib.Path(resource["url"]).name,
+            resource["sha256"],
+            offline,
+        )
+        rows = {row["task_id"]: row for row in read_jsonl(gzip.decompress(compressed))}
+        source_revision = "evalplus@%s;%s@%s;sha256:%s" % (
+            revision,
+            "HumanEvalPlus" if task_prefix == "HumanEval/" else "MbppPlus",
+            resource["version"],
+            resource["sha256"],
+        )
+        for task_id in selected_ids:
+            task = rows[task_id]
+            fixture = fixture_base(
+                fixture_prefix + task_id.split("/")[-1],
+                "code",
+                resource["version"],
+                source_revision,
+                task_id,
+                code_messages(task["prompt"]),
+            )
+            fixture.update(
+                {
+                    "entryPoint": task["entry_point"],
+                    "tests": evalplus_test_code(task),
+                    "codeEvaluation": "function",
+                    "generationBudget": 1024,
+                }
+            )
+            fixtures.append(fixture)
+    return fixtures
+
+
+class SafeUnpickler(pickle.Unpickler):
+    def find_class(self, module, name):
+        raise pickle.UnpicklingError("global objects are forbidden in benchmark data")
+
+
+def decode_lcb_cases(value):
+    try:
+        return json.loads(value)
+    except json.JSONDecodeError:
+        unpacked = zlib.decompress(base64.b64decode(value))
+        encoded_json = SafeUnpickler(io.BytesIO(unpacked)).load()
+        return json.loads(encoded_json)
+
+
+def selected_lcb_rows(source, cache, offline):
+    selected = {item["index"]: item for item in source["selectedRows"]}
+    cache_file = cache / "livecodebench-selected.jsonl"
+    if cache_file.exists():
+        rows = read_jsonl(cache_file.read_bytes())
+        if len(rows) == len(selected):
+            by_index = {row["_mereRowIndex"]: row for row in rows}
+            if all(
+                index in by_index
+                and by_index[index]["_mereRawSHA256"] == pin["rawSHA256"]
+                for index, pin in selected.items()
+            ):
+                return by_index
+    if offline:
+        raise RuntimeError("LiveCodeBench selected-row cache is missing or invalid")
+    request = urllib.request.Request(source["url"], headers={"User-Agent": "mere.run-fused-import/1"})
+    captured = {}
+    with urllib.request.urlopen(request, timeout=180) as response:
+        for index in range(max(selected) + 1):
+            raw = response.readline()
+            if not raw:
+                raise RuntimeError("LiveCodeBench source ended before selected row %d" % index)
+            if index not in selected:
+                continue
+            raw_without_newline = raw.rstrip(b"\r\n")
+            actual = sha256(raw_without_newline)
+            if actual != selected[index]["rawSHA256"]:
+                raise RuntimeError("LiveCodeBench selected row %d changed: %s" % (index, actual))
+            row = json.loads(raw)
+            if row["question_id"] != selected[index]["questionID"]:
+                raise RuntimeError("LiveCodeBench question id mismatch at row %d" % index)
+            row["_mereRowIndex"] = index
+            row["_mereRawSHA256"] = actual
+            captured[index] = row
+    cache_file.parent.mkdir(parents=True, exist_ok=True)
+    cache_file.write_text(
+        "".join(json.dumps(captured[index], sort_keys=True) + "\n" for index in sorted(captured)),
+        encoding="utf-8",
+    )
+    return captured
+
+
+def import_livecodebench(lock, cache, offline):
+    source = lock["liveCodeBench"]
+    rows = selected_lcb_rows(source, cache, offline)
+    fixtures = []
+    revision = "dataset@%s;runner@%s" % (
+        source["datasetRevision"],
+        source["repositoryRevision"],
+    )
+    for pin in source["selectedRows"]:
+        row = rows[pin["index"]]
+        metadata = json.loads(row["metadata"])
+        entry_point = metadata.get("func_name")
+        evaluation = "functional" if entry_point else "stdin"
+        prompt = row["question_content"]
+        if row["starter_code"]:
+            prompt += "\n\nStarter code:\n" + row["starter_code"]
+        cases = decode_lcb_cases(row["public_test_cases"]) + decode_lcb_cases(row["private_test_cases"])
+        fixture = fixture_base(
+            pin["fixtureID"],
+            "code",
+            source["version"],
+            revision,
+            "%s:test:%s" % (source["version"], row["question_id"]),
+            code_messages(prompt),
+        )
+        fixture.update(
+            {
+                "entryPoint": entry_point,
+                "codeEvaluation": evaluation,
+                "codeTests": [{"input": case["input"], "output": case["output"]} for case in cases],
+                "generationBudget": 2048,
+            }
+        )
+        fixtures.append(fixture)
+    return fixtures
+
+
+def bfcl_resource(source, relative_path, cache, offline):
+    return fetch_verified(
+        source["rawBaseURL"] + relative_path,
+        cache / "bfcl" / relative_path,
+        source["resources"][relative_path],
+        offline,
+    )
+
+
+def first_jsonl(data):
+    return json.loads(data.decode("utf-8").splitlines()[0])
+
+
+def tool_definition(item):
+    properties = {}
+    for name, definition in item["parameters"]["properties"].items():
+        properties[name] = {
+            "type": definition.get("type", "string"),
+            "description": definition.get("description", ""),
+        }
+    return {
+        "name": item["name"],
+        "description": item.get("description", ""),
+        "parameters": properties,
+        "required": item["parameters"].get("required", []),
+    }
+
+
+def canonical_argument(value):
+    if value == "":
+        return ""
+    if isinstance(value, str):
+        return value
+    return json.dumps(value, sort_keys=True, separators=(",", ":"))
+
+
+def bfcl_expectations(ground_truth):
+    expectations = []
+    for call in ground_truth:
+        if not isinstance(call, dict) or len(call) != 1:
+            raise RuntimeError("unsupported BFCL ground truth: %r" % call)
+        name, arguments = next(iter(call.items()))
+        expectations.append(
+            {
+                "name": name,
+                "arguments": {
+                    key: [canonical_argument(value) for value in accepted]
+                    for key, accepted in arguments.items()
+                },
+            }
+        )
+    return expectations
+
+
+def parse_call_expression(expression):
+    parsed = ast.parse(expression, mode="eval").body
+    if not isinstance(parsed, ast.Call):
+        raise RuntimeError("unsupported BFCL call expression: %s" % expression)
+
+    def dotted_name(node):
+        if isinstance(node, ast.Name):
+            return node.id
+        if isinstance(node, ast.Attribute):
+            return dotted_name(node.value) + "." + node.attr
+        raise RuntimeError("unsupported BFCL call name")
+
+    return {
+        "name": dotted_name(parsed.func),
+        "arguments": {keyword.arg: ast.literal_eval(keyword.value) for keyword in parsed.keywords},
+    }
+
+
+def history_tool_messages(turn_index, expressions):
+    if not expressions:
+        return [{"role": "assistant", "content": "No available tool can complete this request."}]
+    calls = [parse_call_expression(expression) for expression in expressions]
+    assistant_calls = []
+    messages = []
+    for index, call in enumerate(calls):
+        call_id = "bfcl-turn-%d-call-%d" % (turn_index, index)
+        assistant_calls.append(
+            {
+                "id": call_id,
+                "name": call["name"],
+                "arguments": call["arguments"],
+            }
+        )
+    messages.append({"role": "assistant", "content": "", "toolCalls": assistant_calls})
+    for call in assistant_calls:
+        messages.append(
+            {
+                "role": "tool",
+                "content": "Tool call completed; scenario state updated.",
+                "name": call["name"],
+                "toolCallID": call["id"],
+            }
+        )
+    return messages
+
+
+def import_bfcl(lock, cache, offline):
+    source = lock["bfcl"]
+    revision = source["repositoryRevision"]
+    fixtures = []
+    for fixture_id, original_id, filename, has_answer in BFCL_SINGLE:
+        row = first_jsonl(bfcl_resource(source, filename, cache, offline))
+        fixture = fixture_base(
+            fixture_id,
+            "tool",
+            source["version"],
+            revision,
+            original_id,
+            [
+                {
+                    "role": "system",
+                    "content": "Use the supplied tools exactly. Make every required call, make no extra calls, and do not invent missing functions or parameters.",
+                },
+                row["question"][0][0],
+            ],
+        )
+        fixture["tools"] = [tool_definition(item) for item in row["function"]]
+        if has_answer:
+            answer = first_jsonl(
+                bfcl_resource(source, "possible_answer/" + filename, cache, offline)
+            )
+            fixture["expectedToolCalls"] = bfcl_expectations(answer["ground_truth"])
+        else:
+            fixture["expectsNoToolCalls"] = True
+        fixture["generationBudget"] = 256
+        fixtures.append(fixture)
+
+    function_docs = []
+    for filename in ["multi_turn_func_doc/gorilla_file_system.json", "multi_turn_func_doc/posting_api.json"]:
+        function_docs.extend(read_jsonl(bfcl_resource(source, filename, cache, offline)))
+
+    for fixture_id, original_id, filename, target_turn in BFCL_MULTI:
+        row = first_jsonl(bfcl_resource(source, filename, cache, offline))
+        answer = first_jsonl(
+            bfcl_resource(source, "possible_answer/" + filename, cache, offline)
+        )
+        tools = copy.deepcopy(function_docs)
+        if "miss_func" in filename:
+            held_names = {
+                name for names in row.get("missed_function", {}).values() for name in names
+            }
+            if target_turn < min(map(int, row["missed_function"].keys())):
+                tools = [item for item in tools if item["name"] not in held_names]
+        messages = [
+            {
+                "role": "system",
+                "content": (
+                    "Continue this pinned BFCL scenario using the supplied tools. Initial state:\n"
+                    + json.dumps(row["initial_config"], sort_keys=True, separators=(",", ":"))
+                ),
+            }
+        ]
+        for turn in range(target_turn):
+            current = row["question"][turn]
+            if current:
+                messages.extend(current)
+            else:
+                messages.append(
+                    {
+                        "role": "user",
+                        "content": "I have updated some more functions you can choose from. What about now?",
+                    }
+                )
+            messages.extend(history_tool_messages(turn, answer["ground_truth"][turn]))
+
+        current = row["question"][target_turn]
+        if current:
+            messages.extend(current)
+        else:
+            messages.append(
+                {
+                    "role": "user",
+                    "content": "I have updated some more functions you can choose from. What about now?",
+                }
+            )
+        fixture = fixture_base(
+            fixture_id,
+            "tool",
+            source["version"],
+            revision,
+            original_id,
+            messages,
+        )
+        fixture["tools"] = [tool_definition(item) for item in tools]
+        expected = answer["ground_truth"][target_turn]
+        if expected:
+            fixture["expectedToolCalls"] = [
+                {
+                    "name": call["name"],
+                    "arguments": {
+                        key: [canonical_argument(value)] for key, value in call["arguments"].items()
+                    },
+                }
+                for call in map(parse_call_expression, expected)
+            ]
+        else:
+            fixture["expectsNoToolCalls"] = True
+            if "miss_param" in filename:
+                fixture["requiredPhrases"] = ["file"]
+        fixture["generationBudget"] = 512
+        fixtures.append(fixture)
+    return fixtures
+
+
+def import_longbench(lock, cache, offline):
+    source = lock["longBench"]
+    archive_data = fetch_verified(
+        source["dataURL"], cache / "longbench-data.zip", source["dataSHA256"], offline
+    )
+    prompt_data = fetch_verified(
+        source["promptURL"],
+        cache / "longbench-dataset2prompt.json",
+        source["promptSHA256"],
+        offline,
+    )
+    prompts = json.loads(prompt_data)
+    archive = zipfile.ZipFile(io.BytesIO(archive_data))
+    revision = "dataset@%s;prompts@%s" % (
+        source["datasetRevision"],
+        source["repositoryRevision"],
+    )
+    fixtures = []
+    for fixture_id, dataset, original_id, metric, threshold, budget in LONG_BENCH:
+        with archive.open("data/%s.jsonl" % dataset) as stream:
+            row = json.loads(stream.readline())
+        prompt = prompts[dataset].format(context=row["context"], input=row["input"])
+        fixture = fixture_base(
+            fixture_id,
+            "chat",
+            source["version"],
+            revision,
+            original_id,
+            [{"role": "user", "content": prompt}],
+        )
+        fixture.update(
+            {
+                "textMetric": metric,
+                "referenceAnswers": row["answers"],
+                "passThreshold": threshold,
+                "generationBudget": budget,
+            }
+        )
+        fixtures.append(fixture)
+    return fixtures
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--lock", type=pathlib.Path, default=DEFAULT_LOCK)
+    parser.add_argument("--output", type=pathlib.Path, default=DEFAULT_OUTPUT)
+    parser.add_argument("--cache-dir", type=pathlib.Path, default=DEFAULT_CACHE)
+    parser.add_argument("--offline", action="store_true")
+    return parser.parse_args()
+
+
+def main():
+    args = parse_args()
+    lock = json.loads(args.lock.read_text(encoding="utf-8"))
+    if lock.get("schemaVersion") != 1:
+        raise RuntimeError("unsupported fused source lock schema")
+    fixtures = []
+    fixtures.extend(import_evalplus(lock, args.cache_dir, args.offline))
+    fixtures.extend(import_livecodebench(lock, args.cache_dir, args.offline))
+    fixtures.extend(import_bfcl(lock, args.cache_dir, args.offline))
+    fixtures.extend(import_longbench(lock, args.cache_dir, args.offline))
+    if len(fixtures) != 35 or len({item["id"] for item in fixtures}) != 35:
+        raise RuntimeError("expected 35 unique imported fixtures, got %d" % len(fixtures))
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    with args.output.open("w", encoding="utf-8") as stream:
+        for fixture in fixtures:
+            stream.write(json.dumps(fixture, sort_keys=True, separators=(",", ":")))
+            stream.write("\n")
+    print("Imported 35 pinned fused fixtures to %s" % args.output, file=sys.stderr)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- pin exact upstream revisions and hashes for the selected HumanEval+, MBPP+, LiveCodeBench, BFCL, and LongBench cases, with a deterministic offline-capable importer and license-aware reference-only handling
- expand mere-fused-v1 to 110 comprehensive cases and 24 lite cases across chat, code, tools, long context, and vision, with typed scoring for the imported families
- add non-greedy multi-trial sampling, logprob capture, bounded checkpoint/resume controls, and strict receipt identity for the runner binary, host, Python runtime, and sandbox backend
- keep dry-run source-only: no admission, model loading, inference, download, or Metal work

## Validation

- env -u MERERUN_RUN_E2E nice -n 10 ./scripts/check.sh
  - 3,000 XCTest cases, 219 expected skips, 0 failures
  - 30 Swift Testing cases passed
  - SwiftLint, build, CLI help sweep, and hygiene checks passed
- offline fixture re-import reproduced the checked artifacts byte-for-byte
  - unstamped SHA-256: f8df288a66a890c0ecc9adbcdd48f877d893268fc31b68dcef1f21edb337894a
  - stamped SHA-256: fb6dc00b82de2cfeb38b91fc074904363e325c28cc1553e78258e193f60698e0

## Deferred runtime validation

No installed catalog model or benchmark inference was run, and no checkpoint was downloaded. Controlled Qwen3.8, Nemotron Lightning, and Laguna XS 2.1 receipts are intentionally deferred until Metal use is explicitly authorized after this source PR lands.