### PR TITLE
Release v0.46.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+## 0.46.0 - 2026-08-29
+
+This release expands Qwen3.8 Flash Next with long-context QSA, a smaller
+activation-weighted Q3 profile, and memory and correctness hardening. It also
+adds image-aware external evaluation packs, verified signed plugin-bundle
+installation, and faster Qwen3.8 27B MTP decode.
+
 ### Evaluation
 
 - added manifest-declared local image inputs and structured JSON object
@@ -15,6 +22,11 @@ The format is based on Keep a Changelog.
 
 ### Text
 
+- accelerated Qwen3.8 27B Q4 greedy decoding with an adaptive MTP companion,
+  serial-exact affine-Q4 verification, and verification-state rollback. In a
+  real-checkpoint run with 521 prompt tokens and 128 output tokens, adaptive
+  decode measured 49.3979 tokens per second versus 24.8290 target-only, with
+  exact greedy output parity. BF16 MTP remains opt-in.
 - added an ungated activation-weighted Q3/group-64 Flash-Next profile from the
   pinned BF16 checkpoint. Eligible non-expert matrices remain Q4, including
   Q4/group-32 n-gram storage. The 89.67 GB managed pull requires explicit Qwen
@@ -80,6 +92,24 @@ The format is based on Keep a Changelog.
   already include the required weights. `--context-size` can use the checkpoint's
   262,144-token architectural limit, subject to memory; this is not a full-262k
   qualification on the 128 GB mixed-model profile.
+
+### Plugins
+
+- added verified installation, execution, and rollback for signed macOS Apple
+  Silicon plugin bundles. Before atomic activation, the CLI validates the
+  pinned Ed25519 publisher, package identity and expiry, archive size and hash,
+  contained paths, Developer ID and notarization policy, and plugin manifests.
+  Catalog URLs remain unchanged until compatible immutable bundles are
+  published and tested end to end.
+
+### Included pull requests
+
+- exact release range: [#368](https://github.com/sawfwair/mere-run/pull/368),
+  [#371](https://github.com/sawfwair/mere-run/pull/371),
+  [#372](https://github.com/sawfwair/mere-run/pull/372),
+  [#373](https://github.com/sawfwair/mere-run/pull/373),
+  [#374](https://github.com/sawfwair/mere-run/pull/374), and
+  [#375](https://github.com/sawfwair/mere-run/pull/375).
 
 ## 0.45.0 - 2026-08-26
 

--- a/README.md
+++ b/README.md
@@ -85,14 +85,26 @@ model's manifest and validation status. Replace `MODEL_ID` with its catalog ID.
 Local inference doesn't require a hosted inference service after the models
 are installed.
 
-## Release and source build status
+## Release status
 
-On August 28, 2026, the published release was
-[v0.45.0](https://github.com/sawfwair/mere-run/releases/tag/v0.45.0).
-The following sections distinguish release packages from source builds.
+On August 29, 2026, the published release was
+[v0.46.0](https://github.com/sawfwair/mere-run/releases/tag/v0.46.0).
+The following sections summarize current and previous release packages.
 
 Model names use Q2, Q4, and Q8 for 2-bit, 4-bit, and 8-bit quantization.
 BF16 refers to bfloat16, a 16-bit floating-point format.
+
+### Release v0.46.0
+
+- Flash-Next Qwen Sparse Attention (QSA) beyond the earlier 2,048-token limit,
+  plus the public `vision-chat-q38-flash-next-3bit` activation-weighted Q3
+  profile and memory, cache, vision, and verification fixes.
+- Image inputs and structured JSON object responses in external evaluation
+  packs, with content-pinned images and strict schema validation.
+- Verified installation, execution, and rollback for signed macOS Apple
+  Silicon plugin bundles supplied through an explicit source.
+- Faster Qwen3.8 27B Q4 multi-token prediction (MTP) with exact greedy output
+  parity in the bounded release benchmark. BF16 MTP remains opt-in.
 
 ### Release v0.45.0
 
@@ -113,11 +125,11 @@ BF16 refers to bfloat16, a 16-bit floating-point format.
 - Improvements to Nemotron tool calls, text training templates, and Gemma 4
   Turbo API serving.
 
-### Source builds after v0.45.0
+### Qwen3.8 Flash Next qualification notes
 
-Builds from `main` add Flash-Next Qwen Sparse Attention (QSA) beyond the
-release's 2,048-token limit for the prompt and generated response combined.
-They also add the public, ungated
+Release v0.46.0 adds Flash-Next Qwen Sparse Attention (QSA) beyond the earlier
+2,048-token limit for the prompt and generated response combined. It also adds
+the public, ungated
 `vision-chat-q38-flash-next-3bit` activation-weighted Q3 profile. Its 89.67 GB
 managed pull requires explicit Qwen Community License 1.0 acceptance. Qwen3.8
 27B also has MTP decoding improvements. Its MTP path remains opt-in.
@@ -469,7 +481,7 @@ uses `sudo` only if the destination requires it. For app integrations, see the
 ### Install on Linux
 
 Linux packages contain the headless CLI and runtime assets, not macOS Studio.
-Release v0.45.0 provides CUDA x86_64 tarballs and Debian packages. Its release
+Release v0.46.0 provides CUDA x86_64 tarballs and Debian packages. Its release
 smoke test ran on an RTX 3080 Ti with Ubuntu 24.04. Hosted CPU tests and that
 CUDA test don't establish every model's compatibility on every Linux host.
 

--- a/Sources/MereRunRelayKit/MereRunCLIVersion.swift
+++ b/Sources/MereRunRelayKit/MereRunCLIVersion.swift
@@ -2,7 +2,7 @@
 /// contract version floors, worker probes, and the built-in node catalog
 /// identity.
 public enum MereRunCLIVersion {
-    public static let current = "0.45.0"
+    public static let current = "0.46.0"
 }
 
 /// Lenient three-component version-floor comparison used by worker

--- a/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
+++ b/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
@@ -130,7 +130,7 @@ final class CLIModelStoreBootstrapTests: XCTestCase {
     }
 
     func testMereRunCLIExposesReleaseVersion() {
-        XCTAssertEqual(MereRunCLIVersion.current, "0.45.0")
+        XCTAssertEqual(MereRunCLIVersion.current, "0.46.0")
         XCTAssertEqual(MereRunCLI.configuration.version, MereRunCLIVersion.current)
     }
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -830,7 +830,7 @@ Key options:
   27B use their published 262,144-token limit by default. Inkling-Small advertises
   1,048,576 tokens but uses a 32,768-token operational default because KV
   residency grows with context. Qwen3.8-Flash-Next uses learned QSA selection
-  beyond 2,048 tokens in builds newer than v0.45.0. Its 262,144-token limit is
+  beyond 2,048 tokens in version 0.46.0 and later. Its 262,144-token limit is
   architectural, not a full-context memory qualification for a 128 GB Mac;
   explicitly select a smaller window such as `32768` to bound retained history.
 - `--temperature`: defaults to 0.7, or the model's published value where one

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -312,7 +312,7 @@ against progress-report granularity and per-chunk activation memory.
 Qwen3.8-Flash-Next additionally tiles sparse attention in 16-query groups and
 primes MTP history in 256-token chunks. Those internal bounds do not truncate
 context: retained KV and MTP history still scale with `--context-size`. The QSA
-long-context path is available in builds newer than v0.45.0.
+long-context path is available in version 0.46.0 and later.
 
 ### `MERERUN_Q35_BATCHED_GPU_SAMPLING`
 

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -401,8 +401,8 @@ All three artifacts include the Qwen Community License 1.0 and a complete
 source/output hash receipt. Pulls are explicit and require either
 `--accept-model-license` or its equivalent `--accept-license-terms` alias. The
 native Qwen4Exp runtime supports text generation; image input remains
-unqualified. Builds newer than v0.45.0 implement the trained QSA micro-block
-selector beyond 2,048 tokens, replacing that release's prompt-plus-generation
+unqualified. Version 0.46.0 and later implement the trained QSA micro-block
+selector beyond 2,048 tokens, replacing v0.45.0's prompt-plus-generation
 cap. Up to the indexer budget, standard causal attention is exact because every
 visible block is selected. Beyond it, each query selects 512 complete four-token
 blocks and includes the current partial block. Future blocks are excluded

--- a/scripts/build_mere_run_app.sh
+++ b/scripts/build_mere_run_app.sh
@@ -15,7 +15,7 @@ cd "$repo_root"
 
 # Version/build derive from git when not provided, so the bundle has a single source of
 # truth in CI. Fall back to a pinned value when git metadata is unavailable.
-default_version="0.45.0"
+default_version="0.46.0"
 if git_version="$(git describe --tags --exact-match 2>/dev/null)"; then
   default_version="${git_version#v}"
 fi


### PR DESCRIPTION
## Summary

- bump the CLI and macOS fallback version to 0.46.0
- publish release notes for the exact post-v0.45.0 range: #368 and #371 through #375
- move QSA, Q3, multimodal evaluation, and signed plugin-bundle documentation from source-build status into the v0.46.0 release

## Validation

- env -u MERERUN_RUN_E2E nice -n 10 ./scripts/check.sh
  - SwiftLint: zero violations across 1,396 files
  - XCTest: 3,276 tests, 265 expected asset/GPU skips, zero failures
  - Swift Testing: 30 tests passed
  - build, CLI help sweep, and hygiene checks passed
- pnpm docs:build
- gitleaks protect --staged --redact
- git diff --check

## Release boundary

This PR prepares the source release only. Tagging, signed/notarized packaging, installed-model smoke, CUDA packaging/lifecycle validation, GitHub release publication, R2 upload, and remote readback occur only after this PR merges.