### PR TITLE
Add MiniMax Music 3 composer and mixed quantization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ The format is based on Keep a Changelog.
 
 ### Audio
 
+- added split MiniMax Music 3 quantization tiers: `q8-lm` and `q4-lm`
+  quantize only the 8B global language model while retaining the residual-depth
+  decoder in BF16. Legacy whole-autoregressive `q8` and `q4` remain available;
+  profile schema 3 and recipe schema 7 record the resolved precision of both
+  components.
+- added an opt-in MiniMax Music 3 local composer that plans a bar-aware song
+  timeline, writes lyrics and the structured three-part caption with native
+  constrained-JSON chat models, preserves supplied lyrics, and saves typed
+  composition and lyric-preflight provenance. Duration-aware lyric checks warn
+  by default and can be made strict without silently forcing an EOS floor.
+- added reproducible MiniMax Music 3 experiments for AB2 flow integration,
+  autoregressive CFG cutoff, and flow CFG cutoff across the CLI and speech API.
+  Euler and full CFG remain unchanged defaults, and recipes plus profiles record
+  every experimental setting.
 - fixed MiniMax Music 3 optimized, Q8, and Q4 lyric drift by preserving the
   released full-vocabulary categorical layout behind the compact semantic head
   and keeping the eight-token residual-depth decode on its seeded-parity path.

--- a/README.md
+++ b/README.md
@@ -670,6 +670,16 @@ swift run mere.run music generate \
 # Generate a lyric-driven stereo song with native MiniMax Music 3
 swift run mere.run model pull music-minimax-music3 --accept-model-license
 swift run mere.run music generate \
+  "slow-burn dream pop about leaving a familiar city and finding home" \
+  --model music-minimax-music3 \
+  --compose \
+  --duration 180 \
+  --lyrics-preflight strict \
+  --performance-mode q8-lm \
+  --sampling-tier fast \
+  --output ./minimax-composed-song.wav
+
+swift run mere.run music generate \
   "cinematic synth-pop, female lead, 118 bpm, wide guitars" \
   --model music-minimax-music3 \
   --lyrics-file ./lyrics.txt \
@@ -678,7 +688,7 @@ swift run mere.run music generate \
   --sampling-tier fast \
   --seed 7 \
   --memory-mode staged \
-  --performance-mode q8 \
+  --performance-mode q8-lm \
   --output ./minimax-song.wav
 
 # Compare the experimental whole-song flow windowing recipe without changing defaults
@@ -691,11 +701,22 @@ swift run mere.run music generate \
   --seed-strategy stage-separated-v1 \
   --output ./minimax-overlap-average.wav
 
+# A/B opt-in solver and guidance-taper experiments; Euler and full CFG remain defaults
+swift run mere.run music generate \
+  "cinematic synth-pop, female lead, 118 bpm, wide guitars" \
+  --model music-minimax-music3 \
+  --lyrics-file ./lyrics.txt \
+  --duration 30 \
+  --flow-solver ab2 \
+  --ar-cfg-frames 50 \
+  --flow-cfg-end 0.4 \
+  --output ./minimax-ab2-taper.wav
+
 # Keep MiniMax Music 3 warm behind its speech-compatible HTTP route
 swift run mere.run music serve \
   --model music-minimax-music3 \
   --memory-mode resident \
-  --performance-mode q8 \
+  --performance-mode q8-lm \
   --port 8080
 
 # Generate with ACE-Step XL Turbo on larger Macs

--- a/Sources/MereRunCLI/Commands/MiniMaxMusic3Serve.swift
+++ b/Sources/MereRunCLI/Commands/MiniMaxMusic3Serve.swift
@@ -17,7 +17,11 @@ struct MiniMaxMusic3SpeechRequest: Codable, Sendable {
     var minNewTokens: Int?
     var samplingTier: MiniMaxMusic3SamplingTier?
     var flowStrategy: MiniMaxMusic3FlowStrategy?
+    var flowSolver: MiniMaxMusic3FlowSolver?
+    var autoregressiveGuidanceFrames: Int?
+    var flowGuidanceEnd: Float?
     var seedStrategy: MiniMaxMusic3SeedStrategy?
+    var lyricPreflight: MiniMaxMusic3LyricPreflightPolicy?
     var numInferenceSteps: Int?
     var guidanceScale: Float?
     var sampleRate: Int?
@@ -35,7 +39,11 @@ struct MiniMaxMusic3SpeechRequest: Codable, Sendable {
         case minNewTokens = "min_new_tokens"
         case samplingTier = "sampling_tier"
         case flowStrategy = "flow_strategy"
+        case flowSolver = "flow_solver"
+        case autoregressiveGuidanceFrames = "autoregressive_guidance_frames"
+        case flowGuidanceEnd = "flow_guidance_end"
         case seedStrategy = "seed_strategy"
+        case lyricPreflight = "lyric_preflight"
         case numInferenceSteps = "num_inference_steps"
         case guidanceScale = "guidance_scale"
         case sampleRate = "sample_rate"
@@ -48,6 +56,8 @@ private struct MiniMaxMusic3HealthResponse: Codable {
     var resident: Bool
     var memoryMode: MiniMaxMusic3LoadingStrategy
     var performanceMode: MiniMaxMusic3PerformanceMode
+    var languageModelPrecision: MiniMaxMusic3WeightPrecision
+    var depthDecoderPrecision: MiniMaxMusic3WeightPrecision
     var nativeSampleRate: Int
     var speechSampleRate: Int
 
@@ -57,6 +67,8 @@ private struct MiniMaxMusic3HealthResponse: Codable {
         case resident
         case memoryMode = "memory_mode"
         case performanceMode = "performance_mode"
+        case languageModelPrecision = "language_model_precision"
+        case depthDecoderPrecision = "depth_decoder_precision"
         case nativeSampleRate = "native_sample_rate"
         case speechSampleRate = "speech_sample_rate"
     }
@@ -196,6 +208,26 @@ private actor MiniMaxMusic3ServerSession {
         guard sampleRate == 32_000 || sampleRate == 44_100 else {
             throw ValidationError("sample_rate must be 32000 or 44100.")
         }
+        if let guidanceFrames = request.autoregressiveGuidanceFrames,
+           !(0...MiniMaxMusic3Prompt.maxAudioFrames).contains(guidanceFrames)
+        {
+            throw ValidationError("autoregressive_guidance_frames must be between 0 and 9000.")
+        }
+        let flowGuidanceEnd = request.flowGuidanceEnd ?? 1
+        guard (0...1).contains(flowGuidanceEnd) else {
+            throw ValidationError("flow_guidance_end must be between 0 and 1.")
+        }
+        let instrumental = lyrics.lowercased() == "[instrumental]"
+        if request.lyricPreflight == .strict {
+            let report = MiniMaxMusic3LyricPreflight.inspect(
+                lyrics: lyrics,
+                durationSeconds: duration,
+                instrumental: instrumental
+            )
+            if let issue = report.issues.first {
+                throw ValidationError("lyric preflight failed: \(issue.message)")
+            }
+        }
         return (
             MiniMaxMusic3GenerationOptions(
                 caption: caption,
@@ -207,6 +239,9 @@ private actor MiniMaxMusic3ServerSession {
                 seed: request.seed ?? 0,
                 guidanceScale: guidanceScale,
                 flowStrategy: request.flowStrategy ?? .sequential,
+                flowSolver: request.flowSolver ?? .euler,
+                autoregressiveGuidanceFrames: request.autoregressiveGuidanceFrames,
+                flowGuidanceEnd: flowGuidanceEnd,
                 seedStrategy: request.seedStrategy ?? .legacy
             ),
             sampleRate
@@ -264,6 +299,8 @@ final class MiniMaxMusic3APIServer: @unchecked Sendable {
                     resident: loadingStrategy == .resident,
                     memoryMode: loadingStrategy,
                     performanceMode: performanceMode,
+                    languageModelPrecision: performanceMode.languageModelPrecision,
+                    depthDecoderPrecision: performanceMode.depthDecoderPrecision,
                     nativeSampleRate: 44_100,
                     speechSampleRate: 32_000
                 )

--- a/Sources/MereRunCLI/Commands/MusicGenerateCommand.swift
+++ b/Sources/MereRunCLI/Commands/MusicGenerateCommand.swift
@@ -55,6 +55,42 @@ struct MusicGenerate: AsyncParsableCommand {
     @Flag(name: [.customLong("instrumental")], help: "Use upstream's [Instrumental] lyric marker; cannot be combined with lyrics.")
     var instrumental: Bool = false
 
+    @Flag(
+        name: [.customLong("compose")],
+        help: "Use a local chat model to plan a bar-aware MiniMax Music 3 timeline, lyrics, and structured caption."
+    )
+    var miniMaxCompose: Bool = false
+
+    @Option(
+        name: [.customLong("composer-model")],
+        help: "Native Gemma4 or Qwen-family chat model used by --compose."
+    )
+    var miniMaxComposerModel: String = TextChat.defaultChatModelId
+
+    @Option(
+        name: [.customLong("composer-model-root")],
+        help: "Local composer model root; skips composer auto-download."
+    )
+    var miniMaxComposerModelRoot: String?
+
+    @Flag(
+        name: [.customLong("require-composer-installed")],
+        help: "Require --composer-model to be installed and never download it implicitly."
+    )
+    var miniMaxRequireComposerInstalled: Bool = false
+
+    @Option(
+        name: [.customLong("composition-output")],
+        help: "Composer JSON receipt path (default: <output>.composition.json)."
+    )
+    var miniMaxCompositionOutput: String?
+
+    @Option(
+        name: [.customLong("lyrics-preflight")],
+        help: "MiniMax lyric-duration checks: off, warn (default), or strict."
+    )
+    var miniMaxLyricPreflightPolicy: MiniMaxMusic3LyricPreflightPolicy = .warn
+
     @Option(name: [.customLong("lrc-file")], help: "Synchronized LRC lyrics input. Cannot be combined with plain lyrics options.")
     var lrcFile: String?
 
@@ -188,7 +224,7 @@ struct MusicGenerate: AsyncParsableCommand {
 
     @Option(
         name: [.customLong("performance-mode")],
-        help: "MiniMax Music 3 execution: reference, optimized (default), q8, or q4."
+        help: "MiniMax Music 3 execution: reference, optimized (default), q8-lm/q4-lm with BF16 depth, or legacy whole-AR q8/q4."
     )
     var miniMaxPerformanceMode: MiniMaxMusic3PerformanceMode?
 
@@ -203,6 +239,24 @@ struct MusicGenerate: AsyncParsableCommand {
         help: "MiniMax Music 3 long-form flow: sequential (default) or experimental overlap-average."
     )
     var miniMaxFlowStrategy: MiniMaxMusic3FlowStrategy?
+
+    @Option(
+        name: [.customLong("flow-solver")],
+        help: "MiniMax Music 3 integration: euler (default) or experimental ab2."
+    )
+    var miniMaxFlowSolver: MiniMaxMusic3FlowSolver?
+
+    @Option(
+        name: [.customLong("ar-cfg-frames")],
+        help: "Experimental MiniMax CFG frame count; later autoregressive frames use conditional-only decoding."
+    )
+    var miniMaxAutoregressiveGuidanceFrames: Int?
+
+    @Option(
+        name: [.customLong("flow-cfg-end")],
+        help: "Experimental MiniMax flow CFG cutoff in [0, 1]; later steps use conditional-only decoding."
+    )
+    var miniMaxFlowGuidanceEnd: Float?
 
     @Option(
         name: [.customLong("seed-strategy")],
@@ -546,7 +600,7 @@ struct MusicGenerate: AsyncParsableCommand {
         }
 
         if isMiniMaxMusic3Request {
-            try runMiniMaxMusic3(explicitDurationSeconds: explicitDurationSeconds)
+            try await runMiniMaxMusic3(explicitDurationSeconds: explicitDurationSeconds)
             return
         }
 
@@ -558,11 +612,19 @@ struct MusicGenerate: AsyncParsableCommand {
             || miniMaxPerformanceMode != nil
             || miniMaxSamplingTier != nil
             || miniMaxFlowStrategy != nil
+            || miniMaxFlowSolver != nil
+            || miniMaxAutoregressiveGuidanceFrames != nil
+            || miniMaxFlowGuidanceEnd != nil
             || miniMaxSeedStrategy != nil
             || miniMaxProfileOutput != nil
+            || miniMaxCompose
+            || miniMaxComposerModelRoot != nil
+            || miniMaxRequireComposerInstalled
+            || miniMaxCompositionOutput != nil
+            || miniMaxLyricPreflightPolicy != .warn
         {
             throw ValidationError(
-                "MiniMax duration-frame, sample-rate, memory-mode, performance-mode, flow, seed, sampling-tier, and profiling options require MiniMax Music 3."
+                "MiniMax composer, lyric-preflight, duration-frame, sample-rate, memory-mode, performance-mode, flow, seed, sampling-tier, and profiling options require MiniMax Music 3."
             )
         }
 
@@ -1158,17 +1220,32 @@ struct MusicGenerate: AsyncParsableCommand {
         return MiniMaxMusic3Resources.looksLikeRoot(resolveUserPath(model))
     }
 
-    private func runMiniMaxMusic3(explicitDurationSeconds: Float?) throws {
+    private func runMiniMaxMusic3(explicitDurationSeconds: Float?) async throws {
         try validateMiniMaxMusic3Options(explicitDurationSeconds: explicitDurationSeconds)
         let inputLRC = try loadLRC()
-        let resolvedLyrics = instrumental
+        let inputLyrics = instrumental
             ? "[Instrumental]"
             : try inputLRC?.lyrics ?? loadLyrics()
-        guard !resolvedLyrics.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+        guard miniMaxCompose
+                || !inputLyrics.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             throw ValidationError(
-                "MiniMax Music 3 requires --lyrics, --lyrics-file, --lrc-file, or --instrumental."
+                "MiniMax Music 3 requires --compose, --lyrics, --lyrics-file, --lrc-file, or --instrumental."
             )
         }
+        let requestedDuration = explicitDurationSeconds
+            ?? miniMaxMaximumFrames.map {
+                Float($0) / Float(MiniMaxMusic3Prompt.frameRate)
+            }
+            ?? 60
+        let requestedMinimumFrames = miniMaxMinimumFrames
+            ?? miniMaxMinimumDurationSeconds.map {
+                MiniMaxMusic3Prompt.minimumFrameCount(forDurationSeconds: $0)
+            }
+        let outputURL = CLIOutput.resolveOutputURL(
+            output,
+            defaultPrefix: "mererun-minimax-music3",
+            defaultExtension: "wav"
+        )
 
         let rootURL: URL
         if model == ModelResolver.ModelID.miniMaxMusic3.rawValue {
@@ -1192,15 +1269,65 @@ struct MusicGenerate: AsyncParsableCommand {
             )
         }
 
-        let outputURL = CLIOutput.resolveOutputURL(
-            output,
-            defaultPrefix: "mererun-minimax-music3",
-            defaultExtension: "wav"
-        )
         try FileManager.default.createDirectory(
             at: outputURL.deletingLastPathComponent(),
             withIntermediateDirectories: true
         )
+
+        let composition: MiniMaxMusic3CompositionReceipt?
+        if miniMaxCompose {
+            let authoritativeLyrics = inputLyrics
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+                .isEmpty || instrumental
+                ? nil
+                : inputLyrics
+            composition = try await MiniMaxMusic3LocalComposer.compose(
+                request: MiniMaxMusic3CompositionRequest(
+                    brief: caption,
+                    durationSeconds: requestedDuration,
+                    instrumental: instrumental,
+                    authoritativeLyrics: authoritativeLyrics
+                ),
+                modelID: miniMaxComposerModel,
+                modelRoot: miniMaxComposerModelRoot,
+                requireInstalled: miniMaxRequireComposerInstalled,
+                quiet: quiet
+            )
+            let compositionURL = miniMaxCompositionOutput.map(resolveUserPath)
+                ?? outputURL.deletingPathExtension().appendingPathExtension("composition.json")
+            try FileManager.default.createDirectory(
+                at: compositionURL.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try composition?.write(to: compositionURL)
+            if !quiet {
+                CLIStderr.write("Saved composition: \(compositionURL.path)\n")
+            }
+        } else {
+            composition = nil
+        }
+        let effectiveCaption = composition?.song.caption ?? caption
+        let resolvedLyrics = composition?.song.lyrics ?? inputLyrics
+        let lyricPreflight = miniMaxLyricPreflightPolicy == .off
+            ? nil
+            : MiniMaxMusic3LyricPreflight.inspect(
+                lyrics: resolvedLyrics,
+                durationSeconds: requestedDuration,
+                instrumental: instrumental,
+                blueprint: composition?.blueprint
+            )
+        if let lyricPreflight {
+            for issue in lyricPreflight.issues where !quiet {
+                CLIStderr.write(
+                    "MiniMax lyric preflight [\(issue.severity.rawValue)]: \(issue.message)\n"
+                )
+            }
+            if miniMaxLyricPreflightPolicy == .strict,
+               let issue = lyricPreflight.issues.first
+            {
+                throw ValidationError("MiniMax lyric preflight failed: \(issue.message)")
+            }
+        }
         if !quiet {
             CLIStderr.write("Loading MiniMax Music 3 from \(rootURL.path)\n")
         }
@@ -1210,13 +1337,28 @@ struct MusicGenerate: AsyncParsableCommand {
         }
         let performanceMode = miniMaxPerformanceMode ?? .optimized
         if !quiet {
-            CLIStderr.write("MiniMax performance mode: \(performanceMode.rawValue)\n")
+            CLIStderr.write(
+                "MiniMax performance mode: \(performanceMode.rawValue) "
+                    + "(LM \(performanceMode.languageModelPrecision.rawValue), "
+                    + "depth \(performanceMode.depthDecoderPrecision.rawValue))\n"
+            )
         }
         let inferenceSteps = resolvedMiniMaxInferenceSteps
         let flowStrategy = miniMaxFlowStrategy ?? .sequential
+        let flowSolver = miniMaxFlowSolver ?? .euler
+        let flowGuidanceEnd = miniMaxFlowGuidanceEnd ?? 1
         let seedStrategy = miniMaxSeedStrategy ?? .legacy
         if !quiet {
             CLIStderr.write("MiniMax flow strategy: \(flowStrategy.rawValue)\n")
+            CLIStderr.write("MiniMax flow solver: \(flowSolver.rawValue)\n")
+            if let miniMaxAutoregressiveGuidanceFrames {
+                CLIStderr.write(
+                    "MiniMax autoregressive CFG frames: \(miniMaxAutoregressiveGuidanceFrames)\n"
+                )
+            }
+            if flowGuidanceEnd < 1 {
+                CLIStderr.write("MiniMax flow CFG end: \(flowGuidanceEnd)\n")
+            }
             CLIStderr.write("MiniMax seed strategy: \(seedStrategy.rawValue)\n")
         }
         if !quiet {
@@ -1230,18 +1372,9 @@ struct MusicGenerate: AsyncParsableCommand {
             loadingStrategy: loadingStrategy,
             performanceMode: performanceMode
         )
-        let requestedDuration = explicitDurationSeconds
-            ?? miniMaxMaximumFrames.map {
-                Float($0) / Float(MiniMaxMusic3Prompt.frameRate)
-            }
-            ?? 60
-        let requestedMinimumFrames = miniMaxMinimumFrames
-            ?? miniMaxMinimumDurationSeconds.map {
-                MiniMaxMusic3Prompt.minimumFrameCount(forDurationSeconds: $0)
-            }
         let result = try pipeline.generate(
             options: MiniMaxMusic3GenerationOptions(
-                caption: caption,
+                caption: effectiveCaption,
                 lyrics: resolvedLyrics,
                 durationSeconds: requestedDuration,
                 minimumFrames: requestedMinimumFrames,
@@ -1251,6 +1384,9 @@ struct MusicGenerate: AsyncParsableCommand {
                 guidanceScale: guidanceScale ?? 1.7,
                 profilingEnabled: miniMaxProfileOutput != nil,
                 flowStrategy: flowStrategy,
+                flowSolver: flowSolver,
+                autoregressiveGuidanceFrames: miniMaxAutoregressiveGuidanceFrames,
+                flowGuidanceEnd: flowGuidanceEnd,
                 seedStrategy: seedStrategy
             ),
             progress: { event in
@@ -1316,8 +1452,12 @@ struct MusicGenerate: AsyncParsableCommand {
                 modelID: model,
                 sourceRepository: MiniMaxMusic3Resources.repository,
                 sourceRevision: MiniMaxMusic3Resources.revision,
-                caption: caption,
+                inputBrief: caption,
+                caption: effectiveCaption,
                 lyrics: resolvedLyrics,
+                composition: composition,
+                lyricPreflightPolicy: miniMaxLyricPreflightPolicy,
+                lyricPreflight: lyricPreflight,
                 durationSeconds: requestedDuration,
                 requestedMinimumFrames: requestedMinimumFrames,
                 requestedMaximumFrames: miniMaxMaximumFrames,
@@ -1330,7 +1470,12 @@ struct MusicGenerate: AsyncParsableCommand {
                 outputSampleRate: outputSampleRate,
                 loadingStrategy: loadingStrategy,
                 performanceMode: performanceMode,
+                languageModelPrecision: performanceMode.languageModelPrecision,
+                depthDecoderPrecision: performanceMode.depthDecoderPrecision,
                 flowStrategy: flowStrategy,
+                flowSolver: flowSolver,
+                autoregressiveGuidanceFrames: miniMaxAutoregressiveGuidanceFrames,
+                flowGuidanceEnd: flowGuidanceEnd,
                 seedStrategy: seedStrategy,
                 audioHealth: result.audioHealth,
                 export: exportOptions,
@@ -1356,6 +1501,27 @@ struct MusicGenerate: AsyncParsableCommand {
     }
 
     func validateMiniMaxMusic3Options(explicitDurationSeconds: Float?) throws {
+        if let miniMaxAutoregressiveGuidanceFrames,
+           !(0...MiniMaxMusic3Prompt.maxAudioFrames).contains(
+            miniMaxAutoregressiveGuidanceFrames
+           )
+        {
+            throw ValidationError("--ar-cfg-frames must be between 0 and 9000.")
+        }
+        if let miniMaxFlowGuidanceEnd,
+           !(0...1).contains(miniMaxFlowGuidanceEnd)
+        {
+            throw ValidationError("--flow-cfg-end must be between 0 and 1.")
+        }
+        if !miniMaxCompose,
+           miniMaxComposerModelRoot != nil
+            || miniMaxRequireComposerInstalled
+            || miniMaxCompositionOutput != nil
+        {
+            throw ValidationError(
+                "--composer-model-root, --require-composer-installed, and --composition-output require --compose."
+            )
+        }
         if let miniMaxMinimumDurationSeconds,
            miniMaxMinimumDurationSeconds <= 0 || miniMaxMinimumDurationSeconds > 360
         {
@@ -1396,6 +1562,12 @@ struct MusicGenerate: AsyncParsableCommand {
         }
         if let explicitDurationSeconds, explicitDurationSeconds > 360 {
             throw ValidationError("MiniMax Music 3 supports at most 360 seconds (9,000 frames at 25 Hz).")
+        }
+        if miniMaxCompose,
+           let explicitDurationSeconds,
+           explicitDurationSeconds < 10
+        {
+            throw ValidationError("--compose requires a duration of at least 10 seconds.")
         }
         if let explicitDurationSeconds, let miniMaxMinimumDurationSeconds,
            miniMaxMinimumDurationSeconds > explicitDurationSeconds
@@ -1448,7 +1620,9 @@ struct MusicGenerate: AsyncParsableCommand {
             || velocityNormThreshold != nil
             || velocityEMAFactor != nil
         {
-            throw ValidationError("MiniMax Music 3 uses its fixed flow-matching Euler schedule.")
+            throw ValidationError(
+                "ACE-Step scheduler controls do not apply to MiniMax Music 3; use --flow-solver and --flow-cfg-end for MiniMax experiments."
+            )
         }
         if let candidateCount, candidateCount != 1 {
             throw ValidationError("MiniMax Music 3 currently supports one candidate per invocation.")

--- a/Sources/MereRunCLI/Commands/MusicServeCommand.swift
+++ b/Sources/MereRunCLI/Commands/MusicServeCommand.swift
@@ -201,7 +201,9 @@ struct MusicServe: AsyncParsableCommand {
         let performanceMode = miniMaxPerformanceMode ?? .optimized
         CLIStderr.write(
             "Loading MiniMax Music 3 server in \(loadingStrategy.rawValue) memory mode "
-                + "with \(performanceMode.rawValue) execution\n"
+                + "with \(performanceMode.rawValue) execution "
+                + "(LM \(performanceMode.languageModelPrecision.rawValue), "
+                + "depth \(performanceMode.depthDecoderPrecision.rawValue))\n"
         )
         let server = try MiniMaxMusic3APIServer(
             resources: resources,

--- a/Sources/MereRunCLI/Guides/music-generate-minimax-music3.md
+++ b/Sources/MereRunCLI/Guides/music-generate-minimax-music3.md
@@ -25,41 +25,57 @@ MiniMax Music 3 consumes only these model inputs:
 
 - positional caption: genre, emotional arc, vocals, instrumentation,
   arrangement, and production profile
-- `--lyrics`, `--lyrics-file`, `--lrc-file`, or `--instrumental`
+- `--compose`, `--lyrics`, `--lyrics-file`, `--lrc-file`, or `--instrumental`
+- `--lyrics-preflight off|warn|strict`: duration and section checks; defaults
+  to `warn`
 - `--duration`: upper-bound seconds; defaults to 60
 - `--minimum-duration`: decoded-audio duration floor. The runtime rounds up to
   the first 25 Hz frame whose whole 512-sample vocoder hops meet the request.
 - `--min-frames`: exact acoustic-frame floor; 1 through 9000
 - `--max-frames`: exact 25 Hz acoustic-frame upper bound; 1 through 9000
-- `--sampling-tier quality|fast|draft`: named flow-Euler schedules with 30,
+- `--sampling-tier quality|fast|draft`: named flow schedules with 30,
   20, or 16 steps; defaults to `quality`
-- `--steps`: exact flow-Euler steps per chunk; overrides `--sampling-tier`
+- `--steps`: exact flow steps per chunk; overrides `--sampling-tier`
 - `--profile-output`: write synchronized stage timings as JSON; intended for
   benchmarking because the extra evaluations can affect wall time
 - `--seed`: deterministic MLX seed; defaults to 0
 - `--guidance-scale`: flow classifier-free guidance; defaults to 1.7
 - `--memory-mode staged|resident`: staged loads and releases the autoregressive,
   flow, and vocoder stages separately; resident keeps every component loaded
-- `--performance-mode reference|optimized|q8|q4`: exact upstream graph,
-  parity-safe BF16 acceleration (default), recommended affine Q8 turbo, or
-  maximum-compression affine Q4 turbo
+- `--performance-mode reference|optimized|q8-lm|q4-lm|q8|q4`: exact upstream
+  graph, parity-safe BF16 acceleration (default), split LM-only affine
+  quantization with BF16 depth, or legacy whole-autoregressive quantization
 - `--sample-rate 44100|32000`: native Diffusers output or SGLang-compatible WAV
+- `--flow-solver euler|ab2`: parity-default Euler or opt-in second-order AB2
+- `--ar-cfg-frames`: opt-in count of autoregressive frames that retain CFG
+- `--flow-cfg-end`: opt-in normalized cutoff after which flow runs only the
+  conditional row
 
 When both `--duration` and `--max-frames` are provided, they must describe the
 same limit. The checkpoint hard cap is 9000 frames (360 seconds), while the
 official supported-quality claim is songs up to five minutes.
 
 `optimized` keeps BF16 weights while reducing launch and memory traffic with a
-compact reachable-token head, fused projections, incremental depth KV caches,
-and batched flow guidance. `q8` additionally quantizes the autoregressive
-language and depth transformers with group-64 affine weights; `q4` applies the
-same path at four bits. Quantization changes the sampled composition, so use `reference` or
-`optimized` for upstream-parity investigations and `q8` for the normal turbo
-tradeoff.
+compact reachable-token head, fused global-language-model projections, a
+fixed-capacity global KV cache, and batched flow guidance. The short residual
+depth prefix is deliberately recomputed to preserve seeded lyric trajectories.
+`q8-lm` additionally quantizes the global language model with group-64 affine
+weights while retaining the residual-depth decoder in BF16; `q4-lm` applies
+the same split at four bits. These are the preferred quantized experiments
+because depth codebooks directly shape vocal detail. Legacy `q8` and `q4`
+continue to quantize both autoregressive components for compatible maximum
+compression. Quantization changes the sampled composition, so use `reference`
+or `optimized` for upstream-parity investigations.
 
 The `quality`, `fast`, and `draft` sampling tiers use the same model and fixed
 Euler schedule with 30, 20, and 16 evaluations respectively. Use `--steps`
 when you need an exact custom count; it takes precedence over the named tier.
+Euler and full classifier-free guidance remain the default parity path.
+`--flow-solver ab2` uses Euler for the first update and second-order
+Adams-Bashforth for later updates. `--ar-cfg-frames 50` and
+`--flow-cfg-end 0.4` switch their later work to conditional-only execution.
+Treat these as reproducible full-song A/B controls, not speed or quality
+presets.
 
 Incompatible ACE-Step cover, editing, LM-planner, adapter, VAE,
 candidate-ranking, stem, and DAW settings fail explicitly for this model.
@@ -70,7 +86,7 @@ Magenta RT2 settings also fail instead of being silently ignored.
 | Upstream Diffusers input | mere.run surface |
 | --- | --- |
 | `prompt` | positional caption |
-| `lyrics` | `--lyrics`, `--lyrics-file`, `--lrc-file`, or `--instrumental` |
+| `lyrics` | `--compose`, `--lyrics`, `--lyrics-file`, `--lrc-file`, or `--instrumental` |
 | `audio_duration` | `--duration` |
 | `minimum_audio_duration` | `--minimum-duration` |
 | `min_new_tokens` | `--min-frames` |
@@ -79,9 +95,10 @@ Magenta RT2 settings also fail instead of being silently ignored.
 | `num_inference_steps` | `--steps` |
 | `output_type=np|pt` | `--export-format float32` with mastering disabled as shown below |
 
-The released autoregressive CFG (`1.5`) and top-k (`50`) remain fixed because
-they are checkpoint behavior, not pipeline inputs. Flow guidance defaults to
-the released `1.7` and is available as `--guidance-scale`. The speech route
+The released autoregressive CFG (`1.5`) and top-k (`50`) remain fixed while CFG
+is active. Flow guidance defaults to the released `1.7` and is available as
+`--guidance-scale`. Guidance cutoffs are explicit experimental execution
+controls and never change those scales. The speech route
 maps upstream `max_new_tokens` to the same frame limit exposed by
 `--max-frames`; native `minimum_audio_duration` and `min_new_tokens` map to the
 same duration floor exposed by `--minimum-duration` and `--min-frames`. It
@@ -102,7 +119,7 @@ mere.run music generate \
   --lyrics-file ./lyrics.txt \
   --duration 60 \
   --minimum-duration 60 \
-  --performance-mode q8 \
+  --performance-mode q8-lm \
   --steps 30 \
   --seed 7 \
   --output ./song.wav
@@ -111,7 +128,47 @@ mere.run music generate \
 Use `--instrumental` to pass the upstream `[Instrumental]` marker without a
 lyrics file.
 
-## Structured caption companion
+`--duration` is an upper bound, so sparse lyrics can let the autoregressive
+model emit EOS well before it. The default lyric preflight prints warnings for
+underfilled long-form lyrics, missing structure, and unsupported or inline
+tags. `--lyrics-preflight strict` fails before checkpoint loading when any
+issue remains. It does not add `--minimum-duration` or otherwise force EOS
+masking on the user's behalf.
+
+## Local composer
+
+`--compose` turns the positional caption into a natural-language song brief.
+A local native Gemma4 or Qwen-family chat model runs two constrained-JSON
+passes: a BPM/meter/section blueprint whose bars fill the requested timeline,
+then the final title, tags, lyrics, and `Global Metadata`, `Vocal Details`, and
+`Arrangement` fields. The typed contract normalizes the bar budget, requires a
+supported ordered section sequence ending in an outro, checks
+per-section lyric budgets, and keeps production directions out of lyric lines.
+Each phase gets at most one validation-guided repair attempt while the writer
+model remains loaded.
+
+```bash
+mere.run music generate \
+  "slow-burn dream pop about leaving a familiar city and finding home" \
+  --model music-minimax-music3 \
+  --compose \
+  --duration 180 \
+  --lyrics-preflight strict \
+  --performance-mode q8-lm \
+  --sampling-tier fast \
+  --output ./composed-song.wav
+```
+
+If tagged `--lyrics` or `--lyrics-file` is also present, that text is authoritative:
+the composer plans its existing section order and returns it unchanged while
+writing the caption. `--instrumental` creates a section-only timeline. Use
+`--composer-model`, `--composer-model-root`, and
+`--require-composer-installed` to control the writer model. The writer unloads
+before MiniMax loads. `<output>.composition.json` records the request,
+blueprint, finished inputs, writer model, and preflight; schema 7 recipe JSON
+embeds the same provenance.
+
+## Upstream structured-caption companion
 
 MiniMax publishes a separate `music-caption-rewriter` agent skill containing
 its structured-caption workflow and static template library. It is not
@@ -122,8 +179,10 @@ Install it directly from the official source when you want it:
 npx skills add MiniMax-AI/MiniMax-Music3 --skill music-caption-rewriter
 ```
 
-Pass the resulting `Global Metadata`, `Vocal Details`, and `Arrangement` text
-as the positional caption, while keeping the original lyrics separate.
+The integrated `--compose` workflow is a typed local mere.run implementation;
+it does not vendor that upstream skill. If you use the upstream companion
+instead, pass its `Global Metadata`, `Vocal Details`, and `Arrangement` text as
+the positional caption while keeping the original lyrics separate.
 
 ## Native and reference-server output
 
@@ -146,7 +205,7 @@ Start the SGLang-compatible speech route with all weights warm:
 mere.run music serve \
   --model music-minimax-music3 \
   --memory-mode resident \
-  --performance-mode q8 \
+  --performance-mode q8-lm \
   --port 8081
 ```
 
@@ -164,6 +223,10 @@ curl http://127.0.0.1:8081/v1/audio/speech \
     "max_new_tokens": 750,
     "min_new_tokens": 750,
     "sampling_tier": "fast",
+    "flow_solver": "ab2",
+    "autoregressive_guidance_frames": 50,
+    "flow_guidance_end": 0.4,
+    "lyric_preflight": "strict",
     "stream": false
   }' \
   --output song.wav

--- a/Sources/MereRunCLI/Guides/music-generate.md
+++ b/Sources/MereRunCLI/Guides/music-generate.md
@@ -79,8 +79,10 @@ mere.run guide music generate --model music-magenta-rt2-small
 - `--duration`: output seconds.
 - `--minimum-duration`: MiniMax Music 3 decoded-audio duration floor.
 - `--min-frames`, `--max-frames`: MiniMax Music 3 exact 25 Hz floor and limit.
-- `--performance-mode reference|optimized|q8|q4`: MiniMax Music 3 execution tier;
-  `optimized` is the BF16 default and `q8` is the recommended turbo tier.
+- `--performance-mode reference|optimized|q8-lm|q4-lm|q8|q4`: MiniMax Music 3
+  execution tier; `optimized` is the BF16 default, `q8-lm` is the recommended
+  quantized tier with a BF16 depth decoder, and `q8`/`q4` retain legacy
+  whole-autoregressive quantization.
 - `--sampling-tier quality|fast|draft`: MiniMax Music 3 flow schedule with 30,
   20, or 16 steps.
 - `--steps`, `-s`: exact denoise steps; overrides a MiniMax sampling tier.
@@ -159,9 +161,11 @@ audio without a Python process. `--duration` accepts up to 360 seconds;
 `--minimum-duration` prevents semantic EOS and rounds for the vocoder hop so
 the decoded WAV meets the requested floor. `--guidance-scale` defaults to `1.7`.
 The default `--performance-mode optimized` keeps BF16 quality while using
-compact/fused projections, cached depth decode, and batched flow guidance;
-`q8` is the recommended quantized turbo tier, with `q4` available for maximum
-memory reduction. ACE-Step source audio, adapters, ranked
+compact/fused projections, a fixed-capacity language-model cache, and batched
+flow guidance. `q8-lm` quantizes the global language model while retaining the
+vocal-critical residual-depth decoder in BF16; `q4-lm` is its lower-memory
+counterpart. Legacy `q8` and `q4` still quantize both autoregressive components.
+ACE-Step source audio, adapters, ranked
 candidates, stems, DAW bundles, and LRC export do not apply to this model. A
 reproducibility recipe is written beside the WAV unless `--no-recipe` is used.
 The selective managed download is approximately 26.6 GiB and requires

--- a/Sources/MereRunCLI/Support/MiniMaxMusic3CLIOptions.swift
+++ b/Sources/MereRunCLI/Support/MiniMaxMusic3CLIOptions.swift
@@ -5,4 +5,6 @@ extension MiniMaxMusic3LoadingStrategy: ExpressibleByArgument {}
 extension MiniMaxMusic3PerformanceMode: ExpressibleByArgument {}
 extension MiniMaxMusic3SamplingTier: ExpressibleByArgument {}
 extension MiniMaxMusic3FlowStrategy: ExpressibleByArgument {}
+extension MiniMaxMusic3FlowSolver: ExpressibleByArgument {}
 extension MiniMaxMusic3SeedStrategy: ExpressibleByArgument {}
+extension MiniMaxMusic3LyricPreflightPolicy: ExpressibleByArgument {}

--- a/Sources/MereRunCLI/Support/MiniMaxMusic3GenerationArtifacts.swift
+++ b/Sources/MereRunCLI/Support/MiniMaxMusic3GenerationArtifacts.swift
@@ -2,15 +2,19 @@ import Foundation
 import MereRunCore
 
 struct MiniMaxMusic3GenerationRecipe: Codable {
-    static let currentSchemaVersion = 5
+    static let currentSchemaVersion = 7
 
     var schemaVersion: Int
     var createdAt: Date
     var modelID: String
     var sourceRepository: String
     var sourceRevision: String
+    var inputBrief: String
     var caption: String
     var lyrics: String
+    var composition: MiniMaxMusic3CompositionReceipt?
+    var lyricPreflightPolicy: MiniMaxMusic3LyricPreflightPolicy
+    var lyricPreflight: MiniMaxMusic3LyricPreflightReport?
     var durationSeconds: Float
     var requestedMinimumFrames: Int?
     var requestedMaximumFrames: Int?
@@ -23,7 +27,12 @@ struct MiniMaxMusic3GenerationRecipe: Codable {
     var outputSampleRate: Int
     var loadingStrategy: MiniMaxMusic3LoadingStrategy
     var performanceMode: MiniMaxMusic3PerformanceMode
+    var languageModelPrecision: MiniMaxMusic3WeightPrecision
+    var depthDecoderPrecision: MiniMaxMusic3WeightPrecision
     var flowStrategy: MiniMaxMusic3FlowStrategy
+    var flowSolver: MiniMaxMusic3FlowSolver
+    var autoregressiveGuidanceFrames: Int?
+    var flowGuidanceEnd: Float
     var seedStrategy: MiniMaxMusic3SeedStrategy
     var audioHealth: MiniMaxMusic3AudioHealthReport
     var export: ACEStepAudioExportOptions
@@ -36,8 +45,12 @@ struct MiniMaxMusic3GenerationRecipe: Codable {
         case modelID = "model_id"
         case sourceRepository = "source_repository"
         case sourceRevision = "source_revision"
+        case inputBrief = "input_brief"
         case caption
         case lyrics
+        case composition
+        case lyricPreflightPolicy = "lyric_preflight_policy"
+        case lyricPreflight = "lyric_preflight"
         case durationSeconds = "duration_seconds"
         case requestedMinimumFrames = "requested_minimum_frames"
         case requestedMaximumFrames = "requested_maximum_frames"
@@ -50,7 +63,12 @@ struct MiniMaxMusic3GenerationRecipe: Codable {
         case outputSampleRate = "output_sample_rate"
         case loadingStrategy = "loading_strategy"
         case performanceMode = "performance_mode"
+        case languageModelPrecision = "language_model_precision"
+        case depthDecoderPrecision = "depth_decoder_precision"
         case flowStrategy = "flow_strategy"
+        case flowSolver = "flow_solver"
+        case autoregressiveGuidanceFrames = "autoregressive_guidance_frames"
+        case flowGuidanceEnd = "flow_guidance_end"
         case seedStrategy = "seed_strategy"
         case audioHealth = "audio_health"
         case export

--- a/Sources/MereRunCLI/Support/MiniMaxMusic3LocalComposer.swift
+++ b/Sources/MereRunCLI/Support/MiniMaxMusic3LocalComposer.swift
@@ -1,0 +1,312 @@
+import ArgumentParser
+import Foundation
+import MLX
+import MereRunCore
+
+struct MiniMaxMusic3CompositionReceipt: Codable {
+    static let currentSchemaVersion = 1
+
+    var schemaVersion: Int
+    var createdAt: Date
+    var modelID: String
+    var request: MiniMaxMusic3CompositionRequest
+    var blueprint: MiniMaxMusic3SongBlueprint
+    var song: MiniMaxMusic3ComposedSong
+    var lyricPreflight: MiniMaxMusic3LyricPreflightReport
+
+    enum CodingKeys: String, CodingKey {
+        case schemaVersion = "schema_version"
+        case createdAt = "created_at"
+        case modelID = "model_id"
+        case request
+        case blueprint
+        case song
+        case lyricPreflight = "lyric_preflight"
+    }
+
+    func write(to url: URL) throws {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        try encoder.encode(self).write(to: url, options: .atomic)
+    }
+}
+
+enum MiniMaxMusic3LocalComposer {
+    typealias ChatPass = (ChatRequest) async throws -> ChatResponse
+
+    static func compose(
+        request: MiniMaxMusic3CompositionRequest,
+        modelID: String,
+        modelRoot: String?,
+        requireInstalled: Bool,
+        quiet: Bool
+    ) async throws -> MiniMaxMusic3CompositionReceipt {
+        let normalizedModelID = modelID.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        try TextChat.validate(responseFormat: .jsonObject, modelID: normalizedModelID)
+        guard Gemma4Resources.handles(modelSpec: normalizedModelID)
+                || Q35Resources.profile(for: normalizedModelID) != nil else {
+            throw ValidationError(
+                "--composer-model must select a native Gemma4 or Qwen-family MLX chat model."
+            )
+        }
+
+        let explicitRoot = try modelRoot.map { rawValue -> String in
+            let url = ACEStepCLIHelper.resolveUserPath(rawValue)
+            guard FileManager.default.fileExists(atPath: url.path) else {
+                throw ValidationError("Composer model root not found: \(url.path)")
+            }
+            return url.path
+        }
+        let installedRoot = ManagedModelResolver.resolveInstalledModel(id: normalizedModelID)?.path
+        if requireInstalled, explicitRoot == nil, installedRoot == nil {
+            throw ValidationError(
+                "Composer model '\(normalizedModelID)' is not installed. Run "
+                    + "'mere.run model pull \(normalizedModelID)' explicitly."
+            )
+        }
+        let runtimeRoot = explicitRoot ?? (requireInstalled ? installedRoot : nil)
+        let progressHandler: (@Sendable (ChatProgress) -> Void)?
+        if quiet {
+            progressHandler = nil
+        } else {
+            progressHandler = { progress in
+                guard progress.stage.rawValue != "generating" else { return }
+                CLIStderr.write(
+                    "[composer:\(progress.stage.rawValue)] \(progress.message ?? "")\n"
+                )
+            }
+        }
+
+        if !quiet {
+            CLIStderr.write("Composing MiniMax Music 3 timeline with \(normalizedModelID)\n")
+        }
+        let runPass: (ChatPass) async throws -> MiniMaxMusic3CompositionReceipt = { chat in
+                if !quiet {
+                    CLIStderr.write("Planning MiniMax song timeline\n")
+                }
+                let blueprintPrompt = try MiniMaxMusic3ComposerContract.blueprintPrompt(request)
+                var blueprintResponse = try await chat(Self.chatRequest(
+                    prompt: blueprintPrompt,
+                    maxTokens: 2_048
+                ))
+                var blueprint: MiniMaxMusic3SongBlueprint?
+                for attempt in 0...1 {
+                    do {
+                        let proposed = try decode(
+                            MiniMaxMusic3SongBlueprint.self,
+                            from: blueprintResponse.response,
+                            pass: "blueprint"
+                        )
+                        blueprint = try MiniMaxMusic3ComposerContract.normalize(
+                            blueprint: proposed,
+                            request: request
+                        )
+                        break
+                    } catch {
+                        guard attempt == 0 else { throw error }
+                        if !quiet {
+                            CLIStderr.write("Repairing MiniMax song timeline: \(errorMessage(error))\n")
+                        }
+                        blueprintResponse = try await chat(Self.chatRequest(
+                            prompt: repairPrompt(
+                                phase: "blueprint",
+                                originalPrompt: blueprintPrompt,
+                                previousResponse: blueprintResponse.response,
+                                error: error
+                            ),
+                            maxTokens: 2_048
+                        ))
+                    }
+                }
+                guard let blueprint else {
+                    throw ValidationError("MiniMax composer did not produce a blueprint.")
+                }
+                if !quiet {
+                    CLIStderr.write(
+                        "Composed \(blueprint.sections.count)-section, \(blueprint.bpm) BPM timeline\n"
+                    )
+                }
+
+                if !quiet {
+                    CLIStderr.write("Writing MiniMax lyrics and structured caption\n")
+                }
+                let songPrompt = try MiniMaxMusic3ComposerContract.songPrompt(
+                    request,
+                    blueprint: blueprint
+                )
+                var songResponse = try await chat(Self.chatRequest(
+                    prompt: songPrompt,
+                    maxTokens: 4_096
+                ))
+                var song: MiniMaxMusic3ComposedSong?
+                for attempt in 0...1 {
+                    do {
+                        let proposed = try decode(
+                            MiniMaxMusic3ComposedSong.self,
+                            from: songResponse.response,
+                            pass: "song"
+                        )
+                        song = try MiniMaxMusic3ComposerContract.normalize(
+                            song: proposed,
+                            request: request,
+                            blueprint: blueprint
+                        )
+                        break
+                    } catch {
+                        guard attempt == 0 else { throw error }
+                        if !quiet {
+                            CLIStderr.write("Repairing MiniMax song inputs: \(errorMessage(error))\n")
+                        }
+                        songResponse = try await chat(Self.chatRequest(
+                            prompt: repairPrompt(
+                                phase: "song",
+                                originalPrompt: songPrompt,
+                                previousResponse: songResponse.response,
+                                error: error
+                            ),
+                            maxTokens: 4_096
+                        ))
+                    }
+                }
+                guard let song else {
+                    throw ValidationError("MiniMax composer did not produce finished song inputs.")
+                }
+                let preflight = MiniMaxMusic3LyricPreflight.inspect(
+                    lyrics: song.lyrics,
+                    durationSeconds: request.durationSeconds,
+                    instrumental: request.instrumental,
+                    blueprint: blueprint
+                )
+                return MiniMaxMusic3CompositionReceipt(
+                    schemaVersion: MiniMaxMusic3CompositionReceipt.currentSchemaVersion,
+                    createdAt: Date(),
+                    modelID: normalizedModelID,
+                    request: request,
+                    blueprint: blueprint,
+                    song: song,
+                    lyricPreflight: preflight
+                )
+            }
+
+        let receipt: MiniMaxMusic3CompositionReceipt
+        if Gemma4Resources.handles(modelSpec: normalizedModelID) {
+            let generator = Gemma4Generator(modelId: normalizedModelID)
+            do {
+                receipt = try await runPass { chatRequest in
+                    try await generator.chat(
+                        chatRequest,
+                        modelPath: runtimeRoot,
+                        progressHandler: progressHandler
+                    )
+                }
+                await generator.unload()
+            } catch {
+                await generator.unload()
+                throw error
+            }
+        } else {
+            let generator = Q35Generator(modelId: normalizedModelID)
+            do {
+                receipt = try await runPass { chatRequest in
+                    try await generator.chat(
+                        chatRequest,
+                        modelPath: runtimeRoot,
+                        progressHandler: progressHandler
+                    )
+                }
+                await generator.unload()
+            } catch {
+                await generator.unload()
+                throw error
+            }
+        }
+        MLX.Memory.clearCache()
+        return receipt
+    }
+
+    private static func chatRequest(prompt: String, maxTokens: Int) -> ChatRequest {
+        ChatRequest(
+            messages: [
+                ChatMessage(role: .system, content: MiniMaxMusic3ComposerContract.systemPrompt),
+                ChatMessage(role: .user, content: prompt),
+            ],
+            maxTokens: maxTokens,
+            temperature: 0.4,
+            topP: 0.9,
+            topK: 50,
+            showThinking: false,
+            requiresJSON: true
+        )
+    }
+
+    private static func decode<Value: Decodable>(
+        _ type: Value.Type,
+        from response: String,
+        pass: String
+    ) throws -> Value {
+        do {
+            return try JSONDecoder().decode(Value.self, from: Data(response.utf8))
+        } catch {
+            throw ValidationError(
+                "MiniMax composer \(pass) JSON is invalid: \(decodingDescription(error))"
+            )
+        }
+    }
+
+    private static func repairPrompt(
+        phase: String,
+        originalPrompt: String,
+        previousResponse: String,
+        error: Error
+    ) -> String {
+        """
+        Correct the previous \(phase) JSON. Return exactly one corrected JSON object and no Markdown.
+
+        Validation error:
+        \(errorMessage(error))
+
+        Original contract:
+        \(originalPrompt)
+
+        Previous response:
+        \(previousResponse)
+        """
+    }
+
+    private static func decodingDescription(_ error: Error) -> String {
+        guard let error = error as? DecodingError else {
+            return error.localizedDescription
+        }
+        switch error {
+        case .keyNotFound(let key, let context):
+            return "missing key '\(key.stringValue)' at \(codingPath(context.codingPath))"
+        case .typeMismatch(let type, let context):
+            return "expected \(type) at \(codingPath(context.codingPath)): \(context.debugDescription)"
+        case .valueNotFound(let type, let context):
+            return "missing \(type) at \(codingPath(context.codingPath))"
+        case .dataCorrupted(let context):
+            return "invalid data at \(codingPath(context.codingPath)): \(context.debugDescription)"
+        @unknown default:
+            return "unknown decoding error"
+        }
+    }
+
+    private static func codingPath(_ path: [CodingKey]) -> String {
+        let value = path.map(\.stringValue).joined(separator: ".")
+        return value.isEmpty ? "root" : value
+    }
+
+    private static func errorMessage(_ error: Error) -> String {
+        if let validationError = error as? ValidationError {
+            return validationError.message
+        }
+        if let localizedError = error as? LocalizedError,
+           let description = localizedError.errorDescription,
+           !description.isEmpty
+        {
+            return description
+        }
+        return error.localizedDescription
+    }
+}

--- a/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3Composer.swift
+++ b/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3Composer.swift
@@ -1,0 +1,761 @@
+import Foundation
+
+public enum MiniMaxMusic3SongMeter: String, CaseIterable, Codable, Sendable {
+    case fourFour = "4/4"
+    case threeFour = "3/4"
+    case sixEight = "6/8"
+
+    var beatsPerBar: Int {
+        switch self {
+        case .fourFour:
+            4
+        case .threeFour:
+            3
+        case .sixEight:
+            2
+        }
+    }
+}
+
+public enum MiniMaxMusic3SectionTag: String, CaseIterable, Codable, Sendable {
+    case intro
+    case verse
+    case preChorus = "pre-chorus"
+    case chorus
+    case postChorus = "post-chorus"
+    case bridge
+    case instrumental
+    case solo
+    case outro
+
+    var normallyInstrumental: Bool {
+        self == .instrumental || self == .solo
+    }
+}
+
+public struct MiniMaxMusic3SongSection: Codable, Equatable, Sendable {
+    public var tag: MiniMaxMusic3SectionTag
+    public var approximateBars: Int
+    public var targetLyricLines: Int
+    public var vocalPlan: String
+    public var productionEvents: String
+
+    public init(
+        tag: MiniMaxMusic3SectionTag,
+        approximateBars: Int,
+        targetLyricLines: Int,
+        vocalPlan: String,
+        productionEvents: String
+    ) {
+        self.tag = tag
+        self.approximateBars = approximateBars
+        self.targetLyricLines = targetLyricLines
+        self.vocalPlan = vocalPlan
+        self.productionEvents = productionEvents
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case tag
+        case approximateBars = "approximate_bars"
+        case targetLyricLines = "target_lyric_lines"
+        case vocalPlan = "vocal_plan"
+        case productionEvents = "production_events"
+    }
+}
+
+public struct MiniMaxMusic3SongBlueprint: Codable, Equatable, Sendable {
+    public var bpm: Int
+    public var meter: MiniMaxMusic3SongMeter
+    public var durationUse: String
+    public var sections: [MiniMaxMusic3SongSection]
+
+    public init(
+        bpm: Int,
+        meter: MiniMaxMusic3SongMeter,
+        durationUse: String,
+        sections: [MiniMaxMusic3SongSection]
+    ) {
+        self.bpm = bpm
+        self.meter = meter
+        self.durationUse = durationUse
+        self.sections = sections
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case bpm
+        case meter
+        case durationUse = "duration_use"
+        case sections
+    }
+}
+
+public struct MiniMaxMusic3CompositionRequest: Codable, Equatable, Sendable {
+    public var brief: String
+    public var durationSeconds: Float
+    public var instrumental: Bool
+    public var authoritativeLyrics: String?
+
+    public init(
+        brief: String,
+        durationSeconds: Float,
+        instrumental: Bool,
+        authoritativeLyrics: String? = nil
+    ) {
+        self.brief = brief
+        self.durationSeconds = durationSeconds
+        self.instrumental = instrumental
+        self.authoritativeLyrics = authoritativeLyrics
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case brief
+        case durationSeconds = "duration_seconds"
+        case instrumental
+        case authoritativeLyrics = "authoritative_lyrics"
+    }
+}
+
+public struct MiniMaxMusic3ComposedSong: Codable, Equatable, Sendable {
+    public var title: String
+    public var tags: [String]
+    public var bpm: Int
+    public var language: String
+    public var lyrics: String
+    public var globalMetadata: String
+    public var vocalDetails: String
+    public var arrangement: String
+
+    public init(
+        title: String,
+        tags: [String],
+        bpm: Int,
+        language: String,
+        lyrics: String,
+        globalMetadata: String,
+        vocalDetails: String,
+        arrangement: String
+    ) {
+        self.title = title
+        self.tags = tags
+        self.bpm = bpm
+        self.language = language
+        self.lyrics = lyrics
+        self.globalMetadata = globalMetadata
+        self.vocalDetails = vocalDetails
+        self.arrangement = arrangement
+    }
+
+    public var caption: String {
+        """
+        ### Global Metadata
+        \(globalMetadata)
+
+        ### Vocal Details
+        \(vocalDetails)
+
+        ### Arrangement
+        \(arrangement)
+        """
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case title
+        case tags
+        case bpm
+        case language
+        case lyrics
+        case globalMetadata = "global_metadata"
+        case vocalDetails = "vocal_details"
+        case arrangement
+    }
+}
+
+public enum MiniMaxMusic3CompositionError: LocalizedError, Equatable {
+    case invalid(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalid(let message):
+            "Invalid MiniMax Music 3 composition: \(message)"
+        }
+    }
+}
+
+public enum MiniMaxMusic3LyricIssueSeverity: String, Codable, Equatable, Sendable {
+    case warning
+    case blocker
+}
+
+public enum MiniMaxMusic3LyricPreflightPolicy: String, CaseIterable, Codable, Sendable {
+    case off
+    case warn
+    case strict
+}
+
+public struct MiniMaxMusic3LyricIssue: Codable, Equatable, Sendable {
+    public var id: String
+    public var severity: MiniMaxMusic3LyricIssueSeverity
+    public var message: String
+
+    public init(id: String, severity: MiniMaxMusic3LyricIssueSeverity, message: String) {
+        self.id = id
+        self.severity = severity
+        self.message = message
+    }
+}
+
+public struct MiniMaxMusic3LyricPreflightReport: Codable, Equatable, Sendable {
+    public static let currentSchemaVersion = 1
+
+    public var schemaVersion: Int
+    public var durationSeconds: Float
+    public var instrumental: Bool
+    public var sectionTags: [MiniMaxMusic3SectionTag]
+    public var sungLineCount: Int
+    public var sungWordCount: Int
+    public var issues: [MiniMaxMusic3LyricIssue]
+
+    public init(
+        durationSeconds: Float,
+        instrumental: Bool,
+        sectionTags: [MiniMaxMusic3SectionTag],
+        sungLineCount: Int,
+        sungWordCount: Int,
+        issues: [MiniMaxMusic3LyricIssue]
+    ) {
+        self.schemaVersion = Self.currentSchemaVersion
+        self.durationSeconds = durationSeconds
+        self.instrumental = instrumental
+        self.sectionTags = sectionTags
+        self.sungLineCount = sungLineCount
+        self.sungWordCount = sungWordCount
+        self.issues = issues
+    }
+
+    public var hasBlockers: Bool {
+        issues.contains { $0.severity == .blocker }
+    }
+
+    public var isClean: Bool {
+        issues.isEmpty
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case schemaVersion = "schema_version"
+        case durationSeconds = "duration_seconds"
+        case instrumental
+        case sectionTags = "section_tags"
+        case sungLineCount = "sung_line_count"
+        case sungWordCount = "sung_word_count"
+        case issues
+    }
+}
+
+public enum MiniMaxMusic3ComposerContract {
+    public static let systemPrompt = """
+    You create typed inputs for MiniMax Music 3. Return exactly one JSON object and no Markdown.
+    Keep musical direction separate from lyrical subject. Use only the supported section tags intro,
+    verse, pre-chorus, chorus, post-chorus, bridge, instrumental, solo, and outro. Never put stage
+    directions or production notes in lyrics. Preserve explicit constraints and any authoritative
+    lyrics. Captions must describe an energy arc and instrument lifecycles rather than a static tag
+    list. Do not quote, paraphrase, or summarize lyric lines inside the caption fields. Do not invent
+    an exact key, BPM, singer, or production technique when the brief does not support it.
+    """
+
+    public static func blueprintPrompt(_ request: MiniMaxMusic3CompositionRequest) throws -> String {
+        try validateRequest(request)
+        let requestJSON = try encodedJSONString(request)
+        let range = recommendedSectionRange(durationSeconds: request.durationSeconds)
+        return """
+        Plan the complete song timeline described by this request:
+        \(requestJSON)
+
+        Return this exact JSON shape:
+        {"bpm":96,"meter":"4/4","duration_use":"how the full requested timeline is used","sections":[{"tag":"intro","approximate_bars":4,"target_lyric_lines":0,"vocal_plan":"wordless opening","production_events":"what enters, exits, or changes"}]}
+
+        Requirements:
+        - Use \(range.lowerBound)-\(range.upperBound) ordered sections and end with outro.
+        - BPM must be between 60 and 180. Meter must be 4/4, 3/4, or 6/8.
+        - Fill the requested duration using duration_seconds * bpm / 240 bars for 4/4,
+          / 180 for 3/4, or / 120 for 6/8. Every section needs 1-64 bars; reserve
+          one-bar sections for short-form transitions.
+        - Every vocal section needs a realistic target_lyric_lines budget; instrumental, solo,
+          wordless, and no-lead-vocal sections use zero.
+        - If authoritative_lyrics is present, preserve its exact supported section order instead
+          of the recommended section count, do not add an outro, and copy the actual sung-line
+          count into each target_lyric_lines value.
+        - If instrumental is true, include at least one instrumental section and make every
+          target_lyric_lines value zero.
+        """
+    }
+
+    public static func songPrompt(
+        _ request: MiniMaxMusic3CompositionRequest,
+        blueprint: MiniMaxMusic3SongBlueprint
+    ) throws -> String {
+        try validateRequest(request)
+        let requestJSON = try encodedJSONString(request)
+        let blueprintJSON = try encodedJSONString(blueprint)
+        return """
+        Write the finished MiniMax Music 3 inputs for this request and normalized timeline.
+
+        Request:
+        \(requestJSON)
+
+        Timeline:
+        \(blueprintJSON)
+
+        Return this exact JSON shape:
+        {"title":"short title","tags":["genre","mood","vocal cue"],"bpm":96,"language":"en","lyrics":"[intro]\\n[verse]\\nfirst sung line","global_metadata":"Basic Attributes: ... Global Emotional Progression: ... Application Scenarios & Imagery: ... Sonics & Production Profile: ...","vocal_details":"Vocal Gender & Timbre: ... Vocal Style: ... Harmony/Backing Vocals: ... Vocal FX: ...","arrangement":"Instrument Lifecycle Description (Primary/Secondary Layering): ... Groove & Foundation Progression: ... Embellishments, Textures & Spatial FX: ..."}
+
+        Requirements:
+        - Return 3-6 concise tags and use the timeline BPM exactly.
+        - Put every section tag alone on its own line and follow the exact timeline order.
+        - Meet each vocal section's target_lyric_lines budget with complete sung lines.
+        - If authoritative_lyrics is present, return it unchanged. If instrumental is true, return
+          only supported instrumental section markers and set language to instrumental.
+        - The three caption fields together should be about 250-450 words, concrete, and consistent.
+        - Keep all lyric text out of the three caption fields.
+        """
+    }
+
+    public static func normalize(
+        blueprint: MiniMaxMusic3SongBlueprint,
+        request: MiniMaxMusic3CompositionRequest
+    ) throws -> MiniMaxMusic3SongBlueprint {
+        try validateRequest(request)
+        guard (60...180).contains(blueprint.bpm) else {
+            throw MiniMaxMusic3CompositionError.invalid("blueprint BPM must be between 60 and 180")
+        }
+        let authoritative = request.authoritativeLyrics.map(MiniMaxMusic3LyricPreflight.parse)
+        if let authoritative {
+            guard !authoritative.tags.isEmpty else {
+                throw MiniMaxMusic3CompositionError.invalid(
+                    "authoritative lyrics need supported standalone section tags"
+                )
+            }
+            guard authoritative.tags == blueprint.sections.map(\.tag) else {
+                throw MiniMaxMusic3CompositionError.invalid(
+                    "blueprint section order does not match the authoritative lyrics"
+                )
+            }
+        } else {
+            let range = recommendedSectionRange(durationSeconds: request.durationSeconds)
+            guard range.contains(blueprint.sections.count) else {
+                throw MiniMaxMusic3CompositionError.invalid(
+                    "blueprint needs \(range.lowerBound)-\(range.upperBound) sections for this duration"
+                )
+            }
+            guard blueprint.sections.last?.tag == .outro else {
+                throw MiniMaxMusic3CompositionError.invalid("blueprint must end with outro")
+            }
+            if request.instrumental,
+               !blueprint.sections.contains(where: { $0.tag == .instrumental })
+            {
+                throw MiniMaxMusic3CompositionError.invalid(
+                    "instrumental blueprint needs an instrumental section"
+                )
+            }
+        }
+        guard blueprint.sections.allSatisfy({ (1...64).contains($0.approximateBars) }) else {
+            throw MiniMaxMusic3CompositionError.invalid("every section must contain 1-64 bars")
+        }
+        guard blueprint.sections.allSatisfy({ (0...64).contains($0.targetLyricLines) }) else {
+            throw MiniMaxMusic3CompositionError.invalid("lyric-line targets must be between 0 and 64")
+        }
+
+        let targetBars = Int(round(
+            Double(request.durationSeconds) * Double(blueprint.bpm)
+                / Double(60 * blueprint.meter.beatsPerBar)
+        ))
+        guard targetBars >= blueprint.sections.count,
+              targetBars <= blueprint.sections.count * 64
+        else {
+            throw MiniMaxMusic3CompositionError.invalid(
+                "the selected BPM, meter, and section count cannot fill the requested duration"
+            )
+        }
+
+        var normalized = blueprint
+        normalized.durationUse = normalized.durationUse.trimmingCharacters(in: .whitespacesAndNewlines)
+        normalized.sections = try fitBars(normalized.sections, target: targetBars)
+        for index in normalized.sections.indices {
+            normalized.sections[index].vocalPlan = normalized.sections[index].vocalPlan
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            normalized.sections[index].productionEvents = normalized.sections[index].productionEvents
+                .trimmingCharacters(in: .whitespacesAndNewlines)
+            if let authoritative {
+                normalized.sections[index].targetLyricLines = authoritative.linesBySection[index].count
+            } else if request.instrumental || normalized.sections[index].tag.normallyInstrumental {
+                normalized.sections[index].targetLyricLines = 0
+            } else if normalized.sections[index].targetLyricLines > 0 {
+                normalized.sections[index].targetLyricLines = max(
+                    (normalized.sections[index].approximateBars + 1) / 2,
+                    normalized.sections[index].targetLyricLines
+                )
+            }
+        }
+
+        if !request.instrumental,
+           !normalized.sections.contains(where: { $0.targetLyricLines > 0 })
+        {
+            throw MiniMaxMusic3CompositionError.invalid("a vocal composition needs at least one vocal section")
+        }
+        return normalized
+    }
+
+    public static func normalize(
+        song: MiniMaxMusic3ComposedSong,
+        request: MiniMaxMusic3CompositionRequest,
+        blueprint: MiniMaxMusic3SongBlueprint
+    ) throws -> MiniMaxMusic3ComposedSong {
+        var normalized = song
+        normalized.title = normalized.title.trimmingCharacters(in: .whitespacesAndNewlines)
+        normalized.tags = normalized.tags.map {
+            $0.trimmingCharacters(in: .whitespacesAndNewlines)
+        }.filter { !$0.isEmpty }
+        normalized.language = normalized.language.trimmingCharacters(in: .whitespacesAndNewlines)
+        normalized.globalMetadata = normalized.globalMetadata.trimmingCharacters(in: .whitespacesAndNewlines)
+        normalized.vocalDetails = normalized.vocalDetails.trimmingCharacters(in: .whitespacesAndNewlines)
+        normalized.arrangement = normalized.arrangement.trimmingCharacters(in: .whitespacesAndNewlines)
+        normalized.lyrics = if request.instrumental {
+            blueprint.sections.map { "[\($0.tag.rawValue)]" }.joined(separator: "\n")
+        } else if let authoritativeLyrics = request.authoritativeLyrics {
+            authoritativeLyrics.trimmingCharacters(in: .whitespacesAndNewlines)
+        } else {
+            MiniMaxMusic3LyricPreflight.normalizedTags(in: normalized.lyrics)
+        }
+
+        guard !normalized.title.isEmpty else {
+            throw MiniMaxMusic3CompositionError.invalid("song title is empty")
+        }
+        guard (3...6).contains(normalized.tags.count) else {
+            throw MiniMaxMusic3CompositionError.invalid("song needs 3-6 non-empty tags")
+        }
+        guard normalized.bpm == blueprint.bpm else {
+            throw MiniMaxMusic3CompositionError.invalid("song BPM does not match the blueprint")
+        }
+        guard !normalized.globalMetadata.isEmpty,
+              !normalized.vocalDetails.isEmpty,
+              !normalized.arrangement.isEmpty
+        else {
+            throw MiniMaxMusic3CompositionError.invalid("all three structured caption fields are required")
+        }
+        if request.instrumental {
+            normalized.language = "instrumental"
+            guard normalized.vocalDetails.localizedCaseInsensitiveContains("instrumental")
+                    || normalized.vocalDetails.localizedCaseInsensitiveContains("no vocal")
+            else {
+                throw MiniMaxMusic3CompositionError.invalid(
+                    "instrumental vocal details must state that there are no vocals"
+                )
+            }
+        }
+
+        let report = MiniMaxMusic3LyricPreflight.inspect(
+            lyrics: normalized.lyrics,
+            durationSeconds: request.durationSeconds,
+            instrumental: request.instrumental,
+            blueprint: blueprint
+        )
+        if let blocker = report.issues.first(where: { $0.severity == .blocker }) {
+            throw MiniMaxMusic3CompositionError.invalid(blocker.message)
+        }
+        let caption = normalized.caption.lowercased()
+        for lyricLine in MiniMaxMusic3LyricPreflight.sungLines(in: normalized.lyrics) {
+            let lowered = lyricLine.lowercased()
+            if lowered.count >= 12, caption.contains(lowered) {
+                throw MiniMaxMusic3CompositionError.invalid(
+                    "structured caption reproduces a lyric line"
+                )
+            }
+        }
+        return normalized
+    }
+
+    static func recommendedSectionRange(durationSeconds: Float) -> ClosedRange<Int> {
+        switch durationSeconds {
+        case ...45:
+            2...4
+        case ...90:
+            4...7
+        case ...150:
+            6...10
+        case ...210:
+            8...14
+        default:
+            10...18
+        }
+    }
+
+    private static func validateRequest(_ request: MiniMaxMusic3CompositionRequest) throws {
+        guard !request.brief.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw MiniMaxMusic3CompositionError.invalid("brief is empty")
+        }
+        guard request.durationSeconds >= 10, request.durationSeconds <= 360 else {
+            throw MiniMaxMusic3CompositionError.invalid("composer duration must be 10-360 seconds")
+        }
+        if request.instrumental, request.authoritativeLyrics != nil {
+            throw MiniMaxMusic3CompositionError.invalid(
+                "instrumental composition cannot include authoritative lyrics"
+            )
+        }
+    }
+
+    private static func fitBars(
+        _ sections: [MiniMaxMusic3SongSection],
+        target: Int
+    ) throws -> [MiniMaxMusic3SongSection] {
+        let originalTotal = sections.reduce(0) { $0 + $1.approximateBars }
+        guard originalTotal > 0 else {
+            throw MiniMaxMusic3CompositionError.invalid("blueprint bar total is zero")
+        }
+        let scaled = sections.map {
+            Double(target * $0.approximateBars) / Double(originalTotal)
+        }
+        var bars = scaled.map { min(64, max(1, Int($0.rounded(.down)))) }
+        while bars.reduce(0, +) < target {
+            guard let index = bars.indices.filter({ bars[$0] < 64 }).max(by: {
+                scaled[$0] - Double(bars[$0]) < scaled[$1] - Double(bars[$1])
+            }) else {
+                throw MiniMaxMusic3CompositionError.invalid("could not fit section bars")
+            }
+            bars[index] += 1
+        }
+        while bars.reduce(0, +) > target {
+            guard let index = bars.indices.filter({ bars[$0] > 1 }).max(by: {
+                Double(bars[$0]) - scaled[$0] < Double(bars[$1]) - scaled[$1]
+            }) else {
+                throw MiniMaxMusic3CompositionError.invalid("could not fit section bars")
+            }
+            bars[index] -= 1
+        }
+        return zip(sections, bars).map { section, fittedBars in
+            var fitted = section
+            let ratio = Double(fittedBars) / Double(section.approximateBars)
+            fitted.approximateBars = fittedBars
+            if section.targetLyricLines > 0 {
+                fitted.targetLyricLines = min(64, max(1, Int(round(Double(section.targetLyricLines) * ratio))))
+            }
+            return fitted
+        }
+    }
+
+    private static func encodedJSONString<T: Encodable>(_ value: T) throws -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        return String(decoding: try encoder.encode(value), as: UTF8.self)
+    }
+}
+
+public enum MiniMaxMusic3LyricPreflight {
+    struct ParsedLyrics {
+        var tags: [MiniMaxMusic3SectionTag]
+        var linesBySection: [[String]]
+        var untaggedLines: [String]
+        var issues: [MiniMaxMusic3LyricIssue]
+    }
+
+    public static func inspect(
+        lyrics: String,
+        durationSeconds: Float,
+        instrumental: Bool,
+        blueprint: MiniMaxMusic3SongBlueprint? = nil
+    ) -> MiniMaxMusic3LyricPreflightReport {
+        let parsed = parse(lyrics)
+        let lines = sungLines(in: lyrics)
+        let hasNonLatin = lines.joined().unicodeScalars.contains {
+            CharacterSet.letters.contains($0) && !$0.isASCII
+        }
+        let words = lines.reduce(0) { $0 + wordCount(in: $1) }
+        var issues = parsed.issues
+
+        if instrumental {
+            if !lines.isEmpty {
+                issues.append(.init(
+                    id: "instrumental_has_lyrics",
+                    severity: .blocker,
+                    message: "instrumental input contains sung lyric lines"
+                ))
+            }
+            if !parsed.tags.contains(.instrumental) {
+                issues.append(.init(
+                    id: "instrumental_tag_missing",
+                    severity: .warning,
+                    message: "instrumental input should include an [instrumental] section"
+                ))
+            }
+        } else {
+            let minimums = minimumCoverage(for: durationSeconds)
+            if lines.count < minimums.lines {
+                issues.append(.init(
+                    id: "lyrics_underfilled_lines",
+                    severity: .warning,
+                    message: "lyrics have \(lines.count) sung lines; about \(minimums.lines) are recommended for a \(Int(durationSeconds))-second upper bound"
+                ))
+            }
+            if !hasNonLatin, words < minimums.words {
+                issues.append(.init(
+                    id: "lyrics_underfilled_words",
+                    severity: .warning,
+                    message: "lyrics have \(words) sung words; about \(minimums.words) are recommended for this duration"
+                ))
+            }
+            if parsed.tags.isEmpty {
+                issues.append(.init(
+                    id: "lyrics_sections_missing",
+                    severity: .warning,
+                    message: "lyrics have no supported section tags"
+                ))
+            }
+            if durationSeconds >= 120, parsed.tags.last != .outro {
+                issues.append(.init(
+                    id: "lyrics_outro_missing",
+                    severity: .warning,
+                    message: "long-song lyrics should end with an [outro] section"
+                ))
+            }
+        }
+
+        if !parsed.untaggedLines.isEmpty, !parsed.tags.isEmpty {
+            issues.append(.init(
+                id: "lyrics_untagged_content",
+                severity: .warning,
+                message: "lyrics contain sung lines before the first section tag"
+            ))
+        }
+
+        if let blueprint {
+            let expected = blueprint.sections.map(\.tag)
+            if parsed.tags != expected {
+                issues.append(.init(
+                    id: "lyrics_section_sequence_mismatch",
+                    severity: .blocker,
+                    message: "lyric section order does not match the composed timeline"
+                ))
+            } else {
+                for (index, pair) in zip(blueprint.sections, parsed.linesBySection).enumerated() {
+                    let (section, sectionLines) = pair
+                    if sectionLines.count < section.targetLyricLines {
+                        issues.append(.init(
+                            id: "lyrics_section_\(index + 1)_underfilled",
+                            severity: .blocker,
+                            message: "section \(index + 1) [\(section.tag.rawValue)] has \(sectionLines.count) sung lines but the timeline requires \(section.targetLyricLines)"
+                        ))
+                    }
+                    let maximum = section.targetLyricLines == 0
+                        ? 0
+                        : section.targetLyricLines + max(2, section.targetLyricLines / 2)
+                    if sectionLines.count > maximum {
+                        issues.append(.init(
+                            id: "lyrics_section_\(index + 1)_overfilled",
+                            severity: .blocker,
+                            message: "section \(index + 1) [\(section.tag.rawValue)] has \(sectionLines.count) sung lines but the timeline allows at most \(maximum)"
+                        ))
+                    }
+                }
+            }
+        }
+
+        return MiniMaxMusic3LyricPreflightReport(
+            durationSeconds: durationSeconds,
+            instrumental: instrumental,
+            sectionTags: parsed.tags,
+            sungLineCount: lines.count,
+            sungWordCount: words,
+            issues: uniqueIssues(issues)
+        )
+    }
+
+    public static func normalizedTags(in lyrics: String) -> String {
+        lyrics.split(whereSeparator: \.isNewline).map { rawLine in
+            let line = rawLine.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard let tag = tag(forStandaloneLine: line) else { return line }
+            return "[\(tag.rawValue)]"
+        }.joined(separator: "\n")
+    }
+
+    static func parse(_ lyrics: String) -> ParsedLyrics {
+        var tags: [MiniMaxMusic3SectionTag] = []
+        var linesBySection: [[String]] = []
+        var untaggedLines: [String] = []
+        var issues: [MiniMaxMusic3LyricIssue] = []
+        var currentSection: Int?
+
+        for rawLine in lyrics.split(omittingEmptySubsequences: false, whereSeparator: \.isNewline) {
+            let line = String(rawLine).trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !line.isEmpty else { continue }
+            if let tag = tag(forStandaloneLine: line) {
+                tags.append(tag)
+                linesBySection.append([])
+                currentSection = linesBySection.count - 1
+                continue
+            }
+            if line.hasPrefix("[") || line.hasSuffix("]") {
+                issues.append(.init(
+                    id: "lyrics_unsupported_or_inline_tag",
+                    severity: .blocker,
+                    message: "unsupported or inline lyric tag: \(line)"
+                ))
+                continue
+            }
+            if let currentSection {
+                linesBySection[currentSection].append(line)
+            } else {
+                untaggedLines.append(line)
+            }
+        }
+
+        let lowered = lyrics.lowercased()
+        for placeholder in ["[end]", "[lyrics]", "[lyritic]", "[end song]"] where lowered.contains(placeholder) {
+            issues.append(.init(
+                id: "lyrics_placeholder_tag",
+                severity: .blocker,
+                message: "lyrics contain unsupported placeholder \(placeholder)"
+            ))
+        }
+        return ParsedLyrics(
+            tags: tags,
+            linesBySection: linesBySection,
+            untaggedLines: untaggedLines,
+            issues: issues
+        )
+    }
+
+    static func sungLines(in lyrics: String) -> [String] {
+        let parsed = parse(lyrics)
+        return parsed.untaggedLines + parsed.linesBySection.flatMap { $0 }
+    }
+
+    private static func tag(forStandaloneLine line: String) -> MiniMaxMusic3SectionTag? {
+        guard line.first == "[", line.last == "]", line.count >= 3 else { return nil }
+        let value = line.dropFirst().dropLast()
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        return MiniMaxMusic3SectionTag(rawValue: value)
+    }
+
+    private static func wordCount(in line: String) -> Int {
+        line.split { character in
+            character.isWhitespace || character.isPunctuation || character.isSymbol
+        }.count
+    }
+
+    private static func minimumCoverage(for durationSeconds: Float) -> (lines: Int, words: Int) {
+        switch durationSeconds {
+        case ...30:
+            (2, 12)
+        case ...60:
+            (6, 24)
+        case ...120:
+            (10, 52)
+        default:
+            (12, 60)
+        }
+    }
+
+    private static func uniqueIssues(_ issues: [MiniMaxMusic3LyricIssue]) -> [MiniMaxMusic3LyricIssue] {
+        var seen: Set<String> = []
+        return issues.filter { seen.insert($0.id).inserted }
+    }
+}

--- a/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3ModelLoader.swift
+++ b/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3ModelLoader.swift
@@ -36,20 +36,52 @@ public enum MiniMaxMusic3PerformanceMode: String, CaseIterable, Codable, Sendabl
     case q8
     /// Optimized graph with affine 4-bit autoregressive weights.
     case q4
+    /// Optimized graph with an affine 8-bit global language model and BF16 depth decoder.
+    case q8LM = "q8-lm"
+    /// Optimized graph with an affine 4-bit global language model and BF16 depth decoder.
+    case q4LM = "q4-lm"
 
-    var quantizationBits: Int? {
+    public var languageModelPrecision: MiniMaxMusic3WeightPrecision {
         switch self {
         case .reference, .optimized:
-            nil
+            .bfloat16
+        case .q8, .q8LM:
+            .affineQ8
+        case .q4, .q4LM:
+            .affineQ4
+        }
+    }
+
+    public var depthDecoderPrecision: MiniMaxMusic3WeightPrecision {
+        switch self {
+        case .reference, .optimized, .q8LM, .q4LM:
+            .bfloat16
         case .q8:
-            8
+            .affineQ8
         case .q4:
-            4
+            .affineQ4
         }
     }
 
     var usesOptimizedGraph: Bool {
         self != .reference
+    }
+}
+
+public enum MiniMaxMusic3WeightPrecision: String, Codable, Sendable, Equatable {
+    case bfloat16 = "bf16"
+    case affineQ8 = "affine-q8"
+    case affineQ4 = "affine-q4"
+
+    var quantizationBits: Int? {
+        switch self {
+        case .bfloat16:
+            nil
+        case .affineQ8:
+            8
+        case .affineQ4:
+            4
+        }
     }
 }
 
@@ -107,13 +139,11 @@ public enum MiniMaxMusic3ModelLoader {
             languageModel.prepareCompactSemanticHead()
             languageModel.prepareFusedProjections()
         }
-        if let bits = performanceMode.quantizationBits {
-            quantizeAutoregressive(
-                languageModel: languageModel,
-                depthDecoder: depthDecoder,
-                bits: bits
-            )
-        }
+        applyAutoregressiveQuantization(
+            languageModel: languageModel,
+            depthDecoder: depthDecoder,
+            performanceMode: performanceMode
+        )
         let tokenizer = try ACEStep5HzLMTokenizer.load(
             from: resources.tokenizerURL,
             requireAudioCodeTokens: false
@@ -157,14 +187,21 @@ public enum MiniMaxMusic3ModelLoader {
         )
     }
 
-    private static func quantizeAutoregressive(
+    static func applyAutoregressiveQuantization(
         languageModel: MiniMaxMusic3LanguageModel,
         depthDecoder: MiniMaxMusic3DepthDecoder,
-        bits: Int
+        performanceMode: MiniMaxMusic3PerformanceMode
     ) {
-        for model in [languageModel as Module, depthDecoder as Module] {
-            quantize(model: model, bits: bits)
+        var didQuantize = false
+        if let bits = performanceMode.languageModelPrecision.quantizationBits {
+            quantize(model: languageModel, bits: bits)
+            didQuantize = true
         }
+        if let bits = performanceMode.depthDecoderPrecision.quantizationBits {
+            quantize(model: depthDecoder, bits: bits)
+            didQuantize = true
+        }
+        guard didQuantize else { return }
         MLX.eval(languageModel.parameters(), depthDecoder.parameters())
         MLX.Memory.clearCache()
     }

--- a/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3Pipeline.swift
+++ b/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3Pipeline.swift
@@ -13,6 +13,9 @@ public struct MiniMaxMusic3GenerationOptions: Sendable {
     public var guidanceScale: Float
     public var profilingEnabled: Bool
     public var flowStrategy: MiniMaxMusic3FlowStrategy
+    public var flowSolver: MiniMaxMusic3FlowSolver
+    public var autoregressiveGuidanceFrames: Int?
+    public var flowGuidanceEnd: Float
     public var seedStrategy: MiniMaxMusic3SeedStrategy
 
     public init(
@@ -26,6 +29,9 @@ public struct MiniMaxMusic3GenerationOptions: Sendable {
         guidanceScale: Float = 1.7,
         profilingEnabled: Bool = false,
         flowStrategy: MiniMaxMusic3FlowStrategy = .sequential,
+        flowSolver: MiniMaxMusic3FlowSolver = .euler,
+        autoregressiveGuidanceFrames: Int? = nil,
+        flowGuidanceEnd: Float = 1,
         seedStrategy: MiniMaxMusic3SeedStrategy = .legacy
     ) {
         self.caption = caption
@@ -38,6 +44,9 @@ public struct MiniMaxMusic3GenerationOptions: Sendable {
         self.guidanceScale = guidanceScale
         self.profilingEnabled = profilingEnabled
         self.flowStrategy = flowStrategy
+        self.flowSolver = flowSolver
+        self.autoregressiveGuidanceFrames = autoregressiveGuidanceFrames
+        self.flowGuidanceEnd = flowGuidanceEnd
         self.seedStrategy = seedStrategy
     }
 }
@@ -112,6 +121,16 @@ public final class MiniMaxMusic3Pipeline {
         guard options.inferenceSteps > 0 else {
             throw MiniMaxMusic3Error.invalidPrompt("inference steps must be positive")
         }
+        if let guidanceFrames = options.autoregressiveGuidanceFrames,
+           guidanceFrames < 0 || guidanceFrames > MiniMaxMusic3Prompt.maxAudioFrames
+        {
+            throw MiniMaxMusic3Error.invalidPrompt(
+                "autoregressive guidance frames must be between 0 and \(MiniMaxMusic3Prompt.maxAudioFrames)"
+            )
+        }
+        guard (0...1).contains(options.flowGuidanceEnd) else {
+            throw MiniMaxMusic3Error.invalidPrompt("flow guidance end must be between 0 and 1")
+        }
         if let maximumFrames = options.maximumFrames,
            !(1...MiniMaxMusic3Prompt.maxAudioFrames).contains(maximumFrames)
         {
@@ -166,6 +185,8 @@ public final class MiniMaxMusic3Pipeline {
             steps: options.inferenceSteps,
             guidanceScale: options.guidanceScale,
             strategy: options.flowStrategy,
+            solver: options.flowSolver,
+            guidanceEnd: options.flowGuidanceEnd,
             generator: flowGenerator,
             recorder: recorder,
             progress: progress
@@ -196,6 +217,10 @@ public final class MiniMaxMusic3Pipeline {
                 frameCount: frameHiddens.dim(1),
                 chunkCount: flow.windowCount,
                 inferenceSteps: options.inferenceSteps,
+                performanceMode: performanceMode,
+                flowSolver: options.flowSolver,
+                autoregressiveGuidanceFrames: options.autoregressiveGuidanceFrames,
+                flowGuidanceEnd: options.flowGuidanceEnd,
                 totalSeconds: MiniMaxMusic3ProfileRecorder.seconds(since: totalStart),
                 recorder: $0
             )
@@ -239,6 +264,7 @@ public final class MiniMaxMusic3Pipeline {
             maximumFrames: options.maximumFrames,
             languageModel: models.languageModel,
             depthDecoder: models.depthDecoder,
+            autoregressiveGuidanceFrames: options.autoregressiveGuidanceFrames,
             generator: generator,
             recorder: recorder,
             progress: progress
@@ -252,6 +278,8 @@ public final class MiniMaxMusic3Pipeline {
         steps: Int,
         guidanceScale: Float,
         strategy: MiniMaxMusic3FlowStrategy,
+        solver: MiniMaxMusic3FlowSolver,
+        guidanceEnd: Float,
         generator: MLXRandom.RandomState,
         recorder: MiniMaxMusic3ProfileRecorder?,
         progress: (@Sendable (MiniMaxMusic3Progress) -> Void)?
@@ -272,6 +300,8 @@ public final class MiniMaxMusic3Pipeline {
             steps: steps,
             guidanceScale: guidanceScale,
             strategy: strategy,
+            solver: solver,
+            guidanceEnd: guidanceEnd,
             conditionEncoder: models.conditionEncoder,
             transformer: models.transformer,
             generator: generator,
@@ -353,6 +383,7 @@ public final class MiniMaxMusic3Pipeline {
         maximumFrames explicitMaximumFrames: Int?,
         languageModel: MiniMaxMusic3LanguageModel,
         depthDecoder: MiniMaxMusic3DepthDecoder,
+        autoregressiveGuidanceFrames: Int?,
         generator: MLXRandom.RandomState,
         recorder: MiniMaxMusic3ProfileRecorder?,
         progress: (@Sendable (MiniMaxMusic3Progress) -> Void)?
@@ -372,7 +403,7 @@ public final class MiniMaxMusic3Pipeline {
         }
 
         let cacheCapacity = textIDs.dim(1) + maximumFrames + 1
-        let caches = languageModel.makeCache(
+        var caches = languageModel.makeCache(
             capacity: performanceMode.usesOptimizedGraph ? cacheCapacity : nil
         )
         let prefillStart = ContinuousClock.now
@@ -390,18 +421,44 @@ public final class MiniMaxMusic3Pipeline {
         var frameHiddens: [MLXArray] = []
         frameHiddens.reserveCapacity(maximumFrames)
         for frameIndex in 0...maximumFrames {
+            let guidanceEnabled = Self.autoregressiveGuidanceEnabled(
+                generatedFrameCount: frameHiddens.count,
+                guidanceFrames: autoregressiveGuidanceFrames
+            )
+            if !guidanceEnabled, lastHidden.dim(0) == 2 {
+                let rows = caches.compactMap { $0.unbatchedRows(count: 2)?.first }
+                guard rows.count == caches.count else {
+                    throw MiniMaxMusic3Error.invalidPrompt(
+                        "the autoregressive cache cannot transition to conditional-only decoding"
+                    )
+                }
+                caches = rows
+                lastHidden = lastHidden[0..<1]
+                MLX.eval(lastHidden)
+            }
             let samplingStart = ContinuousClock.now
             let logits = languageModel.logits(lastHidden)
             let allowEnd = frameHiddens.count >= minimumFrames
-            let sampled = performanceMode == .reference
-                ? Self.sampleSemanticReference(logits: logits, allowEnd: allowEnd, generator: generator)
-                : Self.sampleSemantic(
+            let sampled: MLXArray
+            if guidanceEnabled {
+                sampled = performanceMode == .reference
+                    ? Self.sampleSemanticReference(logits: logits, allowEnd: allowEnd, generator: generator)
+                    : Self.sampleSemantic(
+                        logits: logits,
+                        compactHead: languageModel.usesCompactSemanticHead,
+                        fullVocabularySize: languageModel.configuration.vocabSize,
+                        allowEnd: allowEnd,
+                        generator: generator
+                    )
+            } else {
+                sampled = Self.sampleSemanticConditional(
                     logits: logits,
                     compactHead: languageModel.usesCompactSemanticHead,
                     fullVocabularySize: languageModel.configuration.vocabSize,
                     allowEnd: allowEnd,
                     generator: generator
                 )
+            }
             let sampledID = sampled.item(Int.self)
             recorder?.record(.semanticSampling, since: samplingStart)
             if sampledID == MiniMaxMusic3Prompt.audioEndTokenID {
@@ -409,11 +466,13 @@ public final class MiniMaxMusic3Pipeline {
             }
 
             let semantic = sampled.asType(.int32) - MLXArray(Int32(MiniMaxMusic3Prompt.audioCodeOffset))
-            let duplicatedSemantic = MLX.repeated(semantic.reshaped(1), count: 2, axis: 0)
+            let semanticBatch = guidanceEnabled
+                ? MLX.repeated(semantic.reshaped(1), count: 2, axis: 0)
+                : semantic.reshaped(1)
             let depthStart = ContinuousClock.now
             let depth = generateDepthCodes(
                 lastHidden: lastHidden,
-                semanticCode: duplicatedSemantic,
+                semanticCode: semanticBatch,
                 languageModel: languageModel,
                 depthDecoder: depthDecoder,
                 generator: generator
@@ -480,6 +539,13 @@ public final class MiniMaxMusic3Pipeline {
             && generatedFrameCount.isMultiple(of: autoregressiveCacheClearInterval)
     }
 
+    static func autoregressiveGuidanceEnabled(
+        generatedFrameCount: Int,
+        guidanceFrames: Int?
+    ) -> Bool {
+        guidanceFrames.map { generatedFrameCount < $0 } ?? true
+    }
+
     static func sampleSemanticReference(
         logits: MLXArray,
         allowEnd: Bool,
@@ -531,6 +597,52 @@ public final class MiniMaxMusic3Pipeline {
             ? restoreFullSemanticVocabulary(guided[0], vocabularySize: fullVocabularySize)
             : guided[0]
         return sampleTopK(samplingLogits, generator: generator)
+    }
+
+    static func sampleSemanticConditional(
+        logits: MLXArray,
+        compactHead: Bool,
+        fullVocabularySize: Int,
+        allowEnd: Bool,
+        generator: MLXRandom.RandomState
+    ) -> MLXArray {
+        let conditional = conditionalSemanticLogits(logits, allowEnd: allowEnd)
+        let samplingLogits = compactHead
+            ? restoreFullSemanticVocabulary(conditional[0], vocabularySize: fullVocabularySize)
+            : conditional[0]
+        return sampleTopK(samplingLogits, generator: generator)
+    }
+
+    static func conditionalSemanticLogits(
+        _ logits: MLXArray,
+        allowEnd: Bool
+    ) -> MLXArray {
+        let vocabulary = logits.dim(-1)
+        if vocabulary == MiniMaxMusic3Prompt.semanticVocabularySize + 1 {
+            guard !allowEnd else { return logits[0..<1].asType(.float32) }
+            return MLX.concatenated(
+                [
+                    MLXArray.full([1, 1], values: MLXArray(-Float.infinity)),
+                    logits[0..<1, 1...].asType(.float32),
+                ],
+                axis: -1
+            )
+        }
+
+        let tokenIndices = MLX.arange(vocabulary, dtype: .int32).reshaped(1, vocabulary)
+        let semanticStart = MLXArray(Int32(MiniMaxMusic3Prompt.audioCodeOffset))
+        let semanticEnd = MLXArray(Int32(
+            MiniMaxMusic3Prompt.audioCodeOffset + MiniMaxMusic3Prompt.semanticVocabularySize
+        ))
+        let allowedSemantic = (tokenIndices .>= semanticStart) .&& (tokenIndices .< semanticEnd)
+        let allowedEnd = allowEnd
+            ? tokenIndices .== MLXArray(Int32(MiniMaxMusic3Prompt.audioEndTokenID))
+            : MLXArray.zeros(tokenIndices.shape, dtype: .bool)
+        return MLX.where(
+            allowedSemantic .|| allowedEnd,
+            logits[0..<1].asType(.float32),
+            MLXArray(-Float.infinity)
+        )
     }
 
     /// The published sampler draws from the full language-model vocabulary
@@ -659,14 +771,23 @@ public final class MiniMaxMusic3Pipeline {
             hiddenParts.append(hidden[0..<1])
             let logits = depthDecoder.logits(hidden, codebookIndex: codebook - 1)
             let conditional = logits[0..<1].asType(.float32)
-            let unconditional = logits[1..<2].asType(.float32)
-            let guided = unconditional + (conditional - unconditional) * MLXArray(Float(1.5))
+            let guided: MLXArray
+            if logits.dim(0) == 2 {
+                let unconditional = logits[1..<2].asType(.float32)
+                guided = unconditional + (conditional - unconditional) * MLXArray(Float(1.5))
+            } else {
+                guided = conditional
+            }
             let sampled = Self.sampleTopK(guided[0], generator: generator)
-            let duplicated = MLX.repeated(sampled.reshaped(1), count: 2, axis: 0)
-            codes.append(duplicated)
+            let sampledBatch = MLX.repeated(
+                sampled.reshaped(1),
+                count: semanticCode.dim(0),
+                axis: 0
+            )
+            codes.append(sampledBatch)
             if codebook < depthDecoder.configuration.numCodebooks - 1 {
                 let embedding = depthDecoder.embedResidualCodes(
-                    duplicated,
+                    sampledBatch,
                     codebookIndex: codebook - 1
                 )
                 sequence.append(depthDecoder.projection(embedding).expandedDimensions(axis: 1))
@@ -717,6 +838,8 @@ public final class MiniMaxMusic3Pipeline {
         steps: Int,
         guidanceScale: Float,
         strategy: MiniMaxMusic3FlowStrategy,
+        solver: MiniMaxMusic3FlowSolver,
+        guidanceEnd: Float,
         conditionEncoder: MiniMaxMusic3ConditionEncoder,
         transformer: MiniMaxMusic3Transformer,
         generator: MLXRandom.RandomState,
@@ -728,6 +851,8 @@ public final class MiniMaxMusic3Pipeline {
                 frameHiddens: frameHiddens,
                 steps: steps,
                 guidanceScale: guidanceScale,
+                solver: solver,
+                guidanceEnd: guidanceEnd,
                 conditionEncoder: conditionEncoder,
                 transformer: transformer,
                 generator: generator,
@@ -740,6 +865,8 @@ public final class MiniMaxMusic3Pipeline {
                 frameHiddens: frameHiddens,
                 steps: steps,
                 guidanceScale: guidanceScale,
+                solver: solver,
+                guidanceEnd: guidanceEnd,
                 conditionEncoder: conditionEncoder,
                 transformer: transformer,
                 generator: generator,
@@ -782,6 +909,7 @@ public final class MiniMaxMusic3Pipeline {
                 dtype: condition.dtype
             )
             let stepSize = MLXArray(1 / Float(steps)).asType(condition.dtype)
+            var previousVelocity: MLXArray?
 
             for step in 0..<steps {
                 let transformerStart = ContinuousClock.now
@@ -795,27 +923,50 @@ public final class MiniMaxMusic3Pipeline {
                     )
                 }
                 let timestep = MLXArray([time]).asType(latents.dtype)
-                let batchedLatents = MLX.concatenated([latents, latents], axis: 0)
-                let batchedTimestep = MLX.repeated(timestep, count: 2, axis: 0)
+                let guidanceEnabled = Self.flowGuidanceEnabled(
+                    step: step,
+                    stepCount: steps,
+                    guidanceEnd: guidanceEnd
+                )
+                let transformerLatents = guidanceEnabled
+                    ? MLX.concatenated([latents, latents], axis: 0)
+                    : latents
+                let transformerTimestep = guidanceEnabled
+                    ? MLX.repeated(timestep, count: 2, axis: 0)
+                    : timestep
                 let velocities = if let preparedCondition {
                     transformer(
-                        latents: batchedLatents,
-                        timestep: batchedTimestep,
-                        preparedCondition: preparedCondition,
+                        latents: transformerLatents,
+                        timestep: transformerTimestep,
+                        preparedCondition: guidanceEnabled
+                            ? preparedCondition
+                            : preparedCondition[0..<1],
                         rotary: rotary
                     )
                 } else {
                     transformer(
-                        latents: batchedLatents,
-                        timestep: batchedTimestep,
-                        condition: batchedCondition,
+                        latents: transformerLatents,
+                        timestep: transformerTimestep,
+                        condition: guidanceEnabled ? batchedCondition : condition,
                         rotary: rotary
                     )
                 }
                 let conditional = velocities[0..<1]
-                let unconditional = velocities[1..<2]
-                let velocity = unconditional + (conditional - unconditional) * MLXArray(guidanceScale)
-                latents = latents + velocity * stepSize
+                let velocity: MLXArray
+                if guidanceEnabled {
+                    let unconditional = velocities[1..<2]
+                    velocity = unconditional
+                        + (conditional - unconditional) * MLXArray(guidanceScale)
+                } else {
+                    velocity = conditional
+                }
+                let integrationVelocity = Self.flowIntegrationVelocity(
+                    velocity,
+                    previous: previousVelocity,
+                    solver: solver
+                )
+                latents = latents + integrationVelocity * stepSize
+                previousVelocity = velocity
                 MLX.eval(latents)
                 recorder?.record(.flowTransformer, since: transformerStart)
                 progress?(.denoise(
@@ -846,6 +997,8 @@ public final class MiniMaxMusic3Pipeline {
         frameHiddens: MLXArray,
         steps: Int,
         guidanceScale: Float,
+        solver: MiniMaxMusic3FlowSolver,
+        guidanceEnd: Float,
         conditionEncoder: MiniMaxMusic3ConditionEncoder,
         transformer: MiniMaxMusic3Transformer,
         generator: MLXRandom.RandomState,
@@ -885,14 +1038,25 @@ public final class MiniMaxMusic3Pipeline {
         ], key: generator).asType(condition.dtype)
         let stepSize = MLXArray(1 / Float(steps)).asType(condition.dtype)
         var rotaryCaches: [Int: (MLXArray, MLXArray)] = [:]
+        var previousVelocity: MLXArray?
 
         for step in 0..<steps {
             let transformerStart = ContinuousClock.now
             let timestep = MLXArray([Float(step) / Float(steps)]).asType(latents.dtype)
-            let batchedLatents = MLX.concatenated([latents, latents], axis: 0)
-            let batchedTimestep = MLX.repeated(timestep, count: 2, axis: 0)
+            let guidanceEnabled = Self.flowGuidanceEnabled(
+                step: step,
+                stepCount: steps,
+                guidanceEnd: guidanceEnd
+            )
+            let transformerLatents = guidanceEnabled
+                ? MLX.concatenated([latents, latents], axis: 0)
+                : latents
+            let transformerTimestep = guidanceEnabled
+                ? MLX.repeated(timestep, count: 2, axis: 0)
+                : timestep
+            let batchCount = guidanceEnabled ? 2 : 1
             let accumulated = MLXArray.zeros(
-                [2, transformer.configuration.inChannels, latentLength],
+                [batchCount, transformer.configuration.inChannels, latentLength],
                 dtype: latents.dtype
             )
             var firstPendingProgressIndex = 0
@@ -906,16 +1070,16 @@ public final class MiniMaxMusic3Pipeline {
                 rotaryCaches[length] = rotary
                 let velocities = if let preparedCondition {
                     transformer(
-                        latents: batchedLatents[0..., 0..., start..<end],
-                        timestep: batchedTimestep,
-                        preparedCondition: preparedCondition[0..., start..<end, 0...],
+                        latents: transformerLatents[0..., 0..., start..<end],
+                        timestep: transformerTimestep,
+                        preparedCondition: preparedCondition[0..<batchCount, start..<end, 0...],
                         rotary: rotary
                     )
                 } else {
                     transformer(
-                        latents: batchedLatents[0..., 0..., start..<end],
-                        timestep: batchedTimestep,
-                        condition: batchedCondition[0..., start..<end, 0...],
+                        latents: transformerLatents[0..., 0..., start..<end],
+                        timestep: transformerTimestep,
+                        condition: batchedCondition[0..<batchCount, start..<end, 0...],
                         rotary: rotary
                     )
                 }
@@ -941,13 +1105,48 @@ public final class MiniMaxMusic3Pipeline {
             }
             let averaged = accumulated / counts
             let conditional = averaged[0..<1]
-            let unconditional = averaged[1..<2]
-            let velocity = unconditional + (conditional - unconditional) * MLXArray(guidanceScale)
-            latents = latents + velocity * stepSize
+            let velocity: MLXArray
+            if guidanceEnabled {
+                let unconditional = averaged[1..<2]
+                velocity = unconditional
+                    + (conditional - unconditional) * MLXArray(guidanceScale)
+            } else {
+                velocity = conditional
+            }
+            let integrationVelocity = Self.flowIntegrationVelocity(
+                velocity,
+                previous: previousVelocity,
+                solver: solver
+            )
+            latents = latents + integrationVelocity * stepSize
+            previousVelocity = velocity
             MLX.eval(latents)
             recorder?.record(.flowTransformer, since: transformerStart)
         }
         return latents
+    }
+
+    static func flowGuidanceEnabled(
+        step: Int,
+        stepCount: Int,
+        guidanceEnd: Float
+    ) -> Bool {
+        precondition(step >= 0 && step < stepCount)
+        let progress = stepCount == 1
+            ? 0
+            : Float(step) / Float(stepCount - 1)
+        return progress <= guidanceEnd
+    }
+
+    static func flowIntegrationVelocity(
+        _ velocity: MLXArray,
+        previous: MLXArray?,
+        solver: MiniMaxMusic3FlowSolver
+    ) -> MLXArray {
+        guard solver == .adamsBashforth2, let previous else {
+            return velocity
+        }
+        return velocity * MLXArray(Float(1.5)) - previous * MLXArray(Float(0.5))
     }
 
     static func overlapAverageStarts(latentLength: Int) -> [Int] {
@@ -970,6 +1169,8 @@ public final class MiniMaxMusic3Pipeline {
         frameHiddens: MLXArray,
         steps: Int,
         guidanceScale: Float,
+        solver: MiniMaxMusic3FlowSolver,
+        guidanceEnd: Float,
         conditionEncoder: MiniMaxMusic3ConditionEncoder,
         transformer: MiniMaxMusic3Transformer,
         generator: MLXRandom.RandomState,
@@ -998,6 +1199,7 @@ public final class MiniMaxMusic3Pipeline {
                 condition.dim(1),
             ], key: generator).asType(condition.dtype)
             let noisePrompt = overlap > 0 ? latents[0..., 0..., 0..<overlap] : nil
+            var previousVelocity: MLXArray?
 
             for step in 0..<steps {
                 let time = Float(step) / Float(steps)
@@ -1015,13 +1217,30 @@ public final class MiniMaxMusic3Pipeline {
                     timestep: timestep,
                     condition: condition
                 )
-                let unconditional = transformer(
-                    latents: latents,
-                    timestep: timestep,
-                    condition: MLXArray.zeros(condition.shape, dtype: condition.dtype)
+                let guidanceEnabled = Self.flowGuidanceEnabled(
+                    step: step,
+                    stepCount: steps,
+                    guidanceEnd: guidanceEnd
                 )
-                let velocity = unconditional + (conditional - unconditional) * MLXArray(guidanceScale)
-                latents = latents + velocity * MLXArray(1 / Float(steps))
+                let velocity: MLXArray
+                if guidanceEnabled {
+                    let unconditional = transformer(
+                        latents: latents,
+                        timestep: timestep,
+                        condition: MLXArray.zeros(condition.shape, dtype: condition.dtype)
+                    )
+                    velocity = unconditional
+                        + (conditional - unconditional) * MLXArray(guidanceScale)
+                } else {
+                    velocity = conditional
+                }
+                let integrationVelocity = Self.flowIntegrationVelocity(
+                    velocity,
+                    previous: previousVelocity,
+                    solver: solver
+                )
+                latents = latents + integrationVelocity * MLXArray(1 / Float(steps))
+                previousVelocity = velocity
                 MLX.eval(latents)
                 progress?(.denoise(
                     chunk: chunkIndex + 1,

--- a/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3Profiler.swift
+++ b/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3Profiler.swift
@@ -1,12 +1,18 @@
 import Foundation
 
 public struct MiniMaxMusic3GenerationProfile: Codable, Sendable, Equatable {
-    public static let currentSchemaVersion = 1
+    public static let currentSchemaVersion = 3
 
     public let schemaVersion: Int
     public let frameCount: Int
     public let chunkCount: Int
     public let inferenceSteps: Int
+    public let performanceMode: MiniMaxMusic3PerformanceMode
+    public let languageModelPrecision: MiniMaxMusic3WeightPrecision
+    public let depthDecoderPrecision: MiniMaxMusic3WeightPrecision
+    public let flowSolver: MiniMaxMusic3FlowSolver
+    public let autoregressiveGuidanceFrames: Int?
+    public let flowGuidanceEnd: Float
     public let totalSeconds: Double
     public let autoregressiveStageSeconds: Double
     public let autoregressiveLoadSeconds: Double
@@ -26,6 +32,10 @@ public struct MiniMaxMusic3GenerationProfile: Codable, Sendable, Equatable {
         frameCount: Int,
         chunkCount: Int,
         inferenceSteps: Int,
+        performanceMode: MiniMaxMusic3PerformanceMode,
+        flowSolver: MiniMaxMusic3FlowSolver,
+        autoregressiveGuidanceFrames: Int?,
+        flowGuidanceEnd: Float,
         totalSeconds: Double,
         recorder: MiniMaxMusic3ProfileRecorder
     ) {
@@ -33,6 +43,12 @@ public struct MiniMaxMusic3GenerationProfile: Codable, Sendable, Equatable {
         self.frameCount = frameCount
         self.chunkCount = chunkCount
         self.inferenceSteps = inferenceSteps
+        self.performanceMode = performanceMode
+        self.languageModelPrecision = performanceMode.languageModelPrecision
+        self.depthDecoderPrecision = performanceMode.depthDecoderPrecision
+        self.flowSolver = flowSolver
+        self.autoregressiveGuidanceFrames = autoregressiveGuidanceFrames
+        self.flowGuidanceEnd = flowGuidanceEnd
         self.totalSeconds = totalSeconds
         self.autoregressiveStageSeconds = recorder.autoregressiveStageSeconds
         self.autoregressiveLoadSeconds = recorder.autoregressiveLoadSeconds

--- a/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3RuntimeOptions.swift
+++ b/Sources/MereRunCore/MiniMaxMusic3/MiniMaxMusic3RuntimeOptions.swift
@@ -9,6 +9,13 @@ public enum MiniMaxMusic3FlowStrategy: String, CaseIterable, Codable, Sendable {
     case overlapAverage = "overlap-average"
 }
 
+public enum MiniMaxMusic3FlowSolver: String, CaseIterable, Codable, Sendable {
+    /// Preserve the released first-order flow integration path.
+    case euler
+    /// Use Euler for the first step, then second-order Adams-Bashforth updates.
+    case adamsBashforth2 = "ab2"
+}
+
 public enum MiniMaxMusic3SeedStrategy: String, CaseIterable, Codable, Sendable {
     /// Preserve the released recipe: autoregressive sampling and flow noise share one stream.
     case legacy

--- a/Sources/MereRunCore/MiniMaxMusic3/README.md
+++ b/Sources/MereRunCore/MiniMaxMusic3/README.md
@@ -10,9 +10,10 @@ This directory contains the native Swift/MLX inference path for MiniMax Music
 3. a 1D flow-matching transformer denoises overlapping 200-frame windows;
 4. the DAC-style vocoder decodes and stitches stereo waveform chunks.
 
-Keep the prompt tokens, code offsets, chunk overlap, Euler schedule, and
-weight-name mapping in parity with the pinned upstream revision declared by
-`MiniMaxMusic3Resources`.
+Keep the default prompt tokens, code offsets, chunk overlap, Euler schedule,
+full-CFG path, and weight-name mapping in parity with the pinned upstream
+revision declared by `MiniMaxMusic3Resources`. Solver and guidance-taper
+experiments must remain explicit options with parity defaults unchanged.
 
 The default `staged` loading strategy releases each stage before loading the
 next one and clears the MLX cache between stages. `resident` loads the complete
@@ -30,12 +31,23 @@ codebook can cross a categorical boundary and change every later semantic
 frame. Seeded code trajectories and lyric transcription, not logit cosine
 alone, are the admission checks for changing either path.
 
-The released flow and seed recipes remain `sequential` and `legacy`.
+Quantization is component-aware. `q8-lm` and `q4-lm` quantize only the global
+language model and keep the residual-depth decoder in BF16; these are the
+preferred quantized experiments for preserving vocal detail. Legacy `q8` and
+`q4` retain whole-autoregressive quantization for compatible maximum
+compression. Profiles and generation recipes record both resolved component
+precisions rather than relying on the mode name alone.
+
+The released flow, solver, CFG, and seed recipes remain `sequential`, `euler`,
+full guidance, and `legacy`.
 `overlap-average` is an opt-in whole-song flow experiment that averages
 overlapping window velocities at each Euler step, then uses bounded DAV decode
 with retained-center stitching. `stage-separated-v1` independently derives the
-autoregressive and flow random streams. The pipeline validates finite output,
-signal level, peak, and stereo integrity before returning audio.
+autoregressive and flow random streams. `ab2` uses Euler for its first update
+and second-order Adams-Bashforth thereafter. Autoregressive and flow CFG
+cutoffs unbatch the conditional row after their explicit boundary. The pipeline
+validates finite output, signal level, peak, and stereo integrity before
+returning audio.
 
 On an M4 Max with 128 GB unified memory and MLX 0.32.1, the PocketAiHub-style
 direct INT8 ConvRot projection was slower than the converted BF16 dense path at

--- a/Sources/MereRunCore/ZImageTurbo/Model/TextEncoder/LLMGeneration/KVCache.swift
+++ b/Sources/MereRunCore/ZImageTurbo/Model/TextEncoder/LLMGeneration/KVCache.swift
@@ -241,6 +241,23 @@ public final class KVCacheStatic: KVCache {
         copy.offset = offset
         return copy
     }
+
+    public func unbatchedRows(count: Int) -> [KVCache]? {
+        guard count > 0,
+              let keys,
+              let values,
+              keys.dim(0) == count,
+              values.dim(0) == count else {
+            return nil
+        }
+        return (0..<count).map { index in
+            let copy = KVCacheStatic(capacity: capacity)
+            copy.keys = keys[index..<(index + 1), 0..., 0..., 0...]
+            copy.values = values[index..<(index + 1), 0..., 0..., 0...]
+            copy.offset = offset
+            return copy
+        }
+    }
 }
 
 public final class KVRaggedBatchCache: KVCache {

--- a/Tests/MereRunCLITests/MusicGenerateCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/MusicGenerateCommandParsingTests.swift
@@ -86,9 +86,12 @@ final class MusicGenerateCommandParsingTests: XCTestCase {
             "--guidance-scale", "1.7",
             "--sample-rate", "32000",
             "--memory-mode", "staged",
-            "--performance-mode", "q8",
+            "--performance-mode", "q8-lm",
             "--sampling-tier", "fast",
             "--flow-strategy", "overlap-average",
+            "--flow-solver", "ab2",
+            "--ar-cfg-frames", "50",
+            "--flow-cfg-end", "0.4",
             "--seed-strategy", "stage-separated-v1",
             "--profile-output", "/tmp/minimax-profile.json",
         ])
@@ -104,12 +107,53 @@ final class MusicGenerateCommandParsingTests: XCTestCase {
         XCTAssertEqual(command.guidanceScale, 1.7)
         XCTAssertEqual(command.miniMaxOutputSampleRate, 32_000)
         XCTAssertEqual(command.miniMaxLoadingStrategy, .staged)
-        XCTAssertEqual(command.miniMaxPerformanceMode, .q8)
+        XCTAssertEqual(command.miniMaxPerformanceMode, .q8LM)
+        XCTAssertEqual(command.miniMaxPerformanceMode?.languageModelPrecision, .affineQ8)
+        XCTAssertEqual(command.miniMaxPerformanceMode?.depthDecoderPrecision, .bfloat16)
         XCTAssertEqual(command.miniMaxSamplingTier, .fast)
         XCTAssertEqual(command.miniMaxFlowStrategy, .overlapAverage)
+        XCTAssertEqual(command.miniMaxFlowSolver, .adamsBashforth2)
+        XCTAssertEqual(command.miniMaxAutoregressiveGuidanceFrames, 50)
+        XCTAssertEqual(command.miniMaxFlowGuidanceEnd, 0.4)
         XCTAssertEqual(command.miniMaxSeedStrategy, .stageSeparatedV1)
         XCTAssertEqual(command.resolvedMiniMaxInferenceSteps, 24)
         XCTAssertEqual(command.miniMaxProfileOutput, "/tmp/minimax-profile.json")
+    }
+
+    func testMusicGenerateParsesMiniMaxLocalComposer() throws {
+        let command = try MusicGenerate.parse([
+            "slow-burn dream pop about finding home",
+            "--model", MiniMaxMusic3Resources.modelID,
+            "--compose",
+            "--composer-model", Gemma4Resources.nanoModelId,
+            "--require-composer-installed",
+            "--composition-output", "/tmp/composition.json",
+            "--lyrics-preflight", "strict",
+            "--duration", "180",
+        ])
+
+        XCTAssertTrue(command.miniMaxCompose)
+        XCTAssertEqual(command.miniMaxComposerModel, Gemma4Resources.nanoModelId)
+        XCTAssertTrue(command.miniMaxRequireComposerInstalled)
+        XCTAssertEqual(command.miniMaxCompositionOutput, "/tmp/composition.json")
+        XCTAssertEqual(command.miniMaxLyricPreflightPolicy, .strict)
+        XCTAssertNoThrow(
+            try command.validateMiniMaxMusic3Options(explicitDurationSeconds: 180)
+        )
+    }
+
+    func testMiniMaxRejectsInvalidExperimentalCutoffs() throws {
+        let command = try MusicGenerate.parse([
+            "deep house",
+            "--model", MiniMaxMusic3Resources.modelID,
+            "--instrumental",
+            "--ar-cfg-frames", "9001",
+            "--flow-cfg-end", "1.1",
+        ])
+
+        XCTAssertThrowsError(
+            try command.validateMiniMaxMusic3Options(explicitDurationSeconds: nil)
+        )
     }
 
     func testMiniMaxSamplingTiersResolveDocumentedStepCounts() throws {

--- a/Tests/MereRunCLITests/MusicServeAndExportTests.swift
+++ b/Tests/MereRunCLITests/MusicServeAndExportTests.swift
@@ -43,6 +43,18 @@ final class MusicServeAndExportTests: XCTestCase {
         XCTAssertEqual(command.port, 8_091)
     }
 
+    func testMusicServeParsesMiniMaxSplitQuantization() throws {
+        let command = try MusicServe.parse([
+            "--model", MiniMaxMusic3Resources.modelID,
+            "--performance-mode", "q4-lm",
+        ])
+
+        XCTAssertEqual(command.miniMaxPerformanceMode, .q4LM)
+        XCTAssertEqual(command.miniMaxPerformanceMode?.languageModelPrecision, .affineQ4)
+        XCTAssertEqual(command.miniMaxPerformanceMode?.depthDecoderPrecision, .bfloat16)
+        XCTAssertEqual(MiniMaxMusic3GenerationRecipe.currentSchemaVersion, 7)
+    }
+
     func testMiniMaxSpeechRequestDecodesReferenceAndNativeControls() throws {
         let request = try JSONDecoder().decode(
             MiniMaxMusic3SpeechRequest.self,
@@ -61,7 +73,11 @@ final class MusicServeAndExportTests: XCTestCase {
                   "minimum_audio_duration": 20,
                   "sampling_tier": "draft",
                   "flow_strategy": "overlap-average",
+                  "flow_solver": "ab2",
+                  "autoregressive_guidance_frames": 50,
+                  "flow_guidance_end": 0.4,
                   "seed_strategy": "stage-separated-v1",
+                  "lyric_preflight": "strict",
                   "num_inference_steps": 24,
                   "guidance_scale": 1.7,
                   "sample_rate": 44100
@@ -76,7 +92,11 @@ final class MusicServeAndExportTests: XCTestCase {
         XCTAssertEqual(request.minimumAudioDuration, 20)
         XCTAssertEqual(request.samplingTier, .draft)
         XCTAssertEqual(request.flowStrategy, .overlapAverage)
+        XCTAssertEqual(request.flowSolver, .adamsBashforth2)
+        XCTAssertEqual(request.autoregressiveGuidanceFrames, 50)
+        XCTAssertEqual(request.flowGuidanceEnd, 0.4)
         XCTAssertEqual(request.seedStrategy, .stageSeparatedV1)
+        XCTAssertEqual(request.lyricPreflight, .strict)
         XCTAssertEqual(request.numInferenceSteps, 24)
         XCTAssertEqual(request.guidanceScale, 1.7)
         XCTAssertEqual(request.sampleRate, 44_100)

--- a/Tests/MereRunCoreTests/MiniMaxMusic3Tests.swift
+++ b/Tests/MereRunCoreTests/MiniMaxMusic3Tests.swift
@@ -1,14 +1,229 @@
 import MLX
+import MLXNN
 import MLXRandom
 import XCTest
 @testable import MereRunCore
 
 final class MiniMaxMusic3Tests: MereRunCoreTestCase {
+    func testComposerNormalizesBlueprintToRequestedBarBudget() throws {
+        let request = MiniMaxMusic3CompositionRequest(
+            brief: "A patient synth-pop song that blooms into a wide final chorus",
+            durationSeconds: 120,
+            instrumental: false
+        )
+        let proposedBlueprint = MiniMaxMusic3SongBlueprint(
+            bpm: 120,
+            meter: .fourFour,
+            durationUse: "build across the full song",
+            sections: [
+                .init(tag: .intro, approximateBars: 4, targetLyricLines: 0, vocalPlan: "wordless", productionEvents: "pads enter"),
+                .init(tag: .verse, approximateBars: 12, targetLyricLines: 8, vocalPlan: "close lead", productionEvents: "bass enters"),
+                .init(tag: .chorus, approximateBars: 12, targetLyricLines: 8, vocalPlan: "stacked lead", productionEvents: "drums widen"),
+                .init(tag: .verse, approximateBars: 12, targetLyricLines: 8, vocalPlan: "close lead", productionEvents: "guitar enters"),
+                .init(tag: .bridge, approximateBars: 8, targetLyricLines: 4, vocalPlan: "restrained", productionEvents: "drums exit"),
+                .init(tag: .chorus, approximateBars: 12, targetLyricLines: 8, vocalPlan: "stacked lead", productionEvents: "full return"),
+                .init(tag: .outro, approximateBars: 4, targetLyricLines: 2, vocalPlan: "single refrain", productionEvents: "layers exit"),
+            ]
+        )
+
+        let normalized = try MiniMaxMusic3ComposerContract.normalize(
+            blueprint: proposedBlueprint,
+            request: request
+        )
+
+        XCTAssertEqual(normalized.sections.reduce(0) { $0 + $1.approximateBars }, 60)
+        XCTAssertEqual(normalized.sections.last?.tag, .outro)
+        XCTAssertTrue(normalized.sections.allSatisfy { (1...64).contains($0.approximateBars) })
+    }
+
+    func testComposerPreservesAuthoritativeLyricsExactly() throws {
+        let lyrics = "[verse]\nKeep these words exactly\n[chorus]\nHold this line\n[outro]\nStay"
+        let request = MiniMaxMusic3CompositionRequest(
+            brief: "intimate acoustic pop",
+            durationSeconds: 60,
+            instrumental: false,
+            authoritativeLyrics: lyrics
+        )
+        let proposedBlueprint = MiniMaxMusic3SongBlueprint(
+            bpm: 120,
+            meter: .fourFour,
+            durationUse: "complete arc",
+            sections: [
+                .init(tag: .verse, approximateBars: 10, targetLyricLines: 1, vocalPlan: "lead", productionEvents: "guitar"),
+                .init(tag: .chorus, approximateBars: 10, targetLyricLines: 1, vocalPlan: "double", productionEvents: "bass"),
+                .init(tag: .outro, approximateBars: 10, targetLyricLines: 1, vocalPlan: "lead", productionEvents: "fade"),
+            ]
+        )
+        let blueprint = try MiniMaxMusic3ComposerContract.normalize(
+            blueprint: proposedBlueprint,
+            request: request
+        )
+        XCTAssertEqual(blueprint.sections.map(\.targetLyricLines), [1, 1, 1])
+
+        let song = MiniMaxMusic3ComposedSong(
+            title: "Stay",
+            tags: ["acoustic", "intimate", "warm"],
+            bpm: 120,
+            language: "en",
+            lyrics: "the model tried to replace this",
+            globalMetadata: "Basic Attributes: acoustic pop. Global Emotional Progression: calm to open. Application Scenarios & Imagery: morning room. Sonics & Production Profile: natural and close.",
+            vocalDetails: "Vocal Gender & Timbre: neutral warm lead. Vocal Style: conversational. Harmony/Backing Vocals: light doubles. Vocal FX: short room.",
+            arrangement: "Instrument Lifecycle Description (Primary/Secondary Layering): guitar throughout, bass enters. Groove & Foundation Progression: restrained pulse. Embellishments, Textures & Spatial FX: soft piano and room tail."
+        )
+
+        let normalized = try MiniMaxMusic3ComposerContract.normalize(
+            song: song,
+            request: request,
+            blueprint: blueprint
+        )
+
+        XCTAssertEqual(normalized.lyrics, lyrics)
+    }
+
+    func testLyricPreflightFlagsSparseLongSongAndUnsupportedTags() {
+        let report = MiniMaxMusic3LyricPreflight.inspect(
+            lyrics: "[lyrics]\njust one line",
+            durationSeconds: 180,
+            instrumental: false
+        )
+
+        XCTAssertTrue(report.issues.contains { $0.id == "lyrics_underfilled_lines" })
+        XCTAssertTrue(report.issues.contains { $0.id == "lyrics_placeholder_tag" && $0.severity == .blocker })
+    }
+
+    func testExperimentalGuidanceCutoffsAndAB2Update() {
+        XCTAssertTrue(MiniMaxMusic3Pipeline.autoregressiveGuidanceEnabled(
+            generatedFrameCount: 49,
+            guidanceFrames: 50
+        ))
+        XCTAssertFalse(MiniMaxMusic3Pipeline.autoregressiveGuidanceEnabled(
+            generatedFrameCount: 50,
+            guidanceFrames: 50
+        ))
+        XCTAssertTrue(MiniMaxMusic3Pipeline.flowGuidanceEnabled(
+            step: 1,
+            stepCount: 5,
+            guidanceEnd: 0.4
+        ))
+        XCTAssertFalse(MiniMaxMusic3Pipeline.flowGuidanceEnabled(
+            step: 2,
+            stepCount: 5,
+            guidanceEnd: 0.4
+        ))
+
+        let current = MLXArray([Float(4), 8])
+        let previous = MLXArray([Float(2), 6])
+        let ab2 = MiniMaxMusic3Pipeline.flowIntegrationVelocity(
+            current,
+            previous: previous,
+            solver: .adamsBashforth2
+        )
+        MLX.eval(ab2)
+        XCTAssertEqual(ab2.asArray(Float.self), [5, 9])
+    }
+
+    func testStaticKVCacheCanDropTheUnconditionalRow() throws {
+        let cache = KVCacheStatic(capacity: 4)
+        _ = cache.update(
+            keys: MLXArray.zeros([2, 1, 1, 2]),
+            values: MLXArray.zeros([2, 1, 1, 2])
+        )
+
+        let rows = try XCTUnwrap(cache.unbatchedRows(count: 2))
+        XCTAssertEqual(rows.count, 2)
+        XCTAssertEqual(rows[0].offset, 1)
+        let updated = rows[0].update(
+            keys: MLXArray.ones([1, 1, 1, 2]),
+            values: MLXArray.ones([1, 1, 1, 2])
+        )
+        XCTAssertEqual(updated.0.shape, [1, 1, 2, 2])
+        XCTAssertEqual(rows[0].offset, 2)
+    }
+
     func testAutoregressiveCacheClearingUsesBoundedIntervals() {
         XCTAssertFalse(MiniMaxMusic3Pipeline.shouldClearAutoregressiveCache(generatedFrameCount: 0))
         XCTAssertFalse(MiniMaxMusic3Pipeline.shouldClearAutoregressiveCache(generatedFrameCount: 63))
         XCTAssertTrue(MiniMaxMusic3Pipeline.shouldClearAutoregressiveCache(generatedFrameCount: 64))
         XCTAssertTrue(MiniMaxMusic3Pipeline.shouldClearAutoregressiveCache(generatedFrameCount: 128))
+    }
+
+    func testPerformanceModesResolveLanguageAndDepthPrecisionIndependently() {
+        XCTAssertEqual(MiniMaxMusic3PerformanceMode.optimized.languageModelPrecision, .bfloat16)
+        XCTAssertEqual(MiniMaxMusic3PerformanceMode.optimized.depthDecoderPrecision, .bfloat16)
+        XCTAssertEqual(MiniMaxMusic3PerformanceMode.q8LM.languageModelPrecision, .affineQ8)
+        XCTAssertEqual(MiniMaxMusic3PerformanceMode.q8LM.depthDecoderPrecision, .bfloat16)
+        XCTAssertEqual(MiniMaxMusic3PerformanceMode.q4LM.languageModelPrecision, .affineQ4)
+        XCTAssertEqual(MiniMaxMusic3PerformanceMode.q4LM.depthDecoderPrecision, .bfloat16)
+        XCTAssertEqual(MiniMaxMusic3PerformanceMode.q8.depthDecoderPrecision, .affineQ8)
+        XCTAssertEqual(MiniMaxMusic3PerformanceMode.q4.depthDecoderPrecision, .affineQ4)
+    }
+
+    func testLanguageModelOnlyQuantizationLeavesDepthDecoderDense() {
+        func models() -> (MiniMaxMusic3LanguageModel, MiniMaxMusic3DepthDecoder) {
+            let languageModel = MiniMaxMusic3LanguageModel(
+                configuration: .init(
+                    vocabSize: 128,
+                    hiddenSize: 64,
+                    intermediateSize: 128,
+                    numHiddenLayers: 1,
+                    numAttentionHeads: 4,
+                    numKeyValueHeads: 2,
+                    headDim: 16,
+                    maxPositionEmbeddings: 16,
+                    rmsNormEps: 1e-6,
+                    ropeParameters: .init(ropeTheta: 10_000)
+                )
+            )
+            let depthDecoder = MiniMaxMusic3DepthDecoder(
+                configuration: .init(
+                    hiddenSize: 64,
+                    numLayers: 1,
+                    numAttentionHeads: 4,
+                    intermediateSize: 128,
+                    audioVocabSize: 128,
+                    numCodebooks: 4,
+                    maxPositionEmbeddings: 8
+                )
+            )
+            return (languageModel, depthDecoder)
+        }
+
+        let split = models()
+        MiniMaxMusic3ModelLoader.applyAutoregressiveQuantization(
+            languageModel: split.0,
+            depthDecoder: split.1,
+            performanceMode: .q4LM
+        )
+        XCTAssertTrue(split.0.leafModules().flattened().contains { $0.1 is QuantizedLinear })
+        XCTAssertFalse(split.1.leafModules().flattened().contains { $0.1 is QuantizedLinear })
+
+        let legacy = models()
+        MiniMaxMusic3ModelLoader.applyAutoregressiveQuantization(
+            languageModel: legacy.0,
+            depthDecoder: legacy.1,
+            performanceMode: .q4
+        )
+        XCTAssertTrue(legacy.0.leafModules().flattened().contains { $0.1 is QuantizedLinear })
+        XCTAssertTrue(legacy.1.leafModules().flattened().contains { $0.1 is QuantizedLinear })
+    }
+
+    func testGenerationProfileRecordsResolvedSplitPrecision() {
+        let profile = MiniMaxMusic3GenerationProfile(
+            frameCount: 250,
+            chunkCount: 2,
+            inferenceSteps: 15,
+            performanceMode: .q8LM,
+            flowSolver: .adamsBashforth2,
+            autoregressiveGuidanceFrames: 50,
+            flowGuidanceEnd: 0.4,
+            totalSeconds: 1,
+            recorder: MiniMaxMusic3ProfileRecorder()
+        )
+
+        XCTAssertEqual(profile.schemaVersion, 3)
+        XCTAssertEqual(profile.performanceMode, .q8LM)
+        XCTAssertEqual(profile.languageModelPrecision, .affineQ8)
+        XCTAssertEqual(profile.depthDecoderPrecision, .bfloat16)
     }
 
     func testInstalledQuantizedSemanticLogitQuality() throws {

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -873,9 +873,29 @@ compact semantic projection, a full-vocabulary sampling view, fused global
 language-model projections, and batched flow guidance. The eight-token residual
 depth prefix is recomputed without projection fusion because its cached/fused
 BF16 path changed seeded codebook choices and caused lyric drift. The opt-in
-`q8` and `q4` modes apply group-64 affine quantization to the autoregressive
-transformers; `q8` is the recommended turbo tier. Flow stays BF16 because
+`q8-lm` and `q4-lm` apply group-64 affine quantization only to the global
+language model while retaining the residual-depth decoder in BF16. They are
+the preferred quantized experiments because depth codebooks directly affect
+vocal detail. Legacy `q8` and `q4` still quantize both autoregressive
+components for compatible maximum compression. Flow stays BF16 because
 installed-checkpoint timing showed its quantized kernels regress.
+
+`--compose` runs a local native Gemma4 or Qwen-family chat model in two
+constrained-JSON passes before loading MiniMax: a bar-aware song blueprint,
+then lyrics and the checkpoint's three-part structured caption. Supplied lyrics
+remain authoritative. The typed composition receipt and lyric-duration
+preflight are stored separately and in schema 7 generation provenance. The
+recipe and schema 3 profile record resolved language-model and depth-decoder
+precision independently.
+Composer weights are unloaded before music inference. The default lyric
+preflight warns because `--duration` is an upper bound rather than a promise;
+`strict` rejects sparse or structurally invalid inputs without silently adding
+an EOS floor.
+
+Euler, full autoregressive CFG, and full flow CFG remain the parity defaults.
+The opt-in `--flow-solver ab2`, `--ar-cfg-frames`, and `--flow-cfg-end`
+controls support reproducible full-song A/B experiments and are recorded in
+recipes and profiles. They are experimental controls, not admission claims.
 
 Generation defaults to `--memory-mode staged`, which releases the language,
 flow, and vocoder weights between stages. `--memory-mode resident` keeps the
@@ -885,7 +905,8 @@ entire stack loaded for repeated work. Staged mode moves the catalog floor to
 SGLang speech route; 44,100 Hz remains the native CLI default. `music serve
 --model music-minimax-music3` exposes the non-streaming `/v1/audio/speech`
 request shape with `input`, `instructions`, `seed`, and `max_new_tokens`, plus
-explicit native duration, step, guidance, and sample-rate controls.
+explicit native duration, step, guidance, solver, CFG-cutoff, lyric-preflight,
+and sample-rate controls.
 
 MiniMax publishes its optional `music-caption-rewriter` agent skill separately
 in the official

--- a/docs/runtime/music.md
+++ b/docs/runtime/music.md
@@ -83,6 +83,16 @@ swift run mere.run music generate \
 
 swift run mere.run model pull music-minimax-music3 --accept-model-license
 swift run mere.run music generate \
+  "slow-burn dream pop about leaving a familiar city and finding home" \
+  --model music-minimax-music3 \
+  --compose \
+  --duration 180 \
+  --lyrics-preflight strict \
+  --performance-mode q8-lm \
+  --sampling-tier fast \
+  --output ./minimax-composed-song.wav
+
+swift run mere.run music generate \
   "cinematic synth-pop, female lead, 118 bpm, wide guitars" \
   --model music-minimax-music3 \
   --lyrics-file ./lyrics.txt \
@@ -91,7 +101,7 @@ swift run mere.run music generate \
   --sampling-tier fast \
   --seed 7 \
   --memory-mode staged \
-  --performance-mode q8 \
+  --performance-mode q8-lm \
   --output ./minimax-song.wav
 
 swift run mere.run music generate \
@@ -106,7 +116,7 @@ swift run mere.run music generate \
 swift run mere.run music serve \
   --model music-minimax-music3 \
   --memory-mode resident \
-  --performance-mode q8 \
+  --performance-mode q8-lm \
   --port 8080
 
 curl http://127.0.0.1:8080/v1/audio/speech \
@@ -179,14 +189,46 @@ swift run mere.run music separate ./noisy.wav \
 ```
 
 MiniMax Music 3 keeps `--flow-strategy sequential` and
-`--seed-strategy legacy` as its released defaults. The experimental
+`--seed-strategy legacy` as its released defaults. `--compose` adds a local,
+two-pass constrained-JSON writer before music inference: the first pass plans a
+bar-aware timeline, and the second writes the structured three-part caption and
+lyrics against that timeline. Existing `--lyrics` or `--lyrics-file` content is
+authoritative and is preserved exactly; `--instrumental` produces section-only
+lyrics. Each phase has one bounded validation-guided repair attempt. The writer
+is unloaded before MiniMax weights load. Its typed blueprint,
+finished inputs, model ID, and lyric preflight are saved to
+`<output>.composition.json` and embedded in the generation recipe. Use
+`--require-composer-installed` to prevent implicit composer-model download.
+
+`--duration` remains an output upper bound: MiniMax may emit EOS earlier. The
+default `--lyrics-preflight warn` reports sparse lyrics, missing long-form
+structure, unsupported tags, and composed section-budget mismatches before the
+checkpoint loads. `strict` rejects every issue, while `off` bypasses the check.
+Supplying a duration floor still masks EOS; preflight does not silently force
+one for sparse lyrics.
+
+The default `--performance-mode optimized` keeps the global language model and
+residual-depth decoder in BF16. `q8-lm` and `q4-lm` quantize only the global
+language model while preserving BF16 depth codebooks and are the preferred
+quantized experiments. Legacy `q8` and `q4` continue to quantize both
+autoregressive components for compatible maximum compression. Recipes and
+profiles record the resolved precision of each component.
+
+The experimental
 `overlap-average` strategy denoises one song-length latent and averages the
 velocities from overlapping flow windows at every Euler step; it then decodes
 the long latent in bounded DAV chunks. `stage-separated-v1` derives stable,
 independent autoregressive and flow random streams so changes in one stage do
-not perturb the other. Both choices are recorded in schema 5 recipe JSON.
-The speech-compatible HTTP route accepts the same choices as
-`flow_strategy` and `seed_strategy`.
+not perturb the other. The default solver remains Euler with CFG active across
+every autoregressive frame and flow step. `--flow-solver ab2` uses Euler for its
+first update and second-order Adams-Bashforth thereafter;
+`--ar-cfg-frames 50` switches later autoregressive decoding to the conditional
+row; `--flow-cfg-end 0.4` does the same after 40% of flow steps. These are
+opt-in A/B controls, not quality or speed presets. Schema 7 recipe JSON and
+schema 3 profiles record solver, guidance, performance mode, and resolved LM
+and depth precision. The speech-compatible HTTP route accepts
+the corresponding `flow_solver`, `autoregressive_guidance_frames`,
+`flow_guidance_end`, and `lyric_preflight` fields.
 
 Optimized MiniMax modes periodically return completed autoregressive attention
 buffers to MLX while preserving live KV state. This bounds unified-memory use


### PR DESCRIPTION
## Summary

- add an opt-in local MiniMax Music 3 composer backed by native Gemma4 or Qwen chat models, with typed song blueprints, structured captions, lyric preflight, repair, and durable composition receipts
- add opt-in AB2 flow integration plus autoregressive and flow CFG cutoffs, with every resolved control recorded in generation recipes, profiles, and the resident speech API
- add `q8-lm` and `q4-lm` mixed-precision modes that quantize the global language model while retaining the residual-depth decoder in BF16
- document and test the new CLI, provenance, server-health, and compatibility contracts

## Compatibility

- `optimized` remains the default performance mode
- legacy `q8` and `q4` continue to quantize the whole autoregressive stack
- Euler integration and full CFG remain the defaults
- supplied lyrics remain authoritative when composition is enabled
- no vendored runtime artifacts changed

## Validation

- `./scripts/check.sh` — strict lint, build, CLI help/hygiene sweeps, and 3,125 tests with 223 checkpoint-dependent skips and 0 failures
- `pnpm docs:build`
- focused MiniMax/CLI suites — 91 tests executed, 8 checkpoint-dependent skips, 0 failures
- installed-checkpoint `q8-lm` diagnostic smoke — schema-7 recipe and schema-3 profile resolved LM `affine-q8` plus depth `bf16`
- installed-checkpoint composed song — 1,500 frames, 30 Euler steps, 60.07-second 44.1 kHz stereo WAV; lyric preflight and audio-health receipts passed
