### PR TITLE
Reduce LTX 2.5 conditioning memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,11 +14,14 @@ The format is based on Keep a Changelog.
 
 ### Video
 
-- reduced LTX-2.5 image-to-video memory pressure by teaching `model optimize`
-  to build a source-bound 4-bit Gemma language-tower pack, preferring that pack
-  at runtime, and releasing the text encoder and image VAE as soon as their
-  conditioning tensors are materialized. Set `MERERUN_LTX_MEMORY_TRACE=1` to
-  report MLX allocator use at the major generation phases.
+- reduced LTX-2.5 image-to-video memory pressure with a public, pinned,
+  self-contained distilled distribution: the video pipeline remains BF16 while
+  the bundled Gemma 4 language tower uses MLX affine Q4. One accepted model
+  pull now installs every runtime component without downloading the original
+  BF16 text tower or asking users to quantize locally. Runtime releases the text
+  encoder and image VAE as soon as their conditioning tensors are materialized.
+  Set `MERERUN_LTX_MEMORY_TRACE=1` to report MLX allocator use at the major
+  generation phases.
 
 ## 0.44.0 - 2026-08-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ The format is based on Keep a Changelog.
   sharing one shallow fast inventory across chat and companion discovery instead
   of repeatedly validating every installed runtime.
 
+### Video
+
+- reduced LTX-2.5 image-to-video memory pressure by teaching `model optimize`
+  to build a source-bound 4-bit Gemma language-tower pack, preferring that pack
+  at runtime, and releasing the text encoder and image VAE as soon as their
+  conditioning tensors are materialized. Set `MERERUN_LTX_MEMORY_TRACE=1` to
+  report MLX allocator use at the major generation phases.
+
 ## 0.44.0 - 2026-08-25
 
 This release expands native text, image, and music inference with LFM2.5

--- a/Sources/MereRunCLI/Commands/ModelInfoCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelInfoCommand.swift
@@ -307,7 +307,11 @@ struct ModelInfo: ParsableCommand {
         full: Bool = false,
         fileManager: FileManager = .default
     ) -> [String] {
-        var lines = ["  layout: official LTX 2.5 packed BF16 files"]
+        var lines = [
+            full
+                ? "  layout: official LTX 2.5 packed BF16 files"
+                : "  layout: self-contained LTX 2.5 BF16 + MLX Q4 text files",
+        ]
         for file in full ? ltx25FullComponentFiles : ltx25ComponentFiles {
             let url = rootURL.appendingPathComponent(file.relativePath).standardizedFileURL
             let suffix = fileManager.fileExists(atPath: url.path) ? "" : "  (missing)"
@@ -494,7 +498,14 @@ struct ModelInfo: ParsableCommand {
 
     private static let ltx25ComponentFiles: [(label: String, relativePath: String)] = [
         ("transformer_distilled", LTX25Resources.distilledTransformerRelativePath),
-        ("text_encoder", LTX25Resources.textEncoderRelativePath),
+        (
+            "text_encoder_q4",
+            "\(LTX25TextEncoderQuantizedPack.relativeDirectory)/model.safetensors.index.json"
+        ),
+        (
+            "text_encoder_assets",
+            "\(LTX25TextEncoderQuantizedPack.relativeDirectory)/\(LTX25TextEncoderQuantizedPack.runtimeAssetsFilename)"
+        ),
         ("video_vae_conv", LTX25Resources.videoVAERelativePath),
         ("audio_vae_vocoder", LTX25Resources.audioVAERelativePath),
         ("spatial_upscaler", LTX25Resources.spatialUpsamplerRelativePath),

--- a/Sources/MereRunCLI/Commands/ModelOptimizeCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelOptimizeCommand.swift
@@ -14,6 +14,12 @@ struct ModelOptimize: ParsableCommand {
     @Flag(name: [.long], help: "Replace an existing compatible optimization cache.")
     var force: Bool = false
 
+    @Flag(
+        name: [.customLong("text-encoder-only")],
+        help: "For LTX 2.5, build only the self-contained Q4 text-encoder pack."
+    )
+    var textEncoderOnly: Bool = false
+
     @Flag(name: [.long], help: "Emit the result as JSON.")
     var json: Bool = false
 
@@ -23,6 +29,19 @@ struct ModelOptimize: ParsableCommand {
         let optimization: String
         if isLTX25ModelRoot(rootURL) {
             let resources = LTX25Resources(rootURL: rootURL)
+            if textEncoderOnly {
+                _ = try optimizeLTX25TextEncoder(resources: resources)
+                artifacts = LTX25TextEncoderQuantizedPack.artifactURLs(
+                    resources: resources
+                )
+                optimization = "ltx25-text-q4-v1"
+                try emitResult(
+                    rootURL: rootURL,
+                    artifacts: artifacts,
+                    optimization: optimization
+                )
+                return
+            }
             var kinds: [LTX25NativeModelPackKind] = [.distilled, .connector]
             if isLTX25FullModelRoot(rootURL) {
                 kinds.append(.dev)
@@ -42,21 +61,16 @@ struct ModelOptimize: ParsableCommand {
                 )
                 return result.outputURL
             }
-            _ = try LTX25TextEncoderQuantizedPack.optimize(
-                resources: resources,
-                replacing: force,
-                progressHandler: { completed, total in
-                    CLIStderr.write(
-                        "LTX 2.5 Q4 text pack: \(completed)/\(total) shards\n"
-                    )
-                }
-            )
+            _ = try optimizeLTX25TextEncoder(resources: resources)
             ltxArtifacts.append(
                 contentsOf: LTX25TextEncoderQuantizedPack.artifactURLs(resources: resources)
             )
             artifacts = ltxArtifacts
             optimization = "ltx25-native-model-pack+text-q4-v1"
         } else {
+            if textEncoderOnly {
+                throw ValidationError("--text-encoder-only requires an LTX 2.5 model.")
+            }
             let resources = MiniMaxH3Resources(rootURL: rootURL)
             _ = try MiniMaxH3ModelOptimizer.optimize(
                 resources: resources,
@@ -68,6 +82,32 @@ struct ModelOptimize: ParsableCommand {
             artifacts = MiniMaxH3ModelOptimizer.artifactURLs(resources: resources)
             optimization = "minimax-h3-adaln-cache-pack-v1"
         }
+        try emitResult(
+            rootURL: rootURL,
+            artifacts: artifacts,
+            optimization: optimization
+        )
+    }
+
+    private func optimizeLTX25TextEncoder(
+        resources: LTX25Resources
+    ) throws -> LTX25TextEncoderQuantizedPackResult {
+        try LTX25TextEncoderQuantizedPack.optimize(
+            resources: resources,
+            replacing: force,
+            progressHandler: { completed, total in
+                CLIStderr.write(
+                    "LTX 2.5 Q4 text pack: \(completed)/\(total) shards\n"
+                )
+            }
+        )
+    }
+
+    private func emitResult(
+        rootURL: URL,
+        artifacts: [URL],
+        optimization: String
+    ) throws {
         let bytes = artifacts.reduce(0) { total, url in
             total + ((try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0)
         }

--- a/Sources/MereRunCLI/Commands/ModelOptimizeCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelOptimizeCommand.swift
@@ -27,7 +27,7 @@ struct ModelOptimize: ParsableCommand {
             if isLTX25FullModelRoot(rootURL) {
                 kinds.append(.dev)
             }
-            artifacts = try kinds.map { kind in
+            var ltxArtifacts = try kinds.map { kind in
                 let result = try LTX25NativeModelPack.optimize(
                     resources: resources,
                     kind: kind,
@@ -42,7 +42,20 @@ struct ModelOptimize: ParsableCommand {
                 )
                 return result.outputURL
             }
-            optimization = "ltx25-native-model-pack"
+            _ = try LTX25TextEncoderQuantizedPack.optimize(
+                resources: resources,
+                replacing: force,
+                progressHandler: { completed, total in
+                    CLIStderr.write(
+                        "LTX 2.5 Q4 text pack: \(completed)/\(total) shards\n"
+                    )
+                }
+            )
+            ltxArtifacts.append(
+                contentsOf: LTX25TextEncoderQuantizedPack.artifactURLs(resources: resources)
+            )
+            artifacts = ltxArtifacts
+            optimization = "ltx25-native-model-pack+text-q4-v1"
         } else {
             let resources = MiniMaxH3Resources(rootURL: rootURL)
             _ = try MiniMaxH3ModelOptimizer.optimize(

--- a/Sources/MereRunCore/LTX/LTX25Resources.swift
+++ b/Sources/MereRunCore/LTX/LTX25Resources.swift
@@ -5,10 +5,14 @@ public struct LTX25Resources: Sendable, Hashable {
     public static let fullModelID = "video-ltx25-full-bf16"
     public static let sourceRepository = "Lightricks/LTX-2.5"
     public static let sourceRevision = "dd53cc2cd45bbeaa3563dfb575cba3f49cf44761"
+    public static let managedRepository =
+        "Sawfwair/LTX-2.5-Distilled-BF16-MLX-Q4-Text"
+    public static let managedRevision = "9f316bfb18448bf67f716006fd78a37829223b74"
     public static let upstreamCodeRepository = "Lightricks/LTX-2"
     public static let upstreamCodeRevision = "d151147788a9284cca791edc6ce898007e727fe6"
     public static let upstreamCodeRelease = "v1.2.0"
-    public static let estimatedDownloadBytes: Int64 = 71_098_810_082
+    public static let textEncoderSourceBytes: Int64 = 26_263_860_594
+    public static let estimatedDownloadBytes: Int64 = 53_878_648_085
     public static let fullEstimatedDownloadBytes: Int64 = 123_751_083_670
 
     public static let distilledTransformerRelativePath =
@@ -35,7 +39,6 @@ public struct LTX25Resources: Sendable, Hashable {
 
     public static let requiredRelativePaths = [
         distilledTransformerRelativePath,
-        textEncoderRelativePath,
         videoVAERelativePath,
         audioVAERelativePath,
         spatialUpsamplerRelativePath,
@@ -56,12 +59,18 @@ public struct LTX25Resources: Sendable, Hashable {
 
     public static let snapshotPatterns = [
         "README.md",
+        "LICENSE.md",
+        "LTX-ACCEPTABLE-USE-POLICY.pdf",
+        "GEMMA-4-LICENSE.txt",
+        "NOTICE.md",
         transformerRelativePath,
-        textEncoderRelativePath,
         videoVAERelativePath,
         audioVAERelativePath,
         spatialUpsamplerRelativePath,
         durationHeadRelativePath,
+        "\(LTX25TextEncoderQuantizedPack.relativeDirectory)/pack.json",
+        "\(LTX25TextEncoderQuantizedPack.relativeDirectory)/model.safetensors.index.json",
+        "\(LTX25TextEncoderQuantizedPack.relativeDirectory)/*.safetensors",
     ]
 
     public static let fullSnapshotPatterns = [
@@ -103,10 +112,17 @@ public struct LTX25Resources: Sendable, Hashable {
     public var durationHeadURL: URL { rootURL.appendingPathComponent(Self.durationHeadRelativePath) }
 
     public func validate(fileManager: FileManager = .default) -> [URL] {
-        Self.requiredRelativePaths.compactMap { relativePath in
+        var missing = Self.requiredRelativePaths.compactMap { relativePath in
             let url = rootURL.appendingPathComponent(relativePath)
             return fileManager.fileExists(atPath: url.path) ? nil : url
         }
+        let hasOfficialTextEncoder = fileManager.fileExists(atPath: textEncoderURL.path)
+        let hasBundledQ4TextEncoder = LTX25TextEncoderQuantizedPack
+            .optimizedIndexURLIfValid(resources: self, fileManager: fileManager) != nil
+        if !hasOfficialTextEncoder, !hasBundledQ4TextEncoder {
+            missing.append(textEncoderURL)
+        }
+        return missing
     }
 
     public func validateFull(fileManager: FileManager = .default) -> [URL] {

--- a/Sources/MereRunCore/LTX/LTX25TextEncoderQuantizedPack.swift
+++ b/Sources/MereRunCore/LTX/LTX25TextEncoderQuantizedPack.swift
@@ -1,0 +1,384 @@
+import Foundation
+import MLX
+
+public struct LTX25TextEncoderQuantizedPackResult: Codable, Hashable, Sendable {
+    public let sourceURL: URL
+    public let outputDirectoryURL: URL
+    public let indexURL: URL
+    public let manifestURL: URL
+    public let sourceTensorCount: Int
+    public let quantizedTensorCount: Int
+    public let shardCount: Int
+    public let sourceBytes: Int64
+    public let packedBytes: Int64
+}
+
+public struct LTX25TextEncoderQuantizedPackManifest: Codable, Hashable, Sendable {
+    public let format: String
+    public let sourceRevision: String
+    public let sourceFilename: String
+    public let sourceBytes: Int64
+    public let bits: Int
+    public let groupSize: Int
+    public let sourceTensorCount: Int
+    public let quantizedTensorCount: Int
+    public let packedBytes: Int64
+    public let shards: [String]
+
+    private enum CodingKeys: String, CodingKey {
+        case format
+        case sourceRevision = "source_revision"
+        case sourceFilename = "source_filename"
+        case sourceBytes = "source_bytes"
+        case bits
+        case groupSize = "group_size"
+        case sourceTensorCount = "source_tensor_count"
+        case quantizedTensorCount = "quantized_tensor_count"
+        case packedBytes = "packed_bytes"
+        case shards
+    }
+}
+
+public enum LTX25TextEncoderQuantizedPackError: LocalizedError {
+    case sourceMissing(URL)
+    case outputExists(URL)
+    case noLanguageTensors(URL)
+    case missingTensor(String)
+    case invalidOutput(URL)
+
+    public var errorDescription: String? {
+        switch self {
+        case .sourceMissing(let url):
+            "Missing LTX 2.5 packed text encoder: \(url.path)"
+        case .outputExists(let url):
+            "Quantized LTX 2.5 text-encoder pack already exists: \(url.path)"
+        case .noLanguageTensors(let url):
+            "No Gemma language tensors were found in \(url.path)"
+        case .missingTensor(let key):
+            "The LTX 2.5 text-encoder source did not load tensor \(key)"
+        case .invalidOutput(let url):
+            "The generated LTX 2.5 text-encoder pack failed validation: \(url.path)"
+        }
+    }
+}
+
+/// Builds a local, source-bound MLX affine Q4 pack for the custom Gemma 4
+/// language tower embedded in the official LTX 2.5 text encoder. The LTX
+/// projection and tokenizer assets remain in the official BF16 checkpoint.
+public enum LTX25TextEncoderQuantizedPack {
+    public static let format = "mere-run-ltx25-text-q4-v1"
+    public static let relativeDirectory = ".mere-run/ltx25-text-q4-v1"
+    public static let bits = 4
+    public static let groupSize = 64
+
+    public static func outputDirectoryURL(resources: LTX25Resources) -> URL {
+        resources.rootURL.appendingPathComponent(relativeDirectory, isDirectory: true)
+    }
+
+    public static func indexURL(resources: LTX25Resources) -> URL {
+        outputDirectoryURL(resources: resources)
+            .appendingPathComponent("model.safetensors.index.json", isDirectory: false)
+    }
+
+    public static func manifestURL(resources: LTX25Resources) -> URL {
+        outputDirectoryURL(resources: resources)
+            .appendingPathComponent("pack.json", isDirectory: false)
+    }
+
+    public static func optimizedIndexURLIfValid(
+        resources: LTX25Resources,
+        fileManager: FileManager = .default
+    ) -> URL? {
+        let outputDirectory = outputDirectoryURL(resources: resources)
+        let manifestURL = manifestURL(resources: resources)
+        let indexURL = indexURL(resources: resources)
+        guard fileManager.fileExists(atPath: resources.textEncoderURL.path),
+              fileManager.fileExists(atPath: manifestURL.path),
+              fileManager.fileExists(atPath: indexURL.path),
+              let manifestData = try? Data(contentsOf: manifestURL),
+              let manifest = try? JSONDecoder().decode(
+                  LTX25TextEncoderQuantizedPackManifest.self,
+                  from: manifestData
+              ),
+              manifest.format == format,
+              manifest.sourceRevision == LTX25Resources.sourceRevision,
+              manifest.sourceFilename == resources.textEncoderURL.lastPathComponent,
+              manifest.bits == bits,
+              manifest.groupSize == groupSize,
+              manifest.sourceBytes == fileSize(resources.textEncoderURL),
+              !manifest.shards.isEmpty,
+              let indexData = try? Data(contentsOf: indexURL),
+              let index = try? JSONDecoder().decode(HFSafetensorsIndex.self, from: indexData),
+              index.weightMap.keys.contains(where: { $0.hasSuffix(".scales") }),
+              index.shardFilenames == manifest.shards.sorted() else {
+            return nil
+        }
+        for shard in manifest.shards {
+            let url = outputDirectory.appendingPathComponent(shard, isDirectory: false)
+            guard fileManager.fileExists(atPath: url.path),
+                  let metadata = try? SafetensorsStreamingLoader.fileMetadata(url: url),
+                  metadata["format"] == format,
+                  metadata["source_revision"] == LTX25Resources.sourceRevision else {
+                return nil
+            }
+        }
+        return indexURL
+    }
+
+    public static func artifactURLs(
+        resources: LTX25Resources,
+        fileManager: FileManager = .default
+    ) -> [URL] {
+        guard optimizedIndexURLIfValid(
+            resources: resources,
+            fileManager: fileManager
+        ) != nil,
+        let data = try? Data(contentsOf: manifestURL(resources: resources)),
+        let manifest = try? JSONDecoder().decode(
+            LTX25TextEncoderQuantizedPackManifest.self,
+            from: data
+        ) else {
+            return []
+        }
+        let outputDirectory = outputDirectoryURL(resources: resources)
+        let shards = manifest.shards.map {
+            outputDirectory.appendingPathComponent($0, isDirectory: false)
+        }
+        return [manifestURL(resources: resources), indexURL(resources: resources)] + shards
+    }
+
+    public static func optimize(
+        resources: LTX25Resources,
+        replacing: Bool = false,
+        progressHandler: ((Int, Int) -> Void)? = nil,
+        fileManager: FileManager = .default
+    ) throws -> LTX25TextEncoderQuantizedPackResult {
+        let sourceURL = resources.textEncoderURL
+        guard fileManager.fileExists(atPath: sourceURL.path) else {
+            throw LTX25TextEncoderQuantizedPackError.sourceMissing(sourceURL)
+        }
+        let outputDirectory = outputDirectoryURL(resources: resources)
+        if fileManager.fileExists(atPath: outputDirectory.path), !replacing {
+            throw LTX25TextEncoderQuantizedPackError.outputExists(outputDirectory)
+        }
+
+        let sourceMetadata = try SafetensorsStreamingLoader.metadata(url: sourceURL)
+        let languageKeys = sourceMetadata.keys.filter(isLanguageTensor).sorted()
+        guard !languageKeys.isEmpty else {
+            throw LTX25TextEncoderQuantizedPackError.noLanguageTensors(sourceURL)
+        }
+        let groups = makeGroups(keys: languageKeys)
+        let sourceBytes = fileSize(sourceURL)
+        let temporaryDirectory = outputDirectory.deletingLastPathComponent()
+            .appendingPathComponent(
+                ".ltx25-text-q4-\(UUID().uuidString).tmp",
+                isDirectory: true
+            )
+        try fileManager.createDirectory(
+            at: temporaryDirectory,
+            withIntermediateDirectories: true
+        )
+
+        var weightMap: [String: String] = [:]
+        var shardNames: [String] = []
+        var packedBytes: Int64 = 0
+        var quantizedTensorCount = 0
+        do {
+            for (index, group) in groups.enumerated() {
+                let shardName = String(
+                    format: "model-%05d-of-%05d.safetensors",
+                    index + 1,
+                    groups.count
+                )
+                let shardURL = temporaryDirectory.appendingPathComponent(
+                    shardName,
+                    isDirectory: false
+                )
+                let keySet = Set(group.keys)
+                let sourceArrays = try SafetensorsStreamingLoader.loadArrays(
+                    url: sourceURL,
+                    where: { keySet.contains($0) }
+                )
+                var outputArrays: [String: MLXArray] = [:]
+                for sourceKey in group.keys {
+                    guard let sourceArray = sourceArrays[sourceKey],
+                          let metadata = sourceMetadata[sourceKey] else {
+                        throw LTX25TextEncoderQuantizedPackError.missingTensor(sourceKey)
+                    }
+                    let outputKey = nativeLanguageKey(sourceKey)
+                    if shouldQuantize(key: sourceKey, metadata: metadata) {
+                        let quantized = MLX.quantized(
+                            sourceArray,
+                            groupSize: groupSize,
+                            bits: bits,
+                            mode: .affine
+                        )
+                        let baseKey = String(outputKey.dropLast(".weight".count))
+                        outputArrays[outputKey] = quantized.wq
+                        outputArrays[baseKey + ".scales"] = quantized.scales
+                        if let biases = quantized.biases {
+                            outputArrays[baseKey + ".biases"] = biases
+                        }
+                        quantizedTensorCount += 1
+                    } else {
+                        outputArrays[outputKey] = sourceArray
+                    }
+                }
+                MLX.eval(Array(outputArrays.values))
+                try MLX.save(
+                    arrays: outputArrays,
+                    metadata: [
+                        "format": format,
+                        "source_revision": LTX25Resources.sourceRevision,
+                        "bits": String(bits),
+                        "group_size": String(groupSize),
+                    ],
+                    url: shardURL
+                )
+                for key in outputArrays.keys {
+                    weightMap[key] = shardName
+                }
+                shardNames.append(shardName)
+                packedBytes += fileSize(shardURL)
+                Memory.clearCache()
+                progressHandler?(index + 1, groups.count)
+            }
+
+            let index = LTX25TextEncoderPackIndex(
+                metadata: .init(totalSize: packedBytes),
+                weightMap: weightMap
+            )
+            try writeJSON(
+                index,
+                to: temporaryDirectory.appendingPathComponent(
+                    "model.safetensors.index.json",
+                    isDirectory: false
+                )
+            )
+            let manifest = LTX25TextEncoderQuantizedPackManifest(
+                format: format,
+                sourceRevision: LTX25Resources.sourceRevision,
+                sourceFilename: sourceURL.lastPathComponent,
+                sourceBytes: sourceBytes,
+                bits: bits,
+                groupSize: groupSize,
+                sourceTensorCount: languageKeys.count,
+                quantizedTensorCount: quantizedTensorCount,
+                packedBytes: packedBytes,
+                shards: shardNames
+            )
+            try writeJSON(
+                manifest,
+                to: temporaryDirectory.appendingPathComponent("pack.json", isDirectory: false)
+            )
+        } catch {
+            try? fileManager.removeItem(at: temporaryDirectory)
+            throw error
+        }
+
+        if fileManager.fileExists(atPath: outputDirectory.path) {
+            try fileManager.removeItem(at: outputDirectory)
+        }
+        try fileManager.moveItem(at: temporaryDirectory, to: outputDirectory)
+        guard let validIndexURL = optimizedIndexURLIfValid(
+            resources: resources,
+            fileManager: fileManager
+        ) else {
+            throw LTX25TextEncoderQuantizedPackError.invalidOutput(outputDirectory)
+        }
+        return LTX25TextEncoderQuantizedPackResult(
+            sourceURL: sourceURL,
+            outputDirectoryURL: outputDirectory,
+            indexURL: validIndexURL,
+            manifestURL: manifestURL(resources: resources),
+            sourceTensorCount: languageKeys.count,
+            quantizedTensorCount: quantizedTensorCount,
+            shardCount: shardNames.count,
+            sourceBytes: sourceBytes,
+            packedBytes: packedBytes
+        )
+    }
+
+    private static func isLanguageTensor(_ key: String) -> Bool {
+        key == "model.embed_tokens.weight"
+            || key == "model.norm.weight"
+            || key.hasPrefix("model.layers.")
+    }
+
+    private static func shouldQuantize(
+        key: String,
+        metadata: SafetensorsStreamingLoader.TensorMetadata
+    ) -> Bool {
+        let belongsToQuantizedModule = key == "model.embed_tokens.weight"
+            || key.hasPrefix("model.layers.")
+        return belongsToQuantizedModule
+            && key.hasSuffix(".weight")
+            && metadata.shape.count == 2
+            && metadata.shape[0].isMultiple(of: 32)
+            && metadata.shape[1].isMultiple(of: groupSize)
+    }
+
+    private static func nativeLanguageKey(_ sourceKey: String) -> String {
+        String(sourceKey.dropFirst("model.".count))
+    }
+
+    private static func makeGroups(keys: [String]) -> [LTX25TextEncoderTensorGroup] {
+        Dictionary(grouping: keys, by: groupName)
+            .map { name, keys in
+                LTX25TextEncoderTensorGroup(name: name, keys: keys.sorted())
+            }
+            .sorted { groupOrder($0.name) < groupOrder($1.name) }
+    }
+
+    private static func groupName(_ key: String) -> String {
+        if key == "model.embed_tokens.weight" {
+            return "embed_tokens"
+        }
+        let components = key.split(separator: ".")
+        if components.count > 2, components[0] == "model", components[1] == "layers" {
+            return "layer-\(components[2])"
+        }
+        return "final"
+    }
+
+    private static func groupOrder(_ name: String) -> Int {
+        if name == "embed_tokens" { return 0 }
+        if name.hasPrefix("layer-"), let layer = Int(name.dropFirst("layer-".count)) {
+            return layer + 1
+        }
+        return Int.max
+    }
+
+    private static func fileSize(_ url: URL) -> Int64 {
+        Int64((try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0)
+    }
+
+    private static func writeJSON<Value: Encodable>(_ value: Value, to url: URL) throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        try encoder.encode(value).write(to: url, options: .atomic)
+    }
+}
+
+private struct LTX25TextEncoderTensorGroup {
+    let name: String
+    let keys: [String]
+}
+
+private struct LTX25TextEncoderPackIndex: Encodable {
+    struct Metadata: Encodable {
+        let totalSize: Int64
+
+        private enum CodingKeys: String, CodingKey {
+            case totalSize = "total_size"
+        }
+    }
+
+    let metadata: Metadata
+    let weightMap: [String: String]
+
+    private enum CodingKeys: String, CodingKey {
+        case metadata
+        case weightMap = "weight_map"
+    }
+}

--- a/Sources/MereRunCore/LTX/LTX25TextEncoderQuantizedPack.swift
+++ b/Sources/MereRunCore/LTX/LTX25TextEncoderQuantizedPack.swift
@@ -23,6 +23,7 @@ public struct LTX25TextEncoderQuantizedPackManifest: Codable, Hashable, Sendable
     public let sourceTensorCount: Int
     public let quantizedTensorCount: Int
     public let packedBytes: Int64
+    public let runtimeAssetsFilename: String
     public let shards: [String]
 
     private enum CodingKeys: String, CodingKey {
@@ -35,6 +36,7 @@ public struct LTX25TextEncoderQuantizedPackManifest: Codable, Hashable, Sendable
         case sourceTensorCount = "source_tensor_count"
         case quantizedTensorCount = "quantized_tensor_count"
         case packedBytes = "packed_bytes"
+        case runtimeAssetsFilename = "runtime_assets_filename"
         case shards
     }
 }
@@ -63,11 +65,12 @@ public enum LTX25TextEncoderQuantizedPackError: LocalizedError {
 }
 
 /// Builds a local, source-bound MLX affine Q4 pack for the custom Gemma 4
-/// language tower embedded in the official LTX 2.5 text encoder. The LTX
-/// projection and tokenizer assets remain in the official BF16 checkpoint.
+/// language tower embedded in the official LTX 2.5 text encoder. The pack also
+/// carries the BF16 LTX projection and embedded tokenizer assets required at runtime.
 public enum LTX25TextEncoderQuantizedPack {
     public static let format = "mere-run-ltx25-text-q4-v1"
     public static let relativeDirectory = ".mere-run/ltx25-text-q4-v1"
+    public static let runtimeAssetsFilename = "text-encoder-assets-bf16.safetensors"
     public static let bits = 4
     public static let groupSize = 64
 
@@ -85,14 +88,47 @@ public enum LTX25TextEncoderQuantizedPack {
             .appendingPathComponent("pack.json", isDirectory: false)
     }
 
+    public static func runtimeAssetsURL(resources: LTX25Resources) -> URL {
+        outputDirectoryURL(resources: resources)
+            .appendingPathComponent(runtimeAssetsFilename, isDirectory: false)
+    }
+
+    public static func runtimeAssetsURL(indexURL: URL) -> URL {
+        indexURL.deletingLastPathComponent()
+            .appendingPathComponent(runtimeAssetsFilename, isDirectory: false)
+    }
+
     public static func optimizedIndexURLIfValid(
         resources: LTX25Resources,
         fileManager: FileManager = .default
     ) -> URL? {
-        let outputDirectory = outputDirectoryURL(resources: resources)
-        let manifestURL = manifestURL(resources: resources)
-        let indexURL = indexURL(resources: resources)
-        guard fileManager.fileExists(atPath: resources.textEncoderURL.path),
+        let sourceURL = resources.textEncoderURL
+        return validatedIndexURL(
+            outputDirectory: outputDirectoryURL(resources: resources),
+            sourceURL: fileManager.fileExists(atPath: sourceURL.path) ? sourceURL : nil,
+            fileManager: fileManager
+        )
+    }
+
+    private static func validatedIndexURL(
+        outputDirectory: URL,
+        sourceURL: URL?,
+        fileManager: FileManager
+    ) -> URL? {
+        let manifestURL = outputDirectory.appendingPathComponent(
+            "pack.json",
+            isDirectory: false
+        )
+        let indexURL = outputDirectory.appendingPathComponent(
+            "model.safetensors.index.json",
+            isDirectory: false
+        )
+        let expectedSourceFilename = sourceURL?.lastPathComponent
+            ?? URL(fileURLWithPath: LTX25Resources.textEncoderRelativePath).lastPathComponent
+        let expectedSourceBytes = sourceURL.map(fileSize)
+            ?? LTX25Resources.textEncoderSourceBytes
+        let sourceExists = sourceURL.map { fileManager.fileExists(atPath: $0.path) } ?? true
+        guard sourceExists,
               fileManager.fileExists(atPath: manifestURL.path),
               fileManager.fileExists(atPath: indexURL.path),
               let manifestData = try? Data(contentsOf: manifestURL),
@@ -102,15 +138,33 @@ public enum LTX25TextEncoderQuantizedPack {
               ),
               manifest.format == format,
               manifest.sourceRevision == LTX25Resources.sourceRevision,
-              manifest.sourceFilename == resources.textEncoderURL.lastPathComponent,
+              manifest.sourceFilename == expectedSourceFilename,
               manifest.bits == bits,
               manifest.groupSize == groupSize,
-              manifest.sourceBytes == fileSize(resources.textEncoderURL),
+              manifest.sourceBytes == expectedSourceBytes,
+              manifest.runtimeAssetsFilename == runtimeAssetsFilename,
               !manifest.shards.isEmpty,
               let indexData = try? Data(contentsOf: indexURL),
               let index = try? JSONDecoder().decode(HFSafetensorsIndex.self, from: indexData),
               index.weightMap.keys.contains(where: { $0.hasSuffix(".scales") }),
               index.shardFilenames == manifest.shards.sorted() else {
+            return nil
+        }
+        let runtimeAssetsURL = outputDirectory.appendingPathComponent(
+            manifest.runtimeAssetsFilename,
+            isDirectory: false
+        )
+        guard fileManager.fileExists(atPath: runtimeAssetsURL.path),
+              let runtimeMetadata = try? SafetensorsStreamingLoader.metadata(
+                  url: runtimeAssetsURL
+              ),
+              requiredRuntimeAssetKeys.allSatisfy({ runtimeMetadata[$0] != nil }),
+              let runtimeFileMetadata = try? SafetensorsStreamingLoader.fileMetadata(
+                  url: runtimeAssetsURL
+              ),
+              runtimeFileMetadata["format"] == format,
+              runtimeFileMetadata["source_revision"] == LTX25Resources.sourceRevision,
+              runtimeFileMetadata["gemma_config"] != nil else {
             return nil
         }
         for shard in manifest.shards {
@@ -144,7 +198,11 @@ public enum LTX25TextEncoderQuantizedPack {
         let shards = manifest.shards.map {
             outputDirectory.appendingPathComponent($0, isDirectory: false)
         }
-        return [manifestURL(resources: resources), indexURL(resources: resources)] + shards
+        return [
+            manifestURL(resources: resources),
+            indexURL(resources: resources),
+            runtimeAssetsURL(resources: resources),
+        ] + shards
     }
 
     public static func optimize(
@@ -163,6 +221,10 @@ public enum LTX25TextEncoderQuantizedPack {
         }
 
         let sourceMetadata = try SafetensorsStreamingLoader.metadata(url: sourceURL)
+        let sourceFileMetadata = try SafetensorsStreamingLoader.fileMetadata(url: sourceURL)
+        guard let gemmaConfig = sourceFileMetadata["gemma_config"] else {
+            throw LTX25TextEncoderQuantizedPackError.invalidOutput(sourceURL)
+        }
         let languageKeys = sourceMetadata.keys.filter(isLanguageTensor).sorted()
         guard !languageKeys.isEmpty else {
             throw LTX25TextEncoderQuantizedPackError.noLanguageTensors(sourceURL)
@@ -244,6 +306,30 @@ public enum LTX25TextEncoderQuantizedPack {
                 progressHandler?(index + 1, groups.count)
             }
 
+            let runtimeAssets = try SafetensorsStreamingLoader.loadArrays(
+                url: sourceURL,
+                where: { requiredRuntimeAssetKeys.contains($0) }
+            )
+            guard requiredRuntimeAssetKeys.allSatisfy({ runtimeAssets[$0] != nil }) else {
+                throw LTX25TextEncoderQuantizedPackError.invalidOutput(sourceURL)
+            }
+            MLX.eval(Array(runtimeAssets.values))
+            let runtimeAssetsURL = temporaryDirectory.appendingPathComponent(
+                runtimeAssetsFilename,
+                isDirectory: false
+            )
+            try MLX.save(
+                arrays: runtimeAssets,
+                metadata: [
+                    "format": format,
+                    "source_revision": LTX25Resources.sourceRevision,
+                    "gemma_config": gemmaConfig,
+                ],
+                url: runtimeAssetsURL
+            )
+            packedBytes += fileSize(runtimeAssetsURL)
+            Memory.clearCache()
+
             let index = LTX25TextEncoderPackIndex(
                 metadata: .init(totalSize: packedBytes),
                 weightMap: weightMap
@@ -265,6 +351,7 @@ public enum LTX25TextEncoderQuantizedPack {
                 sourceTensorCount: languageKeys.count,
                 quantizedTensorCount: quantizedTensorCount,
                 packedBytes: packedBytes,
+                runtimeAssetsFilename: runtimeAssetsFilename,
                 shards: shardNames
             )
             try writeJSON(
@@ -304,6 +391,15 @@ public enum LTX25TextEncoderQuantizedPack {
             || key == "model.norm.weight"
             || key.hasPrefix("model.layers.")
     }
+
+    private static let requiredRuntimeAssetKeys: Set<String> = [
+        "hf_asset__tokenizer_config.json",
+        "text_embedding_projection.audio_aggregate_embed.bias",
+        "text_embedding_projection.audio_aggregate_embed.weight",
+        "text_embedding_projection.video_aggregate_embed.bias",
+        "text_embedding_projection.video_aggregate_embed.weight",
+        "tokenizer_json",
+    ]
 
     private static func shouldQuantize(
         key: String,

--- a/Sources/MereRunCore/LTX/LTXDistilledLatentGenerator.swift
+++ b/Sources/MereRunCore/LTX/LTXDistilledLatentGenerator.swift
@@ -4354,25 +4354,29 @@ public actor LTXUnifiedAVGenerator {
         guard loadedForLTX25, let loadedRoot else {
             throw LTXUnifiedAVGeneratorError.durationPredictionRequiresLTX25(self.loadedRoot)
         }
-        guard let textEncoder else {
-            throw LTXUnifiedAVGeneratorError.generatorNotLoaded
-        }
         let trimmedPrompt = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedPrompt.isEmpty else {
             throw LTXUnifiedAVGeneratorError.emptyPrompt
         }
-        let encoding = try await textEncoder.encode(
+        let cacheKey = LTXPromptEmbeddingCacheKey(
             prompt: trimmedPrompt,
             maxLength: maxTextLength
         )
+        if !promptEmbeddingCache.contains(cacheKey), textEncoder == nil {
+            try await loadTextEncoderIfNeeded()
+        }
+        let encoding = try await cachedPromptEmbeddings(
+            prompt: trimmedPrompt,
+            maxLength: maxTextLength
+        ).embeddings
         let head = try LTX25DurationHead.load(
             weightsURL: LTX25Resources(rootURL: loadedRoot).durationHeadURL,
             dtype: loadedDType
         )
         let videoTokens: MLXArray? = conditioning == .audioVideo
-            ? encoding.videoEmbeddings
+            ? encoding.video
             : nil
-        let audioTokens = encoding.audioEmbeddings
+        let audioTokens = encoding.audio
         if conditioning == .audioOnly, audioTokens == nil {
             throw LTXUnifiedAVGeneratorError.audioEmbeddingsMissing
         }
@@ -4382,7 +4386,12 @@ public actor LTXUnifiedAVGenerator {
             frameRate: frameRate,
             range: range
         )
+        if let textEncoder {
+            await textEncoder.unload()
+            self.textEncoder = nil
+        }
         Memory.clearCache()
+        ltxTraceMemory("duration-context-ready")
         return frameCount
     }
 
@@ -5073,7 +5082,7 @@ public actor LTXUnifiedAVGenerator {
         }
     }
 
-    private func loadFullTextEncoderIfNeeded() async throws {
+    private func loadTextEncoderIfNeeded() async throws {
         guard textEncoder == nil else { return }
         guard let loadedRoot else {
             throw LTXUnifiedAVGeneratorError.generatorNotLoaded
@@ -5285,7 +5294,7 @@ public actor LTXUnifiedAVGenerator {
         let usesReusableFullTwoStage = loadedForReusableFullTwoStage
         if usesReusableFullTwoStage {
             let reloadStart = ltxMonotonicSeconds()
-            try await loadFullTextEncoderIfNeeded()
+            try await loadTextEncoderIfNeeded()
             textEncoderReloadSeconds = ltxMonotonicSeconds() - reloadStart
         }
         guard loadedForAudioToVideo,
@@ -6283,9 +6292,9 @@ public actor LTXUnifiedAVGenerator {
         let needsNegativeTextEncoder = usesGuidedFullTwoStage
             && !promptEmbeddingCache.contains(negativePromptCacheKey)
         let needsTextEncoder = needsPositiveTextEncoder || needsNegativeTextEncoder
-        if usesReusableFullTwoStage, needsTextEncoder {
+        if needsTextEncoder, textEncoder == nil {
             let reloadStart = ltxMonotonicSeconds()
-            try await loadFullTextEncoderIfNeeded()
+            try await loadTextEncoderIfNeeded()
             textEncoderReloadSeconds = ltxMonotonicSeconds() - reloadStart
         }
         guard let transformer else {
@@ -6360,12 +6369,6 @@ public actor LTXUnifiedAVGenerator {
             }
             videoContext = loadedVideoContext.asType(loadedDType)
             audioContext = loadedAudioContext.asType(loadedDType)
-            MLX.eval(videoContext, audioContext)
-            if let textEncoder {
-                await textEncoder.unload()
-                self.textEncoder = nil
-                Memory.clearCache()
-            }
         } else {
             let result = try await cachedPromptEmbeddings(
                 prompt: prompt,
@@ -6393,20 +6396,18 @@ public actor LTXUnifiedAVGenerator {
                 throw LTXUnifiedAVGeneratorError.audioEmbeddingsMissing
             }
             negativeAudioContext = audioEmbeddings
-            MLX.eval(videoContext, audioContext, result.embeddings.video, audioEmbeddings)
-            if let textEncoder {
-                await textEncoder.unload()
-                self.textEncoder = nil
-                Memory.clearCache()
-            }
-        } else if usesDFR {
-            MLX.eval(videoContext, audioContext)
-            if let textEncoder {
-                await textEncoder.unload()
-                self.textEncoder = nil
-                Memory.clearCache()
-            }
         }
+        if let negativeVideoContext, let negativeAudioContext {
+            MLX.eval(videoContext, audioContext, negativeVideoContext, negativeAudioContext)
+        } else {
+            MLX.eval(videoContext, audioContext)
+        }
+        if let textEncoder {
+            await textEncoder.unload()
+            self.textEncoder = nil
+        }
+        Memory.clearCache()
+        ltxTraceMemory("text-context-ready")
         textEncodingSeconds = textEncoderReloadSeconds + ltxMonotonicSeconds() - textEncodingStart
         let preparationStart = ltxMonotonicSeconds()
 
@@ -6666,10 +6667,9 @@ public actor LTXUnifiedAVGenerator {
                 }
             }
         }
-        if usesFullTwoStage {
-            encoder = nil
-            Memory.clearCache()
-        }
+        encoder = nil
+        Memory.clearCache()
+        ltxTraceMemory("image-conditioning-ready")
 
         if usesGuidedFullTwoStage {
             MLXRandom.seed(UInt64(bitPattern: Int64(options.seed &+ 1)))
@@ -6902,6 +6902,7 @@ public actor LTXUnifiedAVGenerator {
             MLX.eval(dfrDetailingReferenceLatent)
         }
         stage1DenoiseSeconds = ltxMonotonicSeconds() - stage1DenoiseStart
+        ltxTraceMemory("stage1-denoise-ready")
 
         if !usesDevOneStage, !usesRetakeOneStage, !options.skipStage2 {
             let loraFusionStart = ltxMonotonicSeconds()
@@ -7193,6 +7194,7 @@ public actor LTXUnifiedAVGenerator {
         }
         MLX.eval(videoLatents, audioLatents)
         stage2DenoiseSeconds = ltxMonotonicSeconds() - stage2DenoiseStart
+        ltxTraceMemory("stage2-denoise-ready")
         runtimeDetailingLoRAAdapters.forEach { $0.setActive(false) }
         }
 

--- a/Sources/MereRunCore/LTX/LTXGemmaTextEncoder.swift
+++ b/Sources/MereRunCore/LTX/LTXGemmaTextEncoder.swift
@@ -280,7 +280,12 @@ public actor LTXGemmaTextEncoder {
         loadConnectorWeights: Bool
     ) async throws {
         let resources = LTX25Resources(rootURL: root)
-        let textEncoderURL = resources.textEncoderURL
+        let quantizedIndexURL = LTX25TextEncoderQuantizedPack.optimizedIndexURLIfValid(
+            resources: resources
+        )
+        let textEncoderURL = quantizedIndexURL.map {
+            LTX25TextEncoderQuantizedPack.runtimeAssetsURL(indexURL: $0)
+        } ?? resources.textEncoderURL
         let connectorURL = LTX25NativeModelPack.optimizedURLIfValid(
             resources: resources,
             kind: .connector
@@ -302,9 +307,7 @@ public actor LTXGemmaTextEncoder {
         }
 
         let languageModel = Gemma4LanguageModel(config: config.textConfig)
-        if let quantizedIndexURL = LTX25TextEncoderQuantizedPack.optimizedIndexURLIfValid(
-            resources: resources
-        ) {
+        if let quantizedIndexURL {
             try HFSafetensorsWeightsLoader.applyQuantizedWeights(
                 indexURL: quantizedIndexURL,
                 to: languageModel,

--- a/Sources/MereRunCore/LTX/LTXGemmaTextEncoder.swift
+++ b/Sources/MereRunCore/LTX/LTXGemmaTextEncoder.swift
@@ -302,24 +302,38 @@ public actor LTXGemmaTextEncoder {
         }
 
         let languageModel = Gemma4LanguageModel(config: config.textConfig)
-        try SafetensorsStreamingLoader.applyWeightsLazyMaterialized(
-            url: textEncoderURL,
-            to: languageModel,
-            verify: .none,
-            include: { key in
-                key == "model.embed_tokens.weight"
-                    || key == "model.norm.weight"
-                    || key.hasPrefix("model.layers.")
-            },
-            mapper: { key, value in
-                guard key.hasPrefix("model.") else { return [] }
-                return [(
-                    String(key.dropFirst("model.".count)),
-                    HFSafetensorsWeightsLoader.castIfNeeded(value, dtype: dtype)
-                )]
-            },
-            batchSize: 24
-        )
+        if let quantizedIndexURL = LTX25TextEncoderQuantizedPack.optimizedIndexURLIfValid(
+            resources: resources
+        ) {
+            try HFSafetensorsWeightsLoader.applyQuantizedWeights(
+                indexURL: quantizedIndexURL,
+                to: languageModel,
+                groupSize: LTX25TextEncoderQuantizedPack.groupSize,
+                bits: LTX25TextEncoderQuantizedPack.bits,
+                mapper: { key, value in
+                    [(key, HFSafetensorsWeightsLoader.castIfNeeded(value, dtype: dtype))]
+                }
+            )
+        } else {
+            try SafetensorsStreamingLoader.applyWeightsLazyMaterialized(
+                url: textEncoderURL,
+                to: languageModel,
+                verify: .none,
+                include: { key in
+                    key == "model.embed_tokens.weight"
+                        || key == "model.norm.weight"
+                        || key.hasPrefix("model.layers.")
+                },
+                mapper: { key, value in
+                    guard key.hasPrefix("model.") else { return [] }
+                    return [(
+                        String(key.dropFirst("model.".count)),
+                        HFSafetensorsWeightsLoader.castIfNeeded(value, dtype: dtype)
+                    )]
+                },
+                batchSize: 24
+            )
+        }
 
         let textFeatures = LTXGemmaFeaturesExtractorV2(
             captionChannels: config.textConfig.hiddenSize,

--- a/Sources/MereRunCore/LTX/LTXMemoryTrace.swift
+++ b/Sources/MereRunCore/LTX/LTXMemoryTrace.swift
@@ -1,0 +1,35 @@
+import Foundation
+import MLX
+
+let ltxMemoryTraceEnvironmentKey = "MERERUN_LTX_MEMORY_TRACE"
+
+func ltxTraceMemory(
+    _ phase: String,
+    environment: [String: String] = ProcessInfo.processInfo.environment
+) {
+    guard environment[ltxMemoryTraceEnvironmentKey] == "1" else { return }
+    let snapshot = Memory.snapshot()
+    let line = ltxMemoryTraceLine(
+        phase: phase,
+        activeBytes: snapshot.activeMemory,
+        cacheBytes: snapshot.cacheMemory,
+        peakBytes: snapshot.peakMemory
+    )
+    FileHandle.standardError.write(Data((line + "\n").utf8))
+}
+
+func ltxMemoryTraceLine(
+    phase: String,
+    activeBytes: Int,
+    cacheBytes: Int,
+    peakBytes: Int
+) -> String {
+    "[ltx-memory] phase=\(phase)"
+        + " active=\(ltxMemoryGiB(activeBytes))GiB"
+        + " cache=\(ltxMemoryGiB(cacheBytes))GiB"
+        + " peak=\(ltxMemoryGiB(peakBytes))GiB"
+}
+
+private func ltxMemoryGiB(_ bytes: Int) -> String {
+    String(format: "%.2f", Double(bytes) / 1_073_741_824.0)
+}

--- a/Sources/MereRunCore/LTX/README.md
+++ b/Sources/MereRunCore/LTX/README.md
@@ -7,7 +7,7 @@ This directory owns native video generation for mere.run.
 - `LTXGemmaTextEncoder.swift`: text encoder support for LTX models
 - `LTXPromptEmbeddingCache.swift`: bounded resident-session prompt embedding cache
 - `LTXGuidanceProjectionCache.swift`: low-memory-safe full-guidance prompt projection reuse policy
-- `LTX25Resources.swift`: immutable official LTX 2.5 source pins and packed-component layout validation
+- `LTX25Resources.swift`: immutable upstream and managed LTX 2.5 pins plus packed-component layout validation
 - `LTXVideoMP4Writer.swift`: final MP4 assembly
 
 Edit here when you are changing native LTX loading, denoising, decode, or export behavior. Do not mix unrelated CLI concerns into this directory; keep command parsing in `Sources/MereRunCLI/Commands/VideoCommand.swift`.
@@ -16,16 +16,22 @@ Before stopping, run `swift test`, `./scripts/check.sh`, and a smoke path if you
 
 ## LTX 2.5
 
-The official LTX 2.5 distilled release runs through the native `LTXUnifiedAVGenerator` with no Python sidecar. `LTX25Resources` validates the packed Hugging Face layout; `LTXGemmaTextEncoder` reads the embedded tokenizer and Gemma 4 weights directly; and the unified generator loads the packed transformer, video VAE, audio VAE/BWE vocoder, and spatial upsampler. Stage one uses the release's ancestral Euler update and stage two uses its deterministic refinement schedule.
+The LTX 2.5 distilled release runs through the native `LTXUnifiedAVGenerator`
+with no Python sidecar. The managed Sawfwair distribution keeps the video
+transformer, VAEs, upsampler, and duration head in BF16 while bundling a
+self-contained MLX Q4 Gemma 4 language tower with its BF16 projection and
+tokenizer assets. Stage one uses the release's ancestral Euler update and stage
+two uses its deterministic refinement schedule.
 
-Pull the gated checkpoint into the managed model store:
+Pull the public model into the managed model store after reviewing its terms:
 
 ```bash
 mere.run model pull video-ltx25-distilled-bf16 --accept-model-license
 ```
 
-The Hugging Face account behind `HF_TOKEN` must already have access. Then use
-the managed ID (or pass an official checkout with `--model-root`):
+This is one repository and one download; no Hugging Face gate, separate Gemma
+download, or local quantization step is required. Then use the managed ID (or
+pass a compatible official checkout with `--model-root`):
 
 ```bash
 mere.run video generate "a small robot walks across a wooden table" \

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -1032,11 +1032,11 @@ public enum ManagedModelCatalog {
 
     private static let ltx25GemmaTextEncoderUsageTerm = ManagedModelUsageTerm(
         component: "Gemma 4 text encoder",
-        license: "Gemma Terms of Use",
-        summary: "The packed LTX 2.5 text encoder includes Gemma 4 weights distributed under the Gemma Terms of Use and Gemma Prohibited Use Policy.",
+        license: "Apache License 2.0",
+        summary: "The packed LTX 2.5 text encoder includes Gemma 4 weights distributed under the Apache License 2.0.",
         sourceRepoId: LTX25Resources.sourceRepository,
         sourceRevision: LTX25Resources.sourceRevision,
-        licenseURL: "https://ai.google.dev/gemma/terms"
+        licenseURL: "https://ai.google.dev/gemma/apache_2"
     )
 
     private static let geoExpansionSpecs: [ManagedModelSpec] = [
@@ -3435,15 +3435,15 @@ public enum ManagedModelCatalog {
             category: .video,
             installShape: .structuredRoot,
             hubFallback: HubFallbackConfig(
-                repoId: LTX25Resources.sourceRepository,
-                revision: LTX25Resources.sourceRevision,
+                repoId: LTX25Resources.managedRepository,
+                revision: LTX25Resources.managedRevision,
                 patterns: LTX25Resources.snapshotPatterns
             ),
-            upstreamRepoId: LTX25Resources.sourceRepository,
-            upstreamRevision: LTX25Resources.sourceRevision,
+            upstreamRepoId: LTX25Resources.managedRepository,
+            upstreamRevision: LTX25Resources.managedRevision,
             usageRestriction: ltxUsageRestriction(
-                sourceRepoId: LTX25Resources.sourceRepository,
-                sourceRevision: LTX25Resources.sourceRevision,
+                sourceRepoId: LTX25Resources.managedRepository,
+                sourceRevision: LTX25Resources.managedRevision,
                 additionalTerms: [ltx25GemmaTextEncoderUsageTerm]
             ),
             validationKind: .ltxVideo25,

--- a/Sources/MereRunCore/ManagedModelSupport.swift
+++ b/Sources/MereRunCore/ManagedModelSupport.swift
@@ -1117,7 +1117,7 @@ public enum ManagedModelCapabilityCatalog {
             descriptor(
                 ModelResolver.ModelID.ltxVideo25DistilledBF16.rawValue,
                 "LTX 2.5 Distilled BF16",
-                "Generates final-quality video with synchronized stereo audio using the official packed LTX 2.5 release.",
+                "Generates synchronized video and audio with the BF16 LTX pipeline and a bundled MLX Q4 Gemma 4 text tower.",
                 minimum: 96,
                 recommended: 128
             ),

--- a/Sources/MereRunCore/MereRunModelManifest.swift
+++ b/Sources/MereRunCore/MereRunModelManifest.swift
@@ -2330,7 +2330,7 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
                 defaults: Defaults(steps: 8, cfg: 3),
                 supports: [.videoGeneration],
                 components: nil,
-                upstreamRepoId: "\(LTX25Resources.sourceRepository)@\(LTX25Resources.sourceRevision)",
+                upstreamRepoId: "\(LTX25Resources.managedRepository)@\(LTX25Resources.managedRevision)",
                 createdAt: createdAt
             )
         case .ltxVideo25FullBF16:

--- a/Tests/MereRunCLITests/ModelInfoCommandTests.swift
+++ b/Tests/MereRunCLITests/ModelInfoCommandTests.swift
@@ -58,6 +58,17 @@ final class ModelInfoCommandTests: XCTestCase {
             )
             try Data("fixture".utf8).write(to: url)
         }
+        for relativePath in [
+            "\(LTX25TextEncoderQuantizedPack.relativeDirectory)/model.safetensors.index.json",
+            "\(LTX25TextEncoderQuantizedPack.relativeDirectory)/\(LTX25TextEncoderQuantizedPack.runtimeAssetsFilename)",
+        ] {
+            let url = root.appendingPathComponent(relativePath)
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            try Data("fixture".utf8).write(to: url)
+        }
         let manifest = MereRunModelManifest.template(
             for: .ltxVideo25DistilledBF16,
             createdAt: Date(timeIntervalSince1970: 0)
@@ -65,9 +76,13 @@ final class ModelInfoCommandTests: XCTestCase {
         let lines = ModelInfo.ltx25ComponentLines(rootURL: root)
 
         XCTAssertTrue(ModelInfo.usesLTX25Layout(manifest: manifest, expectedModelID: nil))
-        XCTAssertTrue(lines.contains("  layout: official LTX 2.5 packed BF16 files"))
+        XCTAssertTrue(
+            lines.contains("  layout: self-contained LTX 2.5 BF16 + MLX Q4 text files")
+        )
         XCTAssertTrue(lines.contains { $0.contains(LTX25Resources.transformerRelativePath) })
-        XCTAssertTrue(lines.contains { $0.contains(LTX25Resources.textEncoderRelativePath) })
+        XCTAssertTrue(lines.contains {
+            $0.contains(LTX25TextEncoderQuantizedPack.relativeDirectory)
+        })
         XCTAssertTrue(lines.contains { $0.contains(LTX25Resources.audioVAERelativePath) })
         XCTAssertFalse(lines.contains { $0.contains("(missing)") })
     }

--- a/Tests/MereRunCLITests/ModelOptimizeCommandTests.swift
+++ b/Tests/MereRunCLITests/ModelOptimizeCommandTests.swift
@@ -11,10 +11,12 @@ final class ModelOptimizeCommandTests: XCTestCase {
         let command = try ModelOptimize.parse([
             "video-minimax-h3-fl2va-mlx",
             "--force",
+            "--text-encoder-only",
             "--json",
         ])
         XCTAssertEqual(command.target, "video-minimax-h3-fl2va-mlx")
         XCTAssertTrue(command.force)
+        XCTAssertTrue(command.textEncoderOnly)
         XCTAssertTrue(command.json)
     }
 }

--- a/Tests/MereRunCLITests/ModelPullCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/ModelPullCommandParsingTests.swift
@@ -69,7 +69,10 @@ final class ModelPullCommandParsingTests: XCTestCase {
             let blocked = try ModelPull.parse([id])
             let accepted = try ModelPull.parse([id, "--accept-model-license"])
 
-            XCTAssertEqual(spec.hubFallback?.repoId, "Lightricks/LTX-2.5")
+            let expectedRepoID = id == ModelResolver.ModelID.ltxVideo25DistilledBF16.rawValue
+                ? LTX25Resources.managedRepository
+                : LTX25Resources.sourceRepository
+            XCTAssertEqual(spec.hubFallback?.repoId, expectedRepoID)
             XCTAssertEqual(spec.usageRestriction?.terms.count, 2)
             XCTAssertTrue(try XCTUnwrap(blocked.licenseAcceptanceMessage(for: spec)).contains("Gemma 4"))
             XCTAssertNil(accepted.licenseAcceptanceMessage(for: spec))

--- a/Tests/MereRunCLITests/VideoCommandTests.swift
+++ b/Tests/MereRunCLITests/VideoCommandTests.swift
@@ -2065,6 +2065,7 @@ final class VideoCommandTests: XCTestCase {
         for relativePath in LTX25Resources.requiredRelativePaths {
             try createFile(rootURL.appendingPathComponent(relativePath))
         }
+        try createFile(rootURL.appendingPathComponent(LTX25Resources.textEncoderRelativePath))
         return rootURL
     }
 

--- a/Tests/MereRunCoreTests/LTX25ResourcesTests.swift
+++ b/Tests/MereRunCoreTests/LTX25ResourcesTests.swift
@@ -16,6 +16,16 @@ final class LTX25ResourcesTests: XCTestCase {
             )
             XCTAssertTrue(FileManager.default.createFile(atPath: url.path, contents: Data()))
         }
+        try FileManager.default.createDirectory(
+            at: resources.textEncoderURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        XCTAssertTrue(
+            FileManager.default.createFile(
+                atPath: resources.textEncoderURL.path,
+                contents: Data()
+            )
+        )
 
         XCTAssertTrue(resources.validate().isEmpty)
         XCTAssertTrue(isLTX25ModelRoot(root))
@@ -25,7 +35,7 @@ final class LTX25ResourcesTests: XCTestCase {
         XCTAssertFalse(isLTX25ModelRoot(root))
     }
 
-    func testSnapshotPinsOfficialImmutableFiles() {
+    func testSnapshotPinsSelfContainedManagedDistribution() {
         XCTAssertEqual(LTX25Resources.sourceRepository, "Lightricks/LTX-2.5")
         XCTAssertEqual(
             LTX25Resources.sourceRevision,
@@ -36,9 +46,20 @@ final class LTX25ResourcesTests: XCTestCase {
             "d151147788a9284cca791edc6ce898007e727fe6"
         )
         XCTAssertEqual(LTX25Resources.upstreamCodeRelease, "v1.2.0")
-        XCTAssertEqual(LTX25Resources.estimatedDownloadBytes, 71_098_810_082)
+        XCTAssertEqual(
+            LTX25Resources.managedRepository,
+            "Sawfwair/LTX-2.5-Distilled-BF16-MLX-Q4-Text"
+        )
+        XCTAssertEqual(
+            LTX25Resources.managedRevision,
+            "9f316bfb18448bf67f716006fd78a37829223b74"
+        )
+        XCTAssertEqual(LTX25Resources.estimatedDownloadBytes, 53_878_648_085)
         XCTAssertTrue(LTX25Resources.snapshotPatterns.contains(LTX25Resources.transformerRelativePath))
-        XCTAssertTrue(LTX25Resources.snapshotPatterns.contains(LTX25Resources.textEncoderRelativePath))
+        XCTAssertFalse(LTX25Resources.snapshotPatterns.contains(LTX25Resources.textEncoderRelativePath))
+        XCTAssertTrue(LTX25Resources.snapshotPatterns.contains {
+            $0.contains(LTX25TextEncoderQuantizedPack.relativeDirectory)
+        })
         XCTAssertFalse(LTX25Resources.snapshotPatterns.contains {
             $0.contains("dev-transformer") || $0.contains("diffusion-video-vae")
         })

--- a/Tests/MereRunCoreTests/LTX25TextEncoderQuantizedPackTests.swift
+++ b/Tests/MereRunCoreTests/LTX25TextEncoderQuantizedPackTests.swift
@@ -1,0 +1,158 @@
+import Foundation
+import MLX
+import XCTest
+@testable import MereRunCore
+
+final class LTX25TextEncoderQuantizedPackTests: XCTestCase {
+    func testRealOptimizedPackLoadsAndEncodes() async throws {
+        guard let rootPath = ProcessInfo.processInfo.environment[
+            "MERERUN_LTX25_TEXT_ENCODER_ROOT"
+        ] else {
+            throw XCTSkip(
+                "Set MERERUN_LTX25_TEXT_ENCODER_ROOT for real Q4 text-encoder coverage."
+            )
+        }
+        let resources = LTX25Resources(rootURL: URL(fileURLWithPath: rootPath))
+        _ = try XCTUnwrap(
+            LTX25TextEncoderQuantizedPack.optimizedIndexURLIfValid(resources: resources)
+        )
+        let encoder = LTXGemmaTextEncoder()
+        try await encoder.load(modelRoot: resources.rootURL, dtype: .bfloat16)
+        let encoding = try await encoder.encode(
+            prompt: "A camera glides forward through a quiet forest.",
+            maxLength: 32
+        )
+        if let audio = encoding.audioEmbeddings {
+            MLX.eval(encoding.videoEmbeddings, audio)
+            XCTAssertGreaterThan(audio.size, 0)
+        } else {
+            XCTFail("Expected LTX 2.5 audio embeddings.")
+        }
+        XCTAssertGreaterThan(encoding.videoEmbeddings.size, 0)
+        await encoder.unload()
+        Memory.clearCache()
+    }
+
+    func testOptimizerBuildsSourceBoundQ4LanguagePack() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let result = try LTX25TextEncoderQuantizedPack.optimize(
+            resources: fixture.resources
+        )
+        XCTAssertEqual(result.sourceTensorCount, 3)
+        XCTAssertEqual(result.quantizedTensorCount, 2)
+        XCTAssertEqual(result.shardCount, 3)
+        XCTAssertLessThan(result.packedBytes, result.sourceBytes)
+        XCTAssertEqual(
+            LTX25TextEncoderQuantizedPack.optimizedIndexURLIfValid(
+                resources: fixture.resources
+            ),
+            result.indexURL
+        )
+
+        let arrays = try loadPackArrays(resources: fixture.resources)
+        XCTAssertNotNil(arrays["embed_tokens.weight"])
+        XCTAssertNotNil(arrays["embed_tokens.scales"])
+        XCTAssertNotNil(arrays["embed_tokens.biases"])
+        XCTAssertNotNil(arrays["layers.0.mlp.up_proj.weight"])
+        XCTAssertNotNil(arrays["layers.0.mlp.up_proj.scales"])
+        XCTAssertNotNil(arrays["norm.weight"])
+        XCTAssertNil(arrays["text_embedding_projection.aggregate_embed.weight"])
+
+        let restored = MLX.dequantized(
+            try XCTUnwrap(arrays["layers.0.mlp.up_proj.weight"]),
+            scales: try XCTUnwrap(arrays["layers.0.mlp.up_proj.scales"]),
+            biases: arrays["layers.0.mlp.up_proj.biases"],
+            groupSize: LTX25TextEncoderQuantizedPack.groupSize,
+            bits: LTX25TextEncoderQuantizedPack.bits,
+            mode: .affine,
+            dtype: .float32
+        )
+        let error = MLX.mean(
+            MLX.abs(restored - fixture.layerWeight.asType(.float32))
+        ).item(Float.self)
+        XCTAssertLessThan(error, 0.05)
+    }
+
+    func testOptimizerRequiresExplicitReplacement() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        _ = try LTX25TextEncoderQuantizedPack.optimize(resources: fixture.resources)
+        XCTAssertThrowsError(
+            try LTX25TextEncoderQuantizedPack.optimize(resources: fixture.resources)
+        ) { error in
+            guard case LTX25TextEncoderQuantizedPackError.outputExists = error else {
+                return XCTFail("Expected outputExists, got \(error)")
+            }
+        }
+        let replacement = try LTX25TextEncoderQuantizedPack.optimize(
+            resources: fixture.resources,
+            replacing: true
+        )
+        XCTAssertEqual(
+            LTX25TextEncoderQuantizedPack.optimizedIndexURLIfValid(
+                resources: fixture.resources
+            ),
+            replacement.indexURL
+        )
+    }
+
+    private func makeFixture() throws -> (
+        root: URL,
+        resources: LTX25Resources,
+        layerWeight: MLXArray
+    ) {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+            UUID().uuidString,
+            isDirectory: true
+        )
+        let resources = LTX25Resources(rootURL: root)
+        try FileManager.default.createDirectory(
+            at: resources.textEncoderURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let embeddingValues: [Float] = (0..<(32 * 64)).map { index in
+            Float(index % 29) / 14.0 - 1.0
+        }
+        let embedding = MLXArray(embeddingValues)
+            .reshaped(32, 64)
+            .asType(.bfloat16)
+        let layerValues: [Float] = (0..<(64 * 64)).map { index in
+            Float(index % 37) / 18.0 - 1.0
+        }
+        let layerWeight = MLXArray(layerValues)
+            .reshaped(64, 64)
+            .asType(.bfloat16)
+        try MLX.save(
+            arrays: [
+                "model.embed_tokens.weight": embedding,
+                "model.layers.0.mlp.up_proj.weight": layerWeight,
+                "model.norm.weight": MLX.ones([64], dtype: .bfloat16),
+                "text_embedding_projection.aggregate_embed.weight": MLX.ones(
+                    [64, 64],
+                    dtype: .bfloat16
+                ),
+            ],
+            url: resources.textEncoderURL
+        )
+        return (root, resources, layerWeight)
+    }
+
+    private func loadPackArrays(resources: LTX25Resources) throws -> [String: MLXArray] {
+        let indexData = try Data(
+            contentsOf: LTX25TextEncoderQuantizedPack.indexURL(resources: resources)
+        )
+        let index = try JSONDecoder().decode(HFSafetensorsIndex.self, from: indexData)
+        let directory = LTX25TextEncoderQuantizedPack.outputDirectoryURL(
+            resources: resources
+        )
+        var arrays: [String: MLXArray] = [:]
+        for filename in index.shardFilenames {
+            let shard = directory.appendingPathComponent(filename, isDirectory: false)
+            arrays.merge(try MLX.loadArrays(url: shard)) { _, latest in latest }
+        }
+        return arrays
+    }
+}

--- a/Tests/MereRunCoreTests/LTX25TextEncoderQuantizedPackTests.swift
+++ b/Tests/MereRunCoreTests/LTX25TextEncoderQuantizedPackTests.swift
@@ -59,6 +59,15 @@ final class LTX25TextEncoderQuantizedPackTests: XCTestCase {
         XCTAssertNotNil(arrays["layers.0.mlp.up_proj.scales"])
         XCTAssertNotNil(arrays["norm.weight"])
         XCTAssertNil(arrays["text_embedding_projection.aggregate_embed.weight"])
+        let runtimeAssets = try MLX.loadArrays(
+            url: LTX25TextEncoderQuantizedPack.runtimeAssetsURL(
+                resources: fixture.resources
+            )
+        )
+        XCTAssertNotNil(runtimeAssets["tokenizer_json"])
+        XCTAssertNotNil(
+            runtimeAssets["text_embedding_projection.video_aggregate_embed.weight"]
+        )
 
         let restored = MLX.dequantized(
             try XCTUnwrap(arrays["layers.0.mlp.up_proj.weight"]),
@@ -99,6 +108,52 @@ final class LTX25TextEncoderQuantizedPackTests: XCTestCase {
         )
     }
 
+    func testBundledPackValidationUsesPinnedUpstreamReceiptWithoutSourceFile() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let result = try LTX25TextEncoderQuantizedPack.optimize(
+            resources: fixture.resources
+        )
+        let data = try Data(contentsOf: result.manifestURL)
+        let fixtureManifest = try JSONDecoder().decode(
+            LTX25TextEncoderQuantizedPackManifest.self,
+            from: data
+        )
+        let managedManifest = LTX25TextEncoderQuantizedPackManifest(
+            format: fixtureManifest.format,
+            sourceRevision: fixtureManifest.sourceRevision,
+            sourceFilename: fixtureManifest.sourceFilename,
+            sourceBytes: LTX25Resources.textEncoderSourceBytes,
+            bits: fixtureManifest.bits,
+            groupSize: fixtureManifest.groupSize,
+            sourceTensorCount: fixtureManifest.sourceTensorCount,
+            quantizedTensorCount: fixtureManifest.quantizedTensorCount,
+            packedBytes: fixtureManifest.packedBytes,
+            runtimeAssetsFilename: fixtureManifest.runtimeAssetsFilename,
+            shards: fixtureManifest.shards
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        try encoder.encode(managedManifest).write(to: result.manifestURL, options: .atomic)
+        try FileManager.default.removeItem(at: fixture.resources.textEncoderURL)
+        for relativePath in LTX25Resources.requiredRelativePaths {
+            let url = fixture.root.appendingPathComponent(relativePath)
+            try FileManager.default.createDirectory(
+                at: url.deletingLastPathComponent(),
+                withIntermediateDirectories: true
+            )
+            XCTAssertTrue(FileManager.default.createFile(atPath: url.path, contents: Data()))
+        }
+
+        XCTAssertEqual(
+            LTX25TextEncoderQuantizedPack.optimizedIndexURLIfValid(
+                resources: fixture.resources
+            ),
+            result.indexURL
+        )
+        XCTAssertTrue(isLTX25ModelRoot(fixture.root))
+    }
+
     private func makeFixture() throws -> (
         root: URL,
         resources: LTX25Resources,
@@ -130,11 +185,26 @@ final class LTX25TextEncoderQuantizedPackTests: XCTestCase {
                 "model.embed_tokens.weight": embedding,
                 "model.layers.0.mlp.up_proj.weight": layerWeight,
                 "model.norm.weight": MLX.ones([64], dtype: .bfloat16),
-                "text_embedding_projection.aggregate_embed.weight": MLX.ones(
+                "hf_asset__tokenizer_config.json": MLXArray([UInt8(123), UInt8(125)]),
+                "text_embedding_projection.audio_aggregate_embed.bias": MLX.ones(
+                    [32],
+                    dtype: .bfloat16
+                ),
+                "text_embedding_projection.audio_aggregate_embed.weight": MLX.ones(
+                    [32, 64],
+                    dtype: .bfloat16
+                ),
+                "text_embedding_projection.video_aggregate_embed.bias": MLX.ones(
+                    [64],
+                    dtype: .bfloat16
+                ),
+                "text_embedding_projection.video_aggregate_embed.weight": MLX.ones(
                     [64, 64],
                     dtype: .bfloat16
                 ),
+                "tokenizer_json": MLXArray([UInt8(123), UInt8(125)]),
             ],
+            metadata: ["gemma_config": "{}"],
             url: resources.textEncoderURL
         )
         return (root, resources, layerWeight)

--- a/Tests/MereRunCoreTests/LTXMemoryTraceTests.swift
+++ b/Tests/MereRunCoreTests/LTXMemoryTraceTests.swift
@@ -1,0 +1,18 @@
+import XCTest
+@testable import MereRunCore
+
+final class LTXMemoryTraceTests: XCTestCase {
+    func testMemoryTraceLineReportsPhaseAndMLXResidency() {
+        let line = ltxMemoryTraceLine(
+            phase: "text-context-ready",
+            activeBytes: 3 * 1_073_741_824,
+            cacheBytes: 536_870_912,
+            peakBytes: 7 * 1_073_741_824
+        )
+        XCTAssertEqual(
+            line,
+            "[ltx-memory] phase=text-context-ready"
+                + " active=3.00GiB cache=0.50GiB peak=7.00GiB"
+        )
+    }
+}

--- a/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
@@ -2025,7 +2025,7 @@ final class ManagedModelCatalogTests: XCTestCase {
         XCTAssertTrue(manifest.supports?.contains(.audioToVideoGeneration) == true)
     }
 
-    func testLTX25SpecPinsOfficialGatedPackedRelease() throws {
+    func testLTX25SpecPinsSelfContainedSawfwairRelease() throws {
         let id = ModelResolver.ModelID.ltxVideo25DistilledBF16.rawValue
         let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: id))
 
@@ -2033,13 +2033,14 @@ final class ManagedModelCatalogTests: XCTestCase {
         XCTAssertEqual(spec.category, .video)
         XCTAssertEqual(spec.installShape, .structuredRoot)
         XCTAssertEqual(spec.validationKind, .ltxVideo25)
-        XCTAssertEqual(spec.hubFallback?.repoId, LTX25Resources.sourceRepository)
-        XCTAssertEqual(spec.hubFallback?.revision, LTX25Resources.sourceRevision)
+        XCTAssertEqual(spec.hubFallback?.repoId, LTX25Resources.managedRepository)
+        XCTAssertEqual(spec.hubFallback?.revision, LTX25Resources.managedRevision)
         XCTAssertEqual(spec.hubFallback?.patterns, LTX25Resources.snapshotPatterns)
-        XCTAssertEqual(spec.upstreamRepoId, LTX25Resources.sourceRepository)
-        XCTAssertEqual(spec.upstreamRevision, LTX25Resources.sourceRevision)
+        XCTAssertEqual(spec.upstreamRepoId, LTX25Resources.managedRepository)
+        XCTAssertEqual(spec.upstreamRevision, LTX25Resources.managedRevision)
         XCTAssertEqual(spec.estimatedDownloadBytes, LTX25Resources.estimatedDownloadBytes)
         XCTAssertFalse(spec.runtimeAutoDownloadAllowed)
+        XCTAssertTrue(spec.companionModelIDs.isEmpty)
         XCTAssertEqual(spec.usageRestriction?.terms.count, 2)
         XCTAssertTrue(spec.usageRestriction?.terms.contains { $0.component == "Gemma 4 text encoder" } == true)
 
@@ -2053,7 +2054,7 @@ final class ManagedModelCatalogTests: XCTestCase {
         XCTAssertEqual(manifest.precision, .bf16)
         XCTAssertEqual(
             manifest.upstreamRepoId,
-            "\(LTX25Resources.sourceRepository)@\(LTX25Resources.sourceRevision)"
+            "\(LTX25Resources.managedRepository)@\(LTX25Resources.managedRevision)"
         )
     }
 
@@ -2070,6 +2071,7 @@ final class ManagedModelCatalogTests: XCTestCase {
         XCTAssertEqual(spec.hubFallback?.patterns, LTX25Resources.fullSnapshotPatterns)
         XCTAssertEqual(spec.estimatedDownloadBytes, LTX25Resources.fullEstimatedDownloadBytes)
         XCTAssertFalse(spec.runtimeAutoDownloadAllowed)
+        XCTAssertTrue(spec.companionModelIDs.isEmpty)
         XCTAssertEqual(spec.usageRestriction?.terms.count, 2)
 
         let manifest = MereRunModelManifest.template(
@@ -2370,6 +2372,12 @@ final class ManagedModelCatalogTests: XCTestCase {
             )
             XCTAssertTrue(FileManager.default.createFile(atPath: url.path, contents: Data()))
         }
+        let textEncoder = root.appendingPathComponent(LTX25Resources.textEncoderRelativePath)
+        try FileManager.default.createDirectory(
+            at: textEncoder.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        XCTAssertTrue(FileManager.default.createFile(atPath: textEncoder.path, contents: Data()))
     }
 
     private func writeMinimalLTX25FullRoot(at root: URL) throws {

--- a/Tests/MereRunCoreTests/MereRunModelValidatorTests.swift
+++ b/Tests/MereRunCoreTests/MereRunModelValidatorTests.swift
@@ -469,6 +469,9 @@ final class MereRunModelValidatorTests: MereRunCoreTestCase {
             try TestFileSystem.createDirectory(url.deletingLastPathComponent())
             try TestFileSystem.writeFile(url, contents: Data())
         }
+        let textEncoderURL = root.appendingPathComponent(LTX25Resources.textEncoderRelativePath)
+        try TestFileSystem.createDirectory(textEncoderURL.deletingLastPathComponent())
+        try TestFileSystem.writeFile(textEncoderURL, contents: Data())
 
         let report = MereRunModelValidator.validate(
             modelRoot: root,

--- a/Tests/MereRunCoreTests/ModelLocationRegistryTests.swift
+++ b/Tests/MereRunCoreTests/ModelLocationRegistryTests.swift
@@ -61,6 +61,14 @@ final class ModelLocationRegistryTests: XCTestCase {
             try TestFileSystem.createDirectory(url.deletingLastPathComponent())
             try TestFileSystem.writeFile(url, contents: Data())
         }
+        try TestFileSystem.createDirectory(
+            external.appendingPathComponent(LTX25Resources.textEncoderRelativePath)
+                .deletingLastPathComponent()
+        )
+        try TestFileSystem.writeFile(
+            external.appendingPathComponent(LTX25Resources.textEncoderRelativePath),
+            contents: Data()
+        )
 
         let unacceptedLocations = ModelLocationSnapshot(
             primaryRoot: primary,

--- a/Tests/MereRunCoreTests/ModelResolverTests.swift
+++ b/Tests/MereRunCoreTests/ModelResolverTests.swift
@@ -205,6 +205,9 @@ final class ModelResolverTests: MereRunCoreTestCase {
             try TestFileSystem.createDirectory(url.deletingLastPathComponent())
             try TestFileSystem.writeFile(url, contents: Data())
         }
+        let textEncoderURL = root.appendingPathComponent(LTX25Resources.textEncoderRelativePath)
+        try TestFileSystem.createDirectory(textEncoderURL.deletingLastPathComponent())
+        try TestFileSystem.writeFile(textEncoderURL, contents: Data())
 
         let resolved = try ModelResolver().resolve(.ltxVideo25DistilledBF16)
         XCTAssertEqual(resolved.rootURL.standardizedFileURL, root.standardizedFileURL)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -2185,6 +2185,7 @@ Build reusable inference-only artifacts for MiniMax-H3 MLX or LTX 2.5:
 ```bash
 mere.run model optimize ./MiniMax-H3-FL2VA-full-MLX
 mere.run model optimize video-ltx25-full-bf16
+mere.run model optimize /path/to/LTX-2.5 --text-encoder-only
 mere.run model optimize ./MiniMax-H3-FL2VA-full-MLX --json
 ```
 
@@ -2201,8 +2202,11 @@ For LTX 2.5, the command streams the distilled transformer and, for a full
 root, the dev transformer into source-bound BF16 native packs. It also writes a
 compact connector pack so text setup does not open the 42 GB official
 transformer. Transformer packs use mere.run's module-key namespace and every
-artifact preserves its tensor payload bytes. Compatible loads prefer validated
-packs automatically and otherwise fall back to the official checkpoint.
+artifact preserves its tensor payload bytes. The self-contained managed
+distilled model already bundles the Q4 text pack and needs no optimization.
+`--text-encoder-only` reproduces that pack from an official BF16 root for
+offline and development use; it retains the BF16 projection and tokenizer
+assets while quantizing eligible Gemma language weights.
 
 ### `mere.run model remove`
 

--- a/docs/ltx25-upstream-parity.md
+++ b/docs/ltx25-upstream-parity.md
@@ -115,12 +115,20 @@ The acceleration surface remains native Swift, MLX, and Metal:
   path remains the automatic compatibility fallback.
 - `mere.run model optimize video-ltx25-full-bf16` creates source-bound native
   transformer and compact text-connector packs under
-  `.mere-run/ltx25-native-v1`. It streams tensor bytes in physical file order,
-  rewrites transformer keys to the native module namespace, and does not
-  quantize or rewrite payload bytes. Loading applies the same requested BF16
-  normalization as the official path, including the checkpoint's FP32 tensors.
+  `.mere-run/ltx25-native-v1`. It also derives an MLX affine Q4/group-64 pack
+  for the checkpoint's custom Gemma 4 language tower under
+  `.mere-run/ltx25-text-q4-v1`; the LTX projection and embedded tokenizer stay
+  bound to the official BF16 checkpoint. Runtime loading validates the pinned
+  source revision and prefers this local Q4 tower, with the official BF16 tower
+  as the fallback. Transformer payloads are not quantized or rewritten.
   Connector loading no longer has to touch the 42 GB official transformer
   checkpoint.
+- Prompt tensors are evaluated and cached before the Gemma tower is unloaded.
+  Image/reference latents are likewise evaluated before the video VAE encoder
+  is released. Neither encoder remains resident during denoising; a later
+  session request reloads it only when its prompt or conditioning is not cached.
+  Set `MERERUN_LTX_MEMORY_TRACE=1` to print MLX active, cache, and peak memory at
+  the duration, text, image-conditioning, and denoising phase boundaries.
 
 TeaCache and guidance-projection caching are not stacked: enabling TeaCache
 uses the exact projection path against which its drift calibration was
@@ -141,7 +149,7 @@ model capabilities, and therefore have no one-for-one Apple-Silicon switch:
 | Upstream option | Native disposition |
 | --- | --- |
 | CPU/disk offload | Swift loaders stream large safetensors and release phases under unified-memory admission |
-| FP8 and NVFP4 policies | The pinned native catalog uses the BF16 checkpoints; no silent precision substitution |
+| FP8 and NVFP4 policies | Transformer inference stays on the pinned BF16 checkpoint; the optional source-bound text-tower cache is explicit MLX Q4 |
 | `torch.compile` | `--ltx-transformer-execution compiled` provides shared compiled MLX block execution; eager remains the exact-default path |
 | DiffVAE CUDA optimization presets | Apple GPUs use the native fused 3D Metal neighborhood-attention kernel with an MLX fallback; CUTLASS/CuTe remain CUDA-only |
 | `max_batch_size` | `--ltx-guidance-projection-cache` removes repeated positive-context projections without CUDA transfer batching and preserves a unified-memory reserve |

--- a/docs/ltx25-upstream-parity.md
+++ b/docs/ltx25-upstream-parity.md
@@ -7,8 +7,11 @@ The compatibility target is immutable:
 
 - **Code:** `Lightricks/LTX-2` release `v1.2.0`, commit
   `d151147788a9284cca791edc6ce898007e727fe6`
-- **Weights:** `Lightricks/LTX-2`, revision
+- **Weights:** `Lightricks/LTX-2.5`, revision
   `dd53cc2cd45bbeaa3563dfb575cba3f49cf44761`
+- **Managed distilled distribution:**
+  `Sawfwair/LTX-2.5-Distilled-BF16-MLX-Q4-Text`, revision
+  `9f316bfb18448bf67f716006fd78a37829223b74`
 - **DFR detailer:** `Lightricks/LTX-2.5-22b-IC-LoRA-Pixel-Spatial-Upscaler`,
   revision `74c4e68ee7dd99f3997d5a1bb1a3784941822222`
 
@@ -19,17 +22,18 @@ precedence.
 
 ## Install
 
-The standalone distilled bundle is about 71.1 GB. The complete bundle is
-about 123.8 GB and adds the dev transformer, distilled LoRA, DiffVAE, temporal
-upsampler, and duration head.
+The public self-contained managed distilled bundle is exactly 53,878,648,085
+bytes. The complete official BF16 bundle is about 123.8 GB and adds the dev
+transformer, distilled LoRA, DiffVAE, temporal upsampler, and duration head.
 
 ```bash
 mere.run model pull video-ltx25-distilled-bf16 --accept-model-license
 mere.run model pull video-ltx25-full-bf16 --accept-model-license
 ```
 
-The model and the DFR detailer are separately gated on Hugging Face. Accepting
-the main model gate does not accept the detailer gate.
+The managed distilled model is ungated. The official full/dev model and DFR
+detailer are separately gated on Hugging Face; accepting either one does not
+accept the other.
 
 ```bash
 mere.run adapter pull ltx25-pixel-spatial-upscaler-x2 --accept-license
@@ -113,16 +117,16 @@ The acceleration surface remains native Swift, MLX, and Metal:
 - DiffVAE neighborhood attention routes to a fused three-dimensional Metal
   online-softmax kernel on supported Apple GPUs. The bounded MLX SDPA tiling
   path remains the automatic compatibility fallback.
-- `mere.run model optimize video-ltx25-full-bf16` creates source-bound native
-  transformer and compact text-connector packs under
-  `.mere-run/ltx25-native-v1`. It also derives an MLX affine Q4/group-64 pack
-  for the checkpoint's custom Gemma 4 language tower under
-  `.mere-run/ltx25-text-q4-v1`; the LTX projection and embedded tokenizer stay
-  bound to the official BF16 checkpoint. Runtime loading validates the pinned
-  source revision and prefers this local Q4 tower, with the official BF16 tower
-  as the fallback. Transformer payloads are not quantized or rewritten.
-  Connector loading no longer has to touch the 42 GB official transformer
-  checkpoint.
+- The public, immutable
+  `Sawfwair/LTX-2.5-Distilled-BF16-MLX-Q4-Text` distribution is the single
+  managed distilled download after explicit license acceptance. Its LTX
+  transformer, VAEs, upsampler, and duration head preserve upstream BF16 bytes;
+  its self-contained text pack uses MLX affine Q4/group-64 for eligible Gemma
+  language weights while retaining the LTX projection and tokenizer assets in
+  BF16/raw form. Runtime validates the pinned source receipt. `mere.run model
+  optimize /path/to/LTX-2.5 --text-encoder-only` can reproduce the text pack
+  locally; full optimization also creates source-bound native transformer and
+  compact connector packs. The video transformer is never quantized.
 - Prompt tensors are evaluated and cached before the Gemma tower is unloaded.
   Image/reference latents are likewise evaluated before the video VAE encoder
   is released. Neither encoder remains resident during denoising; a later

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -218,7 +218,7 @@ validates all configured models before downloading any; both accept the same
 | `music-muscriptor-{small,medium,large}` | CC BY-NC 4.0 model weights |
 | `sfx-woosh-*` | CC BY-NC 4.0 Woosh or MMAudio Synchformer weights |
 | `sfx-mmaudio-large-44k-v2` | CC BY-NC 4.0 MMAudio checkpoints plus Apple's research-only DFN5B encoder terms |
-| `video-ltx-av`, `video-ltx23-av-mlx`, `video-ltx23-full-mlx`, `video-ltx23-a2vid-mlx`, `video-ltx25-distilled-bf16`, `video-ltx25-full-bf16` | LTX-2 Community License; entities at or above USD 10M annual revenue need a paid commercial license, plus acceptable-use conditions. The 2.3 MLX paths also install a hidden Gemma 3 text encoder; the packed 2.5 checkpoints include Gemma 4 weights. Both are additionally governed by Google's Gemma Terms and Prohibited Use Policy. |
+| `video-ltx-av`, `video-ltx23-av-mlx`, `video-ltx23-full-mlx`, `video-ltx23-a2vid-mlx`, `video-ltx25-distilled-bf16`, `video-ltx25-full-bf16` | LTX-2 Community License; entities at or above USD 10M annual revenue need a paid commercial license, plus acceptable-use conditions. The 2.3 MLX paths also install a hidden Gemma 3 text encoder under Google's Gemma Terms and Prohibited Use Policy. The 2.5 checkpoints include Gemma 4 weights under Apache License 2.0. |
 
 The catalog pins every restricted download source to an immutable commit. New
 managed installs write those repository revisions, every applicable
@@ -1119,12 +1119,16 @@ The official packed LTX 2.5 BF16 root is:
 ```
 
 `mere.run model pull video-ltx25-distilled-bf16 --accept-model-license` pulls
-only the native runtime subset from `Lightricks/LTX-2.5` at immutable revision
-`dd53cc2cd45bbeaa3563dfb575cba3f49cf44761`: the distilled transformer, packed
-Gemma 4 text encoder, video VAE, audio VAE/BWE vocoder, x2 spatial upscaler,
-and optional duration head. The required checkpoint payload is about 71.1 GB.
-The Hugging Face repository is gated, so the account behind `HF_TOKEN` must
-already have access in addition to the explicit local license acknowledgement.
+the complete public runtime from
+`Sawfwair/LTX-2.5-Distilled-BF16-MLX-Q4-Text` at immutable revision
+`9f316bfb18448bf67f716006fd78a37829223b74`. It preserves the upstream BF16
+distilled transformer, video VAE, audio VAE/BWE vocoder, spatial upsampler, and
+duration head from `Lightricks/LTX-2.5@dd53cc2...`. The custom Gemma 4 language
+tower is MLX affine Q4/group-64; its LTX projection and tokenizer support remain
+BF16/raw. The complete selected payload is exactly 53,878,648,085 bytes. The
+repository is ungated, includes the full LTX license/AUP, Apache 2.0 text, and
+modification notice, and requires no separate component pull or local
+quantization.
 
 This model runs natively through Swift and MLX; no Python process or sidecar is
 dispatched. Use `--quality final --output-mode audio-video` for synchronized
@@ -1141,9 +1145,12 @@ The complete official LTX 2.5 root is:
 `mere.run model pull video-ltx25-full-bf16 --accept-model-license` uses the
 same immutable weight revision and adds the dev transformer, official
 distilled LoRA, diffusion video VAE, temporal x2 latent upsampler, and duration
-head. The complete pinned payload is exactly 123,751,083,670 bytes. This root
-supports full/dev and HQ pipelines, source-audio A2Vid, DFR, Retake, HDR/EXR,
-IC-LoRA reference video, Dub-It, and native text-to-audio.
+head. The complete official BF16 payload is exactly 123,751,083,670 bytes. This
+full/dev tier still comes from the official upstream repository and requires
+its Hugging Face gate; unlike the distilled managed tier, it retains the
+original BF16 text encoder unless locally optimized. This root supports
+full/dev and HQ pipelines, source-audio A2Vid, DFR, Retake, HDR/EXR, IC-LoRA
+reference video, Dub-It, and native text-to-audio.
 
 The official DFR pixel-space spatial upscaler is a separately gated managed
 adapter: `ltx25-pixel-spatial-upscaler-x2`. Its repository gate and

--- a/docs/runtime/model-management.md
+++ b/docs/runtime/model-management.md
@@ -172,11 +172,14 @@ Q8, legacy Q4, and Ref2VA packages already bundle source-bound caches.
 
 LTX 2.5 optimization streams the official BF16 transformer payloads into the
 exact native module namespace without materializing the 22B checkpoint or
-changing precision. A full root produces distilled and dev packs under
-`.mere-run/ltx25-native-v1`, plus a compact connector pack so text setup avoids
-opening the official transformer. Compatible loads validate the source revision
-and prefer those packs automatically. Use `--force` for an explicit atomic
-rebuild.
+changing transformer precision. A full root produces distilled and dev packs
+under `.mere-run/ltx25-native-v1`, plus a compact connector pack so text setup
+avoids opening the official transformer. It also derives a sharded MLX affine
+Q4/group-64 cache of the checkpoint's custom Gemma 4 language tower under
+`.mere-run/ltx25-text-q4-v1`. The LTX projection and tokenizer remain in the
+official checkpoint. Compatible loads validate the pinned source revision and
+prefer these packs automatically, falling back to the official BF16 text tower
+when the Q4 cache is absent or invalid. Use `--force` for an explicit rebuild.
 
 ### `mere.run status`
 

--- a/docs/runtime/model-management.md
+++ b/docs/runtime/model-management.md
@@ -170,16 +170,20 @@ legacy roots can synthesize the pack; pruned roots can validate an existing
 complete pack but cannot recreate a missing exact table. Managed compact BF16,
 Q8, legacy Q4, and Ref2VA packages already bundle source-bound caches.
 
-LTX 2.5 optimization streams the official BF16 transformer payloads into the
-exact native module namespace without materializing the 22B checkpoint or
-changing transformer precision. A full root produces distilled and dev packs
-under `.mere-run/ltx25-native-v1`, plus a compact connector pack so text setup
-avoids opening the official transformer. It also derives a sharded MLX affine
-Q4/group-64 cache of the checkpoint's custom Gemma 4 language tower under
-`.mere-run/ltx25-text-q4-v1`. The LTX projection and tokenizer remain in the
-official checkpoint. Compatible loads validate the pinned source revision and
-prefer these packs automatically, falling back to the official BF16 text tower
-when the Q4 cache is absent or invalid. Use `--force` for an explicit rebuild.
+The managed LTX 2.5 distilled pull is a public, self-contained Sawfwair
+distribution accepted with `--accept-model-license`. It bundles an MLX affine
+Q4/group-64 Gemma language tower plus the BF16 LTX projection and tokenizer;
+users do not download the original BF16 text tower or quantize anything. The
+video transformer and every non-text model component remain BF16.
+
+For official or offline roots, LTX 2.5 optimization can stream BF16 transformer
+payloads into the exact native module namespace without changing precision. A
+full root produces distilled and dev packs under `.mere-run/ltx25-native-v1`
+plus a compact connector pack. `--text-encoder-only` builds the self-contained
+text pack under `.mere-run/ltx25-text-q4-v1`. Compatible loads validate the
+pinned source receipt and prefer a valid bundled/local Q4 pack, falling back to
+the official BF16 text tower when it is absent. Use `--force` for an explicit
+rebuild.
 
 ### `mere.run status`
 

--- a/docs/runtime/video.md
+++ b/docs/runtime/video.md
@@ -77,13 +77,13 @@ are an escape hatch, not the capability contract.
   `--quality final`, generated synchronized audio, and source-audio A2Vid.
 - `video-ltx23-a2vid-mlx`: compatibility ID for existing A2Vid installs. New
   installs should use `video-ltx23-full-mlx`.
-- `video-ltx25-distilled-bf16`: official packed LTX 2.5 BF16 checkpoint for
-  native final-quality synchronized video and stereo audio. Pull it with
-  `--accept-model-license`; gated Hugging Face access is also required. Run
-  `mere.run model optimize video-ltx25-distilled-bf16` to derive the local
-  source-bound Q4 text tower and native transformer/connector caches. Gemma and
-  the image VAE encoder are released after their conditioning tensors are
-  evaluated, before denoising begins.
+- `video-ltx25-distilled-bf16`: public, self-contained LTX 2.5 distribution for
+  native synchronized video and stereo audio. The transformer, VAEs, upsampler,
+  and duration head remain BF16; the bundled Gemma 4 language tower is MLX Q4.
+  Pull it once with `--accept-model-license`; no Hugging Face gate, companion
+  download, or local conversion is required. Gemma and the image VAE encoder
+  are released after their conditioning tensors are evaluated, before
+  denoising begins.
 - `video-ltx25-full-bf16`: complete official LTX 2.5 BF16 root with dev and
   distilled transformers, distilled LoRA, convolutional and diffusion VAEs,
   spatial/temporal upsamplers, and DurationHead. It powers the native full,

--- a/docs/runtime/video.md
+++ b/docs/runtime/video.md
@@ -79,7 +79,11 @@ are an escape hatch, not the capability contract.
   installs should use `video-ltx23-full-mlx`.
 - `video-ltx25-distilled-bf16`: official packed LTX 2.5 BF16 checkpoint for
   native final-quality synchronized video and stereo audio. Pull it with
-  `--accept-model-license`; gated Hugging Face access is also required.
+  `--accept-model-license`; gated Hugging Face access is also required. Run
+  `mere.run model optimize video-ltx25-distilled-bf16` to derive the local
+  source-bound Q4 text tower and native transformer/connector caches. Gemma and
+  the image VAE encoder are released after their conditioning tensors are
+  evaluated, before denoising begins.
 - `video-ltx25-full-bf16`: complete official LTX 2.5 BF16 root with dev and
   distilled transformers, distilled LoRA, convolutional and diffusion VAEs,
   spatial/temporal upsamplers, and DurationHead. It powers the native full,


### PR DESCRIPTION
## Summary

- make the normal LTX 2.5 distilled install a single, public, ungated Sawfwair repository pinned at `9f316bfb18448bf67f716006fd78a37829223b74`
- preserve the upstream BF16 video transformer, VAEs, spatial upsampler, and duration head while replacing the 26.3 GB BF16 Gemma language tower with a self-contained 9.04 GB MLX affine Q4/group-64 pack
- keep the LTX text projection in BF16 and tokenizer assets raw; users do not download a second repository or quantize locally
- require the existing `--accept-model-license` acknowledgement before download and surface both the LTX terms and Gemma Apache 2.0 notice
- release the text encoder and image VAE after conditioning tensors materialize, before denoising, and retain the opt-in LTX memory trace
- retain the official 123.8 GB full/dev BF16 model as a separate advanced tier

## Distribution

- repository: `Sawfwair/LTX-2.5-Distilled-BF16-MLX-Q4-Text`
- immutable revision: `9f316bfb18448bf67f716006fd78a37829223b74`
- selected payload: `53,878,648,085` bytes
- text pack: 50 Q4 shards, BF16 projection/runtime assets, tokenizer assets, source-bound manifest and index
- license material: LTX license, LTX acceptable-use policy, Apache 2.0 text, and modification notice are included in the model repository

## Validation

- `./scripts/check.sh`: passed
- focused catalog, resolver, validator, CLI, and LTX pack tests: passed
- real self-contained Q4 text encode with no original BF16 text file: passed in 43.5 seconds, 23,304,257,536-byte maximum RSS, zero swaps
- empty-store pull without acceptance: refused before download and displayed both terms
- empty-store accepted pull of the pinned public package: passed
- real encode from the clean managed install: passed in 32.0 seconds, 22,777,135,104-byte maximum RSS, zero swaps

## Qualification boundary

The real-model checks prove the shipped Q4 language tower plus BF16 LTX projection load and encode without the original 26.3 GB text checkpoint. The diffusion transformer remains BF16 by design. A representative 1024x576 full I2V smoke was queued but not run because an existing Gemma API held two of the four machine-admission permits; that user process was left untouched.
