### PR TITLE
Add native Nemotron Omni execution engine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,14 @@ The format is based on Keep a Changelog.
   rounding at an observed near-tie, so the implementation does not claim
   bit-exact equivalence to one-token execution.
 
+### Nemotron Omni
+
+- added a native Swift/MLX execution engine for NVIDIA Nemotron 3 Nano Omni
+  30B-A3B Reasoning BF16: BF16 Nemotron-H text generation, C-RADIO v4-H image
+  and video understanding, Parakeet audio understanding, local video sampling,
+  media-aware OpenAI chat completions, source-bound expert caching, installed
+  inference smoke coverage, and first-class catalog/runtime-pool support.
+
 ### iOS Studio
 
 - fixed verified artifact downloads on Apple platforms to use the iOS

--- a/Package.swift
+++ b/Package.swift
@@ -370,6 +370,7 @@ targets.append(contentsOf: [
       "MuScriptor/README.md",
       "MuseGlimmer/README.md",
       "NemotronH/README.md",
+      "NemotronOmni/README.md",
       "LFM2/README.md",
       "LightOnOCR/README.md",
       "LTX/README.md",

--- a/README.md
+++ b/README.md
@@ -311,6 +311,23 @@ swift run mere.run model pull text-code-north-mini
 swift run mere.run model pull text-agent-ornith-35b-mlx
 swift run mere.run model pull text-agent-ornith-35b
 
+# Nemotron 3 Nano Omni is an explicit 66.06 GB BF16 pull for 112+ GB machines.
+# It runs text, image, audio, and video understanding through native Swift/MLX.
+swift run mere.run model pull omni-chat-nemotron3-nano-30b-a3b-bf16 \
+  --accept-model-license
+swift run mere.run text chat \
+  --model omni-chat-nemotron3-nano-30b-a3b-bf16 \
+  --image photo.png \
+  --prompt "Describe the image."
+swift run mere.run text chat \
+  --model omni-chat-nemotron3-nano-30b-a3b-bf16 \
+  --audio speech.wav \
+  --prompt "Transcribe the spoken audio."
+swift run mere.run text chat \
+  --model omni-chat-nemotron3-nano-30b-a3b-bf16 \
+  --video clip.mp4 \
+  --prompt "Summarize the video."
+
 # Run Prism ML's binary model for lower residency/faster decode, or substitute
 # text-chat-bonsai-27b-2bit for the larger ternary checkpoint.
 swift run mere.run text chat \

--- a/Sources/MediaIO/AppleMediaVideoIO.swift
+++ b/Sources/MediaIO/AppleMediaVideoIO.swift
@@ -310,6 +310,83 @@ enum AppleMediaVideoIO {
         return VideoFrameSequence(frameURLs: frameURLs, fps: fps, frameWidth: frameWidth, frameHeight: frameHeight)
     }
 
+    static func sampleFrames(
+        from videoURL: URL,
+        into outputDirectoryURL: URL,
+        framesPerSecond: Double,
+        maximumFrames: Int
+    ) throws -> VideoFrameSequence {
+        let asset = AVURLAsset(url: videoURL)
+        guard let track = asset.tracks(withMediaType: .video).first else {
+            throw MediaIOError.videoOperationFailed("Video track missing in asset: \(videoURL.path)")
+        }
+        let sourceRate = try MediaVideoFrameRateResolver.resolve(
+            Double(track.nominalFrameRate),
+            fallbackFPS: 30
+        )
+        let duration = CMTimeGetSeconds(asset.duration)
+        guard duration.isFinite, duration > 0 else {
+            throw MediaIOError.videoOperationFailed("Video duration is not finite or positive.")
+        }
+        let estimatedSourceCount = max(1, Int((duration * sourceRate.framesPerSecond).rounded()))
+        let requestedCount = max(1, min(maximumFrames, Int(duration * framesPerSecond)))
+        let indices = evenlySpacedIndices(
+            sourceCount: estimatedSourceCount,
+            requestedCount: requestedCount
+        )
+        let generator = AVAssetImageGenerator(asset: asset)
+        generator.appliesPreferredTrackTransform = true
+        try FileManager.default.createDirectory(
+            at: outputDirectoryURL,
+            withIntermediateDirectories: true
+        )
+        var frameURLs: [URL] = []
+        var width = 0
+        var height = 0
+        for (outputIndex, sourceIndex) in indices.enumerated() {
+            let time = CMTime(
+                value: CMTimeValue(sourceIndex) * sourceRate.frameDurationValue,
+                timescale: sourceRate.timeScale
+            )
+            let image = try generator.copyCGImage(at: time, actualTime: nil)
+            width = image.width
+            height = image.height
+            let url = outputDirectoryURL
+                .appendingPathComponent(String(format: "frame_%05d", outputIndex))
+                .appendingPathExtension("png")
+            try writeImage(image, to: url)
+            frameURLs.append(url)
+        }
+        return VideoFrameSequence(
+            frameURLs: frameURLs,
+            fps: sourceRate.framesPerSecond,
+            frameWidth: width,
+            frameHeight: height,
+            sourceFrameIndices: indices
+        )
+    }
+
+    private static func evenlySpacedIndices(
+        sourceCount: Int,
+        requestedCount: Int
+    ) -> [Int] {
+        if requestedCount >= sourceCount {
+            return Array(0..<sourceCount)
+        }
+        if requestedCount == 1 {
+            return [0]
+        }
+        let scale = Double(sourceCount - 1) / Double(requestedCount - 1)
+        var result: [Int] = []
+        for index in 0..<requestedCount {
+            let candidate = Int((Double(index) * scale).rounded())
+            if result.last != candidate {
+                result.append(candidate)
+            }
+        }
+        return result
+    }
+
     static func writeVideo(frameURLs: [URL], fps: Double, to outputURL: URL) throws {
         let frameRate = try MediaVideoFrameRateResolver.resolve(fps, fallbackFPS: 1)
         guard let firstURL = frameURLs.first,

--- a/Sources/MediaIO/FFmpegMediaIO.swift
+++ b/Sources/MediaIO/FFmpegMediaIO.swift
@@ -694,6 +694,58 @@ enum FFmpegMediaIO {
         )
     }
 
+    static func sampleFrames(
+        from videoURL: URL,
+        into directoryURL: URL,
+        framesPerSecond: Double,
+        maximumFrames: Int
+    ) throws -> VideoFrameSequence {
+        let sourceFPS = try videoFPS(videoURL)
+        let duration = try videoDurationSeconds(videoURL)
+        let sourceCount = max(1, Int((duration * sourceFPS).rounded()))
+        let requestedCount = max(1, min(maximumFrames, Int(duration * framesPerSecond)))
+        let indices: [Int]
+        if requestedCount >= sourceCount {
+            indices = Array(0..<sourceCount)
+        } else if requestedCount == 1 {
+            indices = [0]
+        } else {
+            let scale = Double(sourceCount - 1) / Double(requestedCount - 1)
+            indices = (0..<requestedCount).reduce(into: []) { result, index in
+                let candidate = Int((Double(index) * scale).rounded())
+                if result.last != candidate {
+                    result.append(candidate)
+                }
+            }
+        }
+        try FileManager.default.createDirectory(at: directoryURL, withIntermediateDirectories: true)
+        let pattern = directoryURL.appendingPathComponent("frame_%05d.png")
+        let expression = indices.map { "eq(n\\,\($0))" }.joined(separator: "+")
+        _ = try FFmpegProcess.run(
+            tool: MediaTool.ffmpegPath,
+            arguments: [
+                "-v", "error", "-y", "-i", videoURL.path,
+                "-map", "0:v:0", "-vf", "select=\(expression)",
+                "-fps_mode", "vfr", "-frames:v", "\(indices.count)", pattern.path,
+            ]
+        )
+        let frameURLs = (try FileManager.default.contentsOfDirectory(
+            at: directoryURL,
+            includingPropertiesForKeys: nil
+        )).filter { $0.pathExtension.lowercased() == "png" }.sorted { $0.path < $1.path }
+        guard let first = frameURLs.first else {
+            throw MediaIOError.videoOperationFailed("No frames sampled from \(videoURL.path).")
+        }
+        let size = try imageSize(of: first)
+        return VideoFrameSequence(
+            frameURLs: frameURLs,
+            fps: sourceFPS,
+            frameWidth: size.width,
+            frameHeight: size.height,
+            sourceFrameIndices: indices
+        )
+    }
+
     static func frameAdmissionPlan(
         fromFFmpegShowInfo output: String,
         maximumFrameCount: Int

--- a/Sources/MediaIO/MediaIO.swift
+++ b/Sources/MediaIO/MediaIO.swift
@@ -84,12 +84,20 @@ public struct VideoFrameSequence: Sendable, Hashable {
     public let fps: Double
     public let frameWidth: Int
     public let frameHeight: Int
+    public let sourceFrameIndices: [Int]?
 
-    public init(frameURLs: [URL], fps: Double, frameWidth: Int, frameHeight: Int) {
+    public init(
+        frameURLs: [URL],
+        fps: Double,
+        frameWidth: Int,
+        frameHeight: Int,
+        sourceFrameIndices: [Int]? = nil
+    ) {
         self.frameURLs = frameURLs
         self.fps = max(1, fps)
         self.frameWidth = max(0, frameWidth)
         self.frameHeight = max(0, frameHeight)
+        self.sourceFrameIndices = sourceFrameIndices
     }
 }
 

--- a/Sources/MediaIO/MediaVideoIO.swift
+++ b/Sources/MediaIO/MediaVideoIO.swift
@@ -244,6 +244,39 @@ public enum MediaVideoIO {
         #endif
     }
 
+    /// Samples frames across the full source timeline. This is intentionally
+    /// distinct from `extractFrames(endFrame:)`, which decodes a contiguous
+    /// prefix and is unsuitable for long-form understanding models.
+    public static func sampleFrames(
+        from videoURL: URL,
+        into outputDirectoryURL: URL,
+        framesPerSecond: Double,
+        maximumFrames: Int
+    ) throws -> VideoFrameSequence {
+        guard framesPerSecond.isFinite,
+              framesPerSecond > 0,
+              maximumFrames > 0 else {
+            throw MediaIOError.videoOperationFailed(
+                "Video sampling requires a positive finite rate and frame limit."
+            )
+        }
+        #if canImport(AVFoundation) && canImport(CoreGraphics)
+        return try AppleMediaVideoIO.sampleFrames(
+            from: videoURL,
+            into: outputDirectoryURL,
+            framesPerSecond: framesPerSecond,
+            maximumFrames: maximumFrames
+        )
+        #else
+        return try FFmpegMediaIO.sampleFrames(
+            from: videoURL,
+            into: outputDirectoryURL,
+            framesPerSecond: framesPerSecond,
+            maximumFrames: maximumFrames
+        )
+        #endif
+    }
+
     public static func writeVideo(frameURLs: [URL], fps: Double, to outputURL: URL) throws {
         #if canImport(AVFoundation) && canImport(CoreGraphics)
         try AppleMediaVideoIO.writeVideo(frameURLs: frameURLs, fps: fps, to: outputURL)

--- a/Sources/MereRunCLI/Commands/APIServeCommand.swift
+++ b/Sources/MereRunCLI/Commands/APIServeCommand.swift
@@ -148,10 +148,10 @@ struct APIServe: AsyncParsableCommand {
     @Option(name: [.long], help: "Host to bind to.")
     var host: String = "127.0.0.1"
 
-    @Option(name: [.customShort("m"), .long, .customLong("model-path")], help: "Model path. For --engine text-code, pass a GGUF file. For --engine text-chat-klein, pass a Klein-root text chat model. For --engine text-chat-gemma4, pass a Gemma 4 model root or repo ID. For --engine text-chat-laguna, pass text-chat-laguna-s-2-1, text-chat-laguna-xs-2-1, or an installed Laguna MLX root. For --engine text-chat-q36, pass a Qwen3.6 text chat model root. For --engine text-chat-lfm2, pass an LFM2 MLX model root or repo ID. For --engine text-chat-deepseek-v4-flash, pass a DS4 GGUF file or managed model root. For --engine text-chat-muse-glimmer, pass vision-chat-muse-glimmer-30b or an installed Muse Glimmer MLX root.")
+    @Option(name: [.customShort("m"), .long, .customLong("model-path")], help: "Model path. For --engine text-code, pass a GGUF file. For --engine text-chat-klein, pass a Klein-root text chat model. For --engine text-chat-gemma4, pass a Gemma 4 model root or repo ID. For --engine text-chat-laguna, pass text-chat-laguna-s-2-1, text-chat-laguna-xs-2-1, or an installed Laguna MLX root. For --engine text-chat-q36, pass a Qwen3.6 text chat model root. For --engine text-chat-lfm2, pass an LFM2 MLX model root or repo ID. For --engine text-chat-deepseek-v4-flash, pass a DS4 GGUF file or managed model root. For --engine text-chat-muse-glimmer, pass vision-chat-muse-glimmer-30b or an installed Muse Glimmer MLX root. For --engine text-chat-nemotron-omni, pass omni-chat-nemotron3-nano-30b-a3b-bf16 or its installed wrapper root.")
     var model: String?
 
-    @Option(name: [.long], help: "Serving engine: text-chat-q36 (default; serves text-chat-q36-nano), text-code, text-chat-klein, text-chat-gemma4, text-chat-laguna, text-chat-lfm2, text-chat-deepseek-v4-flash, or text-chat-muse-glimmer.")
+    @Option(name: [.long], help: "Serving engine: text-chat-q36 (default; serves text-chat-q36-nano), text-code, text-chat-klein, text-chat-gemma4, text-chat-laguna, text-chat-lfm2, text-chat-deepseek-v4-flash, text-chat-muse-glimmer, text-chat-nemotron-h, or text-chat-nemotron-omni.")
     var engine: APIEngine = .textChatQ36
 
     @Option(name: [.long], help: "Default cataloged adapter id or local LoRA path for all requests.")
@@ -270,6 +270,8 @@ struct APIServe: AsyncParsableCommand {
             return MuseGlimmerResources.modelId
         case .textChatNemotronH:
             return NemotronHResources.modelID
+        case .textChatNemotronOmni:
+            return NemotronOmniResources.modelID
         }
     }
 
@@ -362,6 +364,23 @@ struct APIServe: AsyncParsableCommand {
                 return explicit
             }
             return ManagedModelResolver.resolveInstalledModel(id: NemotronHResources.modelID)?.path
+        case .textChatNemotronOmni:
+            if let explicit = model {
+                if explicit == NemotronOmniResources.modelID {
+                    guard let installed = ManagedModelResolver.resolveInstalledModel(
+                        id: NemotronOmniResources.modelID
+                    ) else {
+                        throw ValidationError(
+                            "Model '\(NemotronOmniResources.modelID)' is not installed. Run "
+                                + "'mere.run model pull \(NemotronOmniResources.modelID) "
+                                + "--accept-model-license' first."
+                        )
+                    }
+                    return installed.path
+                }
+                return explicit
+            }
+            return ManagedModelResolver.resolveInstalledModel(id: NemotronOmniResources.modelID)?.path
         }
     }
 
@@ -501,6 +520,7 @@ enum APIEngine: String, ExpressibleByArgument {
     case textChatDeepseekV4Flash = "text-chat-deepseek-v4-flash"
     case textChatMuseGlimmer = "text-chat-muse-glimmer"
     case textChatNemotronH = "text-chat-nemotron-h"
+    case textChatNemotronOmni = "text-chat-nemotron-omni"
 
     var runtimeServingEngine: RuntimeServingEngine {
         switch self {
@@ -524,6 +544,8 @@ enum APIEngine: String, ExpressibleByArgument {
             return .textChatMuseGlimmer
         case .textChatNemotronH:
             return .textChatNemotronH
+        case .textChatNemotronOmni:
+            return .textChatNemotronOmni
         }
     }
 
@@ -542,6 +564,8 @@ struct APIEngineCapabilities: Equatable, Sendable {
     var supportsMaxCompletionTokens: Bool = true
     var supportsUsageInStreaming: Bool = true
     var supportsVisionContentParts: Bool = false
+    var supportsAudioContentParts: Bool = false
+    var supportsVideoContentParts: Bool = false
     var supportsStrictMode: Bool = false
     var supportsStopSequences: Bool = false
     var supportsSeed: Bool = false
@@ -560,6 +584,8 @@ struct APIEngineCapabilities: Equatable, Sendable {
             supportsMaxCompletionTokens: profile.compatibility.maxTokensField == .maxCompletionTokens,
             supportsUsageInStreaming: profile.compatibility.supportsUsageInStreaming,
             supportsVisionContentParts: profile.inputModalities.contains(.image),
+            supportsAudioContentParts: profile.inputModalities.contains(.audio),
+            supportsVideoContentParts: profile.inputModalities.contains(.video),
             supportsStrictMode: profile.compatibility.supportsStrictMode,
             supportsStopSequences: profile.supportsStopSequences,
             supportsSeed: profile.supportsSeed,
@@ -2623,12 +2649,16 @@ enum APIServerContract {
         }
 
         let imageURL = try firstImageURL(from: msg, capabilities: capabilities)
+        let audioURL = try firstAudioURL(from: msg, capabilities: capabilities)
+        let videoURL = try firstVideoURL(from: msg, capabilities: capabilities)
         let content = renderMessageContent(msg)
         let toolCalls = try chatMessageToolCalls(from: msg)
         return ChatMessage(
             role: role,
             content: content,
             imageUrl: imageURL,
+            audioUrl: audioURL,
+            videoUrl: videoURL,
             reasoningContent: msg.reasoning_content,
             name: msg.name,
             toolCallID: msg.tool_call_id,
@@ -2690,6 +2720,46 @@ enum APIServerContract {
             )
         }
         return msg.imageURLs.first
+    }
+
+    private static func firstAudioURL(
+        from msg: OpenAIChatMessage,
+        capabilities: APIEngineCapabilities
+    ) throws -> String? {
+        guard !msg.audioURLs.isEmpty else { return nil }
+        guard capabilities.supportsAudioContentParts else {
+            throw APIRequestValidationError.invalidField(
+                "messages.content",
+                "audio content parts are not supported by this engine"
+            )
+        }
+        guard msg.audioURLs.count == 1 else {
+            throw APIRequestValidationError.invalidField(
+                "messages.content",
+                "only one audio content part per message is currently supported"
+            )
+        }
+        return msg.audioURLs.first
+    }
+
+    private static func firstVideoURL(
+        from msg: OpenAIChatMessage,
+        capabilities: APIEngineCapabilities
+    ) throws -> String? {
+        guard !msg.videoURLs.isEmpty else { return nil }
+        guard capabilities.supportsVideoContentParts else {
+            throw APIRequestValidationError.invalidField(
+                "messages.content",
+                "video content parts are not supported by this engine"
+            )
+        }
+        guard msg.videoURLs.count == 1 else {
+            throw APIRequestValidationError.invalidField(
+                "messages.content",
+                "only one video content part per message is currently supported"
+            )
+        }
+        return msg.videoURLs.first
     }
 
     private static func renderMessageContent(_ msg: OpenAIChatMessage) -> String {

--- a/Sources/MereRunCLI/Commands/ModelBenchmarkVLMCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelBenchmarkVLMCommand.swift
@@ -342,6 +342,8 @@ struct ModelBenchmarkVLM: AsyncParsableCommand {
             return .textChatMuseGlimmer
         case .textChatNemotronH:
             return .textChatNemotronH
+        case .textChatNemotronOmni:
+            return .textChatNemotronOmni
         case .textCode:
             return .textCode
         }

--- a/Sources/MereRunCLI/Commands/OpenWebUICommand.swift
+++ b/Sources/MereRunCLI/Commands/OpenWebUICommand.swift
@@ -949,6 +949,8 @@ private extension APIEngine {
             self = .textChatMuseGlimmer
         case .textChatNemotronH:
             self = .textChatNemotronH
+        case .textChatNemotronOmni:
+            self = .textChatNemotronOmni
         }
     }
 }

--- a/Sources/MereRunCLI/Commands/TextChatCommand.swift
+++ b/Sources/MereRunCLI/Commands/TextChatCommand.swift
@@ -40,6 +40,7 @@ struct TextChat: AsyncParsableCommand {
           - text-chat-laguna-s-2-1 (Poolside Laguna S 2.1 118B-A8B NVFP4 with DFlash)
           - text-chat-laguna-xs-2-1 (Poolside Laguna XS 2.1 33B-A3B NVFP4)
           - text-chat-nemotron-35-lightning (NVIDIA Nemotron 3.5 Lightning 30B-A3B NVFP4 with DSpark)
+          - omni-chat-nemotron3-nano-30b-a3b-bf16 (NVIDIA Nemotron 3 Nano Omni BF16)
           - text-chat-inkling-small (Inkling-Small 276B-A12B mixed MLX: routed-expert q2, non-routed BF16)
           - text-chat-lfm25-2.6b-4bit (LiquidAI LFM2.5 2.6B dense MLX 4-bit native Swift runtime)
           - text-chat-lfm25-a1b-8bit (LiquidAI LFM2.5 8B-A1B MLX 8-bit native Swift runtime)
@@ -58,6 +59,12 @@ struct TextChat: AsyncParsableCommand {
 
     @Option(name: [.long], help: "Optional image path for vision-capable chat models such as Bonsai 27B or vision-chat-gemma4-12b.")
     var image: String?
+
+    @Option(name: [.long], help: "Optional local audio path for audio-capable Omni chat models.")
+    var audio: String?
+
+    @Option(name: [.long], help: "Optional local video path for video-capable Omni chat models.")
+    var video: String?
 
     @Option(name: [.customShort("s"), .customLong("system")], help: "System prompt.")
     var systemPrompt: String?
@@ -152,7 +159,7 @@ struct TextChat: AsyncParsableCommand {
             + firstTokenSeconds
     }
 
-    @Option(name: [.long], help: "Canonical model id. Default: text-chat-gemma4-12b-4bit (Apple Silicon) / text-chat-q36-nano-gguf (Linux CUDA). Others include vision-chat-muse-glimmer-30b, text-chat-nemotron-35-lightning, text-chat-laguna-s-2-1, text-chat-inkling-small, text-chat-bonsai-27b-1bit, text-chat-q36-nano, text-agent-ornith-9b, text-chat-gemma4[-12b|-12b-4bit|-turbo|-max|-nano], and text-chat-lfm25-a1b-8bit.")
+    @Option(name: [.long], help: "Canonical model id. Default: text-chat-gemma4-12b-4bit (Apple Silicon) / text-chat-q36-nano-gguf (Linux CUDA). Others include omni-chat-nemotron3-nano-30b-a3b-bf16, vision-chat-muse-glimmer-30b, text-chat-nemotron-35-lightning, text-chat-laguna-s-2-1, text-chat-inkling-small, text-chat-bonsai-27b-1bit, text-chat-q36-nano, text-agent-ornith-9b, text-chat-gemma4[-12b|-12b-4bit|-turbo|-max|-nano], and text-chat-lfm25-a1b-8bit.")
     var model: String = TextChat.defaultChatModelId
 
     @Option(
@@ -245,12 +252,20 @@ struct TextChat: AsyncParsableCommand {
         } else {
             imageReference = nil
         }
+        let audioReference = try Self.resolveLocalMediaReference(audio, label: "Audio")
+        let videoReference = try Self.resolveLocalMediaReference(video, label: "Video")
 
         var messages: [ChatMessage] = []
         if let systemPrompt, !systemPrompt.isEmpty {
             messages.append(ChatMessage(role: .system, content: systemPrompt))
         }
-        messages.append(ChatMessage(role: .user, content: prompt, imageUrl: imageReference))
+        messages.append(ChatMessage(
+            role: .user,
+            content: prompt,
+            imageUrl: imageReference,
+            audioUrl: audioReference,
+            videoUrl: videoReference
+        ))
 
         let toolDefs: [ToolDefinition]? = try tools.flatMap { raw in
             let names = raw.split(separator: ",").map { String($0).trimmingCharacters(in: .whitespaces) }
@@ -275,6 +290,7 @@ struct TextChat: AsyncParsableCommand {
         let isLaguna = LagunaResources.handles(modelSpec: normalizedModelId)
         let isMuseGlimmer = MuseGlimmerResources.handles(modelSpec: normalizedModelId)
         let isNemotronH = NemotronHResources.handles(modelSpec: normalizedModelId)
+        let isNemotronOmni = NemotronOmniResources.handles(modelSpec: normalizedModelId)
         let isLFM2Vision = normalizedModelId == LFM2Resources.visionModelId
         let q35KVCacheMode = try resolveQ35KVCacheMode(for: normalizedModelId)
         if let contextSize, contextSize <= 0 {
@@ -286,11 +302,13 @@ struct TextChat: AsyncParsableCommand {
             maxTokens: maxTokens,
             temperature: temperature
                 ?? (isLFM2Vision ? 0.2 : nil)
+                ?? (isNemotronOmni ? NemotronOmniResources.thinkingTemperature : nil)
                 ?? (isNemotronH ? NemotronHResources.recommendedTemperature : nil)
                 ?? (isMuseGlimmer ? MuseGlimmerResources.recommendedTemperature : nil)
                 ?? (isLaguna ? LagunaResources.recommendedTemperature : recommendedSampling?.temperature)
                 ?? 0.7,
             topP: topP
+                ?? (isNemotronOmni ? NemotronOmniResources.thinkingTopP : nil)
                 ?? (isNemotronH ? NemotronHResources.recommendedTopP : nil)
                 ?? (isMuseGlimmer ? MuseGlimmerResources.recommendedTopP : nil)
                 ?? (isLaguna ? LagunaResources.recommendedTopP : recommendedSampling?.topP)
@@ -303,7 +321,9 @@ struct TextChat: AsyncParsableCommand {
             reasoningEffort: reasoningEffort,
             showThinking: requiresJSON
                 ? false
-                : (thinking ?? (isMuseGlimmer ? false : Q35Resources.thinkingDefault(forModelId: model))),
+                : (thinking ?? (isNemotronOmni
+                    ? true
+                    : (isMuseGlimmer ? false : Q35Resources.thinkingDefault(forModelId: model)))),
             lora: lora,
             requiresJSON: requiresJSON,
             tools: toolDefs,
@@ -333,6 +353,7 @@ struct TextChat: AsyncParsableCommand {
             )
             : nil
         let nemotronGenerator = isNemotronH ? NemotronHGenerator() : nil
+        let nemotronOmniGenerator = isNemotronOmni ? NemotronOmniGenerator() : nil
 
         let chatOnce: (ChatRequest) async throws -> ChatResponse = { req in
             if normalizedModelId == Psi3ChatResources.defaultModelId {
@@ -385,6 +406,15 @@ struct TextChat: AsyncParsableCommand {
                 )
                 lastMuseDFlashStats = await generator.dflashStats()
                 return response
+            } else if NemotronOmniResources.handles(modelSpec: normalizedModelId) {
+                guard let generator = nemotronOmniGenerator else {
+                    throw NemotronOmniError.generationFailed("generator is unavailable")
+                }
+                return try await generator.chat(
+                    req,
+                    modelPath: runtimeModelRoot,
+                    progressHandler: progressHandler
+                )
             } else if NemotronHResources.handles(modelSpec: normalizedModelId) {
                 guard let generator = nemotronGenerator else {
                     throw NemotronHError.generationFailed("generator is unavailable")
@@ -554,6 +584,25 @@ struct TextChat: AsyncParsableCommand {
         return ManagedModelResolver.resolveInstalledModel(id: modelID)?.path
     }
 
+    private static func resolveLocalMediaReference(
+        _ rawValue: String?,
+        label: String
+    ) throws -> String? {
+        guard let rawValue else { return nil }
+        let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        let url: URL
+        if let parsed = URL(string: trimmed), parsed.scheme?.lowercased() == "file" {
+            url = parsed
+        } else {
+            url = URL(fileURLWithPath: trimmed).standardizedFileURL
+        }
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            throw ValidationError("\(label) file not found: \(url.path)")
+        }
+        return url.path
+    }
+
     private func emitPreflight(modelID: String, installedModelPath: String?) throws {
         var diagnostics: [PreflightDiagnostic] = []
         if modelID.isEmpty || ManagedModelCatalog.spec(for: modelID) == nil {
@@ -581,6 +630,20 @@ struct TextChat: AsyncParsableCommand {
                     severity: .blocker,
                     title: "Chat image is missing",
                     message: "Image file not found: \(imageURL.path)"
+                ))
+            }
+        }
+        for (label, value) in [("Audio", audio), ("Video", video)] {
+            guard let value, !value.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                continue
+            }
+            let url = URL(fileURLWithPath: value).standardizedFileURL
+            if !FileManager.default.fileExists(atPath: url.path) {
+                diagnostics.append(.init(
+                    id: "text_chat_\(label.lowercased())_missing",
+                    severity: .blocker,
+                    title: "Chat \(label.lowercased()) is missing",
+                    message: "\(label) file not found: \(url.path)"
                 ))
             }
         }
@@ -690,9 +753,10 @@ struct TextChat: AsyncParsableCommand {
             || LFM2Resources.handles(modelSpec: modelID)
             || InklingResources.handles(modelSpec: modelID)
             || MuseGlimmerResources.handles(modelSpec: modelID)
-            || NemotronHResources.handles(modelSpec: modelID) {
+            || NemotronHResources.handles(modelSpec: modelID)
+            || NemotronOmniResources.handles(modelSpec: modelID) {
             throw ValidationError(
-                "--response-format json_object is supported by native Gemma4 and Qwen-family MLX chat models; Muse Glimmer and Nemotron-H support structured tool schemas but not constrained JSON decoding."
+                "--response-format json_object is supported by native Gemma4 and Qwen-family MLX chat models; Muse Glimmer and Nemotron runtimes support structured tool schemas but not constrained JSON decoding."
             )
         }
         if LagunaResources.handles(modelSpec: modelID) {

--- a/Sources/MereRunCLI/Commands/TextChatCommand.swift
+++ b/Sources/MereRunCLI/Commands/TextChatCommand.swift
@@ -297,33 +297,74 @@ struct TextChat: AsyncParsableCommand {
             throw ValidationError("--context-size must be greater than zero.")
         }
         let requiresJSON = responseFormat == .jsonObject
+        let resolvedTemperature: Double
+        if let temperature {
+            resolvedTemperature = temperature
+        } else if isLFM2Vision {
+            resolvedTemperature = 0.2
+        } else if isNemotronOmni {
+            resolvedTemperature = NemotronOmniResources.thinkingTemperature
+        } else if isNemotronH {
+            resolvedTemperature = NemotronHResources.recommendedTemperature
+        } else if isMuseGlimmer {
+            resolvedTemperature = MuseGlimmerResources.recommendedTemperature
+        } else if isLaguna {
+            resolvedTemperature = LagunaResources.recommendedTemperature
+        } else {
+            resolvedTemperature = recommendedSampling?.temperature ?? 0.7
+        }
+
+        let resolvedTopP: Double
+        if let topP {
+            resolvedTopP = topP
+        } else if isNemotronOmni {
+            resolvedTopP = NemotronOmniResources.thinkingTopP
+        } else if isNemotronH {
+            resolvedTopP = NemotronHResources.recommendedTopP
+        } else if isMuseGlimmer {
+            resolvedTopP = MuseGlimmerResources.recommendedTopP
+        } else if isLaguna {
+            resolvedTopP = LagunaResources.recommendedTopP
+        } else {
+            resolvedTopP = recommendedSampling?.topP ?? 0.9
+        }
+
+        let resolvedTopK: Int?
+        if let topK {
+            resolvedTopK = topK
+        } else if isLFM2Vision {
+            resolvedTopK = 50
+        } else if isMuseGlimmer {
+            resolvedTopK = MuseGlimmerResources.recommendedTopK
+        } else if isLaguna {
+            resolvedTopK = LagunaResources.recommendedTopK
+        } else {
+            resolvedTopK = recommendedSampling?.topK
+        }
+
+        let resolvedMinP = minP ?? (isLaguna ? LagunaResources.recommendedMinP : 0)
+        let resolvedShowThinking: Bool
+        if requiresJSON {
+            resolvedShowThinking = false
+        } else if let thinking {
+            resolvedShowThinking = thinking
+        } else if isNemotronOmni {
+            resolvedShowThinking = true
+        } else if isMuseGlimmer {
+            resolvedShowThinking = false
+        } else {
+            resolvedShowThinking = Q35Resources.thinkingDefault(forModelId: model)
+        }
+
         let request = ChatRequest(
             messages: messages,
             maxTokens: maxTokens,
-            temperature: temperature
-                ?? (isLFM2Vision ? 0.2 : nil)
-                ?? (isNemotronOmni ? NemotronOmniResources.thinkingTemperature : nil)
-                ?? (isNemotronH ? NemotronHResources.recommendedTemperature : nil)
-                ?? (isMuseGlimmer ? MuseGlimmerResources.recommendedTemperature : nil)
-                ?? (isLaguna ? LagunaResources.recommendedTemperature : recommendedSampling?.temperature)
-                ?? 0.7,
-            topP: topP
-                ?? (isNemotronOmni ? NemotronOmniResources.thinkingTopP : nil)
-                ?? (isNemotronH ? NemotronHResources.recommendedTopP : nil)
-                ?? (isMuseGlimmer ? MuseGlimmerResources.recommendedTopP : nil)
-                ?? (isLaguna ? LagunaResources.recommendedTopP : recommendedSampling?.topP)
-                ?? 0.9,
-            topK: topK
-                ?? (isLFM2Vision ? 50 : nil)
-                ?? (isMuseGlimmer ? MuseGlimmerResources.recommendedTopK : nil)
-                ?? (isLaguna ? LagunaResources.recommendedTopK : recommendedSampling?.topK),
-            minP: minP ?? (isLaguna ? LagunaResources.recommendedMinP : 0),
+            temperature: resolvedTemperature,
+            topP: resolvedTopP,
+            topK: resolvedTopK,
+            minP: resolvedMinP,
             reasoningEffort: reasoningEffort,
-            showThinking: requiresJSON
-                ? false
-                : (thinking ?? (isNemotronOmni
-                    ? true
-                    : (isMuseGlimmer ? false : Q35Resources.thinkingDefault(forModelId: model)))),
+            showThinking: resolvedShowThinking,
             lora: lora,
             requiresJSON: requiresJSON,
             tools: toolDefs,
@@ -473,8 +514,12 @@ struct TextChat: AsyncParsableCommand {
 
                 // Show the model's response (may contain text before/after tool calls)
                 let textBeforeTools = result.response
-                    .replacingOccurrences(of: "<\\|tool_call>.*?<tool_call\\|>", with: "", options: .regularExpression)
-                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                    .replacingOccurrences(
+                        of: "<\\|tool_call>.*?<tool_call\\|>",
+                        with: "",
+                        options: String.CompareOptions.regularExpression
+                    )
+                    .trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
                 if !textBeforeTools.isEmpty {
                     CLIStderr.write(cleanResponse(textBeforeTools, showThinking: request.showThinking) + "\n")
                 }

--- a/Sources/MereRunCLI/Support/InstalledModelGateSupport.swift
+++ b/Sources/MereRunCLI/Support/InstalledModelGateSupport.swift
@@ -195,6 +195,11 @@ enum InstalledModelSmokePlans {
                 try await runner.installedTextCheck(model: spec.id)
             }
 
+        case .nemotronOmni:
+            return direct(spec, route: "text chat through native Omni runtime") { runner in
+                try await runner.installedTextCheck(model: spec.id)
+            }
+
         case .deepseekV4FlashIMatrixGGUF:
             return direct(spec, route: "model benchmark chat via bundled DS4 runtime") { runner in
                 try await runner.installedDeepseekCheck(model: spec.id)
@@ -561,9 +566,35 @@ enum InstalledModelSmokePlans {
             try await run(runner, primary)
         })
     }
+
+    private static func structural(
+        _ spec: ManagedModelSpec,
+        route: String,
+        run: @escaping @Sendable (GateRunner) async throws -> GateObservation
+    ) -> InstalledModelSmokePlan {
+        InstalledModelSmokePlan(check: GateCheck(
+            id: "installed-\(spec.id)",
+            suite: spec.category.rawValue,
+            requiredModels: [spec.id],
+            comparesBaseline: false,
+            successDetail: "structural validation only; native inference is not implemented: \(route)",
+            run: run
+        ))
+    }
 }
 
 extension GateRunner {
+    func installedModelValidationCheck(model: String) async throws -> GateObservation {
+        let run = try await exec(
+            ["model", "info", model],
+            timeout: 1_800
+        )
+        guard run.stdout.contains("isValid: true") else {
+            throw GateError.invalidArtifact("Managed model validation did not report isValid: true")
+        }
+        return stdoutObservation(run, label: "model validation")
+    }
+
     func installedTextCheck(model: String) async throws -> GateObservation {
         let run = try await exec(
             [

--- a/Sources/MereRunCLI/Support/RuntimeModelPool.swift
+++ b/Sources/MereRunCLI/Support/RuntimeModelPool.swift
@@ -1688,6 +1688,11 @@ actor RuntimeModelPool {
                 NemotronHGenerator(),
                 modelPath: resolved.installPath
             )
+        case .textChatNemotronOmni:
+            return .textChatNemotronOmni(
+                NemotronOmniGenerator(),
+                modelPath: resolved.installPath
+            )
         }
     }
 
@@ -1914,6 +1919,8 @@ actor RuntimeModelPool {
             return ManagedModelCategory.textChat.rawValue
         case .textChatMuseGlimmer:
             return ManagedModelCategory.visionChat.rawValue
+        case .textChatNemotronOmni:
+            return ManagedModelCategory.omniChat.rawValue
         }
     }
 
@@ -2234,6 +2241,7 @@ enum RuntimeLoadedModel: Sendable {
     case textChatDeepseekV4Flash(DeepseekV4FlashGenerator, modelPath: String?)
     case textChatMuseGlimmer(MuseGlimmerGenerator, modelPath: String?)
     case textChatNemotronH(NemotronHGenerator, modelPath: String?)
+    case textChatNemotronOmni(NemotronOmniGenerator, modelPath: String?)
 
     func prepare(progressHandler: (@Sendable (ChatProgress) -> Void)?) async throws {
         switch self {
@@ -2265,6 +2273,8 @@ enum RuntimeLoadedModel: Sendable {
             try await generator.prepare(modelPath: modelPath, progressHandler: progressHandler)
         case .textChatNemotronH(let generator, let modelPath):
             try await generator.prepare(modelPath: modelPath, progressHandler: progressHandler)
+        case .textChatNemotronOmni(let generator, let modelPath):
+            try await generator.prepare(modelPath: modelPath, progressHandler: progressHandler)
         }
     }
 
@@ -2288,6 +2298,8 @@ enum RuntimeLoadedModel: Sendable {
             await generator.unload()
         case .textChatNemotronH(let generator, _):
             await generator.unload()
+        case .textChatNemotronOmni(let generator, _):
+            await generator.unload()
         }
     }
 
@@ -2300,7 +2312,7 @@ enum RuntimeLoadedModel: Sendable {
         case .textChatLFM2(let generator, _):
             return await generator.prefixKVCacheStats()
         case .textCode, .textChatKlein, .textChatLaguna, .textChatDeepseekV4Flash,
-             .textChatMuseGlimmer, .textChatNemotronH:
+             .textChatMuseGlimmer, .textChatNemotronH, .textChatNemotronOmni:
             return nil
         }
     }
@@ -2316,7 +2328,7 @@ enum RuntimeLoadedModel: Sendable {
         case .textChatLFM2(let generator, _):
             return await generator.continuousBatchingStats()
         case .textCode, .textChatKlein, .textChatDeepseekV4Flash, .textChatMuseGlimmer,
-             .textChatNemotronH:
+             .textChatNemotronH, .textChatNemotronOmni:
             return nil
         }
     }
@@ -2326,7 +2338,8 @@ enum RuntimeLoadedModel: Sendable {
         case .textChatGemma4(let generator, _):
             return await generator.mtpStats()
         case .textCode, .textChatKlein, .textChatLaguna, .textChatQ35, .textChatLFM2,
-             .textChatDeepseekV4Flash, .textChatMuseGlimmer, .textChatNemotronH:
+             .textChatDeepseekV4Flash, .textChatMuseGlimmer, .textChatNemotronH,
+             .textChatNemotronOmni:
             return nil
         }
     }
@@ -2371,6 +2384,8 @@ enum RuntimeLoadedModel: Sendable {
             return try await generator.chat(request, modelPath: modelPath, progressHandler: progressHandler)
         case .textChatNemotronH(let generator, let modelPath):
             return try await generator.chat(request, modelPath: modelPath, progressHandler: progressHandler)
+        case .textChatNemotronOmni(let generator, let modelPath):
+            return try await generator.chat(request, modelPath: modelPath, progressHandler: progressHandler)
         }
     }
 
@@ -2384,7 +2399,8 @@ enum RuntimeLoadedModel: Sendable {
                 progressHandler: progressHandler
             )
         case .textCode, .textChatKlein, .textChatGemma4, .textChatLaguna, .textChatQ35,
-             .textChatLFM2, .textChatMuseGlimmer, .textChatNemotronH:
+             .textChatLFM2, .textChatMuseGlimmer, .textChatNemotronH,
+             .textChatNemotronOmni:
             throw RuntimeModelPoolError.rawProxyUnavailable("")
         }
     }

--- a/Sources/MereRunCore/CodeGen/OpenAITypes.swift
+++ b/Sources/MereRunCore/CodeGen/OpenAITypes.swift
@@ -406,6 +406,8 @@ public struct OpenAIChatMessage: Codable, Sendable {
     public var tool_call_id: String?
     public var tool_calls: [OpenAIChatToolCall]?
     public var imageURLs: [String]
+    public var audioURLs: [String]
+    public var videoURLs: [String]
 
     public init(
         role: String,
@@ -414,7 +416,9 @@ public struct OpenAIChatMessage: Codable, Sendable {
         name: String? = nil,
         tool_call_id: String? = nil,
         tool_calls: [OpenAIChatToolCall]? = nil,
-        imageURLs: [String] = []
+        imageURLs: [String] = [],
+        audioURLs: [String] = [],
+        videoURLs: [String] = []
     ) {
         self.role = role
         self.content = content
@@ -423,6 +427,8 @@ public struct OpenAIChatMessage: Codable, Sendable {
         self.tool_call_id = tool_call_id
         self.tool_calls = tool_calls
         self.imageURLs = imageURLs
+        self.audioURLs = audioURLs
+        self.videoURLs = videoURLs
     }
 
     private enum CodingKeys: String, CodingKey {
@@ -440,6 +446,8 @@ public struct OpenAIChatMessage: Codable, Sendable {
         let decoded = try container.decodeFlexibleContentIfPresent(forKey: .content)
         content = decoded.text
         imageURLs = decoded.imageURLs
+        audioURLs = decoded.audioURLs
+        videoURLs = decoded.videoURLs
         reasoning_content = try container.decodeIfPresent(String.self, forKey: .reasoning_content)
         name = try container.decodeIfPresent(String.self, forKey: .name)
         tool_call_id = try container.decodeIfPresent(String.self, forKey: .tool_call_id)
@@ -449,7 +457,24 @@ public struct OpenAIChatMessage: Codable, Sendable {
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(role, forKey: .role)
-        try container.encode(content, forKey: .content)
+        if imageURLs.isEmpty, audioURLs.isEmpty, videoURLs.isEmpty {
+            try container.encode(content, forKey: .content)
+        } else {
+            var parts: [OpenAIChatContentPart] = []
+            if !content.isEmpty {
+                parts.append(OpenAIChatContentPart(type: "text", text: content))
+            }
+            parts += imageURLs.map {
+                OpenAIChatContentPart(type: "image_url", image_url: OpenAIImageURL(url: $0))
+            }
+            parts += audioURLs.map {
+                OpenAIChatContentPart(type: "audio_url", audio_url: OpenAIImageURL(url: $0))
+            }
+            parts += videoURLs.map {
+                OpenAIChatContentPart(type: "video_url", video_url: OpenAIImageURL(url: $0))
+            }
+            try container.encode(parts, forKey: .content)
+        }
         try container.encodeIfPresent(reasoning_content, forKey: .reasoning_content)
         try container.encodeIfPresent(name, forKey: .name)
         try container.encodeIfPresent(tool_call_id, forKey: .tool_call_id)
@@ -599,6 +624,8 @@ public struct OpenAIStreamOptions: Codable, Hashable, Sendable {
 private struct OpenAIChatContent: Sendable {
     var text: String
     var imageURLs: [String]
+    var audioURLs: [String]
+    var videoURLs: [String]
 }
 
 public struct OpenAIImageURL: Codable, Hashable, Sendable {
@@ -633,29 +660,43 @@ public struct OpenAIChatContentPart: Codable, Hashable, Sendable {
     public var text: String?
     public var image_url: OpenAIImageURL?
     public var input_image: OpenAIImageURL?
+    public var audio_url: OpenAIImageURL?
+    public var video_url: OpenAIImageURL?
 
-    public init(type: String? = nil, text: String? = nil, image_url: OpenAIImageURL? = nil, input_image: OpenAIImageURL? = nil) {
+    public init(
+        type: String? = nil,
+        text: String? = nil,
+        image_url: OpenAIImageURL? = nil,
+        input_image: OpenAIImageURL? = nil,
+        audio_url: OpenAIImageURL? = nil,
+        video_url: OpenAIImageURL? = nil
+    ) {
         self.type = type
         self.text = text
         self.image_url = image_url
         self.input_image = input_image
+        self.audio_url = audio_url
+        self.video_url = video_url
     }
 
     var extractedImageURL: String? {
         image_url?.url ?? input_image?.url
     }
+
+    var extractedAudioURL: String? { audio_url?.url }
+    var extractedVideoURL: String? { video_url?.url }
 }
 
 private extension KeyedDecodingContainer {
     func decodeFlexibleContentIfPresent(forKey key: Key) throws -> OpenAIChatContent {
         guard contains(key) else {
-            return OpenAIChatContent(text: "", imageURLs: [])
+            return OpenAIChatContent(text: "", imageURLs: [], audioURLs: [], videoURLs: [])
         }
         if try decodeNil(forKey: key) {
-            return OpenAIChatContent(text: "", imageURLs: [])
+            return OpenAIChatContent(text: "", imageURLs: [], audioURLs: [], videoURLs: [])
         }
         if let content = try? decode(String.self, forKey: key) {
-            return OpenAIChatContent(text: content, imageURLs: [])
+            return OpenAIChatContent(text: content, imageURLs: [], audioURLs: [], videoURLs: [])
         }
         if let parts = try? decode([OpenAIChatContentPart].self, forKey: key) {
             let text = parts
@@ -663,13 +704,20 @@ private extension KeyedDecodingContainer {
                 .compactMap(\.text)
                 .joined(separator: "\n")
             let imageURLs = parts.compactMap(\.extractedImageURL)
-            return OpenAIChatContent(text: text, imageURLs: imageURLs)
+            let audioURLs = parts.compactMap(\.extractedAudioURL)
+            let videoURLs = parts.compactMap(\.extractedVideoURL)
+            return OpenAIChatContent(
+                text: text,
+                imageURLs: imageURLs,
+                audioURLs: audioURLs,
+                videoURLs: videoURLs
+            )
         }
         throw DecodingError.typeMismatch(
             String.self,
             DecodingError.Context(
                 codingPath: codingPath + [key],
-                debugDescription: "Expected chat message content to be a string, null, or text content parts."
+                debugDescription: "Expected chat message content to be a string, null, or supported text/media content parts."
             )
         )
     }

--- a/Sources/MereRunCore/Generation.swift
+++ b/Sources/MereRunCore/Generation.swift
@@ -166,6 +166,8 @@ public struct ChatMessage: Sendable, Hashable, Codable {
     public var role: Role
     public var content: String
     public var imageUrl: String?
+    public var audioUrl: String?
+    public var videoUrl: String?
     public var reasoningContent: String?
     public var name: String?
     public var toolCallID: String?
@@ -175,6 +177,8 @@ public struct ChatMessage: Sendable, Hashable, Codable {
         role: Role,
         content: String,
         imageUrl: String? = nil,
+        audioUrl: String? = nil,
+        videoUrl: String? = nil,
         reasoningContent: String? = nil,
         name: String? = nil,
         toolCallID: String? = nil,
@@ -183,6 +187,8 @@ public struct ChatMessage: Sendable, Hashable, Codable {
         self.role = role
         self.content = content
         self.imageUrl = imageUrl
+        self.audioUrl = audioUrl
+        self.videoUrl = videoUrl
         self.reasoningContent = reasoningContent
         self.name = name
         self.toolCallID = toolCallID

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -11,6 +11,7 @@ public enum ManagedModelCategory: String, CaseIterable, Hashable, Sendable {
     case speechDiarization = "speech-diarization"
     case visionOCR = "vision-ocr"
     case visionChat = "vision-chat"
+    case omniChat = "omni-chat"
     case visionSegment = "vision-segment"
     case visionGround = "vision-ground"
     case visionFlood = "vision-flood"
@@ -341,6 +342,22 @@ public extension ManagedModelAPIProfile {
         )
     }
 
+    static func nemotronOmni(
+        contextWindow: Int = NemotronOmniResources.maximumContextLength
+    ) -> ManagedModelAPIProfile {
+        chat(
+            servingEngine: .textChatNemotronOmni,
+            inputModalities: [.text, .image, .audio, .video],
+            contextWindow: contextWindow,
+            maximumOutputTokens: NemotronOmniResources.maximumOutputTokens,
+            thinkingLevels: [.off, .high],
+            thinkingLevelMap: [.high: .high],
+            toolCall: true,
+            supportsStopSequences: true,
+            supportsProviderThinkingControls: true
+        )
+    }
+
     static func runtimeFallback(for engine: RuntimeServingEngine) -> ManagedModelAPIProfile {
         switch engine {
         case .textCode:
@@ -361,6 +378,8 @@ public extension ManagedModelAPIProfile {
             return .museGlimmer()
         case .textChatNemotronH:
             return .nemotronH()
+        case .textChatNemotronOmni:
+            return .nemotronOmni()
         }
     }
 
@@ -490,6 +509,7 @@ public enum ManagedModelValidationKind: String, Hashable, Sendable {
     case museGlimmerAssistant
     case nemotronH
     case nemotronHDSpark
+    case nemotronOmni
     case qwen3TTS
     case qwen3ASR
     case parakeet
@@ -1667,6 +1687,36 @@ public enum ManagedModelCatalog {
             defaultCLICommands: ["text chat", "api serve", "model benchmark chat"],
             companionModelIDs: [NemotronHResources.dsparkModelID],
             apiProfile: .nemotronH()
+        ),
+        ManagedModelSpec(
+            id: NemotronOmniResources.modelID,
+            category: .omniChat,
+            installShape: .directoryRoot,
+            hubFallback: HubFallbackConfig(
+                repoId: NemotronOmniResources.upstreamRepoID,
+                revision: NemotronOmniResources.upstreamRevision,
+                patterns: NemotronOmniResources.snapshotPatterns
+            ),
+            upstreamRepoId: NemotronOmniResources.upstreamRepoID,
+            upstreamRevision: NemotronOmniResources.upstreamRevision,
+            usageRestriction: ManagedModelUsageRestriction(
+                summary: "Use is governed by the NVIDIA Open Model Agreement; review and acknowledge the governing terms before download.",
+                terms: [
+                    ManagedModelUsageTerm(
+                        component: "Nemotron 3 Nano Omni 30B-A3B Reasoning BF16",
+                        license: "NVIDIA Open Model Agreement",
+                        summary: "Review the NVIDIA Open Model Agreement before installing or deploying.",
+                        sourceRepoId: NemotronOmniResources.upstreamRepoID,
+                        sourceRevision: NemotronOmniResources.upstreamRevision,
+                        licenseURL: "https://www.nvidia.com/en-us/agreements/enterprise-software/nvidia-open-model-agreement/"
+                    ),
+                ]
+            ),
+            validationKind: .nemotronOmni,
+            runtimeAutoDownloadAllowed: false,
+            estimatedDownloadBytes: NemotronOmniResources.estimatedDownloadBytes,
+            defaultCLICommands: ["text chat", "api serve", "model benchmark chat"],
+            apiProfile: .nemotronOmni()
         ),
         ManagedModelSpec(
             id: Q35Resources.q36NanoModelId,
@@ -3652,6 +3702,11 @@ public extension ManagedModelSpec {
                 rootURL: rootURL,
                 fileManager: fileManager
             )
+        case .nemotronOmni:
+            return NemotronOmniResources.missingTargetFiles(
+                rootURL: rootURL,
+                fileManager: fileManager
+            )
         case .sam31:
             return SAM31Resources(modelRootURL: rootURL).missingRequiredPaths(fileManager: fileManager)
         case .falconPerception:
@@ -3767,6 +3822,11 @@ public extension ManagedModelSpec {
 
     func validationMessages(in rootURL: URL, fileManager: FileManager = .default) -> [String] {
         switch validationKind {
+        case .nemotronOmni:
+            return NemotronOmniResources.validationMessages(
+                rootURL: normalizedRootURL(rootURL, fileManager: fileManager),
+                fileManager: fileManager
+            )
         case .moge2, .videoDepthAnything, .depthAnything3, .tripoSR:
             guard let pin = GeometryModelPins.pin(for: id) else {
                 return ["Missing exact artifact pin for managed model \(id)."]

--- a/Sources/MereRunCore/ManagedModelSupport.swift
+++ b/Sources/MereRunCore/ManagedModelSupport.swift
@@ -430,6 +430,13 @@ public enum ManagedModelCapabilityCatalog {
                 recommended: 64
             ),
             descriptor(
+                NemotronOmniResources.modelID,
+                "Nemotron 3 Nano Omni 30B-A3B BF16",
+                "Runs NVIDIA's pinned BF16 text, image, video, and audio understanding checkpoint through native Swift/MLX media towers and Nemotron-H language runtime.",
+                minimum: 112,
+                recommended: 128
+            ),
+            descriptor(
                 Q35Resources.q36NanoModelId,
                 "Qwen3.6 A3B chat nano",
                 "Runs the Qwen3.6 35B-A3B OptiQ 4-bit MLX/MTP snapshot through the native Qwen-family runtime.",

--- a/Sources/MereRunCore/MereRunModelManifest.swift
+++ b/Sources/MereRunCore/MereRunModelManifest.swift
@@ -112,6 +112,8 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
         case museGlimmer = "muse-glimmer"
         /// NVIDIA Nemotron-H hybrid Mamba/MoE family via native Swift/MLX.
         case nemotronH = "nemotron-h"
+        /// NVIDIA Nemotron 3 Nano Omni multimodal understanding family.
+        case nemotronOmni = "nemotron-omni"
     }
 
     public enum Family: String, Codable, CaseIterable, Hashable, Sendable {
@@ -196,6 +198,9 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
         case speakerDiarization = "speaker_diarization"
         case visionChat = "vision_chat"
         case visionOCR = "vision_ocr"
+        case audioUnderstanding = "audio_understanding"
+        case videoUnderstanding = "video_understanding"
+        case documentUnderstanding = "document_understanding"
         case musicGeneration = "music_generation"
         case musicTranscription = "music_transcription"
         case musicSeparation = "music_separation"
@@ -1084,6 +1089,29 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
                 components: nil,
                 upstreamRepoId:
                     "\(NemotronHResources.dsparkUpstreamRepoID)@\(NemotronHResources.dsparkUpstreamRevision)",
+                createdAt: createdAt
+            )
+        case .nemotron3NanoOmni30BA3BBF16:
+            return MereRunModelManifest(
+                id: modelID.rawValue,
+                engine: .nemotronOmni,
+                family: .nemotron,
+                tier: .latest,
+                variant: .standard,
+                precision: .bf16,
+                defaults: nil,
+                supports: [
+                    .chat,
+                    .codeGeneration,
+                    .visionChat,
+                    .visionOCR,
+                    .audioUnderstanding,
+                    .videoUnderstanding,
+                    .documentUnderstanding,
+                ],
+                components: genericTextComponents,
+                upstreamRepoId:
+                    "\(NemotronOmniResources.upstreamRepoID)@\(NemotronOmniResources.upstreamRevision)",
                 createdAt: createdAt
             )
         case .q36Nano:

--- a/Sources/MereRunCore/MereRunModelValidator.swift
+++ b/Sources/MereRunCore/MereRunModelValidator.swift
@@ -180,6 +180,7 @@ public enum MereRunModelValidator {
             || spec?.validationKind == .terramindFire
             || spec?.validationKind == .tessera
             || spec?.validationKind == .olmoEarth
+            || spec?.validationKind == .nemotronOmni
             || spec?.validationKind == .inkling {
             errors.append(contentsOf: spec?.validationMessages(in: rootURL, fileManager: fileManager) ?? [])
             transformerDir = nil

--- a/Sources/MereRunCore/ModelResolver.swift
+++ b/Sources/MereRunCore/ModelResolver.swift
@@ -43,6 +43,7 @@ public struct ModelResolver {
         case museGlimmer30BDFlash2 = "vision-chat-muse-glimmer-30b-dflash2"
         case nemotron35Lightning = "text-chat-nemotron-35-lightning"
         case nemotron35LightningDSpark = "text-chat-nemotron-35-lightning-dspark"
+        case nemotron3NanoOmni30BA3BBF16 = "omni-chat-nemotron3-nano-30b-a3b-bf16"
         case ltxGemma3TwelveB4Bit = "text-encoder-ltx-gemma3-12b-4bit"
         case q36Nano = "text-chat-q36-nano"
         case q38TwentySevenB = "vision-chat-q38-27b"

--- a/Sources/MereRunCore/NemotronH/NemotronHConfig.swift
+++ b/Sources/MereRunCore/NemotronH/NemotronHConfig.swift
@@ -12,6 +12,13 @@ public struct NemotronHQuantizationConfig: Decodable, Sendable, Hashable {
         case mode
         case globalScale = "global_scale"
     }
+
+    init(bits: Int, groupSize: Int, mode: String, globalScale: Bool) {
+        self.bits = bits
+        self.groupSize = groupSize
+        self.mode = mode
+        self.globalScale = globalScale
+    }
 }
 
 public struct NemotronHConfig: Decodable, Sendable, Hashable {
@@ -133,6 +140,66 @@ public struct NemotronHConfig: Decodable, Sendable, Hashable {
                 debugDescription: "Unsupported Nemotron-H checkpoint contract."
             )
         }
+    }
+
+    init(
+        modelType: String,
+        vocabSize: Int,
+        hiddenSize: Int,
+        numHiddenLayers: Int,
+        layersBlockType: [String],
+        numAttentionHeads: Int,
+        numKeyValueHeads: Int,
+        headDim: Int,
+        maxPositionEmbeddings: Int,
+        normEps: Float,
+        mambaHeadDim: Int,
+        mambaNumHeads: Int,
+        ssmStateSize: Int,
+        nGroups: Int,
+        convKernel: Int,
+        timeStepMin: Float,
+        timeStepMax: Float,
+        nRoutedExperts: Int,
+        nSharedExperts: Int,
+        numExpertsPerToken: Int,
+        moeIntermediateSize: Int,
+        sharedExpertIntermediateSize: Int,
+        routedScalingFactor: Float,
+        normTopKProbability: Bool,
+        nGroup: Int,
+        topKGroup: Int,
+        eosTokenIDs: [Int],
+        quantization: NemotronHQuantizationConfig
+    ) {
+        self.modelType = modelType
+        self.vocabSize = vocabSize
+        self.hiddenSize = hiddenSize
+        self.numHiddenLayers = numHiddenLayers
+        self.layersBlockType = layersBlockType
+        self.numAttentionHeads = numAttentionHeads
+        self.numKeyValueHeads = numKeyValueHeads
+        self.headDim = headDim
+        self.maxPositionEmbeddings = maxPositionEmbeddings
+        self.normEps = normEps
+        self.mambaHeadDim = mambaHeadDim
+        self.mambaNumHeads = mambaNumHeads
+        self.ssmStateSize = ssmStateSize
+        self.nGroups = nGroups
+        self.convKernel = convKernel
+        self.timeStepMin = timeStepMin
+        self.timeStepMax = timeStepMax
+        self.nRoutedExperts = nRoutedExperts
+        self.nSharedExperts = nSharedExperts
+        self.numExpertsPerToken = numExpertsPerToken
+        self.moeIntermediateSize = moeIntermediateSize
+        self.sharedExpertIntermediateSize = sharedExpertIntermediateSize
+        self.routedScalingFactor = routedScalingFactor
+        self.normTopKProbability = normTopKProbability
+        self.nGroup = nGroup
+        self.topKGroup = topKGroup
+        self.eosTokenIDs = eosTokenIDs
+        self.quantization = quantization
     }
 }
 

--- a/Sources/MereRunCore/NemotronOmni/NemotronOmniAudioProcessor.swift
+++ b/Sources/MereRunCore/NemotronOmni/NemotronOmniAudioProcessor.swift
@@ -1,0 +1,185 @@
+import AudioCodecs
+import Foundation
+import MediaIO
+import MLX
+
+struct NemotronOmniPreparedAudio: @unchecked Sendable {
+    let melFeatures: MLXArray
+    let sampleCount: Int
+
+    var validMelFrameCount: Int {
+        sampleCount / 160
+    }
+
+    var languageTokenCount: Int {
+        NemotronOmniPlaceholderPlanner.audioTokenCount(sampleCount: sampleCount)
+    }
+}
+
+enum NemotronOmniAudioProcessor {
+    private static let sampleRate = 16_000
+    private static let hopLength = 160
+    private static let fftSize = 512
+    private static let windowLength = 400
+    private static let preemphasis: Float = 0.97
+    private static let logGuard: Float = 5.960_464_5e-8
+
+    static func prepare(reference: String) throws -> NemotronOmniPreparedAudio {
+        let url = try localURL(reference: reference)
+        let decoded = try MediaAudioIO.decode(
+            url,
+            targetSampleRate: sampleRate,
+            channels: 1
+        )
+        let maximumSamples = NemotronOmniResources.maximumAudioDurationSeconds * sampleRate
+        guard decoded.samples.count <= maximumSamples else {
+            throw NemotronOmniError.unsupportedMedia(
+                "audio exceeds \(NemotronOmniResources.maximumAudioDurationSeconds) seconds"
+            )
+        }
+        return NemotronOmniPreparedAudio(
+            melFeatures: try logMelSpectrogram(samples: decoded.samples),
+            sampleCount: decoded.samples.count
+        )
+    }
+
+    static func logMelSpectrogram(samples: [Float]) throws -> MLXArray {
+        guard !samples.isEmpty else {
+            throw NemotronOmniError.unsupportedMedia("audio input is empty")
+        }
+        var emphasized = [Float](repeating: 0, count: samples.count)
+        emphasized[0] = samples[0]
+        if samples.count > 1 {
+            for index in 1..<samples.count {
+                emphasized[index] = samples[index] - preemphasis * samples[index - 1]
+            }
+        }
+
+        let padding = fftSize / 2
+        let padded = [Float](repeating: 0, count: padding)
+            + emphasized
+            + [Float](repeating: 0, count: padding)
+        let frameCount = 1 + samples.count / hopLength
+        let plan = try RealFFTPlan(size: fftSize)
+        let window = (0..<windowLength).map { index in
+            Float(0.5 * (1 - cos(2 * Double.pi * Double(index) / Double(windowLength - 1))))
+        }
+        let windowOffset = (fftSize - windowLength) / 2
+        let melFilters = makeMelFilters(count: 128)
+        var features = [Float](repeating: 0, count: frameCount * 128)
+        var frame = [Float](repeating: 0, count: fftSize)
+        for frameIndex in 0..<frameCount {
+            frame = [Float](repeating: 0, count: fftSize)
+            let start = frameIndex * hopLength
+            for index in 0..<windowLength {
+                frame[windowOffset + index] = padded[start + windowOffset + index] * window[index]
+            }
+            let power = plan.powerSpectrum(frame)
+            for melIndex in 0..<128 {
+                var energy: Float = 0
+                for frequency in power.indices {
+                    energy += melFilters[melIndex][frequency] * power[frequency]
+                }
+                features[frameIndex * 128 + melIndex] = log(energy + logGuard)
+            }
+        }
+
+        // Parakeet's center-padded STFT produces one trailing frame that is
+        // excluded by its attention mask. Match the reference feature
+        // extractor by computing statistics over real frames only, then
+        // zeroing that padding frame.
+        let validFrameCount = max(1, samples.count / hopLength)
+        for melIndex in 0..<128 {
+            var mean: Float = 0
+            for frameIndex in 0..<validFrameCount {
+                mean += features[frameIndex * 128 + melIndex]
+            }
+            mean /= Float(validFrameCount)
+            var variance: Float = 0
+            for frameIndex in 0..<validFrameCount {
+                let difference = features[frameIndex * 128 + melIndex] - mean
+                variance += difference * difference
+            }
+            variance /= Float(max(1, validFrameCount - 1))
+            let standardDeviation = sqrt(variance)
+            for frameIndex in 0..<validFrameCount {
+                let index = frameIndex * 128 + melIndex
+                features[index] = (features[index] - mean) / (standardDeviation + 1e-5)
+            }
+            for frameIndex in validFrameCount..<frameCount {
+                features[frameIndex * 128 + melIndex] = 0
+            }
+        }
+        return MLXArray(features, [1, frameCount, 128]).asType(.bfloat16)
+    }
+
+    private static func makeMelFilters(count: Int) -> [[Float]] {
+        let frequencyCount = fftSize / 2 + 1
+        let maximumFrequency = Float(sampleRate) / 2
+        let melMinimum = hzToMel(0)
+        let melMaximum = hzToMel(maximumFrequency)
+        let melPoints = (0..<(count + 2)).map { index in
+            melMinimum + (melMaximum - melMinimum) * Float(index) / Float(count + 1)
+        }
+        let hzPoints = melPoints.map(melToHz)
+        var filters = [[Float]](
+            repeating: [Float](repeating: 0, count: frequencyCount),
+            count: count
+        )
+        for mel in 0..<count {
+            let left = hzPoints[mel]
+            let center = hzPoints[mel + 1]
+            let right = hzPoints[mel + 2]
+            for bin in 0..<frequencyCount {
+                let frequency = maximumFrequency * Float(bin) / Float(frequencyCount - 1)
+                let rising = (frequency - left) / max(center - left, 1e-8)
+                let falling = (right - frequency) / max(right - center, 1e-8)
+                filters[mel][bin] = max(0, min(rising, falling)) * 2 / max(right - left, 1e-8)
+            }
+        }
+        return filters
+    }
+
+    private static func hzToMel(_ frequency: Float) -> Float {
+        let linearSpacing: Float = 200 / 3
+        let minimumLogFrequency: Float = 1_000
+        let minimumLogMel = minimumLogFrequency / linearSpacing
+        let logStep = log(Float(6.4)) / 27
+        if frequency >= minimumLogFrequency {
+            return minimumLogMel + log(frequency / minimumLogFrequency) / logStep
+        }
+        return frequency / linearSpacing
+    }
+
+    private static func melToHz(_ mel: Float) -> Float {
+        let linearSpacing: Float = 200 / 3
+        let minimumLogFrequency: Float = 1_000
+        let minimumLogMel = minimumLogFrequency / linearSpacing
+        let logStep = log(Float(6.4)) / 27
+        if mel >= minimumLogMel {
+            return minimumLogFrequency * exp(logStep * (mel - minimumLogMel))
+        }
+        return mel * linearSpacing
+    }
+
+    private static func localURL(reference: String) throws -> URL {
+        let trimmed = reference.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            throw NemotronOmniError.unsupportedMedia("audio reference is empty")
+        }
+        if let parsed = URL(string: trimmed), parsed.scheme?.lowercased() == "file" {
+            return parsed
+        }
+        if let scheme = URL(string: trimmed)?.scheme?.lowercased(),
+           scheme == "http" || scheme == "https" {
+            throw NemotronOmniError.unsupportedMedia(
+                "remote audio URLs are not fetched; use a local path or file URL"
+            )
+        }
+        let url = URL(fileURLWithPath: trimmed).standardizedFileURL
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            throw NemotronOmniError.unsupportedMedia("audio file not found: \(url.path)")
+        }
+        return url
+    }
+}

--- a/Sources/MereRunCore/NemotronOmni/NemotronOmniConfig.swift
+++ b/Sources/MereRunCore/NemotronOmni/NemotronOmniConfig.swift
@@ -1,0 +1,330 @@
+import Foundation
+
+public struct NemotronOmniVisionConfig: Decodable, Sendable, Hashable {
+    public let version: String
+    public let patchSize: Int
+    public let minNumPatches: Int
+    public let maxNumPatches: Int
+    public let videoTargetNumPatches: Int
+    public let videoTemporalPatchSize: Int
+    public let separateVideoEmbedder: Bool
+
+    private enum CodingKeys: String, CodingKey {
+        case version
+        case patchSize = "patch_size"
+        case minNumPatches = "min_num_patches"
+        case maxNumPatches = "max_num_patches"
+        case videoTargetNumPatches = "video_target_num_patches"
+        case videoTemporalPatchSize = "video_temporal_patch_size"
+        case separateVideoEmbedder = "separate_video_embedder"
+    }
+}
+
+public struct NemotronOmniSoundConfig: Decodable, Sendable, Hashable {
+    public let modelType: String
+    public let hiddenSize: Int
+    public let numAttentionHeads: Int
+    public let numHiddenLayers: Int
+    public let intermediateSize: Int
+    public let convKernelSize: Int
+    public let subsamplingFactor: Int
+    public let subsamplingConvChannels: Int
+    public let subsamplingConvKernelSize: Int
+    public let subsamplingConvStride: Int
+    public let numMelBins: Int
+    public let projectionHiddenSize: Int
+    public let samplingRate: Int
+
+    private enum CodingKeys: String, CodingKey {
+        case modelType = "model_type"
+        case hiddenSize = "hidden_size"
+        case numAttentionHeads = "num_attention_heads"
+        case numHiddenLayers = "num_hidden_layers"
+        case intermediateSize = "intermediate_size"
+        case convKernelSize = "conv_kernel_size"
+        case subsamplingFactor = "subsampling_factor"
+        case subsamplingConvChannels = "subsampling_conv_channels"
+        case subsamplingConvKernelSize = "subsampling_conv_kernel_size"
+        case subsamplingConvStride = "subsampling_conv_stride"
+        case numMelBins = "num_mel_bins"
+        case projectionHiddenSize = "projection_hidden_size"
+        case samplingRate = "sampling_rate"
+    }
+}
+
+public struct NemotronOmniLanguageConfig: Decodable, Sendable, Hashable {
+    public let modelType: String
+    public let hiddenSize: Int
+    public let vocabSize: Int
+    public let numHiddenLayers: Int
+    public let hybridOverridePattern: String
+    public let maxPositionEmbeddings: Int
+    public let numAttentionHeads: Int
+    public let numKeyValueHeads: Int
+    public let headDim: Int
+    public let normEps: Float
+    public let mambaHeadDim: Int
+    public let mambaNumHeads: Int
+    public let ssmStateSize: Int
+    public let nGroups: Int
+    public let convKernel: Int
+    public let timeStepMin: Float
+    public let timeStepMax: Float
+    public let nRoutedExperts: Int
+    public let nSharedExperts: Int
+    public let numExpertsPerToken: Int
+    public let moeIntermediateSize: Int
+    public let sharedExpertIntermediateSize: Int
+    public let routedScalingFactor: Float
+    public let normTopKProbability: Bool
+    public let nGroup: Int
+    public let topKGroup: Int
+    public let eosTokenID: Int
+
+    private enum CodingKeys: String, CodingKey {
+        case modelType = "model_type"
+        case hiddenSize = "hidden_size"
+        case vocabSize = "vocab_size"
+        case numHiddenLayers = "num_hidden_layers"
+        case hybridOverridePattern = "hybrid_override_pattern"
+        case maxPositionEmbeddings = "max_position_embeddings"
+        case numAttentionHeads = "num_attention_heads"
+        case numKeyValueHeads = "num_key_value_heads"
+        case headDim = "head_dim"
+        case normEps = "norm_eps"
+        case mambaHeadDim = "mamba_head_dim"
+        case mambaNumHeads = "mamba_num_heads"
+        case ssmStateSize = "ssm_state_size"
+        case nGroups = "n_groups"
+        case convKernel = "conv_kernel"
+        case timeStepMin = "time_step_min"
+        case timeStepMax = "time_step_max"
+        case nRoutedExperts = "n_routed_experts"
+        case nSharedExperts = "n_shared_experts"
+        case numExpertsPerToken = "num_experts_per_tok"
+        case moeIntermediateSize = "moe_intermediate_size"
+        case sharedExpertIntermediateSize = "moe_shared_expert_intermediate_size"
+        case routedScalingFactor = "routed_scaling_factor"
+        case normTopKProbability = "norm_topk_prob"
+        case nGroup = "n_group"
+        case topKGroup = "topk_group"
+        case eosTokenID = "eos_token_id"
+    }
+
+    public var layerBlockTypes: [String] {
+        hybridOverridePattern.map { value in
+            switch value {
+            case "M": "mamba"
+            case "E": "moe"
+            case "*": "attention"
+            default: "unsupported"
+            }
+        }
+    }
+
+    var runtimeConfig: NemotronHConfig {
+        NemotronHConfig(
+            modelType: modelType,
+            vocabSize: vocabSize,
+            hiddenSize: hiddenSize,
+            numHiddenLayers: numHiddenLayers,
+            layersBlockType: layerBlockTypes,
+            numAttentionHeads: numAttentionHeads,
+            numKeyValueHeads: numKeyValueHeads,
+            headDim: headDim,
+            maxPositionEmbeddings: maxPositionEmbeddings,
+            normEps: normEps,
+            mambaHeadDim: mambaHeadDim,
+            mambaNumHeads: mambaNumHeads,
+            ssmStateSize: ssmStateSize,
+            nGroups: nGroups,
+            convKernel: convKernel,
+            timeStepMin: timeStepMin,
+            timeStepMax: timeStepMax,
+            nRoutedExperts: nRoutedExperts,
+            nSharedExperts: nSharedExperts,
+            numExpertsPerToken: numExpertsPerToken,
+            moeIntermediateSize: moeIntermediateSize,
+            sharedExpertIntermediateSize: sharedExpertIntermediateSize,
+            routedScalingFactor: routedScalingFactor,
+            normTopKProbability: normTopKProbability,
+            nGroup: nGroup,
+            topKGroup: topKGroup,
+            eosTokenIDs: [eosTokenID],
+            quantization: NemotronHQuantizationConfig(
+                bits: 4,
+                groupSize: 16,
+                mode: "nvfp4",
+                globalScale: true
+            )
+        )
+    }
+}
+
+public struct NemotronOmniConfig: Decodable, Sendable, Hashable {
+    public let architectures: [String]
+    public let modelType: String
+    public let maximumSequenceLength: Int
+    public let imageContextTokenID: Int
+    public let videoContextTokenID: Int
+    public let soundContextTokenID: Int
+    public let downsampleRatio: Double
+    public let projectorHiddenSize: Int
+    public let visionHiddenSize: Int
+    public let videoPruningRate: Double
+    public let vision: NemotronOmniVisionConfig
+    public let sound: NemotronOmniSoundConfig
+    public let language: NemotronOmniLanguageConfig
+
+    private enum CodingKeys: String, CodingKey {
+        case architectures
+        case modelType = "model_type"
+        case maximumSequenceLength = "max_sequence_length"
+        case imageContextTokenID = "img_context_token_id"
+        case videoContextTokenID = "video_context_token_id"
+        case soundContextTokenID = "sound_context_token_id"
+        case downsampleRatio = "downsample_ratio"
+        case projectorHiddenSize = "projector_hidden_size"
+        case visionHiddenSize = "vit_hidden_size"
+        case videoPruningRate = "video_pruning_rate"
+        case vision = "vision_config"
+        case sound = "sound_config"
+        case language = "llm_config"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        architectures = try container.decode([String].self, forKey: .architectures)
+        modelType = try container.decode(String.self, forKey: .modelType)
+        maximumSequenceLength = try container.decode(Int.self, forKey: .maximumSequenceLength)
+        imageContextTokenID = try container.decode(Int.self, forKey: .imageContextTokenID)
+        videoContextTokenID = try container.decode(Int.self, forKey: .videoContextTokenID)
+        soundContextTokenID = try container.decode(Int.self, forKey: .soundContextTokenID)
+        downsampleRatio = try container.decode(Double.self, forKey: .downsampleRatio)
+        projectorHiddenSize = try container.decode(Int.self, forKey: .projectorHiddenSize)
+        visionHiddenSize = try container.decode(Int.self, forKey: .visionHiddenSize)
+        videoPruningRate = try container.decode(Double.self, forKey: .videoPruningRate)
+        vision = try container.decode(NemotronOmniVisionConfig.self, forKey: .vision)
+        sound = try container.decode(NemotronOmniSoundConfig.self, forKey: .sound)
+        language = try container.decode(NemotronOmniLanguageConfig.self, forKey: .language)
+
+        let supportedLayerTypes = Set(language.layerBlockTypes)
+        guard architectures == ["NemotronH_Nano_Omni_Reasoning_V3"],
+              modelType == "NemotronH_Nano_Omni_Reasoning_V3",
+              maximumSequenceLength == NemotronOmniResources.maximumContextLength,
+              imageContextTokenID == 18,
+              videoContextTokenID == 131_081,
+              soundContextTokenID == 27,
+              downsampleRatio == 0.5,
+              projectorHiddenSize == 20_480,
+              visionHiddenSize == 1_280,
+              videoPruningRate == 0.7,
+              language.modelType == "nemotron_h",
+              language.hiddenSize == 2_688,
+              language.vocabSize == 131_072,
+              language.numHiddenLayers == 52,
+              language.maxPositionEmbeddings == 262_144,
+              language.layerBlockTypes.count == language.numHiddenLayers,
+              supportedLayerTypes.isSubset(of: ["mamba", "moe", "attention"]),
+              vision.version == "c-radio_v4-h",
+              vision.patchSize == 16,
+              vision.minNumPatches == 1_024,
+              vision.maxNumPatches == 13_312,
+              vision.videoTargetNumPatches == 1_024,
+              vision.videoTemporalPatchSize == 2,
+              vision.separateVideoEmbedder,
+              sound.modelType == "parakeet",
+              sound.hiddenSize == 1_024,
+              sound.numAttentionHeads == 8,
+              sound.numHiddenLayers == 24,
+              sound.intermediateSize == 4_096,
+              sound.convKernelSize == 9,
+              sound.subsamplingFactor == 8,
+              sound.subsamplingConvChannels == 256,
+              sound.subsamplingConvKernelSize == 3,
+              sound.subsamplingConvStride == 2,
+              sound.numMelBins == 128,
+              sound.projectionHiddenSize == 4_096,
+              sound.samplingRate == NemotronOmniResources.audioSampleRate else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .modelType,
+                in: container,
+                debugDescription: "Unsupported Nemotron 3 Nano Omni checkpoint contract."
+            )
+        }
+    }
+}
+
+public struct NemotronOmniPreprocessorConfig: Decodable, Sendable, Hashable {
+    public let patchSize: Int
+    public let downsampleRatio: Double
+    public let normalizationMean: [Float]
+    public let normalizationStandardDeviation: [Float]
+    public let minNumPatches: Int
+    public let maxNumPatches: Int
+
+    private enum CodingKeys: String, CodingKey {
+        case patchSize = "patch_size"
+        case downsampleRatio = "downsample_ratio"
+        case normalizationMean = "norm_mean"
+        case normalizationStandardDeviation = "norm_std"
+        case minNumPatches = "min_num_patches"
+        case maxNumPatches = "max_num_patches"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        patchSize = try container.decode(Int.self, forKey: .patchSize)
+        downsampleRatio = try container.decode(Double.self, forKey: .downsampleRatio)
+        normalizationMean = try container.decode([Float].self, forKey: .normalizationMean)
+        normalizationStandardDeviation = try container.decode(
+            [Float].self,
+            forKey: .normalizationStandardDeviation
+        )
+        minNumPatches = try container.decode(Int.self, forKey: .minNumPatches)
+        maxNumPatches = try container.decode(Int.self, forKey: .maxNumPatches)
+
+        guard patchSize == 16,
+              downsampleRatio == 0.5,
+              normalizationMean == [0.48145466, 0.4578275, 0.40821073],
+              normalizationStandardDeviation == [0.26862954, 0.26130258, 0.27577711],
+              minNumPatches == 1_024,
+              maxNumPatches == 13_312 else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .patchSize,
+                in: container,
+                debugDescription: "Unsupported Nemotron 3 Nano Omni media processor contract."
+            )
+        }
+    }
+}
+
+public enum NemotronOmniPlaceholderPlanner {
+    /// C-RADIO patch tokens are pixel-shuffled by a 0.5 downsample ratio, so
+    /// every four source patches become one language-model placeholder.
+    public static func imageTokenCount(sourcePatchCount: Int, downsampleRatio: Double = 0.5) -> Int {
+        precondition(sourcePatchCount > 0)
+        let divisor = Int((1 / downsampleRatio) * (1 / downsampleRatio))
+        return sourcePatchCount / divisor
+    }
+
+    /// Audio uses a three-stage stride-2 convolutional subsampler after the
+    /// 10 ms mel hop. This mirrors the pinned upstream processor exactly.
+    public static func audioTokenCount(
+        sampleCount: Int,
+        hopLength: Int = 160,
+        kernelSize: Int = 3,
+        stride: Int = 2,
+        subsamplingFactor: Int = 8
+    ) -> Int {
+        precondition(sampleCount >= 0)
+        var frames = 1 + sampleCount / hopLength
+        var remainingFactor = subsamplingFactor
+        let padding = (kernelSize - 1) / 2
+        while remainingFactor > 1 {
+            frames = max(0, (frames + 2 * padding - kernelSize) / stride + 1)
+            remainingFactor /= stride
+        }
+        return max(1, frames)
+    }
+}

--- a/Sources/MereRunCore/NemotronOmni/NemotronOmniExpertPack.swift
+++ b/Sources/MereRunCore/NemotronOmni/NemotronOmniExpertPack.swift
@@ -87,9 +87,10 @@ public enum NemotronOmniExpertPack {
               capacityURL.path != "/" {
             capacityURL.deleteLastPathComponent()
         }
-        let capacity = try capacityURL.resourceValues(
-            forKeys: [.volumeAvailableCapacityForImportantUsageKey]
-        ).volumeAvailableCapacityForImportantUsage ?? 0
+        let capacity = try availableCapacity(
+            at: capacityURL,
+            fileManager: fileManager
+        )
         let reserve: Int64 = 8 * 1_073_741_824
         let required = NemotronOmniResources.packedExpertWeightBytes + reserve
         guard capacity <= 0 || capacity >= required else {
@@ -272,6 +273,14 @@ public enum NemotronOmniExpertPack {
             throw NemotronOmniExpertPackError.invalidOutput(outputURL)
         }
         return outputURL
+    }
+
+    static func availableCapacity(
+        at url: URL,
+        fileManager: FileManager = .default
+    ) throws -> Int64 {
+        let attributes = try fileManager.attributesOfFileSystem(forPath: url.path)
+        return (attributes[.systemFreeSize] as? NSNumber)?.int64Value ?? 0
     }
 
     private static func safetensorsDType(_ dtype: DType) throws -> String {

--- a/Sources/MereRunCore/NemotronOmni/NemotronOmniExpertPack.swift
+++ b/Sources/MereRunCore/NemotronOmni/NemotronOmniExpertPack.swift
@@ -1,0 +1,341 @@
+import Foundation
+import MLX
+
+public enum NemotronOmniExpertPackError: LocalizedError {
+    case outputExists(URL)
+    case insufficientDisk(required: Int64, available: Int64)
+    case invalidExpertInventory(String)
+    case unsupportedDType(DType)
+    case truncatedTensor(String)
+    case invalidOutput(URL)
+
+    public var errorDescription: String? {
+        switch self {
+        case .outputExists(let url):
+            "Nemotron Omni native expert pack already exists: \(url.path)"
+        case .insufficientDisk(let required, let available):
+            "Nemotron Omni expert packing requires \(required) bytes but only \(available) bytes are available."
+        case .invalidExpertInventory(let message):
+            "Nemotron Omni expert inventory is invalid: \(message)"
+        case .unsupportedDType(let dtype):
+            "Nemotron Omni expert packing cannot write dtype \(dtype)."
+        case .truncatedTensor(let key):
+            "Nemotron Omni source ended while copying expert tensor \(key)."
+        case .invalidOutput(let url):
+            "Nemotron Omni native expert pack failed validation: \(url.path)"
+        }
+    }
+}
+
+/// Reorders the official per-expert BF16 tensors into the stacked layout used
+/// by MLX gather matmul. Payload bytes are copied directly and atomically; no
+/// model tensor is converted, rounded, or materialized in unified memory.
+public enum NemotronOmniExpertPack {
+    public static let format = "mere-run-nemotron-omni-experts-v1"
+    public static let relativePath = ".mere-run/nemotron-omni-experts-v1/experts-bf16.safetensors"
+
+    public static func outputURL(
+        rootURL: URL,
+        fileManager: FileManager = .default
+    ) throws -> URL {
+        let standardized = rootURL.standardizedFileURL
+        let configURL = standardized.appendingPathComponent("config.json")
+        let base: URL
+        if let destination = try? fileManager.destinationOfSymbolicLink(atPath: configURL.path) {
+            let destinationURL = URL(fileURLWithPath: destination)
+            let absolute = destinationURL.path.hasPrefix("/")
+                ? destinationURL
+                : configURL.deletingLastPathComponent().appendingPathComponent(destination)
+            base = absolute.deletingLastPathComponent()
+        } else {
+            base = standardized
+        }
+        return base.appendingPathComponent(relativePath)
+    }
+
+    public static func optimizedURLIfValid(
+        rootURL: URL,
+        fileManager: FileManager = .default
+    ) -> URL? {
+        guard let url = try? outputURL(rootURL: rootURL, fileManager: fileManager),
+              fileManager.fileExists(atPath: url.path),
+              let metadata = try? SafetensorsStreamingLoader.fileMetadata(url: url),
+              metadata["format"] == format,
+              metadata["source_revision"] == NemotronOmniResources.upstreamRevision,
+              metadata["payload_bytes"] == String(NemotronOmniResources.packedExpertWeightBytes),
+              let tensors = try? SafetensorsStreamingLoader.metadata(url: url),
+              tensors.count == 46 else {
+            return nil
+        }
+        return url
+    }
+
+    @discardableResult
+    public static func optimize(
+        rootURL: URL,
+        replacing: Bool = false,
+        progressHandler: ((Int, Int) -> Void)? = nil,
+        fileManager: FileManager = .default
+    ) throws -> URL {
+        let rootURL = rootURL.standardizedFileURL
+        let outputURL = try outputURL(rootURL: rootURL, fileManager: fileManager)
+        if fileManager.fileExists(atPath: outputURL.path), !replacing {
+            throw NemotronOmniExpertPackError.outputExists(outputURL)
+        }
+        var capacityURL = outputURL.deletingLastPathComponent()
+        while !fileManager.fileExists(atPath: capacityURL.path),
+              capacityURL.path != "/" {
+            capacityURL.deleteLastPathComponent()
+        }
+        let capacity = try capacityURL.resourceValues(
+            forKeys: [.volumeAvailableCapacityForImportantUsageKey]
+        ).volumeAvailableCapacityForImportantUsage ?? 0
+        let reserve: Int64 = 8 * 1_073_741_824
+        let required = NemotronOmniResources.packedExpertWeightBytes + reserve
+        guard capacity <= 0 || capacity >= required else {
+            throw NemotronOmniExpertPackError.insufficientDisk(
+                required: required,
+                available: capacity
+            )
+        }
+
+        let indexURL = rootURL.appendingPathComponent("model.safetensors.index.json")
+        let index = try JSONDecoder().decode(
+            HFSafetensorsIndex.self,
+            from: Data(contentsOf: indexURL)
+        )
+        let shardMetadata = try Dictionary(uniqueKeysWithValues: index.shardFilenames.map { filename in
+            let url = rootURL.appendingPathComponent(filename)
+            return (filename, (url, try SafetensorsStreamingLoader.metadata(url: url)))
+        })
+        var groups: [NemotronOmniPackedExpertGroupKey: [Int: NemotronOmniPackedExpertSource]] = [:]
+        for (key, filename) in index.weightMap {
+            guard let parsed = NemotronOmniExpertWeightKey(checkpointKey: key) else { continue }
+            guard let shard = shardMetadata[filename], let metadata = shard.1[key] else {
+                throw NemotronOmniExpertPackError.invalidExpertInventory(
+                    "missing metadata for \(key)"
+                )
+            }
+            let group = NemotronOmniPackedExpertGroupKey(
+                layer: parsed.layer,
+                projection: parsed.projection
+            )
+            groups[group, default: [:]][parsed.expert] = NemotronOmniPackedExpertSource(
+                key: key,
+                url: shard.0,
+                metadata: metadata
+            )
+        }
+
+        let expectedLayers = NemotronOmniPackedExpertGroupKey.expectedLayers
+        var outputGroups: [NemotronOmniPackedExpertGroup] = []
+        outputGroups.reserveCapacity(expectedLayers.count * 2)
+        for layer in expectedLayers {
+            for projection in [
+                NemotronOmniExpertWeightKey.Projection.up,
+                NemotronOmniExpertWeightKey.Projection.down,
+            ] {
+                let groupKey = NemotronOmniPackedExpertGroupKey(
+                    layer: layer,
+                    projection: projection
+                )
+                guard let values = groups[groupKey], values.count == 128 else {
+                    throw NemotronOmniExpertPackError.invalidExpertInventory(
+                        "layer \(layer) \(projection.rawValue) has \(groups[groupKey]?.count ?? 0)/128 experts"
+                    )
+                }
+                let sources = try (0..<128).map { expert in
+                    guard let source = values[expert] else {
+                        throw NemotronOmniExpertPackError.invalidExpertInventory(
+                            "layer \(layer) \(projection.rawValue) is missing expert \(expert)"
+                        )
+                    }
+                    return source
+                }
+                guard let first = sources.first,
+                      sources.allSatisfy({
+                          $0.metadata.dtype == first.metadata.dtype
+                              && $0.metadata.shape == first.metadata.shape
+                      }) else {
+                    throw NemotronOmniExpertPackError.invalidExpertInventory(
+                        "layer \(layer) \(projection.rawValue) tensors disagree on shape or dtype"
+                    )
+                }
+                outputGroups.append(NemotronOmniPackedExpertGroup(
+                    outputKey:
+                        "backbone.layers.\(layer).mixer.experts.\(projection.rawValue).weight",
+                    sources: sources,
+                    dtype: try safetensorsDType(first.metadata.dtype),
+                    shape: [128] + first.metadata.shape
+                ))
+            }
+        }
+        outputGroups.sort { $0.outputKey < $1.outputKey }
+
+        var runningOffset = 0
+        var headers: [String: NemotronOmniPackedExpertHeader] = [:]
+        headers.reserveCapacity(outputGroups.count)
+        for group in outputGroups {
+            let byteCount = group.sources.reduce(0) {
+                $0 + ($1.metadata.endOffset - $1.metadata.startOffset)
+            }
+            headers[group.outputKey] = NemotronOmniPackedExpertHeader(
+                dtype: group.dtype,
+                shape: group.shape,
+                dataOffsets: [runningOffset, runningOffset + byteCount]
+            )
+            runningOffset += byteCount
+        }
+        guard Int64(runningOffset) == NemotronOmniResources.packedExpertWeightBytes else {
+            throw NemotronOmniExpertPackError.invalidExpertInventory(
+                "expected \(NemotronOmniResources.packedExpertWeightBytes) payload bytes; found \(runningOffset)"
+            )
+        }
+
+        let header = NemotronOmniPackedExpertFileHeader(
+            tensors: headers,
+            metadata: [
+                "format": format,
+                "source_repo": NemotronOmniResources.upstreamRepoID,
+                "source_revision": NemotronOmniResources.upstreamRevision,
+                "payload_bytes": String(runningOffset),
+            ]
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        var headerData = try encoder.encode(header)
+        let padding = (8 - (headerData.count % 8)) % 8
+        headerData.append(Data(repeating: 0x20, count: padding))
+
+        try fileManager.createDirectory(
+            at: outputURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let temporaryURL = outputURL.deletingLastPathComponent().appendingPathComponent(
+            ".\(outputURL.lastPathComponent).\(UUID().uuidString).tmp"
+        )
+        _ = fileManager.createFile(atPath: temporaryURL.path, contents: nil)
+        do {
+            let output = try FileHandle(forWritingTo: temporaryURL)
+            var handles: [URL: FileHandle] = [:]
+            defer {
+                try? output.close()
+                for handle in handles.values { try? handle.close() }
+            }
+            var headerLength = UInt64(headerData.count).littleEndian
+            try withUnsafeBytes(of: &headerLength) { try output.write(contentsOf: $0) }
+            try output.write(contentsOf: headerData)
+            let sourceCount = outputGroups.reduce(0) { $0 + $1.sources.count }
+            var copiedSources = 0
+            for group in outputGroups {
+                for source in group.sources {
+                    let handle: FileHandle
+                    if let existing = handles[source.url] {
+                        handle = existing
+                    } else {
+                        handle = try FileHandle(forReadingFrom: source.url)
+                        handles[source.url] = handle
+                    }
+                    try handle.seek(toOffset: UInt64(source.metadata.startOffset))
+                    var remaining = source.metadata.endOffset - source.metadata.startOffset
+                    while remaining > 0 {
+                        let requested = min(remaining, 8 * 1_024 * 1_024)
+                        #if canImport(ObjectiveC)
+                        let data = try autoreleasepool {
+                            try handle.read(upToCount: requested)
+                        }
+                        #else
+                        let data = try handle.read(upToCount: requested)
+                        #endif
+                        guard let data, data.count == requested else {
+                            throw NemotronOmniExpertPackError.truncatedTensor(source.key)
+                        }
+                        try output.write(contentsOf: data)
+                        remaining -= data.count
+                    }
+                    copiedSources += 1
+                    if copiedSources.isMultiple(of: 32) || copiedSources == sourceCount {
+                        progressHandler?(copiedSources, sourceCount)
+                    }
+                }
+            }
+            try output.synchronize()
+        } catch {
+            try? fileManager.removeItem(at: temporaryURL)
+            throw error
+        }
+        if fileManager.fileExists(atPath: outputURL.path) {
+            try fileManager.removeItem(at: outputURL)
+        }
+        try fileManager.moveItem(at: temporaryURL, to: outputURL)
+        guard optimizedURLIfValid(rootURL: rootURL, fileManager: fileManager) == outputURL else {
+            throw NemotronOmniExpertPackError.invalidOutput(outputURL)
+        }
+        return outputURL
+    }
+
+    private static func safetensorsDType(_ dtype: DType) throws -> String {
+        switch dtype {
+        case .bfloat16: "BF16"
+        case .float32: "F32"
+        default: throw NemotronOmniExpertPackError.unsupportedDType(dtype)
+        }
+    }
+}
+
+private struct NemotronOmniPackedExpertGroupKey: Hashable {
+    let layer: Int
+    let projection: NemotronOmniExpertWeightKey.Projection
+
+    static let expectedLayers = [
+        1, 3, 6, 8, 10, 13, 15, 17, 20, 22, 24, 27,
+        29, 31, 34, 36, 38, 40, 43, 45, 47, 49, 51,
+    ]
+}
+
+private struct NemotronOmniPackedExpertSource {
+    let key: String
+    let url: URL
+    let metadata: SafetensorsStreamingLoader.TensorMetadata
+}
+
+private struct NemotronOmniPackedExpertGroup {
+    let outputKey: String
+    let sources: [NemotronOmniPackedExpertSource]
+    let dtype: String
+    let shape: [Int]
+}
+
+private struct NemotronOmniPackedExpertHeader: Encodable {
+    let dtype: String
+    let shape: [Int]
+    let dataOffsets: [Int]
+
+    private enum CodingKeys: String, CodingKey {
+        case dtype
+        case shape
+        case dataOffsets = "data_offsets"
+    }
+}
+
+private struct NemotronOmniPackedExpertFileHeader: Encodable {
+    let tensors: [String: NemotronOmniPackedExpertHeader]
+    let metadata: [String: String]
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: NemotronOmniPackedExpertCodingKey.self)
+        try container.encode(metadata, forKey: NemotronOmniPackedExpertCodingKey("__metadata__"))
+        for (key, tensor) in tensors {
+            try container.encode(tensor, forKey: NemotronOmniPackedExpertCodingKey(key))
+        }
+    }
+}
+
+private struct NemotronOmniPackedExpertCodingKey: CodingKey {
+    let stringValue: String
+    let intValue: Int? = nil
+
+    init(_ stringValue: String) { self.stringValue = stringValue }
+    init?(stringValue: String) { self.init(stringValue) }
+    init?(intValue: Int) { return nil }
+}

--- a/Sources/MereRunCore/NemotronOmni/NemotronOmniGenerator.swift
+++ b/Sources/MereRunCore/NemotronOmni/NemotronOmniGenerator.swift
@@ -1,0 +1,471 @@
+import Foundation
+import MLX
+
+public actor NemotronOmniGenerator: ChatGenerator {
+    private static let prefillChunkSize = 128
+
+    private var model: NemotronOmniCausalLM?
+    private var visionTower: NemotronOmniVisionTower?
+    private var soundTower: NemotronOmniSoundTower?
+    private var tokenizer: Q35TokenizerAndTemplate?
+    private var config: NemotronOmniConfig?
+    private var preprocessorConfig: NemotronOmniPreprocessorConfig?
+    private var loadedPath: String?
+
+    public init() {}
+
+    public func chat(
+        _ request: ChatRequest,
+        progressHandler: (@Sendable (ChatProgress) -> Void)?
+    ) async throws -> ChatResponse {
+        try await chat(request, modelPath: nil, progressHandler: progressHandler)
+    }
+
+    public func chat(
+        _ request: ChatRequest,
+        modelPath: String?,
+        progressHandler: (@Sendable (ChatProgress) -> Void)?
+    ) async throws -> ChatResponse {
+        try await Stream.withNewDefaultStream {
+            guard request.lora == nil else {
+                throw NemotronOmniError.generationFailed("LoRA is not supported by this runtime")
+            }
+            guard !request.requiresJSON else {
+                throw NemotronOmniError.generationFailed(
+                    "constrained JSON is not supported by this runtime"
+                )
+            }
+            let root = try await resolveRoot(
+                modelPath: modelPath,
+                progressHandler: progressHandler
+            )
+            let loadStart = Date()
+            try await ensureLoaded(rootURL: root, progressHandler: progressHandler)
+            let loadSeconds = Date().timeIntervalSince(loadStart)
+            var response = try await generate(request, progressHandler: progressHandler)
+            response.timing?.loadSeconds = loadSeconds
+            return response
+        }
+    }
+
+    public func prepare(
+        modelPath: String? = nil,
+        progressHandler: (@Sendable (ChatProgress) -> Void)? = nil
+    ) async throws {
+        try await Stream.withNewDefaultStream {
+            let root = try await resolveRoot(
+                modelPath: modelPath,
+                progressHandler: progressHandler
+            )
+            try await ensureLoaded(rootURL: root, progressHandler: progressHandler)
+        }
+    }
+
+    public func unload() {
+        model = nil
+        visionTower = nil
+        soundTower = nil
+        tokenizer = nil
+        config = nil
+        preprocessorConfig = nil
+        loadedPath = nil
+        Memory.clearCache()
+    }
+
+    private func resolveRoot(
+        modelPath: String?,
+        progressHandler: (@Sendable (ChatProgress) -> Void)?
+    ) async throws -> URL {
+        if let path = modelPath?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !path.isEmpty {
+            let root = URL(fileURLWithPath: path).standardizedFileURL
+            guard FileManager.default.fileExists(atPath: root.path) else {
+                throw NemotronOmniError.modelPathRequired
+            }
+            return root
+        }
+        if let installed = ManagedModelResolver.resolveInstalledModel(
+            id: NemotronOmniResources.modelID
+        ) {
+            return installed.standardizedFileURL
+        }
+        progressHandler?(ChatProgress(
+            stage: .loadingModel,
+            message: "Nemotron Omni must be installed explicitly before inference"
+        ))
+        throw NemotronOmniError.modelPathRequired
+    }
+
+    private func ensureLoaded(
+        rootURL: URL,
+        progressHandler: (@Sendable (ChatProgress) -> Void)?
+    ) async throws {
+        guard loadedPath != rootURL.path || model == nil else { return }
+        let loaded = try await NemotronOmniModelLoader.load(
+            rootURL: rootURL,
+            maxContextLength: NemotronOmniResources.maximumContextLength,
+            progressHandler: progressHandler
+        )
+        model = loaded.model
+        visionTower = loaded.visionTower
+        soundTower = loaded.soundTower
+        tokenizer = loaded.tokenizer
+        config = loaded.config
+        preprocessorConfig = loaded.preprocessorConfig
+        loadedPath = loaded.rootURL.path
+    }
+
+    private func generate(
+        _ request: ChatRequest,
+        progressHandler: (@Sendable (ChatProgress) -> Void)?
+    ) async throws -> ChatResponse {
+        guard let model,
+              let visionTower,
+              let soundTower,
+              let tokenizer,
+              let config,
+              let preprocessorConfig else {
+            throw NemotronOmniError.generationFailed("model is not loaded")
+        }
+        let contextLength = min(
+            request.maxContextTokens ?? NemotronOmniResources.defaultContextLength,
+            NemotronOmniResources.maximumContextLength,
+            config.language.maxPositionEmbeddings
+        )
+        var preparedImages: [Int: NemotronOmniPreparedImage] = [:]
+        var preparedVideos: [Int: NemotronOmniPreparedVideo] = [:]
+        var preparedAudio: [Int: NemotronOmniPreparedAudio] = [:]
+        for index in request.messages.indices {
+            let message = request.messages[index]
+            if let reference = message.imageUrl?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !reference.isEmpty {
+                preparedImages[index] = try NemotronOmniImageProcessor.prepare(
+                    reference: reference,
+                    config: preprocessorConfig,
+                    contextLength: contextLength
+                )
+            }
+            if let reference = message.videoUrl?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !reference.isEmpty {
+                preparedVideos[index] = try NemotronOmniVideoProcessor.prepare(
+                    reference: reference,
+                    config: preprocessorConfig,
+                    contextLength: contextLength
+                )
+            }
+            if let reference = message.audioUrl?.trimmingCharacters(in: .whitespacesAndNewlines),
+               !reference.isEmpty {
+                preparedAudio[index] = try NemotronOmniAudioProcessor.prepare(reference: reference)
+            }
+        }
+        var promptMessages = request.messages
+        if !preparedImages.isEmpty || !preparedVideos.isEmpty || !preparedAudio.isEmpty {
+            for index in promptMessages.indices {
+                var mediaPrefix = ""
+                if preparedImages[index] != nil {
+                    mediaPrefix += "<image>\n"
+                }
+                if let video = preparedVideos[index] {
+                    mediaPrefix += video.promptPrefix
+                }
+                if preparedAudio[index] != nil {
+                    mediaPrefix += "<so_embedding>\n"
+                }
+                promptMessages[index].content = mediaPrefix + promptMessages[index].content
+                promptMessages[index].imageUrl = nil
+                promptMessages[index].videoUrl = nil
+                promptMessages[index].audioUrl = nil
+            }
+        }
+        var promptTokens = try tokenizer.encodeForGeneration(
+            messages: promptMessages,
+            tools: request.tools,
+            addGenerationPrompt: true,
+            includeThinking: request.showThinking,
+            reasoningEffort: request.reasoningEffort.map { String($0) },
+            maxLength: contextLength
+        )
+        var visionTokenCounts: [Int] = []
+        for index in request.messages.indices {
+            if let image = preparedImages[index] {
+                visionTokenCounts.append(image.languageTokenCount)
+            }
+            if let video = preparedVideos[index] {
+                visionTokenCounts.append(contentsOf: video.languageTokenCounts)
+            }
+        }
+        if !visionTokenCounts.isEmpty {
+            promptTokens = try Self.expandImagePlaceholders(
+                promptTokens,
+                tokenCounts: visionTokenCounts,
+                imageTokenID: config.imageContextTokenID
+            )
+        }
+        if !preparedAudio.isEmpty {
+            let audioTokenCounts = request.messages.indices.compactMap {
+                preparedAudio[$0]?.languageTokenCount
+            }
+            promptTokens = try Self.expandAudioPlaceholders(
+                promptTokens,
+                tokenCounts: audioTokenCounts,
+                soundTokenID: config.soundContextTokenID
+            )
+        }
+        if promptTokens.count > contextLength {
+            guard preparedImages.isEmpty,
+                  preparedVideos.isEmpty,
+                  preparedAudio.isEmpty else {
+                throw NemotronOmniError.generationFailed(
+                    "multimodal prompt exceeds the \(contextLength)-token context"
+                )
+            }
+            promptTokens = Array(promptTokens.suffix(contextLength))
+        }
+        guard !promptTokens.isEmpty else {
+            throw NemotronOmniError.generationFailed("prompt tokenization produced no tokens")
+        }
+
+        let cache = model.makeCache()
+        var promptEmbeddings = model.inputEmbeddings(
+            MLXArray(promptTokens.map(Int32.init)).reshaped(1, promptTokens.count)
+        )
+        if !preparedImages.isEmpty || !preparedVideos.isEmpty {
+            progressHandler?(ChatProgress(
+                stage: .encoding,
+                message: "Encoding image/video input with C-RADIO v4-H"
+            ))
+            var replacements: [MLXArray] = []
+            for index in request.messages.indices {
+                if let image = preparedImages[index] {
+                    let embeddings = visionTower.encodeImage(image.pixelValues)
+                    MLX.eval(embeddings)
+                    replacements.append(embeddings)
+                }
+                if let video = preparedVideos[index] {
+                    let embeddings = visionTower.encodeVideo(video.pixelValues)
+                    MLX.eval(embeddings)
+                    for group in 0..<video.tubeletCount {
+                        replacements.append(embeddings[group..<(group + 1), 0..., 0...])
+                    }
+                }
+            }
+            promptEmbeddings = try Self.replaceMediaEmbeddings(
+                promptEmbeddings,
+                promptTokens: promptTokens,
+                placeholderTokenID: config.imageContextTokenID,
+                replacements: replacements
+            )
+        }
+        if !preparedAudio.isEmpty {
+            progressHandler?(ChatProgress(
+                stage: .encoding,
+                message: "Encoding \(preparedAudio.count) audio clip(s) with Parakeet Fast-Conformer"
+            ))
+            let replacements = request.messages.indices.compactMap { index -> MLXArray? in
+                guard let prepared = preparedAudio[index] else { return nil }
+                let embeddings = soundTower(
+                    prepared.melFeatures,
+                    validFrameCount: prepared.validMelFrameCount,
+                    layerProgress: { completed, total in
+                        progressHandler?(ChatProgress(
+                            stage: .encoding,
+                            message: "Audio encoder block \(completed)/\(total)"
+                        ))
+                    }
+                )
+                MLX.eval(embeddings)
+                return embeddings
+            }
+            promptEmbeddings = try Self.replaceMediaEmbeddings(
+                promptEmbeddings,
+                promptTokens: promptTokens,
+                placeholderTokenID: config.soundContextTokenID,
+                replacements: replacements
+            )
+        }
+        let prefillStart = Date()
+        var offset = 0
+        var initialLogits: MLXArray?
+        while offset < promptTokens.count {
+            try Task.checkCancellation()
+            let end = min(promptTokens.count, offset + Self.prefillChunkSize)
+            let logits = model.prefill(
+                embeddings: promptEmbeddings[0..., offset..<end, 0...],
+                cache: cache
+            )
+            MLX.eval(logits)
+            initialLogits = logits
+            offset = end
+            progressHandler?(ChatProgress(
+                stage: .encoding,
+                message: "Prefilled \(offset)/\(promptTokens.count) tokens"
+            ))
+            await Task.yield()
+        }
+        guard let initialLogits else {
+            throw NemotronOmniError.generationFailed("prefill produced no logits")
+        }
+        let prefillSeconds = Date().timeIntervalSince(prefillStart)
+        let tokenBudget = max(0, min(request.maxTokens, contextLength - promptTokens.count))
+        let generationConfig = GenerationConfig(
+            maxTokens: tokenBudget,
+            temperature: Float(request.temperature),
+            topK: request.topK ?? 0,
+            topP: Float(request.topP),
+            minP: Float(request.minP),
+            repetitionPenalty: 1.05,
+            repetitionContextSize: 64
+        )
+        let eosTokens = Set(
+            [config.language.eosTokenID, 11]
+                + [tokenizer.eosTokenId].compactMap { $0 }
+        )
+        progressHandler?(ChatProgress(stage: .generating, message: ""))
+        let decoded = try AutoregressiveDecodeEngine.decode(
+            AutoregressiveDecodeRequest(
+                initialLogits: initialLogits,
+                generationConfig: generationConfig,
+                eosTokens: eosTokens,
+                tokenBudget: tokenBudget,
+                historySeedTokens: promptTokens,
+                logprobCapture: request.logprobCapture,
+                logprobRegion: request.logprobRegionHint ?? .visible
+            ),
+            stepForward: { token in model.lastPositionLogits(token, cache: cache) },
+            decodeToken: { tokenizer.decode(token: $0) },
+            emitPiece: { _, piece in
+                progressHandler?(ChatProgress(stage: .generating, message: piece))
+            },
+            checkCancellation: { try Task.checkCancellation() }
+        )
+        let raw = tokenizer.decode(tokens: decoded.generatedTokens)
+        let trimmed = TextGenerationStopSequences.trimming(
+            raw,
+            sequences: TextGenerationStopSequences.merged(request.stopSequences)
+        )
+        let toolCalls: [ToolCall]? = request.tools?.isEmpty == false ? {
+            let parsed = Gemma4ToolParser.parseToolCalls(trimmed.text)
+            return parsed.isEmpty ? nil : parsed
+        }() : nil
+        return ChatResponse(
+            generatedText: trimmed.text,
+            tokensGenerated: decoded.generatedTokens.count,
+            showThinking: request.showThinking,
+            timing: ChatTiming(
+                prefillSeconds: prefillSeconds,
+                decodeSeconds: decoded.decodeSeconds,
+                firstTokenSeconds: decoded.firstTokenSeconds,
+                kvCacheMode: .default,
+                prefillKVCache: "hybrid-fp32-ssm-bf16-kv",
+                decodeKVCache: "hybrid-fp32-ssm-bf16-kv"
+            ),
+            toolCalls: toolCalls,
+            promptTokens: promptTokens.count,
+            finishReason: decoded.generatedTokens.count >= tokenBudget ? .length : .stop,
+            logprobs: decoded.logprobs,
+            acceleration: ChatAccelerationDiagnostics(route: "nemotron-omni-bf16-native")
+        )
+    }
+
+    static func expandImagePlaceholders(
+        _ tokens: [Int],
+        tokenCounts: [Int],
+        imageTokenID: Int
+    ) throws -> [Int] {
+        guard !tokenCounts.isEmpty else { return tokens }
+        let occurrenceCount = tokens.filter { $0 == imageTokenID }.count
+        guard occurrenceCount == tokenCounts.count else {
+            throw NemotronOmniError.generationFailed(
+                "prompt has \(occurrenceCount) image placeholders for \(tokenCounts.count) image(s)"
+            )
+        }
+        var imageIndex = 0
+        var result: [Int] = []
+        result.reserveCapacity(tokens.count + tokenCounts.reduce(0, +))
+        for token in tokens {
+            guard token == imageTokenID else {
+                result.append(token)
+                continue
+            }
+            result.append(19)
+            result.append(contentsOf: repeatElement(imageTokenID, count: tokenCounts[imageIndex]))
+            result.append(20)
+            imageIndex += 1
+        }
+        return result
+    }
+
+    static func expandAudioPlaceholders(
+        _ tokens: [Int],
+        tokenCounts: [Int],
+        soundTokenID: Int
+    ) throws -> [Int] {
+        guard !tokenCounts.isEmpty else { return tokens }
+        let occurrenceCount = tokens.filter { $0 == soundTokenID }.count
+        guard occurrenceCount == tokenCounts.count else {
+            throw NemotronOmniError.generationFailed(
+                "prompt has \(occurrenceCount) audio placeholders for \(tokenCounts.count) clip(s)"
+            )
+        }
+        var audioIndex = 0
+        var result: [Int] = []
+        result.reserveCapacity(tokens.count + tokenCounts.reduce(0, +))
+        for token in tokens {
+            guard token == soundTokenID else {
+                result.append(token)
+                continue
+            }
+            result.append(28)
+            result.append(contentsOf: repeatElement(soundTokenID, count: tokenCounts[audioIndex]))
+            result.append(29)
+            audioIndex += 1
+        }
+        return result
+    }
+
+    static func replaceMediaEmbeddings(
+        _ embeddings: MLXArray,
+        promptTokens: [Int],
+        placeholderTokenID: Int,
+        replacements: [MLXArray]
+    ) throws -> MLXArray {
+        guard !replacements.isEmpty else { return embeddings }
+        var runs: [Range<Int>] = []
+        var cursor = 0
+        while cursor < promptTokens.count {
+            guard promptTokens[cursor] == placeholderTokenID else {
+                cursor += 1
+                continue
+            }
+            let start = cursor
+            while cursor < promptTokens.count, promptTokens[cursor] == placeholderTokenID {
+                cursor += 1
+            }
+            runs.append(start..<cursor)
+        }
+        guard runs.count == replacements.count else {
+            throw NemotronOmniError.generationFailed(
+                "prompt contains \(runs.count) media spans for \(replacements.count) encoder outputs"
+            )
+        }
+
+        var parts: [MLXArray] = []
+        var inputCursor = 0
+        for (run, replacement) in zip(runs, replacements) {
+            guard replacement.dim(0) == 1, replacement.dim(1) == run.count else {
+                throw NemotronOmniError.generationFailed(
+                    "media span has \(run.count) placeholders but encoder produced \(replacement.dim(1)) embeddings"
+                )
+            }
+            if run.lowerBound > inputCursor {
+                parts.append(embeddings[0..., inputCursor..<run.lowerBound, 0...])
+            }
+            parts.append(replacement.asType(embeddings.dtype))
+            inputCursor = run.upperBound
+        }
+        if inputCursor < promptTokens.count {
+            parts.append(embeddings[0..., inputCursor..., 0...])
+        }
+        return parts.count == 1 ? parts[0] : MLX.concatenated(parts, axis: 1)
+    }
+}

--- a/Sources/MereRunCore/NemotronOmni/NemotronOmniImageProcessor.swift
+++ b/Sources/MereRunCore/NemotronOmni/NemotronOmniImageProcessor.swift
@@ -1,0 +1,243 @@
+import Foundation
+import MediaIO
+import MLX
+
+struct NemotronOmniPreparedImage: @unchecked Sendable {
+    let pixelValues: MLXArray
+    let sourcePatchCount: Int
+
+    var languageTokenCount: Int {
+        NemotronOmniPlaceholderPlanner.imageTokenCount(sourcePatchCount: sourcePatchCount)
+    }
+}
+
+enum NemotronOmniImageProcessor {
+    static func prepare(
+        reference: String,
+        config: NemotronOmniPreprocessorConfig,
+        contextLength: Int,
+        videoMode: Bool = false
+    ) throws -> NemotronOmniPreparedImage {
+        let image = try decode(reference: reference)
+        let patchGrid: (width: Int, height: Int)
+        if videoMode {
+            patchGrid = videoPatchGrid(width: image.width, height: image.height)
+        } else {
+            let available = max(1, contextLength - 4) * 4
+            let budget = max(
+                config.minNumPatches,
+                min(config.maxNumPatches, available)
+            )
+            patchGrid = imagePatchGrid(
+                width: image.width,
+                height: image.height,
+                patchSize: config.patchSize,
+                minimumPatches: config.minNumPatches,
+                budget: budget
+            )
+        }
+
+        let targetWidth = patchGrid.width * config.patchSize
+        let targetHeight = patchGrid.height * config.patchSize
+        let pixels = bicubicResizeRGB(
+            image,
+            targetWidth: targetWidth,
+            targetHeight: targetHeight
+        )
+        var normalized = pixels
+        let pixelCount = targetWidth * targetHeight
+        for pixel in 0..<pixelCount {
+            for channel in 0..<3 {
+                let index = pixel * 3 + channel
+                normalized[index] = (
+                    normalized[index] - config.normalizationMean[channel]
+                ) / config.normalizationStandardDeviation[channel]
+            }
+        }
+        return NemotronOmniPreparedImage(
+            pixelValues: MLXArray(
+                normalized,
+                [1, targetHeight, targetWidth, 3]
+            ).asType(.bfloat16),
+            sourcePatchCount: patchGrid.width * patchGrid.height
+        )
+    }
+
+    static func imagePatchGrid(
+        width: Int,
+        height: Int,
+        patchSize: Int = 16,
+        minimumPatches: Int = 1_024,
+        budget: Int = 13_312
+    ) -> (width: Int, height: Int) {
+        precondition(width > 0 && height > 0 && patchSize > 0 && budget > 0)
+        let closestHeight = (height + patchSize - 1) / patchSize
+        let closestWidth = (width + patchSize - 1) / patchSize
+        let patchCount = max(1, closestHeight * closestWidth)
+        let factor = min(sqrt(Double(budget) / Double(patchCount)), 1)
+        var targetHeight = max(1, Int(floor(factor * Double(closestHeight))))
+        var targetWidth = max(1, Int(floor(factor * Double(closestWidth))))
+
+        if budget > minimumPatches, targetHeight * targetWidth < minimumPatches {
+            let upscale = sqrt(
+                Double(minimumPatches) / Double(max(1, targetHeight * targetWidth))
+            )
+            targetHeight = max(1, Int(ceil(upscale * Double(targetHeight))))
+            targetWidth = max(1, Int(ceil(upscale * Double(targetWidth))))
+        }
+
+        targetHeight = roundedPatchDimension(
+            targetHeight,
+            other: targetWidth,
+            budget: budget
+        )
+        targetWidth = roundedPatchDimension(
+            targetWidth,
+            other: targetHeight,
+            budget: budget
+        )
+        return (targetWidth, targetHeight)
+    }
+
+    static func videoPatchGrid(
+        width: Int,
+        height: Int,
+        targetPatches: Int = 1_024
+    ) -> (width: Int, height: Int) {
+        precondition(width > 0 && height > 0)
+        let aspect = Double(width) / Double(height)
+        var patchHeight = max(1, Int(sqrt(Double(targetPatches) / aspect).rounded()))
+        var patchWidth = max(1, Int(sqrt(Double(targetPatches) * aspect).rounded()))
+        let heightUp = patchHeight + (patchHeight.isMultiple(of: 2) ? 0 : 1)
+        let widthUp = patchWidth + (patchWidth.isMultiple(of: 2) ? 0 : 1)
+        if heightUp * widthUp <= targetPatches {
+            patchHeight = heightUp
+            patchWidth = widthUp
+        } else {
+            patchHeight = max(2, patchHeight - patchHeight % 2)
+            patchWidth = max(2, patchWidth - patchWidth % 2)
+        }
+        return (patchWidth, patchHeight)
+    }
+
+    private static func roundedPatchDimension(
+        _ value: Int,
+        other: Int,
+        budget: Int
+    ) -> Int {
+        let remainder = value % 2
+        guard remainder != 0 else { return value }
+        let increased = value + 1
+        if increased * other <= budget {
+            return increased
+        }
+        return max(2, value - remainder)
+    }
+
+    private static func decode(reference: String) throws -> MediaImage {
+        let trimmed = reference.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            throw NemotronOmniError.unsupportedMedia("image reference is empty")
+        }
+        if trimmed.lowercased().hasPrefix("data:") {
+            guard let comma = trimmed.firstIndex(of: ","),
+                  trimmed[..<comma].lowercased().contains(";base64"),
+                  let data = Data(
+                    base64Encoded: String(trimmed[trimmed.index(after: comma)...]),
+                    options: [.ignoreUnknownCharacters]
+                  ) else {
+                throw NemotronOmniError.unsupportedMedia("invalid base64 image data URL")
+            }
+            return try MediaImageIO.decode(data: data)
+        }
+        if let parsed = URL(string: trimmed), parsed.scheme?.lowercased() == "file" {
+            return try MediaImageIO.decode(parsed)
+        }
+        if let scheme = URL(string: trimmed)?.scheme?.lowercased(),
+           scheme == "http" || scheme == "https" {
+            let data = try Data(contentsOf: URL(string: trimmed)!)
+            return try MediaImageIO.decode(data: data)
+        }
+        return try MediaImageIO.decode(URL(fileURLWithPath: trimmed).standardizedFileURL)
+    }
+
+    /// Separable Keys-cubic resize with antialiasing on reduction. The geometry
+    /// matches PyTorch's align_corners=false media preprocessing contract.
+    private static func bicubicResizeRGB(
+        _ image: MediaImage,
+        targetWidth: Int,
+        targetHeight: Int
+    ) -> [Float] {
+        let horizontal = cubicWeights(source: image.width, target: targetWidth)
+        var intermediate = [Float](
+            repeating: 0,
+            count: image.height * targetWidth * 3
+        )
+        for y in 0..<image.height {
+            for targetX in 0..<targetWidth {
+                let destination = (y * targetWidth + targetX) * 3
+                for (sourceX, weight) in horizontal[targetX] {
+                    let source = (y * image.width + sourceX) * 4
+                    intermediate[destination] += Float(image.rgba8[source]) / 255 * weight
+                    intermediate[destination + 1] += Float(image.rgba8[source + 1]) / 255 * weight
+                    intermediate[destination + 2] += Float(image.rgba8[source + 2]) / 255 * weight
+                }
+            }
+        }
+
+        let vertical = cubicWeights(source: image.height, target: targetHeight)
+        var output = [Float](repeating: 0, count: targetHeight * targetWidth * 3)
+        for targetY in 0..<targetHeight {
+            for (sourceY, weight) in vertical[targetY] {
+                for x in 0..<targetWidth {
+                    let source = (sourceY * targetWidth + x) * 3
+                    let destination = (targetY * targetWidth + x) * 3
+                    output[destination] += intermediate[source] * weight
+                    output[destination + 1] += intermediate[source + 1] * weight
+                    output[destination + 2] += intermediate[source + 2] * weight
+                }
+            }
+        }
+        return output
+    }
+
+    private static func cubicWeights(
+        source: Int,
+        target: Int
+    ) -> [[(index: Int, weight: Float)]] {
+        let scale = Float(source) / Float(target)
+        let filterScale = max(scale, 1)
+        let support = 2 * filterScale
+        return (0..<target).map { destination in
+            let center = scale * (Float(destination) + 0.5)
+            let first = max(0, Int(ceil(center - support - 0.5)))
+            let last = min(source - 1, Int(floor(center + support - 0.5)))
+            var values: [(Int, Float)] = []
+            var total: Float = 0
+            if first <= last {
+                for index in first...last {
+                    let distance = (Float(index) + 0.5 - center) / filterScale
+                    let weight = cubicKernel(distance)
+                    if weight != 0 {
+                        values.append((index, weight))
+                        total += weight
+                    }
+                }
+            }
+            return total == 0 ? values : values.map { ($0.0, $0.1 / total) }
+        }
+    }
+
+    private static func cubicKernel(_ value: Float) -> Float {
+        let distance = abs(value)
+        let coefficient: Float = -0.5
+        if distance < 1 {
+            return ((coefficient + 2) * distance - (coefficient + 3))
+                * distance * distance + 1
+        }
+        if distance < 2 {
+            return (((distance - 5) * distance + 8) * distance - 4) * coefficient
+        }
+        return 0
+    }
+}

--- a/Sources/MereRunCore/NemotronOmni/NemotronOmniLanguageModel.swift
+++ b/Sources/MereRunCore/NemotronOmni/NemotronOmniLanguageModel.swift
@@ -1,0 +1,235 @@
+import MLX
+import MLXNN
+
+/// BF16 routed experts used by the Omni checkpoint. The source checkpoint
+/// publishes one tensor per expert; the loader stacks those tensors lazily so
+/// MLX can issue gather matmuls for only the six selected experts per token.
+final class NemotronOmniExperts: Module {
+    @ModuleInfo(key: "up_proj") var upProjection: Q35SwitchLinear
+    @ModuleInfo(key: "down_proj") var downProjection: Q35SwitchLinear
+
+    init(config: NemotronHConfig) {
+        self._upProjection.wrappedValue = Q35SwitchLinear(
+            weight: MLXArray.zeros(
+                [config.nRoutedExperts, config.moeIntermediateSize, config.hiddenSize],
+                dtype: .bfloat16
+            ),
+            scales: nil,
+            biases: nil,
+            bias: nil,
+            groupSize: 64,
+            bits: 4
+        )
+        self._downProjection.wrappedValue = Q35SwitchLinear(
+            weight: MLXArray.zeros(
+                [config.nRoutedExperts, config.hiddenSize, config.moeIntermediateSize],
+                dtype: .bfloat16
+            ),
+            scales: nil,
+            biases: nil,
+            bias: nil,
+            groupSize: 64,
+            bits: 4
+        )
+        super.init()
+    }
+
+    func callAsFunction(_ input: MLXArray, indices: MLXArray) -> MLXArray {
+        let projected = upProjection(input, indices: indices)
+        let activated = MLX.square(
+            MLX.maximum(projected, MLXArray(0).asType(projected.dtype))
+        )
+        return downProjection(activated, indices: indices)
+    }
+}
+
+final class NemotronOmniSharedExpert: Module {
+    @ModuleInfo(key: "up_proj") var upProjection: Linear
+    @ModuleInfo(key: "down_proj") var downProjection: Linear
+
+    init(config: NemotronHConfig) {
+        self._upProjection.wrappedValue = Linear(
+            config.hiddenSize,
+            config.sharedExpertIntermediateSize,
+            bias: false
+        )
+        self._downProjection.wrappedValue = Linear(
+            config.sharedExpertIntermediateSize,
+            config.hiddenSize,
+            bias: false
+        )
+        super.init()
+    }
+
+    func callAsFunction(_ input: MLXArray) -> MLXArray {
+        let projected = upProjection(input)
+        let activated = MLX.square(
+            MLX.maximum(projected, MLXArray(0).asType(projected.dtype))
+        )
+        return downProjection(activated)
+    }
+}
+
+final class NemotronOmniMoE: NemotronHMixer {
+    @ModuleInfo(key: "gate") var gate: NemotronHRouter
+    @ModuleInfo(key: "experts") var experts: NemotronOmniExperts
+    @ModuleInfo(key: "shared_experts") var sharedExperts: NemotronOmniSharedExpert
+
+    init(config: NemotronHConfig) {
+        self._gate.wrappedValue = NemotronHRouter(config: config)
+        self._experts.wrappedValue = NemotronOmniExperts(config: config)
+        self._sharedExperts.wrappedValue = NemotronOmniSharedExpert(config: config)
+        super.init()
+    }
+
+    override func callAsFunction(
+        _ input: MLXArray,
+        cache: NemotronHLayerCache?
+    ) -> MLXArray {
+        let route = gate(input)
+        let routed = (
+            experts(input, indices: route.indices)
+                * route.weights.expandedDimensions(axis: -1)
+        ).sum(axis: -2)
+        return routed + sharedExperts(input)
+    }
+}
+
+final class NemotronOmniLanguageBlock: Module {
+    @ModuleInfo(key: "norm") var norm: RMSNorm
+    @ModuleInfo(key: "mixer") var mixer: NemotronHMixer
+
+    init(config: NemotronHConfig, blockType: String) {
+        self._norm.wrappedValue = RMSNorm(
+            dimensions: config.hiddenSize,
+            eps: config.normEps
+        )
+        switch blockType {
+        case "mamba": self._mixer.wrappedValue = NemotronHMamba(config: config)
+        case "attention": self._mixer.wrappedValue = NemotronHAttention(config: config)
+        case "moe": self._mixer.wrappedValue = NemotronOmniMoE(config: config)
+        default: preconditionFailure("Unknown Nemotron Omni block type: \(blockType)")
+        }
+        super.init()
+    }
+
+    func callAsFunction(
+        _ input: MLXArray,
+        cache: NemotronHLayerCache?
+    ) -> MLXArray {
+        input + mixer(norm(input), cache: cache)
+    }
+}
+
+final class NemotronOmniLanguageBackbone: Module {
+    @ModuleInfo(key: "embeddings") var embeddings: Embedding
+    @ModuleInfo(key: "layers") var layers: [NemotronOmniLanguageBlock]
+    @ModuleInfo(key: "norm_f") var finalNorm: RMSNorm
+
+    init(config: NemotronHConfig) {
+        self._embeddings.wrappedValue = Embedding(
+            embeddingCount: config.vocabSize,
+            dimensions: config.hiddenSize
+        )
+        self._layers.wrappedValue = config.layersBlockType.map {
+            NemotronOmniLanguageBlock(config: config, blockType: $0)
+        }
+        self._finalNorm.wrappedValue = RMSNorm(
+            dimensions: config.hiddenSize,
+            eps: config.normEps
+        )
+        super.init()
+    }
+
+    func inputEmbeddings(_ inputIDs: MLXArray) -> MLXArray {
+        embeddings(inputIDs.dtype == .int32 ? inputIDs : inputIDs.asType(.int32))
+    }
+
+    func callAsFunction(
+        embeddings inputEmbeddings: MLXArray,
+        cache: [NemotronHLayerCache?]?,
+        evaluateEachLayer: Bool = false
+    ) -> MLXArray {
+        precondition(cache == nil || cache?.count == layers.count)
+        var hidden = inputEmbeddings
+        for (index, layer) in layers.enumerated() {
+            hidden = layer(hidden, cache: cache?[index] ?? nil)
+            if evaluateEachLayer {
+                // A full 30B BF16 prefill graph can exceed the macOS Metal
+                // watchdog while paging external expert weights. Layer-wise
+                // barriers bound each command buffer without slowing the
+                // one-token fused decode path.
+                MLX.eval(hidden)
+            }
+        }
+        return finalNorm(hidden)
+    }
+}
+
+public final class NemotronOmniCausalLM: Module, @unchecked Sendable {
+    @ModuleInfo(key: "backbone") var backbone: NemotronOmniLanguageBackbone
+    @ModuleInfo(key: "lm_head") var lmHead: Linear
+
+    let config: NemotronHConfig
+
+    init(config: NemotronHConfig) {
+        self.config = config
+        self._backbone.wrappedValue = NemotronOmniLanguageBackbone(config: config)
+        self._lmHead.wrappedValue = Linear(config.hiddenSize, config.vocabSize, bias: false)
+        super.init()
+    }
+
+    func inputEmbeddings(_ inputIDs: MLXArray) -> MLXArray {
+        backbone.inputEmbeddings(inputIDs)
+    }
+
+    func forward(
+        embeddings: MLXArray,
+        cache: [NemotronHLayerCache?]?,
+        evaluateEachLayer: Bool = false
+    ) -> (hidden: MLXArray, logits: MLXArray) {
+        let hidden = backbone(
+            embeddings: embeddings,
+            cache: cache,
+            evaluateEachLayer: evaluateEachLayer
+        )
+        return (hidden, lmHead(hidden))
+    }
+
+    func prefill(
+        _ inputIDs: MLXArray,
+        cache: [NemotronHLayerCache?]
+    ) -> MLXArray {
+        prefill(embeddings: inputEmbeddings(inputIDs), cache: cache)
+    }
+
+    func prefill(
+        embeddings: MLXArray,
+        cache: [NemotronHLayerCache?]
+    ) -> MLXArray {
+        let output = forward(
+            embeddings: embeddings,
+            cache: cache,
+            evaluateEachLayer: embeddings.dim(1) > 1
+        ).logits
+        let finalPosition = output.dim(1) - 1
+        return output[0..., finalPosition..., 0...]
+    }
+
+    func lastPositionLogits(
+        _ inputIDs: MLXArray,
+        cache: [NemotronHLayerCache?]
+    ) -> MLXArray {
+        prefill(inputIDs, cache: cache)
+    }
+
+    func makeCache() -> [NemotronHLayerCache?] {
+        config.layersBlockType.map { type in
+            switch type {
+            case "mamba": .mamba(NemotronHMambaCache())
+            case "attention": .attention(Gemma4FullKVCache())
+            default: nil
+            }
+        }
+    }
+}

--- a/Sources/MereRunCore/NemotronOmni/NemotronOmniModelLoader.swift
+++ b/Sources/MereRunCore/NemotronOmni/NemotronOmniModelLoader.swift
@@ -1,0 +1,225 @@
+import Foundation
+import MLX
+import MLXNN
+
+struct NemotronOmniLoadedModel: @unchecked Sendable {
+    let model: NemotronOmniCausalLM
+    let visionTower: NemotronOmniVisionTower
+    let soundTower: NemotronOmniSoundTower
+    let tokenizer: Q35TokenizerAndTemplate
+    let config: NemotronOmniConfig
+    let preprocessorConfig: NemotronOmniPreprocessorConfig
+    let rootURL: URL
+}
+
+struct NemotronOmniExpertWeightKey: Equatable, Sendable {
+    enum Projection: String, Sendable {
+        case up = "up_proj"
+        case down = "down_proj"
+    }
+
+    let layer: Int
+    let expert: Int
+    let projection: Projection
+
+    init?(checkpointKey: String) {
+        let parts = checkpointKey.split(separator: ".").map(String.init)
+        guard parts.count == 9,
+              parts[0] == "language_model",
+              parts[1] == "backbone",
+              parts[2] == "layers",
+              let layer = Int(parts[3]),
+              parts[4] == "mixer",
+              parts[5] == "experts",
+              let expert = Int(parts[6]),
+              let projection = Projection(rawValue: parts[7]),
+              parts[8] == "weight" else {
+            return nil
+        }
+        self.layer = layer
+        self.expert = expert
+        self.projection = projection
+    }
+}
+
+enum NemotronOmniModelLoader {
+    static func load(
+        rootURL: URL,
+        maxContextLength: Int,
+        progressHandler: (@Sendable (ChatProgress) -> Void)?
+    ) async throws -> NemotronOmniLoadedModel {
+        let rootURL = rootURL.standardizedFileURL
+        let missing = NemotronOmniResources.missingTargetFiles(rootURL: rootURL)
+        guard missing.isEmpty else {
+            throw NemotronOmniError.missingFiles(missing.map(\.lastPathComponent))
+        }
+
+        progressHandler?(ChatProgress(stage: .loadingModel, message: "Loading Nemotron Omni config"))
+        let config = try JSONDecoder().decode(
+            NemotronOmniConfig.self,
+            from: Data(contentsOf: rootURL.appendingPathComponent("config.json"))
+        )
+        let preprocessorConfig = try JSONDecoder().decode(
+            NemotronOmniPreprocessorConfig.self,
+            from: Data(contentsOf: rootURL.appendingPathComponent("preprocessor_config.json"))
+        )
+        progressHandler?(ChatProgress(stage: .loadingModel, message: "Loading Nemotron Omni tokenizer"))
+        let tokenizer = try Q35TokenizerAndTemplate.load(
+            from: rootURL,
+            maxLengthOverride: min(maxContextLength, config.maximumSequenceLength)
+        )
+        let model = NemotronOmniCausalLM(config: config.language.runtimeConfig)
+        let visionTower = NemotronOmniVisionTower(config: config)
+        let soundTower = NemotronOmniSoundTower(config: config)
+        let expertPack: URL
+        if let existing = NemotronOmniExpertPack.optimizedURLIfValid(rootURL: rootURL) {
+            expertPack = existing
+        } else {
+            progressHandler?(ChatProgress(
+                stage: .loadingModel,
+                message: "Preparing the native Nemotron Omni BF16 expert cache"
+            ))
+            expertPack = try NemotronOmniExpertPack.optimize(
+                rootURL: rootURL,
+                progressHandler: { completed, total in
+                    let percent = Int((Double(completed) / Double(total)) * 100)
+                    progressHandler?(ChatProgress(
+                        stage: .loadingModel,
+                        message: "Packing Nemotron Omni experts \(percent)%"
+                    ))
+                }
+            )
+        }
+        try loadWeights(
+            indexURL: rootURL.appendingPathComponent("model.safetensors.index.json"),
+            model: model,
+            visionTower: visionTower,
+            soundTower: soundTower,
+            expertPackURL: expertPack,
+            progressHandler: progressHandler
+        )
+        return NemotronOmniLoadedModel(
+            model: model,
+            visionTower: visionTower,
+            soundTower: soundTower,
+            tokenizer: tokenizer,
+            config: config,
+            preprocessorConfig: preprocessorConfig,
+            rootURL: rootURL
+        )
+    }
+
+    private static func loadWeights(
+        indexURL: URL,
+        model: NemotronOmniCausalLM,
+        visionTower: NemotronOmniVisionTower,
+        soundTower: NemotronOmniSoundTower,
+        expertPackURL: URL,
+        progressHandler: (@Sendable (ChatProgress) -> Void)?
+    ) throws {
+        let index = try JSONDecoder().decode(
+            HFSafetensorsIndex.self,
+            from: Data(contentsOf: indexURL)
+        )
+        let root = indexURL.deletingLastPathComponent()
+        for (shardIndex, filename) in index.shardFilenames.enumerated() {
+            let shardURL = root.appendingPathComponent(filename)
+            let arrays = try MLX.loadArrays(url: shardURL)
+            var languageUpdates: [(String, MLXArray)] = []
+            var visionUpdates: [(String, MLXArray)] = []
+            var soundUpdates: [(String, MLXArray)] = []
+            for (key, value) in arrays where key.hasPrefix("language_model.") {
+                if NemotronOmniExpertWeightKey(checkpointKey: key) != nil {
+                    continue
+                }
+                let mappedKey = String(key.dropFirst("language_model.".count))
+                let mappedValue: MLXArray
+                if mappedKey.hasSuffix(".mixer.conv1d.weight"), value.ndim == 3 {
+                    mappedValue = value.transposed(0, 2, 1)
+                } else {
+                    mappedValue = value
+                }
+                languageUpdates.append((mappedKey, mappedValue))
+            }
+            for (key, value) in arrays {
+                if key.hasPrefix("vision_model.radio_model.model.") {
+                    var mappedKey = "model." + String(
+                        key.dropFirst("vision_model.radio_model.model.".count)
+                    )
+                    mappedKey = mappedKey.replacingOccurrences(
+                        of: "patch_generator.cls_token.token",
+                        with: "patch_generator.class_token"
+                    )
+                    visionUpdates.append((mappedKey, value))
+                } else if key.hasPrefix("mlp1.") {
+                    let suffix = String(key.dropFirst("mlp1.".count))
+                    let mappedKey: String
+                    switch suffix {
+                    case "0.weight": mappedKey = "projector.norm.weight"
+                    case "1.weight": mappedKey = "projector.linear1.weight"
+                    case "3.weight": mappedKey = "projector.linear2.weight"
+                    default: continue
+                    }
+                    visionUpdates.append((mappedKey, value))
+                }
+            }
+            for (key, value) in arrays where !key.contains("num_batches_tracked") {
+                let mappedKey: String
+                if key.hasPrefix("sound_encoder.encoder.feature_extractor.") {
+                    continue
+                } else if key.hasPrefix("sound_encoder.") {
+                    mappedKey = String(key.dropFirst("sound_encoder.".count))
+                } else if key.hasPrefix("sound_projection.") {
+                    mappedKey = "projection." + String(
+                        key.dropFirst("sound_projection.".count)
+                    )
+                } else {
+                    continue
+                }
+                let mappedValue: MLXArray
+                if value.ndim == 3,
+                   mappedKey.contains(".conv.") {
+                    mappedValue = value.transposed(0, 2, 1)
+                } else if value.ndim == 4,
+                          mappedKey.hasPrefix("encoder.subsampling.layers.") {
+                    mappedValue = value.transposed(0, 2, 3, 1)
+                } else {
+                    mappedValue = value
+                }
+                soundUpdates.append((mappedKey, mappedValue))
+            }
+            if !languageUpdates.isEmpty {
+                try model.update(
+                    parameters: ModuleParameters.unflattened(languageUpdates),
+                    verify: .shapeMismatch
+                )
+            }
+            if !visionUpdates.isEmpty {
+                try visionTower.update(
+                    parameters: ModuleParameters.unflattened(visionUpdates),
+                    verify: .shapeMismatch
+                )
+            }
+            if !soundUpdates.isEmpty {
+                try soundTower.update(
+                    parameters: ModuleParameters.unflattened(soundUpdates),
+                    verify: .shapeMismatch
+                )
+            }
+            progressHandler?(ChatProgress(
+                stage: .loadingModel,
+                message: "Loading Nemotron Omni language shard \(shardIndex + 1)/\(index.shardFilenames.count)"
+            ))
+        }
+
+        try HFSafetensorsWeightsLoader.applyWeights(
+            url: expertPackURL,
+            to: model,
+            dtype: nil,
+            verify: .shapeMismatch
+        )
+        model.train(false)
+        visionTower.train(false)
+        soundTower.train(false)
+    }
+}

--- a/Sources/MereRunCore/NemotronOmni/NemotronOmniResources.swift
+++ b/Sources/MereRunCore/NemotronOmni/NemotronOmniResources.swift
@@ -1,0 +1,174 @@
+import Foundation
+
+public enum NemotronOmniError: LocalizedError {
+    case modelPathRequired
+    case missingFiles([String])
+    case invalidWeights(String)
+    case unsupportedMedia(String)
+    case generationFailed(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .modelPathRequired:
+            "Nemotron 3 Nano Omni requires the installed BF16 model or an explicit model path."
+        case .missingFiles(let files):
+            "Nemotron 3 Nano Omni is missing required files: \(files.joined(separator: ", "))."
+        case .invalidWeights(let message):
+            "Nemotron 3 Nano Omni checkpoint weights are incompatible: \(message)"
+        case .unsupportedMedia(let message):
+            "Nemotron 3 Nano Omni media input is unsupported: \(message)"
+        case .generationFailed(let message):
+            "Nemotron 3 Nano Omni generation failed: \(message)"
+        }
+    }
+}
+
+/// Pinned artifacts and runtime limits for NVIDIA Nemotron 3 Nano Omni.
+///
+/// The upstream repository contains executable Python reference code. mere.run
+/// downloads it only as provenance for the published checkpoint contract; the
+/// native runtime never imports or executes repository code.
+public enum NemotronOmniResources {
+    public static let modelID = "omni-chat-nemotron3-nano-30b-a3b-bf16"
+    public static let upstreamRepoID =
+        "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16"
+    public static let upstreamRevision = "24e67ea000b7c2837fc8f9488aa2008524fac8ba"
+    public static let estimatedDownloadBytes: Int64 = 66_059_015_328
+    public static let checkpointWeightBytes: Int64 = 66_031_270_520
+    public static let checkpointShardCount = 17
+    public static let packedExpertWeightBytes: Int64 = 58_749_616_128
+
+    /// The composed checkpoint advertises 131,072 tokens even though the
+    /// underlying Nemotron-H text backbone has 262,144 positional slots.
+    public static let defaultContextLength = 32_768
+    public static let maximumContextLength = 131_072
+    public static let maximumOutputTokens = 20_480
+    public static let maximumVideoDurationSeconds = 120
+    public static let maximumAudioDurationSeconds = 3_600
+    public static let audioSampleRate = 16_000
+    public static let maximumVideoFrames1080p = 128
+    public static let maximumVideoFrames720p = 256
+
+    public static let thinkingTemperature = 0.6
+    public static let thinkingTopP = 0.95
+    public static let instructTemperature = 0.2
+    public static let instructTopK = 1
+
+    public static let snapshotPatterns = [
+        "README.md",
+        "bias.md",
+        "explainability.md",
+        "privacy.md",
+        "safety.md",
+        "chat_template.jinja",
+        "config.json",
+        "generation_config.json",
+        "preprocessor_config.json",
+        "special_tokens_map.json",
+        "tokenizer.json",
+        "tokenizer_config.json",
+        "model.safetensors.index.json",
+        "model-*.safetensors",
+        // Reference implementation files are retained for pinned provenance.
+        "__init__.py",
+        "audio_model.py",
+        "configuration.py",
+        "configuration_nemotron_h.py",
+        "configuration_radio.py",
+        "evs.py",
+        "image_processing.py",
+        "modeling.py",
+        "modeling_nemotron_h.py",
+        "processing.py",
+        "processing_utils.py",
+        "video_io.py",
+        "video_processing.py",
+    ]
+
+    public static func handles(modelSpec raw: String) -> Bool {
+        let normalized = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let localName = URL(fileURLWithPath: normalized).lastPathComponent
+        return normalized == modelID
+            || normalized == upstreamRepoID.lowercased()
+            || localName == upstreamRepoID.split(separator: "/").last?.lowercased()
+    }
+
+    public static func missingTargetFiles(
+        rootURL: URL,
+        fileManager: FileManager = .default
+    ) -> [URL] {
+        let required = [
+            "README.md",
+            "chat_template.jinja",
+            "config.json",
+            "generation_config.json",
+            "preprocessor_config.json",
+            "tokenizer.json",
+            "tokenizer_config.json",
+            "model.safetensors.index.json",
+        ]
+        var missing = required.map { rootURL.appendingPathComponent($0) }
+            .filter { !fileManager.fileExists(atPath: $0.path) }
+        let indexURL = rootURL.appendingPathComponent("model.safetensors.index.json")
+        guard fileManager.fileExists(atPath: indexURL.path),
+              let index = try? JSONDecoder().decode(
+                HFSafetensorsIndex.self,
+                from: Data(contentsOf: indexURL)
+              ) else {
+            return missing
+        }
+        missing += index.shardFilenames.map { rootURL.appendingPathComponent($0) }
+            .filter { !fileManager.fileExists(atPath: $0.path) }
+        return missing
+    }
+
+    public static func validationMessages(
+        rootURL: URL,
+        fileManager: FileManager = .default
+    ) -> [String] {
+        let missing = missingTargetFiles(rootURL: rootURL, fileManager: fileManager)
+        guard missing.isEmpty else {
+            return missing.map { "Missing required file: \($0.path)" }
+        }
+
+        var messages: [String] = []
+        do {
+            _ = try JSONDecoder().decode(
+                NemotronOmniConfig.self,
+                from: Data(contentsOf: rootURL.appendingPathComponent("config.json"))
+            )
+        } catch {
+            messages.append("Invalid pinned Nemotron Omni config.json: \(error.localizedDescription)")
+        }
+        do {
+            _ = try JSONDecoder().decode(
+                NemotronOmniPreprocessorConfig.self,
+                from: Data(contentsOf: rootURL.appendingPathComponent("preprocessor_config.json"))
+            )
+        } catch {
+            messages.append(
+                "Invalid pinned Nemotron Omni preprocessor_config.json: \(error.localizedDescription)"
+            )
+        }
+        do {
+            let index = try JSONDecoder().decode(
+                HFSafetensorsIndex.self,
+                from: Data(contentsOf: rootURL.appendingPathComponent("model.safetensors.index.json"))
+            )
+            let expectedShards = (1...checkpointShardCount).map {
+                String(format: "model-%05d-of-%05d.safetensors", $0, checkpointShardCount)
+            }
+            guard index.metadata?.totalSize == checkpointWeightBytes,
+                  index.shardFilenames == expectedShards else {
+                messages.append(
+                    "Safetensors index does not match the pinned 17-shard, "
+                        + "\(checkpointWeightBytes)-byte checkpoint contract."
+                )
+                return messages
+            }
+        } catch {
+            messages.append("Invalid pinned Nemotron Omni safetensors index: \(error.localizedDescription)")
+        }
+        return messages
+    }
+}

--- a/Sources/MereRunCore/NemotronOmni/NemotronOmniSoundModel.swift
+++ b/Sources/MereRunCore/NemotronOmni/NemotronOmniSoundModel.swift
@@ -1,0 +1,411 @@
+import Foundation
+import MLX
+import MLXFast
+import MLXNN
+
+final class NemotronOmniSoundFeedForward: Module {
+    @ModuleInfo(key: "linear1") var first: Linear
+    @ModuleInfo(key: "linear2") var second: Linear
+
+    init(config: NemotronOmniSoundConfig) {
+        self._first.wrappedValue = Linear(config.hiddenSize, config.intermediateSize, bias: false)
+        self._second.wrappedValue = Linear(config.intermediateSize, config.hiddenSize, bias: false)
+        super.init()
+    }
+
+    func callAsFunction(_ input: MLXArray) -> MLXArray {
+        second(silu(first(input)))
+    }
+}
+
+final class NemotronOmniSoundAttention: Module {
+    @ModuleInfo(key: "q_proj") var queryProjection: Linear
+    @ModuleInfo(key: "k_proj") var keyProjection: Linear
+    @ModuleInfo(key: "v_proj") var valueProjection: Linear
+    @ModuleInfo(key: "o_proj") var outputProjection: Linear
+    @ModuleInfo(key: "relative_k_proj") var relativeKeyProjection: Linear
+    @ParameterInfo(key: "bias_u") var contentBias: MLXArray
+    @ParameterInfo(key: "bias_v") var positionBias: MLXArray
+
+    private let headCount: Int
+    private let headDimension: Int
+    private let scale: Float
+
+    init(config: NemotronOmniSoundConfig) {
+        self.headCount = config.numAttentionHeads
+        self.headDimension = config.hiddenSize / config.numAttentionHeads
+        self.scale = 1 / Float(Double(headDimension).squareRoot())
+        self._queryProjection.wrappedValue = Linear(config.hiddenSize, config.hiddenSize, bias: false)
+        self._keyProjection.wrappedValue = Linear(config.hiddenSize, config.hiddenSize, bias: false)
+        self._valueProjection.wrappedValue = Linear(config.hiddenSize, config.hiddenSize, bias: false)
+        self._outputProjection.wrappedValue = Linear(config.hiddenSize, config.hiddenSize, bias: false)
+        self._relativeKeyProjection.wrappedValue = Linear(config.hiddenSize, config.hiddenSize, bias: false)
+        self._contentBias.wrappedValue = MLX.zeros(
+            [config.numAttentionHeads, headDimension],
+            dtype: .bfloat16
+        )
+        self._positionBias.wrappedValue = MLX.zeros(
+            [config.numAttentionHeads, headDimension],
+            dtype: .bfloat16
+        )
+        super.init()
+    }
+
+    func callAsFunction(
+        _ input: MLXArray,
+        positionEmbeddings: MLXArray,
+        validLength: Int
+    ) -> MLXArray {
+        let batch = input.dim(0)
+        let sequence = input.dim(1)
+        let queries = queryProjection(input)
+            .reshaped(batch, sequence, headCount, headDimension)
+        let keys = keyProjection(input)
+            .reshaped(batch, sequence, headCount, headDimension)
+            .transposed(0, 2, 1, 3)
+        let values = valueProjection(input)
+            .reshaped(batch, sequence, headCount, headDimension)
+            .transposed(0, 2, 1, 3)
+        let queryContent = (
+            queries + contentBias.reshaped(1, 1, headCount, headDimension)
+        ).transposed(0, 2, 1, 3)
+        let queryPosition = (
+            queries + positionBias.reshaped(1, 1, headCount, headDimension)
+        ).transposed(0, 2, 1, 3)
+        let relativeKeys = relativeKeyProjection(positionEmbeddings)
+            .reshaped(batch, positionEmbeddings.dim(1), headCount, headDimension)
+            .transposed(0, 2, 1, 3)
+        var relativeBias = MLX.matmul(
+            queryPosition,
+            relativeKeys.transposed(0, 1, 3, 2)
+        )
+        relativeBias = relativeShift(relativeBias)[0..., 0..., 0..., 0..<sequence] * scale
+        if validLength < sequence {
+            let valid = MLXArray((0..<sequence).map { $0 < validLength })
+            let allowed = valid.reshaped(1, 1, sequence, 1)
+                .&& valid.reshaped(1, 1, 1, sequence)
+            relativeBias = MLX.where(
+                allowed,
+                relativeBias,
+                MLXArray(-1e9).asType(relativeBias.dtype)
+            )
+        }
+        let attended = MLXFast.scaledDotProductAttention(
+            queries: queryContent,
+            keys: keys,
+            values: values,
+            scale: scale,
+            mask: .array(relativeBias)
+        )
+        return outputProjection(
+            attended.transposed(0, 2, 1, 3)
+                .reshaped(batch, sequence, headCount * headDimension)
+        )
+    }
+
+    private func relativeShift(_ input: MLXArray) -> MLXArray {
+        let batch = input.dim(0)
+        let heads = input.dim(1)
+        let queryLength = input.dim(2)
+        let positionLength = input.dim(3)
+        let padding = MLX.zeros([batch, heads, queryLength, 1], dtype: input.dtype)
+        return MLX.concatenated([padding, input], axis: 3)
+            .reshaped(batch, heads, positionLength + 1, queryLength)[
+                0..., 0..., 1..<(positionLength + 1), 0...
+            ]
+            .reshaped(batch, heads, queryLength, positionLength)
+    }
+}
+
+final class NemotronOmniSoundConvolution: Module {
+    @ModuleInfo(key: "pointwise_conv1") var firstPointwise: Conv1d
+    @ModuleInfo(key: "depthwise_conv") var depthwise: Conv1d
+    @ModuleInfo(key: "norm") var norm: BatchNorm
+    @ModuleInfo(key: "pointwise_conv2") var secondPointwise: Conv1d
+
+    init(config: NemotronOmniSoundConfig) {
+        self._firstPointwise.wrappedValue = Conv1d(
+            inputChannels: config.hiddenSize,
+            outputChannels: config.hiddenSize * 2,
+            kernelSize: 1,
+            bias: false
+        )
+        self._depthwise.wrappedValue = Conv1d(
+            inputChannels: config.hiddenSize,
+            outputChannels: config.hiddenSize,
+            kernelSize: config.convKernelSize,
+            padding: (config.convKernelSize - 1) / 2,
+            groups: config.hiddenSize,
+            bias: false
+        )
+        self._norm.wrappedValue = BatchNorm(featureCount: config.hiddenSize)
+        self._secondPointwise.wrappedValue = Conv1d(
+            inputChannels: config.hiddenSize,
+            outputChannels: config.hiddenSize,
+            kernelSize: 1,
+            bias: false
+        )
+        super.init()
+    }
+
+    func callAsFunction(_ input: MLXArray, validLength: Int) -> MLXArray {
+        var hidden = firstPointwise(input)
+        hidden = glu(hidden, axis: -1)
+        hidden = maskPadding(hidden, validLength: validLength)
+        hidden = depthwise(hidden)
+        hidden = norm(hidden)
+        hidden = silu(hidden)
+        return secondPointwise(hidden)
+    }
+
+    private func maskPadding(_ input: MLXArray, validLength: Int) -> MLXArray {
+        guard validLength < input.dim(1) else { return input }
+        let mask = MLXArray((0..<input.dim(1)).map { $0 < validLength ? Float(1) : 0 })
+            .reshaped(1, input.dim(1), 1)
+            .asType(input.dtype)
+        return input * mask
+    }
+}
+
+final class NemotronOmniSoundBlock: Module {
+    @ModuleInfo(key: "feed_forward1") var firstFeedForward: NemotronOmniSoundFeedForward
+    @ModuleInfo(key: "self_attn") var attention: NemotronOmniSoundAttention
+    @ModuleInfo(key: "conv") var convolution: NemotronOmniSoundConvolution
+    @ModuleInfo(key: "feed_forward2") var secondFeedForward: NemotronOmniSoundFeedForward
+    @ModuleInfo(key: "norm_feed_forward1") var firstFeedForwardNorm: LayerNorm
+    @ModuleInfo(key: "norm_self_att") var attentionNorm: LayerNorm
+    @ModuleInfo(key: "norm_conv") var convolutionNorm: LayerNorm
+    @ModuleInfo(key: "norm_feed_forward2") var secondFeedForwardNorm: LayerNorm
+    @ModuleInfo(key: "norm_out") var outputNorm: LayerNorm
+
+    init(config: NemotronOmniSoundConfig) {
+        self._firstFeedForward.wrappedValue = NemotronOmniSoundFeedForward(config: config)
+        self._attention.wrappedValue = NemotronOmniSoundAttention(config: config)
+        self._convolution.wrappedValue = NemotronOmniSoundConvolution(config: config)
+        self._secondFeedForward.wrappedValue = NemotronOmniSoundFeedForward(config: config)
+        self._firstFeedForwardNorm.wrappedValue = LayerNorm(dimensions: config.hiddenSize)
+        self._attentionNorm.wrappedValue = LayerNorm(dimensions: config.hiddenSize)
+        self._convolutionNorm.wrappedValue = LayerNorm(dimensions: config.hiddenSize)
+        self._secondFeedForwardNorm.wrappedValue = LayerNorm(dimensions: config.hiddenSize)
+        self._outputNorm.wrappedValue = LayerNorm(dimensions: config.hiddenSize)
+        super.init()
+    }
+
+    func callAsFunction(
+        _ input: MLXArray,
+        positionEmbeddings: MLXArray,
+        validLength: Int
+    ) -> MLXArray {
+        var hidden = input + 0.5 * firstFeedForward(firstFeedForwardNorm(input))
+        hidden = hidden + attention(
+            attentionNorm(hidden),
+            positionEmbeddings: positionEmbeddings,
+            validLength: validLength
+        )
+        hidden = hidden + convolution(convolutionNorm(hidden), validLength: validLength)
+        hidden = hidden + 0.5 * secondFeedForward(secondFeedForwardNorm(hidden))
+        return outputNorm(hidden)
+    }
+}
+
+final class NemotronOmniSoundSubsampling: Module {
+    @ModuleInfo(key: "layers") var layers: [Module]
+    @ModuleInfo(key: "linear") var linear: Linear
+
+    private let layerCount = 3
+
+    init(config: NemotronOmniSoundConfig) {
+        let channels = config.subsamplingConvChannels
+        self._layers.wrappedValue = [
+            Conv2d(
+                inputChannels: 1,
+                outputChannels: channels,
+                kernelSize: 3,
+                stride: 2,
+                padding: 1,
+                bias: true
+            ),
+            Identity(),
+            Conv2d(
+                inputChannels: channels,
+                outputChannels: channels,
+                kernelSize: 3,
+                stride: 2,
+                padding: 1,
+                groups: channels,
+                bias: true
+            ),
+            Conv2d(
+                inputChannels: channels,
+                outputChannels: channels,
+                kernelSize: 1,
+                bias: true
+            ),
+            Identity(),
+            Conv2d(
+                inputChannels: channels,
+                outputChannels: channels,
+                kernelSize: 3,
+                stride: 2,
+                padding: 1,
+                groups: channels,
+                bias: true
+            ),
+            Conv2d(
+                inputChannels: channels,
+                outputChannels: channels,
+                kernelSize: 1,
+                bias: true
+            ),
+        ]
+        self._linear.wrappedValue = Linear(channels * (config.numMelBins / 8), config.hiddenSize)
+        super.init()
+    }
+
+    func callAsFunction(_ input: MLXArray, validLength: Int) -> (MLXArray, Int) {
+        var hidden = input.expandedDimensions(axis: -1)
+        var currentValidLength = validLength
+        for (index, module) in layers.enumerated() {
+            if let convolution = module as? Conv2d {
+                hidden = convolution(hidden)
+                if index == 0 || index == 2 || index == 5 {
+                    currentValidLength = (currentValidLength + 1) / 2
+                }
+                hidden = maskPadding(hidden, validLength: currentValidLength)
+            }
+            if index == 0 || index == 3 || index == 6 {
+                hidden = relu(hidden)
+            }
+        }
+        let batch = hidden.dim(0)
+        let time = hidden.dim(1)
+        // PyTorch's reference path is NCTF -> NT(CF) before the
+        // subsampling projection. MLX Conv2d is NHWC, so transpose the
+        // channel axis ahead of frequency before flattening.
+        hidden = hidden.transposed(0, 1, 3, 2)
+        return (
+            linear(hidden.reshaped(batch, time, hidden.dim(2) * hidden.dim(3))),
+            currentValidLength
+        )
+    }
+
+    private func maskPadding(_ input: MLXArray, validLength: Int) -> MLXArray {
+        guard validLength < input.dim(1) else { return input }
+        let mask = MLXArray((0..<input.dim(1)).map { $0 < validLength ? Float(1) : 0 })
+            .reshaped(1, input.dim(1), 1, 1)
+            .asType(input.dtype)
+        return input * mask
+    }
+}
+
+final class NemotronOmniSoundEncoder: Module {
+    @ModuleInfo(key: "subsampling") var subsampling: NemotronOmniSoundSubsampling
+    @ModuleInfo(key: "layers") var layers: [NemotronOmniSoundBlock]
+
+    private let hiddenSize: Int
+
+    init(config: NemotronOmniSoundConfig) {
+        self.hiddenSize = config.hiddenSize
+        self._subsampling.wrappedValue = NemotronOmniSoundSubsampling(config: config)
+        self._layers.wrappedValue = (0..<config.numHiddenLayers).map { _ in
+            NemotronOmniSoundBlock(config: config)
+        }
+        super.init()
+    }
+
+    func callAsFunction(
+        _ input: MLXArray,
+        validFrameCount: Int,
+        layerProgress: (@Sendable (Int, Int) -> Void)? = nil
+    ) -> MLXArray {
+        var (hidden, validLength) = subsampling(input, validLength: validFrameCount)
+        MLX.eval(hidden)
+        layerProgress?(0, layers.count)
+        let positions = relativePositions(length: hidden.dim(1), dtype: hidden.dtype)
+        for (index, layer) in layers.enumerated() {
+            hidden = layer(
+                hidden,
+                positionEmbeddings: positions,
+                validLength: validLength
+            )
+            // Keep the 24-block conformer from becoming a single oversized
+            // lazy Metal graph. Layer boundaries are also a useful memory
+            // reclamation point for long recordings.
+            MLX.eval(hidden)
+            layerProgress?(index + 1, layers.count)
+        }
+        return hidden
+    }
+
+    private func relativePositions(length: Int, dtype: DType) -> MLXArray {
+        let half = hiddenSize / 2
+        let positions = MLXArray(
+            (-(length - 1)...(length - 1)).reversed().map(Float.init)
+        ).reshaped(1, 2 * length - 1, 1)
+        let logIncrement = logf(10_000) / Float(max(1, half))
+        let inverseValues: [Float] = (0..<half).map { index in
+            expf(-Float(index) * logIncrement)
+        }
+        let inverse = MLXArray(inverseValues).reshaped(1, 1, half)
+        let angles = positions * inverse
+        return MLX.stacked([sin(angles), cos(angles)], axis: -1)
+            .reshaped(1, 2 * length - 1, hiddenSize)
+            .asType(dtype)
+    }
+}
+
+final class NemotronOmniSoundProjection: Module {
+    @ModuleInfo(key: "norm") var norm: RMSNorm
+    @ModuleInfo(key: "linear1") var first: Linear
+    @ModuleInfo(key: "linear2") var second: Linear
+
+    init(config: NemotronOmniConfig) {
+        self._norm.wrappedValue = RMSNorm(dimensions: config.sound.hiddenSize, eps: 1e-5)
+        self._first.wrappedValue = Linear(
+            config.sound.hiddenSize,
+            config.sound.projectionHiddenSize,
+            bias: false
+        )
+        self._second.wrappedValue = Linear(
+            config.sound.projectionHiddenSize,
+            config.language.hiddenSize,
+            bias: false
+        )
+        super.init()
+    }
+
+    func callAsFunction(_ input: MLXArray) -> MLXArray {
+        let normalized = norm(input)
+        MLX.eval(normalized)
+        let hidden = first(normalized)
+        MLX.eval(hidden)
+        let activated = MLX.square(MLX.maximum(hidden, MLXArray(0).asType(hidden.dtype)))
+        MLX.eval(activated)
+        let output = second(activated)
+        MLX.eval(output)
+        return output
+    }
+}
+
+final class NemotronOmniSoundTower: Module {
+    @ModuleInfo(key: "encoder") var encoder: NemotronOmniSoundEncoder
+    @ModuleInfo(key: "projection") var projection: NemotronOmniSoundProjection
+
+    init(config: NemotronOmniConfig) {
+        self._encoder.wrappedValue = NemotronOmniSoundEncoder(config: config.sound)
+        self._projection.wrappedValue = NemotronOmniSoundProjection(config: config)
+        super.init()
+    }
+
+    func callAsFunction(
+        _ melFeatures: MLXArray,
+        validFrameCount: Int,
+        layerProgress: (@Sendable (Int, Int) -> Void)? = nil
+    ) -> MLXArray {
+        projection(encoder(
+            melFeatures,
+            validFrameCount: validFrameCount,
+            layerProgress: layerProgress
+        ))
+    }
+}

--- a/Sources/MereRunCore/NemotronOmni/NemotronOmniVideoProcessor.swift
+++ b/Sources/MereRunCore/NemotronOmni/NemotronOmniVideoProcessor.swift
@@ -1,0 +1,146 @@
+import Foundation
+import MediaIO
+import MLX
+
+struct NemotronOmniPreparedVideo: @unchecked Sendable {
+    let pixelValues: MLXArray
+    let frameCount: Int
+    let tokensPerTubelet: Int
+    let frameLabels: [String]
+
+    var tubeletCount: Int {
+        (frameCount + 1) / 2
+    }
+
+    var languageTokenCounts: [Int] {
+        Array(repeating: tokensPerTubelet, count: tubeletCount)
+    }
+
+    var promptPrefix: String {
+        (0..<tubeletCount).map { group in
+            let first = group * 2 + 1
+            let second = min(frameCount, first + 1)
+            let firstLabel = frameLabels[first - 1]
+            let label = first == second
+                ? "Frame \(first)\(firstLabel): "
+                : "Frame \(first)\(firstLabel) and frame \(second)\(frameLabels[second - 1]): "
+            return label + "<image>"
+        }.joined(separator: "\n") + "\n"
+    }
+}
+
+enum NemotronOmniVideoProcessor {
+    private static let framesPerSecond = 1.0
+
+    static func prepare(
+        reference: String,
+        config: NemotronOmniPreprocessorConfig,
+        contextLength: Int
+    ) throws -> NemotronOmniPreparedVideo {
+        let url = try localURL(reference: reference)
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mererun-nemotron-omni-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(
+            at: directory,
+            withIntermediateDirectories: true
+        )
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        // NVIDIA's published contract permits 128 frames at 1080p and 256
+        // for lower-resolution sources. Probe with the bounded lower limit,
+        // then use the decoded geometry to decide whether a second pass is
+        // useful.
+        var sequence = try MediaVideoIO.sampleFrames(
+            from: url,
+            into: directory,
+            framesPerSecond: framesPerSecond,
+            maximumFrames: NemotronOmniResources.maximumVideoFrames1080p
+        )
+        if max(sequence.frameWidth, sequence.frameHeight) < 1_080,
+           sequence.frameURLs.count == NemotronOmniResources.maximumVideoFrames1080p {
+            try FileManager.default.removeItem(at: directory)
+            try FileManager.default.createDirectory(
+                at: directory,
+                withIntermediateDirectories: true
+            )
+            sequence = try MediaVideoIO.sampleFrames(
+                from: url,
+                into: directory,
+                framesPerSecond: framesPerSecond,
+                maximumFrames: NemotronOmniResources.maximumVideoFrames720p
+            )
+        }
+        guard !sequence.frameURLs.isEmpty else {
+            throw NemotronOmniError.unsupportedMedia("video contains no decodable frames")
+        }
+
+        let prepared = try sequence.frameURLs.map { frameURL in
+            try NemotronOmniImageProcessor.prepare(
+                reference: frameURL.path,
+                config: config,
+                contextLength: contextLength,
+                videoMode: true
+            )
+        }
+        guard let first = prepared.first else {
+            throw NemotronOmniError.unsupportedMedia("video contains no prepared frames")
+        }
+        guard prepared.allSatisfy({
+            $0.pixelValues.dim(1) == first.pixelValues.dim(1)
+                && $0.pixelValues.dim(2) == first.pixelValues.dim(2)
+                && $0.sourcePatchCount == first.sourcePatchCount
+        }) else {
+            throw NemotronOmniError.unsupportedMedia(
+                "video frame dimensions changed during decoding"
+            )
+        }
+        let tokensPerTubelet = NemotronOmniPlaceholderPlanner.imageTokenCount(
+            sourcePatchCount: first.sourcePatchCount
+        )
+        let totalTokens = ((prepared.count + 1) / 2) * tokensPerTubelet
+        guard totalTokens + 64 <= contextLength else {
+            throw NemotronOmniError.unsupportedMedia(
+                "sampled video needs \(totalTokens) visual tokens, exceeding the \(contextLength)-token context"
+            )
+        }
+        return NemotronOmniPreparedVideo(
+            pixelValues: MLX.concatenated(prepared.map(\.pixelValues), axis: 0),
+            frameCount: prepared.count,
+            tokensPerTubelet: tokensPerTubelet,
+            frameLabels: frameLabels(for: sequence)
+        )
+    }
+
+    private static func frameLabels(for sequence: VideoFrameSequence) -> [String] {
+        guard let indices = sequence.sourceFrameIndices,
+              indices.count == sequence.frameURLs.count else {
+            return Array(repeating: "", count: sequence.frameURLs.count)
+        }
+        let frameDurationMilliseconds = Int(1_000 / sequence.fps)
+        return indices.map { index in
+            let seconds = Double(index * frameDurationMilliseconds) / 1_000
+            return String(format: " sampled at %.2f seconds", seconds)
+        }
+    }
+
+    private static func localURL(reference: String) throws -> URL {
+        let trimmed = reference.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            throw NemotronOmniError.unsupportedMedia("video reference is empty")
+        }
+        if let parsed = URL(string: trimmed), parsed.scheme?.lowercased() == "file" {
+            return parsed
+        }
+        if let scheme = URL(string: trimmed)?.scheme?.lowercased(),
+           scheme == "http" || scheme == "https" {
+            throw NemotronOmniError.unsupportedMedia(
+                "remote video URLs are not fetched; use a local path or file URL"
+            )
+        }
+        let url = URL(fileURLWithPath: trimmed).standardizedFileURL
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            throw NemotronOmniError.unsupportedMedia("video file not found: \(url.path)")
+        }
+        return url
+    }
+}

--- a/Sources/MereRunCore/NemotronOmni/NemotronOmniVisionModel.swift
+++ b/Sources/MereRunCore/NemotronOmni/NemotronOmniVisionModel.swift
@@ -1,0 +1,300 @@
+import MLX
+import MLXFast
+import MLXNN
+
+final class NemotronOmniVisionAttention: Module {
+    private let headCount = 16
+    private let headDimension = 80
+    private let scale: Float = 0.111_803_4
+
+    @ModuleInfo(key: "qkv") var qkv: Linear
+    @ModuleInfo(key: "proj") var projection: Linear
+
+    init(hiddenSize: Int) {
+        self._qkv.wrappedValue = Linear(hiddenSize, hiddenSize * 3, bias: true)
+        self._projection.wrappedValue = Linear(hiddenSize, hiddenSize, bias: true)
+        super.init()
+    }
+
+    func callAsFunction(_ input: MLXArray) -> MLXArray {
+        let batch = input.dim(0)
+        let sequence = input.dim(1)
+        let packed = qkv(input)
+            .reshaped(batch, sequence, 3, headCount, headDimension)
+            .transposed(2, 0, 3, 1, 4)
+        let queries = packed[0, 0..., 0..., 0..., 0...]
+        let keys = packed[1, 0..., 0..., 0..., 0...]
+        let values = packed[2, 0..., 0..., 0..., 0...]
+        let attended = MLXFast.scaledDotProductAttention(
+            queries: queries,
+            keys: keys,
+            values: values,
+            scale: scale,
+            mask: .none
+        )
+        return projection(
+            attended.transposed(0, 2, 1, 3)
+                .reshaped(batch, sequence, headCount * headDimension)
+        )
+    }
+}
+
+final class NemotronOmniVisionMLP: Module {
+    @ModuleInfo(key: "fc1") var first: Linear
+    @ModuleInfo(key: "fc2") var second: Linear
+
+    init(hiddenSize: Int) {
+        self._first.wrappedValue = Linear(hiddenSize, hiddenSize * 4, bias: true)
+        self._second.wrappedValue = Linear(hiddenSize * 4, hiddenSize, bias: true)
+        super.init()
+    }
+
+    func callAsFunction(_ input: MLXArray) -> MLXArray {
+        second(MLXNN.gelu(first(input)))
+    }
+}
+
+final class NemotronOmniVisionBlock: Module {
+    @ModuleInfo(key: "norm1") var firstNorm: LayerNorm
+    @ModuleInfo(key: "attn") var attention: NemotronOmniVisionAttention
+    @ModuleInfo(key: "norm2") var secondNorm: LayerNorm
+    @ModuleInfo(key: "mlp") var mlp: NemotronOmniVisionMLP
+
+    init(hiddenSize: Int) {
+        self._firstNorm.wrappedValue = LayerNorm(dimensions: hiddenSize, eps: 1e-6)
+        self._attention.wrappedValue = NemotronOmniVisionAttention(hiddenSize: hiddenSize)
+        self._secondNorm.wrappedValue = LayerNorm(dimensions: hiddenSize, eps: 1e-6)
+        self._mlp.wrappedValue = NemotronOmniVisionMLP(hiddenSize: hiddenSize)
+        super.init()
+    }
+
+    func callAsFunction(_ input: MLXArray) -> MLXArray {
+        let attended = input + attention(firstNorm(input))
+        return attended + mlp(secondNorm(attended))
+    }
+}
+
+final class NemotronOmniVisionPatchGenerator: Module {
+    @ModuleInfo(key: "embedder") var imageEmbedder: Linear
+    @ModuleInfo(key: "video_embedder") var videoEmbedder: Linear
+    @ParameterInfo(key: "pos_embed") var positionEmbedding: MLXArray
+    @ParameterInfo(key: "class_token") var classToken: MLXArray
+
+    private let patchSize: Int
+    private let hiddenSize: Int
+    private let temporalPatchSize: Int
+
+    init(patchSize: Int, hiddenSize: Int, temporalPatchSize: Int) {
+        self.patchSize = patchSize
+        self.hiddenSize = hiddenSize
+        self.temporalPatchSize = temporalPatchSize
+        self._imageEmbedder.wrappedValue = Linear(
+            3 * patchSize * patchSize,
+            hiddenSize,
+            bias: false
+        )
+        self._videoEmbedder.wrappedValue = Linear(
+            temporalPatchSize * 3 * patchSize * patchSize,
+            hiddenSize,
+            bias: false
+        )
+        self._positionEmbedding.wrappedValue = MLX.zeros(
+            [1, 128 * 128, hiddenSize],
+            dtype: .bfloat16
+        )
+        self._classToken.wrappedValue = MLX.zeros([10, hiddenSize], dtype: .bfloat16)
+        super.init()
+    }
+
+    func imagePatches(_ pixels: MLXArray) -> (embeddings: MLXArray, height: Int, width: Int) {
+        precondition(pixels.ndim == 4 && pixels.dim(3) == 3)
+        let batch = pixels.dim(0)
+        let patchHeight = pixels.dim(1) / patchSize
+        let patchWidth = pixels.dim(2) / patchSize
+        let patches = pixels
+            .reshaped(batch, patchHeight, patchSize, patchWidth, patchSize, 3)
+            .transposed(0, 1, 3, 5, 2, 4)
+            .reshaped(batch, patchHeight * patchWidth, 3 * patchSize * patchSize)
+        return (imageEmbedder(patches), patchHeight, patchWidth)
+    }
+
+    func videoPatches(_ frames: MLXArray) -> (embeddings: MLXArray, height: Int, width: Int) {
+        precondition(frames.ndim == 4 && frames.dim(3) == 3)
+        var pixels = frames
+        let remainder = pixels.dim(0) % temporalPatchSize
+        if remainder != 0 {
+            let last = pixels[(pixels.dim(0) - 1)..., 0..., 0..., 0...]
+            let padding = MLX.repeated(
+                last,
+                count: temporalPatchSize - remainder,
+                axis: 0
+            )
+            pixels = MLX.concatenated([pixels, padding], axis: 0)
+        }
+        let groupCount = pixels.dim(0) / temporalPatchSize
+        let patchHeight = pixels.dim(1) / patchSize
+        let patchWidth = pixels.dim(2) / patchSize
+        let patches = pixels
+            .reshaped(
+                groupCount,
+                temporalPatchSize,
+                patchHeight,
+                patchSize,
+                patchWidth,
+                patchSize,
+                3
+            )
+            .transposed(0, 2, 4, 1, 6, 3, 5)
+            .reshaped(
+                groupCount,
+                patchHeight * patchWidth,
+                temporalPatchSize * 3 * patchSize * patchSize
+            )
+        return (videoEmbedder(patches), patchHeight, patchWidth)
+    }
+
+    func addPositionAndClassTokens(
+        _ patchEmbeddings: MLXArray,
+        patchHeight: Int,
+        patchWidth: Int
+    ) -> MLXArray {
+        let positions = interpolatedPositions(height: patchHeight, width: patchWidth)
+            .asType(patchEmbeddings.dtype)
+        let patches = patchEmbeddings + positions
+        let classes = MLX.broadcast(
+            classToken.expandedDimensions(axis: 0).asType(patches.dtype),
+            to: [patches.dim(0), classToken.dim(0), hiddenSize]
+        )
+        return MLX.concatenated([classes, patches], axis: 1)
+    }
+
+    private func interpolatedPositions(height: Int, width: Int) -> MLXArray {
+        let maximumDimension = max(height, width)
+        var positions = positionEmbedding.reshaped(1, 128, 128, hiddenSize)
+        if maximumDimension != 128 {
+            let scale = Float(maximumDimension) / 128
+            positions = Upsample(
+                scaleFactor: .array([scale, scale]),
+                mode: .linear(alignCorners: false)
+            )(positions.asType(.float32)).asType(positionEmbedding.dtype)
+        }
+        positions = positions[0..., 0..<height, 0..<width, 0...]
+        return positions.reshaped(1, height * width, hiddenSize)
+    }
+}
+
+final class NemotronOmniVisionTransformer: Module {
+    @ModuleInfo(key: "patch_generator") var patchGenerator: NemotronOmniVisionPatchGenerator
+    @ModuleInfo(key: "blocks") var blocks: [NemotronOmniVisionBlock]
+
+    init(config: NemotronOmniConfig) {
+        self._patchGenerator.wrappedValue = NemotronOmniVisionPatchGenerator(
+            patchSize: config.vision.patchSize,
+            hiddenSize: config.visionHiddenSize,
+            temporalPatchSize: config.vision.videoTemporalPatchSize
+        )
+        self._blocks.wrappedValue = (0..<32).map { _ in
+            NemotronOmniVisionBlock(hiddenSize: config.visionHiddenSize)
+        }
+        super.init()
+    }
+
+    func encodeImage(_ pixels: MLXArray) -> (features: MLXArray, height: Int, width: Int) {
+        let patches = patchGenerator.imagePatches(pixels)
+        return (
+            forward(
+                patchGenerator.addPositionAndClassTokens(
+                    patches.embeddings,
+                    patchHeight: patches.height,
+                    patchWidth: patches.width
+                )
+            ),
+            patches.height,
+            patches.width
+        )
+    }
+
+    func encodeVideo(_ pixels: MLXArray) -> (features: MLXArray, height: Int, width: Int) {
+        let patches = patchGenerator.videoPatches(pixels)
+        return (
+            forward(
+                patchGenerator.addPositionAndClassTokens(
+                    patches.embeddings,
+                    patchHeight: patches.height,
+                    patchWidth: patches.width
+                )
+            ),
+            patches.height,
+            patches.width
+        )
+    }
+
+    private func forward(_ input: MLXArray) -> MLXArray {
+        var hidden = input
+        for block in blocks {
+            hidden = block(hidden)
+        }
+        return hidden[0..., 10..., 0...]
+    }
+}
+
+final class NemotronOmniVisionProjector: Module {
+    @ModuleInfo(key: "norm") var norm: RMSNorm
+    @ModuleInfo(key: "linear1") var first: Linear
+    @ModuleInfo(key: "linear2") var second: Linear
+
+    init(config: NemotronOmniConfig) {
+        let inputSize = config.visionHiddenSize * 4
+        self._norm.wrappedValue = RMSNorm(dimensions: inputSize, eps: 1e-5)
+        self._first.wrappedValue = Linear(
+            inputSize,
+            config.projectorHiddenSize,
+            bias: false
+        )
+        self._second.wrappedValue = Linear(
+            config.projectorHiddenSize,
+            config.language.hiddenSize,
+            bias: false
+        )
+        super.init()
+    }
+
+    func callAsFunction(_ input: MLXArray) -> MLXArray {
+        let hidden = first(norm(input))
+        let activated = MLX.square(MLX.maximum(hidden, MLXArray(0).asType(hidden.dtype)))
+        return second(activated)
+    }
+}
+
+final class NemotronOmniVisionTower: Module {
+    @ModuleInfo(key: "model") var transformer: NemotronOmniVisionTransformer
+    @ModuleInfo(key: "projector") var projector: NemotronOmniVisionProjector
+
+    init(config: NemotronOmniConfig) {
+        self._transformer.wrappedValue = NemotronOmniVisionTransformer(config: config)
+        self._projector.wrappedValue = NemotronOmniVisionProjector(config: config)
+        super.init()
+    }
+
+    func encodeImage(_ pixels: MLXArray) -> MLXArray {
+        let encoded = transformer.encodeImage(pixels)
+        return projector(pixelShuffle(encoded.features, height: encoded.height, width: encoded.width))
+    }
+
+    func encodeVideo(_ pixels: MLXArray) -> MLXArray {
+        let encoded = transformer.encodeVideo(pixels)
+        return projector(pixelShuffle(encoded.features, height: encoded.height, width: encoded.width))
+    }
+
+    private func pixelShuffle(_ input: MLXArray, height: Int, width: Int) -> MLXArray {
+        precondition(height.isMultiple(of: 2) && width.isMultiple(of: 2))
+        let batch = input.dim(0)
+        let channels = input.dim(2)
+        return input
+            .reshaped(batch, height, width / 2, channels * 2)
+            .transposed(0, 2, 1, 3)
+            .reshaped(batch, width / 2, height / 2, channels * 4)
+            .transposed(0, 2, 1, 3)
+            .reshaped(batch, height / 2 * width / 2, channels * 4)
+    }
+}

--- a/Sources/MereRunCore/NemotronOmni/README.md
+++ b/Sources/MereRunCore/NemotronOmni/README.md
@@ -1,0 +1,37 @@
+# Nemotron Omni runtime
+
+This module is the native Swift/MLX execution engine for NVIDIA's pinned
+Nemotron 3 Nano Omni 30B-A3B Reasoning BF16 checkpoint. It accepts text,
+images, local audio, and local video and generates text without Python,
+Transformers, vLLM, or an intermediate model conversion.
+
+The runtime has four layers:
+
+- `NemotronOmniGenerator` owns model lifetime, prompt/media ordering,
+  multimodal prefill, and autoregressive generation.
+- `NemotronOmniVisionModel` and the image/video processors implement the
+  C-RADIO v4-H vision tower, dynamic image tiling, and two-frame video
+  tubelets.
+- `NemotronOmniSoundModel` and the audio processor implement the Parakeet
+  log-Mel frontend, convolutional subsampling, and conformer encoder.
+- `NemotronOmniLanguageModel` implements the BF16 Nemotron-H hybrid
+  attention/Mamba/MoE backbone. `NemotronOmniExpertPack` creates one
+  source-bound, stacked expert cache beside the source snapshot so the 46
+  routed expert tensors do not require 17-shard gathers on every launch.
+  Multitoken prefill evaluates at layer boundaries to keep every Metal command
+  buffer below the macOS watchdog; one-token decode remains fused.
+
+Managed installation remains explicit because the upstream checkpoint uses
+the NVIDIA Open Model Agreement. The small internal MereRun wrapper may point
+at an immutable snapshot on external storage; the 66 GB source checkpoint and
+58 GB derived expert cache must not be duplicated merely to make the catalog
+entry visible.
+
+Media inputs are decoded locally. Image and video URLs passed to this runtime
+must be local paths or `file:` URLs. Audio uses the shared local audio loader.
+PDF documents are handled by rendering pages to images before inference; PDF
+is not a separate model input modality.
+
+When changing this module, run the focused `NemotronOmniTests`, the repository
+gate, and at least one real installed-checkpoint generation for every media
+tower affected by the change.

--- a/Sources/MereRunCore/Quantization/QuantizedModelManifestWriter.swift
+++ b/Sources/MereRunCore/Quantization/QuantizedModelManifestWriter.swift
@@ -86,7 +86,7 @@ public enum QuantizedModelManifestWriter {
             case .deepseekV4Flash: return .deepseek
             case .inkling: return .inkling
             case .museGlimmer: return .muse
-            case .nemotronH: return .nemotron
+            case .nemotronH, .nemotronOmni: return .nemotron
             }
         }()
 
@@ -129,6 +129,16 @@ public enum QuantizedModelManifestWriter {
                     return [.chat, .codeGeneration, .visionChat]
                 case .nemotronH:
                     return [.chat, .codeGeneration]
+                case .nemotronOmni:
+                    return [
+                        .chat,
+                        .codeGeneration,
+                        .visionChat,
+                        .visionOCR,
+                        .audioUnderstanding,
+                        .videoUnderstanding,
+                        .documentUnderstanding,
+                    ]
                 case .lfm2:
                     return [.chat]
                 case .laguna:
@@ -255,7 +265,7 @@ public enum QuantizedModelManifestWriter {
                 manifest.defaults = MereRunModelManifest.Defaults(steps: 20, cfg: 7.0)
             case .gemma4:
                 break
-            case .museGlimmer, .nemotronH:
+            case .museGlimmer, .nemotronH, .nemotronOmni:
                 break
             case .lfm2:
                 break

--- a/Sources/MereRunCore/RuntimeModelSettings.swift
+++ b/Sources/MereRunCore/RuntimeModelSettings.swift
@@ -11,6 +11,7 @@ public enum RuntimeServingEngine: String, Codable, CaseIterable, Hashable, Senda
     case textChatDeepseekV4Flash = "text-chat-deepseek-v4-flash"
     case textChatMuseGlimmer = "text-chat-muse-glimmer"
     case textChatNemotronH = "text-chat-nemotron-h"
+    case textChatNemotronOmni = "text-chat-nemotron-omni"
 
     public var canonical: RuntimeServingEngine {
         switch self {

--- a/Tests/MereRunCLITests/APIServeCommandTests.swift
+++ b/Tests/MereRunCLITests/APIServeCommandTests.swift
@@ -121,6 +121,22 @@ final class APIServeCommandTests: XCTestCase {
         XCTAssertFalse(cmd.engine.openAICompatibility.supportsStructuredOutputs)
     }
 
+    func testAPIServeParsesNemotronOmniNativeEngine() throws {
+        let cmd = try APIServe.parse([
+            "--engine", "text-chat-nemotron-omni",
+            "--model", NemotronOmniResources.modelID,
+        ])
+
+        XCTAssertEqual(cmd.engine, .textChatNemotronOmni)
+        XCTAssertEqual(cmd.model, NemotronOmniResources.modelID)
+        XCTAssertEqual(cmd.defaultRuntimeModelID(modelPath: nil), NemotronOmniResources.modelID)
+        XCTAssertTrue(cmd.engine.openAICompatibility.supportsTools)
+        XCTAssertTrue(cmd.engine.openAICompatibility.supportsVisionContentParts)
+        XCTAssertTrue(cmd.engine.openAICompatibility.supportsAudioContentParts)
+        XCTAssertTrue(cmd.engine.openAICompatibility.supportsVideoContentParts)
+        XCTAssertFalse(cmd.engine.openAICompatibility.supportsStructuredOutputs)
+    }
+
     func testAPIServeParsesPreflightJSONFlags() throws {
         let cmd = try APIServe.parse([
             "--preflight",
@@ -2393,6 +2409,62 @@ final class APIServeCommandTests: XCTestCase {
         )
         XCTAssertEqual(chatRequest.messages[0].content, "describe")
         XCTAssertEqual(chatRequest.messages[0].imageUrl, "file:///tmp/image.png")
+    }
+
+    func testOmniProfileMapsImageAudioAndVideoContentParts() throws {
+        let data = """
+        {
+          "model": "omni-chat-nemotron3-nano-30b-a3b-bf16",
+          "messages": [
+            {
+              "role": "user",
+              "content": [
+                { "type": "text", "text": "summarize" },
+                { "type": "image_url", "image_url": { "url": "file:///tmp/page.png" } },
+                { "type": "audio_url", "audio_url": { "url": "file:///tmp/audio.wav" } },
+                { "type": "video_url", "video_url": { "url": "file:///tmp/video.mp4" } }
+              ]
+            }
+          ]
+        }
+        """.data(using: .utf8)!
+        let request = try JSONDecoder().decode(OpenAIChatRequest.self, from: data)
+        let capabilities = APIEngineCapabilities.catalog(.nemotronOmni())
+
+        XCTAssertTrue(capabilities.supportsVisionContentParts)
+        XCTAssertTrue(capabilities.supportsAudioContentParts)
+        XCTAssertTrue(capabilities.supportsVideoContentParts)
+        let chatRequest = try APIServerContract.chatRequest(
+            from: request,
+            fallbackLoraPath: nil,
+            contextSize: 131_072,
+            capabilities: capabilities,
+            servedModelID: NemotronOmniResources.modelID
+        )
+        XCTAssertEqual(chatRequest.messages[0].imageUrl, "file:///tmp/page.png")
+        XCTAssertEqual(chatRequest.messages[0].audioUrl, "file:///tmp/audio.wav")
+        XCTAssertEqual(chatRequest.messages[0].videoUrl, "file:///tmp/video.mp4")
+    }
+
+    func testTextProfileRejectsAudioAndVideoContentParts() throws {
+        for part in [
+            "{ \"type\": \"audio_url\", \"audio_url\": { \"url\": \"file:///tmp/audio.wav\" } }",
+            "{ \"type\": \"video_url\", \"video_url\": { \"url\": \"file:///tmp/video.mp4\" } }",
+        ] {
+            let data = """
+            {
+              "model": "mererun-test-model",
+              "messages": [{"role":"user","content":[\(part)]}]
+            }
+            """.data(using: .utf8)!
+            let request = try JSONDecoder().decode(OpenAIChatRequest.self, from: data)
+            XCTAssertThrowsError(try APIServerContract.chatRequest(
+                from: request,
+                fallbackLoraPath: nil,
+                contextSize: 4_096,
+                capabilities: .localText
+            ))
+        }
     }
 
     func testChatRequestMapsSupportedOpenAITools() throws {

--- a/Tests/MereRunCLITests/GateSupportTests.swift
+++ b/Tests/MereRunCLITests/GateSupportTests.swift
@@ -105,6 +105,23 @@ final class GateSupportTests: XCTestCase {
         )
     }
 
+    func testNemotronOmniGateRunsDirectNativeInference() throws {
+        let spec = try XCTUnwrap(
+            ManagedModelCatalog.spec(for: NemotronOmniResources.modelID)
+        )
+        let plan = try XCTUnwrap(InstalledModelSmokePlans.plan(
+            for: spec,
+            installedIDs: [spec.id]
+        ))
+
+        XCTAssertEqual(plan.check.suite, ManagedModelCategory.omniChat.rawValue)
+        XCTAssertEqual(plan.check.requiredModels, [spec.id])
+        XCTAssertEqual(
+            plan.check.successDetail,
+            "direct true inference: text chat through native Omni runtime"
+        )
+    }
+
     func testNewGeoFamiliesHaveDirectNativeInferenceSmokePlans() throws {
         let expectations: [(String, String)] = [
             ("vision-fire-terramind-base", "geo fire normalized tensor smoke"),

--- a/Tests/MereRunCLITests/MachineInferenceAdmissionTests.swift
+++ b/Tests/MereRunCLITests/MachineInferenceAdmissionTests.swift
@@ -366,6 +366,13 @@ final class MachineInferenceAdmissionTests: XCTestCase {
         )
         XCTAssertEqual(
             CLIInferenceAdmissionClassifier.apiServerRequest(
+                engine: .textChatNemotronOmni,
+                modelID: "omni-chat-nemotron3-nano-30b-a3b-bf16"
+            ),
+            MachineInferenceRequest(label: "api serve text-chat-nemotron-omni", resourceClass: .large)
+        )
+        XCTAssertEqual(
+            CLIInferenceAdmissionClassifier.apiServerRequest(
                 engine: .textChatLaguna,
                 modelID: "text-chat-laguna-s-2-1"
             ),

--- a/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
@@ -145,6 +145,7 @@ final class ManagedModelCatalogTests: XCTestCase {
             "vision-embed-olmoearth-v12-small",
             "vision-embed-olmoearth-v12-base",
             MuseGlimmerResources.modelId,
+            NemotronOmniResources.modelID,
             "image-3d-trellis2-4b",
             MiniMaxMusic3Resources.modelID,
             "music-muscriptor-small",

--- a/Tests/MereRunCoreTests/MediaIOTests.swift
+++ b/Tests/MereRunCoreTests/MediaIOTests.swift
@@ -532,6 +532,37 @@ final class MediaIOTests: XCTestCase {
         XCTAssertFalse(FileManager.default.fileExists(atPath: framesURL.path))
     }
 
+    func testVideoSamplingCoversTimelineWithinFrameLimit() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mediaio-video-sampling-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let videoURL = root.appendingPathComponent("input.mp4")
+        let framesURL = root.appendingPathComponent("sampled", isDirectory: true)
+        try MediaVideoIO.writeMP4(
+            rgb24: [UInt8](repeating: 127, count: 32 * 32 * 3 * 16),
+            width: 32,
+            height: 32,
+            frameCount: 16,
+            fps: 4,
+            to: videoURL
+        )
+
+        let sampled = try MediaVideoIO.sampleFrames(
+            from: videoURL,
+            into: framesURL,
+            framesPerSecond: 1,
+            maximumFrames: 3
+        )
+
+        XCTAssertEqual(sampled.frameURLs.count, 3)
+        XCTAssertEqual(sampled.sourceFrameIndices, [0, 8, 15])
+        XCTAssertEqual(sampled.frameWidth, 32)
+        XCTAssertEqual(sampled.frameHeight, 32)
+        XCTAssertTrue(sampled.frameURLs.allSatisfy { FileManager.default.fileExists(atPath: $0.path) })
+    }
+
     func testFFmpegExtractionRunsFrameAdmissionBeforeCreatingOutputDirectory() throws {
         guard isExecutableAvailable(MediaTool.ffmpegPath),
               isExecutableAvailable(MediaTool.ffprobePath) else {

--- a/Tests/MereRunCoreTests/NemotronOmniTests.swift
+++ b/Tests/MereRunCoreTests/NemotronOmniTests.swift
@@ -1,0 +1,402 @@
+import Foundation
+import MLX
+import XCTest
+@testable import MereRunCore
+
+final class NemotronOmniTests: MereRunCoreTestCase {
+    func testPinnedOmniConfigDecodesAllThreeMediaTowers() throws {
+        let config = try JSONDecoder().decode(
+            NemotronOmniConfig.self,
+            from: Data(Self.configJSON.utf8)
+        )
+
+        XCTAssertEqual(config.maximumSequenceLength, 131_072)
+        XCTAssertEqual(config.language.hiddenSize, 2_688)
+        XCTAssertEqual(config.language.layerBlockTypes.count, 52)
+        XCTAssertEqual(config.language.layerBlockTypes.filter { $0 == "mamba" }.count, 23)
+        XCTAssertEqual(config.language.layerBlockTypes.filter { $0 == "moe" }.count, 23)
+        XCTAssertEqual(config.language.layerBlockTypes.filter { $0 == "attention" }.count, 6)
+        XCTAssertEqual(config.vision.version, "c-radio_v4-h")
+        XCTAssertEqual(config.vision.videoTemporalPatchSize, 2)
+        XCTAssertEqual(config.sound.modelType, "parakeet")
+        XCTAssertEqual(config.sound.numHiddenLayers, 24)
+        XCTAssertEqual(config.sound.subsamplingConvChannels, 256)
+        XCTAssertEqual(config.sound.numMelBins, 128)
+    }
+
+    func testPlaceholderCountsMatchPinnedProcessorGeometry() {
+        XCTAssertEqual(
+            NemotronOmniPlaceholderPlanner.imageTokenCount(sourcePatchCount: 1_024),
+            256
+        )
+        XCTAssertEqual(
+            NemotronOmniPlaceholderPlanner.audioTokenCount(sampleCount: 16_000),
+            13
+        )
+    }
+
+    func testVideoPromptUsesOfficialTubeletTimestampLabels() {
+        let video = NemotronOmniPreparedVideo(
+            pixelValues: MLX.zeros([4, 16, 16, 3]),
+            frameCount: 4,
+            tokensPerTubelet: 2,
+            frameLabels: [
+                " sampled at 0.00 seconds",
+                " sampled at 1.25 seconds",
+                " sampled at 2.50 seconds",
+                " sampled at 3.75 seconds",
+            ]
+        )
+
+        XCTAssertEqual(
+            video.promptPrefix,
+            "Frame 1 sampled at 0.00 seconds and frame 2 sampled at 1.25 seconds: <image>\n"
+                + "Frame 3 sampled at 2.50 seconds and frame 4 sampled at 3.75 seconds: <image>\n"
+        )
+    }
+
+    func testParakeetFrontendMatchesReferenceFeatureSamples() throws {
+        let sampleRate = 16_000
+        var state: UInt32 = 0x1234_5678
+        let samples = (0..<sampleRate).map { _ -> Float in
+            state = 1_664_525 &* state &+ 1_013_904_223
+            return (Float(state >> 8) / 16_777_216 - 0.5) * 0.4
+        }
+        let features = try NemotronOmniAudioProcessor.logMelSpectrogram(samples: samples)
+            .asType(.float32)
+            .asArray(Float.self)
+        let expected: [(row: Int, column: Int, value: Float)] = [
+            (0, 0, -2.0018),
+            (0, 20, -0.1479),
+            (0, 60, 0.2351),
+            (1, 0, 0.2397),
+            (50, 20, -0.2435),
+            (99, 127, 0.9031),
+            (100, 0, 0),
+        ]
+        for sample in expected {
+            XCTAssertEqual(
+                features[sample.row * 128 + sample.column],
+                sample.value,
+                accuracy: 0.08,
+                "feature[\(sample.row),\(sample.column)]"
+            )
+        }
+    }
+
+    func testDynamicImagePatchGeometryAndMediaExpansion() throws {
+        let imageGrid = NemotronOmniImageProcessor.imagePatchGrid(
+            width: 1_536,
+            height: 864
+        )
+        XCTAssertEqual(imageGrid.width, 96)
+        XCTAssertEqual(imageGrid.height, 54)
+        let videoGrid = NemotronOmniImageProcessor.videoPatchGrid(
+            width: 1_920,
+            height: 1_080
+        )
+        XCTAssertEqual(videoGrid.width, 42)
+        XCTAssertEqual(videoGrid.height, 24)
+        XCTAssertEqual(
+            try NemotronOmniGenerator.expandImagePlaceholders(
+                [7, 18, 8],
+                tokenCounts: [3],
+                imageTokenID: 18
+            ),
+            [7, 19, 18, 18, 18, 20, 8]
+        )
+        XCTAssertEqual(
+            try NemotronOmniGenerator.expandAudioPlaceholders(
+                [7, 27, 8],
+                tokenCounts: [2],
+                soundTokenID: 27
+            ),
+            [7, 28, 27, 27, 29, 8]
+        )
+    }
+
+    func testBF16ExpertWeightKeyDecodesExactCheckpointNamespace() throws {
+        let key = try XCTUnwrap(NemotronOmniExpertWeightKey(
+            checkpointKey:
+                "language_model.backbone.layers.51.mixer.experts.127.down_proj.weight"
+        ))
+        XCTAssertEqual(key.layer, 51)
+        XCTAssertEqual(key.expert, 127)
+        XCTAssertEqual(key.projection, .down)
+        XCTAssertNil(NemotronOmniExpertWeightKey(
+            checkpointKey: "language_model.backbone.layers.51.mixer.experts.weight"
+        ))
+    }
+
+    func testPinnedConfigRejectsArchitectureDrift() {
+        let drifted = Self.configJSON.replacingOccurrences(
+            of: "\"max_sequence_length\":131072",
+            with: "\"max_sequence_length\":65536"
+        )
+        XCTAssertThrowsError(try JSONDecoder().decode(
+            NemotronOmniConfig.self,
+            from: Data(drifted.utf8)
+        ))
+    }
+
+    func testPinnedPreprocessorContractDecodesAndRejectsDrift() throws {
+        let config = try JSONDecoder().decode(
+            NemotronOmniPreprocessorConfig.self,
+            from: Data(Self.preprocessorJSON.utf8)
+        )
+        XCTAssertEqual(config.normalizationMean.count, 3)
+        XCTAssertEqual(config.maxNumPatches, 13_312)
+
+        let drifted = Self.preprocessorJSON.replacingOccurrences(
+            of: "\"patch_size\":16",
+            with: "\"patch_size\":14"
+        )
+        XCTAssertThrowsError(try JSONDecoder().decode(
+            NemotronOmniPreprocessorConfig.self,
+            from: Data(drifted.utf8)
+        ))
+    }
+
+    func testCatalogDeclaresNativeOmniRuntimeAndInputs() throws {
+        let spec = try XCTUnwrap(
+            ManagedModelCatalog.spec(for: NemotronOmniResources.modelID)
+        )
+        let profile = try XCTUnwrap(spec.apiProfile)
+
+        XCTAssertEqual(spec.category, .omniChat)
+        XCTAssertEqual(spec.validationKind, .nemotronOmni)
+        XCTAssertEqual(spec.hubFallback?.repoId, NemotronOmniResources.upstreamRepoID)
+        XCTAssertEqual(spec.hubFallback?.revision, NemotronOmniResources.upstreamRevision)
+        XCTAssertEqual(spec.estimatedDownloadBytes, 66_059_015_328)
+        XCTAssertFalse(spec.runtimeAutoDownloadAllowed)
+        XCTAssertEqual(spec.defaultRuntimeServingEngine, .textChatNemotronOmni)
+        XCTAssertEqual(profile.inputModalities, [.text, .image, .audio, .video])
+        XCTAssertEqual(profile.outputModalities, [.text])
+        XCTAssertEqual(profile.contextWindow, 131_072)
+        XCTAssertEqual(profile.maximumOutputTokens, 20_480)
+        XCTAssertTrue(profile.reasoning)
+        XCTAssertTrue(profile.toolCall)
+        XCTAssertFalse(profile.structuredOutput)
+        XCTAssertTrue(
+            ManagedModelCapabilityCatalog.support(
+                for: spec,
+                on: MereRunMachineProfile(
+                    physicalMemoryBytes: 128 * 1_073_741_824,
+                    processorName: "Test Mac",
+                    isAppleSiliconMac: true,
+                    isLinux: false
+                )
+            ).isSupported
+        )
+        XCTAssertEqual(
+            spec.usageRestriction?.terms.first?.license,
+            "NVIDIA Open Model Agreement"
+        )
+    }
+
+    func testManifestRetainsOmniCapabilitiesAndPinnedProvenance() {
+        let manifest = MereRunModelManifest.template(
+            for: .nemotron3NanoOmni30BA3BBF16,
+            createdAt: Date(timeIntervalSince1970: 0)
+        )
+
+        XCTAssertEqual(manifest.engine, .nemotronOmni)
+        XCTAssertEqual(manifest.family, .nemotron)
+        XCTAssertEqual(manifest.precision, .bf16)
+        XCTAssertEqual(
+            Set(manifest.supports ?? []),
+            Set([
+                .chat,
+                .codeGeneration,
+                .visionChat,
+                .visionOCR,
+                .audioUnderstanding,
+                .videoUnderstanding,
+                .documentUnderstanding,
+            ])
+        )
+        XCTAssertEqual(
+            manifest.upstreamRepoId,
+            "\(NemotronOmniResources.upstreamRepoID)@\(NemotronOmniResources.upstreamRevision)"
+        )
+    }
+
+    func testValidationRequiresEveryIndexedShard() throws {
+        let root = try TestFileSystem.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+        for filename in [
+            "README.md",
+            "chat_template.jinja",
+            "config.json",
+            "generation_config.json",
+            "preprocessor_config.json",
+            "tokenizer.json",
+            "tokenizer_config.json",
+        ] {
+            try Data().write(to: root.appendingPathComponent(filename))
+        }
+        try Data("""
+        {"metadata":{"total_size":2},"weight_map":{"a":"model-00001-of-00002.safetensors","b":"model-00002-of-00002.safetensors"}}
+        """.utf8).write(to: root.appendingPathComponent("model.safetensors.index.json"))
+        try Data([0]).write(to: root.appendingPathComponent("model-00001-of-00002.safetensors"))
+
+        XCTAssertEqual(
+            NemotronOmniResources.missingTargetFiles(rootURL: root).map(\.lastPathComponent),
+            ["model-00002-of-00002.safetensors"]
+        )
+    }
+
+    func testStructuralValidationPinsConfigProcessorAndShardIndex() throws {
+        let root = try TestFileSystem.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+        for filename in [
+            "README.md",
+            "chat_template.jinja",
+            "generation_config.json",
+            "tokenizer.json",
+            "tokenizer_config.json",
+        ] {
+            try Data().write(to: root.appendingPathComponent(filename))
+        }
+        try Data(Self.configJSON.utf8).write(to: root.appendingPathComponent("config.json"))
+        try Data(Self.preprocessorJSON.utf8).write(
+            to: root.appendingPathComponent("preprocessor_config.json")
+        )
+        let shardEntries = try (1...NemotronOmniResources.checkpointShardCount).map { index in
+            let filename = String(
+                format: "model-%05d-of-%05d.safetensors",
+                index,
+                NemotronOmniResources.checkpointShardCount
+            )
+            try Data([0]).write(to: root.appendingPathComponent(filename))
+            return "\"weight\(index)\":\"\(filename)\""
+        }.joined(separator: ",")
+        let pinnedIndex = """
+        {"metadata":{"total_size":\(NemotronOmniResources.checkpointWeightBytes)},"weight_map":{\(shardEntries)}}
+        """
+        let indexURL = root.appendingPathComponent("model.safetensors.index.json")
+        try Data(pinnedIndex.utf8).write(to: indexURL)
+
+        XCTAssertEqual(NemotronOmniResources.validationMessages(rootURL: root), [])
+
+        let driftedIndex = pinnedIndex.replacingOccurrences(
+            of: String(NemotronOmniResources.checkpointWeightBytes),
+            with: "1"
+        )
+        try Data(driftedIndex.utf8).write(to: indexURL)
+        XCTAssertEqual(
+            NemotronOmniResources.validationMessages(rootURL: root),
+            [
+                "Safetensors index does not match the pinned 17-shard, "
+                    + "66031270520-byte checkpoint contract.",
+            ]
+        )
+    }
+
+    func testOpenAIContentRoundTripsImageAudioAndVideoURLs() throws {
+        let data = Data("""
+        {
+          "role":"user",
+          "content":[
+            {"type":"text","text":"Summarize the meeting."},
+            {"type":"image_url","image_url":{"url":"file:///tmp/slide.png"}},
+            {"type":"audio_url","audio_url":{"url":"file:///tmp/meeting.wav"}},
+            {"type":"video_url","video_url":{"url":"file:///tmp/meeting.mp4"}}
+          ]
+        }
+        """.utf8)
+        let message = try JSONDecoder().decode(OpenAIChatMessage.self, from: data)
+
+        XCTAssertEqual(message.content, "Summarize the meeting.")
+        XCTAssertEqual(message.imageURLs, ["file:///tmp/slide.png"])
+        XCTAssertEqual(message.audioURLs, ["file:///tmp/meeting.wav"])
+        XCTAssertEqual(message.videoURLs, ["file:///tmp/meeting.mp4"])
+
+        let roundTripped = try JSONDecoder().decode(
+            OpenAIChatMessage.self,
+            from: JSONEncoder().encode(message)
+        )
+        XCTAssertEqual(roundTripped.imageURLs, message.imageURLs)
+        XCTAssertEqual(roundTripped.audioURLs, message.audioURLs)
+        XCTAssertEqual(roundTripped.videoURLs, message.videoURLs)
+    }
+
+    private static let configJSON = """
+    {
+      "architectures":["NemotronH_Nano_Omni_Reasoning_V3"],
+      "model_type":"NemotronH_Nano_Omni_Reasoning_V3",
+      "max_sequence_length":131072,
+      "img_context_token_id":18,
+      "video_context_token_id":131081,
+      "sound_context_token_id":27,
+      "downsample_ratio":0.5,
+      "projector_hidden_size":20480,
+      "vit_hidden_size":1280,
+      "video_pruning_rate":0.7,
+      "vision_config":{
+        "version":"c-radio_v4-h",
+        "patch_size":16,
+        "min_num_patches":1024,
+        "max_num_patches":13312,
+        "video_target_num_patches":1024,
+        "video_temporal_patch_size":2,
+        "separate_video_embedder":true
+      },
+      "sound_config":{
+        "model_type":"parakeet",
+        "hidden_size":1024,
+        "num_attention_heads":8,
+        "num_hidden_layers":24,
+        "intermediate_size":4096,
+        "conv_kernel_size":9,
+        "subsampling_factor":8,
+        "subsampling_conv_channels":256,
+        "subsampling_conv_kernel_size":3,
+        "subsampling_conv_stride":2,
+        "num_mel_bins":128,
+        "projection_hidden_size":4096,
+        "sampling_rate":16000
+      },
+      "llm_config":{
+        "model_type":"nemotron_h",
+        "hidden_size":2688,
+        "vocab_size":131072,
+        "num_hidden_layers":52,
+        "hybrid_override_pattern":"MEMEM*EMEMEM*EMEMEM*EMEMEM*EMEMEM*EMEMEMEM*EMEMEMEME",
+        "max_position_embeddings":262144,
+        "num_attention_heads":32,
+        "num_key_value_heads":2,
+        "head_dim":128,
+        "norm_eps":0.00001,
+        "mamba_head_dim":64,
+        "mamba_num_heads":64,
+        "ssm_state_size":128,
+        "n_groups":8,
+        "conv_kernel":4,
+        "time_step_min":0.001,
+        "time_step_max":0.1,
+        "n_routed_experts":128,
+        "n_shared_experts":1,
+        "num_experts_per_tok":6,
+        "moe_intermediate_size":1856,
+        "moe_shared_expert_intermediate_size":3712,
+        "routed_scaling_factor":2.5,
+        "norm_topk_prob":true,
+        "n_group":1,
+        "topk_group":1,
+        "eos_token_id":11
+      }
+    }
+    """
+
+    private static let preprocessorJSON = """
+    {
+      "patch_size":16,
+      "downsample_ratio":0.5,
+      "norm_mean":[0.48145466,0.4578275,0.40821073],
+      "norm_std":[0.26862954,0.26130258,0.27577711],
+      "min_num_patches":1024,
+      "max_num_patches":13312
+    }
+    """
+}

--- a/Tests/MereRunCoreTests/NemotronOmniTests.swift
+++ b/Tests/MereRunCoreTests/NemotronOmniTests.swift
@@ -4,6 +4,14 @@ import XCTest
 @testable import MereRunCore
 
 final class NemotronOmniTests: MereRunCoreTestCase {
+    func testExpertPackCapacityProbeUsesPortableFileSystemAttributes() throws {
+        let capacity = try NemotronOmniExpertPack.availableCapacity(
+            at: FileManager.default.temporaryDirectory
+        )
+
+        XCTAssertGreaterThan(capacity, 0)
+    }
+
     func testPinnedOmniConfigDecodesAllThreeMediaTowers() throws {
         let config = try JSONDecoder().decode(
             NemotronOmniConfig.self,

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -78,6 +78,7 @@ an effective overlay; they are not a second capability catalog.
 | `text-chat` | `text-chat-inkling-small` |
 | `vision-chat` | `vision-chat-muse-glimmer-30b` |
 | `text-chat` | `text-chat-nemotron-35-lightning` |
+| `omni-chat` | `omni-chat-nemotron3-nano-30b-a3b-bf16` |
 | `text-chat` | `text-chat-q36-nano` |
 | `vision-chat` | `vision-chat-q38-27b` |
 | `vision-chat` | `vision-chat-q38-27b-4bit` |
@@ -405,6 +406,37 @@ conversion of NVIDIA's 967M-parameter DSpark companion at artifact revision
 OpenMDW-1.1 license and upstream model cards, never download implicitly, and do
 not require an additional mere.run acceptance gate solely because the public
 repositories use a custom license identifier.
+
+`omni-chat-nemotron3-nano-30b-a3b-bf16` stages NVIDIA's official
+`Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16` snapshot at immutable revision
+`24e67ea000b7c2837fc8f9488aa2008524fac8ba`. The 66.06 GB checkpoint accepts
+text, images, audio, and video and produces reasoning text. Its document
+examples render PDF pages to images before prompting; PDF is not a separate raw
+input modality. The catalog pins all 17 BF16 weight shards, typed
+Nemotron-H/C-RADIO v4-H/Parakeet configuration contracts, tokenizer and media
+processor metadata, NVIDIA Open Model Agreement terms, 131,072-token composed
+context, and 20,480-token maximum output.
+
+The native Swift/MLX runtime implements the C-RADIO vision tower, Parakeet
+audio tower, BF16 Nemotron-H language backbone, multimodal prefill, local video
+sampling, and media-aware OpenAI chat completions. It is supported on Apple
+Silicon machines with at least 112 GB unified memory and recommended at 128 GB.
+The model remains an explicit pull because its NVIDIA terms must be accepted:
+
+```bash
+mere.run model pull omni-chat-nemotron3-nano-30b-a3b-bf16 \
+  --accept-model-license
+mere.run text chat \
+  --model omni-chat-nemotron3-nano-30b-a3b-bf16 \
+  --video clip.mp4 \
+  --prompt "Summarize the clip."
+```
+
+The runtime consumes the 17 upstream BF16 shards in place and creates a
+source-bound stacked expert cache. A lightweight managed-model wrapper may
+point at an immutable snapshot on external storage, avoiding a second copy of
+the checkpoint while keeping it visible to `model list`, `text chat`, and
+`api serve`.
 
 `text-chat-gemma4-12b` and `vision-chat-gemma4-12b` share Google's dense Gemma
 4 12B-it checkpoint; the text id uses the native chat path, while the vision id

--- a/docs/runtime/model-management.md
+++ b/docs/runtime/model-management.md
@@ -102,7 +102,7 @@ button opens the configured model store in Finder; it does not start a download.
 Examples:
 
 - images: `image-klein-nano`, `image-bonsai-binary`, `image-bonsai-ternary`, `image-zimage-nano`, `image-klein-max`, `image-zimage-max`
-- text: `text-chat-gemma4`, `text-chat-laguna-s-2-1`, `text-chat-laguna-xs-2-1`, `text-chat-nemotron-35-lightning`, `text-chat-q36-nano`, `vision-chat-q38-27b`, `vision-chat-q38-27b-4bit`, `text-chat-bonsai-27b-1bit`, `text-chat-bonsai-27b-2bit`, `text-chat-lfm25-2.6b-4bit`, `text-chat-lfm25-a1b-8bit`, `vision-chat-lfm25-3b-8bit`, `text-agent-deepseek-v4-flash`, `text-agent-qwen35-9b`, `text-agent-ornith-9b`, `text-agent-ornith-35b-mlx`, `text-agent-ornith-35b`, `text-code-north-mini`, `text-code-qwen3`, `text-embed-qwen3-0.6b`
+- text and omni chat: `text-chat-gemma4`, `text-chat-laguna-s-2-1`, `text-chat-laguna-xs-2-1`, `text-chat-nemotron-35-lightning`, `omni-chat-nemotron3-nano-30b-a3b-bf16`, `text-chat-q36-nano`, `vision-chat-q38-27b`, `vision-chat-q38-27b-4bit`, `text-chat-bonsai-27b-1bit`, `text-chat-bonsai-27b-2bit`, `text-chat-lfm25-2.6b-4bit`, `text-chat-lfm25-a1b-8bit`, `vision-chat-lfm25-3b-8bit`, `text-agent-deepseek-v4-flash`, `text-agent-qwen35-9b`, `text-agent-ornith-9b`, `text-agent-ornith-35b-mlx`, `text-agent-ornith-35b`, `text-code-north-mini`, `text-code-qwen3`, `text-embed-qwen3-0.6b`
 - speech: `speech-tts-qwen3-nano`, `speech-asr-parakeet`
 - vision: `vision-ocr-lighton`
 - music: `music-acestep`, `music-acestep-xl-turbo`, `music-acestep-xl-turbo-lm4b`, `music-acestep-xl-sft`, `music-acestep-xl-base`, `music-acestep-lm-1.7b`, `music-acestep-lm-4b`, `music-magenta-rt2-small`, `music-magenta-rt2-base`
@@ -240,6 +240,26 @@ source revisions:
 mere.run model pull text-chat-nemotron-35-lightning
 mere.run text chat --model text-chat-nemotron-35-lightning --stats --prompt "Hello"
 ```
+
+Nemotron 3 Nano Omni is a native Swift/MLX omni runtime for 112+ GB Apple
+Silicon machines. It pins the official 66.06 GB BF16 snapshot and accepts text,
+images, local audio, and local video, producing text. PDF documents are rendered
+to page images before prompting, matching the model's actual input contract.
+The explicit licensed pull and first run are:
+
+```bash
+mere.run model pull omni-chat-nemotron3-nano-30b-a3b-bf16 \
+  --accept-model-license
+mere.run text chat \
+  --model omni-chat-nemotron3-nano-30b-a3b-bf16 \
+  --image page.png \
+  --prompt "Read and summarize this page."
+```
+
+The model is also available from `api serve --engine
+text-chat-nemotron-omni`. OpenAI-compatible message content may contain
+`image_url`, `audio_url`, and `video_url` parts. Media stays local: use local
+paths or `file:` URLs for image/video payloads.
 
 ### `mere.run adapter list` and `mere.run adapter pull`
 


### PR DESCRIPTION
## Summary

- add a native Swift/MLX execution engine for NVIDIA Nemotron 3 Nano Omni 30B A3B Reasoning BF16
- support text, image, audio, video, PDF-page images, and OpenAI structured media content through the managed runtime and API server
- add the C-RADIO vision tower, Parakeet audio tower, local video sampling, Nemotron-H language backbone, source-bound expert packing, and bounded prefill watchdog
- document the gated source, external immutable snapshot wrapper, and first-run expert-pack behavior

## Real installed-checkpoint proof

Validated against the licensed BF16 checkpoint on Apple Silicon:

- text: exact `LAYER_BOUNDED_OK`
- image: correctly described the rainy diner fixture
- audio: exact `The future is now, Nemotron Omni hears every word.`
- video: verified a real red-to-blue fixture and returned exact `Red, Blue`
- live `/v1/chat/completions`: exact `API_OMNI_OK`

## Validation

- `swift test --filter NemotronOmniTests|ModelInventoryTests|ManagedModelCatalogTests|APIServeCommandTests`: 224 tests, 1 expected skip, 0 failures
- `env -u MERERUN_RUN_E2E nice -n 10 ./scripts/check.sh`
  - SwiftLint: 0 violations across 1,335 files
  - XCTest: 3,066 tests, 219 expected checkpoint/E2E skips, 0 failures
  - Swift Testing: 30 tests passed

## Storage and fidelity

- license acceptance remains explicit under the NVIDIA Open Model Agreement
- the internal managed wrapper can point at an external immutable checkpoint snapshot without duplicating the weights
- first native load creates a source-bound expert pack for fast subsequent loads
- video currently preserves all visual tokens for fidelity; configurable upstream EVS visual-token pruning is tracked in #342

Follow-up: #342