### PR TITLE
Release v0.42.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+## 0.42.0 - 2026-08-20
+
+This release expands mere.run's native model lineup with official Ornith 1.5,
+Muse Glimmer DFlash2 acceleration, and multimodal Nemotron 3 Nano Omni. It also
+adds portable external evaluation packs, publishes fused benchmark references,
+hardens iOS Studio downloads and runtime residency, ships compact MiniMax-H3
+BF16 and Q8 packages, and brings the Apple app sources under one `apps/`
+layout.
+
 ### Apple app layout
 
 - grouped the open-source macOS and iOS clients under `apps/`, with their
@@ -58,6 +67,14 @@ The format is based on Keep a Changelog.
   authorization, execute without a shell in a reduced environment, and are
   bounded by timeout and output validation.
 
+### Fused benchmark references
+
+- published completed Comprehensive reference results for Qwen3.8 low
+  reasoning, Laguna XS 2.1, and Nemotron Lightning. The frozen receipts retain
+  exact runner, model, plan, and content hashes; the documentation distinguishes
+  strict passes from partial scores and does not present the local results as
+  upstream leaderboard claims.
+
 ### Muse Glimmer DFlash2
 
 - added native Swift/MLX support for Inco's Muse Glimmer DFlash2 companion:
@@ -82,6 +99,12 @@ The format is based on Keep a Changelog.
   and video understanding, Parakeet audio understanding, local video sampling,
   media-aware OpenAI chat completions, source-bound expert caching, installed
   inference smoke coverage, and first-class catalog/runtime-pool support.
+
+### Speech
+
+- established a fresh task-local MLX default stream at the prepared Parakeet
+  decode boundary and routed file and in-memory transcription through the same
+  guarded path, fixing detached-task and generator-actor decode failures.
 
 ### iOS Studio
 
@@ -153,6 +176,28 @@ The format is based on Keep a Changelog.
   transactional managed replacement with rollback after final validation or
   alias-install failures. External cache use is explicit in preflight and
   reports that disconnecting the volume makes the model unavailable.
+
+### Included pull requests
+
+- exact release range: [#327](https://github.com/sawfwair/mere-run/pull/327),
+  [#328](https://github.com/sawfwair/mere-run/pull/328),
+  [#329](https://github.com/sawfwair/mere-run/pull/329),
+  [#330](https://github.com/sawfwair/mere-run/pull/330),
+  [#331](https://github.com/sawfwair/mere-run/pull/331),
+  [#332](https://github.com/sawfwair/mere-run/pull/332),
+  [#333](https://github.com/sawfwair/mere-run/pull/333),
+  [#334](https://github.com/sawfwair/mere-run/pull/334),
+  [#335](https://github.com/sawfwair/mere-run/pull/335),
+  [#337](https://github.com/sawfwair/mere-run/pull/337),
+  [#338](https://github.com/sawfwair/mere-run/pull/338),
+  [#339](https://github.com/sawfwair/mere-run/pull/339),
+  [#340](https://github.com/sawfwair/mere-run/pull/340),
+  [#341](https://github.com/sawfwair/mere-run/pull/341),
+  [#344](https://github.com/sawfwair/mere-run/pull/344),
+  [#345](https://github.com/sawfwair/mere-run/pull/345),
+  [#346](https://github.com/sawfwair/mere-run/pull/346),
+  [#347](https://github.com/sawfwair/mere-run/pull/347), and
+  [#348](https://github.com/sawfwair/mere-run/pull/348).
 
 ## 0.41.0 - 2026-08-18
 

--- a/Sources/MereRunRelayKit/MereRunCLIVersion.swift
+++ b/Sources/MereRunRelayKit/MereRunCLIVersion.swift
@@ -2,7 +2,7 @@
 /// contract version floors, worker probes, and the built-in node catalog
 /// identity.
 public enum MereRunCLIVersion {
-    public static let current = "0.41.0"
+    public static let current = "0.42.0"
 }
 
 /// Lenient three-component version-floor comparison used by worker

--- a/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
+++ b/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
@@ -130,7 +130,7 @@ final class CLIModelStoreBootstrapTests: XCTestCase {
     }
 
     func testMereRunCLIExposesReleaseVersion() {
-        XCTAssertEqual(MereRunCLIVersion.current, "0.41.0")
+        XCTAssertEqual(MereRunCLIVersion.current, "0.42.0")
         XCTAssertEqual(MereRunCLI.configuration.version, MereRunCLIVersion.current)
     }
 

--- a/scripts/build_mere_run_app.sh
+++ b/scripts/build_mere_run_app.sh
@@ -15,7 +15,7 @@ cd "$repo_root"
 
 # Version/build derive from git when not provided, so the bundle has a single source of
 # truth in CI. Fall back to a pinned value when git metadata is unavailable.
-default_version="0.41.0"
+default_version="0.42.0"
 if git_version="$(git describe --tags --exact-match 2>/dev/null)"; then
   default_version="${git_version#v}"
 fi


### PR DESCRIPTION
## Summary

- bump the CLI and app bundle release version to 0.42.0
- finalize the changelog for every merged PR since v0.41.0 (#327–#348, excluding non-merged numbers)
- explicitly document the fused benchmark references and Parakeet MLX stream fix

## Validation

- `env -u MERERUN_RUN_E2E nice -n 10 ./scripts/check.sh`
  - 3,078 XCTest cases passed, 219 skipped, 0 failures
  - 30 Swift Testing cases passed, 0 failures
- verified the changelog PR list exactly matches merge commits in `v0.41.0..origin/main`
- `git diff --check`

## Release range

19 merged PRs: #327, #328, #329, #330, #331, #332, #333, #334, #335, #337, #338, #339, #340, #341, #344, #345, #346, #347, #348.