### PR TITLE
Fix tool schema parity in text SFT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,10 @@ The format is based on Keep a Changelog.
 
 ### Text
 
+- fixed tool-use SFT parity for Gemma 4, Laguna, and Inkling by carrying typed
+  tool schemas into native training templates, training on typed assistant
+  tool-call targets, fingerprinting complete messages and schemas, and
+  deduplicating complete controller states instead of first-user text.
 - added pinned LiquidAI DSpark companions for LFM2.5 1.2B Instruct, 2.6B,
   and 8B-A1B. The native Swift/MLX runtime captures five configured target-layer
   outputs, runs the non-causal diffusion draft block, drafts

--- a/Sources/MereRunCore/Gemma4/Gemma4TextSFTTokenizer.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4TextSFTTokenizer.swift
@@ -13,17 +13,34 @@ public enum Gemma4TextSFTTokenizer {
             let prefixMessages = Array(example.messages.dropLast())
             let prefixTokens = try tokenizerAndTemplate.encodeForGeneration(
                 messages: prefixMessages,
+                tools: example.tools,
                 addGenerationPrompt: true,
                 includeThinking: false,
                 maxLength: tokenizerAndTemplate.maxLength
             )
 
-            var targetTokens = tokenizerAndTemplate.encodeRaw(
-                assistantTargetText(assistant.content),
-                addSpecialTokens: false
-            )
-            if let turnTokenId = tokenizerAndTemplate.turnTokenId {
-                targetTokens.append(turnTokenId)
+            let targetTokens: [Int]
+            if assistant.toolCalls?.isEmpty == false {
+                let fullTokens = try tokenizerAndTemplate.encodeForGeneration(
+                    messages: example.messages,
+                    tools: example.tools,
+                    addGenerationPrompt: false,
+                    includeThinking: false,
+                    maxLength: tokenizerAndTemplate.maxLength
+                )
+                targetTokens = try TextSFTTrainingBatchBuilder.nativeAssistantTarget(
+                    prefixTokenIds: prefixTokens,
+                    fullConversationTokenIds: fullTokens
+                )
+            } else {
+                var contentTokens = tokenizerAndTemplate.encodeRaw(
+                    assistantTargetText(assistant.content),
+                    addSpecialTokens: false
+                )
+                if let turnTokenId = tokenizerAndTemplate.turnTokenId {
+                    contentTokens.append(turnTokenId)
+                }
+                targetTokens = contentTokens
             }
 
             return try TextSFTTrainingBatchBuilder.shiftedTargetExample(

--- a/Sources/MereRunCore/Inkling/InklingTextSFTTokenizer.swift
+++ b/Sources/MereRunCore/Inkling/InklingTextSFTTokenizer.swift
@@ -14,14 +14,30 @@ public enum InklingTextSFTTokenizer {
             }
             let prefixTokens = try tokenizerAndTemplate.encodeForGeneration(
                 messages: Array(example.messages.dropLast()),
+                tools: example.tools,
                 addGenerationPrompt: true,
                 reasoningEffort: reasoningEffort,
                 maxLength: tokenizerAndTemplate.maxLength
             )
-            let targetTokens = tokenizerAndTemplate.encodeRaw(
-                assistantTargetText(assistant.content),
-                addSpecialTokens: false
-            )
+            let targetTokens: [Int]
+            if assistant.toolCalls?.isEmpty == false {
+                let fullTokens = try tokenizerAndTemplate.encodeForGeneration(
+                    messages: example.messages,
+                    tools: example.tools,
+                    addGenerationPrompt: false,
+                    reasoningEffort: reasoningEffort,
+                    maxLength: tokenizerAndTemplate.maxLength
+                )
+                targetTokens = try TextSFTTrainingBatchBuilder.nativeAssistantTarget(
+                    prefixTokenIds: prefixTokens,
+                    fullConversationTokenIds: fullTokens
+                )
+            } else {
+                targetTokens = tokenizerAndTemplate.encodeRaw(
+                    assistantTargetText(assistant.content),
+                    addSpecialTokens: false
+                )
+            }
             return try TextSFTTrainingBatchBuilder.shiftedTargetExample(
                 prefixTokenIds: prefixTokens,
                 targetTokenIds: targetTokens,

--- a/Sources/MereRunCore/Laguna/LagunaTextSFTTokenizer.swift
+++ b/Sources/MereRunCore/Laguna/LagunaTextSFTTokenizer.swift
@@ -13,18 +13,35 @@ public enum LagunaTextSFTTokenizer {
             }
             let prefixTokens = try tokenizerAndTemplate.encodeForGeneration(
                 messages: Array(example.messages.dropLast()),
+                tools: example.tools,
                 addGenerationPrompt: true,
                 includeThinking: false,
                 maxLength: tokenizerAndTemplate.maxLength
             )
-            var targetTokens = tokenizerAndTemplate.encodeRaw(
-                assistantTargetText(assistant.content),
-                addSpecialTokens: false
-            )
-            if let assistantEndTokenID = tokenizerAndTemplate.assistantEndTokenID {
-                targetTokens.append(assistantEndTokenID)
-            } else if let eosTokenID = tokenizerAndTemplate.eosTokenID {
-                targetTokens.append(eosTokenID)
+            let targetTokens: [Int]
+            if assistant.toolCalls?.isEmpty == false {
+                let fullTokens = try tokenizerAndTemplate.encodeForGeneration(
+                    messages: example.messages,
+                    tools: example.tools,
+                    addGenerationPrompt: false,
+                    includeThinking: false,
+                    maxLength: tokenizerAndTemplate.maxLength
+                )
+                targetTokens = try TextSFTTrainingBatchBuilder.nativeAssistantTarget(
+                    prefixTokenIds: prefixTokens,
+                    fullConversationTokenIds: fullTokens
+                )
+            } else {
+                var contentTokens = tokenizerAndTemplate.encodeRaw(
+                    assistantTargetText(assistant.content),
+                    addSpecialTokens: false
+                )
+                if let assistantEndTokenID = tokenizerAndTemplate.assistantEndTokenID {
+                    contentTokens.append(assistantEndTokenID)
+                } else if let eosTokenID = tokenizerAndTemplate.eosTokenID {
+                    contentTokens.append(eosTokenID)
+                }
+                targetTokens = contentTokens
             }
             return try TextSFTTrainingBatchBuilder.shiftedTargetExample(
                 prefixTokenIds: prefixTokens,

--- a/Sources/MereRunCore/Laguna/LagunaTokenizerAndTemplate.swift
+++ b/Sources/MereRunCore/Laguna/LagunaTokenizerAndTemplate.swift
@@ -43,7 +43,7 @@ public final class LagunaTokenizerAndTemplate: @unchecked Sendable {
     ) throws -> [Int] {
         let toolSpecs = tools?.isEmpty == false ? tools!.map { $0.toToolSpec() } : nil
         var encoded = try tokenizer.applyChatTemplate(
-            messages: messages.map(Self.renderMessage),
+            messages: Self.renderMessages(messages),
             chatTemplate: nil,
             addGenerationPrompt: addGenerationPrompt,
             truncation: false,
@@ -77,10 +77,49 @@ public final class LagunaTokenizerAndTemplate: @unchecked Sendable {
         Array(Set([eosTokenID, assistantEndTokenID].compactMap { $0 }))
     }
 
+    static func renderMessages(_ messages: [ChatMessage]) -> [Message] {
+        messages.map(renderMessage)
+    }
+
     private static func renderMessage(_ message: ChatMessage) -> Message {
-        [
+        var rendered: Message = [
             "role": message.role.rawValue,
             "content": message.content,
         ]
+        if let reasoning = message.reasoningContent, !reasoning.isEmpty {
+            rendered["reasoning_content"] = reasoning
+        }
+        if let name = message.name, !name.isEmpty {
+            rendered["name"] = name
+        }
+        if let toolCallID = message.toolCallID, !toolCallID.isEmpty {
+            rendered["tool_call_id"] = toolCallID
+        }
+        if let calls = message.toolCalls, !calls.isEmpty {
+            rendered["tool_calls"] = calls.map { call -> [String: any Sendable] in
+                var result: [String: any Sendable] = [
+                    "function": [
+                        "name": call.name,
+                        "arguments": call.arguments.mapValues(renderJSONValue),
+                    ] as [String: any Sendable],
+                ]
+                if let id = call.id, !id.isEmpty {
+                    result["id"] = id
+                }
+                return result
+            }
+        }
+        return rendered
+    }
+
+    private static func renderJSONValue(_ value: OpenAIJSONValue) -> any Sendable {
+        switch value {
+        case .string(let value): value
+        case .number(let value): value
+        case .bool(let value): value
+        case .object(let value): value.mapValues(renderJSONValue)
+        case .array(let value): value.map(renderJSONValue)
+        case .null: Optional<String>.none
+        }
     }
 }

--- a/Sources/MereRunCore/TextSFTDataset.swift
+++ b/Sources/MereRunCore/TextSFTDataset.swift
@@ -9,11 +9,18 @@ public struct TextSFTExample: Sendable, Hashable, Codable {
     public let id: String?
     public let sources: [String]
     public let messages: [ChatMessage]
+    public let tools: [ToolDefinition]?
 
-    public init(id: String?, sources: [String], messages: [ChatMessage]) {
+    public init(
+        id: String?,
+        sources: [String],
+        messages: [ChatMessage],
+        tools: [ToolDefinition]? = nil
+    ) {
         self.id = id
         self.sources = sources
         self.messages = messages
+        self.tools = tools
     }
 }
 public struct TextSFTDatasetSummary: Sendable, Hashable, Codable {
@@ -66,7 +73,7 @@ public enum TextSFTDataset {
         }
 
         var ids = Set<String>()
-        var prompts = Set<String>()
+        var controllerStates = Set<String>()
         for (index, example) in examples.enumerated() {
             let line = index + 1
             if let id = example.id, !id.isEmpty {
@@ -93,16 +100,16 @@ public enum TextSFTDataset {
 
             for message in example.messages {
                 let trimmed = message.content.trimmingCharacters(in: .whitespacesAndNewlines)
-                guard trimmed.count >= 4 else {
+                let hasToolCalls = message.role == .assistant && message.toolCalls?.isEmpty == false
+                let hasToolResult = message.role == .tool && !trimmed.isEmpty
+                guard trimmed.count >= 4 || hasToolCalls || hasToolResult else {
                     throw TextSFTDatasetError.emptyMessage(line)
                 }
             }
 
-            if let prompt = example.messages.first(where: { $0.role == .user })?.content {
-                let normalized = prompt.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-                guard prompts.insert(normalized).inserted else {
-                    throw TextSFTDatasetError.duplicatePrompt(line)
-                }
+            let state = controllerStateFingerprint(example)
+            guard controllerStates.insert(state).inserted else {
+                throw TextSFTDatasetError.duplicatePrompt(line)
             }
         }
     }
@@ -126,23 +133,69 @@ public enum TextSFTDataset {
     }
 
     public static func fingerprint(_ examples: [TextSFTExample]) -> String {
-        var hasher = SHA256()
-        for example in examples {
-            if let id = example.id {
-                hasher.update(data: Data(id.utf8))
-            }
-            for source in example.sources.sorted() {
-                hasher.update(data: Data(source.utf8))
-            }
-            for message in example.messages {
-                hasher.update(data: Data(message.role.rawValue.utf8))
-                hasher.update(data: Data(message.content.utf8))
-                if let imageUrl = message.imageUrl {
-                    hasher.update(data: Data(imageUrl.utf8))
-                }
-            }
+        digest(canonicalData(examples.map(CanonicalExample.init)))
+    }
+
+    private static func controllerStateFingerprint(_ example: TextSFTExample) -> String {
+        digest(canonicalData(CanonicalControllerState(
+            messages: example.messages.dropLast().map { message in
+                var normalized = message
+                normalized.content = message.content
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                    .lowercased()
+                return normalized
+            },
+            tools: canonicalTools(example.tools)
+        )))
+    }
+
+    private static func canonicalData<Value: Encodable>(_ value: Value) -> Data {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        do {
+            return try encoder.encode(value)
+        } catch {
+            preconditionFailure("Canonical Text SFT state encoding failed: \(error)")
         }
-        return hasher.finalize().map { String(format: "%02x", $0) }.joined()
+    }
+
+    private static func digest(_ data: Data) -> String {
+        SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined()
+    }
+
+    fileprivate static func canonicalTools(_ tools: [ToolDefinition]?) -> [ToolDefinition]? {
+        tools?.map { tool in
+            ToolDefinition(
+                name: tool.name,
+                description: tool.description,
+                parameters: tool.parameters,
+                required: tool.required.sorted()
+            )
+        }.sorted { lhs, rhs in
+            if lhs.name == rhs.name {
+                return lhs.description < rhs.description
+            }
+            return lhs.name < rhs.name
+        }
+    }
+}
+
+private struct CanonicalControllerState: Encodable {
+    let messages: [ChatMessage]
+    let tools: [ToolDefinition]?
+}
+
+private struct CanonicalExample: Encodable {
+    let id: String?
+    let sources: [String]
+    let messages: [ChatMessage]
+    let tools: [ToolDefinition]?
+
+    init(_ example: TextSFTExample) {
+        id = example.id
+        sources = example.sources.sorted()
+        messages = example.messages
+        tools = example.tools
     }
 }
 

--- a/Sources/MereRunCore/TextSFTTrainingBatch.swift
+++ b/Sources/MereRunCore/TextSFTTrainingBatch.swift
@@ -15,6 +15,29 @@ public struct TextSFTTokenizedExample: Sendable, Hashable {
 }
 
 public enum TextSFTTrainingBatchBuilder {
+    public static func nativeAssistantTarget(
+        prefixTokenIds: [Int],
+        fullConversationTokenIds: [Int],
+        maxGenerationPromptBoundaryTokens: Int = 8
+    ) throws -> [Int] {
+        let commonCount = zip(prefixTokenIds, fullConversationTokenIds)
+            .prefix { pair in pair.0 == pair.1 }
+            .count
+        guard commonCount > 0,
+              prefixTokenIds.count - commonCount <= maxGenerationPromptBoundaryTokens else {
+            throw TextSFTTrainingBatchError.nativeTemplatePrefixMismatch
+        }
+        // Some native templates end a generation prompt with empty channel
+        // controls that are absent when the completed assistant tool call is
+        // rendered. Keep the inference prefix intact, then train the complete
+        // assistant serialization from the small template boundary onward.
+        let target = Array(fullConversationTokenIds.dropFirst(commonCount))
+        guard !target.isEmpty else {
+            throw TextSFTTrainingBatchError.noAssistantTargets
+        }
+        return target
+    }
+
     public static func shiftedTargetExample(
         prefixTokenIds: [Int],
         targetTokenIds: [Int],
@@ -217,6 +240,7 @@ public enum TextSFTTrainingBatchError: Error, LocalizedError, Sendable {
     case messageTokenRoleMismatch
     case notEnoughTokens
     case noAssistantTargets
+    case nativeTemplatePrefixMismatch
     case shiftedLengthMismatch
 
     public var errorDescription: String? {
@@ -231,6 +255,8 @@ public enum TextSFTTrainingBatchError: Error, LocalizedError, Sendable {
             return "Text SFT example must contain at least two tokens after truncation."
         case .noAssistantTargets:
             return "Text SFT example contains no assistant target tokens."
+        case .nativeTemplatePrefixMismatch:
+            return "Text SFT native assistant rendering diverges before the generation-prompt boundary."
         case .shiftedLengthMismatch:
             return "Text SFT shifted input, label, and mask lengths must match."
         }

--- a/Tests/MereRunCoreTests/Gemma4TextSFTTokenizerTests.swift
+++ b/Tests/MereRunCoreTests/Gemma4TextSFTTokenizerTests.swift
@@ -22,4 +22,82 @@ final class Gemma4TextSFTTokenizerTests: XCTestCase {
             2
         )
     }
+
+    func testOfficialTokenizerIncludesSchemaAndTypedToolTargetWhenAvailable() async throws {
+        guard let path = ProcessInfo.processInfo.environment[
+            "MERERUN_GEMMA4_TOKENIZER_PATH"
+        ] else {
+            throw XCTSkip(
+                "Set MERERUN_GEMMA4_TOKENIZER_PATH to run the official Gemma 4 tool-SFT test."
+            )
+        }
+        let tokenizer = try await Gemma4TokenizerAndTemplate.load(
+            from: URL(fileURLWithPath: path),
+            maxLengthOverride: 512
+        )
+        let tool = ToolDefinition(
+            name: "create_status_summary",
+            description: "Create a concise status summary.",
+            parameters: [
+                "project": ToolParameterProperty(
+                    type: "string",
+                    description: "Project identifier"
+                ),
+            ],
+            required: ["project"]
+        )
+        let messages = [
+            ChatMessage(role: .system, content: "Use available tools."),
+            ChatMessage(role: .user, content: "Summarize the project status."),
+            ChatMessage(
+                role: .assistant,
+                content: "",
+                toolCalls: [ChatMessageToolCall(
+                    id: "call-1",
+                    name: tool.name,
+                    arguments: ["project": .string("Example App")]
+                )]
+            ),
+        ]
+        let prefixTokens = try tokenizer.encodeForGeneration(
+            messages: Array(messages.dropLast()),
+            tools: [tool],
+            addGenerationPrompt: true,
+            includeThinking: false,
+            maxLength: 512
+        )
+        let fullTokens = try tokenizer.encodeForGeneration(
+            messages: messages,
+            tools: [tool],
+            addGenerationPrompt: false,
+            includeThinking: false,
+            maxLength: 512
+        )
+        let common = Gemma4TextSFTTokenizer.commonPrefixLength(prefixTokens, fullTokens)
+        XCTAssertGreaterThan(
+            common,
+            prefixTokens.count - 8,
+            "prefix=\(tokenizer.decode(tokens: Array(prefixTokens.suffix(16)))) "
+                + "full=\(tokenizer.decode(tokens: Array(fullTokens[common..<min(fullTokens.count, common + 16)])))"
+        )
+        let tokenized = try XCTUnwrap(Gemma4TextSFTTokenizer.tokenize(
+            [TextSFTExample(
+                id: "official-tool-tokenizer",
+                sources: ["test"],
+                messages: messages,
+                tools: [tool]
+            )],
+            tokenizerAndTemplate: tokenizer,
+            maxSequenceLength: 512
+        ).first)
+
+        let prefix = tokenizer.decode(tokens: zip(tokenized.inputTokenIds, tokenized.lossMask)
+            .compactMap { token, mask in mask == 0 ? token : nil })
+        let target = tokenizer.decode(tokens: zip(tokenized.labelTokenIds, tokenized.lossMask)
+            .compactMap { token, mask in mask == 1 ? token : nil })
+        XCTAssertTrue(prefix.contains(tool.name), prefix)
+        XCTAssertTrue(prefix.contains("Project identifier"), prefix)
+        XCTAssertTrue(target.contains(tool.name), target)
+        XCTAssertTrue(target.contains("Example App"), target)
+    }
 }

--- a/Tests/MereRunCoreTests/InklingTextSFTTokenizerTests.swift
+++ b/Tests/MereRunCoreTests/InklingTextSFTTokenizerTests.swift
@@ -2,6 +2,41 @@ import XCTest
 @testable import MereRunCore
 
 final class InklingTextSFTTokenizerTests: XCTestCase {
+    func testNativePromptContainsSchemaAndTypedToolTarget() throws {
+        let tool = ToolDefinition(
+            name: "create_status_summary",
+            description: "Create a concise status summary.",
+            parameters: [
+                "project": ToolParameterProperty(
+                    type: "string",
+                    description: "Project identifier"
+                ),
+            ],
+            required: ["project"]
+        )
+        let prompt = try InklingTokenizerAndTemplate.renderPrompt(
+            messages: [
+                ChatMessage(role: .user, content: "Summarize the project status."),
+                ChatMessage(
+                    role: .assistant,
+                    content: "",
+                    toolCalls: [ChatMessageToolCall(
+                        id: "call-1",
+                        name: tool.name,
+                        arguments: ["project": .string("Example App")]
+                    )]
+                ),
+            ],
+            tools: [tool],
+            addGenerationPrompt: false
+        )
+
+        XCTAssertTrue(prompt.contains("tool_declare"), prompt)
+        XCTAssertTrue(prompt.contains("Project identifier"), prompt)
+        XCTAssertTrue(prompt.contains("create_status_summary"), prompt)
+        XCTAssertTrue(prompt.contains("Example App"), prompt)
+    }
+
     func testAssistantTargetUsesInklingVisibleTextAndSamplingBoundary() {
         XCTAssertEqual(
             InklingTextSFTTokenizer.assistantTargetText("  A concise answer.\n"),

--- a/Tests/MereRunCoreTests/LagunaTextSFTTokenizerTests.swift
+++ b/Tests/MereRunCoreTests/LagunaTextSFTTokenizerTests.swift
@@ -2,6 +2,31 @@ import XCTest
 @testable import MereRunCore
 
 final class LagunaTextSFTTokenizerTests: XCTestCase {
+    func testRendererPreservesTypedToolCallsAndResults() throws {
+        let rendered = LagunaTokenizerAndTemplate.renderMessages([
+            ChatMessage(
+                role: .assistant,
+                content: "",
+                toolCalls: [ChatMessageToolCall(
+                    id: "call-1",
+                    name: "create_status_summary",
+                    arguments: ["project": .string("Example App")]
+                )]
+            ),
+            ChatMessage(
+                role: .tool,
+                content: #"{"state":"ready"}"#,
+                name: "create_status_summary",
+                toolCallID: "call-1"
+            ),
+        ])
+
+        let calls = try XCTUnwrap(rendered[0]["tool_calls"] as? [[String: any Sendable]])
+        XCTAssertEqual(calls.count, 1)
+        XCTAssertEqual(rendered[1]["name"] as? String, "create_status_summary")
+        XCTAssertEqual(rendered[1]["tool_call_id"] as? String, "call-1")
+    }
+
     func testAssistantTargetTextTrimsBoundaryWhitespace() {
         XCTAssertEqual(
             LagunaTextSFTTokenizer.assistantTargetText("  A concise answer.\n"),

--- a/Tests/MereRunCoreTests/TextSFTDatasetTests.swift
+++ b/Tests/MereRunCoreTests/TextSFTDatasetTests.swift
@@ -49,4 +49,188 @@ final class TextSFTDatasetTests: XCTestCase {
             XCTAssertTrue(String(describing: error).contains("duplicatePrompt"))
         }
     }
+
+    func testAllowsSameQuestionAtDifferentToolLoopStates() throws {
+        let tool = Self.summaryTool()
+        let initial = TextSFTExample(
+            id: "initial",
+            sources: ["test"],
+            messages: [
+                ChatMessage(role: .system, content: "Use available tools."),
+                ChatMessage(role: .user, content: "Summarize the project status."),
+                ChatMessage(
+                    role: .assistant,
+                    content: "",
+                    toolCalls: [Self.summaryCall(id: "call-1")]
+                ),
+            ],
+            tools: [tool]
+        )
+        let continued = TextSFTExample(
+            id: "continued",
+            sources: ["test"],
+            messages: [
+                ChatMessage(role: .system, content: "Use available tools."),
+                ChatMessage(role: .user, content: "Summarize the project status."),
+                ChatMessage(
+                    role: .assistant,
+                    content: "",
+                    toolCalls: [Self.summaryCall(id: "call-1")]
+                ),
+                ChatMessage(
+                    role: .tool,
+                    content: #"{"state":"ready"}"#,
+                    name: "create_status_summary",
+                    toolCallID: "call-1"
+                ),
+                ChatMessage(role: .assistant, content: "The project is ready."),
+            ],
+            tools: [tool]
+        )
+
+        XCTAssertNoThrow(try TextSFTDataset.validate([initial, continued]))
+    }
+
+    func testRejectsDuplicateCompleteControllerState() throws {
+        let tool = Self.summaryTool()
+        let messages = [
+            ChatMessage(role: .system, content: "Use available tools."),
+            ChatMessage(role: .user, content: "Summarize the project status."),
+            ChatMessage(
+                role: .assistant,
+                content: "",
+                toolCalls: [Self.summaryCall(id: "call-1")]
+            ),
+        ]
+        let examples = [
+            TextSFTExample(id: "one", sources: ["test"], messages: messages, tools: [tool]),
+            TextSFTExample(id: "two", sources: ["test"], messages: messages, tools: [tool]),
+        ]
+
+        XCTAssertThrowsError(try TextSFTDataset.validate(examples)) { error in
+            XCTAssertTrue(String(describing: error).contains("duplicatePrompt"))
+        }
+    }
+
+    func testFingerprintIncludesTypedCallsAndCompleteToolSchema() {
+        let base = TextSFTExample(
+            id: "one",
+            sources: ["test"],
+            messages: [
+                ChatMessage(role: .system, content: "Use available tools."),
+                ChatMessage(role: .user, content: "Summarize the project status."),
+                ChatMessage(
+                    role: .assistant,
+                    content: "",
+                    toolCalls: [Self.summaryCall(id: "call-1")]
+                ),
+            ],
+            tools: [Self.summaryTool()]
+        )
+        let changedCall = TextSFTExample(
+            id: base.id,
+            sources: base.sources,
+            messages: [
+                ChatMessage(role: .system, content: "Use available tools."),
+                ChatMessage(role: .user, content: "Summarize the project status."),
+                ChatMessage(
+                    role: .assistant,
+                    content: "",
+                    toolCalls: [ChatMessageToolCall(
+                        id: "call-1",
+                        name: "create_status_summary",
+                        arguments: ["project": .string("Example API")]
+                    )]
+                ),
+            ],
+            tools: base.tools
+        )
+        let changedSchema = TextSFTExample(
+            id: base.id,
+            sources: base.sources,
+            messages: base.messages,
+            tools: [ToolDefinition(
+                name: "create_status_summary",
+                description: "Create a concise status report.",
+                parameters: [
+                    "project": ToolParameterProperty(
+                        type: "string",
+                        description: "Project identifier"
+                    ),
+                    "includeRisks": ToolParameterProperty(
+                        type: "boolean",
+                        description: "Include known risks"
+                    ),
+                ],
+                required: ["project", "includeRisks"]
+            )]
+        )
+
+        let fingerprint = TextSFTDataset.fingerprint([base])
+        XCTAssertNotEqual(fingerprint, TextSFTDataset.fingerprint([changedCall]))
+        XCTAssertNotEqual(fingerprint, TextSFTDataset.fingerprint([changedSchema]))
+    }
+
+    func testFingerprintPreservesRenderedToolOrderWhileDuplicatesCanonicalizeIt() throws {
+        let firstTool = Self.summaryTool()
+        let secondTool = ToolDefinition(
+            name: "record_status_note",
+            description: "Record a status note.",
+            parameters: [
+                "note": ToolParameterProperty(type: "string", description: "Status note"),
+            ],
+            required: ["note"]
+        )
+        let messages = [
+            ChatMessage(role: .user, content: "Summarize the project status."),
+            ChatMessage(role: .assistant, content: "The project is ready."),
+        ]
+        let forward = TextSFTExample(
+            id: "forward",
+            sources: ["test"],
+            messages: messages,
+            tools: [firstTool, secondTool]
+        )
+        let reversed = TextSFTExample(
+            id: "reversed",
+            sources: ["test"],
+            messages: messages,
+            tools: [secondTool, firstTool]
+        )
+
+        XCTAssertNotEqual(
+            TextSFTDataset.fingerprint([forward]),
+            TextSFTDataset.fingerprint([reversed])
+        )
+        XCTAssertThrowsError(try TextSFTDataset.validate([forward, reversed]))
+    }
+
+    func testDecodesLegacyRowsWithoutTools() throws {
+        let row = #"{"id":"legacy","sources":["test"],"messages":[{"role":"system","content":"Be concise."},{"role":"user","content":"Say ready now."},{"role":"assistant","content":"Ready now."}]}"#
+        let example = try JSONDecoder().decode(TextSFTExample.self, from: Data(row.utf8))
+
+        XCTAssertNil(example.tools)
+    }
+
+    private static func summaryTool() -> ToolDefinition {
+        ToolDefinition(
+            name: "create_status_summary",
+            description: "Create a status summary.",
+            parameters: [
+                "project": ToolParameterProperty(
+                    type: "string",
+                    description: "Project identifier"
+                ),
+            ],
+            required: ["project"]
+        )
+    }
+
+    private static func summaryCall(id: String) -> ChatMessageToolCall {
+        ChatMessageToolCall(
+            id: id,
+            name: "create_status_summary",
+            arguments: ["project": .string("Example App")]
+        )
+    }
 }

--- a/Tests/MereRunCoreTests/TextSFTTrainingBatchTests.swift
+++ b/Tests/MereRunCoreTests/TextSFTTrainingBatchTests.swift
@@ -3,6 +3,33 @@ import XCTest
 @testable import MereRunCore
 
 final class TextSFTTrainingBatchTests: MereRunCoreTestCase {
+    func testNativeAssistantTargetUsesExactTemplateSuffix() throws {
+        XCTAssertEqual(
+            try TextSFTTrainingBatchBuilder.nativeAssistantTarget(
+                prefixTokenIds: [1, 2, 3],
+                fullConversationTokenIds: [1, 2, 3, 8, 9]
+            ),
+            [8, 9]
+        )
+    }
+
+    func testNativeAssistantTargetRejectsDivergentTemplatePrefix() {
+        XCTAssertThrowsError(try TextSFTTrainingBatchBuilder.nativeAssistantTarget(
+            prefixTokenIds: [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11],
+            fullConversationTokenIds: [1, 2, 40, 80, 90]
+        ))
+    }
+
+    func testNativeAssistantTargetAllowsGenerationPromptBoundaryControls() throws {
+        XCTAssertEqual(
+            try TextSFTTrainingBatchBuilder.nativeAssistantTarget(
+                prefixTokenIds: [1, 2, 3, 4, 5, 6],
+                fullConversationTokenIds: [1, 2, 8, 9]
+            ),
+            [8, 9]
+        )
+    }
+
     func testShiftedTargetExampleMasksOnlyTargetTokens() throws {
         let example = try TextSFTTrainingBatchBuilder.shiftedTargetExample(
             prefixTokenIds: [10, 11, 12, 13],

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -903,8 +903,13 @@ swift run mere.run text train-lora \
   --training-steps 600
 ```
 
-Each non-empty line contains `sources` and at least system, user, and assistant
-messages; the assistant message must be last. `--dry-run --json` validates and
+Each non-empty line contains `sources`, at least system, user, and assistant
+messages, and may include typed `tools`; the assistant message must be last.
+Assistant `toolCalls` and matching `tool` results use the same typed fields as
+inference. Native training templates receive the full schemas, including
+parameters and required fields. Dataset identity and duplicate-controller
+checks include the complete conversation state and schemas, so successive
+tool-loop states may repeat a user question. `--dry-run --json` validates and
 fingerprints the dataset and writes the family-specific manifest without
 loading the model. Gemma 4 and Laguna default to
 `q_proj,k_proj,v_proj,o_proj`. Inkling defaults to those attention projections

--- a/docs/runtime/text.md
+++ b/docs/runtime/text.md
@@ -526,11 +526,21 @@ swift run mere.run text train-lora \
 ```
 
 `text train-lora` is the native MereRun entrypoint for chat-style SFT JSONL.
-The data format is one JSON object per line with `sources` and `messages`;
-messages use the same `system`, `user`, and `assistant` roles as the local chat
-runtime. `--dry-run` validates the dataset, fingerprints it, validates and
-counts an optional held-out SFT dataset, and writes a `.manifest.json` next to
-the requested adapter path.
+The data format is one JSON object per line with `sources`, `messages`, and an
+optional typed `tools` array. Messages use the same `system`, `user`,
+`assistant`, and `tool` roles as the local chat runtime. Assistant messages can
+carry typed `toolCalls`; tool results use `name` and `toolCallID`. The selected
+model's native template receives the same complete tool schemas during
+training that it receives during inference, and native tool-call markup is
+included in the assistant loss target. `--dry-run` validates the dataset,
+fingerprints messages and complete tool schemas, validates and counts an
+optional held-out SFT dataset, and writes a `.manifest.json` next to the
+requested adapter path.
+
+Duplicate detection compares the complete controller prefix and its tool
+schemas, rather than only the first user question. A curriculum may therefore
+repeat a question after an assistant tool call and tool result, while an exact
+duplicate controller state remains invalid.
 
 Without `--dry-run`, the command resolves a supported Gemma 4 text model,
 `text-chat-laguna-xs-2-1`, or `text-chat-inkling-small` through the same managed


### PR DESCRIPTION
## Summary

- carry optional typed tool schemas through text SFT dataset examples
- render schemas and native assistant tool-call targets for Gemma 4, Laguna, and Inkling
- fingerprint complete messages and schemas while deduplicating complete controller states
- preserve legacy schema-free JSONL compatibility and document the updated format

## Validation

- [x] `./scripts/check.sh` — 3,136 tests passed, 224 environment-gated skips
- [x] focused SFT and tokenizer tests — 26 passed, 2 unavailable-checkpoint skips
- [x] installed Gemma 4 tokenizer schema and typed-target test
- [x] `pnpm docs:build`
- [x] no vendored artifacts or package pins changed