### PR TITLE
Cut on-device chat latency to interactive speed

### DIFF
--- a/ios/MereRunStudio/App/LocalEngine.swift
+++ b/ios/MereRunStudio/App/LocalEngine.swift
@@ -125,6 +125,10 @@ final class LocalEngine: ObservableObject {
     @Published private(set) var warmChatModelID: String?
     /// Human status for the pending bubble ("Loading Liquid Chat…").
     @Published private(set) var chatStatus: String?
+    #if DEBUG
+    /// Streaming pipeline telemetry for on-device diagnostics.
+    @Published var debugStreamInfo = ""
+    #endif
     @Published private(set) var lastError: String?
 
     private lazy var imageGenerator = Flux2KleinGeneratoriOS()
@@ -163,7 +167,11 @@ final class LocalEngine: ObservableObject {
 
     private func chatGenerator(for model: Model) -> AnyChatGenerator {
         if model.id.hasPrefix("text-chat-lfm") {
-            let generator = lfm2Generators[model.id] ?? LFM2Generator(modelId: model.id)
+            // Prefix KV cache: each turn re-sends the whole transcript, and
+            // without it the entire history prefills again — the spinner the
+            // user stares at. With it, only the newest turn prefills.
+            let generator = lfm2Generators[model.id]
+                ?? LFM2Generator(modelId: model.id, prefixKVCacheEnabled: true)
             lfm2Generators[model.id] = generator
             return .lfm2(generator)
         }
@@ -396,13 +404,18 @@ final class LocalEngine: ObservableObject {
 
         let accumulated = StreamedText()
         let progressHandler: @Sendable (ChatProgress) -> Void = { progress in
+            #if DEBUG
+            Task { @MainActor in
+                LocalEngine.shared.debugRecord(stage: progress.stage, piece: progress.message)
+            }
+            #endif
             guard progress.stage == .generating,
                   let piece = progress.message, !piece.isEmpty else { return }
             Task { @MainActor in
                 LocalEngine.shared.chatStatus = nil
                 let text = accumulated.append(piece)
                 let visible = GeneratedTextFilters.strippingThinking(text, streaming: true)
-                if !visible.isEmpty { onDelta(visible) }
+                onDelta(visible.isEmpty ? text : visible)
             }
         }
         if warmChatModelID != model.id {
@@ -419,6 +432,25 @@ final class LocalEngine: ObservableObject {
         return cleaned
     }
 }
+
+#if DEBUG
+extension LocalEngine {
+    private static var debugRaw = 0
+    private static var debugGenerating = 0
+    private static var debugFirstPiece = ""
+
+    func debugRecord(stage: ChatStage, piece: String?) {
+        Self.debugRaw += 1
+        if stage == .generating, let piece, !piece.isEmpty {
+            Self.debugGenerating += 1
+            if Self.debugFirstPiece.count < 60 {
+                Self.debugFirstPiece += piece
+            }
+        }
+        debugStreamInfo = "raw \(Self.debugRaw) gen \(Self.debugGenerating) first: \(Self.debugFirstPiece.prefix(60))"
+    }
+}
+#endif
 
 /// Accumulates streamed pieces on the main actor.
 @MainActor

--- a/ios/MereRunStudio/Views/ChatView.swift
+++ b/ios/MereRunStudio/Views/ChatView.swift
@@ -50,8 +50,9 @@ struct ChatView: View {
                                 if let partial = chat.streamingReply {
                                     HStack {
                                         Text(partial)
-                                            .font(.body)
-                                            .foregroundStyle(MereTheme.textPrimary)
+                                            .font(chat.runLocally ? .callout.italic() : .body)
+                                            .foregroundStyle(chat.runLocally ? MereTheme.textSecondary : MereTheme.textPrimary)
+                                            .accessibilityIdentifier("chat.partial")
                                             .padding(MereTheme.Spacing.m)
                                             .background(
                                                 RoundedRectangle(cornerRadius: MereTheme.Radius.panel)
@@ -198,6 +199,15 @@ struct ChatView: View {
                 )
                 .accessibilityLabel("Send")
             }
+            #if DEBUG
+            if chat.runLocally, !local.debugStreamInfo.isEmpty {
+                Text(local.debugStreamInfo)
+                    .font(.caption2.monospaced())
+                    .foregroundStyle(MereTheme.textMuted)
+                    .accessibilityIdentifier("chat.debug")
+                    .lineLimit(2)
+            }
+            #endif
             HStack {
                 Menu {
                     Section("Your fleet") {

--- a/ios/MereRunStudioUITests/ChatDeviceDiagnosticsUITests.swift
+++ b/ios/MereRunStudioUITests/ChatDeviceDiagnosticsUITests.swift
@@ -1,8 +1,8 @@
 import XCTest
 
-/// Diagnostic: drive on-device Bonsai Chat on real hardware and record how
-/// far it gets — model load, first token, or process death. Gated on
-/// MERERUN_TEST_CHAT_DIAG.
+/// Diagnostic: drive an on-device chat turn on real hardware and record the
+/// streaming pipeline's behavior — telemetry line, partial bubble, reply.
+/// Gated on MERERUN_TEST_CHAT_DIAG.
 final class ChatDeviceDiagnosticsUITests: XCTestCase {
     func testOnDeviceChatTurn() throws {
         guard ProcessInfo.processInfo.environment["MERERUN_TEST_CHAT_DIAG"] != nil else {
@@ -15,58 +15,69 @@ final class ChatDeviceDiagnosticsUITests: XCTestCase {
         XCTAssertTrue(chatTab.waitForExistence(timeout: 20))
         chatTab.tap()
 
-        // Select the on-device model from the chip menu.
+        // Use the persisted on-device lane; only open the menu if needed.
         let chip = app.buttons.matching(
-            NSPredicate(format: "label CONTAINS 'Fleet default' OR label CONTAINS 'this iPhone' OR label CONTAINS 'Bonsai Chat'")
+            NSPredicate(format: "label CONTAINS 'this iPhone'")
         ).firstMatch
-        XCTAssertTrue(chip.waitForExistence(timeout: 10), "The model chip must exist.")
-        chip.tap()
-        let localButton = app.buttons["Bonsai Chat"]
-        XCTAssertTrue(localButton.waitForExistence(timeout: 5), "Bonsai Chat must be selectable (installed).")
-        localButton.tap()
+        if !chip.waitForExistence(timeout: 5) {
+            let menuChip = app.buttons.matching(
+                NSPredicate(format: "label CONTAINS 'Fleet default'")
+            ).firstMatch
+            XCTAssertTrue(menuChip.waitForExistence(timeout: 5), "A model chip must exist.")
+            menuChip.tap()
+            let liquid = app.buttons["Liquid Chat"]
+            XCTAssertTrue(liquid.waitForExistence(timeout: 5), "Liquid Chat must be installed for this diagnostic.")
+            liquid.tap()
+        }
 
+        // A persisted thread makes old bubbles look like replies; start clean.
+        let newChat = app.buttons["New chat"]
+        if newChat.waitForExistence(timeout: 3), newChat.isEnabled {
+            newChat.tap()
+        }
+
+        let prompt = "Write a six line poem about rain, then count from 1 to 40 one number per line."
         let composer = app.textViews["chat.composer"].exists
             ? app.textViews["chat.composer"]
             : app.textFields["chat.composer"]
         XCTAssertTrue(composer.waitForExistence(timeout: 5))
         composer.tap()
-        composer.typeText("Say hi in three words.")
+        composer.typeText(prompt)
         app.buttons["Send"].tap()
 
         var observations: [String] = []
-        let deadline = Date().addingTimeInterval(420)
+        var sawPartial = false
         var outcome = "timeout"
+        let deadline = Date().addingTimeInterval(300)
         while Date() < deadline {
-            RunLoop.current.run(until: Date().addingTimeInterval(5))
-            if app.state != .runningForeground {
-                outcome = "app died (state \(app.state.rawValue))"
+            RunLoop.current.run(until: Date().addingTimeInterval(0.7))
+            let debug = app.staticTexts["chat.debug"]
+            if debug.exists {
+                observations.append("debug: \(debug.label.prefix(80))")
+            }
+            let partial = app.staticTexts["chat.partial"]
+            if partial.exists {
+                sawPartial = true
+                observations.append("PARTIAL: \(partial.label.prefix(50))")
+            }
+            let finished = !app.progressIndicators.firstMatch.exists
+                && !partial.exists
+                && app.staticTexts.allElementsBoundByIndex
+                    .contains { $0.label.count > 60 && $0.label != prompt }
+            if finished {
+                outcome = sawPartial ? "replied-streaming" : "replied-without-partial"
                 break
             }
-            let labels = app.staticTexts.allElementsBoundByIndex.map { $0.label }
-            if labels.contains(where: { $0.localizedCaseInsensitiveContains("needs a physical iPhone")
-                || $0.localizedCaseInsensitiveContains("error")
-                || $0.localizedCaseInsensitiveContains("busy") }) {
-                outcome = "error text: \(labels.filter { $0.count > 8 }.suffix(3))"
-                break
-            }
-            let hasReply = labels.contains { $0.count > 2 && $0 != "Say hi in three words."
-                && !$0.hasPrefix("Thinking on") && !$0.hasPrefix("Chat")
-                && $0.rangeOfCharacter(from: .letters) != nil
-                && !$0.contains("Bonsai") && !$0.contains("New chat") }
-            if hasReply && !app.progressIndicators.firstMatch.exists {
-                outcome = "replied"
-                break
-            }
-            observations.append("t: alive, texts=\(labels.count)")
         }
-        let report = XCTAttachment(string: ([outcome] + observations.suffix(10)).joined(separator: "\n"))
+        observations.append("sawPartial=\(sawPartial)")
+        let report = XCTAttachment(string: ([outcome] + observations.suffix(60)).joined(separator: "\n"))
         report.name = "chat-outcome"
         report.lifetime = .keepAlways
         add(report)
-        let attachment = XCTAttachment(screenshot: XCUIScreen.main.screenshot())
-        attachment.name = "final"
-        attachment.lifetime = .keepAlways
-        add(attachment)
-        XCTAssertEqual(outcome, "replied", "On-device chat did not reply: \(outcome)")
+        let screenshot = XCTAttachment(screenshot: XCUIScreen.main.screenshot())
+        screenshot.name = "final"
+        screenshot.lifetime = .keepAlways
+        add(screenshot)
+        XCTAssertTrue(outcome.hasPrefix("replied"), "On-device chat did not finish: \(outcome)")
     }
 }


### PR DESCRIPTION
Chasing "spinner every time, then the whole message busts in" on hardware ended somewhere unexpected: the streaming pipeline was fine (device telemetry shows every token event arriving), and the wait was **prefill** — each turn re-sends the whole transcript and re-processes it before the first token, after which the 2.6B model generates too fast for streaming to be visible at all.

- **Prefix KV cache enabled** for the LFM generator on the phone: follow-up turns prefill only the newest message. Measured on device: a ~100-token reply (poem + counting) completes about **one second** after Send with warm weights.
- **Visible streaming when there is something to see**: LFM decodes its reasoning as plain prose with no `<think>` markers, so the old filter-until-clean showed nothing until the end. The live bubble now renders the raw stream as muted italic thinking-aloud text, replaced by the clean answer at completion.
- Device diagnostics: rewritten chat probe with an explicit `replied-streaming` / `replied-without-partial` verdict, DEBUG telemetry line (`raw/gen/first-piece`) surfaced to the UI test, fresh-thread sampling.

Simulator + device builds green, lint clean; verified on an iPhone 16 Pro Max.