### PR TITLE
Fix Nemotron 3.5 Lightning tool-call parsing and stopping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,14 @@ The format is based on Keep a Changelog.
   tool schemas into native training templates, training on typed assistant
   tool-call targets, fingerprinting complete messages and schemas, and
   deduplicating complete controller states instead of first-user text.
+- fixed Nemotron 3.5 Lightning function calling across native chat and
+  `api serve`: the runtime now parses the checkpoint's Qwen-style XML protocol,
+  stops final-target and DSpark decoding after the first complete call when
+  parallel calls are disabled, removes protocol markup from visible content,
+  validates emitted calls against the advertised schema, and reports OpenAI
+  `finish_reason: "tool_calls"`. Canonical managed-model IDs now resolve to the
+  same installed path during real server startup that preflight reports, and
+  native requests preserve `tool_choice` and `parallel_tool_calls` policy.
 - added pinned LiquidAI DSpark companions for LFM2.5 1.2B Instruct, 2.6B,
   and 8B-A1B. The native Swift/MLX runtime captures five configured target-layer
   outputs, runs the non-causal diffusion draft block, drafts

--- a/Sources/MereRunCLI/Commands/APIServeCommand.swift
+++ b/Sources/MereRunCLI/Commands/APIServeCommand.swift
@@ -361,6 +361,17 @@ struct APIServe: AsyncParsableCommand {
             return ManagedModelResolver.resolveInstalledModel(id: MuseGlimmerResources.modelId)?.path
         case .textChatNemotronH:
             if let explicit = model {
+                if NemotronHResources.handles(modelSpec: explicit) {
+                    guard let installed = ManagedModelResolver.resolveInstalledModel(
+                        id: NemotronHResources.modelID
+                    ) else {
+                        throw ValidationError(
+                            "Model '\(NemotronHResources.modelID)' is not installed. Run "
+                                + "'mere.run model pull \(NemotronHResources.modelID)' first."
+                        )
+                    }
+                    return installed.path
+                }
                 return explicit
             }
             return ManagedModelResolver.resolveInstalledModel(id: NemotronHResources.modelID)?.path
@@ -2528,13 +2539,28 @@ enum APIServerContract {
         let topP = try validateTopP(openaiRequest.top_p)
         let minP = try validateMinP(openaiRequest.min_p)
         let tools = try toolDefinitions(from: openaiRequest, capabilities: capabilities)
+        let toolChoice = try chatToolChoice(from: openaiRequest, capabilities: capabilities)
+        let parallelToolCalls = openaiRequest.parallel_tool_calls ?? true
         let requiresJSON = try requiresJSONResponseFormat(
             openaiRequest.response_format,
             capabilities: capabilities
         )
 
-        let messages = try openaiRequest.messages.map { msg in
+        var messages = try openaiRequest.messages.map { msg in
             try chatMessage(from: msg, capabilities: capabilities)
+        }
+        if let instruction = toolChoiceInstruction(
+            choice: toolChoice,
+            parallelToolCalls: parallelToolCalls,
+            tools: tools
+        ) {
+            if let systemIndex = messages.firstIndex(where: { $0.role == .system }) {
+                messages[systemIndex].content = [messages[systemIndex].content, instruction]
+                    .filter { !$0.isEmpty }
+                    .joined(separator: "\n\n")
+            } else {
+                messages.insert(ChatMessage(role: .system, content: instruction), at: 0)
+            }
         }
 
         let lora: LoRA?
@@ -2596,6 +2622,8 @@ enum APIServerContract {
             lora: lora,
             requiresJSON: requiresJSON,
             tools: tools,
+            toolChoice: toolChoice,
+            parallelToolCalls: parallelToolCalls,
             stopSequences: openaiRequest.stop?.values ?? [],
             maxContextTokens: contextSize,
             logprobCapture: logprobCapture
@@ -2864,7 +2892,15 @@ enum APIServerContract {
         capabilities: APIEngineCapabilities
     ) throws -> [ToolDefinition]? {
         guard let tools = request.tools, !tools.isEmpty else {
-            return nil
+            switch request.tool_choice {
+            case .mode("required")?, .function(_)?:
+                throw APIRequestValidationError.invalidField(
+                    "tool_choice",
+                    "requires at least one function in tools"
+                )
+            default:
+                return nil
+            }
         }
         guard capabilities.supportsTools else {
             throw APIRequestValidationError.invalidField("tools", "tools are not supported by this engine")
@@ -2888,6 +2924,53 @@ enum APIServerContract {
             throw APIRequestValidationError.invalidField("tool_choice", "unsupported object shape")
         case .mode(let value)?:
             throw APIRequestValidationError.invalidField("tool_choice", "unsupported mode '\(value)'")
+        }
+    }
+
+    private static func chatToolChoice(
+        from request: OpenAIChatRequest,
+        capabilities: APIEngineCapabilities
+    ) throws -> ChatToolChoice {
+        guard request.tool_choice != nil else { return .auto }
+        guard capabilities.supportsToolChoice else {
+            throw APIRequestValidationError.invalidField(
+                "tool_choice",
+                "tool choice is not supported by this engine"
+            )
+        }
+        switch request.tool_choice {
+        case nil, .mode("auto")?, .mode("none")?:
+            return .auto
+        case .mode("required")?:
+            return .required
+        case .function(let name)?:
+            return .function(name)
+        case .custom?:
+            throw APIRequestValidationError.invalidField("tool_choice", "unsupported object shape")
+        case .mode(let value)?:
+            throw APIRequestValidationError.invalidField("tool_choice", "unsupported mode '\(value)'")
+        }
+    }
+
+    private static func toolChoiceInstruction(
+        choice: ChatToolChoice,
+        parallelToolCalls: Bool,
+        tools: [ToolDefinition]?
+    ) -> String? {
+        guard tools?.isEmpty == false else { return nil }
+        switch choice {
+        case .auto where !parallelToolCalls:
+            return "If you call a function, call at most one provided function."
+        case .required where parallelToolCalls:
+            return "You must call one or more provided functions. Do not answer without a function call."
+        case .required:
+            return "You must call exactly one provided function. Do not answer without a function call."
+        case .function(let name) where parallelToolCalls:
+            return "You must call the provided function '\(name)' at least once. Do not call any other function."
+        case .function(let name):
+            return "You must call the provided function '\(name)' exactly once. Do not call any other function."
+        case .auto:
+            return nil
         }
     }
 
@@ -4972,6 +5055,11 @@ actor CodeGenServer {
             }
         }
         let result = try await lease.chat(request, progressHandler: nil)
+        let responseToolCalls = openAIToolCalls(
+            from: result.toolCalls,
+            tools: request.tools,
+            parallelToolCalls: request.parallelToolCalls
+        )
 
         let response = OpenAIChatResponse(
             id: "chatcmpl-\(UUID().uuidString.prefix(8))",
@@ -4985,9 +5073,12 @@ actor CodeGenServer {
                         role: "assistant",
                         content: result.response,
                         reasoning_content: result.reasoningContent,
-                        tool_calls: openAIToolCalls(from: result.toolCalls, tools: request.tools)
+                        tool_calls: responseToolCalls
                     ),
-                    finish_reason: Self.openAIFinishReason(for: result),
+                    finish_reason: Self.openAIFinishReason(
+                        for: result,
+                        hasToolCalls: responseToolCalls?.isEmpty == false
+                    ),
                     logprobs: OpenAIChatLogprobs(result.logprobs)
                 )
             ],
@@ -5576,8 +5667,12 @@ actor CodeGenServer {
                         }
                     }
                 }
-                if let toolCalls = openAIToolCalls(from: result.toolCalls, tools: request.tools),
-                   !toolCalls.isEmpty {
+                let responseToolCalls = openAIToolCalls(
+                    from: result.toolCalls,
+                    tools: request.tools,
+                    parallelToolCalls: request.parallelToolCalls
+                )
+                if let toolCalls = responseToolCalls, !toolCalls.isEmpty {
                     let chunk = OpenAIChatResponse(
                         id: id,
                         object: "chat.completion.chunk",
@@ -5631,7 +5726,10 @@ actor CodeGenServer {
                         OpenAIChatChoice(
                             index: 0,
                             delta: OpenAIChatDelta(),
-                            finish_reason: Self.openAIFinishReason(for: result)
+                            finish_reason: Self.openAIFinishReason(
+                                for: result,
+                                hasToolCalls: responseToolCalls?.isEmpty == false
+                            )
                         )
                     ]
                 )
@@ -5687,11 +5785,18 @@ actor CodeGenServer {
 
     private nonisolated func openAIToolCalls(
         from toolCalls: [ToolCall]?,
-        tools: [ToolDefinition]?
+        tools: [ToolDefinition]?,
+        parallelToolCalls: Bool = true
     ) -> [OpenAIChatToolCall]? {
-        guard let toolCalls, !toolCalls.isEmpty else { return nil }
-        return toolCalls.enumerated().map { index, call in
-            let parameterTypes = tools?
+        guard let toolCalls, !toolCalls.isEmpty, let tools, !tools.isEmpty else { return nil }
+        let validated = ToolCallPolicy.validatedCalls(
+            toolCalls,
+            tools: tools,
+            parallelToolCalls: parallelToolCalls
+        )
+        guard !validated.isEmpty else { return nil }
+        return validated.enumerated().map { index, call in
+            let parameterTypes = tools
                 .first(where: { $0.name == call.name })?
                 .parameters
                 .mapValues(\.type) ?? [:]
@@ -5708,8 +5813,11 @@ actor CodeGenServer {
         }
     }
 
-    nonisolated static func openAIFinishReason(for result: ChatResponse) -> String {
-        if result.toolCalls?.isEmpty == false {
+    nonisolated static func openAIFinishReason(
+        for result: ChatResponse,
+        hasToolCalls: Bool? = nil
+    ) -> String {
+        if hasToolCalls ?? (result.toolCalls?.isEmpty == false) {
             return "tool_calls"
         }
         return result.finishReason == .length ? "length" : "stop"

--- a/Sources/MereRunCLI/Guides/api-serve.md
+++ b/Sources/MereRunCLI/Guides/api-serve.md
@@ -208,8 +208,13 @@ download route.
 - DS4 raw-proxies the complete OpenAI chat request to `ds4-server`.
 - Native engines reject unsupported OpenAI fields explicitly instead of silently dropping them.
 - `text-code` maps OpenAI `stop` sequences into native generation stops.
-- Function `tool_choice` values are accepted for native tool-capable engines;
-  specific function choices narrow the advertised tools to the named function.
+- Native tool-capable engines map `required` and specific-function
+  `tool_choice` values into generation policy; specific choices narrow the
+  advertised tools to the named function, while `parallel_tool_calls: false`
+  limits the response to one validated call. Nemotron H parses its native
+  Qwen-style XML envelope, stops both final-target and DSpark decode after the
+  first complete single-call envelope, and never returns the envelope as
+  assistant content.
 - Native Gemma and Qwen-family chat engines accept
   `response_format: {"type":"json_object"}`. JSON-object generation uses a
   token-level prefix grammar, forces thinking off, and permits EOS only after

--- a/Sources/MereRunCore/Generation.swift
+++ b/Sources/MereRunCore/Generation.swift
@@ -289,6 +289,29 @@ public struct ToolCall: Sendable, Hashable {
     }
 }
 
+public enum ChatToolChoice: Sendable, Hashable {
+    case auto
+    case required
+    case function(String)
+}
+
+public enum ToolCallPolicy {
+    public static func validatedCalls(
+        _ calls: [ToolCall],
+        tools: [ToolDefinition],
+        parallelToolCalls: Bool
+    ) -> [ToolCall] {
+        let definitions = tools.reduce(into: [String: ToolDefinition]()) { result, tool in
+            result[tool.name] = tool
+        }
+        let validated = calls.filter { call in
+            guard let definition = definitions[call.name] else { return false }
+            return definition.required.allSatisfy { call.arguments[$0] != nil }
+        }
+        return parallelToolCalls ? validated : Array(validated.prefix(1))
+    }
+}
+
 public struct ChatLogprobCapture: Codable, Sendable, Hashable {
     public enum Mode: String, Codable, Sendable, Hashable {
         case none
@@ -452,6 +475,8 @@ public struct ChatRequest: Sendable, Hashable {
     public var lora: LoRA?
     public var requiresJSON: Bool
     public var tools: [ToolDefinition]?
+    public var toolChoice: ChatToolChoice
+    public var parallelToolCalls: Bool
     public var stopOnEOS: Bool
     public var stopSequences: [String]
     /// Prevent generation of an n-gram already present in the full prompt and decode history.
@@ -477,6 +502,8 @@ public struct ChatRequest: Sendable, Hashable {
         lora: LoRA? = nil,
         requiresJSON: Bool = false,
         tools: [ToolDefinition]? = nil,
+        toolChoice: ChatToolChoice = .auto,
+        parallelToolCalls: Bool = false,
         stopOnEOS: Bool = true,
         stopSequences: [String] = [],
         noRepeatNgramSize: Int? = nil,
@@ -496,6 +523,8 @@ public struct ChatRequest: Sendable, Hashable {
         self.lora = lora
         self.requiresJSON = requiresJSON
         self.tools = tools
+        self.toolChoice = toolChoice
+        self.parallelToolCalls = parallelToolCalls
         self.stopOnEOS = stopOnEOS
         self.stopSequences = stopSequences
         self.noRepeatNgramSize = noRepeatNgramSize

--- a/Sources/MereRunCore/NemotronH/NemotronHDSparkDecoder.swift
+++ b/Sources/MereRunCore/NemotronH/NemotronHDSparkDecoder.swift
@@ -102,6 +102,7 @@ enum NemotronHDSparkDecoder {
         speculativeTokens: Int,
         decodeToken: ((Int) -> String)?,
         emitPiece: ((Int, String) -> Void)?,
+        shouldContinue: ((Int, String) -> Bool)? = nil,
         checkCancellation: (() throws -> Void)?
     ) throws -> NemotronHDSparkDecodeResult {
         let startedAt = Date()
@@ -123,20 +124,22 @@ enum NemotronHDSparkDecoder {
         var fallbackReason: String?
         let captures = Set(dspark.config.speculation.targetLayerIDs)
 
-        func emit(_ token: Int) {
+        func emit(_ token: Int) -> Bool {
             generated.append(token)
             history.append(token)
             if firstTokenSeconds == nil {
                 firstTokenSeconds = Date().timeIntervalSince(startedAt)
             }
-            guard let decodeToken, let emitPiece else { return }
-            let piece = decodeToken(token)
-            if piece.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                pendingWhitespace += piece
-            } else if !piece.isEmpty {
-                emitPiece(token, pendingWhitespace + piece)
-                pendingWhitespace = ""
+            let piece = decodeToken?(token) ?? ""
+            if let emitPiece {
+                if piece.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    pendingWhitespace += piece
+                } else if !piece.isEmpty {
+                    emitPiece(token, pendingWhitespace + piece)
+                    pendingWhitespace = ""
+                }
             }
+            return shouldContinue?(token, piece) ?? true
         }
 
         func result() -> NemotronHDSparkDecodeResult {
@@ -184,7 +187,7 @@ enum NemotronHDSparkDecoder {
                 previousTokens: history
             )
             guard !eosTokens.contains(anchor) else { break }
-            emit(anchor)
+            guard emit(anchor) else { return result() }
             guard generated.count < tokenBudget else { break }
 
             if !dsparkActive {
@@ -296,7 +299,7 @@ enum NemotronHDSparkDecoder {
             if accepted == proposals.count {
                 for proposal in proposals {
                     guard !eosTokens.contains(proposal) else { return result() }
-                    emit(proposal)
+                    guard emit(proposal) else { return result() }
                     guard generated.count < tokenBudget else { return result() }
                 }
                 targetCache = candidateCache
@@ -314,7 +317,7 @@ enum NemotronHDSparkDecoder {
             rejected += 1
             for proposal in proposals.prefix(accepted) {
                 guard !eosTokens.contains(proposal) else { return result() }
-                emit(proposal)
+                guard emit(proposal) else { return result() }
                 guard generated.count < tokenBudget else { return result() }
             }
             guard let replacement, !eosTokens.contains(replacement) else { break }
@@ -331,7 +334,7 @@ enum NemotronHDSparkDecoder {
             )
             MLX.eval([recovery.logits] + Array(recovery.capturedHiddenStates.values))
             recoveryForwards += 1
-            emit(replacement)
+            guard emit(replacement) else { return result() }
             targetCache = recoveryCache
             let finalPosition = recovery.logits.dim(1) - 1
             logits = recovery.logits[0..., finalPosition..., 0...]

--- a/Sources/MereRunCore/NemotronH/NemotronHGenerator.swift
+++ b/Sources/MereRunCore/NemotronH/NemotronHGenerator.swift
@@ -202,6 +202,22 @@ public actor NemotronHGenerator: ChatGenerator {
         )
         let eosTokens = Set(config.eosTokenIDs + [2, 11] + [tokenizer.eosTokenId].compactMap { $0 })
         progressHandler?(ChatProgress(stage: .generating, message: ""))
+        let filtersToolProtocol = request.tools?.isEmpty == false
+        let stopAtCompletedToolCall = filtersToolProtocol && !request.parallelToolCalls
+        var toolCallCompletionDetector = Q35ToolParser.StreamingCompletionDetector()
+        var visibleTextFilter = Q35ToolParser.StreamingVisibleTextFilter()
+
+        func emitGeneratedPiece(_: Int, _ piece: String) {
+            let visiblePiece = filtersToolProtocol ? visibleTextFilter.feed(piece) : piece
+            if !visiblePiece.isEmpty {
+                progressHandler?(ChatProgress(stage: .generating, message: visiblePiece))
+            }
+        }
+
+        func shouldContinueAfterPiece(_: Int, _ piece: String) -> Bool {
+            guard stopAtCompletedToolCall else { return true }
+            return !toolCallCompletionDetector.feed(piece)
+        }
 
         let decode: NemotronHDecodeResult
         if let dspark,
@@ -221,9 +237,8 @@ public actor NemotronHGenerator: ChatGenerator {
                 historySeedTokens: promptTokens,
                 speculativeTokens: NemotronHResources.defaultSpeculativeTokens,
                 decodeToken: { tokenizer.decode(token: $0) },
-                emitPiece: { _, piece in
-                    progressHandler?(ChatProgress(stage: .generating, message: piece))
-                },
+                emitPiece: emitGeneratedPiece,
+                shouldContinue: shouldContinueAfterPiece,
                 checkCancellation: { try Task.checkCancellation() }
             )
             latestDSparkStats = result.stats
@@ -261,9 +276,8 @@ public actor NemotronHGenerator: ChatGenerator {
                 ),
                 stepForward: { token in model.lastPositionLogits(token, cache: targetCache) },
                 decodeToken: { tokenizer.decode(token: $0) },
-                emitPiece: { _, piece in
-                    progressHandler?(ChatProgress(stage: .generating, message: piece))
-                },
+                emitPiece: emitGeneratedPiece,
+                shouldContinue: shouldContinueAfterPiece,
                 checkCancellation: { try Task.checkCancellation() }
             )
             decode = NemotronHDecodeResult(
@@ -274,17 +288,33 @@ public actor NemotronHGenerator: ChatGenerator {
                 acceleration: ChatAccelerationDiagnostics(route: "final-target-pipelined")
             )
         }
+        if filtersToolProtocol {
+            let remainingVisibleText = visibleTextFilter.finish()
+            if !remainingVisibleText.isEmpty {
+                progressHandler?(ChatProgress(stage: .generating, message: remainingVisibleText))
+            }
+        }
         let raw = tokenizer.decode(tokens: decode.tokens)
         let trimmed = TextGenerationStopSequences.trimming(
             raw,
             sequences: TextGenerationStopSequences.merged(request.stopSequences)
         )
-        let toolCalls: [ToolCall]? = request.tools?.isEmpty == false ? {
-            let parsed = Gemma4ToolParser.parseToolCalls(trimmed.text)
-            return parsed.isEmpty ? nil : parsed
-        }() : nil
+        let parsedToolCalls = request.tools?.isEmpty == false
+            ? Q35ToolParser.parseToolCalls(trimmed.text)
+            : []
+        let toolCalls: [ToolCall]? = request.tools.flatMap { tools -> [ToolCall]? in
+            let validated = ToolCallPolicy.validatedCalls(
+                parsedToolCalls,
+                tools: tools,
+                parallelToolCalls: request.parallelToolCalls
+            )
+            return validated.isEmpty ? nil : validated
+        }
+        let visibleText = parsedToolCalls.isEmpty
+            ? trimmed.text
+            : Q35ToolParser.visibleText(trimmed.text)
         return ChatResponse(
-            generatedText: trimmed.text,
+            generatedText: visibleText,
             tokensGenerated: decode.tokens.count,
             showThinking: request.showThinking,
             timing: ChatTiming(

--- a/Sources/MereRunCore/Q35/Q35Generator.swift
+++ b/Sources/MereRunCore/Q35/Q35Generator.swift
@@ -715,7 +715,7 @@ public actor Q35Generator: ChatGenerator {
             promptTokens: promptTokens,
             maxContextTokens: effectiveContext,
             jsonConstrained: jsonConstrained,
-            stopAtCompletedToolCall: request.tools?.isEmpty == false,
+            stopAtCompletedToolCall: request.tools?.isEmpty == false && !request.parallelToolCalls,
             logprobCapture: request.logprobCapture,
             logprobRegion: request.logprobRegionHint ?? .visible,
             progressHandler: progressHandler
@@ -730,13 +730,23 @@ public actor Q35Generator: ChatGenerator {
             tokenBudget: tokenBudget,
             matchedStopSequence: trimmed.matchedSequence != nil
         )
-        let toolCalls: [ToolCall]? = request.tools?.isEmpty == false ? {
-            let parsed = Q35ToolParser.parseToolCalls(decoded)
-            return parsed.isEmpty ? nil : parsed
-        }() : nil
+        let parsedToolCalls = request.tools?.isEmpty == false
+            ? Q35ToolParser.parseToolCalls(decoded)
+            : []
+        let toolCalls: [ToolCall]? = request.tools.flatMap { tools -> [ToolCall]? in
+            let validated = ToolCallPolicy.validatedCalls(
+                parsedToolCalls,
+                tools: tools,
+                parallelToolCalls: request.parallelToolCalls
+            )
+            return validated.isEmpty ? nil : validated
+        }
+        let visibleText = parsedToolCalls.isEmpty
+            ? decoded
+            : Q35ToolParser.visibleText(decoded)
 
         return ChatResponse(
-            generatedText: decoded,
+            generatedText: visibleText,
             tokensGenerated: decodeResult.generatedTokens.count,
             showThinking: includeThinking,
             timing: ChatTiming(

--- a/Sources/MereRunCore/Q35/Q35ToolParser.swift
+++ b/Sources/MereRunCore/Q35/Q35ToolParser.swift
@@ -58,8 +58,58 @@ public enum Q35ToolParser {
         }
     }
 
+    /// Streams only user-visible prose while a tool-capable decode is active.
+    ///
+    /// The checkpoint contract permits prose before a tool call but forbids a
+    /// suffix after the opening envelope. Keep a short marker-sized tail so an
+    /// opening tag split across tokenizer pieces is never exposed, then suppress
+    /// the protocol envelope once it begins.
+    public struct StreamingVisibleTextFilter: Sendable {
+        private var pendingText = ""
+        private var isSuppressingToolCall = false
+
+        public init() {}
+
+        public mutating func feed(_ piece: String) -> String {
+            guard !piece.isEmpty, !isSuppressingToolCall else { return "" }
+            pendingText += piece
+
+            if let openingRange = pendingText.range(of: Q35ToolParser.openingTag) {
+                let visible = String(pendingText[..<openingRange.lowerBound])
+                pendingText = ""
+                isSuppressingToolCall = true
+                return visible
+            }
+
+            let retainedCount = max(0, Q35ToolParser.openingTag.count - 1)
+            let emittedCount = max(0, pendingText.count - retainedCount)
+            guard emittedCount > 0 else { return "" }
+            let emittedEnd = pendingText.index(pendingText.startIndex, offsetBy: emittedCount)
+            let visible = String(pendingText[..<emittedEnd])
+            pendingText.removeSubrange(..<emittedEnd)
+            return visible
+        }
+
+        public mutating func finish() -> String {
+            guard !isSuppressingToolCall else { return "" }
+            defer { pendingText = "" }
+            return pendingText
+        }
+    }
+
     public static func parseToolCalls(_ text: String) -> [ToolCall] {
         parsedEnvelopes(in: text).compactMap(\.toolCall)
+    }
+
+    /// Removes structurally valid tool-call envelopes while preserving any
+    /// allowed prose that precedes them. Malformed marker-shaped text remains
+    /// visible and is never promoted into a typed call.
+    public static func visibleText(_ text: String) -> String {
+        var visible = text
+        for envelope in parsedEnvelopes(in: text).reversed() {
+            visible.removeSubrange(envelope.startIndex..<envelope.endIndex)
+        }
+        return visible.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 
     public static func containsCompletedToolCall(_ text: String) -> Bool {
@@ -67,6 +117,7 @@ public enum Q35ToolParser {
     }
 
     private struct ParsedEnvelope {
+        let startIndex: String.Index
         let endIndex: String.Index
         let toolCall: ToolCall?
     }
@@ -138,7 +189,11 @@ public enum Q35ToolParser {
                 guard text[callClose...].hasPrefix(closingTag) else { return nil }
                 let envelopeEnd = text.index(callClose, offsetBy: closingTag.count)
                 let toolCall = name.isEmpty ? nil : ToolCall(name: name, arguments: arguments)
-                return ParsedEnvelope(endIndex: envelopeEnd, toolCall: toolCall)
+                return ParsedEnvelope(
+                    startIndex: openingRange.lowerBound,
+                    endIndex: envelopeEnd,
+                    toolCall: toolCall
+                )
             }
 
             guard text[cursor...].hasPrefix(parameterOpeningTag) else { return nil }

--- a/Tests/MereRunCLITests/APIServeCommandTests.swift
+++ b/Tests/MereRunCLITests/APIServeCommandTests.swift
@@ -121,6 +121,52 @@ final class APIServeCommandTests: XCTestCase {
         XCTAssertFalse(cmd.engine.openAICompatibility.supportsStructuredOutputs)
     }
 
+    func testAPIServeResolvesInstalledNemotronCanonicalIDForPreflightAndRuntime() throws {
+        let modelsRoot = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mere-run-nemotron-api-\(UUID().uuidString)", isDirectory: true)
+        let modelRoot = modelsRoot
+            .appendingPathComponent(NemotronHResources.modelID, isDirectory: true)
+        defer {
+            MereRunModelPaths.setProcessModelsDirOverride(nil)
+            try? FileManager.default.removeItem(at: modelsRoot)
+        }
+        MereRunModelPaths.setProcessModelsDirOverride(modelsRoot)
+        try FileManager.default.createDirectory(at: modelRoot, withIntermediateDirectories: true)
+        for filename in [
+            "config.json", "tokenizer.json", "tokenizer_config.json", "chat_template.jinja",
+        ] {
+            try Data("{}".utf8).write(to: modelRoot.appendingPathComponent(filename))
+        }
+        try Data("{\"weight_map\":{}}".utf8).write(
+            to: modelRoot.appendingPathComponent("model.safetensors.index.json")
+        )
+        try MereRunModelManifest.template(
+            for: .nemotron35Lightning,
+            createdAt: Date(timeIntervalSince1970: 0)
+        ).write(to: modelRoot)
+
+        let command = try APIServe.parse([
+            "--engine", "text-chat-nemotron-h",
+            "--model", NemotronHResources.modelID,
+            "--preflight",
+            "--json",
+        ])
+
+        XCTAssertEqual(try command.resolveModelPath(), modelRoot.path)
+        let envelope = command.makePreflightEnvelope(
+            environment: [:],
+            now: { Date(timeIntervalSince1970: 0) }
+        )
+        XCTAssertEqual(envelope.status, .ok)
+        XCTAssertTrue(envelope.result.model.installed)
+        XCTAssertEqual(envelope.result.model.path, modelRoot.path)
+        let start = try XCTUnwrap(envelope.actions.first { $0.id == "start-api-server" })
+        let argv = try XCTUnwrap(start.command?.argv)
+        XCTAssertTrue(argv.indices.dropLast().contains { index in
+            argv[index] == "--model" && argv[index + 1] == NemotronHResources.modelID
+        })
+    }
+
     func testAPIServeParsesNemotronOmniNativeEngine() throws {
         let cmd = try APIServe.parse([
             "--engine", "text-chat-nemotron-omni",
@@ -2511,6 +2557,64 @@ final class APIServeCommandTests: XCTestCase {
         XCTAssertEqual(chatRequest.tools?.first?.name, "lookup")
         XCTAssertEqual(chatRequest.tools?.first?.parameters["query"]?.description, "Search query")
         XCTAssertEqual(chatRequest.tools?.first?.required, ["query"])
+        XCTAssertEqual(chatRequest.toolChoice, .auto)
+        XCTAssertTrue(chatRequest.parallelToolCalls)
+    }
+
+    func testChatRequestMapsRequiredSingleToolPolicy() throws {
+        let tool = OpenAIChatTool(
+            function: OpenAIChatToolFunction(
+                name: "create_status_summary",
+                description: "Create a concise status summary.",
+                parameters: .object([
+                    "type": .string("object"),
+                    "properties": .object([
+                        "reason": .object(["type": .string("string")]),
+                    ]),
+                    "required": .array([.string("reason")]),
+                ])
+            )
+        )
+        let request = OpenAIChatRequest(
+            model: NemotronHResources.modelID,
+            messages: [OpenAIChatMessage(role: "user", content: "Summarize the project update.")],
+            tools: [tool],
+            tool_choice: .mode("required"),
+            parallel_tool_calls: false
+        )
+
+        let chatRequest = try APIServerContract.chatRequest(
+            from: request,
+            fallbackLoraPath: nil,
+            contextSize: 32_768,
+            capabilities: .localTextWithTools,
+            servedModelID: NemotronHResources.modelID
+        )
+
+        XCTAssertEqual(chatRequest.toolChoice, .required)
+        XCTAssertFalse(chatRequest.parallelToolCalls)
+        XCTAssertEqual(chatRequest.tools?.map(\.name), ["create_status_summary"])
+        let system = try XCTUnwrap(chatRequest.messages.first { $0.role == .system })
+        XCTAssertTrue(system.content.contains("exactly one provided function"))
+    }
+
+    func testRequiredToolChoiceWithoutToolsIsRejected() {
+        let request = OpenAIChatRequest(
+            model: NemotronHResources.modelID,
+            messages: [OpenAIChatMessage(role: "user", content: "Summarize the project update.")],
+            tool_choice: .mode("required")
+        )
+
+        XCTAssertThrowsError(
+            try APIServerContract.chatRequest(
+                from: request,
+                fallbackLoraPath: nil,
+                contextSize: 32_768,
+                capabilities: .localTextWithTools
+            )
+        ) { error in
+            XCTAssertTrue(error.localizedDescription.contains("requires at least one function"))
+        }
     }
 
     func testOpenAIToolArgumentsPreserveJSONTypesFromModelPayloads() throws {
@@ -2586,6 +2690,9 @@ final class APIServeCommandTests: XCTestCase {
         )
 
         XCTAssertEqual(chatRequest.tools?.map(\.name), ["summarize"])
+        XCTAssertEqual(chatRequest.toolChoice, .function("summarize"))
+        let system = try XCTUnwrap(chatRequest.messages.first { $0.role == .system })
+        XCTAssertTrue(system.content.contains("'summarize' at least once"))
 
         let missing = OpenAIChatRequest(
             model: "mererun-test-model",
@@ -2714,6 +2821,20 @@ final class APIServeCommandTests: XCTestCase {
         )
 
         XCTAssertEqual(CodeGenServer.openAIFinishReason(for: result), "length")
+    }
+
+    func testOpenAIFinishReasonReportsToolCalls() {
+        let result = ChatResponse(
+            response: "",
+            tokensGenerated: 12,
+            toolCalls: [ToolCall(name: "create_status_summary", arguments: ["reason": "test"])]
+        )
+
+        XCTAssertEqual(CodeGenServer.openAIFinishReason(for: result), "tool_calls")
+        XCTAssertEqual(
+            CodeGenServer.openAIFinishReason(for: result, hasToolCalls: false),
+            "stop"
+        )
     }
 
     func testChatRequestRejectsUnsupportedHighImpactFields() {

--- a/Tests/MereRunCoreTests/Q35ToolParserTests.swift
+++ b/Tests/MereRunCoreTests/Q35ToolParserTests.swift
@@ -2,6 +2,46 @@ import XCTest
 @testable import MereRunCore
 
 final class Q35ToolParserTests: XCTestCase {
+    func testParsesNemotronLightningToolCallWithTypedPayloads() {
+        let text = """
+        <tool_call>
+        <function=create_status_summary>
+        <parameter=arguments>
+        {"project":"Example App","audience":"reviewers"}
+        </parameter>
+        <parameter=references>
+        ["change-log","test-report"]
+        </parameter>
+        <parameter=include_details>
+        true
+        </parameter>
+        <parameter=maximum_items>
+        3
+        </parameter>
+        <parameter=reason>
+        Summarize the latest project updates for reviewers.
+        </parameter>
+        </function>
+        </tool_call>
+        """
+
+        XCTAssertEqual(
+            Q35ToolParser.parseToolCalls(text),
+            [
+                ToolCall(
+                    name: "create_status_summary",
+                    arguments: [
+                        "arguments": "{\"project\":\"Example App\",\"audience\":\"reviewers\"}",
+                        "references": "[\"change-log\",\"test-report\"]",
+                        "include_details": "true",
+                        "maximum_items": "3",
+                        "reason": "Summarize the latest project updates for reviewers.",
+                    ]
+                ),
+            ]
+        )
+    }
+
     func testParsesCheckpointToolCallProtocolWithoutArguments() {
         let text = """
         <tool_call>
@@ -130,6 +170,87 @@ final class Q35ToolParserTests: XCTestCase {
 
         XCTAssertFalse(detector.feed("The marker </tool_"))
         XCTAssertFalse(detector.feed("call> is documentation."))
+    }
+
+    func testStreamingVisibleTextNeverExposesSplitToolEnvelope() {
+        let text = """
+        I will summarize that now.
+        <tool_call>
+        <function=create_status_summary>
+        <parameter=reason>
+        Summarize the requested updates.
+        </parameter>
+        </function>
+        </tool_call>
+        """
+
+        for chunkSize in [1, 2, 3, 7, 16, 64] {
+            var filter = Q35ToolParser.StreamingVisibleTextFilter()
+            var visible = ""
+            var offset = 0
+            while offset < text.count {
+                let end = min(text.count, offset + chunkSize)
+                let startIndex = text.index(text.startIndex, offsetBy: offset)
+                let endIndex = text.index(text.startIndex, offsetBy: end)
+                visible += filter.feed(String(text[startIndex..<endIndex]))
+                offset = end
+            }
+            visible += filter.finish()
+
+            XCTAssertEqual(visible, "I will summarize that now.\n", "chunk size \(chunkSize)")
+            XCTAssertFalse(visible.contains("<tool_call>"), "chunk size \(chunkSize)")
+        }
+    }
+
+    func testStreamingVisibleTextPreservesNormalProseExactly() {
+        let text = " Normal prose with <tool_ documentation and a trailing newline.\n"
+        var filter = Q35ToolParser.StreamingVisibleTextFilter()
+        var visible = ""
+
+        for character in text {
+            visible += filter.feed(String(character))
+        }
+        visible += filter.finish()
+
+        XCTAssertEqual(visible, text)
+    }
+
+    func testVisibleTextRemovesOnlyStructurallyValidToolCalls() {
+        let valid = "before <tool_call><function=lookup></function></tool_call> after"
+        let malformed = "before <tool_call><function=lookup></tool_call> after"
+
+        XCTAssertEqual(Q35ToolParser.visibleText(valid), "before  after")
+        XCTAssertEqual(Q35ToolParser.visibleText(malformed), malformed)
+        XCTAssertTrue(Q35ToolParser.parseToolCalls(malformed).isEmpty)
+    }
+
+    func testToolCallPolicyRejectsUnknownAndMissingRequiredCalls() {
+        let tool = ToolDefinition(
+            name: "create_status_summary",
+            description: "Create a concise status summary.",
+            parameters: [
+                "reason": ToolParameterProperty(type: "string", description: "Purpose"),
+            ],
+            required: ["reason"]
+        )
+        let calls = [
+            ToolCall(name: "unadvertised", arguments: ["reason": "wrong function"]),
+            ToolCall(name: tool.name, arguments: [:]),
+            ToolCall(name: tool.name, arguments: ["reason": "first"]),
+            ToolCall(name: tool.name, arguments: ["reason": "second"]),
+        ]
+
+        XCTAssertEqual(
+            ToolCallPolicy.validatedCalls(calls, tools: [tool], parallelToolCalls: false),
+            [ToolCall(name: tool.name, arguments: ["reason": "first"])]
+        )
+        XCTAssertEqual(
+            ToolCallPolicy.validatedCalls(calls, tools: [tool], parallelToolCalls: true),
+            [
+                ToolCall(name: tool.name, arguments: ["reason": "first"]),
+                ToolCall(name: tool.name, arguments: ["reason": "second"]),
+            ]
+        )
     }
 
     func testStreamingCompletionBoundFallsBackToFinalStructuralParse() {

--- a/docs/runtime/api-server.md
+++ b/docs/runtime/api-server.md
@@ -465,8 +465,10 @@ profile for its selected serving engine.
   content parts when the selected engine supports vision
 - assistant `tool_calls` and tool response messages
 - `tools`, `tool_choice`, `parallel_tool_calls`; `tool_choice` accepts `none`,
-  `auto`, `required`, and specific function choices by narrowing the advertised
-  tool list to the named function
+  `auto`, `required`, and specific function choices. Required and specific
+  choices become explicit native generation instructions, specific choices
+  narrow the advertised list to the named function, and
+  `parallel_tool_calls: false` limits the response to one validated call
 - `response_format`
 - `stream_options.include_usage`
 - `stop`, `seed`, penalties, logprobs, reasoning controls, and
@@ -481,8 +483,10 @@ not change local generation.
 
 For non-streaming chat responses, native runtimes split `<think>...</think>`
 blocks out of `message.content` and expose them as OpenAI-compatible
-`message.reasoning_content` when present. Streaming responses still emit token
-chunks as they are produced.
+`message.reasoning_content` when present. Tool-capable streaming requests buffer
+generated chunks until the runtime can emit either typed `tool_calls` or
+protocol-free text, so native XML control markup is never exposed as assistant
+content.
 
 Native Qwen-family, Nemotron Lightning, and Laguna catalog profiles accept
 `logprobs: true` for non-streaming requests, with `top_logprobs` from 0 through
@@ -502,6 +506,11 @@ Engine compatibility:
   `ds4-server`, preserving DS4's OpenAI-compatible behavior.
 - `text-chat-gemma4`: accepts function tools and emits OpenAI tool-call
   responses when the model generates a tool call.
+- `text-chat-nemotron-h`: accepts function tools using the checkpoint's native
+  Qwen-style XML envelope. Both final-target and DSpark decode stop at the first
+  structurally complete envelope when parallel calls are disabled; malformed
+  envelopes and calls that do not match an advertised function or its required
+  arguments are not promoted to OpenAI `tool_calls`.
 - `vision-chat-gemma4-12b`: uses the Gemma4 serving engine and accepts one
   OpenAI image content part per message. The native runtime accepts local file
   paths, `file://` URLs, or base64 data URLs; it does not fetch remote images.


### PR DESCRIPTION
## Summary

- parse Nemotron H Q35 tool envelopes strictly while keeping protocol markup out of visible content
- stop both target and DSpark decoding after the first complete call when parallel calls are disabled
- validate advertised tools and required arguments, preserve typed OpenAI arguments, and honor `tool_choice` and `parallel_tool_calls`
- resolve canonical managed Nemotron model IDs consistently for preflight and runtime startup
- document the behavior and cover normal prose, malformed envelopes, streaming boundaries, request policy, and response finish reasons

## Validation

- `./scripts/check.sh`: 3,145 XCTest cases passed, 224 checkpoint/environment skips, 0 failures; supplemental 30-test suite passed
- focused API/tool-parser suite: 123 tests passed, 0 failures
- `pnpm docs:build`
- real installed Nemotron H Lightning checkpoint loaded through the canonical model ID and returned HTTP 200 with exactly one required caller-supplied tool call, typed JSON arguments, empty visible content, and `finish_reason: "tool_calls"`
- `git diff --check`

## Boundaries

- no hosted service, deployment, or application-specific integration changes
- test fixtures use generic function schemas
