### PR TITLE
feat: add native SenseNova U1.5 image generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+### Image
+
+- added the official BF16 SenseNova U1.5 8B-MoT checkpoint as a pinned managed
+  model. Its native Swift/MLX runtime implements the dual-expert Qwen3 stack,
+  raw-pixel flow matching, resolution-scaled noise, shifted Euler sampling,
+  text CFG, and multi-image instruction editing without Python or an external
+  VAE.
+
 ### Text
 
 - added pinned LiquidAI DSpark companions for LFM2.5 1.2B Instruct, 2.6B,

--- a/Package.swift
+++ b/Package.swift
@@ -394,6 +394,7 @@ targets.append(contentsOf: [
       "QwenImageEdit/Model/Transformer/README.md",
       "QwenImageEdit/Model/VAE/README.md",
       "SAM3/README.md",
+      "SenseNovaU15/README.md",
       "SCAIL2/README.md",
       "Support/README.md",
       "TESSERA/README.md",

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ supported flags.
 
 | Area | Public commands | Supported behavior |
 | --- | --- | --- |
-| Images and LoRAs | `image generate`, `image train-lora`, `adapter list`, `adapter pull` | Klein, ZImage, HiDream O1, Krea 2, Ideogram 4, and Bonsai; text-to-image, edits, multiple references, structured prompts, local Krea/Klein training, and checksum-pinned public adapters |
+| Images and LoRAs | `image generate`, `image train-lora`, `adapter list`, `adapter pull` | Klein, ZImage, HiDream O1, SenseNova U1.5, Krea 2, Ideogram 4, and Bonsai; text-to-image, edits, multiple references, structured prompts, local Krea/Klein training, and checksum-pinned public adapters |
 | Text, code, and agents | `text chat`, `text code`, `text embed`, `text anonymize`, `text train-lora`, `agent` | Local chat and tool use, including Qwen3.8 27B BF16/4-bit and Bonsai 27B binary/ternary vision chat; code generation, embeddings, personally identifiable information (PII) redaction, text LoRA training, and guided local-agent setup |
 | Vision understanding | `vision embed`, `caption`, `inspect`, `face`, `ground`, `segment`, `track`, `track-live`, `pose`, `flow`, `ocr` | Shared text/image embeddings, captioning and VQA, local face detection/identity embeddings, LightOn/GLM/Infinity OCR, Falcon grounding, SAM 3.1 segmentation and tracking, body/hand/face landmarks, and dense optical flow |
 | Depth, geometry, and 3D | `vision depth-video`, `geometry`, `geometry-multiview`, `image-to-3d*`; `image reconstruct-3d*` | Video Depth Anything, MoGe-2, Depth Anything 3, TripoSR, InstantMesh, and TRELLIS.2; depth/confidence EXRs, cameras, point clouds, 3DGS initialization, OBJ, PLY, GLB, and PBR voxel artifacts |
@@ -407,6 +407,15 @@ swift run mere.run image generate \
   --prompt "a clean studio product photo of the subject" \
   --ref-image ./subject.png \
   --output ./subject-studio.png
+
+# SenseNova U1.5 runs its official raw-pixel model natively for generation and editing.
+swift run mere.run model pull image-sensenova-u1-5-8b-mot
+swift run mere.run image generate \
+  --model image-sensenova-u1-5-8b-mot \
+  --prompt "Turn this reference into a cinematic rainy-night scene" \
+  --input ./reference.png \
+  --width 2048 --height 2048 \
+  --output ./sensenova-edit.png
 
 # Krea 2 Turbo runs natively for 8-step text-to-image generation.
 swift run mere.run image generate \

--- a/Sources/MereRunCLI/Commands/APIServeCommand.swift
+++ b/Sources/MereRunCLI/Commands/APIServeCommand.swift
@@ -5029,11 +5029,13 @@ actor CodeGenServer {
         }
         let resolved = try resolveImageModel(plan.modelID)
         let effectiveSteps = plan.steps
-            ?? ((resolved.manifest.family == .hidream || resolved.manifest.family == .krea || resolved.manifest.family == .ideogram)
+            ?? ((resolved.manifest.family == .hidream || resolved.manifest.family == .senseNova
+                    || resolved.manifest.family == .krea || resolved.manifest.family == .ideogram)
                 ? (resolved.manifest.defaults?.steps ?? 4)
                 : 4)
         let effectiveCFG = plan.guidanceScale
-            ?? ((resolved.manifest.family == .hidream || resolved.manifest.family == .krea || resolved.manifest.family == .ideogram)
+            ?? ((resolved.manifest.family == .hidream || resolved.manifest.family == .senseNova
+                    || resolved.manifest.family == .krea || resolved.manifest.family == .ideogram)
                 ? (resolved.manifest.defaults?.cfg ?? 1.0)
                 : 1.0)
         let outputURL = try temporaryOutputURL(directoryName: "mere-run-api-images", extension: "png")
@@ -5076,6 +5078,13 @@ actor CodeGenServer {
         case .hidream:
             _ = try await sidecarPool.generateImage(
                 kind: .hiDreamO1,
+                modelID: resolved.modelID,
+                modelPath: resolved.rootURL.path,
+                request: request
+            )
+        case .senseNova:
+            _ = try await sidecarPool.generateImage(
+                kind: .senseNovaU15,
                 modelID: resolved.modelID,
                 modelPath: resolved.rootURL.path,
                 request: request

--- a/Sources/MereRunCLI/Commands/ImageGenerateCommand.swift
+++ b/Sources/MereRunCLI/Commands/ImageGenerateCommand.swift
@@ -51,7 +51,7 @@ struct ImageGenerate: AsyncParsableCommand {
 
     @Option(
         name: [.customShort("i"), .long],
-        help: "Input image path for image-to-image. For FLUX.2 Klein, this is treated as a single reference image."
+        help: "Input image path for image-to-image. SenseNova U1.5 uses it as an editing reference."
     )
     var input: String?
 
@@ -72,7 +72,7 @@ struct ImageGenerate: AsyncParsableCommand {
 
     @Option(
         name: [.customLong("ref-image")],
-        help: "Reference image path for FLUX.2 Klein or HiDream O1 editing/personalization. Repeat for multiple references."
+        help: "Reference image path for Klein, HiDream O1, or SenseNova U1.5 editing. Repeat for multiple references."
     )
     var referenceImages: [String] = []
 
@@ -267,11 +267,13 @@ struct ImageGenerate: AsyncParsableCommand {
             strength: strength
         )
         let effectiveSteps = steps
-            ?? ((manifest.family == .hidream || manifest.family == .krea || manifest.family == .ideogram)
+            ?? ((manifest.family == .hidream || manifest.family == .senseNova
+                    || manifest.family == .krea || manifest.family == .ideogram)
                 ? (manifest.defaults?.steps ?? 4)
                 : 4)
         let effectiveCFG = cfgScale
-            ?? ((manifest.family == .hidream || manifest.family == .krea || manifest.family == .ideogram)
+            ?? ((manifest.family == .hidream || manifest.family == .senseNova
+                    || manifest.family == .krea || manifest.family == .ideogram)
                 ? (manifest.defaults?.cfg ?? 1.0)
                 : 1.0)
         let effectiveSigmaShift = sigmaShift.map { Float($0) }
@@ -377,6 +379,10 @@ struct ImageGenerate: AsyncParsableCommand {
                 result = try await generator.generate(request, progressHandler: progressHandler)
             case .hidream:
                 let generator = HiDreamO1Generator()
+                defer { generator.unload() }
+                result = try await generator.generate(request, progressHandler: progressHandler)
+            case .senseNova:
+                let generator = SenseNovaU15Generator()
                 defer { generator.unload() }
                 result = try await generator.generate(request, progressHandler: progressHandler)
             case .krea:

--- a/Sources/MereRunCLI/Support/APISidecarModelPool.swift
+++ b/Sources/MereRunCLI/Support/APISidecarModelPool.swift
@@ -534,6 +534,7 @@ enum APISidecarImageKind: String, Hashable, Sendable {
     case flux2Klein
     case zImageTurbo
     case hiDreamO1
+    case senseNovaU15
     case krea2
     case ideogram4
     case qwenImageEdit
@@ -668,6 +669,7 @@ private enum APISidecarImageGenerator: @unchecked Sendable {
     case flux2Klein(Flux2KleinGenerator)
     case zImageTurbo(ZImageTurboGenerator)
     case hiDreamO1(HiDreamO1Generator)
+    case senseNovaU15(SenseNovaU15Generator)
     case krea2(Krea2Generator)
     case ideogram4(Ideogram4Generator)
     case qwenImageEdit(QwenImageEditGenerator)
@@ -797,6 +799,8 @@ struct APISidecarModelPool: Sendable, CLIASRTranscriptionExecutor {
                         return .zImageTurbo(ZImageTurboGenerator())
                     case .hiDreamO1:
                         return .hiDreamO1(HiDreamO1Generator())
+                    case .senseNovaU15:
+                        return .senseNovaU15(SenseNovaU15Generator())
                     case .krea2:
                         return .krea2(Krea2Generator())
                     case .ideogram4:
@@ -813,6 +817,8 @@ struct APISidecarModelPool: Sendable, CLIASRTranscriptionExecutor {
                         await generator.unload()
                     case .hiDreamO1(let generator):
                         generator.unload()
+                    case .senseNovaU15(let generator):
+                        generator.unload()
                     case .krea2(let generator):
                         generator.unload()
                     case .ideogram4(let generator):
@@ -828,6 +834,8 @@ struct APISidecarModelPool: Sendable, CLIASRTranscriptionExecutor {
                     case .zImageTurbo(let generator):
                         return try await generator.generate(request, progressHandler: nil)
                     case .hiDreamO1(let generator):
+                        return try await generator.generate(request, progressHandler: nil)
+                    case .senseNovaU15(let generator):
                         return try await generator.generate(request, progressHandler: nil)
                     case .krea2(let generator):
                         return try await generator.generate(request, progressHandler: nil)
@@ -1447,6 +1455,8 @@ struct APISidecarModelPool: Sendable, CLIASRTranscriptionExecutor {
             await generator.unload()
         case .hiDreamO1(let generator):
             generator.unload()
+        case .senseNovaU15(let generator):
+            generator.unload()
         case .krea2(let generator):
             generator.unload()
         case .ideogram4(let generator):
@@ -1540,6 +1550,8 @@ struct APISidecarModelPool: Sendable, CLIASRTranscriptionExecutor {
             return 12 * gibibyte
         case .hiDreamO1, .krea2, .ideogram4, .qwenImageEdit:
             return 16 * gibibyte
+        case .senseNovaU15:
+            return 48 * gibibyte
         }
     }
 
@@ -1555,7 +1567,7 @@ struct APISidecarModelPool: Sendable, CLIASRTranscriptionExecutor {
                 height: height
             )
             return (resolution.width, resolution.height)
-        case .flux2Klein, .zImageTurbo, .krea2, .ideogram4, .qwenImageEdit:
+        case .flux2Klein, .zImageTurbo, .senseNovaU15, .krea2, .ideogram4, .qwenImageEdit:
             return (width, height)
         }
     }

--- a/Sources/MereRunCLI/Support/ImageGenerationPreflight.swift
+++ b/Sources/MereRunCLI/Support/ImageGenerationPreflight.swift
@@ -941,7 +941,7 @@ struct ImageGenerationPreflightAnalyzer {
         let hasInput = input.input != nil
         let hasReferences = !input.referenceImages.isEmpty
         guard hasInput || hasReferences else { return "text_to_image" }
-        if family == .klein {
+        if family == .klein || family == .senseNova {
             return "reference_image"
         }
         if hasInput && hasReferences {
@@ -954,7 +954,7 @@ struct ImageGenerationPreflightAnalyzer {
     }
 
     private static func familyUsesManifestDefaults(_ family: MereRunModelManifest.Family) -> Bool {
-        family == .hidream || family == .krea || family == .ideogram
+        family == .hidream || family == .krea || family == .ideogram || family == .senseNova
     }
 
     private static let supportedImageFamilies: Set<MereRunModelManifest.Family?> = [
@@ -963,5 +963,6 @@ struct ImageGenerationPreflightAnalyzer {
         .hidream,
         .krea,
         .ideogram,
+        .senseNova,
     ]
 }

--- a/Sources/MereRunCLI/Support/InstalledModelGateSupport.swift
+++ b/Sources/MereRunCLI/Support/InstalledModelGateSupport.swift
@@ -170,7 +170,7 @@ enum InstalledModelSmokePlans {
         installedIDs: Set<String>
     ) -> InstalledModelSmokePlan? {
         switch spec.validationKind {
-        case .flux2Klein, .bonsaiImage, .zimageTurbo, .hidreamO1, .krea2, .ideogram4SDNQ:
+        case .flux2Klein, .bonsaiImage, .zimageTurbo, .hidreamO1, .senseNovaU15, .krea2, .ideogram4SDNQ:
             return direct(spec, route: "image generate") { runner in
                 try await runner.installedImageCheck(model: spec.id)
             }

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -495,6 +495,7 @@ public enum ManagedModelValidationKind: String, Hashable, Sendable {
     case bonsaiImage
     case zimageTurbo
     case hidreamO1
+    case senseNovaU15
     case krea2
     case ideogram4SDNQ
     case gemma4
@@ -1404,6 +1405,35 @@ public enum ManagedModelCatalog {
             validationKind: .hidreamO1,
             runtimeAutoDownloadAllowed: false,
             estimatedDownloadBytes: 35_231_213_079,
+            defaultCLICommands: ["image generate"]
+        ),
+        ManagedModelSpec(
+            id: SenseNovaU15Resources.modelID,
+            category: .image,
+            installShape: .directoryRoot,
+            hubFallback: HubFallbackConfig(
+                repoId: SenseNovaU15Resources.repository,
+                revision: SenseNovaU15Resources.revision,
+                patterns: [
+                    "LICENSE",
+                    "README.md",
+                    "README_CN.md",
+                    "added_tokens.json",
+                    "config.json",
+                    "merges.txt",
+                    "model.safetensors.index.json",
+                    "model-*.safetensors",
+                    "special_tokens_map.json",
+                    "tokenizer.json",
+                    "tokenizer_config.json",
+                    "vocab.json",
+                ]
+            ),
+            upstreamRepoId: SenseNovaU15Resources.repository,
+            upstreamRevision: SenseNovaU15Resources.revision,
+            validationKind: .senseNovaU15,
+            runtimeAutoDownloadAllowed: false,
+            estimatedDownloadBytes: 50_227_451_138,
             defaultCLICommands: ["image generate"]
         ),
         ManagedModelSpec(
@@ -3906,6 +3936,8 @@ public extension ManagedModelSpec {
             return ZImageTurboResources(rootURL: rootURL).validate(fileManager: fileManager)
         case .hidreamO1:
             return HiDreamO1Resources(rootURL: rootURL).validate(fileManager: fileManager)
+        case .senseNovaU15:
+            return SenseNovaU15Resources(rootURL: rootURL).validate(fileManager: fileManager)
         case .krea2:
             return Krea2Resources(rootURL: rootURL).validate(fileManager: fileManager)
         case .ideogram4SDNQ:

--- a/Sources/MereRunCore/ManagedModelSupport.swift
+++ b/Sources/MereRunCore/ManagedModelSupport.swift
@@ -295,6 +295,13 @@ public enum ManagedModelCapabilityCatalog {
                 recommended: 128
             ),
             descriptor(
+                SenseNovaU15Resources.modelID,
+                "Image, SenseNova U1.5",
+                "Runs the native raw-pixel SenseNova U1.5 model for text-to-image and multi-image editing.",
+                minimum: 64,
+                recommended: 96
+            ),
+            descriptor(
                 Krea2RawResources.modelId,
                 "Image training, Krea 2 Raw",
                 "Installs the Krea 2 Raw base checkpoint for LoRA training and post-training workflows.",

--- a/Sources/MereRunCore/MereRunModelManifest.swift
+++ b/Sources/MereRunCore/MereRunModelManifest.swift
@@ -20,6 +20,8 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
         case zimageTurbo = "zimage-turbo"
         /// HiDream O1 unified pixel transformer family.
         case hidreamO1 = "hidream-o1"
+        /// SenseNova U1.5 unified understanding and raw-pixel generation transformer.
+        case senseNovaU15 = "sensenova-u1.5"
         /// Krea 2 text-to-image family.
         case krea2 = "krea-2"
         /// Ideogram 4 text-to-image family.
@@ -120,6 +122,7 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
         case klein
         case zimage
         case hidream
+        case senseNova = "sensenova"
         case krea
         case ideogram
         case gemma
@@ -1636,6 +1639,26 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
                     scheduler: nil
                 ),
                 upstreamRepoId: "HiDream-ai/HiDream-O1-Image-Dev",
+                createdAt: createdAt
+            )
+        case .senseNovaU15:
+            return MereRunModelManifest(
+                id: modelID.rawValue,
+                engine: .senseNovaU15,
+                family: .senseNova,
+                tier: .latest,
+                variant: .standard,
+                precision: .bf16,
+                defaults: Defaults(steps: 50, cfg: 4.0, sigmaShift: 3.0),
+                supports: [.txt2img, .img2img, .referenceEdit, .subjectPersonalization],
+                components: Components(
+                    tokenizer: .local(path: "."),
+                    textEncoder: .local(path: "."),
+                    transformer: .local(path: "."),
+                    vae: nil,
+                    scheduler: nil
+                ),
+                upstreamRepoId: "OpenSenseNova/SenseNova-U1",
                 createdAt: createdAt
             )
         case .krea2Raw:

--- a/Sources/MereRunCore/MereRunModelValidator.swift
+++ b/Sources/MereRunCore/MereRunModelValidator.swift
@@ -131,6 +131,7 @@ public enum MereRunModelValidator {
         let modelResolver = ModelResolver(fileManager: fileManager)
         let componentRefs = manifest?.components
         let usesUnifiedImageTransformer = manifest?.engine == .hidreamO1
+            || manifest?.engine == .senseNovaU15
         let transformerDir: URL?
         let textEncoderDir: URL?
         let vaeDir: URL?
@@ -441,6 +442,8 @@ public enum MereRunModelValidator {
                 warnings.append("Manifest engine mismatch: family=zimage expects zimage-turbo.")
             case .hidream where engine != .hidreamO1:
                 warnings.append("Manifest engine mismatch: family=hidream expects hidream-o1.")
+            case .senseNova where engine != .senseNovaU15:
+                warnings.append("Manifest engine mismatch: family=sensenova expects sensenova-u1.5.")
             case .krea where engine != .krea2:
                 warnings.append("Manifest engine mismatch: family=krea expects krea-2.")
             case .ideogram where engine != .ideogram4:
@@ -546,6 +549,7 @@ public enum MereRunModelValidator {
             return supports.contains(.txt2img) || supports.contains(.img2img) || supports.contains(.referenceEdit)
         }()
         let usesUnifiedImageTransformer = manifest.engine == .hidreamO1
+            || manifest.engine == .senseNovaU15
         let supportsVisionModel = {
             let supports = Set(manifest.supports ?? [])
             return supports.contains(.visionGrounding)
@@ -617,6 +621,7 @@ public enum MereRunModelValidator {
         if modelId.hasPrefix("image-klein-") { return .klein }
         if modelId.hasPrefix("image-zimage-") { return .zimage }
         if modelId.hasPrefix("image-hidream-") { return .hidream }
+        if modelId.hasPrefix("image-sensenova-") { return .senseNova }
         if modelId.hasPrefix("image-krea2-") { return .krea }
         if modelId.hasPrefix("image-ideogram4-") { return .ideogram }
         if modelId.hasPrefix("text-chat-laguna-") { return .laguna }

--- a/Sources/MereRunCore/ModelResolver.swift
+++ b/Sources/MereRunCore/ModelResolver.swift
@@ -22,6 +22,7 @@ public struct ModelResolver {
         case zetaBase = "image-zimage-base"
         case hidreamO1 = "image-hidream-o1"
         case hidreamO1Dev = "image-hidream-o1-dev"
+        case senseNovaU15 = "image-sensenova-u1-5-8b-mot"
         case krea2Raw = "image-krea2-raw"
         case krea2Turbo = "image-krea2-turbo"
         case ideogram4SDNQUInt4 = "image-ideogram4-sdnq-uint4"

--- a/Sources/MereRunCore/Quantization/QuantizedModelManifestWriter.swift
+++ b/Sources/MereRunCore/Quantization/QuantizedModelManifestWriter.swift
@@ -56,6 +56,7 @@ public enum QuantizedModelManifestWriter {
             case .flux2Klein: return .klein
             case .zimageTurbo: return .zimage
             case .hidreamO1: return .hidream
+            case .senseNovaU15: return .senseNova
             case .krea2: return .krea
             case .ideogram4: return .ideogram
             case .gemma4: return .gemma
@@ -120,6 +121,8 @@ public enum QuantizedModelManifestWriter {
                     return [.txt2img, .img2img, .loraInference]
                 case .hidreamO1:
                     return [.txt2img, .referenceEdit, .subjectPersonalization]
+                case .senseNovaU15:
+                    return [.txt2img, .img2img, .referenceEdit, .subjectPersonalization]
                 case .krea2:
                     return [.txt2img]
                 case .ideogram4:
@@ -256,6 +259,8 @@ public enum QuantizedModelManifestWriter {
                 manifest.defaults = MereRunModelManifest.Defaults(steps: 4, cfg: 1.0)
             case .hidreamO1:
                 manifest.defaults = MereRunModelManifest.Defaults(steps: 28, cfg: 0.0)
+            case .senseNovaU15:
+                manifest.defaults = MereRunModelManifest.Defaults(steps: 50, cfg: 4.0, sigmaShift: 3.0)
             case .krea2:
                 manifest.defaults = MereRunModelManifest.Defaults(
                     steps: 8,

--- a/Sources/MereRunCore/SenseNovaU15/README.md
+++ b/Sources/MereRunCore/SenseNovaU15/README.md
@@ -1,0 +1,10 @@
+# SenseNova U1.5
+
+Native Swift/MLX inference for the official `sensenova/SenseNova-U1.5-8B-MoT` checkpoint.
+
+The runtime implements the checkpoint's dual-expert Qwen3 transformer, raw-pixel flow-matching image path,
+resolution-aware noise schedule, text CFG, and multi-image editing. It does not invoke Python and does not use
+an external VAE or text encoder.
+
+The model is intentionally pinned in the managed catalog. Keep checkpoint key mapping limited to layout changes
+required by MLX (PyTorch convolution kernels are OIHW; MLX kernels are OHWI).

--- a/Sources/MereRunCore/SenseNovaU15/SenseNovaU15Config.swift
+++ b/Sources/MereRunCore/SenseNovaU15/SenseNovaU15Config.swift
@@ -1,0 +1,100 @@
+import Foundation
+
+public struct SenseNovaU15Config: Decodable, Sendable, Hashable {
+    public let downsampleRatio: Float
+    public let patchSize: Int
+    public let timestepShift: Float
+    public let timeSchedule: String
+    public let timeShiftType: String
+    public let baseShift: Float
+    public let maxShift: Float
+    public let baseImageSequenceLength: Int
+    public let maxImageSequenceLength: Int
+    public let noiseScaleMode: String
+    public let noiseScaleBaseImageSequenceLength: Int
+    public let addNoiseScaleEmbedding: Bool
+    public let noiseScaleMaxValue: Float
+    public let noiseScale: Float
+    public let tEpsilon: Float
+    public let llmConfig: LLMConfig
+    public let visionConfig: VisionConfig
+
+    public struct LLMConfig: Decodable, Sendable, Hashable {
+        public let hiddenSize: Int
+        public let intermediateSize: Int
+        public let headDimension: Int
+        public let numberOfAttentionHeads: Int
+        public let numberOfKeyValueHeads: Int
+        public let numberOfHiddenLayers: Int
+        public let vocabularySize: Int
+        public let rmsNormEpsilon: Float
+        public let ropeTheta: Float
+        public let ropeThetaHW: Float
+        public let attentionBias: Bool
+
+        private enum CodingKeys: String, CodingKey {
+            case hiddenSize = "hidden_size"
+            case intermediateSize = "intermediate_size"
+            case headDimension = "head_dim"
+            case numberOfAttentionHeads = "num_attention_heads"
+            case numberOfKeyValueHeads = "num_key_value_heads"
+            case numberOfHiddenLayers = "num_hidden_layers"
+            case vocabularySize = "vocab_size"
+            case rmsNormEpsilon = "rms_norm_eps"
+            case ropeTheta = "rope_theta"
+            case ropeThetaHW = "rope_theta_hw"
+            case attentionBias = "attention_bias"
+        }
+    }
+
+    public struct VisionConfig: Decodable, Sendable, Hashable {
+        public let hiddenSize: Int
+        public let numberOfChannels: Int
+        public let patchSize: Int
+        public let ropeTheta: Float
+
+        private enum CodingKeys: String, CodingKey {
+            case hiddenSize = "hidden_size"
+            case numberOfChannels = "num_channels"
+            case patchSize = "patch_size"
+            case ropeTheta = "rope_theta_vision"
+        }
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case downsampleRatio = "downsample_ratio"
+        case patchSize = "patch_size"
+        case timestepShift = "timestep_shift"
+        case timeSchedule = "time_schedule"
+        case timeShiftType = "time_shift_type"
+        case baseShift = "base_shift"
+        case maxShift = "max_shift"
+        case baseImageSequenceLength = "base_image_seq_len"
+        case maxImageSequenceLength = "max_image_seq_len"
+        case noiseScaleMode = "noise_scale_mode"
+        case noiseScaleBaseImageSequenceLength = "noise_scale_base_image_seq_len"
+        case addNoiseScaleEmbedding = "add_noise_scale_embedding"
+        case noiseScaleMaxValue = "noise_scale_max_value"
+        case noiseScale = "noise_scale"
+        case tEpsilon = "t_eps"
+        case llmConfig = "llm_config"
+        case visionConfig = "vision_config"
+    }
+
+    public static func load(from resources: SenseNovaU15Resources) throws -> SenseNovaU15Config {
+        let value = try JSONDecoder().decode(Self.self, from: Data(contentsOf: resources.configURL))
+        try value.validate()
+        return value
+    }
+
+    public func validate() throws {
+        guard patchSize > 0, downsampleRatio > 0,
+              llmConfig.hiddenSize > 0,
+              llmConfig.headDimension.isMultiple(of: 4),
+              llmConfig.numberOfAttentionHeads.isMultiple(of: llmConfig.numberOfKeyValueHeads),
+              llmConfig.hiddenSize == llmConfig.numberOfAttentionHeads * llmConfig.headDimension,
+              visionConfig.patchSize == patchSize else {
+            throw SenseNovaU15Error.invalidConfiguration("inconsistent model dimensions")
+        }
+    }
+}

--- a/Sources/MereRunCore/SenseNovaU15/SenseNovaU15Generator.swift
+++ b/Sources/MereRunCore/SenseNovaU15/SenseNovaU15Generator.swift
@@ -1,0 +1,381 @@
+import Foundation
+import MLX
+import MLXNN
+import MLXRandom
+
+public final class SenseNovaU15Generator: ImageGenerator {
+    private struct LoadedModel {
+        let rootURL: URL
+        let config: SenseNovaU15Config
+        let tokenizer: SenseNovaU15Tokenizer
+        let model: SenseNovaU15Model
+    }
+
+    private struct Conditioning {
+        let prompt: SenseNovaU15Tokenizer.EncodedPrompt
+        let caches: [SenseNovaU15KVCache]
+    }
+
+    private var loaded: LoadedModel?
+
+    public init() {}
+
+    deinit { unload() }
+
+    public func unload() {
+        loaded = nil
+        clearMemory()
+    }
+
+    public func generate(
+        _ request: GenerationRequest,
+        progressHandler: (@Sendable (GenerationProgress) -> Void)?
+    ) async throws -> GenerationResult {
+        guard request.width > 0, request.height > 0,
+              request.width.isMultiple(of: 32), request.height.isMultiple(of: 32) else {
+            throw SenseNovaU15Error.invalidImageSize(width: request.width, height: request.height)
+        }
+        let rootURL = try resolveModelRoot(request)
+        let loaded = try await loadModelIfNeeded(rootURL: rootURL, progressHandler: progressHandler)
+        let references = ([request.inputImage].compactMap { $0 } + request.referenceImages)
+        progressHandler?(GenerationProgress(stage: .encodingReferenceImages, stepIndex: 0, totalSteps: max(1, references.count)))
+        let preparedReferences = try references.enumerated().map { index, url in
+            let prepared = try SenseNovaU15ImageIO.prepareReference(
+                url,
+                patchSize: loaded.config.patchSize,
+                downsampleRatio: loaded.config.downsampleRatio,
+                imageCount: references.count
+            )
+            progressHandler?(GenerationProgress(
+                stage: .encodingReferenceImages,
+                stepIndex: index + 1,
+                totalSteps: references.count
+            ))
+            return prepared
+        }
+
+        progressHandler?(GenerationProgress(stage: .encodingText, stepIndex: 0, totalSteps: 1))
+        let grids = preparedReferences.map { (height: $0.gridHeight, width: $0.gridWidth) }
+        let conditionalPrompt = references.isEmpty
+            ? loaded.tokenizer.textToImage(request.prompt)
+            : loaded.tokenizer.imageEdit(request.prompt, grids: grids)
+        let conditional = try prefill(
+            prompt: conditionalPrompt,
+            references: preparedReferences,
+            model: loaded.model,
+            config: loaded.config
+        )
+        let guidance = Float(request.guidanceScale)
+        let guidanceCondition: Conditioning?
+        if guidance > 1 {
+            let prompt = references.isEmpty
+                ? loaded.tokenizer.unconditional(request.negativePrompt ?? "")
+                : loaded.tokenizer.imageOnly(grids: grids)
+            guidanceCondition = try prefill(
+                prompt: prompt,
+                references: references.isEmpty ? [] : preparedReferences,
+                model: loaded.model,
+                config: loaded.config
+            )
+        } else {
+            guidanceCondition = nil
+        }
+        progressHandler?(GenerationProgress(stage: .encodingText, stepIndex: 1, totalSteps: 1))
+
+        let seed = request.seed ?? deterministicSeed(request.prompt)
+        let result = denoise(
+            model: loaded.model,
+            config: loaded.config,
+            conditional: conditional,
+            guidanceCondition: guidanceCondition,
+            guidanceScale: guidance,
+            width: request.width,
+            height: request.height,
+            steps: request.steps,
+            timestepShift: request.sigmaShift ?? loaded.config.timestepShift,
+            seed: seed,
+            progressHandler: progressHandler
+        )
+        MLX.eval(result)
+        progressHandler?(GenerationProgress(stage: .saving, stepIndex: 0, totalSteps: 1))
+        try FileManager.default.createDirectory(
+            at: request.outputURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try SenseNovaU15ImageIO.save(result, to: request.outputURL)
+        progressHandler?(GenerationProgress(stage: .saving, stepIndex: 1, totalSteps: 1))
+        clearMemory()
+        return GenerationResult(outputURL: request.outputURL, seed: seed)
+    }
+
+    private func prefill(
+        prompt: SenseNovaU15Tokenizer.EncodedPrompt,
+        references: [SenseNovaU15ImageIO.PreparedImage],
+        model: SenseNovaU15Model,
+        config: SenseNovaU15Config
+    ) throws -> Conditioning {
+        let tokenIDs = MLXArray(prompt.tokenIDs.map(Int32.init)).reshaped(1, -1)
+        let embeddings = model.languageModel.model.embed(tokenIDs)
+        if !references.isEmpty {
+            let visualEmbeddings = references.map { model.visionModel.embeddings($0.pixels) }
+            let replacements = visualEmbeddings.count == 1
+                ? visualEmbeddings[0][0, 0..., 0...]
+                : MLX.concatenated(visualEmbeddings.map { $0[0, 0..., 0...] }, axis: 0)
+            guard replacements.dim(0) == prompt.imageContextPositions.count else {
+                throw SenseNovaU15Error.imageTokenMismatch(
+                    expected: prompt.imageContextPositions.count,
+                    actual: replacements.dim(0)
+                )
+            }
+            embeddings[0, MLXArray(prompt.imageContextPositions.map(Int32.init)), 0...] = replacements
+        }
+        let indexes = indexesArray(prompt)
+        let caches = (0..<config.llmConfig.numberOfHiddenLayers).map { _ in SenseNovaU15KVCache() }
+        let hidden = model.languageModel.model.forward(
+            embeddings: embeddings,
+            indexes: indexes,
+            expert: .understanding,
+            caches: caches,
+            updateCache: true
+        )
+        MLX.eval([hidden] + caches.flatMap { [$0.keys, $0.values].compactMap { $0 } })
+        Memory.clearCache()
+        return Conditioning(prompt: prompt, caches: caches)
+    }
+
+    private func denoise(
+        model: SenseNovaU15Model,
+        config: SenseNovaU15Config,
+        conditional: Conditioning,
+        guidanceCondition: Conditioning?,
+        guidanceScale: Float,
+        width: Int,
+        height: Int,
+        steps: Int,
+        timestepShift: Float,
+        seed: UInt64,
+        progressHandler: (@Sendable (GenerationProgress) -> Void)?
+    ) -> MLXArray {
+        let tokenHeight = height / 32
+        let tokenWidth = width / 32
+        let imageTokenCount = tokenHeight * tokenWidth
+        let noiseScale = SenseNovaU15Scheduler.noiseScale(
+            imageTokenCount: imageTokenCount,
+            baseImageTokenCount: config.noiseScaleBaseImageSequenceLength,
+            baseScale: config.noiseScale,
+            maximum: config.noiseScaleMaxValue,
+            mode: config.noiseScaleMode
+        )
+        let initial = MLXRandom.normal(
+            [1, height, width, 3],
+            key: MLXRandom.key(seed)
+        ).asType(.bfloat16) * noiseScale
+        var imageTokens = Self.patchify(initial, patchSize: 32)
+        let timesteps = SenseNovaU15Scheduler.timesteps(steps: steps, shift: timestepShift)
+        let conditionalIndexes = generationIndexes(
+            tokenHeight: tokenHeight,
+            tokenWidth: tokenWidth,
+            prefixTime: (conditional.prompt.timeIndexes.max() ?? -1) + 1
+        )
+        let guidanceIndexes = guidanceCondition.map {
+            generationIndexes(
+                tokenHeight: tokenHeight,
+                tokenWidth: tokenWidth,
+                prefixTime: ($0.prompt.timeIndexes.max() ?? -1) + 1
+            )
+        }
+
+        for step in 0..<steps {
+            progressHandler?(GenerationProgress(stage: .denoising, stepIndex: step, totalSteps: steps))
+            let timestep = timesteps[step]
+            let pixels = Self.unpatchify(
+                imageTokens,
+                patchSize: 32,
+                height: height,
+                width: width
+            )
+            let timestepValues = MLXArray([Float](repeating: timestep, count: imageTokenCount))
+            var timeEmbeddings = model.flowModules.timestepEmbedder(timestepValues)
+            if config.addNoiseScaleEmbedding {
+                let scaleValues = MLXArray(
+                    [Float](repeating: noiseScale / config.noiseScaleMaxValue, count: imageTokenCount)
+                )
+                timeEmbeddings = timeEmbeddings + model.flowModules.noiseScaleEmbedder(scaleValues)
+            }
+            let imageEmbeddings = model.flowModules.generationVisionModel.embeddings(pixels)
+                + timeEmbeddings.reshaped(1, imageTokenCount, -1)
+            let conditionalVelocity = velocity(
+                model: model,
+                imageEmbeddings: imageEmbeddings,
+                imageTokens: imageTokens,
+                indexes: conditionalIndexes,
+                caches: conditional.caches,
+                timestep: timestep,
+                tEpsilon: config.tEpsilon,
+                tokenHeight: tokenHeight,
+                tokenWidth: tokenWidth
+            )
+            let predictedVelocity: MLXArray
+            if let guidanceCondition, let guidanceIndexes, guidanceScale > 1 {
+                let baselineVelocity = velocity(
+                    model: model,
+                    imageEmbeddings: imageEmbeddings,
+                    imageTokens: imageTokens,
+                    indexes: guidanceIndexes,
+                    caches: guidanceCondition.caches,
+                    timestep: timestep,
+                    tEpsilon: config.tEpsilon,
+                    tokenHeight: tokenHeight,
+                    tokenWidth: tokenWidth
+                )
+                predictedVelocity = baselineVelocity
+                    + guidanceScale * (conditionalVelocity - baselineVelocity)
+            } else {
+                predictedVelocity = conditionalVelocity
+            }
+            imageTokens = imageTokens + (timesteps[step + 1] - timestep) * predictedVelocity
+            MLX.eval(imageTokens)
+            Memory.clearCache()
+        }
+        progressHandler?(GenerationProgress(stage: .denoising, stepIndex: steps, totalSteps: steps))
+        return Self.unpatchify(imageTokens, patchSize: 32, height: height, width: width)
+    }
+
+    private func velocity(
+        model: SenseNovaU15Model,
+        imageEmbeddings: MLXArray,
+        imageTokens: MLXArray,
+        indexes: MLXArray,
+        caches: [SenseNovaU15KVCache],
+        timestep: Float,
+        tEpsilon: Float,
+        tokenHeight: Int,
+        tokenWidth: Int
+    ) -> MLXArray {
+        let hidden = model.languageModel.model.forward(
+            embeddings: imageEmbeddings,
+            indexes: indexes,
+            expert: .generation,
+            caches: caches,
+            updateCache: false
+        )
+        let predictedPixels = model.flowModules.flowHead(
+            hidden,
+            tokenHeight: tokenHeight,
+            tokenWidth: tokenWidth
+        )
+        let predictedTokens = Self.patchify(predictedPixels, patchSize: 32)
+        return (predictedTokens - imageTokens) / max(1 - timestep, tEpsilon)
+    }
+
+    private func indexesArray(_ prompt: SenseNovaU15Tokenizer.EncodedPrompt) -> MLXArray {
+        MLXArray(
+            prompt.timeIndexes + prompt.heightIndexes + prompt.widthIndexes,
+            [3, prompt.tokenIDs.count]
+        )
+    }
+
+    private func generationIndexes(
+        tokenHeight: Int,
+        tokenWidth: Int,
+        prefixTime: Int32
+    ) -> MLXArray {
+        let count = tokenHeight * tokenWidth
+        let time = [Int32](repeating: prefixTime, count: count)
+        let height = (0..<count).map { Int32($0 / tokenWidth) }
+        let width = (0..<count).map { Int32($0 % tokenWidth) }
+        return MLXArray(time + height + width, [3, count])
+    }
+
+    static func patchify(_ pixels: MLXArray, patchSize: Int) -> MLXArray {
+        let batch = pixels.dim(0)
+        let height = pixels.dim(1) / patchSize
+        let width = pixels.dim(2) / patchSize
+        return pixels
+            .reshaped(batch, height, patchSize, width, patchSize, 3)
+            .transposed(0, 1, 3, 2, 4, 5)
+            .reshaped(batch, height * width, patchSize * patchSize * 3)
+    }
+
+    static func unpatchify(
+        _ patches: MLXArray,
+        patchSize: Int,
+        height: Int,
+        width: Int
+    ) -> MLXArray {
+        let batch = patches.dim(0)
+        let gridHeight = height / patchSize
+        let gridWidth = width / patchSize
+        return patches
+            .reshaped(batch, gridHeight, gridWidth, patchSize, patchSize, 3)
+            .transposed(0, 1, 3, 2, 4, 5)
+            .reshaped(batch, height, width, 3)
+    }
+
+    private func loadModelIfNeeded(
+        rootURL: URL,
+        progressHandler: (@Sendable (GenerationProgress) -> Void)?
+    ) async throws -> LoadedModel {
+        if let loaded, loaded.rootURL == rootURL { return loaded }
+        unload()
+        let resources = SenseNovaU15Resources(rootURL: rootURL)
+        let missing = resources.validate()
+        guard missing.isEmpty else { throw SenseNovaU15Error.missingModelFiles(missing) }
+        progressHandler?(GenerationProgress(stage: .loadingModel, stepIndex: 0, totalSteps: 1))
+        let config = try SenseNovaU15Config.load(from: resources)
+        let tokenizer = try await SenseNovaU15Tokenizer.load(from: resources)
+        let model = SenseNovaU15Model(config: config)
+        try ModelWeightsLoader.applyHFSafetensors(
+            indexURL: resources.weightsIndexURL,
+            singleURL: resources.singleWeightsURL,
+            to: model,
+            dtype: .bfloat16,
+            verify: .shapeMismatch,
+            mapper: Self.mapWeight,
+            progressHandler: { shard in
+                progressHandler?(GenerationProgress(
+                    stage: .loadingTransformer,
+                    stepIndex: shard.shardIndex + 1,
+                    totalSteps: shard.shardCount
+                ))
+            }
+        )
+        let loaded = LoadedModel(rootURL: rootURL, config: config, tokenizer: tokenizer, model: model)
+        self.loaded = loaded
+        progressHandler?(GenerationProgress(stage: .loadingModel, stepIndex: 1, totalSteps: 1))
+        return loaded
+    }
+
+    private static func mapWeight(_ key: String, value: MLXArray) -> [(String, MLXArray)] {
+        if key == "language_model.lm_head.weight" { return [] }
+        let isConvolution = key.hasSuffix("patch_embedding.weight")
+            || key.hasSuffix("dense_embedding.weight")
+            || key == "fm_modules.fm_head.conv1.weight"
+            || key == "fm_modules.fm_head.conv2.weight"
+        return [(key, isConvolution ? HFSafetensorsWeightsLoader.convWeightOIHWToOHWI(value) : value)]
+    }
+
+    private func resolveModelRoot(_ request: GenerationRequest) throws -> URL {
+        if let model = request.model {
+            let url = URL(fileURLWithPath: model).standardizedFileURL
+            if FileManager.default.fileExists(atPath: url.path) { return url }
+        }
+        if let installed = ManagedModelResolver.resolveInstalledModel(id: SenseNovaU15Resources.modelID) {
+            return installed
+        }
+        throw ModelResolver.ResolverError.modelNotFound(
+            .senseNovaU15,
+            searched: [MereRunModelPaths.modelDir(SenseNovaU15Resources.modelID)],
+            upstreamRepoId: SenseNovaU15Resources.repository
+        )
+    }
+
+    private func deterministicSeed(_ prompt: String) -> UInt64 {
+        prompt.utf8.reduce(UInt64(0xcbf2_9ce4_8422_2325)) { ($0 ^ UInt64($1)) &* 0x100_0000_01b3 }
+    }
+
+    private func clearMemory() {
+        MLX.eval(MLXArray([]))
+        Memory.clearCache()
+    }
+}

--- a/Sources/MereRunCore/SenseNovaU15/SenseNovaU15ImageIO.swift
+++ b/Sources/MereRunCore/SenseNovaU15/SenseNovaU15ImageIO.swift
@@ -1,0 +1,89 @@
+import Foundation
+import MediaIO
+import MLX
+
+enum SenseNovaU15ImageIO {
+    struct PreparedImage {
+        let pixels: MLXArray
+        let gridHeight: Int
+        let gridWidth: Int
+    }
+
+    static func prepareReference(
+        _ url: URL,
+        patchSize: Int,
+        downsampleRatio: Float,
+        imageCount: Int
+    ) throws -> PreparedImage {
+        let image = try whiteComposited(try MediaImageIO.decode(url))
+        let factor = Int(Float(patchSize) / downsampleRatio)
+        let maximum = min(2_048 * 2_048, (4_096 * 4_096) / max(1, imageCount))
+        let resized = smartResize(
+            width: image.width,
+            height: image.height,
+            factor: factor,
+            minimumPixels: 512 * 512,
+            maximumPixels: maximum,
+            upscale: false
+        )
+        let scaled = try MediaImageIO.resized(image, width: resized.width, height: resized.height)
+        let chw = MLXArray(
+            MediaImageIO.rgbCHWFloat(scaled, normalizedToMinusOneToOne: false),
+            [1, 3, resized.height, resized.width]
+        ).asType(.bfloat16)
+        var pixels = chw.transposed(0, 2, 3, 1)
+        let mean = MLXArray([Float(0.485), 0.456, 0.406]).asType(.bfloat16)
+        let standardDeviation = MLXArray([Float(0.229), 0.224, 0.225]).asType(.bfloat16)
+        pixels = (pixels - mean) / standardDeviation
+        return PreparedImage(
+            pixels: pixels,
+            gridHeight: resized.height / patchSize,
+            gridWidth: resized.width / patchSize
+        )
+    }
+
+    static func save(_ pixelsNHWC: MLXArray, to url: URL) throws {
+        let chw = MLX.clip((pixelsNHWC + 1) / 2, min: 0, max: 1)
+            .transposed(0, 3, 1, 2)[0, 0..., 0..., 0...]
+        try QwenImageIO.saveImage(array: chw, to: url)
+    }
+
+    private static func whiteComposited(_ image: MediaImage) throws -> MediaImage {
+        guard image.rgba8.indices.contains(3),
+              stride(from: 3, to: image.rgba8.count, by: 4).contains(where: { image.rgba8[$0] < 255 }) else {
+            return image
+        }
+        var rgba = image.rgba8
+        for pixel in 0..<(image.width * image.height) {
+            let offset = pixel * 4
+            let alpha = Int(rgba[offset + 3])
+            for channel in 0..<3 {
+                rgba[offset + channel] = UInt8((Int(rgba[offset + channel]) * alpha + 255 * (255 - alpha)) / 255)
+            }
+            rgba[offset + 3] = 255
+        }
+        return try MediaImage(width: image.width, height: image.height, rgba8: rgba)
+    }
+
+    static func smartResize(
+        width: Int,
+        height: Int,
+        factor: Int,
+        minimumPixels: Int,
+        maximumPixels: Int,
+        upscale _: Bool
+    ) -> (width: Int, height: Int) {
+        var targetHeight = max(factor, Int((Double(height) / Double(factor)).rounded()) * factor)
+        var targetWidth = max(factor, Int((Double(width) / Double(factor)).rounded()) * factor)
+        if targetHeight * targetWidth > maximumPixels {
+            let beta = sqrt(Double(height * width) / Double(maximumPixels))
+            targetHeight = max(factor, Int(floor(Double(height) / beta / Double(factor))) * factor)
+            targetWidth = max(factor, Int(floor(Double(width) / beta / Double(factor))) * factor)
+        } else if targetHeight * targetWidth < minimumPixels {
+            let beta = sqrt(Double(minimumPixels) / Double(height * width))
+            targetHeight = Int(ceil(Double(height) * beta / Double(factor))) * factor
+            targetWidth = Int(ceil(Double(width) * beta / Double(factor))) * factor
+        }
+        return (targetWidth, targetHeight)
+    }
+}

--- a/Sources/MereRunCore/SenseNovaU15/SenseNovaU15Model.swift
+++ b/Sources/MereRunCore/SenseNovaU15/SenseNovaU15Model.swift
@@ -1,0 +1,271 @@
+import Foundation
+import MLX
+import MLXFast
+import MLXNN
+
+final class SenseNovaU15RMSNorm: Module {
+    @ModuleInfo(key: "weight") var weight: MLXArray
+    private let epsilon: Float
+
+    init(dimensions: Int, epsilon: Float) {
+        self._weight.wrappedValue = MLXArray.ones([dimensions])
+        self.epsilon = epsilon
+        super.init()
+    }
+
+    func callAsFunction(_ input: MLXArray) -> MLXArray {
+        MLXFast.rmsNorm(input, weight: weight, eps: epsilon)
+    }
+}
+
+final class SenseNovaU15MLP: Module {
+    @ModuleInfo(key: "gate_proj") var gateProjection: Linear
+    @ModuleInfo(key: "up_proj") var upProjection: Linear
+    @ModuleInfo(key: "down_proj") var downProjection: Linear
+
+    init(config: SenseNovaU15Config.LLMConfig) {
+        self._gateProjection.wrappedValue = Linear(config.hiddenSize, config.intermediateSize, bias: false)
+        self._upProjection.wrappedValue = Linear(config.hiddenSize, config.intermediateSize, bias: false)
+        self._downProjection.wrappedValue = Linear(config.intermediateSize, config.hiddenSize, bias: false)
+        super.init()
+    }
+
+    func callAsFunction(_ input: MLXArray) -> MLXArray {
+        downProjection(MLXNN.silu(gateProjection(input)) * upProjection(input))
+    }
+}
+
+final class SenseNovaU15KVCache: @unchecked Sendable {
+    var keys: MLXArray?
+    var values: MLXArray?
+
+    func store(keys: MLXArray, values: MLXArray) {
+        self.keys = keys
+        self.values = values
+    }
+}
+
+enum SenseNovaU15Expert {
+    case understanding
+    case generation
+}
+
+final class SenseNovaU15Attention: Module {
+    @ModuleInfo(key: "q_proj") var queryProjection: Linear
+    @ModuleInfo(key: "k_proj") var keyProjection: Linear
+    @ModuleInfo(key: "v_proj") var valueProjection: Linear
+    @ModuleInfo(key: "o_proj") var outputProjection: Linear
+    @ModuleInfo(key: "q_proj_mot_gen") var generationQueryProjection: Linear
+    @ModuleInfo(key: "k_proj_mot_gen") var generationKeyProjection: Linear
+    @ModuleInfo(key: "v_proj_mot_gen") var generationValueProjection: Linear
+    @ModuleInfo(key: "o_proj_mot_gen") var generationOutputProjection: Linear
+    @ModuleInfo(key: "q_norm") var queryNorm: SenseNovaU15RMSNorm
+    @ModuleInfo(key: "k_norm") var keyNorm: SenseNovaU15RMSNorm
+    @ModuleInfo(key: "q_norm_hw") var queryNormHW: SenseNovaU15RMSNorm
+    @ModuleInfo(key: "k_norm_hw") var keyNormHW: SenseNovaU15RMSNorm
+    @ModuleInfo(key: "q_norm_mot_gen") var generationQueryNorm: SenseNovaU15RMSNorm
+    @ModuleInfo(key: "k_norm_mot_gen") var generationKeyNorm: SenseNovaU15RMSNorm
+    @ModuleInfo(key: "q_norm_hw_mot_gen") var generationQueryNormHW: SenseNovaU15RMSNorm
+    @ModuleInfo(key: "k_norm_hw_mot_gen") var generationKeyNormHW: SenseNovaU15RMSNorm
+
+    private let numberOfHeads: Int
+    private let numberOfKeyValueHeads: Int
+    private let headDimension: Int
+    private let scale: Float
+    private let timeBase: Float
+    private let spatialBase: Float
+
+    init(config: SenseNovaU15Config.LLMConfig) {
+        let queryOutput = config.numberOfAttentionHeads * config.headDimension
+        let keyValueOutput = config.numberOfKeyValueHeads * config.headDimension
+        self._queryProjection.wrappedValue = Linear(config.hiddenSize, queryOutput, bias: config.attentionBias)
+        self._keyProjection.wrappedValue = Linear(config.hiddenSize, keyValueOutput, bias: config.attentionBias)
+        self._valueProjection.wrappedValue = Linear(config.hiddenSize, keyValueOutput, bias: config.attentionBias)
+        self._outputProjection.wrappedValue = Linear(queryOutput, config.hiddenSize, bias: config.attentionBias)
+        self._generationQueryProjection.wrappedValue = Linear(config.hiddenSize, queryOutput, bias: config.attentionBias)
+        self._generationKeyProjection.wrappedValue = Linear(config.hiddenSize, keyValueOutput, bias: config.attentionBias)
+        self._generationValueProjection.wrappedValue = Linear(config.hiddenSize, keyValueOutput, bias: config.attentionBias)
+        self._generationOutputProjection.wrappedValue = Linear(queryOutput, config.hiddenSize, bias: config.attentionBias)
+        let half = config.headDimension / 2
+        self._queryNorm.wrappedValue = SenseNovaU15RMSNorm(dimensions: half, epsilon: config.rmsNormEpsilon)
+        self._keyNorm.wrappedValue = SenseNovaU15RMSNorm(dimensions: half, epsilon: config.rmsNormEpsilon)
+        self._queryNormHW.wrappedValue = SenseNovaU15RMSNorm(dimensions: half, epsilon: config.rmsNormEpsilon)
+        self._keyNormHW.wrappedValue = SenseNovaU15RMSNorm(dimensions: half, epsilon: config.rmsNormEpsilon)
+        self._generationQueryNorm.wrappedValue = SenseNovaU15RMSNorm(dimensions: half, epsilon: config.rmsNormEpsilon)
+        self._generationKeyNorm.wrappedValue = SenseNovaU15RMSNorm(dimensions: half, epsilon: config.rmsNormEpsilon)
+        self._generationQueryNormHW.wrappedValue = SenseNovaU15RMSNorm(dimensions: half, epsilon: config.rmsNormEpsilon)
+        self._generationKeyNormHW.wrappedValue = SenseNovaU15RMSNorm(dimensions: half, epsilon: config.rmsNormEpsilon)
+        self.numberOfHeads = config.numberOfAttentionHeads
+        self.numberOfKeyValueHeads = config.numberOfKeyValueHeads
+        self.headDimension = config.headDimension
+        self.scale = 1 / sqrt(Float(config.headDimension))
+        self.timeBase = config.ropeTheta
+        self.spatialBase = config.ropeThetaHW
+        super.init()
+    }
+
+    func callAsFunction(
+        _ input: MLXArray,
+        indexes: MLXArray,
+        expert: SenseNovaU15Expert,
+        cache: SenseNovaU15KVCache,
+        updateCache: Bool
+    ) -> MLXArray {
+        let batch = input.dim(0)
+        let sequence = input.dim(1)
+        let queryLinear = expert == .understanding ? queryProjection(input) : generationQueryProjection(input)
+        let keyLinear = expert == .understanding ? keyProjection(input) : generationKeyProjection(input)
+        let valueLinear = expert == .understanding ? valueProjection(input) : generationValueProjection(input)
+        var queries = queryLinear.reshaped(batch, sequence, numberOfHeads, headDimension)
+        var keys = keyLinear.reshaped(batch, sequence, numberOfKeyValueHeads, headDimension)
+        let values = valueLinear.reshaped(batch, sequence, numberOfKeyValueHeads, headDimension)
+
+        let half = headDimension / 2
+        let qTime = queries[0..., 0..., 0..., 0..<half]
+        let qHW = queries[0..., 0..., 0..., half...]
+        let kTime = keys[0..., 0..., 0..., 0..<half]
+        let kHW = keys[0..., 0..., 0..., half...]
+        let normalizedQTime = expert == .understanding ? queryNorm(qTime) : generationQueryNorm(qTime)
+        let normalizedQHW = expert == .understanding ? queryNormHW(qHW) : generationQueryNormHW(qHW)
+        let normalizedKTime = expert == .understanding ? keyNorm(kTime) : generationKeyNorm(kTime)
+        let normalizedKHW = expert == .understanding ? keyNormHW(kHW) : generationKeyNormHW(kHW)
+        let quarter = headDimension / 4
+        queries = MLX.concatenated([
+            applyRoPE(normalizedQTime, positions: indexes[0, 0...], base: timeBase),
+            applyRoPE(normalizedQHW[0..., 0..., 0..., 0..<quarter], positions: indexes[1, 0...], base: spatialBase),
+            applyRoPE(normalizedQHW[0..., 0..., 0..., quarter...], positions: indexes[2, 0...], base: spatialBase)
+        ], axis: -1).transposed(0, 2, 1, 3)
+        keys = MLX.concatenated([
+            applyRoPE(normalizedKTime, positions: indexes[0, 0...], base: timeBase),
+            applyRoPE(normalizedKHW[0..., 0..., 0..., 0..<quarter], positions: indexes[1, 0...], base: spatialBase),
+            applyRoPE(normalizedKHW[0..., 0..., 0..., quarter...], positions: indexes[2, 0...], base: spatialBase)
+        ], axis: -1).transposed(0, 2, 1, 3)
+        var allValues = values.transposed(0, 2, 1, 3)
+
+        if updateCache {
+            cache.store(keys: keys, values: allValues)
+        } else if let prefixKeys = cache.keys, let prefixValues = cache.values {
+            keys = MLX.concatenated([prefixKeys, keys], axis: 2)
+            allValues = MLX.concatenated([prefixValues, allValues], axis: 2)
+        }
+        let attended = MLXFast.scaledDotProductAttention(
+            queries: queries,
+            keys: keys,
+            values: allValues,
+            scale: scale,
+            mask: updateCache ? .causal : .none
+        ).transposed(0, 2, 1, 3).reshaped(batch, sequence, numberOfHeads * headDimension)
+        return expert == .understanding ? outputProjection(attended) : generationOutputProjection(attended)
+    }
+
+    private func applyRoPE(_ input: MLXArray, positions: MLXArray, base: Float) -> MLXArray {
+        let dimension = input.dim(-1)
+        let doubledDimension = dimension * 2
+        let full = MLXArray(stride(from: Float(0), to: Float(doubledDimension), by: 2))
+        let fullInverseFrequency = 1 / MLX.pow(MLXArray(base), full / Float(doubledDimension))
+        let selector = MLXArray(Array(stride(from: Int32(0), to: Int32(dimension), by: 2)))
+        let inverseFrequency = fullInverseFrequency[selector]
+        let frequencies = positions.asType(.float32)[0..., .newAxis] * inverseFrequency[.newAxis, 0...]
+        let embedding = MLX.concatenated([frequencies, frequencies], axis: -1)
+            .asType(input.dtype)[.newAxis, 0..., .newAxis, 0...]
+        let half = dimension / 2
+        let rotated = MLX.concatenated([
+            -input[0..., 0..., 0..., half...],
+            input[0..., 0..., 0..., 0..<half]
+        ], axis: -1)
+        return input * MLX.cos(embedding) + rotated * MLX.sin(embedding)
+    }
+}
+
+final class SenseNovaU15DecoderLayer: Module {
+    @ModuleInfo(key: "self_attn") var attention: SenseNovaU15Attention
+    @ModuleInfo(key: "mlp") var mlp: SenseNovaU15MLP
+    @ModuleInfo(key: "mlp_mot_gen") var generationMLP: SenseNovaU15MLP
+    @ModuleInfo(key: "input_layernorm") var inputNorm: SenseNovaU15RMSNorm
+    @ModuleInfo(key: "input_layernorm_mot_gen") var generationInputNorm: SenseNovaU15RMSNorm
+    @ModuleInfo(key: "post_attention_layernorm") var postAttentionNorm: SenseNovaU15RMSNorm
+    @ModuleInfo(key: "post_attention_layernorm_mot_gen") var generationPostAttentionNorm: SenseNovaU15RMSNorm
+
+    init(config: SenseNovaU15Config.LLMConfig) {
+        self._attention.wrappedValue = SenseNovaU15Attention(config: config)
+        self._mlp.wrappedValue = SenseNovaU15MLP(config: config)
+        self._generationMLP.wrappedValue = SenseNovaU15MLP(config: config)
+        self._inputNorm.wrappedValue = SenseNovaU15RMSNorm(dimensions: config.hiddenSize, epsilon: config.rmsNormEpsilon)
+        self._generationInputNorm.wrappedValue = SenseNovaU15RMSNorm(dimensions: config.hiddenSize, epsilon: config.rmsNormEpsilon)
+        self._postAttentionNorm.wrappedValue = SenseNovaU15RMSNorm(dimensions: config.hiddenSize, epsilon: config.rmsNormEpsilon)
+        self._generationPostAttentionNorm.wrappedValue = SenseNovaU15RMSNorm(dimensions: config.hiddenSize, epsilon: config.rmsNormEpsilon)
+        super.init()
+    }
+
+    func callAsFunction(
+        _ input: MLXArray,
+        indexes: MLXArray,
+        expert: SenseNovaU15Expert,
+        cache: SenseNovaU15KVCache,
+        updateCache: Bool
+    ) -> MLXArray {
+        let normalized = expert == .understanding ? inputNorm(input) : generationInputNorm(input)
+        var hidden = input + attention(
+            normalized,
+            indexes: indexes,
+            expert: expert,
+            cache: cache,
+            updateCache: updateCache
+        )
+        let postAttention = expert == .understanding ? postAttentionNorm(hidden) : generationPostAttentionNorm(hidden)
+        hidden = hidden + (expert == .understanding ? mlp(postAttention) : generationMLP(postAttention))
+        return hidden
+    }
+}
+
+final class SenseNovaU15Transformer: Module {
+    @ModuleInfo(key: "embed_tokens") var tokenEmbedding: Embedding
+    @ModuleInfo(key: "layers") var layers: [SenseNovaU15DecoderLayer]
+    @ModuleInfo(key: "norm") var norm: SenseNovaU15RMSNorm
+    @ModuleInfo(key: "norm_mot_gen") var generationNorm: SenseNovaU15RMSNorm
+
+    init(config: SenseNovaU15Config.LLMConfig) {
+        self._tokenEmbedding.wrappedValue = Embedding(
+            embeddingCount: config.vocabularySize,
+            dimensions: config.hiddenSize
+        )
+        self._layers.wrappedValue = (0..<config.numberOfHiddenLayers).map { _ in
+            SenseNovaU15DecoderLayer(config: config)
+        }
+        self._norm.wrappedValue = SenseNovaU15RMSNorm(dimensions: config.hiddenSize, epsilon: config.rmsNormEpsilon)
+        self._generationNorm.wrappedValue = SenseNovaU15RMSNorm(dimensions: config.hiddenSize, epsilon: config.rmsNormEpsilon)
+        super.init()
+    }
+
+    func embed(_ tokenIDs: MLXArray) -> MLXArray { tokenEmbedding(tokenIDs) }
+
+    func forward(
+        embeddings: MLXArray,
+        indexes: MLXArray,
+        expert: SenseNovaU15Expert,
+        caches: [SenseNovaU15KVCache],
+        updateCache: Bool
+    ) -> MLXArray {
+        precondition(caches.count == layers.count)
+        var hidden = embeddings
+        for (index, layer) in layers.enumerated() {
+            hidden = layer(
+                hidden,
+                indexes: indexes,
+                expert: expert,
+                cache: caches[index],
+                updateCache: updateCache
+            )
+        }
+        return expert == .understanding ? norm(hidden) : generationNorm(hidden)
+    }
+}
+
+final class SenseNovaU15CausalLM: Module {
+    @ModuleInfo(key: "model") var model: SenseNovaU15Transformer
+
+    init(config: SenseNovaU15Config.LLMConfig) {
+        self._model.wrappedValue = SenseNovaU15Transformer(config: config)
+        super.init()
+    }
+}

--- a/Sources/MereRunCore/SenseNovaU15/SenseNovaU15Resources.swift
+++ b/Sources/MereRunCore/SenseNovaU15/SenseNovaU15Resources.swift
@@ -1,0 +1,59 @@
+import Foundation
+
+public struct SenseNovaU15Resources: Sendable, Hashable {
+    public static let modelID = "image-sensenova-u1-5-8b-mot"
+    public static let repository = "sensenova/SenseNova-U1.5-8B-MoT"
+    public static let revision = "1f6ec60423d29939dde4202fd82ae340b144e280"
+
+    public let rootURL: URL
+
+    public init(rootURL: URL) {
+        self.rootURL = rootURL
+    }
+
+    public var configURL: URL { rootURL.appending(path: "config.json") }
+    public var tokenizerConfigURL: URL { rootURL.appending(path: "tokenizer_config.json") }
+    public var tokenizerJSONURL: URL { rootURL.appending(path: "tokenizer.json") }
+    public var addedTokensURL: URL { rootURL.appending(path: "added_tokens.json") }
+    public var vocabURL: URL { rootURL.appending(path: "vocab.json") }
+    public var mergesURL: URL { rootURL.appending(path: "merges.txt") }
+    public var weightsIndexURL: URL { rootURL.appending(path: "model.safetensors.index.json") }
+    public var singleWeightsURL: URL { rootURL.appending(path: "model.safetensors") }
+
+    public func validate(fileManager: FileManager = .default) -> [URL] {
+        var missing: [URL] = []
+        if !fileManager.fileExists(atPath: configURL.path) { missing.append(configURL) }
+        if !fileManager.fileExists(atPath: tokenizerConfigURL.path) { missing.append(tokenizerConfigURL) }
+        let hasTokenizer = fileManager.fileExists(atPath: tokenizerJSONURL.path)
+            || (fileManager.fileExists(atPath: vocabURL.path) && fileManager.fileExists(atPath: mergesURL.path))
+        if !hasTokenizer { missing.append(tokenizerJSONURL) }
+        if !fileManager.fileExists(atPath: weightsIndexURL.path)
+            && !fileManager.fileExists(atPath: singleWeightsURL.path) {
+            missing.append(weightsIndexURL)
+        }
+        return missing
+    }
+}
+
+public enum SenseNovaU15Error: LocalizedError, Sendable {
+    case invalidConfiguration(String)
+    case missingModelFiles([URL])
+    case invalidImageSize(width: Int, height: Int)
+    case tokenizerTokenMissing(String)
+    case imageTokenMismatch(expected: Int, actual: Int)
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidConfiguration(let detail):
+            return "Invalid SenseNova U1.5 configuration: \(detail)"
+        case .missingModelFiles(let files):
+            return "Missing SenseNova U1.5 model files: \(files.map(\.path).joined(separator: ", "))"
+        case .invalidImageSize(let width, let height):
+            return "SenseNova U1.5 output size must be positive and divisible by 32; got \(width)x\(height)."
+        case .tokenizerTokenMissing(let token):
+            return "SenseNova U1.5 tokenizer is missing required token: \(token)"
+        case .imageTokenMismatch(let expected, let actual):
+            return "SenseNova U1.5 image token mismatch: expected \(expected), found \(actual)."
+        }
+    }
+}

--- a/Sources/MereRunCore/SenseNovaU15/SenseNovaU15Scheduler.swift
+++ b/Sources/MereRunCore/SenseNovaU15/SenseNovaU15Scheduler.swift
@@ -1,0 +1,31 @@
+import Foundation
+
+public enum SenseNovaU15Scheduler {
+    public static func timesteps(steps: Int, shift: Float) -> [Float] {
+        precondition(steps > 0)
+        return (0...steps).map { index in
+            shifted(Float(index) / Float(steps), shift: shift)
+        }
+    }
+
+    public static func shifted(_ timestep: Float, shift: Float) -> Float {
+        let sigma = 1 - timestep
+        let shiftedSigma = shift * sigma / (1 + (shift - 1) * sigma)
+        return 1 - shiftedSigma
+    }
+
+    public static func noiseScale(
+        imageTokenCount: Int,
+        baseImageTokenCount: Int,
+        baseScale: Float,
+        maximum: Float,
+        mode: String
+    ) -> Float {
+        guard mode == "resolution" || mode == "dynamic" || mode == "dynamic_sqrt" else {
+            return min(baseScale, maximum)
+        }
+        var scale = sqrt(Float(imageTokenCount) / Float(baseImageTokenCount)) * baseScale
+        if mode == "dynamic_sqrt" { scale = sqrt(scale) }
+        return min(scale, maximum)
+    }
+}

--- a/Sources/MereRunCore/SenseNovaU15/SenseNovaU15Tokenizer.swift
+++ b/Sources/MereRunCore/SenseNovaU15/SenseNovaU15Tokenizer.swift
@@ -1,0 +1,267 @@
+import Foundation
+@preconcurrency import Hub
+@preconcurrency import Tokenizers
+
+public final class SenseNovaU15Tokenizer {
+    public static let imageStart = "<img>"
+    public static let imageEnd = "</img>"
+    public static let imageContext = "<IMG_CONTEXT>"
+
+    public struct EncodedPrompt: Sendable, Equatable {
+        public let tokenIDs: [Int]
+        public let timeIndexes: [Int32]
+        public let heightIndexes: [Int32]
+        public let widthIndexes: [Int32]
+        public let imageContextPositions: [Int]
+    }
+
+    private static let systemMessage = """
+    You are an image generation and editing assistant that accurately understands and executes user intent.
+
+    You support two modes:
+
+    1. Think Mode:
+    If the task requires reasoning, you MUST start with a <think></think> block. Put all reasoning inside the block using plain text. DO NOT include any image tags. Keep it reasonable and directly useful for producing the final image.
+
+    2. Non-Think Mode:
+    If no reasoning is needed, directly produce the final image.
+
+    Task Types:
+
+    A. Text-to-Image Generation:
+    - Generate a high-quality image based on the user's description.
+    - Ensure visual clarity, semantic consistency, and completeness.
+    - DO NOT introduce elements that contradict or override the user's intent.
+
+    B. Image Editing:
+    - Use the provided image(s) as input or reference for modification or transformation.
+    - The result can be an edited image or a new image based on the reference(s).
+    - Preserve all unspecified attributes unless explicitly changed.
+
+    General Rules:
+    - For any visible text in the image, follow the language specified for the rendered text in the user's description, not the language of the prompt. If no language is specified, use the user's input language.
+    """
+
+    public let tokenizer: any Tokenizer
+    public let imageStartTokenID: Int
+    public let imageEndTokenID: Int
+    public let imageContextTokenID: Int
+
+    public init(tokenizer: any Tokenizer) throws {
+        self.tokenizer = tokenizer
+        guard let imageStartTokenID = tokenizer.convertTokenToId(Self.imageStart),
+              let imageEndTokenID = tokenizer.convertTokenToId(Self.imageEnd),
+              let imageContextTokenID = tokenizer.convertTokenToId(Self.imageContext) else {
+            throw SenseNovaU15Error.tokenizerTokenMissing("<img>, </img>, or <IMG_CONTEXT>")
+        }
+        self.imageStartTokenID = imageStartTokenID
+        self.imageEndTokenID = imageEndTokenID
+        self.imageContextTokenID = imageContextTokenID
+    }
+
+    public static func load(
+        from resources: SenseNovaU15Resources,
+        hubApi: HubApi = .shared
+    ) async throws -> SenseNovaU15Tokenizer {
+        let tokenizer: any Tokenizer
+        if FileManager.default.fileExists(atPath: resources.tokenizerJSONURL.path) {
+            tokenizer = try await AutoTokenizer.from(modelFolder: resources.rootURL, hubApi: hubApi)
+        } else {
+            tokenizer = try AutoTokenizer.from(
+                tokenizerConfig: hubApi.configuration(fileURL: resources.tokenizerConfigURL),
+                tokenizerData: try makeQwenTokenizerData(resources: resources)
+            )
+        }
+        return try SenseNovaU15Tokenizer(tokenizer: tokenizer)
+    }
+
+    public func textToImage(_ prompt: String) -> EncodedPrompt {
+        encode(query(user: prompt, system: Self.systemMessage, suffix: "<think>\n\n</think>\n\n<img>"), grids: [])
+    }
+
+    public func unconditional(_ negativePrompt: String = "") -> EncodedPrompt {
+        encode(query(user: negativePrompt, system: nil, suffix: "<img>"), grids: [])
+    }
+
+    public func imageEdit(_ prompt: String, grids: [(height: Int, width: Int)]) -> EncodedPrompt {
+        var user = prompt
+        let existing = user.components(separatedBy: "<image>").count - 1
+        if existing == 0 && grids.count > 1 {
+            user = grids.indices.map { "Image-\($0 + 1):<image>\n" }.joined() + user
+        } else if existing < grids.count {
+            user = String(repeating: "<image>\n", count: grids.count - existing) + user
+        }
+        let expanded = expandImagePlaceholders(in: user, grids: grids)
+        return encode(
+            query(user: expanded, system: Self.systemMessage, suffix: "<think>\n\n</think>\n\n<img>"),
+            grids: grids
+        )
+    }
+
+    public func imageOnly(grids: [(height: Int, width: Int)]) -> EncodedPrompt {
+        let placeholders = String(repeating: "<image>", count: grids.count)
+        return encode(
+            query(user: expandImagePlaceholders(in: placeholders, grids: grids), system: nil, suffix: "<img>"),
+            grids: grids
+        )
+    }
+
+    private func query(user: String, system: String?, suffix: String) -> String {
+        let systemPart = system.map { "<|im_start|>system\n\($0)<|im_end|>\n" } ?? ""
+        return systemPart
+            + "<|im_start|>user\n\(user)<|im_end|>\n"
+            + "<|im_start|>assistant\n\(suffix)"
+    }
+
+    private func expandImagePlaceholders(
+        in prompt: String,
+        grids: [(height: Int, width: Int)]
+    ) -> String {
+        var result = prompt
+        for grid in grids {
+            let count = grid.height * grid.width / 4
+            let replacement = Self.imageStart
+                + String(repeating: Self.imageContext, count: count)
+                + Self.imageEnd
+            if let range = result.range(of: "<image>") {
+                result.replaceSubrange(range, with: replacement)
+            }
+        }
+        return result
+    }
+
+    private func encode(
+        _ prompt: String,
+        grids: [(height: Int, width: Int)]
+    ) -> EncodedPrompt {
+        let tokenIDs = tokenizer.encode(text: prompt)
+        var timeIndexes = [Int32](repeating: 0, count: tokenIDs.count)
+        var heightIndexes = [Int32](repeating: 0, count: tokenIDs.count)
+        var widthIndexes = [Int32](repeating: 0, count: tokenIDs.count)
+        var positions: [Int] = []
+        var time = -1
+        var startsImage = false
+        for (index, tokenID) in tokenIDs.enumerated() {
+            if startsImage || tokenID != imageContextTokenID { time += 1 }
+            timeIndexes[index] = Int32(time)
+            startsImage = tokenID == imageStartTokenID
+            if tokenID == imageContextTokenID { positions.append(index) }
+        }
+
+        var positionOffset = 0
+        for grid in grids {
+            let mergedHeight = grid.height / 2
+            let mergedWidth = grid.width / 2
+            for row in 0..<mergedHeight {
+                for column in 0..<mergedWidth {
+                    guard positionOffset < positions.count else { break }
+                    let tokenPosition = positions[positionOffset]
+                    heightIndexes[tokenPosition] = Int32(row)
+                    widthIndexes[tokenPosition] = Int32(column)
+                    positionOffset += 1
+                }
+            }
+        }
+        return EncodedPrompt(
+            tokenIDs: tokenIDs,
+            timeIndexes: timeIndexes,
+            heightIndexes: heightIndexes,
+            widthIndexes: widthIndexes,
+            imageContextPositions: positions
+        )
+    }
+
+    private static func makeQwenTokenizerData(resources: SenseNovaU15Resources) throws -> Config {
+        let vocabData = try Data(contentsOf: resources.vocabURL)
+        let vocab = try JSONDecoder().decode([String: Int].self, from: vocabData)
+        let merges = try String(contentsOf: resources.mergesURL, encoding: .utf8)
+            .components(separatedBy: .newlines)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty && !$0.hasPrefix("#") }
+        let tokenizerConfigData = try Data(contentsOf: resources.tokenizerConfigURL)
+        let tokenizerConfig = try JSONDecoder().decode(TokenizerConfigFile.self, from: tokenizerConfigData)
+        let addedTokens = try tokenizerConfig.addedTokensDecoder.map { id, token -> Config in
+            guard let tokenID = Int(id) else {
+                throw SenseNovaU15Error.invalidConfiguration("invalid added token id \(id)")
+            }
+            return Config([
+                "id": Config(tokenID),
+                "content": Config(token.content),
+                "singleWord": Config(token.singleWord),
+                "lstrip": Config(token.lstrip),
+                "rstrip": Config(token.rstrip),
+                "normalized": Config(token.normalized),
+                "special": Config(token.special),
+            ])
+        }.sorted { lhs, rhs in
+            lhs.id.integer(or: 0) < rhs.id.integer(or: 0)
+        }
+
+        let splitPattern = #"(?i:'s|'t|'re|'ve|'m|'ll|'d)|[^\r\n\p{L}\p{N}]?\p{L}+|\p{N}| ?[^\s\p{L}\p{N}]+[\r\n]*|\s*[\r\n]+|\s+(?!\S)|\s+"#
+        let byteLevel = Config([
+            "type": Config("ByteLevel"),
+            "addPrefixSpace": Config(false),
+            "trimOffsets": Config(false),
+            "useRegex": Config(false),
+        ])
+        let vocabValues = vocab.reduce(into: [String: Config]()) { result, item in
+            result[item.key] = Config(item.value)
+        }
+        let mergeValues = merges.map { Config($0) }
+        let model = Config([
+            "type": Config("BPE"),
+            "vocab": Config(vocabValues),
+            "merges": Config(mergeValues),
+            "fuseUnk": Config(false),
+            "byteFallback": Config(false),
+            "ignoreMerges": Config(false),
+        ])
+        let preTokenizer = Config([
+            "type": Config("Sequence"),
+            "pretokenizers": Config([
+                Config([
+                    "type": Config("Split"),
+                    "pattern": Config(["Regex": Config(splitPattern)]),
+                    "behavior": Config("Isolated"),
+                    "invert": Config(false),
+                ]),
+                byteLevel,
+            ]),
+        ])
+        return Config([
+            "version": Config("1.0"),
+            "addedTokens": Config(addedTokens),
+            "normalizer": Config(["type": Config("NFC")]),
+            "preTokenizer": preTokenizer,
+            "postProcessor": byteLevel,
+            "decoder": byteLevel,
+            "model": model,
+        ])
+    }
+}
+
+private struct TokenizerConfigFile: Decodable {
+    let addedTokensDecoder: [String: TokenizerAddedToken]
+
+    enum CodingKeys: String, CodingKey {
+        case addedTokensDecoder = "added_tokens_decoder"
+    }
+}
+
+private struct TokenizerAddedToken: Decodable {
+    let content: String
+    let lstrip: Bool
+    let normalized: Bool
+    let rstrip: Bool
+    let singleWord: Bool
+    let special: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case content
+        case lstrip
+        case normalized
+        case rstrip
+        case singleWord = "single_word"
+        case special
+    }
+}

--- a/Sources/MereRunCore/SenseNovaU15/SenseNovaU15VisionAndHead.swift
+++ b/Sources/MereRunCore/SenseNovaU15/SenseNovaU15VisionAndHead.swift
@@ -1,0 +1,179 @@
+import Foundation
+import MLX
+import MLXNN
+
+final class SenseNovaU15VisionEmbeddings: Module {
+    @ModuleInfo(key: "patch_embedding") var patchEmbedding: Conv2d
+    @ModuleInfo(key: "dense_embedding") var denseEmbedding: Conv2d
+
+    private let hiddenSize: Int
+    private let patchSize: Int
+    private let downsampleFactor: Int
+    private let ropeBase: Float
+
+    init(config: SenseNovaU15Config) {
+        self._patchEmbedding.wrappedValue = Conv2d(
+            inputChannels: config.visionConfig.numberOfChannels,
+            outputChannels: config.visionConfig.hiddenSize,
+            kernelSize: IntOrPair(config.visionConfig.patchSize),
+            stride: IntOrPair(config.visionConfig.patchSize),
+            bias: true
+        )
+        let downsampleFactor = Int(1 / config.downsampleRatio)
+        self._denseEmbedding.wrappedValue = Conv2d(
+            inputChannels: config.visionConfig.hiddenSize,
+            outputChannels: config.llmConfig.hiddenSize,
+            kernelSize: IntOrPair(downsampleFactor),
+            stride: IntOrPair(downsampleFactor),
+            bias: true
+        )
+        self.hiddenSize = config.visionConfig.hiddenSize
+        self.patchSize = config.visionConfig.patchSize
+        self.downsampleFactor = downsampleFactor
+        self.ropeBase = config.visionConfig.ropeTheta
+        super.init()
+    }
+
+    /// Input is normalized NHWC pixels. Output is the merged image-token sequence.
+    func callAsFunction(_ pixels: MLXArray) -> MLXArray {
+        precondition(pixels.ndim == 4 && pixels.dim(0) == 1)
+        let gridHeight = pixels.dim(1) / patchSize
+        let gridWidth = pixels.dim(2) / patchSize
+        var patches = MLXNN.gelu(patchEmbedding(pixels))
+            .reshaped(gridHeight * gridWidth, hiddenSize)
+        patches = applyVisionRoPE(patches, height: gridHeight, width: gridWidth)
+        patches = patches.reshaped(1, gridHeight, gridWidth, hiddenSize)
+        let merged = denseEmbedding(patches)
+        return merged.reshaped(1, gridHeight / downsampleFactor * gridWidth / downsampleFactor, -1)
+    }
+
+    private func applyVisionRoPE(_ input: MLXArray, height: Int, width: Int) -> MLXArray {
+        let half = hiddenSize / 2
+        let xPositions = (0..<height).flatMap { _ in (0..<width).map(Float.init) }
+        let yPositions = (0..<height).flatMap { row in [Float](repeating: Float(row), count: width) }
+        return MLX.concatenated([
+            applyInterleavedRoPE(input[0..., 0..<half], positions: xPositions),
+            applyInterleavedRoPE(input[0..., half...], positions: yPositions)
+        ], axis: -1)
+    }
+
+    private func applyInterleavedRoPE(_ input: MLXArray, positions: [Float]) -> MLXArray {
+        let dimension = input.dim(-1)
+        let indices = MLXArray(stride(from: Float(0), to: Float(dimension), by: 2))
+        let inverseFrequencies = 1 / MLX.pow(MLXArray(ropeBase), indices / Float(dimension))
+        let frequencies = MLXArray(positions)[0..., .newAxis] * inverseFrequencies[.newAxis, 0...]
+        let cosine = MLX.cos(frequencies).asType(input.dtype)
+        let sine = MLX.sin(frequencies).asType(input.dtype)
+        let even = input[0..., .stride(by: 2)]
+        let odd = input[0..., .stride(from: 1, by: 2)]
+        let rotatedEven = even * cosine - odd * sine
+        let rotatedOdd = even * sine + odd * cosine
+        return MLX.stacked([rotatedEven, rotatedOdd], axis: -1).reshaped(input.shape)
+    }
+}
+
+final class SenseNovaU15VisionModel: Module {
+    @ModuleInfo(key: "embeddings") var embeddings: SenseNovaU15VisionEmbeddings
+
+    init(config: SenseNovaU15Config) {
+        self._embeddings.wrappedValue = SenseNovaU15VisionEmbeddings(config: config)
+        super.init()
+    }
+}
+
+final class SenseNovaU15TimestepEmbedder: Module {
+    @ModuleInfo(key: "mlp") var mlp: (Linear, SiLUModule, Linear)
+    private let frequencyEmbeddingSize = 256
+
+    init(hiddenSize: Int) {
+        self._mlp.wrappedValue = (
+            Linear(frequencyEmbeddingSize, hiddenSize, bias: true),
+            SiLUModule(),
+            Linear(hiddenSize, hiddenSize, bias: true)
+        )
+        super.init()
+    }
+
+    func callAsFunction(_ timesteps: MLXArray) -> MLXArray {
+        let half = frequencyEmbeddingSize / 2
+        let frequencies = MLX.exp(
+            -MLX.log(MLXArray(Float(10_000)))
+                * MLXArray(0..<half).asType(.float32)
+                / Float(half)
+        )
+        let arguments = timesteps.asType(.float32)[0..., .newAxis] * frequencies[.newAxis, 0...]
+        let embedding = MLX.concatenated([MLX.cos(arguments), MLX.sin(arguments)], axis: -1)
+        return mlp.2(mlp.1(mlp.0(embedding)))
+    }
+}
+
+final class SenseNovaU15ConvDecoder: Module {
+    @ModuleInfo(key: "conv1") var firstConvolution: Conv2d
+    @ModuleInfo(key: "conv2") var secondConvolution: Conv2d
+
+    init(hiddenSize: Int) {
+        precondition(hiddenSize.isMultiple(of: 16))
+        let intermediate = hiddenSize / 4
+        self._firstConvolution.wrappedValue = Conv2d(
+            inputChannels: intermediate,
+            outputChannels: intermediate,
+            kernelSize: 3,
+            padding: 1,
+            bias: true
+        )
+        self._secondConvolution.wrappedValue = Conv2d(
+            inputChannels: intermediate / 4,
+            outputChannels: 192,
+            kernelSize: 3,
+            padding: 1,
+            bias: true
+        )
+        super.init()
+    }
+
+    func callAsFunction(_ hidden: MLXArray, tokenHeight: Int, tokenWidth: Int) -> MLXArray {
+        var pixels = hidden.reshaped(hidden.dim(0), tokenHeight, tokenWidth, hidden.dim(-1))
+        pixels = MLXNN.gelu(firstConvolution(Self.pixelShuffle(pixels, factor: 2)))
+        pixels = secondConvolution(Self.pixelShuffle(pixels, factor: 2))
+        return Self.pixelShuffle(pixels, factor: 8)
+    }
+
+    static func pixelShuffle(_ input: MLXArray, factor: Int) -> MLXArray {
+        let batch = input.dim(0)
+        let height = input.dim(1)
+        let width = input.dim(2)
+        let channels = input.dim(3) / (factor * factor)
+        return input
+            .reshaped(batch, height, width, channels, factor, factor)
+            .transposed(0, 1, 4, 2, 5, 3)
+            .reshaped(batch, height * factor, width * factor, channels)
+    }
+}
+
+final class SenseNovaU15FlowModules: Module {
+    @ModuleInfo(key: "vision_model_mot_gen") var generationVisionModel: SenseNovaU15VisionModel
+    @ModuleInfo(key: "timestep_embedder") var timestepEmbedder: SenseNovaU15TimestepEmbedder
+    @ModuleInfo(key: "noise_scale_embedder") var noiseScaleEmbedder: SenseNovaU15TimestepEmbedder
+    @ModuleInfo(key: "fm_head") var flowHead: SenseNovaU15ConvDecoder
+
+    init(config: SenseNovaU15Config) {
+        self._generationVisionModel.wrappedValue = SenseNovaU15VisionModel(config: config)
+        self._timestepEmbedder.wrappedValue = SenseNovaU15TimestepEmbedder(hiddenSize: config.llmConfig.hiddenSize)
+        self._noiseScaleEmbedder.wrappedValue = SenseNovaU15TimestepEmbedder(hiddenSize: config.llmConfig.hiddenSize)
+        self._flowHead.wrappedValue = SenseNovaU15ConvDecoder(hiddenSize: config.llmConfig.hiddenSize)
+        super.init()
+    }
+}
+
+final class SenseNovaU15Model: Module {
+    @ModuleInfo(key: "vision_model") var visionModel: SenseNovaU15VisionModel
+    @ModuleInfo(key: "language_model") var languageModel: SenseNovaU15CausalLM
+    @ModuleInfo(key: "fm_modules") var flowModules: SenseNovaU15FlowModules
+
+    init(config: SenseNovaU15Config) {
+        self._visionModel.wrappedValue = SenseNovaU15VisionModel(config: config)
+        self._languageModel.wrappedValue = SenseNovaU15CausalLM(config: config.llmConfig)
+        self._flowModules.wrappedValue = SenseNovaU15FlowModules(config: config)
+        super.init()
+    }
+}

--- a/Tests/MereRunCoreTests/SenseNovaU15Tests.swift
+++ b/Tests/MereRunCoreTests/SenseNovaU15Tests.swift
@@ -1,0 +1,90 @@
+import MLX
+@testable import MereRunCore
+import XCTest
+
+final class SenseNovaU15Tests: MereRunCoreTestCase {
+    func testRecommendedScheduleMatchesEndpointsAndShift() {
+        let values = SenseNovaU15Scheduler.timesteps(steps: 2, shift: 3)
+        XCTAssertEqual(values[0], 0, accuracy: 1e-6)
+        XCTAssertEqual(values[1], 0.25, accuracy: 1e-6)
+        XCTAssertEqual(values[2], 1, accuracy: 1e-6)
+    }
+
+    func testResolutionNoiseScaleUsesMergedImageTokens() {
+        XCTAssertEqual(
+            SenseNovaU15Scheduler.noiseScale(
+                imageTokenCount: 4_096,
+                baseImageTokenCount: 64,
+                baseScale: 1,
+                maximum: 16,
+                mode: "resolution"
+            ),
+            8,
+            accuracy: 1e-6
+        )
+    }
+
+    func testPatchifyRoundTripPreservesRawPixels() {
+        let source = MLXArray(Array(0..<48).map(Float.init), [1, 4, 4, 3])
+        let patches = SenseNovaU15Generator.patchify(source, patchSize: 2)
+        let restored = SenseNovaU15Generator.unpatchify(
+            patches,
+            patchSize: 2,
+            height: 4,
+            width: 4
+        )
+        MLX.eval(restored)
+        XCTAssertEqual(restored.asArray(Float.self), source.asArray(Float.self))
+    }
+
+    func testManagedModelIsPinnedAndUsesUnifiedManifest() throws {
+        let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: SenseNovaU15Resources.modelID))
+        XCTAssertEqual(spec.hubFallback?.repoId, SenseNovaU15Resources.repository)
+        XCTAssertEqual(spec.hubFallback?.revision, SenseNovaU15Resources.revision)
+        XCTAssertEqual(spec.validationKind, .senseNovaU15)
+        XCTAssertFalse(spec.runtimeAutoDownloadAllowed)
+
+        let manifest = MereRunModelManifest.template(for: .senseNovaU15)
+        XCTAssertEqual(manifest.engine, .senseNovaU15)
+        XCTAssertEqual(manifest.family, .senseNova)
+        XCTAssertEqual(manifest.defaults?.steps, 50)
+        XCTAssertEqual(manifest.defaults?.cfg, 4)
+        XCTAssertEqual(manifest.defaults?.sigmaShift, 3)
+        XCTAssertNil(manifest.components?.vae)
+        XCTAssertNil(manifest.components?.scheduler)
+    }
+
+    func testTokenizerLoadsOfficialVocabAndMergesLayout() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("sensenova-tokenizer-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try "{}".write(to: root.appendingPathComponent("vocab.json"), atomically: true, encoding: .utf8)
+        try "#version: 0.2\n".write(
+            to: root.appendingPathComponent("merges.txt"),
+            atomically: true,
+            encoding: .utf8
+        )
+        let config = """
+        {
+          "tokenizer_class": "Qwen2Tokenizer",
+          "added_tokens_decoder": {
+            "151669": {"content":"<IMG_CONTEXT>","lstrip":false,"normalized":false,"rstrip":false,"single_word":false,"special":true},
+            "151670": {"content":"<img>","lstrip":false,"normalized":false,"rstrip":false,"single_word":false,"special":true},
+            "151671": {"content":"</img>","lstrip":false,"normalized":false,"rstrip":false,"single_word":false,"special":true}
+          }
+        }
+        """
+        try config.write(
+            to: root.appendingPathComponent("tokenizer_config.json"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let tokenizer = try await SenseNovaU15Tokenizer.load(from: .init(rootURL: root))
+        XCTAssertEqual(tokenizer.imageContextTokenID, 151_669)
+        XCTAssertEqual(tokenizer.imageStartTokenID, 151_670)
+        XCTAssertEqual(tokenizer.imageEndTokenID, 151_671)
+    }
+}

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -45,6 +45,17 @@ Qwen image editing:
   - `Sources/MereRunCore/QwenImageEdit/QwenImageEditGenerator+ModelLoading.swift`
   - `Sources/MereRunCore/QwenImageEdit/QwenImageEditGenerator+Encoding.swift`
 
+SenseNova U1.5 generation and editing:
+
+- Runtime entry point: `Sources/MereRunCore/SenseNovaU15/SenseNovaU15Generator.swift`
+- Read next:
+  - `Sources/MereRunCore/SenseNovaU15/SenseNovaU15Model.swift`
+  - `Sources/MereRunCore/SenseNovaU15/SenseNovaU15VisionAndHead.swift`
+  - `Sources/MereRunCore/SenseNovaU15/SenseNovaU15Tokenizer.swift`
+  - `Sources/MereRunCore/SenseNovaU15/SenseNovaU15Scheduler.swift`
+  - `Sources/MereRunCore/SenseNovaU15/SenseNovaU15ImageIO.swift`
+  - `Sources/MereRunCore/SenseNovaU15/SenseNovaU15Resources.swift`
+
 Krea 2 generation and LoRA training:
 
 - Runtime entry point: `Sources/MereRunCore/Krea2/Krea2Generator.swift`

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -238,7 +238,7 @@ are:
 
 - Images: `image-klein-nano`, `image-klein-base`, `image-klein-base-9b`, `image-klein-max`,
   `image-bonsai-binary`, `image-bonsai-ternary`, `image-zimage-nano`, `image-zimage-base`, `image-zimage-max`,
-  `image-hidream-o1`, `image-hidream-o1-dev`, `image-krea2-raw`,
+  `image-hidream-o1`, `image-hidream-o1-dev`, `image-sensenova-u1-5-8b-mot`, `image-krea2-raw`,
   `image-krea2-turbo`,
   `image-ideogram4-sdnq-uint4`
 - Text chat: `text-chat-gemma4`, `text-chat-mebot`, `text-chat-psi-agent`, `text-chat-q36-nano`, `vision-chat-q38-27b`, `vision-chat-q38-27b-4bit`, `text-chat-lfm25-2.6b-4bit`, `text-chat-lfm25-a1b-8bit`, `vision-chat-lfm25-3b-8bit`
@@ -478,9 +478,8 @@ Key options:
 - `--width`, `--height`
 - `--steps`: override the model-specific step default
 - `--cfg`: override the model-specific CFG default
-- `--input`: image-to-image source. For FLUX.2 Klein, this is treated as a
-  single reference image.
-- `--ref-image`: repeatable FLUX.2 Klein or HiDream O1 reference image
+- `--input`: image-to-image source. SenseNova U1.5 uses it as an editing reference.
+- `--ref-image`: repeatable Klein, HiDream O1, or SenseNova U1.5 reference image
 - `--keep-original-aspect`: preserve one HiDream reference image's aspect ratio
 - `--strength`: image-to-image/reference change strength
 - `--structured-prompt`, `--json-prompt`: expand the prompt into a structured JSON caption with a local text chat model before image generation
@@ -526,6 +525,12 @@ swift run mere.run image generate \
   --prompt "put this subject in a studio portrait" \
   --ref-image ./subject.png \
   --output ./portrait.png
+swift run mere.run image generate \
+  --model image-sensenova-u1-5-8b-mot \
+  --prompt "replace the background with a snowy mountain pass" \
+  --input ./subject.png \
+  --width 2048 --height 2048 \
+  --output ./sensenova-edit.png
 swift run mere.run image generate \
   --model image-klein-base \
   --prompt "a trading card character with the same sticker layout" \

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -61,6 +61,7 @@ an effective overlay; they are not a second capability catalog.
 | `image` | `image-zimage-base` |
 | `image` | `image-hidream-o1` |
 | `image` | `image-hidream-o1-dev` |
+| `image` | `image-sensenova-u1-5-8b-mot` |
 | `image` | `image-krea2-raw` |
 | `image` | `image-krea2-turbo` |
 | `image` | `image-ideogram4-sdnq-uint4` |
@@ -205,6 +206,7 @@ validates all configured models before downloading any; both accept the same
 | --- | --- |
 | `image-klein-9b`, `image-klein-base-9b` | FLUX Non-Commercial License v2.1; non-commercial, non-production use |
 | `image-krea2-raw`, `image-krea2-turbo` | Krea 2 Community License; commercial use is limited to entities below USD 1M trailing annual revenue, plus use/distribution conditions |
+| `image-sensenova-u1-5-8b-mot` | Apache License 2.0 |
 | `image-ideogram4-sdnq-uint4` | Ideogram Non-Commercial Model Agreement |
 | LFM2.5 text and vision targets plus their DSpark companions | LFM Open License v1.0; commercial use by entities at or above USD 10M annual revenue is excluded |
 | `vision-chat-muse-glimmer-30b` | Apache-2.0 plus Meta's bundled usage policy; upstream says the model is not intended for download or use by people under 18 |
@@ -620,6 +622,20 @@ Runtime defaults come from the managed manifest:
 Both checkpoints are large BF16 unified-transformer roots, about 33 GiB on disk
 each before filesystem compression effects. Expect high unified-memory pressure
 and prefer one-step smokes before full-quality 28/50 step runs.
+
+`image-sensenova-u1-5-8b-mot` maps to the official
+`sensenova/SenseNova-U1.5-8B-MoT` checkpoint at the exact revision recorded in
+the managed catalog. The corresponding reference implementation is published
+at `OpenSenseNova/SenseNova-U1`. The root contains the typed configuration,
+Qwen tokenizer assets, a safetensors index, and 13 shards.
+
+SenseNova uses one unified checkpoint rather than separate text-encoder and VAE
+directories. The native runtime mirrors the checkpoint's understanding and
+generation experts, caches the prompt/reference prefix, embeds RGB patches,
+applies the published shifted Euler flow schedule, and decodes predicted RGB
+pixels with the checkpoint's convolutional pixel head. Text-to-image and
+multi-reference instruction editing share this Swift/MLX path. The managed
+defaults are 50 steps, CFG 4.0, and timestep shift 3.0.
 
 `image-krea2-raw` and `image-krea2-turbo` map to Krea's public Krea 2
 checkpoints:

--- a/docs/repository-tour.md
+++ b/docs/repository-tour.md
@@ -86,6 +86,7 @@ Key subdirectories:
 - `Flux2Klein/`: Klein image-family runtime
 - `ZImageTurbo/`: ZImage image-family runtime
 - `HiDreamO1/`: HiDream O1 image-family runtime
+- `SenseNovaU15/`: native SenseNova U1.5 raw-pixel generation and editing runtime
 - `Krea2/`: Krea 2 image-family runtime and Raw LoRA training
 - `QwenImageEdit/`: image editing flow
 - `Gemma4/`, `Q35/`, `LFM2/`, `Psi/`, `MeBot/`: text/chat model families

--- a/docs/runtime/image.md
+++ b/docs/runtime/image.md
@@ -4,7 +4,7 @@ Use the image runtime to generate an image from a prompt, train a low-rank
 adaptation (LoRA) on your own pictures, replay a generation from a saved plan,
 or convert one photo into a textured three-dimensional (3D) mesh. The runtime
 supports eight model families, from compact ZImage checkpoints through FLUX.2
-Klein, HiDream O1, Krea 2, and Ideogram 4.
+Klein, HiDream O1, SenseNova U1.5, Krea 2, and Ideogram 4.
 
 ## Commands
 
@@ -63,6 +63,7 @@ The public image families are:
 - `image-bonsai-ternary`: PrismML Bonsai ternary FLUX.2 Klein deployment
 - `image-zimage-*`: ZImage image family
 - `image-hidream-o1*`: HiDream O1 unified pixel-transformer family
+- `image-sensenova-u1-5-8b-mot`: SenseNova U1.5 raw-pixel generation and editing family
 - `image-krea2-raw`: Krea 2 Raw base checkpoint for LoRA training
 - `image-krea2-turbo`: Krea 2 Turbo text-to-image and LoRA inference family
 - `image-ideogram4-sdnq-uint4`: Ideogram 4 SDNQ uint4 text-to-image family
@@ -80,6 +81,7 @@ Common managed IDs:
 - `image-zimage-max`
 - `image-hidream-o1-dev`
 - `image-hidream-o1`
+- `image-sensenova-u1-5-8b-mot`
 - `image-krea2-raw`
 - `image-krea2-turbo`
 - `image-ideogram4-sdnq-uint4`
@@ -336,6 +338,37 @@ MERERUN_RUN_E2E=installed MERERUN_E2E_HIDREAM=1 ./scripts/check.sh
 MERERUN_RUN_E2E=installed MERERUN_E2E_HIDREAM_FULL=1 ./scripts/check.sh
 ```
 
+### SenseNova U1.5 generation and editing
+
+`image-sensenova-u1-5-8b-mot` pins the official SenseNova U1.5 MoT checkpoint.
+The native Swift/MLX runtime loads its dual understanding/generation experts,
+builds reusable prefix KV caches, and denoises RGB pixels directly; it does not
+launch Python and does not require a separate text encoder or VAE. The managed
+manifest defaults match the published examples: 50 steps, CFG 4, and timestep
+shift 3. Output dimensions must be multiples of 32.
+
+```bash
+swift run mere.run model pull image-sensenova-u1-5-8b-mot
+
+# Text to image
+swift run mere.run image generate \
+  --model image-sensenova-u1-5-8b-mot \
+  --prompt "A lunar greenhouse at blue hour, cinematic photography" \
+  --width 2048 --height 2048 \
+  --output ./lunar-greenhouse.png
+
+# Instruction editing; repeat --ref-image for additional references.
+swift run mere.run image generate \
+  --model image-sensenova-u1-5-8b-mot \
+  --prompt "Keep the subject, replace the background with a snowy mountain pass" \
+  --input ./subject.png \
+  --width 2048 --height 2048 \
+  --output ./mountain-edit.png
+```
+
+The BF16 checkpoint is about 50 GB on disk. The capability gate requires at
+least 64 GB unified memory and recommends 96 GB for generation headroom.
+
 ### Krea 2 Raw and Turbo
 
 `image-krea2-raw` maps to `krea/Krea-2-Raw` and installs Krea's base
@@ -505,6 +538,16 @@ generation; smaller shapes stay on the byte-identical dense path. In a warm
 - `Sources/MereRunCore/HiDreamO1/HiDreamO1ImagePreprocessor.swift`
 - `Sources/MereRunCore/HiDreamO1/HiDreamO1TokenizerAndTemplate.swift`
 - `Sources/MereRunCore/HiDreamO1/HiDreamO1Scheduler.swift`
+
+### SenseNova U1.5 family
+
+- `Sources/MereRunCore/SenseNovaU15/SenseNovaU15Generator.swift`
+- `Sources/MereRunCore/SenseNovaU15/SenseNovaU15Model.swift`
+- `Sources/MereRunCore/SenseNovaU15/SenseNovaU15VisionAndHead.swift`
+- `Sources/MereRunCore/SenseNovaU15/SenseNovaU15Tokenizer.swift`
+- `Sources/MereRunCore/SenseNovaU15/SenseNovaU15Scheduler.swift`
+- `Sources/MereRunCore/SenseNovaU15/SenseNovaU15ImageIO.swift`
+- `Sources/MereRunCore/SenseNovaU15/SenseNovaU15Resources.swift`
 
 ### Krea 2 family
 


### PR DESCRIPTION
## Summary

- add a native Swift and MLX implementation of SenseNova U1.5 8B MoT for text-to-image and multi-image reference editing
- integrate the model with image generate, API sidecar residency, managed model metadata, manifest validation, capability admission, and installed-model gates
- document the native runtime, official defaults, checkpoint source, and CLI workflows
- add focused coverage for the scheduler, noise scaling, patch packing, managed model pin, and official tokenizer layout

## Runtime proof

- loaded the exact official BF16 checkpoint revision 1f6ec60423d29939dde4202fd82ae340b144e280
- completed real 512x512 text-to-image inference and real reference-edit inference
- verified both outputs as valid PNG files and visually inspected the requested transformation
- used one denoising step for the diagnostic runtime proof; the managed runtime defaults remain the official 50 steps, CFG 4, and timestep shift 3

## Validation

- ./scripts/check.sh
  - 3,107 XCTest cases
  - 219 expected skips
  - 0 failures
  - 30 Swift Testing cases passed
  - strict lint, build, CLI help sweep, docs contracts, and hygiene scans passed
- swift test --filter SenseNovaU15Tests
  - 5 tests passed
- pnpm docs:build
- git diff --check

## Sources

- https://huggingface.co/sensenova/SenseNova-U1.5-8B-MoT
- https://github.com/OpenSenseNova/SenseNova-U1
