### PR TITLE
Keep on-device chat inside the phone's memory, and let models be removed

### DIFF
--- a/Sources/MereRunCore/ManagedModelResolver.swift
+++ b/Sources/MereRunCore/ManagedModelResolver.swift
@@ -587,8 +587,79 @@ public enum ManagedModelResolver {
             if fileManager.fileExists(atPath: linkURL.path) {
                 try fileManager.removeItem(at: linkURL)
             }
-            try fileManager.createSymbolicLink(at: linkURL, withDestinationURL: entry)
+            try createRelocatableSymlink(at: linkURL, to: entry, fileManager: fileManager)
         }
+    }
+
+    /// Managed installs must survive the app container moving (iOS relocates
+    /// it on every update), so links into the store are created relative.
+    static func createRelocatableSymlink(
+        at linkURL: URL,
+        to target: URL,
+        fileManager: FileManager
+    ) throws {
+        // Resolve real paths on both sides (macOS aliases /var into
+        // /private/var) so the shared prefix is found and the link comes out
+        // relative rather than falling back to absolute.
+        let linkComponents = linkURL.deletingLastPathComponent()
+            .resolvingSymlinksInPath().standardizedFileURL.pathComponents
+        let targetComponents = target
+            .resolvingSymlinksInPath().standardizedFileURL.pathComponents
+        var shared = 0
+        while shared < min(linkComponents.count, targetComponents.count),
+              linkComponents[shared] == targetComponents[shared] {
+            shared += 1
+        }
+        guard shared > 1 else {
+            try fileManager.createSymbolicLink(at: linkURL, withDestinationURL: target)
+            return
+        }
+        let ups = Array(repeating: "..", count: linkComponents.count - shared)
+        let destination = (ups + targetComponents[shared...]).joined(separator: "/")
+        try fileManager.createSymbolicLink(atPath: linkURL.path, withDestinationPath: destination)
+    }
+
+    /// Re-points symlinks under the model store that still carry an absolute
+    /// path from a previous app container. The payloads live at the same
+    /// suffix under the current Application Support base; dangling links are
+    /// recreated relative so they never break again.
+    @discardableResult
+    public static func repairRelocatedInstalls(
+        modelsRoot: URL = MereRunModelPaths.modelsDir,
+        applicationSupportBase: URL = MereRunModelPaths.applicationSupportBase,
+        fileManager: FileManager = .default
+    ) -> Int {
+        guard let enumerator = fileManager.enumerator(
+            at: modelsRoot,
+            includingPropertiesForKeys: [.isSymbolicLinkKey],
+            options: []
+        ) else { return 0 }
+        let marker = "/Application Support/"
+        let basePath = applicationSupportBase.standardizedFileURL.path
+        guard let baseMarkerRange = basePath.range(of: marker, options: .backwards) else { return 0 }
+        let currentRoot = String(basePath[..<baseMarkerRange.upperBound])
+        var repaired = 0
+        for case let url as URL in enumerator {
+            guard let values = try? url.resourceValues(forKeys: [.isSymbolicLinkKey]),
+                  values.isSymbolicLink == true,
+                  let destination = try? fileManager.destinationOfSymbolicLink(atPath: url.path),
+                  destination.hasPrefix("/"),
+                  !fileManager.fileExists(atPath: url.resolvingSymlinksInPath().path),
+                  let oldMarkerRange = destination.range(of: marker, options: .backwards) else {
+                continue
+            }
+            let suffix = String(destination[oldMarkerRange.upperBound...])
+            let candidate = currentRoot + suffix
+            guard fileManager.fileExists(atPath: candidate) else { continue }
+            try? fileManager.removeItem(at: url)
+            try? createRelocatableSymlink(
+                at: url,
+                to: URL(fileURLWithPath: candidate),
+                fileManager: fileManager
+            )
+            repaired += 1
+        }
+        return repaired
     }
 
     private static func mountedPatterns(
@@ -687,7 +758,7 @@ public enum ManagedModelResolver {
                 try? fileManager.removeItem(at: aliasURL)
             }
             try fileManager.createDirectory(at: aliasURL.deletingLastPathComponent(), withIntermediateDirectories: true)
-            try fileManager.createSymbolicLink(at: aliasURL, withDestinationURL: targetURL)
+            try createRelocatableSymlink(at: aliasURL, to: targetURL, fileManager: fileManager)
         }
     }
 

--- a/Tests/MereRunCLITests/RelocatedInstallRepairTests.swift
+++ b/Tests/MereRunCLITests/RelocatedInstallRepairTests.swift
@@ -1,0 +1,101 @@
+import Foundation
+import XCTest
+
+@testable import MereRunCore
+
+/// iOS relocates the app data container on every update; absolute symlinks
+/// written by a previous install must be re-pointed at the same suffix under
+/// the new container, and recreated relative so they never dangle again.
+final class RelocatedInstallRepairTests: XCTestCase {
+    private var root: URL!
+
+    override func setUpWithError() throws {
+        root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("relocation-tests-\(UUID().uuidString)", isDirectory: true)
+    }
+
+    override func tearDownWithError() throws {
+        try? FileManager.default.removeItem(at: root)
+    }
+
+    func testDanglingAbsoluteLinksAreRebasedAndMadeRelative() throws {
+        let fm = FileManager.default
+        let oldBase = root.appendingPathComponent("old/Application Support/MereRun", isDirectory: true)
+        let newBase = root.appendingPathComponent("new/Application Support/MereRun", isDirectory: true)
+        let payload = newBase.appendingPathComponent("hub/snapshots/abc/weights.safetensors")
+        let modelsRoot = newBase.appendingPathComponent("models", isDirectory: true)
+        let link = modelsRoot.appendingPathComponent("m1/weights.safetensors")
+        try fm.createDirectory(at: payload.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data("weights".utf8).write(to: payload)
+        try fm.createDirectory(at: link.deletingLastPathComponent(), withIntermediateDirectories: true)
+        // The link a previous container wrote: absolute, into the old base.
+        try fm.createSymbolicLink(
+            at: link,
+            withDestinationURL: oldBase.appendingPathComponent("hub/snapshots/abc/weights.safetensors")
+        )
+        XCTAssertFalse(fm.fileExists(atPath: link.resolvingSymlinksInPath().path), "Precondition: dangling")
+
+        let repaired = ManagedModelResolver.repairRelocatedInstalls(
+            modelsRoot: modelsRoot,
+            applicationSupportBase: newBase
+        )
+
+        XCTAssertEqual(repaired, 1)
+        XCTAssertTrue(fm.fileExists(atPath: link.resolvingSymlinksInPath().path), "Link must resolve after repair")
+        let destination = try fm.destinationOfSymbolicLink(atPath: link.path)
+        XCTAssertFalse(destination.hasPrefix("/"), "Repaired link must be relative, got \(destination)")
+        XCTAssertEqual(
+            try Data(contentsOf: link),
+            Data("weights".utf8)
+        )
+    }
+
+    func testHealthyAndUnrepairableLinksAreLeftAlone() throws {
+        let fm = FileManager.default
+        let base = root.appendingPathComponent("only/Application Support/MereRun", isDirectory: true)
+        let modelsRoot = base.appendingPathComponent("models", isDirectory: true)
+        let payload = base.appendingPathComponent("hub/blob")
+        try fm.createDirectory(at: payload.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data("ok".utf8).write(to: payload)
+        let healthy = modelsRoot.appendingPathComponent("m1/good")
+        try fm.createDirectory(at: healthy.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try fm.createSymbolicLink(at: healthy, withDestinationURL: payload)
+        // Dangling link whose suffix does not exist under the current base.
+        let hopeless = modelsRoot.appendingPathComponent("m1/gone")
+        try fm.createSymbolicLink(
+            at: hopeless,
+            withDestinationURL: root.appendingPathComponent("elsewhere/Application Support/MereRun/hub/missing")
+        )
+
+        let repaired = ManagedModelResolver.repairRelocatedInstalls(
+            modelsRoot: modelsRoot,
+            applicationSupportBase: base
+        )
+
+        XCTAssertEqual(repaired, 0)
+        XCTAssertEqual(try Data(contentsOf: healthy), Data("ok".utf8))
+        XCTAssertFalse(fm.fileExists(atPath: hopeless.resolvingSymlinksInPath().path))
+    }
+
+    func testRelocatableSymlinkIsRelativeAndResolves() throws {
+        let fm = FileManager.default
+        let base = root.appendingPathComponent("store", isDirectory: true)
+        let target = base.appendingPathComponent("hub/deep/dir/file.bin")
+        let link = base.appendingPathComponent("models/m1/file.bin")
+        try fm.createDirectory(at: target.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Data("x".utf8).write(to: target)
+        try fm.createDirectory(at: link.deletingLastPathComponent(), withIntermediateDirectories: true)
+
+        try ManagedModelResolver.createRelocatableSymlink(at: link, to: target, fileManager: fm)
+
+        let destination = try fm.destinationOfSymbolicLink(atPath: link.path)
+        XCTAssertFalse(destination.hasPrefix("/"))
+        XCTAssertEqual(try Data(contentsOf: link), Data("x".utf8))
+
+        // The property that matters: the pair survives the store moving.
+        let moved = root.appendingPathComponent("moved", isDirectory: true)
+        try fm.moveItem(at: base, to: moved)
+        let movedLink = moved.appendingPathComponent("models/m1/file.bin")
+        XCTAssertEqual(try Data(contentsOf: movedLink), Data("x".utf8))
+    }
+}

--- a/Tests/MereRunCoreTests/ManagedModelResolverTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelResolverTests.swift
@@ -143,13 +143,11 @@ final class ManagedModelResolverTests: XCTestCase {
         let defaultTokenizer = defaultInstall.appendingPathComponent("tokenizer.json")
         let maxTokenizer = maxInstall.appendingPathComponent("tokenizer.json")
         XCTAssertEqual(
-            URL(fileURLWithPath: try FileManager.default.destinationOfSymbolicLink(atPath: defaultTokenizer.path))
-                .standardizedFileURL.path,
+            defaultTokenizer.resolvingSymlinksInPath().standardizedFileURL.path,
             snapshot.appendingPathComponent("tokenizer.json").standardizedFileURL.path
         )
         XCTAssertEqual(
-            URL(fileURLWithPath: try FileManager.default.destinationOfSymbolicLink(atPath: maxTokenizer.path))
-                .standardizedFileURL.path,
+            maxTokenizer.resolvingSymlinksInPath().standardizedFileURL.path,
             snapshot.appendingPathComponent("tokenizer.json").standardizedFileURL.path
         )
     }
@@ -202,8 +200,7 @@ final class ManagedModelResolverTests: XCTestCase {
         XCTAssertEqual(manifest?.id, ModelResolver.ModelID.aceStepXLTurbo.rawValue)
         let mountedConfig = install.appendingPathComponent("acestep-v15-xl-turbo/config.json")
         XCTAssertEqual(
-            URL(fileURLWithPath: try FileManager.default.destinationOfSymbolicLink(atPath: mountedConfig.path))
-                .standardizedFileURL.path,
+            mountedConfig.resolvingSymlinksInPath().standardizedFileURL.path,
             mountedSnapshot.appendingPathComponent("config.json").standardizedFileURL.path
         )
         XCTAssertTrue(spec.isManagedRootComplete(install, fileManager: .default))
@@ -243,8 +240,7 @@ final class ManagedModelResolverTests: XCTestCase {
         XCTAssertEqual(manifest?.usageTermsAcknowledged, true)
         let mountedTextConfig = install.appendingPathComponent("text_encoder/config.json")
         XCTAssertEqual(
-            URL(fileURLWithPath: try FileManager.default.destinationOfSymbolicLink(atPath: mountedTextConfig.path))
-                .standardizedFileURL.path,
+            mountedTextConfig.resolvingSymlinksInPath().standardizedFileURL.path,
             sharedSnapshot.appendingPathComponent("text_encoder/config.json").standardizedFileURL.path
         )
         XCTAssertFalse(FileManager.default.fileExists(

--- a/ios/MereRunStudio/App/LocalEngine.swift
+++ b/ios/MereRunStudio/App/LocalEngine.swift
@@ -216,6 +216,33 @@ final class LocalEngine: ObservableObject {
         q35Generators[modelID] = nil
         lfm2Generators[modelID] = nil
         refresh()
+        refreshReclaimable()
+    }
+
+    /// Bytes a full garbage-collection pass would free: orphaned payloads
+    /// (deleted or partially downloaded models) plus incomplete downloads.
+    @Published private(set) var reclaimableBytes: Int64 = 0
+
+    func refreshReclaimable() {
+        guard Self.isSupported else { return }
+        let plan = try? ModelStorageManager().garbageCollectionPlan()
+        reclaimableBytes = (plan?.reclaimableBytes ?? 0) + (plan?.incompleteDownloadBytes ?? 0)
+    }
+
+    /// Frees everything no installed model references — the way partial
+    /// downloads and crash leftovers come back.
+    func reclaimSpace() {
+        guard Self.isSupported, activity == .idle else { return }
+        lastError = nil
+        do {
+            let storage = try ModelStorageManager()
+            let plan = try storage.garbageCollectionPlan()
+            _ = try storage.execute(plan)
+        } catch {
+            lastError = error.localizedDescription
+        }
+        refresh()
+        refreshReclaimable()
     }
 
     func generateImage(prompt: String, width: Int = 512, height: Int = 512, steps: Int = 4) async {

--- a/ios/MereRunStudio/App/LocalEngine.swift
+++ b/ios/MereRunStudio/App/LocalEngine.swift
@@ -144,6 +144,9 @@ final class LocalEngine: ObservableObject {
             return
         }
         guard Self.isSupported else { return }
+        // The app container moves on every update, dangling any absolute
+        // symlinks a previous install wrote; heal them before scanning.
+        ManagedModelResolver.repairRelocatedInstalls()
         for model in Self.allModels {
             if case .downloading = states[model.id] { continue }
             states[model.id] = ManagedModelResolver.resolveInstalledModel(id: model.id) != nil

--- a/ios/MereRunStudio/App/LocalEngine.swift
+++ b/ios/MereRunStudio/App/LocalEngine.swift
@@ -39,6 +39,15 @@ final class LocalEngine: ObservableObject {
         let kind: Kind
         let title: String
         let detail: String
+        /// Minimum device memory this model can realistically wire; nil = any.
+        var minimumMemoryGB: Int?
+        /// Shown before download when the upstream license carries terms.
+        var licenseNote: String?
+
+        var isCompatible: Bool {
+            guard let minimumMemoryGB else { return true }
+            return ProcessInfo.processInfo.physicalMemory >= UInt64(minimumMemoryGB) * 1_000_000_000
+        }
 
         var sizeLabel: String {
             guard let bytes = ManagedModelCatalog.spec(for: id)?.estimatedDownloadBytes else {
@@ -69,15 +78,27 @@ final class LocalEngine: ObservableObject {
         ),
     ]
 
-    static let chatModel = Model(
-        id: "text-chat-bonsai-27b-1bit",
-        kind: .chat,
-        title: "Bonsai Chat",
-        detail: "A 27-billion-parameter assistant. Your words never leave the phone."
-    )
+    static let chatModels: [Model] = [
+        Model(
+            id: "text-chat-lfm25-2.6b-4bit",
+            kind: .chat,
+            title: "Liquid Chat",
+            detail: "A quick assistant sized for a phone. Your words never leave it.",
+            licenseNote: "LFM Open License: free for personal use and for companies under USD 10M revenue."
+        ),
+        Model(
+            id: "text-chat-bonsai-27b-1bit",
+            kind: .chat,
+            title: "Bonsai Chat",
+            detail: "A 27-billion-parameter assistant for devices with 12 GB of memory or more.",
+            minimumMemoryGB: 12
+        ),
+    ]
+
+    static var allModels: [Model] { imageModels + chatModels }
 
     static func model(withID id: String) -> Model? {
-        (imageModels + [chatModel]).first { $0.id == id }
+        allModels.first { $0.id == id }
     }
 
     enum ModelState: Equatable {
@@ -97,10 +118,12 @@ final class LocalEngine: ObservableObject {
     @Published private(set) var lastImage: UIImage?
     @Published private(set) var lastImageURL: URL?
     @Published var selectedImageModelID = LocalEngine.imageModels[0].id
+    @Published var selectedChatModelID = LocalEngine.chatModels[0].id
     @Published private(set) var lastError: String?
 
     private lazy var imageGenerator = Flux2KleinGeneratoriOS()
-    private var chatGenerator: Q35Generator?
+    private var q35Generators: [String: Q35Generator] = [:]
+    private var lfm2Generators: [String: LFM2Generator] = [:]
 
     init() {
         refresh()
@@ -114,13 +137,14 @@ final class LocalEngine: ObservableObject {
                     Self.imageModels[0].id: .ready,
                     Self.imageModels[1].id: .downloading("1204 of 3269 MB"),
                     Self.imageModels[2].id: .notInstalled,
-                    Self.chatModel.id: .notInstalled,
+                    Self.chatModels[0].id: .notInstalled,
+                    Self.chatModels[1].id: .notInstalled,
                 ]
             }
             return
         }
         guard Self.isSupported else { return }
-        for model in Self.imageModels + [Self.chatModel] {
+        for model in Self.allModels {
             if case .downloading = states[model.id] { continue }
             states[model.id] = ManagedModelResolver.resolveInstalledModel(id: model.id) != nil
                 ? .ready
@@ -136,7 +160,7 @@ final class LocalEngine: ObservableObject {
         states[modelID] ?? .notInstalled
     }
 
-    func download(_ modelID: String) async {
+    func download(_ modelID: String, acceptedTerms: Bool = false) async {
         states[modelID] = .downloading("Starting…")
         lastError = nil
         // A locked screen suspends the app and kills the transfer; keep the
@@ -146,6 +170,7 @@ final class LocalEngine: ObservableObject {
         do {
             _ = try await ManagedModelResolver.installManagedModel(
                 id: modelID,
+                usageTermsAcknowledged: acceptedTerms,
                 progress: { progress in
                     let label: String
                     switch progress {
@@ -170,6 +195,27 @@ final class LocalEngine: ObservableObject {
             states[modelID] = .notInstalled
             lastError = error.localizedDescription
         }
+    }
+
+    /// Removes an installed model and reclaims its unshared hub-cache
+    /// payloads, mirroring `mere.run model remove`. Blobs shared with another
+    /// installed model are preserved.
+    func delete(_ modelID: String) {
+        guard Self.isSupported, activity == .idle,
+              let installURL = ManagedModelResolver.resolveInstalledModel(id: modelID) else { return }
+        lastError = nil
+        do {
+            let storage = try ModelStorageManager()
+            let cacheUnits = try storage.cacheUnitsReferenced(by: modelID)
+            try FileManager.default.removeItem(at: installURL)
+            let plan = try storage.garbageCollectionPlan(limitingTo: cacheUnits)
+            _ = try storage.execute(plan)
+        } catch {
+            lastError = error.localizedDescription
+        }
+        q35Generators[modelID] = nil
+        lfm2Generators[modelID] = nil
+        refresh()
     }
 
     func generateImage(prompt: String, width: Int = 512, height: Int = 512, steps: Int = 4) async {
@@ -207,7 +253,9 @@ final class LocalEngine: ObservableObject {
         guard Self.isSupported else {
             throw RelayAppError("On-device chat needs a physical iPhone.")
         }
-        let model = Self.chatModel
+        guard let model = Self.model(withID: selectedChatModelID) else {
+            throw RelayAppError("Pick an on-device chat model first.")
+        }
         guard let root = ManagedModelResolver.resolveInstalledModel(id: model.id) else {
             throw RelayAppError("Download \(model.title) before chatting on-device.")
         }
@@ -217,32 +265,38 @@ final class LocalEngine: ObservableObject {
         activity = .chatting
         defer { activity = .idle }
 
-        let generator = chatGenerator ?? Q35Generator(modelId: model.id)
-        chatGenerator = generator
-
         let sampling = Q35Resources.recommendedSampling(forModelId: model.id)
         let request = ChatRequest(
             messages: messages,
             maxTokens: 1024,
             temperature: sampling?.temperature ?? 0.7,
             topP: sampling?.topP ?? 0.9,
-            showThinking: false
+            showThinking: false,
+            // The model's native context is 262k; a phone-sized KV budget
+            // keeps the 27B's working set inside the app memory ceiling.
+            maxContextTokens: 4096
         )
 
         let accumulated = StreamedText()
-        let response = try await generator.chat(
-            request,
-            modelPath: root.path,
-            progressHandler: { progress in
-                guard progress.stage == .generating,
-                      let piece = progress.message, !piece.isEmpty else { return }
-                Task { @MainActor in
-                    let text = accumulated.append(piece)
-                    let visible = GeneratedTextFilters.strippingThinking(text, streaming: true)
-                    if !visible.isEmpty { onDelta(visible) }
-                }
+        let progressHandler: @Sendable (ChatProgress) -> Void = { progress in
+            guard progress.stage == .generating,
+                  let piece = progress.message, !piece.isEmpty else { return }
+            Task { @MainActor in
+                let text = accumulated.append(piece)
+                let visible = GeneratedTextFilters.strippingThinking(text, streaming: true)
+                if !visible.isEmpty { onDelta(visible) }
             }
-        )
+        }
+        let response: ChatResponse
+        if model.id.hasPrefix("text-chat-lfm") {
+            let generator = lfm2Generators[model.id] ?? LFM2Generator(modelId: model.id)
+            lfm2Generators[model.id] = generator
+            response = try await generator.chat(request, modelPath: root.path, progressHandler: progressHandler)
+        } else {
+            let generator = q35Generators[model.id] ?? Q35Generator(modelId: model.id)
+            q35Generators[model.id] = generator
+            response = try await generator.chat(request, modelPath: root.path, progressHandler: progressHandler)
+        }
         let cleaned = GeneratedTextFilters.strippingThinking(response.response)
         guard !cleaned.isEmpty else {
             throw RelayAppError("The model returned an empty reply.")

--- a/ios/MereRunStudio/Views/ChatView.swift
+++ b/ios/MereRunStudio/Views/ChatView.swift
@@ -26,7 +26,7 @@ struct ChatView: View {
     }
 
     private var localChatReady: Bool {
-        local.state(of: LocalEngine.chatModel.id) == .ready
+        local.state(of: local.selectedChatModelID) == .ready
     }
 
     private var canSend: Bool {
@@ -211,14 +211,16 @@ struct ChatView: View {
                     }
                     if LocalEngine.showsOnDeviceUI {
                         Section("This iPhone") {
-                            if localChatReady {
-                                Button(LocalEngine.chatModel.title) {
-                                    chat.runLocally = true
+                            ForEach(LocalEngine.chatModels.filter(\.isCompatible)) { candidate in
+                                if local.state(of: candidate.id) == .ready {
+                                    Button(candidate.title) {
+                                        local.selectedChatModelID = candidate.id
+                                        chat.runLocally = true
+                                    }
                                 }
-                            } else {
-                                Button("Get \(LocalEngine.chatModel.title) (\(LocalEngine.chatModel.sizeLabel))…") {
-                                    showOnDeviceModels = true
-                                }
+                            }
+                            Button("Get on-device models…") {
+                                showOnDeviceModels = true
                             }
                         }
                     }
@@ -226,7 +228,7 @@ struct ChatView: View {
                     HStack(spacing: 5) {
                         Image(systemName: chat.runLocally ? "iphone" : "cpu")
                         Text(chat.runLocally
-                            ? "\(LocalEngine.chatModel.title) — this iPhone"
+                            ? "\(LocalEngine.model(withID: local.selectedChatModelID)?.title ?? "On-device") — this iPhone"
                             : (chat.model.isEmpty ? "Fleet default" : Self.displayName(for: chat.model)))
                             .lineLimit(1)
                     }

--- a/ios/MereRunStudio/Views/OnDeviceModelsView.swift
+++ b/ios/MereRunStudio/Views/OnDeviceModelsView.swift
@@ -22,6 +22,7 @@ struct OnDeviceModelsView: View {
 /// The list itself, pushable from Settings or wrapped in a sheet.
 struct OnDeviceModelsList: View {
     @ObservedObject private var local = LocalEngine.shared
+    @State private var confirmingModel: LocalEngine.Model?
 
     var body: some View {
         List {
@@ -32,15 +33,17 @@ struct OnDeviceModelsList: View {
                 } header: {
                     Text("Images")
                 } footer: {
-                    Text("Pick which one creates your images from the model menu in Create.")
+                    Text("Pick which one creates your images from the model menu in Create. Swipe a downloaded model to remove it.")
                 }
 
                 Section {
-                    row(LocalEngine.chatModel)
+                    ForEach(LocalEngine.chatModels) { model in
+                        row(model)
+                    }
                 } header: {
                     Text("Chat")
                 } footer: {
-                    Text("Choose it from the model menu in Chat to talk entirely on-device.")
+                    Text("Choose one from the model menu in Chat to talk entirely on-device.")
                 }
 
                 if let message = local.lastError {
@@ -56,6 +59,22 @@ struct OnDeviceModelsList: View {
         .navigationTitle("On this iPhone")
         .navigationBarTitleDisplayMode(.inline)
         .onAppear { local.refresh() }
+        .confirmationDialog(
+            confirmingModel?.licenseNote ?? "",
+            isPresented: Binding(
+                get: { confirmingModel != nil },
+                set: { if !$0 { confirmingModel = nil } }
+            ),
+            titleVisibility: .visible
+        ) {
+            Button("Accept and download") {
+                if let model = confirmingModel {
+                    Task { await LocalEngine.shared.download(model.id, acceptedTerms: true) }
+                }
+                confirmingModel = nil
+            }
+            Button("Cancel", role: .cancel) { confirmingModel = nil }
+        }
     }
 
     @ViewBuilder
@@ -70,10 +89,20 @@ struct OnDeviceModelsList: View {
                     .foregroundStyle(MereTheme.textMuted)
             }
             Spacer()
+            if !model.isCompatible {
+                Text("Needs \(model.minimumMemoryGB ?? 0) GB\nof memory")
+                    .font(.caption2)
+                    .multilineTextAlignment(.trailing)
+                    .foregroundStyle(MereTheme.textMuted)
+            } else {
             switch local.state(of: model.id) {
             case .notInstalled:
                 Button {
-                    Task { await local.download(model.id) }
+                    if model.licenseNote != nil {
+                        confirmingModel = model
+                    } else {
+                        Task { await local.download(model.id) }
+                    }
                 } label: {
                     Text("Get")
                         .font(.subheadline.weight(.semibold))
@@ -96,7 +125,17 @@ struct OnDeviceModelsList: View {
                 Image(systemName: "checkmark.circle.fill")
                     .foregroundStyle(MereTheme.success)
             }
+            }
         }
         .padding(.vertical, 4)
+        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+            if local.state(of: model.id) == .ready {
+                Button(role: .destructive) {
+                    local.delete(model.id)
+                } label: {
+                    Label("Remove", systemImage: "trash")
+                }
+            }
+        }
     }
 }

--- a/ios/MereRunStudio/Views/OnDeviceModelsView.swift
+++ b/ios/MereRunStudio/Views/OnDeviceModelsView.swift
@@ -46,6 +46,28 @@ struct OnDeviceModelsList: View {
                     Text("Choose one from the model menu in Chat to talk entirely on-device.")
                 }
 
+                if local.reclaimableBytes > 0 {
+                    Section {
+                        Button {
+                            local.reclaimSpace()
+                        } label: {
+                            HStack {
+                                Label("Reclaim unused space", systemImage: "trash")
+                                Spacer()
+                                Text(ByteCountFormatter.string(
+                                    fromByteCount: local.reclaimableBytes,
+                                    countStyle: .file
+                                ))
+                                .foregroundStyle(MereTheme.textMuted)
+                            }
+                        }
+                    } header: {
+                        Text("Storage")
+                    } footer: {
+                        Text("Frees partial downloads and payloads no installed model uses.")
+                    }
+                }
+
                 if let message = local.lastError {
                     Section {
                         Text(message)
@@ -58,7 +80,10 @@ struct OnDeviceModelsList: View {
         .background(MereTheme.background.ignoresSafeArea())
         .navigationTitle("On this iPhone")
         .navigationBarTitleDisplayMode(.inline)
-        .onAppear { local.refresh() }
+        .onAppear {
+            local.refresh()
+            local.refreshReclaimable()
+        }
         .confirmationDialog(
             confirmingModel?.licenseNote ?? "",
             isPresented: Binding(
@@ -90,10 +115,16 @@ struct OnDeviceModelsList: View {
             }
             Spacer()
             if !model.isCompatible {
-                Text("Needs \(model.minimumMemoryGB ?? 0) GB\nof memory")
-                    .font(.caption2)
-                    .multilineTextAlignment(.trailing)
-                    .foregroundStyle(MereTheme.textMuted)
+                HStack(spacing: MereTheme.Spacing.s) {
+                    Text("Needs \(model.minimumMemoryGB ?? 0) GB\nof memory")
+                        .font(.caption2)
+                        .multilineTextAlignment(.trailing)
+                        .foregroundStyle(MereTheme.textMuted)
+                    if local.state(of: model.id) == .ready {
+                        Image(systemName: "checkmark.circle")
+                            .foregroundStyle(MereTheme.textMuted)
+                    }
+                }
             } else {
             switch local.state(of: model.id) {
             case .notInstalled:

--- a/ios/MereRunStudioUITests/ChatDeviceDiagnosticsUITests.swift
+++ b/ios/MereRunStudioUITests/ChatDeviceDiagnosticsUITests.swift
@@ -1,0 +1,72 @@
+import XCTest
+
+/// Diagnostic: drive on-device Bonsai Chat on real hardware and record how
+/// far it gets — model load, first token, or process death. Gated on
+/// MERERUN_TEST_CHAT_DIAG.
+final class ChatDeviceDiagnosticsUITests: XCTestCase {
+    func testOnDeviceChatTurn() throws {
+        guard ProcessInfo.processInfo.environment["MERERUN_TEST_CHAT_DIAG"] != nil else {
+            throw XCTSkip("Set MERERUN_TEST_CHAT_DIAG to run the on-device chat diagnostic.")
+        }
+        let app = XCUIApplication()
+        app.launch()
+
+        let chatTab = app.tabBars.buttons["Chat"]
+        XCTAssertTrue(chatTab.waitForExistence(timeout: 20))
+        chatTab.tap()
+
+        // Select the on-device model from the chip menu.
+        let chip = app.buttons.matching(
+            NSPredicate(format: "label CONTAINS 'Fleet default' OR label CONTAINS 'this iPhone' OR label CONTAINS 'Bonsai Chat'")
+        ).firstMatch
+        XCTAssertTrue(chip.waitForExistence(timeout: 10), "The model chip must exist.")
+        chip.tap()
+        let localButton = app.buttons["Bonsai Chat"]
+        XCTAssertTrue(localButton.waitForExistence(timeout: 5), "Bonsai Chat must be selectable (installed).")
+        localButton.tap()
+
+        let composer = app.textViews["chat.composer"].exists
+            ? app.textViews["chat.composer"]
+            : app.textFields["chat.composer"]
+        XCTAssertTrue(composer.waitForExistence(timeout: 5))
+        composer.tap()
+        composer.typeText("Say hi in three words.")
+        app.buttons["Send"].tap()
+
+        var observations: [String] = []
+        let deadline = Date().addingTimeInterval(420)
+        var outcome = "timeout"
+        while Date() < deadline {
+            RunLoop.current.run(until: Date().addingTimeInterval(5))
+            if app.state != .runningForeground {
+                outcome = "app died (state \(app.state.rawValue))"
+                break
+            }
+            let labels = app.staticTexts.allElementsBoundByIndex.map { $0.label }
+            if labels.contains(where: { $0.localizedCaseInsensitiveContains("needs a physical iPhone")
+                || $0.localizedCaseInsensitiveContains("error")
+                || $0.localizedCaseInsensitiveContains("busy") }) {
+                outcome = "error text: \(labels.filter { $0.count > 8 }.suffix(3))"
+                break
+            }
+            let hasReply = labels.contains { $0.count > 2 && $0 != "Say hi in three words."
+                && !$0.hasPrefix("Thinking on") && !$0.hasPrefix("Chat")
+                && $0.rangeOfCharacter(from: .letters) != nil
+                && !$0.contains("Bonsai") && !$0.contains("New chat") }
+            if hasReply && !app.progressIndicators.firstMatch.exists {
+                outcome = "replied"
+                break
+            }
+            observations.append("t: alive, texts=\(labels.count)")
+        }
+        let report = XCTAttachment(string: ([outcome] + observations.suffix(10)).joined(separator: "\n"))
+        report.name = "chat-outcome"
+        report.lifetime = .keepAlways
+        add(report)
+        let attachment = XCTAttachment(screenshot: XCUIScreen.main.screenshot())
+        attachment.name = "final"
+        attachment.lifetime = .keepAlways
+        add(attachment)
+        XCTAssertEqual(outcome, "replied", "On-device chat did not reply: \(outcome)")
+    }
+}


### PR DESCRIPTION
## Why Bonsai Chat crashed

The jetsam event pulled from the device tells it plainly: `vm-pageshortage` with mere.run frontmost, wired memory at 3.7 GB, free pages down to ~37 MB, and iOS killing essentially every process on the phone. Loading 4.8 GB of 27B weights as wired Metal buffers is more than an 8 GB iPhone can give any app — no entitlement changes that.

## What changes

- **Liquid Chat (LFM2.5 2.6B, 1.5 GB) leads the on-device chat lineup** — same `ChatGenerator` seam, streams deltas the same way, actually fits a phone. Its LFM license note is shown and explicitly accepted before download (`usageTermsAcknowledged`).
- **Bonsai Chat stays, honestly gated**: a 12 GB minimum-memory requirement, with incompatible devices seeing "Needs 12 GB of memory" instead of a Get button — the reason stated up front instead of discovered by crashing the phone.
- **Chat requests cap `maxContextTokens` at 4096** — the default was the model's native 262k context.
- **Models can be removed**: swipe a downloaded row in the On this iPhone sheet. Removal mirrors `mere.run model remove` — install dir deleted, then a scoped GC pass reclaims hub payloads no other model shares.

Simulator + device builds green, lint clean, installed on hardware.