### PR TITLE
Release v0.44.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+## 0.44.0 - 2026-08-25
+
+This release expands native text, image, and music inference with LFM2.5
+DSpark acceleration and QAD models, SenseNova U1.5 generation, and a local
+MiniMax Music 3 composer with mixed quantization. It also hardens tool calling,
+text SFT schema parity, and long-running API inference.
+
 ### Audio
 
 - added split MiniMax Music 3 quantization tiers: `q8-lm` and `q4-lm`
@@ -35,6 +42,8 @@ The format is based on Keep a Changelog.
   raw-pixel flow matching, resolution-scaled noise, shifted Euler sampling,
   text CFG, and multi-image instruction editing without Python or an external
   VAE.
+- reduced SenseNova U1.5 denoising overhead by reusing invariant timestep and
+  guidance tensors across the sampling loop without changing generated output.
 
 ### Text
 
@@ -69,6 +78,30 @@ The format is based on Keep a Changelog.
   `LFM2.5-8B-A1B` targets required by their trained DSpark assistants. Existing
   4-bit and 8-bit LFM2.5 variants remain target-only so quantized hidden-state
   drift cannot silently reduce acceptance or change the intended pairing.
+- added pinned QAD Q4_0 MLX models for LFM2.5 1.2B Instruct and 2.6B, including
+  deterministic conversion tooling, managed pulls, validation, memory guidance,
+  CLI documentation, and iOS Studio selection. QAD is presented as quantized
+  accuracy recovery at a 4-bit footprint rather than a runtime speed claim.
+
+### Maintenance
+
+- removed stale implementation-roadmap documents after their shipped behavior
+  moved into the codebase and maintained documentation.
+- updated the GitHub Actions cache dependency from v4 to v6.
+
+### Included pull requests
+
+- exact release range: [#354](https://github.com/sawfwair/mere-run/pull/354),
+  [#355](https://github.com/sawfwair/mere-run/pull/355),
+  [#356](https://github.com/sawfwair/mere-run/pull/356),
+  [#357](https://github.com/sawfwair/mere-run/pull/357),
+  [#358](https://github.com/sawfwair/mere-run/pull/358),
+  [#359](https://github.com/sawfwair/mere-run/pull/359),
+  [#360](https://github.com/sawfwair/mere-run/pull/360),
+  [#362](https://github.com/sawfwair/mere-run/pull/362),
+  [#336](https://github.com/sawfwair/mere-run/pull/336),
+  [#361](https://github.com/sawfwair/mere-run/pull/361), and
+  [#363](https://github.com/sawfwair/mere-run/pull/363).
 
 ## 0.43.0 - 2026-08-20
 

--- a/Sources/MereRunRelayKit/MereRunCLIVersion.swift
+++ b/Sources/MereRunRelayKit/MereRunCLIVersion.swift
@@ -2,7 +2,7 @@
 /// contract version floors, worker probes, and the built-in node catalog
 /// identity.
 public enum MereRunCLIVersion {
-    public static let current = "0.43.0"
+    public static let current = "0.44.0"
 }
 
 /// Lenient three-component version-floor comparison used by worker

--- a/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
+++ b/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
@@ -130,7 +130,7 @@ final class CLIModelStoreBootstrapTests: XCTestCase {
     }
 
     func testMereRunCLIExposesReleaseVersion() {
-        XCTAssertEqual(MereRunCLIVersion.current, "0.43.0")
+        XCTAssertEqual(MereRunCLIVersion.current, "0.44.0")
         XCTAssertEqual(MereRunCLI.configuration.version, MereRunCLIVersion.current)
     }
 

--- a/scripts/build_mere_run_app.sh
+++ b/scripts/build_mere_run_app.sh
@@ -15,7 +15,7 @@ cd "$repo_root"
 
 # Version/build derive from git when not provided, so the bundle has a single source of
 # truth in CI. Fall back to a pinned value when git metadata is unavailable.
-default_version="0.43.0"
+default_version="0.44.0"
 if git_version="$(git describe --tags --exact-match 2>/dev/null)"; then
   default_version="${git_version#v}"
 fi


### PR DESCRIPTION
## Summary

- bump the CLI, relay, app bundle, and bootstrap test version to 0.44.0
- publish the complete 0.44.0 changelog covering PRs #354–#363 and #336
- highlight LFM2.5 DSpark/QAD, SenseNova image generation, MiniMax Music 3 composer improvements, and tool/API hardening

The stars aligned again: Qwen 38 got v0.38.0; this time the release constellations brought us vision, music, and tool calls. ✨

## Validation

- `./scripts/check.sh`
  - SwiftLint strict: passed
  - XCTest: 3,149 tests, 224 expected skips, 0 failures
  - Swift Testing: 30 tests, 0 failures
  - build, CLI help sweep, and hygiene scans: passed
- current `main` hosted CI: passed, including Swift, Linux CLI, macOS bundle, and iOS
