### PR TITLE
perf: reuse SenseNova U1.5 denoising constants

### DIFF
--- a/Sources/MereRunCore/SenseNovaU15/SenseNovaU15Generator.swift
+++ b/Sources/MereRunCore/SenseNovaU15/SenseNovaU15Generator.swift
@@ -184,7 +184,17 @@ public final class SenseNovaU15Generator: ImageGenerator {
                 prefixTime: ($0.prompt.timeIndexes.max() ?? -1) + 1
             )
         }
-
+        let noiseEmbedding: MLXArray?
+        if config.addNoiseScaleEmbedding {
+            let normalizedNoiseScale = noiseScale / config.noiseScaleMaxValue
+            let noiseScaleValues = MLXArray(
+                [Float](repeating: normalizedNoiseScale, count: imageTokenCount)
+            )
+            noiseEmbedding = model.flowModules.noiseScaleEmbedder(noiseScaleValues)
+        } else {
+            noiseEmbedding = nil
+        }
+        MLX.eval([noiseEmbedding].compactMap { $0 })
         for step in 0..<steps {
             progressHandler?(GenerationProgress(stage: .denoising, stepIndex: step, totalSteps: steps))
             let timestep = timesteps[step]
@@ -196,12 +206,7 @@ public final class SenseNovaU15Generator: ImageGenerator {
             )
             let timestepValues = MLXArray([Float](repeating: timestep, count: imageTokenCount))
             var timeEmbeddings = model.flowModules.timestepEmbedder(timestepValues)
-            if config.addNoiseScaleEmbedding {
-                let scaleValues = MLXArray(
-                    [Float](repeating: noiseScale / config.noiseScaleMaxValue, count: imageTokenCount)
-                )
-                timeEmbeddings = timeEmbeddings + model.flowModules.noiseScaleEmbedder(scaleValues)
-            }
+            if let noiseEmbedding { timeEmbeddings = timeEmbeddings + noiseEmbedding }
             let imageEmbeddings = model.flowModules.generationVisionModel.embeddings(pixels)
                 + timeEmbeddings.reshaped(1, imageTokenCount, -1)
             let conditionalVelocity = velocity(

--- a/Sources/MereRunCore/SenseNovaU15/SenseNovaU15VisionAndHead.swift
+++ b/Sources/MereRunCore/SenseNovaU15/SenseNovaU15VisionAndHead.swift
@@ -2,6 +2,21 @@ import Foundation
 import MLX
 import MLXNN
 
+struct SenseNovaU15VisionRoPEKey: Hashable {
+    let height: Int
+    let width: Int
+    let dtype: DType
+}
+
+struct SenseNovaU15VisionRoPETables {
+    let xCosine: MLXArray
+    let xSine: MLXArray
+    let yCosine: MLXArray
+    let ySine: MLXArray
+
+    var arrays: [MLXArray] { [xCosine, xSine, yCosine, ySine] }
+}
+
 final class SenseNovaU15VisionEmbeddings: Module {
     @ModuleInfo(key: "patch_embedding") var patchEmbedding: Conv2d
     @ModuleInfo(key: "dense_embedding") var denseEmbedding: Conv2d
@@ -10,6 +25,7 @@ final class SenseNovaU15VisionEmbeddings: Module {
     private let patchSize: Int
     private let downsampleFactor: Int
     private let ropeBase: Float
+    private var cachedRoPE: (key: SenseNovaU15VisionRoPEKey, tables: SenseNovaU15VisionRoPETables)?
 
     init(config: SenseNovaU15Config) {
         self._patchEmbedding.wrappedValue = Conv2d(
@@ -41,29 +57,80 @@ final class SenseNovaU15VisionEmbeddings: Module {
         let gridWidth = pixels.dim(2) / patchSize
         var patches = MLXNN.gelu(patchEmbedding(pixels))
             .reshaped(gridHeight * gridWidth, hiddenSize)
-        patches = applyVisionRoPE(patches, height: gridHeight, width: gridWidth)
+        let tables = cachedRoPETables(height: gridHeight, width: gridWidth, dtype: patches.dtype)
+        patches = Self.applyVisionRoPE(patches, tables: tables)
         patches = patches.reshaped(1, gridHeight, gridWidth, hiddenSize)
         let merged = denseEmbedding(patches)
         return merged.reshaped(1, gridHeight / downsampleFactor * gridWidth / downsampleFactor, -1)
     }
 
-    private func applyVisionRoPE(_ input: MLXArray, height: Int, width: Int) -> MLXArray {
+    private func cachedRoPETables(height: Int, width: Int, dtype: DType) -> SenseNovaU15VisionRoPETables {
+        let key = SenseNovaU15VisionRoPEKey(height: height, width: width, dtype: dtype)
+        if cachedRoPE?.key == key, let tables = cachedRoPE?.tables { return tables }
+        let tables = Self.makeRoPETables(
+            height: height,
+            width: width,
+            hiddenSize: hiddenSize,
+            base: ropeBase,
+            dtype: dtype
+        )
+        cachedRoPE = (key, tables)
+        return tables
+    }
+
+    static func makeRoPETables(
+        height: Int,
+        width: Int,
+        hiddenSize: Int,
+        base: Float,
+        dtype: DType
+    ) -> SenseNovaU15VisionRoPETables {
         let half = hiddenSize / 2
         let xPositions = (0..<height).flatMap { _ in (0..<width).map(Float.init) }
         let yPositions = (0..<height).flatMap { row in [Float](repeating: Float(row), count: width) }
+        let x = makeInterleavedRoPETable(positions: xPositions, dimension: half, base: base, dtype: dtype)
+        let y = makeInterleavedRoPETable(positions: yPositions, dimension: half, base: base, dtype: dtype)
+        return SenseNovaU15VisionRoPETables(
+            xCosine: x.cosine,
+            xSine: x.sine,
+            yCosine: y.cosine,
+            ySine: y.sine
+        )
+    }
+
+    static func applyVisionRoPE(_ input: MLXArray, tables: SenseNovaU15VisionRoPETables) -> MLXArray {
+        let half = input.dim(-1) / 2
         return MLX.concatenated([
-            applyInterleavedRoPE(input[0..., 0..<half], positions: xPositions),
-            applyInterleavedRoPE(input[0..., half...], positions: yPositions)
+            applyInterleavedRoPE(
+                input[0..., 0..<half],
+                cosine: tables.xCosine,
+                sine: tables.xSine
+            ),
+            applyInterleavedRoPE(
+                input[0..., half...],
+                cosine: tables.yCosine,
+                sine: tables.ySine
+            ),
         ], axis: -1)
     }
 
-    private func applyInterleavedRoPE(_ input: MLXArray, positions: [Float]) -> MLXArray {
-        let dimension = input.dim(-1)
+    private static func makeInterleavedRoPETable(
+        positions: [Float],
+        dimension: Int,
+        base: Float,
+        dtype: DType
+    ) -> (cosine: MLXArray, sine: MLXArray) {
         let indices = MLXArray(stride(from: Float(0), to: Float(dimension), by: 2))
-        let inverseFrequencies = 1 / MLX.pow(MLXArray(ropeBase), indices / Float(dimension))
+        let inverseFrequencies = 1 / MLX.pow(MLXArray(base), indices / Float(dimension))
         let frequencies = MLXArray(positions)[0..., .newAxis] * inverseFrequencies[.newAxis, 0...]
-        let cosine = MLX.cos(frequencies).asType(input.dtype)
-        let sine = MLX.sin(frequencies).asType(input.dtype)
+        return (MLX.cos(frequencies).asType(dtype), MLX.sin(frequencies).asType(dtype))
+    }
+
+    private static func applyInterleavedRoPE(
+        _ input: MLXArray,
+        cosine: MLXArray,
+        sine: MLXArray
+    ) -> MLXArray {
         let even = input[0..., .stride(by: 2)]
         let odd = input[0..., .stride(from: 1, by: 2)]
         let rotatedEven = even * cosine - odd * sine

--- a/Tests/MereRunCoreTests/SenseNovaU15PerformanceTests.swift
+++ b/Tests/MereRunCoreTests/SenseNovaU15PerformanceTests.swift
@@ -1,0 +1,191 @@
+import Foundation
+import MLX
+import MLXRandom
+@testable import MereRunCore
+import XCTest
+
+/// Env-gated, in-process comparisons for exact SenseNova U1.5 optimization candidates.
+/// Run with `MERERUN_SENSENOVA_BENCH=1 swift test --filter SenseNovaU15PerformanceTests`.
+final class SenseNovaU15PerformanceTests: XCTestCase {
+    private let hiddenSize = 4_096
+    private let intermediateSize = 12_288
+    private let keyValueSize = 1_024
+
+    private func requireBenchmark() throws {
+        guard ProcessInfo.processInfo.environment["MERERUN_SENSENOVA_BENCH"] == "1" else {
+            throw XCTSkip("Set MERERUN_SENSENOVA_BENCH=1 to run SenseNova performance tests")
+        }
+    }
+
+    private var tokenCounts: [Int] {
+        let configured = ProcessInfo.processInfo.environment["MERERUN_SENSENOVA_BENCH_TOKENS"]?
+            .split(separator: ",")
+            .compactMap { Int($0.trimmingCharacters(in: .whitespaces)) }
+            .filter { $0 > 0 } ?? []
+        return configured.isEmpty ? [1_024, 4_070] : configured
+    }
+
+    private func measure(_ body: () -> MLXArray) -> Double {
+        let start = CFAbsoluteTimeGetCurrent()
+        MLX.eval(body())
+        return CFAbsoluteTimeGetCurrent() - start
+    }
+
+    private func pairedTimes(
+        rounds: Int = 4,
+        first: @escaping () -> MLXArray,
+        second: @escaping () -> MLXArray
+    ) -> (first: Double, second: Double) {
+        MLX.eval(first(), second())
+        var firstTimes: [Double] = []
+        var secondTimes: [Double] = []
+        for round in 0..<rounds {
+            if round.isMultiple(of: 2) {
+                firstTimes.append(measure(first))
+                secondTimes.append(measure(second))
+            } else {
+                secondTimes.append(measure(second))
+                firstTimes.append(measure(first))
+            }
+        }
+        return (firstTimes.sorted()[rounds / 2], secondTimes.sorted()[rounds / 2])
+    }
+
+    func testFusedGenerationProjections() throws {
+        try requireBenchmark()
+        let queryWeight = MLXRandom.uniform(-0.02 ..< 0.02, [hiddenSize, hiddenSize]).asType(.bfloat16)
+        let keyWeight = MLXRandom.uniform(-0.02 ..< 0.02, [keyValueSize, hiddenSize]).asType(.bfloat16)
+        let valueWeight = MLXRandom.uniform(-0.02 ..< 0.02, [keyValueSize, hiddenSize]).asType(.bfloat16)
+        let gateWeight = MLXRandom.uniform(-0.02 ..< 0.02, [intermediateSize, hiddenSize]).asType(.bfloat16)
+        let upWeight = MLXRandom.uniform(-0.02 ..< 0.02, [intermediateSize, hiddenSize]).asType(.bfloat16)
+        MLX.eval(queryWeight, keyWeight, valueWeight, gateWeight, upWeight)
+
+        let fusedQKVWeight = MLX.concatenated([queryWeight, keyWeight, valueWeight], axis: 0)
+        let fusedGateUpWeight = MLX.concatenated([gateWeight, upWeight], axis: 0)
+        MLX.eval(fusedQKVWeight, fusedGateUpWeight)
+
+        for tokenCount in tokenCounts {
+            let input = MLXRandom.uniform(-0.5 ..< 0.5, [tokenCount, hiddenSize]).asType(.bfloat16)
+            MLX.eval(input)
+
+            let separateQKV = {
+                MLX.concatenated([
+                    MLX.matmul(input, queryWeight.T),
+                    MLX.matmul(input, keyWeight.T),
+                    MLX.matmul(input, valueWeight.T),
+                ], axis: -1)
+            }
+            let fusedQKV = { MLX.matmul(input, fusedQKVWeight.T) }
+            let qkvReference = separateQKV()
+            let qkvCandidate = fusedQKV()
+            MLX.eval(qkvReference, qkvCandidate)
+            XCTAssertTrue(MLX.arrayEqual(qkvReference, qkvCandidate).item(Bool.self))
+            let qkvTimes = pairedTimes(first: separateQKV, second: fusedQKV)
+
+            let separateGateUp = {
+                MLX.concatenated([
+                    MLX.matmul(input, gateWeight.T),
+                    MLX.matmul(input, upWeight.T),
+                ], axis: -1)
+            }
+            let fusedGateUp = { MLX.matmul(input, fusedGateUpWeight.T) }
+            let gateUpReference = separateGateUp()
+            let gateUpCandidate = fusedGateUp()
+            MLX.eval(gateUpReference, gateUpCandidate)
+            XCTAssertTrue(MLX.arrayEqual(gateUpReference, gateUpCandidate).item(Bool.self))
+            let gateUpTimes = pairedTimes(first: separateGateUp, second: fusedGateUp)
+
+            print(
+                String(
+                    format: "[sensenova-bench] tokens=%d qkv %.3f -> %.3f ms (%.3fx)",
+                    tokenCount,
+                    qkvTimes.first * 1_000,
+                    qkvTimes.second * 1_000,
+                    qkvTimes.first / qkvTimes.second
+                )
+            )
+            print(
+                String(
+                    format: "[sensenova-bench] tokens=%d gate-up %.3f -> %.3f ms (%.3fx)",
+                    tokenCount,
+                    gateUpTimes.first * 1_000,
+                    gateUpTimes.second * 1_000,
+                    gateUpTimes.first / gateUpTimes.second
+                )
+            )
+        }
+    }
+
+    func testStaticKVUpdateAgainstConcatenation() throws {
+        try requireBenchmark()
+        let prefixCount = 320
+        for tokenCount in tokenCounts {
+            let prefix = MLXRandom.uniform(
+                -0.5 ..< 0.5,
+                [1, 8, prefixCount, 128]
+            ).asType(.bfloat16)
+            let current = MLXRandom.uniform(
+                -0.5 ..< 0.5,
+                [1, 8, tokenCount, 128]
+            ).asType(.bfloat16)
+            let template = MLX.concatenated([
+                prefix,
+                MLXArray.zeros([1, 8, tokenCount, 128], dtype: .bfloat16),
+            ], axis: 2)
+            MLX.eval(prefix, current, template)
+
+            let concatenate = { MLX.concatenated([prefix, current], axis: 2) }
+            let staticUpdate = {
+                let output = template
+                output[0..., 0..., prefixCount..., 0...] = current
+                return output
+            }
+            let reference = concatenate()
+            let candidate = staticUpdate()
+            MLX.eval(reference, candidate)
+            XCTAssertTrue(MLX.arrayEqual(reference, candidate).item(Bool.self))
+            let times = pairedTimes(first: concatenate, second: staticUpdate)
+            print(
+                String(
+                    format: "[sensenova-bench] tokens=%d kv-concat %.3f vs update %.3f ms (%.3fx)",
+                    tokenCount,
+                    times.first * 1_000,
+                    times.second * 1_000,
+                    times.first / times.second
+                )
+            )
+        }
+    }
+
+    func testAllocatorCacheLimits() throws {
+        try requireBenchmark()
+        let input = MLXRandom.uniform(-0.5 ..< 0.5, [1_024, hiddenSize]).asType(.bfloat16)
+        let weight = MLXRandom.uniform(-0.02 ..< 0.02, [hiddenSize, hiddenSize]).asType(.bfloat16)
+        MLX.eval(input, weight)
+        let originalLimit = Memory.cacheLimit
+        defer {
+            Memory.cacheLimit = originalLimit
+            Memory.clearCache()
+        }
+
+        for limitMiB in [0, 256, 1_024, 2_048] {
+            Memory.clearCache()
+            Memory.cacheLimit = limitMiB * 1_048_576
+            var times: [Double] = []
+            for _ in 0..<6 {
+                times.append(measure { MLX.matmul(input, weight.T) })
+            }
+            let median = times.sorted()[times.count / 2]
+            let snapshot = Memory.snapshot()
+            print(
+                String(
+                    format: "[sensenova-bench] allocator=%d MiB %.3f ms active=%.2f GiB cache=%.2f GiB",
+                    limitMiB,
+                    median * 1_000,
+                    Double(snapshot.activeMemory) / 1_073_741_824,
+                    Double(snapshot.cacheMemory) / 1_073_741_824
+                )
+            )
+        }
+    }
+}

--- a/Tests/MereRunCoreTests/SenseNovaU15Tests.swift
+++ b/Tests/MereRunCoreTests/SenseNovaU15Tests.swift
@@ -37,6 +37,36 @@ final class SenseNovaU15Tests: MereRunCoreTestCase {
         XCTAssertEqual(restored.asArray(Float.self), source.asArray(Float.self))
     }
 
+    func testCachedVisionRoPEMatchesLegacyFormulaExactly() {
+        let input = MLXArray(Array(0..<48).map { Float($0) / 13 }, [6, 8])
+            .asType(.bfloat16)
+        let cached = SenseNovaU15VisionEmbeddings.makeRoPETables(
+            height: 2,
+            width: 3,
+            hiddenSize: 8,
+            base: 10_000,
+            dtype: input.dtype
+        )
+        MLX.eval(cached.arrays)
+
+        let reused = SenseNovaU15VisionEmbeddings.applyVisionRoPE(input, tables: cached)
+        let legacy = legacyVisionRoPE(input, height: 2, width: 3, base: 10_000)
+        MLX.eval(reused, legacy)
+
+        XCTAssertEqual(reused.asArray(Float.self), legacy.asArray(Float.self))
+    }
+
+    func testCachedNoiseEmbeddingMatchesFreshRepeatedInputExactly() {
+        let embedder = SenseNovaU15TimestepEmbedder(hiddenSize: 8)
+        let values = MLXArray([Float](repeating: 0.375, count: 4))
+        let cached = embedder(values)
+        MLX.eval(cached)
+        let fresh = embedder(values)
+        MLX.eval(fresh)
+
+        XCTAssertEqual(cached.asArray(Float.self), fresh.asArray(Float.self))
+    }
+
     func testManagedModelIsPinnedAndUsesUnifiedManifest() throws {
         let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: SenseNovaU15Resources.modelID))
         XCTAssertEqual(spec.hubFallback?.repoId, SenseNovaU15Resources.repository)
@@ -86,5 +116,38 @@ final class SenseNovaU15Tests: MereRunCoreTestCase {
         XCTAssertEqual(tokenizer.imageContextTokenID, 151_669)
         XCTAssertEqual(tokenizer.imageStartTokenID, 151_670)
         XCTAssertEqual(tokenizer.imageEndTokenID, 151_671)
+    }
+
+    private func legacyVisionRoPE(
+        _ input: MLXArray,
+        height: Int,
+        width: Int,
+        base: Float
+    ) -> MLXArray {
+        let half = input.dim(-1) / 2
+        let xPositions = (0..<height).flatMap { _ in (0..<width).map(Float.init) }
+        let yPositions = (0..<height).flatMap { row in [Float](repeating: Float(row), count: width) }
+        return MLX.concatenated([
+            legacyInterleavedRoPE(input[0..., 0..<half], positions: xPositions, base: base),
+            legacyInterleavedRoPE(input[0..., half...], positions: yPositions, base: base),
+        ], axis: -1)
+    }
+
+    private func legacyInterleavedRoPE(
+        _ input: MLXArray,
+        positions: [Float],
+        base: Float
+    ) -> MLXArray {
+        let dimension = input.dim(-1)
+        let indices = MLXArray(stride(from: Float(0), to: Float(dimension), by: 2))
+        let inverseFrequencies = 1 / MLX.pow(MLXArray(base), indices / Float(dimension))
+        let frequencies = MLXArray(positions)[0..., .newAxis] * inverseFrequencies[.newAxis, 0...]
+        let cosine = MLX.cos(frequencies).asType(input.dtype)
+        let sine = MLX.sin(frequencies).asType(input.dtype)
+        let even = input[0..., .stride(by: 2)]
+        let odd = input[0..., .stride(from: 1, by: 2)]
+        let rotatedEven = even * cosine - odd * sine
+        let rotatedOdd = even * sine + odd * cosine
+        return MLX.stacked([rotatedEven, rotatedOdd], axis: -1).reshaped(input.shape)
     }
 }


### PR DESCRIPTION
## Summary

- cache bounded vision RoPE tables by resolution and dtype across denoising steps
- compute the constant noise-scale embedding once per generation
- add exact BF16 parity coverage and an env-gated performance harness for ranked optimization candidates

## Production proof

- native MLX/Metal, 1024x1024, 50 steps, CFG 4, sigma shift 3, seed 7
- optimized and baseline PNGs are byte-for-byte identical: `d8e35e6f041cbe1fb68c8ed80adcbdc3115ab43e97e4c93dd5cb084833216547`
- balanced ABBA denoising average: 48.52s baseline to 43.66s optimized (10.0% less time, about 1.11x throughput)
- balanced median: 4.85s to 4.45s per step (8.3% less time)
- max RSS: 20.04 GiB to 19.90 GiB; peak footprint: 36.27 GiB to 36.14 GiB; zero process swaps

Cross-layer transformer RoPE sharing was rejected because it changed the production image. Projection fusion, KV preallocation, and global allocator policy changes were also left out after production-shape or safety regressions.

## Validation

- `./scripts/check.sh`
- strict lint: 1,355 files, 0 violations
- XCTest: 3,112 tests, 222 expected skips, 0 failures
- Swift Testing: 30 tests, 0 failures
- release-mode full production generation and byte-for-byte output comparison