### PR TITLE
Report Hub download progress on iOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+### Model downloads
+
+- fixed Hub download progress freezing at zero on iOS: the Swift-concurrency
+  `URLSession.download(for:)` convenience never delivers `didWriteData`
+  there (macOS happens to), so multi-gigabyte pulls looked hung while bytes
+  flowed. Downloads now run as classic delegate-driven download tasks, which
+  report byte progress on every platform; behavior on macOS and Linux is
+  unchanged. The iOS app additionally keeps the display awake during a pull
+  (a locked screen suspends the app and kills the transfer), surfaces
+  download failures in Chat's on-device row, and shows absolute megabytes
+  instead of a percent that rounds to zero for most of a large pull.
+
 ## 0.41.0 - 2026-08-18
 
 This release puts mere.run on iPhone with a portable relay client, a full-width

--- a/Sources/MereRunCore/HubSnapshot.swift
+++ b/Sources/MereRunCore/HubSnapshot.swift
@@ -602,9 +602,12 @@ public actor HubSnapshot {
         for _ in 0..<8 {
             var request = authorizedRequest(url: currentURL)
             request.httpMethod = "GET"
+            // A classic delegate-driven download task: the async
+            // `download(for:)` convenience never delivers `didWriteData` on
+            // iOS, so byte progress froze at zero for multi-gigabyte pulls.
             let session = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
             defer { session.invalidateAndCancel() }
-            let (tempURL, response) = try await session.download(for: request)
+            let (tempURL, response) = try await delegate.perform(request, in: session)
             let http = try Self.validateDownloadedResponse(
                 response,
                 errorBodyURL: tempURL,
@@ -1171,9 +1174,26 @@ private final class HubSnapshotDownloadDelegate: NSObject, URLSessionTaskDelegat
     private let startedAt = Date()
     private let progressHandler: @Sendable (Int64, Int64, Double?) -> Void
     private(set) var lastSpeedBytesPerSecond: Double?
+    private let lock = NSLock()
+    private var continuation: CheckedContinuation<(URL, URLResponse), Error>?
+    private var movedURL: URL?
 
     init(progressHandler: @escaping @Sendable (Int64, Int64, Double?) -> Void) {
         self.progressHandler = progressHandler
+    }
+
+    /// Runs one download as a classic delegate-driven task. The async
+    /// `download(for:)` convenience never delivers `didWriteData` on iOS
+    /// (macOS happens to), so byte progress must ride the original delegate
+    /// path on every platform.
+    func perform(_ request: URLRequest, in session: URLSession) async throws -> (URL, URLResponse) {
+        try await withCheckedThrowingContinuation { newContinuation in
+            lock.lock()
+            continuation = newContinuation
+            movedURL = nil
+            lock.unlock()
+            session.downloadTask(with: request).resume()
+        }
     }
 
     func urlSession(
@@ -1189,8 +1209,45 @@ private final class HubSnapshotDownloadDelegate: NSObject, URLSessionTaskDelegat
     func urlSession(
         _: URLSession,
         downloadTask _: URLSessionDownloadTask,
-        didFinishDownloadingTo _: URL
-    ) {}
+        didFinishDownloadingTo location: URL
+    ) {
+        // The system deletes `location` when this callback returns; claim it
+        // synchronously and hand the stable path over at task completion.
+        let stable = FileManager.default.temporaryDirectory
+            .appendingPathComponent("hub-download-\(UUID().uuidString)")
+        do {
+            try FileManager.default.moveItem(at: location, to: stable)
+            lock.lock()
+            movedURL = stable
+            lock.unlock()
+        } catch {
+            lock.lock()
+            movedURL = nil
+            lock.unlock()
+        }
+    }
+
+    func urlSession(_: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        lock.lock()
+        let pending = continuation
+        continuation = nil
+        let stable = movedURL
+        movedURL = nil
+        lock.unlock()
+        guard let pending else { return }
+        if let error {
+            if let stable { try? FileManager.default.removeItem(at: stable) }
+            pending.resume(throwing: error)
+            return
+        }
+        guard let response = task.response, let stable else {
+            pending.resume(throwing: Hub.HubClientError.downloadError(
+                "Download completed without a response or payload file."
+            ))
+            return
+        }
+        pending.resume(returning: (stable, response))
+    }
 
     func urlSession(
         _: URLSession,

--- a/ios/MereRunStudio/App/LocalEngine.swift
+++ b/ios/MereRunStudio/App/LocalEngine.swift
@@ -114,6 +114,10 @@ final class LocalEngine: ObservableObject {
     func download(_ modelID: String) async {
         states[modelID] = .downloading("Starting…")
         lastError = nil
+        // A locked screen suspends the app and kills the transfer; keep the
+        // display on for the duration of the pull.
+        UIApplication.shared.isIdleTimerDisabled = true
+        defer { UIApplication.shared.isIdleTimerDisabled = false }
         do {
             _ = try await ManagedModelResolver.installManagedModel(
                 id: modelID,
@@ -122,7 +126,7 @@ final class LocalEngine: ObservableObject {
                     switch progress {
                     case .downloadingBytes(let completed, let total):
                         if let total, total > 0 {
-                            label = "\(Int(Double(completed) / Double(total) * 100))% of \(total / 1_048_576) MB"
+                            label = "\(completed / 1_048_576) of \(total / 1_048_576) MB"
                         } else {
                             label = "\(completed / 1_048_576) MB"
                         }

--- a/ios/MereRunStudio/Views/ChatView.swift
+++ b/ios/MereRunStudio/Views/ChatView.swift
@@ -126,6 +126,9 @@ struct ChatView: View {
         switch local.state(of: LocalEngine.chatModel.id) {
         case .notInstalled:
             VStack(alignment: .leading, spacing: MereTheme.Spacing.s) {
+                if let message = local.lastError {
+                    MereBannerView(text: message, color: MereTheme.failure)
+                }
                 MereBannerView(
                     text: "\(LocalEngine.chatModel.title) (\(LocalEngine.chatModel.sizeLabel)) chats entirely on this iPhone. Download once over Wi-Fi; it stays in this app's storage.",
                     color: MereTheme.accent

--- a/ios/MereRunStudioTests/HubDownloadDeviceTests.swift
+++ b/ios/MereRunStudioTests/HubDownloadDeviceTests.swift
@@ -1,0 +1,256 @@
+import Foundation
+import os
+import XCTest
+
+/// Diagnostic: exercises the hub download stack inside the app process on a
+/// physical device, in three isolation layers, to pinpoint where on-device
+/// model downloads stall. Gated on MERERUN_TEST_DOWNLOAD_DIAG.
+final class HubDownloadDeviceTests: XCTestCase {
+    private let smallFileURL = URL(
+        string: "https://huggingface.co/prism-ml/bonsai-image-binary-4B-mlx-1bit/resolve/main/manifest.json"
+    )!
+
+    private func requireDiag() throws {
+        guard ProcessInfo.processInfo.environment["MERERUN_TEST_DOWNLOAD_DIAG"] != nil else {
+            throw XCTSkip("Set MERERUN_TEST_DOWNLOAD_DIAG to run download diagnostics.")
+        }
+    }
+
+    func testV1PlainSharedSessionFetch() async throws {
+        try requireDiag()
+        let (data, response) = try await URLSession.shared.data(from: smallFileURL)
+        let http = try XCTUnwrap(response as? HTTPURLResponse)
+        XCTAssertEqual(http.statusCode, 200, "Plain fetch failed: \(http.statusCode)")
+        XCTAssertGreaterThan(data.count, 10)
+    }
+
+    func testV2DownloadWithNoRedirectDelegate() async throws {
+        try requireDiag()
+        // Mirrors HubSnapshot's exact transfer shape: a fresh session whose
+        // delegate refuses redirects, driven through async download(for:).
+        final class NoRedirect: NSObject, URLSessionTaskDelegate, URLSessionDownloadDelegate, @unchecked Sendable {
+            var wroteBytes = false
+            func urlSession(_: URLSession, task _: URLSessionTask, willPerformHTTPRedirection _: HTTPURLResponse, newRequest _: URLRequest, completionHandler: @escaping (URLRequest?) -> Void) {
+                completionHandler(nil)
+            }
+            func urlSession(_: URLSession, downloadTask _: URLSessionDownloadTask, didFinishDownloadingTo _: URL) {}
+            func urlSession(_: URLSession, downloadTask _: URLSessionDownloadTask, didWriteData _: Int64, totalBytesWritten _: Int64, totalBytesExpectedToWrite _: Int64) {
+                wroteBytes = true
+            }
+        }
+        var currentURL = smallFileURL
+        for _ in 0..<8 {
+            let delegate = NoRedirect()
+            let session = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
+            defer { session.invalidateAndCancel() }
+            var request = URLRequest(url: currentURL)
+            request.httpMethod = "GET"
+            let (tempURL, response) = try await session.download(for: request)
+            let http = try XCTUnwrap(response as? HTTPURLResponse)
+            if (200..<300).contains(http.statusCode) {
+                let size = (try? FileManager.default.attributesOfItem(atPath: tempURL.path)[.size] as? Int) ?? 0
+                XCTAssertGreaterThan(size ?? 0, 10, "Downloaded file is empty")
+                return
+            }
+            guard (300..<400).contains(http.statusCode),
+                  let location = http.value(forHTTPHeaderField: "Location"),
+                  let next = URL(string: location, relativeTo: currentURL) else {
+                return XCTFail("Unexpected status \(http.statusCode) with no redirect")
+            }
+            currentURL = next.absoluteURL
+        }
+        XCTFail("Too many redirects")
+    }
+
+
+    func testV4HeadProbeLikeResolveRemoteFile() async throws {
+        try requireDiag()
+        // Mirrors HubSnapshot.resolveRemoteFile: HEAD, identity encoding,
+        // redirect-refusing session delegate, async data(for:).
+        final class NoRedirect: NSObject, URLSessionTaskDelegate, @unchecked Sendable {
+            func urlSession(_: URLSession, task _: URLSessionTask, willPerformHTTPRedirection _: HTTPURLResponse, newRequest _: URLRequest, completionHandler: @escaping (URLRequest?) -> Void) {
+                completionHandler(nil)
+            }
+        }
+        var request = URLRequest(url: smallFileURL)
+        request.httpMethod = "HEAD"
+        request.setValue("identity", forHTTPHeaderField: "Accept-Encoding")
+        let delegate = NoRedirect()
+        let session = URLSession(configuration: .default, delegate: delegate, delegateQueue: nil)
+        defer { session.invalidateAndCancel() }
+        let (_, response) = try await session.data(for: request)
+        let http = try XCTUnwrap(response as? HTTPURLResponse)
+        XCTAssertTrue((200..<400).contains(http.statusCode), "HEAD returned \(http.statusCode)")
+        let report = XCTAttachment(string: "HEAD status \(http.statusCode), etag: \(http.value(forHTTPHeaderField: "ETag") ?? "-"), location: \(http.value(forHTTPHeaderField: "Location") ?? "-")")
+        report.name = "v4-head"
+        report.lifetime = .keepAlways
+        add(report)
+    }
+
+    func testV5LFSRedirectDownloadProgress() async throws {
+        try requireDiag()
+        // The LFS path V2 never exercised: refuse the 302 at the session
+        // delegate, follow Location manually, then measure whether bytes
+        // actually flow from the CDN for a large file.
+        final class Probe: NSObject, URLSessionTaskDelegate, URLSessionDownloadDelegate, @unchecked Sendable {
+            private let counter = OSAllocatedUnfairLock(initialState: Int64(0))
+            var written: Int64 { counter.withLock { $0 } }
+            func urlSession(_: URLSession, task _: URLSessionTask, willPerformHTTPRedirection _: HTTPURLResponse, newRequest _: URLRequest, completionHandler: @escaping (URLRequest?) -> Void) {
+                completionHandler(nil)
+            }
+            func urlSession(_: URLSession, downloadTask _: URLSessionDownloadTask, didFinishDownloadingTo _: URL) {}
+            func urlSession(_: URLSession, downloadTask _: URLSessionDownloadTask, didWriteData _: Int64, totalBytesWritten: Int64, totalBytesExpectedToWrite _: Int64) {
+                counter.withLock { $0 = totalBytesWritten }
+            }
+        }
+        let bigURL = URL(string: "https://huggingface.co/prism-ml/bonsai-image-binary-4B-mlx-1bit/resolve/main/transformer-packed-mflux/diffusion_pytorch_model.safetensors")!
+
+        // Step 1: capture the redirect the way HubSnapshot does.
+        let probe1 = Probe()
+        let session1 = URLSession(configuration: .default, delegate: probe1, delegateQueue: nil)
+        var request = URLRequest(url: bigURL)
+        request.httpMethod = "GET"
+        let (temp1, response1) = try await session1.download(for: request)
+        try? FileManager.default.removeItem(at: temp1)
+        let http1 = try XCTUnwrap(response1 as? HTTPURLResponse)
+        var notes = ["step1 status \(http1.statusCode)"]
+        guard (300..<400).contains(http1.statusCode),
+              let location = http1.value(forHTTPHeaderField: "Location") else {
+            notes.append("no redirect; direct status \(http1.statusCode)")
+            attach(notes, name: "v5-progress")
+            session1.invalidateAndCancel()
+            return
+        }
+        session1.invalidateAndCancel()
+        let resolved = URL(string: location, relativeTo: bigURL)?.absoluteURL
+        notes.append("location parsed: \(resolved != nil), host: \(resolved?.host ?? "NIL")")
+        guard let cdnURL = resolved else {
+            attach(notes, name: "v5-progress")
+            return XCTFail("Location did not parse into a URL")
+        }
+
+        // Step 2: start the CDN download and sample byte progress for 30s.
+        let probe2 = Probe()
+        let session2 = URLSession(configuration: .default, delegate: probe2, delegateQueue: nil)
+        var cdnRequest = URLRequest(url: cdnURL)
+        cdnRequest.httpMethod = "GET"
+        let task = Task { try await session2.download(for: cdnRequest) }
+        for second in stride(from: 5, through: 30, by: 5) {
+            try await Task.sleep(nanoseconds: 5_000_000_000)
+            notes.append("t+\(second)s: \(probe2.written / 1_048_576) MB")
+        }
+        task.cancel()
+        session2.invalidateAndCancel()
+        let finalBytes = probe2.written
+        attach(notes, name: "v5-progress")
+        XCTAssertGreaterThan(finalBytes, 1_048_576, "CDN transfer moved fewer than 1 MB in 30s: \(notes)")
+    }
+
+    private func attach(_ lines: [String], name: String) {
+        let attachment = XCTAttachment(string: lines.joined(separator: "\n"))
+        attachment.name = name
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+
+    func testV5bCDNRequestOutcome() async throws {
+        try requireDiag()
+        // Follow the 302 manually like HubSnapshot, then AWAIT the CDN
+        // response so its status code or transport error is captured.
+        let bigURL = URL(string: "https://huggingface.co/prism-ml/bonsai-image-binary-4B-mlx-1bit/resolve/main/transformer-packed-mflux/diffusion_pytorch_model.safetensors")!
+        final class NoRedirect: NSObject, URLSessionTaskDelegate, @unchecked Sendable {
+            func urlSession(_: URLSession, task _: URLSessionTask, willPerformHTTPRedirection _: HTTPURLResponse, newRequest _: URLRequest, completionHandler: @escaping (URLRequest?) -> Void) {
+                completionHandler(nil)
+            }
+        }
+        let session1 = URLSession(configuration: .default, delegate: NoRedirect(), delegateQueue: nil)
+        defer { session1.invalidateAndCancel() }
+        var request = URLRequest(url: bigURL)
+        request.httpMethod = "GET"
+        let (_, response1) = try await session1.data(for: request)
+        let http1 = try XCTUnwrap(response1 as? HTTPURLResponse)
+        let location = try XCTUnwrap(http1.value(forHTTPHeaderField: "Location"))
+        let cdnURL = try XCTUnwrap(URL(string: location, relativeTo: bigURL)?.absoluteURL)
+
+        var notes = ["cdn url prefix: \(cdnURL.absoluteString.prefix(120))"]
+        var cdnRequest = URLRequest(url: cdnURL, timeoutInterval: 25)
+        cdnRequest.httpMethod = "GET"
+        cdnRequest.setValue("bytes=0-1048575", forHTTPHeaderField: "Range")
+        do {
+            let (data, response2) = try await URLSession.shared.data(for: cdnRequest)
+            let http2 = try XCTUnwrap(response2 as? HTTPURLResponse)
+            notes.append("cdn status \(http2.statusCode), bytes \(data.count)")
+            if !(200..<300).contains(http2.statusCode) {
+                notes.append("body: \(String(decoding: data.prefix(300), as: UTF8.self))")
+            }
+        } catch {
+            notes.append("cdn error: \(error)")
+        }
+        attach(notes, name: "v5b-outcome")
+    }
+
+    func testV6SystemRedirectDownloadProgress() async throws {
+        try requireDiag()
+        // Let URLSession follow the redirect itself; sample byte progress.
+        final class Progress: NSObject, URLSessionTaskDelegate, URLSessionDownloadDelegate, @unchecked Sendable {
+            private let counter = OSAllocatedUnfairLock(initialState: Int64(0))
+            var written: Int64 { counter.withLock { $0 } }
+            func urlSession(_: URLSession, downloadTask _: URLSessionDownloadTask, didFinishDownloadingTo _: URL) {}
+            func urlSession(_: URLSession, downloadTask _: URLSessionDownloadTask, didWriteData _: Int64, totalBytesWritten: Int64, totalBytesExpectedToWrite _: Int64) {
+                counter.withLock { $0 = totalBytesWritten }
+            }
+        }
+        let bigURL = URL(string: "https://huggingface.co/prism-ml/bonsai-image-binary-4B-mlx-1bit/resolve/main/transformer-packed-mflux/diffusion_pytorch_model.safetensors")!
+        let probe = Progress()
+        let session = URLSession(configuration: .default, delegate: probe, delegateQueue: nil)
+        defer { session.invalidateAndCancel() }
+        let task = Task { try await session.download(for: URLRequest(url: bigURL)) }
+        var notes: [String] = []
+        for second in stride(from: 5, through: 25, by: 5) {
+            try await Task.sleep(nanoseconds: 5_000_000_000)
+            notes.append("t+\(second)s: \(probe.written / 1_048_576) MB")
+        }
+        task.cancel()
+        attach(notes, name: "v6-progress")
+        XCTAssertGreaterThan(probe.written, 1_048_576, "System-redirect transfer also moved nothing: \(notes)")
+    }
+
+    func testV7PerTaskDelegateDeliversProgress() async throws {
+        try requireDiag()
+        final class Progress: NSObject, URLSessionTaskDelegate, URLSessionDownloadDelegate, @unchecked Sendable {
+            private let counter = OSAllocatedUnfairLock(initialState: (bytes: Int64(0), events: 0))
+            var state: (bytes: Int64, events: Int) { counter.withLock { $0 } }
+            func urlSession(_: URLSession, downloadTask _: URLSessionDownloadTask, didFinishDownloadingTo _: URL) {}
+            func urlSession(_: URLSession, downloadTask _: URLSessionDownloadTask, didWriteData _: Int64, totalBytesWritten: Int64, totalBytesExpectedToWrite _: Int64) {
+                counter.withLock { $0 = (totalBytesWritten, $0.events + 1) }
+            }
+        }
+        let mediumURL = URL(string: "https://huggingface.co/prism-ml/bonsai-image-binary-4B-mlx-1bit/resolve/main/tokenizer/tokenizer.json")!
+
+        // A: delegate attached to the session (HubSnapshot's current shape).
+        let sessionDelegate = Progress()
+        let sessionA = URLSession(configuration: .default, delegate: sessionDelegate, delegateQueue: nil)
+        let (tempA, _) = try await sessionA.download(for: URLRequest(url: mediumURL))
+        let sizeA = (try? FileManager.default.attributesOfItem(atPath: tempA.path)[.size] as? Int64) ?? 0
+        try? FileManager.default.removeItem(at: tempA)
+        sessionA.invalidateAndCancel()
+
+        // B: delegate passed per-task to the async API.
+        let taskDelegate = Progress()
+        let sessionB = URLSession(configuration: .default)
+        let (tempB, _) = try await sessionB.download(for: URLRequest(url: mediumURL), delegate: taskDelegate)
+        let sizeB = (try? FileManager.default.attributesOfItem(atPath: tempB.path)[.size] as? Int64) ?? 0
+        try? FileManager.default.removeItem(at: tempB)
+        sessionB.invalidateAndCancel()
+
+        let a = sessionDelegate.state
+        let b = taskDelegate.state
+        attach([
+            "A(session delegate): file \(sizeA ?? 0) bytes, didWriteData events \(a.events), reported \(a.bytes)",
+            "B(per-task delegate): file \(sizeB ?? 0) bytes, didWriteData events \(b.events), reported \(b.bytes)",
+        ], name: "v7-delegates")
+        XCTAssertGreaterThan(sizeA ?? 0, 1000, "Session-delegate download produced no file")
+        XCTAssertGreaterThan(sizeB ?? 0, 1000, "Per-task-delegate download produced no file")
+        XCTAssertGreaterThan(b.events, 0, "Per-task delegate never saw progress")
+    }
+}

--- a/ios/MereRunStudioUITests/DownloadDiagnosticsUITests.swift
+++ b/ios/MereRunStudioUITests/DownloadDiagnosticsUITests.swift
@@ -1,0 +1,69 @@
+import XCTest
+
+/// Diagnostic: drive an on-device model download on real hardware and record
+/// what the UI reports. Runs only when MERERUN_TEST_DOWNLOAD_DIAG is set —
+/// this is an investigation tool, not a CI gate.
+final class DownloadDiagnosticsUITests: XCTestCase {
+    override func setUpWithError() throws {
+        continueAfterFailure = true
+    }
+
+    func testObserveLocalModelDownload() throws {
+        guard ProcessInfo.processInfo.environment["MERERUN_TEST_DOWNLOAD_DIAG"] != nil else {
+            throw XCTSkip("Set MERERUN_TEST_DOWNLOAD_DIAG to run the download diagnostic.")
+        }
+
+        let app = XCUIApplication()
+        app.launch()
+
+        let createTab = app.tabBars.buttons["Create"]
+        XCTAssertTrue(createTab.waitForExistence(timeout: 20), "App must be paired before this diagnostic.")
+        createTab.tap()
+
+        let phoneSegment = app.buttons["This iPhone"]
+        if phoneSegment.waitForExistence(timeout: 5) {
+            phoneSegment.tap()
+        } else {
+            app.segmentedControls.buttons.element(boundBy: 1).tap()
+        }
+        snapshot(app, "lane")
+
+        // Tap the first available "Get …" button (Klein nano is smallest).
+        let get = app.buttons.matching(NSPredicate(format: "label BEGINSWITH 'Get '")).firstMatch
+        XCTAssertTrue(get.waitForExistence(timeout: 10), "A download button must be visible.")
+        let tappedLabel = get.label
+        get.tap()
+
+        // Observe for two minutes, logging every visible static text in the
+        // lane so progress, stalls, and error banners are all captured.
+        var observations: [String] = ["tapped: \(tappedLabel)"]
+        let deadline = Date().addingTimeInterval(120)
+        var tick = 0
+        while Date() < deadline {
+            RunLoop.current.run(until: Date().addingTimeInterval(10))
+            tick += 1
+            let labels = app.scrollViews.staticTexts.allElementsBoundByIndex
+                .map { $0.label }
+                .filter { $0.contains("%") || $0.contains("MB") || $0.contains("…")
+                    || $0.localizedCaseInsensitiveContains("error")
+                    || $0.localizedCaseInsensitiveContains("fail")
+                    || $0.localizedCaseInsensitiveContains("could not")
+                    || $0.localizedCaseInsensitiveContains("download") }
+            observations.append("t+\(tick * 10)s: \(labels.joined(separator: " | "))")
+            if tick % 3 == 0 { snapshot(app, "t\(tick * 10)") }
+        }
+        snapshot(app, "final")
+
+        let report = XCTAttachment(string: observations.joined(separator: "\n"))
+        report.name = "download-observations"
+        report.lifetime = .keepAlways
+        add(report)
+    }
+
+    private func snapshot(_ app: XCUIApplication, _ name: String) {
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = name
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -60,6 +60,22 @@ targets:
         # Set for device builds: MERERUN_IOS_TEAM=<team id> xcodegen generate
         # Simulator builds need no team.
         DEVELOPMENT_TEAM: ${MERERUN_IOS_TEAM}
+  MereRunStudioTests:
+    type: bundle.unit-test
+    platform: iOS
+    sources:
+      - MereRunStudioTests
+    dependencies:
+      - target: MereRunStudio
+    settings:
+      base:
+        PRODUCT_BUNDLE_IDENTIFIER: run.mere.studio.ios.tests
+        SWIFT_VERSION: "6.0"
+        GENERATE_INFOPLIST_FILE: YES
+        TEST_HOST: $(BUILT_PRODUCTS_DIR)/mere.run.app/mere.run
+        BUNDLE_LOADER: $(TEST_HOST)
+        CODE_SIGN_STYLE: Automatic
+        DEVELOPMENT_TEAM: ${MERERUN_IOS_TEAM}
   MereRunStudioUITests:
     type: bundle.ui-testing
     platform: iOS
@@ -106,4 +122,5 @@ schemes:
     test:
       config: Debug
       targets:
+        - MereRunStudioTests
         - MereRunStudioUITests


### PR DESCRIPTION
## The bug

On-device model downloads on the phone appeared completely stuck at 0% forever. Device-hosted diagnostics isolated it in layers: plain fetches ✓, the exact download+redirect shape ✓, the CDN behind LFS redirects ✓ (206, 1 MB in 0.86s) — and finally an A/B probe showed the truth: **files were downloading fine the whole time, but `didWriteData` never fires for the async `URLSession.download(for:)` convenience on iOS** — neither on the session delegate nor a per-task delegate. macOS delivers it, which is why CLI progress always worked and this never surfaced.

Frozen progress made working transfers look hung; killing the app or letting the screen lock then genuinely killed them.

## The fix

`HubSnapshot` downloads now run as classic delegate-driven `downloadTask`s bridged through a continuation — the original delegate path that reports byte progress on every platform. The temp payload is claimed synchronously in `didFinishDownloadingTo` (the system deletes it after the callback), and redirect refusal + manual following behave exactly as before.

App-side hardenings that fell out of the investigation: keep the display awake during a pull, surface download failures in Chat's on-device row (previously silent), and show "N of M MB" instead of a percent that rounds to zero for most of a multi-GB file.

## Verified

- **On the phone**: same download that sat at "0 of 4413 MB" for 130s now ticks 36 → 231 MB across the observation window; user-confirmed visually.
- macOS: 3000 tests, 0 failures; swiftlint clean; simulator + device builds green.
- Diagnostics (`MereRunStudioTests` hosted probes + the download observation UI test) are env-gated behind `MERERUN_TEST_DOWNLOAD_DIAG`, so ordinary test runs skip them.