### PR TITLE
fix(asr): install MLX stream for Parakeet decode

### DIFF
--- a/Sources/AudioSTT/Parakeet/ParakeetGenerator.swift
+++ b/Sources/AudioSTT/Parakeet/ParakeetGenerator.swift
@@ -24,6 +24,18 @@ public actor ParakeetGenerator: ASRGenerator {
         self.modelId = modelId
     }
 
+    init(
+        preparedModel: any ParakeetDecodingModel,
+        audioPreprocessor: ParakeetAudioPreprocessor,
+        modelConfig: ParakeetModelConfig
+    ) {
+        self.modelId = ParakeetResources.defaultModelId
+        self.model = preparedModel
+        self.audioPreprocessor = audioPreprocessor
+        self.modelConfig = modelConfig
+        self.loadedModelPath = "<prepared>"
+    }
+
     public func transcribe(
         _ request: ASRRequest,
         progressHandler: (@Sendable (ASRProgress) -> Void)? = nil
@@ -45,7 +57,7 @@ public actor ParakeetGenerator: ASRGenerator {
 
         progressHandler?(ASRProgress(stage: .loadingAudio, message: "Loading audio..."))
         let audio = try AudioReader.readAudio(from: request.audioURL)
-        return try transcribePrepared(
+        return try await transcribePrepared(
             samples: audio,
             language: request.language,
             progressHandler: progressHandler
@@ -65,16 +77,9 @@ public actor ParakeetGenerator: ASRGenerator {
             try await loadModel(from: root, progressHandler: progressHandler)
         }
 
-        guard let model, let audioPreprocessor, let modelConfig else {
-            throw ParakeetError.modelNotLoaded
-        }
-
-        return decode(
+        return try await transcribePrepared(
             samples: samples,
             language: language,
-            model: model,
-            audioPreprocessor: audioPreprocessor,
-            modelConfig: modelConfig,
             progressHandler: progressHandler
         )
     }
@@ -83,19 +88,21 @@ public actor ParakeetGenerator: ASRGenerator {
         samples: [Float],
         language: String? = nil,
         progressHandler: (@Sendable (ASRProgress) -> Void)? = nil
-    ) throws -> ASRResult {
-        guard let model, let audioPreprocessor, let modelConfig else {
-            throw ParakeetError.modelNotLoaded
-        }
+    ) async throws -> ASRResult {
+        try Stream.withNewDefaultStream {
+            guard let model, let audioPreprocessor, let modelConfig else {
+                throw ParakeetError.modelNotLoaded
+            }
 
-        return decode(
-            samples: samples,
-            language: language,
-            model: model,
-            audioPreprocessor: audioPreprocessor,
-            modelConfig: modelConfig,
-            progressHandler: progressHandler
-        )
+            return decode(
+                samples: samples,
+                language: language,
+                model: model,
+                audioPreprocessor: audioPreprocessor,
+                modelConfig: modelConfig,
+                progressHandler: progressHandler
+            )
+        }
     }
 
     private func decode(

--- a/Tests/MereRunCoreTests/ParakeetGeneratorStreamTests.swift
+++ b/Tests/MereRunCoreTests/ParakeetGeneratorStreamTests.swift
@@ -1,0 +1,93 @@
+import AudioCore
+import MLX
+import XCTest
+@testable import AudioSTT
+
+final class ParakeetGeneratorStreamTests: MereRunCoreTestCase {
+    func testPreparedDecodeInstallsMLXStreamAfterGeneratorActorHop() async throws {
+        let config = makeConfig()
+        let generator = ParakeetGenerator(
+            preparedModel: StreamCheckingParakeetModel(config: config),
+            audioPreprocessor: try ParakeetAudioPreprocessor(config: config.preprocessor),
+            modelConfig: config
+        )
+
+        let result = try await Task.detached {
+            try await Device.withDefaultDevice(.gpu) {
+                await Task.yield()
+                return try await generator.transcribePrepared(
+                    samples: Array(repeating: 0.1, count: 800),
+                    language: "en"
+                )
+            }
+        }.value
+
+        XCTAssertEqual(result.text, "stream safe")
+        XCTAssertEqual(result.language, "en")
+    }
+
+    private func makeConfig() -> ParakeetModelConfig {
+        let preprocessor = ParakeetPreprocessorConfig(
+            sampleRate: 16_000,
+            normalize: "per_feature",
+            windowSize: 0.025,
+            windowStride: 0.01,
+            window: "hann",
+            features: 4,
+            nFFT: 512,
+            dither: 0,
+            padTo: 0,
+            padValue: 0,
+            preemph: 0.97
+        )
+        return ParakeetModelConfig(
+            variant: .ctc,
+            target: "test",
+            preprocessor: preprocessor,
+            encoder: ParakeetEncoderConfig(
+                featIn: 4,
+                layers: 1,
+                modelDim: 4,
+                heads: 1,
+                ffExpansionFactor: 1,
+                subsamplingFactor: 1,
+                selfAttentionModel: "abs_pos",
+                subsampling: "dw_striding",
+                convKernelSize: 3,
+                subsamplingConvChannels: 4,
+                posEmbMaxLen: 16,
+                causalDownsampling: false,
+                useBias: true,
+                xScaling: false,
+                subsamplingConvChunkingFactor: 1
+            ),
+            rnntDecoder: nil,
+            ctcDecoder: ParakeetCTCDecoderConfig(
+                featIn: 4,
+                numClasses: 1,
+                vocabulary: ["stream"]
+            ),
+            joint: nil,
+            tdtDurations: nil,
+            maxSymbols: nil,
+            quantizationBits: nil,
+            quantizationGroupSize: nil,
+            supportedLanguageCodes: ["en"]
+        )
+    }
+}
+
+private final class StreamCheckingParakeetModel: ParakeetDecodingModel {
+    let config: ParakeetModelConfig
+
+    init(config: ParakeetModelConfig) {
+        self.config = config
+    }
+
+    func decode(_ mel: MLXArray) -> [ParakeetAlignedResult] {
+        let output = MLX.mean(mel) * 2
+        MLX.eval(output)
+        _ = output.item(Float.self)
+        return [ParakeetAlignedResult(text: "stream safe", sentences: [])]
+    }
+}


### PR DESCRIPTION
## Summary
- establish a fresh task-local MLX default stream at the prepared Parakeet decode boundary
- route file and in-memory sample transcription through the same guarded decode path
- add a regression test covering a detached task and generator actor hop

## Validation
- nice -n 10 swift test --filter ParakeetGeneratorStreamTests
- env -u MERERUN_RUN_E2E nice -n 10 ./scripts/check.sh
- 3,068 tests passed with 219 checkpoint or hardware gated skips and zero failures