### PR TITLE
Release v0.43.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+## 0.43.0 - 2026-08-20
+
+This release adds native multimodal embeddings for shared text, image, and
+mixed-media retrieval with Qwen3-VL. It also hardens optimized Parakeet live
+streaming and removes private build roots from packaged diagnostics.
+
 ### Multimodal embeddings
 
 - added `vision embed`, a generic native Swift/MLX Qwen3-VL embedding command
@@ -14,6 +20,19 @@ The format is based on Keep a Changelog.
   normalized vectors with stable caller IDs, supports Matryoshka dimension
   truncation, and keeps indexing, match thresholds, reranking, and tracking in
   the consuming application.
+
+### Parakeet live streaming
+
+- constructed and evaluated Parakeet models inside task-safe MLX stream scopes,
+  and kept prepared live decoding on explicit CPU and GPU streams across
+  executor hops. Release and installed-model gates now exercise real Parakeet
+  streaming, while packaged diagnostics remap private build roots and packaging
+  rejects unexpected path leakage.
+
+### Included pull requests
+
+- exact release range: [#351](https://github.com/sawfwair/mere-run/pull/351)
+  and [#353](https://github.com/sawfwair/mere-run/pull/353).
 
 ## 0.42.0 - 2026-08-20
 

--- a/Sources/MereRunRelayKit/MereRunCLIVersion.swift
+++ b/Sources/MereRunRelayKit/MereRunCLIVersion.swift
@@ -2,7 +2,7 @@
 /// contract version floors, worker probes, and the built-in node catalog
 /// identity.
 public enum MereRunCLIVersion {
-    public static let current = "0.42.0"
+    public static let current = "0.43.0"
 }
 
 /// Lenient three-component version-floor comparison used by worker

--- a/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
+++ b/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
@@ -130,7 +130,7 @@ final class CLIModelStoreBootstrapTests: XCTestCase {
     }
 
     func testMereRunCLIExposesReleaseVersion() {
-        XCTAssertEqual(MereRunCLIVersion.current, "0.42.0")
+        XCTAssertEqual(MereRunCLIVersion.current, "0.43.0")
         XCTAssertEqual(MereRunCLI.configuration.version, MereRunCLIVersion.current)
     }
 

--- a/scripts/build_mere_run_app.sh
+++ b/scripts/build_mere_run_app.sh
@@ -15,7 +15,7 @@ cd "$repo_root"
 
 # Version/build derive from git when not provided, so the bundle has a single source of
 # truth in CI. Fall back to a pinned value when git metadata is unavailable.
-default_version="0.42.0"
+default_version="0.43.0"
 if git_version="$(git describe --tags --exact-match 2>/dev/null)"; then
   default_version="${git_version#v}"
 fi


### PR DESCRIPTION
## Summary
- release native Qwen3-VL multimodal embeddings for text, image, and mixed records
- harden optimized Parakeet live streaming across executor hops and sanitize packaged build paths
- finalize the v0.43.0 changelog with exact PR provenance
- bump the CLI and macOS bundle fallback version to 0.43.0

Turns out a picture is worth a thousand words—and, conveniently, up to a few thousand embedding dimensions.

## Included pull requests
- #351
- #353

## Validation
- `env -u MERERUN_RUN_E2E nice -n 10 ./scripts/check.sh`
- 3,090 XCTest cases, 219 skipped, 0 failures
- 30 Swift Testing cases, 0 failures
- PR #351 previously completed real local `vision embed` runs against `vision-embed-qwen3-vl-2b` at 256 dimensions
- PR #353 CI passed its Swift, iOS, Linux, security, and packaged compatibility gates before merge
