### PR TITLE
Install verified signed plugin bundles without Python setup

### DIFF
--- a/Sources/MereRunCLI/Commands/PluginBundleCommand.swift
+++ b/Sources/MereRunCLI/Commands/PluginBundleCommand.swift
@@ -1,0 +1,68 @@
+import ArgumentParser
+import Foundation
+
+enum PluginBundleInstaller {
+    static var platform: String {
+        #if os(macOS) && arch(arm64)
+        return "macos-arm64"
+        #else
+        return "unsupported"
+        #endif
+    }
+
+    static func install(plugin: PluginCatalogEntry, source: String, archive: String?, allowLocalManifest: Bool = false) throws {
+        guard platform == "macos-arm64" else {
+            throw ValidationError("This bundle requires macOS on Apple Silicon. Use --source for an explicit pipx installation.")
+        }
+        let temporary = FileManager.default.temporaryDirectory.appendingPathComponent("mere-plugin-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: temporary, withIntermediateDirectories: false,
+                                                attributes: [.posixPermissions: 0o700])
+        defer { try? FileManager.default.removeItem(at: temporary) }
+        let receipt = temporary.appendingPathComponent("release.json")
+        try PluginBundleIO.fetch(source, to: receipt, limit: 65_536, local: allowLocalManifest)
+        let data = try Data(contentsOf: receipt)
+        let envelope = try JSONDecoder().decode(PluginBundleEnvelope.self, from: data)
+        let manifest = try envelope.verified()
+        guard manifest.package == plugin.package, manifest.entrypoints[plugin.id] == plugin.entrypoint else {
+            throw ValidationError("Signed release identity does not match the catalog plugin.")
+        }
+        let payload = temporary.appendingPathComponent("bundle.dmg")
+        try PluginBundleIO.fetch(archive ?? manifest.artifact.url, to: payload,
+                                 limit: manifest.artifact.size, local: archive != nil)
+        _ = try PluginBundleStore.standard.install(envelopeData: data, archive: payload,
+                                                   package: plugin.package, pluginID: plugin.id)
+        print("Installed signed bundle \(plugin.package) \(manifest.version).")
+        print("Verified publisher signature, macOS notarization, and bundled plugin entrypoints.")
+    }
+}
+
+struct PluginRollback: ParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "rollback", abstract: "Restore a retained signed plugin bundle.")
+    @Argument(help: "Plugin id, for example mere-doc-tools.") var id: String
+    @Flag(name: .long, help: "Activate the retained version. Without --yes, print the plan.") var yes = false
+
+    func run() throws {
+        guard let package = try PluginBundleStore.standard.package(containing: id) else {
+            throw ValidationError("No managed bundle is installed for \(id).")
+        }
+        guard yes else {
+            print("Restore the previous verified bundle for \(package). Run again with --yes to activate it.")
+            return
+        }
+        let manifest = try PluginBundleStore.standard.rollback(package: package)
+        print("Restored \(manifest.package) \(manifest.version).")
+    }
+}
+
+struct PluginRun: ParsableCommand {
+    static let configuration = CommandConfiguration(commandName: "run", abstract: "Run an installed plugin without changing PATH.")
+    @Argument(help: "Plugin entrypoint, for example mere-doc-tools.") var entrypoint: String
+    @Argument(parsing: .captureForPassthrough, help: "Arguments forwarded to the plugin.") var arguments: [String] = []
+
+    func run() throws {
+        guard PluginBundleManifest.matches(entrypoint, "^mere-[a-z0-9-]+$") else {
+            throw ValidationError("Expected a plugin entrypoint such as mere-doc-tools.")
+        }
+        try PluginProcess.runExecutable(entrypoint, arguments: arguments.first == "--" ? Array(arguments.dropFirst()) : arguments)
+    }
+}

--- a/Sources/MereRunCLI/Commands/PluginBundleIO.swift
+++ b/Sources/MereRunCLI/Commands/PluginBundleIO.swift
@@ -1,0 +1,139 @@
+import ArgumentParser
+import Crypto
+import Foundation
+#if canImport(Darwin)
+import Darwin
+#else
+import Glibc
+#endif
+
+enum PluginBundleIO {
+    static let maximumArchiveSize: Int64 = 1_073_741_824
+
+    static func hash(_ url: URL) throws -> String {
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { try? handle.close() }
+        var digest = SHA256()
+        while let bytes = try handle.read(upToCount: 1_048_576), !bytes.isEmpty { digest.update(data: bytes) }
+        return digest.finalize().map { String(format: "%02x", $0) }.joined()
+    }
+
+    static func fetch(_ source: String, to destination: URL, limit: Int64, local: Bool = false) throws {
+        if let url = URL(string: source), url.scheme == "https", url.host != nil,
+           url.user == nil, url.password == nil {
+            _ = try capture("/usr/bin/curl", [
+                "--disable", "--globoff", "--fail", "--silent", "--show-error", "--location", "--proto", "=https",
+                "--proto-redir", "=https", "--max-time", "180", "--max-filesize", String(limit),
+                "--output", destination.path, "--", source,
+            ], timeout: 190)
+        } else if local, !source.contains("://") {
+            try FileManager.default.copyItem(
+                at: URL(fileURLWithPath: NSString(string: source).expandingTildeInPath), to: destination
+            )
+        } else {
+            throw ValidationError("Plugin bundle downloads require HTTPS; local files must be supplied explicitly.")
+        }
+        let size = try destination.resourceValues(forKeys: [.fileSizeKey]).fileSize ?? 0
+        guard size > 0, size <= limit else { throw ValidationError("Plugin bundle download has an invalid size.") }
+    }
+
+    /// Files avoid pipe deadlocks when signing tools emit more than a pipe buffer.
+    static func capture(_ executable: String, _ arguments: [String], timeout: TimeInterval = 60) throws -> Data {
+        let temporary = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: temporary, withIntermediateDirectories: false,
+                                                attributes: [.posixPermissions: 0o700])
+        defer { try? FileManager.default.removeItem(at: temporary) }
+        let output = temporary.appendingPathComponent("stdout")
+        let errors = temporary.appendingPathComponent("stderr")
+        FileManager.default.createFile(atPath: output.path, contents: nil)
+        FileManager.default.createFile(atPath: errors.path, contents: nil)
+        let outputHandle = try FileHandle(forWritingTo: output)
+        let errorHandle = try FileHandle(forWritingTo: errors)
+        defer { try? outputHandle.close(); try? errorHandle.close() }
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: executable)
+        process.arguments = arguments
+        process.standardInput = FileHandle.nullDevice
+        process.standardOutput = outputHandle
+        process.standardError = errorHandle
+        try process.run()
+        let deadline = Date().addingTimeInterval(timeout)
+        while process.isRunning, Date() < deadline { Thread.sleep(forTimeInterval: 0.05) }
+        if process.isRunning {
+            process.terminate()
+            let grace = Date().addingTimeInterval(1)
+            while process.isRunning, Date() < grace { Thread.sleep(forTimeInterval: 0.05) }
+            if process.isRunning { kill(process.processIdentifier, SIGKILL) }
+            process.waitUntilExit()
+            throw ValidationError("Plugin bundle operation timed out: \(URL(fileURLWithPath: executable).lastPathComponent)")
+        }
+        process.waitUntilExit()
+        guard process.terminationStatus == 0 else {
+            let detail = String(decoding: try Data(contentsOf: errors).prefix(2_000), as: UTF8.self)
+            throw ValidationError("Plugin bundle operation failed (\(process.terminationStatus)): \(detail)")
+        }
+        return try Data(contentsOf: output)
+    }
+
+    static func validateTree(_ root: URL) throws {
+        let manager = FileManager.default
+        guard try manager.attributesOfItem(atPath: root.path)[.type] as? FileAttributeType == .typeDirectory,
+              let entries = manager.enumerator(at: root, includingPropertiesForKeys: nil) else {
+            throw ValidationError("Plugin bundle must be a directory.")
+        }
+        var total: Int64 = 0
+        for case let url as URL in entries {
+            let attributes = try manager.attributesOfItem(atPath: url.path)
+            let type = attributes[.type] as? FileAttributeType
+            if type == .typeSymbolicLink {
+                let target = try manager.destinationOfSymbolicLink(atPath: url.path)
+                let resolved = url.resolvingSymlinksInPath().standardizedFileURL
+                let prefix = root.resolvingSymlinksInPath().standardizedFileURL.path + "/"
+                guard !target.hasPrefix("/"), resolved.path.hasPrefix(prefix), manager.fileExists(atPath: resolved.path) else {
+                    throw ValidationError("Plugin bundle link escapes the bundle or has no target: \(url.lastPathComponent)")
+                }
+                continue
+            }
+            guard type == .typeDirectory || type == .typeRegular else {
+                throw ValidationError("Plugin bundles cannot contain special files: \(url.lastPathComponent)")
+            }
+            total += (attributes[.size] as? NSNumber)?.int64Value ?? 0
+            guard total <= maximumArchiveSize * 3 else { throw ValidationError("Expanded plugin bundle is too large.") }
+        }
+    }
+
+    static func verifyMacOS(
+        _ app: URL, manifest: PluginBundleManifest,
+        run: (String, [String]) throws -> Data = { try capture($0, $1) }
+    ) throws {
+        #if os(macOS)
+        let requirement = "anchor apple generic and certificate leaf[subject.OU] = \"\(PluginBundleEnvelope.developerTeam)\""
+            + " and identifier \"\(manifest.bundleIdentifier)\""
+        _ = try run("/usr/bin/codesign", ["--verify", "--deep", "--strict", "-R", "=" + requirement, app.path])
+        // Built into macOS 14+. Unlike xcrun stapler, this does not require developer tools.
+        _ = try run("/usr/bin/syspolicy_check", ["distribution", app.path])
+        _ = try run("/usr/sbin/spctl", ["--assess", "--type", "execute", app.path])
+        #else
+        throw ValidationError("Signed plugin bundles require macOS on Apple Silicon.")
+        #endif
+    }
+
+    static func stageDMG(_ archive: URL, manifest: PluginBundleManifest, destination: URL) throws {
+        let mount = destination.deletingLastPathComponent().appendingPathComponent("mount-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: mount, withIntermediateDirectories: false)
+        var needsDetach = true
+        defer {
+            // Also attempt detachment if hdiutil times out after mounting the image.
+            if needsDetach { _ = try? capture("/usr/bin/hdiutil", ["detach", mount.path]) }
+            try? FileManager.default.removeItem(at: mount)
+        }
+        _ = try capture("/usr/bin/hdiutil", ["attach", archive.path, "-readonly", "-nobrowse", "-noautoopen",
+                                            "-mountpoint", mount.path, "-plist"])
+        let app = mount.appendingPathComponent(manifest.appBundle)
+        try validateTree(app)
+        try verifyMacOS(app, manifest: manifest)
+        try FileManager.default.copyItem(at: app, to: destination)
+        _ = try capture("/usr/bin/hdiutil", ["detach", mount.path])
+        needsDetach = false
+    }
+}

--- a/Sources/MereRunCLI/Commands/PluginBundleManifest.swift
+++ b/Sources/MereRunCLI/Commands/PluginBundleManifest.swift
@@ -1,0 +1,81 @@
+import ArgumentParser
+import Crypto
+import Foundation
+
+/// The wire format is owned by mere-run-plugins/contracts/plugin-bundle.v1.schema.json.
+struct PluginBundleManifest: Codable, Equatable {
+    let contractVersion: String
+    let package: String
+    let version: String
+    let sequence: Int
+    let sourceCommit: String
+    let platform: String
+    let minimumOSVersion: String
+    let expiresAt: String
+    let appBundle: String
+    let entrypoints: [String: String]
+    let artifact: Artifact
+
+    struct Artifact: Codable, Equatable {
+        let url: String
+        let sha256: String
+        let size: Int64
+    }
+
+    var bundleIdentifier: String { "run.mere.plugins.\(package)" }
+
+    func validate(now: Date? = Date()) throws {
+        guard contractVersion == "mere.run/plugin-bundle.v1",
+              Self.matches(package, "^mere-[a-z0-9-]+$"),
+              Self.matches(version, "^[0-9]+\\.[0-9]+\\.[0-9]+$"), sequence > 0,
+              Self.matches(sourceCommit, "^[0-9a-f]{40}$"),
+              platform == "macos-arm64", minimumOSVersion == "15.0",
+              Self.matches(appBundle, "^[A-Za-z0-9-]+\\.app$"),
+              !entrypoints.isEmpty, entrypoints.count <= 32,
+              entrypoints.allSatisfy({ Self.matches($0.key, "^mere-[a-z0-9-]+$") && $0.key == $0.value }),
+              Set(entrypoints.values).count == entrypoints.count,
+              Self.matches(artifact.sha256, "^[0-9a-f]{64}$"),
+              artifact.size > 0, artifact.size <= PluginBundleIO.maximumArchiveSize,
+              let url = URL(string: artifact.url), url.scheme == "https", url.host != nil,
+              url.user == nil, url.password == nil, url.fragment == nil,
+              Self.matches(expiresAt, "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"),
+              let expiry = ISO8601DateFormatter().date(from: expiresAt) else {
+            throw ValidationError("Invalid or unsupported plugin bundle manifest.")
+        }
+        if let now, expiry <= now {
+            throw ValidationError("Plugin bundle release metadata has expired. Request a current signed release.")
+        }
+    }
+
+    static func matches(_ value: String, _ pattern: String) -> Bool {
+        value.range(of: pattern, options: .regularExpression) == value.startIndex..<value.endIndex
+    }
+}
+
+struct PluginBundleEnvelope: Codable {
+    let contractVersion: String
+    let keyID: String
+    let payload: String
+    let signature: String
+
+    // The existing Mere release key is also used by the signed macOS app feed.
+    // Rotation requires a reviewed CLI trust-root update; catalogs cannot add keys.
+    static let trustedKeys = ["mere-release-1": "6sFs+7UqYcE7rThPAovzMDsZtKyf/h4/d8rUmPSH2rw="]
+    static let developerTeam = "S5JDPCT8RC"
+
+    func verified(
+        trustedKeys: [String: String] = Self.trustedKeys,
+        now: Date? = Date()
+    ) throws -> PluginBundleManifest {
+        guard contractVersion == "mere.run/plugin-bundle-envelope.v1",
+              let encodedKey = trustedKeys[keyID], let key = Data(base64Encoded: encodedKey),
+              let bytes = Data(base64Encoded: payload), bytes.count <= 32_768,
+              let signatureBytes = Data(base64Encoded: signature),
+              try Curve25519.Signing.PublicKey(rawRepresentation: key).isValidSignature(signatureBytes, for: bytes) else {
+            throw ValidationError("Plugin bundle signature is invalid or its publisher key is not trusted. Installation stopped.")
+        }
+        let manifest = try JSONDecoder().decode(PluginBundleManifest.self, from: bytes)
+        try manifest.validate(now: now)
+        return manifest
+    }
+}

--- a/Sources/MereRunCLI/Commands/PluginBundleStore.swift
+++ b/Sources/MereRunCLI/Commands/PluginBundleStore.swift
@@ -1,0 +1,185 @@
+import ArgumentParser
+import Foundation
+import MereRunCore
+#if canImport(Darwin)
+import Darwin
+#else
+import Glibc
+#endif
+
+struct PluginBundleStore {
+    let root: URL
+    var trustedKeys = PluginBundleEnvelope.trustedKeys
+    var verifyPlatform: (URL, PluginBundleManifest) throws -> Void = { try PluginBundleIO.verifyMacOS($0, manifest: $1) }
+    var smoke: (URL, PluginBundleManifest) throws -> Void = Self.checkEntrypoints
+
+    static var standard: Self {
+        Self(root: MereRunModelPaths.applicationSupportBase.appendingPathComponent("plugins"))
+    }
+
+    struct State: Codable, Equatable {
+        let current: String
+        let previous: String?
+        let highestSequence: Int
+    }
+
+    func install(
+        envelopeData: Data, archive: URL, package: String, pluginID: String,
+        stage: (URL, PluginBundleManifest, URL) throws -> Void = PluginBundleIO.stageDMG
+    ) throws -> PluginBundleManifest {
+        let envelope = try JSONDecoder().decode(PluginBundleEnvelope.self, from: envelopeData)
+        let manifest = try envelope.verified(trustedKeys: trustedKeys)
+        guard manifest.package == package, manifest.entrypoints[pluginID] == pluginID else {
+            throw ValidationError("Signed bundle does not contain the requested plugin/package.")
+        }
+        let size = try archive.resourceValues(forKeys: [.fileSizeKey]).fileSize
+        guard size.map(Int64.init) == manifest.artifact.size,
+              try PluginBundleIO.hash(archive) == manifest.artifact.sha256 else {
+            throw ValidationError("Plugin bundle size or SHA-256 does not match the signed release. Installation stopped.")
+        }
+        return try locked {
+            let old = try state(package)
+            if let old {
+                guard manifest.sequence >= old.highestSequence,
+                      manifest.sequence != old.highestSequence || old.current == manifest.artifact.sha256
+                        || old.previous == manifest.artifact.sha256 else {
+                    throw ValidationError("Refusing a replayed or conflicting bundle release. Use plugin rollback for a retained version.")
+                }
+            }
+            let version = versionURL(package, manifest.artifact.sha256)
+            let app = version.appendingPathComponent(manifest.appBundle)
+            if FileManager.default.fileExists(atPath: version.path) {
+                guard try receipt(package, manifest.artifact.sha256) == manifest else {
+                    throw ValidationError("The retained bundle receipt conflicts with this release. Installation stopped.")
+                }
+            } else {
+                let staging = root.appendingPathComponent("staging-\(UUID().uuidString)")
+                try FileManager.default.createDirectory(at: staging, withIntermediateDirectories: false)
+                defer { try? FileManager.default.removeItem(at: staging) }
+                let stagedApp = staging.appendingPathComponent(manifest.appBundle)
+                try stage(archive, manifest, stagedApp)
+                try PluginBundleIO.validateTree(stagedApp)
+                try verifyPlatform(stagedApp, manifest)
+                try smoke(stagedApp, manifest)
+                try envelopeData.write(to: staging.appendingPathComponent("release.json"), options: .atomic)
+                try FileManager.default.createDirectory(at: version.deletingLastPathComponent(), withIntermediateDirectories: true)
+                try FileManager.default.moveItem(at: staging, to: version)
+            }
+            // Relocation must work too. Never switch the active version before this passes.
+            try PluginBundleIO.validateTree(app)
+            try verifyPlatform(app, manifest)
+            try smoke(app, manifest)
+            let next = State(current: manifest.artifact.sha256,
+                             previous: old?.current == manifest.artifact.sha256 ? old?.previous : old?.current,
+                             highestSequence: max(old?.highestSequence ?? 0, manifest.sequence))
+            try save(next, package: package)
+            return manifest
+        }
+    }
+
+    func rollback(package: String) throws -> PluginBundleManifest {
+        try locked {
+            guard let old = try state(package), let previous = old.previous else {
+                throw ValidationError("No retained plugin bundle is available for rollback.")
+            }
+            let manifest = try receipt(package, previous)
+            let app = versionURL(package, previous).appendingPathComponent(manifest.appBundle)
+            try PluginBundleIO.validateTree(app)
+            try verifyPlatform(app, manifest)
+            try smoke(app, manifest)
+            try save(State(current: previous, previous: old.current, highestSequence: old.highestSequence), package: package)
+            return manifest
+        }
+    }
+
+    func resolve(_ entrypoint: String) throws -> URL? {
+        for (package, state) in try activePackages() {
+            let manifest = try receipt(package, state.current)
+            if let executable = manifest.entrypoints[entrypoint] {
+                return versionURL(package, state.current).appendingPathComponent(manifest.appBundle)
+                    .appendingPathComponent("Contents/MacOS/\(executable)")
+            }
+        }
+        return nil
+    }
+
+    func entrypoints() throws -> [String] {
+        try activePackages().flatMap { package, state in
+            try receipt(package, state.current).entrypoints.keys
+        }.sorted()
+    }
+
+    func package(containing entrypoint: String) throws -> String? {
+        for (package, state) in try activePackages() {
+            if try receipt(package, state.current).entrypoints[entrypoint] != nil { return package }
+        }
+        return nil
+    }
+
+    func state(_ package: String) throws -> State? {
+        guard PluginBundleManifest.matches(package, "^mere-[a-z0-9-]+$") else {
+            throw ValidationError("Invalid plugin bundle package identifier.")
+        }
+        let url = packageURL(package).appendingPathComponent("active.json")
+        guard FileManager.default.fileExists(atPath: url.path) else { return nil }
+        let value = try JSONDecoder().decode(State.self, from: Data(contentsOf: url))
+        guard PluginBundleManifest.matches(value.current, "^[0-9a-f]{64}$"),
+              value.previous.map({ PluginBundleManifest.matches($0, "^[0-9a-f]{64}$") }) ?? true,
+              value.highestSequence > 0 else { throw ValidationError("Invalid plugin bundle installation state.") }
+        return value
+    }
+
+    private func receipt(_ package: String, _ digest: String) throws -> PluginBundleManifest {
+        let data = try Data(contentsOf: versionURL(package, digest).appendingPathComponent("release.json"))
+        let envelope = try JSONDecoder().decode(PluginBundleEnvelope.self, from: data)
+        // Expiry prevents new installs, not offline use of an already verified installation.
+        let manifest = try envelope.verified(trustedKeys: trustedKeys, now: nil)
+        guard manifest.package == package, manifest.artifact.sha256 == digest else {
+            throw ValidationError("Plugin bundle receipt does not match its installation.")
+        }
+        return manifest
+    }
+
+    private func activePackages() throws -> [(String, State)] {
+        let packages = root.appendingPathComponent("packages")
+        guard FileManager.default.fileExists(atPath: packages.path) else { return [] }
+        return try FileManager.default.contentsOfDirectory(atPath: packages.path).sorted().compactMap { name in
+            try state(name).map { (name, $0) }
+        }
+    }
+
+    private func packageURL(_ package: String) -> URL { root.appendingPathComponent("packages/\(package)") }
+    private func versionURL(_ package: String, _ digest: String) -> URL {
+        packageURL(package).appendingPathComponent("versions/\(digest)")
+    }
+    private func save(_ value: State, package: String) throws {
+        try JSONEncoder().encode(value).write(to: packageURL(package).appendingPathComponent("active.json"), options: .atomic)
+    }
+
+    private func locked<T>(_ body: () throws -> T) throws -> T {
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true,
+                                                attributes: [.posixPermissions: 0o700])
+        let descriptor = open(root.appendingPathComponent("install.lock").path, O_CREAT | O_RDWR | O_NOFOLLOW, 0o600)
+        guard descriptor >= 0 else { throw ValidationError("Cannot open plugin installation lock.") }
+        defer { close(descriptor) }
+        guard flock(descriptor, LOCK_EX | LOCK_NB) == 0 else {
+            throw ValidationError("Another plugin installation is running. Retry after it finishes.")
+        }
+        defer { flock(descriptor, LOCK_UN) }
+        return try body()
+    }
+
+    static func checkEntrypoints(_ app: URL, _ manifest: PluginBundleManifest) throws {
+        for (id, command) in manifest.entrypoints.sorted(by: { $0.key < $1.key }) {
+            let executable = app.appendingPathComponent("Contents/MacOS/\(command)")
+            let data = try PluginBundleIO.capture(executable.path, ["manifest", "--json"])
+            let actual = try JSONDecoder().decode(PluginManifest.self, from: data)
+            guard actual.contractVersion == "mere.run/plugin.v1", actual.name == id, actual.version == manifest.version else {
+                throw ValidationError("Bundled plugin identity/version does not match the signed release: \(id)")
+            }
+            if actual.graphProvider != nil {
+                _ = try WorkflowGraphProviderRegistry.loadProvider(entrypoint: executable.path)
+            }
+        }
+    }
+}

--- a/Sources/MereRunCLI/Commands/PluginCommand.swift
+++ b/Sources/MereRunCLI/Commands/PluginCommand.swift
@@ -13,6 +13,8 @@ struct Plugin: ParsableCommand {
             PluginInfo.self,
             PluginInstall.self,
             PluginDoctor.self,
+            PluginRun.self,
+            PluginRollback.self,
         ]
     )
 }
@@ -126,6 +128,15 @@ struct PluginInstall: ParsableCommand {
     @Flag(name: [.long], help: "Pass --force to pipx install.")
     var force: Bool = false
 
+    @Flag(name: .long, help: "Use the catalog's pipx source install instead of an advertised signed bundle.")
+    var source: Bool = false
+
+    @Option(name: .long, help: "Explicit signed bundle manifest URL or local path. Publisher verification is still required.")
+    var bundleManifest: String?
+
+    @Option(name: .long, help: "Local signed bundle DMG for offline installation; its signed hash must match.")
+    var bundleArchive: String?
+
     func run() throws {
         let catalog = try PluginCatalogClient.load(catalogURL: catalogURL)
         let plugin = try catalog.requirePlugin(id)
@@ -133,16 +144,47 @@ struct PluginInstall: ParsableCommand {
         let install = try plugin.install(channel: resolvedChannel)
         let command = PluginInstallCommand(install: install, force: force)
 
+        guard !source || (bundleManifest == nil && bundleArchive == nil) else {
+            throw ValidationError("--source cannot be combined with bundle options.")
+        }
+        let bundle = source ? nil : bundleManifest ?? install.bundles?[PluginBundleInstaller.platform]
+        if !source, install.bundles?.isEmpty == false, bundle == nil {
+            throw ValidationError("No signed bundle is available for this platform. Use --source to explicitly install with pipx.")
+        }
+        guard bundleArchive == nil || bundle != nil else {
+            throw ValidationError("--bundle-archive requires a signed bundle manifest.")
+        }
+        if let bundle {
+            guard bundleManifest != nil || URL(string: bundle)?.scheme == "https" else {
+                throw ValidationError("Catalog bundle manifests must use HTTPS. Use --bundle-manifest for an explicit local file.")
+            }
+            guard yes else {
+                print("Install signed bundle for \(plugin.package) from \(bundle).")
+                print("Verify publisher, platform, notarization, and entrypoints before activation; retain the previous version.")
+                print("  \(confirmationCommand(channel: resolvedChannel))")
+                return
+            }
+            try PluginBundleInstaller.install(plugin: plugin, source: bundle, archive: bundleArchive,
+                                               allowLocalManifest: bundleManifest != nil)
+            return
+        }
+
         if !yes {
             print("Install command:")
             print("  \(command.render())")
             print("")
             print("Run with --yes to execute it:")
-            print("  \(CLICommandDisplay.command("plugin install \(ShellCommand.quote(id)) --channel \(ShellCommand.quote(resolvedChannel)) --yes"))")
+            print("  \(confirmationCommand(channel: resolvedChannel))")
             return
         }
 
-        try command.run()
+        guard try PluginBundleStore.standard.state(plugin.package) == nil else {
+            throw ValidationError(
+                "A signed bundle is active for \(plugin.package). Supply its signed release manifest or use plugin rollback. "
+                    + "A pipx source install cannot replace an active managed bundle; existing PATH commands remain available."
+            )
+        }
+        try command.run(package: plugin.package)
         let manifest = try PluginVerifier.verify(entrypoint: plugin.entrypoint)
         guard manifest.name == plugin.id else {
             throw ValidationError(
@@ -154,6 +196,18 @@ struct PluginInstall: ParsableCommand {
         }
         print("Installed \(plugin.id) with \(install.manager).")
         print("Verified \(plugin.entrypoint) manifest version \(manifest.version).")
+    }
+
+    func confirmationCommand(channel: String) -> String {
+        let catalogArgument = catalogURL.map { " --catalog-url \(ShellCommand.quote($0))" } ?? ""
+        let forceArgument = force ? " --force" : ""
+        let sourceArgument = source ? " --source" : ""
+        let manifestArgument = bundleManifest.map { " --bundle-manifest \(ShellCommand.quote($0))" } ?? ""
+        let archiveArgument = bundleArchive.map { " --bundle-archive \(ShellCommand.quote($0))" } ?? ""
+        return CLICommandDisplay.command(
+            "plugin install \(ShellCommand.quote(id))\(catalogArgument) --channel \(ShellCommand.quote(channel))"
+                + " --yes\(forceArgument)\(sourceArgument)\(manifestArgument)\(archiveArgument)"
+        )
     }
 }
 
@@ -241,6 +295,7 @@ struct PluginCatalogInstall: Codable, Equatable {
     let manager: String
     let spec: String
     let ref: String?
+    var bundles: [String: String]?
 }
 
 struct PluginCatalogSnapshot: Codable, Equatable {
@@ -494,11 +549,20 @@ struct PluginInstallCommand {
         }
     }
 
-    func run() throws {
+    func run(
+        package: String,
+        findExecutable: (String) -> URL? = PluginProcess.which,
+        capture: (String, [String]) throws -> Data = {
+            try PluginProcess.captureExecutable($0, arguments: $1)
+        },
+        execute: (String, [String]) throws -> Void = {
+            try PluginProcess.runExecutable($0, arguments: $1)
+        }
+    ) throws {
         guard install.manager == "pipx" else {
             throw ValidationError("Unsupported plugin install manager: \(install.manager)")
         }
-        guard PluginProcess.which("pipx") != nil else {
+        guard findExecutable("pipx") != nil else {
             throw ValidationError(
                 """
                 pipx is required to install this plugin.
@@ -508,10 +572,11 @@ struct PluginInstallCommand {
         }
         var args = ["install"]
         if force {
+            try PluginPipxInstallCompatibility.validateForcedInstall(package: package, capture: capture)
             args.append("--force")
         }
         args.append(install.spec)
-        try PluginProcess.runExecutable("pipx", arguments: args)
+        try execute("pipx", args)
     }
 }
 
@@ -528,11 +593,17 @@ enum PluginVerifier {
 
 enum PluginProcess {
     static func which(_ name: String) -> URL? {
+        try? resolve(name)
+    }
+
+    static func resolve(_ name: String) throws -> URL? {
         if name.contains("/") {
             let url = URL(fileURLWithPath: NSString(string: name).expandingTildeInPath).standardizedFileURL
             guard FileManager.default.isExecutableFile(atPath: url.path) else { return nil }
             return url
         }
+        // A broken managed installation must never fall through to a different PATH executable.
+        if let managed = try PluginBundleStore.standard.resolve(name) { return managed }
         let process = Process()
         process.executableURL = URL(fileURLWithPath: "/usr/bin/which")
         process.arguments = [name]
@@ -550,7 +621,7 @@ enum PluginProcess {
     }
 
     static func runExecutable(_ executable: String, arguments: [String]) throws {
-        guard let url = which(executable) else {
+        guard let url = try resolve(executable) else {
             throw ValidationError("Executable not found on PATH: \(executable)")
         }
         let process = Process()
@@ -567,27 +638,10 @@ enum PluginProcess {
     }
 
     static func captureExecutable(_ executable: String, arguments: [String]) throws -> Data {
-        guard let url = which(executable) else {
+        guard let url = try resolve(executable) else {
             throw ValidationError("Executable not found on PATH: \(executable)")
         }
-        let process = Process()
-        process.executableURL = url
-        process.arguments = arguments
-        let output = Pipe()
-        let errors = Pipe()
-        process.standardOutput = output
-        process.standardError = errors
-        try process.run()
-        process.waitUntilExit()
-        let data = output.fileHandleForReading.readDataToEndOfFile()
-        let errorData = errors.fileHandleForReading.readDataToEndOfFile()
-        guard process.terminationStatus == 0 else {
-            let detail = String(decoding: errorData, as: UTF8.self)
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-            let suffix = detail.isEmpty ? "" : ": \(String(detail.prefix(500)))"
-            throw ValidationError("\(executable) exited with status \(process.terminationStatus)\(suffix)")
-        }
-        return data
+        return try PluginBundleIO.capture(url.path, arguments)
     }
 }
 

--- a/Sources/MereRunCLI/Commands/PluginInstallationDiagnosis.swift
+++ b/Sources/MereRunCLI/Commands/PluginInstallationDiagnosis.swift
@@ -67,6 +67,11 @@ struct PluginInstallationFailureDiagnosis: Equatable {
 }
 
 enum PluginPipxInstallationMetadata {
+    static func backend(for package: String, metadata: Data) throws -> String? {
+        let list = try JSONDecoder().decode(PipxList.self, from: metadata)
+        return list.venvs[package]?.metadata.backend
+    }
+
     static func missingEditableSourcePath(for plugin: PluginCatalogEntry) -> String? {
         guard PluginProcess.which("pipx") != nil,
               let data = try? PluginProcess.captureExecutable("pipx", arguments: ["list", "--json"]) else {
@@ -118,9 +123,11 @@ private struct PipxEnvironment: Decodable {
 
 private struct PipxEnvironmentMetadata: Decodable {
     let mainPackage: PipxMainPackage
+    let backend: String?
 
     enum CodingKeys: String, CodingKey {
         case mainPackage = "main_package"
+        case backend
     }
 }
 

--- a/Sources/MereRunCLI/Commands/PluginPipxInstallCompatibility.swift
+++ b/Sources/MereRunCLI/Commands/PluginPipxInstallCompatibility.swift
@@ -1,0 +1,71 @@
+import ArgumentParser
+import Foundation
+
+enum PluginPipxInstallCompatibility {
+    static func validateForcedInstall(
+        package: String,
+        capture: (String, [String]) throws -> Data
+    ) throws {
+        let backend: String?
+        do {
+            let metadata = try capture("pipx", ["list", "--json"])
+            backend = try PluginPipxInstallationMetadata.backend(for: package, metadata: metadata)
+        } catch {
+            throw ValidationError(
+                """
+                Cannot inspect pipx installations before a forced reinstall.
+                Run pipx list --json to diagnose the installation, then retry.
+                No plugin installation was attempted.
+                """
+            )
+        }
+        guard backend == "uv" else { return }
+
+        let output = try capture("pipx", ["--version"])
+        guard let version = PipxReleaseVersion(String(decoding: output, as: UTF8.self)) else {
+            throw ValidationError(
+                """
+                Cannot verify pipx compatibility with this plugin's uv environment.
+                Use a stable pipx release, version 1.16.0 or later, then retry.
+                Check the version with: pipx --version
+                No plugin installation was attempted.
+                """
+            )
+        }
+        guard version.supportsUVForcedInstall else {
+            throw ValidationError(
+                """
+                pipx \(version.description) cannot force-reinstall the uv environment for \(package).
+                Upgrade pipx to 1.16.0 or later, then retry the same mere.run command.
+                If you installed pipx with Homebrew: brew upgrade pipx
+                Otherwise, update pipx using its original installer.
+                The plugin has not been changed. Switching pipx backends is not required.
+                """
+            )
+        }
+    }
+}
+
+private struct PipxReleaseVersion {
+    let components: [Int]
+
+    init?(_ output: String) {
+        let fields = output.trimmingCharacters(in: .whitespacesAndNewlines)
+            .split(separator: ".", omittingEmptySubsequences: false)
+        guard fields.count == 3,
+              fields.allSatisfy({ !$0.isEmpty && $0.utf8.allSatisfy { (48...57).contains($0) } }) else {
+            return nil
+        }
+        let components = fields.compactMap { Int($0) }
+        guard components.count == 3 else { return nil }
+        self.components = components
+    }
+
+    var supportsUVForcedInstall: Bool {
+        !components.lexicographicallyPrecedes([1, 16, 0])
+    }
+
+    var description: String {
+        components.map(String.init).joined(separator: ".")
+    }
+}

--- a/Sources/MereRunCLI/Guides/plugin.md
+++ b/Sources/MereRunCLI/Guides/plugin.md
@@ -82,6 +82,10 @@ mere.run plugin list \
 ## Troubleshooting
 
 - `pipx is required`: install it with `brew install pipx`, then retry.
+- `pipx cannot force-reinstall the uv environment`: update pipx to 1.16.0 or
+  later using its original installer, then retry the same command. For a
+  Homebrew installation, run `brew upgrade pipx`. The compatibility check
+  leaves the plugin unchanged; switching pipx backends is not required.
 - `Unknown plugin`: rerun `mere.run plugin list` or check the selected
   `--catalog-url`.
 - `Executable not found on PATH`: ensure `pipx ensurepath` has been run and
@@ -97,3 +101,17 @@ mere.run plugin list \
 
 - https://github.com/sawfwair/mere-run/blob/main/Sources/MereRunCLI/Commands/PluginCommand.swift
 - https://github.com/sawfwair/mere-run-plugins/blob/main/catalog/plugins.v1.json
+
+## Signed bundles
+
+Advertised macOS Apple Silicon bundles include their own runtime. Installation
+verifies the publisher, artifact hash, Developer ID, and notarization before
+activation. Existing pipx installations and PATH remain unchanged.
+
+- Run a managed plugin: `mere.run plugin run mere-doc-tools -- COMMAND ARGS`
+- Restore the previous shared package: `mere.run plugin rollback mere-doc-tools --yes`
+- Explicitly choose source installation: `mere.run plugin install mere-doc-tools --source --yes`
+
+Invalid signatures stop installation. `--force` does not bypass verification.
+Offline installation accepts `--bundle-manifest RELEASE_JSON` and
+`--bundle-archive BUNDLE_DMG` with the same verification requirements.

--- a/Sources/MereRunCLI/Support/WorkflowGraphProvider.swift
+++ b/Sources/MereRunCLI/Support/WorkflowGraphProvider.swift
@@ -228,7 +228,8 @@ enum WorkflowGraphProviderRegistry {
         let persisted = loadInstallRegistry(fileManager: fileManager).entrypoints
         let knownInstalled = knownOfficialEntrypoints.filter { PluginProcess.which($0) != nil }
         var seen = Set<String>()
-        return (configured + persisted + knownInstalled).filter { seen.insert($0).inserted }
+        let managed = (try? PluginBundleStore.standard.entrypoints()) ?? []
+        return (configured + persisted + knownInstalled + managed).filter { seen.insert($0).inserted }
     }
 
     private static func loadInstallRegistry(fileManager: FileManager) -> WorkflowGraphProviderInstallRegistry {

--- a/Tests/MereRunCLITests/PluginBundleTests.swift
+++ b/Tests/MereRunCLITests/PluginBundleTests.swift
@@ -1,0 +1,242 @@
+import Crypto
+import Foundation
+import XCTest
+@testable import MereRunCLI
+
+final class PluginBundleTests: XCTestCase {
+    private let key = Curve25519.Signing.PrivateKey()
+    private var keys: [String: String] { ["test": key.publicKey.rawRepresentation.base64EncodedString()] }
+
+    func testPublisherSignatureBindsExactPayloadAndRejectsUnknownKey() throws {
+        let manifest = makeManifest()
+        let signed = try envelope(manifest)
+        XCTAssertEqual(try signed.verified(trustedKeys: keys), manifest)
+        XCTAssertThrowsError(try signed.verified())
+        let tampered = PluginBundleEnvelope(contractVersion: signed.contractVersion, keyID: "test",
+                                           payload: Data("{}".utf8).base64EncodedString(), signature: signed.signature)
+        XCTAssertThrowsError(try tampered.verified(trustedKeys: keys))
+        let badSignature = PluginBundleEnvelope(contractVersion: signed.contractVersion, keyID: "test",
+                                               payload: signed.payload, signature: Data(repeating: 0, count: 64).base64EncodedString())
+        XCTAssertThrowsError(try badSignature.verified(trustedKeys: keys))
+    }
+
+    func testManifestRejectsExpiryAndUnsafePathsEvenWithValidSignature() throws {
+        for manifest in [makeManifest(package: "../escape"), makeManifest(app: "../Escape.app"),
+                         makeManifest(entrypoint: "../tool"), makeManifest(platform: "linux-x86_64"),
+                         makeManifest(package: "mere-workflow-tools\n"), makeManifest(entrypoint: "mere-doc-tools\n"),
+                         makeManifest(expiry: "2099-01-01T00:00:00Z\n"),
+                         makeManifest(artifactURL: "http://example.com/bundle.dmg"), makeManifest(size: -1),
+                         makeManifest(sequence: 0)] {
+            XCTAssertThrowsError(try envelope(manifest).verified(trustedKeys: keys))
+        }
+        let expired = try envelope(makeManifest(expiry: "2000-01-01T00:00:00Z"))
+        XCTAssertThrowsError(try expired.verified(trustedKeys: keys))
+        XCTAssertNoThrow(try expired.verified(trustedKeys: keys, now: nil))
+    }
+
+    func testArtifactTamperingAndIdentityMismatchNeverStageCode() throws {
+        let root = try temporary()
+        let archive = root.appendingPathComponent("test.dmg")
+        try Data("original".utf8).write(to: archive)
+        let store = testStore(root)
+        let manifest = makeManifest(hash: try PluginBundleIO.hash(archive), size: 8)
+        let data = try JSONEncoder().encode(envelope(manifest))
+        XCTAssertThrowsError(try store.install(envelopeData: data, archive: archive, package: "mere-other", pluginID: "mere-doc-tools"))
+        try Data("modified".utf8).write(to: archive)
+        XCTAssertThrowsError(try store.install(envelopeData: data, archive: archive, package: manifest.package,
+                                               pluginID: "mere-doc-tools", stage: { _, _, _ in XCTFail("Must not stage tampered code") }))
+        XCTAssertNil(try store.state(manifest.package))
+    }
+
+    func testActivationRollbackAndReplayProtection() throws {
+        let root = try temporary()
+        let store = testStore(root)
+        let first = try installFixture(store, sequence: 1)
+        let original = try XCTUnwrap(store.resolve("mere-doc-tools"))
+        XCTAssertTrue(original.path.contains(first.artifact.sha256))
+        XCTAssertEqual(try store.entrypoints(), ["mere-doc-tools"])
+        XCTAssertEqual(try store.package(containing: "mere-doc-tools"), first.package)
+        XCTAssertNil(try store.package(containing: "mere-absent-tools"))
+        let second = try installFixture(store, sequence: 2)
+        XCTAssertEqual(try store.state(first.package)?.previous, first.artifact.sha256)
+        XCTAssertThrowsError(try installFixture(store, sequence: 1))
+        XCTAssertThrowsError(try installFixture(store, sequence: 2, content: "conflict"))
+        XCTAssertEqual(try store.rollback(package: first.package), first)
+        XCTAssertEqual(try store.resolve("mere-doc-tools"), original)
+        XCTAssertEqual(try store.state(first.package)?.highestSequence, 2)
+        XCTAssertEqual(try store.rollback(package: first.package), second)
+    }
+
+    func testFailedRelocationCheckPreservesActiveInstallation() throws {
+        let root = try temporary()
+        var store = testStore(root)
+        let first = try installFixture(store, sequence: 1)
+        let before = try store.state(first.package)
+        store.smoke = { url, _ in
+            if url.path.contains("/versions/") { throw CocoaError(.fileReadCorruptFile) }
+        }
+        XCTAssertThrowsError(try installFixture(store, sequence: 2))
+        XCTAssertEqual(try store.state(first.package), before)
+    }
+
+    func testFailedPlatformVerificationPreservesActiveInstallation() throws {
+        let root = try temporary()
+        var store = testStore(root)
+        let first = try installFixture(store, sequence: 1)
+        let before = try store.state(first.package)
+        store.verifyPlatform = { _, _ in throw CocoaError(.fileReadNoPermission) }
+        XCTAssertThrowsError(try installFixture(store, sequence: 2))
+        XCTAssertEqual(try store.state(first.package), before)
+        XCTAssertThrowsError(try store.rollback(package: first.package))
+    }
+
+    func testBundleTreeRejectsSymlinkEscape() throws {
+        let root = try temporary()
+        try FileManager.default.createSymbolicLink(at: root.appendingPathComponent("escape"),
+                                                   withDestinationURL: URL(fileURLWithPath: "/tmp"))
+        XCTAssertThrowsError(try PluginBundleIO.validateTree(root))
+    }
+
+    func testBundleTreeAllowsOnlyRelativeLinksWithInternalTargets() throws {
+        let root = try temporary()
+        try FileManager.default.createDirectory(at: root.appendingPathComponent("Frameworks"), withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: root.appendingPathComponent("Resources"), withIntermediateDirectories: true)
+        try Data("library".utf8).write(to: root.appendingPathComponent("Frameworks/runtime"))
+        let link = root.appendingPathComponent("Resources/runtime")
+        try FileManager.default.createSymbolicLink(atPath: link.path, withDestinationPath: "../Frameworks/runtime")
+        XCTAssertNoThrow(try PluginBundleIO.validateTree(root))
+        try FileManager.default.removeItem(at: link)
+        try FileManager.default.createSymbolicLink(atPath: link.path, withDestinationPath: "../../outside")
+        XCTAssertThrowsError(try PluginBundleIO.validateTree(root))
+        try FileManager.default.removeItem(at: link)
+        try FileManager.default.createSymbolicLink(atPath: link.path, withDestinationPath: "../Frameworks/missing")
+        XCTAssertThrowsError(try PluginBundleIO.validateTree(root))
+    }
+
+    func testConcurrentInstallCannotEnterStaging() throws {
+        let root = try temporary()
+        let store = testStore(root)
+        let archive = root.appendingPathComponent("fixture.dmg")
+        try Data("fixture".utf8).write(to: archive)
+        let manifest = makeManifest(hash: try PluginBundleIO.hash(archive), size: 7)
+        let data = try JSONEncoder().encode(envelope(manifest))
+        _ = try store.install(envelopeData: data, archive: archive, package: manifest.package,
+                              pluginID: "mere-doc-tools", stage: { _, _, app in
+            XCTAssertThrowsError(try store.install(envelopeData: data, archive: archive, package: manifest.package,
+                                                   pluginID: "mere-doc-tools", stage: { _, _, _ in XCTFail("Lock not held") }))
+            try FileManager.default.createDirectory(at: app, withIntermediateDirectories: true)
+        })
+    }
+
+    func testCorruptManagedReceiptDoesNotResolveAnExecutable() throws {
+        let root = try temporary()
+        let store = testStore(root)
+        let manifest = try installFixture(store, sequence: 1)
+        let receipt = root.appendingPathComponent("store/packages/\(manifest.package)/versions/\(manifest.artifact.sha256)/release.json")
+        try Data("{}".utf8).write(to: receipt)
+        XCTAssertThrowsError(try store.resolve("mere-doc-tools"))
+        XCTAssertThrowsError(try installFixture(store, sequence: 1))
+    }
+
+    func testRetainedArtifactCannotBeReboundToDifferentReleaseMetadata() throws {
+        let root = try temporary()
+        let store = testStore(root)
+        let first = try installFixture(store, sequence: 1)
+        XCTAssertEqual(try installFixture(store, sequence: 1), first)
+        let before = try store.state(first.package)
+        XCTAssertThrowsError(try installFixture(store, sequence: 2, content: "fixture-1"))
+        XCTAssertEqual(try store.state(first.package), before)
+    }
+
+    func testPlatformChecksRequireNoDeveloperToolsAndStopOnFailure() throws {
+        #if os(macOS)
+        let app = URL(fileURLWithPath: "/tmp/Fixture.app")
+        var commands: [String] = []
+        try PluginBundleIO.verifyMacOS(app, manifest: makeManifest()) { executable, _ in
+            commands.append(executable)
+            return Data()
+        }
+        XCTAssertEqual(commands, ["/usr/bin/codesign", "/usr/bin/syspolicy_check", "/usr/sbin/spctl"])
+        commands = []
+        XCTAssertThrowsError(try PluginBundleIO.verifyMacOS(app, manifest: makeManifest()) { executable, _ in
+            commands.append(executable)
+            throw CocoaError(.fileReadNoPermission)
+        })
+        XCTAssertEqual(commands, ["/usr/bin/codesign"])
+        #endif
+    }
+
+    func testBundleOptionsRetainExplicitSourceAndOfflineInputs() throws {
+        let command = try PluginInstall.parse(["mere-doc-tools", "--bundle-manifest", "/tmp/release.json",
+                                              "--bundle-archive", "/tmp/plugin bundle.dmg"])
+        XCTAssertFalse(command.source)
+        XCTAssertTrue(command.confirmationCommand(channel: "main").contains("--bundle-archive '/tmp/plugin bundle.dmg'"))
+        let source = try PluginInstall.parse(["mere-doc-tools", "--source"])
+        XCTAssertTrue(source.source)
+        let run = try PluginRun.parse(["mere-doc-tools", "process", "--input", "document.csv"])
+        XCTAssertEqual(run.arguments, ["process", "--input", "document.csv"])
+    }
+
+    func testRealSignedPilotInstallsAndConvertsAfterRelocation() throws {
+        guard let directory = ProcessInfo.processInfo.environment["MERERUN_BUNDLE_TEST_ARTIFACT"] else {
+            throw XCTSkip("Set MERERUN_BUNDLE_TEST_ARTIFACT to a signed pilot directory for the real macOS acceptance test.")
+        }
+        let fixture = URL(fileURLWithPath: directory)
+        let data = try Data(contentsOf: fixture.appendingPathComponent("release.json"))
+        let manifest = try JSONDecoder().decode(PluginBundleEnvelope.self, from: data).verified()
+        let root = try temporary().appendingPathComponent("Relocated plugin with spaces")
+        let store = PluginBundleStore(root: root)
+        _ = try store.install(envelopeData: data, archive: fixture.appendingPathComponent("bundle.dmg"),
+                              package: manifest.package, pluginID: "mere-doc-tools")
+        let executable = try XCTUnwrap(store.resolve("mere-doc-tools"))
+        let input = root.appendingPathComponent("source.csv")
+        try Data("item,count\nNotebook,3\nPencil,4\n".utf8).write(to: input)
+        _ = try PluginBundleIO.capture(executable.path, ["process", "--extractor", "anydoc", "--no-redact",
+                                                        "--input", input.path, "--output-dir", root.appendingPathComponent("output").path])
+        let outputs = FileManager.default.enumerator(at: root.appendingPathComponent("output"), includingPropertiesForKeys: nil)
+        let markdown = (outputs?.allObjects as? [URL] ?? []).filter { $0.pathExtension == "md" }
+        XCTAssertFalse(markdown.isEmpty)
+        XCTAssertTrue(try String(contentsOf: XCTUnwrap(markdown.first), encoding: .utf8).contains("Notebook"))
+    }
+
+    private func temporary() throws -> URL {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("mere-bundle-tests-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: false)
+        addTeardownBlock { try FileManager.default.removeItem(at: url) }
+        return url
+    }
+
+    private func testStore(_ root: URL) -> PluginBundleStore {
+        PluginBundleStore(root: root.appendingPathComponent("store"), trustedKeys: keys,
+                          verifyPlatform: { _, _ in }, smoke: { _, _ in })
+    }
+
+    private func installFixture(_ store: PluginBundleStore, sequence: Int, content: String? = nil) throws -> PluginBundleManifest {
+        let archive = store.root.deletingLastPathComponent().appendingPathComponent("fixture-\(UUID().uuidString)")
+        let bytes = Data((content ?? "fixture-\(sequence)").utf8)
+        try bytes.write(to: archive)
+        let manifest = makeManifest(sequence: sequence, hash: try PluginBundleIO.hash(archive), size: Int64(bytes.count))
+        return try store.install(envelopeData: JSONEncoder().encode(envelope(manifest)), archive: archive,
+                                 package: manifest.package, pluginID: "mere-doc-tools", stage: { _, _, app in
+            try FileManager.default.createDirectory(at: app.appendingPathComponent("Contents/MacOS"), withIntermediateDirectories: true)
+            try Data("fixture".utf8).write(to: app.appendingPathComponent("Contents/MacOS/mere-doc-tools"))
+        })
+    }
+
+    private func envelope(_ manifest: PluginBundleManifest) throws -> PluginBundleEnvelope {
+        let payload = try JSONEncoder().encode(manifest)
+        return PluginBundleEnvelope(contractVersion: "mere.run/plugin-bundle-envelope.v1", keyID: "test",
+                                    payload: payload.base64EncodedString(), signature: try key.signature(for: payload).base64EncodedString())
+    }
+
+    private func makeManifest(
+        package: String = "mere-workflow-tools", sequence: Int = 1, platform: String = "macos-arm64",
+        expiry: String = "2099-01-01T00:00:00Z", app: String = "MereWorkflowTools.app", entrypoint: String = "mere-doc-tools",
+        artifactURL: String = "https://example.com/plugin.dmg", hash: String = String(repeating: "a", count: 64), size: Int64 = 1
+    ) -> PluginBundleManifest {
+        PluginBundleManifest(contractVersion: "mere.run/plugin-bundle.v1", package: package, version: "0.4.0",
+                             sequence: sequence, sourceCommit: String(repeating: "b", count: 40), platform: platform,
+                             minimumOSVersion: "15.0", expiresAt: expiry, appBundle: app,
+                             entrypoints: [entrypoint: entrypoint], artifact: .init(url: artifactURL, sha256: hash, size: size))
+    }
+}

--- a/Tests/MereRunCLITests/PluginCommandTests.swift
+++ b/Tests/MereRunCLITests/PluginCommandTests.swift
@@ -12,7 +12,7 @@ final class PluginCommandTests: XCTestCase {
     func testPluginCommandExposesCatalogSubcommands() {
         let commandNames = Set(Plugin.configuration.subcommands.map { $0.configuration.commandName })
 
-        XCTAssertEqual(commandNames, Set(["list", "info", "install", "doctor"]))
+        XCTAssertEqual(commandNames, Set(["list", "info", "install", "doctor", "run", "rollback"]))
     }
 
     func testDefaultCatalogTargetsPublicPluginRepository() {
@@ -81,6 +81,122 @@ final class PluginCommandTests: XCTestCase {
             command,
             "pipx install --force git+https://github.com/sawfwair/mere-run-plugins.git@main#subdirectory=packages/mere-runpod"
         )
+    }
+
+    func testInstallConfirmationKeepsChannelAndForce() throws {
+        let command = try PluginInstall.parse([
+            "mere-doc-tools", "--catalog-url", "/tmp/plugin review.json", "--force",
+        ])
+
+        XCTAssertEqual(
+            command.confirmationCommand(channel: "review"),
+            "mere.run plugin install mere-doc-tools --catalog-url '/tmp/plugin review.json' --channel review --yes --force"
+        )
+    }
+
+    func testForcedInstallRejectsAffectedUVEnvironmentBeforeRunningInstaller() {
+        var executed = false
+        let command = workflowInstallCommand(force: true)
+
+        XCTAssertThrowsError(try command.run(
+            package: "mere-workflow-tools",
+            findExecutable: { _ in URL(fileURLWithPath: "/fixture/pipx") },
+            capture: pipxCapture(metadata: pipxMetadata(backend: "uv"), version: "1.15.0\n"),
+            execute: { _, _ in executed = true }
+        )) { error in
+            let message = String(describing: error)
+            XCTAssertTrue(message.contains("pipx 1.15.0"))
+            XCTAssertTrue(message.contains("mere-workflow-tools"))
+            XCTAssertTrue(message.contains("1.16.0 or later"))
+            XCTAssertTrue(message.contains("brew upgrade pipx"))
+            XCTAssertTrue(message.contains("plugin has not been changed"))
+        }
+        XCTAssertFalse(executed)
+    }
+
+    func testForcedInstallAllowsFixedPipxVersionsWithoutChangingArguments() throws {
+        let command = workflowInstallCommand(force: true)
+        for version in ["1.16.0\n", "1.16.1", "1.100.0", "2.0.0"] {
+            var arguments: [String] = []
+            try command.run(
+                package: "mere-workflow-tools",
+                findExecutable: { _ in URL(fileURLWithPath: "/fixture/pipx") },
+                capture: pipxCapture(metadata: pipxMetadata(backend: "uv"), version: version),
+                execute: { executable, args in
+                    XCTAssertEqual(executable, "pipx")
+                    arguments = args
+                }
+            )
+            XCTAssertEqual(arguments, ["install", "--force", command.install.spec], version)
+        }
+    }
+
+    func testNormalInstallDoesNotProbePipxCompatibility() throws {
+        let command = workflowInstallCommand(force: false)
+        var arguments: [String] = []
+
+        try command.run(
+            package: "mere-workflow-tools",
+            findExecutable: { _ in URL(fileURLWithPath: "/fixture/pipx") },
+            capture: { _, _ in
+                XCTFail("A normal install must not probe forced-reinstall compatibility.")
+                return Data()
+            },
+            execute: { _, args in arguments = args }
+        )
+
+        XCTAssertEqual(arguments, ["install", command.install.spec])
+    }
+
+    func testForcedInstallAllowsFreshPipAndLegacyEnvironmentsWithoutVersionProbe() throws {
+        let snapshots = [
+            Data(#"{"venvs":{}}"#.utf8),
+            pipxMetadata(backend: "pip"),
+            pipxMetadata(backend: nil),
+            pipxMetadata(backend: "uv", package: "unrelated-tools"),
+        ]
+        for metadata in snapshots {
+            var executed = false
+            try workflowInstallCommand(force: true).run(
+                package: "mere-workflow-tools",
+                findExecutable: { _ in URL(fileURLWithPath: "/fixture/pipx") },
+                capture: { executable, arguments in
+                    XCTAssertEqual(executable, "pipx")
+                    XCTAssertEqual(arguments, ["list", "--json"])
+                    return metadata
+                },
+                execute: { _, _ in executed = true }
+            )
+            XCTAssertTrue(executed)
+        }
+    }
+
+    func testForcedUVInstallRequiresARecognizableStableVersion() {
+        for version in ["", "unknown", "1.16.0rc1", "1.16.0\nother output"] {
+            var executed = false
+            XCTAssertThrowsError(try workflowInstallCommand(force: true).run(
+                package: "mere-workflow-tools",
+                findExecutable: { _ in URL(fileURLWithPath: "/fixture/pipx") },
+                capture: pipxCapture(metadata: pipxMetadata(backend: "uv"), version: version),
+                execute: { _, _ in executed = true }
+            )) { error in
+                XCTAssertTrue(String(describing: error).contains("Cannot verify pipx compatibility"))
+            }
+            XCTAssertFalse(executed)
+        }
+    }
+
+    func testForcedInstallDoesNotRunAfterMetadataInspectionFails() {
+        var executed = false
+        XCTAssertThrowsError(try workflowInstallCommand(force: true).run(
+            package: "mere-workflow-tools",
+            findExecutable: { _ in URL(fileURLWithPath: "/fixture/pipx") },
+            capture: pipxCapture(metadata: Data(#"{"venvs":[]}"#.utf8), version: "1.15.0"),
+            execute: { _, _ in executed = true }
+        )) { error in
+            XCTAssertTrue(String(describing: error).contains("Run pipx list --json"))
+        }
+        XCTAssertFalse(executed)
     }
 
     func testCatalogSnapshotAddsVerifiedInstallationStateWithoutDroppingCatalogFields() throws {
@@ -214,6 +330,47 @@ final class PluginCommandTests: XCTestCase {
             try? FileManager.default.removeItem(at: directory)
         }
         return catalogURL
+    }
+
+    private func workflowInstallCommand(force: Bool) -> PluginInstallCommand {
+        PluginInstallCommand(
+            install: PluginCatalogInstall(
+                manager: "pipx",
+                spec: "git+https://github.com/sawfwair/mere-run-plugins.git@main#subdirectory=packages/mere-workflow-tools",
+                ref: "main"
+            ),
+            force: force
+        )
+    }
+
+    private func pipxCapture(
+        metadata: Data,
+        version: String
+    ) -> (String, [String]) throws -> Data {
+        { executable, arguments in
+            XCTAssertEqual(executable, "pipx")
+            switch arguments {
+            case ["list", "--json"]: return metadata
+            case ["--version"]: return Data(version.utf8)
+            default:
+                XCTFail("Unexpected pipx probe: \(arguments)")
+                return Data()
+            }
+        }
+    }
+
+    private func pipxMetadata(backend: String?, package: String = "mere-workflow-tools") -> Data {
+        let backendField = backend.map { "\"backend\": \"\($0)\"," } ?? ""
+        return Data("""
+        {"venvs": {"\(package)": {"metadata": {
+          \(backendField)
+          "main_package": {
+            "package": "\(package)",
+            "package_or_url": "\(package)",
+            "pip_args": []
+          }
+        }}}}
+        """.utf8)
     }
 }
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -208,6 +208,8 @@ Public tree:
   - `mere.run plugin info` — Show one plugin's catalog entry and install command.
   - `mere.run plugin install` — Install one official plugin using its catalog install command.
   - `mere.run plugin doctor` — Run an installed plugin's doctor command.
+  - `mere.run plugin run` — Run an installed plugin without changing PATH.
+  - `mere.run plugin rollback` — Restore a retained signed plugin bundle.
 - [`mere.run setup`](/getting-started) — Choose a guided, BYOA, or manual mere.run setup path.
 - [`mere.run agent`](/getting-started) — Install and start the optional guided local setup agent.
   - `mere.run agent onboard` — Summarize this machine's model capabilities and prepare the optional Pi agent.

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -55,6 +55,35 @@ passes validation.
 Use `--channel` to select a non-default catalog channel and `--force` only when
 you intentionally want to forward a forced reinstall to the package manager.
 
+### Update or repair a plugin
+
+To replace a plugin with the selected catalog version, preview the command and
+then confirm it:
+
+```bash
+mere.run plugin install mere-doc-tools --force
+mere.run plugin install mere-doc-tools --yes --force
+```
+
+If the plugin uses a pipx environment managed by uv, forced reinstalls require
+pipx 1.16.0 or later. `mere.run` checks that environment's recorded backend and
+the pipx version before starting the reinstall. An affected version produces
+upgrade instructions and leaves the plugin unchanged. This check does not
+require you to switch backends, and it does not block fresh installations or
+environments managed by pip.
+
+If you installed pipx with Homebrew, update it and retry:
+
+```bash
+brew upgrade pipx
+mere.run plugin install mere-doc-tools --yes --force
+```
+
+For other installation methods, update pipx with the installer you used to
+install it. See the [pipx installation guide](https://pipx.pypa.io/latest/how-to/install-pipx.html).
+Pipx 1.16.0 includes the fix for
+[forced reinstalls in uv environments](https://github.com/pypa/pipx/issues/1924).
+
 ## Diagnose an installation
 
 ```bash
@@ -86,3 +115,52 @@ the graph ABI and [CLI reference](./cli.md) for every plugin option.
   `mere-run-plugins` repository.
 - Hosted-service, billing, and private deployment behavior do not belong in
   this public package.
+
+## Signed bundle pilot
+
+The signed bundle installer supports official macOS Apple Silicon releases on
+macOS 15 or later. The public catalog continues to use pipx until verified
+bundle artifacts and a compatible CLI release are published.
+
+When a channel advertises a bundle, `plugin install` verifies the publisher
+signature, exact download hash, Developer ID, and notarization. It checks the
+plugin manifests and graph providers before switching the active version.
+Installation does not require pipx, uv, Homebrew, a user-installed Python, or
+Xcode. The CLI verifies the app with macOS's built-in `codesign`,
+`syspolicy_check`, and Gatekeeper tools.
+
+```bash
+mere.run plugin install mere-doc-tools --yes
+mere.run plugin run mere-doc-tools -- process --input source.csv --output-dir output --extractor anydoc --no-redact
+mere.run plugin rollback mere-doc-tools --yes
+```
+
+Bundles are stored in the MereRun application support directory. A package's
+entrypoints share one private runtime. Existing pipx environments and PATH
+commands are not removed or rewritten. Use `plugin run` or native graph
+workflows to select the managed bundle; a bare PATH command can still refer
+to an existing pipx installation. Rollback affects all plugins in the shared
+package and revalidates the retained version before activation.
+
+To explicitly select source installation, use `--source`. A signature,
+notarization, compatibility, or download failure never falls back to pipx.
+`--force` does not bypass bundle verification or permit a downloaded downgrade.
+No unsigned bundle mode is provided.
+
+While a signed bundle is active, `plugin install --source` refuses to replace
+it. Its existing pipx entrypoints are still available directly on PATH. This
+pilot supports rollback between retained bundles, not automatic migration
+back to pipx.
+
+For an offline release review, supply the catalog, signed envelope, and DMG:
+
+```bash
+mere.run plugin install mere-doc-tools --catalog-url CATALOG_JSON \
+  --bundle-manifest RELEASE_JSON --bundle-archive BUNDLE_DMG --yes
+```
+
+These options do not change trust: the CLI still requires a known publisher
+key, a matching artifact hash, and valid macOS signatures and notarization.
+The catalog cannot introduce a new trusted key. Release metadata expires for
+new installations; existing installations continue to work offline. Signing
+proves publisher identity and integrity, not sandboxing or code safety.


### PR DESCRIPTION
## Summary

Add verified installation and execution of official macOS Apple Silicon plugin bundles, coordinated with [mere-run-plugins #32](https://github.com/sawfwair/mere-run-plugins/pull/32). Catalog URLs and release publication are deliberately unchanged.

- Verify the pinned Ed25519 publisher key, signed package identity, expiry, archive size/hash, contained paths, Developer ID, notarization policy, and plugin manifests before activation.
- Use only macOS system tools for client verification; Xcode, pipx, uv, Homebrew, and a user-installed Python are not required for advertised bundles.
- Install into a locked, versioned managed store with atomic activation, replay/conflicting-receipt rejection, and explicit retained-version rollback.
- Add `plugin run`, `plugin rollback`, explicit `--source`, and verified offline bundle inputs. Failed verification never falls back to source installation or another PATH executable.
- Preserve existing pipx installations and prevent unsafe forced reinstall of older pipx-managed uv environments. Confirmation commands preserve all supplied inputs.
- Prefer managed entrypoints for native graph providers without rewriting PATH.

## Validation

- `MERERUN_BUNDLE_TEST_ARTIFACT=... ./scripts/check.sh` passed: strict lint/build, 3,203 XCTest cases (227 skipped, zero failures), 30 Swift Testing cases, CLI help sweep, and hygiene checks.
- Real signed-pilot acceptance passed through DMG mounting, platform verification, temporary installation, relocation, and document conversion.
- The same real installer test passed with `DEVELOPER_DIR` set to a nonexistent location, checking that platform verification does not depend on Xcode selection.
- `pnpm docs:build`, staged secret scanning, and whitespace checks passed.
- The original signed bundle also passed a separate-Mac test with quarantine/Gatekeeper checks, networking blocked, an empty runtime PATH, and host Python execution blocked. That test exercised the bundle directly, not this CLI installer.

## Boundaries and rollout

The catalog remains on source installation. Publish a compatible CLI and immutable signed artifacts, then test the complete released download/install/update/rollback path before advertising bundle URLs. No release or catalog mutation occurs in this PR.

The pilot supports macOS 15+ on Apple Silicon. Signing authenticates publisher and bytes; it does not sandbox a plugin. Trust-root rotation requires a reviewed CLI update. Online revocation and transparency logs are outside this pilot.

Existing default-branch Dependabot findings in the documentation toolchain (`pnpm-lock.yaml`: postcss, vite, esbuild) are unchanged by this PR; the dependency lockfile is not modified.
