### PR TITLE
Add native Muse Glimmer DFlash2 acceleration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,23 @@ The format is based on Keep a Changelog.
   authorization, execute without a shell in a reduced environment, and are
   bounded by timeout and output validation.
 
+### Muse Glimmer DFlash2
+
+- added native Swift/MLX support for Inco's Muse Glimmer DFlash2 companion:
+  nested configuration decoding, two-phase grouped dynamic causal convolution
+  around assistant attention and MLP blocks, predecessor-aware sparse candidate
+  selection, exact sparse rejection correction for sampled decoding, and
+  published checkpoint-key normalization.
+- made the immutable 5.54 GB
+  `z-lab/Muse-Glimmer-30B-DFlash2` revision the managed companion installed
+  with Muse Glimmer; existing original Meta DFlash and local Q4 companions
+  remain compatible fallbacks. A real selective-Q4 check reached 17.01 tok/s
+  and 67.7% acceptance versus 7.54 tok/s target-only decode. Its 64-token
+  greedy output was byte-identical to the existing DFlash v1 path. Both
+  speculative paths share MLX's pre-existing quantized block-verification
+  rounding at an observed near-tie, so the implementation does not claim
+  bit-exact equivalence to one-token execution.
+
 ### iOS Studio
 
 - fixed verified artifact downloads on Apple platforms to use the iOS

--- a/README.md
+++ b/README.md
@@ -323,15 +323,17 @@ swift run mere.run text chat \
   --prompt "Plan a recovery-safe repository migration."
 
 # Muse Glimmer is a pinned native Swift/MLX multimodal agent model. The pull
-# installs Sawfwair's 21.38 GB selective MLX Q4 target and Meta's 5.11 GB
-# official DFlash companion;
-# review their shared usage policy first.
+# installs Sawfwair's 21.38 GB selective MLX Q4 target and z-lab's 5.54 GB
+# DFlash2 companion; review the target's bundled usage policy first.
 swift run mere.run text chat \
   --model vision-chat-muse-glimmer-30b \
   --image ./screenshot.png \
   --reasoning-effort 0.8 \
   --stats \
   --prompt "Inspect this interface and propose the safest next action."
+
+# The managed DFlash2 companion can also be refreshed independently.
+swift run mere.run model pull vision-chat-muse-glimmer-30b-dflash2
 
 # Nemotron 3.5 Lightning is a pinned native Swift/MLX hybrid Mamba/MoE target.
 # The managed pull also installs its converted DSpark speculative companion.

--- a/Sources/MereRunCLI/Support/ModelPullPreflight.swift
+++ b/Sources/MereRunCLI/Support/ModelPullPreflight.swift
@@ -209,7 +209,10 @@ struct ModelPullPreflightAnalyzer {
 
     private func selectedSpecs(diagnostics: inout [PreflightDiagnostic]) -> [ManagedModelSpec] {
         if input.all {
-            return ManagedModelCatalog.allSpecs
+            return specsIncludingCompanions(
+                ManagedModelCatalog.allSpecs,
+                diagnostics: &diagnostics
+            )
         }
 
         guard let target = input.target?.trimmingCharacters(in: .whitespacesAndNewlines),
@@ -236,7 +239,36 @@ struct ModelPullPreflightAnalyzer {
             )
             return []
         }
-        return [spec]
+        return specsIncludingCompanions([spec], diagnostics: &diagnostics)
+    }
+
+    private func specsIncludingCompanions(
+        _ roots: [ManagedModelSpec],
+        diagnostics: inout [PreflightDiagnostic]
+    ) -> [ManagedModelSpec] {
+        var specs: [ManagedModelSpec] = []
+        var seen: Set<String> = []
+        var pending = roots
+        while !pending.isEmpty {
+            let spec = pending.removeFirst()
+            guard seen.insert(spec.id).inserted else { continue }
+            specs.append(spec)
+            for companionID in spec.companionModelIDs {
+                guard let companion = ManagedModelCatalog.spec(for: companionID) else {
+                    diagnostics.append(
+                        PreflightDiagnostic(
+                            id: "companion_model_unknown",
+                            severity: .blocker,
+                            title: "Companion model unavailable",
+                            message: "Unknown companion model id for \(spec.id): \(companionID)."
+                        )
+                    )
+                    continue
+                }
+                pending.append(companion)
+            }
+        }
+        return specs
     }
 
     private func resolvedHubCache(diagnostics: inout [PreflightDiagnostic]) -> URL {
@@ -282,7 +314,7 @@ struct ModelPullPreflightAnalyzer {
             ?? runtimeURL(for: spec, installPath: installPath, installed: installedInPrimary)
         let runtimeReady = runtimeURL != nil
         let conversionRequired = spec.requiresManagedConversion && installedInPrimary && !runtimeReady
-        let selected = input.all || spec.id == input.target
+        let selected = true
         let blockedBySupport = !input.allowUnsupported && !support.isSupported
         let blockedBySource = !hasSource
         let requiresUsageTermsAcknowledgement = spec.usageRestriction != nil && (input.force || !installed)

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -1647,7 +1647,7 @@ public enum ManagedModelCatalog {
             runtimeAutoDownloadAllowed: false,
             estimatedDownloadBytes: MuseGlimmerResources.estimatedDownloadBytes,
             defaultCLICommands: ["text chat", "api serve"],
-            companionModelIDs: [MuseGlimmerResources.assistantModelId],
+            companionModelIDs: [MuseGlimmerResources.dflash2ModelId],
             apiProfile: .museGlimmer()
         ),
         ManagedModelSpec(
@@ -3386,6 +3386,21 @@ private extension ManagedModelCatalog {
                 validationKind: .lagunaDFlash,
                 runtimeAutoDownloadAllowed: false,
                 estimatedDownloadBytes: LagunaResources.dflashEstimatedDownloadBytes
+            ),
+            ManagedModelSpec(
+                id: MuseGlimmerResources.dflash2ModelId,
+                category: .textChat,
+                installShape: .directoryRoot,
+                hubFallback: HubFallbackConfig(
+                    repoId: MuseGlimmerResources.dflash2UpstreamRepoId,
+                    revision: MuseGlimmerResources.dflash2UpstreamRevision,
+                    patterns: MuseGlimmerResources.dflash2SnapshotPatterns
+                ),
+                upstreamRepoId: MuseGlimmerResources.dflash2UpstreamRepoId,
+                upstreamRevision: MuseGlimmerResources.dflash2UpstreamRevision,
+                validationKind: .museGlimmerAssistant,
+                runtimeAutoDownloadAllowed: false,
+                estimatedDownloadBytes: MuseGlimmerResources.dflash2EstimatedDownloadBytes
             ),
             ManagedModelSpec(
                 id: MuseGlimmerResources.assistantModelId,

--- a/Sources/MereRunCore/ManagedModelSupport.swift
+++ b/Sources/MereRunCore/ManagedModelSupport.swift
@@ -374,6 +374,13 @@ public enum ManagedModelCapabilityCatalog {
                 recommended: 128
             ),
             descriptor(
+                LagunaResources.dflashModelID,
+                "Laguna S 2.1 DFlash assistant",
+                "Installs the companion drafter used for verified Laguna S 2.1 speculative decoding.",
+                minimum: 96,
+                recommended: 128
+            ),
+            descriptor(
                 LagunaResources.xsModelID,
                 "Laguna XS 2.1 agentic chat",
                 "Runs Poolside's released 33B-A3B Laguna XS 2.1 through its NVFP4 MLX serialization and the native Swift runtime.",
@@ -390,7 +397,21 @@ public enum ManagedModelCapabilityCatalog {
             descriptor(
                 MuseGlimmerResources.modelId,
                 "Muse Glimmer 30B vision agent",
-                "Runs Sawfwair's pinned selective MLX Q4 conversion of Meta Muse Glimmer with its managed DFlash speculative companion through the native Swift/MLX stack.",
+                "Runs Sawfwair's pinned selective MLX Q4 conversion of Meta Muse Glimmer with its managed DFlash2 speculative companion through the native Swift/MLX stack.",
+                minimum: 32,
+                recommended: 64
+            ),
+            descriptor(
+                MuseGlimmerResources.dflash2ModelId,
+                "Muse Glimmer 30B DFlash2 assistant",
+                "Installs z-lab's grouped-convolution DFlash2 drafter for Muse Glimmer speculative decoding.",
+                minimum: 32,
+                recommended: 64
+            ),
+            descriptor(
+                MuseGlimmerResources.assistantModelId,
+                "Muse Glimmer 30B DFlash assistant",
+                "Preserves the original Muse Glimmer DFlash drafter for compatible existing installations.",
                 minimum: 32,
                 recommended: 64
             ),
@@ -398,6 +419,13 @@ public enum ManagedModelCapabilityCatalog {
                 NemotronHResources.modelID,
                 "Nemotron 3.5 Lightning 30B-A3B",
                 "Runs NVIDIA's hybrid Nemotron-H NVFP4 checkpoint with its verified DSpark speculative companion through native Swift/MLX.",
+                minimum: 32,
+                recommended: 64
+            ),
+            descriptor(
+                NemotronHResources.dsparkModelID,
+                "Nemotron 3.5 DSpark assistant",
+                "Installs the companion drafter used for verified Nemotron 3.5 speculative decoding.",
                 minimum: 32,
                 recommended: 64
             ),
@@ -966,6 +994,13 @@ public enum ManagedModelCapabilityCatalog {
                 ModelResolver.ModelID.ltxVideo25FullBF16.rawValue,
                 "LTX 2.5 Full BF16",
                 "Installs the full LTX 2.5 dev, distilled, LoRA, VAE, upscaler, and duration components for every native pipeline.",
+                minimum: 96,
+                recommended: 128
+            ),
+            descriptor(
+                ModelResolver.ModelID.ltxGemma3TwelveB4Bit.rawValue,
+                "LTX Gemma 3 12B text encoder",
+                "Installs the shared 4-bit Gemma text encoder used by managed LTX video models.",
                 minimum: 96,
                 recommended: 128
             ),

--- a/Sources/MereRunCore/MereRunModelManifest.swift
+++ b/Sources/MereRunCore/MereRunModelManifest.swift
@@ -1031,6 +1031,21 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
                 upstreamRepoId: "\(MuseGlimmerResources.artifactRepoId)@\(MuseGlimmerResources.artifactRevision)",
                 createdAt: createdAt
             )
+        case .museGlimmer30BDFlash2:
+            return MereRunModelManifest(
+                id: modelID.rawValue,
+                engine: .museGlimmer,
+                family: .muse,
+                tier: .small,
+                variant: .standard,
+                precision: .bf16,
+                defaults: nil,
+                supports: [],
+                components: nil,
+                upstreamRepoId:
+                    "\(MuseGlimmerResources.dflash2UpstreamRepoId)@\(MuseGlimmerResources.dflash2UpstreamRevision)",
+                createdAt: createdAt
+            )
         case .nemotron35Lightning:
             return MereRunModelManifest(
                 id: modelID.rawValue,

--- a/Sources/MereRunCore/MereRunModelValidator.swift
+++ b/Sources/MereRunCore/MereRunModelValidator.swift
@@ -143,7 +143,8 @@ public enum MereRunModelValidator {
             vaeDir = nil
             tokenizerDir = nil
         } else if spec?.validationKind == .gemma4MTPAssistant
-            || spec?.validationKind == .lagunaDFlash {
+            || spec?.validationKind == .lagunaDFlash
+            || spec?.validationKind == .museGlimmerAssistant {
             errors.append(contentsOf: spec?.validationMessages(in: rootURL, fileManager: fileManager) ?? [])
             transformerDir = nil
             textEncoderDir = nil
@@ -553,7 +554,8 @@ public enum MereRunModelValidator {
         }()
         let skipsComponentValidation = {
             if ManagedModelCatalog.spec(for: manifest.id)?.validationKind == .gemma4MTPAssistant
-                || ManagedModelCatalog.spec(for: manifest.id)?.validationKind == .lagunaDFlash {
+                || ManagedModelCatalog.spec(for: manifest.id)?.validationKind == .lagunaDFlash
+                || ManagedModelCatalog.spec(for: manifest.id)?.validationKind == .museGlimmerAssistant {
                 return true
             }
             switch manifest.engine {

--- a/Sources/MereRunCore/ModelResolver.swift
+++ b/Sources/MereRunCore/ModelResolver.swift
@@ -40,6 +40,7 @@ public struct ModelResolver {
         case lagunaS21DFlash = "text-chat-laguna-s-2-1-dflash"
         case inklingSmall = "text-chat-inkling-small"
         case museGlimmer30B = "vision-chat-muse-glimmer-30b"
+        case museGlimmer30BDFlash2 = "vision-chat-muse-glimmer-30b-dflash2"
         case nemotron35Lightning = "text-chat-nemotron-35-lightning"
         case nemotron35LightningDSpark = "text-chat-nemotron-35-lightning-dspark"
         case ltxGemma3TwelveB4Bit = "text-encoder-ltx-gemma3-12b-4bit"

--- a/Sources/MereRunCore/MuseGlimmer/MuseGlimmerAssistantModel.swift
+++ b/Sources/MereRunCore/MuseGlimmer/MuseGlimmerAssistantModel.swift
@@ -33,6 +33,7 @@ final class MuseGlimmerAssistantAttention: Module {
     private let headDimension: Int
     private let scale: Float
     private let slidingWindow: Int
+    private let usesDFlash2BlockMask: Bool
     private let rope: RoPE
 
     init(config: MuseGlimmerAssistantConfig) {
@@ -41,6 +42,7 @@ final class MuseGlimmerAssistantAttention: Module {
         headDimension = config.headDim
         scale = pow(Float(config.headDim), -0.5)
         slidingWindow = config.slidingWindow
+        usesDFlash2BlockMask = config.isDFlash2
         rope = RoPE(
             dimensions: config.headDim,
             traditional: false,
@@ -93,12 +95,19 @@ final class MuseGlimmerAssistantAttention: Module {
         queries = rope(qNorm(queries), offset: offset)
         keys = rope(kNorm(keys), offset: offset)
         let state = cache.attentionState(appending: keys, values: values)!
-        let mask = bidirectionalSlidingMask(
-            queryLength: sequence,
-            queryOffset: offset,
-            keyLength: state.0.dim(2),
-            dtype: x.dtype
-        )
+        let mask = usesDFlash2BlockMask
+            ? blockSlidingMask(
+                queryLength: sequence,
+                queryOffset: offset,
+                keyLength: state.0.dim(2),
+                dtype: x.dtype
+            )
+            : bidirectionalSlidingMask(
+                queryLength: sequence,
+                queryOffset: offset,
+                keyLength: state.0.dim(2),
+                dtype: x.dtype
+            )
         let attended = MLXFast.scaledDotProductAttention(
             queries: queries,
             keys: state.0,
@@ -124,6 +133,31 @@ final class MuseGlimmerAssistantAttention: Module {
             .transposed(0, 2, 1, 3)
         keys = rope(kNorm(keys), offset: offset)
         cache.append(keys: keys, values: values)
+    }
+
+    private func blockSlidingMask(
+        queryLength: Int,
+        queryOffset: Int,
+        keyLength: Int,
+        dtype: DType
+    ) -> MLXFast.ScaledDotProductAttentionMaskMode {
+        let keyStart = max(0, queryOffset + queryLength - keyLength)
+        let queryPositions = MLXArray(
+            Int32(queryOffset)..<Int32(queryOffset + queryLength)
+        ).reshaped(queryLength, 1)
+        let keyPositions = MLXArray(
+            Int32(keyStart)..<Int32(keyStart + keyLength)
+        ).reshaped(1, keyLength)
+        let context = (keyPositions .< Int32(queryOffset))
+            .&& (keyPositions .> (queryPositions - Int32(slidingWindow)))
+        let block = keyPositions .>= Int32(queryOffset)
+        let allowed = context .|| block
+        let zeros = MLXArray.zeros([1, 1, queryLength, keyLength], dtype: dtype)
+        return .array(MLX.where(
+            allowed.reshaped(1, 1, queryLength, keyLength),
+            zeros,
+            zeros + MLXArray(-1e9).asType(dtype)
+        ))
     }
 
     private func bidirectionalSlidingMask(
@@ -155,6 +189,8 @@ final class MuseGlimmerAssistantDecoderLayer: Module {
     @ModuleInfo(key: "mlp") var mlp: MuseGlimmerAssistantMLP
     @ModuleInfo(key: "input_layernorm") var inputNorm: MuseGlimmerRMSNorm
     @ModuleInfo(key: "post_attention_layernorm") var postAttentionNorm: MuseGlimmerRMSNorm
+    @ModuleInfo(key: "attention_conv") var attentionConv: MuseGlimmerGroupedDynamicCausalConv?
+    @ModuleInfo(key: "mlp_conv") var mlpConv: MuseGlimmerGroupedDynamicCausalConv?
 
     init(config: MuseGlimmerAssistantConfig) {
         self._attention.wrappedValue = MuseGlimmerAssistantAttention(config: config)
@@ -167,10 +203,37 @@ final class MuseGlimmerAssistantDecoderLayer: Module {
             dimensions: config.hiddenSize,
             eps: config.rmsNormEps
         )
+        if let dflash2 = config.dflash2, config.isDFlash2 {
+            self._attentionConv.wrappedValue = MuseGlimmerGroupedDynamicCausalConv(
+                hiddenSize: config.hiddenSize,
+                kernelSize: dflash2.convKernelSize,
+                groupSize: dflash2.convGroupSize
+            )
+            self._mlpConv.wrappedValue = MuseGlimmerGroupedDynamicCausalConv(
+                hiddenSize: config.hiddenSize,
+                kernelSize: dflash2.convKernelSize,
+                groupSize: dflash2.convGroupSize
+            )
+        } else {
+            self._attentionConv.wrappedValue = nil
+            self._mlpConv.wrappedValue = nil
+        }
         super.init()
     }
 
     func callAsFunction(_ x: MLXArray, cache: Gemma4AttentionCache) -> MLXArray {
+        if let attentionConv, let mlpConv {
+            let attentionInput = attentionConv.prepare(inputNorm(x))
+            let attended = x + attentionConv.finish(
+                attention(attentionInput.hidden, cache: cache),
+                dynamic: attentionInput.dynamic
+            )
+            let mlpInput = mlpConv.prepare(postAttentionNorm(attended))
+            return attended + mlpConv.finish(
+                mlp(mlpInput.hidden),
+                dynamic: mlpInput.dynamic
+            )
+        }
         let attended = x + attention(inputNorm(x), cache: cache)
         return attended + mlp(postAttentionNorm(attended))
     }
@@ -206,6 +269,7 @@ final class MuseGlimmerAssistantModel: Module {
     @ModuleInfo(key: "encoder") var encoder: MuseGlimmerAssistantContextProjection
     @ModuleInfo(key: "layers") var layers: [MuseGlimmerAssistantDecoderLayer]
     @ModuleInfo(key: "norm") var norm: MuseGlimmerRMSNorm
+    @ModuleInfo(key: "candidate_selector") var candidateSelector: MuseGlimmerDFlash2CandidateSelector?
 
     let config: MuseGlimmerAssistantConfig
 
@@ -219,6 +283,18 @@ final class MuseGlimmerAssistantModel: Module {
             dimensions: config.hiddenSize,
             eps: config.rmsNormEps
         )
+        if let dflash2 = config.dflash2,
+           let vocabularySize = config.vocabSize,
+           config.isDFlash2 {
+            self._candidateSelector.wrappedValue = MuseGlimmerDFlash2CandidateSelector(
+                vocabularySize: vocabularySize,
+                hiddenSize: config.hiddenSize,
+                rank: dflash2.selectorRank,
+                topK: dflash2.selectorTopK
+            )
+        } else {
+            self._candidateSelector.wrappedValue = nil
+        }
         super.init()
     }
 
@@ -236,12 +312,12 @@ final class MuseGlimmerAssistantModel: Module {
         }
     }
 
-    func draftLogits(
+    func draft(
         anchorTokens: MLXArray,
         speculativeTokenCount: Int,
         cache: [Gemma4AttentionCache],
         target: MuseGlimmerModel
-    ) -> MLXArray {
+    ) -> MuseGlimmerAssistantDraftOutput {
         precondition(speculativeTokenCount > 0 && speculativeTokenCount < config.blockSize)
         let batch = anchorTokens.dim(0)
         let masks = MLX.full(
@@ -252,11 +328,44 @@ final class MuseGlimmerAssistantModel: Module {
             [anchorTokens.reshaped(batch, 1).asType(.int32), masks],
             axis: 1
         )
-        var hidden = target.rawInputEmbeddings(for: inputIds)
+        var hidden = config.isDFlash2
+            ? target.inputEmbeddings(for: inputIds) * (config.dflash2?.inputEmbeddingScale ?? 1)
+            : target.rawInputEmbeddings(for: inputIds)
         for (index, layer) in layers.enumerated() {
             hidden = layer(hidden, cache: cache[index])
         }
-        return target.rawOutputLogits(from: norm(hidden))[0..., 1..., 0...]
+        hidden = norm(hidden)[0..., 1..., 0...]
+        let logits = config.isDFlash2
+            ? target.outputLogits(from: hidden)
+            : target.rawOutputLogits(from: hidden)
+        return MuseGlimmerAssistantDraftOutput(hidden: hidden, logits: logits)
+    }
+
+    func draftLogits(
+        anchorTokens: MLXArray,
+        speculativeTokenCount: Int,
+        cache: [Gemma4AttentionCache],
+        target: MuseGlimmerModel
+    ) -> MLXArray {
+        draft(
+            anchorTokens: anchorTokens,
+            speculativeTokenCount: speculativeTokenCount,
+            cache: cache,
+            target: target
+        ).logits
+    }
+
+    func selectDFlash2Candidates(
+        draft: MuseGlimmerAssistantDraftOutput,
+        anchorTokens: MLXArray,
+        temperature: Float
+    ) -> MuseGlimmerDFlash2Selection? {
+        candidateSelector?.select(
+            hidden: draft.hidden,
+            logits: draft.logits,
+            anchorTokenIds: anchorTokens,
+            temperature: temperature
+        )
     }
 
     func makeCache(initialOffset: Int = 0) -> [Gemma4AttentionCache] {

--- a/Sources/MereRunCore/MuseGlimmer/MuseGlimmerConfig.swift
+++ b/Sources/MereRunCore/MuseGlimmer/MuseGlimmerConfig.swift
@@ -201,6 +201,46 @@ public struct MuseGlimmerConfig: Decodable, Sendable, Hashable {
     }
 }
 
+public struct MuseGlimmerDFlash2Config: Decodable, Sendable, Hashable {
+    public let blockSize: Int
+    public let convGroupSize: Int
+    public let convKernelSize: Int
+    public let finalLogitSoftcapping: Float
+    public let inputEmbeddingScale: Float
+    public let maskTokenId: Int
+    public let outputMultiplier: Float
+    public let selectorRank: Int
+    public let selectorTopK: Int
+    public let targetLayerIds: [Int]
+
+    private enum CodingKeys: String, CodingKey {
+        case blockSize = "block_size"
+        case convGroupSize = "conv_group_size"
+        case convKernelSize = "conv_kernel_size"
+        case finalLogitSoftcapping = "final_logit_softcapping"
+        case inputEmbeddingScale = "input_embedding_scale"
+        case maskTokenId = "mask_token_id"
+        case outputMultiplier = "output_multiplier"
+        case selectorRank = "selector_rank"
+        case selectorTopK = "selector_top_k"
+        case targetLayerIds = "target_layer_ids"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        blockSize = try container.decode(Int.self, forKey: .blockSize)
+        convGroupSize = try container.decode(Int.self, forKey: .convGroupSize)
+        convKernelSize = try container.decode(Int.self, forKey: .convKernelSize)
+        finalLogitSoftcapping = try container.decode(Float.self, forKey: .finalLogitSoftcapping)
+        inputEmbeddingScale = try container.decodeIfPresent(Float.self, forKey: .inputEmbeddingScale) ?? 1
+        maskTokenId = try container.decode(Int.self, forKey: .maskTokenId)
+        outputMultiplier = try container.decode(Float.self, forKey: .outputMultiplier)
+        selectorRank = try container.decode(Int.self, forKey: .selectorRank)
+        selectorTopK = try container.decode(Int.self, forKey: .selectorTopK)
+        targetLayerIds = try container.decode([Int].self, forKey: .targetLayerIds)
+    }
+}
+
 public struct MuseGlimmerAssistantConfig: Decodable, Sendable, Hashable {
     public let modelType: String
     public let architectures: [String]
@@ -217,13 +257,20 @@ public struct MuseGlimmerAssistantConfig: Decodable, Sendable, Hashable {
     public let layerTypes: [String]
     public let attentionDropout: Float
     public let hiddenActivation: String
+    public let vocabSize: Int?
     public let bosTokenId: Int?
     public let eosTokenId: Int?
     public let padTokenId: Int?
     public let blockSize: Int
     public let maskTokenId: Int
     public let targetLayerIds: [Int]
+    public let isCausal: Bool?
+    public let dflash2: MuseGlimmerDFlash2Config?
     public let quantization: MuseGlimmerQuantizationConfig?
+
+    public var isDFlash2: Bool {
+        architectures.contains("DFlash2DraftModel")
+    }
 
     private enum CodingKeys: String, CodingKey {
         case modelType = "model_type"
@@ -241,12 +288,15 @@ public struct MuseGlimmerAssistantConfig: Decodable, Sendable, Hashable {
         case layerTypes = "layer_types"
         case attentionDropout = "attention_dropout"
         case hiddenActivation = "hidden_act"
+        case vocabSize = "vocab_size"
         case bosTokenId = "bos_token_id"
         case eosTokenId = "eos_token_id"
         case padTokenId = "pad_token_id"
         case blockSize = "block_size"
         case maskTokenId = "mask_token_id"
         case targetLayerIds = "target_layer_ids"
+        case isCausal = "is_causal"
+        case dflash2 = "dflash_config"
         case quantization
         case quantizationConfig = "quantization_config"
     }
@@ -268,12 +318,21 @@ public struct MuseGlimmerAssistantConfig: Decodable, Sendable, Hashable {
         layerTypes = try container.decode([String].self, forKey: .layerTypes)
         attentionDropout = try container.decodeIfPresent(Float.self, forKey: .attentionDropout) ?? 0
         hiddenActivation = try container.decode(String.self, forKey: .hiddenActivation)
+        vocabSize = try container.decodeIfPresent(Int.self, forKey: .vocabSize)
         bosTokenId = try container.decodeIfPresent(Int.self, forKey: .bosTokenId)
         eosTokenId = try container.decodeIfPresent(Int.self, forKey: .eosTokenId)
         padTokenId = try container.decodeIfPresent(Int.self, forKey: .padTokenId)
-        blockSize = try container.decode(Int.self, forKey: .blockSize)
-        maskTokenId = try container.decode(Int.self, forKey: .maskTokenId)
-        targetLayerIds = try container.decode([Int].self, forKey: .targetLayerIds)
+        dflash2 = try container.decodeIfPresent(MuseGlimmerDFlash2Config.self, forKey: .dflash2)
+        blockSize = try container.decodeIfPresent(Int.self, forKey: .blockSize)
+            ?? dflash2?.blockSize
+            ?? Self.missingInteger(.blockSize, in: container)
+        maskTokenId = try container.decodeIfPresent(Int.self, forKey: .maskTokenId)
+            ?? dflash2?.maskTokenId
+            ?? Self.missingInteger(.maskTokenId, in: container)
+        targetLayerIds = try container.decodeIfPresent([Int].self, forKey: .targetLayerIds)
+            ?? dflash2?.targetLayerIds
+            ?? []
+        isCausal = try container.decodeIfPresent(Bool.self, forKey: .isCausal)
         quantization = try container.decodeIfPresent(MuseGlimmerQuantizationConfig.self, forKey: .quantization)
             ?? container.decodeIfPresent(MuseGlimmerQuantizationConfig.self, forKey: .quantizationConfig)
 
@@ -292,6 +351,36 @@ public struct MuseGlimmerAssistantConfig: Decodable, Sendable, Hashable {
                 debugDescription: "Muse Glimmer DFlash requires a block larger than one token and target layers."
             )
         }
+        if architectures.contains("DFlash2DraftModel") {
+            guard let dflash2,
+                  let vocabSize,
+                  vocabSize > 0,
+                  dflash2.convKernelSize > 0,
+                  dflash2.convGroupSize > 0,
+                  hiddenSize.isMultiple(of: dflash2.convGroupSize),
+                  dflash2.selectorRank > 0,
+                  dflash2.selectorTopK > 0,
+                  dflash2.selectorTopK <= vocabSize else {
+                throw DecodingError.dataCorruptedError(
+                    forKey: .dflash2,
+                    in: container,
+                    debugDescription: "Muse Glimmer DFlash2 requires valid convolution, vocabulary, and selector dimensions."
+                )
+            }
+        }
+    }
+
+    private static func missingInteger(
+        _ key: CodingKeys,
+        in container: KeyedDecodingContainer<CodingKeys>
+    ) throws -> Int {
+        throw DecodingError.keyNotFound(
+            key,
+            DecodingError.Context(
+                codingPath: container.codingPath,
+                debugDescription: "Muse Glimmer DFlash requires \(key.stringValue)."
+            )
+        )
     }
 }
 

--- a/Sources/MereRunCore/MuseGlimmer/MuseGlimmerDFlash2.swift
+++ b/Sources/MereRunCore/MuseGlimmer/MuseGlimmerDFlash2.swift
@@ -1,0 +1,194 @@
+import MLX
+import MLXNN
+
+struct MuseGlimmerDFlash2Selection {
+    let tokens: MLXArray
+    let candidateTokenIds: MLXArray
+    let candidateProbabilities: MLXArray?
+}
+
+struct MuseGlimmerAssistantDraftOutput {
+    let hidden: MLXArray
+    let logits: MLXArray
+}
+
+enum MuseGlimmerDFlash2WeightKeys {
+    static func normalized(_ key: String) -> String {
+        switch key {
+        case "fc.weight":
+            return "encoder.fc.weight"
+        case "hidden_norm.weight":
+            return "encoder.output_norm_enc.weight"
+        case "candidate_selector.predecessor_codebook":
+            return "candidate_selector.predecessor_codebook.weight"
+        case "candidate_selector.successor_codebook":
+            return "candidate_selector.successor_codebook.weight"
+        default:
+            return key
+        }
+    }
+
+    static func mapped(_ key: String, _ value: MLXArray) -> [(String, MLXArray)] {
+        [(normalized(key), value)]
+    }
+}
+
+func museGlimmerGroupedDynamicConvolution(
+    hidden: MLXArray,
+    dynamic: MLXArray,
+    base: MLXArray,
+    groupSize: Int
+) -> MLXArray {
+    let batch = hidden.dim(0)
+    let length = hidden.dim(1)
+    let hiddenSize = hidden.dim(2)
+    let groups = hiddenSize / groupSize
+    let blocks = hidden.reshaped(batch, length, groups, groupSize)
+    let kernels = dynamic.reshaped(batch, length, base.dim(0), groups, 1)
+    var output = MLXArray.zeros(like: blocks)
+
+    for offset in 0..<base.dim(0) {
+        let values: MLXArray
+        if offset == 0 {
+            values = blocks
+        } else if offset < length {
+            values = concatenated(
+                [
+                    MLXArray.zeros([batch, offset, groups, groupSize], dtype: hidden.dtype),
+                    blocks[0..., 0..<(length - offset), 0..., 0...],
+                ],
+                axis: 1
+            )
+        } else {
+            values = MLXArray.zeros(like: blocks)
+        }
+        let fixed = base[offset, 0...]
+            .reshaped(1, 1, groups, groupSize)
+            .asType(hidden.dtype)
+        output = output + (fixed + kernels[0..., 0..., offset, 0..., 0...]) * values
+    }
+    return output.reshaped(hidden.shape)
+}
+
+final class MuseGlimmerGroupedDynamicCausalConv: Module {
+    @ModuleInfo(key: "base_kernel") var baseKernel: MLXArray
+    @ModuleInfo(key: "kernel_projection") var kernelProjection: Linear
+
+    private let groupSize: Int
+
+    init(hiddenSize: Int, kernelSize: Int, groupSize: Int) {
+        self.groupSize = groupSize
+        let groups = hiddenSize / groupSize
+        self._baseKernel.wrappedValue = MLXArray.zeros([2, kernelSize, hiddenSize])
+        self._kernelProjection.wrappedValue = Linear(
+            hiddenSize,
+            2 * kernelSize * groups,
+            bias: false
+        )
+        super.init()
+    }
+
+    func prepare(_ hidden: MLXArray) -> (hidden: MLXArray, dynamic: MLXArray) {
+        let groups = hidden.dim(-1) / groupSize
+        let projected = kernelProjection(hidden).reshaped(
+            hidden.dim(0),
+            hidden.dim(1),
+            2,
+            baseKernel.dim(1),
+            groups
+        )
+        return (
+            museGlimmerGroupedDynamicConvolution(
+                hidden: hidden,
+                dynamic: projected[0..., 0..., 0, 0..., 0...],
+                base: baseKernel[0, 0..., 0...],
+                groupSize: groupSize
+            ),
+            projected[0..., 0..., 1, 0..., 0...]
+        )
+    }
+
+    func finish(_ hidden: MLXArray, dynamic: MLXArray) -> MLXArray {
+        museGlimmerGroupedDynamicConvolution(
+            hidden: hidden,
+            dynamic: dynamic,
+            base: baseKernel[1, 0..., 0...],
+            groupSize: groupSize
+        )
+    }
+}
+
+final class MuseGlimmerDFlash2CandidateSelector: Module {
+    @ModuleInfo(key: "hidden_projection") var hiddenProjection: Linear
+    @ModuleInfo(key: "predecessor_codebook") var predecessorCodebook: Embedding
+    @ModuleInfo(key: "successor_codebook") var successorCodebook: Embedding
+
+    private let topK: Int
+
+    init(vocabularySize: Int, hiddenSize: Int, rank: Int, topK: Int) {
+        self.topK = topK
+        self._hiddenProjection.wrappedValue = Linear(hiddenSize, rank, bias: false)
+        self._predecessorCodebook.wrappedValue = Embedding(
+            embeddingCount: vocabularySize,
+            dimensions: rank
+        )
+        self._successorCodebook.wrappedValue = Embedding(
+            embeddingCount: vocabularySize,
+            dimensions: rank
+        )
+        super.init()
+    }
+
+    func select(
+        hidden: MLXArray,
+        logits: MLXArray,
+        anchorTokenIds: MLXArray,
+        temperature: Float
+    ) -> MuseGlimmerDFlash2Selection {
+        let candidateTokenIds = argPartition(-logits, kth: topK - 1, axis: -1)[
+            0...,
+            0...,
+            0..<topK
+        ]
+        let unary = takeAlong(logits, candidateTokenIds, axis: -1)
+        let projectedHidden = hiddenProjection(hidden)
+        var predecessor = anchorTokenIds.asType(.int32).reshaped(anchorTokenIds.dim(0))
+        var path: [MLXArray] = []
+        var probabilities: [MLXArray] = []
+        path.reserveCapacity(hidden.dim(1))
+        probabilities.reserveCapacity(hidden.dim(1))
+
+        for position in 0..<hidden.dim(1) {
+            let candidates = candidateTokenIds[0..., position, 0...]
+            let edgeScores = (
+                predecessorCodebook(predecessor).expandedDimensions(axis: 1)
+                    * projectedHidden[0..., position, 0...].expandedDimensions(axis: 1)
+                    * successorCodebook(candidates)
+            ).sum(axis: -1)
+            let scores = unary[0..., position, 0...] + edgeScores
+            let selected: MLXArray
+            if temperature > 0 {
+                let distribution = softmax(
+                    scores.asType(.float32) / temperature,
+                    axis: -1
+                )
+                selected = categorical(MLX.log(distribution)).asType(.int32)
+                probabilities.append(distribution)
+            } else {
+                selected = argMax(scores, axis: -1).asType(.int32)
+            }
+            predecessor = takeAlong(
+                candidates,
+                selected.expandedDimensions(axis: -1),
+                axis: -1
+            ).squeezed(axis: -1)
+            path.append(predecessor)
+        }
+
+        return MuseGlimmerDFlash2Selection(
+            tokens: stacked(path, axis: 1),
+            candidateTokenIds: candidateTokenIds,
+            candidateProbabilities: probabilities.isEmpty ? nil : stacked(probabilities, axis: 1)
+        )
+    }
+}

--- a/Sources/MereRunCore/MuseGlimmer/MuseGlimmerDFlashDecoder.swift
+++ b/Sources/MereRunCore/MuseGlimmer/MuseGlimmerDFlashDecoder.swift
@@ -114,6 +114,11 @@ private struct MuseGlimmerPreparedGreedyRound {
     let candidate: MuseGlimmerForwardOutput
 }
 
+private struct MuseGlimmerProposalDistribution {
+    let probabilities: MLXArray
+    let candidateTokenIds: MLXArray?
+}
+
 enum MuseGlimmerDFlashDecoder {
     static func decode(
         initialLogits: MLXArray,
@@ -186,7 +191,7 @@ enum MuseGlimmerDFlashDecoder {
             if assistantActive,
                draftCount > 0,
                generationConfig.temperature == 0,
-               generationConfig.repetitionPenalty == nil,
+               generationConfig.repetitionPenalty.map({ $0 == 1 }) ?? true,
                generationConfig.bannedTokens.isEmpty {
                 prepared = prepareGreedyRound(
                     logits: logits,
@@ -224,7 +229,7 @@ enum MuseGlimmerDFlashDecoder {
             }
 
             let proposals: [Int]
-            var proposalProbabilities: [MLXArray] = []
+            var proposalDistributions: [MuseGlimmerProposalDistribution] = []
             let candidateTargetCache: [Gemma4AttentionCache]
             let candidate: MuseGlimmerForwardOutput
             if let prepared {
@@ -233,29 +238,68 @@ enum MuseGlimmerDFlashDecoder {
                 candidate = prepared.candidate
             } else {
                 let candidateAssistantCache = assistantCache.map { $0.fork() }
-                let draftLogits = assistant.draftLogits(
-                    anchorTokens: MLXArray([Int32(anchor)]).reshaped(1, 1),
+                let anchorTokens = MLXArray([Int32(anchor)]).reshaped(1, 1)
+                let draft = assistant.draft(
+                    anchorTokens: anchorTokens,
                     speculativeTokenCount: draftCount,
                     cache: candidateAssistantCache,
                     target: target
                 )
-                MLX.eval(draftLogits)
-                var sampled: [Int] = []
-                var proposalHistory = repetitionHistory
-                sampled.reserveCapacity(draftCount)
-                proposalProbabilities.reserveCapacity(draftCount)
-                for index in 0..<draftCount {
-                    let probabilities = samplingProbabilities(
-                        logits: draftLogits[0, index, 0...],
-                        config: generationConfig,
-                        previousTokens: proposalHistory
+                let selectorDraft: MuseGlimmerAssistantDraftOutput
+                if let banMask = tokenBanMask(
+                    vocabularySize: draft.logits.dim(-1),
+                    dtype: draft.logits.dtype,
+                    tokens: generationConfig.bannedTokens
+                ) {
+                    selectorDraft = MuseGlimmerAssistantDraftOutput(
+                        hidden: draft.hidden,
+                        logits: draft.logits + banMask
                     )
-                    let token = sampleToken(probabilities: probabilities)
-                    sampled.append(token)
-                    proposalProbabilities.append(probabilities)
-                    proposalHistory.append(token)
+                } else {
+                    selectorDraft = draft
                 }
-                proposals = sampled
+                if let selection = assistant.selectDFlash2Candidates(
+                    draft: selectorDraft,
+                    anchorTokens: anchorTokens,
+                    temperature: generationConfig.temperature
+                ) {
+                    if let probabilities = selection.candidateProbabilities {
+                        MLX.eval(selection.tokens, selection.candidateTokenIds, probabilities)
+                    } else {
+                        MLX.eval(selection.tokens, selection.candidateTokenIds)
+                    }
+                    proposals = selection.tokens.asArray(Int32.self).map(Int.init)
+                    if let probabilities = selection.candidateProbabilities {
+                        proposalDistributions.reserveCapacity(draftCount)
+                        for index in 0..<draftCount {
+                            proposalDistributions.append(MuseGlimmerProposalDistribution(
+                                probabilities: probabilities[0, index, 0...],
+                                candidateTokenIds: selection.candidateTokenIds[0, index, 0...]
+                            ))
+                        }
+                    }
+                } else {
+                    MLX.eval(draft.logits)
+                    var sampled: [Int] = []
+                    var proposalHistory = repetitionHistory
+                    sampled.reserveCapacity(draftCount)
+                    proposalDistributions.reserveCapacity(draftCount)
+                    for index in 0..<draftCount {
+                        let probabilities = samplingProbabilities(
+                            logits: draft.logits[0, index, 0...],
+                            config: generationConfig,
+                            previousTokens: proposalHistory
+                        )
+                        let token = sampleToken(probabilities: probabilities)
+                        sampled.append(token)
+                        proposalDistributions.append(MuseGlimmerProposalDistribution(
+                            probabilities: probabilities,
+                            candidateTokenIds: nil
+                        ))
+                        proposalHistory.append(token)
+                    }
+                    proposals = sampled
+                }
                 candidateTargetCache = targetCache.map { $0.fork() }
                 candidate = target.forward(
                     MLXArray(([anchor] + proposals).map(Int32.init))
@@ -294,20 +338,37 @@ enum MuseGlimmerDFlashDecoder {
                         config: generationConfig,
                         previousTokens: verificationHistory
                     )
-                    let draftProbabilities = proposalProbabilities[index]
-                    let draftProbability = max(
-                        draftProbabilities[proposal].item(Float.self),
-                        Float.leastNonzeroMagnitude
-                    )
+                    let draftDistribution = proposalDistributions[index]
+                    let draftProbability: Float
+                    if let candidateTokenIds = draftDistribution.candidateTokenIds {
+                        draftProbability = max(
+                            (draftDistribution.probabilities
+                                * (candidateTokenIds .== Int32(proposal))).sum().item(Float.self),
+                            Float.leastNonzeroMagnitude
+                        )
+                    } else {
+                        draftProbability = max(
+                            draftDistribution.probabilities[proposal].item(Float.self),
+                            Float.leastNonzeroMagnitude
+                        )
+                    }
                     let acceptanceProbability = min(
                         1,
                         targetProbabilities[proposal].item(Float.self) / draftProbability
                     )
                     guard Float.random(in: 0..<1) <= acceptanceProbability else {
-                        replacement = sampleToken(probabilities: rejectionDistribution(
-                            target: targetProbabilities,
-                            draft: draftProbabilities
-                        ))
+                        if let candidateTokenIds = draftDistribution.candidateTokenIds {
+                            replacement = sampleToken(probabilities: sparseRejectionDistribution(
+                                target: targetProbabilities,
+                                candidateTokenIds: candidateTokenIds,
+                                draft: draftDistribution.probabilities
+                            ))
+                        } else {
+                            replacement = sampleToken(probabilities: rejectionDistribution(
+                                target: targetProbabilities,
+                                draft: draftDistribution.probabilities
+                            ))
+                        }
                         break
                     }
                 }
@@ -393,13 +454,17 @@ enum MuseGlimmerDFlashDecoder {
         let anchor = MLX.argMax(logits[0, -1, 0...], axis: -1)
             .asType(.int32)
             .reshaped(1, 1)
-        let draftLogits = assistant.draftLogits(
+        let draft = assistant.draft(
             anchorTokens: anchor,
             speculativeTokenCount: draftCount,
             cache: assistantCache.map { $0.fork() },
             target: target
         )
-        let proposalTokens = MLX.argMax(draftLogits, axis: -1).asType(.int32)
+        let proposalTokens = assistant.selectDFlash2Candidates(
+            draft: draft,
+            anchorTokens: anchor,
+            temperature: 0
+        )?.tokens ?? MLX.argMax(draft.logits, axis: -1).asType(.int32)
         let candidateTargetCache = targetCache.map { $0.fork() }
         let candidate = target.forward(
             concatenated([anchor, proposalTokens], axis: 1),
@@ -458,5 +523,22 @@ enum MuseGlimmerDFlashDecoder {
         let residual = MLX.maximum(target - draft, MLXArray(0))
         let mass = residual.sum().item(Float.self)
         return mass > 1e-6 ? residual / residual.sum() : target
+    }
+
+    static func sparseRejectionDistribution(
+        target: MLXArray,
+        candidateTokenIds: MLXArray,
+        draft: MLXArray
+    ) -> MLXArray {
+        let candidateTarget = takeAlong(target, candidateTokenIds, axis: -1)
+        let residual = putAlong(
+            target,
+            candidateTokenIds,
+            values: candidateTarget - draft,
+            axis: -1
+        )
+        let clipped = MLX.maximum(residual, MLXArray(0))
+        let mass = clipped.sum().item(Float.self)
+        return mass > 1e-6 ? clipped / clipped.sum() : target
     }
 }

--- a/Sources/MereRunCore/MuseGlimmer/MuseGlimmerGenerator.swift
+++ b/Sources/MereRunCore/MuseGlimmer/MuseGlimmerGenerator.swift
@@ -337,20 +337,30 @@ public actor MuseGlimmerGenerator: ChatGenerator {
                     indexURL: index,
                     to: assistant,
                     groupSize: quantization.groupSize,
-                    bits: quantization.bits
+                    bits: quantization.bits,
+                    mapper: MuseGlimmerDFlash2WeightKeys.mapped
                 )
             } else {
-                try HFSafetensorsWeightsLoader.applyShardedWeights(indexURL: index, to: assistant)
+                try HFSafetensorsWeightsLoader.applyShardedWeights(
+                    indexURL: index,
+                    to: assistant,
+                    mapper: MuseGlimmerDFlash2WeightKeys.mapped
+                )
             }
         } else if let quantization = config.quantization {
             try HFSafetensorsWeightsLoader.applyQuantizedWeightsFromArrays(
                 try MLX.loadArrays(url: weights),
                 to: assistant,
                 groupSize: quantization.groupSize,
-                bits: quantization.bits
+                bits: quantization.bits,
+                mapper: MuseGlimmerDFlash2WeightKeys.mapped
             )
         } else {
-            try HFSafetensorsWeightsLoader.applyWeights(url: weights, to: assistant)
+            try HFSafetensorsWeightsLoader.applyWeights(
+                url: weights,
+                to: assistant,
+                mapper: MuseGlimmerDFlash2WeightKeys.mapped
+            )
         }
         assistantModel = assistant
         loadedAssistantPath = root.path
@@ -371,10 +381,13 @@ public actor MuseGlimmerGenerator: ChatGenerator {
         let quantized = MereRunModelPaths.modelsDir
             .appendingPathComponent(MuseGlimmerResources.assistantQuantizedModelId, isDirectory: true)
             .standardizedFileURL
-        let managed = ManagedModelResolver.resolveInstalledModel(
+        let dflash2 = ManagedModelResolver.resolveInstalledModel(
+            id: MuseGlimmerResources.dflash2ModelId
+        )?.standardizedFileURL
+        let legacy = ManagedModelResolver.resolveInstalledModel(
             id: MuseGlimmerResources.assistantModelId
         )?.standardizedFileURL
-        return [configured, managed, quantized]
+        return [configured, dflash2, legacy, quantized]
             .compactMap { $0 }
             .first { MuseGlimmerResources.validateAssistant(rootURL: $0).isEmpty }
     }
@@ -383,9 +396,17 @@ public actor MuseGlimmerGenerator: ChatGenerator {
         _ assistant: MuseGlimmerAssistantConfig,
         target: MuseGlimmerTextConfig
     ) throws {
-        guard assistant.modelType == "muse_glimmer_assistant" else {
+        let supportedModelType = assistant.modelType == "muse_glimmer_assistant"
+            || (assistant.isDFlash2 && assistant.modelType == "qwen3")
+        guard supportedModelType else {
             throw MuseGlimmerError.unsupportedConfiguration(
-                "Expected a muse_glimmer_assistant companion."
+                "Expected a Muse Glimmer DFlash or DFlash2 companion."
+            )
+        }
+        if assistant.isDFlash2,
+           assistant.isCausal != false {
+            throw MuseGlimmerError.unsupportedConfiguration(
+                "Muse DFlash2 requires non-causal block attention."
             )
         }
         guard assistant.hiddenSize == target.hiddenSize else {
@@ -396,6 +417,19 @@ public actor MuseGlimmerGenerator: ChatGenerator {
         guard assistant.targetLayerIds.allSatisfy({ (0..<target.numHiddenLayers).contains($0) }) else {
             throw MuseGlimmerError.unsupportedConfiguration(
                 "Muse DFlash target_layer_ids are outside the target layer range."
+            )
+        }
+        if let vocabularySize = assistant.vocabSize,
+           vocabularySize != target.vocabSize {
+            throw MuseGlimmerError.unsupportedConfiguration(
+                "Muse DFlash vocabulary size \(vocabularySize) does not match target \(target.vocabSize)."
+            )
+        }
+        if let dflash2 = assistant.dflash2,
+           dflash2.outputMultiplier != target.outputMultiplier
+            || dflash2.finalLogitSoftcapping != target.finalLogitSoftcapping {
+            throw MuseGlimmerError.unsupportedConfiguration(
+                "Muse DFlash2 logit scaling does not match the target."
             )
         }
         guard assistant.hiddenActivation == "silu",

--- a/Sources/MereRunCore/MuseGlimmer/MuseGlimmerModel.swift
+++ b/Sources/MereRunCore/MuseGlimmer/MuseGlimmerModel.swift
@@ -774,8 +774,16 @@ public final class MuseGlimmerModel: Module, @unchecked Sendable {
         model.languageModel.embedTokens(inputIds.asType(.int32))
     }
 
+    func inputEmbeddings(for inputIds: MLXArray) -> MLXArray {
+        model.languageModel.embeddings(inputIds)
+    }
+
     func rawOutputLogits(from hidden: MLXArray) -> MLXArray {
         lmHead(hidden)
+    }
+
+    func outputLogits(from hidden: MLXArray) -> MLXArray {
+        logits(hidden)
     }
 
     private func logits(_ hidden: MLXArray) -> MLXArray {

--- a/Sources/MereRunCore/MuseGlimmer/MuseGlimmerResources.swift
+++ b/Sources/MereRunCore/MuseGlimmer/MuseGlimmerResources.swift
@@ -16,6 +16,17 @@ public struct MuseGlimmerResources: Sendable, Hashable {
     public static let assistantUpstreamRepoId = "meta-models/Muse-Glimmer-30B-assistant"
     public static let assistantUpstreamRevision = "2c86316d689027b91123638739743fef1d425233"
     public static let assistantEstimatedDownloadBytes: Int64 = 5_111_976_608
+    public static let dflash2ModelId = "vision-chat-muse-glimmer-30b-dflash2"
+    public static let dflash2UpstreamRepoId = "z-lab/Muse-Glimmer-30B-DFlash2"
+    public static let dflash2UpstreamRevision = "b54ffdd11fa9cfe2af370012e5763d492c904128"
+    public static let dflash2EstimatedDownloadBytes: Int64 = 5_544_615_313
+    public static let dflash2SnapshotPatterns = [
+        "README.md",
+        "config.json",
+        "model.safetensors",
+        "model.safetensors.index.json",
+        "*.safetensors",
+    ]
     public static let assistantSnapshotPatterns = [
         "LICENSE",
         "README.md",

--- a/Sources/MereRunCore/MuseGlimmer/README.md
+++ b/Sources/MereRunCore/MuseGlimmer/README.md
@@ -22,9 +22,12 @@ change cannot silently alter model input.
 - `MuseGlimmerImageProcessor.swift`: aspect-preserving patch preparation and
   prompt placeholder expansion.
 - `MuseGlimmerTokenizerAndTemplate.swift`: the released ATEM chat/tool template.
-- `MuseGlimmerAssistantModel.swift`: the official five-layer DFlash assistant,
+- `MuseGlimmerAssistantModel.swift`: five-layer DFlash and DFlash2 assistants,
   including target hidden-state projection and bidirectional sliding attention.
-- `MuseGlimmerDFlashDecoder.swift`: lossless draft verification, rejection
+- `MuseGlimmerDFlash2.swift`: grouped dynamic causal convolution, the
+  predecessor-aware sparse candidate selector, and published checkpoint-key
+  normalization.
+- `MuseGlimmerDFlashDecoder.swift`: target draft verification, rejection
   correction, and acceptance-aware target-only fallback.
 - `MuseGlimmerGenerator.swift`: managed target/assistant loading and native decode.
 
@@ -32,26 +35,43 @@ The managed target is pinned to Sawfwair's selective MLX Q4 artifact at
 `Sawfwair/Muse-Glimmer-30B-MLX-4bit@6532e898dc5c1a55b51b1b108cd36728b79be751`.
 Its receipt pins the original Meta BF16 source at
 `meta-models/Muse-Glimmer-30B@f84ecc3a0ea984a4c04542a84269e3d065350a6e`,
-including every source and output hash. The automatically installed DFlash
+including every source and output hash. The automatically installed DFlash2
 companion is pinned to
-`meta-models/Muse-Glimmer-30B-assistant@2c86316d689027b91123638739743fef1d425233`.
+`z-lab/Muse-Glimmer-30B-DFlash2@b54ffdd11fa9cfe2af370012e5763d492c904128`.
+The original companion at
+`meta-models/Muse-Glimmer-30B-assistant@2c86316d689027b91123638739743fef1d425233`
+remains a compatible fallback for existing installations.
 Inference never invokes Python. The converters under `scripts/model-conversion/`
 are offline release tooling only.
 
-Native DFlash captures target layers 1, 13, 25, 37, and 49 during prefill,
+Native DFlash2 captures target layers 1, 13, 25, 37, and 49 during prefill,
 projects them through the assistant, drafts from one real anchor plus mask
-tokens, and verifies the entire candidate block with one target forward. The
-replacement selected at a rejected position becomes the next anchor, matching
-the released algorithm without an extra recovery forward. Greedy output is
-covered against serial target decode in `MuseGlimmerTests`.
+tokens, applies two-phase grouped dynamic causal convolution around every
+attention and MLP sublayer, and scores sparse top-k candidates with a
+predecessor-aware selector. The target verifies the entire candidate block in
+one forward. Sampled rejection subtracts only the selector's sparse proposal
+mass before drawing a replacement, preserving the target distribution. The
+replacement becomes the next anchor without an extra recovery forward. The
+sampled sparse path and exact greedy behavior on a deterministic test model
+have end-to-end fixtures in `MuseGlimmerTests`.
 
-The checkpoint permits 15 draft tokens per round, but the affine-Q4 target's
-best measured MLX setting on an M4 Max is 3. In two interleaved 128-token
-release runs, target-only decode averaged 14.73 tok/s and native DFlash averaged
-20.07 tok/s with 54.9% draft acceptance: 1.36x, or 36.2% faster. This is a local
-diagnostic, not a cross-machine guarantee. The runtime uses DFlash for output
-budgets of at least 32 tokens and falls back losslessly after two rounds below
-40% acceptance.
+Both checkpoints permit 15 draft tokens per round. The runtime retains the
+measured Apple default of 3; `MERERUN_MUSE_GLIMMER_DFLASH_TOKENS` can override
+it. For the original DFlash checkpoint, two interleaved 128-token M4 Max release
+runs measured 14.73 tok/s target-only versus 20.07 tok/s DFlash at 54.9%
+acceptance: 1.36x. That historical v1 diagnostic is not a DFlash2 result or a
+cross-machine guarantee.
+
+DFlash2 is the managed default. A matched real 64-token selective-Q4 probe
+reached 17.01 tok/s with 67.7% acceptance versus 7.54 tok/s for one-token target
+decode; its visible output was byte-identical to the existing DFlash v1 path,
+which reached 63.1% acceptance on the same prompt. Both speculative paths share
+MLX's pre-existing quantized block-verification rounding: at one near-tie,
+one-token execution favored a token by 0.125 while batched verification rounded
+the pair equally. This is not a new DFlash2 regression, but real-checkpoint
+bit-exact equivalence to one-token execution is not claimed. Either assistant is
+used only for output budgets of at least 32 tokens and returns to target-only
+decode after two rounds below 40% acceptance.
 
 A paired 16-window, 8,192-token WikiText-2 candidate check measured 9.535
 perplexity for selective Q4 and 9.554 for compact Q4. The selective-minus-compact

--- a/Tests/MereRunCLITests/ModelPullCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/ModelPullCommandParsingTests.swift
@@ -228,6 +228,60 @@ final class ModelPullCommandParsingTests: XCTestCase {
         XCTAssertEqual(decoded.result.models.first?.conversionRequired, false)
     }
 
+    func testInstalledMuseTargetStillPreflightsMissingAssistantCompanion() throws {
+        let temp = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: temp) }
+        let modelStore = temp.appendingPathComponent("models", isDirectory: true)
+        let hubCache = temp.appendingPathComponent("hub", isDirectory: true)
+        let targetRoot = modelStore.appendingPathComponent(
+            MuseGlimmerResources.modelId,
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: targetRoot, withIntermediateDirectories: true)
+        for filename in [
+            "config.json",
+            "generation_config.json",
+            "processor_config.json",
+            "tokenizer.json",
+            "tokenizer_config.json",
+            "model.safetensors",
+        ] {
+            try Data("{}".utf8).write(to: targetRoot.appendingPathComponent(filename))
+        }
+        try MereRunModelManifest(
+            id: MuseGlimmerResources.modelId,
+            usageTermsAcknowledged: true
+        ).write(to: targetRoot)
+
+        let companionBytes: Int64 = 1_234
+        let envelope = try ModelPull.parse([
+            MuseGlimmerResources.modelId,
+            "--allow-unsupported",
+            "--accept-model-license",
+            "--preflight",
+            "--json",
+        ]).makePreflightEnvelope(
+            hubCacheURL: hubCache,
+            modelStoreURL: modelStore,
+            estimatedDownloadBytesOverrides: [
+                MuseGlimmerResources.dflash2ModelId: companionBytes,
+            ],
+            diskAvailableBytes: { _ in 100 * ModelPullDiskPreflight.bytesPerGiB }
+        )
+
+        XCTAssertNotEqual(envelope.status, .blocked)
+        XCTAssertEqual(envelope.result.models.count, 2)
+        XCTAssertEqual(envelope.result.selectedModelCount, 2)
+        XCTAssertEqual(envelope.result.willDownloadCount, 1)
+        XCTAssertEqual(envelope.result.estimatedDownloadBytes, companionBytes)
+        XCTAssertEqual(envelope.result.models[0].id, MuseGlimmerResources.modelId)
+        XCTAssertTrue(envelope.result.models[0].installed)
+        XCTAssertFalse(envelope.result.models[0].willDownload)
+        XCTAssertEqual(envelope.result.models[1].id, MuseGlimmerResources.dflash2ModelId)
+        XCTAssertFalse(envelope.result.models[1].installed)
+        XCTAssertTrue(envelope.result.models[1].willDownload)
+    }
+
     func testModelPullPreflightUsesExplicitConversionRequiredStatus() {
         XCTAssertEqual(
             ModelPullPreflightAnalyzer.modelStatus(

--- a/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
@@ -145,7 +145,6 @@ final class ManagedModelCatalogTests: XCTestCase {
             "vision-embed-olmoearth-v12-small",
             "vision-embed-olmoearth-v12-base",
             MuseGlimmerResources.modelId,
-            MuseGlimmerResources.assistantModelId,
             "image-3d-trellis2-4b",
             MiniMaxMusic3Resources.modelID,
             "music-muscriptor-small",
@@ -707,9 +706,12 @@ final class ManagedModelCatalogTests: XCTestCase {
         XCTAssertTrue(LagunaResources.snapshotPatterns.contains("LICENSE*"))
     }
 
-    func testMuseGlimmerUsesPinnedSawfwairQ4TargetAndOfficialDFlashCompanion() throws {
+    func testMuseGlimmerUsesPinnedQ4TargetAndDFlash2Companion() throws {
         let target = try XCTUnwrap(ManagedModelCatalog.spec(for: MuseGlimmerResources.modelId))
         let companion = try XCTUnwrap(
+            ManagedModelCatalog.spec(for: MuseGlimmerResources.dflash2ModelId)
+        )
+        let legacy = try XCTUnwrap(
             ManagedModelCatalog.spec(for: MuseGlimmerResources.assistantModelId)
         )
 
@@ -726,33 +728,32 @@ final class ManagedModelCatalogTests: XCTestCase {
             target.usageRestriction?.terms.first?.sourceRevision,
             MuseGlimmerResources.upstreamRevision
         )
-        XCTAssertEqual(target.companionModelIDs, [MuseGlimmerResources.assistantModelId])
+        XCTAssertEqual(target.companionModelIDs, [MuseGlimmerResources.dflash2ModelId])
         XCTAssertEqual(target.validationKind, .museGlimmer)
         XCTAssertFalse(target.runtimeAutoDownloadAllowed)
 
         XCTAssertFalse(ManagedModelCatalog.allSpecs.contains { $0.id == companion.id })
         XCTAssertEqual(
             companion.hubFallback?.repoId,
-            MuseGlimmerResources.assistantUpstreamRepoId
+            MuseGlimmerResources.dflash2UpstreamRepoId
         )
         XCTAssertEqual(
             companion.hubFallback?.revision,
-            MuseGlimmerResources.assistantUpstreamRevision
+            MuseGlimmerResources.dflash2UpstreamRevision
         )
         XCTAssertEqual(
             companion.hubFallback?.patterns,
-            MuseGlimmerResources.assistantSnapshotPatterns
+            MuseGlimmerResources.dflash2SnapshotPatterns
         )
         XCTAssertEqual(companion.validationKind, .museGlimmerAssistant)
         XCTAssertEqual(
             companion.estimatedDownloadBytes,
-            MuseGlimmerResources.assistantEstimatedDownloadBytes
+            MuseGlimmerResources.dflash2EstimatedDownloadBytes
         )
-        XCTAssertEqual(
-            companion.usageRestriction?.terms.first?.sourceRepoId,
-            MuseGlimmerResources.assistantUpstreamRepoId
-        )
+        XCTAssertNil(companion.usageRestriction)
         XCTAssertFalse(companion.runtimeAutoDownloadAllowed)
+        XCTAssertFalse(ManagedModelCatalog.allSpecs.contains { $0.id == legacy.id })
+        XCTAssertEqual(legacy.upstreamRepoId, MuseGlimmerResources.assistantUpstreamRepoId)
     }
 
     func testQ36NanoUsesOptiQHubSource() throws {

--- a/Tests/MereRunCoreTests/ManagedModelResolverTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelResolverTests.swift
@@ -2,7 +2,7 @@ import XCTest
 @testable import MereRunCore
 
 final class ManagedModelResolverTests: XCTestCase {
-    func testHiddenMuseAssistantResolvesFromManagedInstallRoot() throws {
+    func testHiddenMuseDFlash2AssistantResolvesFromManagedInstallRoot() throws {
         let modelsRoot = try makeTemporaryDirectory()
         defer {
             MereRunModelPaths.setProcessModelsDirOverride(nil)
@@ -11,7 +11,7 @@ final class ManagedModelResolverTests: XCTestCase {
         MereRunModelPaths.setProcessModelsDirOverride(modelsRoot)
 
         let assistantRoot = modelsRoot.appendingPathComponent(
-            MuseGlimmerResources.assistantModelId,
+            MuseGlimmerResources.dflash2ModelId,
             isDirectory: true
         )
         try FileManager.default.createDirectory(at: assistantRoot, withIntermediateDirectories: true)
@@ -19,12 +19,24 @@ final class ManagedModelResolverTests: XCTestCase {
             to: assistantRoot.appendingPathComponent("config.json")
         )
         try Data([0]).write(to: assistantRoot.appendingPathComponent("model.safetensors"))
+        try MereRunModelManifest.template(
+            for: .museGlimmer30BDFlash2,
+            createdAt: Date(timeIntervalSince1970: 0)
+        ).write(to: assistantRoot)
 
-        XCTAssertNil(ModelResolver.ModelID(rawValue: MuseGlimmerResources.assistantModelId))
         XCTAssertEqual(
-            ManagedModelResolver.resolveInstalledModel(id: MuseGlimmerResources.assistantModelId),
+            ModelResolver.ModelID(rawValue: MuseGlimmerResources.dflash2ModelId),
+            .museGlimmer30BDFlash2
+        )
+        XCTAssertEqual(
+            ManagedModelResolver.resolveInstalledModel(id: MuseGlimmerResources.dflash2ModelId),
             assistantRoot.standardizedFileURL
         )
+        let report = MereRunModelValidator.validate(
+            modelRoot: assistantRoot,
+            expectedModelID: MuseGlimmerResources.dflash2ModelId
+        )
+        XCTAssertTrue(report.isValid, report.errors.joined(separator: "\n"))
     }
 
     func testRestrictedInstallRequiresCoreAcknowledgementBeforeDownload() async throws {

--- a/Tests/MereRunCoreTests/ManagedModelSupportTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelSupportTests.swift
@@ -11,6 +11,17 @@ final class ManagedModelSupportTests: XCTestCase {
         }
     }
 
+    func testManagedCompanionsHaveCapabilityDescriptors() throws {
+        let companionIDs = Set(ManagedModelCatalog.allSpecs.flatMap(\.companionModelIDs))
+        for companionID in companionIDs {
+            let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: companionID))
+            XCTAssertNotNil(
+                ManagedModelCapabilityCatalog.descriptor(for: spec.id),
+                "Missing capability descriptor for \(spec.id)"
+            )
+        }
+    }
+
     func testTerraMindFloodSupportRequiresAppleSiliconAndSixteenGB() throws {
         let spec = try XCTUnwrap(
             ManagedModelCatalog.spec(for: ModelResolver.ModelID.visionFloodTerraMindBase.rawValue)

--- a/Tests/MereRunCoreTests/MuseGlimmerTests.swift
+++ b/Tests/MereRunCoreTests/MuseGlimmerTests.swift
@@ -1,4 +1,5 @@
 import MLX
+import MLXNN
 import MediaIO
 @testable import MereRunCore
 import XCTest
@@ -278,6 +279,15 @@ final class MuseGlimmerTests: MereRunCoreTestCase {
         )
         XCTAssertFalse(spec.runtimeAutoDownloadAllowed)
         XCTAssertEqual(spec.defaultRuntimeServingEngine, .textChatMuseGlimmer)
+        XCTAssertEqual(spec.companionModelIDs, [MuseGlimmerResources.dflash2ModelId])
+
+        let dflash2 = try XCTUnwrap(
+            ManagedModelCatalog.spec(for: MuseGlimmerResources.dflash2ModelId)
+        )
+        XCTAssertEqual(dflash2.upstreamRepoId, MuseGlimmerResources.dflash2UpstreamRepoId)
+        XCTAssertEqual(dflash2.upstreamRevision, MuseGlimmerResources.dflash2UpstreamRevision)
+        XCTAssertEqual(dflash2.validationKind, .museGlimmerAssistant)
+        XCTAssertFalse(dflash2.runtimeAutoDownloadAllowed)
 
         let manifest = MereRunModelManifest.template(for: .museGlimmer30B)
         XCTAssertEqual(manifest.engine, .museGlimmer)
@@ -302,7 +312,100 @@ final class MuseGlimmerTests: MereRunCoreTestCase {
         XCTAssertTrue(names.contains("norm.weight"))
     }
 
-    func testAssistantDraftBlockUsesTargetContextAndRawTargetEmbeddings() throws {
+    func testDFlash2ConfigAndWeightPathsMatchPublishedCheckpoint() throws {
+        let config = try Self.dflash2Config()
+        XCTAssertTrue(config.isDFlash2)
+        XCTAssertEqual(config.modelType, "qwen3")
+        XCTAssertEqual(config.blockSize, 4)
+        XCTAssertEqual(config.maskTokenId, 31)
+        XCTAssertEqual(config.targetLayerIds, [0, 2])
+        XCTAssertEqual(config.dflash2?.convKernelSize, 2)
+        XCTAssertEqual(config.dflash2?.convGroupSize, 2)
+        XCTAssertEqual(config.dflash2?.selectorRank, 1)
+        XCTAssertEqual(config.dflash2?.selectorTopK, 2)
+
+        let assistant = MuseGlimmerAssistantModel(config: config)
+        let names = Set(assistant.parameters().flattened().map(\.0))
+        XCTAssertTrue(names.contains("layers.0.attention_conv.base_kernel"))
+        XCTAssertTrue(names.contains("layers.0.attention_conv.kernel_projection.weight"))
+        XCTAssertTrue(names.contains("layers.0.mlp_conv.base_kernel"))
+        XCTAssertTrue(names.contains("candidate_selector.hidden_projection.weight"))
+        XCTAssertTrue(names.contains("candidate_selector.predecessor_codebook.weight"))
+        XCTAssertTrue(names.contains("candidate_selector.successor_codebook.weight"))
+
+        XCTAssertEqual(MuseGlimmerDFlash2WeightKeys.normalized("fc.weight"), "encoder.fc.weight")
+        XCTAssertEqual(
+            MuseGlimmerDFlash2WeightKeys.normalized("hidden_norm.weight"),
+            "encoder.output_norm_enc.weight"
+        )
+        XCTAssertEqual(
+            MuseGlimmerDFlash2WeightKeys.normalized("candidate_selector.predecessor_codebook"),
+            "candidate_selector.predecessor_codebook.weight"
+        )
+    }
+
+    func testDFlash2GroupedDynamicConvolutionIsBlockLocalAndCausal() {
+        let hidden = MLXArray([Float(1), 2, 3, 4, 5, 6], [1, 3, 2])
+        let dynamic = MLXArray.zeros([1, 3, 2, 1])
+        let base = MLXArray([Float(1), 1, 10, 10], [2, 2])
+        let output = museGlimmerGroupedDynamicConvolution(
+            hidden: hidden,
+            dynamic: dynamic,
+            base: base,
+            groupSize: 2
+        )
+        MLX.eval(output)
+
+        XCTAssertEqual(output.asArray(Float.self), [1, 2, 13, 24, 35, 46])
+    }
+
+    func testDFlash2SelectorUsesPredecessorEdgesAcrossPositions() throws {
+        let selector = MuseGlimmerDFlash2CandidateSelector(
+            vocabularySize: 4,
+            hiddenSize: 4,
+            rank: 1,
+            topK: 2
+        )
+        try selector.update(
+            parameters: ModuleParameters.unflattened([
+                ("hidden_projection.weight", MLXArray([Float(1), 0, 0, 0], [1, 4])),
+                ("predecessor_codebook.weight", MLXArray([Float(1), 2, 3, 4], [4, 1])),
+                ("successor_codebook.weight", MLXArray([Float(-2), -1, 1, 2], [4, 1])),
+            ]),
+            verify: .all
+        )
+        let hidden = MLXArray(
+            [Float(1), 0, 0, 0, 1, 0, 0, 0],
+            [1, 2, 4]
+        )
+        let logits = MLXArray(
+            [Float(0), 0, 5, 4, 5, 4, 0, 0],
+            [1, 2, 4]
+        )
+        let selection = selector.select(
+            hidden: hidden,
+            logits: logits,
+            anchorTokenIds: MLXArray([Int32(1)]),
+            temperature: 0
+        )
+        MLX.eval(selection.tokens)
+
+        XCTAssertEqual(selection.tokens.asArray(Int32.self), [3, 1])
+        XCTAssertNil(selection.candidateProbabilities)
+    }
+
+    func testDFlash2SparseRejectionDistributionSubtractsOnlyCandidates() {
+        let residual = MuseGlimmerDFlashDecoder.sparseRejectionDistribution(
+            target: MLXArray([Float(0), 1]),
+            candidateTokenIds: MLXArray([Int32(0)]),
+            draft: MLXArray([Float(1)])
+        )
+        MLX.eval(residual)
+
+        XCTAssertEqual(residual.asArray(Float.self), [0, 1])
+    }
+
+    func testAssistantDraftBlockUsesTargetContextAndTargetEmbeddings() throws {
         let target = MuseGlimmerModel(config: try Self.config())
         let assistant = MuseGlimmerAssistantModel(config: try Self.assistantConfig())
         let targetCache = target.makeCache()
@@ -355,7 +458,7 @@ final class MuseGlimmerTests: MereRunCoreTestCase {
             topK: 0,
             topP: 1,
             minP: 0,
-            repetitionPenalty: nil,
+            repetitionPenalty: 1,
             repetitionContextSize: 8
         )
         let serial = try AutoregressiveDecodeEngine.decode(
@@ -384,6 +487,105 @@ final class MuseGlimmerTests: MereRunCoreTestCase {
 
         XCTAssertEqual(speculative.generatedTokens, serial.generatedTokens)
         XCTAssertGreaterThan(speculative.stats.targetVerificationForwards, 0)
+    }
+
+    func testGreedyDFlash2DecodeMatchesSerialTargetTokens() throws {
+        let target = MuseGlimmerModel(config: try Self.config())
+        let assistant = MuseGlimmerAssistantModel(config: try Self.dflash2Config())
+        let prompt = [1, 4, 7]
+        let serialCache = target.makeCache()
+        let serialInitial = try target.forwardPrefill(
+            inputIds: MLXArray(prompt.map(Int32.init)).reshaped(1, prompt.count),
+            imageBatch: nil,
+            cache: serialCache
+        )
+        let speculativeCache = target.makeCache()
+        let speculativeInitial = try target.forwardPrefillDetailed(
+            inputIds: MLXArray(prompt.map(Int32.init)).reshaped(1, prompt.count),
+            imageBatch: nil,
+            cache: speculativeCache,
+            captureLayerIndices: [0, 2]
+        )
+        let assistantCache = assistant.makeCache()
+        assistant.appendTargetContext(
+            speculativeInitial.capturedHiddenStates,
+            cache: assistantCache
+        )
+        let generation = GenerationConfig(
+            maxTokens: 8,
+            temperature: 0,
+            topK: 0,
+            topP: 1,
+            minP: 0,
+            repetitionPenalty: 1,
+            repetitionContextSize: 8
+        )
+        let serial = try AutoregressiveDecodeEngine.decode(
+            AutoregressiveDecodeRequest(
+                initialLogits: serialInitial,
+                generationConfig: generation,
+                eosTokens: [],
+                tokenBudget: 8,
+                historySeedTokens: prompt
+            ),
+            stepForward: { token in target(token, cache: serialCache) }
+        )
+        let speculative = try MuseGlimmerDFlashDecoder.decode(
+            initialLogits: speculativeInitial.logits,
+            target: target,
+            targetCache: speculativeCache,
+            assistant: assistant,
+            assistantCache: assistantCache,
+            generationConfig: generation,
+            eosTokens: [],
+            tokenBudget: 8,
+            historySeedTokens: prompt,
+            speculativeTokens: 3,
+            assistantModelPath: nil
+        )
+
+        XCTAssertEqual(speculative.generatedTokens, serial.generatedTokens)
+        XCTAssertGreaterThan(speculative.stats.targetVerificationForwards, 0)
+    }
+
+    func testSampledDFlash2DecodeUsesSparseProposalPath() throws {
+        MLXRandom.seed(7_103)
+        let target = MuseGlimmerModel(config: try Self.config())
+        let assistant = MuseGlimmerAssistantModel(config: try Self.dflash2Config())
+        let prompt = [1, 4, 7]
+        let targetCache = target.makeCache()
+        let initial = try target.forwardPrefillDetailed(
+            inputIds: MLXArray(prompt.map(Int32.init)).reshaped(1, prompt.count),
+            imageBatch: nil,
+            cache: targetCache,
+            captureLayerIndices: [0, 2]
+        )
+        let assistantCache = assistant.makeCache()
+        assistant.appendTargetContext(initial.capturedHiddenStates, cache: assistantCache)
+        let result = try MuseGlimmerDFlashDecoder.decode(
+            initialLogits: initial.logits,
+            target: target,
+            targetCache: targetCache,
+            assistant: assistant,
+            assistantCache: assistantCache,
+            generationConfig: GenerationConfig(
+                maxTokens: 8,
+                temperature: 1,
+                topK: 0,
+                topP: 1,
+                minP: 0,
+                repetitionPenalty: nil,
+                repetitionContextSize: 8
+            ),
+            eosTokens: [],
+            tokenBudget: 8,
+            historySeedTokens: prompt,
+            speculativeTokens: 3,
+            assistantModelPath: nil
+        )
+
+        XCTAssertEqual(result.generatedTokens.count, 8)
+        XCTAssertGreaterThan(result.stats.targetVerificationForwards, 0)
     }
 
     func testWarmUpMaterializesSerialAndProductionDFlashPaths() throws {
@@ -438,6 +640,13 @@ final class MuseGlimmerTests: MereRunCoreTestCase {
         )
     }
 
+    private static func dflash2Config() throws -> MuseGlimmerAssistantConfig {
+        try JSONDecoder().decode(
+            MuseGlimmerAssistantConfig.self,
+            from: Data(dflash2ConfigJSON.utf8)
+        )
+    }
+
     private static let assistantConfigJSON = #"""
     {
       "model_type":"muse_glimmer_assistant",
@@ -461,6 +670,42 @@ final class MuseGlimmerTests: MereRunCoreTestCase {
       "block_size":4,
       "mask_token_id":31,
       "target_layer_ids":[0,2]
+    }
+    """#
+
+    private static let dflash2ConfigJSON = #"""
+    {
+      "model_type":"qwen3",
+      "architectures":["DFlash2DraftModel"],
+      "is_causal":false,
+      "hidden_size":16,
+      "intermediate_size":32,
+      "num_hidden_layers":2,
+      "num_attention_heads":4,
+      "num_key_value_heads":2,
+      "head_dim":4,
+      "rms_norm_eps":0.00001,
+      "rope_parameters":{"rope_theta":500000,"rope_type":"default"},
+      "max_position_embeddings":64,
+      "sliding_window":8,
+      "layer_types":["sliding_attention","sliding_attention"],
+      "attention_dropout":0,
+      "hidden_act":"silu",
+      "vocab_size":32,
+      "bos_token_id":1,
+      "eos_token_id":2,
+      "pad_token_id":0,
+      "dflash_config":{
+        "block_size":4,
+        "conv_group_size":2,
+        "conv_kernel_size":2,
+        "final_logit_softcapping":20,
+        "mask_token_id":31,
+        "output_multiplier":0.19611613513818404,
+        "selector_rank":1,
+        "selector_top_k":2,
+        "target_layer_ids":[0,2]
+      }
     }
     """#
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -188,16 +188,16 @@ entries, and the typed ledger lives under
 
 ### `MERERUN_MUSE_GLIMMER_DFLASH`
 
-Muse Glimmer DFlash is enabled by default when the official managed assistant
-companion is installed. Set this to `0`, `false`, `no`, or `off` to force
+Muse Glimmer DFlash is enabled by default when a managed assistant companion is
+installed. The runtime prefers DFlash2, then falls back to an existing original
+DFlash or local Q4 companion. Set this to `0`, `false`, `no`, or `off` to force
 target-only decode. The runtime uses the assistant after both text and image
-prefill, verifies every proposal with the target, and preserves the target's
-greedy or sampled output distribution.
+prefill and verifies every proposal with the target.
 
 ### `MERERUN_MUSE_GLIMMER_DFLASH_TOKENS`
 
-Overrides proposals per DFlash round. The checkpoint supports up to `15`, but
-the measured affine-Q4 MLX target defaults to `3`; values are clamped to the
+Overrides proposals per DFlash round. Both Muse assistants support up to `15`;
+the measured affine-Q4 MLX default is `3`, and values are clamped to the active
 assistant's supported range.
 
 ### `MERERUN_MUSE_GLIMMER_DFLASH_MIN_OUTPUT`
@@ -214,8 +214,9 @@ fallback for the rest of the request.
 ### `MERERUN_MUSE_GLIMMER_DFLASH_PATH`
 
 Selects an explicit local Muse Glimmer assistant directory. When unset, the
-runtime prefers the managed official BF16 assistant, then the optional local
-`vision-chat-muse-glimmer-30b-assistant-q4` conversion.
+runtime prefers managed DFlash2, then an existing managed original DFlash
+install, then the optional local `vision-chat-muse-glimmer-30b-assistant-q4`
+conversion.
 
 ### `MERERUN_GEMMA4_MTP`
 

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -374,15 +374,16 @@ the token
 embedding and complete vision tower in BF16; pass `--quantization-scope compact`
 to quantize all 721 eligible matrices for an explicit lower-memory experiment.
 The runtime discovers quantized modules from their `.scales` arrays, so both
-layouts use the same inference implementation. The same pull installs the 5.11
-GB official DFlash assistant
-from `meta-models/Muse-Glimmer-30B-assistant` at revision
-`2c86316d689027b91123638739743fef1d425233`; the native verifier accelerates
-eligible decode without changing target-model output. Pulls require explicit
-review and acceptance of the bundled `LICENSE` and `USAGE_POLICY.md`; upstream
-says the model is not intended for download or use by people under 18. Python
-conversion scripts are offline artifact tooling only and are not part of
-inference.
+layouts use the same inference implementation. The same pull installs z-lab's
+5.54 GB DFlash2 assistant as the hidden managed model
+`vision-chat-muse-glimmer-30b-dflash2`, pinned to
+`z-lab/Muse-Glimmer-30B-DFlash2@b54ffdd11fa9cfe2af370012e5763d492c904128`.
+The earlier 5.11 GB assistant from `meta-models/Muse-Glimmer-30B-assistant` at
+revision `2c86316d689027b91123638739743fef1d425233` remains a compatible fallback
+for existing installations. Pulls require explicit review and acceptance of
+the target's bundled `LICENSE` and `USAGE_POLICY.md`; upstream says the model is
+not intended for download or use by people under 18. Python conversion scripts
+are offline artifact tooling only and are not part of inference.
 
 `text-chat-nemotron-35-lightning` pins Sawfwair's native MLX conversion at
 revision `6699e5fd3f0c5b392bb3f8bac2443276bb41958a`, produced from NVIDIA's

--- a/docs/runtime/api-server.md
+++ b/docs/runtime/api-server.md
@@ -103,7 +103,7 @@ swift run mere.run api serve \
 ```
 
 For Muse Glimmer multimodal agent chat (explicit 21.38 GB Q4 target plus the
-5.11 GB assistant):
+5.54 GB DFlash2 assistant):
 
 ```bash
 swift run mere.run model pull vision-chat-muse-glimmer-30b --accept-model-license
@@ -114,9 +114,17 @@ swift run mere.run api serve \
 
 This engine accepts OpenAI image content parts and function tools. It exposes
 reasoning effort, but does not claim constrained `json_object` decoding. The
-managed pull also installs Meta's pinned 5.11 GB DFlash assistant. Requests for
-at least 32 output tokens use native target-verified speculation and fall back
-losslessly when draft acceptance is poor.
+managed pull also installs z-lab's pinned DFlash2 assistant. Requests for
+at least 32 output tokens use target-verified speculation and return to
+target-only decode when draft acceptance is poor.
+
+The native DFlash2 companion can be refreshed independently:
+
+```bash
+swift run mere.run model pull vision-chat-muse-glimmer-30b-dflash2
+swift run mere.run api serve \
+  --model vision-chat-muse-glimmer-30b
+```
 
 For NVIDIA Nemotron 3.5 Lightning with its automatically installed DSpark
 companion:

--- a/docs/runtime/text.md
+++ b/docs/runtime/text.md
@@ -96,18 +96,23 @@ non-repetitive text, and worth ~2× when generation echoes the prompt
 [Configuration](../configuration.md#mererun_gemma4_prompt_lookup)).
 
 `vision-chat-muse-glimmer-30b` installs Sawfwair's pinned 21.38 GB selective MLX
-Q4 target plus Meta's official 2.56B-parameter DFlash assistant. The target's
-receipt pins every source and output hash and retains Meta's bundled terms.
-Native DFlash captures the five
-released target hidden-state taps during text or image prefill, drafts masked
-blocks with the assistant, and verifies them against the target without
-changing the target's output distribution. It engages for output budgets of at
-least 32 tokens, defaults to 3 proposals per round on MLX, and returns to
-target-only decode after two rounds below 40% acceptance. Add `--stats` to see
-the proposal width, acceptance, verification forwards, and fallback state.
+Q4 target plus z-lab's DFlash2 assistant. The target's receipt pins every
+source and output hash and retains Meta's bundled terms. Native DFlash captures
+the five released target hidden-state taps during text or image prefill, drafts
+masked blocks, and verifies them against the target. It engages for output
+budgets of at least 32 tokens, defaults to 3 proposals per round on MLX, and
+returns to target-only decode after two rounds below 40% acceptance. Add
+`--stats` to see the proposal width, acceptance, verification forwards, and
+fallback state.
 Loading performs one target and DFlash warmup before the first user-visible
 decode, so lazy MLX graph compilation is reported in `loadSeconds` and a
 persistent CLI/API model session pays that cost once.
+
+DFlash2 adds two-phase grouped dynamic causal convolution and predecessor-aware
+sparse candidate selection. It is installed and preferred automatically; an
+existing original DFlash or local Q4 assistant remains a fallback. A real
+64-token selective-Q4 probe produced the same bytes as the original DFlash path
+while improving acceptance from 63.1% to 67.7% on that prompt.
 
 ```bash
 swift run mere.run model pull vision-chat-muse-glimmer-30b --accept-model-license


### PR DESCRIPTION
## Summary

- add native Swift/MLX support for the published Muse Glimmer DFlash2 architecture, including nested config decoding, grouped dynamic causal convolution, non-causal block attention, checkpoint-key normalization, and predecessor-aware sparse candidate selection
- extend greedy and sampled speculative decoding with DFlash2 candidate selection and exact sparse rejection correction
- make the immutable `z-lab/Muse-Glimmer-30B-DFlash2` artifact the managed Muse Glimmer companion while retaining installed DFlash v1 and local Q4 fallbacks
- recursively account for managed companions during pull preflight and document the new default/fallback behavior

## Validation

- `env -u MERERUN_RUN_E2E nice -n 10 ./scripts/check.sh`
  - strict lint: 1,323 files, 0 violations
  - XCTest: 3,046 tests, 219 expected skips, 0 failures
  - Swift Testing: 30 tests, 0 failures
- focused Muse Glimmer suite: 23 tests, 0 failures
- managed-model coverage: 169 tests, 1 expected skip, 0 failures
- model-pull/preflight coverage: 32 tests, 0 failures

## Real checkpoint evidence

Matched 64-token greedy prompt using the installed selective-Q4 Muse Glimmer target:

- DFlash2: 17.01 tok/s, 67.7% acceptance, 21 verification rounds
- target-only serial decode: 7.54 tok/s
- DFlash2 output was byte-identical to the existing DFlash v1 path on this prompt; DFlash v1 acceptance was 63.1%

This is one clean local A/B, not a universal speedup claim. Both speculative paths retain the existing selective-Q4 block-verification near-tie rounding behavior, so this PR does not claim bit-exact equivalence to one-token serial execution.