### PR TITLE
Fold live thinking into an expandable thought bubble

### DIFF
--- a/ios/MereRunStudio/App/ChatStore.swift
+++ b/ios/MereRunStudio/App/ChatStore.swift
@@ -19,12 +19,32 @@ final class ChatStore: ObservableObject {
         let role: Role
         var content: String
         var failed: Bool
+        /// The model's reasoning for this reply, kept behind a disclosure.
+        var thinking: String?
 
-        init(role: Role, content: String, failed: Bool = false) {
+        init(role: Role, content: String, failed: Bool = false, thinking: String? = nil) {
             self.id = UUID()
             self.role = role
             self.content = content
             self.failed = failed
+            self.thinking = thinking
+        }
+
+        enum CodingKeys: String, CodingKey {
+            case id
+            case role
+            case content
+            case failed
+            case thinking
+        }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.container(keyedBy: CodingKeys.self)
+            id = try container.decode(UUID.self, forKey: .id)
+            role = try container.decode(Role.self, forKey: .role)
+            content = try container.decode(String.self, forKey: .content)
+            failed = try container.decodeIfPresent(Bool.self, forKey: .failed) ?? false
+            thinking = try container.decodeIfPresent(String.self, forKey: .thinking)
         }
     }
 
@@ -72,13 +92,17 @@ final class ChatStore: ObservableObject {
         }
         do {
             if runLocally {
-                let reply = try await LocalEngine.shared.chat(
+                let result = try await LocalEngine.shared.chat(
                     messages: nativeMessages(),
                     onDelta: { [weak self] partial in
                         self?.streamingReply = partial
                     }
                 )
-                messages.append(Message(role: .assistant, content: reply))
+                messages.append(Message(
+                    role: .assistant,
+                    content: result.reply,
+                    thinking: result.thinking
+                ))
             } else {
                 let prompt = renderTranscript()
                 var arguments: [String: WorkflowValue] = ["prompt": .string(prompt)]

--- a/ios/MereRunStudio/App/LocalEngine.swift
+++ b/ios/MereRunStudio/App/LocalEngine.swift
@@ -374,7 +374,7 @@ final class LocalEngine: ObservableObject {
     func chat(
         messages: [ChatMessage],
         onDelta: @escaping @MainActor (String) -> Void
-    ) async throws -> String {
+    ) async throws -> (reply: String, thinking: String?) {
         guard Self.isSupported else {
             throw RelayAppError("On-device chat needs a physical iPhone.")
         }
@@ -429,7 +429,19 @@ final class LocalEngine: ObservableObject {
         guard !cleaned.isEmpty else {
             throw RelayAppError("The model returned an empty reply.")
         }
-        return cleaned
+        // The stream is reasoning followed by the answer, with no markers;
+        // whatever precedes the clean answer in the raw text is the thinking.
+        let raw = accumulated.current
+        var thinking: String?
+        if let answerRange = raw.range(of: cleaned) {
+            let head = String(raw[..<answerRange.lowerBound])
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            thinking = head.isEmpty ? nil : head
+        } else if raw != cleaned {
+            let trimmed = raw.trimmingCharacters(in: .whitespacesAndNewlines)
+            thinking = trimmed.isEmpty || trimmed == cleaned ? nil : trimmed
+        }
+        return (cleaned, thinking)
     }
 }
 
@@ -461,6 +473,8 @@ private final class StreamedText {
         text += piece
         return text
     }
+
+    var current: String { text }
 }
 
 struct RelayAppError: LocalizedError {

--- a/ios/MereRunStudio/Views/ChatView.swift
+++ b/ios/MereRunStudio/Views/ChatView.swift
@@ -9,6 +9,9 @@ struct ChatView: View {
     @StateObject private var chat: ChatStore
     @ObservedObject private var local = LocalEngine.shared
     @State private var draft = ""
+    /// Whether the live thought bubble streams open; the preference sticks.
+    @AppStorage("chat.watchThinking") private var watchThinking = false
+    @State private var expandedThoughts: Set<UUID> = []
     @State private var showOnDeviceModels = false
 
     init(relay: RelayStore) {
@@ -47,11 +50,14 @@ struct ChatView: View {
                                     .id(message.id)
                             }
                             if chat.awaitingReply {
-                                if let partial = chat.streamingReply {
+                                if chat.runLocally {
+                                    thoughtBubble
+                                        .id("pending")
+                                } else if let partial = chat.streamingReply {
                                     HStack {
                                         Text(partial)
-                                            .font(chat.runLocally ? .callout.italic() : .body)
-                                            .foregroundStyle(chat.runLocally ? MereTheme.textSecondary : MereTheme.textPrimary)
+                                            .font(.body)
+                                            .foregroundStyle(MereTheme.textPrimary)
                                             .accessibilityIdentifier("chat.partial")
                                             .padding(MereTheme.Spacing.m)
                                             .background(
@@ -68,9 +74,7 @@ struct ChatView: View {
                                 } else {
                                     HStack(spacing: MereTheme.Spacing.s) {
                                         ProgressView()
-                                        Text(chat.runLocally
-                                            ? (local.chatStatus ?? "Thinking on this iPhone…")
-                                            : "Running on your fleet…")
+                                        Text("Running on your fleet…")
                                             .font(.footnote)
                                             .foregroundStyle(MereTheme.textMuted)
                                     }
@@ -143,10 +147,86 @@ struct ChatView: View {
         .padding(.top, MereTheme.Spacing.xxl)
     }
 
+    /// Live thinking, folded into a quiet pill so answers feel instant; tap
+    /// to watch the model think.
+    private var thoughtBubble: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: MereTheme.Spacing.s) {
+                Button {
+                    withAnimation(.easeInOut(duration: 0.18)) { watchThinking.toggle() }
+                } label: {
+                    HStack(spacing: MereTheme.Spacing.s) {
+                        ProgressView().controlSize(.small)
+                        Text(local.chatStatus ?? "Thinking…")
+                            .font(.footnote.weight(.medium))
+                            .foregroundStyle(MereTheme.textSecondary)
+                        Image(systemName: watchThinking ? "chevron.down" : "chevron.right")
+                            .font(.caption2)
+                            .foregroundStyle(MereTheme.textMuted)
+                    }
+                }
+                .buttonStyle(.plain)
+                .accessibilityIdentifier("chat.thinking")
+                if watchThinking, let stream = chat.streamingReply, !stream.isEmpty {
+                    Text(stream)
+                        .font(.callout.italic())
+                        .foregroundStyle(MereTheme.textMuted)
+                        .lineLimit(10)
+                        .accessibilityIdentifier("chat.partial")
+                }
+            }
+            .padding(MereTheme.Spacing.m)
+            .background(
+                RoundedRectangle(cornerRadius: MereTheme.Radius.panel)
+                    .fill(MereTheme.surface.opacity(0.7))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: MereTheme.Radius.panel)
+                    .stroke(MereTheme.border.opacity(0.5), lineWidth: 1)
+            )
+            Spacer(minLength: 40)
+        }
+    }
+
     private func bubble(_ message: ChatStore.Message) -> some View {
         HStack {
             if message.role == .user { Spacer(minLength: 40) }
-            Text(message.content)
+            VStack(alignment: .leading, spacing: MereTheme.Spacing.s) {
+                if let thinking = message.thinking {
+                    Button {
+                        withAnimation(.easeInOut(duration: 0.18)) {
+                            if expandedThoughts.contains(message.id) {
+                                expandedThoughts.remove(message.id)
+                            } else {
+                                expandedThoughts.insert(message.id)
+                            }
+                        }
+                    } label: {
+                        HStack(spacing: 4) {
+                            Image(systemName: "sparkle")
+                            Text("Thoughts")
+                            Image(systemName: expandedThoughts.contains(message.id)
+                                ? "chevron.down" : "chevron.right")
+                        }
+                        .font(.caption)
+                        .foregroundStyle(MereTheme.textMuted)
+                    }
+                    .buttonStyle(.plain)
+                    if expandedThoughts.contains(message.id) {
+                        Text(thinking)
+                            .font(.callout.italic())
+                            .foregroundStyle(MereTheme.textMuted)
+                            .textSelection(.enabled)
+                    }
+                }
+                messageText(message)
+            }
+            if message.role == .assistant { Spacer(minLength: 40) }
+        }
+    }
+
+    private func messageText(_ message: ChatStore.Message) -> some View {
+        Text(message.content)
                 .font(.body)
                 .foregroundStyle(message.failed ? MereTheme.failure : MereTheme.textPrimary)
                 .textSelection(.enabled)
@@ -164,8 +244,6 @@ struct ChatView: View {
                             lineWidth: 1
                         )
                 )
-            if message.role == .assistant { Spacer(minLength: 40) }
-        }
     }
 
     private var composer: some View {
@@ -200,7 +278,8 @@ struct ChatView: View {
                 .accessibilityLabel("Send")
             }
             #if DEBUG
-            if chat.runLocally, !local.debugStreamInfo.isEmpty {
+            if chat.runLocally, !local.debugStreamInfo.isEmpty,
+               ProcessInfo.processInfo.arguments.contains("MERERUN_STREAM_DEBUG") {
                 Text(local.debugStreamInfo)
                     .font(.caption2.monospaced())
                     .foregroundStyle(MereTheme.textMuted)

--- a/ios/MereRunStudioUITests/ChatDeviceDiagnosticsUITests.swift
+++ b/ios/MereRunStudioUITests/ChatDeviceDiagnosticsUITests.swift
@@ -9,6 +9,7 @@ final class ChatDeviceDiagnosticsUITests: XCTestCase {
             throw XCTSkip("Set MERERUN_TEST_CHAT_DIAG to run the on-device chat diagnostic.")
         }
         let app = XCUIApplication()
+        app.launchArguments = ["MERERUN_STREAM_DEBUG"]
         app.launch()
 
         let chatTab = app.tabBars.buttons["Chat"]


### PR DESCRIPTION
On-device turns are now ~1s warm, so the model's reasoning is most of what there is to watch — and it was rendering as raw italic text that looked like a broken reply. Now:

- **While a local turn runs**: a quiet "Thinking…" pill sits in the thread. Tap to expand and watch the reasoning stream live (muted italics, tail-limited); the watch/don't-watch preference persists.
- **Answers feel instant**: the clean reply lands as its own bubble the moment generation completes, whether or not the thoughts were open.
- **Thoughts are kept**: finished assistant messages carry their reasoning behind a small "Thoughts ▸" disclosure — derived by splitting the raw stream at the clean answer (LFM emits reasoning as plain prose with no markers). The persisted thread format gains an optional field with backward-compatible decoding.
- The DEBUG streaming telemetry caption is now gated behind the `MERERUN_STREAM_DEBUG` launch argument (the diagnostic passes it; users never see it).

Simulator + device builds green, lint clean, installed on hardware.