### PR TITLE
Harden iOS Studio downloads and runtime lifecycle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -107,6 +107,91 @@ jobs:
             | grep -q 'com.apple.security.device.audio-input'
           codesign --verify --strict --verbose=2 "$bundle"
 
+  ios:
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
+    runs-on: macos-26
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+      - uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '26.4'
+      - name: Restore iOS SwiftPM dependencies
+        uses: actions/cache@v4
+        with:
+          path: .build/ios-source-packages
+          key: ios-swiftpm-${{ runner.os }}-${{ runner.arch }}-xcode-26.4-${{ hashFiles('Package.swift', 'Package.resolved') }}
+      - name: Install XcodeGen
+        run: |
+          # Keep this in sync with the native Swift job's runner workaround.
+          brew untap --force aws/tap
+          brew install xcodegen
+      - name: Generate iOS project
+        run: xcodegen generate --spec ios/project.yml --project ios
+      - name: Build iOS app and tests for release
+        run: |
+          xcodebuild build-for-testing \
+            -project ios/MereRunStudio.xcodeproj \
+            -scheme MereRunStudio \
+            -configuration Release \
+            -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=latest' \
+            -derivedDataPath .build/ios-derived \
+            -clonedSourcePackagesDirPath .build/ios-source-packages \
+            ONLY_ACTIVE_ARCH=YES \
+            CODE_SIGNING_ALLOWED=NO
+      - name: Run iOS unit tests
+        run: |
+          xcodebuild test-without-building \
+            -project ios/MereRunStudio.xcodeproj \
+            -scheme MereRunStudio \
+            -configuration Release \
+            -destination 'platform=iOS Simulator,name=iPhone 17 Pro,OS=latest' \
+            -derivedDataPath .build/ios-derived \
+            -clonedSourcePackagesDirPath .build/ios-source-packages \
+            -only-testing:MereRunStudioTests \
+            ONLY_ACTIVE_ARCH=YES \
+            CODE_SIGNING_ALLOWED=NO
+      - name: Verify iOS release metadata
+        run: |
+          set -euo pipefail
+
+          app='.build/ios-derived/Build/Products/Release-iphonesimulator/mere.run.app'
+          widget="${app}/PlugIns/MereRunWidgets.appex"
+          test -d "$app"
+          test -d "$widget"
+
+          app_version="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "${app}/Info.plist")"
+          widget_version="$(/usr/libexec/PlistBuddy -c 'Print :CFBundleShortVersionString' "${widget}/Info.plist")"
+          test "$app_version" = "$widget_version"
+
+          executable="${app}/mere.run"
+          executable_archs="$(lipo -archs "$executable")"
+          test "$executable_archs" = 'arm64'
+          executable_bytes="$(stat -f '%z' "$executable")"
+          maximum_executable_bytes="$((80 * 1024 * 1024))"
+          if (( executable_bytes > maximum_executable_bytes )); then
+            echo "iOS Release executable is ${executable_bytes} bytes; budget is ${maximum_executable_bytes}." >&2
+            echo 'Audit MereRunCore dependencies before raising the budget.' >&2
+            exit 1
+          fi
+          echo "iOS Release executable: ${executable_bytes} bytes (${executable_archs})"
+
+          release_entitlements='ios/MereRunStudio/MereRunStudio.entitlements'
+          debug_entitlements='ios/MereRunStudio/MereRunStudio.Debug.entitlements'
+          grep -q '<string>applinks:mere.world</string>' "$release_entitlements"
+          if grep -q 'mode=developer' "$release_entitlements"; then
+            echo 'Release entitlements must not use associated-domain developer mode.' >&2
+            exit 1
+          fi
+          grep -q '<string>applinks:mere.world?mode=developer</string>' "$debug_entitlements"
+
+          debug_setting="$(xcodebuild -project ios/MereRunStudio.xcodeproj -scheme MereRunStudio -configuration Debug -showBuildSettings | awk -F ' = ' '/CODE_SIGN_ENTITLEMENTS/ { print $2; exit }')"
+          release_setting="$(xcodebuild -project ios/MereRunStudio.xcodeproj -scheme MereRunStudio -configuration Release -showBuildSettings | awk -F ' = ' '/CODE_SIGN_ENTITLEMENTS/ { print $2; exit }')"
+          test "$debug_setting" = 'MereRunStudio/MereRunStudio.Debug.entitlements'
+          test "$release_setting" = 'MereRunStudio/MereRunStudio.entitlements'
+
   # Keep the existing protected-check context while the real bundle build and
   # verification share the warm SwiftPM build directory in the swift job.
   macos-app-bundle:

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,6 +1,7 @@
 included:
   - Sources
   - Tests
+  - ios
   - Package.swift
 
 excluded:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,37 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+### iOS Studio
+
+- fixed verified artifact downloads on Apple platforms to use the iOS
+  Keychain-backed relay credential, including refresh, instead of falling back
+  to CLI token-file and environment authentication.
+- made browserless device-code pairing persist directly to the Keychain, so
+  the newly paired relay is usable immediately instead of only after a restart
+  migrated the credential.
+- split associated-domain entitlements by configuration: Debug keeps Apple's
+  developer-mode origin lookup while Release uses the production AASA CDN.
+  The widget now inherits the containing app's version, and CI regenerates and
+  release-builds the iOS project while checking both contracts.
+- added explicit on-device runtime residency management: chat warmup is evicted
+  after two idle minutes, while model/lane changes, backgrounding, memory
+  warnings, and model removal unload chat and image state without interrupting
+  active inference.
+- made runtime release a deterministic state transition that rejects new work
+  while unloading, and added unit coverage for deferred release, repeated
+  release requests, and inference completion.
+- bounded Live Activity polling to one task per job with exponential failure
+  backoff, terminal failure handling, and cancellation when the relay unpairs.
+- made run-artifact refresh transactional: a complete verified refresh replaces
+  the prior local result atomically, while a failed refresh preserves the last
+  verified copy.
+- made execution privacy text reflect the selected on-device, direct-machine,
+  or hosted-relay lane instead of applying a local-only claim to every route.
+- kept the unused llama.cpp binary dependency macOS-only, added a clean arm64
+  Release-footprint audit, and set an 80 MiB CI ceiling for the main iOS
+  executable, making growth in the broad `MereRunCore` dependency closure
+  visible ahead of a narrower mobile-runtime extraction.
+
 ### Model downloads
 
 - fixed Hub download progress freezing at zero on iOS: the Swift-concurrency
@@ -13,10 +44,19 @@ The format is based on Keep a Changelog.
   there (macOS happens to), so multi-gigabyte pulls looked hung while bytes
   flowed. Downloads now run as classic delegate-driven download tasks, which
   report byte progress on every platform; behavior on macOS and Linux is
-  unchanged. The iOS app additionally keeps the display awake during a pull
-  (a locked screen suspends the app and kills the transfer), surfaces
-  download failures in Chat's on-device row, and shows absolute megabytes
-  instead of a percent that rounds to zero for most of a large pull.
+  unchanged. The iOS app surfaces failures in Chat's on-device row and shows
+  absolute megabytes instead of a percent that rounds to zero for most of a
+  large pull.
+- moved iOS model payloads onto one fixed system background session, with
+  deterministic task identities, durable completed-file staging, relaunch
+  reattachment, app-container-relocatable destinations, cross-host credential
+  stripping, and a persisted pending install queue. Background delivery returns
+  through the application delegate; ordinary model pinning, byte-count checks,
+  receipts, and final validation still gate installation. Abandoned staging is
+  included in model-storage garbage collection after its safety grace period.
+- made unmetered, unconstrained Wi-Fi the default for new iOS model downloads,
+  with an explicit cellular/expensive/constrained-network opt-in persisted per
+  pending install so relaunch reattachment preserves the user's choice.
 
 ### MiniMax-H3 compact BF16 and Q8
 

--- a/Package.swift
+++ b/Package.swift
@@ -211,7 +211,10 @@ if isLinuxPackage {
       path: "vendor/llama.xcframework"
     )
   )
-  mereRunCoreDependencies.append(.target(name: "llama"))
+  // The iOS Studio runtime uses the native MLX chat and image paths. Keeping
+  // llama.cpp macOS-only also avoids embedding unused platform slices in the
+  // phone app.
+  mereRunCoreDependencies.append(.target(name: "llama", condition: .when(platforms: [.macOS])))
 }
 if hasMagentaRT2Binary {
   targets.append(

--- a/Sources/MereRunCore/Flux2Klein/Flux2KleinGeneratoriOS.swift
+++ b/Sources/MereRunCore/Flux2Klein/Flux2KleinGeneratoriOS.swift
@@ -22,6 +22,17 @@ public actor Flux2KleinGeneratoriOS: ImageGenerator {
         Memory.cacheLimit = 256 * 1024 * 1024
     }
 
+    /// Releases the small persistent tokenizer/statistics residency and any
+    /// cached GPU allocations retained between phone generations.
+    public func unload() {
+        tokenizer = nil
+        bnRunningMean = nil
+        bnRunningVar = nil
+        loadedModelPath = nil
+        loadedManifest = nil
+        clearGPUMemory()
+    }
+
     /// Clear GPU cached memory
     func clearGPUMemory(synchronize: Bool = true) {
         // Clearing while kernels are in-flight can lead to corrupted outputs (e.g. blurry images).

--- a/Sources/MereRunCore/HubBackgroundTransferSession.swift
+++ b/Sources/MereRunCore/HubBackgroundTransferSession.swift
@@ -1,0 +1,366 @@
+import Foundation
+
+#if !canImport(FoundationNetworking)
+/// Owns the single background URL session used for long-running Hub payloads.
+///
+/// A completed payload is moved out of URLSession's temporary directory before
+/// the delegate returns. The regular `HubSnapshot` pipeline subsequently
+/// validates its size and pinned Hub identity before the model is installed.
+public final class HubBackgroundTransferSession: NSObject, @unchecked Sendable {
+    package struct Descriptor: Codable, Equatable, Sendable {
+        package let id: String
+        package let stagingPath: String
+        package let applicationSupportRelativePath: String?
+
+        package init(id: String, stagingURL: URL) {
+            self.id = id
+            stagingPath = stagingURL.standardizedFileURL.path
+            guard let applicationSupport = FileManager.default.urls(
+                for: .applicationSupportDirectory,
+                in: .userDomainMask
+            ).first else {
+                applicationSupportRelativePath = nil
+                return
+            }
+            let rootPath = applicationSupport.standardizedFileURL.path
+            let prefix = rootPath + "/"
+            if stagingPath.hasPrefix(prefix) {
+                applicationSupportRelativePath = String(stagingPath.dropFirst(prefix.count))
+            } else {
+                applicationSupportRelativePath = nil
+            }
+        }
+
+        package var stagingURL: URL {
+            if let applicationSupportRelativePath,
+               let applicationSupport = FileManager.default.urls(
+                   for: .applicationSupportDirectory,
+                   in: .userDomainMask
+               ).first {
+                return applicationSupport.appendingPathComponent(
+                    applicationSupportRelativePath
+                )
+            }
+            return URL(fileURLWithPath: stagingPath)
+        }
+    }
+
+    private struct CompletionRecord: Codable, Sendable {
+        let statusCode: Int
+        let responseURL: String?
+    }
+
+    private struct PendingTransfer {
+        let continuation: CheckedContinuation<URL, Error>
+        let progress: @Sendable (Int64, Int64) -> Void
+    }
+
+    public static let shared = HubBackgroundTransferSession()
+
+    public static var sessionIdentifier: String {
+        let bundleID = Bundle.main.bundleIdentifier ?? "run.mere"
+        return "\(bundleID).hub-model-downloads"
+    }
+
+    private let lock = NSLock()
+    private var pending: [String: [PendingTransfer]] = [:]
+    private var taskResults: [Int: Result<URL, Error>] = [:]
+    private var unclaimedResults: [String: Result<URL, Error>] = [:]
+    private var backgroundCompletionHandler: (() -> Void)?
+
+    private lazy var session: URLSession = {
+        let configuration = URLSessionConfiguration.background(
+            withIdentifier: Self.sessionIdentifier
+        )
+        configuration.isDiscretionary = false
+        configuration.sessionSendsLaunchEvents = true
+        configuration.waitsForConnectivity = true
+        configuration.allowsCellularAccess = true
+        configuration.allowsExpensiveNetworkAccess = true
+        configuration.allowsConstrainedNetworkAccess = true
+        configuration.timeoutIntervalForResource = 7 * 24 * 60 * 60
+        return URLSession(configuration: configuration, delegate: self, delegateQueue: nil)
+    }()
+
+    private override init() {
+        super.init()
+    }
+
+    /// Reconnects the system-owned session after iOS relaunches the app for
+    /// completed background events. Returns false for an unrelated session.
+    @discardableResult
+    public static func handleEvents(
+        for identifier: String,
+        completionHandler: @escaping () -> Void
+    ) -> Bool {
+        guard identifier == sessionIdentifier else { return false }
+        shared.setBackgroundCompletionHandler(completionHandler)
+        shared.reconnect()
+        return true
+    }
+
+    /// Recreates the session on an ordinary launch so in-flight tasks can
+    /// reconnect even though UIKit only calls the app delegate after completion.
+    public func reconnect() {
+        _ = session
+    }
+
+    /// Downloads or rejoins one durable transfer. Cancellation of the caller
+    /// intentionally does not cancel the system task; a later install attempt
+    /// can rejoin it by transfer ID.
+    public func download(
+        request: URLRequest,
+        transferID: String,
+        stagingDirectory: URL,
+        progress: @escaping @Sendable (Int64, Int64) -> Void
+    ) async throws -> URL {
+        try FileManager.default.createDirectory(
+            at: stagingDirectory,
+            withIntermediateDirectories: true
+        )
+        let stagingURL = stagingDirectory.appendingPathComponent("\(transferID).download")
+        if Self.hasCompletedTransfer(at: stagingURL) {
+            discardUnclaimedResult(for: transferID)
+            return stagingURL
+        }
+        Self.removeTransferFiles(at: stagingURL)
+
+        let description = try Self.taskDescription(
+            for: Descriptor(id: transferID, stagingURL: stagingURL)
+        )
+        let existingTask = await session.allTasks.first { task in
+            Self.descriptor(from: task.taskDescription)?.id == transferID
+        }
+        if Self.hasCompletedTransfer(at: stagingURL) {
+            discardUnclaimedResult(for: transferID)
+            return stagingURL
+        }
+
+        return try await withCheckedThrowingContinuation { continuation in
+            let pendingTransfer = PendingTransfer(
+                continuation: continuation,
+                progress: progress
+            )
+            lock.lock()
+            if let completedResult = unclaimedResults.removeValue(forKey: transferID) {
+                lock.unlock()
+                continuation.resume(with: completedResult)
+                return
+            }
+            pending[transferID, default: []].append(pendingTransfer)
+            lock.unlock()
+
+            if let existingTask {
+                progress(
+                    max(existingTask.countOfBytesReceived, 0),
+                    max(existingTask.countOfBytesExpectedToReceive, 0)
+                )
+                existingTask.resume()
+                return
+            }
+
+            let task = session.downloadTask(with: request)
+            task.taskDescription = description
+            task.resume()
+        }
+    }
+
+    /// Removes the completion sidecar after HubSnapshot has consumed the file.
+    public static func finishConsuming(_ stagingURL: URL) {
+        try? FileManager.default.removeItem(at: completionRecordURL(for: stagingURL))
+    }
+
+    package static func taskDescription(for descriptor: Descriptor) throws -> String {
+        try JSONEncoder().encode(descriptor).base64EncodedString()
+    }
+
+    package static func descriptor(from taskDescription: String?) -> Descriptor? {
+        guard let taskDescription,
+              let data = Data(base64Encoded: taskDescription) else {
+            return nil
+        }
+        return try? JSONDecoder().decode(Descriptor.self, from: data)
+    }
+
+    package static func hasCompletedTransfer(at stagingURL: URL) -> Bool {
+        guard FileManager.default.fileExists(atPath: stagingURL.path),
+              let data = try? Data(contentsOf: completionRecordURL(for: stagingURL)),
+              let record = try? JSONDecoder().decode(CompletionRecord.self, from: data) else {
+            return false
+        }
+        return (200..<300).contains(record.statusCode)
+    }
+
+    private static func completionRecordURL(for stagingURL: URL) -> URL {
+        stagingURL.appendingPathExtension("json")
+    }
+
+    private static func removeTransferFiles(at stagingURL: URL) {
+        try? FileManager.default.removeItem(at: stagingURL)
+        try? FileManager.default.removeItem(at: completionRecordURL(for: stagingURL))
+    }
+
+    private func setBackgroundCompletionHandler(_ completionHandler: @escaping () -> Void) {
+        lock.lock()
+        backgroundCompletionHandler = completionHandler
+        lock.unlock()
+    }
+
+    private func discardUnclaimedResult(for transferID: String) {
+        lock.lock()
+        unclaimedResults[transferID] = nil
+        lock.unlock()
+    }
+
+    private func storeResult(_ result: Result<URL, Error>, taskIdentifier: Int) {
+        lock.lock()
+        taskResults[taskIdentifier] = result
+        lock.unlock()
+    }
+
+    private func complete(task: URLSessionTask, error: Error?) {
+        guard let descriptor = Self.descriptor(from: task.taskDescription) else { return }
+
+        lock.lock()
+        let transfers = pending.removeValue(forKey: descriptor.id) ?? []
+        let storedResult = taskResults.removeValue(forKey: task.taskIdentifier)
+        lock.unlock()
+
+        let result: Result<URL, Error>
+        if let error {
+            Self.removeTransferFiles(at: descriptor.stagingURL)
+            result = .failure(error)
+        } else if let storedResult {
+            result = storedResult
+        } else if Self.hasCompletedTransfer(at: descriptor.stagingURL) {
+            result = .success(descriptor.stagingURL)
+        } else {
+            result = .failure(HubBackgroundTransferError.missingPayload)
+        }
+        if transfers.isEmpty {
+            if case .failure = result {
+                lock.lock()
+                unclaimedResults[descriptor.id] = result
+                lock.unlock()
+            }
+            return
+        }
+        for transfer in transfers {
+            transfer.continuation.resume(with: result)
+        }
+    }
+}
+
+extension HubBackgroundTransferSession: URLSessionDownloadDelegate {
+    public func urlSession(
+        _: URLSession,
+        task: URLSessionTask,
+        willPerformHTTPRedirection _: HTTPURLResponse,
+        newRequest: URLRequest,
+        completionHandler: @escaping (URLRequest?) -> Void
+    ) {
+        var redirectedRequest = newRequest
+        if task.currentRequest?.url?.host != newRequest.url?.host {
+            redirectedRequest.setValue(nil, forHTTPHeaderField: "Authorization")
+        }
+        completionHandler(redirectedRequest)
+    }
+
+    public func urlSession(
+        _: URLSession,
+        downloadTask: URLSessionDownloadTask,
+        didFinishDownloadingTo location: URL
+    ) {
+        guard let descriptor = Self.descriptor(from: downloadTask.taskDescription),
+              let response = downloadTask.response as? HTTPURLResponse else {
+            storeResult(
+                .failure(HubBackgroundTransferError.missingResponse),
+                taskIdentifier: downloadTask.taskIdentifier
+            )
+            return
+        }
+        guard (200..<300).contains(response.statusCode) else {
+            Self.removeTransferFiles(at: descriptor.stagingURL)
+            storeResult(
+                .failure(HubBackgroundTransferError.httpStatus(response.statusCode)),
+                taskIdentifier: downloadTask.taskIdentifier
+            )
+            return
+        }
+
+        do {
+            try FileManager.default.createDirectory(
+                at: descriptor.stagingURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            Self.removeTransferFiles(at: descriptor.stagingURL)
+            try FileManager.default.moveItem(at: location, to: descriptor.stagingURL)
+            let record = CompletionRecord(
+                statusCode: response.statusCode,
+                responseURL: response.url?.absoluteString
+            )
+            let data = try JSONEncoder().encode(record)
+            try data.write(
+                to: Self.completionRecordURL(for: descriptor.stagingURL),
+                options: .atomic
+            )
+            storeResult(
+                .success(descriptor.stagingURL),
+                taskIdentifier: downloadTask.taskIdentifier
+            )
+        } catch {
+            Self.removeTransferFiles(at: descriptor.stagingURL)
+            storeResult(.failure(error), taskIdentifier: downloadTask.taskIdentifier)
+        }
+    }
+
+    public func urlSession(
+        _: URLSession,
+        task: URLSessionTask,
+        didCompleteWithError error: Error?
+    ) {
+        complete(task: task, error: error)
+    }
+
+    public func urlSession(
+        _: URLSession,
+        downloadTask: URLSessionDownloadTask,
+        didWriteData _: Int64,
+        totalBytesWritten: Int64,
+        totalBytesExpectedToWrite: Int64
+    ) {
+        guard let descriptor = Self.descriptor(from: downloadTask.taskDescription) else { return }
+        lock.lock()
+        let transfers = pending[descriptor.id] ?? []
+        lock.unlock()
+        for transfer in transfers {
+            transfer.progress(totalBytesWritten, totalBytesExpectedToWrite)
+        }
+    }
+
+    public func urlSessionDidFinishEvents(forBackgroundURLSession _: URLSession) {
+        lock.lock()
+        let completionHandler = backgroundCompletionHandler
+        backgroundCompletionHandler = nil
+        lock.unlock()
+        completionHandler?()
+    }
+}
+
+private enum HubBackgroundTransferError: LocalizedError {
+    case httpStatus(Int)
+    case missingPayload
+    case missingResponse
+
+    var errorDescription: String? {
+        switch self {
+        case .httpStatus(let status):
+            return "Background model download failed with HTTP \(status)."
+        case .missingPayload:
+            return "Background model download completed without a payload."
+        case .missingResponse:
+            return "Background model download completed without an HTTP response."
+        }
+    }
+}
+#endif

--- a/Sources/MereRunCore/HubSnapshot.swift
+++ b/Sources/MereRunCore/HubSnapshot.swift
@@ -22,6 +22,20 @@ public struct HubSnapshotReceipt: Codable, Equatable, Sendable {
     public let files: [File]
 }
 
+public enum HubDownloadNetworkPolicy: String, Codable, Equatable, Sendable {
+    case wifiOnly
+    case allNetworks
+
+    package func applying(to request: URLRequest) -> URLRequest {
+        var request = request
+        let unrestricted = self == .allNetworks
+        request.allowsCellularAccess = unrestricted
+        request.allowsExpensiveNetworkAccess = unrestricted
+        request.allowsConstrainedNetworkAccess = unrestricted
+        return request
+    }
+}
+
 public struct HubSnapshotOptions: Sendable {
     public var repoId: String
     public var revision: String
@@ -31,6 +45,7 @@ public struct HubSnapshotOptions: Sendable {
     public var accessToken: String?
     public var offline: Bool
     public var useBackgroundSession: Bool
+    public var backgroundNetworkPolicy: HubDownloadNetworkPolicy
     public var reuseRoots: [URL]
 
     public init(
@@ -42,6 +57,7 @@ public struct HubSnapshotOptions: Sendable {
         accessToken: String? = nil,
         offline: Bool = false,
         useBackgroundSession: Bool = false,
+        backgroundNetworkPolicy: HubDownloadNetworkPolicy = .wifiOnly,
         reuseRoots: [URL] = []
     ) {
         self.repoId = repoId
@@ -52,6 +68,7 @@ public struct HubSnapshotOptions: Sendable {
         self.accessToken = accessToken
         self.offline = offline
         self.useBackgroundSession = useBackgroundSession
+        self.backgroundNetworkPolicy = backgroundNetworkPolicy
         self.reuseRoots = reuseRoots
     }
 }
@@ -489,13 +506,33 @@ public actor HubSnapshot {
                     estimatedSpeedBytesPerSecond: speed
                 ))
             }
-            let tempURL = try await download(remote.downloadURL, delegate: delegate, relativePath: entry.path)
+            let tempURL = try await download(
+                remote.downloadURL,
+                delegate: delegate,
+                relativePath: entry.path,
+                resolvedRevision: resolvedRevision,
+                etag: remote.etag
+            )
+            guard expectedBytes <= 0 || Self.fileSize(at: tempURL) == expectedBytes else {
+                try? FileManager.default.removeItem(at: tempURL)
+                #if !canImport(FoundationNetworking)
+                HubBackgroundTransferSession.finishConsuming(tempURL)
+                #endif
+                throw Hub.HubClientError.downloadError(
+                    "Downloaded size mismatch for \(options.repoId)/\(entry.path)"
+                )
+            }
             try FileManager.default.createDirectory(
                 at: destination.deletingLastPathComponent(),
                 withIntermediateDirectories: true
             )
             try? FileManager.default.removeItem(at: destination)
             try materializeDownloadedPayload(tempURL, remote: remote, destination: destination)
+            #if !canImport(FoundationNetworking)
+            if options.useBackgroundSession {
+                HubBackgroundTransferSession.finishConsuming(tempURL)
+            }
+            #endif
             try writeDownloadMetadata(remote, to: metadataDestination)
             completedBytes += max(expectedBytes, Self.fileSize(at: destination))
             receiptFiles.append(
@@ -654,8 +691,39 @@ public actor HubSnapshot {
     private func download(
         _ url: URL,
         delegate: HubSnapshotDownloadDelegate,
-        relativePath: String
+        relativePath: String,
+        resolvedRevision: String,
+        etag: String?
     ) async throws -> URL {
+        #if !canImport(FoundationNetworking)
+        if options.useBackgroundSession {
+            var request = authorizedRequest(url: url)
+            request.httpMethod = "GET"
+            request = options.backgroundNetworkPolicy.applying(to: request)
+            let transferID = Self.backgroundTransferID(
+                repoType: options.repoType.rawValue,
+                repoID: options.repoId,
+                revision: resolvedRevision,
+                relativePath: relativePath,
+                etag: etag
+            )
+            return try await HubBackgroundTransferSession.shared.download(
+                request: request,
+                transferID: transferID,
+                stagingDirectory: downloadBase.appending(
+                    path: "background-transfers",
+                    directoryHint: .isDirectory
+                ),
+                progress: { completed, total in
+                    delegate.recordProgress(
+                        totalBytesWritten: completed,
+                        totalBytesExpectedToWrite: total
+                    )
+                }
+            )
+        }
+        #endif
+
         var currentURL = url
         for _ in 0..<8 {
             var request = authorizedRequest(url: currentURL)
@@ -683,6 +751,20 @@ public actor HubSnapshot {
             currentURL = redirected
         }
         throw Hub.HubClientError.downloadError("Too many redirects while downloading \(options.repoId)/\(relativePath)")
+    }
+
+    package static func backgroundTransferID(
+        repoType: String,
+        repoID: String,
+        revision: String,
+        relativePath: String,
+        etag: String?
+    ) -> String {
+        let identity = [repoType, repoID, revision, relativePath, etag ?? ""]
+            .joined(separator: "\n")
+        return SHA256.hash(data: Data(identity.utf8))
+            .map { String(format: "%02x", $0) }
+            .joined()
     }
 
     private func writeDownloadMetadata(_ remote: HubSnapshotRemoteFile, to metadataURL: URL) throws {
@@ -1396,6 +1478,16 @@ private final class HubSnapshotDownloadDelegate: NSObject, URLSessionTaskDelegat
         _: URLSession,
         downloadTask _: URLSessionDownloadTask,
         didWriteData _: Int64,
+        totalBytesWritten: Int64,
+        totalBytesExpectedToWrite: Int64
+    ) {
+        recordProgress(
+            totalBytesWritten: totalBytesWritten,
+            totalBytesExpectedToWrite: totalBytesExpectedToWrite
+        )
+    }
+
+    func recordProgress(
         totalBytesWritten: Int64,
         totalBytesExpectedToWrite: Int64
     ) {

--- a/Sources/MereRunCore/HubSnapshot.swift
+++ b/Sources/MereRunCore/HubSnapshot.swift
@@ -30,8 +30,10 @@ public enum HubDownloadNetworkPolicy: String, Codable, Equatable, Sendable {
         var request = request
         let unrestricted = self == .allNetworks
         request.allowsCellularAccess = unrestricted
+        #if !canImport(FoundationNetworking)
         request.allowsExpensiveNetworkAccess = unrestricted
         request.allowsConstrainedNetworkAccess = unrestricted
+        #endif
         return request
     }
 }

--- a/Sources/MereRunCore/ManagedModelResolver.swift
+++ b/Sources/MereRunCore/ManagedModelResolver.swift
@@ -220,6 +220,8 @@ public enum ManagedModelResolver {
         force: Bool = false,
         usageTermsAcknowledged: Bool = false,
         hubCacheURL: URL? = nil,
+        useBackgroundSession: Bool = false,
+        backgroundNetworkPolicy: HubDownloadNetworkPolicy = .wifiOnly,
         fileManager: FileManager = .default,
         progress: (@Sendable (InstallProgress) -> Void)? = nil
     ) async throws -> InstallResult {
@@ -246,12 +248,16 @@ public enum ManagedModelResolver {
             config: hubFallback,
             reuseRoots: reuseRoots,
             hubCacheURL: hubCacheURL,
+            useBackgroundSession: useBackgroundSession,
+            backgroundNetworkPolicy: backgroundNetworkPolicy,
             progress: progress
         )
         let mountedSnapshots = try await downloadMountedHubSnapshots(
             for: spec,
             modelDir: modelDir,
             hubCacheURL: hubCacheURL,
+            useBackgroundSession: useBackgroundSession,
+            backgroundNetworkPolicy: backgroundNetworkPolicy,
             fileManager: fileManager,
             progress: progress
         )
@@ -496,6 +502,8 @@ public enum ManagedModelResolver {
         config: HubFallbackConfig,
         reuseRoots: [URL] = [],
         hubCacheURL: URL? = nil,
+        useBackgroundSession: Bool = false,
+        backgroundNetworkPolicy: HubDownloadNetworkPolicy = .wifiOnly,
         progress: (@Sendable (InstallProgress) -> Void)?
     ) async throws -> URL {
         do {
@@ -505,6 +513,8 @@ public enum ManagedModelResolver {
                     revision: config.revision,
                     patterns: config.patterns,
                     cacheDirectory: hubCacheURL,
+                    useBackgroundSession: useBackgroundSession,
+                    backgroundNetworkPolicy: backgroundNetworkPolicy,
                     reuseRoots: reuseRoots
                 )
             )
@@ -533,6 +543,8 @@ public enum ManagedModelResolver {
         for spec: ManagedModelSpec,
         modelDir: URL,
         hubCacheURL: URL? = nil,
+        useBackgroundSession: Bool = false,
+        backgroundNetworkPolicy: HubDownloadNetworkPolicy = .wifiOnly,
         fileManager: FileManager,
         progress: (@Sendable (InstallProgress) -> Void)?
     ) async throws -> [(MountedHubFallbackConfig, URL)] {
@@ -549,6 +561,8 @@ public enum ManagedModelResolver {
                 config: mounted.hubFallback,
                 reuseRoots: reuseRoots,
                 hubCacheURL: hubCacheURL,
+                useBackgroundSession: useBackgroundSession,
+                backgroundNetworkPolicy: backgroundNetworkPolicy,
                 progress: progress
             )
             snapshots.append((mounted, snapshotURL))

--- a/Sources/MereRunCore/ModelStorageManager.swift
+++ b/Sources/MereRunCore/ModelStorageManager.swift
@@ -373,6 +373,23 @@ public final class ModelStorageManager {
             }
         }
 
+        if cacheUnitPaths == nil {
+            let backgroundTransfers = hubDirectory.appendingPathComponent(
+                "background-transfers",
+                isDirectory: true
+            )
+            for record in fileRecords(at: backgroundTransfers)
+                where !cacheUnitIsWithinGracePeriod(record.url) {
+                items.append(ModelStorageGarbageItem(
+                    kind: .incompleteDownload,
+                    path: record.url.path,
+                    logicalBytes: record.size
+                ))
+                plannedFilePaths.insert(record.url.path)
+                incompleteBytes += record.size
+            }
+        }
+
         let blobRoot = hubDirectory.appendingPathComponent("blobs", isDirectory: true)
         let referencedBlobPaths = Set(
             references

--- a/Sources/MereRunRelayKit/RelayClient.swift
+++ b/Sources/MereRunRelayKit/RelayClient.swift
@@ -17,7 +17,7 @@ public struct RelayWorkflowExecutor: Sendable {
         self.credentialStorage = credentialStorage
     }
 
-    private func resolveCredential(forceRefresh: Bool = false) async throws -> RelayResolvedCredential {
+    package func resolveCredential(forceRefresh: Bool = false) async throws -> RelayResolvedCredential {
         if let credentialStorage {
             return try await RelayAuthentication.resolveCredential(
                 profile: profile,
@@ -239,7 +239,7 @@ public struct RelayWorkflowExecutor: Sendable {
         guard let baseURL = profile.url, let url = URL(string: "\(baseURL)\(path)") else {
             throw RelayClientError("Relay executor profile has an invalid URL.")
         }
-        var credential = try await RelayAuthentication.resolveCredential(profile: profile)
+        var credential = try await resolveCredential()
         var attempt = 0
         while true {
             attempt += 1
@@ -254,7 +254,7 @@ public struct RelayWorkflowExecutor: Sendable {
             }
             if http.statusCode == 401, credential.refreshable, attempt == 1 {
                 try? FileManager.default.removeItem(at: temporary)
-                credential = try await RelayAuthentication.resolveCredential(profile: profile, forceRefresh: true)
+                credential = try await resolveCredential(forceRefresh: true)
                 continue
             }
             guard (200..<300).contains(http.statusCode) else {

--- a/Tests/MereRunCoreTests/HubSnapshotTests.swift
+++ b/Tests/MereRunCoreTests/HubSnapshotTests.swift
@@ -45,6 +45,64 @@ final class HubSnapshotTests: XCTestCase {
         XCTAssertEqual(HubSnapshot.revisionKey("main").count, 64)
     }
 
+    func testBackgroundTransferIdentityIncludesPinnedPayloadIdentity() {
+        let base = HubSnapshot.backgroundTransferID(
+            repoType: "models",
+            repoID: "mere/image",
+            revision: "commit-a",
+            relativePath: "weights/model.safetensors",
+            etag: "etag-a"
+        )
+        let same = HubSnapshot.backgroundTransferID(
+            repoType: "models",
+            repoID: "mere/image",
+            revision: "commit-a",
+            relativePath: "weights/model.safetensors",
+            etag: "etag-a"
+        )
+        let changedRevision = HubSnapshot.backgroundTransferID(
+            repoType: "models",
+            repoID: "mere/image",
+            revision: "commit-b",
+            relativePath: "weights/model.safetensors",
+            etag: "etag-a"
+        )
+
+        XCTAssertEqual(base, same)
+        XCTAssertNotEqual(base, changedRevision)
+        XCTAssertEqual(base.count, 64)
+    }
+
+    #if !canImport(FoundationNetworking)
+    func testBackgroundNetworkPolicyConfiguresEachRequest() throws {
+        let url = try XCTUnwrap(URL(string: "https://example.test/model.safetensors"))
+
+        let wifiOnly = HubDownloadNetworkPolicy.wifiOnly.applying(to: URLRequest(url: url))
+        XCTAssertFalse(wifiOnly.allowsCellularAccess)
+        XCTAssertFalse(wifiOnly.allowsExpensiveNetworkAccess)
+        XCTAssertFalse(wifiOnly.allowsConstrainedNetworkAccess)
+
+        let unrestricted = HubDownloadNetworkPolicy.allNetworks.applying(to: URLRequest(url: url))
+        XCTAssertTrue(unrestricted.allowsCellularAccess)
+        XCTAssertTrue(unrestricted.allowsExpensiveNetworkAccess)
+        XCTAssertTrue(unrestricted.allowsConstrainedNetworkAccess)
+    }
+
+    func testBackgroundTransferTaskDescriptionRoundTripsDurableDestination() throws {
+        let descriptor = HubBackgroundTransferSession.Descriptor(
+            id: "transfer-id",
+            stagingURL: URL(fileURLWithPath: "/tmp/mere run/background/transfer.download")
+        )
+        let encoded = try HubBackgroundTransferSession.taskDescription(for: descriptor)
+
+        XCTAssertEqual(
+            HubBackgroundTransferSession.descriptor(from: encoded),
+            descriptor
+        )
+        XCTAssertNil(HubBackgroundTransferSession.descriptor(from: "not-base64"))
+    }
+    #endif
+
     func testMaterializedPatternClosureSupportsExactAndGlobSelections() throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("mere-run-hub-closure-\(UUID().uuidString)", isDirectory: true)

--- a/Tests/MereRunCoreTests/ModelStorageManagerTests.swift
+++ b/Tests/MereRunCoreTests/ModelStorageManagerTests.swift
@@ -227,6 +227,27 @@ final class ModelStorageManagerTests: XCTestCase {
         XCTAssertEqual(try noGraceManager.garbageCollectionPlan().reclaimableBytes, 72)
     }
 
+    func testGlobalCollectionReclaimsAbandonedBackgroundTransferStaging() throws {
+        let transfers = hub.appendingPathComponent("background-transfers", isDirectory: true)
+        _ = try writePayload(at: transfers.appendingPathComponent("payload.download"), bytes: 32)
+        _ = try writePayload(at: transfers.appendingPathComponent("payload.download.json"), bytes: 7)
+        let manager = try ModelStorageManager(
+            modelsDirectory: models,
+            hubDirectory: hub,
+            applicationSupportDirectory: applicationSupport,
+            fileManager: fileManager,
+            unreferencedGracePeriod: 0
+        )
+
+        let plan = try manager.garbageCollectionPlan()
+
+        XCTAssertEqual(plan.reclaimableBytes, 39)
+        XCTAssertEqual(plan.incompleteDownloadBytes, 39)
+        XCTAssertEqual(plan.items.map(\.kind), [.incompleteDownload, .incompleteDownload])
+        XCTAssertEqual(try manager.execute(plan).reclaimedBytes, 39)
+        XCTAssertTrue(try manager.garbageCollectionPlan().items.isEmpty)
+    }
+
     func testExecutionRechecksReferencesUnderStorageLock() throws {
         let unit = legacyUnit(repository: "recheck")
         let payload = try writePayload(at: unit.appendingPathComponent("model.bin"), bytes: 88)

--- a/Tests/MereRunRelayKitTests/WorkflowRelayExecutorTests.swift
+++ b/Tests/MereRunRelayKitTests/WorkflowRelayExecutorTests.swift
@@ -6,6 +6,27 @@ import XCTest
 @testable import MereRunRelayKit
 
 final class WorkflowRelayExecutorTests: XCTestCase {
+    func testExecutorResolvesInjectedCredentialStorageWithoutTokenFile() async throws {
+        let storage = FixedCredentialStorage(
+            tokenSet: RelayOAuthTokenSet(
+                accessToken: "keychain-bearer",
+                refreshToken: nil,
+                tokenType: "Bearer",
+                expiresIn: nil,
+                obtainedAtEpochSeconds: nil
+            )
+        )
+        let executor = RelayWorkflowExecutor(
+            profile: relayProfile(tokenFile: nil),
+            credentialStorage: storage
+        )
+
+        let credential = try await executor.resolveCredential()
+
+        XCTAssertEqual(credential.accessToken, "keychain-bearer")
+        XCTAssertFalse(credential.refreshable)
+    }
+
     func testTransientServerFailuresRetryUntilSuccess() async throws {
         var attempts = 0
         let result = try await RelayWorkflowExecutor.performWithTransientRetries(
@@ -59,4 +80,30 @@ final class WorkflowRelayExecutorTests: XCTestCase {
             headerFields: nil
         )!
     }
+
+    private func relayProfile(tokenFile: String?) -> WorkflowExecutorProfile {
+        WorkflowExecutorProfile(
+            name: "phone",
+            kind: .relay,
+            destination: nil,
+            remoteRoot: nil,
+            port: nil,
+            identityFile: nil,
+            mereRunPath: nil,
+            url: "https://relay.example.test",
+            tokenFile: tokenFile
+        )
+    }
+}
+
+private struct FixedCredentialStorage: RelayCredentialStorage {
+    let tokenSet: RelayOAuthTokenSet
+
+    func load() throws -> RelayOAuthTokenSet? {
+        tokenSet
+    }
+
+    func save(_ tokenSet: RelayOAuthTokenSet) throws {}
+
+    func clear() throws {}
 }

--- a/docs/ios-studio.md
+++ b/docs/ios-studio.md
@@ -1,10 +1,10 @@
 # iOS Studio
 
-The iOS app (`ios/`) is the third thin client in the family that hosted Graph
-Studio established: it signs in to a relay, submits and watches work, and
-fetches verified artifacts, while paired nodes own model execution. This
-document records the architecture decisions and phasing; `ios/README.md`
-covers building.
+The iOS app (`ios/`) combines the portable relay client established by hosted
+Graph Studio with a constrained on-device runtime. It can submit and watch
+fleet work, fetch verified artifacts, connect directly to a machine, or run
+supported image and chat models on a physical iPhone. `ios/README.md` covers
+building.
 
 ## Two lanes
 
@@ -14,21 +14,20 @@ covers building.
    hosted-Studio pattern — never from local discovery, which needs process
    spawning that iOS forbids), and reads the same `graph-event-v1` /
    `graph-run-v1` documents published in `docs/public/schemas/`.
-2. **On-device lane (experimental, landed).** `MereRunCore` builds for
-   iOS; the app's image mode offers "This iPhone" alongside the fleet,
-   installing FLUX.2 Klein nano through the managed store into the app
-   sandbox and generating through the memory-optimized iOS pipeline. First
-   on-device generation still needs real-device validation of the MLX Metal
-   kernel path. Sizing: small models genuinely fit Pro-class devices —
+2. **On-device lane (experimental).** `MereRunCore` builds for iOS; the app's
+   image and chat modes offer "This iPhone" alongside the fleet and install
+   managed models into the app sandbox. These paths require a physical device;
+   a simulator build is portability evidence, not inference proof. Sizing:
+   small models genuinely fit Pro-class devices —
    the Bonsai image binary (4B, 1-bit, ~3.4 GB) runs through the same FLUX.2
    Klein pipeline that already has a memory-constrained iOS generator in
    `MereRunCore` (`Flux2KleinGeneratoriOS`, ~2 GB peak via sequential
    loading), and `text-chat-bonsai-27b-1bit` (~5.1 GB, Apache-2.0,
-   vision-capable) is plausible on 12 GB+ devices with the increased-memory
-   entitlement. This lane requires an iOS build gate for a trimmed
-   `MereRunCore` (ONNX paths are already macOS-conditional; the `IOKit`
-   linker setting needs a platform condition) and a storage/download UX, and
-   is explicitly out of scope for the first shippable phase.
+   vision-capable) targets 12 GB+ devices with the increased-memory
+   entitlement. The current app links the broad `MereRunCore` target; a
+   narrower mobile runtime remains a build-time and binary-size optimization.
+   CI builds only the active simulator architecture so test coverage does not
+   accidentally turn into a universal two-architecture product-size proxy.
 
 ## What exists today
 
@@ -38,14 +37,15 @@ covers building.
   artifact fetch, the workflow wire types, and SSE event-text normalization.
   Foundation + swift-crypto only; builds and tests on Linux; the CLI consumes
   it with unchanged behavior.
-- `ios/` — the SwiftUI scaffold: pairing via device grant, fleet view, run
-  inbox, run detail with polled events/progress, cancel/retry, and artifact
-  fetch with share. Generated with XcodeGen; first Xcode build still pending
-  (authored in a Linux environment).
+- `ios/` — the SwiftUI client: PKCE and device-code relay sign-in, direct
+  machine pairing, fleet and run views, polled events/progress, cancel/retry,
+  verified artifact fetch and sharing, Live Activities, and on-device model
+  management, image generation, and chat. XcodeGen owns the project, and CI
+  regenerates and Release-builds it for the simulator.
 
 ## Phasing
 
-- **Phase A — run inbox and prompt-first submission (current).** Pair,
+- **Phase A — run inbox and prompt-first submission (landed).** Pair,
   watch, fetch, cancel/retry, fleet, and Create: the graph documents, node
   registry, validator, and bundle materializer now live in
   `MereRunRelayKit`, so the phone materializes byte-identical bundles and
@@ -55,7 +55,7 @@ covers building.
   from the worker probe, and pins models from the fleet's installed list.
   Provider-qualified nodes stay excluded on iOS, and modes whose required
   inputs are assets wait for the photo/file picker step.
-- **Phase B — chat.** Route chat to the best available transport: on-device
+- **Phase B — chat (landed).** Route chat to the selected transport: on-device
   small models when present, a machine reached directly when paired (the
   `mere.run relay serve` direct lane — the app's "Connect to a machine"
   pairing serves the full job vocabulary over the LAN or a tailnet with no
@@ -67,8 +67,42 @@ covers building.
   implementation — but `graph-event-v1` is a closed schema, so a
   `node_output_delta` event needs a coordinated contract revision with the
   relay and node repositories' shared fixtures.
-- **Phase C — on-device tiny models.** The Bonsai lane above, gated by
-  device RAM, Wi-Fi-only multi-GB pulls, and a storage manager.
+- **Phase C — on-device models (experimental).** The managed Bonsai/Liquid
+  lane above is gated by device RAM and available storage. Model payloads use
+  one fixed, system-owned background session, so the active file can continue
+  while the app is suspended. The app durably records the requested install,
+  rejoins matching system tasks after relaunch, stages completed payloads out
+  of URLSession's temporary directory, and then resumes the normal pinned
+  snapshot and final validation pipeline. A user-initiated download currently
+  defaults to unmetered, unconstrained Wi-Fi. Users can explicitly allow
+  cellular, expensive, and constrained networks before starting a download;
+  that choice is recorded with the pending install so a relaunch cannot
+  silently change the transfer policy.
+
+## On-device lifecycle
+
+- Chat warmup remains immediate, but resident chat or image state is released
+  after two idle minutes, when the selected chat model or inference lane
+  changes, when the app enters the background, and on an iOS memory warning.
+- A lifecycle release never interrupts active inference. It is deferred until
+  the current image or chat request finishes, and the engine rejects another
+  request while release is in progress.
+- Removing an installed model unloads all runtime state before deleting its
+  install and reclaiming only cache payloads not referenced by another model.
+- iOS may relaunch the app to deliver background-session events. The app
+  reconnects that session through its application delegate and resumes every
+  durable pending install. Explicit user force-quit behavior remains controlled
+  by iOS and is not treated as a supported continuation path.
+- Live Activity polling is single-owner per job. Transient request failures use
+  bounded exponential backoff; persistent failures end the activity instead of
+  leaving an immortal poller behind. Unpairing cancels all outstanding pollers.
+- Refreshing a run's artifacts stages and validates the complete new result
+  beside the existing result, then atomically replaces it. A failed refresh
+  leaves the last verified local copy intact.
+- Privacy copy follows the selected execution lane: on-device work stays on the
+  phone, a direct-machine lane names that machine connection, and hosted relay
+  work describes the authenticated relay/fleet path rather than claiming every
+  remote request is local-only.
 
 ## iOS-specific follow-ups
 
@@ -79,8 +113,25 @@ covers building.
   remains as the browserless fallback).
 - Artifact downloads stream to disk with digest verification (done);
   incremental in-flight hashing remains a refinement.
+- Physical-device interruption coverage still needs a release-signed run that
+  backgrounds the app during a real multi-gigabyte model pull, verifies
+  relaunch reattachment, and observes runtime memory returning after eviction.
+- Debug uses the associated-domain developer alternate mode; Release uses the
+  production AASA CDN. The app and widget versions must remain identical.
 - Live Activities ship with app-driven updates; completion pushes and
   push-updated activities need APNs support in the relay repository.
+
+## Release footprint
+
+A clean arm64 Release-simulator build on 2026-08-19 measured 75.4 MiB
+uncompressed, including a 68.3 MiB main executable and a 4.3 MiB MLX Metal
+library. The unused llama.cpp binary dependency is macOS-only. This is not an
+App Store download-size measurement, but it confirms that the broad
+`MereRunCore` closure is the main compile-time and binary-size cost. CI now
+rejects a non-arm64-only simulator executable and caps that executable at 80
+MiB. Extracting the image/chat/model storage surface into a narrower mobile
+runtime remains a separate architectural optimization; a facade that still
+depends on `MereRunCore` would not reduce the dependency closure.
 
 ## Boundaries
 

--- a/ios/MereRunStudio/App/ExecutionPrivacyCopy.swift
+++ b/ios/MereRunStudio/App/ExecutionPrivacyCopy.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+enum ExecutionPrivacyLane: Equatable, Sendable {
+    case onDevice
+    case directMachine
+    case hostedRelay
+}
+
+enum ExecutionPrivacyCopy {
+    static func chat(for lane: ExecutionPrivacyLane) -> String {
+        switch lane {
+        case .onDevice:
+            "Runs entirely on this iPhone. Your words stay on this device."
+        case .directMachine:
+            "Sent directly to your paired machine over your network or tailnet."
+        case .hostedRelay:
+            "Sent through your configured relay to a fleet machine."
+        }
+    }
+
+    static func create(for lane: ExecutionPrivacyLane) -> String {
+        switch lane {
+        case .onDevice:
+            "Runs entirely on this iPhone. Prompts, inputs, and outputs stay on this device."
+        case .directMachine:
+            "Runs directly on your paired machine over your network or tailnet."
+        case .hostedRelay:
+            "Runs on your fleet. Prompts, inputs, status, and artifacts pass through your configured relay."
+        }
+    }
+}

--- a/ios/MereRunStudio/App/LocalEngine.swift
+++ b/ios/MereRunStudio/App/LocalEngine.swift
@@ -10,6 +10,7 @@ import UIKit
 /// generation exercises MLX Metal on the device.
 @MainActor
 final class LocalEngine: ObservableObject {
+    static let allowsCellularDownloadsKey = "models.allowCellularDownloads"
     /// One shared engine so Create and Chat agree on what is installed.
     static let shared = LocalEngine()
 
@@ -107,19 +108,24 @@ final class LocalEngine: ObservableObject {
         case ready
     }
 
-    enum Activity: Equatable {
-        case idle
-        case generatingImage
-        case chatting
-    }
-
     @Published private(set) var states: [String: ModelState] = [:]
-    @Published private(set) var activity: Activity = .idle
+    @Published private(set) var activity: RuntimeResidencyState.Activity = .idle
     @Published private(set) var lastImage: UIImage?
     @Published private(set) var lastImageURL: URL?
-    @Published var selectedImageModelID = LocalEngine.imageModels[0].id
+    @Published var selectedImageModelID = LocalEngine.imageModels[0].id {
+        didSet {
+            if oldValue != selectedImageModelID {
+                releaseRuntime()
+            }
+        }
+    }
     @Published var selectedChatModelID: String {
-        didSet { UserDefaults.standard.set(selectedChatModelID, forKey: "local.selectedChatModelID") }
+        didSet {
+            UserDefaults.standard.set(selectedChatModelID, forKey: "local.selectedChatModelID")
+            if oldValue != selectedChatModelID {
+                releaseRuntime()
+            }
+        }
     }
     /// Which chat model currently has its weights resident, if any.
     @Published private(set) var warmChatModelID: String?
@@ -131,9 +137,17 @@ final class LocalEngine: ObservableObject {
     #endif
     @Published private(set) var lastError: String?
 
-    private lazy var imageGenerator = Flux2KleinGeneratoriOS()
+    private var imageGenerator: Flux2KleinGeneratoriOS?
     private var q35Generators: [String: Q35Generator] = [:]
     private var lfm2Generators: [String: LFM2Generator] = [:]
+    private let pendingDownloadStore = PendingModelDownloadStore()
+    private var activeDownloadIDs: Set<String> = []
+    private var warmTask: Task<Void, Never>?
+    private var warmRequestID: UUID?
+    private var idleEvictionTask: Task<Void, Never>?
+    private var residency = RuntimeResidencyState()
+
+    private static let idleResidencySeconds: Duration = .seconds(120)
 
     private enum AnyChatGenerator {
         case q35(Q35Generator)
@@ -183,21 +197,37 @@ final class LocalEngine: ObservableObject {
     /// Loads the selected chat model's weights ahead of the first message so
     /// it answers immediately. Safe to call repeatedly; the generators cache.
     func warmChat() {
-        guard Self.isSupported,
+        guard Self.isSupported, activity == .idle,
+              warmTask == nil,
               let model = Self.model(withID: selectedChatModelID),
               warmChatModelID != model.id,
               let root = ManagedModelResolver.resolveInstalledModel(id: model.id) else { return }
+        idleEvictionTask?.cancel()
+        let requestID = UUID()
+        warmRequestID = requestID
         let generator = chatGenerator(for: model)
         chatStatus = "Loading \(model.title)…"
-        Task { [weak self] in
+        warmTask = Task { [weak self] in
             do {
                 try await generator.prepare(modelPath: root.path, progressHandler: nil)
-                await MainActor.run {
-                    self?.warmChatModelID = model.id
-                    self?.chatStatus = nil
+                guard let self else { return }
+                if !Task.isCancelled,
+                   self.warmRequestID == requestID,
+                   self.selectedChatModelID == model.id,
+                   self.activity == .idle {
+                    self.warmChatModelID = model.id
+                    self.chatStatus = nil
+                    self.warmTask = nil
+                    self.scheduleIdleEviction()
+                } else if self.selectedChatModelID != model.id
+                            || self.activity != .chatting {
+                    await generator.unload()
+                    self.removeChatGenerator(modelID: model.id)
                 }
             } catch {
-                await MainActor.run { self?.chatStatus = nil }
+                guard let self, self.warmRequestID == requestID else { return }
+                self.chatStatus = nil
+                self.warmTask = nil
             }
         }
     }
@@ -205,13 +235,100 @@ final class LocalEngine: ObservableObject {
     /// Frees resident chat weights (an image generation is about to need the
     /// memory, or the user left the on-device lane).
     func coolChat() {
+        releaseRuntime()
+    }
+
+    /// Drops every resident model after backgrounding, memory pressure, model
+    /// changes, or the idle timeout. Active inference is allowed to finish and
+    /// then releases before another request can begin.
+    func releaseRuntime() {
+        idleEvictionTask?.cancel()
+        warmTask?.cancel()
+        guard residency.requestRelease() else { return }
+        activity = residency.activity
+        performRuntimeRelease()
+    }
+
+    private func performRuntimeRelease() {
+        Task { [weak self] in
+            guard let self else { return }
+            await self.unloadRuntimeNow()
+            self.residency.completeRelease()
+            self.activity = self.residency.activity
+        }
+    }
+
+    private func unloadRuntimeNow() async {
+        idleEvictionTask?.cancel()
+        idleEvictionTask = nil
+        warmTask?.cancel()
+        warmTask = nil
+        warmRequestID = nil
+        chatStatus = nil
+        warmChatModelID = nil
+
+        let chatGenerators = lfm2Generators.values.map(AnyChatGenerator.lfm2)
+            + q35Generators.values.map(AnyChatGenerator.q35)
+        lfm2Generators.removeAll()
+        q35Generators.removeAll()
+        let residentImageGenerator = imageGenerator
+        imageGenerator = nil
+
+        for generator in chatGenerators {
+            await generator.unload()
+        }
+        await residentImageGenerator?.unload()
+    }
+
+    private func unloadChatRuntime() async {
+        warmTask?.cancel()
+        warmTask = nil
+        warmRequestID = nil
+        chatStatus = nil
+        warmChatModelID = nil
         let generators = lfm2Generators.values.map(AnyChatGenerator.lfm2)
             + q35Generators.values.map(AnyChatGenerator.q35)
-        warmChatModelID = nil
-        Task {
-            for generator in generators {
-                await generator.unload()
+        lfm2Generators.removeAll()
+        q35Generators.removeAll()
+        for generator in generators {
+            await generator.unload()
+        }
+    }
+
+    private func unloadImageRuntime() async {
+        let generator = imageGenerator
+        imageGenerator = nil
+        await generator?.unload()
+    }
+
+    private func removeChatGenerator(modelID: String) {
+        lfm2Generators[modelID] = nil
+        q35Generators[modelID] = nil
+        if warmChatModelID == modelID {
+            warmChatModelID = nil
+        }
+    }
+
+    private func finishActivity() {
+        if residency.completeActivity() {
+            activity = residency.activity
+            performRuntimeRelease()
+        } else {
+            activity = residency.activity
+            scheduleIdleEviction()
+        }
+    }
+
+    private func scheduleIdleEviction() {
+        idleEvictionTask?.cancel()
+        idleEvictionTask = Task { [weak self] in
+            do {
+                try await Task.sleep(for: Self.idleResidencySeconds)
+            } catch {
+                return
             }
+            guard !Task.isCancelled else { return }
+            self?.releaseRuntime()
         }
     }
 
@@ -219,6 +336,9 @@ final class LocalEngine: ObservableObject {
         let saved = UserDefaults.standard.string(forKey: "local.selectedChatModelID")
         selectedChatModelID = Self.chatModels.first { $0.id == saved }?.id ?? Self.chatModels[0].id
         refresh()
+        guard Self.isSupported else { return }
+        HubBackgroundTransferSession.shared.reconnect()
+        resumePendingDownloads()
     }
 
     func refresh() {
@@ -255,17 +375,58 @@ final class LocalEngine: ObservableObject {
         states[modelID] ?? .notInstalled
     }
 
+    var isDownloadingModel: Bool {
+        states.values.contains { state in
+            if case .downloading = state { return true }
+            return false
+        }
+    }
+
     func download(_ modelID: String, acceptedTerms: Bool = false) async {
+        await download(
+            PendingModelDownload(
+                modelID: modelID,
+                usageTermsAcknowledged: acceptedTerms,
+                requestedAt: Date(),
+                allowsCellular: UserDefaults.standard.bool(forKey: Self.allowsCellularDownloadsKey)
+            ),
+            persistRequest: true
+        )
+    }
+
+    func resumePendingDownloads() {
+        guard Self.isSupported else { return }
+        HubBackgroundTransferSession.shared.reconnect()
+        for pending in pendingDownloadStore.all() {
+            if ManagedModelResolver.resolveInstalledModel(id: pending.modelID) != nil {
+                try? pendingDownloadStore.remove(modelID: pending.modelID)
+                continue
+            }
+            Task { await self.download(pending, persistRequest: false) }
+        }
+    }
+
+    private func download(
+        _ pending: PendingModelDownload,
+        persistRequest: Bool
+    ) async {
+        let modelID = pending.modelID
+        guard Self.isSupported,
+              Self.model(withID: modelID) != nil,
+              !activeDownloadIDs.contains(modelID) else { return }
+        activeDownloadIDs.insert(modelID)
+        defer { activeDownloadIDs.remove(modelID) }
         states[modelID] = .downloading("Starting…")
         lastError = nil
-        // A locked screen suspends the app and kills the transfer; keep the
-        // display on for the duration of the pull.
-        UIApplication.shared.isIdleTimerDisabled = true
-        defer { UIApplication.shared.isIdleTimerDisabled = false }
         do {
+            if persistRequest {
+                try pendingDownloadStore.save(pending)
+            }
             _ = try await ManagedModelResolver.installManagedModel(
                 id: modelID,
-                usageTermsAcknowledged: acceptedTerms,
+                usageTermsAcknowledged: pending.usageTermsAcknowledged,
+                useBackgroundSession: true,
+                backgroundNetworkPolicy: pending.allowsCellular ? .allNetworks : .wifiOnly,
                 progress: { progress in
                     let label: String
                     switch progress {
@@ -285,8 +446,11 @@ final class LocalEngine: ObservableObject {
                     }
                 }
             )
+            try pendingDownloadStore.remove(modelID: modelID)
             states[modelID] = .ready
+            refreshReclaimable()
         } catch {
+            try? pendingDownloadStore.remove(modelID: modelID)
             states[modelID] = .notInstalled
             lastError = error.localizedDescription
         }
@@ -295,9 +459,12 @@ final class LocalEngine: ObservableObject {
     /// Removes an installed model and reclaims its unshared hub-cache
     /// payloads, mirroring `mere.run model remove`. Blobs shared with another
     /// installed model are preserved.
-    func delete(_ modelID: String) {
-        guard Self.isSupported, activity == .idle,
-              let installURL = ManagedModelResolver.resolveInstalledModel(id: modelID) else { return }
+    func delete(_ modelID: String) async {
+        guard Self.isSupported,
+              let installURL = ManagedModelResolver.resolveInstalledModel(id: modelID),
+              residency.beginRelease() else { return }
+        activity = residency.activity
+        await unloadRuntimeNow()
         lastError = nil
         do {
             let storage = try ModelStorageManager()
@@ -308,10 +475,10 @@ final class LocalEngine: ObservableObject {
         } catch {
             lastError = error.localizedDescription
         }
-        q35Generators[modelID] = nil
-        lfm2Generators[modelID] = nil
         refresh()
         refreshReclaimable()
+        residency.completeRelease()
+        activity = residency.activity
     }
 
     /// Bytes a full garbage-collection pass would free: orphaned payloads
@@ -343,13 +510,14 @@ final class LocalEngine: ObservableObject {
     func generateImage(prompt: String, width: Int = 512, height: Int = 512, steps: Int = 4) async {
         guard Self.isSupported else { return }
         let modelID = selectedImageModelID
-        guard state(of: modelID) == .ready, activity == .idle else { return }
-        if warmChatModelID != nil {
-            coolChat()
-        }
-        activity = .generatingImage
+        guard state(of: modelID) == .ready, residency.begin(.generatingImage) else { return }
+        activity = residency.activity
+        idleEvictionTask?.cancel()
         lastError = nil
-        defer { activity = .idle }
+        defer { finishActivity() }
+        await unloadChatRuntime()
+        let generator = imageGenerator ?? Flux2KleinGeneratoriOS()
+        imageGenerator = generator
         let output = FileManager.default.temporaryDirectory
             .appendingPathComponent("local-\(UUID().uuidString).png")
         let request = GenerationRequest(
@@ -361,7 +529,7 @@ final class LocalEngine: ObservableObject {
             model: modelID
         )
         do {
-            let result = try await imageGenerator.generate(request, progressHandler: nil)
+            let result = try await generator.generate(request, progressHandler: nil)
             lastImage = UIImage(contentsOfFile: result.outputURL.path)
             lastImageURL = result.outputURL
         } catch {
@@ -384,11 +552,16 @@ final class LocalEngine: ObservableObject {
         guard let root = ManagedModelResolver.resolveInstalledModel(id: model.id) else {
             throw RelayAppError("Download \(model.title) before chatting on-device.")
         }
-        guard activity == .idle else {
+        guard residency.begin(.chatting) else {
             throw RelayAppError("The on-device engine is busy with another run.")
         }
-        activity = .chatting
-        defer { activity = .idle }
+        activity = residency.activity
+        idleEvictionTask?.cancel()
+        warmTask?.cancel()
+        warmTask = nil
+        warmRequestID = nil
+        defer { finishActivity() }
+        await unloadImageRuntime()
 
         let sampling = Q35Resources.recommendedSampling(forModelId: model.id)
         let request = ChatRequest(

--- a/ios/MereRunStudio/App/MereRunStudioApp.swift
+++ b/ios/MereRunStudio/App/MereRunStudioApp.swift
@@ -1,7 +1,29 @@
+import MereRunCore
 import SwiftUI
+import UIKit
+
+final class StudioAppDelegate: NSObject, UIApplicationDelegate {
+    func application(
+        _: UIApplication,
+        handleEventsForBackgroundURLSession identifier: String,
+        completionHandler: @escaping () -> Void
+    ) {
+        guard HubBackgroundTransferSession.handleEvents(
+            for: identifier,
+            completionHandler: completionHandler
+        ) else {
+            completionHandler()
+            return
+        }
+        Task { @MainActor in
+            LocalEngine.shared.resumePendingDownloads()
+        }
+    }
+}
 
 @main
 struct MereRunStudioApp: App {
+    @UIApplicationDelegateAdaptor(StudioAppDelegate.self) private var appDelegate
     @StateObject private var relay = RelayStore()
 
     var body: some Scene {
@@ -15,24 +37,44 @@ struct MereRunStudioApp: App {
 
 struct RootView: View {
     @EnvironmentObject private var relay: RelayStore
+    @Environment(\.scenePhase) private var scenePhase
 
     var body: some View {
-        if relay.pairing == .paired {
-            TabView {
-                CreateView()
-                    .tabItem { Label("Create", systemImage: "sparkles") }
-                ChatView(relay: relay)
-                    .tabItem { Label("Chat", systemImage: "bubble.left.and.bubble.right") }
-                RunsView()
-                    .tabItem { Label("Runs", systemImage: "tray.full") }
-                FleetView()
-                    .tabItem { Label("Fleet", systemImage: "server.rack") }
-                SettingsView()
-                    .tabItem { Label("Settings", systemImage: "gearshape") }
+        Group {
+            if relay.pairing == .paired {
+                TabView {
+                    CreateView()
+                        .tabItem { Label("Create", systemImage: "sparkles") }
+                    ChatView(relay: relay)
+                        .tabItem { Label("Chat", systemImage: "bubble.left.and.bubble.right") }
+                    RunsView()
+                        .tabItem { Label("Runs", systemImage: "tray.full") }
+                    FleetView()
+                        .tabItem { Label("Fleet", systemImage: "server.rack") }
+                    SettingsView()
+                        .tabItem { Label("Settings", systemImage: "gearshape") }
+                }
+                .background(MereTheme.background)
+            } else {
+                PairingView()
             }
-            .background(MereTheme.background)
-        } else {
-            PairingView()
+        }
+        .onChange(of: scenePhase) { _, phase in
+            switch phase {
+            case .active:
+                LocalEngine.shared.resumePendingDownloads()
+            case .background:
+                LocalEngine.shared.releaseRuntime()
+            case .inactive:
+                break
+            @unknown default:
+                break
+            }
+        }
+        .onReceive(NotificationCenter.default.publisher(
+            for: UIApplication.didReceiveMemoryWarningNotification
+        )) { _ in
+            LocalEngine.shared.releaseRuntime()
         }
     }
 }
@@ -64,7 +106,7 @@ struct SettingsView: View {
                         relay.unpair()
                     }
                 } footer: {
-                    Text("Work runs on your paired nodes. Prompts and outputs move only between this phone and your relay.")
+                    Text(ExecutionPrivacyCopy.create(for: relay.executionPrivacyLane))
                 }
             }
             .scrollContentBackground(.hidden)

--- a/ios/MereRunStudio/App/PendingModelDownloadStore.swift
+++ b/ios/MereRunStudio/App/PendingModelDownloadStore.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+struct PendingModelDownload: Codable, Equatable, Sendable {
+    let modelID: String
+    let usageTermsAcknowledged: Bool
+    let requestedAt: Date
+    let allowsCellular: Bool
+
+    init(
+        modelID: String,
+        usageTermsAcknowledged: Bool,
+        requestedAt: Date,
+        allowsCellular: Bool = false
+    ) {
+        self.modelID = modelID
+        self.usageTermsAcknowledged = usageTermsAcknowledged
+        self.requestedAt = requestedAt
+        self.allowsCellular = allowsCellular
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case modelID
+        case usageTermsAcknowledged
+        case requestedAt
+        case allowsCellular
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        modelID = try container.decode(String.self, forKey: .modelID)
+        usageTermsAcknowledged = try container.decode(Bool.self, forKey: .usageTermsAcknowledged)
+        requestedAt = try container.decode(Date.self, forKey: .requestedAt)
+        allowsCellular = try container.decodeIfPresent(Bool.self, forKey: .allowsCellular) ?? false
+    }
+}
+
+struct PendingModelDownloadStore {
+    static let defaultKey = "local.pendingModelDownloads"
+
+    private let defaults: UserDefaults
+    private let key: String
+
+    init(
+        defaults: UserDefaults = .standard,
+        key: String = PendingModelDownloadStore.defaultKey
+    ) {
+        self.defaults = defaults
+        self.key = key
+    }
+
+    func all() -> [PendingModelDownload] {
+        guard let data = defaults.data(forKey: key),
+              let downloads = try? JSONDecoder().decode([PendingModelDownload].self, from: data) else {
+            return []
+        }
+        return downloads.sorted { $0.requestedAt < $1.requestedAt }
+    }
+
+    func save(_ download: PendingModelDownload) throws {
+        var downloads = all().filter { $0.modelID != download.modelID }
+        downloads.append(download)
+        try persist(downloads)
+    }
+
+    func remove(modelID: String) throws {
+        try persist(all().filter { $0.modelID != modelID })
+    }
+
+    private func persist(_ downloads: [PendingModelDownload]) throws {
+        if downloads.isEmpty {
+            defaults.removeObject(forKey: key)
+            return
+        }
+        defaults.set(try JSONEncoder().encode(downloads), forKey: key)
+    }
+}

--- a/ios/MereRunStudio/App/RelayStore.swift
+++ b/ios/MereRunStudio/App/RelayStore.swift
@@ -8,8 +8,8 @@ import UIKit
 /// Application Support directory, protected with complete file protection, so
 /// a profile paired on the phone is the same document the CLI would write.
 @MainActor
-final class RelayStore: ObservableObject {
-    enum PairingState: Equatable {
+public final class RelayStore: ObservableObject {
+    public enum PairingState: Equatable {
         case unpaired
         case discovering
         case awaitingApproval(verificationURL: String, userCode: String)
@@ -17,37 +17,44 @@ final class RelayStore: ObservableObject {
         case failed(String)
     }
 
-    @Published private(set) var profile: WorkflowExecutorProfile?
-    @Published private(set) var pairing: PairingState = .unpaired
+    @Published public private(set) var profile: WorkflowExecutorProfile?
+    @Published public private(set) var pairing: PairingState = .unpaired
     @Published private(set) var authStatus: RelayAuthStatusResult?
 
     static let iosClientID = "mererun-ios"
     static let iosRedirectURI = "https://mere.world/oauth/ios-done"
 
     private let supportBase: URL
+    private let credentialStorageFactory: (String) -> any RelayCredentialStorage
     private var profilesURL: URL { supportBase.appendingPathComponent("executors.json") }
 
     /// Keychain is the credential's home on iOS; the legacy protected file
     /// migrates in on first load and is removed.
-    private func keychain(for profileName: String) -> KeychainCredentialStorage {
-        KeychainCredentialStorage(service: "run.mere.studio.relay", account: profileName)
+    private func credentialStorage(for profileName: String) -> any RelayCredentialStorage {
+        credentialStorageFactory(profileName)
     }
 
-    init() {
-        let base = FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
-            .appendingPathComponent("MereRun", isDirectory: true)
+    public init(
+        supportBase requestedSupportBase: URL? = nil,
+        credentialStorageFactory: @escaping (String) -> any RelayCredentialStorage = { profileName in
+            KeychainCredentialStorage(service: "run.mere.studio.relay", account: profileName)
+        }
+    ) {
+        let base = requestedSupportBase
+            ?? FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+                .appendingPathComponent("MereRun", isDirectory: true)
         supportBase = base
+        self.credentialStorageFactory = credentialStorageFactory
         try? FileManager.default.createDirectory(
             at: base,
             withIntermediateDirectories: true,
             attributes: [.protectionKey: FileProtectionType.complete]
         )
-        // iOS moves the data container to a new absolute path on app updates,
-        // so the persisted token-file path is advisory only: recompute it from
-        // the current container (the file itself migrates with the app).
+        // Credentials now live in the Keychain. Recompute the old sandbox path
+        // only to migrate installations that predate Keychain storage.
         if let stored = (try? WorkflowExecutorProfileStore.load(from: profilesURL))?
             .profiles.first(where: { $0.kind == .relay }) {
-            let tokenFile = RelayAuthentication.defaultTokenFile(
+            let legacyTokenFile = RelayAuthentication.defaultTokenFile(
                 profileName: stored.name,
                 applicationSupportBase: base
             )
@@ -60,13 +67,13 @@ final class RelayStore: ObservableObject {
                 identityFile: stored.identityFile,
                 mereRunPath: stored.mereRunPath,
                 url: stored.url,
-                tokenFile: tokenFile.path
+                tokenFile: nil
             )
-            let storage = keychain(for: stored.name)
+            let storage = credentialStorage(for: stored.name)
             if (try? storage.load()) == nil,
-               let legacy = try? FileCredentialStorage(url: tokenFile).load() {
+               let legacy = try? FileCredentialStorage(url: legacyTokenFile).load() {
                 try? storage.save(legacy)
-                try? FileCredentialStorage(url: tokenFile).clear()
+                try? FileCredentialStorage(url: legacyTokenFile).clear()
             }
             pairing = .paired
             refreshAuthStatus()
@@ -80,13 +87,17 @@ final class RelayStore: ObservableObject {
         #endif
     }
 
-    var client: RelayWorkflowExecutor? {
-        profile.map { RelayWorkflowExecutor(profile: $0, credentialStorage: keychain(for: $0.name)) }
+    public var client: RelayWorkflowExecutor? {
+        profile.map { RelayWorkflowExecutor(profile: $0, credentialStorage: credentialStorage(for: $0.name)) }
+    }
+
+    var executionPrivacyLane: ExecutionPrivacyLane {
+        profile?.name == "direct" ? .directMachine : .hostedRelay
     }
 
     func refreshAuthStatus() {
         guard let profile else { return }
-        if let tokenSet = try? keychain(for: profile.name).load() {
+        if let tokenSet = try? credentialStorage(for: profile.name).load() {
             authStatus = RelayAuthStatusResult(
                 executor: "relay:\(profile.name)",
                 credentialKind: "keychain-token-set",
@@ -140,7 +151,7 @@ final class RelayStore: ObservableObject {
                 url: trimmed,
                 tokenFile: nil
             )
-            try keychain(for: profileName).save(tokenSet)
+            try credentialStorage(for: profileName).save(tokenSet)
             try WorkflowExecutorProfileStore.save(
                 WorkflowExecutorProfiles(schemaVersion: 1, profiles: [candidate]),
                 to: profilesURL
@@ -197,7 +208,7 @@ final class RelayStore: ObservableObject {
                 clientID: Self.iosClientID,
                 redirectURI: Self.iosRedirectURI
             )
-            try keychain(for: profileName).save(tokenSet)
+            try credentialStorage(for: profileName).save(tokenSet)
             try WorkflowExecutorProfileStore.save(
                 WorkflowExecutorProfiles(schemaVersion: 1, profiles: [candidate]),
                 to: profilesURL
@@ -217,7 +228,7 @@ final class RelayStore: ObservableObject {
     /// The mere.world account this pairing belongs to, from the token's
     /// email claim. Fleet visibility is scoped by account.
     var accountEmail: String? {
-        guard let name = profile?.name, let tokenSet = try? keychain(for: name).load() else {
+        guard let name = profile?.name, let tokenSet = try? credentialStorage(for: name).load() else {
             return nil
         }
         return tokenSet.accountEmail
@@ -232,10 +243,6 @@ final class RelayStore: ObservableObject {
             pairing = .failed("Relay URL must use HTTPS.")
             return
         }
-        let tokenFile = RelayAuthentication.defaultTokenFile(
-            profileName: profileName,
-            applicationSupportBase: supportBase
-        )
         let candidate = WorkflowExecutorProfile(
             name: profileName,
             kind: .relay,
@@ -245,7 +252,7 @@ final class RelayStore: ObservableObject {
             identityFile: nil,
             mereRunPath: nil,
             url: trimmed,
-            tokenFile: tokenFile.path
+            tokenFile: nil
         )
         pairing = .discovering
         do {
@@ -261,7 +268,7 @@ final class RelayStore: ObservableObject {
                 authorization,
                 configuration: configuration
             )
-            try RelayAuthentication.save(tokenSet, to: tokenFile)
+            try credentialStorage(for: profileName).save(tokenSet)
             try WorkflowExecutorProfileStore.save(
                 WorkflowExecutorProfiles(schemaVersion: 1, profiles: [candidate]),
                 to: profilesURL
@@ -338,9 +345,12 @@ final class RelayStore: ObservableObject {
         return job
     }
 
-    func unpair() {
+    public func unpair() {
+        #if canImport(ActivityKit)
+        RunActivityTracker.cancelAll()
+        #endif
         if let profile {
-            try? keychain(for: profile.name).clear()
+            try? credentialStorage(for: profile.name).clear()
             if let tokenFile = profile.tokenFile {
                 try? FileManager.default.removeItem(atPath: tokenFile)
             }

--- a/ios/MereRunStudio/App/RunActivityTracker.swift
+++ b/ios/MereRunStudio/App/RunActivityTracker.swift
@@ -7,9 +7,15 @@ import MereRunRelayKit
 /// state, updating progress from the worker's event stream. Updates are
 /// app-driven for now; push-updated activities need APNs support in the
 /// relay and are a documented follow-up.
+@MainActor
 enum RunActivityTracker {
+    private static let pollingPolicy = RunPollingPolicy()
+    private static var tasks: [String: Task<Void, Never>] = [:]
+    private static var taskTokens: [String: UUID] = [:]
+
     static func track(job: WorkflowRemoteJob, title: String, client: RelayWorkflowExecutor) {
-        guard ActivityAuthorizationInfo().areActivitiesEnabled else { return }
+        guard ActivityAuthorizationInfo().areActivitiesEnabled,
+              tasks[job.jobID] == nil else { return }
         let attributes = RunActivityAttributes(jobID: job.jobID, title: title)
         let initial = RunActivityAttributes.ContentState(
             stateLabel: job.state.rawValue,
@@ -18,17 +24,53 @@ enum RunActivityTracker {
         )
         let jobID = job.jobID
         let startLabel = job.state.rawValue
-        // The Activity handle is not Sendable; confining its whole lifetime to
-        // one detached task keeps request, update, and end in a single region.
-        Task.detached {
+        let token = UUID()
+        taskTokens[jobID] = token
+        tasks[jobID] = Task { @MainActor in
+            defer { clear(jobID: jobID, token: token) }
             guard let activity = try? Activity.request(
                 attributes: attributes,
                 content: .init(state: initial, staleDate: nil)
             ) else { return }
             var lastLabel = startLabel
-            while true {
-                try? await Task.sleep(for: .seconds(2))
-                guard let current = try? await client.inspect(jobID: jobID) else { continue }
+            var consecutiveFailures = 0
+            while !Task.isCancelled {
+                let current: WorkflowRemoteJob
+                do {
+                    current = try await client.inspect(jobID: jobID)
+                    consecutiveFailures = 0
+                } catch {
+                    consecutiveFailures += 1
+                    if pollingPolicy.shouldStop(afterConsecutiveFailures: consecutiveFailures) {
+                        let paused = RunActivityAttributes.ContentState(
+                            stateLabel: lastLabel,
+                            fraction: nil,
+                            detail: "Updates paused — open mere.run"
+                        )
+                        await activity.end(
+                            .init(state: paused, staleDate: nil),
+                            dismissalPolicy: .default
+                        )
+                        return
+                    }
+                    guard await sleep(
+                        nanoseconds: pollingPolicy.delayNanoseconds(
+                            afterConsecutiveFailures: consecutiveFailures
+                        )
+                    ) else {
+                        let stopped = RunActivityAttributes.ContentState(
+                            stateLabel: lastLabel,
+                            fraction: nil,
+                            detail: "Updates stopped"
+                        )
+                        await activity.end(
+                            .init(state: stopped, staleDate: nil),
+                            dismissalPolicy: .default
+                        )
+                        return
+                    }
+                    continue
+                }
                 var fraction: Double?
                 var detail: String?
                 if let raw = try? await client.events(jobID: jobID) {
@@ -61,8 +103,53 @@ enum RunActivityTracker {
                     return
                 }
                 await activity.update(.init(state: state, staleDate: nil))
+                guard await sleep(nanoseconds: pollingPolicy.regularDelayNanoseconds) else {
+                    let stopped = RunActivityAttributes.ContentState(
+                        stateLabel: lastLabel,
+                        fraction: nil,
+                        detail: "Updates stopped"
+                    )
+                    await activity.end(
+                        .init(state: stopped, staleDate: nil),
+                        dismissalPolicy: .default
+                    )
+                    return
+                }
             }
+            let stopped = RunActivityAttributes.ContentState(
+                stateLabel: lastLabel,
+                fraction: nil,
+                detail: "Updates stopped"
+            )
+            await activity.end(
+                .init(state: stopped, staleDate: nil),
+                dismissalPolicy: .default
+            )
         }
+    }
+
+    static func cancelAll() {
+        let running = Array(tasks.values)
+        tasks.removeAll()
+        taskTokens.removeAll()
+        for task in running {
+            task.cancel()
+        }
+    }
+
+    private static func sleep(nanoseconds: UInt64) async -> Bool {
+        do {
+            try await Task.sleep(nanoseconds: nanoseconds)
+            return !Task.isCancelled
+        } catch {
+            return false
+        }
+    }
+
+    private static func clear(jobID: String, token: UUID) {
+        guard taskTokens[jobID] == token else { return }
+        tasks[jobID] = nil
+        taskTokens[jobID] = nil
     }
 }
 #endif

--- a/ios/MereRunStudio/App/RunArtifactStore.swift
+++ b/ios/MereRunStudio/App/RunArtifactStore.swift
@@ -1,0 +1,81 @@
+import Foundation
+
+struct RunArtifactStore: Sendable {
+    enum StoreError: LocalizedError {
+        case invalidJobID
+        case missingArtifact(String)
+        case invalidArtifactPath(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .invalidJobID:
+                "The run identifier cannot be used for local artifact storage."
+            case .missingArtifact(let path):
+                "The refreshed run is missing artifact \(path)."
+            case .invalidArtifactPath(let path):
+                "The refreshed run contains an invalid artifact path: \(path)."
+            }
+        }
+    }
+
+    let runsRoot: URL
+    private var fileManager: FileManager { .default }
+
+    init(runsRoot: URL) {
+        self.runsRoot = runsRoot
+    }
+
+    func refresh(
+        jobID: String,
+        fetch: @Sendable (URL) async throws -> [String]
+    ) async throws -> [URL] {
+        guard isPathSegment(jobID) else { throw StoreError.invalidJobID }
+        try fileManager.createDirectory(at: runsRoot, withIntermediateDirectories: true)
+        let destination = runsRoot.appendingPathComponent(jobID, isDirectory: true)
+        let staging = runsRoot.appendingPathComponent(
+            ".\(jobID).refresh-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        defer { try? fileManager.removeItem(at: staging) }
+
+        let artifactPaths = try await fetch(staging)
+        for path in artifactPaths {
+            guard isRelativePath(path) else { throw StoreError.invalidArtifactPath(path) }
+            let artifact = staging.appendingPathComponent(path).standardizedFileURL
+            guard artifact.path.hasPrefix(staging.standardizedFileURL.path + "/"),
+                  fileManager.fileExists(atPath: artifact.path) else {
+                throw StoreError.missingArtifact(path)
+            }
+        }
+
+        try replace(destination: destination, with: staging)
+        return artifactPaths.map { destination.appendingPathComponent($0).standardizedFileURL }
+    }
+
+    private func replace(destination: URL, with staging: URL) throws {
+        guard fileManager.fileExists(atPath: destination.path) else {
+            try fileManager.moveItem(at: staging, to: destination)
+            return
+        }
+        let backupName = ".\(destination.lastPathComponent).backup-\(UUID().uuidString)"
+        _ = try fileManager.replaceItemAt(
+            destination,
+            withItemAt: staging,
+            backupItemName: backupName,
+            options: .usingNewMetadataOnly
+        )
+        try? fileManager.removeItem(at: runsRoot.appendingPathComponent(backupName))
+    }
+
+    private func isPathSegment(_ value: String) -> Bool {
+        !value.isEmpty && value != "." && value != ".." && !value.contains("/")
+    }
+
+    private func isRelativePath(_ value: String) -> Bool {
+        !value.isEmpty
+            && !value.hasPrefix("/")
+            && value.split(separator: "/", omittingEmptySubsequences: false).allSatisfy {
+                !$0.isEmpty && $0 != "." && $0 != ".."
+            }
+    }
+}

--- a/ios/MereRunStudio/App/RunPollingPolicy.swift
+++ b/ios/MereRunStudio/App/RunPollingPolicy.swift
@@ -1,0 +1,29 @@
+import Foundation
+
+struct RunPollingPolicy: Equatable, Sendable {
+    let regularDelayNanoseconds: UInt64
+    let maximumDelayNanoseconds: UInt64
+    let maximumConsecutiveFailures: Int
+
+    init(
+        regularDelayNanoseconds: UInt64 = 2_000_000_000,
+        maximumDelayNanoseconds: UInt64 = 30_000_000_000,
+        maximumConsecutiveFailures: Int = 6
+    ) {
+        self.regularDelayNanoseconds = regularDelayNanoseconds
+        self.maximumDelayNanoseconds = maximumDelayNanoseconds
+        self.maximumConsecutiveFailures = maximumConsecutiveFailures
+    }
+
+    func delayNanoseconds(afterConsecutiveFailures failures: Int) -> UInt64 {
+        guard failures > 0 else { return regularDelayNanoseconds }
+        let exponent = min(failures - 1, 62)
+        let multiplier = UInt64(1) << UInt64(exponent)
+        let (delay, overflow) = regularDelayNanoseconds.multipliedReportingOverflow(by: multiplier)
+        return overflow ? maximumDelayNanoseconds : min(delay, maximumDelayNanoseconds)
+    }
+
+    func shouldStop(afterConsecutiveFailures failures: Int) -> Bool {
+        failures >= maximumConsecutiveFailures
+    }
+}

--- a/ios/MereRunStudio/App/RuntimeResidencyState.swift
+++ b/ios/MereRunStudio/App/RuntimeResidencyState.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+/// The small, deterministic state machine behind LocalEngine residency.
+/// Runtime objects stay in LocalEngine; this type only decides when a release
+/// starts immediately and when it must wait for active inference to finish.
+struct RuntimeResidencyState: Equatable, Sendable {
+    enum Activity: Equatable, Sendable {
+        case idle
+        case generatingImage
+        case chatting
+        case releasing
+    }
+
+    private(set) var activity: Activity = .idle
+    private(set) var releasePending = false
+
+    mutating func begin(_ next: Activity) -> Bool {
+        guard activity == .idle, next == .generatingImage || next == .chatting else {
+            return false
+        }
+        activity = next
+        return true
+    }
+
+    /// Returns true when the caller should begin unloading now. Otherwise the
+    /// release remains pending until `completeActivity()` is called.
+    mutating func requestRelease() -> Bool {
+        guard activity != .releasing else { return false }
+        releasePending = true
+        guard activity == .idle else { return false }
+        activity = .releasing
+        releasePending = false
+        return true
+    }
+
+    mutating func beginRelease() -> Bool {
+        guard activity == .idle else { return false }
+        activity = .releasing
+        releasePending = false
+        return true
+    }
+
+    /// Returns true when a deferred release should start immediately.
+    mutating func completeActivity() -> Bool {
+        guard activity == .generatingImage || activity == .chatting else {
+            return false
+        }
+        activity = .idle
+        guard releasePending else { return false }
+        activity = .releasing
+        releasePending = false
+        return true
+    }
+
+    mutating func completeRelease() {
+        guard activity == .releasing else { return }
+        activity = .idle
+        releasePending = false
+    }
+}

--- a/ios/MereRunStudio/MereRunStudio.Debug.entitlements
+++ b/ios/MereRunStudio/MereRunStudio.Debug.entitlements
@@ -4,7 +4,7 @@
 <dict>
 	<key>com.apple.developer.associated-domains</key>
 	<array>
-		<string>applinks:mere.world</string>
+		<string>applinks:mere.world?mode=developer</string>
 		<string>webcredentials:mere.world</string>
 	</array>
 	<key>com.apple.developer.kernel.increased-memory-limit</key>

--- a/ios/MereRunStudio/Views/ChatView.swift
+++ b/ios/MereRunStudio/Views/ChatView.swift
@@ -140,7 +140,9 @@ struct ChatView: View {
             Text("Think it through.")
                 .font(.system(.largeTitle, design: .serif))
                 .foregroundStyle(MereTheme.textPrimary)
-            Text("Your words go to your machines and nowhere else.")
+            Text(ExecutionPrivacyCopy.chat(
+                for: chat.runLocally ? .onDevice : relay.executionPrivacyLane
+            ))
                 .font(.callout)
                 .foregroundStyle(MereTheme.textSecondary)
         }

--- a/ios/MereRunStudio/Views/CreateView.swift
+++ b/ios/MereRunStudio/Views/CreateView.swift
@@ -255,7 +255,9 @@ struct CreateView: View {
 
                     runButton
 
-                    Text("Runs on your machines. Prompts, photos, and outputs stay between your devices.")
+                    Text(ExecutionPrivacyCopy.create(
+                        for: runsOnThisPhone ? .onDevice : relay.executionPrivacyLane
+                    ))
                         .font(.footnote)
                         .foregroundStyle(MereTheme.textMuted)
                         .frame(maxWidth: .infinity, alignment: .center)
@@ -430,9 +432,10 @@ struct CreateView: View {
         } else {
             switch selected.assetMedia {
             case .image:
+                let title = selected.assetRequired ? "Choose a photo" : "Add a photo (optional)"
                 PhotosPicker(selection: $photoItem, matching: .images) {
                     AttachLabel(
-                        title: selected.assetRequired ? "Choose a photo" : "Add a photo (optional)",
+                        title: title,
                         symbol: "photo.badge.plus"
                     )
                 }

--- a/ios/MereRunStudio/Views/OnDeviceModelsView.swift
+++ b/ios/MereRunStudio/Views/OnDeviceModelsView.swift
@@ -22,6 +22,7 @@ struct OnDeviceModelsView: View {
 /// The list itself, pushable from Settings or wrapped in a sheet.
 struct OnDeviceModelsList: View {
     @ObservedObject private var local = LocalEngine.shared
+    @AppStorage(LocalEngine.allowsCellularDownloadsKey) private var allowsCellularDownloads = false
     @State private var confirmingModel: LocalEngine.Model?
 
     var body: some View {
@@ -66,6 +67,25 @@ struct OnDeviceModelsList: View {
                     } footer: {
                         Text("Frees partial downloads and payloads no installed model uses.")
                     }
+                }
+
+                if local.isDownloadingModel {
+                    Section {
+                        Label("Safe to leave the app", systemImage: "arrow.down.circle")
+                            .font(.footnote)
+                    } footer: {
+                        Text("iOS continues model transfers in the background and finishes verification when mere.run resumes.")
+                    }
+                }
+
+                Section {
+                    Toggle("Allow cellular downloads", isOn: $allowsCellularDownloads)
+                } header: {
+                    Text("Downloads")
+                } footer: {
+                    Text(allowsCellularDownloads
+                        ? "New model downloads may use cellular, expensive, or constrained networks."
+                        : "New model downloads wait for an unrestricted Wi-Fi connection.")
                 }
 
                 if let message = local.lastError {
@@ -162,7 +182,7 @@ struct OnDeviceModelsList: View {
         .swipeActions(edge: .trailing, allowsFullSwipe: false) {
             if local.state(of: model.id) == .ready {
                 Button(role: .destructive) {
-                    local.delete(model.id)
+                    Task { await local.delete(model.id) }
                 } label: {
                     Label("Remove", systemImage: "trash")
                 }

--- a/ios/MereRunStudio/Views/PairingView.swift
+++ b/ios/MereRunStudio/Views/PairingView.swift
@@ -140,7 +140,9 @@ struct PairingView: View {
                 EmptyView()
             }
             Spacer()
-            Text("Stays between your devices.")
+            Text(directConnect
+                ? "Connects directly to your machine over your network or tailnet."
+                : "Hosted relay infrastructure carries prompts, status, and artifacts to your fleet.")
                 .font(.footnote)
                 .foregroundStyle(MereTheme.textMuted)
         }

--- a/ios/MereRunStudio/Views/RunDetailView.swift
+++ b/ios/MereRunStudio/Views/RunDetailView.swift
@@ -222,17 +222,14 @@ struct RunDetailView: View {
         guard let client = relay.client else { return }
         busy = true
         defer { busy = false }
-        let destination = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
-            .appendingPathComponent("runs", isDirectory: true)
-            .appendingPathComponent(jobID, isDirectory: true)
-        // Fetch validates a pre-existing destination as a materialized bundle,
-        // which the phone never has; start each fetch from a clean directory.
-        try? FileManager.default.removeItem(at: destination)
+        let store = RunArtifactStore(
+            runsRoot: FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+                .appendingPathComponent("runs", isDirectory: true)
+        )
         do {
-            let fetched = try await client.fetch(jobID: jobID, into: destination, allArtifacts: false)
-            fetchedFiles = fetched.artifacts.compactMap { artifact in
-                let url = destination.appendingPathComponent(artifact.path)
-                return FileManager.default.fileExists(atPath: url.path) ? url : nil
+            fetchedFiles = try await store.refresh(jobID: jobID) { staging in
+                let fetched = try await client.fetch(jobID: jobID, into: staging, allArtifacts: false)
+                return fetched.artifacts.map(\.path)
             }
         } catch let error as RelayClientError {
             errorMessage = AppErrorText.presentable(error.message)

--- a/ios/MereRunStudioTests/ExecutionPrivacyCopyTests.swift
+++ b/ios/MereRunStudioTests/ExecutionPrivacyCopyTests.swift
@@ -1,0 +1,19 @@
+import XCTest
+
+final class ExecutionPrivacyCopyTests: XCTestCase {
+    func testHostedCopyNamesRelayBoundary() {
+        XCTAssertTrue(ExecutionPrivacyCopy.chat(for: .hostedRelay).contains("relay"))
+        XCTAssertTrue(ExecutionPrivacyCopy.create(for: .hostedRelay).contains("relay"))
+    }
+
+    func testOnDeviceCopyNamesSingleDeviceBoundary() {
+        XCTAssertTrue(ExecutionPrivacyCopy.chat(for: .onDevice).contains("this device"))
+        XCTAssertTrue(ExecutionPrivacyCopy.create(for: .onDevice).contains("this device"))
+    }
+
+    func testDirectCopyNamesNetworkBoundaryWithoutHostedRelay() {
+        let copy = ExecutionPrivacyCopy.create(for: .directMachine)
+        XCTAssertTrue(copy.contains("network or tailnet"))
+        XCTAssertFalse(copy.contains("relay"))
+    }
+}

--- a/ios/MereRunStudioTests/HubDownloadDeviceTests.swift
+++ b/ios/MereRunStudioTests/HubDownloadDeviceTests.swift
@@ -49,7 +49,7 @@ final class HubDownloadDeviceTests: XCTestCase {
             let http = try XCTUnwrap(response as? HTTPURLResponse)
             if (200..<300).contains(http.statusCode) {
                 let size = (try? FileManager.default.attributesOfItem(atPath: tempURL.path)[.size] as? Int) ?? 0
-                XCTAssertGreaterThan(size ?? 0, 10, "Downloaded file is empty")
+                XCTAssertGreaterThan(size, 10, "Downloaded file is empty")
                 return
             }
             guard (300..<400).contains(http.statusCode),
@@ -246,11 +246,11 @@ final class HubDownloadDeviceTests: XCTestCase {
         let a = sessionDelegate.state
         let b = taskDelegate.state
         attach([
-            "A(session delegate): file \(sizeA ?? 0) bytes, didWriteData events \(a.events), reported \(a.bytes)",
-            "B(per-task delegate): file \(sizeB ?? 0) bytes, didWriteData events \(b.events), reported \(b.bytes)",
+            "A(session delegate): file \(sizeA) bytes, didWriteData events \(a.events), reported \(a.bytes)",
+            "B(per-task delegate): file \(sizeB) bytes, didWriteData events \(b.events), reported \(b.bytes)",
         ], name: "v7-delegates")
-        XCTAssertGreaterThan(sizeA ?? 0, 1000, "Session-delegate download produced no file")
-        XCTAssertGreaterThan(sizeB ?? 0, 1000, "Per-task-delegate download produced no file")
+        XCTAssertGreaterThan(sizeA, 1000, "Session-delegate download produced no file")
+        XCTAssertGreaterThan(sizeB, 1000, "Per-task-delegate download produced no file")
         XCTAssertGreaterThan(b.events, 0, "Per-task delegate never saw progress")
     }
 }

--- a/ios/MereRunStudioTests/PendingModelDownloadStoreTests.swift
+++ b/ios/MereRunStudioTests/PendingModelDownloadStoreTests.swift
@@ -1,0 +1,71 @@
+import Foundation
+import XCTest
+
+final class PendingModelDownloadStoreTests: XCTestCase {
+    private var suiteName: String!
+    private var defaults: UserDefaults!
+
+    override func setUpWithError() throws {
+        try super.setUpWithError()
+        suiteName = "PendingModelDownloadStoreTests.\(UUID().uuidString)"
+        defaults = try XCTUnwrap(UserDefaults(suiteName: suiteName))
+    }
+
+    override func tearDownWithError() throws {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        suiteName = nil
+        try super.tearDownWithError()
+    }
+
+    func testSaveReplacesSameModelAndPreservesTerms() throws {
+        let store = PendingModelDownloadStore(defaults: defaults, key: "downloads")
+        let first = PendingModelDownload(
+            modelID: "image-bonsai-binary",
+            usageTermsAcknowledged: false,
+            requestedAt: Date(timeIntervalSince1970: 1)
+        )
+        let replacement = PendingModelDownload(
+            modelID: first.modelID,
+            usageTermsAcknowledged: true,
+            requestedAt: Date(timeIntervalSince1970: 2),
+            allowsCellular: true
+        )
+
+        try store.save(first)
+        try store.save(replacement)
+
+        XCTAssertEqual(store.all(), [replacement])
+    }
+
+    func testRemoveClearsOnlyCompletedModel() throws {
+        let store = PendingModelDownloadStore(defaults: defaults, key: "downloads")
+        let image = PendingModelDownload(
+            modelID: "image-bonsai-binary",
+            usageTermsAcknowledged: false,
+            requestedAt: Date(timeIntervalSince1970: 1)
+        )
+        let chat = PendingModelDownload(
+            modelID: "text-chat-lfm25-2.6b-4bit",
+            usageTermsAcknowledged: true,
+            requestedAt: Date(timeIntervalSince1970: 2)
+        )
+        try store.save(image)
+        try store.save(chat)
+
+        try store.remove(modelID: image.modelID)
+
+        XCTAssertEqual(store.all(), [chat])
+    }
+
+    func testLegacyRecordDefaultsToWifiOnly() throws {
+        let legacy = """
+        [{"modelID":"image-bonsai-binary","usageTermsAcknowledged":false,"requestedAt":0}]
+        """
+        defaults.set(try XCTUnwrap(legacy.data(using: .utf8)), forKey: "downloads")
+
+        let download = try XCTUnwrap(PendingModelDownloadStore(defaults: defaults, key: "downloads").all().first)
+
+        XCTAssertFalse(download.allowsCellular)
+    }
+}

--- a/ios/MereRunStudioTests/RelayStoreTests.swift
+++ b/ios/MereRunStudioTests/RelayStoreTests.swift
@@ -1,0 +1,72 @@
+import Foundation
+import MereRunRelayKit
+import XCTest
+import mere_run
+
+@MainActor
+final class RelayStoreTests: XCTestCase {
+    func testLegacyCredentialMigratesAndClientUsesInjectedStorage() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("RelayStoreTests-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+
+        let profile = WorkflowExecutorProfile(
+            name: "phone",
+            kind: .relay,
+            destination: nil,
+            remoteRoot: nil,
+            port: nil,
+            identityFile: nil,
+            mereRunPath: nil,
+            url: "https://relay.example.test",
+            tokenFile: nil
+        )
+        try WorkflowExecutorProfileStore.save(
+            WorkflowExecutorProfiles(schemaVersion: 1, profiles: [profile]),
+            to: root.appendingPathComponent("executors.json")
+        )
+        let legacyURL = RelayAuthentication.defaultTokenFile(
+            profileName: profile.name,
+            applicationSupportBase: root
+        )
+        let token = RelayOAuthTokenSet(
+            accessToken: "legacy-token",
+            refreshToken: "refresh-token",
+            tokenType: "Bearer",
+            expiresIn: nil,
+            obtainedAtEpochSeconds: nil
+        )
+        try FileCredentialStorage(url: legacyURL).save(token)
+        let storage = MemoryCredentialStorage()
+
+        let store = RelayStore(supportBase: root) { _ in storage }
+
+        XCTAssertEqual(store.pairing, .paired)
+        XCTAssertNil(store.profile?.tokenFile)
+        XCTAssertEqual(try storage.load(), token)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: legacyURL.path))
+        XCTAssertEqual(try store.client?.credentialStorage?.load(), token)
+
+        store.unpair()
+        XCTAssertNil(try storage.load())
+        XCTAssertFalse(FileManager.default.fileExists(atPath: root.appendingPathComponent("executors.json").path))
+    }
+}
+
+private final class MemoryCredentialStorage: RelayCredentialStorage, @unchecked Sendable {
+    private let lock = NSLock()
+    private var tokenSet: RelayOAuthTokenSet?
+
+    func load() throws -> RelayOAuthTokenSet? {
+        lock.withLock { tokenSet }
+    }
+
+    func save(_ tokenSet: RelayOAuthTokenSet) throws {
+        lock.withLock { self.tokenSet = tokenSet }
+    }
+
+    func clear() throws {
+        lock.withLock { tokenSet = nil }
+    }
+}

--- a/ios/MereRunStudioTests/RunArtifactStoreTests.swift
+++ b/ios/MereRunStudioTests/RunArtifactStoreTests.swift
@@ -1,0 +1,49 @@
+import Foundation
+import XCTest
+
+final class RunArtifactStoreTests: XCTestCase {
+    private enum ExpectedFailure: Error { case fetch }
+
+    func testFailedRefreshPreservesLastVerifiedBundle() async throws {
+        let root = temporaryRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let destination = root.appendingPathComponent("job-1", isDirectory: true)
+        try FileManager.default.createDirectory(at: destination, withIntermediateDirectories: true)
+        let good = destination.appendingPathComponent("result.txt")
+        try Data("last-good".utf8).write(to: good)
+
+        do {
+            _ = try await RunArtifactStore(runsRoot: root).refresh(jobID: "job-1") { staging in
+                try FileManager.default.createDirectory(at: staging, withIntermediateDirectories: true)
+                try Data("partial".utf8).write(to: staging.appendingPathComponent("result.txt"))
+                throw ExpectedFailure.fetch
+            }
+            XCTFail("Expected refresh failure")
+        } catch ExpectedFailure.fetch {}
+
+        XCTAssertEqual(try String(contentsOf: good, encoding: .utf8), "last-good")
+    }
+
+    func testSuccessfulRefreshReplacesBundle() async throws {
+        let root = temporaryRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let destination = root.appendingPathComponent("job-1", isDirectory: true)
+        try FileManager.default.createDirectory(at: destination, withIntermediateDirectories: true)
+        try Data("old".utf8).write(to: destination.appendingPathComponent("old.txt"))
+
+        let files = try await RunArtifactStore(runsRoot: root).refresh(jobID: "job-1") { staging in
+            try FileManager.default.createDirectory(at: staging, withIntermediateDirectories: true)
+            try Data("new".utf8).write(to: staging.appendingPathComponent("result.txt"))
+            return ["result.txt"]
+        }
+
+        XCTAssertEqual(files, [destination.appendingPathComponent("result.txt")])
+        XCTAssertEqual(try String(contentsOf: files[0], encoding: .utf8), "new")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: destination.appendingPathComponent("old.txt").path))
+    }
+
+    private func temporaryRoot() -> URL {
+        FileManager.default.temporaryDirectory
+            .appendingPathComponent("RunArtifactStoreTests-\(UUID().uuidString)", isDirectory: true)
+    }
+}

--- a/ios/MereRunStudioTests/RunPollingPolicyTests.swift
+++ b/ios/MereRunStudioTests/RunPollingPolicyTests.swift
@@ -1,0 +1,24 @@
+import XCTest
+
+final class RunPollingPolicyTests: XCTestCase {
+    func testBackoffIsExponentialAndCapped() {
+        let policy = RunPollingPolicy(
+            regularDelayNanoseconds: 2,
+            maximumDelayNanoseconds: 10,
+            maximumConsecutiveFailures: 4
+        )
+
+        XCTAssertEqual(policy.delayNanoseconds(afterConsecutiveFailures: 0), 2)
+        XCTAssertEqual(policy.delayNanoseconds(afterConsecutiveFailures: 1), 2)
+        XCTAssertEqual(policy.delayNanoseconds(afterConsecutiveFailures: 2), 4)
+        XCTAssertEqual(policy.delayNanoseconds(afterConsecutiveFailures: 3), 8)
+        XCTAssertEqual(policy.delayNanoseconds(afterConsecutiveFailures: 4), 10)
+    }
+
+    func testFailureBudgetStopsPersistentPolling() {
+        let policy = RunPollingPolicy(maximumConsecutiveFailures: 3)
+
+        XCTAssertFalse(policy.shouldStop(afterConsecutiveFailures: 2))
+        XCTAssertTrue(policy.shouldStop(afterConsecutiveFailures: 3))
+    }
+}

--- a/ios/MereRunStudioTests/RuntimeResidencyStateTests.swift
+++ b/ios/MereRunStudioTests/RuntimeResidencyStateTests.swift
@@ -1,0 +1,30 @@
+import XCTest
+
+final class RuntimeResidencyStateTests: XCTestCase {
+    func testReleaseWaitsForActiveInferenceThenBlocksNewWork() {
+        var state = RuntimeResidencyState()
+
+        XCTAssertTrue(state.begin(.chatting))
+        XCTAssertFalse(state.requestRelease())
+        XCTAssertEqual(state.activity, .chatting)
+        XCTAssertTrue(state.releasePending)
+
+        XCTAssertTrue(state.completeActivity())
+        XCTAssertEqual(state.activity, .releasing)
+        XCTAssertFalse(state.begin(.generatingImage))
+
+        state.completeRelease()
+        XCTAssertEqual(state.activity, .idle)
+        XCTAssertTrue(state.begin(.generatingImage))
+    }
+
+    func testIdleReleaseStartsImmediately() {
+        var state = RuntimeResidencyState()
+
+        XCTAssertTrue(state.requestRelease())
+        XCTAssertEqual(state.activity, .releasing)
+        XCTAssertFalse(state.releasePending)
+        XCTAssertFalse(state.requestRelease())
+        XCTAssertFalse(state.releasePending)
+    }
+}

--- a/ios/MereRunStudioUITests/ChatDeviceDiagnosticsUITests.swift
+++ b/ios/MereRunStudioUITests/ChatDeviceDiagnosticsUITests.swift
@@ -3,6 +3,7 @@ import XCTest
 /// Diagnostic: drive an on-device chat turn on real hardware and record the
 /// streaming pipeline's behavior — telemetry line, partial bubble, reply.
 /// Gated on MERERUN_TEST_CHAT_DIAG.
+@MainActor
 final class ChatDeviceDiagnosticsUITests: XCTestCase {
     func testOnDeviceChatTurn() throws {
         guard ProcessInfo.processInfo.environment["MERERUN_TEST_CHAT_DIAG"] != nil else {

--- a/ios/MereRunStudioUITests/DirectLaneUITests.swift
+++ b/ios/MereRunStudioUITests/DirectLaneUITests.swift
@@ -14,6 +14,7 @@ import XCTest
 ///
 /// Without those variables the test skips, so plain `xcodebuild test` stays
 /// green on machines with no relay running.
+@MainActor
 final class DirectLaneUITests: XCTestCase {
     override func setUpWithError() throws {
         continueAfterFailure = false

--- a/ios/MereRunStudioUITests/DownloadDiagnosticsUITests.swift
+++ b/ios/MereRunStudioUITests/DownloadDiagnosticsUITests.swift
@@ -3,6 +3,7 @@ import XCTest
 /// Diagnostic: drive an on-device model download on real hardware and record
 /// what the UI reports. Runs only when MERERUN_TEST_DOWNLOAD_DIAG is set —
 /// this is an investigation tool, not a CI gate.
+@MainActor
 final class DownloadDiagnosticsUITests: XCTestCase {
     override func setUpWithError() throws {
         continueAfterFailure = true

--- a/ios/MereRunStudioUITests/UXShotsUITests.swift
+++ b/ios/MereRunStudioUITests/UXShotsUITests.swift
@@ -3,6 +3,7 @@ import XCTest
 /// Screenshot harness for design iteration: launches the app in UI-preview
 /// mode and captures the on-device model surfaces. Gated on
 /// MERERUN_TEST_UX_SHOTS so ordinary test runs skip it.
+@MainActor
 final class UXShotsUITests: XCTestCase {
     func testCaptureOnDeviceSurfaces() throws {
         guard ProcessInfo.processInfo.environment["MERERUN_TEST_UX_SHOTS"] != nil else {

--- a/ios/MereRunWidgets/Info.plist
+++ b/ios/MereRunWidgets/Info.plist
@@ -17,9 +17,9 @@
 	<key>CFBundlePackageType</key>
 	<string>XPC!</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>$(MARKETING_VERSION)</string>
 	<key>CFBundleVersion</key>
-	<string>1</string>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
 	<key>NSExtension</key>
 	<dict>
 		<key>NSExtensionPointIdentifier</key>

--- a/ios/README.md
+++ b/ios/README.md
@@ -1,20 +1,19 @@
 # mere.run Studio for iOS
 
-The iOS client for a paired mere.run fleet. The phone is a relay client in the
-same family as hosted Graph Studio: it signs in to a relay, watches the run
-inbox, streams worker events, fetches digest-verified artifacts, and inspects
-fleet nodes. Model execution stays on the paired nodes; nothing infers on the
-phone in this phase. The architecture and phasing live in
+The iOS client for mere.run. It can sign in to a hosted relay or pair directly
+with a machine, submit and watch work, fetch digest-verified artifacts, and
+inspect fleet nodes. Supported image and chat models can also execute entirely
+on a physical iPhone. The architecture and current boundaries live in
 [`docs/ios-studio.md`](../docs/ios-studio.md).
 
 ## Status
 
-Scaffold. The sources here compile against `MereRunRelayKit` (the portable
-relay client extracted from the CLI) but have not yet been built or run on a
-Mac with Xcode — this directory was authored in a Linux environment where the
-`MereRunRelayKit` package target and its tests build and pass, and where iOS
-toolchains do not exist. Treat the first `xcodegen generate && xcodebuild`
-on a Mac as part of landing this change.
+Active client. The local Xcode project is generated from `project.yml`; CI
+regenerates it, performs a Release simulator build, and verifies the app/widget
+version and Debug/Release associated-domain contracts. Simulator builds cover
+the UI, portable client, and background-session integration. Actual suspended
+multi-gigabyte transfer, MLX inference and memory release, browser sign-in, and
+direct-machine pairing still require physical-device validation.
 
 ## Building
 
@@ -28,10 +27,9 @@ MERERUN_IOS_TEAM=<team id> xcodegen generate   # device builds (automatic signin
 open MereRunStudio.xcodeproj
 ```
 
-The app target links only the `MereRunRelayKit` product from the repository's
-root package. Xcode will resolve the whole package graph on first open (the
-root package also declares the runtime's dependencies); only RelayKit's small
-closure is compiled into the app.
+The app target links `MereRunRelayKit` for portable relay workflows and
+`MereRunCore` for on-device inference. Xcode resolves the root package graph on
+first open.
 
 ## Layout
 
@@ -42,8 +40,42 @@ MereRunStudio/
   Views/     pairing, fleet, run inbox, and run detail surfaces
 ```
 
-Storage: the executor profile and OAuth token set persist in the app's
-Application Support directory with complete file protection, using the same
-JSON shapes as the CLI (`executors.json`, `executor-auth/<profile>.json`).
-Keychain-backed credential storage and an Authorization Code + PKCE sign-in
-(matching hosted Studio) are planned follow-ups tracked in the design doc.
+Storage: the executor profile persists in the app's protected Application
+Support directory using the CLI-compatible `executors.json` shape. OAuth and
+direct-pairing credentials live in the device-only Keychain. Existing
+file-backed OAuth credentials migrate to Keychain once and are removed.
+
+Browser sign-in uses Authorization Code + PKCE and returns through the
+`mere.world` universal link. Device-code authorization remains the browserless
+fallback.
+
+## Model downloads and runtime residency
+
+On-device model installs use a fixed iOS background URL session. The app stores
+pending install intent in `UserDefaults`, rejoins the matching system transfer
+after relaunch, moves completed files into durable staging, and only removes
+the pending record after the managed snapshot is pinned and validated. Leaving
+the app does not cancel an active payload transfer. New transfers default to
+unmetered, unconstrained Wi-Fi; Settings can opt a new download into cellular,
+expensive, and constrained networks. The selected policy is persisted with that
+pending download across relaunch. User force-quit behavior is owned by iOS and
+is not a supported continuation path.
+
+The local engine unloads chat and image runtime state when the app backgrounds,
+on memory warnings, on model or inference-lane switches, before model removal,
+and after two idle minutes. Active inference is allowed to finish before a
+requested unload begins, and new inference is rejected during the release
+transition. Live Activities use one bounded poller per run with exponential
+backoff and stop after persistent transport failures. Artifact refreshes are
+staged and validated before replacing an earlier verified local copy.
+
+## Release footprint
+
+The 2026-08-19 clean arm64 Release-simulator audit measured a 75.4 MiB
+uncompressed app and a 68.3 MiB main executable after keeping the unused
+llama.cpp binary dependency macOS-only. That is not an App Store download-size
+estimate. It is a reproducible signal that the current broad `MereRunCore`
+import dominates the mobile build. CI keeps the simulator build arm64-only and
+fails if the Release executable exceeds 80 MiB; a future mobile runtime target
+must actually extract the needed image, chat, and model-storage sources rather
+than wrap the existing core dependency.

--- a/ios/project.yml
+++ b/ios/project.yml
@@ -1,7 +1,7 @@
 # XcodeGen manifest for the iOS Studio app.
 # Generate the project on a Mac:  cd ios && xcodegen generate
-# The app links only the portable MereRunRelayKit product from the root
-# package; no inference runtime is built for the phone in this phase.
+# The app links the portable relay client and the on-device runtime from the
+# root package.
 name: MereRunStudio
 options:
   bundleIdPrefix: run.mere
@@ -29,16 +29,6 @@ targets:
         NSLocalNetworkUsageDescription: mere.run connects to your own machines on your network to run the work you submit.
         NSAppTransportSecurity:
           NSAllowsLocalNetworking: true
-    entitlements:
-      path: MereRunStudio/MereRunStudio.entitlements
-      properties:
-        # ?mode=developer bypasses Apple's AASA CDN on Developer Mode
-        # devices; drop the suffix for release signing.
-        com.apple.developer.associated-domains:
-          - applinks:mere.world?mode=developer
-          - webcredentials:mere.world
-        # Bonsai 27B 1-bit chat needs the expanded per-app memory ceiling.
-        com.apple.developer.kernel.increased-memory-limit: true
     settings:
       base:
         PRODUCT_NAME: mere.run
@@ -60,17 +50,29 @@ targets:
         # Set for device builds: MERERUN_IOS_TEAM=<team id> xcodegen generate
         # Simulator builds need no team.
         DEVELOPMENT_TEAM: ${MERERUN_IOS_TEAM}
+      configs:
+        Debug:
+          CODE_SIGN_ENTITLEMENTS: MereRunStudio/MereRunStudio.Debug.entitlements
+        Release:
+          CODE_SIGN_ENTITLEMENTS: MereRunStudio/MereRunStudio.entitlements
   MereRunStudioTests:
     type: bundle.unit-test
     platform: iOS
     sources:
       - MereRunStudioTests
+      - MereRunStudio/App/PendingModelDownloadStore.swift
+      - MereRunStudio/App/RuntimeResidencyState.swift
+      - MereRunStudio/App/RunPollingPolicy.swift
+      - MereRunStudio/App/RunArtifactStore.swift
+      - MereRunStudio/App/ExecutionPrivacyCopy.swift
     dependencies:
       - target: MereRunStudio
     settings:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: run.mere.studio.ios.tests
         SWIFT_VERSION: "6.0"
+        # The app module imports MereRunCore, which uses C++ interoperability.
+        OTHER_SWIFT_FLAGS: -cxx-interoperability-mode=default
         GENERATE_INFOPLIST_FILE: YES
         TEST_HOST: $(BUILT_PRODUCTS_DIR)/mere.run.app/mere.run
         BUNDLE_LOADER: $(TEST_HOST)
@@ -101,6 +103,8 @@ targets:
       path: MereRunWidgets/Info.plist
       properties:
         CFBundleDisplayName: mere.run
+        CFBundleShortVersionString: $(MARKETING_VERSION)
+        CFBundleVersion: $(CURRENT_PROJECT_VERSION)
         NSExtension:
           NSExtensionPointIdentifier: com.apple.widgetkit-extension
     settings:


### PR DESCRIPTION
## Summary

- add durable background Hub transfers with relaunch reattachment, staging, pending-install state, and Wi-Fi-first network policy
- make chat and image runtime residency transitions deterministic without interrupting active inference
- propagate verified-download credentials through Keychain and persist device-code fallback immediately
- bound and cancel Live Activity pollers, refresh artifacts transactionally, and render lane-specific privacy copy
- split Debug and Release associated-domain entitlements, align widget/app versions, narrow the iOS dependency graph, and enforce a Release footprint ceiling
- add iOS CI, deterministic tests, and updated operator documentation

## Validation

- XcodeGen generation passed
- Release iPhone 17 Pro / iOS 26.4 simulator build passed
- MereRunStudioTests: 13 passed, 0 failed, 7 explicit opt-in device/download diagnostics skipped
- clean Release simulator app: 75.4 MiB uncompressed; 68.3 MiB main executable; arm64; below the 80 MiB gate
- SwiftLint strict: 0 violations
- env -u MERERUN_RUN_E2E nice -n 10 ./scripts/check.sh passed
- XCTest: 3,022 tests, 219 skipped, 0 failures
- Swift Testing: 30 tests passed
- git diff --check passed

## Deferred physical-device proof

1. suspended multi-GB pull and relaunch reattachment
2. on-device MLX/Metal generation plus observed memory eviction
3. production universal-link PKCE/browser sign-in
4. direct-lane pairing plus a phone-originated Fleet job
5. release-signed archive metadata and final archive-size readback

No real multi-GB download was started during validation.