### PR TITLE
Fix /v1/models latency on large model stores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+### API
+
+- fixed `GET /v1/models` latency on large or externally linked model stores by
+  sharing one shallow fast inventory across chat and companion discovery instead
+  of repeatedly validating every installed runtime.
+
 ## 0.44.0 - 2026-08-25
 
 This release expands native text, image, and music inference with LFM2.5

--- a/Sources/MereRunCLI/Commands/APIServeCommand.swift
+++ b/Sources/MereRunCLI/Commands/APIServeCommand.swift
@@ -4096,11 +4096,20 @@ actor CodeGenServer {
         let includeLoopbackArtifactModels = APIVFXArtifactRoutePolicy.allows(
             remoteAddress: remoteAddress
         )
-        var models = try await pool.modelsResponse(serverContextSize: contextSize)
+        let inventory = ModelInventory.snapshot(mode: .fast)
+        var installedModelIDs = inventory.installedModelIDs
+        if QwenImageEditRepository.resolveInstalledModelRoot() != nil {
+            installedModelIDs.insert(QwenImageEditRepository.modelId)
+        }
+        var models = try await pool.modelsResponse(
+            installedModelIDs: installedModelIDs,
+            serverContextSize: contextSize
+        )
         if !includeLoopbackArtifactModels {
             models.data.removeAll { APIVFXArtifactRoutePolicy.modelIDs.contains($0.id) }
         }
         for modelID in APIServerContract.companionModelIDs(
+            installedModelIDs: installedModelIDs,
             includeLoopbackArtifactModels: includeLoopbackArtifactModels
         )
             where !models.data.contains(where: { $0.id == modelID }) {

--- a/Sources/MereRunCLI/Support/ModelInventory.swift
+++ b/Sources/MereRunCLI/Support/ModelInventory.swift
@@ -17,6 +17,10 @@ struct ModelInventorySnapshot: Equatable {
     let mode: ModelInventoryMode
     let complete: Bool
     let durationMs: Int
+
+    var installedModelIDs: Set<String> {
+        Set(rows.lazy.filter(\.isInstalled).map(\.id))
+    }
 }
 
 struct ModelInventoryRow: Equatable {

--- a/Sources/MereRunCLI/Support/RuntimeModelPool.swift
+++ b/Sources/MereRunCLI/Support/RuntimeModelPool.swift
@@ -1125,10 +1125,11 @@ actor RuntimeModelPool {
     }
 
     func modelsResponse(
+        installedModelIDs: Set<String>,
         serverContextSize: Int = 32_768,
         createdAt: Date = Date()
     ) throws -> OpenAIModelsResponse {
-        let models = try listedOpenAIModelIDs().map { listedID in
+        let models = try listedOpenAIModelIDs(installedModelIDs: installedModelIDs).map { listedID in
             let resolved = try resolveModel(listedID, requireInstalled: false)
             let profile = resolved.apiProfile
             let configuredContextWindow = resolved.settings.maxContextTokens ?? serverContextSize
@@ -1902,6 +1903,9 @@ actor RuntimeModelPool {
         if spec.id == defaultModelID, let startupModelPath {
             return startupModelPath
         }
+        guard requireInstalled else {
+            return nil
+        }
         if let runtimeURL = spec.managedRuntimeURL() {
             return runtimeURL.path
         }
@@ -1914,9 +1918,9 @@ actor RuntimeModelPool {
         return nil
     }
 
-    private func listedOpenAIModelIDs() throws -> [String] {
+    private func listedOpenAIModelIDs(installedModelIDs: Set<String>) throws -> [String] {
         let settings = try settingsStore.load().models
-        var ids = Set(installedServableCatalogIDs())
+        var ids = Set(installedServableCatalogIDs(in: installedModelIDs))
         ids.insert(defaultModelID)
         for (modelID, modelSettings) in settings {
             guard modelSettings.alias != nil,
@@ -1928,6 +1932,16 @@ actor RuntimeModelPool {
             }
         }
         return ids.sorted()
+    }
+
+    private func installedServableCatalogIDs(in installedModelIDs: Set<String>) -> [String] {
+        ManagedModelCatalog.allSpecs.compactMap { spec in
+            guard spec.isAPIServableRuntimeModel,
+                  installedModelIDs.contains(spec.id) else {
+                return nil
+            }
+            return spec.id
+        }
     }
 
     private func installedServableCatalogIDs() -> [String] {

--- a/Tests/MereRunCLITests/ModelInventoryTests.swift
+++ b/Tests/MereRunCLITests/ModelInventoryTests.swift
@@ -30,6 +30,7 @@ final class ModelInventoryTests: XCTestCase {
         XCTAssertTrue(row.manifestPresent)
         XCTAssertEqual(row.runtimeAvailable, true)
         XCTAssertEqual(row.verification, .notChecked)
+        XCTAssertEqual(snapshot.installedModelIDs, [modelID.rawValue])
     }
 
     func testVerifiedInventoryChecksRuntimeWithoutMeasuringSize() throws {
@@ -75,5 +76,6 @@ final class ModelInventoryTests: XCTestCase {
 
         XCTAssertEqual(row.status, "offline")
         XCTAssertEqual(row.verification, .notChecked)
+        XCTAssertTrue(snapshot.installedModelIDs.isEmpty)
     }
 }

--- a/Tests/MereRunCLITests/RuntimeModelPoolTests.swift
+++ b/Tests/MereRunCLITests/RuntimeModelPoolTests.swift
@@ -209,6 +209,7 @@ final class RuntimeModelPoolTests: XCTestCase {
         )
 
         let response = try await pool.modelsResponse(
+            installedModelIDs: [],
             serverContextSize: 8_192,
             createdAt: Date(timeIntervalSince1970: 10)
         )
@@ -238,7 +239,10 @@ final class RuntimeModelPoolTests: XCTestCase {
             settingsStore: settingsStore
         )
 
-        let response = try await pool.modelsResponse(serverContextSize: 32_768)
+        let response = try await pool.modelsResponse(
+            installedModelIDs: [],
+            serverContextSize: 32_768
+        )
         let model = try XCTUnwrap(
             response.data.first { $0.id == Q35Resources.ornith9BModelId }
         )
@@ -250,6 +254,31 @@ final class RuntimeModelPoolTests: XCTestCase {
         XCTAssertEqual(
             model.modalities,
             OpenAIModelModalities(input: ["text", "image"], output: ["text"])
+        )
+    }
+
+    func testModelsResponseUsesSuppliedFastInventoryForInstalledModelsAndAliases() async throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let settingsStore = RuntimeModelSettingsStore(modelsDir: root)
+        try settingsStore.writeSettings(
+            RuntimeModelSettings(alias: "coding-agent"),
+            for: Q35Resources.ornith9BModelId
+        )
+        let pool = RuntimeModelPool(
+            defaultModelID: "custom.gguf",
+            defaultEngine: .textCode,
+            startupModelPath: root.appendingPathComponent("custom.gguf").path,
+            settingsStore: settingsStore
+        )
+
+        let response = try await pool.modelsResponse(
+            installedModelIDs: [Q35Resources.ornith9BModelId]
+        )
+
+        XCTAssertEqual(
+            Set(response.data.map(\.id)),
+            ["coding-agent", "custom.gguf", Q35Resources.ornith9BModelId]
         )
     }
 


### PR DESCRIPTION
## Summary

- build the installed model ID set from one shallow `ModelInventory` snapshot for `GET /v1/models`
- share that inventory across runtime-pool and companion-model discovery while preserving aliases and model metadata
- avoid repeated installed-path validation during response formatting
- document the user-visible latency fix in the changelog

Live readback against the same model store improved from 5.67-6.17 seconds on v0.44.0 to 40-70 ms with this patch. The response remained HTTP 200 with the same 18,781-byte payload and 42 unique model IDs.

## Validation

- [x] `./scripts/check.sh` (3,150 XCTest cases and 30 Swift Testing cases; zero failures)
- [x] focused `ModelInventoryTests`
- [x] focused `RuntimeModelPoolTests`
- [x] focused `APIServeCommandTests`
- [x] live `/v1/models` latency and response-shape readback
- [x] changelog updated for public behavior
- [x] no vendored artifacts or package pins changed