### PR TITLE
docs: apply repository writing style pass

### DIFF
--- a/CODEBASE.md
+++ b/CODEBASE.md
@@ -1,8 +1,15 @@
-# mere.run Codebase Map
+# mere.run codebase map
 
-mere.run is a Swift package, CLI, and optional macOS GUI for local-first inference on Apple Silicon. The repo exposes the public `mere.run` executable plus a thin `mere.run.app` SwiftUI wrapper that runs that CLI. Runtime code lives in `MereRunCore`, shared audio primitives live in `AudioCore` and `AudioCodecs`, speech runtimes live in `AudioSTT` and `AudioTTS`, `MereRunCLI` owns the modality-first command surface, and `MereRunApp` owns the GUI shell.
+`mere.run` is a Swift package, command-line interface (CLI), and optional macOS
+graphical user interface (GUI) for local-first inference on Apple Silicon. Use
+this map to find the module that owns your change. The repository exposes the
+public `mere.run` executable and a thin `mere.run.app` SwiftUI wrapper that runs
+the CLI. `MereRunCore` owns runtime code. `AudioCore` and `AudioCodecs` own
+shared audio primitives. `AudioSTT` and `AudioTTS` own speech runtimes.
+`MereRunCLI` owns the modality-first command surface, and `MereRunApp` owns the
+GUI shell.
 
-## Read This First
+## Read this first
 
 1. `Package.swift` for target and dependency flow
 2. `Sources/MereRunCLI/MereRunCLI.swift` for the public command tree
@@ -11,7 +18,7 @@ mere.run is a Swift package, CLI, and optional macOS GUI for local-first inferen
 5. `docs/architecture.md` for runtime reading order
 6. the module README inside the subsystem you are editing
 
-## Key Modules
+## Key modules
 
 - `Sources/MereRunCLI/Commands/`: one file per public command family or large subcommand cluster
 - `apps/macos/`: macOS Studio sources, tests, assets, command templates, and CLI process launching
@@ -38,17 +45,25 @@ mere.run is a Swift package, CLI, and optional macOS GUI for local-first inferen
 - Runtime smoke: `MERERUN_RUN_E2E=core ./scripts/check.sh`
 - Installed-model smoke: `MERERUN_RUN_E2E=installed ./scripts/check.sh`
 
-## Do Not Touch Blindly
+## Review before editing
 
-- `vendor/`: vendored runtime artifacts
-- giant model-definition files in `Sources/MereRunCore/` without first reading the local module README
-- canonical model IDs, migration vocabulary, or hosted-default hygiene checks without updating docs and tests together
+- Do not modify `vendor/` without reviewing the vendored runtime requirements.
+- Before editing a large model-definition file in `Sources/MereRunCore/`, read
+  the local module README.
+- When you change canonical model IDs, migration vocabulary, or hosted-default
+  hygiene checks, update the documentation and tests together.
 
-## Editing Rules
+## Editing rules
 
-- Prefer typed decoding at config/tokenizer boundaries over `[String: Any]`
-- Keep stdout machine-readable and stderr diagnostic in CLI commands
-- Add or update the closest test file for command parsing, model resolution, or compatibility behavior
-- After changing the command tree or command abstracts, run `./scripts/update-docs-command-reference.sh`; the docs contract owns every top-level command and fails `swift test` on drift
-- Add a module README before a source directory grows past 500 direct Swift lines
-- If a change requires real checkpoint assets or GPU-only validation, stop after the local gate and report the remaining validation gap explicitly
+- Prefer typed decoding at configuration and tokenizer boundaries over
+  `[String: Any]`.
+- Keep stdout machine-readable and stderr diagnostic in CLI commands.
+- Add or update the closest test file for command parsing, model resolution, or
+  compatibility behavior.
+- After changing the command tree or command abstracts, run
+  `./scripts/update-docs-command-reference.sh`. The documentation contract owns
+  every top-level command and fails `swift test` on drift.
+- Add a module README before a source directory grows past 500 direct Swift
+  lines.
+- If a change requires real checkpoint assets or GPU-only validation, stop
+  after the local gate and report the remaining validation gap explicitly.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,24 @@
 - If you touch vendored artifacts or third-party package pins, update [`THIRD_PARTY_NOTICES.md`](./THIRD_PARTY_NOTICES.md).
 - Do not add hosted-service, billing, or app-store-only surfaces back into this repo.
 
+## Writing documentation
+
+Follow the [documentation style guide](./docs/documentation-style.md) for public
+pages, command descriptions, and examples. In particular:
+
+- write directly to the reader in active voice and present tense
+- use sentence case for titles and headings
+- use descriptive link text and accessible document structure
+- use reserved domains and fictional identifiers in examples
+- identify dated evidence and historical benchmark receipts precisely
+
+Run the focused documentation checks before you open a pull request:
+
+```bash
+bash ./scripts/check-docs-examples.sh
+pnpm docs:build
+```
+
 ## Opening issues
 
 - Use GitHub issues for bugs, docs gaps, and feature requests.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 <p align="center">
   <a href="https://mere.run">mere.run</a> ·
-  <a href="https://docs.mere.run/">Docs</a> ·
+  <a href="https://docs.mere.run/">Documentation</a> ·
   <a href="https://mere.run/releases">Downloads</a> ·
   <a href="https://relay.mere.run">Relay + Nodes</a> ·
   <a href="https://plugins.mere.run">Plugins</a> ·
@@ -46,19 +46,19 @@ mere.run image generate \
 
 Use `mere.run guide <command path>` for the packaged offline cookbook behind a
 creative or model-specific command, and `mere.run <group> --help` for the exact
-current flags.
+supported flags.
 
-## What works today
+## Supported capabilities
 
-| Area | Public commands | Current surface |
+| Area | Public commands | Supported behavior |
 | --- | --- | --- |
 | Images and LoRAs | `image generate`, `image train-lora`, `adapter list`, `adapter pull` | Klein, ZImage, HiDream O1, Krea 2, Ideogram 4, and Bonsai; text-to-image, edits, multiple references, structured prompts, local Krea/Klein training, and checksum-pinned public adapters |
-| Text, code, and agents | `text chat`, `text code`, `text embed`, `text anonymize`, `text train-lora`, `agent` | Local chat and tool use, including Qwen3.8 27B BF16/4-bit and Bonsai 27B binary/ternary vision chat; code generation, embeddings, PII redaction, text LoRA training, and guided local-agent setup |
+| Text, code, and agents | `text chat`, `text code`, `text embed`, `text anonymize`, `text train-lora`, `agent` | Local chat and tool use, including Qwen3.8 27B BF16/4-bit and Bonsai 27B binary/ternary vision chat; code generation, embeddings, personally identifiable information (PII) redaction, text LoRA training, and guided local-agent setup |
 | Vision understanding | `vision caption`, `inspect`, `face`, `ground`, `segment`, `track`, `track-live`, `pose`, `flow`, `ocr` | Captioning and VQA, local face detection/identity embeddings, LightOn/GLM/Infinity OCR, Falcon grounding, SAM 3.1 segmentation and tracking, body/hand/face landmarks, and dense optical flow |
 | Depth, geometry, and 3D | `vision depth-video`, `geometry`, `geometry-multiview`, `image-to-3d*`; `image reconstruct-3d*` | Video Depth Anything, MoGe-2, Depth Anything 3, TripoSR, InstantMesh, and TRELLIS.2; depth/confidence EXRs, cameras, point clouds, 3DGS initialization, OBJ, PLY, GLB, and PBR voxel artifacts |
 | Audio enhancement | `audio enhance` | Native AP-BWE speech bandwidth extension and UniverSR general-audio super-resolution to hashed 48 kHz mono WAVs |
 | Video and worlds | `video generate`, `video cosmos3`, `video prepare-masks`, `video animate`, `video session`, `video export-latents`, `world serve` | MiniMax-H3 FL2VA/Ref2VA synchronized video and audio, native LTX 2.5 and LTX 2.3 synchronized audio/video, resident distilled and full-dev LTX workers, Wan 2.2 TI2V, native Cosmos3-Edge generation/reasoning/action dynamics, native SAM 3.1 mask preparation, native SCAIL-2 subject animation/replacement, and warm DreamX or Cosmos3 world sessions |
-| Music and sound | `music analyze`, `generate`, `realtime`, `separate`, `transcribe`; `sfx generate`, `sfx video generate` | Native MiniMax Music 3 full-song generation; ACE-Step generation, analysis, and covers; Magenta RT2 realtime MIDI performance; native RoFormer separation, dereverb, and denoise; MuScriptor full-mix MIDI transcription; Woosh and native MMAudio text/video-conditioned sound |
+| Music and sound | `music analyze`, `generate`, `realtime`, `separate`, `transcribe`; `sfx generate`, `sfx video generate` | Native MiniMax Music 3 full-song generation; ACE-Step generation, analysis, and covers; Magenta RT2 real-time MIDI performance; native RoFormer separation, dereverb, and denoise; MuScriptor full-mix MIDI transcription; Woosh and native MMAudio text/video-conditioned sound |
 | Speech | `speech synthesize`, `speech transcribe`, `speech diarize`, `speech listen`, `speech profile` | Qwen3 TTS, saved voice profiles, Qwen3 live ASR, Parakeet transcription, and native MLX Sortformer speaker diarization |
 | Serving and operations | `api serve`, `open-webui quickstart`, `status`, `run`, `model runtime`, `gate` | OpenAI-compatible chat, embeddings, images, TTS, and STT; resident model pooling, TTL/pinning, memory guards, durable run inspection, and installed-model quality gates |
 | Automation | `--preflight --json`, `--progress-json`, `image run-plan`, `guide` | Typed preflight actions, machine-readable progress, replayable plans, durable run directories, checksums, and offline command cookbooks |
@@ -70,14 +70,14 @@ vary by command, so check `mere.run model capabilities` before a large pull and
 [`docs/model-sources.md`](./docs/model-sources.md) before redistributing model
 artifacts.
 
-## Relay, Nodes, and plugins
+## Relay, nodes, and plugins
 
 The core runtime stays local, but it does not have to stay on one machine.
 
 - [Relay](https://relay.mere.run) pools Macs and Linux hosts approved under the
   same mere.world account. The separate `mere.run node` desktop app advertises
   each machine's models and availability, then accepts work through an outbound
-  connection. Current node downloads cover macOS, Linux x86_64, and Linux arm64.
+  connection. Active Node builds are available for macOS and Linux x86_64.
 - [Official plugins](https://plugins.mere.run) are companion executables for
   VFX, realtime performance, production tracking, private document workflows,
   automation, and user-owned GPU training. They keep plans, manifests,
@@ -94,7 +94,7 @@ Relay/Node code lives in `sawfwair/relay-mere-run`; plugin contracts and source
 live in [`sawfwair/mere-run-plugins`](https://github.com/sawfwair/mere-run-plugins).
 Neither adds a hosted inference backend to this repository.
 
-## What’s included in this repo
+## Included components
 
 - `Sources/MereRunCore`: shared model resolution, manifests, generation primitives, and MLX-backed inference code
 - `Sources/AudioCore`, `Sources/AudioCodecs`, `Sources/AudioSTT`, `Sources/AudioTTS`: audio generation and transcription support
@@ -108,19 +108,30 @@ Neither adds a hosted inference backend to this repository.
 
 ## Platform expectations
 
-- the public CLI and local runtime are developed and validated on Apple Silicon macOS 15 or newer
-- the optional SwiftUI studio, app bundle, installer, and DMG are macOS-only; Linux compatibility work is for the headless `mere.run` CLI
-- `Package.swift` uses Swift tools 6.0 and declares macOS 15 / iOS 18 package platforms
-- `swift build` and `swift test` are the supported first-run validation path for macOS contributors
-- Linux CLI compatibility work expects a Swift 6.x toolchain, `clang`, `cmake`, `ninja`, `pkg-config`, `gfortran`, curl/zlib/OpenBLAS/LAPACK development headers, `ffmpeg`, `ffprobe`, `gzip`, `unzip`, and `zip`
-- media I/O should discover `ffmpeg` and `ffprobe` on `PATH`, with `MERERUN_FFMPEG` and `MERERUN_FFPROBE` reserved for absolute executable overrides
-- hosted Linux CI should stay CPU MLX-oriented and fixture-sized; Linux arm64 release packages must use a real CUDA lane
-- Linux CUDA validation is limited to the exact hosts that have run the CUDA package and smoke path
-- some vendored binaries include additional Apple platform slices for package consumers, while Linux release artifacts stay headless CLI-only
+- The public CLI and local runtime are developed and validated on Apple Silicon
+  with macOS 15 or later.
+- The optional SwiftUI Studio, app bundle, installer, and DMG are available only
+  on macOS. Linux compatibility work applies to the headless `mere.run` CLI.
+- `Package.swift` uses Swift tools 6.0 and declares macOS 15 and iOS 18 package
+  platforms.
+- `swift build` and `swift test` are the supported first-run validation path for
+  macOS contributors.
+- Linux CLI compatibility work requires a Swift 6.x toolchain, `clang`,
+  `cmake`, `ninja`, `pkg-config`, `gfortran`, curl/zlib/OpenBLAS/LAPACK
+  development headers, `ffmpeg`, `ffprobe`, `gzip`, `unzip`, and `zip`.
+- Media I/O discovers `ffmpeg` and `ffprobe` on `PATH`.
+  `MERERUN_FFMPEG` and `MERERUN_FFPROBE` provide absolute executable overrides.
+- Hosted Linux CI remains CPU MLX-oriented and fixture-sized. Active release
+  builds cover macOS and the configured `tensor.local` x86_64 CUDA builder.
+  The arm64 CUDA release lane is paused until a matching host is available.
+- Linux CUDA validation applies only to hosts that have run the CUDA package
+  and smoke path.
+- Some vendored binaries include additional Apple platform slices for package
+  consumers. Linux release artifacts remain headless and CLI-only.
 
-## Install the latest release
+## Install a signed release
 
-The latest signed macOS build is mirrored at:
+The signed macOS build is mirrored at:
 
 ```bash
 curl -L https://mere.run/releases/mere-run.dmg -o mere-run.dmg
@@ -153,11 +164,11 @@ Pass `preview` one percent-encoded absolute artifact path. It supports images,
 audio, video, text, and Quick Look-compatible 3D files:
 
 ```text
-mererun://preview?path=%2FUsers%2Fme%2FDesktop%2Fresult.png
+mererun://preview?path=%2FUsers%2Fdana%2FDesktop%2Fresult.png
 ```
 
 ```bash
-open 'mererun://preview?path=%2FUsers%2Fme%2FDesktop%2Fresult.png'
+open 'mererun://preview?path=%2FUsers%2Fdana%2FDesktop%2Fresult.png'
 ```
 
 The target must already exist and be a readable file. MereRun rejects relative
@@ -165,17 +176,17 @@ paths, directories, missing files, duplicate `path` values, and extra query
 parameters. This route remains an explicit preview-only option; it does not
 import, move, or modify the artifact.
 
-See [macOS Deep Links](./docs/macos-deep-links.md) for both route contracts and
+See [macOS deep links](./docs/macos-deep-links.md) for both route contracts and
 security boundaries. The separate [Raycast integration](./docs/raycast.md) is
 one example client built on the same public handoff.
 
 Linux package builds are headless CLI-only. They install the `mere.run` CLI plus
 colocated runtime assets; they do not include the macOS SwiftUI studio or DMG
-layout. See the dedicated [Linux QuickStart](./docs/linux-quickstart.md) for the
-current validation boundary, CUDA notes, and first commands. On Linux arm64, if a distro Clang shadows Swift's
+layout. See the dedicated [Linux quickstart](./docs/linux-quickstart.md) for the
+validation boundary, CUDA notes, and first commands. On Linux arm64, if a distribution's Clang shadows Swift's
 bundled Clang and cannot compile MLX bf16 headers, the Linux scripts select a
 bf16-capable C++ driver or report the `CXX` override to use. Linux arm64 release
-packages should be built with CUDA enabled on a host with the CUDA Toolkit
+packages must be built with CUDA enabled on a host with the CUDA Toolkit
 headers, CUDA CCCL headers, cuDNN, and NCCL installed. CUDA `.deb` artifacts
 derive their runtime/JIT dependencies from the linked `libcudart` major. CUDA
 12 packages target the 12.8 NVIDIA packages with Lambda Stack alternatives;
@@ -189,8 +200,8 @@ MERERUN_LINUX_ACCEL=cuda MERERUN_SKIP_MLX_CUDA_EXAMPLE=1 \
   scripts/package-linux.sh --version 0.23.0 --artifact-suffix cuda
 ```
 
-Current CUDA validation should be treated as limited to the exact hosts that
-have run the CUDA package/smoke path.
+CUDA validation applies only to hosts that have run the CUDA package and smoke
+path.
 
 ## Build from source
 
@@ -456,7 +467,7 @@ swift run mere.run text chat \
 
 # Redact PII locally
 swift run mere.run text anonymize \
-  "My name is Alice Smith and my email is alice@example.com"
+  "My name is Dana Example and my email is dana@example.com"
 
 # Serve the OpenAI-compatible local API on loopback
 swift run mere.run api serve --engine text-chat-gemma4
@@ -994,10 +1005,11 @@ management, API serving, and arbitrary arguments in Advanced details.
 
 ## Vision notes
 
-- `vision-segment-sam31` is the single managed SAM 3.1 package for segmentation and tracking
-- `mere.run vision segment` supports text prompts plus box and point prompting
-- `mere.run vision track` seeds objects on the init frame, then propagates them through later frames
-- `mere.run vision track-live` currently records a camera clip first, searches a short warm-up window for seed objects, and then runs tracking over that recording
+- `vision-segment-sam31` is the single managed SAM 3.1 package for segmentation and tracking.
+- `mere.run vision segment` supports text prompts and box or point prompting.
+- `mere.run vision track` seeds objects on the initial frame and then propagates them through later frames.
+- `mere.run vision track-live` records a camera clip, searches a short warm-up
+  window for seed objects, and then runs tracking over that recording.
 
 ## Model store
 
@@ -1020,8 +1032,8 @@ Keep one writable store while unifying models already held on other disks:
 # Search a catalog laid out as <root>/<canonical-model-id>/
 mere.run model location add /Volumes/Models
 
-# Or bind an arbitrary folder name to one canonical model id
-mere.run model location bind video-ltx23-full-mlx /Volumes/SALVATION/models/LTX-2.3 \
+# Or bind an arbitrary folder name to one canonical model ID
+mere.run model location bind video-ltx23-full-mlx /Volumes/ExampleModels/LTX-2.3 \
   --accept-model-license
 
 mere.run model location list
@@ -1062,33 +1074,38 @@ mere.run model gc          # read-only plan
 mere.run model gc --force  # recompute under lock, then delete
 ```
 
-`model remove <id>` reclaims backing payloads only when no other current or
+`model remove <id>` reclaims backing payloads only when no other active or
 legacy model link uses them; `--keep-cache` retains those bytes intentionally.
-New pulls are revision-addressed and hard-link matching content blobs, while
+Managed pulls are revision-addressed and hard-link matching content blobs, while
 existing legacy cache directories remain compatible and can be adopted without
 copying payload bytes.
 
 ## Security defaults
 
-The public OSS build keeps local-first behavior by default and requires explicit opt-in for higher-risk modes:
+The public open-source build keeps local-first behavior by default and requires
+explicit opt-in for higher-risk modes:
 
 - `mere.run api serve --preflight --json` reports host/port, auth, model,
   runtime, and redacted follow-up actions before starting a server or loading a
   model
-- `mere.run api serve` can bind to loopback without auth, but non-loopback hosts require `--api-key` or `MERERUN_API_KEY`
+- `mere.run api serve` can bind to loopback without authentication, but
+  non-loopback hosts require `--api-key` or `MERERUN_API_KEY`.
 - the OpenAI-compatible chat and embedding routes require `Content-Type: application/json`, support `--rate-limit-per-minute` for basic abuse control, decode the common OpenAI request shapes, and reject unsupported high-impact fields before generation
 - `/v1/models` adds task, tool-call, reasoning, modality, limit, and
-  compatibility metadata. The bundled Pi provider consumes these fields and
+  compatibility metadata. The bundled Pi provider uses these fields and
   exposes only tool-capable chat models instead of guessing from model names.
   Those fields project from typed managed-model catalog profiles; aliases and
   active runtime limit overrides are layered on when the server responds.
 - API LoRA adapters are operator-controlled with `--lora`; it accepts a
   verified installed adapter catalog id or a local path, while per-request LoRA
-  paths are rejected
-- tool-loop execution in `mere.run text chat` requires interactive approval unless `--auto-approve-tools` is passed for non-shell tools
-- `shell_exec` is disabled unless `--allow-shell-exec` is set, and still requires interactive approval when enabled
-- `write_file` stays inside the sandbox unless `--allow-absolute-tool-paths` is set
-- remote model and LoRA downloads reject plaintext HTTP except for loopback and local-dev cases
+  paths are rejected.
+- Tool-loop execution in `mere.run text chat` requires interactive approval
+  unless `--auto-approve-tools` is passed for non-shell tools.
+- `shell_exec` is disabled unless `--allow-shell-exec` is set and requires
+  interactive approval when enabled.
+- `write_file` stays inside the sandbox unless `--allow-absolute-tool-paths` is set.
+- Remote model and LoRA downloads reject plaintext HTTP except for loopback and
+  local-development cases.
 
 These flags are intentionally explicit because they weaken the default safety posture:
 
@@ -1110,7 +1127,7 @@ MERERUN_RUN_E2E=core ./scripts/check.sh
 MERERUN_RUN_E2E=installed ./scripts/check.sh
 ```
 
-## Docs
+## Documentation
 
 Start with the docs home:
 
@@ -1129,6 +1146,8 @@ Core guides:
   relay, worker protocol, and remote run lifecycle
 - [`docs/repository-tour.md`](./docs/repository-tour.md): top-level layout and module ownership
 - [`docs/development-workflow.md`](./docs/development-workflow.md): how to work in the repo day to day
+- [`docs/documentation-style.md`](./docs/documentation-style.md): voice,
+  headings, accessibility, example data, and review checks
 - [`docs/testing.md`](./docs/testing.md): validation layers, smoke runs, and troubleshooting
 - [`docs/runtime/vision.md`](./docs/runtime/vision.md): native SAM 3.1 segmentation and tracking details
 - [`docs/runtime/sfx.md`](./docs/runtime/sfx.md): native Woosh and MMAudio SFX generation, CLAP scoring, and video-conditioned generation details
@@ -1161,7 +1180,7 @@ mere-run/
   vendor/
 ```
 
-## Acknowledgements
+## Acknowledgments
 
 mere.run exists because the Python MLX community proved that local-first inference on Apple Silicon could feel fast, practical, and joyful. This Swift package is not a replacement for that work; it is a port of those ideas into a public Swift runtime and CLI. The shape of mere.run — what to expose, how to manage models, how to keep inference paths Metal-native — was directly informed by these projects:
 
@@ -1173,4 +1192,8 @@ mere.run exists because the Python MLX community proved that local-first inferen
   how `mere.run image` loads components, schedules denoising, decodes VAE
   output, exposes engines, and validates generated images.
 
-Where these projects ship runtime artifacts that mere.run actually links against, attribution and license terms live in [`THIRD_PARTY_NOTICES.md`](./THIRD_PARTY_NOTICES.md). The credits above are for the architectural debt: the design conversations, reference implementations, and hard-won model bring-up work these repos held in public before mere.run wrote its first line of Swift.
+When these projects ship runtime artifacts that mere.run links against,
+[`THIRD_PARTY_NOTICES.md`](./THIRD_PARTY_NOTICES.md) records their attribution
+and license terms. The acknowledgments recognize the design discussions,
+reference implementations, and model bring-up work that these repositories
+published before mere.run began its Swift implementation.

--- a/Sources/MereRunCLI/Commands/AgentCommand.swift
+++ b/Sources/MereRunCLI/Commands/AgentCommand.swift
@@ -188,7 +188,7 @@ struct AgentOnboard: AsyncParsableCommand {
     )
     var acceptModelLicense: Bool = false
 
-    @Flag(name: [.long], help: "Install the latest Pi coding-agent release from GitHub.")
+    @Flag(name: [.long], help: "Install the most recent published Pi coding-agent release from GitHub.")
     var installPi: Bool = false
 
     @Flag(name: [.long], help: "Write a Pi extension that registers the local mere.run API provider.")
@@ -374,7 +374,7 @@ struct AgentOnboard: AsyncParsableCommand {
 struct AgentInstallPi: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "install-pi",
-        abstract: "Install the latest Pi coding-agent release for use with mere.run."
+        abstract: "Install the most recent published Pi coding-agent release for use with mere.run."
     )
 
     @Flag(name: [.long], help: "Re-download and replace the current installed Pi release.")
@@ -417,7 +417,7 @@ struct AgentStart: AsyncParsableCommand {
     @Option(name: [.long], help: "Working directory for the Pi process.")
     var workingDirectory: String?
 
-    @Flag(name: [.long], help: "Run Pi in the current terminal instead of opening Terminal.app.")
+    @Flag(name: [.long], help: "Run Pi in the active terminal instead of opening Terminal.app.")
     var inline: Bool = false
 
     @Option(name: [.long], help: "Managed agent model id to serve through Pi.")

--- a/Sources/MereRunCLI/Commands/GeoFireCommand.swift
+++ b/Sources/MereRunCLI/Commands/GeoFireCommand.swift
@@ -6,7 +6,7 @@ import MereRunCore
 struct GeoFire: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "fire",
-        abstract: "Run native TerraMind Fire tile inference with MLX on Apple silicon."
+        abstract: "Run native TerraMind Fire tile inference with MLX on Apple Silicon."
     )
 
     @Argument(help: "Safetensors input containing normalized S2L2A, S1RTC, and DEM tile batches.")

--- a/Sources/MereRunCLI/Commands/GeoFloodCommand.swift
+++ b/Sources/MereRunCLI/Commands/GeoFloodCommand.swift
@@ -6,7 +6,7 @@ import MereRunCore
 struct GeoFlood: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "flood",
-        abstract: "Run native TerraMind Flood tile inference with MLX on Apple silicon."
+        abstract: "Run native TerraMind Flood tile inference with MLX on Apple Silicon."
     )
 
     @Argument(help: "Safetensors input containing normalized S2L2A, S1RTC, and DEM tile batches.")

--- a/Sources/MereRunCLI/Commands/ImageReconstruct3DMultiviewCommand.swift
+++ b/Sources/MereRunCLI/Commands/ImageReconstruct3DMultiviewCommand.swift
@@ -11,7 +11,7 @@ struct InstantMeshCameraDocument: Codable, Equatable {
 struct ImageReconstruct3DMultiview: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "reconstruct-3d-multiview",
-        abstract: "Reconstruct a colored mesh from 4 or 6 user-supplied views with native InstantMesh."
+        abstract: "Reconstruct a colored mesh from four or six supplied views with native InstantMesh."
     )
 
     @Option(
@@ -171,7 +171,7 @@ struct ImageReconstruct3DMultiview: AsyncParsableCommand {
 struct VisionImageTo3DMultiview: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "image-to-3d-multiview",
-        abstract: "VFX alias for native 4/6-view InstantMesh reconstruction."
+        abstract: "VFX alias for native four-view or six-view InstantMesh reconstruction."
     )
 
     @Option(name: [.customLong("view")], parsing: .singleValue, help: "Ordered view path; repeat 4 or 6 times.")

--- a/Sources/MereRunCLI/Commands/ModelBenchmarkChatCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelBenchmarkChatCommand.swift
@@ -5,7 +5,7 @@ import MereRunCore
 struct ModelBenchmarkChat: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "chat",
-        abstract: "Run a small grounded-chat eval slice against local assistant models."
+        abstract: "Run a small grounded-chat evaluation slice against local assistant models."
     )
 
     @Option(name: [.long], help: "Comma-separated model ids. Defaults to the local chat comparison lane.")

--- a/Sources/MereRunCLI/Commands/ModelBenchmarkCodeCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelBenchmarkCodeCommand.swift
@@ -5,7 +5,7 @@ import MereRunCore
 struct ModelBenchmarkCode: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "code",
-        abstract: "Run a real coding-eval slice against local coding models."
+        abstract: "Run a real coding-evaluation slice against local coding models."
     )
 
     @Option(name: [.long], help: "Comma-separated model ids. Defaults to the installed coding comparison lane.")

--- a/Sources/MereRunCLI/Commands/ModelBenchmarkToolCallsCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelBenchmarkToolCallsCommand.swift
@@ -5,7 +5,7 @@ import MereRunCore
 struct ModelBenchmarkToolCalls: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "tool-calls",
-        abstract: "Run a small tool-call selection eval against local chat models."
+        abstract: "Run a small tool-call selection evaluation against local chat models."
     )
 
     @Option(name: [.long], help: "Comma-separated model ids. Defaults to Q36 and Gemma 4 12B 4-bit.")

--- a/Sources/MereRunCLI/Commands/ModelLocationCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelLocationCommand.swift
@@ -129,7 +129,7 @@ struct ModelLocationRemove: ParsableCommand {
 struct ModelLocationBind: ParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "bind",
-        abstract: "Bind a canonical model id to an arbitrary read-only directory."
+        abstract: "Bind a canonical model ID to an arbitrary read-only directory."
     )
 
     @Argument(help: "Canonical model id.")

--- a/Sources/MereRunCLI/Commands/SpeechProfileCommand.swift
+++ b/Sources/MereRunCLI/Commands/SpeechProfileCommand.swift
@@ -122,7 +122,7 @@ struct SpeechProfileCreate: AsyncParsableCommand {
 struct SpeechProfileDelete: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "delete",
-        abstract: "Delete a speech profile by id."
+        abstract: "Delete a speech profile by ID."
     )
 
     @Option(name: [.long], help: "Profile UUID.")

--- a/Tests/MereRunCLITests/DocumentationContractTests.swift
+++ b/Tests/MereRunCLITests/DocumentationContractTests.swift
@@ -162,7 +162,7 @@ final class DocumentationContractTests: XCTestCase {
         XCTAssertTrue(studio.contains("https://studio.mere.run/"))
         XCTAssertTrue(workflows.contains("Graph v2 runtime and v1 contract"))
         XCTAssertTrue(studio.contains("Do not change a workflow to `schema_version: 2`"))
-        XCTAssertTrue(studio.contains("Local Studio never requires Mere World sign-in"))
+        XCTAssertTrue(studio.contains("Local Studio does not require Mere World sign-in"))
         XCTAssertTrue(studio.contains("Mere World OAuth Authorization Code with PKCE"))
         XCTAssertTrue(studio.contains("OAuth device grant"))
         XCTAssertTrue(studio.contains("does not open a browser callback or local web server"))

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -50,71 +50,73 @@ export default defineConfig({
       {
         text: 'Introduction',
         items: [
-          { text: 'Docs Home', link: '/' },
-          { text: 'Getting Started', link: '/getting-started' },
-          { text: 'macOS Deep Links', link: '/macos-deep-links' },
-          { text: 'Linux QuickStart', link: '/linux-quickstart' },
-          { text: 'CLI Reference', link: '/cli' },
-          { text: 'Offline Cookbooks', link: '/cookbooks' },
+          { text: 'Docs home', link: '/' },
+          { text: 'Getting started', link: '/getting-started' },
+          { text: 'macOS deep links', link: '/macos-deep-links' },
+          { text: 'Linux quickstart', link: '/linux-quickstart' },
+          { text: 'CLI reference', link: '/cli' },
+          { text: 'Offline cookbooks', link: '/cookbooks' },
         ]
       },
       {
-        text: 'Workflows and Operations',
+        text: 'Workflows and operations',
         items: [
-          { text: 'Portable Workflows', link: '/workflows' },
+          { text: 'Portable workflows', link: '/workflows' },
           { text: 'Graph Studio', link: '/graph/studio' },
           { text: 'Configuration', link: '/configuration' },
-          { text: 'Quality Gate', link: '/gate' },
-          { text: 'Model Sources', link: '/model-sources' },
-          { text: 'Companion Plugins', link: '/plugins' },
-          { text: 'Raycast Example', link: '/raycast' }
+          { text: 'Quality gate', link: '/gate' },
+          { text: 'Model sources', link: '/model-sources' },
+          { text: 'Companion plugins', link: '/plugins' },
+          { text: 'Raycast example', link: '/raycast' }
         ]
       },
       {
         text: 'Benchmarks',
         items: [
-          { text: 'Benchmarking Overview', link: '/benchmarking' },
-          { text: 'Fused Model Evaluation', link: '/benchmark-fused' },
-          { text: 'Fused Reference Runs', link: '/benchmarks/fused-reference-runs' },
-          { text: 'External Evaluation Packs', link: '/evaluation-packs' }
+          { text: 'Benchmarking overview', link: '/benchmarking' },
+          { text: 'Fused model evaluation', link: '/benchmark-fused' },
+          { text: 'Fused reference runs', link: '/benchmarks/fused-reference-runs' },
+          { text: 'External evaluation packs', link: '/evaluation-packs' }
         ]
       },
       {
-        text: 'Repository Guides',
+        text: 'Repository guides',
         items: [
-          { text: 'Repository Tour', link: '/repository-tour' },
-          { text: 'Development Workflow', link: '/development-workflow' },
-          { text: 'Testing Guide', link: '/testing' },
-          { text: 'Architecture Reading Map', link: '/architecture' },
-          { text: 'mlx-swift Fork Policy', link: '/mlx-swift-fork' }
+          { text: 'Repository tour', link: '/repository-tour' },
+          { text: 'Development workflow', link: '/development-workflow' },
+          { text: 'Testing guide', link: '/testing' },
+          { text: 'Documentation style', link: '/documentation-style' },
+          { text: 'Documentation style audit', link: '/documentation-style-audit' },
+          { text: 'Architecture reading map', link: '/architecture' },
+          { text: 'mlx-swift fork policy', link: '/mlx-swift-fork' }
         ]
       },
       {
-        text: 'Runtime Families',
+        text: 'Runtime families',
         items: [
-          { text: 'Image Runtime', link: '/runtime/image' },
-          { text: 'Text Runtime', link: '/runtime/text' },
-          { text: 'Speech Runtime', link: '/runtime/speech' },
-          { text: 'Vision Runtime', link: '/runtime/vision' },
-          { text: 'Geospatial Runtime', link: '/runtime/geo' },
-          { text: 'Audio Enhancement', link: '/runtime/audio' },
-          { text: 'Music Runtime', link: '/runtime/music' },
-          { text: 'ACE-Step Validation', link: '/runtime/acestep-validation' },
-          { text: 'SFX Runtime', link: '/runtime/sfx' },
-          { text: 'Video Runtime', link: '/runtime/video' },
-          { text: 'Persistent Worlds', link: '/runtime/world' },
-          { text: 'Model Management', link: '/runtime/model-management' },
-          { text: 'Local API Server', link: '/runtime/api-server' }
+          { text: 'Image runtime', link: '/runtime/image' },
+          { text: 'Text runtime', link: '/runtime/text' },
+          { text: 'Speech runtime', link: '/runtime/speech' },
+          { text: 'Vision runtime', link: '/runtime/vision' },
+          { text: 'Geospatial runtime', link: '/runtime/geo' },
+          { text: 'Audio enhancement', link: '/runtime/audio' },
+          { text: 'Music runtime', link: '/runtime/music' },
+          { text: 'ACE-Step validation', link: '/runtime/acestep-validation' },
+          { text: 'SFX runtime', link: '/runtime/sfx' },
+          { text: 'Video runtime', link: '/runtime/video' },
+          { text: 'Persistent worlds', link: '/runtime/world' },
+          { text: 'Model management', link: '/runtime/model-management' },
+          { text: 'Local API server', link: '/runtime/api-server' }
         ]
       },
       {
         text: 'Internals',
         items: [
-          { text: 'CLI and Runtime Internals', link: '/internals/cli-and-runtime' },
-          { text: 'Structured Runs, Preflights, and Declarative Actions', link: '/internals/structured-runs-preflight-actions' },
-          { text: 'Source Layout Reference', link: '/internals/source-layout' },
-          { text: 'Guarded Acceleration Audit', link: '/internals/guarded-acceleration' },
-          { text: 'DiT Forward-Pass Performance', link: '/internals/dit-performance' }
+          { text: 'CLI and runtime internals', link: '/internals/cli-and-runtime' },
+          { text: 'Structured runs, preflights, and declarative actions', link: '/internals/structured-runs-preflight-actions' },
+          { text: 'Source layout reference', link: '/internals/source-layout' },
+          { text: 'Guarded acceleration audit', link: '/internals/guarded-acceleration' },
+          { text: 'DiT forward-pass performance', link: '/internals/dit-performance' }
         ]
       }
     ],

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,13 +1,13 @@
-# mere.run Documentation
+# mere.run documentation
 
-This documentation set is organized like a practical manual for the public
-`mere.run` package, CLI, and optional macOS studio. The goal is to make it easy to learn the tool,
-understand the repository, and navigate the runtime code without guessing where
-things live.
+Use this documentation to learn the public `mere.run` package, CLI, and optional
+macOS Studio. The pages are organized by task, runtime family, and contributor
+workflow so you can find the relevant command or source module directly.
 
 ## Run the docs site locally
 
-The repo ships with a VitePress site for these docs:
+The repository includes a VitePress site for these docs. Install the site
+dependencies, and then start the local development server:
 
 ```bash
 brew install node pnpm
@@ -24,7 +24,7 @@ Build the static site with:
 pnpm docs:build
 ```
 
-The repo also includes a dedicated GitHub Pages workflow at
+The repository also includes a GitHub Pages workflow at
 `.github/workflows/docs.yml`. On pull requests it builds the site as a docs-only
 CI job, and on `main` it deploys the VitePress output to Pages at
 `https://docs.mere.run/`.
@@ -33,116 +33,121 @@ CI job, and on `main` it deploys the VitePress output to Pages at
 
 If you are new to the repo, read these in order:
 
-1. [Getting Started](./getting-started.md)
-2. [macOS Deep Links](./macos-deep-links.md), if a local tool should preview or import artifacts in MereRun
-3. [Linux QuickStart](./linux-quickstart.md), if you are installing the headless CLI on Linux
-4. [CLI Reference](./cli.md)
-5. [Portable Workflows](./workflows.md), if you are automating local or remote jobs
+1. [Getting started](./getting-started.md)
+2. [macOS deep links](./macos-deep-links.md), if a local tool should preview or import artifacts in MereRun
+3. [Linux quickstart](./linux-quickstart.md), if you are installing the headless CLI on Linux
+4. [CLI reference](./cli.md)
+5. [Portable workflows](./workflows.md), if you are automating local or remote jobs
 6. [Graph Studio](./graph/studio.md), if you want to author Graph v2 workflows visually
 7. [Benchmarking](./benchmarking.md)
 8. [External evaluation packs](./evaluation-packs.md)
 9. [Cookbooks](./cookbooks.md)
 10. [Configuration](./configuration.md)
-11. [Model Sources](./model-sources.md)
-12. [Companion Plugins](./plugins.md)
-13. [Repository Tour](./repository-tour.md)
+11. [Model sources](./model-sources.md)
+12. [Companion plugins](./plugins.md)
+13. [Repository tour](./repository-tour.md)
 
 ## Choose your path
 
 ### I want to use `mere.run`
 
-- [Getting Started](./getting-started.md)
-- [macOS Deep Links](./macos-deep-links.md)
-- [Linux QuickStart](./linux-quickstart.md)
-- [CLI Reference](./cli.md)
+- [Getting started](./getting-started.md)
+- [macOS deep links](./macos-deep-links.md)
+- [Linux quickstart](./linux-quickstart.md)
+- [CLI reference](./cli.md)
 - [Benchmarking](./benchmarking.md)
 - [External evaluation packs](./evaluation-packs.md)
 - [Cookbooks](./cookbooks.md)
-- [Portable Workflows](./workflows.md)
+- [Portable workflows](./workflows.md)
 - [Graph Studio](./graph/studio.md)
 - [Configuration](./configuration.md)
-- [Model Sources](./model-sources.md)
-- [Companion Plugins](./plugins.md)
+- [Model sources](./model-sources.md)
+- [Companion plugins](./plugins.md)
 
 ### I want to contribute code
 
-- [Repository Tour](./repository-tour.md)
-- [Development Workflow](./development-workflow.md)
-- [Testing Guide](./testing.md)
-- [Architecture Reading Map](./architecture.md)
-- [CLI and Runtime Internals](./internals/cli-and-runtime.md)
+- [Repository tour](./repository-tour.md)
+- [Development workflow](./development-workflow.md)
+- [Testing guide](./testing.md)
+- [Documentation style](./documentation-style.md)
+- [Architecture reading map](./architecture.md)
+- [CLI and runtime internals](./internals/cli-and-runtime.md)
 
 ### I want to understand the runtime families
 
-- [Image Runtime](./runtime/image.md)
-- [Text Runtime](./runtime/text.md)
-- [Speech Runtime](./runtime/speech.md)
-- [Vision Runtime](./runtime/vision.md)
-- [Music Runtime](./runtime/music.md)
-- [SFX Runtime](./runtime/sfx.md)
-- [Video Runtime](./runtime/video.md)
-- [Persistent World Runtime](./runtime/world.md)
-- [Model Management](./runtime/model-management.md)
-- [Local API Server](./runtime/api-server.md)
+- [Image runtime](./runtime/image.md)
+- [Text runtime](./runtime/text.md)
+- [Speech runtime](./runtime/speech.md)
+- [Vision runtime](./runtime/vision.md)
+- [Music runtime](./runtime/music.md)
+- [SFX runtime](./runtime/sfx.md)
+- [Video runtime](./runtime/video.md)
+- [Persistent world runtime](./runtime/world.md)
+- [Model management](./runtime/model-management.md)
+- [Local API server](./runtime/api-server.md)
 
 ## Documentation map
 
 ### Fundamentals
 
-- [Getting Started](./getting-started.md): clone, build, first commands, first
+- [Getting started](./getting-started.md): clone, build, first commands, first
   status checks, Linux release artifacts, model pulls, and local setup
-- [macOS Deep Links](./macos-deep-links.md): preview or import completed local
+- [macOS deep links](./macos-deep-links.md): preview or import completed local
   artifacts from launchers, automations, agents, and other macOS apps
-- [Raycast Example Integration](./raycast.md): one launcher client built on the
+- [Raycast example integration](./raycast.md): one launcher client built on the
   public macOS deep-link surface
-- [Linux QuickStart](./linux-quickstart.md): Linux package install, first
+- [Linux quickstart](./linux-quickstart.md): Linux package install, first
   commands, release asset verification, and CUDA validation boundaries
 - [Cookbooks](./cookbooks.md): `mere.run guide` command topics for practical
   prompting, parameters, examples, and troubleshooting
 - [Configuration](./configuration.md): supported environment variables and
   debug toggles
-- [Model Sources](./model-sources.md): canonical model IDs, Hugging Face sources,
+- [Model sources](./model-sources.md): canonical model IDs, Hugging Face sources,
   and local model-store behavior
-- [LTX 2.5 Upstream Parity](./ltx25-upstream-parity.md): pinned upstream
+- [LTX 2.5 upstream parity](./ltx25-upstream-parity.md): pinned upstream
   pipeline matrix, native controls, and hardware-specific boundaries
 - [Benchmarking](./benchmarking.md): local quality evals, generated-code
   execution, VLM datasets, API workload, and runtime microbenchmarks
 - [External evaluation packs](./evaluation-packs.md): content-addressed private
   packs, adapter comparisons, calibration, gates, and promotion receipts
-- [Portable Workflows](./workflows.md): typed graphs, immutable job bundles,
+- [Portable workflows](./workflows.md): typed graphs, immutable job bundles,
   local execution, SSH and relay executors, run artifacts, and remote lifecycle
 - [Graph Studio](./graph/studio.md): visual Graph v2 authoring in the browser or
   a cross-platform Tauri desktop app, using the same version-1 workflow contract
-- [Companion Plugins](./plugins.md): public catalog discovery, safe installation,
+- [Companion plugins](./plugins.md): public catalog discovery, safe installation,
   doctor checks, and the typed graph-provider boundary
 
 ### Repository guides
 
-- [Repository Tour](./repository-tour.md): top-level layout, SwiftPM targets,
+- [Repository tour](./repository-tour.md): top-level layout, SwiftPM targets,
   and where each subsystem lives
-- [Development Workflow](./development-workflow.md): day-to-day edit, build,
+- [Development workflow](./development-workflow.md): day-to-day edit, build,
   test, Linux packaging, and smoke-test loop
-- [Testing Guide](./testing.md): what each validation command does and when to
+- [Testing guide](./testing.md): what each validation command does and when to
   run it
-- [Architecture Reading Map](./architecture.md): code-reader-oriented entry
+- [Documentation style](./documentation-style.md): voice, headings,
+  accessibility, example data, command examples, and review checks
+- [Documentation style audit](./documentation-style-audit.md): line-by-line,
+  targeted, and pending review status for every public Markdown file
+- [Architecture reading map](./architecture.md): code-reader-oriented entry
   points for each runtime family
 
 ### Runtime family guides
 
-- [Image Runtime](./runtime/image.md)
-- [Text Runtime](./runtime/text.md)
-- [Speech Runtime](./runtime/speech.md)
-- [Vision Runtime](./runtime/vision.md)
-- [Music Runtime](./runtime/music.md)
-- [SFX Runtime](./runtime/sfx.md)
-- [Video Runtime](./runtime/video.md)
-- [Persistent World Runtime](./runtime/world.md)
-- [Model Management](./runtime/model-management.md)
-- [Local API Server](./runtime/api-server.md)
+- [Image runtime](./runtime/image.md)
+- [Text runtime](./runtime/text.md)
+- [Speech runtime](./runtime/speech.md)
+- [Vision runtime](./runtime/vision.md)
+- [Music runtime](./runtime/music.md)
+- [SFX runtime](./runtime/sfx.md)
+- [Video runtime](./runtime/video.md)
+- [Persistent world runtime](./runtime/world.md)
+- [Model management](./runtime/model-management.md)
+- [Local API server](./runtime/api-server.md)
 
 ## Keep command docs synchronized
 
-The generated command inventories on the docs home, Getting Started, and CLI
+The generated command inventories on the docs home, Getting started, and CLI
 reference come directly from `MereRunCLI.configuration`. Every top-level command
 also has an explicit owner in `.vitepress/command-pages.tsv`.
 
@@ -162,19 +167,19 @@ After adding, renaming, removing, or redescribing a command, run:
 
 ### Internal implementation guides
 
-- [CLI and Runtime Internals](./internals/cli-and-runtime.md)
-- [Source Layout Reference](./internals/source-layout.md)
+- [CLI and runtime internals](./internals/cli-and-runtime.md)
+- [Source layout reference](./internals/source-layout.md)
 
 ## What this docs set is for
 
 These docs are intentionally split by audience:
 
-- end users should be able to install models and run commands without reading
+- End users can install models and run commands without reading
   source code
-- contributors should be able to understand the package layout and validation
+- Contributors can understand the package layout and validation
   flow before editing runtime code
-- code readers should be able to follow a command into the correct subsystem in
-  a few clicks
+- Code readers can follow a command into the correct subsystem without
+  searching unrelated modules
 
-If you only read one page before opening the code, read
-[Repository Tour](./repository-tour.md).
+Before you open the code, start with the
+[repository tour](./repository-tour.md).

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,14 +1,15 @@
-# Architecture Reading Map
+# Architecture reading map
 
-This repo is easiest to understand by starting at the CLI surface and then
-following one runtime family at a time. The goal of this map is not to explain
-every model detail, but to give contributors a reliable reading order.
+Start at the CLI surface, and then follow one runtime family at a time. This map
+gives contributors a reliable reading order without explaining every model
+detail.
 
-For the broader documentation set, start at [mere.run Documentation](/).
+For the broader documentation set, start at the
+[mere.run documentation home](/).
 
 ## Start here
 
-- CLI entrypoint: `Sources/MereRunCLI/MereRunCLI.swift`
+- CLI entry point: `Sources/MereRunCLI/MereRunCLI.swift`
 - Shared CLI helpers: `Sources/MereRunCLI/Support`
 - Model paths and manifests:
   - `Sources/MereRunCore/MereRunModelPaths.swift`
@@ -16,14 +17,14 @@ For the broader documentation set, start at [mere.run Documentation](/).
   - `Sources/MereRunCore/ModelResolver.swift`
 
 If you want to understand what a command does end to end, start at the command
-file, then jump to the family entrypoint listed below.
+file, and then use the table to open the family entry point.
 
 ## Image families
 
 Klein image generation:
 
 - CLI: `Sources/MereRunCLI/Commands/ImageGenerateCommand.swift`
-- Runtime entrypoint: `Sources/MereRunCore/Flux2Klein/Flux2KleinGenerator.swift`
+- Runtime entry point: `Sources/MereRunCore/Flux2Klein/Flux2KleinGenerator.swift`
 - Read next:
   - `Sources/MereRunCore/Flux2Klein/Flux2KleinGenerator+ModelLoading.swift`
   - `Sources/MereRunCore/Flux2Klein/Flux2KleinGenerator+Generation.swift`
@@ -31,7 +32,7 @@ Klein image generation:
 
 ZImage generation:
 
-- Runtime entrypoint: `Sources/MereRunCore/ZImageTurbo/ZImageTurboGenerator.swift`
+- Runtime entry point: `Sources/MereRunCore/ZImageTurbo/ZImageTurboGenerator.swift`
 - Read next:
   - `Sources/MereRunCore/ZImageTurbo/ZImageTurboGenerator+ModelLoading.swift`
   - `Sources/MereRunCore/ZImageTurbo/ZImageTurboGenerator+Inference.swift`
@@ -39,14 +40,14 @@ ZImage generation:
 
 Qwen image editing:
 
-- Runtime entrypoint: `Sources/MereRunCore/QwenImageEdit/QwenImageEditGenerator.swift`
+- Runtime entry point: `Sources/MereRunCore/QwenImageEdit/QwenImageEditGenerator.swift`
 - Read next:
   - `Sources/MereRunCore/QwenImageEdit/QwenImageEditGenerator+ModelLoading.swift`
   - `Sources/MereRunCore/QwenImageEdit/QwenImageEditGenerator+Encoding.swift`
 
 Krea 2 generation and LoRA training:
 
-- Runtime entrypoint: `Sources/MereRunCore/Krea2/Krea2Generator.swift`
+- Runtime entry point: `Sources/MereRunCore/Krea2/Krea2Generator.swift`
 - Read next:
   - `Sources/MereRunCore/Krea2/Krea2RawResources.swift`
   - `Sources/MereRunCore/Krea2/Krea2Resources.swift`
@@ -59,7 +60,7 @@ Krea 2 generation and LoRA training:
 
 Shared text encoder stack used by image models:
 
-- Public entrypoint:
+- Public entry point:
   `Sources/MereRunCore/ZImageTurbo/Model/TextEncoder/TextEncoder.swift`
 - Architecture internals:
   - `Sources/MereRunCore/ZImageTurbo/Model/TextEncoder/TextEncoder+RoPE.swift`
@@ -70,7 +71,7 @@ Shared text encoder stack used by image models:
 Speech synthesis command path:
 
 - CLI: `Sources/MereRunCLI/Commands/SpeechSynthesizeCommand.swift`
-- Runtime entrypoint: `Sources/AudioTTS/Qwen3TTS/Qwen3TTSGenerator.swift`
+- Runtime entry point: `Sources/AudioTTS/Qwen3TTS/Qwen3TTSGenerator.swift`
 - Read next:
   - `Sources/AudioTTS/Qwen3TTS/Qwen3TTSGenerator+Loading.swift`
   - `Sources/AudioTTS/Qwen3TTS/Qwen3TTSGenerator+Generation.swift`
@@ -103,7 +104,7 @@ Speaker diarization:
 OCR:
 
 - CLI: `Sources/MereRunCLI/Commands/VisionOCRCommand.swift`
-- Runtime entrypoint: `Sources/MereRunCore/LightOnOCR/LightOnOCRGenerator.swift`
+- Runtime entry point: `Sources/MereRunCore/LightOnOCR/LightOnOCRGenerator.swift`
 - Read next:
   - `Sources/MereRunCore/LightOnOCR/LightOnOCRGenerator+Loading.swift`
   - `Sources/MereRunCore/LightOnOCR/LightOnOCRGenerator+Inference.swift`
@@ -156,7 +157,7 @@ Native object reconstruction:
 Music generation:
 
 - CLI: `Sources/MereRunCLI/Commands/MusicGenerateCommand.swift`
-- Runtime entrypoint: `Sources/MereRunCore/ACEStep/ACEStepPipeline.swift`
+- Runtime entry point: `Sources/MereRunCore/ACEStep/ACEStepPipeline.swift`
 - Read next:
   - `Sources/MereRunCore/ACEStep/ACEStepPipeline+Prompting.swift`
   - `Sources/MereRunCore/ACEStep/ACEStepPipeline+Generation.swift`
@@ -164,7 +165,7 @@ Music generation:
 Music source separation:
 
 - CLI: `Sources/MereRunCLI/Commands/MusicSeparateCommand.swift`
-- Runtime entrypoint: `Sources/MereRunCore/RoFormer/RoFormerSeparator.swift`
+- Runtime entry point: `Sources/MereRunCore/RoFormer/RoFormerSeparator.swift`
 - Read next:
   - `Sources/MereRunCore/RoFormer/RoFormerResources.swift`
   - `Sources/MereRunCore/RoFormer/BSRoFormer.swift`
@@ -173,8 +174,8 @@ Music source separation:
 Audio bandwidth extension and super-resolution:
 
 - CLI: `Sources/MereRunCLI/Commands/AudioEnhanceCommand.swift`
-- Runtime entrypoint: `Sources/MereRunCore/APBWE/APBWEEnhancer.swift`
-- General-audio entrypoint: `Sources/MereRunCore/UniverSR/UniverSREnhancer.swift`
+- Runtime entry point: `Sources/MereRunCore/APBWE/APBWEEnhancer.swift`
+- General-audio entry point: `Sources/MereRunCore/UniverSR/UniverSREnhancer.swift`
 - Read next:
   - `Sources/MereRunCore/APBWE/APBWEResources.swift`
   - `Sources/MereRunCore/APBWE/APBWEModel.swift`
@@ -216,7 +217,7 @@ Cosmos3-Edge omnimodal generation and world simulation:
   `Sources/MereRunCLI/Commands/VideoCosmos3Command.swift`
 - Persistent world server:
   `Sources/MereRunCLI/Commands/WorldCommand.swift`
-- Runtime entrypoints:
+- Runtime entry points:
   - `Sources/MereRunCore/Cosmos3/Cosmos3EdgeGenerator.swift`
   - `Sources/MereRunCore/Cosmos3/Cosmos3Reasoner.swift`
   - `Sources/MereRunCore/Cosmos3/Cosmos3WorldSession.swift`
@@ -239,12 +240,12 @@ The advanced image validator is intentionally separate from generation:
   - `Sources/MereRunCLI/Commands/ImageValidateCommand+EncoderTransformer.swift`
   - `Sources/MereRunCLI/Commands/ImageValidateCommand+Pipeline.swift`
 
-## Suggested reading order for new contributors
+## Contributor reading order
 
 1. Start with `Sources/MereRunCLI/MereRunCLI.swift`.
 2. Pick one modality and read the matching command file.
-3. Jump to that modality’s runtime entrypoint.
+3. Jump to that modality's runtime entry point.
 4. Follow companion files in order: loading or preparation, then generation,
    then output.
-5. Only then drop into the larger model-definition files if you need
-   implementation detail.
+5. If you need implementation detail, continue to the larger model-definition
+   files.

--- a/docs/architecture/audio-enhancement-ap-bwe-report.md
+++ b/docs/architecture/audio-enhancement-ap-bwe-report.md
@@ -1,5 +1,8 @@
 # AP-BWE speech bandwidth-extension implementation report
 
+This report is for contributors who review AP-BWE runtime admission,
+implementation parity, and validation evidence.
+
 ## Decision
 
 AP-BWE's 16 kHz to 48 kHz profile is admitted as a separate native audio
@@ -7,6 +10,9 @@ enhancement runtime. It is intentionally not presented as music mastering or
 general audio super-resolution.
 
 ## Source and license admission
+
+The following table records the admitted source, checkpoint, and transport
+identities:
 
 | Item | Frozen identity | License/admission result |
 | --- | --- | --- |
@@ -22,20 +28,22 @@ count and SHA-256. Runtime readiness fails if any of the four changes.
 
 ## Native graph
 
-The typed graph contains 162 float32 tensors and 29,760,515 scalars. It follows
-the published 16→48 kHz profile:
+The typed graph contains 162 `float32` tensors and 29,760,515 scalars. It
+follows the published 16 kHz to 48 kHz profile:
 
-- mono 16 kHz decoding and deterministic 3x band-limited interpolation;
-- centered 1,024-point STFT with a periodic 320-sample Hann window padded to
-  the FFT size and an 80-sample hop;
-- magnitude and phase input convolutions from 513 bins to 512 channels;
-- eight paired ConvNeXt blocks per stream using depthwise kernel-7 convolution,
-  layer norm, exact GELU, 3x channel expansion, layer scale, and residuals;
-- the upstream sequential magnitude/phase cross-add update;
-- residual log-magnitude prediction, atan2 phase reconstruction, and native
-  ISTFT back to the input duration.
+- Mono 16 kHz decoding and deterministic threefold band-limited interpolation
+- Centered 1,024-point short-time Fourier transform (STFT) with a periodic
+  320-sample Hann window, padding to the fast Fourier transform (FFT) size, and
+  an 80-sample hop
+- Magnitude and phase input convolutions from 513 bins to 512 channels
+- Eight paired ConvNeXt blocks per stream with depthwise kernel-7 convolution,
+  layer normalization, exact GELU, threefold channel expansion, layer scale,
+  and residuals
+- The upstream sequential magnitude and phase cross-add update
+- Residual log-magnitude prediction, `atan2` phase reconstruction, and native
+  inverse STFT cropped to the input duration
 
-PyTorch Conv1d tensors are transposed from `[out, in, kernel]` to MLX's
+PyTorch `Conv1d` tensors are transposed from `[out, in, kernel]` to the MLX
 `[out, kernel, in]` layout. The loader rejects key, shape, dtype, tensor-count,
 scalar-count, byte-count, and whole-file hash drift.
 
@@ -46,8 +54,8 @@ extension and general-audio super-resolution do not get conflated with music
 stem separation. AP-BWE remains independently reviewable from the stacked
 UniverSR runtime.
 
-The installed-model gate produces a real WAV artifact through the public
-command. The manual checkpoint smoke additionally verifies a 48 kHz mono,
-finite, non-silent output and reports energy above the original 8 kHz
+The installed-model gate produces a WAV file through the public command. The
+manual checkpoint smoke also verifies finite, non-silent, 48 kHz mono output
+and reports energy above the original 8 kHz
 narrowband boundary. These checks prove execution and artifact integrity, not
 a perceptual benchmark.

--- a/docs/architecture/audio-enhancement-universr-report.md
+++ b/docs/architecture/audio-enhancement-universr-report.md
@@ -1,5 +1,8 @@
 # UniverSR general-audio super-resolution implementation report
 
+This report is for contributors who review UniverSR runtime admission,
+implementation parity, and validation evidence.
+
 ## Decision
 
 The official general-audio UniverSR profile is admitted as a separate native
@@ -9,6 +12,8 @@ audio. It is described as audio super-resolution, not a complete mastering
 chain.
 
 ## Source and license admission
+
+The following table records the admitted source and checkpoint identities:
 
 | Item | Frozen identity | License/admission result |
 | --- | --- | --- |
@@ -24,20 +29,22 @@ three artifacts changes.
 
 ## Native graph
 
-The typed graph contains 394 float32 tensors and 57,231,302 scalars. It follows
-the published general-audio profile:
+The typed graph contains 394 `float32` tensors and 57,231,302 scalars. It
+follows the published general-audio profile:
 
-- deterministic integer-ratio, windowed-sinc interpolation to 48 kHz;
-- symmetric-Hann, 1,024-point complex STFT with a 512-sample hop;
-- power-law magnitude compression with alpha 0.2, beta 1, and epsilon 1e-4;
-- conditional ConvNeXt V2 U-Net dimensions `[96, 192, 384, 768]`, depths
-  `[2, 2, 4, 2]`, 384 conditioning channels, and a 256-dimensional time path;
-- rate-conditioned low-frequency observations and reconstruction of the
-  remaining spectrum;
-- deterministic noise seeding and Euler, midpoint, or RK4 ODE integration;
-- inverse compression and native ISTFT cropped back to the source duration.
+- Deterministic integer-ratio, windowed-sinc interpolation to 48 kHz
+- Symmetric-Hann, 1,024-point complex short-time Fourier transform (STFT) with
+  a 512-sample hop
+- Power-law magnitude compression with alpha 0.2, beta 1, and epsilon 1e-4
+- Conditional ConvNeXt V2 U-Net dimensions `[96, 192, 384, 768]`, depths
+  `[2, 2, 4, 2]`, 384 conditioning channels, and a 256-dimensional time path
+- Rate-conditioned low-frequency observations and reconstruction of the
+  remaining spectrum
+- Deterministic noise seeding and Euler, midpoint, or RK4 ordinary differential
+  equation (ODE) integration
+- Inverse compression and native inverse STFT cropped to the source duration
 
-PyTorch Conv2d and ConvTranspose2d tensors are transformed into the MLX kernel
+PyTorch `Conv2d` and `ConvTranspose2d` tensors are transformed into MLX kernel
 layouts only after the restricted state-dict reader verifies archive metadata,
 key set, shape, dtype, tensor count, scalar count, byte count, and whole-file
 hash.
@@ -52,6 +59,6 @@ four steps, guidance scale 1.5, and seed 42, all recorded in the output
 provenance manifest.
 
 The installed-model gate and manual smoke use the public command to produce a
-real WAV. Finite, non-silent output and spectral energy above the declared
+WAV file. Finite, non-silent output and spectral energy above the declared
 input boundary prove the native path executed; they are not a perceptual
 quality benchmark.

--- a/docs/architecture/music-source-separation-roformer-report.md
+++ b/docs/architecture/music-source-separation-roformer-report.md
@@ -1,6 +1,6 @@
 # RoFormer music source-separation implementation report
 
-Research snapshot: 2026-08-01.
+Research snapshot: August 1, 2026.
 
 This report evaluates ViperX's BS-RoFormer checkpoint and the source-separation
 tools catalogued in the community-maintained
@@ -9,7 +9,7 @@ The guide is a useful routing index, but model quality claims in it are not a
 runtime or licensing authority. This report therefore checks implementation,
 artifact, and license facts against the relevant upstream projects.
 
-The exploration has now produced a native runtime, managed model contract, and
+The exploration produced a native runtime, managed model contract, and
 public `music separate` command in this worktree. This report preserves the
 upstream/tool audit and records which admission and implementation claims are
 proven separately from the remaining parity and quality work.
@@ -17,7 +17,7 @@ proven separately from the remaining parity and quality work.
 ## Decision
 
 A native Swift/MLX BS-RoFormer lane is feasible and fits the existing
-`mere.run` architecture. The first parity target should be the widely mirrored
+`mere.run` architecture. Use the widely mirrored
 ViperX `model_bs_roformer_ep_317_sdr_12.9755.ckpt` vocals checkpoint, usually
 called ViperX 1297. It is a stable, well-understood two-stem target, not a claim
 that it is the best separator for every recording.
@@ -25,7 +25,7 @@ that it is the best separator for every recording.
 Use [`pymss`](https://github.com/pymss-project/pymss) and
 [`pymss-core`](https://github.com/pymss-project/pymss-core) as frozen reference
 implementations and fixture generators. Do not make either a product runtime
-dependency: the product path should load safetensors and execute the graph in
+dependency. The product path must load safetensors and execute the graph in
 the existing Swift package with MLX. This keeps inference local, avoids a
 Python/Torch sidecar, and lets the CLI preserve its machine-readable-output
 contract.
@@ -34,7 +34,7 @@ Checkpoint admission is closed for this exact mirror. The AEmotion Studio
 repository includes an MIT `LICENSE` covering the mirrored model release, its
 model card declares `license: mit` and states that the upstream model releases
 use the same license, and the mirror attributes the original ViperX checkpoint
-through the upstream training repository. mere.run pins the mirror revision,
+through the upstream training repository. `mere.run` pins the mirror revision,
 license, model card, source YAML, and weights as one accepted artifact set; it
 does not generalize that finding to differently hosted RoFormer checkpoints.
 
@@ -79,13 +79,13 @@ and the ViperX config/checkpoint table in
 [`ZFTurbo/Music-Source-Separation-Training@e247dfe`](https://github.com/ZFTTurbo/Music-Source-Separation-Training/blob/e247dfe4abc1f17c69dff719207fe045dc04413a/docs/pretrained_models.md).
 Both codebases are MIT-licensed. The separately hosted AEmotion model release
 also carries its own explicit MIT license and is admitted only at the pinned
-revision above.
+recorded revision.
 
 ## Tool landscape
 
 | Tool or service | What it contributes | Fit for `mere.run` |
 | --- | --- | --- |
-| [`pymss@7ff129f`](https://github.com/pymss-project/pymss/tree/7ff129f784bd070b60543d1715edf59284f15ebd) | Current CLI/API, Apple-Silicon MLX backend, chunking, workflows, and waveform/FFT ensembles | Primary parity oracle and UX reference; not a runtime dependency |
+| [`pymss@7ff129f`](https://github.com/pymss-project/pymss/tree/7ff129f784bd070b60543d1715edf59284f15ebd) | CLI/API at the recorded revision, Apple-Silicon MLX backend, chunking, workflows, and waveform/FFT ensembles | Primary parity oracle and UX reference; not a runtime dependency |
 | [`pymss-core@9eadda9`](https://github.com/pymss-project/pymss-core/tree/9eadda9ee4bc7ad476e37e26dd769963669831c7) | Low-level BS/Mel-RoFormer graphs, MLX STFT/ISTFT, config and checkpoint helpers | Closest implementation reference for the native port |
 | [`Music-Source-Separation-Training@e247dfe`](https://github.com/ZFTurbo/Music-Source-Separation-Training/tree/e247dfe4abc1f17c69dff719207fe045dc04413a) | Training/evaluation framework and a broad pretrained-model index | Fixture provenance, configs, and later training experiments |
 | [`python-audio-separator@4fe3540`](https://github.com/nomadkaraoke/python-audio-separator/tree/4fe3540c249ff130bd5395c0e9377b3d16970c1a) | Mature model registry, large-file chunking, CLI, and reusable API | Behavior and packaging reference; Python/ONNX/Torch runtime is out of product scope |
@@ -95,20 +95,20 @@ revision above.
 | `pymss-studio`, `pymss-ara`, and `MSST-WebUI` | Desktop, plugin, and workflow ideas | AGPL-3.0 boundary: study behavior, do not copy or embed code in this public distribution |
 | MVSep and other hosted separators | Rapid comparisons across many community checkpoints | Evaluation aid only; hosted processing conflicts with the local-first runtime path |
 
-The guide also tracks newer community checkpoint families such as PolarFormer,
+The guide also tracks other community checkpoint families such as PolarFormer,
 HyperACE, Becruily Deux, Leap, SCNet, MDX23, DrumSep, karaoke/backing-vocal,
-dereverb, denoise, and crowd-removal models. They should be treated as a
+dereverb, denoise, and crowd-removal models. Treat them as a
 candidate backlog. Their names, quality rankings, and availability are not
 sufficient artifact contracts.
 
 ViperX 1296/1297 also appear in modern workflows as phase-correction donors.
 That makes 1297 useful beyond the initial two-stem baseline, but phase
-correction and ensembles should come only after one native model matches a
+correction and ensembles must come only after one native model matches a
 frozen reference end to end.
 
 ## Native integration shape
 
-The repo already provides most of the infrastructure the port needs:
+The repository provides most of the infrastructure the port needs:
 
 - `MediaAudioIO.decode` and `writeFloatWAV` cover platform audio decode and
   floating-point WAV output. Separation must decode directly without the
@@ -175,7 +175,7 @@ the original decoded mixture is important for residual closure.
 ### Stage 1: frozen parity oracle
 
 - Pin a disposable Python environment to the audited `pymss` and `pymss-core`
-  revisions; it never ships with the product.
+  revisions. It does not ship with the product.
 - Generate fixtures from synthetic impulses, tones, stereo phase cases, and a
   redistributable short music mixture.
 - Record input/output hashes, exact package versions, config, model digest,
@@ -241,7 +241,7 @@ The native spike is complete only when all of the following are proven:
   thermal context are recorded. An interrupted or thermally contaminated run
   is not performance evidence.
 
-## Current validation boundary
+## Validation boundary
 
 The worktree now proves typed configuration decoding, the exact 699-tensor and
 159,758,796-scalar native parameter inventory, all checkpoint keys and shapes,
@@ -259,7 +259,8 @@ not a thermal-controlled performance benchmark or a music-quality result.
 
 The remaining validation boundary is frozen-reference parity and quality:
 intermediate tensor comparison, a redistributable music fixture, multiple
-chunk boundaries, and the broader impulse/noise/phase corpus described above.
+chunk boundaries, and the broader impulse, noise, and phase corpus in the
+acceptance gates.
 
 The four-stem follow-on also passed a real managed-model smoke. The downloaded
 526,964,800-byte safetensors artifact independently matched SHA-256

--- a/docs/architecture/vfx-geometry-model-report.md
+++ b/docs/architecture/vfx-geometry-model-report.md
@@ -1,13 +1,13 @@
 # OSS depth and 3D models for native VFX workflows
 
-Research snapshot: 2026-07-13.
+Research snapshot: July 13, 2026.
 
 This report records five permissively licensed model lanes plus the separately
 license-gated DINOv3 dependency used by TRELLIS.2, all selected for native
 Swift/MLX execution in `mere.run`. It separates what each neural model actually
 predicts from downstream files that `mere.run` derives, and it makes the
 InstantMesh and DINOv3 licensing boundaries explicit. Exact TRELLIS.2 artifact
-identities live in `Trellis2Resources`; the other geometry identities live in
+identities live in `Trellis2Resources`. The other geometry identities live in
 `GeometryModelPins`.
 
 ## Recommendation at a glance
@@ -34,79 +34,79 @@ runtime admission controls, not approximate download sizes.
 
 ### MoGe-2 ViT-S Normal
 
-- Managed ID: `vision-geometry-moge2-small`
-- Pinned model: [`Ruicheng/moge-2-vits-normal-onnx@e50ffda`](https://huggingface.co/Ruicheng/moge-2-vits-normal-onnx/tree/e50ffda41565591092adea54c6ac83d6212e1e23)
-- Pinned source: [`microsoft/MoGe@0744441`](https://github.com/microsoft/MoGe/tree/07444410f1e33f402353b99d6ccd26bd31e469e8)
-- `model.onnx`: 140,852,051 bytes
-- SHA-256: `24eacb5dc7a2c54c7bc98f7de085ffbed79ad006ea5b664c2c2cdc02ff3a52f0`
-- License boundary: MIT for MoGe; the bundled DINOv2 portion is Apache-2.0.
+- **Managed ID:** `vision-geometry-moge2-small`.
+- **Pinned model:** [`Ruicheng/moge-2-vits-normal-onnx@e50ffda`](https://huggingface.co/Ruicheng/moge-2-vits-normal-onnx/tree/e50ffda41565591092adea54c6ac83d6212e1e23).
+- **Pinned source:** [`microsoft/MoGe@0744441`](https://github.com/microsoft/MoGe/tree/07444410f1e33f402353b99d6ccd26bd31e469e8).
+- **`model.onnx`:** 140,852,051 bytes.
+- **SHA-256:** `24eacb5dc7a2c54c7bc98f7de085ffbed79ad006ea5b664c2c2cdc02ff3a52f0`.
+- **License boundary:** MIT for MoGe; the bundled DINOv2 portion is Apache-2.0.
   The conversion repository has no Hugging Face license tag, so distribution
   must retain the notices from the [upstream MoGe project](https://github.com/microsoft/MoGe/blob/07444410f1e33f402353b99d6ccd26bd31e469e8/LICENSE)
   and DINOv2 rather than relying on model-card metadata alone.
 
 ### Video Depth Anything Small
 
-- Managed ID: `vision-depth-vda-small`
-- Pinned model: [`depth-anything/Video-Depth-Anything-Small@2568753`](https://huggingface.co/depth-anything/Video-Depth-Anything-Small/tree/256875362cff76724b920335dfb4b29dd611f66e)
-- Pinned source: [`DepthAnything/Video-Depth-Anything@4f5ae23`](https://github.com/DepthAnything/Video-Depth-Anything/tree/4f5ae23172ba60fd7bc11ef671cca678842c7072)
-- `video_depth_anything_vits.pth`: 116,440,756 bytes
-- SHA-256: `13379300b739e659f076a59d52e9801bd8d38c541a7e71f73bbca4dcfb013609`
-- License: Apache-2.0.
+- **Managed ID:** `vision-depth-vda-small`.
+- **Pinned model:** [`depth-anything/Video-Depth-Anything-Small@2568753`](https://huggingface.co/depth-anything/Video-Depth-Anything-Small/tree/256875362cff76724b920335dfb4b29dd611f66e).
+- **Pinned source:** [`DepthAnything/Video-Depth-Anything@4f5ae23`](https://github.com/DepthAnything/Video-Depth-Anything/tree/4f5ae23172ba60fd7bc11ef671cca678842c7072).
+- **`video_depth_anything_vits.pth`:** 116,440,756 bytes.
+- **SHA-256:** `13379300b739e659f076a59d52e9801bd8d38c541a7e71f73bbca4dcfb013609`.
+- **License:** Apache-2.0.
 
 Metric variant:
 
-- Managed ID: `vision-depth-vda-small-metric`
-- Pinned model: [`depth-anything/Metric-Video-Depth-Anything-Small@273d090`](https://huggingface.co/depth-anything/Metric-Video-Depth-Anything-Small/tree/273d090f2ce17df50c2872d82c8322c45da5b4dd)
-- `metric_video_depth_anything_vits.pth`: 116,444,063 bytes
-- SHA-256: `3c28432b4e1f0d7bb31cad5151b6313b49457db5aa58d82e85bfb0f8b1311b33`
-- License: Apache-2.0.
+- **Managed ID:** `vision-depth-vda-small-metric`.
+- **Pinned model:** [`depth-anything/Metric-Video-Depth-Anything-Small@273d090`](https://huggingface.co/depth-anything/Metric-Video-Depth-Anything-Small/tree/273d090f2ce17df50c2872d82c8322c45da5b4dd).
+- **`metric_video_depth_anything_vits.pth`:** 116,444,063 bytes.
+- **SHA-256:** `3c28432b4e1f0d7bb31cad5151b6313b49457db5aa58d82e85bfb0f8b1311b33`.
+- **License:** Apache-2.0.
 
 ### Depth Anything 3 Small
 
-- Managed ID: `vision-geometry-da3-small`
-- Pinned model: [`depth-anything/DA3-SMALL@e08cab6`](https://huggingface.co/depth-anything/DA3-SMALL/tree/e08cab65ca0ec38e7826075418411ab90cab4da3)
-- Pinned source: [`ByteDance-Seed/Depth-Anything-3@4173623`](https://github.com/ByteDance-Seed/Depth-Anything-3/tree/41736238f5bced4debf3f2a12375d2466874866d)
-- `config.json`: 1,202 bytes; SHA-256
+- **Managed ID:** `vision-geometry-da3-small`.
+- **Pinned model:** [`depth-anything/DA3-SMALL@e08cab6`](https://huggingface.co/depth-anything/DA3-SMALL/tree/e08cab65ca0ec38e7826075418411ab90cab4da3).
+- **Pinned source:** [`ByteDance-Seed/Depth-Anything-3@4173623`](https://github.com/ByteDance-Seed/Depth-Anything-3/tree/41736238f5bced4debf3f2a12375d2466874866d).
+- **`config.json`:** 1,202 bytes; SHA-256
   `a486e29e82b7ab4a7d4cefc1ea4526cfe2ae438a572c8ca98917cfbcde7447d2`
-- `model.safetensors`: 137,248,940 bytes; SHA-256
+- **`model.safetensors`:** 137,248,940 bytes; SHA-256
   `364492e38a3a06d221ac75da7f6621ada3f2361cd24fde11ba79091e9f40efcf`
-- License: Apache-2.0.
+- **License:** Apache-2.0.
 
 ### TripoSR
 
-- Managed ID: `image-3d-triposr`
-- Pinned model: [`stabilityai/TripoSR@5b52193`](https://huggingface.co/stabilityai/TripoSR/tree/5b521936b01fbe1890f6f9baed0254ab6351c04a)
-- Pinned source: [`VAST-AI-Research/TripoSR@107cefd`](https://github.com/VAST-AI-Research/TripoSR/tree/107cefdc244c39106fa830359024f6a2f1c78871)
-- `config.yaml`: 987 bytes; SHA-256
+- **Managed ID:** `image-3d-triposr`.
+- **Pinned model:** [`stabilityai/TripoSR@5b52193`](https://huggingface.co/stabilityai/TripoSR/tree/5b521936b01fbe1890f6f9baed0254ab6351c04a).
+- **Pinned source:** [`VAST-AI-Research/TripoSR@107cefd`](https://github.com/VAST-AI-Research/TripoSR/tree/107cefdc244c39106fa830359024f6a2f1c78871).
+- **`config.yaml`:** 987 bytes; SHA-256
   `74ca708ce086bf68e97709ea6b3d91f14717921c04691e84043f0eb8fcc68e62`
-- `model.ckpt`: 1,677,246,742 bytes; SHA-256
+- **`model.ckpt`:** 1,677,246,742 bytes; SHA-256
   `429e2c6b22a0923967459de24d67f05962b235f79cde6b032aa7ed2ffcd970ee`
-- License: MIT for code and pretrained model, as stated by both the
+- **License:** MIT for code and pretrained model, as stated by both the
   [model card](https://huggingface.co/stabilityai/TripoSR) and
   [source repository](https://github.com/VAST-AI-Research/TripoSR/tree/107cefdc244c39106fa830359024f6a2f1c78871#license).
 
 ### InstantMesh Base, reconstruction only
 
-- Managed ID: `image-3d-instantmesh-base`
-- Pinned model: [`TencentARC/InstantMesh@b785b4e`](https://huggingface.co/TencentARC/InstantMesh/tree/b785b4ecfb6636ef34a08c748f96f6a5686244d0)
-- Pinned source: [`TencentARC/InstantMesh@08822c5`](https://github.com/TencentARC/InstantMesh/tree/08822c52fdc399b93ea00e4fa9e596344ed52ccc)
-- `instant_mesh_base.ckpt`: 1,253,574,354 bytes
-- SHA-256: `22701cd25201d624ebb1568b93cf91b43a2c32006835c08fe73e1f3c9f6c44b5`
-- License boundary: Apache-2.0 reconstruction checkpoint only. The runtime
+- **Managed ID:** `image-3d-instantmesh-base`.
+- **Pinned model:** [`TencentARC/InstantMesh@b785b4e`](https://huggingface.co/TencentARC/InstantMesh/tree/b785b4ecfb6636ef34a08c748f96f6a5686244d0).
+- **Pinned source:** [`TencentARC/InstantMesh@08822c5`](https://github.com/TencentARC/InstantMesh/tree/08822c52fdc399b93ea00e4fa9e596344ed52ccc).
+- **`instant_mesh_base.ckpt`:** 1,253,574,354 bytes.
+- **SHA-256:** `22701cd25201d624ebb1568b93cf91b43a2c32006835c08fe73e1f3c9f6c44b5`.
+- **License boundary:** Apache-2.0 reconstruction checkpoint only. The runtime
   excludes view synthesis and NVIDIA's proprietary FlexiCubes implementation.
 
 ### TRELLIS.2-4B 512
 
-- Managed ID: `image-3d-trellis2-4b`
-- Pinned model: [`microsoft/TRELLIS.2-4B@af44b45`](https://huggingface.co/microsoft/TRELLIS.2-4B/tree/af44b45f2e35a493886929c6d786e563ec68364d)
-- Pinned source: [`microsoft/TRELLIS.2`](https://github.com/microsoft/TRELLIS.2)
-- Pinned sparse-structure dependency:
+- **Managed ID:** `image-3d-trellis2-4b`.
+- **Pinned model:** [`microsoft/TRELLIS.2-4B@af44b45`](https://huggingface.co/microsoft/TRELLIS.2-4B/tree/af44b45f2e35a493886929c6d786e563ec68364d).
+- **Pinned source:** [`microsoft/TRELLIS.2`](https://github.com/microsoft/TRELLIS.2).
+- **Pinned sparse-structure dependency:**
   [`microsoft/TRELLIS-image-large@25e0d31`](https://huggingface.co/microsoft/TRELLIS-image-large/tree/25e0d31ffbebe4b5a97464dd851910efc3002d96)
-- Pinned conditioner:
+- **Pinned conditioner:**
   [`facebook/dinov3-vitl16-pretrain-lvd1689m@ea8dc28`](https://huggingface.co/facebook/dinov3-vitl16-pretrain-lvd1689m/tree/ea8dc2863c51be0a264bab82070e3e8836b02d51)
-- Seven pinned safetensors total 11,010,775,158 bytes; each byte count and
+- **Artifact size:** Seven pinned safetensors total 11,010,775,158 bytes; each byte count and
   SHA-256 is enforced by `Trellis2Resources`.
-- License boundary: TRELLIS.2 code and weights are MIT. DINOv3 has separate
+- **License boundary:** TRELLIS.2 code and weights are MIT. DINOv3 has separate
   terms and a gated model repository; users must accept those terms and
   authenticate before installation.
 
@@ -118,11 +118,11 @@ Metric variant:
 | VDA-S relative/metric | PyTorch state dict | Exact pinned PTH is parsed by a restricted non-executing tensor reader; exact converted packages are also accepted | Deterministic conversion proven byte-identical twice per variant, with frozen environment, 351-tensor inventory, and mandatory license |
 | DA3-S | Safetensors | Exact pinned safetensors and config are checksum-verified and loaded directly | No conversion required |
 | TripoSR | Lightning/PyTorch CKPT | Exact CKPT is accepted by the restricted state-dict grammar; verified converted safetensors is also accepted | Deterministic conversion proven byte-identical twice |
-| InstantMesh Base | Lightning CKPT | Runtime accepts only the verified reconstruction-only safetensors package | Deterministic conversion proven byte-identical twice; view-generation tensors are never accepted |
+| InstantMesh Base | Lightning CKPT | Runtime accepts only the verified reconstruction-only safetensors package | Deterministic conversion proven byte-identical twice; view-generation tensors are not accepted |
 | TRELLIS.2-4B 512 | Safetensors | Official BF16/FP16 files are checksum-verified and loaded directly into native dense/sparse MLX graphs | No conversion required |
 
 Every inference path is native Swift/MLX. Python appears only in audited
-release conversion and upstream-reference fixture generation, never as a
+release conversion and upstream-reference fixture generation, not as a
 runtime sidecar.
 
 ## Model profiles
@@ -149,7 +149,7 @@ not a multi-view camera solver and does not create a watertight object mesh.
 
 Apple Silicon fit is strong: the small backbone is the lightest still-geometry
 choice here, token count is capped and controllable, and inference is entirely
-MLX. The published 128x128, 3,600-token native row completed in 0.88 seconds,
+MLX. The published 128 x 128, 3,600-token native row completed in 0.88 seconds,
 with 748.9 MiB max RSS and an 8.50 GiB MLX/Metal peak footprint.
 
 ### 2. Video Depth Anything Small and Metric Small
@@ -200,7 +200,7 @@ triangles. The 3DGS handoff contains cameras and colored points, not learned
 Gaussian parameters. Those distinctions should remain visible in every plugin
 contract and UI.
 
-DA3 is the right primitive for multi-view camera bootstrap, plate alignment,
+Use DA3 for multi-view camera bootstrap, plate alignment,
 point-based set reconstruction, scene-scale occlusion proxies, and seeding a
 separate Nerfstudio or 3DGS optimization. It is not the right primitive for
 metric measurements or a finished mesh.
@@ -237,7 +237,7 @@ The upstream project combines a sparse-view reconstruction network with a
 single-image-to-multiview diffusion stage. Only the reconstruction network is
 in scope. `mere.run` accepts exactly four or six ordered, user-supplied views,
 with either the official camera rig or explicit 16-value camera conditioning.
-It never downloads or runs the view generator.
+It does not download or run the view generator.
 
 The pinned reconstruction checkpoint contains 455 tensors and 313,352,516
 scalars. Its native graph uses a camera-conditioned ViT-B/16 encoder, 3,072
@@ -261,9 +261,9 @@ set-dressing proxies, and occlusion/collision assets. It is deliberately not a
 single-image plugin: callers must supply views they are licensed to use.
 
 The graph uses view batching plus attention, feed-forward, field-query, and
-isosurface chunking for Apple Silicon. The benchmark ledger now includes native
+isosurface chunking for Apple Silicon. The benchmark ledger includes native
 six-view grid-16 and grid-24 runs through the verified converted package; the
-measured figures are summarized below.
+measured figures appear in the Apple Silicon evidence section.
 
 ### 6. TRELLIS.2-4B 512
 
@@ -278,7 +278,7 @@ Official BF16 and FP16 safetensors load directly into MLX. Stages are loaded
 and released independently rather than retaining the roughly 11 GB checkpoint
 set at once. The result includes normalized colored OBJ, PLY, and GLB meshes.
 A deterministic `.pbrvox` sidecar preserves base color RGB, metallic,
-roughness, and alpha for every decoded sparse voxel; the current canonical GLB
+roughness, and alpha for every decoded sparse voxel; the canonical GLB
 writer does not claim a synthesized texture-atlas representation.
 
 The native public surface deliberately starts with 512. It does not claim the
@@ -316,7 +316,7 @@ by an upstream project safe to ship. The engineering boundary is:
   notice, and input-asset rights remain distribution obligations. This is an
   engineering policy, not a substitute for product-specific legal review.
 
-## What "parity" means
+## Parity definition
 
 Exact neural parity means the native MLX graph is compared with the pinned
 upstream implementation at model-internal boundaries using the same weights
@@ -338,7 +338,7 @@ The parity surfaces are:
 InstantMesh SDF parity is measured before extraction. If an extraction grid's
 interior is entirely one-signed, the run then applies the pinned upstream
 center/boundary sign repair, records that intervention, and meshes the repaired
-field. It never presents a repaired sample as a raw neural-parity value.
+field. It does not present a repaired sample as a raw neural-parity value.
 
 Neural-field parity does **not** imply triangle-topology parity:
 
@@ -350,7 +350,8 @@ Neural-field parity does **not** imply triangle-topology parity:
   the parity-tested SDF/deformation/color field. It intentionally reports
   `topologyMatchesUpstreamFlexiCubes=false`.
 
-Plugins should compare semantic assets, bounds, field samples, and durable
+When comparing results, plugins should compare semantic assets, bounds, field
+samples, and durable
 hashes produced by the same native settings. They must not promise identical
 upstream triangle IDs or topology.
 
@@ -358,7 +359,7 @@ upstream triangle IDs or topology.
 
 The full methodology and tables live in
 [VFX geometry Apple Silicon benchmarks](../benchmarks/vfx-geometry-apple-silicon.md).
-The current measurements are from a debug build on an M4 Max with 128 GB unified
+The measurements are from a debug build on an M4 Max with 128 GB unified
 memory and macOS 26.4:
 
 - MoGe-2 ViT-S Normal: one 128 x 128 image at 3,600 tokens completed in
@@ -395,7 +396,7 @@ Keep model truth explicit in plugin outputs:
 - Label VDA relative depth as affine-relative and VDA metric depth as meters.
   Do not add confidence or camera fields to either model.
 - Label DA3 output as relative, its GLB as a point cloud, and its 3DGS handoff
-  as initialization only. Never imply learned Gaussians or a triangle mesh.
+  as initialization only. Do not imply learned Gaussians or a triangle mesh.
 - Label TripoSR and InstantMesh meshes as normalized object space unless a
   separate scale/alignment operation establishes world units.
 - Label TRELLIS.2 meshes as normalized object space and keep the `.pbrvox`

--- a/docs/benchmark-fused.md
+++ b/docs/benchmark-fused.md
@@ -9,8 +9,8 @@ them with authored scenarios.
 ## Suites
 
 - `lite` contains 24 fixed cases and touches every source family: 12
-  chat/long-context, 4 code, 5 tool-use, and 3 vision. It is not random and is
-  not an easiest-case sample. The default is two sampled trials per model
+  chat/long-context, 4 code, 5 tool-use, and 3 vision. It is a fixed,
+  difficulty-balanced selection. The default is two sampled trials per model
   profile.
 - `comprehensive` contains 110 cases: 59 chat/long-context, 21 code, 20
   tool-use, and 10 vision. It includes every Mere-authored chat and tool case,
@@ -38,16 +38,17 @@ The default model matrix covers Qwen3.8 BF16 and 4-bit, Nemotron Lightning, and
 Laguna XS 2.1. Override it with `--models`.
 
 Completed local reference results for Qwen3.8 low reasoning, Laguna XS 2.1, and
-Nemotron Lightning are recorded in [Fused Comprehensive reference runs](benchmarks/fused-reference-runs.md).
+Nemotron Lightning are recorded in
+[Fused comprehensive reference runs](benchmarks/fused-reference-runs.md).
 That page preserves the exact plan, runner, model-manifest, and receipt hashes
 alongside the per-source results, comparable non-vision scores, and limitations.
 
 ### Exact source mix
 
-Counts below are cases before repeated trials. Lite therefore produces 48
-case-trial rows per model profile by default; Comprehensive produces 550.
+The table lists case counts before repeated trials. By default, `lite` produces
+48 case-trial rows per model profile, and `comprehensive` produces 550.
 
-| Source family | Lite | Comprehensive | Pinned selection | What a passing answer must do |
+| Source family | `lite` | `comprehensive` | Pinned selection | Passing requirement |
 | --- | ---: | ---: | --- | --- |
 | Mere authored chat | 10 | 52 | Grounding, abstention, JSON and format following, summaries, action boundaries, chronology, arithmetic, conflict handling, privacy, explanation, rewriting, empathy, false-premise correction, uncertainty, recommendations, planning, injection resistance, synthesis, counterexamples, constrained creativity, and clarification | Satisfy every required phrase, required-alternative group, forbidden phrase, regex, JSON, bullet, and word-limit check declared by the case |
 | LongBench v1 | 2 | 7 | `hotpotqa`, `gov_report`, `qasper`, `2wikimqa`, `musique`, `multi_news`, and `passage_retrieval_en`, one pinned row from each | Meet the case's Mere threshold under QA-F1, ROUGE-L, or numeric retrieval scoring |
@@ -58,10 +59,10 @@ case-trial rows per model profile by default; Comprehensive produces 550.
 | Mere authored tools | 3 | 10 | Email, project, audit, workspace, safe command-plan, attachment, no-tool, and destructive-confirmation cases | Emit the exact tool and required arguments, or correctly emit no tool call |
 | BFCL v3 | 2 | 10 | Simple Python and Java calls, parallel, multiple, parallel-multiple, irrelevance/no-call, and four pinned multi-turn histories | Match every expected call and argument with no missing or extra calls, or correctly make no call |
 | Mere authored vision | 3 | 10 | OCR, conflicting panels, chart extraction, spatial relation, counting, document layout, negative evidence, multi-panel consistency, dense captioning, and action boundary | Ground the answer in the generated image and satisfy every required and forbidden phrase check |
-| **Total** | **24** | **110** | **12 chat/long-context, 4 code, 5 tool, and 3 vision in Lite; 59, 21, 20, and 10 respectively in Comprehensive** | **Report category results separately; do not hide a weak lane in one composite** |
+| **Total** | **24** | **110** | **12 chat/long-context, 4 code, 5 tool, and 3 vision in `lite`; 59, 21, 20, and 10 respectively in `comprehensive`** | **Report category results separately; do not hide a weak lane in one composite** |
 
 The complete machine-readable case list, including difficulty, capability tags,
-selection rationale, and upstream id, lives in
+selection rationale, and upstream ID, lives in
 `Sources/MereRunCLI/BenchmarkSuites/mere-fused-v1.json`. The exact external
 revisions and file hashes live in `mere-fused-sources-v1.json`. A dry run prints
 the resolved list without loading a model:
@@ -72,10 +73,17 @@ mere.run model benchmark fused --suite comprehensive --dry-run --json
 
 ### What the questions and answers look like
 
-The chat, tool, and vision prompts below are literal Mere-owned suite cases.
-The HumanEval example abbreviates its MIT-licensed contract for readability,
-and the LongBench example is deliberately paraphrased; the frozen external
-fixture contains the exact pinned prompts, tests, and references.
+The examples show the prompt structure and scoring contract for each lane.
+Public examples use reserved identifiers where the specific value does not
+affect the behavior under test. The HumanEval example abbreviates its
+MIT-licensed contract for readability, and the LongBench example is
+paraphrased. Frozen external fixtures contain the exact pinned prompts, tests,
+and references.
+
+All documentation examples follow the repository's
+[example-data guidance](documentation-style.md#use-unmistakable-example-data).
+Benchmark receipts remain tied to their original content hashes; changing a
+documentation example does not change a completed run.
 
 #### Grounded chat and false-premise correction
 
@@ -103,10 +111,10 @@ premise, and rejects explanations beginning from an invented failure.
 
 #### Tool selection and exact arguments
 
-Case `mere.tool.email-search` asks:
+The tool-selection example asks:
 
 ```text
-Find recent email from abenewsoil@gmail.com in sawfwair after 2026-06-01.
+Find recent email from dana@example.com in greenhouse-ops after 2026-06-01.
 ```
 
 The answer is not prose. It must be the equivalent of this parsed tool call:
@@ -115,21 +123,22 @@ The answer is not prose. It must be the equivalent of this parsed tool call:
 {
   "name": "mere_email_search",
   "arguments": {
-    "sender": "abenewsoil@gmail.com",
-    "workspace": "sawfwair",
+    "sender": "dana@example.com",
+    "workspace": "greenhouse-ops",
     "after": "2026-06-01"
   }
 }
 ```
 
-Changing the workspace, dropping the date, calling a different tool, or adding
-an extra tool call fails the strict case. Other tool cases explicitly require
-no call when visible evidence is already sufficient or confirmation is absent.
+Changing the workspace, omitting the date, calling a different tool, or adding
+a tool call fails the strict case. Other tool cases require no call when the
+visible evidence is sufficient or the user has not confirmed a destructive
+action.
 
 #### Executed code, not prose similarity
 
-The embedded `HumanEval/0` task supplies this signature and contract (docstring
-abbreviated here):
+The embedded `HumanEval/0` task supplies this signature and contract. The
+example abbreviates the docstring.
 
 ```python
 def has_close_elements(numbers: list[float], threshold: float) -> bool:
@@ -196,17 +205,17 @@ supports it:
 - LongBench records its 0-to-1 text metric and separately applies the pinned
   pass threshold.
 - Unsupported capabilities, such as an image case sent to a text-only catalog
-  model, are unscored and reported separately rather than counted as wrong.
+model, are unscored and reported separately instead of being counted as wrong.
 
-Always compare the strict pass rate, mean score, unscored count, and per-source
-breakdown together. A model can be excellent at chat and tool use while being
+Compare the strict pass rate, mean score, unscored count, and per-source
+breakdown together. A model can perform well at chat and tool use while being
 materially weaker at executable code, or the reverse.
 
-A real fused run never downloads a missing model. Every selected catalog id
-must already resolve under the active `--models-root`; otherwise the command
+A real fused run never downloads a missing model. Every selected catalog ID
+must already resolve under the configured `--models-root`; otherwise the command
 stops before MLX initialization. The plan records the mere.run version and exact
 runner-executable SHA-256, host processor/memory/architecture/OS identity,
-catalog repository and revision, plus the installed `mererun_model.json` id,
+catalog repository and revision, plus the installed `mererun_model.json` ID,
 schema version, source pins, and exact manifest SHA-256. This makes a receipt
 identify the code, host, and checkpoint metadata that were actually visible to
 the runtime without recursively scanning model storage.
@@ -216,7 +225,7 @@ the runtime without recursively scanning model storage.
 The fused quality lane never uses temperature zero. It evaluates the models
 under their published native sampling profiles:
 
-| family | temperature | top-p | top-k | min-p |
+| Family | Temperature | Top-p | Top-k | Min-p |
 | --- | ---: | ---: | ---: | ---: |
 | Qwen3.8 | 1.0 | 0.95 | 20 | 0 |
 | Nemotron Lightning | 1.0 | 0.95 | disabled | 0 |
@@ -227,7 +236,7 @@ sample does not become the model result. Correctness is reported per lane,
 source, and capability; there is no single composite that hides a weak
 category.
 
-## Logprob contract
+## Log-probability contract
 
 Quality runs default to `--logprobs summary`. Use `tokens` for chosen-token
 records or `top --top-logprobs 5` for visible-token candidate lists:
@@ -243,12 +252,12 @@ mere.run model benchmark fused \
 
 Each measurement distinguishes:
 
-- raw model logprob before temperature, top-k, top-p, and min-p;
-- policy logprob after the exact sampling transforms that selected the token;
-- raw and policy entropy;
-- raw and policy top-1/top-2 logprob margin;
-- output region, with reasoning text redacted;
-- the optional visible-token top candidates.
+- Raw model log probability before temperature, top-k, top-p, and min-p
+- Policy log probability after the exact sampling transforms that selected the token
+- Raw and policy entropy
+- Raw and policy top-1/top-2 log-probability margin
+- Output region, with reasoning text redacted
+- Optional visible-token top candidates
 
 Aggregate reports include mean/min logprob, expected calibration error,
 selective accuracy, fragile passes, and confident failures. Token and top
@@ -270,20 +279,20 @@ mere.run model benchmark fused \
   --json
 ```
 
-Performance-lane rows have no correctness score and no logprobs. This keeps
+Performance-lane rows have no correctness score and no log probabilities. This keeps
 readback overhead and acceleration routing out of the quality result.
 
 ## Provenance and external fixtures
 
 Every planned case reports:
 
-- source and pinned/imported version;
-- upstream original id;
-- license and redistribution mode;
-- a hash of the exact source reference;
-- a content SHA-256 when the content is present;
-- an image-byte SHA-256 for every vision fixture;
-- capability tags, difficulty, and selection rationale.
+- Source and pinned or imported version
+- Upstream original ID
+- License and redistribution mode
+- A hash of the exact source reference
+- A content SHA-256 when the content is present
+- An image-byte SHA-256 for every vision fixture
+- Capability tags, difficulty, and selection rationale
 
 The run plan also records a canonical SHA-256 of the complete suite manifest,
 so two reports claiming the same semantic version can still be compared byte
@@ -318,7 +327,7 @@ python3 scripts/import-fused-benchmark-fixtures.py
 ```
 
 After one online import, `--offline` reproduces the same normalized fixtures
-using only the verified source cache. Generated source and fixture files remain
+by using only the verified source cache. Generated source and fixture files remain
 under `.tmp/` and are not committed.
 
 The normalized selection contains:
@@ -362,7 +371,7 @@ absolute `imageUrl` on a vision message. A vision record also carries
 `imageSHA256`. The fixture helper computes both the image-byte hash and the
 content hash over the sorted canonical payload excluding `contentSHA256`; an
 import is rejected before any model loads when either hash does not match. The
-importer-generated upstream id, source revision, and resolved hashes become the
+importer-generated upstream ID, source revision, and resolved hashes become the
 run receipt.
 
 Run the frozen selection with either suite:
@@ -392,7 +401,7 @@ and performance lane. Duplicate or out-of-plan rows are rejected. Checkpoints
 also preserve ISO-8601 creation and last-update timestamps.
 
 Model preparation or generation failures abort the invocation without writing
-the current row. Rows checkpointed before the failure remain intact, and an
+the row in progress. Rows checkpointed before the failure remain intact, and an
 exact `--resume` retries the pending row instead of recording infrastructure
 failure as model quality.
 

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -1,17 +1,16 @@
 # Benchmarking
 
-Small, local, repeatable lanes that answer one question: on *this* machine, is
-this model better than the alternative? Use them to compare installed models,
-verify a runtime change, and catch a regression before you claim support for
-something.
+Use these local, repeatable lanes to answer one question: on *this* machine, is
+this model better than the alternative? They compare installed models, verify
+runtime changes, and catch regressions before you claim support.
 
 They are not public leaderboards and do not try to be. For command syntax, see
-the generated [CLI Reference](./cli.md); this page is the decision guide for
+the generated [CLI reference](./cli.md). This page is the decision guide for
 picking a lane and reading what it tells you.
 
-## Benchmark Map
+## Benchmark map
 
-| Goal | Command | What It Measures |
+| Goal | Command | What it measures |
 | --- | --- | --- |
 | Grounded assistant behavior | `model benchmark chat` | Answers over provided evidence, abstention, formats, concise summaries, and local-action boundaries |
 | Tool selection | `model benchmark tool-calls` | Parsed tool names and arguments for synthetic Mere-style tools |
@@ -30,13 +29,13 @@ and raw-versus-policy logprob semantics, see
 For the completed August 2026 Qwen3.8 low-reasoning, Laguna XS 2.1, and
 Nemotron Lightning receipts, including comparable non-vision results,
 per-source scores, and exact hashes, see
-[Fused Comprehensive reference runs](benchmarks/fused-reference-runs.md).
+[Fused comprehensive reference runs](benchmarks/fused-reference-runs.md).
 
 For repository-owned cases, prompts, scorers, and qualification gates that must
 remain outside this public repository, use the open
 [external evaluation-pack interface](evaluation-packs.md).
 
-## Recommended Workflow
+## Recommended workflow
 
 1. Pull the exact models you want to compare.
 2. Dry-run the benchmark plan before loading models.
@@ -44,7 +43,7 @@ remain outside this public repository, use the open
 4. For quality, use the suite's pinned non-greedy native profile and repeated
    trials. Reserve deterministic settings for isolated runtime microbenchmarks.
 5. Save JSON output for comparisons and keep the raw command with the result.
-6. Treat capped generations, missing models, and skipped cases as separate from correctness.
+6. Report capped generations, missing models, and skipped cases separately from correctness.
 
 Example:
 
@@ -59,7 +58,7 @@ swift run mere.run model benchmark chat \
 The benchmark commands do not auto-pull models during scoring. Missing models are
 reported as skipped so the comparison remains explicit.
 
-## Quality Evals
+## Quality evaluations
 
 ### Chat
 
@@ -98,7 +97,7 @@ swift run mere.run model benchmark chat \
   --log-responses
 ```
 
-### Tool Calls
+### Tool calls
 
 `model benchmark tool-calls` is separate from the chat benchmark on purpose. It
 passes synthetic `ToolDefinition` schemas to the model and scores the parsed
@@ -118,7 +117,7 @@ swift run mere.run model benchmark tool-calls \
 ### Code
 
 `model benchmark code` runs a real functional-code eval slice. The default suite
-is `humaneval-slice`, currently three public HumanEval tasks:
+is `humaneval-slice`, which contains three public HumanEval tasks:
 
 - `HumanEval/0`
 - `HumanEval/3`
@@ -135,7 +134,7 @@ swift run mere.run model benchmark code \
 ```
 
 Without `--models`, the code benchmark uses the supported members of the default
-comparison lane for the current machine. On 32 GB Macs that means
+comparison lane for this machine. On 32 GB Macs that means
 `text-agent-ornith-9b` and `text-code-north-mini`; `text-code-qwen3` joins the
 default comparison on 64 GB and larger machines.
 
@@ -162,7 +161,7 @@ captured `<think>...</think>` content is reported as reasoning metadata. A secon
 generated reasoning block is reported as `reasoning_reopened=true`; treat that as
 a loop or phase-restart warning, not an automatic correctness failure.
 
-### Laguna S 2.1 Evaluation
+### Laguna S 2.1 evaluation
 
 Laguna S 2.1 is available as the opt-in managed model
 `text-chat-laguna-s-2-1`. Pull it once with
@@ -252,7 +251,7 @@ gate/up projection and SwiGLU behind
 `MERERUN_LAGUNA_FUSED_SORTED_NVFP4_MOE`. The matching expert-aligned down
 projection is controlled independently by
 `MERERUN_LAGUNA_FUSED_SORTED_NVFP4_DOWN`; weighting and reduction retain the
-native operation order. Set either flag to `0` for a portable-path A/B or
+native operation order. Set either flag to `0` for a portable-path comparison or
 rollback. `MERERUN_LAGUNA_FAST_SORTED_INVERSE=0` independently restores the
 reference second route sort. The guarded kernels recognize both M4 Max
 `applegpu_g16s` and M5 Max `applegpu_g17s` on macOS 26.
@@ -263,7 +262,7 @@ sliding masks default on and can be disabled with
 ladder can be changed or disabled with `MERERUN_LAGUNA_PREFILL_ASYNC_LADDER`.
 Exact fused residual/RMSNorm and QK-norm/RoPE kernels default on only for M5
 Max; use `MERERUN_LAGUNA_PREFILL_FUSED_RESIDUAL_RMSNORM` and
-`MERERUN_LAGUNA_PREFILL_QK_NORM_ROPE` for explicit A/Bs on either architecture.
+`MERERUN_LAGUNA_PREFILL_QK_NORM_ROPE` for explicit comparisons on either architecture.
 
 These flags are an evaluation boundary, not a pull or serving contract. Do not
 infer catalog support from a successful local checkpoint run.
@@ -293,9 +292,9 @@ swift run mere.run model benchmark vlm \
   --dry-run
 ```
 
-## Runtime Benchmarks
+## Runtime benchmarks
 
-### Gemma 4 Tool Continuation
+### Gemma 4 tool continuation
 
 `model benchmark tool-continuations` runs two deterministic real-checkpoint
 Gemma 4 histories: a typed tool call containing boolean, nested, and null JSON
@@ -310,7 +309,7 @@ mere.run model benchmark tool-continuations --log-responses
 Use `--model-root` to validate a locally converted Gemma 4 directory without
 installing or replacing the managed model.
 
-### API Workload
+### API workload
 
 `model benchmark api-workload` measures the real local API serving path. Run it
 against an already-started `mere.run api serve` process when you need request
@@ -332,7 +331,7 @@ swift run mere.run model benchmark api-workload \
 For cache or batching work, compare runs against `/runtime/status` before and
 after the benchmark instead of inferring behavior from prose.
 
-### KV Cache And Speculative Decode
+### KV cache and speculative decode
 
 The microbenchmark commands are for runtime implementation work:
 
@@ -351,12 +350,12 @@ so their source-level structural/numerical checks are separate:
 swift test --filter 'AffineQuantizedKVCacheTests|GLM47AccelerationTests'
 ```
 
-Before promoting either path, run release-mode real-checkpoint A/B with a fixed
+Before promoting either path, run a release-mode real-checkpoint comparison with a fixed
 greedy prompt corpus and report output parity, resident memory, TTFT, prefill
 tokens/s, and decode tokens/s. See the
 [guarded acceleration audit](./internals/guarded-acceleration.md).
 
-## Interpreting Results
+## Interpret results
 
 Use these conventions when reporting benchmark outcomes:
 
@@ -371,10 +370,10 @@ Use these conventions when reporting benchmark outcomes:
 - For large models, prefer one model per command invocation when memory pressure
   could affect fairness.
 
-## Related References
+## Related references
 
-- [CLI Reference](./cli.md)
-- [Testing Guide](./testing.md)
+- [CLI reference](./cli.md)
+- [Testing guide](./testing.md)
 - [Configuration](./configuration.md)
-- [Text Runtime](./runtime/text.md)
-- [Local API Server](./runtime/api-server.md)
+- [Text runtime](./runtime/text.md)
+- [Local API server](./runtime/api-server.md)

--- a/docs/benchmarks/fused-reference-runs.md
+++ b/docs/benchmarks/fused-reference-runs.md
@@ -1,10 +1,10 @@
-# Fused Comprehensive reference runs
+# Fused comprehensive reference runs
 
-These are completed local reference receipts captured on August 18–20, 2026.
-They are **not** upstream leaderboard scores. They measure the pinned Mere
-Comprehensive subset, scorers, sampling profiles, and runtime identified below.
-Future runner, fixture, sandbox, model, or profile changes require a new dated
-receipt; they do not silently replace these results.
+These completed local reference receipts were captured from August 18 through
+August 20, 2026. They are **not** upstream leaderboard scores. They measure the
+pinned Mere `comprehensive` subset, scorers, sampling profiles, and runtime
+listed on this page. Runner, fixture, sandbox, model, or profile changes require
+a new dated receipt; they do not replace these results.
 
 ## Completed profile scope
 
@@ -75,58 +75,59 @@ about the complete upstream benchmark collections.
 
 ### Qwen3.8 27B low-reasoning receipt
 
-- Model id: `vision-chat-q38-27b`
-- Artifact: `Qwen/Qwen3.8-27B`
-- Artifact revision: `1d4bf0f2ff6012fd82039f2fa52739d0dd7c60c0`
-- Runtime-manifest SHA-256:
+- **Model ID:** `vision-chat-q38-27b`.
+- **Artifact:** `Qwen/Qwen3.8-27B`.
+- **Artifact revision:** `1d4bf0f2ff6012fd82039f2fa52739d0dd7c60c0`.
+- **Runtime-manifest SHA-256:**
   `c5813b1044dff6f7aec2464c31d829f96aba19671839b70d83d617a6a1c42ec0`
-- Profile: `qwen3.8-native-low`; reasoning effort 0.2, thinking enabled,
+- **Profile:** `qwen3.8-native-low`; reasoning effort 0.2, thinking enabled,
   temperature 1.0, top-p 0.95, top-k 20, min-p 0
-- Checkpoint window: `2026-08-20T01:15:56Z` to `2026-08-20T09:21:19Z`
-- Completion scope: low 550/550; medium 0/550; xhigh 0/550
-- Plan SHA-256:
+- **Checkpoint window:** `2026-08-20T01:15:56Z` to `2026-08-20T09:21:19Z`.
+- **Completion scope:** Low 550/550; medium 0/550; xhigh 0/550.
+- **Plan SHA-256:**
   `64a9b0fa53478c177947101cb385ef73ac6025827fbb8be2d9031a719c13d5b2`
-- Frozen receipt filename: `qwen38-low-comprehensive-b944c0e7.json`
-- Receipt SHA-256:
+- **Frozen receipt filename:** `qwen38-low-comprehensive-b944c0e7.json`.
+- **Receipt SHA-256:**
   `c6b70396f183ec7183563d0b2789a32893841285e843cafb8d3ff796e18698f4`
 
 ### Laguna XS 2.1 receipt
 
-- Model id: `text-chat-laguna-xs-2-1`
-- Artifact: `poolside/Laguna-XS-2.1-NVFP4-mlx`
-- Artifact revision: `841778bda563a36104dd521e37d99218e46f4f25`
-- Runtime-manifest SHA-256:
+- **Model ID:** `text-chat-laguna-xs-2-1`.
+- **Artifact:** `poolside/Laguna-XS-2.1-NVFP4-mlx`.
+- **Artifact revision:** `841778bda563a36104dd521e37d99218e46f4f25`.
+- **Runtime-manifest SHA-256:**
   `213b9c6ee642824a2294715aa37c84ee5772e45ca2d671f3cc2aafa2e5c368f7`
-- Profile: temperature 1.0, top-p 1.0, top-k 20, min-p 0.02
-- Checkpoint window: `2026-08-19T12:47:30Z` to `2026-08-19T14:47:50Z`
-- Plan SHA-256:
+- **Profile:** Temperature 1.0, top-p 1.0, top-k 20, min-p 0.02.
+- **Checkpoint window:** `2026-08-19T12:47:30Z` to `2026-08-19T14:47:50Z`.
+- **Plan SHA-256:**
   `ba0c0785c17f857a58428c024eae9448130b749e39c4e525eb60910c16720af1`
-- Receipt filename: `laguna-xs-2-1-comprehensive-b944c0e7.json`
-- Receipt SHA-256:
+- **Receipt filename:** `laguna-xs-2-1-comprehensive-b944c0e7.json`.
+- **Receipt SHA-256:**
   `6b8ddccd034cd00515becbb6f7eb31d12a2f8aae2ccb93d00cc7212237dd522d`
 
 ### Nemotron Lightning receipt
 
-- Model id: `text-chat-nemotron-35-lightning`
-- Managed artifact:
+- **Model ID:** `text-chat-nemotron-35-lightning`.
+- **Managed artifact:**
   `Sawfwair/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4-MLX`
-- Managed artifact revision:
+- **Managed artifact revision:**
   `6699e5fd3f0c5b392bb3f8bac2443276bb41958a`
-- Pinned base-model revision:
+- **Pinned base-model revision:**
   `nvidia/NVIDIA-Nemotron-3.5-Lightning-30B-A3B-NVFP4@e0b753dc24903ad4d62f5696077da22020eca89a`
-- Runtime-manifest SHA-256:
+- **Runtime-manifest SHA-256:**
   `369da6748557f0a3a05256cbeea933e789b7a9b15c5e08403a24946ec6b453e7`
-- Profile: temperature 1.0, top-p 0.95, top-k disabled, min-p 0
-- Checkpoint window: `2026-08-18T18:20:13Z` to `2026-08-19T12:24:41Z`
-- Plan SHA-256:
+- **Profile:** Temperature 1.0, top-p 0.95, top-k disabled, min-p 0.
+- **Checkpoint window:** `2026-08-18T18:20:13Z` to `2026-08-19T12:24:41Z`.
+- **Plan SHA-256:**
   `bd04d29ac3a67b23d9c23ffc9477b7284274adf22de14af65cd7ac14de5aa8a7`
-- Receipt filename: `nemotron-lightning-comprehensive-b944c0e7.json`
-- Receipt SHA-256:
+- **Receipt filename:** `nemotron-lightning-comprehensive-b944c0e7.json`.
+- **Receipt SHA-256:**
   `b1631e7504c74fcf41a34b44c1969dc2d6984b75e43a3bdac29fe9894b3ecd68`
 
 ## Interpretation limits
 
-- These results apply to the exact Mere subset and hashes above, not the full
+- These results apply to the exact Mere subset and hashes in the shared run
+  contract, not the full
   HumanEval+, MBPP+, LiveCodeBench, BFCL, or LongBench leaderboards.
 - Qwen3.8 medium and xhigh were intentionally deferred. The Qwen checkpoint is
   complete for low reasoning and partial for its three-profile plan.

--- a/docs/benchmarks/laguna-min-p-m4-max.md
+++ b/docs/benchmarks/laguna-min-p-m4-max.md
@@ -1,6 +1,6 @@
-# Laguna S 2.1 Min-P Evaluation
+# Laguna S 2.1 min-p evaluation
 
-This report records the 2026-07-27 Laguna S 2.1 min-p promotion gate on an
+This report records the July 27, 2026, Laguna S 2.1 min-p promotion gate on an
 AC-powered Apple M4 Max with 128 GB unified memory, macOS 26.5.2, the official
 `Laguna-S-2.1-NVFP4-mlx` target, and the official
 `Laguna-S-2.1-DFlash` companion.

--- a/docs/benchmarks/minimax-h3-bf16-m4-max.md
+++ b/docs/benchmarks/minimax-h3-bf16-m4-max.md
@@ -6,19 +6,19 @@ transformer-only extrapolation.
 
 ## Locked workload
 
-- checkpoint: managed `video-minimax-h3-fl2va-bf16-mlx`
-- mode: resident BF16 transformer, historical scheduled-tail `maximum`
-- geometry: 832x480, 124 frames, 24 fps
-- schedule: 20 points / 19 model evaluations
-- seed: `20260804`
-- packed rows: 14,928
-- execution: blockwise compiled
-- policy: six complete 50-block evaluations and thirteen nine-block cached-tail
+- **Checkpoint:** Managed `video-minimax-h3-fl2va-bf16-mlx`.
+- **Mode:** Resident BF16 transformer, historical scheduled-tail `maximum`.
+- **Geometry:** 832 x 480 pixels, 124 frames, 24 frames per second.
+- **Schedule:** 20 points and 19 model evaluations.
+- **Seed:** `20260804`.
+- **Packed rows:** 14,928.
+- **Execution:** Blockwise compiled.
+- **Policy:** Six complete 50-block evaluations and thirteen nine-block cached-tail
   evaluations, with native start, refresh, and endpoint evaluations
 
-This historical artifact is reproducible on the current runtime with
-`MERERUN_H3_CACHE_STRATEGY=scheduled-tail`. Production `maximum` now selects
-the adaptive first-block policy measured below.
+This historical artifact is reproducible on the runtime with
+`MERERUN_H3_CACHE_STRATEGY=scheduled-tail`. Production `maximum` selects
+the adaptive first-block policy in the adaptive cache comparison.
 
 The command is reproducible with the repository benchmark harness:
 
@@ -41,21 +41,22 @@ The six full evaluations averaged 184.268 seconds. The thirteen cached-tail
 evaluations averaged 32.372 seconds with a 32.191-second median. Peak reported
 Metal memory was 43.41 GiB and active memory remained approximately 38.24 GiB.
 
-The output is an H.264/AAC MP4 at 832x480, 24 fps, with synchronized 32 kHz
+The output is an H.264/AAC MP4 at 832 x 480 pixels and 24 frames per second,
+with synchronized 32 kHz
 stereo audio. Its SHA-256 is
 `270544693662769fd8f90971d1ccabce3405fe00ff21885f96b9b0e218cb921f`.
 Visual acceptance confirmed a coherent caped figure and yellow umbrella,
 wet-street reflections, levitating bus, and luminous dragon motion without the
 spatial lattice rejected in earlier aggressive cache experiments.
 
-## Adaptive first-block cache A/B
+## Adaptive first-block cache comparison
 
 A later release-build A/B held checkpoint, prompt, seed, geometry, schedule,
 weight residency, and packed layout fixed while changing only the cache
-decision. This practical proxy used resident BF16 at 416x256, 107 frames,
-20 schedule points / 19 evaluations, and 3,768 packed rows.
+decision. This practical proxy used resident BF16 at 416 x 256 pixels, 107 frames,
+20 schedule points and 19 evaluations, and 3,768 packed rows.
 
-| Policy | Full / cached evaluations | Executed blocks | Denoising | End to end |
+| Policy | Full and cached evaluations | Executed blocks | Denoising | End to end |
 | --- | ---: | ---: | ---: | ---: |
 | Scheduled-tail baseline | 6 / 13 | 417 | 222.220 s | 257.814 s |
 | Adaptive first-block `maximum` | 7 / 12 | 362 | **163.953 s** | **194.174 s** |
@@ -67,7 +68,7 @@ performance warning at its start. A deliberately conservative 0.12/0.18
 calibration was also measured and rejected: it admitted only 7 cache hits,
 executed 607 blocks, and took 328.364 seconds to denoise.
 
-Both accepted MP4s contain H.264 416x256 video at 24 fps and AAC 32 kHz stereo
+Both accepted MP4s contain H.264 416 x 256 video at 24 frames per second and AAC 32 kHz stereo
 audio. Contact-sheet inspection confirmed the same coherent bus-lift-to-dragon
 trajectory without lattice collapse. The baseline SHA-256 is
 `02fb184e6cc8213197e52ecaf4b6b344eb4b292b6233213605bc36d5d50cb66b`; the
@@ -77,17 +78,17 @@ adaptive output SHA-256 is
 ## Resident sliding-window and frame-injection receipts
 
 A real two-window FL2VA generation then exercised the long-form path with the
-same managed BF16 checkpoint. It generated 56 frames at 416x256 using 39-frame
+same managed BF16 checkpoint. It generated 56 frames at 416 x 256 pixels using 39-frame
 windows, an 18-frame video-and-audio overlap, nine schedule points per window,
 and the adaptive `maximum` policy. The second window reused the resident Qwen
 conditioner and transformer: both model-load phases measured 0.000 seconds.
 
-| Window | Full / cached evaluations | Executed blocks | Denoising | Generation |
+| Window | Full and cached evaluations | Executed blocks | Denoising | Generation |
 | --- | ---: | ---: | ---: | ---: |
 | First | 5 / 3 | 253 | 43.268 s | 67.796 s |
 | Continuation | 5 / 3 | 253 | 51.273 s | 63.421 s |
 
-The resulting H.264/AAC MP4 contains exactly 56 frames at 24 fps and 32 kHz
+The resulting H.264/AAC MP4 contains exactly 56 frames at 24 frames per second and 32 kHz
 stereo audio, both 2.333 seconds long. At the window boundary, frame-to-frame
 RGB mean absolute difference was 4.128, below every adjacent comparison in the
 local inspection range (6.418–7.609). Audio sample jumps at the same boundary
@@ -97,7 +98,7 @@ nor an audio-click impulse. The artifact SHA-256 is
 `ac51d8eb9623e9f7ea996204a415370058241f912aadffc058dde3a2525f25de`.
 
 A separate release-mode FL2VA generation injected an exact image at output
-frame 11 of a 22-frame, 416x256 shot. The Qwen multimodal presentation and
+frame 11 of a 22-frame, 416 x 256 shot. The Qwen multimodal presentation and
 video-VAE condition path both consumed the frame; the run completed in 46.944
 seconds with 28.532 seconds of denoising. The valid H.264/AAC output has
 SHA-256
@@ -113,13 +114,13 @@ to the typed continuation-layout coverage here.
 The locked MP4 predates the audio-VAE bias-loading correction documented in
 the kernel lab. Its video remains the accepted visual and timing receipt, but
 its hissy soundtrack is not an audio-quality reference. The corrected decoder
-matches the released FP32 reference at `rel_l2=0.0000194`; a future long render
-must replace the soundtrack acceptance receipt rather than reusing this file.
+matches the released FP32 reference at `rel_l2=0.0000194`; a later long render
+must replace the soundtrack acceptance receipt instead of reusing this file.
 
 ## Duration boundary
 
 MiniMax-H3 frame counts follow `17*n+5`. The locked 124-frame artifact is
-5.167 seconds at 24 fps. It proves the near-30-minute target for this workload;
+5.167 seconds at 24 frames per second. It proves the near-30-minute target for this workload;
 it is not a ten-second runtime claim. The first valid frame count beyond ten
 seconds is 243 frames (10.125 seconds), which requires a separate measured
 receipt.
@@ -130,13 +131,13 @@ The optional `minimax-h3-turbo-4step` adapter was validated separately with a
 real release-mode generation rather than extrapolating its tiny-shape smoke
 test:
 
-- checkpoint: managed `video-minimax-h3-fl2va-bf16-mlx`
-- adapter: checksum-pinned `minimax-h3-turbo-4step`, strength `0.9`
-- geometry: 1280x768, 124 frames, 24 fps
-- schedule: five points / four complete model evaluations
-- seed: `20260804`
-- packed rows: 36,047
-- execution: dense BF16, blockwise compiled, exact `quality` acceleration
+- **Checkpoint:** Managed `video-minimax-h3-fl2va-bf16-mlx`.
+- **Adapter:** Checksum-pinned `minimax-h3-turbo-4step`, strength `0.9`.
+- **Geometry:** 1280 x 768 pixels, 124 frames, 24 frames per second.
+- **Schedule:** Five points and four complete model evaluations.
+- **Seed:** `20260804`.
+- **Packed rows:** 36,047.
+- **Execution:** Dense BF16, blockwise compiled, exact `quality` acceleration.
 
 | Phase | Time |
 | --- | ---: |
@@ -167,14 +168,14 @@ hiss acceptance reference.
 The Apple-GPU dynamic-sparse path was accepted with a real synchronized-video
 generation, not from random-tensor timing alone:
 
-- checkpoint: managed `video-minimax-h3-fl2va-bf16-mlx`
-- adapter: checksum-pinned `minimax-h3-lightx2v-4step`, strength `1.0`
-- geometry: 768x448, 124 frames, 24 fps, 13,085 packed rows
-- schedule: five points / four transformer evaluations
-- seed: `20260808`
-- dense arm: resident BF16, exact `quality`
-- sparse arm: resident BF16, attention-only `maximum`, tau `1.0`, no cache reuse
-- prompt: a continuous rain-soaked railway-platform two-shot with a detective,
+- **Checkpoint:** Managed `video-minimax-h3-fl2va-bf16-mlx`.
+- **Adapter:** Checksum-pinned `minimax-h3-lightx2v-4step`, strength `1.0`.
+- **Geometry:** 768 x 448 pixels, 124 frames, 24 frames per second, and 13,085 packed rows.
+- **Schedule:** Five points and four transformer evaluations.
+- **Seed:** `20260808`.
+- **Dense arm:** Resident BF16, exact `quality`.
+- **Sparse arm:** Resident BF16, attention-only `maximum`, tau `1.0`, and no cache reuse.
+- **Prompt:** A continuous rain-soaked railway-platform two-shot with a detective,
   a paramedic, a recorder handoff, a passing train, and two spoken lines
 
 | Phase | Dense | Dynamic sparse |
@@ -203,8 +204,8 @@ an in-process thermal control for the 20.6% faster sparse step.
 
 Before sparse execution was admitted, the custom all-routes-dense Metal sample
 matched fused SDPA at `max_abs=0.10026`, `mean_abs=0.00219996`, and
-`rel_l2=0.0027471`. Both outputs then passed the artifact boundary: 768x448
-H.264, exactly 124 frames at 24 fps and 5.167 seconds, plus stereo AAC at
+`rel_l2=0.0027471`. Both outputs then passed the artifact boundary: 768 x 448
+H.264, exactly 124 frames at 24 frames per second and 5.167 seconds, plus stereo AAC at
 32 kHz. Eight matched frame samples retained both actor identities, the
 recorder handoff, coherent faces, train movement, and the final composition.
 Native Parakeet transcribed both soundtracks exactly as
@@ -224,11 +225,11 @@ pretending that a two-point sampler is a quality result:
 scripts/h3-end-to-end-benchmark.sh probe-768
 ```
 
-- geometry: 1344x768, 124 frames, 24 fps
-- schedule: two points / one complete 50-block model evaluation
-- packed rows: 37,794
-- execution: dense BF16, blockwise compiled, 768-query single-evaluation attention chunks
-- acceleration: exact `quality` (no tail reuse)
+- **Geometry:** 1344 x 768 pixels, 124 frames, 24 frames per second.
+- **Schedule:** Two points and one complete 50-block model evaluation.
+- **Packed rows:** 37,794.
+- **Execution:** Dense BF16, blockwise compiled, with 768-query single-evaluation attention chunks.
+- **Acceleration:** Exact `quality` with no tail reuse.
 
 | Phase | Baseline | Optimized exact |
 | --- | ---: | ---: |
@@ -240,12 +241,12 @@ scripts/h3-end-to-end-benchmark.sh probe-768
 | End to end | 1,253.425 s | **1,027.310 s (17:07.310)** |
 
 The full model evaluation itself fell from 953.192 to 775.062 seconds, a
-1.230x throughput improvement and 18.7% less wall time. End to end, the boundary
+1.230 times the throughput and 18.7% less wall time. End to end, the boundary
 is 3:46.115 faster (18.0%). Peak reported Metal memory remained 48.77 GiB, so
 this workload is compute-bound rather than blocked by unified-memory capacity.
-The valid H.264/AAC output is 1344x768 at 24 fps with 32 kHz stereo audio and a
+The valid H.264/AAC output is 1344 x 768 at 24 frames per second with 32 kHz stereo audio and a
 5.167-second duration. Its SHA-256 is
-`f74e0d2ab0cf9a58233e954560a9aa6c05a1f905fd78914350a077b70f7e5848`—exactly
+`f74e0d2ab0cf9a58233e954560a9aa6c05a1f905fd78914350a077b70f7e5848`, exactly
 the same as the baseline artifact, proving the optimized execution did not
 change model output.
 
@@ -259,17 +260,17 @@ model/block evaluations rather than another small scheduling adjustment.
 ## VAE tile frontier
 
 A later fresh-process sweep of the released BF16 video decoder changed the
-production spatial tile from 256 to 320 pixels. At 832x480 and 124 frames, the
-matched decode fell from 96.091 to 76.421 seconds (1.257x) while reported peak
+production spatial tile from 256 to 320 pixels. At 832 x 480 pixels and 124 frames, the
+matched decode fell from 96.091 to 76.421 seconds (1.257 times) while reported peak
 Metal memory fell from 9.85 to 8.91 GiB. A 480-pixel arm reached 77.577 seconds
-and lost. At the true 1344x768 shape, the accepted 320-pixel arm completed in
+and lost. At the true 1344 x 768 shape, the accepted 320-pixel arm completed in
 213.005 seconds at a 15.12 GiB reported peak; the 480-pixel arm crossed 252
 seconds without completing and was stopped.
 
 This is a non-quantized runtime change: the released decoder, precision,
 causal tiling, and overlap blend remain intact. The larger tile performs fewer
 overlapping tile evaluations and gives each evaluation more spatial context.
-At true 1344x768 spatial geometry, an order-balanced 22-frame screen confirmed
+At true 1344 x 768 spatial geometry, an order-balanced 22-frame screen confirmed
 that 320 pixels also beats the tempting overlap-count breakpoints: a hot-state
 416-versus-320 pair measured 33.756 versus 32.321 seconds, and 432- and
 496-pixel arms were materially slower. A two-temporal-chunk submission
@@ -286,7 +287,7 @@ which yields 72 video latent frames and 73,470 packed rows for the locked prompt
 The accepted exact attention schedule splits the 56 independent heads into
 eight-head submissions with 640 query rows per kernel. An order-balanced
 full-block gate measured 32.249 seconds for the previous 768-query/56-head
-schedule and 25.173 seconds for the new schedule, a 1.281x speedup with
+schedule and 25.173 seconds for the accepted schedule, a 1.281-times speedup with
 bit-identical BF16 output (`rel_l2=0`). That puts one exact 50-block model
 evaluation near 21 minutes. Scaling the measured 124-frame VAE decode only as
 an arithmetic estimate adds roughly seven minutes, placing the
@@ -309,7 +310,7 @@ checkpoint; the exact head-scheduling win does not remove the remaining
 evaluation-count multiplier.
 
 Inference-only solver screens did not change that conclusion. On the locked
-416x256 proxy, 12-point variable-step Adams-Bashforth was less faithful to the
+416 x 256 proxy, 12-point variable-step Adams-Bashforth was less faithful to the
 20-point Euler artifact than plain 12-point Euler (0.667 versus 0.694 SSIM).
 A two-evaluation Heun solve reached the desired compute class—45.548 seconds of
 proxy denoise—but produced tiled chromatic noise at 0.327 SSIM. Both candidates

--- a/docs/benchmarks/minimax-h3-compact-bf16-q8-m4-max.md
+++ b/docs/benchmarks/minimax-h3-compact-bf16-q8-m4-max.md
@@ -2,22 +2,23 @@
 
 This receipt records the official-source compact-artifact rollout and real
 native Swift/MLX inference on an Apple M4 Max with 128 GB unified memory. The
-test media uses 416x256, 22 frames at 24 fps, stereo AAC at 32 kHz, and matched
+test media uses 416 x 256 pixels, 22 frames at 24 frames per second, stereo AAC
+at 32 kHz, and matched
 prompts/seeds so several lanes could be reviewed without projecting a large
 production render.
 
 ## Artifact identity
 
-- official source: `MiniMaxAI/MiniMax-H3@ec19cc6daf5d8add9417c18e86b6b58cc6c55027`
-- official source bytes: `144,035,116,604` across 48 files
-- cache-producing source tensors: 106 tensors / `26,142,079,488` bytes
-- cache source closure SHA-256:
+- **Official source:** `MiniMaxAI/MiniMax-H3@ec19cc6daf5d8add9417c18e86b6b58cc6c55027`
+- **Official source bytes:** `144,035,116,604` across 48 files.
+- **Cache-producing source tensors:** 106 tensors and `26,142,079,488` bytes.
+- **Cache source closure SHA-256:**
   `e2ccc0cab72b9183a0347e3999f4559cdc315b7b363a5fe9196890dd315f5a40`
-- compact BF16: `Sawfwair/MiniMax-H3-FL2VA-MLX-BF16@6f2c1edb4d31d9110d4a51457ba1d6401a05dfd0`
-- BF16 managed bytes: `76,861,026,073`
-- affine Q8/group-64: `Sawfwair/MiniMax-H3-FL2VA-MLX-8bit@57a926c2422e09c8563cd2e0c43b2e94ef791de4`
-- Q8 managed bytes: `58,075,175,639`
-- rollback source: `Sawfwair/MiniMax-H3-FL2VA-MLX-BF16@c768b13a964f646a8000e641608189289e4514af`
+- **Compact BF16:** `Sawfwair/MiniMax-H3-FL2VA-MLX-BF16@6f2c1edb4d31d9110d4a51457ba1d6401a05dfd0`.
+- **BF16 managed bytes:** `76,861,026,073`.
+- **Affine Q8/group-64:** `Sawfwair/MiniMax-H3-FL2VA-MLX-8bit@57a926c2422e09c8563cd2e0c43b2e94ef791de4`.
+- **Q8 managed bytes:** `58,075,175,639`.
+- **Rollback source:** `Sawfwair/MiniMax-H3-FL2VA-MLX-BF16@c768b13a964f646a8000e641608189289e4514af`.
 
 Both denoising cores were reproduced from the pinned official checkpoint on an
 ephemeral RTX A6000 host in Sweden with MLX/MLX CUDA 0.29.3. The BF16 core is
@@ -45,7 +46,7 @@ contains the Metal receipt and exact 9-/21-point media parity.
 The old full BF16 root and compact BF16 candidate used the same release binary,
 prompt, seed, geometry, schedule, resident-BF16 policy, and compiled execution.
 
-| Workload | Full and compact MP4 SHA-256 | Video / audio result |
+| Workload | Full and compact MP4 SHA-256 | Video and audio result |
 | --- | --- | --- |
 | Base, 9 points | `29c76863cae58644d3747e7fd362d46877fdc7c31c5dc60d8be98d4651843f21` | SSIM 1.0, PSNR infinite, audio correlation 1.0, audio relative L2 0 |
 | Base, 21 points | `5449b7e66b803f71d4e78d558f1710b6558b684ff722f0155992df6d94f05ad1` | SSIM 1.0, PSNR infinite, audio correlation 1.0, audio relative L2 0 |
@@ -63,14 +64,14 @@ staging roots. Its base, Larry, and LightX2V MP4 SHA-256 values were
 `748a77ce065d8efeb85a186f0fd226e824f277af8c301e8b527119fbfe147b3b`,
 `1dbfb7e01cad686dc798578a510d0e9e014920277adbbf9ad85846fa078634a2`,
 and `ad45678a374de7c27e71833be503cbdadf28413d7f1672bc2f550ddedbc781a7`.
-All three outputs contained 416x256 H.264 video and stereo 32 kHz AAC audio,
+All three outputs contained 416 x 256 H.264 video and stereo 32 kHz AAC audio,
 and all three processes reported zero swaps.
 
-## Q8 quality against BF16 and rejected Q4
+## Q8 quality compared with BF16 and rejected Q4
 
 Three matched prompt/seed lanes covered character identity/dialogue, rally-car
 camera motion, and lighthouse fine texture/weather. Contact-sheet review found
-no Q8 collapse, lattice, identity loss, broken motion, or new audio failure.
+no Q8 collapse, lattice, identity loss, broken motion, or additional audio failure.
 Q4 changed the character into a helmeted figure and materially changed motion,
 background, and lighthouse structure. This was an operator review rather than
 an independent blinded panel, so the latter remains a release-note limitation.
@@ -110,8 +111,8 @@ motion without lattice or collapse.
 The most comparable 9-point BF16 runs measured 38.698 seconds for the full
 root and 38.542 seconds for compact BF16 denoising, a 0.4% improvement. Larry
 measured 28.943 versus 19.521 seconds, and LightX2V measured 18.929 versus
-18.070 seconds. Those adapter pairs confirm there is no observed 3% runtime-
-LoRA steady-state penalty; they are not generalized speed claims.
+18.070 seconds. Those adapter pairs show no observed 3% runtime LoRA
+steady-state penalty. They are not generalized speed claims.
 
 The external ExFAT candidate made cold preparation and end-to-end numbers
 storage-bound: compact BF16 preparation took about 97 seconds from the external
@@ -149,12 +150,12 @@ afterward it was `83,435,384` KiB, a measured increase of `64,725,612` KiB
 (`66,279,026,688` bytes). The reclaimed amount is lower than the old root's
 allocated size because APFS had clone-shared blocks with other local payloads.
 SALVATION changed by only 128 KiB during the pull because every payload blob was
-already present. The old internal directory and all staging/previous siblings
-are gone; the BF16 and Q8 managed roots now occupy 4 KiB each and resolve all 21
+already present. The earlier internal directory and all staging and previous
+siblings are gone. The BF16 and Q8 managed roots occupy 4 KiB each and resolve all 21
 payload files through absolute links to SALVATION. Shared conditioner, VAE,
 tokenizer, license, and cache-table links resolve to identical content-addressed
 blob paths for both models.
-`model pull --cache-dir /Volumes/SALVATION/MereRun/hub` prepared each new
+`model pull --cache-dir /Volumes/SALVATION/MereRun/hub` prepared each
 revision completely, validated a sibling staged root, atomically exchanged the
 managed install, revalidated aliases/source identity, and only then removed the
 previous root. The internal managed roots resolve through absolute symlinks to
@@ -163,7 +164,7 @@ unavailable.
 
 ## Commands and remaining boundaries
 
-Representative commands:
+The following commands reproduce the preparation and validation steps:
 
 ```bash
 mere.run model optimize /tmp/h3-adaln-rebuild --json

--- a/docs/benchmarks/minimax-h3-h3c-transfer.md
+++ b/docs/benchmarks/minimax-h3-h3c-transfer.md
@@ -1,7 +1,7 @@
 # MiniMax-H3 h3.c transfer program
 
 This document defines the evidence contract for transferring useful h3.c
-techniques into mere.run. It is not a performance receipt. Production behavior
+techniques into `mere.run`. It is not a performance receipt. Production behavior
 does not change until a candidate passes its tensor, checkpoint, quality,
 memory, and fallback gates.
 
@@ -16,10 +16,10 @@ shapes. MLX's public quantized-matmul primitive does not accept an output
 stride or custom epilogue, so eliminating the remaining projection
 materializations competitively requires an MLX/MLXFast primitive with a tiled
 quantized core and H3-specific epilogue, or an M5 TensorOps implementation. It
-is not achievable by further tuning the current standalone scalar kernels.
+is not achievable by further tuning the standalone scalar kernels.
 
 Resident BF16 has a separate M3/M4 opportunity. The refreshed MLX source has
-a Metal 4 NAX GEMM implementation, but its runtime capability gate currently
+a Metal 4 NAX GEMM implementation, but its runtime capability gate
 requires Apple GPU generation 18 or newer, so it does not dispatch on the local
 generation-16 M4 Max. The H3 lab now includes an independently gated MPP BF16
 projection candidate, adapted from WeeTodd's measured MiniMax-H3 tiles. Both
@@ -78,7 +78,8 @@ scripts/h3c-oracle.sh run --help
 No h3.c source code, binary, or library is vendored, linked, or shipped by
 mere.run. The optional runner fetches an ignored checkout under
 `.build/h3c-oracle` by default and refuses revision drift by checking out the
-immutable commit above on every build. It does not download checkpoint weights.
+immutable h3.c commit listed in this section on every build. It does not download
+checkpoint weights.
 h3.c expects the original upstream `FL2VA/` and `Ref2VA/` directory trees;
 mere.run consumes its own flat managed MLX artifacts, so output comparisons
 must record which weight representation each arm used.
@@ -103,15 +104,15 @@ MERERUN_H3_BF16_OVERLAY_ROOT=/absolute/path/to/overlay \
 
 Each kernel candidate must first reproduce an explicit decomposed oracle. If a
 candidate deliberately changes arithmetic, such as dynamic INT8 activation
-quantization, it also needs a same-seed checkpoint quality A/B and may not be
+quantization, it also needs a same-seed checkpoint quality comparison and may not be
 described as trajectory-exact.
 
 | ID | Candidate | First proving shape | Required fallback |
 | --- | --- | --- | --- |
 | K1 | Attention residual gate + following MLP AdaLN, then optional activation quantization | BF16 `[1, rows, 5376]` | Existing decomposed MLX graph |
-| K2 | QKV projection directly to `[1, 56, rows, 128]`, with fused Q/K RMSNorm and RoPE | H3 QKV `5376 -> 21504` | Current linear, split, transpose, norm, and RoPE path |
-| K3 | Head-major SDPA output directly into the INT8 output projection | H3 attention output `7168 -> 5376` | Current transpose, reshape, and linear path |
-| K4 | FC1, SwiGLU, and FC2 with H3-specialized `5376 -> 28672 -> 14336 -> 5376` dimensions | Complete production MLP | Current MLX compiled MLP |
+| K2 | QKV projection directly to `[1, 56, rows, 128]`, with fused Q/K RMSNorm and RoPE | H3 QKV `5376 -> 21504` | Existing linear, split, transpose, norm, and RoPE path |
+| K3 | Head-major SDPA output directly into the INT8 output projection | H3 attention output `7168 -> 5376` | Existing transpose, reshape, and linear path |
+| K4 | FC1, SwiGLU, and FC2 with H3-specialized `5376 -> 28672 -> 14336 -> 5376` dimensions | Complete production MLP | Existing MLX compiled MLP |
 | K5 | Activation lifetime aliases for QKV, attention, and MLP arenas | Complete block | Independent MLX arrays |
 
 K1 has BF16 and mixed BF16/Float32 custom-Metal canaries in
@@ -125,7 +126,8 @@ through h3.c-compatible per-row symmetric activation quantization:
 row. A standalone quantizer provides the two-kernel oracle and release timing
 arm. Both paths are byte-exact at the INT8 boundary in the deterministic GPU
 canary. The floating K1 path participates in the opt-in installed-checkpoint
-dispatch below. The activation-INT8 continuation remains lab-only.
+dispatch described in the installed-checkpoint section. The activation-INT8
+continuation remains lab-only.
 
 The managed H3 artifacts use affine Q8/group-64 *weights*. Stock MLX
 `QuantizedLinear` still accepts floating activations and does not expose a
@@ -157,7 +159,7 @@ scripts/h3-kernel-suite.sh --output .build/h3-kernel-suite/ref2va --resume
 
 The default queue covers K1 floating and activation-INT8 boundaries, K2a/K2b,
 K3, K4, K5, and the installed Ref2VA full-forward gate. Each attempt gets its
-own stdout, stderr, and start-gate receipt, so resuming never overwrites failed
+own stdout, stderr, and start-gate receipt, so resuming does not overwrite failed
 evidence. A clean-host rejection stops the suite immediately with exit 75;
 other failures are recorded while remaining modes continue. Successful modes
 leave commit-bound pass markers, so `--resume` skips only proven passes. The
@@ -168,8 +170,8 @@ after its recorded PID no longer exists.
 
 K2 through K4 need two implementations where hardware requires it:
 
-- a portable MLX/Metal fallback for current M-series Macs;
-- an M5-gated Metal 4/TensorOps implementation, never selected by device-name
+- A portable MLX and Metal fallback for supported M-series Macs.
+- An M5-gated Metal 4 or TensorOps implementation that is not selected by device-name
   assumptions alone if capability probing is available.
 
 K2 is split into two proof stages so layout correctness is not confounded with
@@ -186,7 +188,7 @@ projection arithmetic:
   raw head-major Q/K remain explicit until the normalization kernel finishes;
   the path is projection-direct but not allocation-free.
 
-The K2a deterministic GPU canary compares all three outputs with the current
+The K2a deterministic GPU canary compares all three outputs with the existing
 decomposed graph; V is byte-exact and Q/K remain inside the declared BF16
 tolerance. Its isolated release arm is:
 
@@ -210,7 +212,7 @@ contiguous `[1, 56, rows, 128]` BF16 or Float32 output directly and applies the 
 checkpoint's existing affine Q8/group-64 output weight (`uint32` packed codes,
 BF16 scale and bias per 64 input columns). The kernel writes
 `[1, rows, 5376]`, eliminating the head-major transpose/reshape materialization.
-This is weight INT8 with floating activations, matching the current artifact;
+This is weight INT8 with floating activations, matching the managed artifact;
 it is not h3.c's separate symmetric activation-INT8 arithmetic. The deterministic GPU
 canary compares it with MLX `quantizedMM` using the same packed arrays. Its
 isolated release arm is:
@@ -257,12 +259,12 @@ quantized projections instead of selecting the slower custom affine-Q8 GEMMs.
 The mode remains explicit, requires `--h3-acceleration quality`, and falls back
 per call when the exact H3 shape or dtype contract is unavailable. Sequences at
 or below 12,000 rows retain whole-step compilation. Larger sequences use eager
-layer evaluation because the clean Ref2VA A/B below measured a larger gain and
+layer evaluation because the clean Ref2VA comparison measured a larger gain and
 lower peak footprint than embedding these custom boundaries in independently
 compiled blocks.
 
 `MERERUN_H3_EXACT_KERNELS=affine-q8` enables the exact kernel candidates inside
-the real transformer loop for controlled checkpoint A/Bs. Admission is typed
+the real transformer loop for controlled checkpoint comparisons. Admission is typed
 and fail-closed: the request must use `--h3-acceleration quality`, every main
 transformer block must retain its unadapted affine Q8/group-64 QKV, output, FC1,
 and FC2 linears, and resident-BF16 materialization must be off. The mode forces
@@ -318,7 +320,7 @@ MERERUN_H3_BAKEOFF_ARMS=quality,exact-affine-q8 \
 
 This is an experimental evidence surface, not a production default. The
 50-block real-weight arithmetic pass and fixed-seed generated-media review are
-complete. The generated results below justify the shape-aware execution policy,
+complete. The generated-media results justify the shape-aware execution policy,
 but not ordinary dispatch: FL2VA has no measured speed win and Ref2VA has only
 one fixed prompt/reference fixture so far.
 
@@ -348,7 +350,7 @@ advanced to generated-media evaluation from this run.
 
 ### Clean generated-media result
 
-The fixed railway-platform fixture used a 512x256 canvas, 124 frames at 24 fps,
+The fixed railway-platform fixture used a 512 x 256 canvas, 124 frames at 24 frames per second,
 seed `20260810`, one pinned 110,364-byte image with SHA-256
 `34ea0fee383e3b5d353f6a9556af12b5e7d3a7846c6899e768791b5354818ebd`,
 and, for Ref2VA, one pinned 663,630-byte audio reference with SHA-256
@@ -358,7 +360,7 @@ FL2VA used the same image as its first-frame condition and the installed
 clean worktree, no matched build/ML process, and no thermal or performance
 warning; all arms also ended at zero swap.
 
-| Model / boundary execution | Commit | Baseline | Boundary | Wall delta | Peak-footprint delta | Decision |
+| Model and boundary execution | Commit | Baseline | Boundary | Wall delta | Peak-footprint delta | Decision |
 | --- | --- | ---: | ---: | ---: | ---: | --- |
 | Ref2VA / eager | `e93bf2ab` | 1,920.079 s | 1,860.912 s | -59.167 s (-3.08%) | -1.344 GiB | Retain above 12,000 rows |
 | FL2VA / eager | `e93bf2ab` | 174.096 s | 194.674 s | +20.578 s (+11.82%) | effectively unchanged | Reject as a universal policy |
@@ -373,11 +375,11 @@ the blockwise-compiled Ref2VA arm reduced steady MLX cache from 16.11 to 12.61
 GiB but did not reduce the 88.59 GiB MLX peak and increased process peak
 footprint, so the small wall-time delta is not a promotion candidate.
 
-All four selected outputs passed the structural gate: H.264 video at 512x256,
-124 frames, 24 fps, 5.167 seconds, plus stereo AAC at 32 kHz. Matched-seed
+All four selected outputs passed the structural gate: H.264 video at 512 x 256,
+124 frames, 24 frames per second, 5.167 seconds, plus stereo AAC at 32 kHz. Matched-seed
 quality for the selected shape-aware paths was:
 
-| Model / candidate | Video SSIM | PSNR | VMAF | Audio correlation | Audio relative L2 |
+| Model and candidate | Video SSIM | PSNR | VMAF | Audio correlation | Audio relative L2 |
 | --- | ---: | ---: | ---: | ---: | ---: |
 | Ref2VA / eager boundary | 0.989612 | 45.954653 dB | 91.309876 | 0.999354733 | 0.0359229473 |
 | FL2VA / compiled boundary | 0.988137 | 46.453891 dB | 91.366412 | 0.998332539 | 0.0577492307 |
@@ -398,20 +400,20 @@ quality envelopes have been measured.
 | --- | --- | --- |
 | A1 | Same-aspect reduced internal render canvas followed by high-quality upscale | Native output, 75%, and 62.5% internal dimensions |
 | A2 | AdaLN-gate-ranked layer thinning with protected first/final blocks | 50, 45, and 40 active blocks |
-| A3 | Whole-velocity or transformer-core reuse | Current adaptive tail reuse, interval-2 velocity reuse, and interval-4 core reuse |
+| A3 | Whole-velocity or transformer-core reuse | Adaptive tail reuse, interval-2 velocity reuse, and interval-4 core reuse |
 | A4 | Target-video token pairing with full-resolution bypass and delta restoration | Blocks 4-40 early, then 4-30, versus full tokens |
 
-The current adaptive block-tail cache is not equivalent to h3.c whole-velocity
+The adaptive block-tail cache is not equivalent to h3.c whole-velocity
 or core reuse. It remains a separate bake-off arm rather than being silently
 relabelled.
 
 A3 now has its first explicit runtime arm: `--h3-acceleration
 velocity-reuse-2`. It runs the first and final denoise evaluations in full,
 linearly extrapolates both complete video and audio velocity outputs from the
-two latest full evaluations on intervening odd steps, and keeps the quality
+two most recent full evaluations on intervening odd steps, and keeps the quality
 schedule point count. Selecting it disables the adaptive tail and dynamic-sparse
 policies so its quality and timing deltas remain attributable. It is
-experimental and non-default. Fixed FL2VA and three-seed Ref2VA A/Bs found a
+experimental and non-default. Fixed FL2VA and three-seed Ref2VA comparisons found a
 repeatable speed benefit but failed the visual-trajectory promotion gate.
 
 A2 has two equally isolated arms: `--h3-acceleration layers-45` and
@@ -419,7 +421,7 @@ A2 has two equally isolated arms: `--h3-acceleration layers-45` and
 mean absolute attention and MLP AdaLN gate values over every cached schedule
 point and modality, with blocks 0, 1, and 49 always protected. The lowest
 remaining scores are skipped while original block indices and weights remain
-unchanged. The current prototype reduces executed transformer work but retains
+unchanged. The prototype reduces executed transformer work but retains
 all loaded weights; it must not claim h3.c's additional residency reduction
 until loading itself prunes the inactive blocks.
 
@@ -471,7 +473,7 @@ schedule and disables the other approximation policies.
 
 Run the fixed-seed algorithm matrix with one installed FL2VA or Ref2VA model.
 The harness refuses another active ML workload, builds release once, emits one
-preflight JSON and stderr log per arm, and records wall time plus output SHA256:
+preflight JSON and stderr log per arm, and records wall time plus output SHA-256:
 
 ```bash
 scripts/h3-algorithm-bakeoff.sh \
@@ -512,12 +514,12 @@ MERERUN_H3_BAKEOFF_REFERENCE_MANIFEST=./references.expected.tsv \
   --reference audio:./voice.wav
 ```
 
-The default 512x512 matrix includes native resolution, 384x384 (75%), 320x320
+The default 512 x 512 matrix includes native resolution, 384 x 384 (75%), 320 x 320
 (62.5%), 45 and 40 layers, interval-2 velocity reuse, and token reduction.
 Override geometry, seed, frame count, executable, or the comma-separated arm
 list with the `MERERUN_H3_BAKEOFF_*` variables documented by the script's
 defaults. A render arm is marked skipped when an exact same-aspect scale cannot
-remain on the 32px grid; the harness never rounds it into a different aspect.
+remain on the 32-pixel grid; the harness does not round it into a different aspect.
 
 The runner fails closed when a matching ML process, `mere.run` process, Swift
 compiler, or Xcode build is active. It also rejects a host starting above
@@ -528,12 +530,13 @@ the results; it is not a way to describe swap-heavy timing as clean.
 The process and swap gates are checked again immediately before every arm and
 the arm's starting swap is written directly to `receipts.tsv`. A long matrix
 therefore cannot silently cross the evidence policy after its initial gate; a
-new competing process is captured as sanitized PID/executable/cwd evidence. To
+additional competing process is captured as sanitized process ID, executable,
+and working-directory evidence. To
 score a narrow follow-up without regenerating a byte-identical expensive
 baseline, omit the `quality` arm and set `MERERUN_H3_BAKEOFF_BASELINE` to the
 existing MP4. The runner rejects a missing baseline, records its resolved path,
 byte count, and SHA-256, and does not allow an external baseline together with
-a new `quality` arm.
+another `quality` arm.
 
 `receipts.tsv` measures generation only; preflight is completed before its
 clock starts. Every passing arm records wall time, `/usr/bin/time` maximum RSS
@@ -550,7 +553,7 @@ rejected process and swap evidence even when no arm runs. Per-arm before/after
 snapshots capture thermal, swap, and VM state around the timed region.
 
 After generation, `scripts/h3-bakeoff-score.py` verifies that every MP4 matches
-the requested width, height, frame count, 24 fps video, 32 kHz stereo audio,
+the requested width, height, frame count, 24-frames-per-second video, 32 kHz stereo audio,
 and duration. It compares each arm with the same-seed dense-quality output and
 writes a matched eight-frame baseline/candidate contact sheet, one JSON report,
 and a `quality.tsv` summary containing video SSIM, PSNR, VMAF, decoded-audio
@@ -580,7 +583,7 @@ scripts/h3-bakeoff-score.py \
 ### Fixed-seed algorithm result
 
 The post-reboot algorithm screen used the same pinned railway fixture as the
-exact-kernel bake-off: 512x256, 124 frames at 24 fps, seed `20260810`, image
+exact-kernel bake-off: 512 x 256, 124 frames at 24 frames per second, seed `20260810`, image
 SHA-256 `34ea0fee383e3b5d353f6a9556af12b5e7d3a7846c6899e768791b5354818ebd`,
 and, for Ref2VA, audio SHA-256
 `444afb780a0b1a8fe5b1bb90ac744669ef9086c721439c4a0d569389c2e1df80`.
@@ -590,7 +593,7 @@ from commit `ee64b21c`.
 
 This first screen predates the h3.c-aligned reference-serving contract. Its
 Ref2VA latency and 88.59 GiB peak describe the former 2,048-pixel-short-edge
-reference preprocessing path, not the current dense runtime.
+reference preprocessing path, not the dense runtime.
 
 The full FL2VA matrix began with zero swap. Every arm through A3 also began at
 zero swap; A3 caused macOS to retain 200.62 MiB, so A4 began below, but not at,
@@ -599,8 +602,8 @@ the 1024 MiB ceiling. No arm recorded a thermal or performance warning.
 | FL2VA arm | Wall time | Delta vs quality | Video SSIM | VMAF | Audio correlation | Decision |
 | --- | ---: | ---: | ---: | ---: | ---: | --- |
 | quality / 50 blocks | 211.995 s | baseline | 1.000000 | 99.543328 | 1.000000 | dense reference |
-| A1 / 75% internal canvas | 129.447 s | -38.94% | 0.808859 | 2.761354 | 0.398702743 | reject current scale |
-| A1 / 62.5% internal canvas | 96.570 s | -54.45% | 0.797838 | 1.490763 | 0.408785695 | reject current scale |
+| A1 / 75% internal canvas | 129.447 s | -38.94% | 0.808859 | 2.761354 | 0.398702743 | reject tested scale |
+| A1 / 62.5% internal canvas | 96.570 s | -54.45% | 0.797838 | 1.490763 | 0.408785695 | reject tested scale |
 | A2 / 45 active blocks | 211.230 s | -0.36% | 0.820338 | 3.437342 | 0.095347761 | no useful speed win |
 | A2 / 40 active blocks | 181.841 s | -14.22% | 0.792344 | 2.987691 | 0.082693270 | reject quality |
 | A3 / interval-2 velocity reuse | 177.169 s | -16.43% | 0.870424 | 18.213738 | 0.376719974 | reject complete reuse |
@@ -619,9 +622,9 @@ scored against the clean dense baseline MP4 whose SHA-256 is
 `e2a2af06e1c3b3ac4f8cfc25f46de0d8edcab2a729e40afc003a2eac572aeb9f`.
 That artifact was generated twice byte-identically in zero-swap sessions at
 1,920.079 and 1,911.015 seconds; their 1,915.547-second mean is used only as the
-timing reference below. The selected follow-up began with 200.62 MiB of swap,
+timing reference for this comparison. The selected follow-up began with 200.62 MiB of swap,
 dropped to 192.62 MiB, and recorded no thermal or performance warning, so these
-are screening timings rather than new zero-swap baselines.
+are screening timings rather than additional zero-swap baselines.
 
 | Ref2VA arm | Wall time | Delta vs baseline mean | Process-peak delta | Video SSIM | VMAF | Audio correlation | Decision |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: | --- |
@@ -642,7 +645,7 @@ perceptual quality, this fixture does not establish that A3 is visually worse.
 A1 kept the subjects, dialogue waveform, and moving-train concept, but changed
 train trajectory/color and softened faces. Neither mode advances to ordinary
 dispatch from this single fixture. This result selected A3 for the multi-seed
-follow-up below; it did not itself authorize promotion.
+multi-seed follow-up; it did not itself authorize promotion.
 
 ### Post-alignment Ref2VA multi-seed result
 
@@ -652,7 +655,8 @@ aligned with the pinned h3.c serving contract. It used commit `2fe645f7`,
 release executable SHA-256
 `34854543dfacf58383e1feebaaeeced65aed3b532676e1e768979235420f9125`,
 the same prompt and pinned image/audio references, and explicitly disabled the
-exact-kernel mode. Every output passed the 512x256, 124-frame, 24 fps, stereo
+exact-kernel mode. Every output passed the 512 x 256, 124-frame,
+24-frames-per-second, stereo
 32 kHz structural gate.
 
 These runs began with 12,694.5 to 12,710.5 MiB of swap after earlier model
@@ -678,7 +682,7 @@ run and kept audio correlation above 0.998. It nevertheless changed train
 appearance, lighting, or trajectory in all three contact sheets; seed
 `20260811` also developed a conspicuous magenta train-light artifact late in
 the clip. The result rejects velocity reuse as an ordinary default. It stays
-available only as a named experimental policy for future research.
+available only as a named experimental policy for later research.
 
 ### Zero-swap finalist retake
 
@@ -689,10 +693,10 @@ started with zero swap, a clean worktree, no matching build or ML process, and
 no thermal or performance warning. Ref2VA also ended at zero swap; the larger
 LightX2V arm ended with 15.94 MiB.
 
-| Finalist | Geometry / evaluations | Wall time | Denoising | Non-denoise remainder | MLX peak | Process peak footprint | Output SHA-256 |
+| Finalist | Geometry and evaluations | Wall time | Denoising | Non-denoise remainder | MLX peak | Process peak footprint | Output SHA-256 |
 | --- | --- | ---: | ---: | ---: | ---: | ---: | --- |
-| Dense Ref2VA | 512x256 / 8 | 578.450 s | 528.492 s | 49.958 s | 41.14 GiB | 47,255,358,296 bytes | `7b716380a857c3203e8434db11493fbf8e9b2b26166da41bf5f84e18f95c0866` |
-| LightX2V v1.0 8-step | 960x544 / 8 | 2,457.841 s | 2,277.428 s | 180.413 s | 61.90 GiB | 68,143,584,184 bytes | `cebc0d88c80145057cd7e6daeaf45568a59122ac72173d91c94c048681995822` |
+| Dense Ref2VA | 512 x 256, 8 | 578.450 s | 528.492 s | 49.958 s | 41.14 GiB | 47,255,358,296 bytes | `7b716380a857c3203e8434db11493fbf8e9b2b26166da41bf5f84e18f95c0866` |
+| LightX2V v1.0 8-step | 960 x 544, 8 | 2,457.841 s | 2,277.428 s | 180.413 s | 61.90 GiB | 68,143,584,184 bytes | `cebc0d88c80145057cd7e6daeaf45568a59122ac72173d91c94c048681995822` |
 
 The Ref2VA output is byte-identical to seed `20260810` from the post-alignment
 multi-seed screen. Compared with the old clean 1,920.079-second,
@@ -703,7 +707,7 @@ they are retained for cross-seed behavior, not averaged into this cold-host
 timing.
 
 The selected LightX2V finalist uses the released v1.0 8-step recipe at its
-960x544 training geometry: shifts 12/3, LoRA alpha 8, eight evaluations, and
+960 x 544 training geometry: shifts 12 and 3, LoRA alpha 8, eight evaluations, and
 19,317 packed rows. Its output is byte-identical to the earlier screening
 artifact, including 124 H.264 frames and stereo 32 kHz AAC with mean/max levels
 of -23.2/-5.6 dB. The cold-host wall was 3.59% slower and denoising 4.54% slower
@@ -721,7 +725,7 @@ useful attribution evidence but remain labeled as screening timings. The
 harness now enables both phase and step profiling for every subsequent arm.
 
 The portable direction is therefore narrower, not more aggressive: retain the
-exact reference-serving alignment, evaluate a 448x224 (87.5%) internal canvas,
+exact reference-serving alignment, evaluate a 448 x 224 (87.5%) internal canvas,
 at most one reused middle evaluation, less aggressive token pairing/block
 spans, and true load-time pruning for A2 before another promotion attempt.
 Exact `boundary-layout` remains the only h3.c kernel lane with a supported

--- a/docs/benchmarks/minimax-h3-ref2va-mlx-8bit.md
+++ b/docs/benchmarks/minimax-h3-ref2va-mlx-8bit.md
@@ -7,15 +7,15 @@ FL2VA or LTX.
 
 ## Artifact identity
 
-- managed ID: `video-minimax-h3-ref2va-mlx`
-- repository: `Sawfwair/MiniMax-H3-Ref2VA-MLX-8bit`
-- immutable revision: `61dc387ef1a7166425cdacd63c2340598dcc364f`
-- managed bytes: `70,941,103,245`
-- source: `Comfy-Org/MiniMax-H3@fd70b39279d1ae6eb214c903f53e1bec3af19a77`
-- source file bytes: `34,038,894,550`
-- source SHA-256: `9eef934046a0671bc8a5daf87100705e1478419c574cfde70c50fbe6885f76a9`
-- converted transformer bytes: `36,024,412,656`
-- converted transformer SHA-256:
+- **Managed ID:** `video-minimax-h3-ref2va-mlx`
+- **Repository:** `Sawfwair/MiniMax-H3-Ref2VA-MLX-8bit`
+- **Immutable revision:** `61dc387ef1a7166425cdacd63c2340598dcc364f`
+- **Managed bytes:** `70,941,103,245`
+- **Source:** `Comfy-Org/MiniMax-H3@fd70b39279d1ae6eb214c903f53e1bec3af19a77`
+- **Source file bytes:** `34,038,894,550`
+- **Source SHA-256:** `9eef934046a0671bc8a5daf87100705e1478419c574cfde70c50fbe6885f76a9`
+- **Converted transformer bytes:** `36,024,412,656`
+- **Converted transformer SHA-256:**
   `234f22f69f8d40d6ed81cceed8259fa287f3c9417d40fba5274e3a7aa84e18a2`
 
 The transformer and Qwen3-VL conditioner are MLX affine INT8/group-64. The
@@ -30,14 +30,14 @@ was built one three-modality timestep batch per released schedule point, then
 reloaded and compared with both a fresh cache and direct live AdaLN evaluation.
 At schedule step 10, maximum video and audio output error were both zero.
 
-### Managed revision-upgrade receipt
+### Managed revision upgrade
 
 The artifact was first installed at pre-cache revision
 `abb9114fe9d6e3cccc6376eee1abaf09d3f2a9fe`, with the corrected cache added to
-the model root locally. After the catalog pin moved to the revision above,
-ordinary `model pull` now treats the old manifest as stale and asks the Hub
-tree for the target revision's Git/LFS object identities. It preserves the
-installed root while preparing the new immutable snapshot and adopts a local
+the model root locally. After the catalog pin moved to the recorded revision,
+`model pull` treats the earlier manifest as stale and asks the Hub tree for the
+target revision's Git or LFS object identities. It preserves the installed
+root while preparing the immutable snapshot and adopts a local
 payload only after its byte count and Git blob SHA-1 or LFS SHA-256 match the
 target object.
 
@@ -45,7 +45,7 @@ On that real stale install, structured preflight reported 4,362 bytes rather
 than the package's 70.94 GB logical size. Those bytes were the two changed
 managed provenance files; every large target object, including the
 873,820,740-byte cache, was already available by exact content identity. A
-normal pull, without `--force` or a preparation command, produced a 14-file
+pull, without `--force` or a preparation command, produced a 14-file
 snapshot receipt whose requested and resolved revision are both
 `61dc387ef1a7166425cdacd63c2340598dcc364f`. Post-pull model validation checks
 the cache byte count and safetensors format, schema, and transformer-bound
@@ -72,21 +72,21 @@ operation after INT8 requantization.
 ## Native generation receipt
 
 The full validation used real reference conditioning and maximum acceleration.
-It produced:
+The run produced these results:
 
-- 512x320 H.264 video;
-- 124 frames at 24 fps (`5.167` seconds);
-- AAC stereo audio at 32 kHz;
-- wall time: `1,724.17` seconds;
-- MP4 SHA-256:
+- **Video:** 512 x 320 H.264.
+- **Duration:** 124 frames at 24 frames per second (`5.167` seconds).
+- **Audio:** AAC stereo at 32 kHz.
+- **Wall time:** `1,724.17` seconds.
+- **MP4 SHA-256:**
   `08ce4cfb9fe305ba67297d94f6a54f3ce49c12bb8e242c38561cb6cb6237c9b0`.
 
 The output was visually coherent, retained usable motion and subject structure,
 and generated intelligible synchronized dialogue transcribed as: “You kept up
-the recording? Yeah. Every second.” A preceding 256x160, 22-frame smoke was
+the recording? Yeah. Every second.” A preceding 256 x 160, 22-frame smoke was
 also coherent. This establishes that the corrected artifact executes the real
 Ref2VA path without the all-noise failure.
 
 The 28-minute wall time confirms that this path remains substantially slower
-than desirable. The result should therefore enter the planned LTX/H3 bake-off
-as a quality and conditioning candidate, with performance measured separately.
+than desirable. Treat the result as a quality and conditioning candidate for
+an LTX and H3 comparison, and measure performance separately.

--- a/docs/benchmarks/minimax-music3-m4-max.md
+++ b/docs/benchmarks/minimax-music3-m4-max.md
@@ -1,7 +1,7 @@
 # MiniMax Music 3 on M4 Max
 
 This receipt records installed-checkpoint MiniMax Music 3 performance work on a
-16-core CPU / 40-core GPU M4 Max MacBook Pro with 128 GB unified memory. Tests
+16-core CPU and 40-core GPU M4 Max MacBook Pro with 128 GB unified memory. Tests
 used the immutable managed `MiniMaxAI/MiniMax-Music3` snapshot, staged loading,
 44.1 kHz stereo PCM24 export, seed 37, guidance 1.7, and 30 flow steps unless a
 row says otherwise.
@@ -10,10 +10,10 @@ row says otherwise.
 
 | Runtime | Wall time | Max resident | Relative speed |
 | --- | ---: | ---: | ---: |
-| mere.run 0.37.0 reference | 143.29 s | 18.67 GB | 1.00x |
-| optimized BF16 | 105.46 s | 7.14 GB | 1.36x |
-| Q8 autoregressive turbo | 52.66 s | 4.36 GB | 2.72x |
-| Q4 autoregressive turbo | 51.40 s | 3.19 GB | 2.79x |
+| `mere.run` 0.37.0 reference | 143.29 s | 18.67 GB | 1.00 times |
+| Optimized BF16 | 105.46 s | 7.14 GB | 1.36 times |
+| Q8 autoregressive turbo | 52.66 s | 4.36 GB | 2.72 times |
+| Q4 autoregressive turbo | 51.40 s | 3.19 GB | 2.79 times |
 
 Q8 is the recommended turbo tier. Its first-step installed-checkpoint semantic
 logits measured cosine similarity 0.99985 and retained 98 of the BF16 top 100
@@ -29,7 +29,8 @@ released graph for parity investigations.
 
 ## MLX 0.32.1 follow-on
 
-The next pass rebased onto mere.run PR #297 after it landed. The tested chain
+The follow-on pass rebased onto `mere.run` pull request #297 after it landed.
+The tested chain
 pins `mlx-swift` at `3e6df6d8163a8f212061d15739eeeec12d5b89e3`, its embedded
 MLX at `b57bd7640f3f7c743b76a58478faaf1e8ee084f2`, and MLX core 0.32.1.
 
@@ -41,7 +42,7 @@ used the same prompt, checkpoint, seed, 30-step schedule, and one flow chunk:
 | --- | ---: | ---: | ---: | ---: | ---: |
 | Refreshed dependency baseline | 30.90 s | 13.16 s | 16.88 s | 16.31 s | baseline |
 | Static KV cache | 22.21 s | 7.25 s | 14.61 s | 14.29 s | 28.1% less total |
-| Static KV + fused flow inputs | 19.24 s | 6.70 s | 12.21 s | 11.81 s | 37.7% less total |
+| Static KV and fused flow inputs | 19.24 s | 6.70 s | 12.21 s | 11.81 s | 37.7% less total |
 
 The baseline and static-cache WAVs were byte-identical. Combining the flow
 preprocess, residual, and input projections changes floating-point association;
@@ -54,9 +55,9 @@ override. A clean 100-frame series from the final graph measured:
 
 | Tier | Flow steps | Profiled total | Autoregressive | Flow | Wall time | Total speedup |
 | --- | ---: | ---: | ---: | ---: | ---: | ---: |
-| `quality` | 30 | 20.03 s | 6.79 s | 12.89 s | 22.92 s | 1.00x |
-| `fast` | 20 | 15.04 s | 5.52 s | 9.19 s | 15.13 s | 1.33x |
-| `draft` | 16 | 13.41 s | 5.61 s | 7.47 s | 13.51 s | 1.49x |
+| `quality` | 30 | 20.03 s | 6.79 s | 12.89 s | 22.92 s | 1.00 times |
+| `fast` | 20 | 15.04 s | 5.52 s | 9.19 s | 15.13 s | 1.33 times |
+| `draft` | 16 | 13.41 s | 5.61 s | 7.47 s | 13.51 s | 1.49 times |
 
 Profiler JSON is opt-in with `--profile-output`. It synchronizes stage
 boundaries so its internal totals are useful for hotspot attribution, while
@@ -84,7 +85,7 @@ isolated tensor fixtures.
   series regressed from a 1.851 s eager median to a 2.157 s compiled median,
   16.5% slower. The fixed-capacity cache remains eager.
 - A production-shape ConvRot W8A8 Metal oracle retained 0.999929 cosine and
-  0.01192 relative RMSE, but took 57.64 ms versus 3.47 ms for BF16 GEMM, 16.6x
+  0.01192 relative RMSE, but took 57.64 ms versus 3.47 ms for BF16 GEMM, 16.6 times
   slower on this M4 Max. The research test remains env-gated; the runtime does
   not ship a slower W8A8 path.
 - A real, derived Q8 checkpoint repack occupied 9.01 GB and produced a
@@ -95,11 +96,11 @@ isolated tensor fixtures.
 
 ## ComfyUI comparison
 
-The current ComfyUI implementation validates several architectural choices:
+The evaluated ComfyUI implementation validates several architectural choices:
 its autoregressive model uses a fixed KV cache, prunes the semantic projection
 to 16,385 reachable rows, and has optional prefetch/graph support for the
 residual-depth blocks. Its flow transformer still constructs the aligned input
-inside each forward; mere.run now precomputes the invariant condition side and
+inside each forward; `mere.run` precomputes the invariant condition side and
 fuses the latent-side projections. See ComfyUI's pinned
 [autoregressive implementation](https://github.com/Comfy-Org/ComfyUI/blob/7fe8a6138504f90ff7be82f3babf416da32876b1/comfy/ldm/minimax_music/ar.py)
 and [flow transformer](https://github.com/Comfy-Org/ComfyUI/blob/7fe8a6138504f90ff7be82f3babf416da32876b1/comfy/ldm/minimax_music/dit.py).
@@ -110,7 +111,7 @@ quantization, not evidence that activation-quantized W8A8 is faster on M4-class
 Apple GPUs. See the pinned
 [workflow template](https://github.com/Comfy-Org/workflow_templates/blob/d9e66019b85da231b7c936ad9cb7ff08cec16557/templates/audio_minimax_music_3.json).
 
-A frequently cited public timing log is also easy to misread: it generates
+A frequently cited public timing log is often misread: it generates
 1,501 frames, approximately 60 seconds of audio, in about 170 seconds before
 decode on a 24 GB AMD/HIP GPU. It is not a three-minute output and it is not an
 MPS result. See the
@@ -120,17 +121,17 @@ MPS result. See the
 
 The model emits semantic frames at 25 Hz, but the vocoder emits whole
 512-sample hops. At 44.1 kHz, 250 semantic frames decode to 440,832 samples, or
-9.99619 seconds. A requested 10-second minimum now selects 251 frames and
+9.99619 seconds. A requested 10-second minimum selects 251 frames and
 decodes to 10.04263 seconds. This is why second-based floors must not use only
 `duration * 25` truncation.
 
 Long-form Q8 floor runs from the same release binary confirm both the corrected
 duration contract and approximately linear scaling:
 
-| Requested minimum | Frames / flow chunks | Wall time | Max resident | Peak footprint | Decoded duration |
+| Requested minimum | Frames and flow chunks | Wall time | Max resident | Peak footprint | Decoded duration |
 | --- | ---: | ---: | ---: | ---: | ---: |
-| 60 s | 1,501 / 15 | 457.54 s | 4.30 GB | 19.19 GB | 60.10485 s |
-| 180 s | 4,501 / 45 | 1,413.81 s | 4.50 GB | 41.64 GB | 180.26812 s |
+| 60 s | 1,501 and 15 | 457.54 s | 4.30 GB | 19.19 GB | 60.10485 s |
+| 180 s | 4,501 and 45 | 1,413.81 s | 4.50 GB | 41.64 GB | 180.26812 s |
 
 The 180-second receipt used native 44.1 kHz stereo PCM24 export. Its audio
 SHA-256 was

--- a/docs/benchmarks/vfx-geometry-apple-silicon.md
+++ b/docs/benchmarks/vfx-geometry-apple-silicon.md
@@ -4,6 +4,9 @@ These measurements exercise the native Swift/MLX runtime and the audited
 managed checkpoints. They are implementation evidence, not cross-device
 performance promises.
 
+Use this report to compare the measured native geometry paths and understand
+their validation boundaries.
+
 ## Host
 
 - Apple M4 Max, 16 CPU cores, 128 GB unified memory
@@ -14,14 +17,14 @@ performance promises.
 
 ## MoGe-2 ViT-S Normal
 
-A 128x128 RGB PNG was processed at the production 3,600-token setting through
-the managed `vision-geometry-moge2-small` checkpoint. The row is a fresh CLI
-process and includes strict ONNX digest verification, native MLX loading,
-metric camera recovery, and all artifact exports.
+A 128 x 128 RGB PNG was processed at the production 3,600-token setting through
+the managed `vision-geometry-moge2-small` checkpoint. Each row represents a
+fresh CLI process. The measurements include strict ONNX digest verification,
+native MLX loading, metric camera recovery, and all artifact exports.
 
 | Input | Tokens | Valid points | Model load | Inference | Postprocess | Wall | Max RSS | Peak footprint |
 | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
-| 128x128 | 3,600 | 13,186 | 0.179 s | 0.397 s | 0.016 s | 0.88 s | 748.9 MiB | 8.50 GiB |
+| 128 x 128 | 3,600 | 13,186 | 0.179 s | 0.397 s | 0.016 s | 0.88 s | 748.9 MiB | 8.50 GiB |
 
 The run emitted metric depth and confidence EXRs, normal EXR, preview PNGs,
 validity, camera JSON, and a colored PLY. Its schema-2 manifest binds the exact
@@ -32,8 +35,9 @@ treated as a high-quality production setting, not a small-memory default.
 
 ## Video Depth Anything Small
 
-Synthetic 128x128 H.264 source at 8 fps, decoded and exported at source
-resolution. The managed relative checkpoint was used through
+The test used a synthetic 128 x 128 H.264 source at 8 frames per second. It
+decoded and exported the source at its original resolution. The test used the
+managed relative checkpoint through
 `vision-depth-vda-small`.
 
 | Frames | Network input | Windows | Model load | Inference | Export/review | Wall | Max RSS | Peak footprint |
@@ -56,7 +60,7 @@ depth/preview artifact hashes were byte-identical.
 
 ## Depth Anything 3 Small
 
-Two 128x128 PNG views were processed through the managed
+Two 128 x 128 PNG views were processed through the managed
 `vision-geometry-da3-small` checkpoint. Each CLI invocation was a fresh
 process; later rows benefited from filesystem and Metal cache warming. Peak
 footprint includes the MLX/Metal allocations that are not visible in RSS.
@@ -70,8 +74,8 @@ footprint includes the MLX/Metal allocations that are not visible in RSS.
 The 504 run emitted two depth EXRs, two confidence EXRs, review and processed
 PNGs, predicted camera JSON, a 76,208-point colored binary PLY, a glTF 2.0 GLB
 point cloud, and a Nerfstudio/3DGS initialization handoff. The handoff is
-explicitly camera-plus-colored-points only; it contains no learned Gaussian
-parameters and no triangle mesh. A separate pose-conditioned run preserved the
+explicitly contains only camera data and colored points; it contains no learned
+Gaussian parameters and no triangle mesh. A separate pose-conditioned run preserved the
 supplied cameras, used the checkpoint's camera encoder, and recorded the
 pairwise camera-baseline scale divisor in both structured output and the durable
 scene manifest.
@@ -80,7 +84,7 @@ scene manifest.
 
 The deterministic 512x512 parity image was reconstructed through the managed
 `image-3d-triposr` checkpoint. These rows use the exact pinned upstream CKPT,
-full native MLX scene encoding, learned vertex colors, and the native marching-
+full native MLX scene encoding, learned vertex colors, and the native marching
 tetrahedra exporter. Each invocation was a fresh process.
 
 | Density grid | Vertices | Triangles | Checkpoint verify | Model load | Scene encode | Mesh/color | Export | Wall | Max RSS | Peak footprint |
@@ -91,7 +95,7 @@ tetrahedra exporter. Each invocation was a fresh process.
 The runtime verifies the whole 1.67 GB checkpoint SHA-256 before parsing it.
 Because that exact content digest supersedes ZIP entry CRCs, the pinned loader
 does not rescan every tensor byte in a pure-Swift CRC loop; managed cold model
-load fell from 153.3 seconds to about 1.0–1.3 seconds without weakening the
+load fell from 153.3 seconds to about 1.0 to 1.3 seconds without weakening the
 restricted non-executing state-dict grammar. Arbitrary checkpoint readers keep
 entry CRC verification enabled by default.
 
@@ -102,7 +106,7 @@ checkpoint format/source pins, foreground processing, density controls,
 topology algorithm, mesh summary, and the hash of each mesh plus the shared
 mesh manifest. Extraction cost grows cubically with grid resolution; the CLI's
 default 256 grid is a quality setting, not a claim that the smaller benchmark
-rows match final-production topology density.
+rows match production topology density.
 
 ## InstantMesh Base reconstruction
 
@@ -128,7 +132,7 @@ Two independent grid-24 runs produced identical OBJ, PLY, and GLB hashes:
 `47e94a1f...`, `0239415b...`, and `583e819d...`. The authoritative run
 manifest separately hashes the shared mesh manifest and durably records view
 order/sizes, camera mode, source and converted pins, extraction controls,
-Zero123++/runtime-Python/proprietary-FlexiCubes exclusions, and the native
+Zero123++, runtime Python, and proprietary FlexiCubes exclusions, and the native
 marching-tetrahedra topology caveat. Learned field parity is covered by the
 reference fixture; triangle topology is not claimed to match upstream
 FlexiCubes.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,16 +1,17 @@
-# mere.run CLI
+# mere.run CLI reference
 
 The complete command tree, generated from the binary itself. Commands are
 organized by what you want to make — `image`, `text`, `speech`, `vision`,
 `music`, `sfx`, `video`, `world` — with separate families for portable graphs,
 executors, run artifacts, models, adapters, serving, and status.
 
-Every path on this page is real: a test in the repo fails if the docs and the
-CLI ever disagree. For per-command advice — prompting patterns, which flags
-matter, troubleshooting — read the offline [cookbooks](/cookbooks) with
+The repository tests this command tree against the CLI and fails if they
+disagree. For per-command advice, including prompting patterns, important
+flags, and troubleshooting, read the offline [cookbooks](/cookbooks) with
 `mere.run guide <command path>`.
 
-New here? Start at [mere.run Documentation](/).
+If this is your first time using mere.run, start with the
+[mere.run documentation](/).
 
 ## Overview
 
@@ -29,7 +30,7 @@ Public tree:
   - `mere.run image generate` — Generate images with local image models.
   - `mere.run image reconstruct-3d` — Reconstruct a colored object mesh from one image with native TripoSR.
   - `mere.run image reconstruct-3d-trellis2` — Reconstruct a 512-resolution PBR O-Voxel mesh with native MLX TRELLIS.2.
-  - `mere.run image reconstruct-3d-multiview` — Reconstruct a colored mesh from 4 or 6 user-supplied views with native InstantMesh.
+  - `mere.run image reconstruct-3d-multiview` — Reconstruct a colored mesh from four or six supplied views with native InstantMesh.
   - `mere.run image run-plan` — Run a saved image workflow plan.
   - `mere.run image train-lora` — Train a local image LoRA adapter.
   - `mere.run image visualize-run` — Open a local LoRA training run viewer.
@@ -48,7 +49,7 @@ Public tree:
   - `mere.run speech profile` — Manage saved voice clone profiles.
     - `mere.run speech profile list` — List saved speech voice profiles.
     - `mere.run speech profile create` — Create a speech profile from reference audio.
-    - `mere.run speech profile delete` — Delete a speech profile by id.
+    - `mere.run speech profile delete` — Delete a speech profile by ID.
 - [`mere.run vision`](/runtime/vision) — Caption, inspect, face-analyze, segment, track, pose, depth, geometry, optical flow, and OCR visual media.
   - `mere.run vision caption` — Generate training-friendly captions for images.
   - `mere.run vision inspect` — Describe or answer questions about an image using Qwen3-VL.
@@ -69,11 +70,11 @@ Public tree:
   - `mere.run vision geometry-multiview` — Solve native DA3-Small multi-view relative geometry, confidence, and cameras.
   - `mere.run vision image-to-3d` — Reconstruct a colored object mesh from one image with native TripoSR.
   - `mere.run vision image-to-3d-trellis2` — Reconstruct a 512-resolution PBR O-Voxel mesh with native MLX TRELLIS.2.
-  - `mere.run vision image-to-3d-multiview` — VFX alias for native 4/6-view InstantMesh reconstruction.
+  - `mere.run vision image-to-3d-multiview` — VFX alias for native four-view or six-view InstantMesh reconstruction.
   - `mere.run vision ocr` — Extract text from images using LightOnOCR, GLM-OCR, or Infinity-Parser2.
 - [`mere.run geo`](/runtime/geo) — Run native geospatial inference models on local Earth-observation data.
-  - `mere.run geo flood` — Run native TerraMind Flood tile inference with MLX on Apple silicon.
-  - `mere.run geo fire` — Run native TerraMind Fire tile inference with MLX on Apple silicon.
+  - `mere.run geo flood` — Run native TerraMind Flood tile inference with MLX on Apple Silicon.
+  - `mere.run geo fire` — Run native TerraMind Fire tile inference with MLX on Apple Silicon.
   - `mere.run geo tessera` — Encode local Sentinel-1/2 time series with a native TESSERA v2 student.
   - `mere.run geo olmoearth` — Encode multisensor Earth observations with native OlmoEarth v1.2.
 - [`mere.run audio`](/runtime/audio) — Enhance general audio locally.
@@ -160,7 +161,7 @@ Public tree:
     - `mere.run model location list` — List the writable store, search roots, and explicit bindings.
     - `mere.run model location add` — Register a read-only root containing directories named for canonical model IDs.
     - `mere.run model location remove` — Unregister a search root without deleting its files.
-    - `mere.run model location bind` — Bind a canonical model id to an arbitrary read-only directory.
+    - `mere.run model location bind` — Bind a canonical model ID to an arbitrary read-only directory.
     - `mere.run model location unbind` — Remove explicit bindings without deleting model files.
   - `mere.run model pull` — Download a managed model into the local model store.
   - `mere.run model remove` — Remove a model from the local model store.
@@ -173,12 +174,12 @@ Public tree:
     - `mere.run model runtime set` — Update typed API runtime settings for a managed model.
   - `mere.run model optimize` — Build inference-only caches for a supported installed model.
   - `mere.run model benchmark` — Run focused local model benchmarks.
-    - `mere.run model benchmark chat` — Run a small grounded-chat eval slice against local assistant models.
+    - `mere.run model benchmark chat` — Run a small grounded-chat evaluation slice against local assistant models.
     - `mere.run model benchmark fused` — Run the versioned Mere Lite or Mere Comprehensive fused quality suite.
     - `mere.run model benchmark fused-fixture` — Stamp or verify normalized fused-benchmark JSONL fixture hashes.
-    - `mere.run model benchmark tool-calls` — Run a small tool-call selection eval against local chat models.
+    - `mere.run model benchmark tool-calls` — Run a small tool-call selection evaluation against local chat models.
     - `mere.run model benchmark tool-continuations` — Evaluate Gemma 4 continuation after completed tool calls.
-    - `mere.run model benchmark code` — Run a real coding-eval slice against local coding models.
+    - `mere.run model benchmark code` — Run a real coding-evaluation slice against local coding models.
     - `mere.run model benchmark gemma4-kv` — Compare Gemma4 default KV cache decode against packed PolarKV.
     - `mere.run model benchmark gemma4-mtp` — Compare Gemma4 serial decode against verified MTP speculative decode.
     - `mere.run model benchmark q36-mtp` — Compare Qwen3.6 serial decode against adaptive and forced MTP speculative decode.
@@ -210,7 +211,7 @@ Public tree:
 - [`mere.run agent`](/getting-started) — Install and start the optional guided local setup agent.
   - `mere.run agent onboard` — Summarize this machine's model capabilities and prepare the optional Pi agent.
   - `mere.run agent status` — Inspect local agent, Pi, provider, and model readiness.
-  - `mere.run agent install-pi` — Install the latest Pi coding-agent release for use with mere.run.
+  - `mere.run agent install-pi` — Install the most recent published Pi coding-agent release for use with mere.run.
   - `mere.run agent start` — Start Pi against a local mere.run setup-agent API server.
 <!-- END GENERATED: CLI TREE -->
 
@@ -384,7 +385,7 @@ mere.run run inspect ./runs/local --json
 ```
 
 The same immutable job bundle can run through configured SSH or relay
-executors. See [Portable Workflows](./workflows.md).
+executors. See [Portable workflows](./workflows.md).
 
 ### Start a persistent world session
 
@@ -395,7 +396,7 @@ mere.run world serve \
   --prepare
 ```
 
-See [Persistent World Runtime](./runtime/world.md) for the HTTP lifecycle,
+See [Persistent world runtime](./runtime/world.md) for the HTTP lifecycle,
 camera controls, state artifacts, and authentication boundary.
 
 ### Serve a local API
@@ -418,12 +419,15 @@ swift run mere.run plugin install mere-runpod --yes
 swift run mere.run plugin doctor mere-runpod
 ```
 
-See [Companion Plugins](./plugins.md) for installation verification and the
+See [Companion plugins](./plugins.md) for installation verification and the
 typed graph-provider boundary.
 
 ## Command reference
 
-Model installation in the OSS repo is explicit. `mere.run model pull` uses cataloged Hugging Face snapshots only; local-path-only models must be supplied with command-specific `--model` or `--model-root` options. See [`configuration.md`](./configuration.md) and [`model-sources.md`](./model-sources.md).
+Model installation in the open-source repository is explicit. `mere.run model
+pull` uses only cataloged Hugging Face snapshots. Supply local-path-only models
+with the command-specific `--model` or `--model-root` options. See
+[Configuration](./configuration.md) and [Model sources](./model-sources.md).
 
 Public LoRA releases use the separate checksum-pinned adapter catalog:
 
@@ -433,7 +437,7 @@ mere.run adapter pull mere-platform-assistant
 mere.run text chat \
   --model text-chat-gemma4-12b-4bit \
   --lora mere-platform-assistant \
-  --prompt "Summarize the current Mere workspace."
+  --prompt "Summarize the active project workspace."
 ```
 
 ### `mere.run plugin`
@@ -763,8 +767,8 @@ diagnostic count, and action count. For plan files, it reports the plan kind,
 command, creation timestamp, and captured working directory. Legacy/plugin run
 manifests are kept warning-level and expose `legacy_manifest` details such as
 provider, GPU, dataset path/count, recipe id, command, and run status. Run
-directories also include a compact `metrics` object with loss CSV summary,
-latest loss, step range, sample image count, checkpoint count, and adapter
+directories also include a compact `metrics` object with a loss CSV summary,
+most recent loss, step range, sample image count, checkpoint count, and adapter
 count.
 
 ### `mere.run image visualize-run`
@@ -978,7 +982,7 @@ Key options:
 Detect and redact PII with the native OpenAI Privacy Filter model.
 
 ```bash
-swift run mere.run text anonymize "My name is Alice Smith and my email is alice@example.com"
+swift run mere.run text anonymize "My name is Dana Example and my email is dana@example.com"
 swift run mere.run text anonymize --json --pretty "Phone: 555-1234"
 cat notes.txt | swift run mere.run text anonymize --output redacted.txt
 ```
@@ -1244,9 +1248,9 @@ Key options:
 
 Notes:
 
-- `track-live` currently records a camera clip first, then runs tracking over the recorded media
+- `track-live` records a camera clip first, then runs tracking over the recorded media
 - live tracking searches a short warm-up window after the init frame so startup exposure or motion blur does not silently produce an unsegmented output
-- live mode accepts text prompts only in the current implementation
+- live mode accepts only text prompts
 - `--output` is required; `--json-output` is optional
 
 ### `mere.run vision face`
@@ -1499,7 +1503,7 @@ Key options:
 - `--beam-size`
 - `--chunk-batch-size`: upper bound on independent five-second chunks decoded
   together for greedy, sampling, or beam mode (default `4`). The runtime may
-  reduce it for current unified-memory headroom and model/beam saturation;
+  reduce it for available unified-memory headroom and model/beam saturation;
   `1` always selects the single-chunk path.
 - `--dtype`: `bfloat16`, `float16`, or `float32`
 - `--context-output`: optional JSON path for detected tempo, meter, key,
@@ -1892,7 +1896,7 @@ a retimed clip. LTX 2.3 unified AV is trained around 24 fps; using 8 fps can
 make generated motion look slow while audio remains normal. Use `--duration`
 for clip length so the CLI can choose the nearest legal `8n+1` frame count.
 Use the default `--quality draft` lane for fast iterations. Use `--quality
-final` for the current high-quality two-stage checkpoint. Output is a separate
+final` for the LTX 2.3 high-quality two-stage checkpoint. Output is a separate
 choice: both qualities default to video-only, and `--output-mode audio-video`
 adds synchronized generated audio. Suppressing audio on the same checkpoint is
 an output contract, not the source of the draft lane's speed advantage.
@@ -1954,7 +1958,7 @@ fidelity matters.
 `velocity-reuse-2` is a separate experimental h3.c transfer arm. It retains the
 quality schedule, runs the first and final denoise evaluations in full, and
 linearly extrapolates complete video and audio velocity outputs from the two
-latest full evaluations on intervening odd steps. The two modalities use their
+most recent full evaluations on intervening odd steps. The two modalities use their
 independent shifted schedules. It does not compose with dynamic-sparse
 attention or either block-cache policy. Use it only for controlled same-seed
 FL2VA and Ref2VA comparisons until the quality envelope is published.
@@ -1967,7 +1971,7 @@ the released independent seeded streams.
 
 `layers-45` and `layers-40` are separate gate-ranked thinning arms. They rank
 the cached schedule's mean absolute attention/MLP AdaLN gates, always protect
-blocks 0, 1, and 49, and skip the lowest remaining scores. They currently save
+blocks 0, 1, and 49, and skip the lowest remaining scores. They save
 block execution only: mere.run still retains every loaded transformer weight,
 so these modes do not yet claim h3.c's weight-residency reduction.
 
@@ -2311,7 +2315,7 @@ unavailable until it is reconnected.
 Use `--allow-unsupported` only when you intentionally accept the runtime risk.
 
 Models that are access-gated or carry material non-commercial, research-only,
-or revenue-limited terms require `--accept-model-license` before a new
+or revenue-limited terms require `--accept-model-license` before a
 download. A custom license alone does not trigger the flag.
 The preflight reports the exact component terms and blocks without
 acceptance; `--all` skips restricted entries unless the flag is present.
@@ -2351,7 +2355,7 @@ expanded to resident BF16. All bases remain subject to MiniMax-H3 Community
 License acceptance.
 
 For a cross-command decision guide, see [Benchmarking](./benchmarking.md). The
-sections below are the command reference for each benchmark lane.
+following subsections provide the command reference for each benchmark lane.
 
 ### `mere.run model benchmark gemma4-kv`
 
@@ -2653,7 +2657,7 @@ Start an OpenAI-compatible local API server.
 swift run mere.run api serve [options]
 ```
 
-Current endpoint surface:
+Supported endpoint surface:
 
 - `GET /health`
 - `GET /v1/models`
@@ -2817,7 +2821,7 @@ OpenAI image/audio compatibility:
 - `POST /v1/images/edits` accepts multipart `image` uploads, Open WebUI-style
   `image[]` repeated uploads, an optional `mask`, and an edit `prompt`; it uses
   the same image runtime with input-image conditioning and the same size
-  limits. Masks are accepted for client compatibility; current native edit
+  limits. Masks are accepted for client compatibility; native edit
   models use whole-image conditioning.
 - `POST /v1/audio/speech` serves `speech-tts-qwen3-nano` and returns WAV by
   default, with `mp3`, `opus`, `aac`, and `flac` available when `ffmpeg` is
@@ -2878,13 +2882,13 @@ swift run mere.run setup --mode manual
 Agent model choices:
 
 - `small`: `text-agent-ornith-9b`, a tool-capable native OptiQ setup agent for 16 GB machines
-- `tier`: the best supported tool-capable local tier for this machine, currently Ornith 9B, Gemma 4, Qwen3.6 nano on Linux, or DeepSeek V4 Flash on 96 GB+ machines
+- `tier`: the best supported tool-capable local tier for this machine: Ornith 9B, Gemma 4, Qwen3.6 nano on Linux, or DeepSeek V4 Flash on 96 GB+ machines
 - `premier`: `text-agent-deepseek-v4-flash`, the preferred managed 96 GB+ setup-agent tier served by the bundled DS4 engine
 
 North Mini Code (`text-code-north-mini`) is available as a managed native GGUF
 coding model. It is pullable through `model pull`, can be served with
 `api serve --engine text-code --model text-code-north-mini`, and can be used
-for direct code sessions and evals. The `text-code` API lane rejects tool calls,
+for direct code sessions and evaluations. The `text-code` API lane rejects tool calls,
 so it is not exposed to Pi.
 
 Ornith (`text-agent-ornith-9b`) is available as an experimental native
@@ -2894,7 +2898,7 @@ The official Ornith 1.5 35B-A3B BF16 MLX target
 (`text-agent-ornith-35b-mlx`) uses the same native Qwen-family serving engine
 after an explicit managed pull.
 The larger Ornith 35B GGUF target (`text-agent-ornith-35b`) is also available
-for explicit evals and runs through:
+for explicit evaluations and runs through:
 
 ```bash
 swift run mere.run api serve --engine text-chat-q36 --model text-agent-ornith-35b-mlx
@@ -2904,12 +2908,12 @@ swift run mere.run api serve --engine text-code --model text-agent-ornith-35b
 BYOA prints a ready-to-paste Claude/Codex prompt. Manual mode prints the
 commands for capabilities, model pulls, serving, and optional Pi installation.
 Pi auto-install uses the published macOS release assets; on Linux, put a `pi`
-binary on `PATH` or pass `--pi-path` and the agent runs in the current terminal.
+binary on `PATH` or pass `--pi-path` and the agent runs in the active terminal.
 
 ### `mere.run agent onboard`
 
 Lower-level agent plumbing used by `mere.run setup`. Print a guided setup
-summary for the current machine. Optional flags can pull the
+summary for this machine. Optional flags can pull the
 recommended supported model package, install Pi, and write a Pi provider
 extension that points at `mere.run api serve`.
 
@@ -2923,7 +2927,7 @@ swift run mere.run agent onboard --configure-pi --model text-agent-ornith-9b --p
 
 ### `mere.run agent status`
 
-Inspect the current machine, Pi install, generated provider extension, selected
+Inspect this machine, the Pi installation, the generated provider extension, the selected
 provider endpoint/model, recommended setup tier, and every startable agent
 model without mutating the setup.
 
@@ -2939,7 +2943,7 @@ extension that the CLI will actually use.
 
 ### `mere.run agent install-pi`
 
-Install the latest `earendil-works/pi` release asset for the current macOS
+Install the most recent published `earendil-works/pi` release asset for this macOS
 architecture into the mere.run application-support directory.
 
 ```bash
@@ -2953,7 +2957,7 @@ launch Pi against the native `mere-run` provider. Qwen-family models use a
 native chat engine and DeepSeek V4 Flash uses the DS4-backed
 `--engine text-chat-deepseek-v4-flash`. If `--model` is omitted, `agent start`
 uses the best installed startable setup agent first, then a valid persisted Pi
-provider model, then the current machine's startable hardware tier. On 96 GB+
+provider model, then this machine's startable hardware tier. On 96 GB+
 Apple Silicon Macs, DeepSeek V4 Flash is the preferred setup-agent tier; smaller
 Qwen models are alternatives, not upgrades. Qwen3.8 advertises its native
 `low`, `medium`, and `xhigh` reasoning levels to Pi; Pi's `minimal`, `high`, and
@@ -2967,7 +2971,7 @@ swift run mere.run agent start --model text-agent-deepseek-v4-flash
 
 ## Validation and smoke runs
 
-Standard repo validation:
+Standard repository validation:
 
 ```bash
 ./scripts/check.sh

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -1,22 +1,23 @@
 # Configuration
 
-There are two ways to change how `mere.run` behaves: settings that persist
-across shells, and environment variables you set for a single run. This page
-covers both, and marks which ones hold secrets.
+Configure `mere.run` with persisted settings or environment variables. Persisted
+settings apply across shells, and environment variables apply to an individual
+run. This page also identifies settings that contain secrets.
 
 ## Persisted settings: `mere.run config`
 
-`mere.run config` persists settings that should survive across shells without
-environment variables, in `~/Library/Application Support/MereRun/config.json`
-(written with `0600` permissions because it carries secrets). Subcommands:
-`set`, `get`, `unset`, `list`, and `path` (prints the config file path).
+`mere.run config` writes persisted settings to
+`~/Library/Application Support/MereRun/config.json`. Because the file can
+contain secrets, `mere.run` writes it with `0600` permissions. Use the `set`,
+`get`, `unset`, `list`, and `path` subcommands. The `path` subcommand prints the
+configuration file path.
 
-Keys:
+The following keys are available:
 
-- `hf-token` — Hugging Face access token, used to pull gated models
-  (e.g. `image-klein-9b`). Treated as a secret: `get` and `list` print it
-  masked; pass `--reveal` to `get` to print it in full.
-- `hf-endpoint` — alternate Hugging Face endpoint for managed downloads.
+- `hf-token`: Hugging Face access token used to pull gated models, such as
+  `image-klein-9b`. The `get` and `list` commands mask this secret. To print the
+  full token, pass `--reveal` to `get`.
+- `hf-endpoint`: Alternative Hugging Face endpoint for managed downloads.
 
 ```bash
 swift run mere.run config set hf-token hf_xxxxxxxx
@@ -24,7 +25,8 @@ swift run mere.run config get hf-token --reveal
 swift run mere.run config list
 ```
 
-For scripts and GUI launchers, keep the token out of process arguments:
+To keep the token out of process arguments in scripts and GUI launchers, use an
+environment variable:
 
 ```bash
 export MERERUN_CONFIG_VALUE=hf_xxxxxxxx
@@ -34,16 +36,16 @@ unset MERERUN_CONFIG_VALUE
 
 The macOS Studio Settings screen uses this environment-backed path.
 
-Environment variables take precedence over the config file: the HF token
-resolves from `HF_TOKEN` (then `HUGGING_FACE_HUB_TOKEN`) before falling back to
-the stored `hf-token`, and the endpoint resolves from `HF_ENDPOINT` before the
-stored `hf-endpoint`, defaulting to `https://huggingface.co`.
+Environment variables take precedence over the configuration file. The Hugging
+Face token resolves from `HF_TOKEN`, then `HUGGING_FACE_HUB_TOKEN`, and then the
+stored `hf-token`. The endpoint resolves from `HF_ENDPOINT`, then the stored
+`hf-endpoint`, and finally defaults to `https://huggingface.co`.
 
 ## Model store
 
 ### `MERERUN_MODELS_DIR`
 
-Overrides the model links and model-local-files store. Large managed Hub
+Overrides the model links and model-local file store. Large managed Hub
 payloads normally live under `MERERUN_HUB_CACHE`, so moving only this directory
 does not move most downloaded bytes.
 
@@ -63,7 +65,7 @@ Default:
 ### `MERERUN_HUB_CACHE`
 
 Overrides the physical payload store used by managed model pulls. This is the
-location to move when large downloaded weights need to live on another disk.
+location to move if large downloaded weights must reside on another disk.
 
 ```bash
 export MERERUN_HUB_CACHE=/Volumes/Models/huggingface
@@ -81,7 +83,7 @@ Checksum-pinned public adapter releases install under:
 ~/Library/Application Support/MereRun/adapters
 ```
 
-`mere.run adapter pull` uses public HTTPS release URLs and never requires or
+`mere.run adapter pull` uses public HTTPS release URLs and does not require or
 accepts R2 credentials. Catalog ids resolve from this verified local store when
 passed to `text chat --lora` or `api serve --lora`.
 
@@ -89,13 +91,14 @@ passed to `text chat --lora` or `api serve --lora`.
 
 ### `MERERUN_VIDEO_LTX_MODEL_ROOT`
 
-Sets the default root used by `mere.run video generate` and `mere.run video export-latents` when `--model-root` is omitted.
+Sets the default root used by `mere.run video generate` and
+`mere.run video export-latents` when you omit `--model-root`.
 
 ### `MERERUN_MUSIC_ACESTEP_ROOT`
 
 Sets the default checkpoint root used by `mere.run music generate` and
-`mere.run music analyze` when the command is not resolving from the shared model
-store.
+`mere.run music analyze` when the command does not resolve a model from the
+shared model store.
 
 ## API server security
 
@@ -105,14 +108,15 @@ Provides the bearer token accepted by `mere.run api serve` for `/v1/models`,
 `/v1/chat/completions`, `/v1/embeddings`, `/v1/images/generations`,
 `/v1/images/edits`, `/v1/audio/speech`, and `/v1/audio/transcriptions`.
 
-This is optional for loopback-only usage and required for non-loopback binds.
+This key is optional for loopback-only use and required for non-loopback binds.
 `mere.run status` also reads it when probing `/v1/models`.
 
 ## Runtime experiments
 
 ### `MERERUN_GEMMA4_PREFIX_KV_CACHE`
 
-Gemma4 in-memory prefix KV reuse is enabled by default in `mere.run api serve`.
+Gemma4 in-memory prefix key-value (KV) reuse is enabled by default in
+`mere.run api serve`.
 Set this to `0`, `false`, `no`, or `off` to disable it for a baseline run. The
 runtime stores bounded, forked Gemma4 prompt-prefix cache state for matching
 token prefixes and reports entries, hits, and reused tokens through
@@ -125,28 +129,33 @@ Continuous batching and SSD KV cache are not enabled by this flag.
 
 ### `MERERUN_LFM2_PREFIX_KV_CACHE`
 
-In-memory prompt-prefix reuse for the LFM2 chat runtime, enabled by default
-in `mere.run api serve` (set `0`, `false`, or `off` to disable; one-shot CLI
-invocations keep it off since a prefix cache cannot outlive the process),
-mirroring the Qwen-family implementation. Forked layer caches (attention KV
-and short-conv states both support forking) retain exact prompts plus the
+In-memory prompt-prefix reuse for the LFM2 chat runtime is enabled by default
+in `mere.run api serve`. Set `0`, `false`, or `off` to disable it. One-shot CLI
+invocations keep it off because a prefix cache cannot outlive the process. The
+implementation mirrors the Qwen-family implementation. Forked layer caches
+(attention KV and short-convolution states both support forking) retain exact prompts plus the
 stable conversation prefix before the final message. The longest matching
 token prefix seeds later requests, so a repeated or extended prompt re-prefills
 only its tail. Intermediate prefill chunks are not cloned. The cache is bounded
 to 4 entries with the shared retention planner, which keeps semantic
 conversation checkpoints ahead of exact-prompt entries when pruning.
 
-### Continuous batching (`MERERUN_GEMMA4_CONTINUOUS_BATCHING`, `MERERUN_LAGUNA_CONTINUOUS_BATCHING`, `MERERUN_Q35_CONTINUOUS_BATCHING`, `MERERUN_LFM2_CONTINUOUS_BATCHING`)
+### Continuous batching
+
+Use `MERERUN_GEMMA4_CONTINUOUS_BATCHING`,
+`MERERUN_LAGUNA_CONTINUOUS_BATCHING`, `MERERUN_Q35_CONTINUOUS_BATCHING`, or
+`MERERUN_LFM2_CONTINUOUS_BATCHING` to override continuous batching for an
+individual engine.
 
 Decode batching for concurrent requests engages automatically when
-`mere.run api serve` runs with `--max-active-requests` above 1 — the
-concurrency flag is the single switch. The per-engine environment variables
+`mere.run api serve` runs with `--max-active-requests` above 1. The concurrency
+flag is the primary switch. The per-engine environment variables
 remain as explicit overrides in both directions (`1` forces batching on even
 at concurrency 1, `0` forces the serial path). `/runtime/status` reports
 engagement under `decodeBatching` (`batchedDecodeSteps`, `maxBatchSize`);
 per-model stats include `recentDecodeTokensPerSecond`, a rolling last-10
-window that surfaces mid-flight throughput regressions lifetime averages
-hide.
+window that surfaces mid-flight throughput regressions that lifetime averages
+can hide.
 
 Laguna follows the same switch through
 `MERERUN_LAGUNA_CONTINUOUS_BATCHING`. The target supports ragged decode rows;
@@ -163,7 +172,7 @@ token-budget-complete rows. `0` keeps the serial pipelined decoder.
 
 ### Machine-wide inference admission
 
-Every allocation-heavy direct `mere.run` command joins a crash-safe weighted
+Every allocation-heavy direct `mere.run` command joins a crash-safe, weighted
 FIFO shared by Studio, terminals, launchers, scripts, and agents. API-server
 processes hold a reservation while preserving their own model-pool and request
 concurrency. Lightweight inspection and management commands such as `status`,
@@ -178,11 +187,11 @@ larger, and an explicit local model file of that size, is also promoted to the
 exclusive class. FIFO ordering prevents a stream of small jobs from starving
 an earlier large job.
 
-Before registration and admission, the coordinator checks reclaimable memory
-and preserves free disk for swap and temporary files. The disk floor is one
+Before it registers and admits a command, the coordinator checks reclaimable
+memory and preserves free disk for swap and temporary files. The disk floor is one
 eighth of physical memory, clamped from 8 to 32 GiB. A command below that floor
-fails before loading a model. Cancelled waiters remove their tickets; dead
-processes are pruned automatically. `mere.run status` shows active and queued
+fails before loading a model. Cancelled waiters remove their tickets, and the
+coordinator automatically prunes dead processes. `mere.run status` shows active and queued
 entries, and the typed ledger lives under
 `~/Library/Application Support/MereRun/admission/` without prompts or content.
 
@@ -235,7 +244,7 @@ to `2048`.
 ### `MERERUN_GEMMA4_MTP_BLOCK_SIZE`
 
 Override the Gemma 4 12B assistant draft block size. Defaults to the assistant
-config value, currently `4`, and is clamped to the native runtime's supported
+configuration value, which is `4`, and is clamped to the native runtime's supported
 range.
 
 ### `MERERUN_GEMMA4_MTP_SAMPLED`
@@ -244,7 +253,7 @@ Opt-in (`1`, `true`, or `on`) Gemma 4 12B MTP for sampled (temperature > 0)
 requests. The verify loop samples the target model at every drafted position
 and emits either the matching draft token or the target's own sample, so
 sampled outputs remain true target-model samples; drafts run greedily to
-maximize the match rate. Off by default: with the current assistant the
+maximize the match rate. This mode is disabled by default because the selected assistant's
 acceptance economics measured below the pipelined sampled decode path at long
 context.
 
@@ -257,12 +266,12 @@ fallback) of the generated context recurs earlier in the context, the
 pipelined decode loop runs a burst: the continuation of that earlier
 occurrence is drafted and verified in one batched forward, exactly like an
 MTP draft, so outputs are token-identical to plain greedy decode. A
-no-match token costs one host-side scan and no GPU work — decode speed on
-non-repetitive text is unchanged — while echo-heavy generation (quoted
+no-match token costs one host-side scan and no GPU work. Decode speed on
+non-repetitive text is unchanged, while echo-heavy generation, such as quoted
 documents, retrieval answers, code edits, tool loops) measured 1.9× on an
 echo workload. Three consecutive zero-accept rounds stop further lookups
 for the request. MTP takes precedence when its assistant is active;
-JSON-constrained requests never use lookup.
+JSON-constrained requests do not use lookup.
 
 ### `MERERUN_GEMMA4_PROMPT_LOOKUP_BLOCK`
 
@@ -284,7 +293,7 @@ each attention call issues one fused matmul instead of three. Quantized
 packing is per-output-row, so results are bit-identical to the separate
 projections (greedy outputs verified byte-equal). Enabled by default; set to
 `0`, `false`, or `off` to fall back. On the 35B MoE this measured +1% decode
-throughput for roughly 130 MB of additional resident weight copies —
+throughput for roughly 130 MB of additional resident weight copies. In this case,
 attention is a small slice of a MoE's per-token weights, unlike the dense
 Gemma case where the same fusion bought +17%.
 
@@ -292,7 +301,7 @@ Gemma case where the same fusion bought +17%.
 
 Prefill chunk length for Qwen-family models, accepted range 64–8192, default
 1024. Qwen3.8 uses live host-memory headroom rather than total physical RAM: it
-caps the current chunk at 512 below 16 GiB of reclaimable headroom. The same cap
+caps the active chunk at 512 below 16 GiB of reclaimable headroom. The same cap
 applies when another request is admitted so a decoder is not stalled behind a
 wide prefill. An explicit value remains an upper bound and is still reduced
 under memory pressure or contention. On the Ornith 35B MoE (M4 Max), a
@@ -305,7 +314,7 @@ against progress-report granularity and per-chunk activation memory.
 Qwen-family continuous-batching decode samples every active request's row on
 GPU (the same sampler the serial pipelined path uses, including the on-GPU
 repetition window) and reads the whole batch back in a single sync per step.
-The legacy path sampled per row on the host — one blocking GPU→CPU readback
+The legacy path sampled per row on the host, with one blocking GPU-to-CPU readback
 per request per token, scaling linearly with serve concurrency. Enabled by
 default; set to `0`, `false`, or `off` to restore per-row host sampling.
 
@@ -329,7 +338,7 @@ Off by default: throughput is neutral on an idle GPU and the kernels' float32
 single-rounding numerics reduce Gemma MTP speculative acceptance at long
 context. They cut per-token kernel dispatches roughly in half, which helps
 when the GPU is shared with other heavy work (for example concurrent
-training) — enable explicitly for that scenario.
+training). Enable the kernels explicitly for that scenario.
 
 ### `MERERUN_GEMMA4_COMPILED_SEGMENTS`
 
@@ -347,8 +356,8 @@ tunable: overlapping `mrt2_engine_generate_frame` with the asynchronous
 encode segfaults, verified live against the engine by the gated
 `MagentaRT2PromptSwapTests`. Stall-free swaps require the engine's threaded
 `mrt2_runner_*` API with its buffered audio ring. Note the engine's Metal
-libraries inside `vendor/magentart.xcframework` are Git LFS objects — a
-checkout without hydrated LFS fails at model load with a metallib error; run
+libraries inside `vendor/magentart.xcframework` are Git LFS objects. A
+checkout without hydrated LFS fails at model load with a metallib error. Run
 `git lfs install --local && git lfs pull` and rebuild.
 
 ### `MERERUN_SAMPLER_TOP_P_PREFILTER`
@@ -362,7 +371,7 @@ practical temperatures.
 
 ### `MERERUN_LORA_TRAIN_GRAD_CHECKPOINT`
 
-Gradient checkpointing for image-LoRA training — Krea 2 and FLUX.2 Klein.
+Gradient checkpointing applies to image LoRA training for Krea 2 and FLUX.2 Klein.
 Transformer blocks recompute their activations during backward instead of
 retaining every intermediate. Unset, the default is resolution-aware: it
 engages when the peak training resolution (after `--max-resolution` capping)
@@ -381,14 +390,14 @@ prints its decision at startup (`grad_checkpoint=` on stderr).
 
 MLX buffer-cache cap during image-LoRA training, in gigabytes (default `16`;
 `0` leaves the cache unlimited). The cache grows to the transient high-water
-mark and never shrinks, so without a cap the process footprint stays pinned at
+mark and does not shrink, so without a cap the process footprint stays pinned at
 the worst spike of the run. Applies to both image-LoRA trainers.
 
 ### `MERERUN_LORA_TRAIN_SYNC_EVAL`
 
 Set to `1` to evaluate each image-LoRA training step synchronously. The
 default overlapped evaluation lets the next step's graph (and its full
-activation set) go live while the current step executes, which can nearly
+activation set) go live while the active step executes, which can nearly
 double the peak memory footprint at training-sized activations. Synchronous
 mode caps in-flight activations at one step's worth at the cost of graph-build
 overlap, which is negligible next to a training step.
@@ -398,7 +407,7 @@ overlap, which is negligible next to a training step.
 Adapter checkpoint cadence, in optimizer steps, for image-LoRA training
 (default `100`; `0` disables). A `<name>.partial.safetensors` file is written
 next to the output and removed once the final save succeeds, so a run killed
-mid-training — for example by memory pressure — no longer loses everything.
+mid-training, for example by memory pressure, retains its partial work.
 The trainer also logs `step_s` and `footprint_gb` diagnostics at the metrics
 cadence.
 
@@ -408,7 +417,7 @@ Native text LoRA training (`text train-lora`) projects only loss-masked
 target positions through the 262k-vocabulary lm_head and computes cross
 entropy as logSumExp-minus-gather, instead of materializing full-sequence
 logits plus a second full-vocabulary log-probability tensor. Gradients are
-identical to the full path — prompt and padding rows never contribute loss —
+identical to the full path. Prompt and padding rows do not contribute loss, so
 so this is on by default; set `0`, `false`, or `off` to restore the legacy
 full-logits loss. The trainer prints its decision at startup
 (`gathered_loss=` on stderr).
@@ -432,8 +441,8 @@ is written every 100 steps and removed after the final save.
 
 Parakeet transducer decoding (TDT and RNN-T) evaluates the joint network for
 this many contiguous encoder frames per batched call (default `16`). The
-decoder state only changes when a token is emitted, so blank frames — the
-majority — scan host-side from a single readback instead of one (RNN-T) or
+decoder state changes only when a token is emitted, so the host scans blank
+frames from a single readback instead of one RNN-T or
 two (TDT) scalar readbacks per frame. Greedy semantics are identical to the
 per-frame loop. Set `1` to restore the legacy per-frame readback cadence.
 
@@ -441,7 +450,7 @@ per-frame loop. Set `1` to restore the legacy per-frame readback cadence.
 
 Qwen3 ASR token decoding samples on GPU and pipelines the loop at depth 1:
 the sampled token feeds the next forward as a GPU array and the previous
-step's token is read back while the current step executes (the legacy loop
+step's token is read back while the active step executes (the legacy loop
 synchronized twice per token). Enabled by default; set `0`, `false`, or
 `off` to restore the legacy loop.
 
@@ -453,7 +462,7 @@ each back with `.item()`, roughly nine GPU→CPU round trips per emitted
 frame), the ~1k-entry suppress list becomes a mask built once per generation
 instead of a per-token upload, top-k uses argPartition instead of a
 full-vocabulary sort, and the previous step's token is read back while the
-current step executes. EOS therefore costs one speculative frame of discarded
+active step executes. EOS therefore costs one speculative frame of discarded
 GPU work. Enabled by default; set `0`, `false`, or `off` to restore the
 legacy synchronous loop.
 
@@ -479,7 +488,7 @@ contended request uses ordinary continuous batching; a late peer does not
 migrate an MTP request that is already running.
 
 The `Q35` name is an internal compatibility prefix for the Qwen-family runtime;
-the public managed model ids retain their Qwen release names.
+the public managed model IDs retain their Qwen release names.
 
 ### `MERERUN_Q35_MTP_MIN_PROMPT_TOKENS`
 
@@ -579,7 +588,7 @@ When unset, `mere.run api serve` enables Gemma4 same-offset decode batching when
 with equal KV offsets into typed batched KV caches, splits the cache rows back
 after each step, and reports same-position batched decode steps, queued rows,
 and max observed batch size through `/runtime/status`. Gemma4 variable-position
-decode batching is not enabled because its current attention path applies RoPE
+decode batching is not enabled because its attention path applies RoPE
 with scalar cache offsets.
 
 ### `MERERUN_Q35_CONTINUOUS_BATCHING`

--- a/docs/cookbooks.md
+++ b/docs/cookbooks.md
@@ -1,8 +1,8 @@
 # Cookbooks
 
 Every command carries its own manual. `mere.run guide` is a cookbook reader
-built into the binary, and it works with the network off — on a plane, in a
-locked-down lab, or on a machine that has never had an API key. It prints
+built into the binary, and it works with the network off, such as on a plane or
+in a locked-down lab. It prints
 Markdown by default, emits JSON for agents and tools, and renders the topic
 list as a Markdown table with `--markdown`.
 
@@ -19,11 +19,11 @@ mere.run guide open-webui
 mere.run guide video generate --json
 ```
 
-Each guide is written to be used, not skimmed: what the command does, which
-model to install, which flags actually change the output, prompting patterns,
+Each guide explains what the command does, which model to install, which flags
+change the output, prompting patterns,
 worked examples, iteration tips, troubleshooting, and links into the source.
 
-## Available Topics
+## Available topics
 
 Creative and runtime workflows:
 
@@ -80,7 +80,7 @@ Operational workflows:
 - `agent install-pi`
 - `agent start`
 
-## Model-Focused Guides
+## Model-focused guides
 
 Some topics support model focus. The CLI validates that the requested model is
 covered by the guide before printing:
@@ -95,9 +95,9 @@ mere.run guide music transcribe --model music-muscriptor-medium
 ```
 
 If the model does not belong to the topic, the command prints a validation error
-with the supported model ids.
+with the supported model IDs.
 
-## Agent Usage
+## Agent usage
 
 Agents should keep their own prompt context small:
 
@@ -107,5 +107,5 @@ Agents should keep their own prompt context small:
 3. Use `--json` when the agent needs a structured payload with topic metadata
    and Markdown content.
 
-The guide command is the canonical source for per-command usage advice; skills
+The guide command is the canonical source for per-command usage advice. Skills
 should route to it instead of duplicating cookbook content.

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -1,4 +1,4 @@
-# Development Workflow
+# Development workflow
 
 This page describes the expected local workflow for editing `mere-run`.
 
@@ -31,14 +31,14 @@ export MERERUN_FFMPEG=/opt/ffmpeg/bin/ffmpeg
 export MERERUN_FFPROBE=/opt/ffmpeg/bin/ffprobe
 ```
 
-## The normal loop
+## Standard development loop
 
 For most changes:
 
-1. make the code or docs change
-2. run the smallest relevant local check
-3. run `./scripts/check.sh`
-4. run the installed smoke sweep if you touched real runtime behavior
+1. Make the code or documentation change.
+2. Run the smallest relevant local check.
+3. Run `./scripts/check.sh`.
+4. If you changed real runtime behavior, run the installed smoke sweep.
 
 That keeps the package healthy without forcing a full manual validation cycle
 for every tiny edit.
@@ -51,7 +51,7 @@ for every tiny edit.
 ./scripts/check.sh
 ```
 
-This catches docs hygiene regressions and verifies the CLI help surface still
+This catches documentation hygiene regressions and verifies the CLI help surface still
 matches the public tree.
 
 If the change adds, removes, renames, or redescribes a CLI command, first run:
@@ -158,7 +158,8 @@ That writes artifacts such as
 `mere-run-<version>-linux-x86_64-cuda.tar.gz` and
 `mere-run-cuda_<version>_amd64.deb`. Real CUDA runtime smoke belongs on an
 actual GPU host. CUDA package builders need CMake 3.25 or newer for the
-upstream `mlx-swift` CUDA bridge. On Ubuntu 22.04/Jammy images, install a current CMake with
+upstream `mlx-swift` CUDA bridge. On Ubuntu 22.04/Jammy images, install CMake
+3.25 or later with
 `python3 -m pip install --upgrade "cmake>=3.25,<4"` before starting the CUDA
 package build.
 
@@ -174,17 +175,22 @@ An explicit `MERERUN_PACKAGE_LINUX_DEPS` value bypasses the automatic CUDA
 major gate and is written verbatim, making dependency compatibility the
 packager's responsibility.
 
+Active release builds cover macOS and the configured `tensor.local` x86_64 CUDA
+builder. The arm64 CUDA release lane is paused while no matching build host is
+available. Do not publish an arm64 CUDA artifact until it has been rebuilt and
+smoke-tested on matching hardware.
+
 ## Model-store expectations
 
 The public runtime is hard-cut to the canonical OSS model IDs. That means:
 
-- runtime code should use canonical public IDs only
-- examples should use canonical public IDs only
-- model-store and server troubleshooting should point readers at
+- Runtime code must use canonical public IDs only.
+- Examples must use canonical public IDs only.
+- Model-store and server troubleshooting must point readers at
   `mere.run status`, `mere.run model list`, `mere.run model info`, and
-  `mere.run model repair-manifests`
+  `mere.run model repair-manifests`.
 
-When testing locally, inspect your current state with:
+When testing locally, inspect the machine state with:
 
 ```bash
 swift run mere.run status
@@ -196,51 +202,54 @@ swift run mere.run model info image-klein-max
 
 ### If you touch the public command tree
 
-- keep the modality-first structure intact
-- preserve stdout and stderr discipline
-- update `docs/cli.md` if the user-facing behavior changes
-- update quickstarts, cookbooks, and runtime docs when the command becomes part
-  of setup or troubleshooting
-- add or update `Tests/MereRunCLITests`
+- Keep the modality-first structure intact.
+- Preserve stdout and stderr discipline.
+- Update `docs/cli.md` if the user-facing behavior changes.
+- Update quickstarts, cookbooks, and runtime documentation when the command
+  becomes part of setup or troubleshooting.
+- Add or update `Tests/MereRunCLITests`.
 
 ### If you touch runtime code
 
-- keep debug output behind the internal debug helper
-- avoid introducing new implicit hosted defaults
-- keep model resolution explicit and canonical
-- add or update the most local tests you can
-- for Linux media I/O, test executable discovery through `MERERUN_FFMPEG`,
-  `MERERUN_FFPROBE`, and `PATH` without requiring real model checkpoints
+- Keep debug output behind the internal debug helper.
+- Do not introduce implicit hosted defaults.
+- Keep model resolution explicit and canonical.
+- Add or update the closest relevant tests.
+- For Linux media I/O, test executable discovery through `MERERUN_FFMPEG`,
+  `MERERUN_FFPROBE`, and `PATH` without requiring real model checkpoints.
 
 ### If you touch docs
 
-- teach the current public OSS surface
-- prefer links between docs pages over repeating large blocks of reference text
+- Follow the [documentation style guide](documentation-style.md).
+- Describe the public OSS behavior that the repository implements.
+- Link to the canonical page instead of repeating large reference sections.
+- Use reserved domains and fictional identifiers in examples.
+- Run `bash ./scripts/check-docs-examples.sh` and `pnpm docs:build`.
 
 ## Contribution boundaries
 
-This repo is intentionally scoped to the package and CLI. Changes should not
+This repository is intentionally scoped to the package and CLI. Changes must not
 reintroduce:
 
-- hosted-service assumptions
-- billing or entitlement logic
-- app-store-only release behavior
-- relay/web/app-specific product layers
+- Hosted-service assumptions.
+- Billing or entitlement logic.
+- App-store-only release behavior.
+- Relay, web, or app-specific product layers.
 
 See the root `CONTRIBUTING.md` file for the short policy version.
 
-## A good contributor checklist
+## Contributor checklist
 
-Before opening a PR:
+Before you open a pull request:
 
-- `swift build` passes
-- `swift test` passes
-- `./scripts/check.sh` passes
-- `pnpm docs:build` passes if you changed docs
+- `swift build` passes.
+- `swift test` passes.
+- `./scripts/check.sh` passes.
+- `pnpm docs:build` passes if you changed documentation.
 - `gitleaks detect --source . --config .gitleaks.toml --redact --no-banner`
-  passes before a public release
-- the docs reflect any user-facing change
-- the public command and model vocabulary remain canonical
+  passes before a public release.
+- The documentation reflects any user-facing change.
+- The public command and model vocabulary remain canonical.
 
 If you changed runtime behavior against real models, also include the result of:
 

--- a/docs/documentation-style-audit.md
+++ b/docs/documentation-style-audit.md
@@ -1,0 +1,107 @@
+# Documentation style audit
+
+This inventory tracks the Google developer documentation style pass across the
+61 Markdown files in the public documentation site and its root contributor
+entry points: `README.md`, `CODEBASE.md`, and `CONTRIBUTING.md`.
+
+Audit date: August 20, 2026
+
+## Status definitions
+
+- **Complete:** Reviewed line by line for audience, active voice, present tense,
+  sentence case, terminology, link text, accessibility, example data, and
+  time-sensitive claims.
+- **Targeted:** Updated for a specific issue or normalized structurally, but
+  still requires a complete line-by-line review.
+- **Pending:** Not changed during this pass.
+
+Generated command inventories and historical benchmark receipts have additional
+constraints. Update generated text through its source, and preserve recorded
+measurements, hashes, versions, and limitations when improving historical prose.
+
+## Complete
+
+- `CODEBASE.md`
+- `CONTRIBUTING.md`
+- `README.md`
+- `docs/architecture/audio-enhancement-ap-bwe-report.md`
+- `docs/architecture/audio-enhancement-universr-report.md`
+- `docs/architecture.md`
+- `docs/architecture/music-source-separation-roformer-report.md`
+- `docs/architecture/vfx-geometry-model-report.md`
+- `docs/benchmark-fused.md`
+- `docs/benchmarks/minimax-h3-bf16-m4-max.md`
+- `docs/benchmarks/minimax-h3-compact-bf16-q8-m4-max.md`
+- `docs/benchmarks/minimax-h3-h3c-transfer.md`
+- `docs/benchmarks/minimax-h3-ref2va-mlx-8bit.md`
+- `docs/benchmarks/vfx-geometry-apple-silicon.md`
+- `docs/benchmarks/laguna-min-p-m4-max.md`
+- `docs/benchmarks/fused-reference-runs.md`
+- `docs/benchmarks/minimax-music3-m4-max.md`
+- `docs/benchmarking.md`
+- `docs/cli.md`
+- `docs/cookbooks.md`
+- `docs/configuration.md`
+- `docs/development-workflow.md`
+- `docs/README.md`
+- `docs/documentation-style.md`
+- `docs/documentation-style-audit.md`
+- `docs/gate.md`
+- `docs/graph/studio.md`
+- `docs/index.md`
+- `docs/internals/cli-and-runtime.md`
+- `docs/internals/dit-performance.md`
+- `docs/internals/guarded-acceleration.md`
+- `docs/internals/source-layout.md`
+- `docs/ios-studio.md`
+- `docs/ltx25-upstream-parity.md`
+- `docs/linux-quickstart.md`
+- `docs/macos-deep-links.md`
+- `docs/macos-studio-roadmap.md`
+- `docs/mlx-swift-fork.md`
+- `docs/plugins.md`
+- `docs/raycast.md`
+- `docs/repository-tour.md`
+- `docs/evaluation-packs.md`
+- `docs/falcon-perception-disparity-report.md`
+- `docs/runtime/acestep-validation.md`
+- `docs/getting-started.md`
+- `docs/internals/structured-runs-preflight-actions.md`
+- `docs/model-sources.md`
+- `docs/runtime/api-server.md`
+- `docs/runtime/audio.md`
+- `docs/runtime/geo.md`
+- `docs/runtime/image.md`
+- `docs/runtime/model-management.md`
+- `docs/runtime/music.md`
+- `docs/runtime/sfx.md`
+- `docs/runtime/speech.md`
+- `docs/runtime/text.md`
+- `docs/runtime/video.md`
+- `docs/runtime/vision.md`
+- `docs/runtime/world.md`
+- `docs/testing.md`
+- `docs/workflows.md`
+
+The VitePress navigation in `docs/.vitepress/config.mts` also received a full
+sentence-case and destination review.
+
+## Remaining pages
+
+None. All 61 files in this audit have received a complete pass.
+
+## Complete-pass checklist
+
+Move a page to **Complete** only after all of these checks pass:
+
+1. Identify the intended reader and lead with the task or outcome.
+2. Use direct, active, present-tense instructions.
+3. Use sentence case while preserving proper names.
+4. Replace vague links and positional references with descriptive wording.
+5. Use reserved values for examples and label real public sources accurately.
+6. Replace unstable words such as "latest" with a version, date, or named state
+   when possible.
+7. Preserve command accuracy, generated-content ownership, benchmark receipts,
+   security boundaries, and validation limits.
+8. Run `bash ./scripts/check-docs-examples.sh`, `pnpm docs:build`, and the
+   relevant documentation contract tests.

--- a/docs/documentation-style.md
+++ b/docs/documentation-style.md
@@ -1,0 +1,117 @@
+# Documentation style
+
+Use this guide for every public page, example, command description, and pull
+request that changes documentation. The goal is consistent documentation that
+helps readers complete a task without needing repository context.
+
+## Write for the reader
+
+- Start with the outcome or decision the reader needs.
+- Address the reader as "you" when giving instructions.
+- Use active voice and present tense.
+- Keep sentences and paragraphs focused on one idea.
+- Define unfamiliar terms before using abbreviations.
+- Use the same term for the same concept throughout a page.
+- Separate verified behavior, limitations, and planned work.
+
+Prefer direct instructions:
+
+> Run `mere.run model capabilities` before you download a model.
+
+Avoid indirect wording:
+
+> The model capabilities command can be run by users before a model is
+> downloaded.
+
+## Use sentence case
+
+Use sentence case for page titles, headings, table headings, and link text.
+Capitalize product names, model names, and other proper nouns as their owners
+write them.
+
+- Use **Getting started**, not **Getting Started**.
+- Use **Local API server**, not **Local API Server**.
+- Keep **Graph Studio**, **Open WebUI**, and **Apple Silicon** capitalized.
+
+## Make links and structure accessible
+
+- Use link text that describes the destination. Avoid "here," "this link," and
+  raw URLs when a descriptive label works.
+- Do not rely on position, color, or visual styling to convey meaning.
+- Give every table a header row and keep list items grammatically parallel.
+- Introduce code blocks and tables before they appear.
+- Use ordered lists for sequences and unordered lists for collections.
+- Add concise alt text to meaningful images. Use empty alt text only for
+  decorative images.
+
+## Use unmistakable example data
+
+Public documentation must use fictional people, organizations, workspaces,
+hostnames, and account identifiers unless the text identifies a real public
+project or source.
+
+- Use reserved email domains such as `dana@example.com`.
+- Use reserved DNS names under `example.com`, `example.net`, or `example.org`.
+- Use fictional identifiers such as `greenhouse-ops`, `project-alpha`, and
+  `deployment-123`.
+- Use the documentation IP ranges `192.0.2.0/24`, `198.51.100.0/24`, and
+  `203.0.113.0/24`.
+- Never copy customer, contributor, internal, or proprietary data into a public
+  example.
+
+Project-owned addresses under `mere.run` and accurate third-party attribution
+in `THIRD_PARTY_NOTICES.md` are not example data.
+
+Run the example-data check before you open a pull request:
+
+```bash
+bash ./scripts/check-docs-examples.sh
+```
+
+## Describe versions and time precisely
+
+Prefer a version, date, or named state over words such as "latest" and
+"current" when the statement can become stale.
+
+- Write "The v0.41.0 package includes ..." for a release-specific claim.
+- Write "As of 2026-08-20, the validation covers ..." for dated evidence.
+- Use "current working directory" when it is the technical name of a process
+  property.
+
+Do not rewrite a historical benchmark receipt to match a newer runtime. Add a
+new dated result and preserve the original hashes, environment, and limitations.
+
+## Document commands completely
+
+For each command workflow:
+
+1. State what the command does and whether it changes local state.
+2. List prerequisites before the command.
+3. Show a copyable command with realistic reserved values.
+4. Describe the expected output or artifact.
+5. Explain important failure modes and safety boundaries.
+
+Keep machine-readable output on stdout and diagnostics on stderr when you
+describe or change CLI behavior.
+
+## Review documentation changes
+
+Before you open a pull request:
+
+1. Read the changed pages as a new user, not as the implementation author.
+2. Check headings, links, lists, tables, code blocks, and example data.
+3. Confirm that commands and model IDs match the source.
+4. Regenerate command documentation when the command tree changes.
+5. Build the documentation site.
+
+```bash
+bash ./scripts/check-docs-examples.sh
+pnpm docs:build
+```
+
+For a command-tree change, also run:
+
+```bash
+./scripts/update-docs-command-reference.sh
+./scripts/check.sh
+```

--- a/docs/evaluation-packs.md
+++ b/docs/evaluation-packs.md
@@ -1,18 +1,18 @@
-# External Evaluation Packs
+# External evaluation packs
 
-External evaluation packs let a separate repository use mere.run's local model
+External evaluation packs let a separate repository use `mere.run`'s local model
 runtime, adapters, logprobs, scoring lifecycle, gates, and promotion receipts
-without moving that repository's content into mere.run.
+without moving that repository's content into `mere.run`.
 
 This is an ownership boundary, not a packaging convention:
 
-- mere.run owns the generic schema, validation, execution, checkpointing,
-  calibration, and receipt formats;
-- the external repository owns its questions, expected behavior, prompts,
-  policies, private datasets, personas, scorers, and release decisions;
-- packs are loaded from a path and are never copied into this repository or the
-  public model catalog;
-- the public source tree contains one synthetic fixture solely to test the
+- `mere.run` owns the generic schema, validation, execution, checkpointing,
+  calibration, and receipt formats.
+- The external repository owns its questions, expected behavior, prompts,
+  policies, private datasets, personas, scorers, and release decisions.
+- Packs load from a path and are not copied into this repository or the public
+  model catalog.
+- The public source tree contains one synthetic fixture solely to test the
   contract.
 
 The first version evaluates text-chat models and adapters. Existing image,
@@ -73,7 +73,7 @@ can require the manifest, completed status, and an exact base-model match with
 `adapter_requirements`; those checks connect training to qualification without
 moving the owning repository's corpus.
 
-## Pack Layout
+## Pack layout
 
 A pack is a directory with an `eval-pack.json` manifest. Case files are JSONL;
 prompt sets and an optional scorer executable are separate declared files.
@@ -112,14 +112,14 @@ set.
 
 Built-in assertion kinds are:
 
-- `contains` and `excludes`;
-- `regex` and `not-regex`;
+- `contains` and `excludes`.
+- `regex` and `not-regex`.
 - `valid-json-object`.
 
 Use assertions for mechanical checks. Use an external scorer for richer domain
 judgment.
 
-## Matched Arms and Adapter Comparisons
+## Matched arms and adapter comparisons
 
 The manifest declares named model and adapter slots rather than machine-local
 paths. An arm selects a model slot, optional adapter slot and scale, optional
@@ -136,9 +136,9 @@ the effects of an adapter and a prompt:
 The resulting report pins the model identity and the adapter content hash. It
 does not serialize a private pack path or adapter path into the plan.
 
-## Sampling and Logprobs
+## Sampling and logprobs
 
-Quality lanes should use a pinned, non-greedy profile and repeated trials. A
+For quality lanes, use a pinned, non-greedy profile and repeated trials. A
 temperature-zero lane is useful for compliance checks, replay, and narrow
 runtime comparisons; it is not a substitute for measuring a model's normal
 quality distribution.
@@ -152,18 +152,18 @@ Reports derive calibration diagnostics per arm/profile, including expected
 calibration error, selective accuracy, fragile passes, and confident failures.
 These diagnostics complement correctness gates; they do not replace them.
 
-## Scorers and Gates
+## Scorers and gates
 
 The built-in assertion scorer does not launch another process. An
 `external-process` scorer must be a declared, executable file inside the pack
-and is pinned with the rest of the pack. It is never run during validation or a
+and is pinned with the rest of the pack. It does not run during validation or a
 dry run. A real evaluation requires the explicit `--allow-external-scorer`
 authorization flag.
 
-The scorer is launched directly, never through a shell. Its environment is
+The scorer launches directly, not through a shell. Its environment is
 reduced to `HOME`, locale, `PATH`, and `TMPDIR`, so tokens and service-specific
 environment variables are not inherited. Temporary response files are private
-to the current user, and a timed-out scorer is forcibly reaped.
+to the process user, and a timed-out scorer is forcibly reaped.
 
 For each completed row, the scorer receives one versioned JSON request on
 standard input. It includes pack/case hashes, arm and profile IDs, trial, model
@@ -175,14 +175,14 @@ object containing:
 ```
 
 The runner enforces the pack's scorer timeout and caps output. A scorer can
-emit named metrics without exposing its rubric to mere.run.
+emit named metrics without exposing its rubric to `mere.run`.
 
 Gates aggregate filtered rows using `pass-rate`, `mean-score`,
 `hard-failure-count`, or `metric-mean` with `>=`, `<=`, or `==`. Filters can
 select splits, arms, profiles, and capability tags. Required gates determine
 promotion eligibility; optional gates remain visible diagnostics.
 
-## Public-Repository Boundary
+## Public-repository boundary
 
 `scripts/check-evaluation-boundary.sh` rejects tracked `eval-pack.json`
 manifests outside the synthetic contract fixture and rejects pack directories

--- a/docs/falcon-perception-disparity-report.md
+++ b/docs/falcon-perception-disparity-report.md
@@ -1,35 +1,39 @@
-# Falcon Perception Disparity Report
+# Falcon Perception disparity report
 
-Date: 2026-04-12
-Repo: `mere-run`
-Reference: `../mlx-vlm/mlx_vlm/models/falcon_perception`
+**Date:** 2026-04-12
+
+**Repository:** `mere-run`
+**Reference:** `../mlx-vlm/mlx_vlm/models/falcon_perception`
 
 ## Goal
 
-Trace the native Swift Falcon Perception path end to end, compare it to the `mlx-vlm`
-reference implementation, and identify the concrete disparities that explain why:
+This report traces the native Swift Falcon Perception path end to end, compares
+it with the `mlx-vlm` reference implementation, and identifies the disparities
+behind an incorrect grounding result. The recorded run used this command:
 
 ```bash
- mere.run vision ground ./test.jpeg --query "person"
+mere.run vision ground ./test.jpeg --query "person"
 ```
 
-currently returns clearly wrong results:
+The command returned these incorrect results:
 
 - `Detections: 55`
-- repeated centerline boxes with nearly identical `x`, `h`, and only slightly varying `y`
-- output written to:
+- Repeated centerline boxes with nearly identical `x` and `h` values and only
+  slightly different `y` values
+- Output written to:
   - `./test_grounded.jpeg`
   - `./test_grounded.json`
 
 Observed sample from the emitted JSON:
 
-- detection 0: `x=0.50048876`, `y=0.50048876`, `h=0.71263784`, `w=1`
-- detection 1: `x=0.56989247`, `y=0.50048876`, `h=0.71263784`, `w=0.038948007`
-- detections 2..19: mostly the same narrow centerline box repeated with tiny `y` shifts
+- Detection 0: `x=0.50048876`, `y=0.50048876`, `h=0.71263784`, `w=1`
+- Detection 1: `x=0.56989247`, `y=0.50048876`, `h=0.71263784`, `w=0.038948007`
+- Detections 2 through 19: mostly the same narrow centerline box, repeated
+  with small `y` shifts
 
 This is not “over-detecting people.” It is a malformed generation pattern.
 
-## E2E Trace
+## End-to-end trace
 
 ### 1. CLI entry
 
@@ -37,11 +41,11 @@ Swift path:
 
 - `Sources/MereRunCLI/Commands/VisionGroundCommand.swift`
 
-Behavior:
+The command:
 
-- resolves `vision-ground-falcon-perception` by default
-- constructs `FalconPerceptionGrounder`
-- calls `ground(imageURL:queries:...)`
+- Resolves `vision-ground-falcon-perception` by default.
+- Constructs `FalconPerceptionGrounder`.
+- Calls `ground(imageURL:queries:...)`.
 
 Status:
 
@@ -56,7 +60,7 @@ Swift paths:
 - `Sources/MereRunCore/FalconPerception/FalconPerceptionTokenizer.swift`
 - `Sources/MereRunCore/FalconPerception/FalconPerceptionConfig.swift`
 
-Model root used on this machine:
+The recorded run used this model root:
 
 - `<models-root>/vision-ground-falcon-perception`
 - symlink target:
@@ -110,26 +114,26 @@ Swift path:
 
 - `Sources/MereRunCore/FalconPerception/FalconPerceptionProcessor.swift`
 
-Reference behavior:
+The reference implementation:
 
-- resize shortest/longest into `256...1024`
-- smart-resize to patch multiples
-- normalize with mean/std `0.5`
-- prompt:
+- Resizes the shortest and longest dimensions into `256...1024`.
+- Resizes to patch multiples.
+- Normalizes with a mean and standard deviation of `0.5`.
+- Uses this prompt:
   `"<|image|>Segment these expressions in the image:<|start_of_query|>{query}<|REF_SEG|>"`
-- expand `<|image|>` into:
+- Expands `<|image|>` into:
   - `image_cls`
   - `image_reg_1...4`
   - repeated `img_id` patch tokens
   - `img_end_id`
 
-Swift behavior:
+The Swift implementation:
 
-- matches the same resize policy
-- matches the same smart-resize policy
-- matches the same normalization
-- matches the same prompt text
-- matches the same image-token expansion strategy
+- Matches the resize policy.
+- Matches the patch-aligned resize policy.
+- Matches the normalization.
+- Matches the prompt text.
+- Matches the image-token expansion strategy.
 
 Findings:
 
@@ -148,7 +152,7 @@ Swift paths:
 - `Sources/MereRunCore/FalconPerception/FalconPerceptionGrounder.swift`
 - `Sources/MereRunCore/FalconPerception/FalconPerceptionModel.swift`
 
-Reference behavior:
+The reference implementation:
 
 - precomputes:
   - `position_ids`
@@ -163,13 +167,13 @@ Reference behavior:
   - keeps `_full_attn_mask`
 - decode then derives positions from `cache_offset + rope_delta`
 
-Previous Swift behavior:
+Before the recorded fixes, the Swift implementation:
 
 - computed prefill position data
 - passed it during prefill
 - dropped the decode-time rope/position state on subsequent single-token decode
 
-Current Swift behavior:
+After the recorded fixes, the Swift implementation:
 
 - now stores prefill state on the language model
 - now clears only prefill-sized tables after prefill
@@ -235,7 +239,7 @@ Swift path:
 
 - `Sources/MereRunCore/FalconPerception/FalconPerceptionModel.swift`
 
-Reference behavior:
+The reference implementation:
 
 - each attention layer owns:
   - `self.sinks = mx.zeros((self.n_heads,))`
@@ -244,7 +248,7 @@ Reference behavior:
   - `scaled_dot_product_attention(q, k, v, cache=cache, scale=self.scale, mask=mask, sinks=self.sinks)`
 - `mlx-vlm` passes that through to MLX attention with sinks support
 
-Current Swift behavior:
+At the time of this report, the Swift implementation:
 
 - attention layer has:
   - `wqkv`
@@ -261,7 +265,7 @@ Current Swift behavior:
 
 Confirmed disparity:
 
-- The native Swift attention implementation ignores a serialized Falcon tensor family
+- The native Swift attention implementation ignored a serialized Falcon tensor family
   that the reference uses on every layer.
 
 Severity:
@@ -270,7 +274,7 @@ Severity:
 
 Reason:
 
-- This is the strongest remaining e2e mismatch between the reference model and the
+- This was the strongest remaining end-to-end mismatch between the reference model and the
   native port.
 - It affects the core language-model decoding loop, which is exactly where the malformed
   repeated box pattern is appearing.
@@ -285,13 +289,14 @@ Swift path:
 
 - `Sources/MereRunCore/FalconPerception/FalconPerceptionGrounder.swift`
 
-Comparison:
+Both implementations:
 
-- Both implementations:
-  - greedy sample `argmax(logits[:, -1, :])`
-  - interpret coord/size/seg from the hidden state of the previous step
-  - feed the sampled token back through token embedding
-  - inject encoded coord/size features when the sampled token is coord/size
+- Greedily sample `argmax(logits[:, -1, :])`.
+- Interpret coordinate, size, and segmentation values from the hidden state of
+  the previous step.
+- Feed the sampled token back through token embedding.
+- Inject encoded coordinate or size features when the sampled token represents
+  a coordinate or size.
 
 Finding:
 
@@ -309,12 +314,12 @@ Swift paths:
 Status:
 
 - AnyUp and segmentation feature plumbing were ported.
-- They are not the best explanation for the current failure because the malformed pattern
+- They are not the best explanation for the recorded failure because the malformed pattern
   is already visible at the box-generation stage before mask quality matters.
 
-## Fixed Disparities
+## Fixed disparities
 
-These were real bugs found during the trace:
+The trace found these bugs:
 
 1. Flat Hugging Face Falcon config decode
    - Native code originally assumed nested `text_config` / `vision_config`.
@@ -339,7 +344,7 @@ These were investigated but ruled out as the primary remaining cause:
    - Checkpoint header inspection shows those tensors do not exist in the Falcon weights.
    - Not the primary issue.
 
-## Open Disparities
+## Open disparities
 
 ### A. Attention sinks are missing end to end
 
@@ -365,7 +370,7 @@ Priority:
 Evidence:
 
 - reference uses `scaled_dot_product_attention(..., cache=cache, sinks=sinks)`
-- Swift currently implements attention manually
+- Swift implements attention manually
 
 Risk:
 
@@ -382,10 +387,12 @@ Priority:
 
 ### C. Weight-mapping audit should explicitly report skipped tensor families
 
-Current problem:
+Recorded problem:
 
-- `loadWeights` silently skips tensors whose mapped keys do not match a native parameter
-- this made the missing `attention.sinks` family invisible until direct header inspection
+- `loadWeights` silently skips tensors whose mapped keys do not match a native
+  parameter.
+- This behavior hid the missing `attention.sinks` family until direct header
+  inspection.
 
 Expected fix:
 
@@ -399,20 +406,21 @@ Priority:
 
 - P1
 
-## Most Likely Root Cause
+## Most likely root cause
 
 The highest-confidence root cause of the remaining bad grounding behavior is:
 
 1. Falcon attention sinks are serialized in the checkpoint.
 2. The `mlx-vlm` reference uses them in every attention call.
-3. The native Swift attention implementation currently ignores them completely.
+3. At the time of the report, the native Swift attention implementation ignored
+   them completely.
 4. The malformed output pattern is a generation-time failure, not a prompt-time or
    segmentation-time failure.
 
-That makes the missing sink-aware attention path the most important unresolved e2e
+That makes the missing sink-aware attention path the most important unresolved end-to-end
 disparity.
 
-## Recommended Next Patch Order
+## Recommended next patch order
 
 1. Add `attention.sinks` to `FalconPerceptionAttention`.
 2. Map `layers.*.attention.sinks` in checkpoint loading.
@@ -431,7 +439,7 @@ disparity.
    - whether the repeated centerline pattern disappears
 6. Add an audit command or debug mode that prints skipped checkpoint tensor families.
 
-## Appendix: Repro Evidence
+## Appendix: reproduction evidence
 
 Command:
 
@@ -439,7 +447,7 @@ Command:
 mere.run vision ground ./test.jpeg --query "person"
 ```
 
-Current native result:
+Recorded native result:
 
 - `Model: vision-ground-falcon-perception`
 - `Detections: 55`
@@ -452,9 +460,9 @@ Key artifact for inspection:
 
 Symptoms inside JSON:
 
-- repeated boxes centered around `x ~= 0.5005`
-- repeated `h ~= 0.7126`
-- many boxes differ only by small `y` deltas
+- Repeated boxes centered around `x ~= 0.5005`
+- Repeated `h ~= 0.7126`
+- Many boxes that differ only by small `y` deltas
 
 This is consistent with a broken decode/attention path, not with genuine multi-person
 grounding.

--- a/docs/gate.md
+++ b/docs/gate.md
@@ -1,17 +1,17 @@
 # Quality gate
 
-`mere.run gate` is the platform's flight recorder: it runs the real
+Use `mere.run gate` as the platform's flight recorder. It runs the real
 user-facing commands against the installed models at temperature 0, hashes
 their outputs, proves in-run determinism, and compares everything against
-machine-local baselines. It exists because a stale Metal library once shipped
-broken ≥1024-token decode to every clone for two months without anything
-noticing — the gate's text checks deliberately include a long-context lane in
-exactly that regime, and its determinism check would have caught the failure
-on the first nightly run.
+machine-local baselines. The gate exists because a stale Metal library once
+shipped broken decode for 1,024 or more tokens to every clone for two months
+without detection. Its text checks include a long-context lane in that regime,
+and its determinism check would have caught the failure during the first nightly
+run.
 
 ## What it checks
 
-| check | what it runs | hard-fails on |
+| Check | Operation | Failure conditions |
 | --- | --- | --- |
 | `text-*-short` / `text-*-long` | `text chat` at temp 0 (Gemma 4 12B, Ornith 35B, LFM2.5), long lane ≥1200 prompt tokens, each executed twice | run-to-run nondeterminism, empty output, output hash drift vs baseline |
 | `tts-wav` | `speech synthesize` at temp 0 | WAV hash drift, truncated audio |
@@ -23,14 +23,15 @@ on the first nightly run.
 | `video-ltx23-full-av` | 9-frame full two-stage LTX 2.3 render with generated audio | generation failure, MP4 decode failure, missing audio, or silent audio |
 | `video-ltx23-a2vid` | 9-frame full two-stage LTX 2.3 render conditioned on a generated non-silent WAV fixture | generation failure, MP4 decode failure, missing audio, or silent audio |
 
-Performance (wall time, `decode_tps` where the engine reports it) is compared
-against the baseline too: regressions beyond 0.75× tok/s or 1.5× wall are
+The gate also compares performance, including wall time and `decode_tps` when
+the engine reports it. Regressions beyond 0.75 times the tokens per second or
+1.5 times the wall time are
 warnings by default and failures with `--strict-perf` (suitable for a
-dedicated runner; on a shared workstation, background load makes hard perf
-gates noisy).
+dedicated runner). On a shared workstation, background load makes strict
+performance gates noisy.
 
-Checks whose models are not installed are skipped and reported. Every check
-shells out to the same `mere.run` binary that users run — the gate covers the
+If a model is not installed, the gate skips and reports its checks. Every check
+invokes the same `mere.run` binary that users run. The gate covers the
 CLI surface, model resolution, and the runtime together, not a parallel test
 path.
 
@@ -56,7 +57,7 @@ model:
 - every Woosh/MMAudio generator, CLAP, and Synchformer
 - every installed LTX, Wan, Cosmos3, SCAIL-2, and DreamX video/world model
 
-Component-only entries are not waved through as a family. Their report row
+The gate does not accept component-only entries as a family. Their report row
 names the true companion inference that consumes them. For example,
 Synchformer must be loaded by `sfx video generate`; DreamX must complete a
 queued `world serve` transition using its Wan base. If the required companion
@@ -99,10 +100,10 @@ so a release host cannot silently turn a required real-generation check into a
 skip. The three LTX checks cover the standalone draft checkpoint, the full
 generated-audio path, and the compatibility A2Vid model ID separately.
 
-The final packaged candidate must run `--all-installed` from the exact
+For the final packaged candidate, run `--all-installed` from the exact
 extracted CLI. The JSON report has one result per installed model ID. Compare
 `gate --all-installed --list` with `model list` before starting a long run if
-you need a quick inventory audit; the gate performs that mapping itself and
+you need an inventory audit. The gate performs that mapping itself and
 fails closed if it cannot account for an installed entry.
 
 A documented exceptional release quarantine can add
@@ -111,13 +112,13 @@ explicit `skipped` row; it is never counted as a pass. The option is valid only
 with `--all-installed`, and unknown or non-installed IDs fail closed.
 
 Baselines live at `~/Library/Application Support/MereRun/gate/baselines.json`.
-After an intentionally output-changing merge (sampler changes, model updates,
-scheduler changes), refresh them with `--update-baselines` — the failure
-message says so when a hash drifts.
+After a merge intentionally changes output, such as a sampler, model, or
+scheduler change, refresh the baselines with `--update-baselines`. The failure
+message also directs you to refresh them when a hash drifts.
 
-## Running it nightly
+## Run the gate nightly
 
-launchd (per-machine, recommended for workstations):
+For a per-machine workstation schedule, use `launchd`:
 
 ```xml
 <?xml version="1.0" encoding="UTF-8"?>
@@ -139,11 +140,14 @@ launchd (per-machine, recommended for workstations):
 </dict></plist>
 ```
 
-Save as `~/Library/LaunchAgents/run.mere.gate.plist`, then
-`launchctl load ~/Library/LaunchAgents/run.mere.gate.plist`.
+Save the file as `~/Library/LaunchAgents/run.mere.gate.plist`, and then run:
 
-GitHub Actions (requires a self-hosted Apple-silicon runner with models
-installed; the hosted runners have no GPU or model store):
+```bash
+launchctl load ~/Library/LaunchAgents/run.mere.gate.plist
+```
+
+To use GitHub Actions, configure a self-hosted Apple silicon runner with the
+models installed. Hosted runners do not have a GPU or model store.
 
 ```yaml
 name: quality-gate

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,23 +1,24 @@
-# Getting Started
+# Getting started
 
-By the end of this page you will have built the package from source, pulled a
-model, and generated your first image, paragraph, and spoken line — all on your
-own machine, with nothing leaving it.
+By the end of this page, you will have built the package from source, pulled a
+model, and generated your first image, paragraph, and spoken line. All inference
+stays on your machine.
 
 If you only want to use the app, install a signed build from
-[mere.run/releases](https://mere.run/releases) instead and jump straight to
-[Pull a model](#pull-a-model). Everything below is the from-source path.
+[mere.run releases](https://mere.run/releases) and go to
+[Pull a model](#pull-a-model). The remaining sections describe the from-source
+path.
 
 ## What you are building
 
 `mere-run` is one Swift package that produces:
 
-- the public `mere.run` executable — the CLI that does all the actual work
-- `mere.run.app`, an optional macOS studio that drives that same CLI rather
-  than a separate backend
-- reusable inference libraries in `Sources/MereRunCore`, `Sources/AudioCore`,
+- The public `mere.run` executable, which provides the command-line interface
+  (CLI) and performs the work
+- `mere.run.app`, an optional macOS studio that uses the same CLI
+- Reusable inference libraries in `Sources/MereRunCore`, `Sources/AudioCore`,
   `Sources/AudioCodecs`, `Sources/AudioSTT`, and `Sources/AudioTTS`
-- tests and smoke harnesses for both surfaces
+- Tests and smoke harnesses for both interfaces
 
 There is no hosted inference service behind it. Inference stays local; network
 access happens only for explicit operations such as model downloads,
@@ -27,21 +28,23 @@ installation and update checks, or Relay.
 
 For the supported macOS developer path:
 
-- Apple Silicon Mac
-- macOS 15 or newer
-- Xcode command line tools
+- An Apple Silicon Mac
+- macOS 15 or later
+- Xcode command-line tools
 - SwiftLint and ripgrep for `./scripts/check.sh`
   (`brew install swiftlint ripgrep`)
-- enough disk space for model installs in
+- Enough disk space for model installs in
   `~/Library/Application Support/MereRun/models`
 
 For Linux CLI compatibility work:
 
-- Swift 6.x toolchain
-- `clang`, `cmake`, `ninja`, `pkg-config`, `gfortran`, curl/zlib/OpenBLAS/LAPACK development headers
+- A Swift 6.x toolchain
+- `clang`, `cmake`, `ninja`, `pkg-config`, `gfortran`, and the curl, zlib,
+  OpenBLAS, and LAPACK development headers
 - `ffmpeg` and `ffprobe` for media probing and conversion
-- `gzip`, `unzip`, and `zip` for portable LoRA checkpoint archives
-- enough disk space for a headless model store
+- `gzip`, `unzip`, and `zip` for portable low-rank adaptation (LoRA)
+  checkpoint archives
+- Enough disk space for a headless model store
 
 On Ubuntu-style runners, the system package layer is:
 
@@ -69,8 +72,8 @@ app_path="$(./scripts/build_mere_run_app.sh debug)"
 open "$app_path"
 ```
 
-If all five succeed, the package resolves, the CLI builds and parses, and the
-Mac app bundles and opens. That is the whole toolchain proven in one pass.
+If all five commands succeed, the package resolves, the CLI builds and parses,
+and the Mac app bundles and opens.
 
 On Linux compatibility branches, keep the first pass headless and stop at the
 CLI surface:
@@ -83,10 +86,10 @@ The macOS app product is intentionally outside the Linux target.
 
 ## Launch the macOS studio
 
-The studio is a prompt-first face on the same CLI you just built — one canvas,
-one prompt bar, and a local library of everything you have made. The exact
-command behind each generation is always one click away under Advanced. Launch
-it from a checkout with:
+The Studio is a prompt-first interface for the CLI you built. It provides one
+canvas, one prompt bar, and a local library of generated artifacts. Open
+**Advanced** to see the exact command behind a generation. Launch the Studio
+from a checkout:
 
 ```bash
 app_path="$(./scripts/build_mere_run_app.sh debug)"
@@ -96,7 +99,7 @@ open "$app_path"
 For contributor smoke tests, `swift run mere.run.app` still builds the executable
 product, but the bundle script is the recommended local launch path for normal
 macOS window behavior. The app auto-detects a bundled CLI first, then nearby
-SwiftPM build products, common install locations, and finally the current
+Swift Package Manager build products, common install locations, and then the active
 package checkout. It does not silently install the terminal command on launch;
 open Settings and choose `Install CLI` or `Install Skill` when you want the
 bundled command or `use-mere-run` Codex skill copied into user-visible
@@ -116,26 +119,27 @@ final manual DMG install before future updates can arrive in-app.
 
 Linux package artifacts are headless CLI-only. They install the `mere.run` CLI
 plus colocated runtime assets; they do not include `mere.run.app`, SwiftUI
-studio flows, or the macOS DMG layout. For a Linux-only setup path, first
-commands, package checks, and CUDA validation limits, see
-[Linux QuickStart](./linux-quickstart.md).
+studio flows, or the macOS DMG layout. For Linux setup commands, package
+checks, and Compute Unified Device Architecture (CUDA) validation limits, see
+the [Linux quickstart](./linux-quickstart.md).
 
 ```bash
 scripts/package-linux.sh --version 0.23.0
 ls dist/linux/
 ```
 
-CUDA packages must be built and smoke-tested on matching CUDA hardware before
-being treated as supported. Linux arm64 packages are CUDA-only and should be
-built on a real arm64 CUDA host with `MERERUN_LINUX_ACCEL=cuda`; CPU arm64
-packages are local smoke artifacts, not useful release targets.
+Build and smoke-test CUDA packages on matching CUDA hardware before treating
+them as supported. Active release builds cover macOS and the configured
+`tensor.local` x86_64 CUDA builder. The arm64 CUDA release lane is paused while
+no matching build host is available. CPU arm64 packages are local smoke
+artifacts, not release targets.
 
 ## Understand the command tree
 
 Commands are organized by what you want to make — `image`, `text`, `speech`,
 `vision`, `music`, `sfx`, `video`, `world` — with separate families for running
 graphs, managing models, and serving. This table is generated from the CLI
-itself, so it always matches the binary you just built:
+itself, so it matches the binary you built:
 
 <!-- BEGIN GENERATED: CLI TOP LEVEL -->
 | Command | Purpose |
@@ -169,7 +173,7 @@ itself, so it always matches the binary you just built:
 | [`mere.run agent`](/getting-started) | Install and start the optional guided local setup agent. |
 <!-- END GENERATED: CLI TOP LEVEL -->
 
-For the full reference, see [CLI Reference](./cli.md).
+For all commands and options, see the [CLI reference](./cli.md).
 
 ## Choose a model store location
 
@@ -193,15 +197,14 @@ swift run mere.run --models-root /path/to/models model list
 
 ## Check local status
 
-Use `status` whenever you want a quick snapshot of this machine's mere.run
-state:
+Use `status` for a quick snapshot of this machine's mere.run state:
 
 ```bash
 swift run mere.run status
 ```
 
 It reports whether the local API server is reachable, which model the server
-currently exposes through `/v1/models`, the active model store, and the managed
+exposes through `/v1/models`, the active model store, and the managed
 models installed there. Use JSON output when scripting:
 
 ```bash
@@ -236,12 +239,13 @@ For guided onboarding, run:
 swift run mere.run setup
 ```
 
-The setup command offers a local Mere agent powered by Pi, a bring-your-own-agent
-handoff prompt for Claude/Codex, or manual commands. Use
+The setup command offers a local Mere agent powered by Pi, a
+bring-your-own-agent handoff prompt for Claude or Codex, or manual commands. Use
 `--mode agent --agent-model small` to select the tool-capable native Ornith 9B
-setup agent explicitly. On 96 GB+ Apple Silicon Macs, the hardware-tier and premier agent
-path selects DeepSeek V4 Flash as the preferred setup agent. On Linux, install
-or provide Pi separately with `--pi-path` or PATH before using `--start`.
+setup agent explicitly. On Apple Silicon Macs with at least 96 GB of unified
+memory, the hardware-tier and premier-agent path selects DeepSeek V4 Flash as
+the preferred setup agent. On Linux, install Pi or provide it with `--pi-path`
+or `PATH` before you use `--start`.
 
 ### Agent commands
 
@@ -250,7 +254,7 @@ the default subcommand:
 
 - `mere.run agent onboard` — summarize this machine's model capabilities and
   prepare the optional Pi agent
-- `mere.run agent install-pi` — install the latest Pi coding-agent release
+- `mere.run agent install-pi` — install the most recent published Pi coding-agent release
 - `mere.run agent start` — start Pi against a local mere.run setup-agent API
   server
 
@@ -268,8 +272,8 @@ Face and auto-installs Pi; pass `--no-bootstrap` to refuse both. Other
 
 ## Make something
 
-Each of these writes a real file to disk, and none of them depend on the
-others. Start wherever you are curious.
+Each command writes a file to disk and runs independently. Start with any
+modality.
 
 ### Image generation
 
@@ -353,8 +357,8 @@ MERERUN_RUN_E2E=installed ./scripts/check.sh
 
 ## What to read next
 
-- [CLI Reference](./cli.md) if you want command details
+- [CLI reference](./cli.md) if you want command details
 - [Configuration](./configuration.md) if you need to tune paths or runtime
   behavior
-- [Repository Tour](./repository-tour.md) if you want to work on the code
-- [Testing Guide](./testing.md) if you plan to contribute
+- [Repository tour](./repository-tour.md) if you want to work on the code
+- [Testing guide](./testing.md) if you plan to contribute

--- a/docs/graph/studio.md
+++ b/docs/graph/studio.md
@@ -1,14 +1,14 @@
 # Graph Studio
 
-Build workflows on a canvas instead of by hand in JSON. Mere Graph Studio is
-the visual authoring and operations surface for the current `mere.run` Graph v2
-runtime — either the hosted app at
+Use Mere Graph Studio to build workflows on a canvas instead of writing JSON by
+hand. Graph Studio is the visual authoring and operations surface for the
+`mere.run` Graph v2 runtime. Use either the hosted app at
 [studio.mere.run](https://studio.mere.run/) or the cross-platform Tauri 2
 desktop build for macOS, Windows, and Linux.
 
 Studio is a client, not a second engine. It authors exactly the typed graph,
 inputs, and immutable job bundle that the CLI validates and executes locally,
-over SSH, or through Relay — so anything you draw there runs headless
+over SSH, or through Relay. A workflow that you draw in Studio runs headless
 everywhere else, unchanged.
 
 ## Graph v2 versus `schema_version: 1`
@@ -17,8 +17,8 @@ Two version labels describe different layers:
 
 | Label | Meaning |
 | --- | --- |
-| Graph v2 | The current runtime generation: catalog-driven nodes, immutable bundles, preflight, parallel and resumable execution, providers, Relay placement, and typed artifacts. |
-| `schema_version: 1` | The stable serialized `mere.run/workflow-graph` ABI consumed by every current executor. |
+| Graph v2 | The runtime generation: catalog-driven nodes, immutable bundles, preflight, parallel and resumable execution, providers, Relay placement, and typed artifacts. |
+| `schema_version: 1` | The stable serialized `mere.run/workflow-graph` ABI consumed by every supported executor. |
 
 Do not change a workflow to `schema_version: 2`. Graph v2 intentionally keeps
 the version-1 document contract so the CLI, desktop Studio, hosted Studio,
@@ -37,7 +37,7 @@ The hosted site does not run models. Relay owns admission, scheduling, leases,
 retry state, and artifact delivery; the paired Node owns model execution. A
 stale worker cannot settle a newer attempt.
 
-Hosted execution currently accepts graphs whose inputs are JSON values. Use the
+Hosted execution accepts graphs whose inputs are JSON values. Use the
 desktop app for workflows that bind local files or directories; browser asset
 upload is a separate transport boundary and is not inferred from a machine-local
 path.
@@ -45,13 +45,13 @@ path.
 ### Desktop Studio
 
 The desktop app packages the React/XYFlow editor in a Rust and Tauri 2 shell.
-It is designed for:
+Use the desktop app for these tasks:
 
-- macOS, Windows, and Linux native installation;
-- local file and directory inputs;
-- local, SSH, and Relay execution;
-- offline authoring and local execution;
-- native project and run workspaces.
+- Install a native app on macOS, Windows, or Linux.
+- Bind local file and directory inputs.
+- Run workflows locally, over SSH, or through Relay.
+- Author workflows and run them locally while offline.
+- Manage native project and run workspaces.
 
 Desktop Studio requires a compatible `mere.run` executable for local execution.
 Optional workflow tools add templates, programs, and conservative ComfyUI
@@ -68,7 +68,7 @@ gate; the hosted app remains available without a desktop install.
 
 ## Authentication boundary
 
-Local Studio never requires Mere World sign-in. Launch, authoring, project
+Local Studio does not require Mere World sign-in. Launch, authoring, project
 save and load, catalog discovery, validation, preflight, and local execution
 remain available without an account or network connection when the required
 CLI and model assets are already installed.
@@ -100,9 +100,10 @@ editor sidecar   node positions, groups, notes, selections, view state
 program          optional higher-level map and branch authoring document
 ```
 
-Import and export use a `.meregraph.json` project package to carry those
+Studio import and export use a `.meregraph.json` project package to carry those
 documents together. Execution still materializes the canonical
-`mere.run/job-bundle.v1` files described in [Portable Workflows](../workflows.md).
+`mere.run/job-bundle.v1` files described in
+[Portable workflows](../workflows.md).
 
 ## Run from the CLI
 
@@ -114,7 +115,7 @@ mere.run graph preflight workflow.json --inputs-json inputs.json --executor loca
 mere.run graph run workflow.json --inputs-json inputs.json --run-dir ./runs/studio --json
 ```
 
-For a paired fleet, select the Relay executor in Studio or submit the same
+If you use a paired fleet, select the Relay executor in Studio or submit the same
 materialized bundle with `mere.run graph submit-job`. Run reports, events, and
 artifact hashes use the same contract in either client.
 
@@ -124,7 +125,7 @@ Studio does not keep a private hard-coded execution schema. Desktop Studio
 reads `mere.run graph catalog --json`; hosted Studio reads catalogs reported by
 connected Nodes through Relay. The catalog carries node fields, requirements,
 provider versions, and provider catalog digests, so an unavailable or outdated
-node is rejected during authoring or preflight instead of failing after queueing.
+node is rejected during authoring or preflight instead of failing after it is queued.
 
 The `mere.run` repository keeps its CLI and documentation synchronized through
 `DocumentationContractTests`. Graph Studio, Relay, and Node maintain shared

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,7 +46,8 @@ mere.run video generate "a drone flight over snowy peaks" --output flight.mp4
 mere.run vision image-to-3d-trellis2 ./mug.png --output ./mug-3d
 ```
 
-Same binary. Same grammar. No inference API key in any of them.
+Every command uses the same binary and grammar. None requires an inference API
+key.
 
 Start with `mere.run model capabilities` — it reads your hardware and tells you
 which models this machine can actually run before you spend a gigabyte finding
@@ -54,7 +55,7 @@ out.
 
 ## The full command surface
 
-All of it ships in that one executable. The table below is generated from the
+All of it ships in that one executable. This table is generated from the
 CLI itself, so it cannot drift from what your copy really does — and every row
 links to the page that owns that command.
 
@@ -96,44 +97,46 @@ links to the page that owns that command.
 
 Install, pull a first model, and make something in the next ten minutes.
 
-- [Getting Started](/getting-started)
-- [macOS Deep Links](/macos-deep-links) — preview or import local artifacts from launchers, automations, agents, and apps
-- [Linux QuickStart](/linux-quickstart)
-- [CLI Reference](/cli)
-- [Offline Cookbooks](/cookbooks) — `mere.run guide` works without a network
+- [Getting started](/getting-started)
+- [macOS deep links](/macos-deep-links) — preview or import local artifacts from launchers, automations, agents, and apps
+- [Linux quickstart](/linux-quickstart)
+- [CLI reference](/cli)
+- [Offline cookbooks](/cookbooks) — `mere.run guide` works without a network
 - [Configuration](/configuration)
-- [Model Sources](/model-sources)
+- [Model sources](/model-sources)
 
 ### Make things
 
 Each family is its own page: what it generates, which model to pull, and the
 flags that actually change the output.
 
-- [Image](/runtime/image) — text-to-image, edits, and local LoRA training
+- [Image generation](/runtime/image) — text-to-image, edits, and local LoRA training
 - [Text](/runtime/text) — chat, code, embeddings, tool use, PII redaction
 - [Speech](/runtime/speech) — synthesis, voice cloning, live transcription
 - [Vision and 3D](/runtime/vision) — caption, segment, track, depth, mesh, OCR
 - [Music](/runtime/music) — generation, covers, realtime MIDI, transcription
-- [Sound Effects](/runtime/sfx) — Foley from text or from a silent video
+- [Sound effects](/runtime/sfx) — Foley from text or from a silent video
 - [Video](/runtime/video) — clips with synchronized audio, subject animation
-- [Persistent Worlds](/runtime/world) — a scene that remembers where you walked
+- [Persistent worlds](/runtime/world) — a scene that remembers where you walked
 
 ### Put it to work
 
 Serve it, schedule it, measure it, and keep it honest.
 
-- [Portable Workflows, Executors, and Run Artifacts](/workflows)
-- [Model and Adapter Management](/runtime/model-management)
-- [Raycast Example Integration](/raycast) — one launcher client for the macOS deep-link routes
-- [Local API Server and Open WebUI](/runtime/api-server)
-- [Official Companion Plugins](/plugins)
-- [Quality Gate](/gate) — the check that catches a bad build before you do
+- [Portable workflows, executors, and run artifacts](/workflows)
+- [Model and adapter management](/runtime/model-management)
+- [Raycast example integration](/raycast) — one launcher client for the macOS deep-link routes
+- [Local API server and Open WebUI](/runtime/api-server)
+- [Official companion plugins](/plugins)
+- [Quality gate](/gate) — the check that catches a bad build before you do
 - [Benchmarking](/benchmarking)
 
 ### Work on the code
 
-- [Repository Tour](/repository-tour)
-- [Development Workflow](/development-workflow)
-- [Testing Guide](/testing)
-- [Architecture Reading Map](/architecture)
-- [CLI and Runtime Internals](/internals/cli-and-runtime)
+- [Repository tour](/repository-tour)
+- [Development workflow](/development-workflow)
+- [Testing guide](/testing)
+- [Documentation style](/documentation-style)
+- [Documentation style audit](/documentation-style-audit)
+- [Architecture reading map](/architecture)
+- [CLI and runtime internals](/internals/cli-and-runtime)

--- a/docs/internals/cli-and-runtime.md
+++ b/docs/internals/cli-and-runtime.md
@@ -1,16 +1,17 @@
-# CLI and Runtime Internals
+# CLI and runtime internals
 
 This page explains how the public `mere.run` command tree maps to the package
 internals.
 
 ## Top-level flow
 
-1. `Sources/MereRunCLI/MereRunCLI.swift` defines the public modality-first tree
-2. each command in `Sources/MereRunCLI/Commands` parses arguments and performs
-   small amounts of orchestration
-3. shared CLI helpers in `Sources/MereRunCLI/Support` bootstrap the model store,
-   expose the managed model registry, and provide output helpers
-4. runtime code in `MereRunCore`, `AudioSTT`, and `AudioTTS` does the actual work
+1. `Sources/MereRunCLI/MereRunCLI.swift` defines the public modality-first tree.
+2. Each command in `Sources/MereRunCLI/Commands` parses arguments and performs
+   small amounts of orchestration.
+3. Shared CLI helpers in `Sources/MereRunCLI/Support` bootstrap the model store,
+   expose the managed model registry, and provide output helpers.
+4. Runtime code in `MereRunCore`, `AudioSTT`, and `AudioTTS` performs the
+   inference work.
 
 The package is intentionally organized so public command concerns do not live in
 the deep model code.
@@ -81,7 +82,7 @@ That pattern is used heavily in:
 - `ACEStepPipeline`
 - `ImageValidateCommand`
 
-## When to start in the CLI vs the runtime
+## Choose the CLI or runtime starting point
 
 ### Start in the CLI when
 
@@ -95,10 +96,10 @@ That pattern is used heavily in:
 - you are debugging loading, decoding, or generation internals
 - you are working inside one modality family already
 
-## Recommended reading sequence for contributors
+## Contributor reading sequence
 
-1. [Repository Tour](../repository-tour.md)
-2. [Architecture Reading Map](../architecture.md)
-3. one command file in `Sources/MereRunCLI/Commands`
-4. the matching runtime family entrypoint
-5. the related tests in `Tests/`
+1. Read the [repository tour](../repository-tour.md).
+2. Read the [architecture map](../architecture.md).
+3. Read one command file in `Sources/MereRunCLI/Commands`.
+4. Read the matching runtime family entry point.
+5. Read the related tests in `Tests/`.

--- a/docs/internals/dit-performance.md
+++ b/docs/internals/dit-performance.md
@@ -1,10 +1,10 @@
-# DiT Forward-Pass Performance
+# DiT forward-pass performance
 
-Findings from the image-stack deep dive (July 2026, M4 Max 128 GB), asking why
-the diffusion-transformer denoise step — 91-96% of image generation wall time —
-appears to run at low hardware utilization, and which optimizations are worth
-carrying. Short version: the step is roofline-bound on GEMM/SDPA kernels;
-almost everything else was measured and rejected.
+This July 2026 report records an image-stack investigation on an M4 Max with
+128 GB of unified memory. The investigation asks why the diffusion-transformer
+denoise step, which represents 91% to 96% of image-generation wall time,
+appears to use little of the hardware. The step is roofline-bound on GEMM and
+SDPA kernels. Most other candidates were measured and rejected.
 
 The measurement harness lives in `Tests/MereRunCoreTests/DiTShapeBenchTests.swift`
 (env-gated, in-process, interleaved arms so ambient load hits both sides):
@@ -22,12 +22,12 @@ cp .build/arm64-apple-macosx/release/Resources/default.metallib \
    .build/arm64-apple-macosx/release/MereRunPackageTests.xctest/Contents/MacOS/mlx.metallib
 ```
 
-## Where a klein-nano step goes (1024², 4-bit, ~3.8 s/step)
+## Klein Nano step profile (1024², 4-bit, approximately 3.8 seconds per step)
 
 Cumulative-prefix timing of one single-block attention and block-count scaling
 of the full transformer close the ledger:
 
-| component | share of step |
+| Component | Share of step |
 | --- | --- |
 | fused projection + output GEMMs (4-bit qmm) | ~65% |
 | SDPA (`MLXFast.scaledDotProductAttention`) | ~15% |
@@ -53,7 +53,7 @@ lower resolution, or smaller models — not kernel work.
   microbench, 4-bit qmm costs 1.24-1.45x bf16 at DiT shapes and in-graph
   dequantize+GEMM looked ~20% faster. In the full model the effect inverts:
   transient dequant is +10% and cached dense weights +13% versus qmm
-  (paired in-process A/B, `testKleinNanoQmmVsDensePaired`). The microbench
+  (paired in-process comparison, `testKleinNanoQmmVsDensePaired`). The microbench
   win was a hot-cache artifact — an isolated op re-reads the same weights
   every iteration, while the real forward reads each layer's weights once,
   cold, where 4-bit's 4x-smaller weight traffic wins. Native qmm is the
@@ -98,14 +98,14 @@ the measured 14,958-row shape:
 scripts/h3-kernel-lab.sh quick
 ```
 
-The script reuses the release XCTest bundle while it is newer than `Package.swift`,
+The script reuses the release XCTest bundle while its modification time is later than `Package.swift`,
 `Sources/`, and `Tests/`; set `MERERUN_H3_LAB_REBUILD=1` to force a cold rebuild.
 
 The quick loop walks query chunk size, attention-head chunk size, and the number
 of Metal kernels queued before synchronization using coordinate descent. That
 keeps the default inner loop to about a dozen arms instead of a Cartesian sweep.
 It reports wall time, effective TFLOP/s, peak memory, and speedup relative to the
-current production schedule. Every arm is compared with that schedule using
+production schedule. Every arm is compared with that schedule using
 maximum absolute and relative-L2 error; a numerically divergent arm fails the
 test instead of becoming a runtime candidate.
 
@@ -211,7 +211,7 @@ against the default output before the dependency checkout was restored:
 The default was both fastest and bit-identical to its repeated control. The
 different-key-tile arms remained well inside the numerical gate but did not
 improve time. H3 is already using MLX's fused Steel full-attention path on M4;
-the NAX path is unavailable on this generation, and replacing Steel with a new
+the NAX path is unavailable on this generation, and replacing Steel with an
 approximate attention algorithm would be a model-math change rather than a
 runtime scheduling optimization.
 
@@ -259,7 +259,7 @@ one runner rather than multiplying compiled state for a small-shape-only win.
 Reproduce the release-mode comparison with `scripts/h3-kernel-lab.sh turnover`.
 
 The first valid ten-second geometry is 243 frames, which produces 72 video
-latent frames. At 1344x768, the locked benchmark prompt therefore packs 73,470
+latent frames. At 1344 x 768, the locked benchmark prompt therefore packs 73,470
 rows: 72,576 video rows, 810 audio rows, and 84 text rows. A phase ledger at
 that shape measured 32.645 seconds for one split block: 24.351 seconds (74.6%)
 in exact attention, 2.079 seconds in its input projection, and 4.424 seconds in
@@ -349,14 +349,14 @@ unattainable 36-TFLOP/s-perfect execution would require 5.872 seconds per block
 and 293.6 seconds per complete 50-block evaluation. Nineteen exact evaluations
 have a compute-only floor of about 93 minutes; the 417-block `maximum` schedule
 has a floor of about 40.8 minutes before VAE decode. This is an arithmetic
-lower bound, not a performance forecast, and shows why the current checkpoint
+lower bound, not a performance forecast, and shows why the evaluated checkpoint
 cannot reach a 30-minute ten-second render through exact dispatch tuning alone.
 
-The video VAE did retain a separate full-precision runtime win. Fresh-process released-
-checkpoint sweeps at 832x480 and 124 frames measured 96.091 s with 256-pixel
+The video VAE did retain a separate full-precision runtime win. Fresh-process
+released-checkpoint sweeps at 832 x 480 and 124 frames measured 96.091 seconds with 256-pixel
 tiles, 76.421 s with 320-pixel tiles, and 77.577 s with 480-pixel tiles. The
 320-pixel arm was 1.257x faster than the old default and reduced reported peak
-Metal memory from 9.85 to 8.91 GiB. At 1344x768 it decoded the same 124 frames
+Metal memory from 9.85 to 8.91 GiB. At 1344 x 768 it decoded the same 124 frames
 in 213.005 s at 15.12 GiB peak; the 480-pixel arm crossed 252 seconds without
 finishing and was stopped. The production default is therefore 320 pixels.
 The model, precision, causal tile algorithm, and overlap blend are unchanged;
@@ -417,7 +417,7 @@ summed values in the same online-softmax accumulator.
 
 The first two transformer layers, the first 20% of schedule evaluations, and
 the final evaluation remain dense. Production eligibility starts at 12,000
-packed rows. Before the first sparse layer at a new shape, an all-routes-dense
+packed rows. Before the first sparse layer at an unseen shape, an all-routes-dense
 sample compares the custom Metal result with fused SDPA; unsupported devices,
 dtypes, or a failed error envelope fall back to dense attention. On the real
 13,085-row checkpoint tensors, FP32 projection outputs staged through BF16 MMA
@@ -427,14 +427,14 @@ passed at `max_abs=0.10026`, `mean_abs=0.00219996`, and
 The bounded release benchmarks separate kernel throughput from artifact
 quality:
 
-| Input | Rows / prefix / heads | Dense | Sparse | Speedup | Routed blocks |
+| Input | Rows, prefix, and heads | Dense | Sparse | Speedup | Routed blocks |
 | --- | --- | ---: | ---: | ---: | ---: |
 | BF16 | 12,930 / 951 / 56 | 389 ms | 293 ms | 1.327x | 14.44% |
 | FP32 staged to BF16 MMA | 13,085 / 653 / 56 | 717 ms | 371 ms | 1.931x | 15.84% |
 
 Those random-tensor timings establish the execution win, not approximation
 quality. The acceptance boundary was a real fixed-seed LightX2V generation at
-768x448, 124 frames, 24 fps, and four transformer evaluations. Dense denoising
+768 x 448, 124 frames, 24 frames per second, and four transformer evaluations. Dense denoising
 took 631.826 seconds; dynamic sparse attention took 444.216 seconds, a measured
 29.7% reduction. The clean sparse step measured 101.294 seconds versus
 131.430 and 134.311 seconds for the comparable late dense steps. The final
@@ -455,7 +455,7 @@ block corruption. Native Parakeet transcribed both soundtracks as
 
 Exact attention scheduling and resident BF16 improve each native call, but H3
 still executes 50 sequential transformer blocks. The explicit `balanced` and
-`maximum` acceleration modes now execute block 1 on every schedule point and
+`maximum` acceleration modes execute block 1 on every schedule point and
 use its measured change to decide whether blocks 2 through 50 can be reused.
 A full refresh stores the target-only tail residual. The next candidate stacks
 four statistics into one host boundary: global and worst-time-slice relative
@@ -466,12 +466,12 @@ mode's envelope; otherwise the runtime executes all 50 blocks and refreshes.
 adjacent hits, and reserves the final two evaluations for complete refreshes.
 `maximum` uses the measured 0.30/0.40 envelope, admits at most four adjacent
 hits, and reserves the final evaluation. Both require two complete evaluations
-before reuse and apply the cached residual only to target rows, never the text
+before reuse and apply the cached residual only to target rows, not the text
 or media-condition prefix.
 
 The former fixed-depth scheduled-tail policy remains available solely for
 matched comparisons through `MERERUN_H3_CACHE_STRATEGY=scheduled-tail`. On the
-locked 416x256, 107-frame, 20-point resident-BF16 proxy, scheduled-tail ran 417
+locked 416 x 256, 107-frame, 20-point resident-BF16 proxy, scheduled-tail ran 417
 blocks in 222.220 seconds of denoise. Adaptive `maximum` ran 362 blocks in
 163.953 seconds: 26.2% less denoise time and 24.7% less end-to-end time. A
 conservative 0.12/0.18 calibration was explicitly rejected after it admitted
@@ -489,11 +489,11 @@ hash, and the important 124-frame duration boundary, is recorded in
 
 A first-order tail-residual extrapolation was also tested at the accepted
 four-cache-step block count. It added no meaningful runtime cost, but the
-same-seed 416x256 proxy fell from 0.688 SSIM against the exact trajectory to
+same-seed 416 x 256 proxy fell from 0.688 SSIM against the exact trajectory to
 0.583 and visibly shifted exposure and composition. The predictor was removed;
 maximum mode keeps the more faithful bounded stale residual.
 
-Lower-evaluation ODE math was tested on that same 416x256, 107-frame prompt and
+Lower-evaluation ODE math was tested on that same 416 x 256, 107-frame prompt and
 seed before any long render. A 12-point variable-step Adams-Bashforth candidate
 completed denoise in 314.742 seconds but reached only 0.667 SSIM and 19.22 dB
 PSNR against the 20-point Euler reference. Plain 12-point Euler was both faster
@@ -513,7 +513,7 @@ than an inference-only integrator swap.
 Spatial token reduction and depth pruning were also screened behind temporary
 laboratory controls, then removed. A KV-only candidate kept conditioning tokens
 exact, retained full-resolution keys and values for nearby video frames, and
-2x2-pooled only distant video keys and values. On the 416x256, 107-frame,
+2 x 2-pooled only distant video keys and values. On the 416 x 256, 107-frame,
 12-point proxy, a one-frame-radius arm measured 0.591 SSIM and 16.18 dB PSNR
 against dense 12-point Euler. A three-frame-radius arm improved that to 0.617
 SSIM and 16.73 dB and remained visually coherent, but still changed composition
@@ -531,7 +531,7 @@ three-frame arm. Combining the one-frame arm with an intentionally more
 aggressive 235-block reuse schedule fell to 0.488 SSIM and 15.21 dB and exposed
 a visible spatial lattice. None of those variants moved into production.
 
-Pooling 2x2 video queries as well as distant keys and values reduced the proxy
+Pooling 2 x 2 video queries as well as distant keys and values reduced the proxy
 one-evaluation denoise from 24.556 to 21.012 seconds, but the decoded result
 collapsed into large spatial blocks (0.444 SSIM, 10.39 dB). Executing alternate
 transformer layers was faster still, but both unscaled and 2x-residual-scaled

--- a/docs/internals/guarded-acceleration.md
+++ b/docs/internals/guarded-acceleration.md
@@ -1,4 +1,4 @@
-# Guarded Acceleration Audit
+# Guarded acceleration audit
 
 This audit separates acceleration paths that preserve model semantics from
 paths that change numerical precision, require checkpoint metadata, or only
@@ -26,7 +26,7 @@ dispatches.
 
 The decode path is enabled by default only when running on an Apple GPU with
 BF16/FP16 activations, input width divisible by 512, output width divisible by
-8, matching gate/up shapes, and the exact quantization contract above. The
+8, matching gate/up shapes, and the specified quantization contract. The
 prefill path is narrower: macOS 26, M4 Max `applegpu_g16s` or M5 Max
 `applegpu_g17s`, BF16, group-16 NVFP4, aligned projection dimensions, and at
 least 64 sequence tokens. A failed guard returns to the portable path. The
@@ -52,7 +52,7 @@ The shared-mask graph and eight-layer evaluation ladder are architecture-
 independent defaults. The exact residual/RMSNorm and QK-norm/RoPE fusions are
 M5 Max defaults and remain explicit opt-ins on M4 Max. Final-position slicing
 before the output norm and language-model head avoids projecting prompt rows
-that generation never consumes.
+that generation does not consume.
 
 The M5 Max default also prepares a decode-only group-32 affine INT8 Q/K/V side
 layout for the first 28 Laguna XS layers. It leaves checkpoint parameters,
@@ -98,7 +98,7 @@ bandwidth are at their physical limit.
 
 The ranked Laguna XS work contains both reusable execution ideas and kernels
 whose correctness depends on that checkpoint's exact shapes. Promotion across
-the catalog follows the matrix below; sharing an operator name is not enough.
+the catalog follows the portability matrix; sharing an operator name is not enough.
 
 This work originated in the public [MLX Fast Laguna XS 2.1
 challenge](https://mlx.fast/). Submission
@@ -106,21 +106,21 @@ challenge](https://mlx.fast/). Submission
 was promoted on July 30, 2026 with score `1.8435177465`, decode
 `7.089954 ms/token`, and prefill `0.240295 ms/token`, taking first place at
 the time of promotion under the official paired M5 Max validation. The
-production port retains only mechanisms compatible with mere.run's broader
+production port retains only mechanisms compatible with `mere.run`'s broader
 sampling, serving, capture, and concurrency contracts.
 
 | Ranked mechanism | Production status | Portability boundary |
 | --- | --- | --- |
 | Last-position terminal prefill | Shipped for guarded Laguna XS M5 execution | The graph idea can apply to decoder-only models whose caller consumes only the final logit row. Each engine must separately preserve every K/V row, cache offset, batch behavior, multimodal inputs, speculative/DFlash captures, and requested hidden states. |
-| Exact `[Q; gate]` and `[K; V]` projection banks | Shipped for the terminal Laguna XS BF16 layer | Combining independent output rows is generally valid for bias-free projections, but the current side banks require Laguna's 2,048-wide input, per-head gate, 128 head dimension, eight K/V heads, and 48/64 query-head layouts. Other engines need their own retained-memory and kernel-selection measurements. |
-| Retained affine INT8 Q/K/V side layout | Shipped for the officially validated first 28 XS decode layers on M5 Max | This changes projection precision and retains about 598.5 MiB. It is not an automatic catalog-wide optimization. Every new checkpoint, layer mask, and hardware generation needs token/behavior gates, quality evidence, bounded-memory proof, and paired timing. |
+| Exact `[Q; gate]` and `[K; V]` projection banks | Shipped for the terminal Laguna XS BF16 layer | Combining independent output rows is generally valid for bias-free projections, but the existing side banks require Laguna's 2,048-wide input, per-head gate, 128 head dimension, eight K/V heads, and 48/64 query-head layouts. Other engines need their own retained-memory and kernel-selection measurements. |
+| Retained affine INT8 Q/K/V side layout | Shipped for the officially validated first 28 XS decode layers on M5 Max | This changes projection precision and retains about 598.5 MiB. It is not an automatic catalog-wide optimization. Each additional checkpoint, layer mask, and hardware generation needs token and behavior gates, quality evidence, bounded-memory proof, and paired timing. |
 | Fused routed/shared down projection and residual | Shipped only behind exact XS shape, dtype, quantization, scaling, and M5-default guards | The implementation assumes hidden width 2,048, expert intermediate width 512, top-8 routing, group-16 NVFP4, 256 experts, fixed 2.5 scaling, and the existing BF16 reduction order. Other MoE models need model-specific kernels rather than relaxed guards. |
 | Fused NVFP4 gate/up plus SwiGLU | Shipped for guarded Laguna layouts; LFM2 has a separate affine-8 implementation | The reusable idea is avoiding repeated routed activations. Quantization codes, scales, group size, tile geometry, activation dtype, and output alignment remain engine-specific. |
 | Sorted expert routing, fast inverse scatter, and expert-aligned prefill tiles | Shipped for Laguna with portable fallbacks | The ordering/locality idea is reusable across MoE runtimes. It must be benchmarked per route count and expert geometry; short verification and concurrent decode can lose more to sorting than they gain from locality. |
 | Shared masks, bounded asynchronous evaluation, residual/RMSNorm, and QK-norm/RoPE fusion | Shipped within Laguna under independent controls | These are the broadest graph-level candidates. A cross-engine port still must preserve mask semantics, RoPE offsets, materialization/cast boundaries, capture behavior, and the engine's own scheduling break-even point. |
-| Retained base-weight layouts with runtime adapters | Laguna invalidates native affine QKV and terminal projection banks when a text LoRA loads | This lifecycle rule applies across model families: any cached, fused, packed, or requantized weight representation must be rebuilt from the wrapped module or discarded when an adapter replaces its source projection. Gemma's fused projection cache already keys reuse to source-module identity; new retained layouts need an equivalent contract before adapter support ships. |
+| Retained base-weight layouts with runtime adapters | Laguna invalidates native affine QKV and terminal projection banks when a text LoRA loads | This lifecycle rule applies across model families: any cached, fused, packed, or requantized weight representation must be rebuilt from the wrapped module or discarded when an adapter replaces its source projection. Gemma's fused projection cache already keys reuse to source-module identity; additional retained layouts need an equivalent contract before adapter support ships. |
 | Challenge expert-gather threadgroup expansion | Not transplanted literally | Production Laguna already assigns actual sorted expert tiles independently. The ranked change lived in the challenge's pinned MLX/vendor path; this repository does not modify vendored runtime code merely to copy its launch constant. |
-| Certified/approximate lm-head pruning and packing | Deliberately excluded | The challenge only had to preserve the greedy winner. mere.run exposes temperature, top-k, min-p, structured output, and DFlash paths that consume the logit distribution. Approximating non-winning logits would change public sampling semantics. |
+| Certified/approximate lm-head pruning and packing | Deliberately excluded | The challenge only had to preserve the greedy winner. `mere.run` exposes temperature, top-k, min-p, structured output, and DFlash paths that consume the logit distribution. Approximating non-winning logits would change public sampling semantics. |
 
 An additional rollout is allowed only after the same revision, prompt corpus,
 seed, and token budget pass the portable fallback and candidate paths with:
@@ -146,7 +146,7 @@ before the host confirms the preceding token. The final token-budget boundary
 samples without scheduling an unused forward. This keeps immediate EOS and
 short budgets bounded without draining the GPU queue between ordinary tokens.
 
-A matched release-mode gate on 2026-07-11 used the managed
+A matched release-mode gate on July 11, 2026, used the managed
 `LiquidAI/LFM2.5-8B-A1B-MLX-8bit@984aa3f` checkpoint, a fixed prompt, greedy
 sampling, and 96 output tokens on an M4 Max with 128 GB unified memory. The
 three-run median was 63.25 decode tokens/s versus 62.47 for the pre-change
@@ -209,12 +209,12 @@ after latent attention, retaining only the shared latent and decoupled RoPE key.
 
 For representative dimensions (32 heads, rank 512, 128 no-PE dimensions, 64
 RoPE dimensions, and 128 value dimensions), resident elements per token per
-layer fall from 10,240 to 1,088, a 9.4x structural reduction. Weight absorption
+layer fall from 10,240 to 1,088, a 9.4-times structural reduction. Weight absorption
 reassociates floating-point operations and keeps dequantized projection weights
 resident, so the default remains off pending a real-checkpoint quality corpus.
 
 ```bash
-# Force for an A/B run.
+# Force a comparison run.
 MERERUN_PSI_COMPRESSED_MLA=1 swift run mere.run text chat \
   --model text-chat-psi-agent --temperature 0 --prompt "..."
 
@@ -226,7 +226,7 @@ MERERUN_PSI_COMPRESSED_MLA_MIN_PROMPT_TOKENS=2048 \
 
 ### Psi sparse-MoE dispatch
 
-The Psi expert loader now starts with packed placeholder tensors instead of
+The Psi expert loader starts with packed placeholder tensors instead of
 constructing enormous dense random expert tensors that are immediately
 replaced by quantized checkpoint arrays. Long routed batches sort expert rows
 before gather matmul. `MERERUN_PSI_FUSED_MOE=1` additionally stacks gate/up
@@ -240,7 +240,7 @@ end-to-end gain.
 The relevant Qwen3.8 runtime techniques were reviewed against the native Swift
 implementation:
 
-| Technique | mere.run disposition |
+| Technique | `mere.run` disposition |
 | --- | --- |
 | Structural streamed XML tool parsing | Adopted with bounded reparsing and adversarial literal-tag tests. |
 | Native Qwen3.8 reasoning effort | Adopted as `low`, `medium`, and `xhigh`, with explicit Pi aliases. |
@@ -250,7 +250,7 @@ implementation:
 | Conv3d vision weight conversion | Already present for both MLX and PyTorch layouts. |
 | Embedded and mounted MTP weights | Already present for official `mtp.*` shards and the managed `mtp/model.safetensors` component. |
 | One-block scaled dot-product attention | Already present through one `MLXFast.scaledDotProductAttention` call per full-attention layer. |
-| Private ANE/GPU hybrid prefill | Research only. It depends on a private fixed-shape ANE runtime and a separate native extension, so production mere.run does not depend on or advertise it. |
+| Private ANE/GPU hybrid prefill | Research only. It depends on a private fixed-shape ANE runtime and a separate native extension, so production `mere.run` does not depend on or advertise it. |
 
 The ANE path may be reconsidered only with a public supported runtime contract,
 fixed-shape parity, failure fallback, and matched end-to-end measurements. Its
@@ -290,13 +290,13 @@ before any automatic wide-chunk promotion.
 
 ## Not honestly promotable
 
-| Candidate | Current blocker |
+| Candidate | Blocker |
 | --- | --- |
 | Activation quantization | MLX exposes quantized weight matmul, not a native activation-quantized attention/MoE contract. Quantize-then-dequantize would add kernels and quality loss without reducing the following operation. |
 | MTP on every text model | Speculation requires a compatible draft head/model and verifier integration. Model metadata such as a next-token-layer count is not sufficient; unrecognized draft weights are not silently loaded. |
 | Distilled steps on base diffusion checkpoints | Step distillation is checkpoint training, not a scheduler shortcut. Applying four-step schedules to base weights is a quality regression. |
 | Compressed MLA outside Psi | Qwen and Gemma use GQA/hybrid attention rather than an MLA latent. The DeepSeek V4 Flash managed lane is an external native binary, so its internal cache cannot be changed in this Swift runtime. |
-| Automatic Psi MLA/fused-MoE | Structural and algebraic tests pass, but no public Psi checkpoint is managed for repeatable output-quality and throughput A/B. Both controls remain explicit. |
+| Automatic Psi MLA/fused-MoE | Structural and algebraic tests pass, but no public Psi checkpoint is managed for repeatable output-quality and throughput comparisons. Both controls remain explicit. |
 
 ## Promotion gate
 
@@ -312,7 +312,7 @@ swift test --filter 'AffineQuantizedKVCacheTests|GLM47AccelerationTests'
 ```
 
 When the managed LFM2 checkpoint is installed, run the gated real-checkpoint
-greedy parity A/B on a GPU device:
+greedy parity comparison on a GPU device:
 
 ```bash
 MERERUN_TEST_GUARDED_ACCELERATION_CHECKPOINTS=1 \

--- a/docs/internals/source-layout.md
+++ b/docs/internals/source-layout.md
@@ -1,6 +1,7 @@
-# Source Layout Reference
+# Source layout reference
 
-This page is a concise reference for where each major subsystem lives.
+Use this reference to find the public target, test suite, or operational file
+that owns your change.
 
 ## Public package targets
 
@@ -25,9 +26,9 @@ Main areas:
 - `VLM/`: vision-language model support
 - `ZImageI2L/`, `ZImageTurbo/`: image-family support
 
-Linux CLI compatibility should enter through reusable core surfaces here, not
-through app bundle code. Media-tool discovery belongs behind typed APIs and
-should honor `MERERUN_FFMPEG`, `MERERUN_FFPROBE`, and then `PATH`.
+Implement Linux CLI compatibility through reusable core surfaces, not app
+bundle code. Keep media-tool discovery behind typed APIs, and resolve
+`MERERUN_FFMPEG`, then `MERERUN_FFPROBE`, and then `PATH`.
 
 ### `AudioCore`
 
@@ -62,11 +63,11 @@ The public executable target.
 - `Commands/`
 - `Support/`
 
-This is the product Linux compatibility work should exercise.
+Exercise product Linux compatibility through this target.
 
 ### `MereRunApp`
 
-The optional SwiftUI studio target. It stays macOS-only and should not become a
+The optional SwiftUI Studio target. It stays macOS-only and must not become a
 Linux compatibility dependency.
 
 ## Tests
@@ -93,6 +94,6 @@ Use this for:
 - `scripts/check.sh`: main validation gate
 - `scripts/e2e_smoke.sh`: installed-model smoke runner
 - `vendor/llama.xcframework`: vendored native dependency for code and API paths
-- `vendor/mlx-swift_Cmlx.bundle`: macOS MLX shader resources; hosted Linux CI
-  should use CPU MLX-sized fixtures, while Linux arm64 package validation needs
+- `vendor/mlx-swift_Cmlx.bundle`: macOS MLX shader resources. Hosted Linux CI
+  uses CPU MLX-sized fixtures, while Linux arm64 package validation requires
   the CUDA path on real arm64 CUDA hardware

--- a/docs/internals/structured-runs-preflight-actions.md
+++ b/docs/internals/structured-runs-preflight-actions.md
@@ -1,13 +1,15 @@
-# Structured Runs, Preflights, and Declarative Actions
+# Structured runs, preflights, and declarative actions
 
-This document defines the headless-first run contract for
-`mere.run`: structured `--json` output, cheap `--preflight` checks, and
-declarative next actions that can later power optional local UIs without making
-the UI the source of behavior.
+This document defines the headless-first run contract for `mere.run`:
+structured `--json` output, low-cost `--preflight` checks, and declarative next
+actions that can power optional local user interfaces (UIs) without making a
+UI the source of behavior.
 
-The immediate goal is not to build another standing app surface. The goal is to
-make every substantial command able to describe what it will do, what it did,
-what artifacts it produced, and what the caller can safely do next.
+The contract lets each substantial command describe what it will do, what it
+did, which artifacts it produced, and what the caller can safely do next.
+
+The implementation-phase sections are retained as a design record. The public
+contract and acceptance criteria remain normative.
 
 ## Product thesis
 
@@ -71,8 +73,8 @@ Every feature must work from the CLI and be useful to:
 
 ### stdout is contract, stderr is diagnostics
 
-This repo already treats stdout as machine-readable output and stderr as
-diagnostic progress. The new JSON surfaces must preserve that contract.
+This repository treats standard output as machine-readable output and standard
+error as diagnostic progress. JSON surfaces must preserve that contract.
 
 When `--json` is set:
 
@@ -84,8 +86,8 @@ When `--json` is set:
 
 ### Typed contracts
 
-All output contracts should be typed Swift structs with `Codable` conformance.
-Avoid ad hoc dictionaries. This keeps tests, docs, and future UI clients aligned
+Use typed Swift structures with `Codable` conformance for all output contracts.
+Avoid ad hoc dictionaries. This keeps tests, documentation, and UI clients aligned
 with compiler-checked fields.
 
 ### Stable but evolvable schemas
@@ -130,7 +132,7 @@ and API keys must be masked.
 
 Add or normalize `--json` across commands that produce structured state.
 
-For commands that currently print a single path or human text, `--json` should
+For commands that print a single path or human text, `--json` should
 emit an envelope and keep the existing default output unchanged.
 
 Example:
@@ -268,7 +270,7 @@ mere.run run cancel relay://fleet/<job-id> --json
 mere.run run retry relay://fleet/<job-id> --json
 ```
 
-The public schemas live under `/schemas/`. See [Portable Workflows](../workflows.md)
+The public schemas live under `/schemas/`. See [Portable workflows](../workflows.md)
 for the complete graph, bundle, executor, worker, and run-directory contract.
 
 ## JSON envelope
@@ -439,9 +441,9 @@ logs/
 
 Required files:
 
-- `run.json`: latest run envelope and request summary.
+- `run.json`: most recent run envelope and request summary.
 - `events.jsonl`: append-only event stream.
-- `actions.json`: next actions valid for the current run state.
+- `actions.json`: next actions valid for the active run state.
 - `plan.json`: normalized executable request, when the run came from a saved
   plan.
 
@@ -477,17 +479,17 @@ mere.run image train-lora \
   --json
 ```
 
-Should:
+The command must:
 
-1. resolve CLI options and named recipes
-2. inspect dataset files and captions
-3. validate output path and parent directory
-4. resolve model id or model path without pulling large missing models
-5. estimate training image buckets
-6. estimate memory and disk footprint when possible
-7. report known incompatibilities
-8. emit diagnostics and actions
-9. exit before loading the full training runtime
+1. Resolve CLI options and named recipes.
+2. Inspect dataset files and captions.
+3. Validate the output path and parent directory.
+4. Resolve the model ID or model path without pulling large missing models.
+5. Estimate training image buckets.
+6. Estimate memory and disk footprint when possible.
+7. Report known incompatibilities.
+8. Emit diagnostics and actions.
+9. Exit before loading the full training runtime.
 
 ### Preflight checks
 
@@ -630,9 +632,9 @@ Resource estimates:
 Deliverables:
 
 - this planning document
-- inventory of current commands with existing `--json` support
+- Inventory of commands with existing `--json` support
 - inventory of commands where preflight is valuable
-- list of current output conventions that must not break
+- List of existing output conventions that must not break
 
 Likely files:
 
@@ -645,7 +647,7 @@ Likely files:
 Acceptance:
 
 - no behavior changes
-- document reviewed against current command tree
+- Document reviewed against the command tree
 
 ### Phase 1: shared typed contracts
 
@@ -734,7 +736,7 @@ Behavior matrix:
 
 | Flags | Behavior |
 | --- | --- |
-| none | current behavior |
+| none | Existing behavior |
 | `--json` | final success emits structured run result, if feasible in this phase |
 | `--preflight` | human-readable preflight summary |
 | `--preflight --json` | structured preflight report |
@@ -799,7 +801,7 @@ Docs should show:
 
 Acceptance:
 
-- docs examples use repo-relative paths
+- Documentation examples use repository-relative paths
 - no workstation-specific paths
 - no stale model IDs
 
@@ -908,7 +910,7 @@ The result should include:
 - suggested upload/submission actions
 - local run metadata for later readback import
 
-Relay integration can then live in the relay repo:
+Relay integration can then live in the relay repository:
 
 - client API accepts graph job payloads
 - scheduler matches graph requirements to online node capabilities
@@ -944,7 +946,7 @@ warning-level `legacy_manifest` summary instead of treating the directory as an
 opaque blocker. Unknown or corrupt manifests still block inspection.
 
 Run-directory inspection also emits a compact `metrics` summary derived from
-loss CSVs and discovered artifacts, so clients can show latest loss, step range,
+loss CSVs and discovered artifacts, so clients can show the most recent loss, step range,
 sample count, checkpoint count, and adapter count without parsing artifact
 files themselves.
 
@@ -960,7 +962,7 @@ Viewer rule:
 - viewer buttons render declarative actions
 - viewer does not invent hidden command behavior
 
-There is no generic run-view command. The current viewer entrypoint is
+There is no generic run-view command. The supported viewer entrypoint is
 `mere.run image visualize-run` for compatible local image-training runs. Other
 clients should build views from `mere.run run inspect --json` and the same
 reports, events, metrics, artifacts, and declarative actions that the CLI
@@ -1014,17 +1016,17 @@ Rules:
 
 ## Compatibility
 
-The implementation should be additive.
+The implementation must be additive.
 
 Must preserve:
 
-- current default stdout behavior
-- current `--quiet` behavior unless explicitly documented
-- current `--visualize` behavior
+- Existing default stdout behavior
+- Existing `--quiet` behavior unless explicitly documented
+- Existing `--visualize` behavior
 - existing LoRA run directories
-- existing docs examples until the new feature lands
+- Existing documentation examples until the feature lands
 
-The first PR should not require users to change existing commands.
+The first pull request must not require users to change existing commands.
 
 ## Open decisions
 
@@ -1041,7 +1043,7 @@ The first PR should not require users to change existing commands.
 5. Should the run directory contract live in `MereRunCLI` or `MereRunCore`?
    Recommended: start in `MereRunCLI/Support`; move shared artifact/event types
    lower only if runtimes need to write them directly.
-6. Should graph jobs enter relay as a new first-class work kind or as a
+6. Should graph jobs enter relay as a separate first-class work kind or as a
    tool-style request carrying a `mere.run/workflow-graph` payload? Recommended:
    first-class long-term, tool-style only as a compatibility bridge.
 7. Should `mere.run` submit directly to relay? Recommended: no for the public
@@ -1053,15 +1055,15 @@ The first PR should not require users to change existing commands.
    plugin nodes only when their manifests declare typed inputs, outputs, and
    artifact behavior.
 
-## PR sequencing
+## Pull request sequencing
 
-### PR 1: contract and LoRA preflight JSON
+### Pull request 1: contract and LoRA preflight JSON
 
 Scope:
 
 - shared typed envelope, diagnostics, actions
 - `image train-lora --preflight --json`
-- tests and docs for the new preflight path
+- Tests and documentation for the preflight path
 
 Avoid:
 
@@ -1069,15 +1071,15 @@ Avoid:
 - viewer changes
 - cross-command adoption
 
-### PR 2: LoRA run actions and normalized files
+### Pull request 2: LoRA run actions and normalized files
 
 Scope:
 
 - write `run.json` and `actions.json` for LoRA training
 - keep existing viewer working
-- add compatibility tests for old and new run dirs
+- Add compatibility tests for both run-directory formats
 
-### PR 3: model and image generation preflights
+### Pull request 3: model and image generation preflights
 
 Scope:
 
@@ -1095,7 +1097,7 @@ Scope:
 - redacted start-server, status, model-store, and pull actions
 - shared model availability diagnostics
 
-### PR 4: long-running media commands
+### Pull request 4: long-running media commands
 
 Scope:
 
@@ -1110,7 +1112,7 @@ Scope:
 - `start-sfx-video-generation`, `pull-model`, `pull-synchformer`, input reveal, and output actions
 - benchmark commands where useful
 
-### PR 5: run inspection
+### Pull request 5: run inspection
 
 Scope:
 
@@ -1118,7 +1120,7 @@ Scope:
 - generic `run inspect --json` readback for run directories, report files, and
   plan files
 
-### PR 6: workflow graph contract
+### Pull request 6: workflow graph contract
 
 Scope:
 
@@ -1135,7 +1137,7 @@ Avoid:
 - visual graph editor
 - private relay assumptions
 
-### PR 7: local graph run and relay job export
+### Pull request 7: local graph run and relay job export
 
 Scope:
 
@@ -1143,14 +1145,14 @@ Scope:
 - graph parent run directory with child node reports
 - `graph export-job --target relay`
 - asset manifest and capability requirement payload
-- docs describing how an external relay should consume the payload
+- Documentation that describes how an external relay consumes the payload
 
 Avoid:
 
-- embedding relay auth or hosted scheduling in this repo
+- Embedding relay authentication or hosted scheduling in this repository
 - requiring a GPU node for local tests
 
-### PR 8: optional viewer refresh
+### Pull request 8: optional viewer refresh
 
 Scope:
 
@@ -1179,7 +1181,7 @@ The first milestone is complete when:
 This turns `mere.run` into a better headless runtime without expanding the
 standing UI surface.
 
-The runtime becomes easier to drive from scripts, Codex, remote workers, and
-small local dashboards. Bad runs fail earlier. Good runs explain themselves.
+Scripts, Codex, remote workers, and small local dashboards can drive the runtime
+through one contract. Invalid runs fail earlier. Valid runs explain themselves.
 Optional UIs can appear later as faithful renderers of structured truth instead
 of becoming a second workflow engine.

--- a/docs/ios-studio.md
+++ b/docs/ios-studio.md
@@ -4,39 +4,39 @@ The iOS app (`apps/ios/`) combines the portable relay client established by host
 Graph Studio with a constrained on-device runtime. It can submit and watch
 fleet work, fetch verified artifacts, connect directly to a machine, or run
 supported image and chat models on a physical iPhone. `apps/ios/README.md` covers
-building.
+the build process.
 
-## Two lanes
+## Choose an execution lane
 
-1. **Relay lane (primary).** Full capability comes from the paired fleet: the
-   phone speaks the same authenticated HTTPS + JSON job API as the CLI's
+1. **Relay lane (primary).** Use a paired fleet for the full capability set. The
+   phone uses the same authenticated HTTPS and JSON job API as the CLI's
    relay executor, gets its node catalog from the fleet through relay (the
-   hosted-Studio pattern — never from local discovery, which needs process
+   hosted-Studio pattern. It does not use local discovery, which requires process
    spawning that iOS forbids), and reads the same `graph-event-v1` /
    `graph-run-v1` documents published in `docs/public/schemas/`.
-2. **On-device lane (experimental).** `MereRunCore` builds for iOS; the app's
+2. **On-device lane (experimental).** `MereRunCore` builds for iOS. The app's
    image and chat modes offer "This iPhone" alongside the fleet and install
    managed models into the app sandbox. These paths require a physical device;
    a simulator build is portability evidence, not inference proof. Sizing:
-   small models genuinely fit Pro-class devices —
+   small models fit Pro-class devices. For example,
    the Bonsai image binary (4B, 1-bit, ~3.4 GB) runs through the same FLUX.2
    Klein pipeline that already has a memory-constrained iOS generator in
    `MereRunCore` (`Flux2KleinGeneratoriOS`, ~2 GB peak via sequential
    loading), and `text-chat-bonsai-27b-1bit` (~5.1 GB, Apache-2.0,
    vision-capable) targets 12 GB+ devices with the increased-memory
-   entitlement. The current app links the broad `MereRunCore` target; a
+   entitlement. The app links the broad `MereRunCore` target; a
    narrower mobile runtime remains a build-time and binary-size optimization.
-   CI builds only the active simulator architecture so test coverage does not
+   CI builds only the selected simulator architecture so test coverage does not
    accidentally turn into a universal two-architecture product-size proxy.
 
-## What exists today
+## Components
 
 - `Sources/MereRunRelayKit` — the portable client half of relay execution,
   extracted from `MereRunCLI`: executor profiles and references, OAuth
   device-grant authentication, the graph-job/fleet HTTP client with verified
   artifact fetch, the workflow wire types, and SSE event-text normalization.
-  Foundation + swift-crypto only; builds and tests on Linux; the CLI consumes
-  it with unchanged behavior.
+  It depends only on Foundation and swift-crypto, builds and tests on Linux,
+  and preserves CLI behavior.
 - `apps/ios/` — the SwiftUI client: PKCE and device-code relay sign-in, direct
   machine pairing, fleet and run views, polled events/progress, cancel/retry,
   verified artifact fetch and sharing, Live Activities, and on-device model
@@ -55,10 +55,11 @@ building.
   from the worker probe, and pins models from the fleet's installed list.
   Provider-qualified nodes stay excluded on iOS, and modes whose required
   inputs are assets wait for the photo/file picker step.
-- **Phase B — chat (landed).** Route chat to the selected transport: on-device
+- **Phase B — chat (landed).** The app routes chat to the selected transport:
+  on-device
   small models when present, a machine reached directly when paired (the
   `mere.run relay serve` direct lane — the app's "Connect to a machine"
-  pairing serves the full job vocabulary over the LAN or a tailnet with no
+  pairing serves the full job vocabulary over a LAN or tailnet with no
   cloud hop, superseding the earlier `api serve`-over-LAN idea), relay jobs
   otherwise. Token streaming
   *through relay* is an additive event-type revision, not an architecture
@@ -67,16 +68,16 @@ building.
   implementation — but `graph-event-v1` is a closed schema, so a
   `node_output_delta` event needs a coordinated contract revision with the
   relay and node repositories' shared fixtures.
-- **Phase C — on-device models (experimental).** The managed Bonsai/Liquid
+- **Phase C — on-device models (experimental).** The managed Bonsai and Liquid
   lane above is gated by device RAM and available storage. Model payloads use
   one fixed, system-owned background session, so the active file can continue
   while the app is suspended. The app durably records the requested install,
   rejoins matching system tasks after relaunch, stages completed payloads out
-  of URLSession's temporary directory, and then resumes the normal pinned
-  snapshot and final validation pipeline. A user-initiated download currently
+  of URLSession's temporary directory, and then resumes the pinned
+  snapshot and final validation pipeline. A user-initiated download
   defaults to unmetered, unconstrained Wi-Fi. Users can explicitly allow
-  cellular, expensive, and constrained networks before starting a download;
-  that choice is recorded with the pending install so a relaunch cannot
+  cellular, expensive, and constrained networks before starting a download.
+  The app records that choice with the pending install so a relaunch cannot
   silently change the transfer policy.
 
 ## On-device lifecycle
@@ -84,27 +85,27 @@ building.
 - Chat warmup remains immediate, but resident chat or image state is released
   after two idle minutes, when the selected chat model or inference lane
   changes, when the app enters the background, and on an iOS memory warning.
-- A lifecycle release never interrupts active inference. It is deferred until
-  the current image or chat request finishes, and the engine rejects another
+- A lifecycle release does not interrupt active inference. The app defers it until
+  the active image or chat request finishes, and the engine rejects another
   request while release is in progress.
-- Removing an installed model unloads all runtime state before deleting its
+- When you remove an installed model, the app unloads all runtime state before deleting its
   install and reclaiming only cache payloads not referenced by another model.
-- iOS may relaunch the app to deliver background-session events. The app
+- iOS might relaunch the app to deliver background-session events. The app
   reconnects that session through its application delegate and resumes every
   durable pending install. Explicit user force-quit behavior remains controlled
   by iOS and is not treated as a supported continuation path.
-- Live Activity polling is single-owner per job. Transient request failures use
+- Each job has one owner for Live Activity polling. Transient request failures use
   bounded exponential backoff; persistent failures end the activity instead of
   leaving an immortal poller behind. Unpairing cancels all outstanding pollers.
-- Refreshing a run's artifacts stages and validates the complete new result
+- Refreshing a run's artifacts stages and validates the complete replacement result
   beside the existing result, then atomically replaces it. A failed refresh
   leaves the last verified local copy intact.
 - Privacy copy follows the selected execution lane: on-device work stays on the
-  phone, a direct-machine lane names that machine connection, and hosted relay
+  phone, a direct-machine lane names that machine connection, and a hosted relay
   work describes the authenticated relay/fleet path rather than claiming every
   remote request is local-only.
 
-## iOS-specific follow-ups
+## Follow-up work
 
 - Keychain-backed credential storage and Authorization Code + PKCE sign-in
   (done: `ASWebAuthenticationSession` over the broker's advertised
@@ -112,7 +113,7 @@ building.
   tokens in the Keychain with file→Keychain migration; the device grant
   remains as the browserless fallback).
 - Artifact downloads stream to disk with digest verification (done);
-  incremental in-flight hashing remains a refinement.
+  incremental in-flight hashing remains planned.
 - Physical-device interruption coverage still needs a release-signed run that
   backgrounds the app during a real multi-gigabyte model pull, verifies
   relaunch reattachment, and observes runtime memory returning after eviction.
@@ -123,11 +124,11 @@ building.
 
 ## Release footprint
 
-A clean arm64 Release-simulator build on 2026-08-19 measured 75.4 MiB
+A clean arm64 release simulator build on 2026-08-19 measured 75.4 MiB
 uncompressed, including a 68.3 MiB main executable and a 4.3 MiB MLX Metal
 library. The unused llama.cpp binary dependency is macOS-only. This is not an
 App Store download-size measurement, but it confirms that the broad
-`MereRunCore` closure is the main compile-time and binary-size cost. CI now
+`MereRunCore` closure is the main compile-time and binary-size cost. CI
 rejects a non-arm64-only simulator executable and caps that executable at 80
 MiB. Extracting the image/chat/model storage surface into a narrower mobile
 runtime remains a separate architectural optimization; a facade that still
@@ -135,7 +136,7 @@ depends on `MereRunCore` would not reduce the dependency closure.
 
 ## Boundaries
 
-The wire shapes in `MereRunRelayKit` are the published contract. Anything the
-iOS app needs that would change those shapes — new event types, new job
-fields — is a cross-repository contract revision first, an app feature
-second. The app never gains a private schema.
+The wire shapes in `MereRunRelayKit` are the published contract. If the iOS app
+needs different shapes, revise the cross-repository contract before you add the
+app feature. This requirement applies to fields, event types, and similar
+changes. The app does not use a private schema.

--- a/docs/linux-quickstart.md
+++ b/docs/linux-quickstart.md
@@ -1,17 +1,17 @@
-# Linux QuickStart
+# Linux quickstart
 
-Installing or building the headless `mere.run` CLI on Linux.
+Use this guide to install or build the headless `mere.run` CLI on Linux.
 
 Be clear about what you are getting. The Linux path is real but deliberately
 narrow: CLI only, Ubuntu-style hosts, and CUDA on x86_64 or arm64. There is no
 CPU-only Linux release and no studio app here; macOS remains the primary
-development and runtime-validation environment for this repo.
+development and runtime-validation environment for this repository.
 
 Nothing is treated as supported until it has been built and smoke-tested on the
-host class it targets — CUDA artifacts on real CUDA hardware, never a
-cross-build taken on faith.
+host class it targets. Validate CUDA artifacts on real CUDA hardware; do not
+treat a cross-build as runtime proof.
 
-## Current validation boundary
+## Validation boundary
 
 - Linux package artifacts are headless CLI-only.
 - Package validation must cover the portable tarball, Debian package, runtime
@@ -19,11 +19,11 @@ cross-build taken on faith.
 - CUDA package validation must include a real CUDA GPU host.
 - Linux packages do not include `MereRun.app`, the SwiftUI studio, the macOS
   installer UI, or the DMG layout.
-- Published Linux package builds must use `MERERUN_LINUX_ACCEL=cuda` on both
-  x86_64 and arm64. CPU builds are test fixtures, not release artifacts.
-- NVIDIA GB10/DGX Spark is a valid arm64 CUDA target when the package is built
-  and smoke-tested on matching hardware.
-- Current CUDA validation should be treated as limited to the exact hosts that
+- Published Linux package builds must use `MERERUN_LINUX_ACCEL=cuda`. CPU
+  builds are test fixtures, not release artifacts.
+- Active release builds use the configured `tensor.local` x86_64 CUDA builder.
+  The arm64 CUDA lane is paused while no matching build host is available.
+- CUDA validation applies only to hosts that
   have run the CUDA package and smoke path.
 
 ## Install with apt
@@ -90,8 +90,8 @@ mere.run --version
 mere.run status
 ```
 
-The CUDA tarball is the right build pack for companion remote-runner plugins.
-It is not a source/bootstrap archive and should not compile on paid GPU time.
+Use the CUDA tarball as the build pack for companion remote-runner plugins.
+It is not a source or bootstrap archive and must not compile on paid GPU time.
 No CPU-only tarball is published.
 
 ## First commands
@@ -108,7 +108,7 @@ mere.run status
 ```
 
 Use `mere.run model capabilities` before pulling large checkpoints. It gives a
-machine-local view of the recommended public model IDs for the current host.
+machine-local view of the recommended public model IDs for the host.
 
 ## Media commands
 
@@ -141,7 +141,7 @@ ls dist/linux/
 On rented GPU builders, keep paid compile time down by setting
 `MERERUN_NATIVE_BUILD_JOBS` to the worker's real vCPU count and
 `MERERUN_CUDA_ARCHITECTURES` to the target build policy. For example, an RTX
-A4000 builder that should also ship forward-compatible H100 PTX can use:
+A4000 builder that must also ship forward-compatible H100 PTX can use:
 
 ```bash
 MERERUN_LINUX_ACCEL=cuda \
@@ -161,7 +161,7 @@ publish or recommend CPU-only arm64 packages as release artifacts.
 Build arm64 packages on a native arm64 Linux host with an NVIDIA GPU, driver,
 CUDA Toolkit, `nvcc`, CUDA CCCL headers, cuDNN, NCCL, Swift,
 OpenBLAS/LAPACK headers, and `ffmpeg` available. On NVIDIA's Ubuntu 24.04 SBSA
-repo this includes `cuda-cccl-13-0`, `libcudnn9-dev-cuda-13`, and
+repository this includes `cuda-cccl-13-0`, `libcudnn9-dev-cuda-13`, and
 `libnccl-dev`:
 
 ```bash
@@ -199,21 +199,23 @@ Linux Swift toolchain, then builds the CMake CUDA bridge from that exact
 `mlx-swift` checkout. This keeps the bridge aligned when an older Swift
 toolchain selects a compatibility revision different from a Mac checkout.
 `MLX_SWIFT_CUDA_COMMIT` is available only as a deliberate maintainer diagnostic
-override; normal source builds should use the SwiftPM-selected revision.
+override. Standard source builds must use the SwiftPM-selected revision.
 
 Do not describe a CUDA configuration as supported unless it has been run on that
 matching host.
 
-### Spark CUDA smoke status
+### Historical Spark CUDA smoke receipt
 
-The arm64 CUDA smoke path has been validated on NVIDIA GB10/DGX Spark after
+The arm64 CUDA smoke path was validated on NVIDIA GB10/DGX Spark after
 installing the package and pulling public managed models. MLX-backed image,
 speech, vision, music, SFX, video, embedding, anonymization, and dense Gemma
-chat paths are expected to run there with the packaged CUDA setup. The packaged
+chat paths ran with the packaged CUDA setup. This receipt does not make Spark
+an active release builder. The arm64 lane remains paused until a compatible
+host is available for a fresh build and smoke test. The packaged
 Linux CUDA build also carries the matching `llama-cli`; `mere.run text code`
 uses that subprocess on Linux so GGUF coding models do not share a process with
-MLX CUDA. If a future CUDA run fails inside an upstream MLX or llama.cpp kernel,
-keep that failure in the release notes or PR description until the exact package
+MLX CUDA. If a later CUDA run fails inside an upstream MLX or llama.cpp kernel,
+keep that failure in the release notes or pull request description until the exact package
 has been rebuilt and rerun on matching hardware.
 
 Quantized MLX paths default to `MERERUN_MLX_CUDA_NATIVE_QUANT=auto`: each
@@ -233,7 +235,7 @@ sudo apt-get install -y cmake ninja-build pkg-config gfortran libcurl4-openssl-d
 
 CUDA package builds also require CMake 3.25 or newer because the CUDA bridge
 build follows upstream `mlx-swift`. On Ubuntu 22.04/Jammy images, install a
-newer CMake before running the CUDA package path:
+CMake 3.25 or later before running the CUDA package path:
 
 ```bash
 sudo apt-get install -y python3-pip

--- a/docs/ltx25-upstream-parity.md
+++ b/docs/ltx25-upstream-parity.md
@@ -1,20 +1,21 @@
 # LTX 2.5 upstream parity
 
-mere.run implements the official LTX 2.5 inference family directly in Swift
+`mere.run` implements the official LTX 2.5 inference family directly in Swift
 and MLX. It does not launch Python, PyTorch, a sidecar, or an upstream script.
 
 The compatibility target is immutable:
 
-- code: `Lightricks/LTX-2` release `v1.2.0`, commit
+- **Code:** `Lightricks/LTX-2` release `v1.2.0`, commit
   `d151147788a9284cca791edc6ce898007e727fe6`
-- weights: `Lightricks/LTX-2`, revision
+- **Weights:** `Lightricks/LTX-2`, revision
   `dd53cc2cd45bbeaa3563dfb575cba3f49cf44761`
-- DFR detailer: `Lightricks/LTX-2.5-22b-IC-LoRA-Pixel-Spatial-Upscaler`,
+- **DFR detailer:** `Lightricks/LTX-2.5-22b-IC-LoRA-Pixel-Spatial-Upscaler`,
   revision `74c4e68ee7dd99f3997d5a1bb1a3784941822222`
 
 When `--width` and `--height` are omitted, recipe-native geometry is preserved:
-1536x1024 for standard two-stage, keyframe interpolation, and DFR; 1920x1088
-for HQ; and 768x512 for dev one-stage. Explicit dimensions always win.
+1536 x 1024 for standard two-stage, keyframe interpolation, and DFR;
+1920 x 1088 for HQ; and 768 x 512 for dev one-stage. Explicit dimensions take
+precedence.
 
 ## Install
 
@@ -40,7 +41,7 @@ does not prove that every checkpoint file is installed.
 
 ## Pipeline matrix
 
-| Official pipeline | Native mere.run surface | Coverage |
+| Official pipeline | Native `mere.run` surface | Coverage |
 | --- | --- | --- |
 | Distilled two-stage | `video generate --model video-ltx25-distilled-bf16` | Ancestral distilled schedule, x2 latent upsampling, generated AV or video-only |
 | Dev plus distilled-LoRA two-stage | `video generate --model video-ltx25-full-bf16` | Guided dev stage, runtime LoRA fusion, distilled refinement |
@@ -56,7 +57,7 @@ does not prove that every checkpoint file is installed.
 | Dub-It | `video dub-it` | Reference video identity plus clean negative-time reference audio, original fractional FPS |
 | Text-to-audio | `audio generate` | Audio-only denoising and decode with CFG/STG, LoRA, custom sigma, and DurationHead controls |
 
-The upstream repository has twelve entry-point files but thirteen rows here
+The upstream repository has twelve entry-point files but thirteen table rows
 because generated keyframes are an independently testable checkpoint feature
 shared by multiple official pipelines.
 
@@ -64,17 +65,18 @@ shared by multiple official pipelines.
 
 The native surface includes the model-affecting upstream controls:
 
-- arbitrary finite LoRA strengths, including zero and negative weights;
-- explicit descending sigma schedules, Euler ancestral sampling, HQ Res2s,
-  Bong math controls, and independent random streams;
-- video/audio CFG, STG, rescale, modality guidance, block selection, and skip
-  intervals;
-- native Gemma 4 prompt enhancement and precomputed text contexts;
+- Arbitrary finite LoRA strengths, including zero and negative weights.
+- Explicit descending sigma schedules, Euler ancestral sampling, HQ Res2s,
+  Bong math controls, and independent random streams.
+- Video and audio CFG, STG, rescale, modality guidance, block selection, and skip
+  intervals.
+- Native Gemma 4 prompt enhancement and precomputed text contexts.
 - DurationHead prediction. Omitting `--num-frames` on supported LTX 2.5
-  generation uses the official 1–20 second range; an explicit frame count wins;
-- fractional frame rates. The same value drives temporal RoPE, audio length,
-  retake masks, and the encoded MP4 clock;
-- convolutional or diffusion video VAE decode, explicit spatial tiling, HDR
+  generation uses the official 1–20 second range; an explicit frame count takes
+  precedence.
+- Fractional frame rates. The same value drives temporal RoPE, audio length,
+  retake masks, and the encoded MP4 clock.
+- Convolutional or diffusion video VAE decode, explicit spatial tiling, HDR
   transfer, half-float EXR output, and BT.2020/HLG Main10 masters.
 
 `--image` and `--end-image` remain convenient first/last-frame aliases. Use
@@ -127,7 +129,7 @@ and computed versus reused transformer stacks.
 
 The residual-reuse policy follows the
 [TeaCache paper](https://arxiv.org/abs/2411.19108) and
-[official implementation](https://github.com/ali-vilab/TeaCache), with new
+[official implementation](https://github.com/ali-vilab/TeaCache), with calibrated
 coefficients measured against the pinned LTX 2.5 checkpoint and this native
 transformer rather than copied from an older LTX release.
 
@@ -147,14 +149,14 @@ model capabilities, and therefore have no one-for-one Apple-Silicon switch:
 | multi-GPU runners | Apple Silicon uses one unified-memory device |
 
 The upstream HDR command also accepts a directory for batch convenience.
-mere.run exposes the full single-item model workflow through CLI, Studio, and
+`mere.run` exposes the full single-item model workflow through CLI, Studio, and
 the local API; shell or graph workflows provide batching without a second
 inference implementation.
 
-## API and Studio
+## API and Studio integration
 
 `POST /v1/videos/generations` accepts the same flags through its `options`
-object, so new model controls do not require a parallel Python schema. The
+object, so additional model controls do not require a parallel Python schema. The
 macOS Studio exposes primary LTX 2.5 controls directly and retains an extra
 arguments field for the complete CLI surface. Capabilities advertise native
 LTX 2.5, source/reference media, audio-video output, HDR, Retake, Dub-It, and

--- a/docs/macos-deep-links.md
+++ b/docs/macos-deep-links.md
@@ -1,4 +1,4 @@
-# macOS Deep Links
+# macOS deep links
 
 MereRun.app exposes two typed local handoff routes through the `mererun://`
 scheme. A launcher, automation, agent, or another macOS app can preview an
@@ -13,7 +13,7 @@ only and cannot open MereRun Studio.
 Open one existing readable file in MereRun's native Quick Look panel:
 
 ```text
-mererun://preview?path=%2FUsers%2Fme%2FDesktop%2Fresult.png
+mererun://preview?path=%2FUsers%2Fdana%2FDesktop%2Fresult.png
 ```
 
 Build the URL with a URL-components API so the absolute path is percent encoded
@@ -21,7 +21,7 @@ exactly once. From a shell, an already encoded link can be passed to Launch
 Services with `open`:
 
 ```bash
-open 'mererun://preview?path=%2FUsers%2Fme%2FDesktop%2Fresult.png'
+open 'mererun://preview?path=%2FUsers%2Fdana%2FDesktop%2Fresult.png'
 ```
 
 The target may be an image, audio, video, text, or Quick Look-compatible 3D
@@ -35,7 +35,7 @@ move, or modify the artifact.
 JSON receipt:
 
 ```text
-mererun://library/import?receipt=%2FUsers%2Fme%2FLibrary%2FApplication%20Support%2FMyLauncher%2Fimports%2F5cb7dc90-a9d4-4634-a486-0b8140226b42.json
+mererun://library/import?receipt=%2FUsers%2Fdana%2FLibrary%2FApplication%20Support%2FExampleLauncher%2Fimports%2F5cb7dc90-a9d4-4634-a486-0b8140226b42.json
 ```
 
 A version 1 receipt contains the completed local run metadata MereRun needs:
@@ -47,21 +47,21 @@ A version 1 receipt contains the completed local run metadata MereRun needs:
   "source": "raycast",
   "kind": "image",
   "prompt": "a ceramic coffee mug in soft morning light",
-  "artifactPath": "/Users/me/MereRun/Artifacts/mere-image-result.png",
+  "artifactPath": "/Users/dana/MereRun/Artifacts/mere-image-result.png",
   "createdAt": "2026-08-01T22:42:07Z"
 }
 ```
 
-Version 1 currently accepts the `raycast` source and the typed `image`,
+Version 1 accepts the `raycast` source and the typed `image`,
 `video`, `music`, and `speech` kinds. The source vocabulary is intentionally
-strict even though the deep-link transport is not coupled to Raycast. New
-maintained clients should add a source case and contract tests before emitting
-receipts under a new source name.
+strict even though the deep-link transport is not coupled to Raycast. Before a
+maintained client emits receipts under another source name, add a source case
+and contract tests.
 
 MereRun validates the receipt and referenced artifact, deduplicates repeated
 handoffs, records the completed result through its own Library store, activates
 the matching workspace, reveals Library, and selects the imported row. The
-caller must never read or write `library.json` directly.
+caller must not read or write `library.json` directly.
 
 ## Local and security boundaries
 

--- a/docs/macos-studio-roadmap.md
+++ b/docs/macos-studio-roadmap.md
@@ -1,10 +1,13 @@
-# MereRun macOS Studio — Review & Roadmap to v1.0
+# MereRun macOS Studio historical review and v1.0 roadmap
 
-_Verified multi-agent review of `apps/macos/MereRunStudio` (~6,500 LOC) against the CLI source of truth (`Sources/MereRunCLI`) and the bundling pipeline. Findings below were adversarially re-checked against source; refuted/adjusted claims were dropped or down-graded._
+This page preserves a historical source review of `apps/macos/MereRunStudio`
+(approximately 6,500 lines of code) against the CLI source of truth in
+`Sources/MereRunCLI` and the bundling pipeline. The implementation update
+identifies which findings no longer describe the product.
 
-> **Implementation update (2026-07-27):** This document preserves the original
-> pre-parity audit and sequencing rationale. The capability gaps described below
-> are no longer the current product state. The app now consumes the shared
+> **Implementation update (July 27, 2026):** This document preserves the original
+> pre-parity audit and sequencing rationale. The capability gaps in the
+> historical findings no longer describe the product. The app consumes the shared
 > machine-readable 89-command capability contract and has executable drift tests
 > for every local Advanced template. Studio provides typed Text, Image, Video,
 > Music, Speech, SFX, Vision/VFX, adapter, run, world, setup, model, plugin,
@@ -12,12 +15,12 @@ _Verified multi-agent review of `apps/macos/MereRunStudio` (~6,500 LOC) against 
 > external boundaries. Structured receipts, file pickers, validation, retry and
 > resume controls are implemented. See
 > [`apps/macos/README.md`](../apps/macos/README.md) for the
-> current surface. On 2026-07-27, the release pipeline produced a Developer
+> implemented surface. On July 27, 2026, the release pipeline produced a Developer
 > ID-signed and Apple-notarized app and DMG, both passed Gatekeeper and stapler
 > validation, and the installed app completed a real image-generation workflow
-> through its embedded CLI. The findings and phases below are retained as the
-> historical audit that motivated the implementation; they are not a statement
-> of current capability or release readiness.
+> through its embedded CLI. The remaining findings and phases are retained as the
+> historical audit that motivated the implementation. They are not a statement
+> of product capability or release readiness.
 
 ## Historical verdict (superseded by the implementation update)
 
@@ -29,79 +32,97 @@ of tests). The missing work was concentrated exactly where "finished" lives:
 it could not ship (ad-hoc signed, no notarization, a camera-permission crash),
 and core modes dead-ended (audio/video showed an icon, chat was one-shot, and
 downloads showed a wall of logs). Those claims are historical and superseded by
-the implementation update above.
+the implementation update.
 
 ### Dimension scorecard
 
 | Dimension | State | Headline problem |
 |---|---|---|
-| Architecture & orchestration | **55%** | Output detected by scanning stdout for paths that `fileExists`, not the CLI's `--json`/`--quiet` contract; engine hard-capped at one run; UTF-8 chunks silently dropped |
-| UX & interaction | **45%** | Speak/Music/Video dead-end on an icon; chat single-shot; spinner-only progress; library has no search/delete; Read Image opens on a blocked action |
-| Feature parity vs CLI | **62%** | `sfx`, `music realtime`/`analyze`, `config`, `status`, `plugin`, `open-webui`, `benchmark`, `guide` have zero GUI; chat omits tools/vision; voice cloning unwired |
-| Native platform | **28%** | Ad-hoc signed, no entitlements, no `NSCameraUsageDescription` while shipping `vision track-live` (TCC kill); child processes orphaned on quit; hardcoded dark; no a11y |
-| Visual & polish | **55%** | Strong identity, but 1210px Advanced panel jammed in a 560px viewport; invalid `Image(systemName: "finder")`; no semantic tokens; native controls clash in light mode |
-| Build & distribution | **30%** | Hand-rolled bundle, executables under `Contents/Resources` (notarization-fatal), no DMG/notarization step despite README promising one, no macOS CI |
+| Architecture and orchestration | **55%** | Output detected by scanning stdout for paths that `fileExists`, not the CLI's `--json` or `--quiet` contract; engine hard-capped at one run; UTF-8 chunks silently dropped |
+| UX and interaction | **45%** | Speak, Music, and Video dead-end on an icon; chat single-shot; spinner-only progress; library has no search or delete; Read Image opens on a blocked action |
+| Feature parity compared with the CLI | **62%** | `sfx`, `music realtime`, `music analyze`, `config`, `status`, `plugin`, `open-webui`, `benchmark`, and `guide` have no GUI; chat omits tools and vision; voice cloning unwired |
+| Native platform | **28%** | Ad hoc signed, no entitlements, no `NSCameraUsageDescription` while shipping `vision track-live` (TCC termination); child processes orphaned on quit; hardcoded dark theme; no accessibility coverage |
+| Visual and polish | **55%** | Strong identity, but 1,210-pixel Advanced panel placed in a 560-pixel viewport; invalid `Image(systemName: "finder")`; no semantic tokens; native controls clash in light mode |
+| Build and distribution | **30%** | Hand-built bundle, executables under `Contents/Resources` (notarization failure), no DMG or notarization step despite the README claim, and no macOS CI |
 
 ---
 
-## Historical ship-blockers (resolved)
+## Historical release blockers (resolved)
 
 1. **Camera TCC crash.** `vision track-live` → `SAM31CameraCapture` opens `AVCaptureDevice`, but the generated `Info.plist` has no `NSCameraUsageDescription`. Because the CLI runs as a child of `MereRun.app`, TCC attributes camera access to the app bundle → process is terminated with no prompt. _(scripts/build_mere_run_app.sh, VisionTrackLiveCommand.swift:79)_
 2. **Gatekeeper rejection.** `codesign --force --sign -` (ad-hoc), no hardened runtime, no entitlements, no `notarytool`/`stapler`. Any downloaded copy gets the "damaged / can't be opened" error. _(scripts/build_mere_run_app.sh:94)_
 3. **Notarization-fatal layout.** The CLI binary, `llama.framework`, `mlx` bundle, and `vendor/ds4/ds4-server` are copied into `Contents/Resources/`. `notarytool` rejects executable Mach-O under Resources.
 4. **Orphaned processes.** No `applicationShouldTerminate` hook — quitting mid-run (especially `api serve`) leaves the child CLI running. `terminate()` only fires on explicit Stop.
-5. **README lie.** README advertises a "signed and notarized macOS DMG"; no pipeline produces a DMG at all.
+5. **README mismatch.** The README advertises a "signed and notarized macOS DMG," but no pipeline produces a DMG.
 
 ---
 
 ## Historical quick wins
 
-- **Read Image default:** change `readImageAction` default/reset from `.inspect` to `.ocr`, or register the auto-download VLM in the capability catalog — the mode currently opens on a permanently blocked action. _(StudioTypes.swift:190,202)_
+- **Read Image default:** Change `readImageAction` default and reset from
+  `.inspect` to `.ocr`, or register the auto-download VLM in the capability
+  catalog. At audit time, the mode opened on a permanently blocked action.
+  _(StudioTypes.swift:190,202)_
 - **Invalid SF Symbol:** `Image(systemName: "finder")` is not a real symbol; renders as a missing glyph in 3 places. Use `magnifyingglass`/`folder`. _(StudioRootView.swift:733, MereRunRootView.swift:382, StudioModelsView.swift:403)_
 - **`.preferredColorScheme(.dark)`** at the WindowGroup root so native pickers/steppers/sheets stop rendering light-on-dark against the custom dark panels.
 - **UTF-8 data loss:** buffer raw `Data` per stream and retain incomplete trailing bytes instead of dropping whole chunks when a codepoint straddles a read. _(MereRunController.swift:267-277)_
 - **Library error visibility:** publish a `lastPersistenceError` instead of the empty `catch` so silent history loss is detectable. _(StudioLibraryStore.swift:135-137)_
 - **`.windowResizability(.contentMinSize)`** + explicit minimum frame so the prompt bar can't be clipped. _(MereRunApp.swift:14)_
 - **Add `NSCameraUsageDescription`** to the plist insert block and hide `visionTrackLive` until permission is gated.
-- **Correct the README** DMG claim until the pipeline produces a notarized artifact.
+- **Correct the README:** Remove the DMG claim until the pipeline produces a notarized artifact.
 
 ---
 
 ## Original phased roadmap
 
-### Phase 0 — Platform correctness & releasable pipeline _(3–4 wk · foundational, non-negotiable first)_
+### Phase 0 — Platform correctness and releasable pipeline _(3–4 weeks; foundational)_
 Make the bundle structurally valid, signable, notarizable, Gatekeeper-clean, crash-free on permissions, and CI-built.
-- **TCC & camera safety** — add usage strings; gate `track-live` behind `AVCaptureDevice.requestAccess` before launch.
-- **Signing & notarization** — `MereRun.entitlements` (notarized-unsandboxed first); Developer ID + `--options runtime --timestamp`, inside-out signing; `scripts/package-macos.sh` (DMG → `notarytool submit --wait` → `stapler staple`).
+- **TCC and camera safety:** Add usage strings, and gate `track-live` behind
+  `AVCaptureDevice.requestAccess` before launch.
+- **Signing and notarization:** Add `MereRun.entitlements`, use Developer ID
+  with `--options runtime --timestamp`, sign from the inside out, and run
+  `scripts/package-macos.sh` for DMG creation, notarization, and stapling.
 - **Bundle layout** — frameworks → `Contents/Frameworks`, helper executables → `Contents/MacOS`/`Helpers`; update `CLIResolver.bundledCandidates()`.
 - **macOS packaging** — `scripts/package-macos.sh`; per-PR `build_mere_run_app.sh debug` job; version from git tag + commit count.
 - **Process lifecycle** — `applicationShouldTerminate` kills all children; UTF-8 fix; README correction.
 
 **Exit:** downloaded DMG opens clean (`spctl --assess` passes); `track-live` prompts for camera; `notarytool` accepts; quit kills all children; CI publishes a notarized DMG.
 
-> ⚠️ Start Developer ID cert + `notarytool` credential provisioning on **day one** — it's an external dependency that gates the whole pipeline and only reproduces on a clean machine.
+> **Note:** Start Developer ID certificate and `notarytool` credential
+> provisioning on day one. This external dependency gates the pipeline and can
+> be reproduced only on a clean machine.
 
-### Phase 1 — Run engine & CLI-contract refactor _(4–6 wk · architectural foundation)_
+### Phase 1 — Run engine and CLI contract refactor _(4–6 weeks; architectural foundation)_
 Replace heuristic orchestration and the single-run ceiling so later features sit on contracts, not guesses.
 - **Structured result channel** — consume `--quiet` path lines / `--json` (already emitted by ~14 commands) instead of `detectOutputURL`'s last-40-line `fileExists` scan; decode into typed `RunResult`/artifacts; collapse the dual poll/per-chunk triggers into one debounced off-main path.
 - **Per-run session model** — `RunSession` keyed by id (own process, log buffer, status, immutable request) behind a coordinator with N concurrent slots; lift `guard !isRunning`; cancel/remove/reorder queued items; per-run logs (the shared `logs` is wiped every run).
-- **Decouple editing vs running** — `startRun` consumes `request.template/draft`; per-surface editing drafts so a dequeuing run never clobbers Advanced input.
-- **State ownership & testability** — runtime server params (host/port/key) become dedicated persisted state (Models sheet currently piggybacks the transient command draft); inject CLI-locator + filesystem abstraction; URLProtocol stub + real-binary runner tests.
+- **Decouple editing from running:** `startRun` consumes
+  `request.template/draft`. Use per-surface editing drafts so a dequeuing run
+  does not overwrite Advanced input.
+- **State ownership and testability:** Move runtime server parameters, such as
+  host, port, and key, into dedicated persisted state. At audit time, the
+  Models sheet used the transient command draft. Inject a CLI locator and file
+  system abstraction, and add URLProtocol stub and real-binary runner tests.
 
-**Exit:** artifacts resolved from the CLI contract (incl. directory/multi-file); two modes run concurrently with isolated logs; editing never clobbered; Models load/unload targets the real runtime; new tests cover resolution/detection/runner/HTTP.
+**Exit:** Artifacts resolve from the CLI contract, including directory and
+multi-file results. Two modes run concurrently with isolated logs. Editing does
+not overwrite active runs. Models load and unload targets the real runtime.
+Tests cover resolution, detection, the runner, and HTTP.
 
 > Land the CLI contract and the session model as **separate incremental drops behind existing behavior** to avoid a long-lived branch on the controller everything depends on.
 
-### Phase 2 — Headline media & progress UX _(3–4 wk · compounding value)_
+### Phase 2 — Media and progress UX _(3–4 weeks)_
 Make every mode's output actually usable.
 - **Inline playback** — AVKit `VideoPlayer` for `.mp4/.mov`; `AVAudioPlayer` transport (play/scrub/time/waveform) for `.wav/.mp3/.m4a`; extend `StudioOutputFileKind.classify` for audio/video.
 - **Determinate progress** — parse ModelPull's `[id] NN% done/total (speed/s)` stderr lines into a progress model; `ProgressView(value:)` with bytes/speed/ETA; collapse repeated `\r` updates; same for step-based generation.
 - **File ingestion** — `.dropDestination` on canvas + prompt for each mode's accepted types; paste-image for createImage/readImage; Read Image default fix; finder-symbol fix.
 - **Library management** — `.searchable`, mode/status/date filter chips, section grouping, context-menu Delete/Rename (+ backing store APIs); scope canvas selection to the active mode.
 
-**Exit:** audio/video play inline; pulls/generations show a real bar; drop/paste works; Read Image works on first launch; library is searchable & manageable.
+**Exit:** Audio and video play inline. Pulls and generations show determinate
+progress. Drop and paste work. Read Image works on first launch. The library is
+searchable and manageable.
 
-### Phase 3 — Conversational depth & CLI parity _(5–7 wk)_
+### Phase 3 — Conversational depth and CLI parity _(5–7 weeks)_
 Turn shallow modes into full experiences; surface the missing CLI families.
 - **Multi-turn chat/code + vision + tools** — app-side conversation model (CLI is stateless): user/assistant bubbles, persistent composer, New chat, per-message copy/retry/edit, re-send accumulated context; image attachment for vision-chat; expose `--tools/--tool-loop/--allow-shell-exec/--thinking` in Advanced.
 - **Voice cloning** — Speak gets a profile picker (`speech profile list`), style/clone toggle, ref-audio attach + save-as-profile; wire `mode/profile/refAudio/refText/saveProfile/language` into the Advanced template.
@@ -110,11 +131,16 @@ Turn shallow modes into full experiences; surface the missing CLI families.
 
 **Exit:** chat keeps context with history UI + vision; voice cloning end-to-end from Speak; Studio options have real depth; sfx/analyze/config/status usable from the GUI.
 
-### Phase 4 — Native polish, accessibility & distribution hardening _(4–5 wk · ship v1.0)_
+### Phase 4 — Native polish, accessibility, and distribution hardening _(4–5 weeks)_
 - **Native affordances** — real menus (File/View/Help, New Window, restore window/tabs removed by replacing `.newItem`); SceneStorage state restore; `UNUserNotificationCenter` completion notifications; Quick Look.
 - **Theming system** — semantic color tokens + a real light theme; themed Button/Toggle/Field styles; spacing/radius/type scales; `.ultraThinMaterial`/`NSVisualEffectView` for the chromeless title bar; one shared error/banner component (genuine failures in red, not warning yellow).
-- **Accessibility** — `.accessibilityLabel`/`value` on all icon buttons & status pills; announce readiness/run state (color-only today); relative text styles for Dynamic Type; full VoiceOver pass.
-- **Onboarding & lifecycle** — first-run welcome + guided starter-model download (wire the CLI `guide`); Sparkle (EdDSA appcast) so bundle + CLI update atomically; app↔CLI version handshake; opt-in MetricKit crash capture + Export Diagnostics.
+- **Accessibility:** Add `.accessibilityLabel` and `value` to all icon buttons
+  and status pills. Announce readiness and run state, use relative text styles
+  for Dynamic Type, and complete a VoiceOver pass.
+- **Onboarding and lifecycle:** Add a first-run welcome and guided starter-model
+  download through the CLI `guide`. Use Sparkle with an EdDSA appcast so the
+  bundle and CLI update atomically. Add an app-to-CLI version handshake,
+  opt-in MetricKit crash capture, and Export Diagnostics.
 
 **Exit:** standard menus/windows/notifications/Quick Look; correct light+dark with Dynamic Type; VoiceOver pass; onboarding downloads a starter model; Sparkle delivers a signed update.
 
@@ -122,9 +148,10 @@ Turn shallow modes into full experiences; surface the missing CLI families.
 
 ## Original key risks
 
-- **Camera permission is subtle:** the usage string must live in the *app* bundle (TCC blames the parent), and only reproduces on a fresh machine — easy to "fix" on the dev box and still ship broken.
+- **Camera permission is subtle:** the usage string must live in the *app* bundle (TCC blames the parent), and the problem reproduces only on a fresh machine. A development machine can appear fixed while a release remains broken.
 - **Bundle relocation** is coupled to `CLIResolver` paths and the framework search paths baked into the CLI/ds4 binaries; moving executables can break dylib loading. Test the relocated, signed bundle on a clean machine.
-- **The concurrent-engine refactor** touches the controller both UIs and all tests depend on — land it incrementally behind existing behavior.
+- **The concurrent-engine refactor** touches the controller that both UIs and
+  all tests depend on. Land it incrementally behind existing behavior.
 - **`--json`/`--quiet` coverage is ~14 commands today** — audit each subcommand before deleting `detectOutputURL` entirely; some modes may still need the path-line fallback.
 - **Multi-turn threading lives in the app** (stateless CLI) — handle context-window growth / token budgeting or long chats silently truncate.
 - **Two parallel UIs** are a standing drift liability; the shared per-mode option schema (Phase 3) is what prevents it — skipping it makes the inconsistency permanent.

--- a/docs/mlx-swift-fork.md
+++ b/docs/mlx-swift-fork.md
@@ -1,6 +1,6 @@
 # mlx-swift fork policy and compiled-call overhead
 
-mere-run pins the public `sawfwair/mlx-swift` fork at
+`mere.run` pins the public `sawfwair/mlx-swift` fork at
 `7558b9cff75746e3ce25802aecbdc498b240af7f`. It contains upstream
 `mlx-swift` through `97cf19efeaa4e929415e75982e999adb34f62c0d`. The embedded
 `sawfwair/mlx` revision is
@@ -18,7 +18,7 @@ fast dispatch; the fork instead tests matching host/kernel alignment directly.
 Changes stay scoped to their bit width, group size, quantization mode, and
 backend so stock 2-bit and wider models keep their existing paths.
 
-The current pin also lets an MLXFast custom Metal kernel explicitly request
+The pin also lets an MLXFast custom Metal kernel explicitly request
 the core quantized helper headers. The source marker
 `MLX_INCLUDE_FP_QUANTIZED_HEADERS` exposes the NVFP4 helpers, while
 `MLX_INCLUDE_AFFINE_QUANTIZED_HEADERS` exposes the affine helpers. Kernels
@@ -35,8 +35,7 @@ to the generated kernel tree, and `--verify-only` checks the resulting symbols.
 
 ## Refresh procedure
 
-Refresh the dependency chain from the bottom up and publish it in the same
-order:
+Refresh and publish the dependency chain in dependency order:
 
 1. Record immutable upstream cutoffs for both repositories and classify every
    fork-only commit as replay, replace with upstream, or drop with a regression
@@ -48,7 +47,7 @@ order:
    AOT sources, regenerate a second time to prove the tree is idempotent, and
    run the full Xcode test plan so the Metal shader bundle is present.
 4. Publish the reviewed core revision, then pin that immutable revision from
-   mlx-swift and publish the reviewed Swift revision. Never make mere.run depend
+   mlx-swift and publish the reviewed Swift revision. Do not make `mere.run` depend
    on an unpushed or floating dependency ref.
 5. Pin the immutable mlx-swift revision in `Package.swift` and
    `Package.resolved`, rebuild the vendored Metal library, and update its
@@ -66,14 +65,14 @@ order:
 Perform this audit at least once per upstream minor release, and sooner for a
 security fix or a correctness/performance change in a path mere.run owns.
 
-The previously staged compiled-call optimization is now included: MLX v0.32.1
+The previously staged compiled-call optimization is included. MLX v0.32.1
 makes compile caches thread-local and cache erasure thread-safe, and the Swift
 bridge retains the originating cache identities across executors. With that
 core prerequisite in place, independent compiled functions no longer take the
 global Swift evaluation lock. The regression suite covers concurrent first
 traces, shape changes, numerical evaluation, and cross-thread cache erasure.
 
-An eight-worker, 2,000-call-per-worker A/B on the same machine isolates that
+An eight-worker, 2,000-call-per-worker comparison on the same machine isolates that
 lock change on the same v0.32.1 core. Across five alternating trials, median
 compiled graph-build wall time fell from 7.56 us/call to 1.38 us/call (5.5x
 higher concurrent call throughput); median build-plus-evaluation wall time fell
@@ -88,13 +87,13 @@ TransformTests.testConcurrentCompiledCallOverheadMicrobench`.
 call rates this is a cliff, measured on an M4 Max (Gemma4 12B, 96 compiled
 calls/token):
 
-| | per-token wall | per-call cost |
+| Variant | Per-token wall time | Per-call cost |
 |---|---|---|
 | stock 0.31.4 | 70.8 ms (2.6× slower than uncompiled) | ~0.45 ms |
 | lock removed | 28.2 ms (parity) | ~5 µs (= one raw op) |
 
 Every MLXNN compiled activation (`geluApproximate`, swiglu helpers, …) pays
-this cost per call, not just explicit `compile(...)` users. Confirmed present
+this cost per call, including code that does not call `compile(...)` directly. Confirmed present
 through upstream v0.31.6 (the file is unchanged upstream since 2026-05-07).
 
 ## Why the one-line fix was previously held back
@@ -110,7 +109,7 @@ exercises in production:
   cross-function serialization of that path; the per-function `NSLock` does
   not cover two *different* compiled functions racing their first traces.
 - mlx-swift's own comment documents the lock as guarding eval re-entrancy,
-  i.e. the maintainers treat this path as not thread-safe without it.
+  which means the maintainers treat this path as not thread-safe without it.
 - mere-run runs concurrent generator actors (text serving while image/LoRA
   training, multiple model families resident) — exactly the workload that can
   first-trace independent compiled functions on different threads at once.
@@ -122,14 +121,15 @@ For a serving runtime the burden of proof is on the patch, and
 "maintainer-documented not-thread-safe + globals on the unlocked path + our
 architecture exercises it" is past the threshold to hold it back.
 
-## The paired fix this needs (before re-attempting)
+## Required paired fix
 
-1. **Core-side thread safety**: bump/patch the vendored mlx core so compile
+1. **Core-side thread safety:** Update the vendored MLX core so compile
    tracing state is thread-local and the compile cache has its own narrow
    lock, making a cache-hit `mlx_closure_apply` genuinely lock-free-safe and
    first-traces mutually safe.
-2. **Swift-side lock removal** (the existing one-liner), only on top of (1).
-3. **A stress test that can actually fail**: concurrently first-trace many
+2. **Swift-side lock removal:** Apply the existing one-line change only after
+   the core-side change.
+3. **A stress test that can detect the failure:** Concurrently first-trace many
    *independent* compiled functions (and new shapes of shared ones) from
    multiple threads. Repeated calls to a single closure — including the
    existing `MLXCompiledFunctionOverheadTests` micro-bench — cannot catch
@@ -159,5 +159,5 @@ erase bridge and the concurrency regressions.
   release, and generated-kernel source hash compiled into `mere.run`.
   `scripts/check.sh` recomputes the same provenance and release ancestry from
   the clean pinned checkout.
-- Never edit `.build/checkouts/` to change dependency behavior — checkout
-  edits silently vanish on the next `swift package resolve/update`.
+- Do not edit `.build/checkouts/` to change dependency behavior. Checkout
+  edits disappear during the next `swift package resolve` or `swift package update`.

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -1,4 +1,4 @@
-# Model Sources
+# Model sources
 
 Weights reach `mere.run` in three local-first ways:
 
@@ -31,7 +31,7 @@ metadata into the external directory. Externally registered files remain
 read-only and are outside `model remove`, `model gc`, manifest repair, and
 storage-reclamation ownership.
 
-## Canonical Managed Model IDs
+## Canonical managed model IDs
 
 This is the authoritative public catalog list. It is kept in sync with
 `ManagedModelCatalog.allSpecs`, and the test suite fails if the table drifts
@@ -171,13 +171,12 @@ an effective overlay; they are not a second capability catalog.
 ### Restricted model downloads
 
 mere.run is free and open source, but model and component licenses remain the
-terms of their respective owners. mere.run does not bundle these weights,
-decide whether a user's intended use qualifies, or police use after install.
-For every new download that is access-gated or carries a material use limit—
-such as non-commercial, research-only, or revenue-limited terms—the user must
-review the listed terms and pass `--accept-model-license`. Passing the flag and
-continuing with the download confirms that the user accepts those terms and
-agrees to comply with them:
+terms of their respective owners. mere.run does not bundle these weights or
+decide whether your intended use qualifies. Before downloading an access-gated
+model or one with a material use limit, such as non-commercial, research-only,
+or revenue-limited terms, review the listed terms and pass
+`--accept-model-license`. Passing the flag and continuing with the download
+confirms that you accept those terms and agree to comply with them:
 
 ```bash
 mere.run model pull vision-face-buffalo-l --accept-model-license
@@ -261,8 +260,8 @@ treated as a new restriction on the converted weights.
 `fafaab5faa1617a0ca52d38dd3dc4bd636800d3d`; the weights are installed
 separately and are not vendored in this repository.
 
-Most catalog IDs have managed Hugging Face sources and can be installed with
-`mere.run model pull`. A small number of legacy/local catalog IDs remain so
+Install most catalog IDs from managed Hugging Face sources with `mere.run model
+pull`. A small number of legacy and local catalog IDs remain so
 existing installs and explicit local paths keep working:
 
 - `image-klein-shared`
@@ -306,7 +305,7 @@ metadata; the MLX conversion repository does not duplicate the license file.
 `deepreinforce-ai/Ornith-1.0-35B-GGUF` Q4_K_M file at the pinned catalog
 revision. It runs through the native Swift/llama.cpp `text code` path for
 larger Ornith coding-agent comparisons and uses a 32K runtime context by
-default to keep local evals predictable.
+default to keep local evaluations predictable.
 
 `text-agent-deepseek-v4-flash` is the preferred managed setup-agent tier on
 96 GB+ Apple Silicon Macs, with 128 GB recommended. It pulls the official
@@ -633,14 +632,14 @@ Managed or local roots are expected to contain:
 
 The managed manifest records SDNQ asymmetric uint4 weights and the separate
 positive and unconditional transformer branches used by Ideogram 4 guidance.
-The current native support can pull, inspect, validate, decode SDNQ uint4
+The native runtime can pull, inspect, validate, and decode SDNQ uint4
 linear, embedding, and Conv2d weights, build Qwen3-VL concatenated text
 features, pack Ideogram 4 text/image samples, run positive/unconditional CFG
 denoising, and decode PNG output through the Flux2-style VAE. Text-to-image
 `image generate` is wired; image-to-image, reference inputs, and LoRA are still
 unsupported for this family.
 
-## Hugging Face Cache
+## Hugging Face cache
 
 Hub snapshots use the shared cache location managed by the runtime. Override it
 when you want large models on an external disk:
@@ -654,11 +653,11 @@ Model pulls are resumable at the file level through the Hugging Face snapshot
 cache. The CLI writes a managed-model symlink from the mere.run model store to
 the prepared snapshot when needed.
 
-## Hardware Support Checks
+## Hardware support checks
 
 Managed pulls are gated by the local capability catalog before any download. The
 check uses supported local runtimes plus memory thresholds for each model
-family, then blocks models that are unlikely to run reliably on the current machine.
+family, then blocks models that are unlikely to run reliably on this machine.
 
 Inspect the local recommendation first:
 
@@ -670,7 +669,7 @@ swift run mere.run model capabilities --all
 If you are intentionally testing an unsupported setup, pass
 `--allow-unsupported` to `mere.run model pull`.
 
-## Model Store Behavior
+## Model store behavior
 
 The CLI resolves models in this order:
 
@@ -691,13 +690,13 @@ MERERUN_MODELS_DIR=/Volumes/Models swift run mere.run model pull text-chat-lfm25
 MERERUN_MODELS_DIR=/Volumes/Models swift run mere.run model pull text-chat-lfm25-2.6b-4bit --accept-model-license
 MERERUN_MODELS_DIR=/Volumes/Models swift run mere.run model pull vision-chat-lfm25-3b-8bit --accept-model-license
 
-# Inspect what is currently installed
+# Inspect installed models
 swift run mere.run status
 swift run mere.run model list
 swift run mere.run model info image-klein-max
 ```
 
-## Music, SFX, And Video Layouts
+## Music, SFX, and video layouts
 
 Some retained surfaces have more structure than a flat model root.
 
@@ -1004,8 +1003,8 @@ This deprecated compatibility ID preserves existing A2Vid installs and scripts:
 
 Its legacy narrow manifest may omit the vocoder, so it can run final-quality
 video-only and source-audio A2Vid but not generated-audio output. Requests for
-either the legacy ID or the new full ID resolve to an already-installed
-compatible root when possible. New pulls should use `video-ltx23-full-mlx`.
+either the legacy ID or the replacement full ID resolve to an already-installed
+compatible root when possible. Use `video-ltx23-full-mlx` for pulls.
 
 ### `video-ltx25-distilled-bf16`
 
@@ -1073,7 +1072,7 @@ configuration, source manifest, conversion receipt, hashes, `LICENSE`,
 QKV matrices are deinterleaved from MiniMax's released per-head row order into
 the global Q/K/V slabs consumed by the native runtime. Runtime auto-download is
 disabled. This compatibility ID remains installable, but Q4 did not meet the
-current visual-quality bar and is no longer recommended.
+release visual-quality bar and is no longer recommended.
 
 The maximum-fidelity `video-minimax-h3-fl2va-bf16-mlx` ID now resolves to the
 single-root `Sawfwair/MiniMax-H3-FL2VA-MLX-BF16` compact artifact pinned at
@@ -1098,7 +1097,7 @@ reduction order is not bit-identical to Apple Silicon.
 affine INT8/group-64; the conditioner, VAEs, tokenizer, cache tables, and
 official-source provenance remain the same as compact BF16. Its independently
 verified runtime payload is exactly 58,075,175,639 bytes. Q8 is a disk and
-memory option rather than a speed claim. Both new packages are explicit-pull
+memory option instead of a speed claim. Both compact packages are explicit-pull
 only and runtime auto-download remains disabled.
 
 The explicit-pull Ref2VA root is the flat
@@ -1217,7 +1216,7 @@ generation. One session retains the models, prompt cache, and terminal-frame
 latent across transitions; callers receive MP4/PNG state artifacts and opaque
 state IDs rather than mutable MLX tensors. Camera controls are represented as
 XYZ translation and rotation so a DreamX-derived causal camera conditioner can
-replace the current text-plus-first-frame mode without changing the session
+replace the text-plus-first-frame mode without changing the session
 schema.
 
 ### `video-scail2-14b-mlx`
@@ -1294,12 +1293,12 @@ The native DreamX-World autoregressive checkpoint root is:
 ```
 
 The public CLI does not convert this local-only checkpoint. Supply a previously
-converted `GD-ML/DreamX-World-5B` root at the managed path above or pass its
+converted `GD-ML/DreamX-World-5B` root at the documented managed path or pass its
 directory to `mere.run world serve --model`. The runtime pairs it with
 `video-wan22-ti2v-5b-mlx` for tokenizer, text encoder, and VAE resources. The
 checkpoint provides learned camera conditioning, block-causal attention,
 persistent attention caches, and autoregressive forcing for long-lived local
 world sessions. It is never downloaded or converted automatically at runtime.
 
-See [Persistent World Runtime](./runtime/world.md) for the server and request
+See [Persistent world runtime](./runtime/world.md) for the server and request
 lifecycle.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -1,4 +1,4 @@
-# Companion Plugins
+# Companion plugins
 
 Extend `mere.run` without letting anything into its process. Official plugins
 are separate executables shipped outside the Swift package: they can add
@@ -29,7 +29,7 @@ they do not maintain a second plugin registry.
 ## macOS Studio
 
 Open **Plugins** from the Studio sidebar or **View → Plugins**. The first-class
-workspace supports catalog search, installed/verified status, channel
+workspace supports catalog search, installed and verified status, channel
 selection, repository access, copyable install commands, confirmed install or
 update, and the fixed plugin doctor operation. A custom catalog URL or local
 JSON path is available for development.
@@ -48,7 +48,7 @@ mere.run plugin install mere-runpod
 mere.run plugin install mere-runpod --yes
 ```
 
-After installation, mere.run verifies the plugin manifest and entrypoint. A
+After installation, `mere.run` verifies the plugin manifest and entrypoint. A
 plugin that declares a graph provider is registered only after that manifest
 passes validation.
 
@@ -63,7 +63,7 @@ mere.run plugin doctor mere-runpod
 
 The doctor command resolves the catalog entry, verifies that its executable is
 on `PATH`, verifies its manifest, and invokes the plugin's fixed `doctor` verb.
-If the entrypoint cannot start, mere.run diagnoses the installation before
+If the entrypoint cannot start, `mere.run` diagnoses the installation before
 delegating. A stale editable `pipx` install reports its missing source path and
 the exact forced-reinstall command instead of exposing only a Python traceback.
 Plugin stdout and exit status remain owned by a verified executable.
@@ -75,8 +75,8 @@ verbs: catalog, preflight, and execute. The core runtime validates typed
 requests and events; plugin manifests cannot inject arbitrary shell commands
 into workflow bundles.
 
-See [Portable Workflows](./workflows.md#graph-v2-runtime-and-v1-contract) for
-the graph ABI and [CLI Reference](./cli.md) for every plugin option.
+See [Portable workflows](./workflows.md#graph-v2-runtime-and-v1-contract) for
+the graph ABI and [CLI reference](./cli.md) for every plugin option.
 
 ## Source boundary
 

--- a/docs/raycast.md
+++ b/docs/raycast.md
@@ -1,7 +1,7 @@
-# Raycast Integration
+# Raycast integration
 
 Raycast is one example client of MereRun's public macOS handoff surface. Read
-[macOS Deep Links](./macos-deep-links.md) for the app-owned route contracts and
+[macOS deep links](./macos-deep-links.md) for the app-owned route contracts and
 security boundaries independent of any launcher.
 
 Generate an image, video, music track, or spoken-audio file from Raycast, then
@@ -14,20 +14,19 @@ executable plugin and is not installed through the MereRun plugin catalog.
 
 ## Requirements
 
-- macOS with [Raycast](https://www.raycast.com/) installed;
-- a MereRun.app build containing the `mererun://library/import` route; v0.31.0
-  supports the optional preview-only route but not Library import;
-- the app-bundled `mere.run` helper, or another executable CLI path configured
-  in the extension;
-- a locally installed model for the generation command you want to run.
+- macOS with [Raycast](https://www.raycast.com/) installed.
+- A MereRun.app build containing the `mererun://library/import` route. Version
+  0.31.0 supports the optional preview-only route but not Library import.
+- The app-bundled `mere.run` helper, or another executable CLI path configured
+  in the extension.
+- A locally installed model for the generation command you want to run.
 
 The native import and preview deep links are part of the macOS app. Linux
 packages contain the headless CLI only and cannot open the MereRun Studio.
 
 ## Install the extension
 
-The extension is not in the Raycast Store yet. Load the development extension
-from its public repository:
+Load the development extension from its public repository:
 
 ```bash
 git clone https://github.com/sawfwair/mere-run-raycast.git
@@ -53,9 +52,9 @@ Raycast's **Uninstall Extension** action.
 | **Synthesize Speech** | `mere speech` | `mere.run speech synthesize` | WAV |
 
 Choose a command, enter its prompt in Raycast, and press Return. Raycast shows
-the CLI's latest diagnostic while generation is active. After the command exits
+the CLI's most recent diagnostic while generation is active. After the command exits
 successfully and the output is readable, the extension imports the artifact,
-opens its owning MereRun workspace, reveals Library, and selects the new row.
+opens its owning MereRun workspace, reveals Library, and selects the imported row.
 
 Generated files are durable. By default they are written to
 `~/MereRun/Raycast` with a media-specific name and UTC timestamp, for example:
@@ -69,10 +68,10 @@ mere-speech-2026-08-01T22-46-28-054Z.wav
 
 Open Raycast's extension preferences for **Mere.run** to change either setting:
 
-- **MereRun CLI Path** — optional absolute path to a `mere.run` executable;
-- **Output Directory** — artifact directory, defaulting to
-  `~/MereRun/Raycast`. Tilde paths are supported;
-- **Open Result In** — **MereRun Library** by default, or **Quick Look Only**
+- **MereRun CLI Path:** Optional absolute path to a `mere.run` executable.
+- **Output Directory:** Artifact directory, defaulting to
+  `~/MereRun/Raycast`. Tilde paths are supported.
+- **Open Result In:** **MereRun Library** by default, or **Quick Look Only**
   when the artifact should not be imported.
 
 When no CLI path is configured, the extension selects the first executable in
@@ -98,7 +97,7 @@ version 1 receipt contains only the completed local run metadata MereRun needs:
   "source": "raycast",
   "kind": "image",
   "prompt": "a ceramic coffee mug in soft morning light",
-  "artifactPath": "/Users/me/MereRun/Raycast/mere-image-result.png",
+  "artifactPath": "/Users/dana/MereRun/Raycast/mere-image-result.png",
   "createdAt": "2026-08-01T22:42:07Z"
 }
 ```
@@ -106,7 +105,7 @@ version 1 receipt contains only the completed local run metadata MereRun needs:
 It then asks Launch Services to open one percent-encoded absolute receipt path:
 
 ```text
-mererun://library/import?receipt=%2FUsers%2Fme%2FLibrary%2FApplication%20Support%2Fcom.raycast.macos%2Fextensions%2Fmere-run%2Flibrary-imports%2F5cb7dc90-a9d4-4634-a486-0b8140226b42.json
+mererun://library/import?receipt=%2FUsers%2Fdana%2FLibrary%2FApplication%20Support%2Fcom.raycast.macos%2Fextensions%2Fmere-run%2Flibrary-imports%2F5cb7dc90-a9d4-4634-a486-0b8140226b42.json
 ```
 
 MereRun accepts receipt version 1 and the typed `image`, `video`, `music`, and
@@ -114,7 +113,7 @@ MereRun accepts receipt version 1 and the typed `image`, `video`, `music`, and
 versions, empty prompts, missing or unreadable artifacts, and media that does
 not match the declared kind. Reopening the same receipt or artifact selects the
 existing row instead of duplicating it. MereRun owns `library.json`; the
-launcher never reads or writes that file.
+launcher does not read or write that file.
 
 ## Preview an existing artifact
 
@@ -122,7 +121,7 @@ MereRun.app registers `mererun://preview`. A launcher can pass one
 percent-encoded absolute path:
 
 ```text
-mererun://preview?path=%2FUsers%2Fme%2FDesktop%2Fresult.png
+mererun://preview?path=%2FUsers%2Fdana%2FDesktop%2Fresult.png
 ```
 
 Raycast extensions should let the URL API encode the path:
@@ -201,6 +200,6 @@ npm run check
 ```
 
 MereRun owns the CLI behavior, both typed deep-link routes, Library persistence,
-and the signed macOS release. See [Getting Started](./getting-started.md) for
-installation and [Model Management](./runtime/model-management.md) for managed
+and the signed macOS release. See [Getting started](./getting-started.md) for
+installation and [Model management](./runtime/model-management.md) for managed
 downloads.

--- a/docs/repository-tour.md
+++ b/docs/repository-tour.md
@@ -1,6 +1,6 @@
-# Repository Tour
+# Repository tour
 
-This page explains the shape of the repo and what each major directory owns.
+This page explains the shape of the repository and what each major directory owns.
 Use it as the bridge between the end-user docs and the source tree.
 
 ## Top-level layout
@@ -57,7 +57,7 @@ The public command-line surface.
 - `Support/`: shared CLI bootstrap, model inventory, output helpers, and local
   API support
 
-If you want to understand the CLI end to end, start here.
+To understand the CLI end to end, start with `Sources/MereRunCLI`.
 
 ### `apps/macos/MereRunStudio`
 
@@ -67,7 +67,7 @@ child process, streams stdout and stderr, saves local library metadata, and keep
 the raw command surface available in Advanced details.
 
 Do not make this target part of Linux compatibility work. Linux contributors
-should validate the CLI and local API surfaces directly.
+must validate the CLI and local API surfaces directly.
 
 ### `apps/ios`
 
@@ -149,15 +149,15 @@ surface or command semantics, this is where you should add or update coverage.
 
 The main repo validation entrypoint. It runs:
 
-- build and unit tests
-- CLI help smoke for the public command tree
-- output-format and hygiene checks
-- optional e2e smoke runs
+- Build and unit tests.
+- CLI help smoke for the public command tree.
+- Output-format and hygiene checks.
+- Optional end-to-end smoke runs.
 
 ### `scripts/e2e_smoke.sh`
 
 Sequential real-world smoke tests for installed models. Use this when you want
-to validate actual runtime paths instead of just build and parse coverage.
+to validate actual runtime paths in addition to build and parse coverage.
 
 ### `scripts/package-linux.sh`
 
@@ -204,14 +204,14 @@ The docs are layered intentionally:
 - runtime-family guides in `docs/runtime/`
 - contributor/source-reading material in `docs/internals/`
 
-Start at [mere.run Documentation](/) to navigate by audience.
+Start at the [mere.run documentation home](/) to navigate by audience.
 
 ## Recommended code reading order
 
-1. Read [Architecture Reading Map](./architecture.md)
-2. Open `Sources/MereRunCLI/MereRunCLI.swift`
-3. Pick one command family in `Sources/MereRunCLI/Commands`
+1. Read the [architecture map](./architecture.md).
+2. Open `Sources/MereRunCLI/MereRunCLI.swift`.
+3. Pick one command family in `Sources/MereRunCLI/Commands`.
 4. Jump to the matching runtime family in `Sources/MereRunCore`,
    `Sources/AudioSTT`, or `Sources/AudioTTS`
-5. Use the runtime family docs to follow the load -> prepare -> generate ->
-   decode -> output path
+5. Use the runtime family documentation to follow the load, prepare, generate,
+   decode, and output path.

--- a/docs/runtime/acestep-validation.md
+++ b/docs/runtime/acestep-validation.md
@@ -1,8 +1,8 @@
-# ACE-Step Validation
+# ACE-Step validation
 
-This is the evidence contract for the native Swift/MLX ACE-Step 1.5 runtime.
-It separates source parity, local tests, installed-checkpoint execution,
-performance, and listening review.
+Use this evidence contract to qualify the native Swift/MLX ACE-Step 1.5
+runtime. The contract separates source parity, local tests,
+installed-checkpoint execution, performance, and listening review.
 
 ## Immutable sources
 
@@ -35,21 +35,21 @@ components.
 
 The deterministic test surface covers:
 
-- Turbo and continuous timestep schedules, Euler/Heun updates, CFG, APG, ADG,
-  guidance windows, and stabilization;
-- typed task/checkpoint capability routing and exact Base-only restrictions;
+- Turbo and continuous timestep schedules, Euler and Heun updates, CFG, APG,
+  ADG, guidance windows, and stabilization.
+- Typed task and checkpoint capability routing and exact Base-only restrictions.
 - source conditioning, repaint masks/injection/splice, retake endpoints and
-  spherical interpolation, and flow-edit integration windows;
+  spherical interpolation, and flow-edit integration windows.
 - prompt/condition encoder, audio-tokenizer, DCW, first-velocity, final-latent,
-  and VAE parity dump paths;
+  and VAE parity dump paths.
 - Python-contract metadata precedence: explicit duration and language survive
   conflicting planner proposals, 1.7B is discovered before 4B, and separately
-  managed planners resolve without checkpoint-store symlinks;
+  managed planners resolve without checkpoint-store symlinks.
 - upstream two-phase LM prompting: metadata uses CFG `1.0`; code generation
   continues from the planned CoT, guides conditional/unconditional logits at
-  `2.0`, and keeps the sampled token streams synchronized;
+  `2.0`, and keeps the sampled token streams synchronized.
 - stable seed fanout, candidate metrics/ranking, batch/session serialization,
-  API decoding/security, WAV headers, LRC, recipes, and DAW bundle topology;
+  API decoding and security, WAV headers, LRC, recipes, and DAW bundle topology.
 - PEFT LoRA and LyCORIS LoKr key mapping, numerical contributions, alpha/scale,
   decomposed Kronecker factors, and adapter stacking.
 
@@ -75,7 +75,8 @@ environment variables and skip truthfully when an asset is absent.
 
 ## Installed-model evidence
 
-All files below were generated locally at 48 kHz stereo. Hashes make the
+All files in the installed-model evidence table were generated locally at
+48 kHz stereo. Hashes make the
 specific validation artifacts identifiable without committing model output.
 
 | Path exercised | Configuration | Result |
@@ -88,7 +89,7 @@ specific validation artifacts identifiable without committing model output.
 | XL-Turbo + 4B recipe v2 | one-second LM-planned vocal, one step | `68b170220cf5849635f3f97f2b75d87d7a80045f2401edf9a707d677db2f2122` |
 | XL-Turbo + 4B upstream LM replay | 85-second trailer prompt, seed 4747, 16-step Heun | `65eaaac55db062189ab2d923ad5dcda0ecaa7287dcee00a7c2003af3b999ffad` |
 | Resident API WAV | warm one-second XL-Turbo request, one step | `9c6f3ef3752f15636aa2f4eb7b74b3dcee556e78a62158e4bc4ac344f6eaee32` |
-| Float32 artifact/DAW workflow | recipe, LRC, candidates, bundle | `d44d8386c6b479e209d169c74ff2aa69bd2b13dd980f83a708b9f381c985e629` |
+| Float32 artifact and DAW workflow | recipe, LRC, candidates, bundle | `d44d8386c6b479e209d169c74ff2aa69bd2b13dd980f83a708b9f381c985e629` |
 | LoRA train/save | one real backward and AdamW step, 256 layers | `b7c9c40c3b74aca7fb8f12fb4999c0be1175db82bf9e1504bb9c19794a29c8dd` |
 | LoRA reload/generate | trained artifact applied to 256 layers | `1ba7876df682c626b1f08da80a739ed0685becdf0182e492bb1c533d07d41449` |
 | LoKr train/save | one real backward and AdamW step, 256 layers | `5175420753533a736b43afa608dfc957e48c8d216ac0ec0d6ac824030e1c739e` |
@@ -176,7 +177,7 @@ For a repeatable timing capture:
 ./scripts/acestep-performance-proof.sh
 ```
 
-The installed one-second/one-step XL-Turbo proof completed in 3.14 seconds,
+The installed one-second, one-step XL-Turbo proof completed in 3.14 seconds,
 including process startup and checkpoint load, with 21.35 GB maximum RSS,
 25.35 GB peak footprint, and zero swap. It produced PCM24 stereo at 48 kHz with
 SHA-256

--- a/docs/runtime/api-server.md
+++ b/docs/runtime/api-server.md
@@ -1,8 +1,9 @@
-# Local API Server
+# Local API server
 
-The rest of `mere.run`, behind an OpenAI-compatible endpoint on localhost.
-Point an existing client, your editor, or Open WebUI at it and nothing about
-your setup changes except where the weights live — and where your prompts stop.
+Use the local API server to expose supported `mere.run` models through an
+OpenAI-compatible endpoint. Point an existing client, your editor, or Open
+WebUI at the loopback endpoint to keep model weights and prompts on the serving
+machine.
 
 ## Commands
 
@@ -13,26 +14,26 @@ your setup changes except where the weights live — and where your prompts stop
 | `mere.run model runtime set` | Update typed API runtime settings for a managed model. |
 | `mere.run status` | Show local server, loaded model, and installed model status. |
 
-## macOS Serving & Agents Console
+## macOS Serving & Agents console
 
 MereRun Studio exposes this control plane as a top-level **Serving & Agents**
 destination (or `Shift-Command-S`). It is an operational client of the public
 CLI and HTTP contracts, not a second runtime. The console provides:
 
-- API preflight, app-owned start/stop/restart, and reconnection to a server
+- API preflight, app-owned start, stop, restart, and reconnection to a server
   started outside Studio
-- explicit loopback/LAN authentication safety; Studio blocks a non-loopback
+- Explicit loopback and local area network (LAN) authentication safety; Studio blocks a non-loopback
   app-owned launch until an API key is configured
-- the live text and image/speech/transcription/embedding sidecar pools,
+- Live text, image, speech, transcription, and embedding sidecar pools,
   readiness, activity, queues, pinning, TTLs, aliases, model settings, and
   text-model load/unload controls
-- unified-memory guard pressure, process CPU, honest Metal allocation and
+- Unified-memory guard pressure, process CPU, Metal allocation and
   recommended working set, and macOS thermal/power state where available
-- observed request totals, failures, tokens, latency/throughput, prefix reuse,
+- Observed request totals, failures, tokens, latency, throughput, prefix reuse,
   decode batching, and MTP counters
-- typed Pi readiness/install/configure/start flows plus copyable OpenAI SDK,
+- Typed Pi readiness, install, configure, and start flows, plus copyable OpenAI software development kit (SDK),
   curl, BYOA, and Open WebUI connection setup
-- a sanitized lifecycle/activity feed that excludes prompts, messages, media,
+- A sanitized lifecycle and activity feed that excludes prompts, messages, media,
   and generated content
 
 Server launches and agent setup sessions use the normal Studio Library
@@ -55,13 +56,12 @@ lifecycle. API keys still cross the process boundary only through
 
 ## What it is for
 
-Serving beats shelling out to the CLI once you are making more than one request
-— the model stays loaded between them. It suits:
+Use the server for repeated requests so the model stays loaded. It supports:
 
-- editor tooling and local automation
-- RAG and knowledge-base embeddings over private documents
-- image generation, speech, and transcription from an existing OpenAI client
-- trying the runtime out over HTTP before wiring anything permanent
+- Editor tooling and local automation
+- Retrieval-augmented generation (RAG) and knowledge-base embeddings over private documents
+- Image generation, speech, and transcription from an existing OpenAI client
+- Runtime evaluation over HTTP before a permanent integration
 
 It is not a hosted service or a relay layer. The server binds to loopback by
 default. For remote jobs, prefer [portable workflows](../workflows.md); when
@@ -253,10 +253,10 @@ swift run mere.run model runtime set text-chat-gemma4 \
   --min-p 0.05
 ```
 
-Network-exposed example:
+For a network-exposed server, configure an API key and a rate limit:
 
 ```bash
-export MERERUN_API_KEY=change-me
+export MERERUN_API_KEY=example-api-key
 swift run mere.run api serve \
   --engine text-chat-gemma4 \
   --host 0.0.0.0 \
@@ -268,39 +268,39 @@ swift run mere.run api serve \
 
 ## Design notes
 
-- the API server follows the same model-resolution and model-store rules as the
-  rest of the CLI
+- The API server follows the same model-resolution and model-store rules as the
+  rest of the CLI.
 - `ManagedModelCatalog` is the API model authority; the server does not scan
-  arbitrary model folders as request-addressable models
+  arbitrary model folders as request-addressable models.
 - `--engine` and `--model` still define and preload the startup default, while
   each chat request can select another installed API-capable catalog model with
-  the OpenAI `model` field
+  the OpenAI `model` field.
 - `/v1/embeddings` uses the native `text-embed-qwen3-0.6b` sidecar model; it is
-  listed in `/v1/models` when installed even though it is not a chat-serving engine
+  listed in `/v1/models` when installed even though it is not a chat-serving engine.
 - `/v1/images/generations`, `/v1/images/edits`, `/v1/audio/speech`, and
   `/v1/audio/transcriptions` are sidecar routes over existing native CLI
-  runtime paths. Installed embedding, image, TTS, and ASR sidecar catalog ids are listed in
+  runtime paths. Installed embedding, image, TTS, and ASR sidecar catalog IDs are listed in
   `/v1/models` even though they are not chat-serving engines.
-- the server keeps one most-recently-used embedding lane, one image lane shared
+- The server keeps one most-recently-used embedding lane, one image lane shared
   by generation and editing, one TTS lane, and one ASR lane resident. Repeated requests for the
   same model reuse loaded components; mutable generators execute exclusively,
   and a model or ASR-backend switch unloads the previous runtime before loading
   the next one so request-selected local paths cannot grow residency without
   bound.
-- sidecars default to a 300-second idle TTL. Per-lane autonomous timers expire
+- Sidecars default to a 300-second idle time to live (TTL). Per-lane autonomous timers expire
   idle residents without waiting for another request and re-read managed
   `pinned` and `ttlSeconds` settings while idle, so live settings changes take
   effect. Managed embedding, image, TTS, and ASR models accept
   `model runtime set <id> --ttl-seconds <seconds>` and `--pinned`;
   sidecar-specific settings reject text-only sampling, engine, alias, context,
   and KV controls. The special `qwen-image-edit` repository lane is resident but
-  currently uses the default lifecycle policy because it is not configurable
+  uses the default lifecycle policy because it is not configurable
   through `model runtime`.
-- sidecar admission samples the same `--memory-guard` policy before and after an
+- Sidecar admission samples the same `--memory-guard` policy before and after an
   operation. Cold sidecar operations are exclusive across lanes, preventing two
   model loads from racing each other or an already-running warm sidecar. Image
   operations remain exclusive because staged image pipelines can reload
-  components even when their resident generator is warm. Before a new resident loads, the
+  components even when their resident generator is warm. Before another resident loads, the
   catalog estimate (or resolved local directory size) is projected against the
   hard guard with conservative per-family working-set floors; idle unpinned residents are proactively released, and the request
   fails with a memory-pressure error if adequate headroom cannot be recovered.
@@ -309,21 +309,22 @@ swift run mere.run api serve \
   eviction; the idle startup default is eligible for this sidecar admission
   path. If pressure remains, eligible idle sidecars are evicted oldest first.
   Active, queued, or pinned residents are protected throughout.
-- chat, embedding, image, TTS, and ASR inference pass through a fair FIFO request
+- Chat, embedding, image, TTS, and ASR inference pass through a fair first-in,
+  first-out (FIFO) request
   admission actor; the default `--max-active-requests 1` serializes local
   inference across text and media activation peaks and exposes queue depth in
   status. Raising it is an explicit throughput and unified-memory tradeoff;
   queued client cancellations are removed from the FIFO instead of being
   admitted later. Explicit runtime model load/unload maintenance shares the
-  same queue
-- machine admission complements rather than replaces `--max-active-requests`:
+  same queue.
+- Machine admission complements rather than replaces `--max-active-requests`:
   the server's local limit controls request and batching concurrency inside its
-  weighted machine reservation
+  weighted machine reservation.
 - Gemma4, Qwen-family, and LFM2 prefills are chunked with cancellation and
   progress checkpoints before decode; this is cooperative single-request
   prefill, not continuous batching. Qwen3.8 defaults to 1,024-token chunks and
   caps them at 512 when live reclaimable memory falls below 16 GiB or a peer is
-  admitted, so a live decoder is not held behind a pressure-heavy prefill
+  admitted, so a live decoder is not held behind a pressure-heavy prefill.
 - Gemma4 uses in-memory prefix KV reuse by default in `api serve`; set
   `MERERUN_GEMMA4_PREFIX_KV_CACHE=0` for a baseline. `/runtime/status` reports
   cache entries, hits, and reused tokens when the Gemma4 model is loaded; the
@@ -357,7 +358,7 @@ swift run mere.run api serve \
   attention and LFM2 short-convolution layers use typed recurrent state, so
   compatible rows may batch across decode positions. The scheduler services the
   earliest decode position first, batching compatible rows there or advancing a
-  single lower-offset row until it can join one
+  single lower-offset row until it can join one.
 - Gemma4 has an experimental packed PolarKV path behind
   `--kv-quant-scheme polar --kv-bits 2`; use it for memory-pressure and
   long-context synthetic decode testing. It is not the default until checkpoint
@@ -380,36 +381,37 @@ swift run mere.run api serve \
   signal that a resident object exists; additive `ready: false` means text
   preparation is in progress or a sidecar's first operation is loading or
   failed. Older payloads can omit `ready`, and older clients can ignore it. SSD
-  KV persistence remains unavailable until the in-memory counters justify it
-- runtime settings are stored at
-  `<active model store>/.mere-run/runtime-model-settings.json`
-- the runtime pool applies `ttlSeconds` opportunistically when handling pool
+  KV persistence remains unavailable until the in-memory counters justify it.
+- Runtime settings are stored at
+  `<active model store>/.mere-run/runtime-model-settings.json`.
+- The runtime pool applies `ttlSeconds` opportunistically when handling pool
   operations; expired idle models unload automatically unless their settings are
   pinned. Explicit unload remains available for pinned models.
-- memory-pressure LRU uses the API server's `--memory-guard` tier. The guard
+- Memory-pressure least-recently-used (LRU) eviction uses the API server's
+  `--memory-guard` tier. The guard
   derives soft/hard ceilings from Darwin physical footprint (RSS elsewhere),
   host memory
   headroom, and a tier reserve (`safe`, `balanced`, `aggressive`, or
   `custom`). Elevated pressure pauses extra concurrent admissions and evicts the
   least-recently-used idle unpinned model; critical pressure evicts every idle
   unpinned model. Active requests are never evicted.
-- `mere.run status` is the preferred quick check before wiring an editor or
-  agent to a local server
-- it is intentionally local-first
-- it should not reintroduce relay, billing, or hosted-infrastructure concerns
-- non-loopback binds require an API key, and the OpenAI-compatible routes
-  support basic rate limiting
-- chat, embedding, image generation, and TTS requests must use
+- `mere.run status` is the preferred quick check before you connect an editor or
+  agent to a local server.
+- The server is local-first.
+- The server must not introduce relay, billing, or hosted-infrastructure concerns.
+- Non-loopback binds require an API key, and the OpenAI-compatible routes
+  support basic rate limiting.
+- Chat, embedding, image generation, and TTS requests must use
   `Content-Type: application/json`; image editing, STT, and vision
   geometry/3D/depth requests must use `multipart/form-data`; browser-simple
-  form/text posts are rejected before the request body is processed
-- chat requests are validated before generation; `max_tokens`,
+  form and text posts are rejected before the request body is processed.
+- Chat requests are validated before generation; `max_tokens`,
   `max_completion_tokens`, `temperature`, `top_p`, and the supported `min_p`
-  extension must stay within bounded ranges
+  extension must stay within bounded ranges.
 - LoRA adapters are configured at server startup with `--lora`; request bodies
-  cannot select local LoRA paths
-- streaming and JSON error paths are sanitized so the local server does not
-  reflect raw internal runtime details back to clients
+  cannot select local LoRA paths.
+- Streaming and JSON error paths are sanitized so the local server does not
+  reflect raw internal runtime details back to clients.
 
 ## Runtime control endpoints
 
@@ -423,7 +425,7 @@ The control endpoints use the same bearer-token behavior as `/v1/models`,
   aggregate traffic stats measured from completed native chat requests.
   Newer servers also include additive `process` telemetry: PID, start time,
   uptime, sampled process CPU, macOS thermal/low-power state, Metal device,
-  current Metal allocation, recommended maximum working set, and unified-memory
+  live Metal allocation, recommended maximum working set, and unified-memory
   capability. Older clients ignore it and older servers may omit it.
 - `POST /runtime/models/{id}/load`: explicitly load an installed API-capable
   text-pool catalog model.
@@ -484,7 +486,7 @@ chunks as they are produced.
 
 Native Qwen-family, Nemotron Lightning, and Laguna catalog profiles accept
 `logprobs: true` for non-streaming requests, with `top_logprobs` from 0 through
-20. Logprob capture currently requires unconstrained text output rather than
+20. Log-probability capture requires unconstrained text output instead of
 `json_object` or `json_schema`. The response keeps the OpenAI
 `choices[].logprobs.content[]` shape and adds
 explicit `raw_logprob`, `policy_logprob`, entropy, margin, region, summary, and
@@ -583,7 +585,7 @@ Qwen3 embedding model has a fixed vector size and returns float vectors.
 
 `POST /v1/images/generations` accepts:
 
-- `model`: a mere.run image model id, local image model path, or an OpenAI image
+- `model`: a mere.run image model ID, local image model path, or an OpenAI image
   model name such as `dall-e-3` mapped to `image-zimage-nano`
 - `prompt`: required text prompt
 - `size`: `WIDTHxHEIGHT`; defaults to `1024x1024`; each dimension must be a
@@ -599,7 +601,7 @@ Qwen3 embedding model has a fixed vector size and returns float vectors.
 - `image`: required input image file part; Open WebUI-style `image[]` repeated
   parts are accepted for multi-image edit requests
 - `mask`: optional mask file part
-- `model`: a mere.run image model id, local image model path, `qwen-image-edit`,
+- `model`: a mere.run image model ID, local image model path, `qwen-image-edit`,
   or an OpenAI image model name such as `gpt-image-1` mapped to
   `image-zimage-nano`
 - `prompt`: required edit instruction
@@ -611,7 +613,7 @@ Qwen3 embedding model has a fixed vector size and returns float vectors.
 - local extensions: `strength`, `seed`, `negative_prompt`, `steps` (1 through
   100), and `guidance_scale`
 
-Masks are accepted for client compatibility. Current native edit models use
+Masks are accepted for client compatibility. Native edit models use
 whole-image conditioning rather than strict masked inpainting.
 
 `POST /v1/audio/speech` accepts:
@@ -646,10 +648,10 @@ instead of being ignored.
 The five `/v1/vision/*` routes take `multipart/form-data` and return JSON whose
 artifacts are server-local `file://` URLs, retained for one hour. Because those
 URLs only make sense on the serving machine, the routes are loopback-only:
-authenticated remote clients get an error, and their model ids are filtered out
+authenticated remote clients get an error, and their model IDs are filtered out
 of `/v1/models` for non-loopback clients. Inputs must be uploaded file parts;
 client filesystem paths are rejected. Each route accepts only its managed
-default model id (depth video also accepts its metric variant).
+default model ID (depth video also accepts its metric variant).
 
 `POST /v1/vision/geometry` accepts:
 
@@ -746,7 +748,7 @@ scripts/smoke-open-webui.sh live-smoke
 
 `live-smoke` waits for Open WebUI, signs in to the disposable no-auth smoke
 admin user, filters the OpenAI chat connection to the configured text and vision
-chat ids, imports per-model metadata wrappers, sends text and vision chat
+chat IDs, imports per-model metadata wrappers, sends text and vision chat
 through Open WebUI's own proxy, then exercises the direct mere.run API surface
 and the Open WebUI model list. Use `configure`, `proxy-smoke`, `api-smoke`, and
 `ui-smoke` separately when debugging one stage.
@@ -807,7 +809,8 @@ docker run -d \
   ghcr.io/open-webui/open-webui:main
 ```
 
-The environment variables above preconfigure Open WebUI on a fresh data volume.
+The environment variables in the Docker command preconfigure Open WebUI on a
+fresh data volume.
 Run `scripts/smoke-open-webui.sh configure` after the container is healthy to
 set Open WebUI's OpenAI connection `model_ids` filter and import per-model
 capability wrappers. That keeps image, embedding, TTS, and STT sidecars out of
@@ -826,10 +829,10 @@ the same values in the admin UI:
 - STT engine/model: `openai` / `speech-asr-parakeet`
 - Function calling: native mode with `{"function_calling":"native"}`
 
-Docker Compose / DGX Spark path:
+### Docker Compose host path
 
-Keep mere.run on the host and run only Open WebUI in Docker. This is the
-cleaner path for Linux, DGX Spark, or LAN workstations because the mere.run
+Keep mere.run on the host and run only Open WebUI in Docker. Use this path for
+Linux or LAN workstations because the mere.run
 process owns the local model store and runtime/GPU setup while Open WebUI keeps
 its persistent app data in a Docker volume.
 
@@ -850,7 +853,7 @@ MERERUN_API_KEY=change-me
 WEBUI_SECRET_KEY=replace-with-openssl-rand-hex-32
 OPEN_WEBUI_IMAGE=ghcr.io/open-webui/open-webui:main
 OPEN_WEBUI_BIND=0.0.0.0
-OPEN_WEBUI_URL=http://spark.local:3000
+OPEN_WEBUI_URL=http://host.example.com:3000
 MERERUN_OPENWEBUI_API_URL=http://host.docker.internal:8080/v1
 MERERUN_OPENWEBUI_TEXT_MODEL=text-chat-gemma4-12b
 ```
@@ -915,7 +918,7 @@ docker compose up -d
 ```
 
 For Open WebUI on a different machine, set `MERERUN_OPENWEBUI_API_URL` to the
-mere.run host's LAN URL, for example `http://192.168.1.50:8080/v1`. Keep
+mere.run host's LAN URL, for example `http://192.0.2.50:8080/v1`. Keep
 `WEBUI_AUTH=True`, keep a stable `WEBUI_SECRET_KEY`, and pin
 `OPEN_WEBUI_IMAGE` to a tested release tag before treating the instance as
 shared or production-like.
@@ -975,7 +978,8 @@ install. If an existing Open WebUI data directory ignores changed environment
 variables, update the values in the admin UI, set `ENABLE_PERSISTENT_CONFIG=False`
 for smoke, or start with a fresh data directory. Set the
 `vision-chat-gemma4-12b` per-model capability `vision=true` before UI vision
-upload smoke if you use the conservative global model metadata above.
+upload smoke if you use the conservative global model metadata from this
+example.
 
 uv path:
 
@@ -1015,7 +1019,7 @@ AUDIO_STT_OPENAI_API_BASE_URL=http://127.0.0.1:8080/v1 \
 AUDIO_STT_OPENAI_API_KEY="$MERERUN_API_KEY" \
 ENABLE_PERSISTENT_CONFIG=False \
 WEBUI_AUTH=False \
-uvx --python 3.11 open-webui@latest serve --host 127.0.0.1 --port 3000
+uvx --python 3.11 open-webui serve --host 127.0.0.1 --port 3000
 ```
 
 Run the mere.run API on `127.0.0.1:8080` in another terminal. The explicit
@@ -1027,7 +1031,7 @@ The CLI cookbook has the longer copy-paste recipe:
 mere.run guide open-webui
 ```
 
-Fair FIFO request admission is part of the runtime pool now, and Gemma4,
+Fair FIFO request admission is part of the runtime pool, and Gemma4,
 Qwen-family, and LFM2 chat use engine-specific chunked prefill checkpoints.
 Matching text prefixes reuse in-memory KV by default for all three families;
 Qwen-family vision requests remain excluded, and the engine-specific prefix
@@ -1043,7 +1047,8 @@ persistence remains later, measured work; use `cacheStats` plus
 `benchmarkStats` to decide whether that experiment is worth expanding on a real
 machine.
 
-If you are working on this area, read [CLI and Runtime Internals](../internals/cli-and-runtime.md) after the command source.
+If you are working on this area, read
+[CLI and runtime internals](../internals/cli-and-runtime.md) after the command source.
 
 ## Troubleshooting
 

--- a/docs/runtime/audio.md
+++ b/docs/runtime/audio.md
@@ -1,4 +1,4 @@
-# Audio Enhancement Runtime
+# Audio enhancement runtime
 
 Extend narrowband speech or bandwidth-limited general audio to a 48 kHz
 artifact with native Swift/MLX ports of AP-BWE and UniverSR. Both runtimes are
@@ -11,7 +11,7 @@ machine-readable results on stdout.
 | --- | --- |
 | `mere.run audio enhance` | Reconstruct a 48 kHz mono float WAV with AP-BWE speech bandwidth extension or UniverSR general-audio super-resolution. |
 
-## Model
+## Models
 
 - `audio-enhance-ap-bwe-16kto48k`
 - `audio-enhance-universr-audio`
@@ -19,8 +19,8 @@ machine-readable results on stdout.
 The source implementation is pinned to
 [`yxlu-0102/AP-BWE@751710f`](https://github.com/yxlu-0102/AP-BWE/tree/751710f22404c27e5bcc983248f8b856a04b8422).
 The official repository states that both code and pretrained weights are MIT.
-The public Hugging Face transport snapshot is pinned independently; mere.run
-accepts its 16→48 kHz archive only because it is byte-identical to the official
+The public Hugging Face transport snapshot is pinned independently. `mere.run`
+accepts its 16 to 48 kHz archive only because it is byte-identical to the official
 Google Drive checkpoint.
 
 UniverSR's native graph is pinned to
@@ -51,15 +51,17 @@ swift run mere.run audio enhance ./limited-48k.wav \
 
 Input is decoded to 16 kHz mono, then upsampled threefold with a deterministic
 windowed-sinc/Lanczos filter before the neural reconstruction stage. The pinned
-profile uses a 1,024-point STFT, 320-sample periodic Hann window, 80-sample hop,
+profile uses a 1,024-point short-time Fourier transform (STFT), 320-sample
+periodic Hann window, 80-sample hop,
 512 channels, and eight paired magnitude/phase ConvNeXt blocks. Chunked overlap
 uses two-second 48 kHz windows by default.
 
 UniverSR accepts effective input rates of 8, 12, 16, or 24 kHz. It applies a
 1,024-point complex STFT, conditions a 394-tensor ConvNeXt V2 U-Net on the
 observed low-frequency region, and reconstructs the remaining spectrum with
-flow matching. The published defaults are midpoint integration, four ODE
-steps, classifier-free guidance 1.5, and seed 42. Native-rate files supply the
+flow matching. The published defaults are midpoint integration, four ordinary
+differential equation (ODE) steps, classifier-free guidance 1.5, and seed 42.
+Native-rate files supply the
 effective rate automatically; a bandwidth-limited 48 kHz container requires
 `--input-rate`.
 
@@ -75,7 +77,7 @@ rather than a complete mastering chain. A decoded, finite, non-silent output
 proves the native route executed; it does not by itself establish perceptual
 improvement for a particular recording.
 
-See the [implementation report](../architecture/audio-enhancement-ap-bwe-report.md)
-for AP-BWE admission evidence and the
-[UniverSR report](../architecture/audio-enhancement-universr-report.md) for its
+See the [AP-BWE implementation report](../architecture/audio-enhancement-ap-bwe-report.md)
+for admission evidence and the
+[UniverSR implementation report](../architecture/audio-enhancement-universr-report.md) for its
 separate graph, artifact, and license evidence.

--- a/docs/runtime/geo.md
+++ b/docs/runtime/geo.md
@@ -1,4 +1,4 @@
-# Geospatial Runtime
+# Geospatial runtime
 
 `mere.run geo` is a local-first inference boundary for Earth-observation and
 humanitarian workflows. Any
@@ -6,7 +6,7 @@ workflow can prepare the documented tensors, run the native model locally, and
 carry the resulting candidates or embeddings into its own evidence process.
 
 Acquisition, cloud masking, reprojection, tiling, georeferencing, source
-citations, and analyst review remain workflow responsibilities. mere.run owns
+citations, and analyst review remain workflow responsibilities. `mere.run` owns
 immutable model provenance, native Swift/MLX execution, hardware-aware model
 selection, and machine-readable outputs.
 
@@ -21,7 +21,7 @@ selection, and machine-readable outputs.
 
 When `--model` is omitted, the runtime chooses the strongest tier recommended
 for the machine. If that tier is not installed, it selects the strongest
-installed tier below it. It never silently downloads model weights. An
+installed tier below it. It does not silently download model weights. An
 explicit model ID or converted model path always overrides automatic choice.
 
 ### TerraMind Fire
@@ -72,7 +72,7 @@ statistics. The runtime selects the correct contract from the immutable model
 variant.
 
 The Teacher evaluates 2.064B parameters per pixel. It is valuable for focused
-research and distillation but is not the sensible bulk-embedding default. The
+research and distillation but is not the recommended bulk-embedding default. The
 Large student is the automatic ceiling below 32 GB unified memory.
 
 ### OlmoEarth v1.2
@@ -103,12 +103,12 @@ OlmoEarth's artifact license permits broad environmental and humanitarian
 work, but prohibits military and defense applications, intelligence gathering,
 human surveillance and policing, and listed extractive activities. Managed
 pulls require `--accept-model-license`; the flag records review and acceptance
-of upstream terms, not a mere.run judgment that a proposed use qualifies.
+of upstream terms, not a `mere.run` judgment that a proposed use qualifies.
 
 ## Immutable conversion
 
 Managed pulls download the pinned upstream checkpoint and source metadata.
-The Python checkpoint is never interpreted by the Swift runtime. Convert it
+The Swift runtime does not interpret the Python checkpoint. Convert it
 once into the checksum-pinned float32 safetensors package:
 
 ```bash
@@ -139,25 +139,25 @@ For numerical verification against the official implementations, use
 `scripts/validate-olmoearth-v12-reference.py`. The repository's installed-model
 gate constructs real input tensors and exercises the public `geo` commands.
 
-## Why THOR is not a fourth runtime yet
+## Why THOR is deferred
 
 [THOR](https://github.com/FM4CS/THOR) was evaluated at source commit
 `7ded3cea673ac21fe2bcadf9f3d9d4506eb6ab5f`. Its flexible 10-1,000 m
 Sentinel-1/2/3 backbone is promising, especially for coarse Sentinel-3 climate
-and ocean observations. The current release is an embedding backbone rather
+and ocean observations. The evaluated release is an embedding backbone rather
 than a humanitarian decision head, however, and its S1/S2 role overlaps the
 validated TESSERA and OlmoEarth routes.
 
 THOR is therefore deferred until a workflow needs its genuinely distinct
 Sentinel-3/native-resolution contract and can supply a usefulness gate for
 that output. Adding another generic encoder without that consumer would expand
-download, preprocessing, ALiBi, and validation surface without improving a
-current result.
+download, preprocessing, ALiBi, and validation surface without improving an
+implemented result.
 
 ## Responsibility boundary
 
 Flood and fire logits are candidates, not authoritative findings. Embeddings
-are features, not conclusions. Humanitarian promotion should retain source
+are features, not conclusions. For humanitarian promotion, retain source
 imagery and acquisition time, preprocessing provenance, model ID and immutable
 revision, output artifact hashes, corroborating evidence, and accountable
 human review.

--- a/docs/runtime/image.md
+++ b/docs/runtime/image.md
@@ -1,10 +1,10 @@
-# Image Runtime
+# Image runtime
 
-Generate an image from a prompt — then keep going. Train a LoRA on your own
-pictures without renting a GPU, replay any generation from a saved plan, or
-lift a single photo into a textured 3D mesh. Eight model families are
-supported, from compact ZImage checkpoints up to FLUX.2 Klein, HiDream O1,
-Krea 2, and Ideogram 4.
+Use the image runtime to generate an image from a prompt, train a low-rank
+adaptation (LoRA) on your own pictures, replay a generation from a saved plan,
+or convert one photo into a textured three-dimensional (3D) mesh. The runtime
+supports eight model families, from compact ZImage checkpoints through FLUX.2
+Klein, HiDream O1, Krea 2, and Ideogram 4.
 
 ## Commands
 
@@ -18,7 +18,7 @@ Krea 2, and Ideogram 4.
 | `mere.run image validate` | Run advanced deterministic validation for local image model families. |
 | `mere.run image reconstruct-3d` | Reconstruct a colored object mesh from one image with native TripoSR. |
 | `mere.run image reconstruct-3d-trellis2` | Reconstruct a 512-resolution PBR O-Voxel mesh with native MLX TRELLIS.2. |
-| `mere.run image reconstruct-3d-multiview` | Reconstruct a colored mesh from 4 or 6 user-supplied views with native InstantMesh. |
+| `mere.run image reconstruct-3d-multiview` | Reconstruct a colored mesh from four or six supplied views with native InstantMesh. |
 
 ## macOS Studio
 
@@ -41,15 +41,15 @@ preflight, launch/resume, live loss charts, samples, checkpoints, history, and
 run comparison. **Utilities** opens deterministic validation, dataset discovery
 candidate cards, and saved-plan preflight/materialization with durable paths.
 
-Advanced → Image also exposes the entire public family as guided forms:
+**Advanced > Image** also exposes the public command family as guided forms:
 
-- generation/editing with repeatable references, structured prompts, and LoRAs;
+- Generation and editing with repeatable references, structured prompts, and LoRAs
 - Krea 2 and FLUX.2 Klein LoRA training, recipes, memory controls, checkpoints,
   preview samples, schedules, benchmarks, and the live dashboard;
-- dataset discovery, saved workflow preflight/materialization/execution, and
-  durable-run visualization;
-- deterministic image-stack validation; and
-- TripoSR, TRELLIS.2, and four/six-view InstantMesh reconstruction.
+- Dataset discovery, saved-workflow preflight, materialization, execution, and
+  durable-run visualization
+- Deterministic image-stack validation
+- TripoSR, TRELLIS.2, and four-view or six-view InstantMesh reconstruction
 
 The app launches the public CLI for all work. `mere.run catalog --json` and the
 shared contract tests keep every form flag aligned with ArgumentParser help.
@@ -128,7 +128,7 @@ printed.
 ### Klein generation and LoRA training
 
 Klein models run through the native Swift FLUX.2 Klein runtime. Base Klein
-models can also train LoRA adapters with `image train-lora`. For serious Klein
+models can also train LoRA adapters with `image train-lora`. For production Klein
 LoRA training, use the undistilled BF16 `image-klein-base-9b` model id or a
 local equivalent model root, then use the saved adapter with Klein
 `image generate --lora`. The loader accepts mflux-format Klein transformer
@@ -154,12 +154,12 @@ Core `train-lora` hyperparameters and their defaults:
 
 `--recipe` presets set curated values for steps, learning rate, rank, and
 alpha; an explicit flag always wins over the recipe. `swift run mere.run image
-train-lora --help` and the [CLI Reference](../cli.md) list the full flag
+train-lora --help` and the [CLI reference](../cli.md) list the full flag
 surface.
 
 Klein resume restores the selected adapter checkpoint before the next optimizer
-step. Krea 2 rejects `--resume-from` explicitly rather than silently starting a
-new run. Training Studio discovers checkpoint artifacts beside a prior output
+step. Krea 2 rejects `--resume-from` explicitly instead of silently starting
+another run. Training Studio discovers checkpoint artifacts beside a prior output
 and sends the same public flag.
 
 ```bash
@@ -182,7 +182,7 @@ swift run mere.run image generate \
 For reference-guided Klein LoRA inference, run the adapter on the distilled
 Klein model and pass the source composition with `--ref-image`. A practical
 starting point for style transfer is `--strength 0.55`, `--lora-scale 1.5`,
-1024x768, 16 steps, and a locked seed once the composition is close. Put the
+1024 x 768, 16 steps, and a locked seed after the composition is close. Put the
 trigger token first, then describe the subject/action relationship, visible
 anatomy, and style:
 
@@ -201,8 +201,8 @@ swift run mere.run image generate \
 ```
 
 For cleaner public-facing exports, keep the seed and prompt fixed, render at a
-larger matching aspect ratio such as 1280x960 with 24 steps, then downsample to
-1024x768 with a high-quality image resizer.
+larger matching aspect ratio such as 1280 x 960 with 24 steps, and then
+downsample to 1024 x 768 with a high-quality image resizer.
 
 If you are starting from a project data root instead of a specific dataset
 folder, discover image-caption leaves first:
@@ -370,12 +370,13 @@ weight 1.0. The native Krea target set matches the published adapter surface:
 264 Linear modules on the full model, including image input, text
 projection/fusion, time embedding/projection, transformer attention/feed-forward
 gates, and final output projection.
-Use `--recipe krea-fast-style` for a quick local Krea proof pass: Raw base, 100
+Use `--recipe krea-fast-style` for a local Krea smoke test: Raw base, 100
 steps, LR `0.0005`, 10-step warmup/cosine decay, 768 square, rank `32`, alpha
 `32`, and the full native Krea target surface. Treat this as a smoke recipe and
 inspect images before trusting it as a final style adapter. Use
-`--recipe krea-cinematic-style` for the safer movie-style lane: 200 steps, LR
-`0.0001`, 20-step warmup/cosine decay, 768x416, rank `32`, alpha `32`, and
+`--recipe krea-cinematic-style` for the lower-learning-rate movie-style lane:
+200 steps, learning rate (LR) `0.0001`, 20-step warmup and cosine decay,
+768 x 416, rank `32`, alpha `32`, and
 compiled-step disablement. Override `--width`/`--height` when your source set is
 not widescreen.
 
@@ -403,17 +404,18 @@ the user already requested a larger value. Use `--structured-prompt-output` to
 save the generated JSON for review or later refinement.
 
 The supported packer emits one uniform segment, so Ideogram skips the redundant
-block mask exactly and by default. At a representative 1024x1024 shape with
+block mask exactly and by default. At a representative 1024 x 1024 shape with
 4096 image tokens, 64 text tokens, and 18 heads, this avoids a 16.50 MiB
 one-byte mask plus a 1.160 GiB float32 masked-score graph intermediate per
 layer. Those are avoided transient allocation and memory-traffic estimates, not
 a guaranteed RSS reduction; layer buffers are reused, so the per-layer number
 must not be multiplied by the model's 34 layers to predict peak memory.
 
-Custom QKV-normalization, AdaLN, and residual Metal kernels remain opt-in with
+Custom query-key-value (QKV) normalization, adaptive layer normalization
+(AdaLN), and residual Metal kernels remain opt-in with
 `MERERUN_IDEOGRAM4_FUSED_KERNELS=1`. Although their isolated microbenchmarks
-were faster, a fixed 256x256, one-step installed-checkpoint release A/B measured
-the warm portable graph at 2.532s and the custom path at 4.169s, 1.65x slower,
+were faster, a fixed 256 x 256, one-step installed-checkpoint release A/B measured
+the warm portable graph at 2.532 seconds and the custom path at 4.169 seconds, 1.65x slower,
 with the same roughly 2.94 GiB warm incremental MLX peak. The two paths were
 internally deterministic and visually close but not bit-exact, so the portable
 graph remains the production default. The exact uniform-mask removal is
@@ -425,13 +427,13 @@ Three subcommands turn object images into colored meshes, each backed by a
 native runtime:
 
 - `image reconstruct-3d`: single-image reconstruction with native TripoSR
-  (managed id `image-3d-triposr`). This is the canonical image-family spelling
+  (managed ID `image-3d-triposr`). This is the canonical image-family spelling
   of `vision image-to-3d`; both run the same implementation.
 - `image reconstruct-3d-trellis2`: single-image 512-resolution PBR O-Voxel
-  reconstruction with native MLX TRELLIS.2 (managed id `image-3d-trellis2-4b`).
-- `image reconstruct-3d-multiview`: reconstruction from user-supplied views
-  with native InstantMesh (managed id `image-3d-instantmesh-base`). Repeat
-  `--view` exactly 4 or 6 times; no views are generated for you.
+  reconstruction with native MLX TRELLIS.2 (managed ID `image-3d-trellis2-4b`).
+- `image reconstruct-3d-multiview`: reconstruction from views you supply with
+  native InstantMesh (managed ID `image-3d-instantmesh-base`). Repeat `--view`
+  exactly four or six times; the command does not generate views.
 
 ```bash
 swift run mere.run image reconstruct-3d ./object.png --output ./object-3d
@@ -451,7 +453,8 @@ without loading weights, and `--json` for structured stdout. TripoSR and
 InstantMesh take a `--resolution` extraction-grid override (2 through 512 and
 2 through 256 respectively) plus `--no-vertex-colors` for geometry-only
 export; multiview optionally takes a `--cameras` JSON file with one 16-value
-C2W/intrinsics camera per view. The [Vision Runtime](./vision.md) page covers
+C2W transformation and intrinsics camera per view. The
+[Vision runtime](./vision.md) page covers
 the equivalent `vision image-to-3d*` commands and TRELLIS.2 output artifacts.
 
 ### Deterministic validation
@@ -522,7 +525,7 @@ generation; smaller shapes stay on the byte-identical dense path. In a warm
 - `Sources/MereRunCore/QwenImageEdit/QwenImageEditGenerator+Encoding.swift`
 
 Qwen Image Edit, Z-Image, FLUX.2 Klein, and HiDream O1 automatically combine
-unconditional and conditional CFG into one transformer batch on Apple silicon
+unconditional and conditional CFG into one transformer batch on Apple Silicon
 Macs with at least 24 GiB of physical memory and sufficient estimated MLX
 allocation headroom for the requested resolution. The estimate subtracts MLX
 active and cache allocations from physical memory; it is not host-wide
@@ -543,14 +546,15 @@ increase peak memory or exhaust unified memory at large resolutions.
 
 ## How image generation flows
 
-At a high level:
+Image generation follows these steps:
 
-1. the CLI parses prompt, model choice, size, steps, optional image input, and optional reference images
-2. model resolution maps a canonical model ID or explicit path to a local root
-3. the runtime loads the matching components for the chosen family
-4. prompt encoding and optional conditioning data are prepared
-5. the denoise loop or family-specific generation path runs
-6. latents are decoded and written as an image artifact
+1. The CLI parses the prompt, model choice, size, steps, optional image input,
+   and optional reference images.
+2. Model resolution maps a canonical model ID or explicit path to a local root.
+3. The runtime loads the matching components for the chosen family.
+4. The runtime prepares prompt encoding and optional conditioning data.
+5. The denoise loop or family-specific generation path runs.
+6. The runtime decodes the latents and writes an image artifact.
 
 The image families do not share identical implementation internals, but they are
 presented through the same public `mere.run image generate` command.
@@ -570,6 +574,6 @@ family still behaves consistently.
 
 ## Related docs
 
-- [CLI Reference](../cli.md)
-- [Model Management](./model-management.md)
-- [Architecture Reading Map](../architecture.md)
+- [CLI reference](../cli.md)
+- [Model management](./model-management.md)
+- [Architecture reading map](../architecture.md)

--- a/docs/runtime/model-management.md
+++ b/docs/runtime/model-management.md
@@ -1,9 +1,9 @@
-# Model Management
+# Model management
 
-One writable store, a unified catalog, canonical IDs, and honest accounting. `mere.run` checks whether this
-machine can run a model before it spends your bandwidth on it, reports what a
-model actually costs on disk once shared payloads are counted once, and shows
-exactly what is safe to delete.
+Use model-management commands to work with one writable store, a unified
+catalog, canonical IDs, and physical-storage accounting. Before downloading a
+model, `mere.run` checks whether the machine can run it. Storage reports count
+shared payloads once and identify data that is safe to delete.
 
 ## Commands
 
@@ -53,8 +53,9 @@ catalog normally.
 
 ## Registered catalog locations
 
-The primary store is the only writable location. Existing model collections on
-other disks can participate without copying files or building a symlink facade:
+The primary store is the only writable location. Register existing model
+collections on other disks without copying files or building a symbolic-link
+facade:
 
 ```bash
 # A canonical catalog root: /Volumes/Models/<model-id>/
@@ -74,7 +75,7 @@ Resolution order is deterministic:
 2. explicit bindings, in registration order
 3. registered search roots, in registration order
 
-An unavailable removable disk is skipped, so the next valid location can win.
+If a removable disk is unavailable, resolution tries the next valid location.
 Search-root models must live at `<root>/<canonical-model-id>/` and carry a
 matching `mererun_model.json`. A binding supplies the canonical identity for an
 arbitrarily named folder; mere.run validates it but does not write a manifest or
@@ -91,15 +92,16 @@ remove registrations. Both operations preserve every payload byte.
 
 Open **Models**, switch the scope to **All**, and select any missing model to
 download it directly. Studio streams the underlying `model pull` output, keeps
-cancelled partial downloads resumable, and refreshes the inventory after a
+canceled partial downloads resumable, and refreshes the inventory after a
 successful install. Models with restricted third-party terms show their source
 links and require **Accept & Download** before transfer. Continuing confirms
-that the user reviewed and accepts the listed terms and agrees to comply. The **Files**
-button opens the configured model store in Finder; it does not start a download.
+that you reviewed and accept the listed terms and agree to comply. The
+**Files** button opens the configured model store in Finder; it does not start
+a download.
 
 ## Canonical model IDs
 
-Examples:
+The following list shows representative canonical IDs by modality:
 
 - images: `image-klein-nano`, `image-bonsai-binary`, `image-bonsai-ternary`, `image-zimage-nano`, `image-klein-max`, `image-zimage-max`
 - text and omni chat: `text-chat-gemma4`, `text-chat-laguna-s-2-1`, `text-chat-laguna-xs-2-1`, `text-chat-nemotron-35-lightning`, `omni-chat-nemotron3-nano-30b-a3b-bf16`, `text-chat-q36-nano`, `vision-chat-q38-27b`, `vision-chat-q38-27b-4bit`, `text-chat-bonsai-27b-1bit`, `text-chat-bonsai-27b-2bit`, `text-chat-lfm25-2.6b-4bit`, `text-chat-lfm25-a1b-8bit`, `vision-chat-lfm25-3b-8bit`, `text-agent-deepseek-v4-flash`, `text-agent-qwen35-9b`, `text-agent-ornith-9b`, `text-agent-ornith-35b-mlx`, `text-agent-ornith-35b`, `text-code-north-mini`, `text-code-qwen3`, `text-embed-qwen3-0.6b`
@@ -113,7 +115,7 @@ Examples:
   `video-ltx25-distilled-bf16`, `video-ltx25-full-bf16`,
   `video-wan22-ti2v-5b-mlx`, `video-scail2-14b-mlx`
 
-The public runtime resolves these IDs directly, so docs and examples should use
+The public runtime resolves these IDs directly. Documentation and examples must use
 the canonical names shown by `mere.run model list`.
 
 ## Runtime entrypoints
@@ -148,7 +150,7 @@ keep their backing payloads live.
 
 ### `mere.run model optimize`
 
-For compatible MiniMax-H3 or LTX 2.5 roots, build the model-specific native
+For compatible MiniMax-H3 or LTX 2.5 roots, the command builds the model-specific native
 inference artifact:
 
 ```bash
@@ -182,7 +184,7 @@ the primary readout; the model IDs from `/v1/models` are the fallback.
 
 ### `mere.run model capabilities`
 
-Summarizes the current machine, the managed models it can run, the preferred
+Summarizes this machine, the managed models it can run, the preferred
 setup-agent tier, chat winners by RAM band, and cross-modality starter coverage.
 Pass `--all` to include models that are blocked by platform or memory
 requirements.
@@ -212,14 +214,14 @@ validated before the old root is renamed, and a failed final validation or
 alias installation restores the old root.
 
 Access-gated models and models with material non-commercial, research-only, or
-revenue-limited terms require `--accept-model-license` for new downloads and
+revenue-limited terms require `--accept-model-license` for restricted downloads and
 never auto-download at runtime. A custom license alone does not trigger the
 flag. The CLI and macOS app show the
 applicable model/component terms before acceptance. Passing the flag or choosing
-**Accept & Download** confirms that the user reviewed and accepts those terms
-and agrees to comply. Schema 3 of the installed `mererun_model.json` records the
+**Accept & Download** confirms that you reviewed and accept those terms and
+agree to comply. Schema 3 of the installed `mererun_model.json` records the
 immutable source revisions, term URLs, and acceptance confirmation. mere.run
-does not determine whether a user's intended use is
+does not determine whether your intended use is
 permitted. The complete inventory is in
 [`model-sources.md`](../model-sources.md#restricted-model-downloads).
 
@@ -286,7 +288,7 @@ mere.run text chat \
 
 `adapter pull` downloads the immutable upstream artifact, verifies its exact
 byte count and SHA-256, and prints the installed adapter path on stdout.
-Catalog ids are accepted by `text chat --lora`, `api serve --lora`, and the
+Catalog IDs are accepted by `text chat --lora`, `api serve --lora`, and the
 compatible SCAIL `video animate --distilled-adapter` surface; local paths
 remain supported. The default `video animate --profile fast` selects the SCAIL
 adapter ID and its published four-step schedule automatically.
@@ -352,11 +354,11 @@ separate warning confirmation. Every gate writes a JSON report.
 
 ### `mere.run model runtime`
 
-Reads and updates typed per-model API runtime settings — how a model behaves
-when served by `mere.run api serve`. `get` prints the stored settings for one
-managed model id or configured alias; `set` updates them:
+Reads and updates typed per-model API runtime settings that control how a model
+behaves when served by `mere.run api serve`. `get` prints the stored settings
+for one managed model ID or configured alias; `set` updates them.
 
-The macOS Studio's top-level **Serving & Agents → Model Pool** view uses these
+The macOS Studio's top-level **Serving & Agents > Model Pool** view uses these
 same settings for both text models and managed sidecars. Text rows additionally
 support explicit HTTP load/unload. Sidecars load on first request and expose
 their lifecycle, readiness, queue, replacement, failure, and eviction state;
@@ -400,7 +402,8 @@ not part of the everyday inference workflow. Lanes:
 - `tool-continuations` — evaluates Gemma 4 continuation after completed tool
   calls.
 - `code` — runs a real coding-eval slice against local coding models.
-- `gemma4-kv` — compares Gemma4 default KV cache decode against packed PolarKV.
+- `gemma4-kv` — compares Gemma4 default key-value (KV) cache decode against
+  packed PolarKV.
 - `gemma4-mtp` — compares Gemma4 serial decode against verified MTP speculative
   decode.
 - `q36-mtp` — compares Qwen3.6 serial decode against adaptive and forced MTP
@@ -415,6 +418,6 @@ Each lane accepts `--json` for machine-readable reports; see
 
 ## Related docs
 
-- [Model Sources](../model-sources.md)
+- [Model sources](../model-sources.md)
 - [Configuration](../configuration.md)
-- [Testing Guide](../testing.md)
+- [Testing guide](../testing.md)

--- a/docs/runtime/music.md
+++ b/docs/runtime/music.md
@@ -1,10 +1,10 @@
-# Music Runtime
+# Music runtime
 
-Write a track from a text prompt, cover an existing song in a different genre,
-play a model live from a MIDI controller, split a mix into vocal and
-instrumental WAVs, or turn it back into instrument-separated MIDI with tempo,
-meter, and key already filled in.
-Generation, analysis, adapter training, resident serving, realtime steering,
+Use the music runtime to write a track from a text prompt, cover a song in a
+different genre, play a model from a Musical Instrument Digital Interface
+(MIDI) controller, split a mix into vocal and instrumental WAV files, or
+convert it into instrument-separated MIDI with tempo, meter, and key metadata.
+Generation, analysis, adapter training, resident serving, real-time steering,
 source separation, and transcription are native Swift and MLX paths. MiniMax
 Music 3 uses its staged language-model, RVQ, flow-transformer, and stereo
 vocoder stack locally; Magenta RT2 takes CC knobs while it is still generating.
@@ -17,17 +17,17 @@ vocoder stack locally; Magenta RT2 takes CC knobs while it is still generating.
 | `mere.run music analyze` | Analyze source audio with ACE-Step audio understanding. |
 | `mere.run music serve` | Keep an ACE-Step pipeline resident behind the native music API. |
 | `mere.run music train-adapter` | Train a reloadable ACE-Step LoRA or LoKr adapter. |
-| `mere.run music realtime` | Run Magenta RealTime 2 music generation, steerable from stdin or CoreMIDI. |
+| `mere.run music realtime` | Run Magenta RealTime 2 music generation with stdin or CoreMIDI steering. |
 | `mere.run music separate` | Separate stems or restore audio with native BS/MelBand RoFormer models. |
 | `mere.run music transcribe` | Transcribe a full music mix into instrument-separated MIDI with MuScriptor. |
 
 The macOS Studio app exposes its music workflows through first-class
 workspaces backed by `MereRunContract`. Its primary Music composer covers the
-normal production loop—create or edit, source/reference audio, quality and LM
+production loop: create or edit, source or reference audio, quality and language-model (LM)
 planning, ranked candidates, adapter stacks, stems, LRC, recipes, and DAW
 export. **Music Tools** provides structured audio analysis, MuScriptor controls
 and an embedded MIDI piano roll, plus resident-server start/stop and health.
-**Realtime** owns Magenta playback and MIDI steering. **Training Studio** owns
+**Real-time** owns Magenta playback and MIDI steering. **Training Studio** owns
 LoRA/LoKr dataset inspection, launch, metrics, and run comparison. Advanced
 remains available for raw command-level control. App-to-CLI tests reject any
 emitted flag absent from `mere.run catalog --json`.
@@ -55,7 +55,7 @@ emitted flag absent from `mere.run catalog --json`.
 ## Guides
 
 Music guidance follows the command/cookbook shape used by the rest of
-`mere.run`: choose the command first, then focus the guide with a model id.
+`mere.run`: choose the command first, and then focus the guide with a model ID.
 
 ```bash
 mere.run guide music generate --model music-acestep
@@ -225,7 +225,7 @@ exact 684-tensor, 228,203,172-scalar geometry but retain different weight and
 source-config hashes. The dereverb inference config publishes overlap `2`; the
 denoise config publishes overlap `4`.
 
-The accepted AEmotion Studio snapshot is explicitly MIT-licensed and pinned at
+The accepted AEmotion Studio snapshot uses the MIT License and is pinned at
 revision `d323194290f8488ea51814143806609bfbd7a1e5`. mere.run verifies the exact
 model, upstream YAML, model-card README, and license hashes before loading.
 Inference preserves each profile's published chunk geometry, centered
@@ -244,7 +244,7 @@ values, confidence scores, and beat positions as JSON, or
 `--no-musical-context` for the legacy fixed-120-BPM writer.
 
 MuScriptor treats `--chunk-batch-size` (default `4`) as an upper bound, not a
-forced allocation. On Apple Silicon, the runtime subtracts current MLX active
+forced allocation. On Apple Silicon, the runtime subtracts active MLX
 and cache allocations plus a reserve of the greater of 4 GiB or one-eighth of
 physical memory. It estimates each requested chunk at
 `numLayers * dim * 65,536 * max(1, beamSize)` bytes for bfloat16 and float16;
@@ -272,7 +272,7 @@ peak footprint, while the four-chunk group was both slower and substantially
 larger. Lower-headroom systems fall back to one chunk, which measured about
 4.8x faster than baseline at about 2.5x its peak footprint.
 
-Greedy and sampling pipeline selected tokens into the next model step. Beam
+Greedy and sampling pipelines feed selected tokens into the next model step. Beam
 search packs live beams across the effective chunk group into as few bounded
 forwards per step as the lane budget allows, keeps an independently forked
 typed cache lane for every beam, and removes ended beams from later forwards.
@@ -386,8 +386,9 @@ For faithful covers, keep `--audio-cover-strength 1.0` and leave
 `--cover-noise-strength 0.0` while exploring, and use `--reference-audio` for an
 optional target-style/timbre example.
 
-For demo-style steering, pass `--interactive`. The command reads stdin while it
-runs, paces generation to realtime, and applies changes between native frames:
+For interactive steering, pass `--interactive`. The command reads standard
+input while it runs, paces generation in real time, and applies changes between
+native frames:
 
 ```bash
 swift run mere.run music realtime \
@@ -429,7 +430,7 @@ swift run mere.run music realtime \
 
 `--midi-cc` mappings use `cc=target:min:max`. Supported targets are `temp`,
 `topk`, `mc`, `notes`, `drums`, `drumless`, `unmask`, `seed`, and `onset`.
-`--midi-log-events` writes parsed note and CC events to stderr during realtime
+`--midi-log-events` writes parsed note and CC events to stderr during real-time
 runs, while `--midi-log-raw` writes raw packet bytes. Prompt changes still use
 stdin and may briefly stall while the prompt encoder runs; MIDI is intended for
 notes and continuous controls.
@@ -463,7 +464,7 @@ notes and continuous controls.
 
 ## Reading order
 
-The ACEStep runtime now follows a clean phase split:
+The ACEStep runtime uses three phases:
 
 1. `ACEStepPipeline.swift` for the public pipeline and orchestration
 2. `ACEStepPipeline+Prompting.swift` for prompt preparation and conditioning
@@ -473,22 +474,22 @@ See [ACE-Step validation](./acestep-validation.md) for immutable checkpoint
 pins, parity coverage, installed-model evidence, listening review fixtures,
 and measured performance.
 
-That makes it much easier to follow than a single pipeline monolith.
+This structure separates orchestration, prompt preparation, and generation.
 
 Magenta RT2 is a native Apple Silicon macOS runtime. The managed model layout
 contains exported `.mlxfn` models, matching state files, and shared MusicCoCa and
 SpectroStream resources; raw upstream checkpoint files are not enough for
 `mere.run`.
 
-`--style-conditioning streaming` matches upstream's realtime C++ path by using
+`--style-conditioning streaming` matches upstream's real-time C++ path by using
 the coarsest MusicCoCa style tokens. `--style-conditioning full` uses all style
 tokens, matching upstream's high-level Python `.mlxfn` generator more closely.
 
 ## Contributor notes
 
-- this is a native Swift/MLX path, not a Python bridge
-- Magenta RT2 uses a pinned C ABI bridge built by
+- This is a native Swift/MLX path, not a Python bridge.
+- Magenta RT2 uses a pinned C application binary interface (ABI) bridge built by
   `scripts/rebuild_magentart_xcframework.sh`; Linux builds keep compiling with
-  an unsupported-runtime error for Magenta
-- model resolution and storage still follow the same canonical public rules as
-  the rest of the repo
+  an unsupported-runtime error for Magenta.
+- Model resolution and storage follow the same canonical public rules as the
+  rest of the repository.

--- a/docs/runtime/sfx.md
+++ b/docs/runtime/sfx.md
@@ -1,8 +1,8 @@
-# SFX Runtime
+# SFX runtime
 
-Foley from a sentence — or from a silent video. Describe the sound you want and
-get a WAV back, or hand the runtime a clip and let it watch the footage and
-place the hits in sync with what is on screen.
+Generate Foley from a sentence or silent video. Describe the sound you want to
+create, or provide a clip so the runtime can align the generated sound with the
+on-screen action.
 
 ## Commands
 
@@ -15,7 +15,7 @@ place the hits in sync with what is on screen.
 | `mere.run sfx ae encode` | Encode audio into normalized Woosh-AE latents. |
 | `mere.run sfx ae decode` | Decode normalized Woosh-AE latents into audio. |
 
-## Model family
+## Model families
 
 - `sfx-woosh-dflow`
 - `sfx-woosh-flow`
@@ -31,12 +31,12 @@ The Sound FX workspace opens **SFX Lab**, a dedicated surface for all six
 command families. It provides text generation and video-synchronized Foley,
 renoise and negative-conditioning controls, text-conditioning export, Woosh-AE
 encode/decode, and CLAP prompt/audio scoring. Generated audio and source video
-are reviewable in place; encoded NPY results show their dtype, shape, NumPy
+are reviewable in place. Encoded NPY results show their data type, shape, NumPy
 version, layout, and size. Progress and every output remain durable in Library.
 
 ## Writing prompts
 
-Woosh is trained on caption datasets — AudioCaps, WavCaps and Freesound — where
+Woosh is trained on the AudioCaps, WavCaps, and Freesound caption datasets, where
 every label is a natural-language clause describing an event, and Sony's own
 examples follow that form ("A crowd applauds", "An engine humming and brakes
 squealing"). Keyword lists usually work too, but caption phrasing is more
@@ -53,10 +53,11 @@ Measured on `sfx-woosh-dflow`, seed 7, peak amplitude of the generated WAV:
 | `ceramic mug shattering on a tile floor` | 0.082 — very quiet |
 | `A ceramic mug shatters on a tile floor` | 0.893 |
 
-The collapse is not about the subject: `piano` and `lid closing` each generate
-fine on their own, and `piano lid closing, loud` recovers. Nor is it sampling —
-seed, `--cfg` and `--steps` change nothing, and the `dflow` and `flow`
-checkpoints fail identically on the same prompts.
+The subject does not cause the collapse. `piano` and `lid closing` each generate
+audible output independently, and `piano lid closing, loud` recovers. Sampling
+also does not cause the collapse. The seed, `--cfg`, and `--steps` do not change
+the result, and the `dflow` and `flow` checkpoints fail identically on the same
+prompts.
 
 When a generation comes out inaudible, `sfx generate` warns with the measured
 peak. Rephrase as a caption before reaching for other parameters:
@@ -166,7 +167,7 @@ both DFN5B CLIP frames and Synchformer features. A Synchformer-only `.npy`
 input cannot supply the CLIP stream. The model produces 44.1 kHz audio and
 defaults to 8 seconds, 25 Euler flow steps, and CFG 4.5.
 
-## Runtime entrypoints
+## Runtime entry points
 
 ### CLI
 
@@ -195,19 +196,20 @@ defaults to 8 seconds, 25 Euler flow steps, and CFG 4.5.
 
 ## Reading order
 
-1. `WooshResources.swift` for model IDs, validation, and checkpoint layout
-2. `WooshGenerator.swift` for prompt/video conditioning, Flow/DFlow/VFlow/DVFlow sampling, and WAV-ready samples
-3. `WooshRobertaTextEncoder.swift` for TextConditionerA / RoBERTa conditioning
-4. `WooshDiT.swift` for the native Flow and FlowMap DiTs
-5. `WooshVideoDiT.swift` for VFlow/DVFlow video-feature-conditioned DiTs
+1. `WooshResources.swift` for model IDs, validation, and checkpoint layout.
+2. `WooshGenerator.swift` for prompt and video conditioning,
+   Flow/DFlow/VFlow/DVFlow sampling, and WAV-ready samples.
+3. `WooshRobertaTextEncoder.swift` for TextConditionerA and RoBERTa conditioning.
+4. `WooshDiT.swift` for the native Flow and FlowMap DiTs.
+5. `WooshVideoDiT.swift` for VFlow and DVFlow video-feature-conditioned DiTs.
 6. `WooshSynchformer.swift` for raw-video frame preprocessing and
    Synchformer `synch_out` extraction
-7. `WooshCLAP.swift` for Woosh-CLAP text/audio scoring
-8. `WooshVocosDecoder.swift` for Woosh-AE encode/decode
+7. `WooshCLAP.swift` for Woosh-CLAP text and audio scoring.
+8. `WooshVocosDecoder.swift` for Woosh-AE encoding and decoding.
 
 ## Contributor notes
 
-- Woosh is a sound-effect and Foley model, not a song model; keep it under
+- Woosh is a sound-effect and Foley model, not a song model. Keep it under
   `sfx`, not `music`.
 - The managed install uses the Hugging Face mirror
   `AEmotionStudio/woosh-models`, which mirrors Sony Research Woosh v1.0.0.
@@ -216,7 +218,7 @@ defaults to 8 seconds, 25 Euler flow steps, and CFG 4.5.
   and needs more steps for quality.
 - TextConditionerA/TextConditionerV are exported Woosh-CLAP text-conditioning
   components. `sfx condition text` exposes the text-token conditioning tensors,
-  and `sfx clap score` runs the native RoBERTa + PaSST retrieval path.
+  and `sfx clap score` runs the native RoBERTa and PaSST retrieval path.
 - `sfx video generate` runs native VFlow/DVFlow from a raw video file. It can
   also take precomputed Synchformer `synch_out` tensors as `.npy` with shape
   `[frames, 768]` or `[1, frames, 768]`.

--- a/docs/runtime/speech.md
+++ b/docs/runtime/speech.md
@@ -1,9 +1,10 @@
-# Speech Runtime
+# Speech runtime
 
 Read text aloud, clone a voice from a short reference clip and save it for
 reuse, transcribe either a file or a live microphone, and identify who spoke
-when in a recording. Two ASR backends and one speaker-diarization backend are
-available — none of the audio leaves the machine.
+when in a recording. Two automatic speech recognition (ASR) backends and one
+speaker-diarization backend are available. These operations run locally, so
+the audio does not leave the machine.
 
 ## Commands
 
@@ -115,8 +116,8 @@ Sortformer answers “who spoke when”; it does not transcribe the words or inf
 real identities. Labels such as `speaker_0` are stable within one recording
 but are not identities that carry between recordings. The v2.1 checkpoint has
 four output channels, so recordings with more than four distinct speakers are
-outside this model's supported range. This first runtime is offline/file-based;
-streaming diarization is not exposed yet.
+outside this model's supported range. This runtime is offline and file-based.
+Streaming diarization is not supported.
 
 ### Manage voice profiles
 
@@ -130,7 +131,7 @@ swift run mere.run speech profile delete --id <profile-uuid>
 ### Voice cloning
 
 `speech synthesize` defaults to `--mode style`, which renders the `--voice`
-description. Pass `--mode clone` with either a saved profile or ad-hoc
+description. Pass `--mode clone` with either a saved profile or one-time
 reference audio:
 
 ```bash
@@ -140,7 +141,7 @@ swift run mere.run speech synthesize \
   --mode clone --profile narrator \
   --output ./cloned.wav
 
-# Clone ad-hoc reference audio and save it as a reusable profile.
+# Clone one-time reference audio and save it as a reusable profile.
 swift run mere.run speech synthesize \
   "Hello from mere.run" \
   --mode clone --ref-audio ./ref.wav \
@@ -149,12 +150,12 @@ swift run mere.run speech synthesize \
   --output ./cloned.wav
 ```
 
-If `--ref-text` is omitted, the reference audio is auto-transcribed with the
+If `--ref-text` is omitted, the speech transcriber automatically transcribes the
 speech transcriber. `--language` hints the language (default `auto`). Add
 `--stream` to emit audio incrementally while generating; `--stream-chunk-tokens`
 sets the chunk interval (default 25).
 
-## Runtime entrypoints
+## Runtime entry points
 
 ### CLI
 
@@ -194,11 +195,11 @@ Tokenizer internals:
 
 At a high level:
 
-1. the CLI resolves the chosen TTS model
-2. optional profile or voice configuration is loaded
-3. text is converted into the model’s intermediate token representation
-4. the generator produces waveform data
-5. audio is written to disk through the codec/output helpers
+1. The CLI resolves the selected text-to-speech (TTS) model.
+2. The runtime loads the optional profile or voice configuration.
+3. The runtime converts text into the model's intermediate token representation.
+4. The generator produces waveform data.
+5. The codec and output helpers write the audio to disk.
 
 `MediaAudioIO` can write float WAV output incrementally from chunk providers,
 including device-backed producers, which avoids constructing a second
@@ -208,25 +209,25 @@ not by itself make every synthesis model incremental.
 
 ## How transcription flows
 
-1. audio input is decoded into the expected local format
-2. the selected backend loads its model components
-3. the backend produces a transcript
-4. the CLI prints or writes the output
+1. The runtime decodes audio input into the expected local format.
+2. The selected backend loads its model components.
+3. The backend produces a transcript.
+4. The CLI prints or writes the output.
 
 ## How diarization flows
 
-1. audio input is decoded and resampled to 16 kHz mono
-2. the MLX feature extractor produces NeMo-compatible mel features
-3. Sortformer predicts activity independently across four speaker channels
+1. The runtime decodes and resamples audio input to 16 kHz mono.
+2. The MLX feature extractor produces NeMo-compatible mel features.
+3. Sortformer predicts activity independently across four speaker channels.
 4. thresholding, minimum-duration filtering, and same-speaker gap merging
-   produce time segments
-5. the CLI emits versioned JSON or standard RTTM text
+   produce time segments.
+5. The CLI emits versioned JSON or standard RTTM text.
 
 ## Notes for contributors
 
-- speech code spans both `AudioTTS` and `AudioSTT`; do not assume it all lives
-  under `MereRunCore`
-- profile management is CLI-facing but depends on the same canonical model and
-  model-store conventions as the rest of the repo
+- Speech code spans both `AudioTTS` and `AudioSTT`. Do not assume it all lives
+  under `MereRunCore`.
+- Profile management is CLI-facing but depends on the same canonical model and
+  model-store conventions as the rest of the repository.
 
-See [Architecture Reading Map](../architecture.md) for a recommended reading order.
+See the [architecture map](../architecture.md) for a recommended reading order.

--- a/docs/runtime/text.md
+++ b/docs/runtime/text.md
@@ -1,10 +1,10 @@
-# Text Runtime
+# Text runtime
 
-Local chat that can actually do things: stream tokens, run a sandboxed tool
-loop, take an image alongside the prompt, hold a grammar-checked JSON object to
-the last brace, and fine-tune on your own conversations. Alongside it sits a
-separate GGUF path for code, an embedding model for local search, and a PII
-redactor that never sends the text it is redacting anywhere.
+Use the text runtime to stream chat tokens, run a sandboxed tool loop, include
+an image with a prompt, produce a grammar-checked JSON object, and fine-tune on
+your own conversations. Separate paths provide GGUF code generation, embeddings
+for local search, and local personally identifiable information (PII)
+redaction.
 
 ## Commands
 
@@ -21,12 +21,12 @@ redactor that never sends the text it is redacting anywhere.
 The macOS app compiles against the same `MereRunContract` emitted by
 `mere.run catalog --json`. Chat's Options panel exposes text versus constrained
 `json_object` output, model-default/show/disable reasoning, context and sampling
-controls, KV quantization, a catalog adapter id or local LoRA file, tool
+controls, key-value (KV) quantization, a catalog adapter ID or local LoRA file, tool
 permissions, preflight, and installed-model enforcement. **Utilities** turns
 Embeddings into a vector explorer with dimensions, norms, previews, and cosine
 similarity, and turns Anonymize into original/protected text review with labeled
 PII spans. **Training** opens a text-dataset preview, preflight, live metrics,
-artifact, history, and comparison workspace for native LoRA. Advanced retains
+artifacts, history, and comparison workspace for native LoRA. Advanced retains
 guided raw forms; every generated flag is checked against public ArgumentParser
 help in the repository gate.
 
@@ -146,23 +146,22 @@ proposal, verification, recovery, and adaptive-fallback counts. Set
 `MERERUN_NEMOTRON35_DSPARK=0` to compare serial target decode, or tune the
 break-even gate with `MERERUN_NEMOTRON35_DSPARK_MIN_ACCEPTANCE`. The model is
 never selected or downloaded implicitly; 32 GB is the catalog floor and 64 GB
-is recommended for comfortable runtime headroom.
+provides additional runtime headroom.
 
-Use these chat winners by RAM band instead of treating every supported model as
-equally recommended:
+Use these recommended chat models by unified-memory band:
 
-| Unified memory | Winner | Notes |
+| Unified memory | Recommended model | Notes |
 | --- | --- | --- |
-| 16-23 GB | `text-chat-gemma4-12b-4bit` | Best compact first chat pick; `text-chat-gemma4-nano` is the safer smallest fallback. |
+| 16-23 GB | `text-chat-gemma4-12b-4bit` | Compact default; `text-chat-gemma4-nano` has the smallest memory requirement. |
 | 24-63 GB | `text-chat-gemma4-12b-4bit` | Default grounded local-assistant tier; `text-chat-gemma4-turbo` is the larger Gemma alternate. |
-| 64-95 GB | `text-chat-gemma4-12b-4bit` | Keep the proven Gemma assistant lane; spend headroom on context, concurrency, or larger Gemma alternates. |
-| 96+ GB | `text-agent-deepseek-v4-flash` | Premier agent/API chat tier; keep Gemma 12B 4-bit for normal interactive local chat. |
+| 64-95 GB | `text-chat-gemma4-12b-4bit` | Retain the measured Gemma assistant lane; use additional memory for context, concurrency, or larger Gemma alternatives. |
+| 96+ GB | `text-agent-deepseek-v4-flash` | Agent and API chat tier; retain Gemma 12B 4-bit for interactive local chat. |
 
 The DeepSeek V4 Flash tier uses the official 80.76 GiB pure-Q2 0731 imatrix
 GGUF. Its persistent DS4 server defaults to a 32K operational context, a
-1,024-token prefill chunk, and an 8 GiB disk-KV budget. A 128 GB Mac is the
-comfortable target; close other memory-heavy workloads before using it on a
-96 GB machine.
+1,024-token prefill chunk, and an 8 GiB disk-KV budget. A 128 GB Mac provides
+additional headroom. Close other memory-heavy workloads before using the model
+on a 96 GB machine.
 
 `text-chat-lfm25-2.6b-4bit` installs the pinned 4-bit partition of
 `LiquidAI/LFM2.5-2.6B-MLX`; `text-chat-lfm25-a1b-8bit` installs
@@ -286,7 +285,7 @@ Qwen3.8 image sizing floor. Its native reasoning-effort values are `low`,
 native values without inventing unsupported template labels. Tool calls use a
 streaming structural Qwen XML parser, including when parameter strings contain
 tag-like text. The checkpoint also contains video understanding weights, but
-the current native command accepts text and local images only. Its embedded
+the native command accepts text and local images only. Its embedded
 dense MTP head can be loaded from the official shards with
 `MERERUN_Q35_MTP_SPECULATION=1`. This materially accelerates greedy decode, but
 is experimental: BF16 multi-token verification can choose a different greedy
@@ -296,7 +295,7 @@ uses speculation only while uncontended; peers use the continuous-batching lane.
 
 Qwen3.8 prefill defaults to 1,024-token chunks. Live reclaimable host-memory
 headroom below 16 GiB, or an admitted peer, caps a chunk at 512 tokens. This
-uses current pressure rather than total physical RAM because the dense BF16
+uses live pressure instead of total physical memory because the dense BF16
 checkpoint and concurrent workloads can consume most unified memory before
 prefill begins. `MERERUN_Q35_PREFILL_CHUNK_TOKENS` remains an explicit upper
 bound and is still pressure-capped.
@@ -410,7 +409,7 @@ always requires interactive approval even when that flag is set.
 ```bash
 swift run mere.run text chat \
   --model text-chat-gemma4-12b-4bit \
-  --prompt "Create hello.py that prints the current time, then run it." \
+  --prompt "Create hello.py that prints the system time, then run it." \
   --tools write_file,shell_exec \
   --tool-loop \
   --allow-shell-exec \
@@ -468,7 +467,7 @@ swift run mere.run text embed \
 
 ```bash
 swift run mere.run text anonymize \
-  "My name is Alice Smith and my email is alice@example.com"
+  "My name is Dana Example and my email is dana@example.com"
 ```
 
 ### Native text LoRA training
@@ -499,8 +498,8 @@ surface, and writes a `.safetensors` adapter plus a family-specific manifest. Ad
 training; text runs write `run.json`, `*.events.jsonl`, `*.loss.csv`, and
 `*.loss.html` beside the adapter so loss and training events can be inspected
 while the optimizer runs. Keep local text fine-tuning in `mere.run` so the same
-model ids, manifests, runtime constraints, and eval artifacts remain under the
-MereRun command plane.
+model IDs, manifests, runtime constraints, and evaluation artifacts remain
+under the MereRun command surface.
 
 When `--eval` is supplied for a real training run, mere.run tokenizes that
 held-out SFT JSONL with the same model chat template and reports assistant-token
@@ -601,7 +600,7 @@ training graph uses a differentiable MLX mask path and treats discrete expert
 selection indices as non-differentiable while retaining gradients through the
 selected router scores and quantized expert computation.
 
-Loss improvement is diagnostic, not a behavioral acceptance gate. The repo
+Loss improvement is diagnostic, not a behavioral acceptance gate. The repository
 includes a deterministic codebook task with 32 train examples and four unseen
 paraphrases. The following proven recipe covers 12 complete shuffled epochs
 using balanced batch-4 updates, then requires the adapter to answer all
@@ -700,8 +699,9 @@ mixed-precision MLX artifact.
 
 If you want to understand the text stack:
 
-1. start at the matching CLI command
-2. follow model resolution through `MereRunModelManifest` and `ModelResolver`
-3. jump to the family-specific runtime in `MereRunCore`
+1. Start at the matching CLI command.
+2. Follow model resolution through `MereRunModelManifest` and `ModelResolver`.
+3. Continue to the family-specific runtime in `MereRunCore`.
 
-For repo orientation, pair this page with [CLI and Runtime Internals](../internals/cli-and-runtime.md).
+For repository orientation, pair this page with
+[CLI and runtime internals](../internals/cli-and-runtime.md).

--- a/docs/runtime/video.md
+++ b/docs/runtime/video.md
@@ -1,10 +1,10 @@
-# Video Runtime
+# Video runtime
 
-Generate a clip from a prompt. With a unified A/V checkpoint, the model writes
-the soundtrack in the same pass rather than layering it on afterwards. Anchor
-the clip to a start frame, steer it toward an end frame, or condition the motion
-on a song you already have. Recast a performer in an existing shot. Keep the
-checkpoint resident and render take after take without paying for the reload.
+Use the video runtime to generate a clip from a prompt. With a unified
+audiovisual (AV) checkpoint, the model writes the soundtrack in the same pass.
+Anchor the clip to a start frame, steer it toward an end frame, condition its
+motion on a song, or recast a performer in an existing shot. Keep the checkpoint
+resident to render multiple takes without reloading it.
 
 ## Commands
 
@@ -41,7 +41,7 @@ dimensions, profile, adapter, seed, segmentation/overlap, tail, audio, output,
 and preflight controls map directly to the public CLI contract. Every mask and
 animation run remains live and restartable in Library.
 
-Advanced Video remains the typed home for Cosmos3 generation/action modes, raw
+**Advanced Video** provides typed controls for Cosmos3 generation and action modes, raw
 mask-plan execution, LTX latent export, and resident LTX sessions. Raw arguments
 are an escape hatch, not the capability contract.
 
@@ -49,9 +49,10 @@ are an escape hatch, not the capability contract.
 
 - `video-minimax-h3-fl2va-mlx`: legacy compatibility MiniMax-H3 FL2VA package
   with a direct-from-official Q4 transformer core, Q8 conditioner, and bundled
-  source-bound AdaLN cache. It generates 24 fps RGB and synchronized 32 kHz
-  stereo audio from text, a first frame, or directed first/last frames. Frame
-  counts follow `17*n+5`; width and height are multiples of 32. It remains
+  source-bound AdaLN cache. It generates RGB video at 24 frames per second and
+  synchronized 32 kHz stereo audio from text, a first frame, or directed
+  first and last frames. Frame
+  counts follow `17*n+5`; width and height are multiples of 32. The package remains
   installable but is no longer the recommended quality path.
 - `video-minimax-h3-fl2va-bf16-mlx`: maximum-fidelity compact FL2VA package.
   Its official-source BF16 denoising core omits the schedule-only AdaLN,
@@ -214,9 +215,9 @@ and boundary audio latents. Only new frames and samples are appended, so the
 final MP4 has the exact aligned global duration. Conditioner, transformer,
 AdaLN table, reference encodings, and both VAEs remain resident across windows.
 
-The compact BF16, Q8, legacy Q4, and Ref2VA managed packages already include
+The compact BF16, Q8, legacy Q4, and Ref2VA managed packages include
 source-bound inference-only AdaLN caches; no post-pull optimization is
-required. New BF16 and Q8 packages select exact tables for 5, 9, 12, 16, 21,
+required. Compact BF16 and Q8 packages select exact tables for 5, 9, 12, 16, 21,
 or 31 points at shifts 12/3 and the LightX2V 768p 5-point schedule at shifts
 6/3. A custom schedule interpolates from the densest table and emits a visible
 non-bit-exact diagnostic. Generation skips the 13B-parameter
@@ -252,7 +253,7 @@ and seed; use `quality` when exact-seed fidelity matters.
 `--h3-acceleration velocity-reuse-2` is an isolated experimental bake-off arm.
 It keeps the quality schedule, protects the first and final full evaluations,
 and linearly extrapolates the complete synchronized video/audio velocity from
-the two latest full evaluations on intervening odd steps. Video and audio use
+the two most recent full evaluations on intervening odd steps. Video and audio use
 their independent shifted schedules, and the extrapolation ratio is clamped to
 `[-2, 2]`. It disables the other approximation policies so its timing and
 quality deltas can be attributed directly; it is not an automatic or default
@@ -268,7 +269,7 @@ seeded streams and native latent layouts.
 
 The isolated `layers-45` and `layers-40` arms rank mean absolute attention and
 MLP gates from the exact AdaLN table, protect blocks 0, 1, and 49, and skip the
-lowest remaining blocks. They reduce executed block work but currently keep all
+lowest remaining blocks. They reduce executed block work but keep all
 weights loaded, so no residency reduction is claimed.
 
 `--h3-acceleration token-reduction` preserves the complete packed prefix and
@@ -283,10 +284,10 @@ isolated from the other approximation policies and is not a default.
 `--h3-render-width` and `--h3-render-height` select an explicit internal target
 canvas for FL2VA or Ref2VA. Set both; they must be same-aspect 32px multiples no
 larger than the requested output. DiT and VAE decode operate on that smaller
-grid, then the decoded RGB frames are returned to `--width` and `--height` with
+grid. The decoded RGB frames are then returned to `--width` and `--height` with
 the pinned h3.c high-quality vImage scaling contract. A 512x512 output can use
-384x384 for the 75% arm or 320x320 for the 62.5% arm. Reduced rendering is
-currently rejected with sliding windows because continuation conditioning has
+384 x 384 for the 75% arm or 320 x 320 for the 62.5% arm. Reduced rendering is
+rejected with sliding windows because continuation conditioning has
 not yet been resampled and qualified.
 
 ### Cosmos3 generation, actions, and reasoning
@@ -350,7 +351,7 @@ SHA-256 manifest. Set the plan's `mode` to `replacement` to aspect-fit every
 reference into the target canvas and matte all non-subject pixels to black;
 `animation` preserves the fitted reference scene. The plan
 supports one to six stable subjects, text/box/point selectors, and dense painted
-PNG corrections. White is background; legal subject colours are blue, red,
+PNG corrections. White is background; legal subject colors are blue, red,
 green, magenta, cyan, and yellow.
 
 The native transformer preserves upstream global self-attention while splitting
@@ -420,7 +421,7 @@ target to match exactly, applies the compatible 487 LoRA pairs and parameter
 differences, and explicitly leaves only that incompatible input-projection
 weight untouched. It does not use a general skip-mismatch mode.
 
-Decoded mask pixels are snapped to the nearest legal colour inside a strict
+Decoded mask pixels are snapped to the nearest legal color inside a strict
 tolerance, and ambiguous or out-of-tolerance pixels are rejected. The default
 long-video contract uses 81-frame segments with five decoded frames of clean
 overlap. Compatibility defaults remain `--tail-policy drop` and
@@ -441,7 +442,7 @@ and reference/mask ordering is preserved.
 The default `--quality draft` lane is the speed path. It generates video-only
 MP4s by default and is the right first pass for prompt, camera, subject, and
 composition checks.
-For the current split-layout LTX 2.3 model, it retains the joint AV denoising
+For the split-layout LTX 2.3 model, it retains the joint AV denoising
 tokens that influence video through audio-to-video cross attention, but skips
 loading and decoding the audio VAE/vocoder and writes no audio stream.
 
@@ -492,7 +493,7 @@ change comes from selecting the draft checkpoint.
 
 ### Synchronized AV final render
 
-For LTX 2.3 audio/video, pull the managed model id and let it install its Gemma
+For LTX 2.3 audio and video, pull the managed model ID and let it install its Gemma
 3 companion:
 
 ```bash
@@ -506,9 +507,9 @@ swift run mere.run video generate \
   --output ./ltx23.mp4
 ```
 
-Use `--duration` rather than hand-pairing `--num-frames` and `--fps` for
-representative unified AV tests. LTX 2.3 expects 24 fps timing; for example,
-15 seconds resolves to 361 frames at 24 fps because LTX frame counts must
+Use `--duration` instead of pairing `--num-frames` and `--fps` manually for
+representative unified AV tests. LTX 2.3 expects 24 frames per second; for
+example, 15 seconds resolves to 361 frames at 24 frames per second because LTX frame counts must
 satisfy `8n+1`.
 
 `--quality final --output-mode audio-video` runs the official two-stage quality
@@ -633,19 +634,20 @@ zero-memory. MP4 formats and backend selection are unchanged.
 - `Sources/MereRunCore/SCAIL2/SCAIL2Generator.swift`
 - `Sources/MereRunCore/SCAIL2/SCAIL2Transformer.swift`
 
-## Source Reading Notes
+## Source reading notes
 
 The LTX runtime has more low-level model, media, and checkpoint-layout code
-than most other runtime families in this repo. Start from the public generation
+than most other runtime families in this repository. Start from the public generation
 flow before reading the lower-level model definitions.
 
-The best reading order is:
+Use this reading order:
 
-1. public generation types and `LTXDistilledLatentGenerator`
-2. request normalization and generation flow
-3. denoise and latent-conditioning helpers
-4. decoding and media assembly code
-5. lower-level model definitions
+1. Public generation types and `LTXDistilledLatentGenerator`
+2. Request normalization and generation flow
+3. Denoise and latent-conditioning helpers
+4. Decoding and media assembly code
+5. Lower-level model definitions
 
-If you are new to the repo, use [Architecture Reading Map](../architecture.md)
+If you are new to the repository, use the
+[Architecture reading map](../architecture.md)
 before diving directly into the LTX implementation.

--- a/docs/runtime/vision.md
+++ b/docs/runtime/vision.md
@@ -1,9 +1,9 @@
-# Vision Runtime
+# Vision runtime
 
-The widest surface in `mere.run`. Ask a question about a photo, cut out any
-object you can name, follow it through a video, read a document, recover metric
-depth and camera intrinsics from a single frame, or reconstruct a PBR mesh —
-nineteen commands, every one of them running on your own machine.
+Use the vision runtime to ask a question about a photo, isolate a named object,
+follow it through a video, read a document, recover metric depth and camera
+intrinsics from one frame, or reconstruct a physically based rendering (PBR)
+mesh. The runtime provides 19 commands that run on your machine.
 
 ## Commands
 
@@ -48,10 +48,10 @@ nineteen commands, every one of them running on your own machine.
 
 The macOS Studio app exposes the same surface through its shared capability
 contract. Read Image remains the fast caption/inspection entry point. Its
-**Vision Lab** button (also present in Find, Segment, and Track) opens a
-first-class workspace for live camera tracking; Buffalo-L detection, embedding,
-comparison, and batch analysis; native pose and optical flow; video depth; and
-single/multi-view geometry. The Lab draws native face/pose overlays and
+**Vision Lab** button, also present in Find, Segment, and Track, opens a
+workspace for live camera tracking, Buffalo-L detection, embedding, comparison,
+batch analysis, native pose and optical flow, video depth, and single-view or
+multi-view geometry. The Lab draws native face and pose overlays and
 direction-colored flow vectors, plays annotated/depth video, embeds orbitable
 point clouds, reports request-scoped progress, and preserves structured and
 visual sidecars in Library.
@@ -60,7 +60,7 @@ Advanced retains typed forms for every command and raw-argument escape hatches.
 Image-to-3D commands live in the Image workspace so the app has one canonical
 reconstruction flow.
 
-## Model family
+## Model families
 
 - `vision-ocr-lighton`
 - `vision-ground-falcon-perception`
@@ -96,19 +96,23 @@ representative prototype selection, and identity-outlier review. Neither model
 claims emotion, demographic attributes, liveness, deepfake detection, or
 general image understanding.
 
-## Current SAM 3.1 scope
+## SAM 3.1 scope
 
-- `vision segment` supports text prompts plus geometry prompting with boxes and points
-- `vision track` supports text, box, and point prompts on the init frame, then propagates tracked objects through later frames
-- `vision track-live` records a camera clip, searches a short warm-up window for seed objects, and then runs the same native tracking path over the saved recording
-- the managed model package `vision-segment-sam31` is the single SAM 3.1 package for segmentation and tracking
+- `vision segment` supports text prompts and geometry prompts with boxes and points.
+- `vision track` supports text, box, and point prompts on the initial frame. It
+  then propagates tracked objects through later frames.
+- `vision track-live` records a camera clip, searches a short warm-up window
+  for seed objects, and then runs the same native tracking path over the saved
+  recording.
+- The managed `vision-segment-sam31` package supports segmentation and tracking.
 
-## Current implementation notes
+## Implementation notes
 
-- still-image text prompting uses the native detector path
-- still-image box and point prompting use the native interactive SAM prompt path
-- offline video tracking currently uses native prompt propagation built on top of the image segmenter rather than a full SAM memory-bank tracker
-- live capture is text-prompt seeded only in the current CLI surface
+- Still-image text prompting uses the native detector path.
+- Still-image box and point prompting use the native interactive SAM prompt path.
+- Offline video tracking uses native prompt propagation built on the image
+  segmenter instead of a full SAM memory-bank tracker.
+- Live capture supports text-prompt seeding in the CLI.
 
 ## Fused attention policy
 
@@ -119,9 +123,9 @@ compatibility fallback or a controlled A/B.
 
 The installed-model gate on 2026-07-11 used release binaries on an M4 Max with
 128 GB unified memory. A SAM 3.1 text-prompt segmentation run was about 3%
-faster (1.36s to 1.32s) and reduced peak footprint by 13.2%; all 11 exported
+faster (1.36 seconds to 1.32 seconds) and reduced peak footprint by 13.2%; all 11 exported
 masks were bit-exact, with only negligible score/box deltas. A warm LightOn OCR
-run improved from 2.87s to 1.97s (1.46x throughput) and reduced peak footprint
+run improved from 2.87 seconds to 1.97 seconds (1.46x throughput) and reduced peak footprint
 by 55%, with byte-identical text. Process RSS was effectively flat in both
 comparisons, so these measurements are not presented as general RSS savings or
 as guarantees for other models, prompts, or shapes.
@@ -437,7 +441,8 @@ swift run mere.run vision ocr ./page.png --backend lighton
 swift run mere.run vision ocr ./page.png --backend infinity --infinity-task doc2md
 ```
 
-For an external Infinity-Parser2 parity eval against an already-running vLLM server:
+For an external Infinity-Parser2 parity evaluation against an already-running
+vLLM server, run:
 
 ```bash
 swift run mere.run vision ocr ./page.png \
@@ -514,11 +519,11 @@ swift run mere.run vision ocr ./page.png \
 
 ## How the OCR path works
 
-1. the CLI resolves the OCR model
-2. the OCR runtime loads the required components
-3. the input image is normalized into the expected tensor form
-4. OCR inference runs
-5. text is emitted without internal bring-up logs on stdout
+1. The CLI resolves the OCR model.
+2. The OCR runtime loads the required components.
+3. The runtime normalizes the input image into the expected tensor form.
+4. OCR inference runs.
+5. The command emits text on standard output without internal bring-up logs.
 
 LightOnOCR uses the dedicated LightOn runtime and remains the default `vision ocr`
 backend. Native Infinity-Parser2 uses the Q35 text runtime plus the Qwen-family
@@ -533,25 +538,35 @@ target an upstream Transformers, vLLM engine, or vLLM server run.
 
 ## How segmentation and tracking work
 
-1. the CLI resolves `vision-segment-sam31` from the model store or uses the local root passed with `--model`
-2. the native SAM 3.1 runtime validates the root, loads tokenizer/config/weights, and preprocesses the input image or video frames
-3. still-image text prompts run the detector once, then text + DETR + mask decode per prompt
-4. geometry prompts use the interactive SAM path, and video tracking reuses those prompts frame to frame after the seed frame
-5. native postprocessing applies thresholding, mask resize, score ordering, NMS, and optional mask export
-6. the runtime writes annotated media plus structured JSON metadata
+1. The CLI resolves `vision-segment-sam31` from the model store or uses the
+   local root passed with `--model`.
+2. The native SAM 3.1 runtime validates the root, loads the tokenizer,
+   configuration, and weights, and preprocesses the input image or video frames.
+3. Still-image text prompts run the detector once and then run text, Detection
+   Transformer (DETR), and mask decoding for each prompt.
+4. Geometry prompts use the interactive SAM path. Video tracking reuses those
+   prompts frame to frame after the seed frame.
+5. Native postprocessing applies thresholding, mask resizing, score ordering,
+   non-maximum suppression (NMS), and optional mask export.
+6. The runtime writes annotated media and structured JSON metadata.
 
 ## How grounding works
 
-1. the CLI resolves `vision-ground-falcon-perception` from the model store or uses the local root passed with `--model`
-2. the native Falcon runtime validates the root, loads config/tokenizer/weights, and preprocesses the image plus text query
-3. the model autoregressively emits grounded detections, including coordinate and size tokens, and decodes optional segmentation masks
-4. native postprocessing derives normalized centers, sizes, bounding boxes, and optional exported mask artifacts
-5. the runtime writes an annotated image plus structured JSON metadata designed for downstream agent use
+1. The CLI resolves `vision-ground-falcon-perception` from the model store or
+   uses the local root passed with `--model`.
+2. The native Falcon runtime validates the root, loads the configuration,
+   tokenizer, and weights, and preprocesses the image and text query.
+3. The model autoregressively emits grounded detections, including coordinate
+   and size tokens, and decodes optional segmentation masks.
+4. Native postprocessing derives normalized centers, sizes, bounding boxes,
+   and optional exported mask artifacts.
+5. The runtime writes an annotated image and structured JSON metadata for
+   downstream agents.
 
 ## How caption and inspect differ
 
-- `caption` is a direct descriptive task
-- `inspect` is a question-driven vision-language path
+- `caption` is a direct descriptive task.
+- `inspect` is a question-driven vision-language path.
 
 They share some of the same underlying vision support code, but they are
-presented as separate public tasks because the user intent differs.
+presented as separate public tasks because your intent differs.

--- a/docs/runtime/world.md
+++ b/docs/runtime/world.md
@@ -1,10 +1,10 @@
-# Persistent World Runtime
+# Persistent world runtime
 
-A generated place you can walk around in. Send a camera move and get back a
-video chunk; send another and it continues from where the last one ended — same
-corridor, same light, same scene. The session is a navigation graph rather than
-a one-way chain, so an exact inverse move replays the edge you arrived on
-instead of inventing a new room on the way back.
+Use the persistent world runtime to navigate a generated place. Send a camera
+move to receive a video chunk. Send another move to continue from the previous
+endpoint with the same corridor, light, and scene. The session uses a
+navigation graph, so an exact inverse move replays the arrival edge instead of
+generating a different room on the return path.
 
 It runs as a long-lived local HTTP server, loopback-first, on either of two
 native Swift/MLX backends:
@@ -13,7 +13,7 @@ native Swift/MLX backends:
 - `cosmos3`: the official Cosmos3-Edge checkpoint with learned action
   conditioning and the `camera_pose` action domain
 
-The macOS Studio app exposes the same resident server in Advanced → Operations
+The macOS Studio app exposes the same resident server in **Advanced > Operations**
 with typed backend, model, state-directory, warmup, host, port, and
 authentication controls. API keys are injected with `MERERUN_API_KEY` so they
 do not appear in the child process argument list.
@@ -83,6 +83,9 @@ use `Authorization: Bearer <token>`.
 
 ## HTTP lifecycle
 
+Use the Hypertext Transfer Protocol (HTTP) endpoints in this section to manage
+the session lifecycle.
+
 The server exposes:
 
 | Method | Path | Purpose |
@@ -133,10 +136,11 @@ curl -X POST http://127.0.0.1:8791/v1/world/session/rollouts \
 As in upstream DreamX, `num_output_frames` is the latent-frame count and must
 be divisible by three. The public pixel-frame count is
 `(num_output_frames - 1) * 4 + 1`: `21` produces `81` frames and `63` produces
-`249`. The current upstream one-minute recipe ends at 252 latent / 1,005 pixel
-frames (62.8 encoded seconds at 16 fps, including the initial frame), and
-resolution may not exceed the official 1280x704 geometry. The defaults are
-1280x704, 21 latent frames, speed 1.5, seed 42, and 16 fps.
+`249`. The upstream DreamX one-minute recipe ends at 252 latent frames and
+1,005 pixel frames (62.8 encoded seconds at 16 frames per second, including the
+initial frame). Resolution must not exceed the official 1280 x 704 geometry.
+The defaults are 1280 x 704, 21 latent frames, speed 1.5, seed 42, and 16 frames
+per second.
 
 A browser or app can seed the first frame without knowing a path on the runtime
 host:
@@ -154,8 +158,8 @@ each following block emits 12 new frames after removing the shared boundary.
 When continuing an already-active causal session, the first streamed chunk also
 contains the prior terminal boundary frame, so clients must trust each chunk's
 reported `pixel_frame_count` instead of assuming nine. A completed job also
-includes a `rollout_receipt` with the final output and terminal-frame media paths. Browser
-clients may fetch and queue those MP4 chunks in order instead of waiting for
+includes a `rollout_receipt` with the final output and terminal-frame media
+paths. Browser clients may fetch and queue those MP4 chunks in order instead of waiting for
 the full rollout. The server supplies CORS headers for local product clients;
 Bearer authentication still applies when configured.
 
@@ -188,7 +192,7 @@ compounding character scale or appearance on repeated loop closure. The first
 origin entry stays pinned while capacity eviction removes the oldest
 non-origin entry.
 
-The default can be reproduced or deliberately swept from the command line:
+Reproduce or deliberately sweep the default from the command line:
 
 ```bash
 mere.run world serve --prepare \
@@ -236,7 +240,7 @@ curl -X POST \
 `GET /v1/world/session/checkpoints` lists live locks, and
 `GET /v1/world/session/checkpoints/:id/media/frame` returns a lock's PNG for a
 browser client. `DELETE /v1/world/session/checkpoints/:id` releases it. Locks
-are exact within the current loaded session and intentionally cleared by
+are exact within the loaded session and intentionally cleared by
 `reset` or `unload`; they are not mislabeled restart-persistent checkpoints.
 Artifact numbering remains collision-free across restores, logical resets, and
 existing files in the state directory, while the next rollout's
@@ -257,9 +261,10 @@ python3 scripts/reference-parity/run_dreamx_world_eval.py \
   --output /tmp/dreamx-world-eval
 ```
 
-The runner saves requests, jobs, receipts, MP4s, terminal PNGs, `ffprobe`
-truth, pose closure, and scene-memory telemetry. Add deterministic PSNR/SSIM
-scores with:
+The runner saves requests, jobs, receipts, MP4 files, terminal PNG files,
+`ffprobe` data, pose closure, and scene-memory telemetry. Add deterministic
+peak signal-to-noise ratio (PSNR) and structural similarity index measure (SSIM)
+scores:
 
 ```bash
 uv run --script scripts/reference-parity/score_dreamx_world_eval.py \
@@ -317,8 +322,9 @@ Camera motion values are `hold`, `forward`, `backward`, `strafeLeft`,
 arrays are XYZ values in meters and degrees.
 
 Omitted sampling fields use backend-specific recipes. DreamX defaults to
-512x320, 17 frames, 40 steps, CFG 5, shift 5, seed 42, and 24 fps. Cosmos3
-uses 320x176, 17 frames, 30 steps, CFG 1, shift 3, seed 0, and 30 fps. Every
+512 x 320, 17 frames, 40 steps, classifier-free guidance (CFG) 5, shift 5, seed
+42, and 24 frames per second. Cosmos3 uses 320 x 176, 17 frames, 30 steps, CFG
+1, shift 3, seed 0, and 30 frames per second. Every
 interactive camera primitive uses NVIDIA's default 16-action cadence and the
 same pinned translation-magnitude envelope. Rotation intent is divided into a
 constant per-frame pose delta. This keeps each generative chunk local enough to
@@ -328,13 +334,13 @@ matching NVIDIA's autoregressive sampling policy. Cosmos3 frame counts must be
 `4n+1`.
 
 The session is a small navigation graph rather than a write-only frame chain.
-An exact inverse control at the same magnitude replays the current path edge in
+An exact inverse control at the same magnitude replays the active path edge in
 reverse, pops it, and restores its source state, model-space action, and
 generation depth. Repeated backtracking can therefore traverse multiple parent
 edges without spending stochastic chunks or compounding avoidable scene drift.
 
 For Cosmos3, the semantic camera request selects a normalized model-space
-trajectory. NVIDIA defines every 9D `camera_pose` row as the relative pose delta
+trajectory. NVIDIA defines every nine-dimensional `camera_pose` row as the relative pose delta
 between consecutive visual states: XYZ translation plus column-based
 rotation-6D. The released 60x9 trajectory is retained byte-for-byte as a parity
 fixture, but it is an arbitrary camera sample rather than a canonical forward

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,18 +1,20 @@
-# Testing Guide
+# Testing guide
 
-This repo has three layers of validation:
+This repository has three layers of validation:
 
 1. Swift build and unit tests
 2. CLI help and hygiene checks
-3. end-to-end smoke runs against real installed models
+3. End-to-end smoke runs against real installed models
 
 Use the smallest layer that covers your change, then scale up before opening a
-PR.
+pull request.
 
 Linux CLI compatibility uses a narrower fixture boundary for hosted CI:
 headless CLI behavior and media-tool discovery. There is no CPU-only Linux
 release. Every release-worthy Linux package must exercise its CUDA lane on
-matching real CUDA hardware.
+matching real CUDA hardware. Active release validation covers macOS and the
+configured `tensor.local` x86_64 CUDA builder. The arm64 CUDA lane remains
+paused until a matching host is available.
 
 ## Fast validation
 
@@ -23,9 +25,9 @@ swift test
 
 Use this for:
 
-- pure library changes
-- parser changes that already have test coverage
-- refactors that should not change public behavior
+- Pure library changes
+- Parser changes that already have test coverage
+- Refactors that should not change public behavior
 
 ## Repo-wide validation
 
@@ -37,13 +39,13 @@ This script is the main gate for contributors. It runs:
 
 - `swift build`
 - `swift test`
-- help smoke for the public command tree
-- generated CLI documentation and command-owner synchronization
+- Help smoke for the public command tree
+- Generated CLI documentation and command-owner synchronization
 - `mere.run model list` output sanity checks
 - `mere.run status` output sanity checks
-- docs and source hygiene sweeps
+- Documentation and source hygiene sweeps
 
-Use this for almost every change before you stop.
+Run this gate for most changes before you open a pull request.
 
 ### CLI documentation contract
 
@@ -85,7 +87,7 @@ export MERERUN_FFMPEG=/usr/bin/ffmpeg
 export MERERUN_FFPROBE=/usr/bin/ffprobe
 ```
 
-The pull-request fixture should stay CPU MLX-compatible on hosted x86 runners.
+The pull-request fixture must remain CPU MLX-compatible on hosted x86 runners.
 CUDA machines can run additional package and smoke tests, but CUDA installation,
 driver selection, and GPU availability are not assumptions in the shared hosted
 CI contract. Do not describe a CUDA configuration as tested until that exact
@@ -172,8 +174,12 @@ The model directory must come from a license-acknowledged managed installation
 or an equivalent local checkpoint. A CUDA build without this real-audio GPU and
 speaker-reidentification result is not diarization runtime proof.
 
-For a real GB10/DGX Spark model sweep, use the installed CUDA binary and record
-the quantized-kernel choice alongside artifacts and throughput:
+### Historical GB10 and DGX Spark sweep
+
+The GB10 and DGX Spark command remains as a historical validation recipe. These
+machines are not active release builders. If an arm64 CUDA host becomes
+available again, use the installed CUDA binary and record the quantized-kernel
+choice alongside artifacts and throughput:
 
 ```bash
 scripts/e2e_gb10.sh --bin /usr/bin/mere.run --quant-mode auto --out ./e2e-gb10-auto
@@ -192,9 +198,9 @@ covers pure Swift image, WAV, and FFT behavior in the normal test suite.
 to exercise Linux `ffmpeg`/`ffprobe` image, audio, MP4, mux, and frame
 extraction paths without requiring host media files or model checkpoints.
 
-### Unified AV audio comparison
+### Unified audiovisual audio comparison
 
-When unified AV audio sounds too hot, bandwidth-limited, fluttery, or different
+When unified audiovisual (AV) audio sounds too hot, bandwidth-limited, fluttery, or different
 from the upstream LTX-2 reference, generate the same prompt/seed through both
 paths and compare the finished MP4s:
 
@@ -235,10 +241,10 @@ drop-in native MLX model root.
 
 This runs a smaller, stable subset of real workflows. Use it when you touched:
 
-- model resolution
-- runtime orchestration
-- output writing
-- common CLI paths
+- Model resolution
+- Runtime orchestration
+- Output writing
+- Common CLI paths
 
 ### Installed sweep
 
@@ -250,12 +256,12 @@ This runs the established cross-modality installed-model subset against the
 local model store. It is useful for broad development feedback, but it is not a
 claim that every installed checkpoint ran. Use it when you changed:
 
-- image generation
-- speech generation or transcription
+- Image generation
+- Speech generation or transcription
 - OCR
 - music or video generation
 - SAM segmentation or tracking behavior
-- manifest handling or installed model discovery
+- Manifest handling or installed model discovery
 
 ### Strict pre-release video generation
 
@@ -329,7 +335,8 @@ swift test
 MERERUN_RUN_E2E=core ./scripts/check.sh
 ```
 
-If you touched the SAM runtime, also run at least one real local smoke like:
+If you changed the Segment Anything Model (SAM) runtime, also run at least one
+real local smoke test:
 
 ```bash
 swift run mere.run model pull vision-segment-sam31 --accept-model-license
@@ -388,7 +395,7 @@ need manifest and component details for one model.
 ### `mere.run model pull` fails immediately
 
 That usually means the requested model is local-path-only in the public build or
-the current Mac does not pass the capability check.
+the Mac does not pass the capability check.
 
 Run:
 
@@ -396,7 +403,7 @@ Run:
 swift run mere.run model capabilities --all
 ```
 
-See [Model Sources](./model-sources.md) and [Configuration](./configuration.md).
+See [Model sources](./model-sources.md) and [Configuration](./configuration.md).
 
 ### A smoke test fails only in `--installed`
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -1,20 +1,19 @@
-# Portable Workflows
+# Portable workflows
 
-Describe a job once as a typed graph, and the same bundle runs on your laptop,
-over SSH to a GPU box, or across a relay fleet — with the same resolved seeds,
-the same fingerprints, and the same execution contract at the other end.
+Describe a job once as a typed graph. The same bundle then runs on your laptop,
+over Secure Shell (SSH) on a graphics processing unit (GPU) host, or across a
+relay fleet with the same resolved seeds, fingerprints, and execution contract.
 
-Workflows are immutable and headless. Nothing about *where* a job runs is baked
-into it: executor profiles, tokens, URLs, and machine paths never enter the
+Workflows are immutable and headless. Execution-location details do not enter
+the bundle: executor profiles, tokens, URLs, and machine paths remain external.
 bundle. Visual editors such as [Graph Studio](./graph/studio.md) author these
 documents, but execution behavior is defined here, not on the canvas.
 
 ## Graph v2 runtime and v1 contract
 
-Two different things carry version numbers here, and mixing them up causes real
-bugs.
+The runtime and serialized workflow contract use separate version numbers.
 
-**Graph v2** is the current runtime generation: immutable job bundles, typed
+**Graph v2** is the runtime generation with immutable job bundles, typed
 provider catalogs, executor preflight, resumable runs, parallel scheduling, and
 one execution contract shared by local, SSH, and Relay.
 
@@ -45,7 +44,7 @@ Independent ready nodes may run concurrently when the graph declares
 all scheduling, event commits, and final outputs retain stable topological order.
 Each node may independently set retry, timeout, and cache policy.
 
-The V1 node catalog contains:
+The version 1 node catalog contains:
 
 - `text.value`, `integer.value`, `number.value`, `boolean.value`, `json.value`
 - `seed.value`, `choice.value`
@@ -158,7 +157,7 @@ Materialization records source graph and input fingerprints, resolves defaults
 and random seeds, fingerprints the portable graph and inputs, and copies
 declared file inputs into a content-addressed store. The optional source
 fingerprints also flow into `run.json`, allowing authoring clients to display
-results only when they match the currently open source documents.
+results only when they match the source documents open in the editor.
 
 ```bash
 mere.run graph materialize workflow.json \
@@ -302,7 +301,8 @@ mere.run graph worker inspect --run-dir PATH --json
 mere.run graph worker cancel --run-dir PATH --json
 ```
 
-`execute --json-stream` emits the run event model as NDJSON on stdout. It
+`execute --json-stream` emits the run event model as newline-delimited JSON
+(NDJSON) on standard output. It
 preserves node progress, preview, artifact, diagnostic, metric, heartbeat, and
 lifecycle events. Diagnostics produced outside the machine protocol stay on
 stderr.
@@ -404,23 +404,23 @@ and reused bytes and parts.
 ## Direct relay (`relay serve`)
 
 `mere.run relay serve` hosts the same client-facing graph-job HTTP surface
-directly on a machine and runs submitted jobs there — no broker, no cloud
-hop. It is the single-machine, self-sovereign lane: reach it over the LAN or
+directly on a machine and runs submitted jobs there without a broker or cloud
+hop. It is the single-machine, self-sovereign lane. Reach it over the local area network (LAN) or
 a tailnet (Tailscale users can front it with `tailscale serve` for HTTPS),
 and prompts, inputs, and outputs never leave your network.
 
 ```bash
 # On the machine that will run the work:
 mere.run relay serve
-# → prints the address and a six-digit pairing code
+# The command prints the address and a six-digit pairing code.
 
 # On any other machine, exchange the code for a bearer token:
-curl -X POST http://lab.local:6373/api/pair \
+curl -X POST http://192.0.2.10:6373/api/pair \
   -H 'Content-Type: application/json' \
-  -d '{"code": "123-456", "device_name": "laptop"}'
+  -d '{"code": "123-456", "device_name": "example-laptop"}'
 
 # Save the token and add a normal relay executor profile:
-mere.run executor add relay lab --url http://lab.local:6373 --token-file ./lab-token
+mere.run executor add relay lab --url http://192.0.2.10:6373 --token-file ./lab-token
 mere.run graph submit workflow.json --executor relay:lab --run-dir ./runs/job
 ```
 
@@ -473,7 +473,7 @@ forms remain available for raw arguments and JSON streaming.
 
 Relay profile setup and device authorization also stay on the public
 `executor add relay`, `executor auth-status`, and `executor login` contracts.
-Studio streams the CLI's approval URL, opens it after the user chooses **Sign
+Studio streams the CLI's approval URL, opens it after you choose **Sign
 In**, and never reads or stores bearer credentials itself.
 
 The ownership boundary is deliberate:
@@ -491,13 +491,13 @@ and does not keep parallel graph, fleet, node, or scheduling schemas.
 
 ## Schemas
 
-- [Workflow Graph V1](/schemas/workflow-graph-v1.schema.json)
-- [Workflow Inputs V1](/schemas/workflow-inputs-v1.schema.json)
-- [Asset Manifest V1](/schemas/asset-manifest-v1.schema.json)
-- [Job Bundle V1](/schemas/job-bundle-v1.schema.json)
-- [Graph Run V1](/schemas/graph-run-v1.schema.json)
-- [Worker Probe V1](/schemas/worker-probe-v1.schema.json)
-- [Plugin Graph Provider V1](/schemas/graph-node-provider.v1.schema.json)
-- [Plugin Graph Invocation V1](/schemas/graph-node-invocation.v1.schema.json)
-- [Plugin Graph Preflight V1](/schemas/graph-node-preflight.v1.schema.json)
-- [Plugin Graph Event V1](/schemas/graph-node-event.v1.schema.json)
+- [Workflow graph V1](/schemas/workflow-graph-v1.schema.json)
+- [Workflow inputs V1](/schemas/workflow-inputs-v1.schema.json)
+- [Asset manifest V1](/schemas/asset-manifest-v1.schema.json)
+- [Job bundle V1](/schemas/job-bundle-v1.schema.json)
+- [Graph run V1](/schemas/graph-run-v1.schema.json)
+- [Worker probe V1](/schemas/worker-probe-v1.schema.json)
+- [Plugin graph provider V1](/schemas/graph-node-provider.v1.schema.json)
+- [Plugin graph invocation V1](/schemas/graph-node-invocation.v1.schema.json)
+- [Plugin graph preflight V1](/schemas/graph-node-preflight.v1.schema.json)
+- [Plugin graph event V1](/schemas/graph-node-event.v1.schema.json)

--- a/scripts/check-docs-examples.sh
+++ b/scripts/check-docs-examples.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$repo_root"
+
+matches_file="$(mktemp "${TMPDIR:-/tmp}/mere-run-doc-examples.XXXXXX")"
+trap 'rm -f "$matches_file"' EXIT
+
+scan_targets=(
+  README.md
+  CONTRIBUTING.md
+  CODEBASE.md
+  docs
+)
+
+email_pattern='[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z]{2,}'
+rg --no-heading --with-filename --line-number --only-matching \
+  "$email_pattern" "${scan_targets[@]}" >"$matches_file" || true
+
+unexpected=()
+while IFS=: read -r path line email; do
+  [[ -n "${email:-}" ]] || continue
+  domain="${email##*@}"
+  domain="$(printf '%s' "$domain" | tr '[:upper:]' '[:lower:]')"
+
+  case "$domain" in
+    example.com|*.example.com|example.net|*.example.net|example.org|*.example.org)
+      ;;
+    *.example|*.test|*.invalid)
+      ;;
+    mere.run|*.mere.run)
+      ;;
+    *)
+      unexpected+=("$path:$line:$email")
+      ;;
+  esac
+done <"$matches_file"
+
+if (( ${#unexpected[@]} > 0 )); then
+  printf '%s\n' "Documentation contains email domains that are not reserved examples:" >&2
+  printf '  %s\n' "${unexpected[@]}" >&2
+  printf '%s\n' \
+    "Use example.com, example.net, example.org, a special-use example TLD," \
+    "or an intentional project-owned mere.run address." >&2
+  exit 1
+fi
+
+if rg --line-number --ignore-case \
+  '\[(click here|here|this link|link)\]\(' "${scan_targets[@]}"
+then
+  printf '%s\n' \
+    "Documentation contains vague link text. Describe the link destination." >&2
+  exit 1
+fi
+
+printf '%s\n' "Documentation example-data and link-text checks passed."

--- a/scripts/check-linux.sh
+++ b/scripts/check-linux.sh
@@ -81,6 +81,7 @@ check_linux_package_view() {
 }
 
 bash ./scripts/check-evaluation-boundary.sh
+bash ./scripts/check-docs-examples.sh
 
 if [[ "$manifest_only" == "1" ]]; then
   check_linux_package_view

--- a/scripts/check.sh
+++ b/scripts/check.sh
@@ -35,6 +35,7 @@ fi
 swiftlint --strict --cache-path .build/swiftlint.cache
 bash ./scripts/agent_readiness_check.sh
 bash ./scripts/check-evaluation-boundary.sh
+bash ./scripts/check-docs-examples.sh
 swiftpm() {
   local subcommand="$1"
   shift


### PR DESCRIPTION
## Summary

- Apply a line-by-line Google developer documentation style pass to all 61 Markdown files in the public documentation site and root contributor entry points.
- Add a repository documentation style guide, a complete audit inventory, and automated checks for reserved example data and descriptive link text.
- Refresh generated CLI descriptions from their Swift sources and keep the Graph Studio version-boundary contract aligned with the revised wording.
- Clarify that active release validation covers macOS and tensor.local, while the arm64 CUDA lane remains paused.

## Validation

- bash ./scripts/check-docs-examples.sh
- pnpm docs:build
- swift test --filter DocumentationContractTests (4 passed)
- env -u MERERUN_RUN_E2E nice -n 10 ./scripts/check.sh (3,067 tests, 219 expected skips, 0 failures)
- gitleaks detect --source . --no-banner --redact

No installed-model smoke, benchmark inference, or release action ran.