### PR TITLE
Release v0.46.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,24 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+## 0.46.1 - 2026-08-29
+
+This corrective release restores the advertised vision and video contracts
+that the full installed-model release gate caught before v0.46.0 publication.
+
+### Text
+
+- fixed `vision-chat-q38-27b-4bit` image inference by mounting the pinned
+  official Qwen3.8 vision configuration and first indexed weight shard under
+  `vision/`. The optimized EigenLabs language target and its MTP companion
+  remain unchanged.
+
+### Video
+
+- fixed LTX 2.3 text-to-video and audio-to-video checkpoint loading by matching
+  that release's biased video feed-forward layers. LTX 2.5 retains its
+  bias-free layer layout.
+
 ## 0.46.0 - 2026-08-29
 
 This release expands Qwen3.8 Flash Next with long-context QSA, a smaller

--- a/README.md
+++ b/README.md
@@ -88,11 +88,19 @@ are installed.
 ## Release status
 
 On August 29, 2026, the published release was
-[v0.46.0](https://github.com/sawfwair/mere-run/releases/tag/v0.46.0).
+[v0.46.1](https://github.com/sawfwair/mere-run/releases/tag/v0.46.1).
 The following sections summarize current and previous release packages.
 
 Model names use Q2, Q4, and Q8 for 2-bit, 4-bit, and 8-bit quantization.
 BF16 refers to bfloat16, a 16-bit floating-point format.
+
+### Release v0.46.1
+
+- Restored image inference for the optimized Qwen3.8 27B Q4 package by adding
+  its pinned official vision component without replacing the optimized text
+  target or MTP companion.
+- Restored LTX 2.3 text-to-video and audio-to-video loading while preserving
+  the separate LTX 2.5 checkpoint layout.
 
 ### Release v0.46.0
 
@@ -481,7 +489,7 @@ uses `sudo` only if the destination requires it. For app integrations, see the
 ### Install on Linux
 
 Linux packages contain the headless CLI and runtime assets, not macOS Studio.
-Release v0.46.0 provides CUDA x86_64 tarballs and Debian packages. Its release
+Release v0.46.1 provides CUDA x86_64 tarballs and Debian packages. Its release
 smoke test ran on an RTX 3080 Ti with Ubuntu 24.04. Hosted CPU tests and that
 CUDA test don't establish every model's compatibility on every Linux host.
 

--- a/Sources/MereRunCore/LTX/LTXDistilledLatentGenerator.swift
+++ b/Sources/MereRunCore/LTX/LTXDistilledLatentGenerator.swift
@@ -4583,7 +4583,9 @@ public actor LTXUnifiedAVGenerator {
         let textEncoderSeconds = ltxMonotonicSeconds() - textStart
 
         let transformerStart = ltxMonotonicSeconds()
-        let model = LTXUnifiedAVTransformerV2()
+        let model = LTXUnifiedAVTransformerV2(
+            checkpointKind: isLTX25 ? .ltx25 : .ltx23
+        )
         if isLTX25 {
             try loadLTX25TransformerWeights(url: transformerURL, model: model, dtype: dtype)
         } else {
@@ -4766,7 +4768,7 @@ public actor LTXUnifiedAVGenerator {
         let transformerStart = ltxMonotonicSeconds()
         let model: any LTXUnifiedAVTransformerRuntime
         if isLTX23 {
-            let splitModel = LTXUnifiedAVTransformerV2()
+            let splitModel = LTXUnifiedAVTransformerV2(checkpointKind: .ltx23)
             try SafetensorsStreamingLoader.applyWeightsStreaming(
                 url: transformerURL,
                 to: splitModel,
@@ -10187,6 +10189,15 @@ private struct LTXV2TextProjectionCache {
     let audio: [LTXAttentionProjectedContext]
 }
 
+enum LTXUnifiedAVTransformerCheckpointKind {
+    case ltx23
+    case ltx25
+
+    var videoFeedForwardBias: Bool {
+        self == .ltx23
+    }
+}
+
 private final class LTXUnifiedAVTransformerV2: Module, LTXUnifiedAVTransformerRuntime {
     let videoDim = 4096
     let audioDim = 2048
@@ -10205,6 +10216,7 @@ private final class LTXUnifiedAVTransformerV2: Module, LTXUnifiedAVTransformerRu
     private var activeTextProjectionCache: LTXV2TextProjectionCache?
     private var activeTeaCacheController: LTXTeaCacheController?
     private var activeTeaCacheRequest: LTXTeaCacheRequest?
+    private let videoFeedForwardBias: Bool
 
     @ModuleInfo(key: "patchify_proj") var patchifyProj: Linear
     @ModuleInfo(key: "keyframes_abs_pos_embedding") var keyframesAbsPosEmbedding: MLXArray
@@ -10226,7 +10238,8 @@ private final class LTXUnifiedAVTransformerV2: Module, LTXUnifiedAVTransformerRu
     @ModuleInfo(key: "norm_out") var normOut: LayerNorm
     @ModuleInfo(key: "audio_norm_out") var audioNormOut: LayerNorm
 
-    override init() {
+    init(checkpointKind: LTXUnifiedAVTransformerCheckpointKind = .ltx25) {
+        self.videoFeedForwardBias = checkpointKind.videoFeedForwardBias
         self._patchifyProj.wrappedValue = Linear(128, videoDim, bias: true)
         self._keyframesAbsPosEmbedding.wrappedValue = MLX.zeros([1, videoDim], dtype: .float32)
         self._audioPatchifyProj.wrappedValue = Linear(128, audioDim, bias: true)
@@ -10258,7 +10271,9 @@ private final class LTXUnifiedAVTransformerV2: Module, LTXUnifiedAVTransformerRu
             embeddingCoefficient: 1
         )
         self._transformerBlocks.wrappedValue = (0..<48).map { _ in
-            LTXUnifiedAVTransformerV2Block()
+            LTXUnifiedAVTransformerV2Block(
+                videoFeedForwardBias: checkpointKind.videoFeedForwardBias
+            )
         }
         self._normOut.wrappedValue = LayerNorm(dimensions: videoDim, eps: 1e-6, affine: false)
         self._audioNormOut.wrappedValue = LayerNorm(dimensions: audioDim, eps: 1e-6, affine: false)
@@ -10643,7 +10658,9 @@ private final class LTXUnifiedAVTransformerV2: Module, LTXUnifiedAVTransformerRu
         if let compiledBlockRunner {
             runner = compiledBlockRunner
         } else {
-            let created = LTXUnifiedAVTransformerV2Block()
+            let created = LTXUnifiedAVTransformerV2Block(
+                videoFeedForwardBias: videoFeedForwardBias
+            )
             compiledBlockRunner = created
             runner = created
         }
@@ -10767,7 +10784,7 @@ private final class LTXUnifiedAVTransformerV2Block: Module {
     @ModuleInfo(key: "scale_shift_table_a2v_ca_video") var scaleShiftTableA2VCAVideo: MLXArray
     @ModuleInfo(key: "scale_shift_table_a2v_ca_audio") var scaleShiftTableA2VCAAudio: MLXArray
 
-    override init() {
+    init(videoFeedForwardBias: Bool = false) {
         self._attn1.wrappedValue = LTXDistilledAttention(
             queryDim: videoDim,
             contextDim: nil,
@@ -10820,7 +10837,7 @@ private final class LTXUnifiedAVTransformerV2Block: Module {
             dim: videoDim,
             dimOut: videoDim,
             mult: 4,
-            bias: false
+            bias: videoFeedForwardBias
         )
         self._audioFF.wrappedValue = LTXDistilledFeedForward(dim: audioDim, dimOut: audioDim, mult: 4)
         self._scaleShiftTable.wrappedValue = MLX.zeros([9, videoDim], dtype: .float32)

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -1799,6 +1799,14 @@ public enum ManagedModelCatalog {
                     )
                 ),
                 MountedHubFallbackConfig(
+                    destinationPath: Q35Resources.q38VisionComponentPath,
+                    hubFallback: HubFallbackConfig(
+                        repoId: Q35Resources.q38TwentySevenBUpstreamRepoId,
+                        revision: Q35Resources.q38TwentySevenBUpstreamRevision,
+                        patterns: Q35Resources.q38VisionComponentSnapshotPatterns
+                    )
+                ),
+                MountedHubFallbackConfig(
                     destinationPath: Q35Resources.q38LicenseComponentPath,
                     hubFallback: HubFallbackConfig(
                         repoId: Q35Resources.q38TwentySevenBUpstreamRepoId,
@@ -1811,7 +1819,8 @@ public enum ManagedModelCatalog {
             upstreamRevision: Q35Resources.q38TwentySevenB4BitUpstreamRevision,
             validationKind: .q35,
             runtimeAutoDownloadAllowed: false,
-            estimatedDownloadBytes: Q35Resources.q38TwentySevenB4BitEstimatedDownloadBytes,
+            estimatedDownloadBytes: Q35Resources.q38TwentySevenB4BitEstimatedDownloadBytes
+                + Q35Resources.q38VisionComponentEstimatedDownloadBytes,
             defaultCLICommands: [
                 "text chat",
                 "api serve",
@@ -4059,6 +4068,7 @@ public extension ManagedModelSpec {
             var missing = resources.validate(fileManager: fileManager)
             if id == Q35Resources.q38TwentySevenB4BitModelId {
                 missing.append(contentsOf: resources.validateQ38MTPComponent(fileManager: fileManager))
+                missing.append(contentsOf: resources.validateQ38VisionComponent(fileManager: fileManager))
             }
             return missing
         case .q35MTPAssistant:

--- a/Sources/MereRunCore/Q35/Q35Generator.swift
+++ b/Sources/MereRunCore/Q35/Q35Generator.swift
@@ -159,6 +159,7 @@ public actor Q35Generator: ChatGenerator {
     private var loadedConfig: Q35Config?
     private var loadedGenerationEOSTokenIds: [Int] = []
     private var loadedResources: Q35Resources?
+    private var loadedVisionResources: Q35Resources?
 
     #if DEBUG
     private var checkpointTransformForTesting: (@Sendable (Q35Model) throws -> Void)?
@@ -405,6 +406,7 @@ public actor Q35Generator: ChatGenerator {
         loadedConfig = nil
         loadedGenerationEOSTokenIds = []
         loadedResources = nil
+        loadedVisionResources = nil
         Memory.clearCache()
     }
 
@@ -496,7 +498,22 @@ public actor Q35Generator: ChatGenerator {
             _ = q35Model.prepareFusedSwitchGLU()
         }
 
-        let tower = config.visionConfig == nil ? nil : Q35VisionTower(config: config)
+        let primaryResources = Q35Resources(rootURL: normalizedRoot)
+        let visionConfigAndResources: (Q35Config, Q35Resources)?
+        if config.visionConfig != nil {
+            visionConfigAndResources = (config, primaryResources)
+        } else if modelId == Q35Resources.q38TwentySevenB4BitModelId {
+            let companionResources = primaryResources.q38VisionComponentResources
+            let companionConfigData = try Data(contentsOf: companionResources.configURL)
+            let companionConfig = try JSONDecoder().decode(Q35Config.self, from: companionConfigData)
+            guard companionConfig.visionConfig != nil else {
+                throw Q35Error.generationFailed("Qwen3.8 4-bit vision companion does not include a vision config.")
+            }
+            visionConfigAndResources = (companionConfig, companionResources)
+        } else {
+            visionConfigAndResources = nil
+        }
+        let tower = visionConfigAndResources.map { Q35VisionTower(config: $0.0) }
         // Load the MTP draft head whenever it ships with the model and isn't
         // explicitly disabled. Whether speculation is actually USED is decided
         // by the model-specific policy in Self.shouldSpeculate. Dense Qwen3.8
@@ -566,6 +583,7 @@ public actor Q35Generator: ChatGenerator {
         loadedConfig = config
         loadedGenerationEOSTokenIds = generationEOSTokenIds
         loadedResources = resources
+        loadedVisionResources = visionConfigAndResources?.1
         loadedModelPath = normalizedRoot.path
     }
 
@@ -2882,10 +2900,10 @@ public actor Q35Generator: ChatGenerator {
     ) throws {
         guard let visionTower else { return }
         guard !visionTower.isLoaded else { return }
-        guard let loadedResources else { throw Q35Error.modelNotLoaded }
+        guard let loadedVisionResources else { throw Q35Error.modelNotLoaded }
 
         progressHandler?(ChatProgress(stage: .loadingModel, message: "Loading Qwen-family vision tower"))
-        try visionTower.loadWeights(from: loadedResources)
+        try visionTower.loadWeights(from: loadedVisionResources)
     }
 
     private func buildVisionReplacements(

--- a/Sources/MereRunCore/Q35/Q35Resources.swift
+++ b/Sources/MereRunCore/Q35/Q35Resources.swift
@@ -127,6 +127,15 @@ public struct Q35Resources: Sendable, Hashable {
     public static let q38MTP4BitUpstreamRepoId = "morgan/qwen38-27b-mtp-r20k-lr3-q4-g64-q2-rerank"
     public static let q38MTP4BitUpstreamRevision = "fd4a99c590dd6e468c0e2a28168c235e32151a4b"
     public static let q38MTPComponentSnapshotPatterns = ["model.safetensors"]
+    public static let q38VisionComponentPath = "vision"
+    public static let q38VisionComponentSnapshotPatterns = [
+        "config.json",
+        "model.safetensors.index.json",
+        "model-00001-of-00018.safetensors",
+        "preprocessor_config.json",
+        "video_preprocessor_config.json",
+    ]
+    public static let q38VisionComponentEstimatedDownloadBytes: Int64 = 3_967_000_000
     public static let q38LicenseComponentPath = "licenses/qwen3.8"
     public static let q38LicenseComponentSnapshotPatterns = ["LICENSE"]
     public static let q38TwentySevenBContextLength = 262_144
@@ -400,6 +409,20 @@ public struct Q35Resources: Sendable, Hashable {
             isDirectory: true
         )
         return Self.q38MTPComponentSnapshotPatterns
+            .map { componentRoot.appendingPathComponent($0, isDirectory: false) }
+            .filter { !fileManager.fileExists(atPath: $0.path) }
+    }
+
+    public var q38VisionComponentResources: Q35Resources {
+        Q35Resources(rootURL: rootURL.appendingPathComponent(
+            Self.q38VisionComponentPath,
+            isDirectory: true
+        ))
+    }
+
+    public func validateQ38VisionComponent(fileManager: FileManager = .default) -> [URL] {
+        let componentRoot = q38VisionComponentResources.rootURL
+        return Self.q38VisionComponentSnapshotPatterns
             .map { componentRoot.appendingPathComponent($0, isDirectory: false) }
             .filter { !fileManager.fileExists(atPath: $0.path) }
     }

--- a/Sources/MereRunRelayKit/MereRunCLIVersion.swift
+++ b/Sources/MereRunRelayKit/MereRunCLIVersion.swift
@@ -2,7 +2,7 @@
 /// contract version floors, worker probes, and the built-in node catalog
 /// identity.
 public enum MereRunCLIVersion {
-    public static let current = "0.46.0"
+    public static let current = "0.46.1"
 }
 
 /// Lenient three-component version-floor comparison used by worker

--- a/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
+++ b/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
@@ -130,7 +130,7 @@ final class CLIModelStoreBootstrapTests: XCTestCase {
     }
 
     func testMereRunCLIExposesReleaseVersion() {
-        XCTAssertEqual(MereRunCLIVersion.current, "0.46.0")
+        XCTAssertEqual(MereRunCLIVersion.current, "0.46.1")
         XCTAssertEqual(MereRunCLI.configuration.version, MereRunCLIVersion.current)
     }
 

--- a/Tests/MereRunCoreTests/LTXUnifiedAVTransformerV2Tests.swift
+++ b/Tests/MereRunCoreTests/LTXUnifiedAVTransformerV2Tests.swift
@@ -36,4 +36,9 @@ final class LTXUnifiedAVTransformerV2Tests: XCTestCase {
             dtype: .float32
         ).isEmpty)
     }
+
+    func testLTX23AndLTX25UseTheirPublishedVideoFeedForwardBiasContracts() {
+        XCTAssertTrue(LTXUnifiedAVTransformerCheckpointKind.ltx23.videoFeedForwardBias)
+        XCTAssertFalse(LTXUnifiedAVTransformerCheckpointKind.ltx25.videoFeedForwardBias)
+    }
 }

--- a/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
@@ -801,7 +801,7 @@ final class ManagedModelCatalogTests: XCTestCase {
         XCTAssertEqual(spec.apiProfile?.compatibility.supportsReasoningEffort, true)
     }
 
-    func testQ38TwentySevenB4BitUsesCrownedTargetAndQuantizedMTPHead() throws {
+    func testQ38TwentySevenB4BitUsesCrownedTargetWithMTPAndVisionComponents() throws {
         let spec = try XCTUnwrap(
             ManagedModelCatalog.spec(for: Q35Resources.q38TwentySevenB4BitModelId)
         )
@@ -811,7 +811,7 @@ final class ManagedModelCatalogTests: XCTestCase {
         XCTAssertEqual(spec.installShape, .directoryRoot)
         XCTAssertEqual(spec.hubFallback?.repoId, Q35Resources.q38TwentySevenB4BitUpstreamRepoId)
         XCTAssertEqual(spec.hubFallback?.revision, Q35Resources.q38TwentySevenB4BitUpstreamRevision)
-        XCTAssertEqual(spec.mountedHubFallbacks.count, 2)
+        XCTAssertEqual(spec.mountedHubFallbacks.count, 3)
         XCTAssertEqual(spec.mountedHubFallbacks.first?.destinationPath, Q35Resources.q38MTPComponentPath)
         XCTAssertEqual(
             spec.mountedHubFallbacks.first?.hubFallback.repoId,
@@ -834,6 +834,22 @@ final class ManagedModelCatalogTests: XCTestCase {
             Q35Resources.q38MTPComponentSnapshotPatterns
         )
         XCTAssertEqual(
+            spec.mountedHubFallbacks[1].destinationPath,
+            Q35Resources.q38VisionComponentPath
+        )
+        XCTAssertEqual(
+            spec.mountedHubFallbacks[1].hubFallback.repoId,
+            Q35Resources.q38TwentySevenBUpstreamRepoId
+        )
+        XCTAssertEqual(
+            spec.mountedHubFallbacks[1].hubFallback.revision,
+            Q35Resources.q38TwentySevenBUpstreamRevision
+        )
+        XCTAssertEqual(
+            spec.mountedHubFallbacks[1].hubFallback.patterns,
+            Q35Resources.q38VisionComponentSnapshotPatterns
+        )
+        XCTAssertEqual(
             spec.mountedHubFallbacks.last?.destinationPath,
             Q35Resources.q38LicenseComponentPath
         )
@@ -847,7 +863,7 @@ final class ManagedModelCatalogTests: XCTestCase {
         )
         XCTAssertEqual(spec.validationKind, .q35)
         XCTAssertEqual(spec.defaultRuntimeServingEngine, .textChatQ36)
-        XCTAssertEqual(spec.estimatedDownloadBytes, 15_520_000_000)
+        XCTAssertEqual(spec.estimatedDownloadBytes, 19_487_000_000)
         XCTAssertFalse(spec.runtimeAutoDownloadAllowed)
         XCTAssertTrue(spec.defaultCLICommands.contains("model benchmark code"))
         XCTAssertEqual(spec.apiProfile?.thinkingLevels, [.low, .medium, .xhigh])
@@ -882,7 +898,7 @@ final class ManagedModelCatalogTests: XCTestCase {
         XCTAssertNotNil(q4.usageRestriction)
     }
 
-    func testQ38TwentySevenB4BitValidationRequiresMountedMTPFiles() throws {
+    func testQ38TwentySevenB4BitValidationRequiresMountedComponents() throws {
         let spec = try XCTUnwrap(
             ManagedModelCatalog.spec(for: Q35Resources.q38TwentySevenB4BitModelId)
         )
@@ -894,13 +910,24 @@ final class ManagedModelCatalogTests: XCTestCase {
 
         XCTAssertEqual(
             Set(spec.missingPaths(in: root).map(\.lastPathComponent)),
-            Set(Q35Resources.q38MTPComponentSnapshotPatterns)
+            Set(
+                Q35Resources.q38MTPComponentSnapshotPatterns
+                    + Q35Resources.q38VisionComponentSnapshotPatterns
+            )
         )
 
         let mtpRoot = root.appendingPathComponent(Q35Resources.q38MTPComponentPath, isDirectory: true)
         try FileManager.default.createDirectory(at: mtpRoot, withIntermediateDirectories: true)
         for filename in Q35Resources.q38MTPComponentSnapshotPatterns {
             try Data().write(to: mtpRoot.appendingPathComponent(filename))
+        }
+        let visionRoot = root.appendingPathComponent(
+            Q35Resources.q38VisionComponentPath,
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: visionRoot, withIntermediateDirectories: true)
+        for filename in Q35Resources.q38VisionComponentSnapshotPatterns {
+            try Data().write(to: visionRoot.appendingPathComponent(filename))
         }
         let licenseRoot = root.appendingPathComponent(
             Q35Resources.q38LicenseComponentPath,

--- a/Tests/MereRunCoreTests/MereRunModelManifestTests.swift
+++ b/Tests/MereRunCoreTests/MereRunModelManifestTests.swift
@@ -233,7 +233,7 @@ final class MereRunModelManifestTests: MereRunCoreTestCase {
         )
     }
 
-    func testQ38TwentySevenB4BitTemplateRecordsTargetAndMTPSources() throws {
+    func testQ38TwentySevenB4BitTemplateRecordsTargetMTPAndVisionSources() throws {
         let manifest = MereRunModelManifest.template(
             for: .q38TwentySevenB4Bit,
             createdAt: Date(timeIntervalSince1970: 0)
@@ -252,12 +252,15 @@ final class MereRunModelManifestTests: MereRunCoreTestCase {
             "\(Q35Resources.q38TwentySevenB4BitUpstreamRepoId)"
                 + "@\(Q35Resources.q38TwentySevenB4BitUpstreamRevision)"
         )
-        XCTAssertEqual(manifest.sources?.count, 3)
+        XCTAssertEqual(manifest.sources?.count, 4)
         XCTAssertEqual(manifest.sources?.first?.role, "primary")
         XCTAssertEqual(manifest.sources?.first?.repository, Q35Resources.q38TwentySevenB4BitUpstreamRepoId)
         XCTAssertEqual(manifest.sources?[1].role, "component")
         XCTAssertEqual(manifest.sources?[1].repository, Q35Resources.q38MTP4BitUpstreamRepoId)
         XCTAssertEqual(manifest.sources?[1].destinationPath, Q35Resources.q38MTPComponentPath)
+        XCTAssertEqual(manifest.sources?[2].role, "component")
+        XCTAssertEqual(manifest.sources?[2].repository, Q35Resources.q38TwentySevenBUpstreamRepoId)
+        XCTAssertEqual(manifest.sources?[2].destinationPath, Q35Resources.q38VisionComponentPath)
         XCTAssertEqual(manifest.sources?.last?.role, "component")
         XCTAssertEqual(manifest.sources?.last?.repository, Q35Resources.q38TwentySevenBUpstreamRepoId)
         XCTAssertEqual(manifest.sources?.last?.destinationPath, Q35Resources.q38LicenseComponentPath)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -2538,7 +2538,8 @@ uses the supported members of the coding comparison lane for this machine:
 specific explicit comparison. The installed `vision-chat-q38-27b` and
 `vision-chat-q38-27b-4bit` code-generation lanes are available as explicit
 targets but are not added to the default comparison. The BF16 checkpoint is
-55.59 GB; the 4-bit target plus official MTP shard is 19.47 GB.
+55.59 GB; the 4-bit target plus its MTP and official vision components is
+19.49 GB.
 
 ```bash
 swift run mere.run model benchmark code \

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -486,9 +486,10 @@ Qwen3.8-Flash-Next profiles. Set this to
 window is large enough; set it to `0`, `false`, or `no` to disable MTP. Any other
 value, including unset, uses the model-specific policy. Qwen3.8's dense head is
 embedded in the BF16 checkpoint; `vision-chat-q38-27b-4bit` mounts the matching
-4-bit/group-64 MLX Fast proposal head with a 2-bit shortlist readout. The Q4
-target enables serial-exact MTP by default; BF16 remains opt-in. Qwen3.6 hybrid
-MoE retains its adaptive default. Flash-Next uses its bundled
+4-bit/group-64 MLX Fast proposal head with a 2-bit shortlist readout and mounts
+its pinned official vision tower separately under `vision/`. The Q4 target
+enables serial-exact MTP by default; BF16 remains opt-in. Qwen3.6 hybrid MoE
+retains its adaptive default. Flash-Next uses its bundled
 one-layer head by default for greedy short-prompt decode after exact target
 verification and real-checkpoint speed qualification. When continuous batching is enabled, an eligible
 MTP request takes the speculative lane only if no peer is already admitted. A

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -362,10 +362,14 @@ The managed pull mounts the track's matching proposal-only 4-bit/group-64 head,
 `morgan/qwen38-27b-mtp-r20k-lr3-q4-g64-q2-rerank` at revision
 `fd4a99c590dd6e468c0e2a28168c235e32151a4b`, under `mtp/`. The companion uses
 a proposal-only 2-bit compact readout with exact 4-bit shortlist reranking.
-Qwen's official Apache-2.0 license is retained separately from the official
-pinned revision. The sources total about 15.52 GB. Greedy MTP decode is enabled
-by default for this quantized target because its small-batch Q4 verification is
-serial-exact; set `MERERUN_Q35_MTP_SPECULATION=0` to use target-only decode.
+Because the optimized target doesn't contain a vision tower, the managed pull
+also mounts the official Qwen3.8 configuration, processor metadata, weight
+index, and the first indexed BF16 shard under `vision/` from the pinned official
+revision above. That shard contains all 333 vision tensors; language tensors in
+it are not loaded. Qwen's official Apache-2.0 license is retained separately.
+The sources total about 19.49 GB. Greedy MTP decode is enabled by default for
+this quantized target because its small-batch Q4 verification is serial-exact;
+set `MERERUN_Q35_MTP_SPECULATION=0` to use target-only decode.
 
 `vision-chat-q38-flash-next-mixed` installs Sawfwair's immutable
 `Qwen3.8-Flash-Next-MLX-Mixed-2bit` revision

--- a/docs/runtime/api-server.md
+++ b/docs/runtime/api-server.md
@@ -529,7 +529,8 @@ Engine compatibility:
   or the pinned MLX 4-bit conversion. Both accept function tools, one
   local/base64 image content part per message, and structured JSON output; both
   default to thinking and the published 1.0/0.95/20 sampling. Pull the 55.59 GB
-  BF16 lane or 19.47 GB 4-bit-plus-MTP lane explicitly before serving it.
+  BF16 lane or 19.49 GB 4-bit lane with its MTP and official vision components
+  explicitly before serving it.
 - `text-chat-bonsai-27b-1bit` and `text-chat-bonsai-27b-2bit`: use the same
   native Qwen-family serving engine for Prism ML's dense packed binary and
   ternary 27B checkpoints. They accept function tools and one local/base64

--- a/docs/runtime/text.md
+++ b/docs/runtime/text.md
@@ -44,7 +44,7 @@ help in the repository gate.
 - `text-chat-nemotron-35-lightning` (managed NVIDIA Nemotron 3.5 Lightning 30B-A3B NVFP4 target plus DSpark)
 - `text-chat-q36-nano`
 - `vision-chat-q38-27b` (managed official Qwen3.8 27B BF16 vision-language snapshot)
-- `vision-chat-q38-27b-4bit` (managed MLX 4-bit target plus pinned official MTP shard)
+- `vision-chat-q38-27b-4bit` (managed MLX 4-bit target plus pinned MTP and official vision components)
 - `text-chat-bonsai-27b-1bit` (managed packed 1-bit dense Qwen3.6 27B vision/reasoning snapshot)
 - `text-chat-bonsai-27b-2bit` (managed packed 2-bit ternary dense Qwen3.6 27B vision/reasoning snapshot)
 - `text-chat-lfm25-2.6b-4bit` (managed LiquidAI LFM2.5 2.6B dense MLX 4-bit snapshot)
@@ -349,10 +349,12 @@ swift run mere.run text chat \
   --prompt "Implement a bounded async work queue in Swift."
 ```
 
-This installs the pinned MLX Fast 4-bit/group-64 target and its matching
-proposal-only 4-bit/group-64 MTP head under `mtp/`, totaling about 15.39 GB;
-the managed install also retains Qwen's official Apache-2.0 license. On the
-measured M4 Max coding slice,
+This installs the pinned MLX Fast 4-bit/group-64 target, its matching
+proposal-only 4-bit/group-64 MTP head under `mtp/`, and the pinned official BF16
+vision component under `vision/`, totaling about 19.49 GB. Only the official
+shard containing the vision tower is mounted, and language tensors in that
+shard are not loaded. The managed install also retains Qwen's official
+Apache-2.0 license. On the measured M4 Max coding slice,
 target-only warm decode reached about 26.5 tok/s versus 8.8 tok/s for BF16;
 explicit MTP reached 37.8–43.8 tok/s across the three short cases. All cases
 passed. On a deterministic 24-task stride through the official HumanEval set,

--- a/scripts/build_mere_run_app.sh
+++ b/scripts/build_mere_run_app.sh
@@ -15,7 +15,7 @@ cd "$repo_root"
 
 # Version/build derive from git when not provided, so the bundle has a single source of
 # truth in CI. Fall back to a pinned value when git metadata is unavailable.
-default_version="0.46.0"
+default_version="0.46.1"
 if git_version="$(git describe --tags --exact-match 2>/dev/null)"; then
   default_version="${git_version#v}"
 fi


### PR DESCRIPTION
## Summary

- restore image inference for `vision-chat-q38-27b-4bit` by mounting the pinned official Qwen3.8 vision component alongside the optimized text target and MTP head
- load LTX 2.3 video feed-forward layers with their checkpoint bias contract while retaining the bias-free LTX 2.5 layout
- bump the distribution to v0.46.1 and document the corrected component footprint

The v0.46.0 tag and locally built artifacts were never published. Its full installed-model release smoke caught these four failures before publication, so this patch release supersedes that candidate without moving the existing tag.

## Validation

- `./scripts/check.sh` (3,277 tests, 0 failures; strict lint and hygiene passed)
- `pnpm install --frozen-lockfile && pnpm docs:build`
- `gitleaks detect --source . --no-banner --redact --log-level warn`
- real Qwen3.8 Q4 image prompt against the optimized target plus pinned official vision shard
- real LTX 2.3 draft, full text-to-video, and audio-to-video generation at the release-gate recipes