### PR TITLE
Release v0.41.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+## 0.41.0 - 2026-08-18
+
+This release puts mere.run on iPhone with a portable relay client, a full-width
+creation surface, live chat and run activity, secure browser sign-in, direct
+machine pairing, and the first on-device image and text model lineup. It also
+accelerates native LTX 2.5, hardens Qwen3.8 and the MLX runtime, and introduces
+reproducible fused evaluation with model-native confidence diagnostics.
+
 ### MLX v0.32.1 runtime refresh
 
 - refreshed the maintained MLX and mlx-swift forks through upstream MLX
@@ -16,6 +24,20 @@ The format is based on Keep a Changelog.
   mlx-swift revision, MLX fork revision, upstream release tag and revision,
   generated-kernel source digest, and bundled metallib digest before builds or
   runtime startup.
+
+### LTX 2.5 video acceleration
+
+- added source-bound native LTX 2.5 transformer and connector packs with
+  streaming safetensors loading, resident video sessions, exact bounded Gemma
+  connector prompt caching, and explicit timing reports.
+- added shared compiled transformer execution, reusable positive-context
+  guidance projections, and calibrated TeaCache controls with unified-memory
+  admission and safe eager fallbacks. Exact eager execution remains the
+  default wherever an optimization changes floating-point order or output.
+- added a fused Metal DiffVAE 3D neighborhood-attention kernel with MLX
+  fallback. The measured release proof retained sample-identical audio and
+  reached 1.59x faster decode at 0.989548 video SSIM; a repeated resident
+  prompt reused the exact cached connector result and completed 23.8x faster.
 
 ### Fused model evaluation and logprobs
 
@@ -126,6 +148,9 @@ The format is based on Keep a Changelog.
   a `RelayCredentialStorage` protocol with file and Keychain backends,
   and executor-level storage injection so refreshed tokens persist
   wherever the credential came from.
+- restored the signed app's associated-domains and increased-memory
+  entitlements, completing the `mere.world` universal-link/passkey binding and
+  enabling the declared on-device Bonsai 27B chat memory budget.
 - the on-device lane grows into a lineup: Bonsai 1-bit and Bonsai
   ternary image models join Klein nano behind a model picker in Create,
   and Chat gains a fully on-device option running Bonsai 27B 1-bit with
@@ -188,6 +213,19 @@ The format is based on Keep a Changelog.
 
 - documented the Apache-2.0 provenance of the adapted Qwen GDN verification
   kernel in `THIRD_PARTY_NOTICES.md`.
+
+### Included pull requests
+
+- exact release range: [#316](https://github.com/sawfwair/mere-run/pull/316),
+  [#317](https://github.com/sawfwair/mere-run/pull/317),
+  [#318](https://github.com/sawfwair/mere-run/pull/318),
+  [#319](https://github.com/sawfwair/mere-run/pull/319),
+  [#320](https://github.com/sawfwair/mere-run/pull/320),
+  [#321](https://github.com/sawfwair/mere-run/pull/321),
+  [#322](https://github.com/sawfwair/mere-run/pull/322),
+  [#323](https://github.com/sawfwair/mere-run/pull/323),
+  [#324](https://github.com/sawfwair/mere-run/pull/324), and
+  [#325](https://github.com/sawfwair/mere-run/pull/325).
 
 ## 0.40.1 - 2026-08-16
 

--- a/Sources/MereRunRelayKit/MereRunCLIVersion.swift
+++ b/Sources/MereRunRelayKit/MereRunCLIVersion.swift
@@ -2,7 +2,7 @@
 /// contract version floors, worker probes, and the built-in node catalog
 /// identity.
 public enum MereRunCLIVersion {
-    public static let current = "0.40.1"
+    public static let current = "0.41.0"
 }
 
 /// Lenient three-component version-floor comparison used by worker

--- a/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
+++ b/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
@@ -130,7 +130,7 @@ final class CLIModelStoreBootstrapTests: XCTestCase {
     }
 
     func testMereRunCLIExposesReleaseVersion() {
-        XCTAssertEqual(MereRunCLIVersion.current, "0.40.1")
+        XCTAssertEqual(MereRunCLIVersion.current, "0.41.0")
         XCTAssertEqual(MereRunCLI.configuration.version, MereRunCLIVersion.current)
     }
 

--- a/scripts/build_mere_run_app.sh
+++ b/scripts/build_mere_run_app.sh
@@ -15,7 +15,7 @@ cd "$repo_root"
 
 # Version/build derive from git when not provided, so the bundle has a single source of
 # truth in CI. Fall back to a pinned value when git metadata is unavailable.
-default_version="0.40.1"
+default_version="0.41.0"
 if git_version="$(git describe --tags --exact-match 2>/dev/null)"; then
   default_version="${git_version#v}"
 fi


### PR DESCRIPTION
## Summary

- cut v0.41.0 for the ten merged PRs after v0.40.1 (#316-#325)
- make the first full iOS Studio build-out the headline: portable RelayKit, broad Create vocabulary, live chat and activities, PKCE/Keychain sign-in, direct machine pairing, and on-device image/text models
- complete the changelog with the previously omitted LTX 2.5 acceleration and restored iOS entitlement work
- include the fused evaluation/logprob, Qwen3.8 runtime, and MLX v0.32.1 changes
- bump the shared CLI/worker contract version, app fallback, and version assertion to 0.41.0

## Validation

- env -u MERERUN_RUN_E2E nice -n 10 ./scripts/check.sh
  - SwiftLint: 0 violations across 1,282 files
  - agent readiness: passed
  - XCTest: 3,000 executed, 219 expected asset-gated skips, 0 failures
  - Swift Testing: 30 passed, 0 failures
  - build, CLI help sweep, provenance, and hygiene checks passed
- .build/debug/mere.run --version -> 0.41.0
- git diff --check

## Release boundary

The annotated tag and signed/notarized macOS plus x86_64 CUDA artifacts will be built from the exact merged release commit. This metadata PR does not rerun installed-model inference; the included feature PRs retain their own runtime proof and documented unavailable-model gaps.