### PR TITLE
Add Flash-Next long-context QSA support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+### Text
+
+- added native Qwen3.8-Flash-Next QSA selection beyond the former 2,048-token
+  prompt-plus-generation cap. Learned compressed-block scoring selects causal
+  history for both target attention and the bundled MTP head. Query tiling and
+  chunked MTP priming bound temporary allocations; indexer state follows prefix
+  forks, rejected-draft rollback, and ragged batching. Existing model packs
+  already include the required weights. `--context-size` can use the checkpoint's
+  262,144-token architectural limit, subject to memory; this is not a full-262k
+  qualification on the 128 GB mixed-model profile.
+
 ## 0.45.0 - 2026-08-26
 
 This release adds native Qwen3.8 Flash Next inference with qualified mixed-Q2/Q4

--- a/README.md
+++ b/README.md
@@ -355,12 +355,12 @@ swift run mere.run text chat \
   --context-size 32768 \
   --prompt "Plan a recovery-safe repository migration."
 
-# Qwen3.8-Flash-Next mixed Q2/Q4 is the 128 GB Mac profile. Its verified MTP
-# path is enabled by default for greedy decode. Prompt plus generation is
-# limited to 2,048 tokens while the long-context QSA selector is integrated.
+# Qwen3.8-Flash-Next mixed Q2/Q4 is the 128 GB Mac profile, with MTP enabled
+# for greedy decode. Long-context QSA requires a build newer than v0.45.0.
+# Context includes both prompt and generation; leave RAM for KV and MTP history.
 swift run mere.run text chat \
   --model vision-chat-q38-flash-next-mixed \
-  --context-size 2048 \
+  --context-size 32768 \
   --max-tokens 256 \
   --prompt "Explain sparse attention in one paragraph."
 

--- a/Sources/MereRunCore/Q35/Q35FullAttention.swift
+++ b/Sources/MereRunCore/Q35/Q35FullAttention.swift
@@ -107,6 +107,7 @@ final class Q35FullAttention: Module {
     ) -> MLXArray {
         let b = x.dim(0)
         let s = x.dim(1)
+        let offsets = cache?.rowOffsets ?? Array(repeating: cache?.offset ?? 0, count: b)
 
         let qFlat: MLXArray
         let kFlat: MLXArray
@@ -161,7 +162,12 @@ final class Q35FullAttention: Module {
         let queryCount = q.dim(2)
         let keyCount = k.dim(2)
         let attn: MLXArray
-        if targetVerify,
+        if let indexer, let sparse = indexer.attention(
+            hidden: x, queries: q, keys: k, values: v, offsets: offsets,
+            positionIds: positionIds, cache: cache as? Q38QSACache, scale: scale
+        ) {
+            attn = sparse
+        } else if targetVerify,
            b == 1,
            (6...9).contains(queryCount),
            keyCount >= queryCount,

--- a/Sources/MereRunCore/Q35/Q35Generator.swift
+++ b/Sources/MereRunCore/Q35/Q35Generator.swift
@@ -600,13 +600,6 @@ public actor Q35Generator: ChatGenerator {
         if promptTokens.count > effectiveContext {
             promptTokens = Array(promptTokens.suffix(effectiveContext))
         }
-        if loadedConfig.textConfig.isQwen4Exp,
-           promptTokens.count + request.maxTokens > loadedConfig.textConfig.indexerBudget {
-            throw Q35Error.generationFailed(
-                "Qwen4Exp exact inference is currently limited to \(loadedConfig.textConfig.indexerBudget) "
-                    + "prompt-plus-generation tokens while the long-context QSA indexer is being integrated."
-            )
-        }
         if let dumpPath = ProcessInfo.processInfo.environment["MERERUN_Q35_DEBUG_PROMPT_TOKENS"] {
             try? promptTokens.map(String.init).joined(separator: ",")
                 .write(toFile: dumpPath, atomically: true, encoding: .utf8)
@@ -1080,7 +1073,8 @@ public actor Q35Generator: ChatGenerator {
         var mtpAdaptivePolicy = Q35MTPAdaptivePolicy(maxDraftDepth: mtpBlockSize - 1)
         let mtpDraftSession = Q35MTPDraftSession(
             promptTokens: promptTokens,
-            promptHidden: prefillMTPHidden
+            promptHidden: prefillMTPHidden,
+            historyCache: model.config.textConfig.isQwen4Exp ? Q38QSACache() : KVCacheSimple()
         )
         let decodeStart = Date()
 
@@ -1271,21 +1265,13 @@ public actor Q35Generator: ChatGenerator {
                             totalTokens: draftTokens.count + 1,
                             tokenCount: committedTokenCount
                         ) {
-                            mtpDraftSession.recordCommittedTransitions(
-                                hiddenStates: candidate.hidden,
-                                nextTokens: acceptedPrefix
+                            let restored = mtpDraftSession.restoredVerificationState(
+                                from: candidate,
+                                acceptedTokens: acceptedPrefix
                             )
                             layerCaches = candidateCaches
-                            logits = candidate.logits[
-                                0...,
-                                accepted..<(accepted + 1),
-                                0...
-                            ]
-                            previousHidden = candidate.hidden[
-                                0...,
-                                accepted..<(accepted + 1),
-                                0...
-                            ]
+                            logits = restored.logits
+                            previousHidden = restored.hidden
                             continue
                         }
 
@@ -2800,14 +2786,17 @@ public actor Q35Generator: ChatGenerator {
             }
             let layerType = layerIndex < text.layerTypes.count ? text.layerTypes[layerIndex] : "linear_attention"
             if layerType == "full_attention" {
+                let attention: KVCache
                 if kvCacheMode == .affine4 || kvCacheMode == .affine8 {
-                    return .full(AffineQuantizedKVCache(
+                    attention = AffineQuantizedKVCache(
                         groupSize: Self.affineKVGroupSize(headDimension: text.headDim),
                         bits: kvCacheMode == .affine4 ? 4 : 8,
                         step: 256
-                    ))
+                    )
+                } else {
+                    attention = KVCacheSimple(step: 256)
                 }
-                return .full(KVCacheSimple(step: 256))
+                return .full(text.isQwen4Exp ? Q38QSACache(attention: attention) : attention)
             }
             return .linear(Q35LinearCache())
         }
@@ -2816,11 +2805,12 @@ public actor Q35Generator: ChatGenerator {
     private func cacheMode(for caches: [Q35LayerCache?]) -> RuntimeKVCacheMode {
         caches.contains { entry in
             guard case .full(let cache)? = entry else { return false }
-            guard let affine = cache as? AffineQuantizedKVCache else { return false }
+            let main = (cache as? Q38QSACache)?.attention ?? cache
+            guard let affine = main as? AffineQuantizedKVCache else { return false }
             return affine.bitWidth == 4
         } ? .affine4 : caches.contains { entry in
             guard case .full(let cache)? = entry else { return false }
-            return cache is AffineQuantizedKVCache
+            return ((cache as? Q38QSACache)?.attention ?? cache) is AffineQuantizedKVCache
         } ? .affine8 : .default
     }
 

--- a/Sources/MereRunCore/Q35/Q35MTP.swift
+++ b/Sources/MereRunCore/Q35/Q35MTP.swift
@@ -451,11 +451,12 @@ final class Q38MTPModel: Module, Q35MTPDraftModel {
 /// rows run on a fork and are discarded after the round, so proposal history
 /// can improve acceptance without becoming an output authority.
 final class Q35MTPDraftSession {
-    private let historyCache = KVCacheSimple(step: 256)
+    private let historyCache: KVCache
     private var backlogHidden: [MLXArray] = []
     private var backlogTokens: [Int] = []
 
-    init(promptTokens: [Int] = [], promptHidden: MLXArray? = nil) {
+    init(promptTokens: [Int] = [], promptHidden: MLXArray? = nil, historyCache: KVCache = KVCacheSimple()) {
+        self.historyCache = historyCache
         guard let promptHidden,
               promptTokens.count > 1,
               promptHidden.dim(1) == promptTokens.count else {
@@ -476,6 +477,21 @@ final class Q35MTPDraftSession {
         }
         backlogHidden.append(hiddenStates[0..., 0..<nextTokens.count, 0...])
         backlogTokens.append(contentsOf: nextTokens)
+    }
+
+    /// Reuse the target's accepted prefix after cache rollback. Flash-Next's
+    /// predictor consumes the four-stream residual, not the reduced LM hidden.
+    func restoredVerificationState(
+        from output: Q35ForwardOutput,
+        acceptedTokens: [Int]
+    ) -> (logits: MLXArray, hidden: MLXArray) {
+        let hidden = output.mtpHidden ?? output.hidden
+        recordCommittedTransitions(hiddenStates: hidden, nextTokens: acceptedTokens)
+        let last = acceptedTokens.count
+        return (
+            output.logits[0..., last..<(last + 1), 0...],
+            hidden[0..., last..<(last + 1), 0...]
+        )
     }
 
     func draftBlock(
@@ -500,10 +516,23 @@ final class Q35MTPDraftSession {
         backlogHidden.removeAll(keepingCapacity: true)
         backlogTokens.removeAll(keepingCapacity: true)
 
-        let flushEmbeddings = baseModel.embeddings(for: flushTokens)
+        // A long prompt must not become one giant MTP MoE/attention graph.
+        let chunkSize = 256
+        var processed = 0
+        while flushTokens.dim(1) - processed > chunkSize {
+            let end = processed + chunkSize
+            let partial = mtpModel.forwardDraft(
+                inputEmbeddings: baseModel.embeddings(for: flushTokens[0..., processed..<end]),
+                hiddenStates: flushHidden[0..., processed..<end, 0...],
+                cache: historyCache
+            )
+            MLX.eval(partial.recurrentHidden)
+            processed = end
+        }
+        let flushEmbeddings = baseModel.embeddings(for: flushTokens[0..., processed...])
         let flushed = mtpModel.forwardDraft(
             inputEmbeddings: flushEmbeddings,
-            hiddenStates: flushHidden,
+            hiddenStates: flushHidden[0..., processed..., 0...],
             cache: historyCache
         )
         var previousHidden = flushed.recurrentHidden[

--- a/Sources/MereRunCore/Q35/Q35Model.swift
+++ b/Sources/MereRunCore/Q35/Q35Model.swift
@@ -36,6 +36,10 @@ public enum Q35LayerCache: @unchecked Sendable {
         case .linear(let cache):
             return cache.restoreVerificationPrefix(tokenCount: tokenCount)
         case .full(let genericCache):
+            if let cache = genericCache as? Q38QSACache {
+                cache.rollback(toOffset: cache.offset - totalTokens + tokenCount)
+                return true
+            }
             guard let cache = genericCache as? KVCacheSimple else { return false }
             cache.rollback(toOffset: cache.offset - totalTokens + tokenCount)
             return true
@@ -48,6 +52,9 @@ public enum Q35LayerCache: @unchecked Sendable {
         case .linear(let cache):
             return cache.canRestoreVerificationPrefix(tokenCount: tokenCount)
         case .full(let cache):
+            if let cache = cache as? Q38QSACache {
+                return cache.canRollback && cache.offset >= totalTokens
+            }
             guard let cache = cache as? KVCacheSimple else { return false }
             return cache.offset >= totalTokens
         }

--- a/Sources/MereRunCore/Q35/Q38FlashNext.swift
+++ b/Sources/MereRunCore/Q35/Q38FlashNext.swift
@@ -2,34 +2,6 @@ import Foundation
 import MLX
 import MLXNN
 
-final class Q38QSAIndexer: Module {
-    @ModuleInfo(key: "index_qk_proj") var indexQKProjection: Linear
-    @ModuleInfo(key: "q_layernorm") var queryNorm: Q35RMSNorm
-    @ModuleInfo(key: "k_layernorm") var keyNorm: Q35RMSNorm
-
-    init(config: Q35Config) {
-        let text = config.textConfig
-        let outputDimensions = (text.indexerHeadCount + text.indexerKVHeadCount)
-            * text.indexerHeadDimension
-        self._indexQKProjection.wrappedValue = Linear(
-            text.hiddenSize,
-            outputDimensions,
-            bias: false
-        )
-        self._queryNorm.wrappedValue = Q35RMSNorm(
-            dimensions: text.indexerHeadDimension,
-            eps: text.rmsNormEps,
-            zeroCenteredWeight: false
-        )
-        self._keyNorm.wrappedValue = Q35RMSNorm(
-            dimensions: text.indexerHeadDimension,
-            eps: text.rmsNormEps,
-            zeroCenteredWeight: false
-        )
-        super.init()
-    }
-}
-
 final class Q38GatedResidual: Module {
     @ModuleInfo(key: "hc_norm") var norm: Q35RMSNorm
     @ModuleInfo(key: "input_mix_weight_down") var inputMixDown: Linear

--- a/Sources/MereRunCore/Q35/Q38QSACache.swift
+++ b/Sources/MereRunCore/Q35/Q38QSACache.swift
@@ -1,0 +1,54 @@
+import MLX
+import MLXFast
+
+/// The learned indexer's unpooled keys and rotary positions belong to the same
+/// request snapshot as the target KV. Never keep them on the shared model.
+final class Q38QSACache: KVCache {
+    let attention: KVCache
+    private let indexer: KVCache
+
+    init(attention: KVCache = KVCacheSimple(), indexer: KVCache = KVCacheSimple()) {
+        self.attention = attention
+        self.indexer = indexer
+    }
+
+    var offset: Int { attention.offset }
+    var rowOffsets: [Int]? { attention.rowOffsets }
+    var supportsVariablePositionBatching: Bool { attention.supportsVariablePositionBatching }
+    var canRollback: Bool { attention is KVCacheSimple && indexer is KVCacheSimple }
+
+    func update(keys: MLXArray, values: MLXArray) -> (MLXArray, MLXArray) {
+        attention.update(keys: keys, values: values)
+    }
+
+    func updateIndexer(keys: MLXArray, positions: MLXArray) -> (MLXArray, MLXArray) {
+        indexer.update(keys: keys, values: positions)
+    }
+
+    func makeMask(n: Int) -> MLXFast.ScaledDotProductAttentionMaskMode {
+        attention.makeMask(n: n)
+    }
+
+    func fork() -> KVCache {
+        Q38QSACache(attention: attention.fork(), indexer: indexer.fork())
+    }
+
+    func rollback(toOffset offset: Int) {
+        precondition(canRollback)
+        (attention as? KVCacheSimple)?.rollback(toOffset: offset)
+        (indexer as? KVCacheSimple)?.rollback(toOffset: offset)
+    }
+
+    func batched(with caches: [KVCache]) -> KVCache? {
+        guard let caches = caches as? [Q38QSACache], !caches.isEmpty,
+              let main = attention.batched(with: caches.map(\.attention)),
+              let side = indexer.batched(with: caches.map(\.indexer)) else { return nil }
+        return Q38QSACache(attention: main, indexer: side)
+    }
+
+    func unbatchedRows(count: Int) -> [KVCache]? {
+        guard let main = attention.unbatchedRows(count: count),
+              let side = indexer.unbatchedRows(count: count) else { return nil }
+        return zip(main, side).map { Q38QSACache(attention: $0, indexer: $1) }
+    }
+}

--- a/Sources/MereRunCore/Q35/Q38QSAIndexer.swift
+++ b/Sources/MereRunCore/Q35/Q38QSAIndexer.swift
@@ -1,0 +1,126 @@
+import Foundation
+import MLX
+import MLXNN
+
+final class Q38QSAIndexer: Module {
+    @ModuleInfo(key: "index_qk_proj") var indexQKProjection: Linear
+    @ModuleInfo(key: "q_layernorm") var queryNorm: Q35RMSNorm
+    @ModuleInfo(key: "k_layernorm") var keyNorm: Q35RMSNorm
+
+    let budget: Int
+    private let headCount: Int
+    private let kvHeadCount: Int
+    private let headDimension: Int
+    private let ratio: Int
+    private let rotaryDimensions: Int
+    private let rotary: Qwen3VLRotaryEmbedding
+
+    init(config: Q35Config) {
+        let text = config.textConfig
+        self.budget = text.indexerBudget
+        self.headCount = text.indexerHeadCount
+        self.kvHeadCount = text.indexerKVHeadCount
+        self.headDimension = text.indexerHeadDimension
+        self.ratio = text.indexerCompressionRatio
+        self.rotaryDimensions = Int(Float(text.headDim) * text.ropeParameters.partialRotaryFactor)
+        self.rotary = Qwen3VLRotaryEmbedding(
+            dim: rotaryDimensions,
+            base: text.ropeParameters.ropeTheta,
+            mropeSection: text.ropeParameters.mropeSection ?? []
+        )
+        self._indexQKProjection.wrappedValue = Linear(
+            text.hiddenSize, (headCount + kvHeadCount) * headDimension, bias: false
+        )
+        self._queryNorm.wrappedValue = Q35RMSNorm(
+            dimensions: headDimension, eps: text.rmsNormEps, zeroCenteredWeight: false
+        )
+        self._keyNorm.wrappedValue = Q35RMSNorm(
+            dimensions: headDimension, eps: text.rmsNormEps, zeroCenteredWeight: false
+        )
+        super.init()
+    }
+
+    func attention(
+        hidden: MLXArray,
+        queries: MLXArray,
+        keys: MLXArray,
+        values: MLXArray,
+        offsets: [Int],
+        positionIds: MLXArray?,
+        cache: Q38QSACache?,
+        scale: Float
+    ) -> MLXArray? {
+        let batch = hidden.dim(0)
+        let count = hidden.dim(1)
+        let projected = indexQKProjection(hidden)
+        let indexQueries = queryNorm(projected[.ellipsis, 0..<(headCount * headDimension)]
+            .reshaped(batch, count, headCount, headDimension)).transposed(0, 2, 1, 3)
+        var rawKeys = projected[.ellipsis, (headCount * headDimension)...]
+            .reshaped(batch, count, kvHeadCount, headDimension).transposed(0, 2, 1, 3)
+        var positions = Self.positionRows(batch: batch, count: count, offsets: offsets, positionIds: positionIds)
+        let rotatedQueries = rotate(indexQueries, positions: positions)
+        if let cache {
+            (rawKeys, positions) = cache.updateIndexer(
+                keys: rawKeys,
+                positions: MLX.broadcast(positions, to: [batch, kvHeadCount, count, 3])
+            )
+        }
+        // Still record raw index keys below the budget: later decode can cross
+        // the boundary, including on a fork restored from a short prompt.
+        guard keys.dim(2) > budget else { return nil }
+        precondition(rawKeys.dim(2) == keys.dim(2), "QSA needs indexer history aligned with target KV")
+        let compressed = compressedKeys(rawKeys, positions: positions)
+        var outputs: [MLXArray] = []
+        for start in stride(from: 0, to: count, by: Q38SparseAttention.queryChunkSize) {
+            let end = min(count, start + Q38SparseAttention.queryChunkSize)
+            let indexQ = rotatedQueries[0..., 0..., start..<end, 0...]
+            let scoreHeads = MLX.matmul(
+                indexQ.asType(.float32), compressed.asType(.float32).swappedAxes(-1, -2)
+            )
+            let scores = MLX.maximum(scoreHeads, 0).sum(axis: 1) / sqrt(Float(headDimension))
+            let selected = Q38SparseAttention.select(
+                scores: scores, offsets: offsets.map { $0 + start }, budget: budget, ratio: ratio
+            )
+            let output = Q38SparseAttention.attend(
+                queries: queries[0..., 0..., start..<end, 0...],
+                keys: keys, values: values, indices: selected.indices, valid: selected.valid, scale: scale
+            )
+            if count > Q38SparseAttention.queryChunkSize { MLX.eval(output) }
+            outputs.append(output)
+        }
+        return outputs.count == 1 ? outputs[0] : MLX.concatenated(outputs, axis: 2)
+    }
+
+    func compressedKeys(_ rawKeys: MLXArray, positions: MLXArray) -> MLXArray {
+        let groups = rawKeys.dim(2) / ratio
+        let complete = groups * ratio
+        let pooled = rawKeys[0..., 0..., 0..<complete, 0...]
+            .reshaped(rawKeys.dim(0), kvHeadCount, groups, ratio, headDimension)
+            .asType(.float32).mean(axis: 3).asType(rawKeys.dtype)
+        let firstPositions = positions[0..., 0..<1, 0..<complete, 0...]
+            .reshaped(positions.dim(0), 1, groups, ratio, 3)[0..., 0..., 0..., 0, 0...]
+        return rotate(keyNorm(pooled), positions: firstPositions)
+    }
+
+    private func rotate(_ value: MLXArray, positions: MLXArray) -> MLXArray {
+        let ids = positions.squeezed(axis: 1).transposed(2, 0, 1)
+        let (cos, sin) = rotary(positionIds: ids, dtype: value.dtype)
+        let rotating = value[.ellipsis, 0..<rotaryDimensions]
+        let rotated = applyRotaryPosEmb(rotating, rotating, cos: cos, sin: sin).0
+        return rotaryDimensions == headDimension ? rotated
+            : MLX.concatenated([rotated, value[.ellipsis, rotaryDimensions...]], axis: -1)
+    }
+
+    static func positionRows(
+        batch: Int, count: Int, offsets: [Int], positionIds: MLXArray?
+    ) -> MLXArray {
+        if let positionIds, positionIds.ndim == 3 {
+            return positionIds.transposed(1, 2, 0).expandedDimensions(axis: 1)
+        }
+        let positions = positionIds ?? (
+            MLXArray(offsets.map(Int32.init)).reshaped(batch, 1)
+                + MLXArray(0..<Int32(count)).reshaped(1, count)
+        )
+        return MLX.broadcast(positions.reshaped(batch, 1, count, 1), to: [batch, 1, count, 3])
+    }
+}

--- a/Sources/MereRunCore/Q35/Q38SparseAttention.swift
+++ b/Sources/MereRunCore/Q35/Q38SparseAttention.swift
@@ -1,0 +1,91 @@
+import Foundation
+import MLX
+import MLXNN
+
+/// Qwen4Exp's compressed micro-block selector. The mathematical reference is
+/// Ollama's MIT-licensed qwen4_exp/qsa.go; see THIRD_PARTY_NOTICES.md.
+enum Q38SparseAttention {
+    static let queryChunkSize = 16
+
+    static func select(
+        scores: MLXArray,
+        offsets: [Int],
+        budget: Int,
+        ratio: Int
+    ) -> (indices: MLXArray, valid: MLXArray) {
+        let batch = scores.dim(0)
+        let count = scores.dim(1)
+        let blocks = scores.dim(2)
+        let selectedCount = min(blocks, budget / ratio)
+        let visible = MLXArray(offsets.map(Int32.init)).reshaped(batch, 1, 1)
+            + MLXArray(1...Int32(count)).reshaped(1, count, 1)
+        let visibleBlocks = MLX.floorDivide(visible, MLXArray(Int32(ratio)))
+        let blockIDs = MLXArray(0..<Int32(blocks)).reshaped(1, 1, blocks)
+        let selected: MLXArray
+        if blocks > selectedCount {
+            let masked = MLX.which(blockIDs .< visibleBlocks, scores, -Float.infinity)
+            selected = MLX.argPartition(-masked, kth: selectedCount - 1, axis: -1)[
+                .ellipsis, 0..<selectedCount
+            ].asType(.int32)
+        } else {
+            selected = MLX.broadcast(blockIDs, to: [batch, count, blocks])
+        }
+        let withinBlock = MLXArray(0..<Int32(ratio)).reshaped(1, 1, 1, ratio)
+        let tokens = selected.expandedDimensions(axis: -1) * ratio + withinBlock
+        let selectedValid = MLX.broadcast(
+            (selected .< visibleBlocks).expandedDimensions(axis: -1),
+            to: tokens.shape
+        )
+        let tailStart = visibleBlocks * ratio
+        let tail = tailStart + MLXArray(0..<Int32(ratio - 1)).reshaped(1, 1, ratio - 1)
+        let valid = MLX.concatenated([
+            selectedValid.reshaped(batch, count, selectedCount * ratio),
+            tail .< visible,
+        ], axis: -1)
+        let indices = MLX.concatenated([
+            tokens.reshaped(batch, count, selectedCount * ratio), tail,
+        ], axis: -1)
+        return (MLX.which(valid, indices, MLXArray(Int32(0))), valid)
+    }
+
+    /// Each query gathers at most budget + ratio - 1 tokens. Query tiling and
+    /// eager tile evaluation bound the temporary KV working set during prefill.
+    static func attend(
+        queries: MLXArray,
+        keys: MLXArray,
+        values: MLXArray,
+        indices: MLXArray,
+        valid: MLXArray,
+        scale: Float
+    ) -> MLXArray {
+        let batch = queries.dim(0)
+        let heads = queries.dim(1)
+        let kvHeads = keys.dim(1)
+        let count = queries.dim(2)
+        let dimension = queries.dim(3)
+        let selectedKeys = gather(keys, indices: indices).asType(.float32)
+        let selectedValues = gather(values, indices: indices).asType(.float32)
+        let groupedQueries = queries.asType(.float32)
+            .reshaped(batch, kvHeads, heads / kvHeads, count, 1, dimension)
+        let groupedKeys = selectedKeys.expandedDimensions(axis: 2).swappedAxes(-1, -2)
+        let scores = MLX.matmul(groupedQueries, groupedKeys).squeezed(axis: -2) * scale
+        let masked = MLX.which(
+            valid.expandedDimensions(axes: [1, 2]), scores, -Float.infinity
+        )
+        let probabilities = MLX.softmax(masked, axis: -1, precise: true)
+        return MLX.matmul(
+            probabilities.expandedDimensions(axis: -2),
+            selectedValues.expandedDimensions(axis: 2)
+        ).reshaped(batch, heads, count, dimension).asType(queries.dtype)
+    }
+
+    private static func gather(_ history: MLXArray, indices: MLXArray) -> MLXArray {
+        let batch = history.dim(0)
+        let heads = history.dim(1)
+        let length = history.dim(2)
+        let dimension = history.dim(3)
+        let batchOffsets = (MLXArray(0..<Int32(batch)) * length).reshaped(batch, 1, 1)
+        let flat = history.transposed(1, 0, 2, 3).reshaped(heads, batch * length, dimension)
+        return MLX.take(flat, indices + batchOffsets, axis: 1).transposed(1, 0, 2, 3, 4)
+    }
+}

--- a/Sources/MereRunCore/Q35/README.md
+++ b/Sources/MereRunCore/Q35/README.md
@@ -68,13 +68,26 @@ parts are installed from the physical safetensors shards without duplicating
 the table. Four-layer evaluation boundaries keep the 48-layer lazy graph below
 the macOS Metal watchdog while preserving each hybrid block.
 
-QSA indexer weights load with every full-attention layer, but selection is not
-executed yet. Generation therefore fails closed when prompt plus requested
-output exceeds the model's 2,048-token indexer budget. At or below that budget,
-QSA selects every visible causal block and the regular causal attention result
-is exact. Qwen4Exp's bundled one-layer MTP head consumes the target's four-stream
+QSA indexers run in every full-attention layer. Raw index keys are mean-pooled
+in four-token blocks in FP32, normalized, and rotated at the block's first
+position. Normalized/rotated index queries score those blocks by summed ReLU
+head scores. Future blocks are masked before selecting the best 512 complete
+blocks; the current partial block is always included. At or below the 2,048-token
+budget every visible token is selected, so the original causal SDPA path remains
+exact. Above it, 16-query tiles bound gathered KV temporaries without allocating
+a dense sequence-squared attention matrix. The model's 262,144-token context
+limit remains subject to total KV, MTP-history, and model residency.
+
+`Q38QSACache` snapshots raw index keys and rotary positions alongside the main
+KV cache, including prefix forks, accepted-prefix MTP rollback, and right-padded
+ragged batching. Quantized main KV retains unquantized indexer history. Tests
+cover selector causality, GQA dense-mask parity, pool-before-norm/first-position
+RoPE, chunk/serial parity, cache lifecycle, and the published 2,048-token boundary.
+
+Qwen4Exp's bundled one-layer MTP head consumes the target's four-stream
 hidden state, drafts through its trained hyper-connection/full-attention/MoE
-block, and leaves every emitted token under exact target verification. Managed
+block with the same QSA history, and leaves every emitted token under exact
+target verification. MTP history priming uses 256-token chunks. Managed
 Flash-Next models enable this path from short prompts; API startup warmup runs a
 representative eight-token decode so its lazy target and draft graphs are paid
 before the server reports healthy. `MERERUN_Q35_MTP_SPECULATION=0` keeps the

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -301,6 +301,37 @@ SOFTWARE.
 
 ## Source-derived runtime implementations
 
+### Qwen4Exp sparse-attention reference
+
+The native QSA micro-block selection, index-key pooling, and sparse-attention
+math in `Sources/MereRunCore/Q35/Q38QSAIndexer.swift` and
+`Sources/MereRunCore/Q35/Q38SparseAttention.swift` are adapted from Ollama's
+`x/models/qwen4_exp/blocks.go` and `qsa.go` at commit
+`39f7f91563f65dd8e6183a5be1855820bf6e0ba8`.
+Upstream: <https://github.com/ollama/ollama>. License: MIT.
+
+```text
+Copyright (c) Ollama
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+```
+
 ### MLX Fast Qwen3.8 decode-kernel provenance
 
 - purpose: the macOS Metal path for serial-exact affine 4-bit, group-size-64

--- a/Tests/MereRunCoreTests/Q38SparseAttentionTests.swift
+++ b/Tests/MereRunCoreTests/Q38SparseAttentionTests.swift
@@ -1,0 +1,328 @@
+import Foundation
+import MLX
+import MLXFast
+import MLXRandom
+import XCTest
+@testable import MereRunCore
+
+final class Q38SparseAttentionTests: MereRunCoreTestCase {
+    func testSelectorIncludesTopCompleteBlocksAndCurrentPartialBlock() {
+        let selection = Q38SparseAttention.select(
+            scores: MLXArray([Float(1), 9, 2, 8]).reshaped(1, 1, 4),
+            offsets: [16], budget: 8, ratio: 4
+        )
+        XCTAssertEqual(selectedTokens(selection), Set(Array(4..<8) + Array(12..<17)))
+    }
+
+    func testSelectorMasksFutureBlocksBeforeTopKAndSeparatesBatchRows() {
+        let selection = Q38SparseAttention.select(
+            scores: MLXArray([Float(1), 2, 3, 100, 1, 2, 3, 100]).reshaped(2, 1, 4),
+            offsets: [8, 16], budget: 8, ratio: 4
+        )
+        XCTAssertEqual(selectedTokens(selection, row: 0), Set(0..<9))
+        XCTAssertEqual(selectedTokens(selection, row: 1), Set(8..<17))
+    }
+
+    func testSelectorCoversFirstTokensAndExact2048Boundary() {
+        let first = Q38SparseAttention.select(
+            scores: MLXArray.ones([1, 5, 4]), offsets: [0], budget: 8, ratio: 4
+        )
+        for query in 0..<5 {
+            XCTAssertEqual(selectedTokens(first, query: query), Set(0...query))
+        }
+        let boundary = Q38SparseAttention.select(
+            scores: MLXArray.ones([1, 2, 512]), offsets: [2_047], budget: 2_048, ratio: 4
+        )
+        XCTAssertEqual(selectedTokens(boundary), Set(0..<2_048))
+        XCTAssertEqual(selectedTokens(boundary, query: 1), Set(0..<2_049))
+    }
+
+    func testGatheredAttentionMatchesDenseMaskedGQAForEachBatchRow() {
+        MLXRandom.seed(81)
+        let queries = MLXRandom.normal([2, 4, 3, 4])
+        let keys = MLXRandom.normal([2, 2, 12, 4])
+        let values = MLXRandom.normal([2, 2, 12, 4])
+        let selection = Q38SparseAttention.select(
+            scores: MLXRandom.normal([2, 3, 3]), offsets: [5, 9], budget: 4, ratio: 4
+        )
+        let actual = Q38SparseAttention.attend(
+            queries: queries, keys: keys, values: values,
+            indices: selection.indices, valid: selection.valid, scale: 0.5
+        )
+        for row in 0..<2 {
+            for query in 0..<3 {
+                let selected = selectedTokens(selection, row: row, query: query)
+                let mask = MLXArray((0..<12).map { selected.contains($0) ? Float(0) : -Float.infinity })
+                    .reshaped(1, 1, 1, 12)
+                let expected = MLXFast.scaledDotProductAttention(
+                    queries: queries[row..<(row + 1), 0..., query..<(query + 1), 0...],
+                    keys: keys[row..<(row + 1), 0..., 0..., 0...],
+                    values: values[row..<(row + 1), 0..., 0..., 0...], scale: 0.5, mask: .array(mask)
+                )
+                assertClose(actual[row..<(row + 1), 0..., query..<(query + 1), 0...], expected)
+            }
+        }
+    }
+
+    func testCompressionPoolsRawKeysBeforeNormalizationAndUsesFirstPosition() throws {
+        let indexer = Q38QSAIndexer(config: try config())
+        let raw = MLXArray((0..<32).map { Float($0 + 1) }).reshaped(1, 1, 8, 4)
+        let positions = Q38QSAIndexer.positionRows(
+            batch: 1, count: 8, offsets: [0],
+            positionIds: MLXArray([Int32(5), 6, 9, 10, 17, 18, 21, 22]).reshaped(1, 8)
+        )
+        let actual = indexer.compressedKeys(raw, positions: positions)
+        var expected: [Float] = []
+        for group in 0..<2 {
+            let mean = (0..<4).map { Float(group * 16 + $0 + 7) }
+            let norm = sqrt(mean.reduce(Float(0)) { $0 + $1 * $1 } / 4 + 0.000001)
+            let unit = mean.map { $0 / norm }
+            let angle = Float(group == 0 ? 5 : 17)
+            expected.append(contentsOf: [
+                unit[0] * cos(angle) - unit[1] * sin(angle),
+                unit[1] * cos(angle) + unit[0] * sin(angle), unit[2], unit[3],
+            ])
+        }
+        assertClose(actual, MLXArray(expected).reshaped(1, 1, 2, 4))
+    }
+
+    func testLongPrefillMatchesChunkedAndSerialAttentionAcrossBudget() throws {
+        MLXRandom.seed(82)
+        let attention = Q35FullAttention(config: try config())
+        let input = MLXRandom.normal([1, 25, 8])
+        let expected = forward(attention, input, Q38QSACache())
+        let chunkCache = Q38QSACache()
+        var chunks: [MLXArray] = []
+        for bounds in [0..<4, 4..<11, 11..<25] {
+            chunks.append(forward(attention, input[0..., bounds, 0...], chunkCache))
+        }
+        assertClose(MLX.concatenated(chunks, axis: 1), expected)
+        let serialCache = Q38QSACache()
+        let serial = (0..<25).map {
+            forward(attention, input[0..., $0..<($0 + 1), 0...], serialCache)
+        }
+        assertClose(MLX.concatenated(serial, axis: 1), expected)
+    }
+
+    func testPublishedBudgetAt32KUsesSparseHistoryAndMatchesFreshPrefillTail() throws {
+        MLXRandom.seed(87)
+        let attention = Q35FullAttention(config: try config(budget: 2_048))
+        // Populate a long history without running every preceding query. Then
+        // compare the final query against a real prefill across the 2K boundary.
+        let input = MLXRandom.normal([1, 2_053, 8])
+        let expected = forward(attention, input, Q38QSACache())
+        let cache = Q38QSACache()
+        _ = forward(attention, input[0..., 0..<2_047, 0...], cache)
+        let actual = forward(attention, input[0..., 2_047..., 0...], cache)
+        assertClose(actual, expected[0..., 2_047..., 0...])
+
+        let longCache = Q38QSACache()
+        let historyLength = 32_768
+        let keys = MLXRandom.normal([1, 2, historyLength, 4])
+        let values = MLXRandom.normal([1, 2, historyLength, 4])
+        let indexKeys = MLXRandom.normal([1, 1, historyLength, 4])
+        let positions = Q38QSAIndexer.positionRows(
+            batch: 1, count: historyLength, offsets: [0], positionIds: nil
+        )
+        _ = longCache.update(keys: keys, values: values)
+        _ = longCache.updateIndexer(keys: indexKeys, positions: positions)
+        let output = forward(attention, MLXRandom.normal([1, 1, 8]), longCache)
+        XCTAssertTrue(MLX.abs(output).max().item(Float.self).isFinite)
+        XCTAssertEqual(longCache.offset, 32_769)
+    }
+
+    func testQuantizedMainCacheForkRetainsSeparateUnquantizedIndexerState() throws {
+        MLXRandom.seed(88)
+        let cache = Q38QSACache(attention: AffineQuantizedKVCache(groupSize: 64, bits: 4, step: 256))
+        let keys = MLXRandom.normal([1, 1, 9, 64])
+        let indexKeys = MLXRandom.normal([1, 1, 9, 4])
+        let positions = Q38QSAIndexer.positionRows(batch: 1, count: 9, offsets: [0], positionIds: nil)
+        _ = cache.update(keys: keys, values: -keys)
+        _ = cache.updateIndexer(keys: indexKeys, positions: positions)
+        XCTAssertFalse(Q35LayerCache.full(cache).canRestoreVerificationPrefix(totalTokens: 3, tokenCount: 1))
+        let fork = try XCTUnwrap(cache.fork() as? Q38QSACache)
+        let extra = MLXArray.ones([1, 1, 1, 64])
+        _ = fork.update(keys: extra, values: extra)
+        let history = fork.updateIndexer(
+            keys: MLXArray.ones([1, 1, 1, 4]),
+            positions: Q38QSAIndexer.positionRows(batch: 1, count: 1, offsets: [9], positionIds: nil)
+        )
+        assertClose(history.0[0..., 0..., 0..<9, 0...], indexKeys)
+        XCTAssertEqual(history.1[0, 0, 9, 0].item(Int32.self), 9)
+        XCTAssertEqual(cache.offset, 9)
+        XCTAssertEqual(fork.offset, 10)
+    }
+
+    func testShortPrefixForkKeepsIndexerHistoryAndIsolatesBranches() throws {
+        MLXRandom.seed(83)
+        let attention = Q35FullAttention(config: try config())
+        let prefix = MLXRandom.normal([1, 7, 8])
+        let suffix = MLXRandom.normal([1, 11, 8])
+        let original = Q38QSACache()
+        _ = forward(attention, prefix, original)
+        let fork = try XCTUnwrap(original.fork() as? Q38QSACache)
+        let actual = forward(attention, suffix, fork)
+        let fresh = forward(attention, MLX.concatenated([prefix, suffix], axis: 1), Q38QSACache())
+        assertClose(actual, fresh[0..., 7..., 0...])
+        XCTAssertEqual(original.offset, 7)
+        let other = -suffix
+        let otherActual = forward(attention, other, original)
+        let otherFresh = forward(attention, MLX.concatenated([prefix, other], axis: 1), Q38QSACache())
+        assertClose(otherActual, otherFresh[0..., 7..., 0...])
+    }
+
+    func testRejectedDraftRollbackRestoresBothHistoriesAcrossBlockBoundary() throws {
+        MLXRandom.seed(84)
+        let attention = Q35FullAttention(config: try config())
+        let prefix = MLXRandom.normal([1, 11, 8])
+        let verified = MLXRandom.normal([1, 6, 8])
+        let next = MLXRandom.normal([1, 3, 8])
+        let cache = Q38QSACache()
+        _ = forward(attention, prefix, cache)
+        _ = forward(attention, verified, cache)
+        let layerCache = Q35LayerCache.full(cache)
+        XCTAssertTrue(layerCache.restoreVerificationPrefix(totalTokens: 6, tokenCount: 2))
+        XCTAssertEqual(cache.offset, 13)
+        let actual = forward(attention, next, cache)
+        let fresh = forward(attention, MLX.concatenated([
+            prefix, verified[0..., 0..<2, 0...], next,
+        ], axis: 1), Q38QSACache())
+        assertClose(actual, fresh[0..., 13..., 0...])
+    }
+
+    func testRaggedBatchAndUnbatchMatchIndependentCachedRequests() throws {
+        MLXRandom.seed(85)
+        let attention = Q35FullAttention(config: try config())
+        let caches = [Q38QSACache(), Q38QSACache()]
+        _ = forward(attention, MLXRandom.normal([1, 5, 8]), caches[0])
+        _ = forward(attention, MLXRandom.normal([1, 19, 8]), caches[1])
+        let batched = try XCTUnwrap(caches[0].batched(with: caches) as? Q38QSACache)
+        XCTAssertEqual(batched.rowOffsets, [5, 19])
+        let input = MLXRandom.normal([2, 3, 8])
+        let expected = caches.enumerated().map { row, cache in
+            forward(attention, input[row..<(row + 1), 0..., 0...], cache)
+        }
+        assertClose(forward(attention, input, batched), MLX.concatenated(expected, axis: 0))
+        let split = try XCTUnwrap(batched.unbatchedRows(count: 2) as? [Q38QSACache])
+        XCTAssertEqual(split.map(\.offset), [8, 22])
+        for row in 0..<2 {
+            let next = MLXRandom.normal([1, 2, 8])
+            assertClose(forward(attention, next, split[row]), forward(attention, next, caches[row]))
+        }
+    }
+
+    func testMTPHistoryPrimingIsChunkedAndKeepsOnlyCommittedTransitions() throws {
+        MLXRandom.seed(86)
+        let config = try config()
+        let model = Q35Model(config: config)
+        let mtp = Q38MTPModel(config: config)
+        let tokens = (0..<300).map { $0 % 30 }
+        let hidden = MLXRandom.normal([1, 300, 32])
+        let cache = Q38QSACache()
+        let session = Q35MTPDraftSession(promptTokens: tokens, promptHidden: hidden, historyCache: cache)
+        let drafts = mtp.draftBlock(
+            lastToken: 4, hidden: hidden[0..., 299..., 0...], blockSize: 4,
+            session: session, baseModel: model
+        )
+        XCTAssertEqual(drafts.count, 3)
+        XCTAssertTrue(drafts.tokens.allSatisfy { $0 >= 0 && $0 < 32 })
+        XCTAssertEqual(session.committedHistoryCount, 300)
+        XCTAssertEqual(cache.offset, 300)
+        let referenceCache = Q38QSACache()
+        let nextTokens = MLXArray((Array(tokens.dropFirst()) + [4]).map(Int32.init)).reshaped(1, 300)
+        let reference = mtp.forwardDraft(
+            inputEmbeddings: model.embeddings(for: nextTokens), hiddenStates: hidden, cache: referenceCache
+        )
+        let expectedToken = model.greedyDraftToken(from: reference.logitsHidden[0..., 299..., 0...])
+        XCTAssertEqual(drafts.tokens[0], Int(expectedToken.item(Int32.self)))
+        let continuation = MLXRandom.normal([1, 1, 8])
+        let hiddenContinuation = MLXRandom.normal([1, 1, 32])
+        let actual = mtp.forwardDraft(inputEmbeddings: continuation, hiddenStates: hiddenContinuation, cache: cache)
+        let expected = mtp.forwardDraft(inputEmbeddings: continuation, hiddenStates: hiddenContinuation, cache: referenceCache)
+        assertClose(actual.logitsHidden, expected.logitsHidden)
+    }
+
+    func testRejectedMTPDraftRestoresMultiStreamHiddenBeforeNextProposal() throws {
+        MLXRandom.seed(89)
+        let config = try config()
+        let model = Q35Model(config: config)
+        let mtp = Q38MTPModel(config: config)
+        let prompt = Array(1...11)
+        for accepted in 0..<3 {
+            let cache = Q38QSACache()
+            let output = model.forward(
+                MLXArray(prompt.map(Int32.init)).reshaped(1, prompt.count), cache: [.full(cache)]
+            )
+            let promptHidden = try XCTUnwrap(output.mtpHidden)
+            let session = Q35MTPDraftSession(
+                promptTokens: prompt, promptHidden: promptHidden, historyCache: Q38QSACache()
+            )
+            let proposals = mtp.draftBlock(
+                lastToken: 12, hidden: promptHidden[0..., 10..., 0...], blockSize: 4,
+                session: session, baseModel: model
+            ).tokens
+            let candidate = model.forward(
+                MLXArray(([12] + proposals).map(Int32.init)).reshaped(1, 4),
+                cache: [.full(cache)], targetVerify: true
+            )
+            XCTAssertTrue(Q35LayerCache.full(cache).restoreVerificationPrefix(
+                totalTokens: 4, tokenCount: accepted + 1
+            ))
+            let restored = session.restoredVerificationState(
+                from: candidate, acceptedTokens: Array(proposals.prefix(accepted))
+            )
+            XCTAssertEqual(restored.hidden.shape, [1, 1, 32])
+            assertClose(restored.hidden, try XCTUnwrap(candidate.mtpHidden)[0..., accepted..<(accepted + 1), 0...])
+            assertClose(restored.logits, candidate.logits[0..., accepted..<(accepted + 1), 0...])
+            let next = mtp.draftBlock(
+                lastToken: 13, hidden: restored.hidden, blockSize: 4,
+                session: session, baseModel: model
+            )
+            XCTAssertEqual(next.tokens.count, 3)
+            XCTAssertEqual(session.committedHistoryCount, prompt.count + accepted + 1)
+        }
+    }
+
+    private func forward(_ attention: Q35FullAttention, _ input: MLXArray, _ cache: Q38QSACache) -> MLXArray {
+        let output = attention(input, mask: cache.makeMask(n: input.dim(1)), cache: cache)
+        MLX.eval(output)
+        return output
+    }
+
+    private func assertClose(_ actual: MLXArray, _ expected: MLXArray, file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertEqual(actual.shape, expected.shape, file: file, line: line)
+        XCTAssertLessThan(MLX.abs(actual - expected).max().item(Float.self), 0.0001, file: file, line: line)
+    }
+
+    private func selectedTokens(
+        _ selection: (indices: MLXArray, valid: MLXArray), row: Int = 0, query: Int = 0
+    ) -> Set<Int> {
+        let indices = selection.indices[row, query, 0...].asArray(Int32.self)
+        let valid = selection.valid[row, query, 0...].asArray(Bool.self)
+        return Set(zip(indices, valid).compactMap { $1 ? Int($0) : nil })
+    }
+
+    private func config(budget: Int = 8) throws -> Q35Config {
+        try JSONDecoder().decode(Q35Config.self, from: Data(#"""
+        {
+          "model_type": "qwen4_exp", "architectures": ["Qwen4ExpForConditionalGeneration"],
+          "tie_word_embeddings": false,
+          "text_config": {
+            "model_type": "qwen4_exp_text", "hidden_size": 8, "num_hidden_layers": 1,
+            "intermediate_size": 8, "num_experts": 2, "num_experts_per_tok": 1,
+            "num_attention_heads": 4, "num_key_value_heads": 2, "head_dim": 4,
+            "layer_types": ["full_attention"], "linear_num_value_heads": 1,
+            "linear_num_key_heads": 1, "linear_key_head_dim": 4, "linear_value_head_dim": 4,
+            "linear_conv_kernel_dim": 2, "max_position_embeddings": 4096,
+            "rms_norm_eps": 0.000001, "attention_bias": false, "attention_dropout": 0,
+            "attn_output_gate": true, "output_gate_type": "sigmoid", "hc_count": 4, "hc_lowrank": 4,
+            "indexer_n_heads": 2, "indexer_kv_heads": 1, "indexer_head_dim": 4,
+            "indexer_budget": \#(budget), "indexer_compress_ratio": 4, "ple_layer_ids": [],
+            "vocab_size": 32, "eos_token_id": 31,
+            "mtp": {"hybrid": true, "layer_types": ["full_attention"], "num_hidden_layers": 1},
+            "rope_parameters": {"rope_theta": 10000000, "partial_rotary_factor": 0.5}
+          }
+        }
+        """#.utf8))
+    }
+}

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -827,8 +827,10 @@ Key options:
 - `--context-size`: maximum prompt plus generation context. Qwen3.8 and Bonsai
   27B use their published 262,144-token limit by default. Inkling-Small advertises
   1,048,576 tokens but uses a 32,768-token operational default because KV
-  residency grows with context. Qwen3.8-Flash-Next currently requires prompt
-  plus requested generation to fit its 2,048-token QSA indexer budget.
+  residency grows with context. Qwen3.8-Flash-Next uses learned QSA selection
+  beyond 2,048 tokens in builds newer than v0.45.0. Its 262,144-token limit is
+  architectural, not a full-context memory qualification for a 128 GB Mac;
+  explicitly select a smaller window such as `32768` to bound retained history.
 - `--temperature`: defaults to 0.7, or the model's published value where one
   exists (Bonsai: 0.7; Qwen3.8 and Ornith lanes: 1.0)
 - `--top-p`: defaults to 0.9, or the model's published value (Qwen3.8/Bonsai/Ornith: 0.95)
@@ -867,7 +869,7 @@ Examples:
 ```bash
 swift run mere.run text chat --prompt "What is classifier-free guidance?"
 swift run mere.run text chat --model vision-chat-q38-27b --image ./diagram.png --prompt "Explain this diagram."
-swift run mere.run text chat --model vision-chat-q38-flash-next-mixed --context-size 2048 --max-tokens 256 --prompt "Explain sparse attention."
+swift run mere.run text chat --model vision-chat-q38-flash-next-mixed --context-size 32768 --max-tokens 256 --prompt "Explain sparse attention."
 swift run mere.run text chat --model text-chat-bonsai-27b-1bit --context-size 262144 --kv-bits 4 --prompt "Plan a long-context repository review."
 swift run mere.run text chat --model text-chat-bonsai-27b-2bit --context-size 262144 --kv-bits 4 --prompt "Compare two repository migration plans."
 swift run mere.run text chat --model text-chat-inkling-small --context-size 32768 --prompt "Plan a recovery-safe repository migration."

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -309,6 +309,11 @@ under memory pressure or contention. On the Ornith 35B MoE (M4 Max), a
 at 2048. Chunked causal prefill is exact, so the setting trades throughput
 against progress-report granularity and per-chunk activation memory.
 
+Qwen3.8-Flash-Next additionally tiles sparse attention in 16-query groups and
+primes MTP history in 256-token chunks. Those internal bounds do not truncate
+context: retained KV and MTP history still scale with `--context-size`. The QSA
+long-context path is available in builds newer than v0.45.0.
+
 ### `MERERUN_Q35_BATCHED_GPU_SAMPLING`
 
 Qwen-family continuous-batching decode samples every active request's row on

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -384,14 +384,24 @@ than as a 128 GB alternative.
 Both artifacts include the Qwen Community License 1.0 and a complete
 source/output hash receipt. Pulls are explicit and require either
 `--accept-model-license` or its equivalent `--accept-license-terms` alias. The
-native Qwen4Exp runtime currently qualifies text generation only and rejects
-requests whose prompt plus requested generation exceeds the published
-2,048-token QSA indexer budget. At or below that boundary every visible block
-is selected, so standard causal attention is exact. Long-context QSA
-selection and image input remain unqualified. The bundled one-layer MTP path is
-qualified for greedy text generation and enabled by default from short prompts.
-Every proposed token remains under exact target verification; the mixed
-checkpoint measured 1.43–1.78x faster decode in real-checkpoint comparisons.
+native Qwen4Exp runtime supports text generation; image input remains
+unqualified. Builds newer than v0.45.0 implement the trained QSA micro-block
+selector beyond 2,048 tokens, replacing that release's prompt-plus-generation
+cap. Up to the indexer budget, standard causal attention is exact because every
+visible block is selected. Beyond it, each query selects 512 complete four-token
+blocks and includes the current partial block. Future blocks are excluded
+before selection. The same QSA path is used by the bundled one-layer MTP head,
+with exact target verification of proposed tokens.
+
+`--context-size` bounds prompt plus generation up to the checkpoint's published
+262,144-token limit. This is an architectural limit, not a 262k memory or quality
+qualification on a 128 GB Mac. KV and MTP history still grow with context even
+though sparse-attention temporaries are tiled; an explicit `--context-size 32768`
+keeps the requested window smaller. Existing model downloads already contain
+the indexer weights, so no new quantization or download is needed.
+
+The mixed checkpoint measured 1.43–1.78x faster MTP decode in the original
+short-context real-checkpoint comparisons; these are not long-context timings.
 Set `MERERUN_Q35_MTP_SPECULATION=0` to retain target-only decode for comparison
 or memory pressure.
 


### PR DESCRIPTION
## Summary

- Replace Flash-Next's 2,048-token admission cap with native learned QSA micro-block selection for target attention and the bundled MTP head.
- Keep raw index keys and positions aligned with KV snapshots, prefix reuse, ragged batching, and rejected-draft rollback. Tile sparse attention and chunk MTP history priming to bound temporary allocations.
- Fix partial-acceptance MTP recovery to retain Flash-Next's four-stream hidden state; add 13 focused tests and update CLI/runtime documentation plus upstream MIT attribution.

Existing mixed-Q2/Q4 and Q4 model packs already contain the indexer weights. No model repack, download, Hugging Face change, or release is part of this PR.

## Validation

- `./scripts/check.sh` passed after the final code change: 3,182 XCTest tests, 227 skipped, zero failures, plus 30 Swift Testing tests. Includes lint, build, help sweep, and hygiene checks.
- `MERERUN_TEST_MLX_DEVICE=gpu swift test --filter Q38SparseAttentionTests`: 13 passed; the same tests pass on CPU in the full gate.
- `pnpm docs:build` passed.
- Staged `gitleaks protect --staged --redact` and `git diff --cached --check` passed.

Tests cover causal top-k selection, pool-before-normalization and first-position RoPE, dense-mask GQA parity, chunked/serial attention, short-prefix forks, rollback across block boundaries, ragged batching, quantized KV, MTP history priming, and rejection after zero/one/two accepted drafts. A synthetic 32,768-token cache uses the published 2,048-token selection budget.

## Real-checkpoint evidence

On a 128 GiB Apple Silicon Mac, the existing mixed checkpoint ran a deterministic archive retrieval prompt with the passphrase near the beginning, temperature zero, thinking disabled, and a 32,768-token configured window. Prompt lengths below are actual tokenizer counts, not window-size claims.

| Mode | Prompt tokens | Outcome | Peak process footprint |
| --- | ---: | --- | ---: |
| MTP | 3,782 | Correct passphrase, extra prose | 76.3 GiB |
| MTP, final code | 8,016 | Completed 64 output tokens; correct passphrase, extra prose | 77.3 GiB |
| Target-only, final code | 8,016 | Completed 64 output tokens; correct passphrase, extra prose | 73.1 GiB |

The initial 8k run exposed the rejected-draft hidden-state assertion fixed here. The final MTP run accepted 45/85 drafts across 19 verification rounds with zero replacement re-forward passes, exercising the corrected recovery path.

## Qualification limits

- **Not exact-greedy parity:** the two final 8k outputs differ slightly (target-only includes “explicitly” in the opening sentence). Both recover the passphrase but fail the strict answer-only formatting assertion. The retrieval harness retains its nonzero format-check status even though both inference processes exited successfully.
- Full-checkpoint testing stops at 8,016 prompt tokens. Neither a full 32k run nor the published 262,144-token architectural limit is qualified for quality or memory here. KV and MTP history still grow with context.
- Other workloads remained active and system swap grew. Peak process footprint is not total system memory; timings are not a controlled performance benchmark.
- Image input and the larger Q4 checkpoint were not newly qualified. Hosted CI is separate from these local results.

Kept as a draft for review of these limits; no merge or release requested.
