### PR TITLE
Fix Gemma 4 Turbo API timeout behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,6 +50,12 @@ The format is based on Keep a Changelog.
   `finish_reason: "tool_calls"`. Canonical managed-model IDs now resolve to the
   same installed path during real server startup that preflight reports, and
   native requests preserve `tool_choice` and `parallel_tool_calls` policy.
+- fixed Gemma 4 Turbo API timeout behavior by warming its first graph before
+  readiness, keeping serving KV full precision unless explicitly quantized,
+  sorting large NVFP4 expert batches like the upstream sparse path, propagating
+  client disconnect cancellation, keeping runtime status responsive during
+  inference, and reporting startup, TTFT, prefill, decode, throughput, token,
+  cancellation, and slot-release telemetry.
 - added pinned LiquidAI DSpark companions for LFM2.5 1.2B Instruct, 2.6B,
   and 8B-A1B. The native Swift/MLX runtime captures five configured target-layer
   outputs, runs the non-causal diffusion draft block, drafts

--- a/Sources/MereRunCLI/Commands/APIServeCommand.swift
+++ b/Sources/MereRunCLI/Commands/APIServeCommand.swift
@@ -4,6 +4,7 @@ import Foundation
 import FoundationNetworking
 #endif
 import Hummingbird
+import HTTPTypes
 import NIOCore
 import AudioCore
 import AudioSTT
@@ -181,6 +182,13 @@ struct APIServe: AsyncParsableCommand {
     @Option(name: [.long], help: "Context size (default: 32768).")
     var contextSize: Int = 32768
 
+    @Flag(
+        name: [.customLong("warmup")],
+        inversion: .prefixedNo,
+        help: "Warm the default Gemma 4 Turbo graph before the server becomes healthy."
+    )
+    var warmup: Bool = true
+
     @Option(name: [.long], help: "Quantize the Gemma4 KV cache to this many bits. Supports integer widths for uniform/polar and integer/.5 widths for turboquant.")
     var kvBits: Double?
 
@@ -237,7 +245,8 @@ struct APIServe: AsyncParsableCommand {
             engine: engine,
             contextSize: contextSize,
             gemma4KVCacheQuantization: gemma4KVCacheQuantization,
-            memoryPressurePolicy: memoryPressurePolicy
+            memoryPressurePolicy: memoryPressurePolicy,
+            warmupDefaultModel: warmup
         )
         try await server.run(host: host, port: port)
     }
@@ -405,24 +414,13 @@ struct APIServe: AsyncParsableCommand {
         )
     }
 
-    private var requestedGemma4ModelSpec: String {
-        model?.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() ?? Gemma4Resources.defaultModelId
-    }
-
-    private var usesGemma4TurboKVDefaults: Bool {
-        Gemma4Resources.usesTurboDefaults(modelSpec: requestedGemma4ModelSpec)
-            && Gemma4Resources.supportsDefaultTurboKVQuantization
-    }
-
     private var resolvedGemma4KVBits: Double? {
-        kvBits ?? (usesGemma4TurboKVDefaults ? Gemma4Resources.defaultTurboKVBits : nil)
+        kvBits
     }
 
     private func resolveGemma4KVQuantizationScheme() throws -> Gemma4KVQuantizationScheme {
         let raw = kvQuantScheme
-            ?? (usesGemma4TurboKVDefaults
-                ? Gemma4Resources.defaultTurboKVQuantizationScheme.rawValue
-                : Gemma4Resources.defaultKVQuantizationScheme.rawValue)
+            ?? Gemma4Resources.defaultKVQuantizationScheme.rawValue
         guard let scheme = Gemma4KVQuantizationScheme(
             rawValue: raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         ) else {
@@ -432,9 +430,7 @@ struct APIServe: AsyncParsableCommand {
     }
 
     private var resolvedGemma4QuantizedKVStart: Int {
-        quantizedKVStart ?? (usesGemma4TurboKVDefaults
-            ? Gemma4Resources.defaultTurboQuantizedKVStart
-            : Gemma4Resources.defaultQuantizedKVStart)
+        quantizedKVStart ?? Gemma4Resources.defaultQuantizedKVStart
     }
 
     func resolveAPIKey() -> String? {
@@ -3872,7 +3868,8 @@ actor CodeGenServer {
         contextSize: Int = 32768,
         gemma4KVCacheQuantization: Gemma4KVCacheQuantization = Gemma4KVCacheQuantization(),
         memoryPressurePolicy: RuntimeMemoryPressurePolicy = .default,
-        artifactCleanupScheduler: APIArtifactDirectoryCleanupScheduler = APIArtifactDirectoryCleanupScheduler()
+        artifactCleanupScheduler: APIArtifactDirectoryCleanupScheduler = APIArtifactDirectoryCleanupScheduler(),
+        warmupDefaultModel: Bool = true
     ) async throws {
         self.apiKey = apiKey
         self.contextSize = contextSize
@@ -3919,7 +3916,7 @@ actor CodeGenServer {
                 await runtimePool.currentMemoryPressure()
             }
         )
-        try await pool.preloadDefault()
+        try await pool.preloadDefault(warmup: warmupDefaultModel)
     }
 
     func run(host: String, port: Int) async throws {
@@ -4127,7 +4124,8 @@ actor CodeGenServer {
         )
     }
 
-    private func handleChatCompletions(_ request: Request) async throws -> Response {
+    private func handleChatCompletions(_ incomingRequest: Request) async throws -> Response {
+        var request = incomingRequest
         if let unauthorized = unauthorizedResponseIfNeeded(for: request) {
             return unauthorized
         }
@@ -4149,7 +4147,7 @@ actor CodeGenServer {
         // Decode request body
         let body: ByteBuffer
         do {
-            body = try await request.body.collect(upTo: 10 * 1024 * 1024) // 10MB limit
+            body = try await request.collectBody(upTo: 10 * 1024 * 1024) // 10MB limit
         } catch {
             return makeErrorResponse(status: .badRequest, message: "Invalid request body.", type: "invalid_request_error")
         }
@@ -4173,6 +4171,12 @@ actor CodeGenServer {
             await admissionLease.release()
             return runtimeErrorResponse(error)
         }
+        await admissionLease.configure(
+            modelID: plan.modelID,
+            streaming: openaiRequest.stream == true,
+            requestedMaxTokens: plan.request.maxTokens,
+            toolCount: plan.request.tools?.count ?? 0
+        )
 
         if plan.engine == .textChatDeepseekV4Flash {
             do {
@@ -4199,7 +4203,7 @@ actor CodeGenServer {
                     admissionLease: admissionLease
                 )
             } else {
-                return try await handleNonStreamingChat(
+                return handleNonStreamingChat(
                     plan.request,
                     modelID: plan.modelID,
                     lease: plan.lease,
@@ -5047,51 +5051,156 @@ actor CodeGenServer {
         modelID: String,
         lease: RuntimeModelLease,
         admissionLease: RuntimeRequestAdmissionLease
-    ) async throws -> Response {
-        defer {
-            Task {
-                await lease.release()
-                await admissionLease.release()
+    ) -> Response {
+        let (stream, continuation) = AsyncStream<NonStreamingChatEvent>.makeStream()
+        let heartbeatTask = Task<Void, Never> {
+            do {
+                while !Task.isCancelled {
+                    try await Task.sleep(for: .milliseconds(250))
+                    guard !Task.isCancelled else { break }
+                    continuation.yield(.heartbeat)
+                }
+            } catch {
+                // Cancellation ends the heartbeat loop.
             }
         }
-        let result = try await lease.chat(request, progressHandler: nil)
-        let responseToolCalls = openAIToolCalls(
-            from: result.toolCalls,
-            tools: request.tools,
-            parallelToolCalls: request.parallelToolCalls
-        )
-
-        let response = OpenAIChatResponse(
-            id: "chatcmpl-\(UUID().uuidString.prefix(8))",
-            object: "chat.completion",
-            created: Int(Date().timeIntervalSince1970),
-            model: modelID,
-            choices: [
-                OpenAIChatChoice(
-                    index: 0,
-                    message: OpenAIChatMessage(
-                        role: "assistant",
-                        content: result.response,
-                        reasoning_content: result.reasoningContent,
-                        tool_calls: responseToolCalls
-                    ),
-                    finish_reason: Self.openAIFinishReason(
-                        for: result,
-                        hasToolCalls: responseToolCalls?.isEmpty == false
-                    ),
-                    logprobs: OpenAIChatLogprobs(result.logprobs)
+        let generationTask = Task {
+            do {
+                let result = try await lease.chat(request) { progress in
+                    admissionLease.observe(progress)
+                }
+                let responseToolCalls = openAIToolCalls(
+                    from: result.toolCalls,
+                    tools: request.tools,
+                    parallelToolCalls: request.parallelToolCalls
                 )
-            ],
-            usage: Self.openAIUsage(for: result)
-        )
+                let response = OpenAIChatResponse(
+                    id: "chatcmpl-\(UUID().uuidString.prefix(8))",
+                    object: "chat.completion",
+                    created: Int(Date().timeIntervalSince1970),
+                    model: modelID,
+                    choices: [
+                        OpenAIChatChoice(
+                            index: 0,
+                            message: OpenAIChatMessage(
+                                role: "assistant",
+                                content: result.response,
+                                reasoning_content: result.reasoningContent,
+                                tool_calls: responseToolCalls
+                            ),
+                            finish_reason: Self.openAIFinishReason(
+                                for: result,
+                                hasToolCalls: responseToolCalls?.isEmpty == false
+                            ),
+                            logprobs: OpenAIChatLogprobs(result.logprobs)
+                        )
+                    ],
+                    usage: Self.openAIUsage(for: result)
+                )
+                let data = try JSONEncoder().encode(response)
+                var trailers = Self.openAITimingHeaders(for: result)
+                trailers["x-mere-runtime-status"] = "200"
+                await lease.release()
+                await admissionLease.release()
+                heartbeatTask.cancel()
+                continuation.yield(.completion(NonStreamingChatPayload(
+                    data: data,
+                    trailers: trailers
+                )))
+                continuation.finish()
+            } catch {
+                await lease.release()
+                await admissionLease.release(
+                    cancelled: Task.isCancelled || error is CancellationError
+                )
+                heartbeatTask.cancel()
+                if !Task.isCancelled,
+                   let data = try? JSONEncoder().encode(OpenAIErrorResponse(
+                       error: OpenAIError(message: "Request failed.", type: "server_error")
+                   )) {
+                    continuation.yield(.completion(NonStreamingChatPayload(
+                        data: data,
+                        trailers: ["x-mere-runtime-status": "500"]
+                    )))
+                }
+                continuation.finish()
+            }
+        }
+        continuation.onTermination = { termination in
+            if case .cancelled = termination {
+                admissionLease.observeClientDisconnect()
+                heartbeatTask.cancel()
+                generationTask.cancel()
+            }
+        }
 
-        let data = try JSONEncoder().encode(response)
+        var headers: HTTPFields = [
+            .contentType: "application/json",
+            .trailer: Self.openAITimingTrailerNames.joined(separator: ", "),
+        ]
+        if let requestIDName = HTTPField.Name("x-mere-request-id") {
+            headers[requestIDName] = admissionLease.requestID.uuidString
+        }
+
         return Response(
             status: .ok,
-            headers: [.contentType: "application/json"],
-            body: .init(byteBuffer: ByteBuffer(bytes: data))
+            headers: headers,
+            body: .init { writer in
+                do {
+                    // Leading JSON whitespace doubles as a bounded outbound
+                    // disconnect probe without exposing partial model output.
+                    try await writer.write(ByteBuffer(string: "\n"))
+                    var iterator = stream.makeAsyncIterator()
+                    while let event = await iterator.next() {
+                        switch event {
+                        case .heartbeat:
+                            try await writer.write(ByteBuffer(string: " "))
+                        case .completion(let payload):
+                            try await writer.write(ByteBuffer(bytes: payload.data))
+                            try await writer.finish(Self.httpFields(payload.trailers))
+                            return
+                        }
+                    }
+                    try await writer.finish(nil)
+                } catch {
+                    admissionLease.observeClientDisconnect()
+                    heartbeatTask.cancel()
+                    generationTask.cancel()
+                    throw error
+                }
+            }
         )
     }
+
+    private nonisolated static func httpFields(_ values: [String: String]) -> HTTPFields {
+        var fields: HTTPFields = [:]
+        for (name, value) in values {
+            if let fieldName = HTTPField.Name(name) {
+                fields[fieldName] = value
+            }
+        }
+        return fields
+    }
+
+    private struct NonStreamingChatPayload: Sendable {
+        let data: Data
+        let trailers: [String: String]
+    }
+
+    private enum NonStreamingChatEvent: Sendable {
+        case heartbeat
+        case completion(NonStreamingChatPayload)
+    }
+
+    private nonisolated static let openAITimingTrailerNames = [
+        "Server-Timing",
+        "x-mere-prompt-tokens",
+        "x-mere-generated-tokens",
+        "x-mere-prefill-tokens-per-second",
+        "x-mere-decode-tokens-per-second",
+        "x-mere-kv-cache",
+        "x-mere-runtime-status",
+    ]
 
     private func embeddingModel(for requestedModel: String) async throws -> (modelID: String, modelPath: String) {
         let normalized = requestedModel.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -5635,12 +5744,12 @@ actor CodeGenServer {
         // Create async stream for SSE
         let (stream, continuation) = AsyncStream<ByteBuffer>.makeStream()
 
-        // Start generation in a detached task
-        Task {
+        let generationTask = Task {
             do {
                 let streamedContent = StreamingContentTracker()
                 let shouldBufferForToolCalls = request.tools?.isEmpty == false
                 let result = try await lease.chat(request) { progress in
+                    admissionLease.observe(progress)
                     guard !shouldBufferForToolCalls else { return }
                     if progress.stage == .generating,
                        let token = progress.message,
@@ -5758,17 +5867,26 @@ actor CodeGenServer {
                 await admissionLease.release()
                 continuation.finish()
             } catch {
-                // Send error in SSE format
-                let errorResponse = OpenAIErrorResponse(
-                    error: OpenAIError(message: "Request failed.", type: "server_error")
-                )
-                if let data = try? encoder.encode(errorResponse),
-                   let json = String(data: data, encoding: .utf8) {
-                    continuation.yield(ByteBuffer(string: "data: \(json)\n\n"))
+                if !Task.isCancelled {
+                    let errorResponse = OpenAIErrorResponse(
+                        error: OpenAIError(message: "Request failed.", type: "server_error")
+                    )
+                    if let data = try? encoder.encode(errorResponse),
+                       let json = String(data: data, encoding: .utf8) {
+                        continuation.yield(ByteBuffer(string: "data: \(json)\n\n"))
+                    }
                 }
                 await lease.release()
-                await admissionLease.release()
+                await admissionLease.release(
+                    cancelled: Task.isCancelled || error is CancellationError
+                )
                 continuation.finish()
+            }
+        }
+        continuation.onTermination = { termination in
+            if case .cancelled = termination {
+                admissionLease.observeClientDisconnect()
+                generationTask.cancel()
             }
         }
 
@@ -5832,6 +5950,50 @@ actor CodeGenServer {
             completion_tokens: result.tokensGenerated,
             total_tokens: promptTokens + result.tokensGenerated
         )
+    }
+
+    nonisolated static func openAITimingHeaders(for result: ChatResponse) -> [String: String] {
+        var headers = [
+            "x-mere-prompt-tokens": String(result.promptTokens ?? 0),
+            "x-mere-generated-tokens": String(result.tokensGenerated),
+        ]
+        guard let timing = result.timing else { return headers }
+
+        let timeToFirstToken = timing.loadSeconds
+            + timing.prefillSeconds
+            + (timing.cacheConversionSeconds ?? 0)
+            + (timing.firstTokenSeconds ?? 0)
+        var serverTiming = [
+            "model_load;dur=\(milliseconds(timing.loadSeconds))",
+            "prefill;dur=\(milliseconds(timing.prefillSeconds))",
+            "decode;dur=\(milliseconds(timing.decodeSeconds))",
+            "ttft;dur=\(milliseconds(timeToFirstToken))",
+        ]
+        if let cacheConversionSeconds = timing.cacheConversionSeconds {
+            serverTiming.insert(
+                "kv_pack;dur=\(milliseconds(cacheConversionSeconds))",
+                at: 2
+            )
+        }
+        headers["server-timing"] = serverTiming.joined(separator: ", ")
+        if let throughput = timing.prefillTokensPerSecond {
+            headers["x-mere-prefill-tokens-per-second"] = fixedPrecision(throughput)
+        }
+        if let throughput = timing.decodeTokensPerSecond {
+            headers["x-mere-decode-tokens-per-second"] = fixedPrecision(throughput)
+        }
+        if let kvCache = timing.decodeKVCache {
+            headers["x-mere-kv-cache"] = kvCache
+        }
+        return headers
+    }
+
+    private nonisolated static func milliseconds(_ seconds: Double) -> String {
+        fixedPrecision(seconds * 1_000)
+    }
+
+    private nonisolated static func fixedPrecision(_ value: Double) -> String {
+        String(format: "%.3f", value)
     }
 
     private func unauthorizedResponseIfNeeded(for request: Request) -> Response? {

--- a/Sources/MereRunCLI/Commands/APIServeCommand.swift
+++ b/Sources/MereRunCLI/Commands/APIServeCommand.swift
@@ -5074,6 +5074,7 @@ actor CodeGenServer {
                     tools: request.tools,
                     parallelToolCalls: request.parallelToolCalls
                 )
+                let hasToolCalls = responseToolCalls?.isEmpty == false
                 let response = OpenAIChatResponse(
                     id: "chatcmpl-\(UUID().uuidString.prefix(8))",
                     object: "chat.completion",
@@ -5084,13 +5085,16 @@ actor CodeGenServer {
                             index: 0,
                             message: OpenAIChatMessage(
                                 role: "assistant",
-                                content: result.response,
+                                content: Self.openAIMessageContent(
+                                    for: result,
+                                    hasToolCalls: hasToolCalls
+                                ),
                                 reasoning_content: result.reasoningContent,
                                 tool_calls: responseToolCalls
                             ),
                             finish_reason: Self.openAIFinishReason(
                                 for: result,
-                                hasToolCalls: responseToolCalls?.isEmpty == false
+                                hasToolCalls: hasToolCalls
                             ),
                             logprobs: OpenAIChatLogprobs(result.logprobs)
                         )
@@ -5939,6 +5943,13 @@ actor CodeGenServer {
             return "tool_calls"
         }
         return result.finishReason == .length ? "length" : "stop"
+    }
+
+    nonisolated static func openAIMessageContent(
+        for result: ChatResponse,
+        hasToolCalls: Bool
+    ) -> String {
+        hasToolCalls ? "" : result.response
     }
 
     /// Generators that don't report a prompt token count fall back to zero

--- a/Sources/MereRunCLI/Support/RuntimeModelPool.swift
+++ b/Sources/MereRunCLI/Support/RuntimeModelPool.swift
@@ -191,6 +191,10 @@ struct RuntimeRequestAdmissionSnapshot: Codable, Equatable, Sendable {
     let totalCancelledRequests: Int
     let admissionPaused: Bool?
     let pressure: String?
+    var activeRequestDetails: [RuntimeActiveRequestSnapshot]? = nil
+    var lastClientDisconnectAt: Date? = nil
+    var lastCancellationAt: Date? = nil
+    var lastSlotReleaseAt: Date? = nil
 
     init(
         maxActiveRequests: Int,
@@ -200,7 +204,11 @@ struct RuntimeRequestAdmissionSnapshot: Codable, Equatable, Sendable {
         totalCompletedRequests: Int,
         totalCancelledRequests: Int,
         admissionPaused: Bool? = nil,
-        pressure: String? = nil
+        pressure: String? = nil,
+        activeRequestDetails: [RuntimeActiveRequestSnapshot]? = nil,
+        lastClientDisconnectAt: Date? = nil,
+        lastCancellationAt: Date? = nil,
+        lastSlotReleaseAt: Date? = nil
     ) {
         self.maxActiveRequests = maxActiveRequests
         self.activeRequests = activeRequests
@@ -210,7 +218,24 @@ struct RuntimeRequestAdmissionSnapshot: Codable, Equatable, Sendable {
         self.totalCancelledRequests = totalCancelledRequests
         self.admissionPaused = admissionPaused
         self.pressure = pressure
+        self.activeRequestDetails = activeRequestDetails
+        self.lastClientDisconnectAt = lastClientDisconnectAt
+        self.lastCancellationAt = lastCancellationAt
+        self.lastSlotReleaseAt = lastSlotReleaseAt
     }
+}
+
+struct RuntimeActiveRequestSnapshot: Codable, Equatable, Sendable {
+    let id: UUID
+    let admittedAt: Date
+    let modelID: String?
+    let streaming: Bool?
+    let requestedMaxTokens: Int?
+    let toolCount: Int?
+    let phase: String
+    let phaseDetail: String?
+    let firstTokenAt: Date?
+    let generatedTokenUpdates: Int
 }
 
 struct RuntimeFutureStats: Codable, Equatable, Sendable {
@@ -237,6 +262,7 @@ struct RuntimeModelBenchmarkStats: Codable, Equatable, Sendable {
     /// servers.
     let recentDecodeTokensPerSecond: Double?
     let lastCompletedAt: Date?
+    var lastRequest: RuntimeRequestTimingSnapshot? = nil
 
     init(
         completedRequests: Int,
@@ -247,7 +273,8 @@ struct RuntimeModelBenchmarkStats: Codable, Equatable, Sendable {
         totalDecodeSeconds: Double,
         recentDecodeTokens: Int = 0,
         recentDecodeSeconds: Double = 0,
-        lastCompletedAt: Date?
+        lastCompletedAt: Date?,
+        lastRequest: RuntimeRequestTimingSnapshot? = nil
     ) {
         self.completedRequests = completedRequests
         self.failedRequests = failedRequests
@@ -266,11 +293,48 @@ struct RuntimeModelBenchmarkStats: Codable, Equatable, Sendable {
             ? Double(recentDecodeTokens) / recentDecodeSeconds
             : nil
         self.lastCompletedAt = lastCompletedAt
+        self.lastRequest = lastRequest
     }
 
     private static func average(_ value: Double, count: Int) -> Double? {
         guard count > 0 else { return nil }
         return value / Double(count)
+    }
+}
+
+struct RuntimeRequestTimingSnapshot: Codable, Equatable, Sendable {
+    let promptTokens: Int
+    let generatedTokens: Int
+    let loadSeconds: Double
+    let prefillSeconds: Double
+    let cacheConversionSeconds: Double?
+    let decodeSeconds: Double
+    let timeToFirstTokenSeconds: Double?
+    let prefillTokensPerSecond: Double?
+    let decodeTokensPerSecond: Double?
+    let prefillKVCache: String?
+    let decodeKVCache: String?
+
+    init(response: ChatResponse) {
+        let timing = response.timing
+        promptTokens = response.promptTokens ?? 0
+        generatedTokens = response.tokensGenerated
+        loadSeconds = timing?.loadSeconds ?? 0
+        prefillSeconds = timing?.prefillSeconds ?? 0
+        cacheConversionSeconds = timing?.cacheConversionSeconds
+        decodeSeconds = timing?.decodeSeconds ?? 0
+        if let timing, let firstTokenSeconds = timing.firstTokenSeconds {
+            timeToFirstTokenSeconds = timing.loadSeconds
+                + timing.prefillSeconds
+                + (timing.cacheConversionSeconds ?? 0)
+                + firstTokenSeconds
+        } else {
+            timeToFirstTokenSeconds = nil
+        }
+        prefillTokensPerSecond = timing?.prefillTokensPerSecond
+        decodeTokensPerSecond = timing?.decodeTokensPerSecond
+        prefillKVCache = timing?.prefillKVCache
+        decodeKVCache = timing?.decodeKVCache
     }
 }
 
@@ -817,6 +881,18 @@ struct RuntimeModelPoolEntrySnapshot: Codable, Equatable, Sendable {
     let continuousBatching: RuntimeDecodeBatchingStats?
     let mtp: Gemma4MTPStats?
     let benchmarkStats: RuntimeModelBenchmarkStats?
+    /// Startup load and optional graph-warmup timing. Older servers omit it.
+    var startupTiming: RuntimeModelStartupTiming? = nil
+}
+
+struct RuntimeModelStartupTiming: Codable, Equatable, Sendable {
+    let loadSeconds: Double
+    let warmupSeconds: Double?
+    let warmupPrefillSeconds: Double?
+    let warmupDecodeSeconds: Double?
+    let warmupTimeToFirstTokenSeconds: Double?
+    let graphCompilationAccounting: String?
+    let completedAt: Date
 }
 
 struct RuntimeChatPlan: Sendable {
@@ -875,6 +951,8 @@ actor RuntimeModelPool {
         var totalDecodeSeconds: Double = 0
         var recentDecodeSamples: [(tokens: Int, seconds: Double)] = []
         var lastCompletedAt: Date?
+        var startupTiming: RuntimeModelStartupTiming?
+        var lastRequestTiming: RuntimeRequestTimingSnapshot?
 
         var benchmarkStats: RuntimeModelBenchmarkStats {
             RuntimeModelBenchmarkStats(
@@ -886,7 +964,8 @@ actor RuntimeModelPool {
                 totalDecodeSeconds: totalDecodeSeconds,
                 recentDecodeTokens: recentDecodeSamples.reduce(0) { $0 + $1.tokens },
                 recentDecodeSeconds: recentDecodeSamples.reduce(0) { $0 + $1.seconds },
-                lastCompletedAt: lastCompletedAt
+                lastCompletedAt: lastCompletedAt,
+                lastRequest: lastRequestTiming
             )
         }
     }
@@ -994,8 +1073,55 @@ actor RuntimeModelPool {
         self.clearMLXCache = clearMLXCache
     }
 
-    func preloadDefault() async throws {
-        _ = try await loadModel(idOrAlias: defaultModelID)
+    func preloadDefault(warmup: Bool = false) async throws {
+        let resolved = try resolveModel(defaultModelID)
+        let loadStart = currentDate()
+        let loaded = try await ensureLoaded(resolved)
+        let loadSeconds = currentDate().timeIntervalSince(loadStart)
+        var startupTiming = RuntimeModelStartupTiming(
+            loadSeconds: loadSeconds,
+            warmupSeconds: nil,
+            warmupPrefillSeconds: nil,
+            warmupDecodeSeconds: nil,
+            warmupTimeToFirstTokenSeconds: nil,
+            graphCompilationAccounting: nil,
+            completedAt: currentDate()
+        )
+        if warmup,
+           resolved.engine == .textChatGemma4,
+           Gemma4Resources.usesTurboDefaults(modelSpec: resolved.id) {
+            let warmupStart = currentDate()
+            let response = try await loaded.chat(
+                ChatRequest(
+                    messages: [ChatMessage(role: .user, content: "Reply with ready.")],
+                    maxTokens: 1,
+                    temperature: 0,
+                    topP: 1,
+                    showThinking: false
+                ),
+                progressHandler: nil
+            )
+            let timing = response.timing
+            startupTiming = RuntimeModelStartupTiming(
+                loadSeconds: loadSeconds,
+                warmupSeconds: currentDate().timeIntervalSince(warmupStart),
+                warmupPrefillSeconds: timing?.prefillSeconds,
+                warmupDecodeSeconds: timing?.decodeSeconds,
+                warmupTimeToFirstTokenSeconds: timing.map(Self.timeToFirstToken),
+                graphCompilationAccounting: "included_in_warmup_prefill",
+                completedAt: currentDate()
+            )
+        }
+        var state = state(for: resolved.id)
+        state.startupTiming = startupTiming
+        states[resolved.id] = state
+    }
+
+    private static func timeToFirstToken(_ timing: ChatTiming) -> Double {
+        timing.loadSeconds
+            + timing.prefillSeconds
+            + (timing.cacheConversionSeconds ?? 0)
+            + (timing.firstTokenSeconds ?? 0)
     }
 
     func modelsResponse(
@@ -1052,6 +1178,10 @@ actor RuntimeModelPool {
         var mtpStats: [String: Gemma4MTPStats] = [:]
         let currentLoadedModels = loadedModels
         for (id, loaded) in currentLoadedModels {
+            // Generator actors can spend tens of seconds inside one evaluated
+            // prefill chunk. Keep the control plane responsive while a model
+            // is active; its cached counters return on the next idle status poll.
+            guard state(for: id).activeRequests == 0 else { continue }
             if let stats = await loaded.prefixKVCacheStats() {
                 prefixStats[id] = stats
             }
@@ -1278,6 +1408,7 @@ actor RuntimeModelPool {
             }
         }
         state.lastCompletedAt = currentDate()
+        state.lastRequestTiming = RuntimeRequestTimingSnapshot(response: response)
         state.lastError = nil
         states[modelID] = state
     }
@@ -1865,6 +1996,7 @@ actor RuntimeModelPool {
             benchmarkStats: state.benchmarkStats
         )
         snapshot.ready = loadedModels[id] != nil && !preparingModelIDs.contains(id)
+        snapshot.startupTiming = state.startupTiming
         return snapshot
     }
 
@@ -1972,6 +2104,34 @@ actor RuntimeRequestAdmission {
         case cancelled
     }
 
+    private struct ActiveRequestState {
+        let id: UUID
+        let admittedAt: Date
+        var modelID: String?
+        var streaming: Bool?
+        var requestedMaxTokens: Int?
+        var toolCount: Int?
+        var phase = "admitted"
+        var phaseDetail: String?
+        var firstTokenAt: Date?
+        var generatedTokenUpdates = 0
+
+        var snapshot: RuntimeActiveRequestSnapshot {
+            RuntimeActiveRequestSnapshot(
+                id: id,
+                admittedAt: admittedAt,
+                modelID: modelID,
+                streaming: streaming,
+                requestedMaxTokens: requestedMaxTokens,
+                toolCount: toolCount,
+                phase: phase,
+                phaseDetail: phaseDetail,
+                firstTokenAt: firstTokenAt,
+                generatedTokenUpdates: generatedTokenUpdates
+            )
+        }
+    }
+
     private let maxActiveRequests: Int
     private let pressureProvider: @Sendable () async -> RuntimeMemoryPressureLevel
     private var activeRequests = 0
@@ -1980,6 +2140,10 @@ actor RuntimeRequestAdmission {
     private var totalAdmittedRequests = 0
     private var totalCompletedRequests = 0
     private var totalCancelledRequests = 0
+    private var activeRequestStates: [UUID: ActiveRequestState] = [:]
+    private var lastClientDisconnectAt: Date?
+    private var lastCancellationAt: Date?
+    private var lastSlotReleaseAt: Date?
 
     init(
         maxActiveRequests: Int,
@@ -2027,9 +2191,59 @@ actor RuntimeRequestAdmission {
         return admit()
     }
 
-    fileprivate func releaseLease() async {
+    fileprivate func configureLease(
+        id: UUID,
+        modelID: String,
+        streaming: Bool,
+        requestedMaxTokens: Int,
+        toolCount: Int
+    ) {
+        guard var state = activeRequestStates[id] else { return }
+        state.modelID = modelID
+        state.streaming = streaming
+        state.requestedMaxTokens = requestedMaxTokens
+        state.toolCount = toolCount
+        activeRequestStates[id] = state
+    }
+
+    fileprivate func recordProgress(id: UUID, progress: ChatProgress) {
+        guard var state = activeRequestStates[id] else { return }
+        switch progress.stage {
+        case .loadingModel:
+            state.phase = "loading_model"
+            state.phaseDetail = progress.message
+        case .encoding:
+            state.phase = "prefill"
+            state.phaseDetail = progress.message
+        case .generating:
+            state.phase = "decode"
+            state.phaseDetail = nil
+            if progress.message?.isEmpty == false {
+                state.firstTokenAt = state.firstTokenAt ?? Date()
+                state.generatedTokenUpdates += 1
+            }
+        }
+        activeRequestStates[id] = state
+    }
+
+    fileprivate func recordClientDisconnect(id: UUID) {
+        guard var state = activeRequestStates[id] else { return }
+        state.phase = "cancelling"
+        state.phaseDetail = "Client disconnected"
+        activeRequestStates[id] = state
+        lastClientDisconnectAt = Date()
+    }
+
+    fileprivate func releaseLease(id: UUID, cancelled: Bool) async {
         activeRequests = max(0, activeRequests - 1)
-        totalCompletedRequests += 1
+        activeRequestStates.removeValue(forKey: id)
+        lastSlotReleaseAt = Date()
+        if cancelled {
+            totalCancelledRequests += 1
+            lastCancellationAt = Date()
+        } else {
+            totalCompletedRequests += 1
+        }
         await drain()
     }
 
@@ -2043,7 +2257,13 @@ actor RuntimeRequestAdmission {
             totalCompletedRequests: totalCompletedRequests,
             totalCancelledRequests: totalCancelledRequests,
             admissionPaused: admissionPaused(for: pressure),
-            pressure: pressure.rawValue
+            pressure: pressure.rawValue,
+            activeRequestDetails: activeRequestStates.values
+                .map(\.snapshot)
+                .sorted { $0.admittedAt < $1.admittedAt },
+            lastClientDisconnectAt: lastClientDisconnectAt,
+            lastCancellationAt: lastCancellationAt,
+            lastSlotReleaseAt: lastSlotReleaseAt
         )
     }
 
@@ -2103,9 +2323,11 @@ actor RuntimeRequestAdmission {
     }
 
     private func admit() -> RuntimeRequestAdmissionLease {
+        let id = UUID()
         activeRequests += 1
         totalAdmittedRequests += 1
-        return RuntimeRequestAdmissionLease(admission: self)
+        activeRequestStates[id] = ActiveRequestState(id: id, admittedAt: Date())
+        return RuntimeRequestAdmissionLease(id: id, admission: self)
     }
 
     private func canAdmitNow(requireEmptyQueue: Bool = false) async -> Bool {
@@ -2137,25 +2359,61 @@ actor RuntimeRequestAdmission {
 }
 
 final class RuntimeRequestAdmissionLease: @unchecked Sendable {
+    private let id: UUID
     private let admission: RuntimeRequestAdmission
     private let lock = NSLock()
     private var released = false
 
-    init(admission: RuntimeRequestAdmission) {
+    init(id: UUID, admission: RuntimeRequestAdmission) {
+        self.id = id
         self.admission = admission
     }
+
+    var requestID: UUID { id }
 
     deinit {
         guard markReleased() else { return }
         let admission = admission
+        let id = id
         Task {
-            await admission.releaseLease()
+            await admission.releaseLease(id: id, cancelled: false)
         }
     }
 
-    func release() async {
+    func configure(
+        modelID: String,
+        streaming: Bool,
+        requestedMaxTokens: Int,
+        toolCount: Int
+    ) async {
+        await admission.configureLease(
+            id: id,
+            modelID: modelID,
+            streaming: streaming,
+            requestedMaxTokens: requestedMaxTokens,
+            toolCount: toolCount
+        )
+    }
+
+    func observe(_ progress: ChatProgress) {
+        let admission = admission
+        let id = id
+        Task {
+            await admission.recordProgress(id: id, progress: progress)
+        }
+    }
+
+    func observeClientDisconnect() {
+        let admission = admission
+        let id = id
+        Task {
+            await admission.recordClientDisconnect(id: id)
+        }
+    }
+
+    func release(cancelled: Bool = false) async {
         guard markReleased() else { return }
-        await admission.releaseLease()
+        await admission.releaseLease(id: id, cancelled: cancelled)
     }
 
     private func markReleased() -> Bool {
@@ -2206,7 +2464,9 @@ final class RuntimeModelLease: @unchecked Sendable {
             await pool.recordChatCompletion(modelID: modelID, response: response)
             return response
         } catch {
-            await pool.recordChatFailure(modelID: modelID, error: error)
+            if !(error is CancellationError) {
+                await pool.recordChatFailure(modelID: modelID, error: error)
+            }
             throw error
         }
     }

--- a/Sources/MereRunCLI/Support/RuntimeModelPool.swift
+++ b/Sources/MereRunCLI/Support/RuntimeModelPool.swift
@@ -2115,6 +2115,7 @@ actor RuntimeRequestAdmission {
         var phaseDetail: String?
         var firstTokenAt: Date?
         var generatedTokenUpdates = 0
+        var lastEventSequence: UInt64 = 0
 
         var snapshot: RuntimeActiveRequestSnapshot {
             RuntimeActiveRequestSnapshot(
@@ -2206,8 +2207,26 @@ actor RuntimeRequestAdmission {
         activeRequestStates[id] = state
     }
 
-    fileprivate func recordProgress(id: UUID, progress: ChatProgress) {
+    func recordProgress(
+        id: UUID,
+        sequence: UInt64,
+        progress: ChatProgress,
+        observedAt: Date = Date()
+    ) {
         guard var state = activeRequestStates[id] else { return }
+        if progress.stage == .generating, progress.message?.isEmpty == false {
+            if let firstTokenAt = state.firstTokenAt {
+                state.firstTokenAt = min(firstTokenAt, observedAt)
+            } else {
+                state.firstTokenAt = observedAt
+            }
+            state.generatedTokenUpdates += 1
+        }
+        guard state.phase != "cancelling", sequence > state.lastEventSequence else {
+            activeRequestStates[id] = state
+            return
+        }
+        state.lastEventSequence = sequence
         switch progress.stage {
         case .loadingModel:
             state.phase = "loading_model"
@@ -2218,20 +2237,17 @@ actor RuntimeRequestAdmission {
         case .generating:
             state.phase = "decode"
             state.phaseDetail = nil
-            if progress.message?.isEmpty == false {
-                state.firstTokenAt = state.firstTokenAt ?? Date()
-                state.generatedTokenUpdates += 1
-            }
         }
         activeRequestStates[id] = state
     }
 
-    fileprivate func recordClientDisconnect(id: UUID) {
+    func recordClientDisconnect(id: UUID, sequence: UInt64, observedAt: Date = Date()) {
         guard var state = activeRequestStates[id] else { return }
         state.phase = "cancelling"
         state.phaseDetail = "Client disconnected"
+        state.lastEventSequence = max(state.lastEventSequence, sequence)
         activeRequestStates[id] = state
-        lastClientDisconnectAt = Date()
+        lastClientDisconnectAt = observedAt
     }
 
     fileprivate func releaseLease(id: UUID, cancelled: Bool) async {
@@ -2363,6 +2379,8 @@ final class RuntimeRequestAdmissionLease: @unchecked Sendable {
     private let admission: RuntimeRequestAdmission
     private let lock = NSLock()
     private var released = false
+    private var clientDisconnected = false
+    private var nextEventSequence: UInt64 = 0
 
     init(id: UUID, admission: RuntimeRequestAdmission) {
         self.id = id
@@ -2396,18 +2414,31 @@ final class RuntimeRequestAdmissionLease: @unchecked Sendable {
     }
 
     func observe(_ progress: ChatProgress) {
+        guard let sequence = reserveEventSequence() else { return }
         let admission = admission
         let id = id
+        let observedAt = Date()
         Task {
-            await admission.recordProgress(id: id, progress: progress)
+            await admission.recordProgress(
+                id: id,
+                sequence: sequence,
+                progress: progress,
+                observedAt: observedAt
+            )
         }
     }
 
     func observeClientDisconnect() {
+        guard let sequence = reserveDisconnectSequence() else { return }
         let admission = admission
         let id = id
+        let observedAt = Date()
         Task {
-            await admission.recordClientDisconnect(id: id)
+            await admission.recordClientDisconnect(
+                id: id,
+                sequence: sequence,
+                observedAt: observedAt
+            )
         }
     }
 
@@ -2422,6 +2453,23 @@ final class RuntimeRequestAdmissionLease: @unchecked Sendable {
         guard !released else { return false }
         released = true
         return true
+    }
+
+    private func reserveEventSequence() -> UInt64? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !released, !clientDisconnected else { return nil }
+        nextEventSequence += 1
+        return nextEventSequence
+    }
+
+    private func reserveDisconnectSequence() -> UInt64? {
+        lock.lock()
+        defer { lock.unlock() }
+        guard !released, !clientDisconnected else { return nil }
+        clientDisconnected = true
+        nextEventSequence += 1
+        return nextEventSequence
     }
 }
 

--- a/Sources/MereRunCore/Gemma4/Gemma4Generator.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4Generator.swift
@@ -637,7 +637,13 @@ public actor Gemma4Generator: ChatGenerator {
                 firstTokenSeconds: decodeResult.firstTokenSeconds,
                 kvCacheMode: effectiveKVCacheMode,
                 prefillKVCache: prefillKVCacheQuantization.statusDescription,
-                decodeKVCache: kvCacheQuantization.statusDescription
+                decodeKVCache: kvCacheQuantization.statusDescription,
+                prefillTokensPerSecond: prefillSeconds > 0
+                    ? Double(max(0, promptTokens.count - (prefixSeed?.tokenCount ?? 0))) / prefillSeconds
+                    : nil,
+                decodeTokensPerSecond: decodeResult.decodeSeconds > 0
+                    ? Double(generated.count) / decodeResult.decodeSeconds
+                    : nil
             ),
             toolCalls: toolCalls,
             promptTokens: promptTokens.count,

--- a/Sources/MereRunCore/Gemma4/Gemma4KVQuantization.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4KVQuantization.swift
@@ -32,7 +32,7 @@ public struct Gemma4KVCacheQuantization: Sendable, Hashable {
 
     var statusDescription: String {
         guard let bits else {
-            return "default"
+            return "full-precision"
         }
         return "\(scheme.rawValue):\(bits)-bit:start-\(quantizedStart)"
     }

--- a/Sources/MereRunCore/Gemma4/Gemma4Model.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4Model.swift
@@ -652,7 +652,8 @@ final class Gemma4SwitchLinear: Module {
         groupSize: Int = 16,
         bits: Int = 4,
         mode: QuantizationMode = .nvfp4,
-        bias: Bool = false
+        bias: Bool = false,
+        quantized: Bool = true
     ) {
         self.groupSize = groupSize
         self.bits = bits
@@ -664,7 +665,9 @@ final class Gemma4SwitchLinear: Module {
             [numExperts, outputDims, inputDims]
         )
         let groups = max(1, (inputDims + groupSize - 1) / groupSize)
-        self._scales.wrappedValue = MLXArray.zeros([numExperts, outputDims, groups])
+        self._scales.wrappedValue = quantized
+            ? MLXArray.zeros([numExperts, outputDims, groups])
+            : nil
         self._biases.wrappedValue = nil
         if bias {
             self._bias.wrappedValue = MLXArray.zeros([numExperts, outputDims])
@@ -673,56 +676,54 @@ final class Gemma4SwitchLinear: Module {
     }
 
     func callAsFunction(_ x: MLXArray, indices: MLXArray) -> MLXArray {
-        let batch = x.dim(0)
-        let sequenceLength = x.dim(1)
+        let batchTokens = x.dim(0) * x.dim(1)
         let topK = indices.dim(2)
         let inputDim = x.dim(x.ndim - 1)
-        let batchTokens = batch * sequenceLength
 
-        let flatX: MLXArray
         if x.ndim == 4 && x.dim(2) == topK {
-            flatX = x.reshaped([batchTokens * topK, 1, inputDim])
-        } else {
-            var expanded = x.reshaped([batchTokens, 1, inputDim])
-            expanded = MLX.expandedDimensions(expanded, axis: 1)
-            expanded = MLX.repeated(expanded, count: topK, axis: 1)
-            flatX = expanded.reshaped([batchTokens * topK, 1, inputDim])
+            let flatX = x.reshaped([batchTokens * topK, 1, inputDim])
+            let flatIndices = indices.reshaped([batchTokens * topK])
+            let output = applyFlat(flatX, indices: flatIndices, sortedIndices: false)
+            return output.reshaped([x.dim(0), x.dim(1), topK, output.dim(2)])
         }
 
-        let flatIndices = indices.reshaped([batchTokens * topK])
+        let expanded = MLX.expandedDimensions(x, axes: [-2, -3])
+        return applyGather(expanded, indices: indices, sortedIndices: false)
+            .squeezed(axis: -2)
+    }
+
+    func applyFlat(_ x: MLXArray, indices: MLXArray, sortedIndices: Bool) -> MLXArray {
+        applyGather(x, indices: indices, sortedIndices: sortedIndices)
+    }
+
+    private func applyGather(_ x: MLXArray, indices: MLXArray, sortedIndices: Bool) -> MLXArray {
         let output: MLXArray
         if let scales {
             output = portableGatherQuantizedMM(
-                flatX,
+                x,
                 weight,
                 scales: scales,
                 biases: biases,
-                rhsIndices: flatIndices,
+                rhsIndices: indices,
                 transpose: true,
                 groupSize: groupSize,
                 bits: bits,
                 mode: mode,
-                sortedIndices: false
+                sortedIndices: sortedIndices
             )
         } else {
             output = gatherMM(
-                flatX,
+                x,
                 weight.swappedAxes(-1, -2),
-                rhsIndices: flatIndices,
-                sortedIndices: false
+                rhsIndices: indices,
+                sortedIndices: sortedIndices
             )
         }
 
-        let outputDim = output.dim(2)
-        var reshaped = output.reshaped([batchTokens, topK, outputDim])
-        reshaped = reshaped.reshaped([batch, sequenceLength, topK, outputDim])
-
         if let bias {
-            let selectedBias = take(bias, flatIndices, axis: 0)
-                .reshaped([batch, sequenceLength, topK, outputDim])
-            return reshaped + selectedBias
+            return output + take(bias, indices, axis: 0).expandedDimensions(axis: -2)
         }
-        return reshaped
+        return output
     }
 }
 
@@ -731,29 +732,56 @@ final class Gemma4SwitchGLU: Module {
     @ModuleInfo(key: "up_proj") var upProj: Gemma4SwitchLinear
     @ModuleInfo(key: "down_proj") var downProj: Gemma4SwitchLinear
 
-    init(config: Gemma4TextConfig) {
+    init(config: Gemma4TextConfig, quantized: Bool = true) {
         self._gateProj.wrappedValue = Gemma4SwitchLinear(
             inputDims: config.hiddenSize,
             outputDims: max(1, config.moeIntermediateSize),
-            numExperts: max(1, config.numExperts)
+            numExperts: max(1, config.numExperts),
+            quantized: quantized
         )
         self._upProj.wrappedValue = Gemma4SwitchLinear(
             inputDims: config.hiddenSize,
             outputDims: max(1, config.moeIntermediateSize),
-            numExperts: max(1, config.numExperts)
+            numExperts: max(1, config.numExperts),
+            quantized: quantized
         )
         self._downProj.wrappedValue = Gemma4SwitchLinear(
             inputDims: max(1, config.moeIntermediateSize),
             outputDims: config.hiddenSize,
-            numExperts: max(1, config.numExperts)
+            numExperts: max(1, config.numExperts),
+            quantized: quantized
         )
         super.init()
     }
 
     func callAsFunction(_ x: MLXArray, indices: MLXArray) -> MLXArray {
-        let up = upProj(x, indices: indices)
-        let gate = gateProj(x, indices: indices)
-        return downProj(geluApproximate(gate) * up, indices: indices)
+        let batchTokens = x.dim(0) * x.dim(1)
+        let topK = indices.dim(2)
+        let routeCount = batchTokens * topK
+        guard routeCount >= 64 else {
+            let up = upProj(x, indices: indices)
+            let gate = gateProj(x, indices: indices)
+            return downProj(geluApproximate(gate) * up, indices: indices)
+        }
+
+        let inputDim = x.dim(x.ndim - 1)
+        let flatIndices = indices.reshaped([routeCount])
+        let order = argSort(flatIndices, axis: 0)
+        let inverseOrder = argSort(order, axis: 0)
+        let sortedIndices = take(flatIndices, order, axis: 0)
+        let tokenOrder = order.floorDivide(topK)
+        let flatInput = x.reshaped([batchTokens, inputDim])
+            .take(tokenOrder, axis: 0)
+            .reshaped([routeCount, 1, inputDim])
+
+        let up = upProj.applyFlat(flatInput, indices: sortedIndices, sortedIndices: true)
+        let gate = gateProj.applyFlat(flatInput, indices: sortedIndices, sortedIndices: true)
+        let output = downProj.applyFlat(
+            geluApproximate(gate) * up,
+            indices: sortedIndices,
+            sortedIndices: true
+        ).take(inverseOrder, axis: 0)
+        return output.reshaped([x.dim(0), x.dim(1), topK, output.dim(2)])
     }
 }
 

--- a/Tests/MereRunCLITests/APIServeCommandTests.swift
+++ b/Tests/MereRunCLITests/APIServeCommandTests.swift
@@ -48,6 +48,7 @@ final class APIServeCommandTests: XCTestCase {
         XCTAssertEqual(cmd.memoryGuard, .balanced)
         XCTAssertNil(cmd.memoryGuardCustomCeilingGB)
         XCTAssertEqual(cmd.contextSize, 32_768)
+        XCTAssertTrue(cmd.warmup)
         XCTAssertNil(cmd.kvBits)
         XCTAssertNil(cmd.kvQuantScheme)
         XCTAssertNil(cmd.kvGroupSize)
@@ -69,6 +70,7 @@ final class APIServeCommandTests: XCTestCase {
             "--memory-guard", "custom",
             "--memory-guard-custom-ceiling-gb", "42.5",
             "--context-size", "8192",
+            "--no-warmup",
             "--kv-bits", "3.5",
             "--kv-quant-scheme", "turboquant",
             "--kv-group-size", "32",
@@ -86,6 +88,7 @@ final class APIServeCommandTests: XCTestCase {
         XCTAssertEqual(cmd.memoryGuard, .custom)
         XCTAssertEqual(cmd.memoryGuardCustomCeilingGB, 42.5)
         XCTAssertEqual(cmd.contextSize, 8192)
+        XCTAssertFalse(cmd.warmup)
         XCTAssertEqual(cmd.kvBits, 3.5)
         XCTAssertEqual(cmd.kvQuantScheme, "turboquant")
         XCTAssertEqual(cmd.kvGroupSize, 32)
@@ -444,7 +447,7 @@ final class APIServeCommandTests: XCTestCase {
         XCTAssertFalse(startServer.command?.argv.contains("--api-key") == true)
     }
 
-    func testAPIServeGemma4TurboModelDefaultsToTurboQuantKVCache() throws {
+    func testAPIServeGemma4TurboModelDefaultsToUnquantizedKVCache() throws {
         let cmd = try APIServe.parse([
             "--engine", "text-chat-gemma4",
             "--model-path", Gemma4Resources.turboModelId,
@@ -452,10 +455,10 @@ final class APIServeCommandTests: XCTestCase {
 
         let quantization = try cmd.resolveGemma4KVCacheQuantization()
 
-        XCTAssertEqual(quantization.bits, Gemma4Resources.defaultTurboKVBits)
-        XCTAssertEqual(quantization.scheme, .turboquant)
+        XCTAssertNil(quantization.bits)
+        XCTAssertEqual(quantization.scheme, .uniform)
         XCTAssertEqual(quantization.groupSize, Gemma4Resources.defaultKVGroupSize)
-        XCTAssertEqual(quantization.quantizedStart, Gemma4Resources.defaultTurboQuantizedKVStart)
+        XCTAssertEqual(quantization.quantizedStart, Gemma4Resources.defaultQuantizedKVStart)
     }
 
     func testAPIServeParsesLFM2Engine() throws {
@@ -522,7 +525,7 @@ final class APIServeCommandTests: XCTestCase {
         XCTAssertEqual(cmd.engine.runtimeServingEngine, .textChatQ36)
     }
 
-    func testAPIServeGemma4TurboKVFlagsOverrideIndependently() throws {
+    func testAPIServeGemma4TurboKVOptionsWithoutBitsRemainDisabled() throws {
         let cmd = try APIServe.parse([
             "--engine", "text-chat-gemma4",
             "--model-path", Gemma4Resources.turboModelId,
@@ -533,7 +536,7 @@ final class APIServeCommandTests: XCTestCase {
 
         let quantization = try cmd.resolveGemma4KVCacheQuantization()
 
-        XCTAssertEqual(quantization.bits, Gemma4Resources.defaultTurboKVBits)
+        XCTAssertNil(quantization.bits)
         XCTAssertEqual(quantization.scheme, .uniform)
         XCTAssertEqual(quantization.groupSize, 32)
         XCTAssertEqual(quantization.quantizedStart, 128)
@@ -3103,6 +3106,38 @@ final class APIServeCommandTests: XCTestCase {
         XCTAssertEqual(usage.prompt_tokens, 0)
         XCTAssertEqual(usage.completion_tokens, 7)
         XCTAssertEqual(usage.total_tokens, 7)
+    }
+
+    func testOpenAITimingHeadersExposeRequestPhasesAndThroughput() {
+        let result = ChatResponse(
+            response: "ready",
+            tokensGenerated: 3,
+            timing: ChatTiming(
+                loadSeconds: 0.25,
+                prefillSeconds: 2,
+                cacheConversionSeconds: 0.125,
+                decodeSeconds: 1.5,
+                firstTokenSeconds: 0.5,
+                prefillKVCache: "full-precision",
+                decodeKVCache: "full-precision",
+                prefillTokensPerSecond: 100,
+                decodeTokensPerSecond: 2
+            ),
+            promptTokens: 200
+        )
+
+        let headers = CodeGenServer.openAITimingHeaders(for: result)
+
+        XCTAssertEqual(headers["x-mere-prompt-tokens"], "200")
+        XCTAssertEqual(headers["x-mere-generated-tokens"], "3")
+        XCTAssertEqual(headers["x-mere-prefill-tokens-per-second"], "100.000")
+        XCTAssertEqual(headers["x-mere-decode-tokens-per-second"], "2.000")
+        XCTAssertEqual(headers["x-mere-kv-cache"], "full-precision")
+        XCTAssertEqual(
+            headers["server-timing"],
+            "model_load;dur=250.000, prefill;dur=2000.000, kv_pack;dur=125.000, "
+                + "decode;dur=1500.000, ttft;dur=2875.000"
+        )
     }
 
     func testChatRequestDefaultsToThinkingForOrnithLanes() throws {

--- a/Tests/MereRunCLITests/APIServeCommandTests.swift
+++ b/Tests/MereRunCLITests/APIServeCommandTests.swift
@@ -2828,12 +2828,17 @@ final class APIServeCommandTests: XCTestCase {
 
     func testOpenAIFinishReasonReportsToolCalls() {
         let result = ChatResponse(
-            response: "",
+            response: #"<|tool_call>call:create_status_summary{reason:<|\"|>test<|\"|>}"#,
             tokensGenerated: 12,
             toolCalls: [ToolCall(name: "create_status_summary", arguments: ["reason": "test"])]
         )
 
         XCTAssertEqual(CodeGenServer.openAIFinishReason(for: result), "tool_calls")
+        XCTAssertEqual(CodeGenServer.openAIMessageContent(for: result, hasToolCalls: true), "")
+        XCTAssertEqual(
+            CodeGenServer.openAIMessageContent(for: result, hasToolCalls: false),
+            result.response
+        )
         XCTAssertEqual(
             CodeGenServer.openAIFinishReason(for: result, hasToolCalls: false),
             "stop"

--- a/Tests/MereRunCLITests/RuntimeModelPoolTests.swift
+++ b/Tests/MereRunCLITests/RuntimeModelPoolTests.swift
@@ -1289,6 +1289,54 @@ final class RuntimeModelPoolTests: XCTestCase {
         await third.release()
     }
 
+    func testRequestAdmissionReportsActivePhaseAndCancellationRelease() async throws {
+        let admission = RuntimeRequestAdmission(maxActiveRequests: 1)
+        let lease = try await admission.acquire()
+        await lease.configure(
+            modelID: Gemma4Resources.turboModelId,
+            streaming: false,
+            requestedMaxTokens: 64,
+            toolCount: 3
+        )
+        lease.observe(ChatProgress(stage: .encoding, message: "Encoding prompt"))
+        lease.observe(ChatProgress(stage: .generating, message: "{"))
+
+        var snapshot = await admission.snapshot()
+        for _ in 0..<50 {
+            if snapshot.activeRequestDetails?.first?.phase == "decode" { break }
+            try await Task.sleep(nanoseconds: 10_000_000)
+            snapshot = await admission.snapshot()
+        }
+
+        let active = try XCTUnwrap(snapshot.activeRequestDetails?.first)
+        XCTAssertEqual(active.modelID, Gemma4Resources.turboModelId)
+        XCTAssertEqual(active.streaming, false)
+        XCTAssertEqual(active.requestedMaxTokens, 64)
+        XCTAssertEqual(active.toolCount, 3)
+        XCTAssertEqual(active.phase, "decode")
+        XCTAssertNotNil(active.firstTokenAt)
+        XCTAssertEqual(active.generatedTokenUpdates, 1)
+
+        lease.observeClientDisconnect()
+        for _ in 0..<50 {
+            snapshot = await admission.snapshot()
+            if snapshot.lastClientDisconnectAt != nil { break }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTAssertEqual(snapshot.activeRequestDetails?.first?.phase, "cancelling")
+        XCTAssertNotNil(snapshot.lastClientDisconnectAt)
+
+        await lease.release(cancelled: true)
+        snapshot = await admission.snapshot()
+
+        XCTAssertEqual(snapshot.activeRequests, 0)
+        XCTAssertEqual(snapshot.totalCompletedRequests, 0)
+        XCTAssertEqual(snapshot.totalCancelledRequests, 1)
+        XCTAssertEqual(snapshot.activeRequestDetails, [])
+        XCTAssertNotNil(snapshot.lastCancellationAt)
+        XCTAssertNotNil(snapshot.lastSlotReleaseAt)
+    }
+
     func testRequestAdmissionCancelsQueuedWaiterWithoutLaterAdmission() async throws {
         let admission = RuntimeRequestAdmission(maxActiveRequests: 1)
         let first = try await admission.acquire()

--- a/Tests/MereRunCLITests/RuntimeModelPoolTests.swift
+++ b/Tests/MereRunCLITests/RuntimeModelPoolTests.swift
@@ -1337,6 +1337,45 @@ final class RuntimeModelPoolTests: XCTestCase {
         XCTAssertNotNil(snapshot.lastSlotReleaseAt)
     }
 
+    func testRequestAdmissionKeepsNewestPhaseWhenProgressArrivesOutOfOrder() async throws {
+        let admission = RuntimeRequestAdmission(maxActiveRequests: 1)
+        let lease = try await admission.acquire()
+        await lease.configure(
+            modelID: Gemma4Resources.turboModelId,
+            streaming: false,
+            requestedMaxTokens: 64,
+            toolCount: 3
+        )
+
+        await admission.recordProgress(
+            id: lease.requestID,
+            sequence: 2,
+            progress: ChatProgress(stage: .generating, message: "{")
+        )
+        await admission.recordProgress(
+            id: lease.requestID,
+            sequence: 1,
+            progress: ChatProgress(stage: .encoding, message: "Encoding prompt")
+        )
+
+        var snapshot = await admission.snapshot()
+        XCTAssertEqual(snapshot.activeRequestDetails?.first?.phase, "decode")
+        XCTAssertEqual(snapshot.activeRequestDetails?.first?.generatedTokenUpdates, 1)
+
+        await admission.recordClientDisconnect(id: lease.requestID, sequence: 4)
+        await admission.recordProgress(
+            id: lease.requestID,
+            sequence: 3,
+            progress: ChatProgress(stage: .encoding, message: "Late prefill update")
+        )
+
+        snapshot = await admission.snapshot()
+        XCTAssertEqual(snapshot.activeRequestDetails?.first?.phase, "cancelling")
+        XCTAssertEqual(snapshot.activeRequestDetails?.first?.phaseDetail, "Client disconnected")
+
+        await lease.release(cancelled: true)
+    }
+
     func testRequestAdmissionCancelsQueuedWaiterWithoutLaterAdmission() async throws {
         let admission = RuntimeRequestAdmission(maxActiveRequests: 1)
         let first = try await admission.acquire()

--- a/Tests/MereRunCoreTests/Gemma4ModelTests.swift
+++ b/Tests/MereRunCoreTests/Gemma4ModelTests.swift
@@ -329,6 +329,36 @@ final class Gemma4ModelTests: MereRunCoreTestCase {
         XCTAssertNotNil(layer.experts)
     }
 
+    func testSortedExpertPrefillMatchesSerialUnsortedRouting() throws {
+        MLXRandom.seed(71)
+        var configObject = makeBaseConfig()
+        configObject["enable_moe_block"] = true
+        configObject["num_experts"] = 4
+        configObject["top_k_experts"] = 2
+        configObject["moe_intermediate_size"] = 4
+        let config = try decodeTextConfig(configObject)
+        let experts = Gemma4SwitchGLU(config: config, quantized: false)
+        let input = MLXRandom.normal([1, 32, config.hiddenSize])
+        let routeValues = (0..<32).flatMap { index in
+            [Int32((index + 2) % 4), Int32(index % 4)]
+        }
+        let routes = MLXArray(routeValues).reshaped(1, 32, 2)
+
+        let batched = experts(input, indices: routes)
+        let serial = MLX.concatenated((0..<32).map { index in
+            experts(
+                input[0..., index..<(index + 1), 0...],
+                indices: routes[0..., index..<(index + 1), 0...]
+            )
+        }, axis: 1)
+        MLX.eval(batched, serial)
+
+        XCTAssertLessThan(
+            MLX.max(MLX.abs(batched - serial)).item(Float.self),
+            1e-5
+        )
+    }
+
     func testPrefixCacheForkMatchesFullForwardForSuffixLogits() throws {
         MLXRandom.seed(19)
         let config = try decodeTextConfig(makeBaseConfig())

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -2724,6 +2724,13 @@ Security defaults:
   Values above `1` automatically engage supported Gemma4, Qwen-family,
   and LFM2 decode batching unless an engine-specific environment variable forces
   the serial path
+- `--warmup` is enabled by default for Gemma 4 Turbo. The server evaluates a
+  one-token warmup before it starts listening, so model loading and the first
+  lazy graph/materialization prefill are paid before `/health` reports ready.
+  Use `--no-warmup` only when startup latency matters more than the first
+  request. MLX does not expose compiler time separately, so startup telemetry
+  reports `warmupPrefillSeconds` and marks graph compilation as included in that
+  measurement instead of presenting an invented compile-only duration.
 - `--memory-guard` controls runtime memory pressure behavior. Accepted values
   are `off`, `safe`, `balanced`, `aggressive`, and `custom`; `custom` also
   requires `--memory-guard-custom-ceiling-gb`.
@@ -2779,19 +2786,34 @@ Security defaults:
   `--kv-quant-scheme polar --kv-bits 2`; use it for memory-pressure and
   long-context synthetic decode testing. It is not the default until checkpoint
   benchmarks prove the end-to-end model path.
-- Per-model runtime settings can set `kvCacheMode` to `affine8` for Gemma4,
+- API serving keeps Gemma 4 Turbo KV full precision by default because the
+  previous token-zero TurboQuant default caused severe long-prompt decode
+  latency. Operators can still opt into the memory tradeoff explicitly with
+  `--kv-bits 4 --kv-quant-scheme turboquant --quantized-kv-start 0`.
+  Per-model runtime settings can set `kvCacheMode` to `affine8` for Gemma4,
   Qwen-family, and LFM2 as a memory control relative to full-precision KV.
   Qwen-family and LFM2 dequantize the generic cache for attention, so this is an
-  explicit tradeoff. Gemma Turbo already defaults to a smaller 4-bit TurboQuant
-  cache, so forcing affine 8-bit can increase its KV residency. `default`
-  restores the selected engine/model/server default, not necessarily full
-  precision. Gemma4 also accepts `polar2` or `auto`; `auto` keeps the default KV
+  explicit tradeoff. `default` restores the selected engine/model/server
+  default. Gemma4 also accepts `polar2` or `auto`; `auto` keeps the default KV
   path below 1024 prompt tokens and switches to decode-deferred packed PolarKV
   at or above that threshold.
 - `/runtime/status` and `mere.run status` aggregate prefix hits, reused tokens,
   batched decode steps, completed chat requests, generated tokens, and average
   load/prefill/decode timings across loaded models under `cacheStats` and
-  `benchmarkStats`
+  `benchmarkStats`. Model entries include startup load/warmup timing and the
+  last completed request's TTFT and throughput. Admission status includes the
+  phase and generated-token updates for active requests plus cancellation and
+  slot-release timestamps. Busy model counters are deferred so the status
+  route remains responsive during long prefill/decode work.
+- non-streaming chat responses expose `x-mere-request-id` immediately, send
+  JSON-safe whitespace heartbeats while the final object remains buffered, and
+  finish with declared HTTP trailers. Those trailers include standard
+  `Server-Timing` entries for load, prefill, KV packing, decode, and TTFT plus
+  `x-mere-*` token, throughput, KV-mode, and final runtime-status fields. This
+  lets an outbound disconnect cancel native generation without leaking partial
+  text or malformed tool calls. Closing either a streaming or non-streaming
+  client releases its active-request slot; `/runtime/status` records the
+  disconnect receipt, cancellation completion, and slot release separately.
 - generation parameters are bounded before execution; for example, `max_tokens` must fit the configured context size, and native chat engines receive that same context cap for prompt truncation
 - LoRA adapters for the API server are selected by the operator with `--lora`; request bodies cannot provide local LoRA paths
 

--- a/docs/runtime/text.md
+++ b/docs/runtime/text.md
@@ -300,10 +300,12 @@ flag on `text chat` or `api serve`. For Gemma4, Qwen-family, and LFM2 models
 you can select explicit `affine4` or `affine8` as long-context memory
 controls relative to full-precision K/V. Qwen-family and LFM2 dequantize the
 generic cache for attention, so these modes are not assumed faster. Gemma uses
-its model-specific quantized KV path; `text-chat-gemma4-turbo` already defaults
-to a smaller 4-bit TurboQuant cache, so forcing affine 8-bit can increase that
-model's KV residency. `default` restores the engine/model/server default rather
-than promising full precision.
+its model-specific quantized KV path. Interactive `text chat` retains the
+memory-oriented Gemma Turbo recipe, while `api serve` defaults Turbo to
+full-precision KV after long-schema serving showed that token-zero TurboQuant
+could dominate decode latency. API operators can request that memory tradeoff
+explicitly with `--kv-bits 4 --kv-quant-scheme turboquant
+--quantized-kv-start 0`. `default` restores the engine/model/server default.
 
 `vision-chat-q38-27b` is the official dense Qwen3.8 27B BF16 checkpoint. Pull
 it explicitly before use because the pinned snapshot is 55.59 GB:


### PR DESCRIPTION
## Summary

- warm Gemma 4 Turbo before API readiness and keep serving KV full precision unless explicitly quantized
- sort large sparse-expert route batches around the native projections
- propagate streaming and non-streaming client disconnects into native cancellation and active-slot release
- keep runtime status responsive and make concurrent request-phase telemetry monotonic
- expose load, warmup, prefill, decode, TTFT, throughput, token, cancellation, and release telemetry
- preserve atomic non-streaming JSON with whitespace heartbeats and declared timing trailers
- suppress native control text when a typed OpenAI tool call is returned

## Performance

- the original large generic-schema workload completed in 25.5 seconds on the first post-warmup patched run and 11.6 seconds warm, versus 251.7 seconds on the installed 0.43.0 release
- the final combined tree returned a required generic tool call from the installed `text-chat-gemma4-turbo` checkpoint in 0.88 seconds, with 0.289-second TTFT, 446 prompt tokens/s, and 27.2 decode tokens/s
- the response contained exactly one typed tool call, empty assistant content, `finish_reason: tool_calls`, atomic JSON, heartbeats, and complete timing trailers
- a forced non-streaming client timeout released the single active slot about 0.6 seconds after the client abort and 22 milliseconds after server-side disconnect receipt

## Validation

- [x] `./scripts/check.sh` on the exact final tree — 3,149 XCTest tests passed, 224 environment-gated skips, 0 failures; 30 supplemental tests passed
- [x] combined API, runtime-pool, Gemma 4, and Nemotron tool-call suite — 184 passed, 0 failures
- [x] installed `text-chat-gemma4-turbo` tool-call, timing-trailer, status, and cancellation reproduction
- [x] `pnpm docs:build`
- [x] final squash-base transplant preserved the validated tree exactly
- [x] no vendored artifacts or package pins changed
