### PR TITLE
Release v0.45.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+## 0.45.0 - 2026-08-26
+
+This release adds native Qwen3.8 Flash Next inference with qualified mixed-Q2/Q4
+and Q4 MLX distributions and verified MTP acceleration. It also makes LTX 2.5
+generation substantially more memory-bounded and keeps model inventory fast on
+large or externally linked stores.
+
 ### Text
 
 - added pinned mixed Q2/Q4 and Q4 MLX distributions of
@@ -44,6 +51,13 @@ The format is based on Keep a Changelog.
   generation now automatically decodes long or high-resolution clips in
   overlapped temporal tiles instead of attempting a full-frame decode that can
   exhaust unified memory.
+
+### Included pull requests
+
+- exact release range: [#365](https://github.com/sawfwair/mere-run/pull/365),
+  [#366](https://github.com/sawfwair/mere-run/pull/366),
+  [#367](https://github.com/sawfwair/mere-run/pull/367), and
+  [#369](https://github.com/sawfwair/mere-run/pull/369).
 
 ## 0.44.0 - 2026-08-25
 

--- a/Sources/MereRunRelayKit/MereRunCLIVersion.swift
+++ b/Sources/MereRunRelayKit/MereRunCLIVersion.swift
@@ -2,7 +2,7 @@
 /// contract version floors, worker probes, and the built-in node catalog
 /// identity.
 public enum MereRunCLIVersion {
-    public static let current = "0.44.0"
+    public static let current = "0.45.0"
 }
 
 /// Lenient three-component version-floor comparison used by worker

--- a/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
+++ b/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
@@ -130,7 +130,7 @@ final class CLIModelStoreBootstrapTests: XCTestCase {
     }
 
     func testMereRunCLIExposesReleaseVersion() {
-        XCTAssertEqual(MereRunCLIVersion.current, "0.44.0")
+        XCTAssertEqual(MereRunCLIVersion.current, "0.45.0")
         XCTAssertEqual(MereRunCLI.configuration.version, MereRunCLIVersion.current)
     }
 

--- a/scripts/build_mere_run_app.sh
+++ b/scripts/build_mere_run_app.sh
@@ -15,7 +15,7 @@ cd "$repo_root"
 
 # Version/build derive from git when not provided, so the bundle has a single source of
 # truth in CI. Fall back to a pinned value when git metadata is unavailable.
-default_version="0.44.0"
+default_version="0.45.0"
 if git_version="$(git describe --tags --exact-match 2>/dev/null)"; then
   default_version="${git_version#v}"
 fi


### PR DESCRIPTION
## Summary

- promote the complete unreleased changelog into v0.45.0
- document the exact merged range: #365, #366, #367, and #369
- bump the CLI and macOS package fallback version to 0.45.0

The release train looked at Qwen3.8 Flash Next, checked the LTX memory gauge, and decided it was time to leave the station. 🚂

## Validation

- `./scripts/check.sh`
  - SwiftLint: 1,362 files
  - XCTest: 3,166 passed/expected skips, zero failures
  - Swift Testing: 30 passed, zero failures
  - build, command-help sweep, and hygiene checks passed

## Scope

PR #368 remains open and conflicting and is intentionally not included in this release.