### PR TITLE
Ship native-only LTX 2.5 model packages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+### Video
+
+- moved both managed LTX 2.5 downloads to immutable inference-only MLX
+  distributions whose BF16 transformers are already stored in mere.run's
+  native module-key layout. Distilled retains its bundled Q4 Gemma 4 text
+  tower, while Full retains BF16 text and every full/dev parity component.
+  Fresh installs no longer keep official transformer files beside generated
+  native optimization copies, and `model optimize` treats a pre-keyed package
+  as already optimized.
+
 ## 0.46.1 - 2026-08-29
 
 This corrective release restores the advertised vision and video contracts

--- a/Sources/MereRunCLI/Commands/ModelInfoCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelInfoCommand.swift
@@ -307,12 +307,28 @@ struct ModelInfo: ParsableCommand {
         full: Bool = false,
         fileManager: FileManager = .default
     ) -> [String] {
-        var lines = [
-            full
+        let resources = LTX25Resources(rootURL: rootURL)
+        let usesNativeLayout = !fileManager.fileExists(
+            atPath: resources.distilledTransformerURL.path
+        )
+        let layout: String
+        if usesNativeLayout {
+            layout = full
+                ? "  layout: self-contained native LTX 2.5 full BF16 files"
+                : "  layout: self-contained native LTX 2.5 BF16 + MLX Q4 text files"
+        } else {
+            layout = full
                 ? "  layout: official LTX 2.5 packed BF16 files"
-                : "  layout: self-contained LTX 2.5 BF16 + MLX Q4 text files",
-        ]
-        for file in full ? ltx25FullComponentFiles : ltx25ComponentFiles {
+                : "  layout: official LTX 2.5 BF16 + MLX Q4 text files"
+        }
+        var lines = [layout]
+        let componentFiles = switch (full, usesNativeLayout) {
+        case (true, true): ltx25NativeFullComponentFiles
+        case (true, false): ltx25FullComponentFiles
+        case (false, true): ltx25NativeComponentFiles
+        case (false, false): ltx25ComponentFiles
+        }
+        for file in componentFiles {
             let url = rootURL.appendingPathComponent(file.relativePath).standardizedFileURL
             let suffix = fileManager.fileExists(atPath: url.path) ? "" : "  (missing)"
             lines.append("  \(file.label): \(url.path)\(suffix)")
@@ -511,6 +527,11 @@ struct ModelInfo: ParsableCommand {
         ("spatial_upscaler", LTX25Resources.spatialUpsamplerRelativePath),
     ]
 
+    private static let ltx25NativeComponentFiles: [(label: String, relativePath: String)] = [
+        ("transformer_distilled", LTX25Resources.nativeDistilledTransformerRelativePath),
+        ("connector", LTX25Resources.nativeConnectorRelativePath),
+    ] + Array(ltx25ComponentFiles.dropFirst())
+
     private static let ltx25FullComponentFiles: [(label: String, relativePath: String)] = [
         ("transformer_dev", LTX25Resources.devTransformerRelativePath),
         ("transformer_distilled", LTX25Resources.distilledTransformerRelativePath),
@@ -523,6 +544,12 @@ struct ModelInfo: ParsableCommand {
         ("distilled_lora", LTX25Resources.distilledLoRARelativePath),
         ("duration_head", LTX25Resources.durationHeadRelativePath),
     ]
+
+    private static let ltx25NativeFullComponentFiles: [(label: String, relativePath: String)] = [
+        ("transformer_dev", LTX25Resources.nativeDevTransformerRelativePath),
+        ("transformer_distilled", LTX25Resources.nativeDistilledTransformerRelativePath),
+        ("connector", LTX25Resources.nativeConnectorRelativePath),
+    ] + Array(ltx25FullComponentFiles.dropFirst(2))
 
     private static let ltx23A2VidComponentFiles: [(label: String, relativePath: String)] = [
         ("split_model", "split_model.json"),

--- a/Sources/MereRunCLI/Commands/ModelOptimizeCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelOptimizeCommand.swift
@@ -30,7 +30,15 @@ struct ModelOptimize: ParsableCommand {
         if isLTX25ModelRoot(rootURL) {
             let resources = LTX25Resources(rootURL: rootURL)
             if textEncoderOnly {
-                _ = try optimizeLTX25TextEncoder(resources: resources)
+                let hasTextSource = FileManager.default.fileExists(
+                    atPath: resources.textEncoderURL.path
+                )
+                let hasOptimizedText = LTX25TextEncoderQuantizedPack.optimizedIndexURLIfValid(
+                    resources: resources
+                ) != nil
+                if !hasOptimizedText || (force && hasTextSource) {
+                    _ = try optimizeLTX25TextEncoder(resources: resources)
+                }
                 artifacts = LTX25TextEncoderQuantizedPack.artifactURLs(
                     resources: resources
                 )
@@ -46,7 +54,40 @@ struct ModelOptimize: ParsableCommand {
             if isLTX25FullModelRoot(rootURL) {
                 kinds.append(.dev)
             }
+            let existingNativeArtifacts = kinds.compactMap { kind in
+                LTX25NativeModelPack.optimizedURLIfValid(resources: resources, kind: kind)
+            }
+            let hasTransformerSources = FileManager.default.fileExists(
+                atPath: resources.distilledTransformerURL.path
+            ) && (!kinds.contains(.dev) || FileManager.default.fileExists(
+                atPath: resources.devTransformerURL.path
+            ))
+            if existingNativeArtifacts.count == kinds.count,
+               !force || !hasTransformerSources
+            {
+                let textArtifacts = LTX25TextEncoderQuantizedPack.artifactURLs(
+                    resources: resources
+                )
+                artifacts = existingNativeArtifacts + textArtifacts
+                optimization = textArtifacts.isEmpty
+                    ? "ltx25-native-model-pack-v1"
+                    : "ltx25-native-model-pack+text-q4-v1"
+                try emitResult(
+                    rootURL: rootURL,
+                    artifacts: artifacts,
+                    optimization: optimization
+                )
+                return
+            }
             var ltxArtifacts = try kinds.map { kind in
+                if !force,
+                   let existing = LTX25NativeModelPack.optimizedURLIfValid(
+                       resources: resources,
+                       kind: kind
+                   )
+                {
+                    return existing
+                }
                 let result = try LTX25NativeModelPack.optimize(
                     resources: resources,
                     kind: kind,
@@ -61,7 +102,11 @@ struct ModelOptimize: ParsableCommand {
                 )
                 return result.outputURL
             }
-            _ = try optimizeLTX25TextEncoder(resources: resources)
+            if LTX25TextEncoderQuantizedPack.optimizedIndexURLIfValid(
+                resources: resources
+            ) == nil {
+                _ = try optimizeLTX25TextEncoder(resources: resources)
+            }
             ltxArtifacts.append(
                 contentsOf: LTX25TextEncoderQuantizedPack.artifactURLs(resources: resources)
             )

--- a/Sources/MereRunCore/LTX/LTX25Resources.swift
+++ b/Sources/MereRunCore/LTX/LTX25Resources.swift
@@ -7,13 +7,15 @@ public struct LTX25Resources: Sendable, Hashable {
     public static let sourceRevision = "dd53cc2cd45bbeaa3563dfb575cba3f49cf44761"
     public static let managedRepository =
         "Sawfwair/LTX-2.5-Distilled-BF16-MLX-Q4-Text"
-    public static let managedRevision = "9f316bfb18448bf67f716006fd78a37829223b74"
+    public static let managedRevision = "cf8a174746cd14796c81ca2b54e035dc32e69bd8"
+    public static let fullManagedRepository = "Sawfwair/LTX-2.5-Full-BF16-MLX"
+    public static let fullManagedRevision = "ac74d124f7211fc3cb8b32f418a08d8e71655c8d"
     public static let upstreamCodeRepository = "Lightricks/LTX-2"
     public static let upstreamCodeRevision = "d151147788a9284cca791edc6ce898007e727fe6"
     public static let upstreamCodeRelease = "v1.2.0"
     public static let textEncoderSourceBytes: Int64 = 26_263_860_594
-    public static let estimatedDownloadBytes: Int64 = 53_878_648_085
-    public static let fullEstimatedDownloadBytes: Int64 = 123_751_083_670
+    public static let estimatedDownloadBytes: Int64 = 53_878_517_792
+    public static let fullEstimatedDownloadBytes: Int64 = 119_718_579_164
 
     public static let distilledTransformerRelativePath =
         "diffusion_models/ltx-2.5-22b-distilled-transformer-bf16.safetensors"
@@ -36,9 +38,21 @@ public struct LTX25Resources: Sendable, Hashable {
         "loras/ltx-2.5-22b-distilled-lora-450-bf16.safetensors"
     public static let durationHeadRelativePath =
         "model_patches/ltx-2.5-duration-head-bf16.safetensors"
+    public static let nativeDistilledTransformerRelativePath =
+        "\(LTX25NativeModelPack.relativeDirectory)/distilled-transformer-bf16.safetensors"
+    public static let nativeDevTransformerRelativePath =
+        "\(LTX25NativeModelPack.relativeDirectory)/dev-transformer-bf16.safetensors"
+    public static let nativeConnectorRelativePath =
+        "\(LTX25NativeModelPack.relativeDirectory)/connector-bf16.safetensors"
 
     public static let requiredRelativePaths = [
         distilledTransformerRelativePath,
+        videoVAERelativePath,
+        audioVAERelativePath,
+        spatialUpsamplerRelativePath,
+    ]
+
+    private static let sharedRequiredRelativePaths = [
         videoVAERelativePath,
         audioVAERelativePath,
         spatialUpsamplerRelativePath,
@@ -63,7 +77,8 @@ public struct LTX25Resources: Sendable, Hashable {
         "LTX-ACCEPTABLE-USE-POLICY.pdf",
         "GEMMA-4-LICENSE.txt",
         "NOTICE.md",
-        transformerRelativePath,
+        nativeDistilledTransformerRelativePath,
+        nativeConnectorRelativePath,
         videoVAERelativePath,
         audioVAERelativePath,
         spatialUpsamplerRelativePath,
@@ -75,8 +90,13 @@ public struct LTX25Resources: Sendable, Hashable {
 
     public static let fullSnapshotPatterns = [
         "README.md",
-        devTransformerRelativePath,
-        distilledTransformerRelativePath,
+        "LICENSE.md",
+        "LTX-ACCEPTABLE-USE-POLICY.pdf",
+        "GEMMA-4-LICENSE.txt",
+        "NOTICE.md",
+        nativeDevTransformerRelativePath,
+        nativeDistilledTransformerRelativePath,
+        nativeConnectorRelativePath,
         textEncoderRelativePath,
         videoVAERelativePath,
         diffusionVideoVAERelativePath,
@@ -112,9 +132,19 @@ public struct LTX25Resources: Sendable, Hashable {
     public var durationHeadURL: URL { rootURL.appendingPathComponent(Self.durationHeadRelativePath) }
 
     public func validate(fileManager: FileManager = .default) -> [URL] {
-        var missing = Self.requiredRelativePaths.compactMap { relativePath in
+        var missing = Self.sharedRequiredRelativePaths.compactMap { relativePath in
             let url = rootURL.appendingPathComponent(relativePath)
             return fileManager.fileExists(atPath: url.path) ? nil : url
+        }
+        missing.append(contentsOf: missingTransformerPaths(kinds: [.distilled], fileManager: fileManager))
+        if !fileManager.fileExists(atPath: distilledTransformerURL.path),
+           LTX25NativeModelPack.optimizedURLIfValid(
+               resources: self,
+               kind: .connector,
+               fileManager: fileManager
+           ) == nil
+        {
+            missing.append(LTX25NativeModelPack.outputURL(resources: self, kind: .connector))
         }
         let hasOfficialTextEncoder = fileManager.fileExists(atPath: textEncoderURL.path)
         let hasBundledQ4TextEncoder = LTX25TextEncoderQuantizedPack
@@ -126,9 +156,44 @@ public struct LTX25Resources: Sendable, Hashable {
     }
 
     public func validateFull(fileManager: FileManager = .default) -> [URL] {
-        Self.fullRequiredRelativePaths.compactMap { relativePath in
+        let transformerPaths = Set([
+            Self.devTransformerRelativePath,
+            Self.distilledTransformerRelativePath,
+        ])
+        var missing = Self.fullRequiredRelativePaths.compactMap { relativePath -> URL? in
+            guard !transformerPaths.contains(relativePath) else { return nil }
             let url = rootURL.appendingPathComponent(relativePath)
             return fileManager.fileExists(atPath: url.path) ? nil : url
+        }
+        missing.append(contentsOf: missingTransformerPaths(kinds: [.dev, .distilled], fileManager: fileManager))
+        if !fileManager.fileExists(atPath: distilledTransformerURL.path),
+           LTX25NativeModelPack.optimizedURLIfValid(
+               resources: self,
+               kind: .connector,
+               fileManager: fileManager
+           ) == nil
+        {
+            missing.append(LTX25NativeModelPack.outputURL(resources: self, kind: .connector))
+        }
+        return missing
+    }
+
+    private func missingTransformerPaths(
+        kinds: [LTX25NativeModelPackKind],
+        fileManager: FileManager
+    ) -> [URL] {
+        kinds.compactMap { kind in
+            let sourceURL = kind == .dev ? devTransformerURL : distilledTransformerURL
+            if fileManager.fileExists(atPath: sourceURL.path)
+                || LTX25NativeModelPack.optimizedURLIfValid(
+                    resources: self,
+                    kind: kind,
+                    fileManager: fileManager
+                ) != nil
+            {
+                return nil
+            }
+            return LTX25NativeModelPack.outputURL(resources: self, kind: kind)
         }
     }
 }

--- a/Sources/MereRunCore/LTX/README.md
+++ b/Sources/MereRunCore/LTX/README.md
@@ -16,12 +16,15 @@ Before stopping, run `swift test`, `./scripts/check.sh`, and a smoke path if you
 
 ## LTX 2.5
 
-The LTX 2.5 distilled release runs through the native `LTXUnifiedAVGenerator`
-with no Python sidecar. The managed Sawfwair distribution keeps the video
-transformer, VAEs, upsampler, and duration head in BF16 while bundling a
-self-contained MLX Q4 Gemma 4 language tower with its BF16 projection and
-tokenizer assets. Stage one uses the release's ancestral Euler update and stage
-two uses its deterministic refinement schedule.
+The LTX 2.5 release runs through the native `LTXUnifiedAVGenerator` with no
+Python sidecar. Both managed Sawfwair distributions store their BF16
+transformers directly in mere.run's native module-key layout, so a pull does
+not keep an official source transformer beside a generated optimization copy.
+The Distilled distribution bundles a self-contained MLX Q4 Gemma 4 language
+tower with its BF16 projection and tokenizer assets. The Full distribution
+retains the official BF16 text tower and every full/dev parity component.
+Stage one uses the release's ancestral Euler update and stage two uses its
+deterministic refinement schedule.
 
 Pull the public model into the managed model store after reviewing its terms:
 
@@ -29,9 +32,9 @@ Pull the public model into the managed model store after reviewing its terms:
 mere.run model pull video-ltx25-distilled-bf16 --accept-model-license
 ```
 
-This is one repository and one download; no Hugging Face gate, separate Gemma
-download, or local quantization step is required. Then use the managed ID (or
-pass a compatible official checkout with `--model-root`):
+Each model ID resolves to one inference-only repository and download; no local
+re-keying, optimization, or quantization step is required. Then use the managed
+ID (or pass a compatible official checkout with `--model-root`):
 
 ```bash
 mere.run video generate "a small robot walks across a wooden table" \

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -3564,15 +3564,15 @@ public enum ManagedModelCatalog {
             category: .video,
             installShape: .structuredRoot,
             hubFallback: HubFallbackConfig(
-                repoId: LTX25Resources.sourceRepository,
-                revision: LTX25Resources.sourceRevision,
+                repoId: LTX25Resources.fullManagedRepository,
+                revision: LTX25Resources.fullManagedRevision,
                 patterns: LTX25Resources.fullSnapshotPatterns
             ),
-            upstreamRepoId: LTX25Resources.sourceRepository,
-            upstreamRevision: LTX25Resources.sourceRevision,
+            upstreamRepoId: LTX25Resources.fullManagedRepository,
+            upstreamRevision: LTX25Resources.fullManagedRevision,
             usageRestriction: ltxUsageRestriction(
-                sourceRepoId: LTX25Resources.sourceRepository,
-                sourceRevision: LTX25Resources.sourceRevision,
+                sourceRepoId: LTX25Resources.fullManagedRepository,
+                sourceRevision: LTX25Resources.fullManagedRevision,
                 additionalTerms: [ltx25GemmaTextEncoderUsageTerm]
             ),
             validationKind: .ltxVideo25,

--- a/Sources/MereRunCore/MereRunModelManifest.swift
+++ b/Sources/MereRunCore/MereRunModelManifest.swift
@@ -2397,7 +2397,8 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
                 defaults: Defaults(steps: 30, cfg: 3),
                 supports: [.videoGeneration, .audioToVideoGeneration],
                 components: nil,
-                upstreamRepoId: "\(LTX25Resources.sourceRepository)@\(LTX25Resources.sourceRevision)",
+                upstreamRepoId:
+                    "\(LTX25Resources.fullManagedRepository)@\(LTX25Resources.fullManagedRevision)",
                 createdAt: createdAt
             )
         case .wan22TI2V5BMLX:

--- a/Tests/MereRunCLITests/ModelInfoCommandTests.swift
+++ b/Tests/MereRunCLITests/ModelInfoCommandTests.swift
@@ -77,7 +77,7 @@ final class ModelInfoCommandTests: XCTestCase {
 
         XCTAssertTrue(ModelInfo.usesLTX25Layout(manifest: manifest, expectedModelID: nil))
         XCTAssertTrue(
-            lines.contains("  layout: self-contained LTX 2.5 BF16 + MLX Q4 text files")
+            lines.contains("  layout: official LTX 2.5 BF16 + MLX Q4 text files")
         )
         XCTAssertTrue(lines.contains { $0.contains(LTX25Resources.transformerRelativePath) })
         XCTAssertTrue(lines.contains {
@@ -120,7 +120,10 @@ final class ModelInfoCommandTests: XCTestCase {
 
         XCTAssertEqual(manifest.id, ModelResolver.ModelID.ltxVideo25FullBF16.rawValue)
         XCTAssertEqual(manifest.engine, .ltxVideo)
-        XCTAssertEqual(manifest.upstreamRepoId, "\(LTX25Resources.sourceRepository)@\(LTX25Resources.sourceRevision)")
+        XCTAssertEqual(
+            manifest.upstreamRepoId,
+            "\(LTX25Resources.fullManagedRepository)@\(LTX25Resources.fullManagedRevision)"
+        )
         XCTAssertEqual(manifest.usageTermsAcknowledged, true)
         XCTAssertNil(manifest.createdAt)
     }

--- a/Tests/MereRunCLITests/ModelPullCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/ModelPullCommandParsingTests.swift
@@ -86,7 +86,7 @@ final class ModelPullCommandParsingTests: XCTestCase {
 
             let expectedRepoID = id == ModelResolver.ModelID.ltxVideo25DistilledBF16.rawValue
                 ? LTX25Resources.managedRepository
-                : LTX25Resources.sourceRepository
+                : LTX25Resources.fullManagedRepository
             XCTAssertEqual(spec.hubFallback?.repoId, expectedRepoID)
             XCTAssertEqual(spec.usageRestriction?.terms.count, 2)
             XCTAssertTrue(try XCTUnwrap(blocked.licenseAcceptanceMessage(for: spec)).contains("Gemma 4"))

--- a/Tests/MereRunCoreTests/LTX25NativeModelPackTests.swift
+++ b/Tests/MereRunCoreTests/LTX25NativeModelPackTests.swift
@@ -3,7 +3,7 @@ import MLX
 import XCTest
 @testable import MereRunCore
 
-final class LTX25NativeModelPackTests: XCTestCase {
+final class LTX25NativeModelPackTests: MereRunCoreTestCase {
     func testRealNativePackCoversV2TransformerParameters() throws {
         guard let rootPath = ProcessInfo.processInfo.environment["MERERUN_LTX25_MODEL_ROOT"] else {
             throw XCTSkip("Set MERERUN_LTX25_MODEL_ROOT for real-checkpoint coverage.")

--- a/Tests/MereRunCoreTests/LTX25ResourcesTests.swift
+++ b/Tests/MereRunCoreTests/LTX25ResourcesTests.swift
@@ -52,10 +52,18 @@ final class LTX25ResourcesTests: XCTestCase {
         )
         XCTAssertEqual(
             LTX25Resources.managedRevision,
-            "9f316bfb18448bf67f716006fd78a37829223b74"
+            "cf8a174746cd14796c81ca2b54e035dc32e69bd8"
         )
-        XCTAssertEqual(LTX25Resources.estimatedDownloadBytes, 53_878_648_085)
-        XCTAssertTrue(LTX25Resources.snapshotPatterns.contains(LTX25Resources.transformerRelativePath))
+        XCTAssertEqual(LTX25Resources.estimatedDownloadBytes, 53_878_517_792)
+        XCTAssertFalse(LTX25Resources.snapshotPatterns.contains(LTX25Resources.transformerRelativePath))
+        XCTAssertTrue(
+            LTX25Resources.snapshotPatterns.contains(
+                LTX25Resources.nativeDistilledTransformerRelativePath
+            )
+        )
+        XCTAssertTrue(
+            LTX25Resources.snapshotPatterns.contains(LTX25Resources.nativeConnectorRelativePath)
+        )
         XCTAssertFalse(LTX25Resources.snapshotPatterns.contains(LTX25Resources.textEncoderRelativePath))
         XCTAssertTrue(LTX25Resources.snapshotPatterns.contains {
             $0.contains(LTX25TextEncoderQuantizedPack.relativeDirectory)
@@ -102,5 +110,94 @@ final class LTX25ResourcesTests: XCTestCase {
         try FileManager.default.removeItem(at: resources.distilledLoRAURL)
         XCTAssertEqual(resources.validateFull(), [resources.distilledLoRAURL])
         XCTAssertFalse(isLTX25FullModelRoot(root))
+    }
+
+    func testManagedNativeDistilledLayoutDoesNotRequireOfficialTransformer() throws {
+        let root = try TestFileSystem.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let resources = LTX25Resources(rootURL: root)
+        for relativePath in LTX25Resources.requiredRelativePaths.dropFirst() {
+            try writeEmptyFile(root.appendingPathComponent(relativePath))
+        }
+        try writeEmptyFile(resources.textEncoderURL)
+        try writeNativePack(resources: resources, kind: .distilled)
+        try writeNativePack(resources: resources, kind: .connector)
+
+        XCTAssertFalse(FileManager.default.fileExists(atPath: resources.distilledTransformerURL.path))
+        XCTAssertTrue(resources.validate().isEmpty)
+        XCTAssertTrue(isLTX25ModelRoot(root))
+
+        let connectorURL = LTX25NativeModelPack.outputURL(resources: resources, kind: .connector)
+        try FileManager.default.removeItem(at: connectorURL)
+        XCTAssertEqual(resources.validate(), [connectorURL])
+    }
+
+    func testManagedNativeFullLayoutDoesNotRequireOfficialTransformers() throws {
+        let root = try TestFileSystem.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let resources = LTX25Resources(rootURL: root)
+        let transformerPaths = Set([
+            LTX25Resources.devTransformerRelativePath,
+            LTX25Resources.distilledTransformerRelativePath,
+        ])
+        for relativePath in LTX25Resources.fullRequiredRelativePaths
+            where !transformerPaths.contains(relativePath)
+        {
+            try writeEmptyFile(root.appendingPathComponent(relativePath))
+        }
+        try writeNativePack(resources: resources, kind: .dev)
+        try writeNativePack(resources: resources, kind: .distilled)
+        try writeNativePack(resources: resources, kind: .connector)
+
+        XCTAssertTrue(resources.validateFull().isEmpty)
+        XCTAssertTrue(isLTX25FullModelRoot(root))
+
+        let devURL = LTX25NativeModelPack.outputURL(resources: resources, kind: .dev)
+        try FileManager.default.removeItem(at: devURL)
+        XCTAssertEqual(resources.validateFull(), [devURL])
+    }
+
+    private func writeEmptyFile(_ url: URL) throws {
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        XCTAssertTrue(FileManager.default.createFile(atPath: url.path, contents: Data()))
+    }
+
+    private func writeNativePack(
+        resources: LTX25Resources,
+        kind: LTX25NativeModelPackKind
+    ) throws {
+        let url = LTX25NativeModelPack.outputURL(resources: resources, kind: kind)
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let header: [String: Any] = [
+            "__metadata__": [
+                "format": LTX25NativeModelPack.format,
+                "kind": kind.rawValue,
+                "source_revision": LTX25Resources.sourceRevision,
+            ],
+            "fixture.weight": [
+                "dtype": "BF16",
+                "shape": [1],
+                "data_offsets": [0, 2],
+            ],
+        ]
+        var headerData = try JSONSerialization.data(
+            withJSONObject: header,
+            options: [.sortedKeys]
+        )
+        let padding = (8 - (headerData.count % 8)) % 8
+        headerData.append(Data(repeating: 0x20, count: padding))
+        var headerLength = UInt64(headerData.count).littleEndian
+        var fileData = withUnsafeBytes(of: &headerLength) { Data($0) }
+        fileData.append(headerData)
+        fileData.append(contentsOf: [0, 0])
+        try fileData.write(to: url, options: .atomic)
     }
 }

--- a/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
@@ -2123,7 +2123,7 @@ final class ManagedModelCatalogTests: XCTestCase {
         )
     }
 
-    func testLTX25FullSpecPinsEveryOfficialParityComponent() throws {
+    func testLTX25FullSpecPinsPrekeyedSawfwairRelease() throws {
         let id = ModelResolver.ModelID.ltxVideo25FullBF16.rawValue
         let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: id))
 
@@ -2131,9 +2131,11 @@ final class ManagedModelCatalogTests: XCTestCase {
         XCTAssertEqual(spec.category, .video)
         XCTAssertEqual(spec.installShape, .structuredRoot)
         XCTAssertEqual(spec.validationKind, .ltxVideo25)
-        XCTAssertEqual(spec.hubFallback?.repoId, LTX25Resources.sourceRepository)
-        XCTAssertEqual(spec.hubFallback?.revision, LTX25Resources.sourceRevision)
+        XCTAssertEqual(spec.hubFallback?.repoId, LTX25Resources.fullManagedRepository)
+        XCTAssertEqual(spec.hubFallback?.revision, LTX25Resources.fullManagedRevision)
         XCTAssertEqual(spec.hubFallback?.patterns, LTX25Resources.fullSnapshotPatterns)
+        XCTAssertEqual(spec.upstreamRepoId, LTX25Resources.fullManagedRepository)
+        XCTAssertEqual(spec.upstreamRevision, LTX25Resources.fullManagedRevision)
         XCTAssertEqual(spec.estimatedDownloadBytes, LTX25Resources.fullEstimatedDownloadBytes)
         XCTAssertFalse(spec.runtimeAutoDownloadAllowed)
         XCTAssertTrue(spec.companionModelIDs.isEmpty)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -2205,15 +2205,16 @@ atomically rebuilds a pack from a full legacy root; a pruned root can validate
 its existing pack but cannot synthesize a missing exact table. Managed compact
 BF16, Q8, legacy Q4, and Ref2VA artifacts already include source-bound caches.
 
-For LTX 2.5, the command streams the distilled transformer and, for a full
-root, the dev transformer into source-bound BF16 native packs. It also writes a
-compact connector pack so text setup does not open the 42 GB official
-transformer. Transformer packs use mere.run's module-key namespace and every
-artifact preserves its tensor payload bytes. The self-contained managed
-distilled model already bundles the Q4 text pack and needs no optimization.
-`--text-encoder-only` reproduces that pack from an official BF16 root for
-offline and development use; it retains the BF16 projection and tokenizer
-assets while quantizing eligible Gemma language weights.
+For official or offline LTX 2.5 roots, the command streams the distilled
+transformer and, for a full root, the dev transformer into source-bound BF16
+native packs. It also writes a compact connector pack so text setup does not
+open the 42 GB official transformer. Transformer packs use mere.run's
+module-key namespace and every artifact preserves its tensor payload bytes.
+Managed Distilled and Full downloads are already pre-keyed, so the command
+reports their existing artifacts without creating another copy.
+`--text-encoder-only` reproduces the Distilled Q4 text pack from an official
+BF16 root for offline and development use; it retains the BF16 projection and
+tokenizer assets while quantizing eligible Gemma language weights.
 
 ### `mere.run model remove`
 

--- a/docs/ltx25-upstream-parity.md
+++ b/docs/ltx25-upstream-parity.md
@@ -11,7 +11,9 @@ The compatibility target is immutable:
   `dd53cc2cd45bbeaa3563dfb575cba3f49cf44761`
 - **Managed distilled distribution:**
   `Sawfwair/LTX-2.5-Distilled-BF16-MLX-Q4-Text`, revision
-  `9f316bfb18448bf67f716006fd78a37829223b74`
+  `cf8a174746cd14796c81ca2b54e035dc32e69bd8`
+- **Managed full distribution:** `Sawfwair/LTX-2.5-Full-BF16-MLX`, revision
+  `ac74d124f7211fc3cb8b32f418a08d8e71655c8d`
 - **DFR detailer:** `Lightricks/LTX-2.5-22b-IC-LoRA-Pixel-Spatial-Upscaler`,
   revision `74c4e68ee7dd99f3997d5a1bb1a3784941822222`
 
@@ -22,16 +24,18 @@ precedence.
 
 ## Install
 
-The public self-contained managed distilled bundle is exactly 53,878,648,085
-bytes. The complete official BF16 bundle is about 123.8 GB and adds the dev
-transformer, distilled LoRA, DiffVAE, temporal upsampler, and duration head.
+The public self-contained managed distilled bundle is about 53.9 GB. The
+managed Full BF16 bundle is about 119.7 GB and adds the dev transformer,
+distilled LoRA, DiffVAE, temporal upsampler, and duration head. Both packages
+ship transformers directly in mere.run's native module-key layout, without a
+second source checkpoint or post-install re-keying step.
 
 ```bash
 mere.run model pull video-ltx25-distilled-bf16 --accept-model-license
 mere.run model pull video-ltx25-full-bf16 --accept-model-license
 ```
 
-The managed distilled model is ungated. The official full/dev model and DFR
+The managed distilled model is ungated. The managed full/dev model and DFR
 detailer are separately gated on Hugging Face; accepting either one does not
 accept the other.
 
@@ -117,16 +121,14 @@ The acceleration surface remains native Swift, MLX, and Metal:
 - DiffVAE neighborhood attention routes to a fused three-dimensional Metal
   online-softmax kernel on supported Apple GPUs. The bounded MLX SDPA tiling
   path remains the automatic compatibility fallback.
-- The public, immutable
-  `Sawfwair/LTX-2.5-Distilled-BF16-MLX-Q4-Text` distribution is the single
-  managed distilled download after explicit license acceptance. Its LTX
-  transformer, VAEs, upsampler, and duration head preserve upstream BF16 bytes;
-  its self-contained text pack uses MLX affine Q4/group-64 for eligible Gemma
-  language weights while retaining the LTX projection and tokenizer assets in
-  BF16/raw form. Runtime validates the pinned source receipt. `mere.run model
-  optimize /path/to/LTX-2.5 --text-encoder-only` can reproduce the text pack
-  locally; full optimization also creates source-bound native transformer and
-  compact connector packs. The video transformer is never quantized.
+- The public, immutable managed Distilled and Full distributions store their
+  transformers directly in mere.run's native module-key namespace. Tensor
+  payload bytes and BF16 precision are unchanged; no source transformer is
+  retained beside a generated cache. Distilled uses MLX affine Q4/group-64 for
+  eligible Gemma language weights while retaining the LTX projection and
+  tokenizer assets in BF16/raw form. Full retains the official BF16 text tower.
+  `mere.run model optimize` remains available for compatible official or
+  offline roots and treats a managed pre-keyed package as already optimized.
 - Prompt tensors are evaluated and cached before the Gemma tower is unloaded.
   Image/reference latents are likewise evaluated before the video VAE encoder
   is released. Neither encoder remains resident during denoising; a later

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -1184,14 +1184,15 @@ The official packed LTX 2.5 BF16 root is:
 `mere.run model pull video-ltx25-distilled-bf16 --accept-model-license` pulls
 the complete public runtime from
 `Sawfwair/LTX-2.5-Distilled-BF16-MLX-Q4-Text` at immutable revision
-`9f316bfb18448bf67f716006fd78a37829223b74`. It preserves the upstream BF16
-distilled transformer, video VAE, audio VAE/BWE vocoder, spatial upsampler, and
-duration head from `Lightricks/LTX-2.5@dd53cc2...`. The custom Gemma 4 language
-tower is MLX affine Q4/group-64; its LTX projection and tokenizer support remain
-BF16/raw. The complete selected payload is exactly 53,878,648,085 bytes. The
-repository is ungated, includes the full LTX license/AUP, Apache 2.0 text, and
-modification notice, and requires no separate component pull or local
-quantization.
+`cf8a174746cd14796c81ca2b54e035dc32e69bd8`. It stores the upstream BF16
+distilled transformer directly in mere.run's native module-key layout, together
+with the shared connector, video VAE, audio VAE/BWE vocoder, spatial upsampler,
+and duration head from `Lightricks/LTX-2.5@dd53cc2...`. The custom Gemma 4
+language tower is MLX affine Q4/group-64; its LTX projection and tokenizer
+support remain BF16/raw. The complete selected payload is exactly
+53,878,517,792 bytes. The repository is ungated, includes the governing LTX and
+Gemma terms and modification notice, and requires no separate component pull,
+local quantization, or post-install re-keying.
 
 This model runs natively through Swift and MLX; no Python process or sidecar is
 dispatched. Use `--quality final --output-mode audio-video` for synchronized
@@ -1205,15 +1206,15 @@ The complete official LTX 2.5 root is:
 .../models/video-ltx25-full-bf16
 ```
 
-`mere.run model pull video-ltx25-full-bf16 --accept-model-license` uses the
-same immutable weight revision and adds the dev transformer, official
-distilled LoRA, diffusion video VAE, temporal x2 latent upsampler, and duration
-head. The complete official BF16 payload is exactly 123,751,083,670 bytes. This
-full/dev tier still comes from the official upstream repository and requires
-its Hugging Face gate; unlike the distilled managed tier, it retains the
-original BF16 text encoder unless locally optimized. This root supports
-full/dev and HQ pipelines, source-audio A2Vid, DFR, Retake, HDR/EXR, IC-LoRA
-reference video, Dub-It, and native text-to-audio.
+`mere.run model pull video-ltx25-full-bf16 --accept-model-license` pulls
+`Sawfwair/LTX-2.5-Full-BF16-MLX` at immutable revision
+`ac74d124f7211fc3cb8b32f418a08d8e71655c8d`. It includes native-layout dev and
+distilled BF16 transformers, one shared connector, the official BF16 text
+encoder, distilled LoRA, diffusion video VAE, temporal x2 latent upsampler, and
+duration head. The complete selected payload is exactly 119,718,579,164 bytes.
+The repository is gated and needs no local optimization or source-transformer
+copy. This root supports full/dev and HQ pipelines, source-audio A2Vid, DFR,
+Retake, HDR/EXR, IC-LoRA reference video, Dub-It, and native text-to-audio.
 
 The official DFR pixel-space spatial upscaler is a separately gated managed
 adapter: `ltx25-pixel-spatial-upscaler-x2`. Its repository gate and

--- a/docs/runtime/model-management.md
+++ b/docs/runtime/model-management.md
@@ -176,14 +176,15 @@ Q4/group-64 Gemma language tower plus the BF16 LTX projection and tokenizer;
 users do not download the original BF16 text tower or quantize anything. The
 video transformer and every non-text model component remain BF16.
 
-For official or offline roots, LTX 2.5 optimization can stream BF16 transformer
-payloads into the exact native module namespace without changing precision. A
-full root produces distilled and dev packs under `.mere-run/ltx25-native-v1`
-plus a compact connector pack. `--text-encoder-only` builds the self-contained
-text pack under `.mere-run/ltx25-text-q4-v1`. Compatible loads validate the
-pinned source receipt and prefer a valid bundled/local Q4 pack, falling back to
-the official BF16 text tower when it is absent. Use `--force` for an explicit
-rebuild.
+Managed LTX 2.5 Distilled and Full downloads already contain BF16 transformers
+in the exact native module namespace, so no post-install optimization copy is
+created. For official or offline roots, `model optimize` can still stream the
+source transformer payloads into `.mere-run/ltx25-native-v1` without changing
+precision. `--text-encoder-only` builds the self-contained text pack under
+`.mere-run/ltx25-text-q4-v1`. Compatible loads validate the pinned source
+receipt and prefer a valid bundled/local Q4 pack, falling back to the official
+BF16 text tower when it is absent. Use `--force` for an explicit rebuild when
+source transformers are present.
 
 ### `mere.run status`
 

--- a/scripts/model-conversion/model-cards/ltx25-distilled-bf16-mlx-q4-text.md
+++ b/scripts/model-conversion/model-cards/ltx25-distilled-bf16-mlx-q4-text.md
@@ -1,0 +1,55 @@
+---
+base_model: Lightricks/LTX-2.5
+license: other
+license_name: ltx-2-community-license-agreement
+license_link: https://github.com/Lightricks/LTX-2/blob/main/LICENSE.md
+pipeline_tag: text-to-video
+tags:
+  - ltx-video
+  - ltx-2.5
+  - mlx
+  - mere.run
+---
+
+# LTX 2.5 Distilled BF16 for mere.run
+
+This is the self-contained, inference-only LTX 2.5 Distilled package used by
+`mere.run` on Apple Silicon. It is derived from the immutable
+`Lightricks/LTX-2.5` revision
+`dd53cc2cd45bbeaa3563dfb575cba3f49cf44761`.
+
+The video transformer remains BF16. Its tensor payload bytes are copied into
+mere.run's native module-key namespace and physical order so installation does
+not retain an upstream checkpoint beside a generated optimization cache. The
+Gemma 4 language tower uses MLX affine Q4/group-64 for eligible language
+weights; the LTX projection and tokenizer assets remain BF16/raw.
+
+## Contents
+
+- native BF16 distilled transformer and shared connector;
+- MLX Q4 Gemma 4 text tower with BF16 LTX projection;
+- convolutional video VAE, audio VAE/vocoder, spatial upsampler, and duration
+  head;
+- governing LTX and Gemma license and notice files.
+
+There are no ComfyUI INT8, NVFP4, dev-transformer, DiffVAE, temporal-upscaler,
+or training artifacts in this distribution.
+
+## Use
+
+```bash
+mere.run model pull video-ltx25-distilled-bf16 --accept-model-license
+mere.run video generate \
+  "a clockwork observatory turns beneath a starry sky" \
+  --model video-ltx25-distilled-bf16 \
+  --output-mode audio-video \
+  --output observatory.mp4
+```
+
+No local conversion, re-keying, or `mere.run model optimize` step is required.
+
+## Terms
+
+LTX 2.5 is governed by the LTX-2 Community License Agreement and Acceptable Use
+Policy included in this repository. The bundled Gemma 4 weights are governed by
+the included Gemma terms. Review all terms before use or redistribution.

--- a/scripts/model-conversion/model-cards/ltx25-full-bf16-mlx.md
+++ b/scripts/model-conversion/model-cards/ltx25-full-bf16-mlx.md
@@ -1,0 +1,55 @@
+---
+base_model: Lightricks/LTX-2.5
+license: other
+license_name: ltx-2-community-license-agreement
+license_link: https://github.com/Lightricks/LTX-2/blob/main/LICENSE.md
+pipeline_tag: text-to-video
+tags:
+  - ltx-video
+  - ltx-2.5
+  - mlx
+  - mere.run
+---
+
+# LTX 2.5 Full BF16 for mere.run
+
+This is the self-contained, inference-only Full/Dev LTX 2.5 package used by
+`mere.run` on Apple Silicon. It is derived from the immutable
+`Lightricks/LTX-2.5` revision
+`dd53cc2cd45bbeaa3563dfb575cba3f49cf44761`.
+
+The dev and distilled video transformers and Gemma 4 text encoder remain BF16.
+Transformer tensor payload bytes are copied into mere.run's native module-key
+namespace and physical order. Installation therefore does not retain two
+official transformers beside generated native optimization copies.
+
+## Contents
+
+- native BF16 dev and distilled transformers plus one shared connector;
+- official BF16 Gemma 4 text encoder and LTX projection;
+- convolutional and diffusion video VAEs plus the audio VAE/vocoder;
+- spatial and temporal upsamplers, distilled LoRA, and duration head;
+- governing LTX and Gemma license and notice files.
+
+There are no ComfyUI INT8, NVFP4, duplicate source-transformer, IC-LoRA adapter,
+or training artifacts in this distribution. Optional DFR, HDR, and Dub-It
+adapters remain separate installs.
+
+## Use
+
+```bash
+mere.run model pull video-ltx25-full-bf16 --accept-model-license
+mere.run video generate \
+  "an intricate clockwork observatory turns beneath the stars" \
+  --model video-ltx25-full-bf16 \
+  --output-mode audio-video \
+  --output observatory.mp4
+```
+
+No local conversion, re-keying, or `mere.run model optimize` step is required.
+
+## Terms
+
+LTX 2.5 is governed by the LTX-2 Community License Agreement and Acceptable Use
+Policy included in this repository. The bundled Gemma 4 weights are governed by
+the included Gemma terms. Review all terms before use or redistribution.


### PR DESCRIPTION
## Summary

- switch the managed LTX 2.5 Full and Distilled pulls to immutable Sawfwair packages that contain runtime-native BF16 transformer packs
- accept native-only packages while preserving compatibility with official source-transformer layouts
- make `model optimize` idempotent for already-native packages and report the resolved native component layout in `model info`
- add release model cards, public documentation, and coverage for native-only validation and managed catalog metadata

Published package revisions:

- Full BF16 MLX: `Sawfwair/LTX-2.5-Full-BF16-MLX@ac74d124f7211fc3cb8b32f418a08d8e71655c8d`
- Distilled BF16 + Q4 text: `Sawfwair/LTX-2.5-Distilled-BF16-MLX-Q4-Text@cf8a174746cd14796c81ca2b54e035dc32e69bd8`

Users no longer need to download an official source transformer and then create a second re-keyed cache. The managed pull is directly runnable, and a later `model optimize` returns the existing artifacts without rebuilding them. Existing official-layout installations remain supported.

## Validation

- [x] `./scripts/check.sh` — 3,279 XCTest cases with 265 skips and zero failures; 30 Swift Testing cases passed
- [x] focused LTX resource, native-pack, model-info, pull-parsing, and managed-catalog tests
- [x] real-checkpoint `LTX25NativeModelPackTests` — native parameter coverage and native-versus-official value parity passed; 5 tests executed with the opt-in applied-weight test skipped
- [x] native-only Full and Distilled roots validated through `model info`; `model optimize` was idempotent for both
- [x] Hugging Face remote heads, package contents, LFS object hashes, access settings, and absence of source transformers read back at the immutable revisions above
- [x] docs and release model cards updated for the public behavior change
- [x] `THIRD_PARTY_NOTICES.md` not applicable; no vendored runtime artifacts or dependency pins changed

## Remaining runtime qualification

A full video-generation smoke was not forced because an existing user API server held machine-admission permits. The server was left uninterrupted. Real-checkpoint pack structure and tensor-value parity, native-only resolution, and the full repository gate passed.
