### PR TITLE
fix: preserve MiniMax Music 3 compact sampling parity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+### Audio
+
+- fixed MiniMax Music 3 optimized, Q8, and Q4 lyric drift by preserving the
+  released full-vocabulary categorical layout behind the compact semantic head
+  and keeping the eight-token residual-depth decode on its seeded-parity path.
+  Installed 250-frame vocal renders now transcribe the requested opening lyric
+  across all three compact modes.
+
 ### Image
 
 - added the official BF16 SenseNova U1.5 8B-MoT checkpoint as a pinned managed

--- a/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3ModelLoader.swift
+++ b/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3ModelLoader.swift
@@ -106,7 +106,6 @@ public enum MiniMaxMusic3ModelLoader {
         if performanceMode.usesOptimizedGraph {
             languageModel.prepareCompactSemanticHead()
             languageModel.prepareFusedProjections()
-            depthDecoder.prepareFusedProjections()
         }
         if let bits = performanceMode.quantizationBits {
             quantizeAutoregressive(

--- a/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3Pipeline.swift
+++ b/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3Pipeline.swift
@@ -394,10 +394,11 @@ public final class MiniMaxMusic3Pipeline {
             let logits = languageModel.logits(lastHidden)
             let allowEnd = frameHiddens.count >= minimumFrames
             let sampled = performanceMode == .reference
-                ? sampleSemanticReference(logits: logits, allowEnd: allowEnd, generator: generator)
-                : sampleSemantic(
+                ? Self.sampleSemanticReference(logits: logits, allowEnd: allowEnd, generator: generator)
+                : Self.sampleSemantic(
                     logits: logits,
                     compactHead: languageModel.usesCompactSemanticHead,
+                    fullVocabularySize: languageModel.configuration.vocabSize,
                     allowEnd: allowEnd,
                     generator: generator
                 )
@@ -479,7 +480,7 @@ public final class MiniMaxMusic3Pipeline {
             && generatedFrameCount.isMultiple(of: autoregressiveCacheClearInterval)
     }
 
-    private func sampleSemanticReference(
+    static func sampleSemanticReference(
         logits: MLXArray,
         allowEnd: Bool,
         generator: MLXRandom.RandomState
@@ -487,7 +488,7 @@ public final class MiniMaxMusic3Pipeline {
         let guided = allowEnd
             ? Self.guidedSemanticLogitsReference(logits)
             : Self.guidedSemanticLogits(logits, allowEnd: false)
-        return sampleTopK(guided[0], generator: generator)
+        return Self.sampleTopK(guided[0], generator: generator)
     }
 
     /// Keep the released full-vocabulary graph byte-for-byte available for
@@ -518,20 +519,57 @@ public final class MiniMaxMusic3Pipeline {
         return MLX.where(allowed, guided, MLXArray(-Float.infinity))
     }
 
-    private func sampleSemantic(
+    static func sampleSemantic(
         logits: MLXArray,
         compactHead: Bool,
+        fullVocabularySize: Int,
         allowEnd: Bool,
         generator: MLXRandom.RandomState
     ) -> MLXArray {
         let guided = Self.guidedSemanticLogits(logits, allowEnd: allowEnd)
-        let sampled = sampleTopK(guided[0], generator: generator)
-        guard compactHead else { return sampled }
-        return MLX.where(
-            sampled .== MLXArray(Int32(0)),
-            MLXArray(Int32(MiniMaxMusic3Prompt.audioEndTokenID)),
-            sampled + MLXArray(Int32(MiniMaxMusic3Prompt.audioCodeOffset - 1))
-        ).asType(.int32)
+        let samplingLogits = compactHead
+            ? restoreFullSemanticVocabulary(guided[0], vocabularySize: fullVocabularySize)
+            : guided[0]
+        return sampleTopK(samplingLogits, generator: generator)
+    }
+
+    /// The published sampler draws from the full language-model vocabulary
+    /// after masking unreachable tokens. Keep that coordinate layout for seeded
+    /// parity even when the optimized projection retains only reachable rows.
+    static func restoreFullSemanticVocabulary(
+        _ compactLogits: MLXArray,
+        vocabularySize: Int
+    ) -> MLXArray {
+        let semanticEnd = MiniMaxMusic3Prompt.audioCodeOffset
+            + MiniMaxMusic3Prompt.semanticVocabularySize
+        precondition(
+            compactLogits.dim(-1) == MiniMaxMusic3Prompt.semanticVocabularySize + 1,
+            "compact MiniMax Music 3 logits must contain EOS and every semantic token"
+        )
+        precondition(
+            vocabularySize >= semanticEnd,
+            "MiniMax Music 3 vocabulary does not contain every semantic token"
+        )
+        let masked = MLXArray(-Float.infinity)
+        return MLX.concatenated(
+            [
+                MLXArray.full(
+                    [MiniMaxMusic3Prompt.audioEndTokenID],
+                    values: masked
+                ),
+                compactLogits[0..<1],
+                MLXArray.full(
+                    [MiniMaxMusic3Prompt.audioCodeOffset - MiniMaxMusic3Prompt.audioEndTokenID - 1],
+                    values: masked
+                ),
+                compactLogits[1...],
+                MLXArray.full(
+                    [vocabularySize - semanticEnd],
+                    values: masked
+                ),
+            ],
+            axis: -1
+        )
     }
 
     static func guidedSemanticLogits(
@@ -606,9 +644,11 @@ public final class MiniMaxMusic3Pipeline {
         sequence.append(depthDecoder.projection(semanticEmbedding).expandedDimensions(axis: 1))
         var codes = [semanticCode]
         var hiddenParts: [MLXArray] = []
-        let caches = performanceMode.usesOptimizedGraph
-            ? depthDecoder.makeCache(capacity: depthDecoder.configuration.numCodebooks)
-            : nil
+        // The depth sequence is only eight tokens long. Recomputing its prefix
+        // preserves the released seeded trajectory; cached/fused BF16 depth
+        // projections can move a late codebook across a categorical boundary,
+        // which then changes every following semantic frame.
+        let caches: [KVCache]? = nil
         for codebook in 1..<depthDecoder.configuration.numCodebooks {
             let input = if caches == nil || codebook == 1 {
                 MLX.concatenated(sequence, axis: 1)
@@ -621,7 +661,7 @@ public final class MiniMaxMusic3Pipeline {
             let conditional = logits[0..<1].asType(.float32)
             let unconditional = logits[1..<2].asType(.float32)
             let guided = unconditional + (conditional - unconditional) * MLXArray(Float(1.5))
-            let sampled = sampleTopK(guided[0], generator: generator)
+            let sampled = Self.sampleTopK(guided[0], generator: generator)
             let duplicated = MLX.repeated(sampled.reshaped(1), count: 2, axis: 0)
             codes.append(duplicated)
             if codebook < depthDecoder.configuration.numCodebooks - 1 {
@@ -638,7 +678,7 @@ public final class MiniMaxMusic3Pipeline {
         )
     }
 
-    private func sampleTopK(
+    private static func sampleTopK(
         _ logits: MLXArray,
         generator: MLXRandom.RandomState
     ) -> MLXArray {

--- a/Sources/MereRunCore/MiniMaxMusic3/README.md
+++ b/Sources/MereRunCore/MiniMaxMusic3/README.md
@@ -21,6 +21,15 @@ model math and generation schedule. Optimized autoregressive generation also
 returns completed variable-length attention buffers to MLX every 64 frames;
 live model weights, KV state, and generated conditioning remain resident.
 
+The optimized language-model head retains only EOS plus the 16,384 reachable
+semantic rows, but sampling restores those logits to their original positions
+in a masked full-vocabulary view before the categorical draw. The residual
+depth decoder intentionally recomputes its eight-token prefix with separate
+projections. Cached or fused depth evaluation is numerically close, but a late
+codebook can cross a categorical boundary and change every later semantic
+frame. Seeded code trajectories and lyric transcription, not logit cosine
+alone, are the admission checks for changing either path.
+
 The released flow and seed recipes remain `sequential` and `legacy`.
 `overlap-average` is an opt-in whole-song flow experiment that averages
 overlapping window velocities at each Euler step, then uses bounded DAV decode

--- a/Tests/MereRunCoreTests/MiniMaxMusic3Tests.swift
+++ b/Tests/MereRunCoreTests/MiniMaxMusic3Tests.swift
@@ -1,4 +1,5 @@
 import MLX
+import MLXRandom
 import XCTest
 @testable import MereRunCore
 
@@ -84,6 +85,63 @@ final class MiniMaxMusic3Tests: MereRunCoreTestCase {
         XCTAssertGreaterThanOrEqual(q8Overlap, 80)
         XCTAssertGreaterThan(q4Cosine, 0.80)
         XCTAssertGreaterThanOrEqual(q4Overlap, 50)
+    }
+
+    func testInstalledCompactSemanticHeadPreservesSeededFirstToken() throws {
+        let environment = ProcessInfo.processInfo.environment
+        guard environment["MERERUN_MINIMAX_MUSIC3_E2E"] == "1",
+              let root = environment["MERERUN_MINIMAX_MUSIC3_MODEL_ROOT"]
+        else {
+            throw XCTSkip("set the MiniMax Music 3 model root and E2E flag for compact-head parity")
+        }
+        let resources = MiniMaxMusic3Resources(rootURL: URL(fileURLWithPath: root))
+        let models = try MiniMaxMusic3ModelLoader.loadAutoregressive(
+            from: resources,
+            performanceMode: .reference
+        )
+        let prompt = MiniMaxMusic3Prompt.assemble(
+            caption: "Warm acoustic pop, intimate vocal, fingerpicked guitar, soft piano.",
+            lyrics: "[verse]\nMorning light across the room\nA quiet road will lead me home"
+        )
+        let conditional = models.tokenizer.encode(prompt, addSpecialTokens: false)
+        var unconditional = conditional
+        for index in 1..<(unconditional.count - 2) {
+            unconditional[index] = MiniMaxMusic3Prompt.audioCFGTokenID
+        }
+        let ids = MLXArray((conditional + unconditional).map(Int32.init))
+            .reshaped(2, conditional.count)
+        let hidden = models.languageModel.hidden(
+            embeddings: models.languageModel.embed(tokenIDs: ids),
+            cache: models.languageModel.makeCache(),
+            lastPositionOnly: true
+        ).squeezed(axis: 1)
+        let fullLogits = models.languageModel.logits(hidden)
+        MLX.eval(fullLogits)
+        models.languageModel.prepareCompactSemanticHead()
+        let compactLogits = models.languageModel.logits(hidden)
+        MLX.eval(compactLogits)
+
+        for seed in UInt64(0)..<16 {
+            let fullSample = MiniMaxMusic3Pipeline.sampleSemanticReference(
+                logits: fullLogits,
+                allowEnd: true,
+                generator: MLXRandom.RandomState(seed: seed)
+            )
+            let compactSample = MiniMaxMusic3Pipeline.sampleSemantic(
+                logits: compactLogits,
+                compactHead: true,
+                fullVocabularySize: models.languageModel.configuration.vocabSize,
+                allowEnd: true,
+                generator: MLXRandom.RandomState(seed: seed)
+            )
+            MLX.eval(fullSample, compactSample)
+
+            XCTAssertEqual(
+                compactSample.item(Int.self),
+                fullSample.item(Int.self),
+                "compact projection changed the installed checkpoint's first token for seed \(seed)"
+            )
+        }
     }
 
     func testInstalledStagedAndResidentGenerationAreSeedEquivalent() throws {
@@ -785,6 +843,56 @@ final class MiniMaxMusic3Tests: MereRunCoreTestCase {
         XCTAssertTrue(model.usesCompactSemanticHead)
         XCTAssertEqual(compact.shape, [2, MiniMaxMusic3Prompt.semanticVocabularySize + 1])
         XCTAssertTrue(MLX.allClose(expected, compact, rtol: 1e-5, atol: 1e-5).item(Bool.self))
+    }
+
+    func testCompactSemanticSamplingPreservesFullVocabularySeedTrajectory() {
+        let vocabulary = 200_000
+        let compactVocabulary = MiniMaxMusic3Prompt.semanticVocabularySize + 1
+        var fullValues = [Float](repeating: -100, count: 2 * vocabulary)
+        var compactValues = [Float](repeating: -100, count: 2 * compactVocabulary)
+
+        for batch in 0..<2 {
+            let fullBase = batch * vocabulary
+            let compactBase = batch * compactVocabulary
+            let endValue = Float(5.25 - Float(batch) * 0.2)
+            fullValues[fullBase + MiniMaxMusic3Prompt.audioEndTokenID] = endValue
+            compactValues[compactBase] = endValue
+            for semanticToken in 0..<80 {
+                let value = Float(6 - Float(semanticToken) * 0.03 - Float(batch) * 0.01)
+                fullValues[
+                    fullBase + MiniMaxMusic3Prompt.audioCodeOffset + semanticToken
+                ] = value
+                compactValues[compactBase + semanticToken + 1] = value
+            }
+        }
+
+        let fullLogits = MLXArray(fullValues).reshaped(2, vocabulary)
+        let compactLogits = MLXArray(compactValues).reshaped(2, compactVocabulary)
+        for allowEnd in [false, true] {
+            for seed in UInt64(0)..<16 {
+                let fullSample = MiniMaxMusic3Pipeline.sampleSemantic(
+                    logits: fullLogits,
+                    compactHead: false,
+                    fullVocabularySize: vocabulary,
+                    allowEnd: allowEnd,
+                    generator: MLXRandom.RandomState(seed: seed)
+                )
+                let compactSample = MiniMaxMusic3Pipeline.sampleSemantic(
+                    logits: compactLogits,
+                    compactHead: true,
+                    fullVocabularySize: vocabulary,
+                    allowEnd: allowEnd,
+                    generator: MLXRandom.RandomState(seed: seed)
+                )
+                MLX.eval(fullSample, compactSample)
+
+                XCTAssertEqual(
+                    compactSample.item(Int.self),
+                    fullSample.item(Int.self),
+                    "compact sampling changed the seed trajectory for seed \(seed)"
+                )
+            }
+        }
     }
 
     func testSemanticTopKIgnoresTextVocabularyLogits() {

--- a/docs/benchmarks/minimax-music3-m4-max.md
+++ b/docs/benchmarks/minimax-music3-m4-max.md
@@ -6,7 +6,14 @@ used the immutable managed `MiniMaxAI/MiniMax-Music3` snapshot, staged loading,
 44.1 kHz stereo PCM24 export, seed 37, guidance 1.7, and 30 flow steps unless a
 row says otherwise.
 
-## Matched 250-frame result
+## Historical matched 250-frame result
+
+The timings below describe the original acceleration graph. A later
+seeded-lyric parity correction retained the compact semantic head, global
+language-model fusion, and fixed-capacity global KV cache, but restored the
+masked 200,000-token sampling layout and removed incremental/fused execution
+from the eight-token residual-depth decoder. Treat these numbers as the
+pre-correction performance baseline, not current release timing.
 
 | Runtime | Wall time | Max resident | Relative speed |
 | --- | ---: | ---: | ---: |
@@ -20,12 +27,13 @@ logits measured cosine similarity 0.99985 and retained 98 of the BF16 top 100
 candidates. Q4 measured 0.99166 and retained 80 of 100; its small additional
 speedup comes with a larger sampling-distribution change.
 
-The BF16 optimized graph uses a 16,385-row reachable semantic head instead of
-projecting the full 200,000-token vocabulary at every 25 Hz frame, fused QKV
-and gate/up projections, incremental residual-depth KV caches, cached rotary
-and zero conditioning, batched conditional/unconditional flow evaluation, and
-fewer forced graph evaluations. `--performance-mode reference` preserves the
-released graph for parity investigations.
+The corrected BF16 optimized graph still projects only the 16,385 reachable
+semantic rows instead of the full 200,000-token vocabulary at every 25 Hz
+frame. It restores those values to their original vocabulary coordinates only
+for the lightweight categorical draw. Global QKV and gate/up projections,
+cached rotary/zero conditioning, batched conditional/unconditional flow
+evaluation, and fewer forced graph evaluations remain. Residual-depth prefix
+recomputation preserves the released seeded trajectory.
 
 ## MLX 0.32.1 follow-on
 
@@ -81,9 +89,11 @@ isolated tensor fixtures.
   BF16.
 - Serial flow CFG took 18.43 s versus 17.38 s for batched CFG on a matched
   100-frame, one-chunk, 30-step Q8 run. Batched CFG stays as the default.
-- Compiling only the residual-depth graph was waveform-identical, but an ABBA
-  series regressed from a 1.851 s eager median to a 2.157 s compiled median,
-  16.5% slower. The fixed-capacity cache remains eager.
+- Compiling only the residual-depth graph was waveform-identical in the
+  original benchmark, but an ABBA series regressed from a 1.851 s eager median
+  to a 2.157 s compiled median, 16.5% slower. Later lyric-level validation also
+  showed that cached/fused depth evaluation could change a late categorical
+  codebook choice, so the release path now recomputes the short depth prefix.
 - A production-shape ConvRot W8A8 Metal oracle retained 0.999929 cosine and
   0.01192 relative RMSE, but took 57.64 ms versus 3.47 ms for BF16 GEMM, 16.6 times
   slower on this M4 Max. The research test remains env-gated; the runtime does

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -868,11 +868,14 @@ minutes; 9,000 frames is the six-minute runtime hard limit.
 
 `--minimum-duration` and `--min-frames` add an EOS floor; duration floors round
 up across the vocoder's whole 512-sample hops so the decoded WAV does not
-undershoot. `--performance-mode optimized` is the BF16 default and uses compact
-semantic logits, fused projections, incremental depth caches, and batched flow
-guidance. The opt-in `q8` and `q4` modes apply group-64 affine quantization to
-the autoregressive transformers; `q8` is the recommended turbo tier. Flow stays
-BF16 because installed-checkpoint timing showed its quantized kernels regress.
+undershoot. `--performance-mode optimized` is the BF16 default and uses a
+compact semantic projection, a full-vocabulary sampling view, fused global
+language-model projections, and batched flow guidance. The eight-token residual
+depth prefix is recomputed without projection fusion because its cached/fused
+BF16 path changed seeded codebook choices and caused lyric drift. The opt-in
+`q8` and `q4` modes apply group-64 affine quantization to the autoregressive
+transformers; `q8` is the recommended turbo tier. Flow stays BF16 because
+installed-checkpoint timing showed its quantized kernels regress.
 
 Generation defaults to `--memory-mode staged`, which releases the language,
 flow, and vocoder weights between stages. `--memory-mode resident` keeps the


### PR DESCRIPTION
## Summary

- restore the released 200,000-token categorical coordinate layout before sampling while retaining the compact 16,385-row semantic projection
- recompute the short residual-depth prefix without fused projections or incremental caches so seeded codebook choices match the reference path
- add synthetic and installed-checkpoint parity regressions, and mark the pre-correction performance table as historical

## Validation

- `./scripts/check.sh`
  - 3,109 XCTest cases, 220 expected skips, 0 failures
  - 30 Swift Testing cases, 0 failures
  - lint, build, docs, CLI help sweep, and hygiene scans passed
- installed checkpoint compact-head parity across 16 seeds
- exact 250-frame, seed-0, 30-step vocal renders with two independent local ASR paths
  - optimized BF16: requested opening lyric through `teaching my own heart the patience...`
  - Q8: requested opening lyric through `teaching my own heart`
  - Q4: requested opening lyric through `every space I used to leave`

## Performance note

The compact semantic projection, global language-model fusion, static global KV cache, and batched flow guidance remain. Current release timing should be remeasured because incremental/fused residual-depth execution was removed for seeded lyric parity.