### PR TITLE
Make fleet-or-device one seamless choice

### DIFF
--- a/ios/MereRunStudio/App/LocalEngine.swift
+++ b/ios/MereRunStudio/App/LocalEngine.swift
@@ -15,7 +15,7 @@ final class LocalEngine: ObservableObject {
 
     /// MLX cannot create a Metal device in the simulator; the on-device lane
     /// exists only on hardware. Constructing a generator in the simulator
-    /// aborts the process, so every entry point gates on this first.
+    /// aborts the process, so every compute entry point gates on this first.
     static let isSupported: Bool = {
         #if targetEnvironment(simulator)
         return false
@@ -23,6 +23,14 @@ final class LocalEngine: ObservableObject {
         return true
         #endif
     }()
+
+    /// UI preview in the simulator (`MERERUN_UI_PREVIEW` launch argument):
+    /// the on-device surfaces render with mocked install states so the design
+    /// can be iterated without hardware. Compute stays gated on hardware.
+    static let isPreview = ProcessInfo.processInfo.arguments.contains("MERERUN_UI_PREVIEW")
+
+    /// Whether on-device surfaces appear at all.
+    static var showsOnDeviceUI: Bool { isSupported || isPreview }
 
     struct Model: Identifiable, Equatable {
         enum Kind { case image, chat }
@@ -44,29 +52,33 @@ final class LocalEngine: ObservableObject {
         Model(
             id: "image-klein-nano",
             kind: .image,
-            title: "Klein nano",
-            detail: "FLUX.2 Klein distilled to nano. The fastest local option."
+            title: "Klein Nano",
+            detail: "Makes images. The fastest one."
         ),
         Model(
             id: "image-bonsai-binary",
             kind: .image,
-            title: "Bonsai 1-bit",
-            detail: "Bonsai 4B with binary weights. Small download, full pipeline."
+            title: "Bonsai Binary",
+            detail: "Makes images. The smallest download."
         ),
         Model(
             id: "image-bonsai-ternary",
             kind: .image,
-            title: "Bonsai ternary",
-            detail: "Bonsai 4B with ternary weights. A quality step up from 1-bit."
+            title: "Bonsai Ternary",
+            detail: "Makes images. The best-looking of the three."
         ),
     ]
 
     static let chatModel = Model(
         id: "text-chat-bonsai-27b-1bit",
         kind: .chat,
-        title: "Bonsai 27B 1-bit",
-        detail: "A 27B chat model in binary weights, running entirely on this iPhone."
+        title: "Bonsai Chat",
+        detail: "A 27-billion-parameter assistant. Your words never leave the phone."
     )
+
+    static func model(withID id: String) -> Model? {
+        (imageModels + [chatModel]).first { $0.id == id }
+    }
 
     enum ModelState: Equatable {
         case notInstalled
@@ -83,6 +95,7 @@ final class LocalEngine: ObservableObject {
     @Published private(set) var states: [String: ModelState] = [:]
     @Published private(set) var activity: Activity = .idle
     @Published private(set) var lastImage: UIImage?
+    @Published private(set) var lastImageURL: URL?
     @Published var selectedImageModelID = LocalEngine.imageModels[0].id
     @Published private(set) var lastError: String?
 
@@ -94,6 +107,18 @@ final class LocalEngine: ObservableObject {
     }
 
     func refresh() {
+        if Self.isPreview {
+            // Mocked variety for design iteration in the simulator.
+            if states.isEmpty {
+                states = [
+                    Self.imageModels[0].id: .ready,
+                    Self.imageModels[1].id: .downloading("1204 of 3269 MB"),
+                    Self.imageModels[2].id: .notInstalled,
+                    Self.chatModel.id: .notInstalled,
+                ]
+            }
+            return
+        }
         guard Self.isSupported else { return }
         for model in Self.imageModels + [Self.chatModel] {
             if case .downloading = states[model.id] { continue }
@@ -167,6 +192,7 @@ final class LocalEngine: ObservableObject {
         do {
             let result = try await imageGenerator.generate(request, progressHandler: nil)
             lastImage = UIImage(contentsOfFile: result.outputURL.path)
+            lastImageURL = result.outputURL
         } catch {
             lastError = error.localizedDescription
         }

--- a/ios/MereRunStudio/App/MereRunStudioApp.swift
+++ b/ios/MereRunStudio/App/MereRunStudioApp.swift
@@ -52,6 +52,13 @@ struct SettingsView: View {
                         value: relay.authStatus?.authenticated == true ? "Yes" : "No"
                     )
                 }
+                if LocalEngine.showsOnDeviceUI {
+                    Section("On this iPhone") {
+                        NavigationLink("On-device models") {
+                            OnDeviceModelsList()
+                        }
+                    }
+                }
                 Section {
                     Button("Sign out and unpair", role: .destructive) {
                         relay.unpair()

--- a/ios/MereRunStudio/Views/ChatView.swift
+++ b/ios/MereRunStudio/Views/ChatView.swift
@@ -9,6 +9,7 @@ struct ChatView: View {
     @StateObject private var chat: ChatStore
     @ObservedObject private var local = LocalEngine.shared
     @State private var draft = ""
+    @State private var showOnDeviceModels = false
 
     init(relay: RelayStore) {
         _chat = StateObject(wrappedValue: ChatStore(relay: relay))
@@ -100,11 +101,6 @@ struct ChatView: View {
                     .padding(.bottom, MereTheme.Spacing.s)
                 }
 
-                if chat.runLocally, !localChatReady {
-                    localChatSetup
-                        .padding(.horizontal, MereTheme.Spacing.l)
-                        .padding(.bottom, MereTheme.Spacing.s)
-                }
 
                 composer
             }
@@ -118,38 +114,17 @@ struct ChatView: View {
                 }
             }
             .task { await relay.refreshWorkerProbe() }
+            .sheet(isPresented: $showOnDeviceModels) { OnDeviceModelsView() }
         }
     }
 
-    @ViewBuilder
-    private var localChatSetup: some View {
-        switch local.state(of: LocalEngine.chatModel.id) {
-        case .notInstalled:
-            VStack(alignment: .leading, spacing: MereTheme.Spacing.s) {
-                if let message = local.lastError {
-                    MereBannerView(text: message, color: MereTheme.failure)
-                }
-                MereBannerView(
-                    text: "\(LocalEngine.chatModel.title) (\(LocalEngine.chatModel.sizeLabel)) chats entirely on this iPhone. Download once over Wi-Fi; it stays in this app's storage.",
-                    color: MereTheme.accent
-                )
-                Button {
-                    Task { await local.download(LocalEngine.chatModel.id) }
-                } label: {
-                    Text("Download \(LocalEngine.chatModel.title)").frame(maxWidth: .infinity)
-                }
-                .buttonStyle(.bordered)
-            }
-        case .downloading(let label):
-            HStack(spacing: MereTheme.Spacing.s) {
-                ProgressView()
-                Text("Downloading — \(label)")
-                    .font(.footnote)
-                    .foregroundStyle(MereTheme.textSecondary)
-            }
-        case .ready:
-            EmptyView()
+    /// Fleet model IDs carry their kind as a prefix; the menu already says
+    /// what kind this is, so display just the model's own name.
+    static func displayName(for id: String) -> String {
+        for prefix in ["text-chat-", "text-agent-"] where id.hasPrefix(prefix) {
+            return String(id.dropFirst(prefix.count))
         }
+        return id
     }
 
     private var emptyState: some View {
@@ -228,16 +203,22 @@ struct ChatView: View {
                             chat.model = ""
                         }
                         ForEach(chatModels, id: \.self) { id in
-                            Button(id) {
+                            Button(Self.displayName(for: id)) {
                                 chat.runLocally = false
                                 chat.model = id
                             }
                         }
                     }
-                    if LocalEngine.isSupported {
+                    if LocalEngine.showsOnDeviceUI {
                         Section("This iPhone") {
-                            Button("\(LocalEngine.chatModel.title) — on device") {
-                                chat.runLocally = true
+                            if localChatReady {
+                                Button(LocalEngine.chatModel.title) {
+                                    chat.runLocally = true
+                                }
+                            } else {
+                                Button("Get \(LocalEngine.chatModel.title) (\(LocalEngine.chatModel.sizeLabel))…") {
+                                    showOnDeviceModels = true
+                                }
                             }
                         }
                     }
@@ -245,8 +226,8 @@ struct ChatView: View {
                     HStack(spacing: 5) {
                         Image(systemName: chat.runLocally ? "iphone" : "cpu")
                         Text(chat.runLocally
-                            ? "\(LocalEngine.chatModel.title) — on device"
-                            : (chat.model.isEmpty ? "Fleet default" : chat.model))
+                            ? "\(LocalEngine.chatModel.title) — this iPhone"
+                            : (chat.model.isEmpty ? "Fleet default" : Self.displayName(for: chat.model)))
                             .lineLimit(1)
                     }
                     .font(.footnote)

--- a/ios/MereRunStudio/Views/CreateView.swift
+++ b/ios/MereRunStudio/Views/CreateView.swift
@@ -169,7 +169,12 @@ struct CreateView: View {
 
     @EnvironmentObject private var relay: RelayStore
     @ObservedObject private var local = LocalEngine.shared
-    @State private var runLocally = false
+    @State private var localModelID: String?
+    @State private var showOnDeviceModels = false
+
+    private var runsOnThisPhone: Bool {
+        localModelID != nil && selected.kind == "image.generate"
+    }
     @State private var selected = Self.modes[0]
     @State private var prompt = ""
     @State private var model = ""
@@ -231,14 +236,10 @@ struct CreateView: View {
 
                     modeRail
 
-                    if selected.kind == "image.generate", LocalEngine.isSupported {
-                        destinationToggle
-                    }
-
                     composer
 
-                    if runLocally, selected.kind == "image.generate" {
-                        localLane
+                    if selected.kind == "image.generate", runsOnThisPhone {
+                        localResult
                     }
 
                     if !isAvailable(selected) {
@@ -268,6 +269,7 @@ struct CreateView: View {
                 RunDetailView(jobID: jobID)
             }
             .sheet(isPresented: $showOptions) { optionsSheet }
+            .sheet(isPresented: $showOnDeviceModels) { OnDeviceModelsView() }
             .fileImporter(
                 isPresented: $showAudioImporter,
                 allowedContentTypes: [.audio],
@@ -341,19 +343,44 @@ struct CreateView: View {
 
             HStack {
                 Menu {
-                    Button("Fleet default") { model = "" }
-                    ForEach(installedModels, id: \.self) { id in
-                        Button(id) { model = id }
+                    Section("Your fleet") {
+                        Button("Fleet default") {
+                            model = ""
+                            localModelID = nil
+                        }
+                        ForEach(installedModels, id: \.self) { id in
+                            Button(fleetDisplayName(for: id)) {
+                                model = id
+                                localModelID = nil
+                            }
+                        }
+                    }
+                    if selected.kind == "image.generate", LocalEngine.showsOnDeviceUI {
+                        Section("This iPhone") {
+                            ForEach(LocalEngine.imageModels) { candidate in
+                                if local.state(of: candidate.id) == .ready {
+                                    Button(candidate.title) {
+                                        localModelID = candidate.id
+                                        local.selectedImageModelID = candidate.id
+                                        model = ""
+                                    }
+                                }
+                            }
+                            Button("Get on-device models…") {
+                                showOnDeviceModels = true
+                            }
+                        }
                     }
                 } label: {
                     HStack(spacing: 5) {
-                        Image(systemName: "cpu")
-                        Text(model.isEmpty ? "Fleet default" : model)
+                        Image(systemName: runsOnThisPhone ? "iphone" : "cpu")
+                        Text(modelChipTitle)
                             .lineLimit(1)
                     }
                     .font(.footnote)
                     .foregroundStyle(MereTheme.textSecondary)
                 }
+                .accessibilityIdentifier("create.model")
                 Spacer()
                 Button {
                     showOptions = true
@@ -420,91 +447,54 @@ struct CreateView: View {
     }
 
 
-    private var destinationToggle: some View {
-        Picker("Runs on", selection: $runLocally) {
-            Text("Your fleet").tag(false)
-            Text("This iPhone").tag(true)
-        }
-        .pickerStyle(.segmented)
-    }
-
+    /// On-device results render right here: the phone is the runner, so the
+    /// image lands where the prompt was written, with save and share to hand.
     @ViewBuilder
-    private var localLane: some View {
-        VStack(alignment: .leading, spacing: MereTheme.Spacing.m) {
-            ForEach(LocalEngine.imageModels) { candidate in
-                localModelRow(candidate)
+    private var localResult: some View {
+        if let message = local.lastError {
+            MereBannerView(text: message, color: MereTheme.failure)
+        }
+        if local.activity == .generatingImage {
+            HStack(spacing: MereTheme.Spacing.s) {
+                ProgressView()
+                Text("Creating on this iPhone…")
+                    .font(.footnote)
+                    .foregroundStyle(MereTheme.textSecondary)
             }
-
-            if let message = local.lastError {
-                MereBannerView(text: message, color: MereTheme.failure)
-            }
-
-            if let image = local.lastImage {
+            .frame(maxWidth: .infinity, alignment: .center)
+        }
+        if let image = local.lastImage {
+            VStack(alignment: .trailing, spacing: MereTheme.Spacing.s) {
                 Image(uiImage: image)
                     .resizable()
                     .scaledToFit()
                     .clipShape(RoundedRectangle(cornerRadius: MereTheme.Radius.panel))
-            }
-            if local.activity == .generatingImage {
-                HStack(spacing: MereTheme.Spacing.s) {
-                    ProgressView()
-                    Text("Generating on this iPhone…")
-                        .font(.footnote)
-                        .foregroundStyle(MereTheme.textSecondary)
+                if let url = local.lastImageURL {
+                    ShareLink(item: url) {
+                        Label("Save or share", systemImage: "square.and.arrow.up")
+                            .font(.footnote)
+                    }
                 }
             }
         }
     }
 
-    @ViewBuilder
-    private func localModelRow(_ candidate: LocalEngine.Model) -> some View {
-        let state = local.state(of: candidate.id)
-        HStack(spacing: MereTheme.Spacing.m) {
-            Image(systemName: local.selectedImageModelID == candidate.id
-                ? "largecircle.fill.circle"
-                : "circle")
-                .foregroundStyle(local.selectedImageModelID == candidate.id
-                    ? MereTheme.accent
-                    : MereTheme.textMuted)
-            VStack(alignment: .leading, spacing: 2) {
-                Text(candidate.title)
-                    .font(.subheadline.weight(.medium))
-                    .foregroundStyle(MereTheme.textPrimary)
-                Text(candidate.detail)
-                    .font(.caption)
-                    .foregroundStyle(MereTheme.textMuted)
-            }
-            Spacer()
-            switch state {
-            case .notInstalled:
-                Button("Get \(candidate.sizeLabel)") {
-                    Task { await local.download(candidate.id) }
-                }
-                .font(.caption.weight(.semibold))
-                .buttonStyle(.bordered)
-            case .downloading(let label):
-                HStack(spacing: MereTheme.Spacing.xs) {
-                    ProgressView().controlSize(.small)
-                    Text(label)
-                        .font(.caption2)
-                        .foregroundStyle(MereTheme.textSecondary)
-                }
-            case .ready:
-                Image(systemName: "checkmark.circle.fill")
-                    .foregroundStyle(MereTheme.success)
-            }
+    private var modelChipTitle: String {
+        if runsOnThisPhone, let id = localModelID, let candidate = LocalEngine.model(withID: id) {
+            return "\(candidate.title) — this iPhone"
         }
-        .contentShape(Rectangle())
-        .onTapGesture {
-            if state == .ready {
-                local.selectedImageModelID = candidate.id
-            }
-        }
+        return model.isEmpty ? "Fleet default" : fleetDisplayName(for: model)
+    }
+
+    /// The menu already says which kind of model this is; show just the
+    /// model's own name, not its catalog prefix.
+    private func fleetDisplayName(for id: String) -> String {
+        id.hasPrefix(selected.modelPrefix) ? String(id.dropFirst(selected.modelPrefix.count)) : id
     }
 
     private var runButton: some View {
         Button {
-            if runLocally, selected.kind == "image.generate" {
+            if runsOnThisPhone {
                 Task { await local.generateImage(prompt: prompt) }
             } else {
                 Task { await submit() }
@@ -514,7 +504,7 @@ struct CreateView: View {
                 if submitting || local.activity == .generatingImage {
                     ProgressView().tint(.white)
                 } else {
-                    Text(runLocally && selected.kind == "image.generate" ? "Run on this iPhone" : "Run on your fleet")
+                    Text("Create")
                         .font(.body.weight(.semibold))
                 }
             }
@@ -522,7 +512,7 @@ struct CreateView: View {
             .padding(.vertical, 6)
         }
         .buttonStyle(.borderedProminent)
-        .disabled(runLocally && selected.kind == "image.generate"
+        .disabled(runsOnThisPhone
             ? (prompt.isEmpty
                 || local.state(of: local.selectedImageModelID) != .ready
                 || local.activity != .idle)
@@ -590,6 +580,7 @@ struct CreateView: View {
     private func select(_ mode: Mode) {
         selected = mode
         model = ""
+        localModelID = nil
         textFields = [:]
         numberFields = [:]
         enumFields = [:]

--- a/ios/MereRunStudio/Views/OnDeviceModelsView.swift
+++ b/ios/MereRunStudio/Views/OnDeviceModelsView.swift
@@ -1,0 +1,102 @@
+import SwiftUI
+
+/// The one place on-device models live: what runs on this iPhone, what each
+/// model does, and their download state. Reached from Create's and Chat's
+/// model menus and from Settings; pickers elsewhere only ever *select* from
+/// what is installed here.
+struct OnDeviceModelsView: View {
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            OnDeviceModelsList()
+                .toolbar {
+                    ToolbarItem(placement: .confirmationAction) {
+                        Button("Done") { dismiss() }
+                    }
+                }
+        }
+    }
+}
+
+/// The list itself, pushable from Settings or wrapped in a sheet.
+struct OnDeviceModelsList: View {
+    @ObservedObject private var local = LocalEngine.shared
+
+    var body: some View {
+        List {
+                Section {
+                    ForEach(LocalEngine.imageModels) { model in
+                        row(model)
+                    }
+                } header: {
+                    Text("Images")
+                } footer: {
+                    Text("Pick which one creates your images from the model menu in Create.")
+                }
+
+                Section {
+                    row(LocalEngine.chatModel)
+                } header: {
+                    Text("Chat")
+                } footer: {
+                    Text("Choose it from the model menu in Chat to talk entirely on-device.")
+                }
+
+                if let message = local.lastError {
+                    Section {
+                        Text(message)
+                            .font(.footnote)
+                            .foregroundStyle(MereTheme.failure)
+                    }
+                }
+            }
+        .scrollContentBackground(.hidden)
+        .background(MereTheme.background.ignoresSafeArea())
+        .navigationTitle("On this iPhone")
+        .navigationBarTitleDisplayMode(.inline)
+        .onAppear { local.refresh() }
+    }
+
+    @ViewBuilder
+    private func row(_ model: LocalEngine.Model) -> some View {
+        HStack(spacing: MereTheme.Spacing.m) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(model.title)
+                    .font(.subheadline.weight(.medium))
+                    .foregroundStyle(MereTheme.textPrimary)
+                Text(model.detail)
+                    .font(.caption)
+                    .foregroundStyle(MereTheme.textMuted)
+            }
+            Spacer()
+            switch local.state(of: model.id) {
+            case .notInstalled:
+                Button {
+                    Task { await local.download(model.id) }
+                } label: {
+                    Text("Get")
+                        .font(.subheadline.weight(.semibold))
+                }
+                .buttonStyle(.bordered)
+                .overlay(alignment: .bottom) {
+                    Text(model.sizeLabel)
+                        .font(.system(size: 9))
+                        .foregroundStyle(MereTheme.textMuted)
+                        .offset(y: 12)
+                }
+            case .downloading(let progress):
+                VStack(alignment: .trailing, spacing: 2) {
+                    ProgressView().controlSize(.small)
+                    Text(progress)
+                        .font(.caption2.monospacedDigit())
+                        .foregroundStyle(MereTheme.textSecondary)
+                }
+            case .ready:
+                Image(systemName: "checkmark.circle.fill")
+                    .foregroundStyle(MereTheme.success)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+}

--- a/ios/MereRunStudioUITests/DownloadDiagnosticsUITests.swift
+++ b/ios/MereRunStudioUITests/DownloadDiagnosticsUITests.swift
@@ -20,12 +20,10 @@ final class DownloadDiagnosticsUITests: XCTestCase {
         XCTAssertTrue(createTab.waitForExistence(timeout: 20), "App must be paired before this diagnostic.")
         createTab.tap()
 
-        let phoneSegment = app.buttons["This iPhone"]
-        if phoneSegment.waitForExistence(timeout: 5) {
-            phoneSegment.tap()
-        } else {
-            app.segmentedControls.buttons.element(boundBy: 1).tap()
-        }
+        app.buttons["create.model"].tap()
+        let manage = app.buttons["Get on-device models…"]
+        XCTAssertTrue(manage.waitForExistence(timeout: 5), "The model menu must offer the on-device sheet.")
+        manage.tap()
         snapshot(app, "lane")
 
         // Tap the first available "Get …" button (Klein nano is smallest).
@@ -42,7 +40,7 @@ final class DownloadDiagnosticsUITests: XCTestCase {
         while Date() < deadline {
             RunLoop.current.run(until: Date().addingTimeInterval(10))
             tick += 1
-            let labels = app.scrollViews.staticTexts.allElementsBoundByIndex
+            let labels = app.staticTexts.allElementsBoundByIndex
                 .map { $0.label }
                 .filter { $0.contains("%") || $0.contains("MB") || $0.contains("…")
                     || $0.localizedCaseInsensitiveContains("error")

--- a/ios/MereRunStudioUITests/UXShotsUITests.swift
+++ b/ios/MereRunStudioUITests/UXShotsUITests.swift
@@ -1,0 +1,46 @@
+import XCTest
+
+/// Screenshot harness for design iteration: launches the app in UI-preview
+/// mode and captures the on-device model surfaces. Gated on
+/// MERERUN_TEST_UX_SHOTS so ordinary test runs skip it.
+final class UXShotsUITests: XCTestCase {
+    func testCaptureOnDeviceSurfaces() throws {
+        guard ProcessInfo.processInfo.environment["MERERUN_TEST_UX_SHOTS"] != nil else {
+            throw XCTSkip("Set MERERUN_TEST_UX_SHOTS to capture UX screenshots.")
+        }
+        let app = XCUIApplication()
+        app.launchArguments = ["MERERUN_UI_PREVIEW"]
+        app.launch()
+
+        XCTAssertTrue(app.tabBars.buttons["Create"].waitForExistence(timeout: 15))
+        app.tabBars.buttons["Create"].tap()
+        shot(app, "create")
+
+        app.buttons["create.model"].tap()
+        sleep(1)
+        shot(app, "create-model-menu")
+
+        if app.buttons["Get on-device models…"].waitForExistence(timeout: 3) {
+            app.buttons["Get on-device models…"].tap()
+            sleep(1)
+            shot(app, "ondevice-sheet")
+            app.buttons["Done"].tap()
+        }
+
+        app.tabBars.buttons["Chat"].tap()
+        sleep(1)
+        let chip = app.buttons.matching(NSPredicate(format: "label CONTAINS 'Fleet default'")).firstMatch
+        if chip.waitForExistence(timeout: 3) {
+            chip.tap()
+            sleep(1)
+            shot(app, "chat-model-menu")
+        }
+    }
+
+    private func shot(_ app: XCUIApplication, _ name: String) {
+        let attachment = XCTAttachment(screenshot: app.screenshot())
+        attachment.name = name
+        attachment.lifetime = .keepAlways
+        add(attachment)
+    }
+}


### PR DESCRIPTION
Direct response to on-device UX feedback: the fleet/iPhone toggle fought the "Fleet default" chip, three near-identically-named models sat unexplained in Create (two of which people read as chat models), and the run button kept changing its label.

## The new shape

- **No toggle.** The phone is a section in the model menu: "Your fleet" (default + fleet models, shown without their catalog prefixes) and "This iPhone" (installed on-device models by name). Picking an on-device model runs locally; one prompt box, one **Create** button either way. On-device results land inline with a Save-or-share link.
- **One home for on-device models**: an "On this iPhone" sheet reachable from Create's menu, Chat's menu, and Settings — grouped **Images** / **Chat**, each with a plain-language line ("Makes images. The fastest one." / "A 27-billion-parameter assistant. Your words never leave the phone."), size, and live install state.
- **Names stop colliding**: Klein Nano, Bonsai Binary, Bonsai Ternary (images) vs Bonsai Chat.
- **Simulator preview mode** (`MERERUN_UI_PREVIEW`) renders the on-device surfaces with mocked install states so this design was — and can keep being — iterated entirely in the simulator, plus a screenshot-capture UI test.

Simulator + device builds green, lint clean, installed on hardware. Screenshots in the session.