### PR TITLE
Add FastH3 VSA DataFree Metal runtime

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,10 +32,18 @@ The format is based on Keep a Changelog.
   stores the compression gates in Q8. Prepared geometry and compact selected
   route tables reduce VSA traversal work on Metal without changing the released
   90% video-key sparsity contract. Managed affine Q8 FastH3 roots also select
-  matrix-tiled Metal FC1/SwiGLU and FC2 kernels. At 89,188 rows on an M4 Max,
-  the isolated real-checkpoint stages measured 1.107x and 1.050x faster than
-  the correct chunked portable path; the fused FC1 avoids a 5.11 GiB
-  intermediate that exceeds the portable path's 4 GiB addressing boundary.
+  a combined Metal recipe that fuses attention AdaLN, the post-attention gate
+  and AdaLN, Q/K normalization and rotary embedding, FC1 and SwiGLU, and FC2.
+  The MLP kernels preserve the live Float32 activation stream with Float32
+  SIMD-group matrices. At 89,188 rows on an M4 Max, an exploratory
+  real-checkpoint run measured the FC1 and FC2 stages at 1.079x and 1.085x the
+  correct chunked portable path. FC1 relative L2 was `3.82194e-8`, and FC2 was
+  bit-identical. The fused FC1 avoids a 9.53 GiB intermediate that exceeds the
+  portable path's 4 GiB addressing boundary. The compiled runner materializes
+  the 4.76 GiB compact activation before FC2 when that activation exceeds
+  4 GiB. The installed 50-block gate dispatched all five selected stages
+  without fallback and stayed below `0.0012` relative L2 for both output
+  modalities.
 
 ## 0.46.1 - 2026-08-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,11 @@ The format is based on Keep a Changelog.
   exact four-evaluation sampler, 64-token sparse video attention, compression
   gates, and source-bound AdaLN cache. The dedicated
   `video-minimax-h3-fasth3-vsa-datafree-mlx` model packages every supported
-  inference asset behind one explicit license-accepting pull.
+  inference asset behind one explicit license-accepting pull. Its published
+  package premerges the student into an affine Q8/group-64 transformer and
+  stores the compression gates in Q8. Prepared geometry and compact selected
+  route tables reduce VSA traversal work on Metal without changing the released
+  90% video-key sparsity contract.
 
 ## 0.46.1 - 2026-08-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,11 @@ The format is based on Keep a Changelog.
   package premerges the student into an affine Q8/group-64 transformer and
   stores the compression gates in Q8. Prepared geometry and compact selected
   route tables reduce VSA traversal work on Metal without changing the released
-  90% video-key sparsity contract.
+  90% video-key sparsity contract. Managed affine Q8 FastH3 roots also select
+  matrix-tiled Metal FC1/SwiGLU and FC2 kernels. At 89,188 rows on an M4 Max,
+  the isolated real-checkpoint stages measured 1.107x and 1.050x faster than
+  the correct chunked portable path; the fused FC1 avoids a 5.11 GiB
+  intermediate that exceeds the portable path's 4 GiB addressing boundary.
 
 ## 0.46.1 - 2026-08-29
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,11 @@ The format is based on Keep a Changelog.
   on MLX Metal. The refresh receipt proves source-range and baseline-table
   tensor closure; custom schedules still disclose interpolation as not
   bit-exact.
+- added native Metal execution for FastVideo FastH3 VSA DataFree, including its
+  exact four-evaluation sampler, 64-token sparse video attention, compression
+  gates, and source-bound AdaLN cache. The dedicated
+  `video-minimax-h3-fasth3-vsa-datafree-mlx` model packages every supported
+  inference asset behind one explicit license-accepting pull.
 
 ## 0.46.1 - 2026-08-29
 

--- a/Sources/MereRunCLI/Commands/VideoCommand.swift
+++ b/Sources/MereRunCLI/Commands/VideoCommand.swift
@@ -1205,8 +1205,17 @@ struct VideoGenerate: AsyncParsableCommand {
             } else {
                 h3AdapterBaseModelID = ModelResolver.ModelID.miniMaxH3FL2VABF16MLX.rawValue
             }
+            let effectiveH3Adapter: String?
+            if let h3Adapter {
+                effectiveH3Adapter = h3Adapter
+            } else if resolvedRequestedModel
+                == ModelResolver.ModelID.miniMaxH3FastH3VSADataFreeMLX.rawValue {
+                effectiveH3Adapter = h3Resources.fastH3AdapterURL.path
+            } else {
+                effectiveH3Adapter = nil
+            }
             let resolvedH3Adapter = try ManagedAdapterArgumentResolver.resolve(
-                h3Adapter,
+                effectiveH3Adapter,
                 baseModelID: h3AdapterBaseModelID
             ).map { URL(fileURLWithPath: $0).standardizedFileURL }
             let h3AdapterRecipe = resolvedH3Adapter.map(MiniMaxH3TurboAdapter.inferenceRecipe(for:))
@@ -2913,6 +2922,7 @@ struct VideoGenerate: AsyncParsableCommand {
         if requested == ModelResolver.ModelID.miniMaxH3FL2VAMLX.rawValue
             || requested == ModelResolver.ModelID.miniMaxH3FL2VABF16MLX.rawValue
             || requested == ModelResolver.ModelID.miniMaxH3FL2VAQ8MLX.rawValue
+            || requested == ModelResolver.ModelID.miniMaxH3FastH3VSADataFreeMLX.rawValue
             || requested == ModelResolver.ModelID.miniMaxH3Ref2VAMLX.rawValue {
             return true
         }

--- a/Sources/MereRunCLI/Support/InstalledModelGateSupport.swift
+++ b/Sources/MereRunCLI/Support/InstalledModelGateSupport.swift
@@ -1637,7 +1637,9 @@ extension GateRunner {
             "--width", "128",
             "--height", "128",
             "--num-frames", "22",
-            "--steps", "2",
+            "--steps", model == ModelResolver.ModelID.miniMaxH3FastH3VSADataFreeMLX.rawValue
+                ? "5"
+                : "2",
             "--seed", "7",
             "--output", output.path,
             "--quiet",

--- a/Sources/MereRunCLI/Support/VideoGenerationPreflight.swift
+++ b/Sources/MereRunCLI/Support/VideoGenerationPreflight.swift
@@ -477,6 +477,7 @@ struct VideoGenerationPreflightAnalyzer {
         if requested == ModelResolver.ModelID.miniMaxH3FL2VAMLX.rawValue
             || requested == ModelResolver.ModelID.miniMaxH3FL2VABF16MLX.rawValue
             || requested == ModelResolver.ModelID.miniMaxH3FL2VAQ8MLX.rawValue
+            || requested == ModelResolver.ModelID.miniMaxH3FastH3VSADataFreeMLX.rawValue
             || requested == ModelResolver.ModelID.miniMaxH3Ref2VAMLX.rawValue {
             return true
         }
@@ -492,7 +493,8 @@ struct VideoGenerationPreflightAnalyzer {
         }
         if requested == ModelResolver.ModelID.miniMaxH3FL2VAMLX.rawValue
             || requested == ModelResolver.ModelID.miniMaxH3FL2VABF16MLX.rawValue
-            || requested == ModelResolver.ModelID.miniMaxH3FL2VAQ8MLX.rawValue {
+            || requested == ModelResolver.ModelID.miniMaxH3FL2VAQ8MLX.rawValue
+            || requested == ModelResolver.ModelID.miniMaxH3FastH3VSADataFreeMLX.rawValue {
             return false
         }
         let candidate = input.modelRoot ?? input.model
@@ -519,10 +521,20 @@ struct VideoGenerationPreflightAnalyzer {
     }
 
     private var h3AdapterInferenceRecipe: MiniMaxH3TurboAdapter.InferenceRecipe? {
-        guard let reference = input.h3Adapter else { return nil }
+        guard let reference = input.h3Adapter else {
+            return usesEmbeddedFastH3Adapter
+                ? MiniMaxH3TurboAdapter.fastH3VSADataFreeRecipe
+                : nil
+        }
         let filename = ManagedAdapterCatalog.spec(for: reference)?.artifact.filename
             ?? URL(fileURLWithPath: reference).lastPathComponent
         return MiniMaxH3TurboAdapter.inferenceRecipe(filename: filename)
+    }
+
+    private var usesEmbeddedFastH3Adapter: Bool {
+        input.h3Adapter == nil
+            && input.model.trimmingCharacters(in: .whitespacesAndNewlines)
+                == ModelResolver.ModelID.miniMaxH3FastH3VSADataFreeMLX.rawValue
     }
 
     func envelope() -> VideoGenerationPreflightEnvelope {
@@ -1100,7 +1112,7 @@ struct VideoGenerationPreflightAnalyzer {
                 message: "--video-decoder is available for official LTX 2.5 model roots."
             ))
         }
-        if input.h3Adapter != nil, usesMiniMaxH3Geometry {
+        if h3AdapterInferenceRecipe != nil, usesMiniMaxH3Geometry {
             let expectedBaseModelID: String
             if usesMiniMaxH3Ref2VA {
                 expectedBaseModelID = ModelResolver.ModelID.miniMaxH3Ref2VAMLX.rawValue
@@ -1129,6 +1141,7 @@ struct VideoGenerationPreflightAnalyzer {
                     supportsTurbo = model.requested
                         == ModelResolver.ModelID.miniMaxH3FL2VABF16MLX.rawValue
                         || model.requested == MiniMaxH3Resources.fl2vaQ8ModelID
+                        || model.requested == MiniMaxH3Resources.fastH3ModelID
                 }
                 if !supportsTurbo {
                     diagnostics.append(PreflightDiagnostic(
@@ -1901,7 +1914,7 @@ struct VideoGenerationPreflightAnalyzer {
         }
         let h3AccelerationMode = MiniMaxH3AccelerationMode(rawValue: input.h3AccelerationMode) ?? .quality
         let resolvedH3Steps: Int? = if usesMiniMaxH3Geometry {
-            input.steps ?? (input.h3Adapter != nil
+            input.steps ?? (h3AdapterInferenceRecipe != nil
                 ? h3AdapterInferenceRecipe?.defaultSchedulePointCount
                 : (try? MiniMaxH3StepPolicy.recommendedPointCount(
                 width: validH3RenderWidth ?? resolvedWidth,
@@ -1939,8 +1952,12 @@ struct VideoGenerationPreflightAnalyzer {
             h3AccelerationMode: usesMiniMaxH3Geometry ? input.h3AccelerationMode : nil,
             h3RenderWidth: usesMiniMaxH3Geometry ? input.h3RenderWidth : nil,
             h3RenderHeight: usesMiniMaxH3Geometry ? input.h3RenderHeight : nil,
-            h3Adapter: usesMiniMaxH3Geometry ? input.h3Adapter : nil,
-            h3AdapterStrength: usesMiniMaxH3Geometry && input.h3Adapter != nil
+            h3Adapter: usesMiniMaxH3Geometry
+                ? (usesEmbeddedFastH3Adapter
+                    ? MiniMaxH3TurboAdapter.fastH3VSADataFreeFilename
+                    : input.h3Adapter)
+                : nil,
+            h3AdapterStrength: usesMiniMaxH3Geometry && h3AdapterInferenceRecipe != nil
                 ? input.h3AdapterStrength
                 : nil,
             h3FrameCount: usesMiniMaxH3Geometry ? input.h3FrameInputs.count : nil,

--- a/Sources/MereRunCore/ManagedAdapterCatalog.swift
+++ b/Sources/MereRunCore/ManagedAdapterCatalog.swift
@@ -100,6 +100,8 @@ public enum ManagedAdapterCatalog {
     public static let miniMaxH3LightX2VV1Revision = "e6346777701aa2b64d42ed058cdd71ae00e7cd52"
     public static let miniMaxH3LightX2VRef2VFourStepV01ID = "minimax-h3-lightx2v-ref2v-4step-v0.1"
     public static let miniMaxH3LightX2VRef2VFourStepV01Revision = "5d1d4829fe614c1b93fcfd9cc7718e9ba71f73e1"
+    public static let miniMaxH3FastH3VSADataFreeID = "minimax-h3-fasth3-vsa-datafree-4step"
+    public static let miniMaxH3FastH3VSADataFreeRevision = "bcf40ca6f457ed66f8badf13514943e390205fca"
     public static let ltx25PixelSpatialUpscalerID = "ltx25-pixel-spatial-upscaler-x2"
     public static let ltx25PixelSpatialUpscalerRevision = "74c4e68ee7dd99f3997d5a1bb1a3784941822222"
 
@@ -292,6 +294,31 @@ public enum ManagedAdapterCatalog {
             )
         ),
         ManagedAdapterSpec(
+            id: miniMaxH3FastH3VSADataFreeID,
+            title: "FastH3 4-step VSA DataFree",
+            version: String(miniMaxH3FastH3VSADataFreeRevision.prefix(12)),
+            summary: "FastVideo four-evaluation MiniMax-H3 student with MLX Metal VSA-H3 sparse attention.",
+            baseModelID: ModelResolver.ModelID.miniMaxH3FL2VABF16MLX.rawValue,
+            compatibleBaseModelIDs: [
+                ModelResolver.ModelID.miniMaxH3FastH3VSADataFreeMLX.rawValue,
+            ],
+            format: MiniMaxH3TurboAdapter.fastVideoFormat,
+            license: "MiniMax-H3 Community License",
+            upstreamRevision: miniMaxH3FastH3VSADataFreeRevision,
+            usageRestriction: miniMaxH3UsageRestriction,
+            releaseManifestURL: URL(
+                string: "https://huggingface.co/FastVideo/FastVideo-FastH3-4-step-Preview-v1-LoRA/commit/\(miniMaxH3FastH3VSADataFreeRevision)"
+            )!,
+            downloadURL: URL(
+                string: "https://huggingface.co/FastVideo/FastVideo-FastH3-4-step-Preview-v1-LoRA/resolve/\(miniMaxH3FastH3VSADataFreeRevision)/vsa-datafree/adapter_model.safetensors?download=true"
+            )!,
+            artifact: ModelArtifactPin(
+                filename: MiniMaxH3TurboAdapter.fastH3VSADataFreeFilename,
+                byteCount: 5_339_117_712,
+                sha256: "42dc502a2078f166c396a1fa75f29728d1844363652d345d5ef3e2b444ed6470"
+            )
+        ),
+        ManagedAdapterSpec(
             id: ltx25PixelSpatialUpscalerID,
             title: "LTX-2.5 Pixel Spatial Upscaler x2",
             version: String(ltx25PixelSpatialUpscalerRevision.prefix(12)),
@@ -326,6 +353,20 @@ public enum ManagedAdapterCatalog {
             )
         ),
     ]
+
+    private static let miniMaxH3UsageRestriction = ManagedModelUsageRestriction(
+        summary: "MiniMax-H3 weights may not be used, distributed, or displayed in the United States, European Union, United Kingdom, or Republic of Korea; downstream distribution also requires the Community License agreement, notice, and safeguards.",
+        terms: [
+            ManagedModelUsageTerm(
+                component: "MiniMax-H3 base and FastH3 student",
+                license: "MiniMax-H3 Community License",
+                summary: "Use is governed by the MiniMax-H3 Community License, including its territory and downstream-distribution restrictions.",
+                sourceRepoId: MiniMaxH3Resources.sourceRepository,
+                sourceRevision: MiniMaxH3Resources.sourceRevision,
+                licenseURL: "https://huggingface.co/MiniMaxAI/MiniMax-H3/blob/ec19cc6daf5d8add9417c18e86b6b58cc6c55027/LICENSE"
+            ),
+        ]
+    )
 
     public static func spec(for id: String) -> ManagedAdapterSpec? {
         let normalized = id.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -3692,7 +3692,7 @@ public enum ManagedModelCatalog {
             usageRestriction: miniMaxH3UsageRestriction,
             validationKind: .miniMaxH3MLX,
             runtimeAutoDownloadAllowed: false,
-            estimatedDownloadBytes: 82_316_599_044,
+            estimatedDownloadBytes: 57_559_079_710,
             defaultCLICommands: ["video generate"]
         ),
         ManagedModelSpec(
@@ -4398,9 +4398,15 @@ public extension ManagedModelSpec {
                     return resources.validateCompactCachePack(fileManager: fileManager)
                 }
                 if id == ModelResolver.ModelID.miniMaxH3FastH3VSADataFreeMLX.rawValue {
-                    guard try resources.transformerStorage() == .compactBF16,
-                          configuration.quantization == nil else {
-                        return ["FastH3 VSA DataFree requires an unquantized compact BF16 transformer."]
+                    let expectedQuantization = MiniMaxH3QuantizationConfiguration(
+                        bits: 8,
+                        groupSize: 64,
+                        mode: "affine"
+                    )
+                    guard try resources.transformerStorage() == .affineQ8,
+                          configuration.quantization == expectedQuantization,
+                          configuration.textEncoderQuantization == expectedQuantization else {
+                        return ["FastH3 VSA DataFree requires MLX affine INT8/group-64 transformer and conditioner weights."]
                     }
                     return resources.validateManagedFastH3Artifact(fileManager: fileManager)
                 }

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -3679,6 +3679,23 @@ public enum ManagedModelCatalog {
             defaultCLICommands: ["video generate"]
         ),
         ManagedModelSpec(
+            id: ModelResolver.ModelID.miniMaxH3FastH3VSADataFreeMLX.rawValue,
+            category: .video,
+            installShape: .structuredRoot,
+            hubFallback: HubFallbackConfig(
+                repoId: MiniMaxH3Resources.fastH3ArtifactRepository,
+                revision: MiniMaxH3Resources.fastH3ArtifactRevision,
+                patterns: MiniMaxH3Resources.fastH3ArtifactFiles
+            ),
+            upstreamRepoId: MiniMaxH3Resources.fastH3ArtifactRepository,
+            upstreamRevision: MiniMaxH3Resources.fastH3ArtifactRevision,
+            usageRestriction: miniMaxH3UsageRestriction,
+            validationKind: .miniMaxH3MLX,
+            runtimeAutoDownloadAllowed: false,
+            estimatedDownloadBytes: 82_316_599_044,
+            defaultCLICommands: ["video generate"]
+        ),
+        ManagedModelSpec(
             id: ModelResolver.ModelID.miniMaxH3Ref2VAMLX.rawValue,
             category: .video,
             installShape: .structuredRoot,
@@ -4380,6 +4397,13 @@ public extension ManagedModelSpec {
                     }
                     return resources.validateCompactCachePack(fileManager: fileManager)
                 }
+                if id == ModelResolver.ModelID.miniMaxH3FastH3VSADataFreeMLX.rawValue {
+                    guard try resources.transformerStorage() == .compactBF16,
+                          configuration.quantization == nil else {
+                        return ["FastH3 VSA DataFree requires an unquantized compact BF16 transformer."]
+                    }
+                    return resources.validateManagedFastH3Artifact(fileManager: fileManager)
+                }
                 if id == ModelResolver.ModelID.miniMaxH3FL2VAQ8MLX.rawValue {
                     let expectedQuantization = MiniMaxH3QuantizationConfiguration(
                         bits: 8,
@@ -4509,6 +4533,7 @@ public extension ManagedModelSpec {
             || id == ModelResolver.ModelID.miniMaxH3Ref2VAMLX.rawValue
             || id == ModelResolver.ModelID.miniMaxH3FL2VABF16MLX.rawValue
             || id == ModelResolver.ModelID.miniMaxH3FL2VAQ8MLX.rawValue
+            || id == ModelResolver.ModelID.miniMaxH3FastH3VSADataFreeMLX.rawValue
         guard requiresPinnedSource, let expectedRepo = upstreamRepoId else {
             return true
         }
@@ -4517,10 +4542,12 @@ public extension ManagedModelSpec {
               let installedRepo = manifest.upstreamRepoId else {
             return id != ModelResolver.ModelID.miniMaxH3FL2VABF16MLX.rawValue
                 && id != ModelResolver.ModelID.miniMaxH3FL2VAQ8MLX.rawValue
+                && id != ModelResolver.ModelID.miniMaxH3FastH3VSADataFreeMLX.rawValue
         }
 
         let requiresExactRevision = id == ModelResolver.ModelID.miniMaxH3FL2VABF16MLX.rawValue
             || id == ModelResolver.ModelID.miniMaxH3FL2VAQ8MLX.rawValue
+            || id == ModelResolver.ModelID.miniMaxH3FastH3VSADataFreeMLX.rawValue
         if installedRepo == expectedRepo, !requiresExactRevision {
             return true
         }

--- a/Sources/MereRunCore/ManagedModelSupport.swift
+++ b/Sources/MereRunCore/ManagedModelSupport.swift
@@ -1199,6 +1199,13 @@ public enum ManagedModelCapabilityCatalog {
                 recommended: 128
             ),
             descriptor(
+                ModelResolver.ModelID.miniMaxH3FastH3VSADataFreeMLX.rawValue,
+                "MiniMax-H3 FastH3 VSA DataFree MLX",
+                "Runs the packaged FastH3 four-evaluation adapter and VSA-H3 sparse attention with no separate model assets.",
+                minimum: 96,
+                recommended: 128
+            ),
+            descriptor(
                 ModelResolver.ModelID.miniMaxH3Ref2VAMLX.rawValue,
                 "MiniMax-H3 Ref2VA MLX",
                 "Runs the explicit-pull 8-bit Ref2VA package with ordered image, video, and audio references and synchronized generated audio.",

--- a/Sources/MereRunCore/ManagedModelSupport.swift
+++ b/Sources/MereRunCore/ManagedModelSupport.swift
@@ -1201,7 +1201,7 @@ public enum ManagedModelCapabilityCatalog {
             descriptor(
                 ModelResolver.ModelID.miniMaxH3FastH3VSADataFreeMLX.rawValue,
                 "MiniMax-H3 FastH3 VSA DataFree MLX",
-                "Runs the packaged FastH3 four-evaluation adapter and VSA-H3 sparse attention with no separate model assets.",
+                "Runs the premerged Q8 FastH3 student and compact VSA-H3 sparse attention with no separate model assets.",
                 minimum: 96,
                 recommended: 128
             ),

--- a/Sources/MereRunCore/MereRunModelManifest.swift
+++ b/Sources/MereRunCore/MereRunModelManifest.swift
@@ -2502,7 +2502,8 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
                 family: .video,
                 tier: .latest,
                 variant: .distilled,
-                precision: .bf16,
+                precision: .int8,
+                quantization: Quantization(bits: 8, groupSize: 64, scheme: "mlx-affine"),
                 defaults: Defaults(steps: 5, cfg: 1.0, sigmaShift: 12.0),
                 supports: [.videoGeneration],
                 components: Components(

--- a/Sources/MereRunCore/MereRunModelManifest.swift
+++ b/Sources/MereRunCore/MereRunModelManifest.swift
@@ -2495,6 +2495,27 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
                     + "@\(MiniMaxH3Resources.compactBF16ArtifactRevision)",
                 createdAt: createdAt
             )
+        case .miniMaxH3FastH3VSADataFreeMLX:
+            return MereRunModelManifest(
+                id: modelID.rawValue,
+                engine: .miniMaxH3,
+                family: .video,
+                tier: .latest,
+                variant: .distilled,
+                precision: .bf16,
+                defaults: Defaults(steps: 5, cfg: 1.0, sigmaShift: 12.0),
+                supports: [.videoGeneration],
+                components: Components(
+                    tokenizer: .local(path: "."),
+                    textEncoder: .local(path: "."),
+                    transformer: .local(path: "."),
+                    vae: .local(path: "."),
+                    scheduler: nil
+                ),
+                upstreamRepoId: "\(MiniMaxH3Resources.fastH3ArtifactRepository)"
+                    + "@\(MiniMaxH3Resources.fastH3ArtifactRevision)",
+                createdAt: createdAt
+            )
         case .miniMaxH3FL2VAQ8MLX:
             return MereRunModelManifest(
                 id: modelID.rawValue,

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3FastVSA.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3FastVSA.swift
@@ -92,6 +92,34 @@ struct MiniMaxH3FastVSAPreparedContext {
     let poolingSizes: MLXArray
 }
 
+enum MiniMaxH3FastVSAKernelMode: String, Sendable {
+    case halfTile = "half-tile"
+    case fullTile = "full-tile"
+    #if DEBUG
+    // Benchmark-only rejected candidate; never selected by the runtime environment.
+    case fullTileKV16 = "full-tile-kv16"
+    #endif
+
+    var queryTileRows: Int {
+        switch self {
+        case .halfTile: 32
+        case .fullTile: MiniMaxH3FastVSAGeometry.tileSize
+        #if DEBUG
+        case .fullTileKV16: MiniMaxH3FastVSAGeometry.tileSize
+        #endif
+        }
+    }
+
+    var simdgroupCount: Int { queryTileRows / 8 }
+
+    static let runtimeDefault: Self = {
+        let requested = Self(
+            rawValue: ProcessInfo.processInfo.environment["MERERUN_H3_FASTVSA_KERNEL"] ?? ""
+        )
+        return requested == .halfTile ? .halfTile : .fullTile
+    }()
+}
+
 /// Metal implementation of FastVideo's released VSA-H3 tile-64 inference contract.
 ///
 /// Prefix query tiles remain dense, every query retains all prefix key tiles,
@@ -108,7 +136,8 @@ enum MiniMaxH3FastVSA {
         values: MLXArray,
         compressionGate: MLXArray,
         layout: MiniMaxH3PackedLayout,
-        sparsity: Float = sparsity
+        sparsity: Float = sparsity,
+        kernelMode: MiniMaxH3FastVSAKernelMode = .fullTile
     ) -> MLXArray? {
         call(
             queries: queries,
@@ -116,7 +145,8 @@ enum MiniMaxH3FastVSA {
             values: values,
             compressionGate: compressionGate,
             prepared: prepare(layout: layout),
-            sparsity: sparsity
+            sparsity: sparsity,
+            kernelMode: kernelMode
         )
     }
 
@@ -143,7 +173,8 @@ enum MiniMaxH3FastVSA {
         values: MLXArray,
         compressionGate: MLXArray,
         prepared: MiniMaxH3FastVSAPreparedContext,
-        sparsity: Float = sparsity
+        sparsity: Float = sparsity,
+        kernelMode: MiniMaxH3FastVSAKernelMode = .fullTile
     ) -> MLXArray? {
         guard supports(queries: queries, keys: keys, values: values, gate: compressionGate),
               (0..<1).contains(sparsity) else { return nil }
@@ -190,7 +221,8 @@ enum MiniMaxH3FastVSA {
             videoRoutes: videoRoutes,
             blockSizes: prepared.blockSizes,
             prefixTileCount: geometry.prefixTileCount,
-            scale: scale
+            scale: scale,
+            kernelMode: kernelMode
         )
 
         let compressed = MLX.matmul(
@@ -233,6 +265,27 @@ enum MiniMaxH3FastVSA {
             prefixTileCount: prefixTileCount,
             videoTileCount: videoTileCount,
             sparsity: sparsity
+        )
+    }
+
+    static func sparseOutputForTesting(
+        queries: MLXArray,
+        keys: MLXArray,
+        values: MLXArray,
+        videoRoutes: MLXArray,
+        blockSizes: MLXArray,
+        prefixTileCount: Int,
+        kernelMode: MiniMaxH3FastVSAKernelMode
+    ) -> MLXArray {
+        sparseKernelOutput(
+            queries: queries,
+            keys: keys,
+            values: values,
+            videoRoutes: videoRoutes,
+            blockSizes: blockSizes,
+            prefixTileCount: prefixTileCount,
+            scale: 1 / sqrt(Float(headDimension)),
+            kernelMode: kernelMode
         )
     }
 
@@ -349,7 +402,8 @@ enum MiniMaxH3FastVSA {
         videoRoutes: MLXArray,
         blockSizes: MLXArray,
         prefixTileCount: Int,
-        scale: Float
+        scale: Float,
+        kernelMode: MiniMaxH3FastVSAKernelMode
     ) -> MLXArray {
         let tokenCount = queries.dim(2)
         let blockCount = blockSizes.dim(0)
@@ -358,16 +412,39 @@ enum MiniMaxH3FastVSA {
         precondition(videoRoutes.dim(2) == blockCount)
         precondition(prefixTileCount + keepVideo <= blockCount)
         #if os(macOS) || os(iOS) || os(tvOS) || os(visionOS)
+        let queryTileRows = kernelMode.queryTileRows
+        let simdgroupCount = kernelMode.simdgroupCount
+        let inputs = [queries, keys, values, videoRoutes, blockSizes, MLXArray([scale])]
+        let template: [(String, any KernelTemplateArg)] = [
+            ("TOKEN_COUNT", tokenCount),
+            ("BLOCK_COUNT", blockCount),
+            ("PREFIX_TILE_COUNT", prefixTileCount),
+            ("KEEP_VIDEO", keepVideo),
+            ("QUERY_TILE_ROWS", queryTileRows),
+            ("SIMDGROUP_COUNT", simdgroupCount),
+        ]
+        let grid = (
+            32,
+            ((tokenCount + queryTileRows - 1) / queryTileRows) * simdgroupCount,
+            queries.dim(1)
+        )
+        #if DEBUG
+        if kernelMode == .fullTileKV16 {
+            return attentionKV16Kernel(
+                inputs,
+                template: template,
+                grid: grid,
+                threadGroup: (32, simdgroupCount, 1),
+                outputShapes: [queries.shape],
+                outputDTypes: [.bfloat16]
+            )[0]
+        }
+        #endif
         return attentionKernel(
-            [queries, keys, values, videoRoutes, blockSizes, MLXArray([scale])],
-            template: [
-                ("TOKEN_COUNT", tokenCount),
-                ("BLOCK_COUNT", blockCount),
-                ("PREFIX_TILE_COUNT", prefixTileCount),
-                ("KEEP_VIDEO", keepVideo),
-            ],
-            grid: (32, ((tokenCount + 31) / 32) * 4, queries.dim(1)),
-            threadGroup: (32, 4, 1),
+            inputs,
+            template: template,
+            grid: grid,
+            threadGroup: (32, simdgroupCount, 1),
             outputShapes: [queries.shape],
             outputDTypes: [.bfloat16]
         )[0]
@@ -378,7 +455,7 @@ enum MiniMaxH3FastVSA {
 
     #if os(macOS) || os(iOS) || os(tvOS) || os(visionOS)
     private static let attentionKernel = MLXFast.metalKernel(
-        name: "mere_fasth3_vsa64_online_softmax_bf16_d128_compact_v2",
+        name: "mere_fasth3_vsa64_online_softmax_bf16_d128_compact_v3",
         inputNames: ["queries", "keys", "values", "video_routes", "block_sizes", "scale_value"],
         outputNames: ["output"],
         source: """
@@ -386,8 +463,8 @@ enum MiniMaxH3FastVSA {
             constexpr uint head_dimension = 128;
             constexpr uint matrix_size = 8;
             constexpr uint matrix_count = head_dimension / matrix_size;
-            constexpr uint query_tile_rows = 32;
-            constexpr uint simdgroup_count = 4;
+            constexpr uint query_tile_rows = QUERY_TILE_ROWS;
+            constexpr uint simdgroup_count = SIMDGROUP_COUNT;
             constexpr uint query_stride = head_dimension + 8;
             constexpr uint key_stride = matrix_size + 8;
             constexpr uint value_stride = head_dimension + 8;
@@ -553,5 +630,222 @@ enum MiniMaxH3FastVSA {
         header: "#include <metal_simdgroup_matrix>\n",
         ensureRowContiguous: true
     )
+
+    #if DEBUG
+    /// Full 64-row query tile with 16-row K/V staging. Two score fragments are
+    /// retained before each V load, halving barriers without the register and
+    /// occupancy cost of retaining an entire 64-column score tile.
+    private static let attentionKV16Kernel = MLXFast.metalKernel(
+        name: "mere_fasth3_vsa64_online_softmax_bf16_d128_kv16_v1",
+        inputNames: ["queries", "keys", "values", "video_routes", "block_sizes", "scale_value"],
+        outputNames: ["output"],
+        source: """
+            constexpr uint block_size = 64;
+            constexpr uint head_dimension = 128;
+            constexpr uint matrix_size = 8;
+            constexpr uint matrix_count = head_dimension / matrix_size;
+            constexpr uint key_tile_rows = 16;
+            constexpr uint key_matrix_count = key_tile_rows / matrix_size;
+            constexpr uint simdgroup_count = 8;
+            constexpr float log2e = 1.4426950408889634f;
+
+            uint lane = thread_index_in_simdgroup;
+            uint simd_group = simdgroup_index_in_threadgroup;
+            uint thread_linear = thread_position_in_threadgroup.y * 32
+                + thread_position_in_threadgroup.x;
+            uint query_block = threadgroup_position_in_grid.y;
+            uint head = threadgroup_position_in_grid.z;
+            uint quad = lane / 4;
+            uint matrix_row = (quad & 4) + ((lane / 2) % 4);
+            uint matrix_column = (quad & 2) * 2 + (lane % 2) * 2;
+            uint group_query_start = query_block * block_size;
+            uint local_query = group_query_start + simd_group * matrix_size + matrix_row;
+            uint query_offset = simd_group * matrix_size + matrix_row;
+            bool query_valid = query_offset < uint(block_sizes[query_block]);
+            float attention_scale = float(scale_value[0]) * log2e;
+
+            threadgroup bfloat query_shared[block_size * head_dimension];
+            threadgroup bfloat key_value_shared[key_tile_rows * head_dimension];
+            for (uint index = thread_linear;
+                 index < block_size * head_dimension;
+                 index += 32 * simdgroup_count) {
+                uint row = index / head_dimension;
+                uint dimension = index - row * head_dimension;
+                uint token = group_query_start + row;
+                bool valid = row < uint(block_sizes[query_block]);
+                query_shared[index] = valid
+                    ? bfloat(queries[(head * TOKEN_COUNT + token) * head_dimension + dimension])
+                    : bfloat(0.0f);
+            }
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+
+            thread simdgroup_matrix<float, 8, 8> accumulated[matrix_count];
+            for (uint frag = 0; frag < matrix_count; ++frag) {
+                accumulated[frag].thread_elements()[0] = 0.0f;
+                accumulated[frag].thread_elements()[1] = 0.0f;
+            }
+            float row_maximum = -INFINITY;
+            float row_sum = 0.0f;
+
+            uint route_count = query_block < PREFIX_TILE_COUNT
+                ? BLOCK_COUNT
+                : PREFIX_TILE_COUNT + KEEP_VIDEO;
+            for (uint route_index = 0; route_index < route_count; ++route_index) {
+                uint key_block;
+                if (query_block < PREFIX_TILE_COUNT || route_index < PREFIX_TILE_COUNT) {
+                    key_block = route_index;
+                } else {
+                    uint route_offset = (head * BLOCK_COUNT + query_block) * KEEP_VIDEO
+                        + route_index - PREFIX_TILE_COUNT;
+                    key_block = uint(video_routes[route_offset]);
+                }
+                uint key_start = key_block * block_size;
+                uint key_size = uint(block_sizes[key_block]);
+                for (uint key_tile_offset = 0;
+                     key_tile_offset < key_size;
+                     key_tile_offset += key_tile_rows) {
+                    uint key_tile_size = metal::min(key_tile_rows, key_size - key_tile_offset);
+                    threadgroup_barrier(mem_flags::mem_threadgroup);
+                    for (uint index = thread_linear;
+                         index < key_tile_rows * head_dimension;
+                         index += 32 * simdgroup_count) {
+                        uint dimension = index / key_tile_rows;
+                        uint key_column = index - dimension * key_tile_rows;
+                        key_value_shared[index] = key_column < key_tile_size
+                            ? bfloat(keys[
+                                (head * TOKEN_COUNT + key_start + key_tile_offset + key_column)
+                                    * head_dimension + dimension
+                            ])
+                            : bfloat(0.0f);
+                    }
+                    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+                    thread simdgroup_matrix<float, 8, 8> probabilities[key_matrix_count];
+                    float tile_maximum = -INFINITY;
+                    for (uint key_fragment_index = 0;
+                         key_fragment_index < key_matrix_count;
+                         ++key_fragment_index) {
+                        thread simdgroup_matrix<float, 8, 8> scores;
+                        scores.thread_elements()[0] = 0.0f;
+                        scores.thread_elements()[1] = 0.0f;
+                        for (uint frag = 0; frag < matrix_count; ++frag) {
+                            thread simdgroup_matrix<bfloat, 8, 8> query_fragment;
+                            thread simdgroup_matrix<bfloat, 8, 8> key_fragment;
+                            uint query_dimension = frag * matrix_size + matrix_column;
+                            uint query_row = simd_group * matrix_size + matrix_row;
+                            query_fragment.thread_elements()[0] =
+                                query_shared[query_row * head_dimension + query_dimension];
+                            query_fragment.thread_elements()[1] =
+                                query_shared[query_row * head_dimension + query_dimension + 1];
+                            uint key_dimension = frag * matrix_size + matrix_row;
+                            uint key_column = key_fragment_index * matrix_size + matrix_column;
+                            key_fragment.thread_elements()[0] =
+                                key_value_shared[key_dimension * key_tile_rows + key_column];
+                            key_fragment.thread_elements()[1] =
+                                key_value_shared[key_dimension * key_tile_rows + key_column + 1];
+                            thread simdgroup_matrix<float, 8, 8> next_scores;
+                            simdgroup_multiply_accumulate(
+                                next_scores, query_fragment, key_fragment, scores
+                            );
+                            scores = next_scores;
+                        }
+                        float score0 = scores.thread_elements()[0] * attention_scale;
+                        float score1 = scores.thread_elements()[1] * attention_scale;
+                        uint key_column = key_fragment_index * matrix_size + matrix_column;
+                        if (key_column >= key_tile_size) score0 = -INFINITY;
+                        if (key_column + 1 >= key_tile_size) score1 = -INFINITY;
+                        scores.thread_elements()[0] = score0;
+                        scores.thread_elements()[1] = score1;
+                        probabilities[key_fragment_index] = scores;
+                        tile_maximum = metal::max(tile_maximum, metal::max(score0, score1));
+                    }
+                    tile_maximum = metal::max(
+                        tile_maximum,
+                        simd_shuffle_xor(tile_maximum, ushort(1))
+                    );
+                    tile_maximum = metal::max(
+                        tile_maximum,
+                        simd_shuffle_xor(tile_maximum, ushort(8))
+                    );
+                    float new_maximum = metal::max(row_maximum, tile_maximum);
+                    float alpha = metal::fast::exp2(row_maximum - new_maximum);
+                    float probability_sum = 0.0f;
+                    for (uint key_fragment_index = 0;
+                         key_fragment_index < key_matrix_count;
+                         ++key_fragment_index) {
+                        float probability0 = metal::fast::exp2(
+                            probabilities[key_fragment_index].thread_elements()[0] - new_maximum
+                        );
+                        float probability1 = metal::fast::exp2(
+                            probabilities[key_fragment_index].thread_elements()[1] - new_maximum
+                        );
+                        probabilities[key_fragment_index].thread_elements()[0] = probability0;
+                        probabilities[key_fragment_index].thread_elements()[1] = probability1;
+                        probability_sum += probability0 + probability1;
+                    }
+                    probability_sum += simd_shuffle_xor(probability_sum, ushort(1));
+                    probability_sum += simd_shuffle_xor(probability_sum, ushort(8));
+                    row_sum = row_sum * alpha + probability_sum;
+                    row_maximum = new_maximum;
+                    for (uint frag = 0; frag < matrix_count; ++frag) {
+                        accumulated[frag].thread_elements()[0] *= alpha;
+                        accumulated[frag].thread_elements()[1] *= alpha;
+                    }
+
+                    threadgroup_barrier(mem_flags::mem_threadgroup);
+                    for (uint index = thread_linear;
+                         index < key_tile_rows * head_dimension;
+                         index += 32 * simdgroup_count) {
+                        uint value_row = index / head_dimension;
+                        uint dimension = index - value_row * head_dimension;
+                        key_value_shared[index] = value_row < key_tile_size
+                            ? bfloat(values[
+                                (head * TOKEN_COUNT + key_start + key_tile_offset + value_row)
+                                    * head_dimension + dimension
+                            ])
+                            : bfloat(0.0f);
+                    }
+                    threadgroup_barrier(mem_flags::mem_threadgroup);
+                    for (uint key_fragment_index = 0;
+                         key_fragment_index < key_matrix_count;
+                         ++key_fragment_index) {
+                        for (uint frag = 0; frag < matrix_count; ++frag) {
+                            thread simdgroup_matrix<bfloat, 8, 8> value_fragment;
+                            uint value_row = key_fragment_index * matrix_size + matrix_row;
+                            uint output_dimension = frag * matrix_size + matrix_column;
+                            value_fragment.thread_elements()[0] =
+                                key_value_shared[value_row * head_dimension + output_dimension];
+                            value_fragment.thread_elements()[1] =
+                                key_value_shared[value_row * head_dimension + output_dimension + 1];
+                            thread simdgroup_matrix<float, 8, 8> next_accumulated;
+                            simdgroup_multiply_accumulate(
+                                next_accumulated,
+                                probabilities[key_fragment_index],
+                                value_fragment,
+                                accumulated[frag]
+                            );
+                            accumulated[frag] = next_accumulated;
+                        }
+                    }
+                }
+            }
+
+            if (query_valid) {
+                uint output_base = (head * TOKEN_COUNT + local_query) * head_dimension;
+                for (uint frag = 0; frag < matrix_count; ++frag) {
+                    uint output_dimension = frag * matrix_size + matrix_column;
+                    output[output_base + output_dimension] = bfloat(
+                        accumulated[frag].thread_elements()[0] / row_sum
+                    );
+                    output[output_base + output_dimension + 1] = bfloat(
+                        accumulated[frag].thread_elements()[1] / row_sum
+                    );
+                }
+            }
+        """,
+        header: "#include <metal_simdgroup_matrix>\n",
+        ensureRowContiguous: true
+    )
+    #endif
     #endif
 }

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3FastVSA.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3FastVSA.swift
@@ -84,6 +84,14 @@ struct MiniMaxH3FastVSAGeometry: Sendable, Equatable {
     }
 }
 
+struct MiniMaxH3FastVSAPreparedContext {
+    let geometry: MiniMaxH3FastVSAGeometry
+    let paddedIndices: MLXArray
+    let originalIndices: MLXArray
+    let blockSizes: MLXArray
+    let poolingSizes: MLXArray
+}
+
 /// Metal implementation of FastVideo's released VSA-H3 tile-64 inference contract.
 ///
 /// Prefix query tiles remain dense, every query retains all prefix key tiles,
@@ -102,10 +110,45 @@ enum MiniMaxH3FastVSA {
         layout: MiniMaxH3PackedLayout,
         sparsity: Float = sparsity
     ) -> MLXArray? {
+        call(
+            queries: queries,
+            keys: keys,
+            values: values,
+            compressionGate: compressionGate,
+            prepared: prepare(layout: layout),
+            sparsity: sparsity
+        )
+    }
+
+    static func prepare(layout: MiniMaxH3PackedLayout) -> MiniMaxH3FastVSAPreparedContext {
+        let geometry = MiniMaxH3FastVSAGeometry(layout: layout)
+        let paddedIndices = MLXArray(geometry.paddedToOriginal)
+        let originalIndices = MLXArray(geometry.originalToPadded)
+        let blockSizes = MLXArray(geometry.blockSizes)
+        let poolingSizes = blockSizes.asType(.float32)
+            .reshaped(1, 1, geometry.tileCount, 1)
+        MLX.eval(paddedIndices, originalIndices, blockSizes, poolingSizes)
+        return MiniMaxH3FastVSAPreparedContext(
+            geometry: geometry,
+            paddedIndices: paddedIndices,
+            originalIndices: originalIndices,
+            blockSizes: blockSizes,
+            poolingSizes: poolingSizes
+        )
+    }
+
+    static func call(
+        queries: MLXArray,
+        keys: MLXArray,
+        values: MLXArray,
+        compressionGate: MLXArray,
+        prepared: MiniMaxH3FastVSAPreparedContext,
+        sparsity: Float = sparsity
+    ) -> MLXArray? {
         guard supports(queries: queries, keys: keys, values: values, gate: compressionGate),
               (0..<1).contains(sparsity) else { return nil }
-        let geometry = MiniMaxH3FastVSAGeometry(layout: layout)
-        guard queries.dim(2) == layout.sequenceLength else { return nil }
+        let geometry = prepared.geometry
+        guard queries.dim(2) == geometry.originalToPadded.count else { return nil }
 
         // RoPE coefficients are FP32, so the normal H3 projection path can
         // promote Q/K even when the checkpoint and hidden state are BF16.
@@ -117,24 +160,24 @@ enum MiniMaxH3FastVSA {
         let attentionValues = values.asType(.bfloat16)
         let attentionGate = compressionGate.asType(.bfloat16)
 
-        let paddedIndices = MLXArray(geometry.paddedToOriginal)
-        let originalIndices = MLXArray(geometry.originalToPadded)
-        let tiledQueries = tile(attentionQueries, paddedIndices: paddedIndices)
-        let tiledKeys = tile(attentionKeys, paddedIndices: paddedIndices)
-        let tiledValues = tile(attentionValues, paddedIndices: paddedIndices)
-        let tiledGate = tile(attentionGate, paddedIndices: paddedIndices)
-        let sizes = MLXArray(geometry.blockSizes).asType(.float32)
-            .reshaped(1, 1, geometry.tileCount, 1)
+        let tiledQueries = tile(attentionQueries, paddedIndices: prepared.paddedIndices)
+        let tiledKeys = tile(attentionKeys, paddedIndices: prepared.paddedIndices)
+        let tiledValues = tile(attentionValues, paddedIndices: prepared.paddedIndices)
+        let tiledGate = tile(attentionGate, paddedIndices: prepared.paddedIndices)
 
-        let pooledQueries = pool(tiledQueries, sizes: sizes, tileCount: geometry.tileCount)
-        let pooledKeys = pool(tiledKeys, sizes: sizes, tileCount: geometry.tileCount)
-        let pooledValues = pool(tiledValues, sizes: sizes, tileCount: geometry.tileCount)
+        let pooledQueries = pool(
+            tiledQueries,
+            sizes: prepared.poolingSizes,
+            tileCount: geometry.tileCount
+        )
+        let pooledKeys = pool(tiledKeys, sizes: prepared.poolingSizes, tileCount: geometry.tileCount)
+        let pooledValues = pool(tiledValues, sizes: prepared.poolingSizes, tileCount: geometry.tileCount)
         let scale = 1 / sqrt(Float(headDimension))
         let scores = MLX.matmul(
             pooledQueries,
             pooledKeys.transposed(0, 1, 3, 2)
         ) * scale
-        let routes = routes(
+        let videoRoutes = selectedVideoRoutes(
             scores: scores,
             prefixTileCount: geometry.prefixTileCount,
             videoTileCount: geometry.videoTileCount,
@@ -144,8 +187,9 @@ enum MiniMaxH3FastVSA {
             queries: tiledQueries,
             keys: tiledKeys,
             values: tiledValues,
-            routes: routes,
-            blockSizes: MLXArray(geometry.blockSizes),
+            videoRoutes: videoRoutes,
+            blockSizes: prepared.blockSizes,
+            prefixTileCount: geometry.prefixTileCount,
             scale: scale
         )
 
@@ -161,7 +205,7 @@ enum MiniMaxH3FastVSA {
         )
         let corrected = sparseTiles + compressed.expandedDimensions(axis: 3) * gateTiles
         let tiledOutput = corrected.reshaped(1, heads, geometry.paddedTokenCount, headDimension)
-        return MLX.take(tiledOutput, originalIndices, axis: 2)
+        return MLX.take(tiledOutput, prepared.originalIndices, axis: 2)
     }
 
     static func routesForTesting(
@@ -171,6 +215,20 @@ enum MiniMaxH3FastVSA {
         sparsity: Float = sparsity
     ) -> MLXArray {
         routes(
+            scores: scores,
+            prefixTileCount: prefixTileCount,
+            videoTileCount: videoTileCount,
+            sparsity: sparsity
+        )
+    }
+
+    static func selectedVideoRoutesForTesting(
+        scores: MLXArray,
+        prefixTileCount: Int,
+        videoTileCount: Int,
+        sparsity: Float = sparsity
+    ) -> MLXArray {
+        selectedVideoRoutes(
             scores: scores,
             prefixTileCount: prefixTileCount,
             videoTileCount: videoTileCount,
@@ -243,6 +301,28 @@ enum MiniMaxH3FastVSA {
         return result
     }
 
+    private static func selectedVideoRoutes(
+        scores: MLXArray,
+        prefixTileCount: Int,
+        videoTileCount: Int,
+        sparsity: Float
+    ) -> MLXArray {
+        precondition(scores.dim(2) == prefixTileCount + videoTileCount)
+        precondition(scores.dim(3) == prefixTileCount + videoTileCount)
+        let keepVideo = max(1, min(Int(ceil((1 - sparsity) * Float(videoTileCount))), videoTileCount))
+        let videoScores = scores[.ellipsis, prefixTileCount...]
+        if keepVideo == videoTileCount {
+            let indices = (
+                MLX.arange(videoTileCount, dtype: .int32) + MLXArray(Int32(prefixTileCount))
+            ).reshaped(1, 1, 1, videoTileCount)
+            return MLX.broadcast(indices, to: Array(scores.shape.dropLast()) + [videoTileCount])
+        }
+        return (
+            MLX.argPartition(-videoScores, kth: keepVideo - 1, axis: -1)[.ellipsis, 0..<keepVideo]
+                .asType(.int32) + MLXArray(Int32(prefixTileCount))
+        )
+    }
+
     private static func supports(
         queries: MLXArray,
         keys: MLXArray,
@@ -266,20 +346,25 @@ enum MiniMaxH3FastVSA {
         queries: MLXArray,
         keys: MLXArray,
         values: MLXArray,
-        routes: MLXArray,
+        videoRoutes: MLXArray,
         blockSizes: MLXArray,
+        prefixTileCount: Int,
         scale: Float
     ) -> MLXArray {
         let tokenCount = queries.dim(2)
-        let blockCount = routes.dim(3)
+        let blockCount = blockSizes.dim(0)
+        let keepVideo = videoRoutes.dim(3)
         precondition(tokenCount == blockCount * MiniMaxH3FastVSAGeometry.tileSize)
-        precondition(routes.dim(2) == blockCount)
+        precondition(videoRoutes.dim(2) == blockCount)
+        precondition(prefixTileCount + keepVideo <= blockCount)
         #if os(macOS) || os(iOS) || os(tvOS) || os(visionOS)
         return attentionKernel(
-            [queries, keys, values, routes, blockSizes, MLXArray([scale])],
+            [queries, keys, values, videoRoutes, blockSizes, MLXArray([scale])],
             template: [
                 ("TOKEN_COUNT", tokenCount),
                 ("BLOCK_COUNT", blockCount),
+                ("PREFIX_TILE_COUNT", prefixTileCount),
+                ("KEEP_VIDEO", keepVideo),
             ],
             grid: (32, ((tokenCount + 31) / 32) * 4, queries.dim(1)),
             threadGroup: (32, 4, 1),
@@ -293,8 +378,8 @@ enum MiniMaxH3FastVSA {
 
     #if os(macOS) || os(iOS) || os(tvOS) || os(visionOS)
     private static let attentionKernel = MLXFast.metalKernel(
-        name: "mere_fasth3_vsa64_online_softmax_bf16_d128_v1",
-        inputNames: ["queries", "keys", "values", "routes", "block_sizes", "scale_value"],
+        name: "mere_fasth3_vsa64_online_softmax_bf16_d128_compact_v2",
+        inputNames: ["queries", "keys", "values", "video_routes", "block_sizes", "scale_value"],
         outputNames: ["output"],
         source: """
             constexpr uint block_size = 64;
@@ -352,9 +437,18 @@ enum MiniMaxH3FastVSA {
             float row_maximum = -INFINITY;
             float row_sum = 0.0f;
 
-            for (uint key_block = 0; key_block < BLOCK_COUNT; ++key_block) {
-                uint route_offset = (head * BLOCK_COUNT + query_block) * BLOCK_COUNT + key_block;
-                if (routes[route_offset] == 0) continue;
+            uint route_count = query_block < PREFIX_TILE_COUNT
+                ? BLOCK_COUNT
+                : PREFIX_TILE_COUNT + KEEP_VIDEO;
+            for (uint route_index = 0; route_index < route_count; ++route_index) {
+                uint key_block;
+                if (query_block < PREFIX_TILE_COUNT || route_index < PREFIX_TILE_COUNT) {
+                    key_block = route_index;
+                } else {
+                    uint route_offset = (head * BLOCK_COUNT + query_block) * KEEP_VIDEO
+                        + route_index - PREFIX_TILE_COUNT;
+                    key_block = uint(video_routes[route_offset]);
+                }
                 uint key_start = key_block * block_size;
                 uint key_end = key_start + uint(block_sizes[key_block]);
                 for (uint key_tile = key_start; key_tile < key_end; key_tile += matrix_size) {

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3FastVSA.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3FastVSA.swift
@@ -1,0 +1,463 @@
+import Foundation
+import MLX
+import MLXFast
+
+struct MiniMaxH3FastVSAGeometry: Sendable, Equatable {
+    static let tileSize = 64
+    static let videoTileShape = (temporal: 4, height: 4, width: 4)
+
+    let paddedToOriginal: [Int32]
+    let originalToPadded: [Int32]
+    let blockSizes: [Int32]
+    let prefixTileCount: Int
+    let videoTileCount: Int
+
+    var tileCount: Int { blockSizes.count }
+    var paddedTokenCount: Int { paddedToOriginal.count }
+
+    init(layout: MiniMaxH3PackedLayout) {
+        let prefixSegments = [
+            layout.textRows.count,
+            layout.conditionRows.count,
+            layout.targetAudioRows.count,
+        ].filter { $0 > 0 }
+        let prefixCount = prefixSegments.reduce(0, +)
+        precondition(prefixCount == layout.targetVideoRows.lowerBound)
+
+        var tiles: [[Int32]] = []
+        var prefixStart = 0
+        for segment in prefixSegments {
+            for start in stride(from: 0, to: segment, by: Self.tileSize) {
+                let count = min(Self.tileSize, segment - start)
+                tiles.append((0..<count).map { Int32(prefixStart + start + $0) })
+            }
+            prefixStart += segment
+        }
+        self.prefixTileCount = tiles.count
+
+        let temporal = layout.videoLatentFrames
+        let height = layout.latentHeight / 2
+        let width = layout.latentWidth / 2
+        let shape = Self.videoTileShape
+        for tileT in stride(from: 0, to: temporal, by: shape.temporal) {
+            for tileH in stride(from: 0, to: height, by: shape.height) {
+                for tileW in stride(from: 0, to: width, by: shape.width) {
+                    var tile: [Int32] = []
+                    tile.reserveCapacity(Self.tileSize)
+                    for t in tileT..<min(tileT + shape.temporal, temporal) {
+                        for h in tileH..<min(tileH + shape.height, height) {
+                            for w in tileW..<min(tileW + shape.width, width) {
+                                tile.append(Int32(prefixCount + (t * height + h) * width + w))
+                            }
+                        }
+                    }
+                    tiles.append(tile)
+                }
+            }
+        }
+        self.videoTileCount = tiles.count - prefixTileCount
+        precondition(videoTileCount > 0)
+
+        let sentinel = Int32(layout.sequenceLength)
+        var paddedToOriginal: [Int32] = []
+        var originalToPadded = Array(repeating: Int32(-1), count: layout.sequenceLength)
+        var blockSizes: [Int32] = []
+        paddedToOriginal.reserveCapacity(tiles.count * Self.tileSize)
+        blockSizes.reserveCapacity(tiles.count)
+        for tile in tiles {
+            precondition(!tile.isEmpty && tile.count <= Self.tileSize)
+            blockSizes.append(Int32(tile.count))
+            let paddedStart = paddedToOriginal.count
+            for (offset, original) in tile.enumerated() {
+                precondition(original >= 0 && Int(original) < layout.sequenceLength)
+                precondition(originalToPadded[Int(original)] == -1)
+                originalToPadded[Int(original)] = Int32(paddedStart + offset)
+                paddedToOriginal.append(original)
+            }
+            paddedToOriginal += Array(repeating: sentinel, count: Self.tileSize - tile.count)
+        }
+        precondition(originalToPadded.allSatisfy { $0 >= 0 })
+        precondition(blockSizes.reduce(0, { $0 + Int($1) }) == layout.sequenceLength)
+        self.paddedToOriginal = paddedToOriginal
+        self.originalToPadded = originalToPadded
+        self.blockSizes = blockSizes
+    }
+}
+
+/// Metal implementation of FastVideo's released VSA-H3 tile-64 inference contract.
+///
+/// Prefix query tiles remain dense, every query retains all prefix key tiles,
+/// and video keys are selected by per-head top-k pooled QK scores. The selected
+/// blocks use exact token attention; the trained compression branch separately
+/// supplies dense pooled-value context through the released gate projection.
+enum MiniMaxH3FastVSA {
+    static let sparsity: Float = 0.9
+    static let headDimension = 128
+
+    static func call(
+        queries: MLXArray,
+        keys: MLXArray,
+        values: MLXArray,
+        compressionGate: MLXArray,
+        layout: MiniMaxH3PackedLayout,
+        sparsity: Float = sparsity
+    ) -> MLXArray? {
+        guard supports(queries: queries, keys: keys, values: values, gate: compressionGate),
+              (0..<1).contains(sparsity) else { return nil }
+        let geometry = MiniMaxH3FastVSAGeometry(layout: layout)
+        guard queries.dim(2) == layout.sequenceLength else { return nil }
+
+        // RoPE coefficients are FP32, so the normal H3 projection path can
+        // promote Q/K even when the checkpoint and hidden state are BF16.
+        // FastH3's released VSA kernels run attention in BF16; normalize every
+        // projected branch at this boundary instead of rejecting the faithful
+        // FP32 rotary result.
+        let attentionQueries = queries.asType(.bfloat16)
+        let attentionKeys = keys.asType(.bfloat16)
+        let attentionValues = values.asType(.bfloat16)
+        let attentionGate = compressionGate.asType(.bfloat16)
+
+        let paddedIndices = MLXArray(geometry.paddedToOriginal)
+        let originalIndices = MLXArray(geometry.originalToPadded)
+        let tiledQueries = tile(attentionQueries, paddedIndices: paddedIndices)
+        let tiledKeys = tile(attentionKeys, paddedIndices: paddedIndices)
+        let tiledValues = tile(attentionValues, paddedIndices: paddedIndices)
+        let tiledGate = tile(attentionGate, paddedIndices: paddedIndices)
+        let sizes = MLXArray(geometry.blockSizes).asType(.float32)
+            .reshaped(1, 1, geometry.tileCount, 1)
+
+        let pooledQueries = pool(tiledQueries, sizes: sizes, tileCount: geometry.tileCount)
+        let pooledKeys = pool(tiledKeys, sizes: sizes, tileCount: geometry.tileCount)
+        let pooledValues = pool(tiledValues, sizes: sizes, tileCount: geometry.tileCount)
+        let scale = 1 / sqrt(Float(headDimension))
+        let scores = MLX.matmul(
+            pooledQueries,
+            pooledKeys.transposed(0, 1, 3, 2)
+        ) * scale
+        let routes = routes(
+            scores: scores,
+            prefixTileCount: geometry.prefixTileCount,
+            videoTileCount: geometry.videoTileCount,
+            sparsity: sparsity
+        )
+        let sparse = sparseKernelOutput(
+            queries: tiledQueries,
+            keys: tiledKeys,
+            values: tiledValues,
+            routes: routes,
+            blockSizes: MLXArray(geometry.blockSizes),
+            scale: scale
+        )
+
+        let compressed = MLX.matmul(
+            MLX.softmax(scores, axis: -1, precise: true),
+            pooledValues
+        ).asType(sparse.dtype)
+        let tileCount = geometry.tileCount
+        let heads = attentionQueries.dim(1)
+        let sparseTiles = sparse.reshaped(1, heads, tileCount, MiniMaxH3FastVSAGeometry.tileSize, headDimension)
+        let gateTiles = tiledGate.reshaped(
+            1, heads, tileCount, MiniMaxH3FastVSAGeometry.tileSize, headDimension
+        )
+        let corrected = sparseTiles + compressed.expandedDimensions(axis: 3) * gateTiles
+        let tiledOutput = corrected.reshaped(1, heads, geometry.paddedTokenCount, headDimension)
+        return MLX.take(tiledOutput, originalIndices, axis: 2)
+    }
+
+    static func routesForTesting(
+        scores: MLXArray,
+        prefixTileCount: Int,
+        videoTileCount: Int,
+        sparsity: Float = sparsity
+    ) -> MLXArray {
+        routes(
+            scores: scores,
+            prefixTileCount: prefixTileCount,
+            videoTileCount: videoTileCount,
+            sparsity: sparsity
+        )
+    }
+
+    private static func tile(_ value: MLXArray, paddedIndices: MLXArray) -> MLXArray {
+        let zero = MLXArray.zeros(
+            [value.dim(0), value.dim(1), 1, value.dim(3)],
+            dtype: value.dtype
+        )
+        return MLX.take(MLX.concatenated([value, zero], axis: 2), paddedIndices, axis: 2)
+    }
+
+    private static func pool(
+        _ value: MLXArray,
+        sizes: MLXArray,
+        tileCount: Int
+    ) -> MLXArray {
+        value.asType(.float32)
+            .reshaped(1, value.dim(1), tileCount, MiniMaxH3FastVSAGeometry.tileSize, headDimension)
+            .sum(axis: 3) / sizes
+    }
+
+    private static func routes(
+        scores: MLXArray,
+        prefixTileCount: Int,
+        videoTileCount: Int,
+        sparsity: Float
+    ) -> MLXArray {
+        precondition(scores.dim(2) == prefixTileCount + videoTileCount)
+        precondition(scores.dim(3) == prefixTileCount + videoTileCount)
+        let keepVideo = max(1, min(Int(ceil((1 - sparsity) * Float(videoTileCount))), videoTileCount))
+        let videoScores = scores[.ellipsis, prefixTileCount...]
+        let videoRoutes: MLXArray
+        if keepVideo == videoTileCount {
+            videoRoutes = MLXArray.ones(videoScores.shape, dtype: .uint8)
+        } else {
+            let selected = MLX.argPartition(
+                -videoScores,
+                kth: keepVideo - 1,
+                axis: -1
+            )[.ellipsis, 0..<keepVideo]
+            videoRoutes = MLX.putAlong(
+                MLXArray.zeros(videoScores.shape, dtype: .uint8),
+                selected,
+                values: MLXArray.ones(selected.shape, dtype: .uint8),
+                axis: -1
+            )
+        }
+        var result = prefixTileCount == 0
+            ? videoRoutes
+            : MLX.concatenated([
+                MLXArray.ones(
+                    [scores.dim(0), scores.dim(1), scores.dim(2), prefixTileCount],
+                    dtype: .uint8
+                ),
+                videoRoutes,
+            ], axis: -1)
+        if prefixTileCount > 0 {
+            result = MLX.concatenated([
+                MLXArray.ones(
+                    [scores.dim(0), scores.dim(1), prefixTileCount, scores.dim(3)],
+                    dtype: .uint8
+                ),
+                result[0..., 0..., prefixTileCount..., 0...],
+            ], axis: 2)
+        }
+        return result
+    }
+
+    private static func supports(
+        queries: MLXArray,
+        keys: MLXArray,
+        values: MLXArray,
+        gate: MLXArray
+    ) -> Bool {
+        #if os(macOS) || os(iOS) || os(tvOS) || os(visionOS)
+        return Device.defaultDevice().deviceType == .gpu
+            && queries.shape == keys.shape
+            && queries.shape == values.shape
+            && queries.shape == gate.shape
+            && queries.ndim == 4
+            && queries.dim(0) == 1
+            && queries.dim(3) == headDimension
+        #else
+        return false
+        #endif
+    }
+
+    private static func sparseKernelOutput(
+        queries: MLXArray,
+        keys: MLXArray,
+        values: MLXArray,
+        routes: MLXArray,
+        blockSizes: MLXArray,
+        scale: Float
+    ) -> MLXArray {
+        let tokenCount = queries.dim(2)
+        let blockCount = routes.dim(3)
+        precondition(tokenCount == blockCount * MiniMaxH3FastVSAGeometry.tileSize)
+        precondition(routes.dim(2) == blockCount)
+        #if os(macOS) || os(iOS) || os(tvOS) || os(visionOS)
+        return attentionKernel(
+            [queries, keys, values, routes, blockSizes, MLXArray([scale])],
+            template: [
+                ("TOKEN_COUNT", tokenCount),
+                ("BLOCK_COUNT", blockCount),
+            ],
+            grid: (32, ((tokenCount + 31) / 32) * 4, queries.dim(1)),
+            threadGroup: (32, 4, 1),
+            outputShapes: [queries.shape],
+            outputDTypes: [.bfloat16]
+        )[0]
+        #else
+        preconditionFailure("FastH3 VSA requires Metal")
+        #endif
+    }
+
+    #if os(macOS) || os(iOS) || os(tvOS) || os(visionOS)
+    private static let attentionKernel = MLXFast.metalKernel(
+        name: "mere_fasth3_vsa64_online_softmax_bf16_d128_v1",
+        inputNames: ["queries", "keys", "values", "routes", "block_sizes", "scale_value"],
+        outputNames: ["output"],
+        source: """
+            constexpr uint block_size = 64;
+            constexpr uint head_dimension = 128;
+            constexpr uint matrix_size = 8;
+            constexpr uint matrix_count = head_dimension / matrix_size;
+            constexpr uint query_tile_rows = 32;
+            constexpr uint simdgroup_count = 4;
+            constexpr uint query_stride = head_dimension + 8;
+            constexpr uint key_stride = matrix_size + 8;
+            constexpr uint value_stride = head_dimension + 8;
+            constexpr float log2e = 1.4426950408889634f;
+
+            uint lane = thread_index_in_simdgroup;
+            uint simd_group = simdgroup_index_in_threadgroup;
+            uint thread_linear = thread_position_in_threadgroup.y * 32
+                + thread_position_in_threadgroup.x;
+            uint query_group = threadgroup_position_in_grid.y;
+            uint head = threadgroup_position_in_grid.z;
+            uint quad = lane / 4;
+            uint matrix_row = (quad & 4) + ((lane / 2) % 4);
+            uint matrix_column = (quad & 2) * 2 + (lane % 2) * 2;
+            uint group_query_start = query_group * query_tile_rows;
+            uint local_query = group_query_start + simd_group * matrix_size + matrix_row;
+            uint safe_query = metal::min(local_query, uint(TOKEN_COUNT - 1));
+            uint query_block = safe_query / block_size;
+            uint query_offset = safe_query - query_block * block_size;
+            bool query_valid = local_query < TOKEN_COUNT
+                && query_offset < uint(block_sizes[query_block]);
+            float attention_scale = float(scale_value[0]) * log2e;
+
+            threadgroup bfloat query_shared[query_tile_rows * query_stride];
+            threadgroup bfloat key_value_shared[head_dimension * key_stride];
+            for (uint index = thread_linear;
+                 index < query_tile_rows * head_dimension;
+                 index += 32 * simdgroup_count) {
+                uint row = index / head_dimension;
+                uint dimension = index - row * head_dimension;
+                uint candidate = group_query_start + row;
+                bool valid = candidate < TOKEN_COUNT;
+                uint token = metal::min(candidate, uint(TOKEN_COUNT - 1));
+                uint block = token / block_size;
+                valid = valid && token - block * block_size < uint(block_sizes[block]);
+                query_shared[row * query_stride + dimension] = valid
+                    ? bfloat(queries[(head * TOKEN_COUNT + token) * head_dimension + dimension])
+                    : bfloat(0.0f);
+            }
+            threadgroup_barrier(mem_flags::mem_threadgroup);
+
+            thread simdgroup_matrix<float, 8, 8> accumulated[matrix_count];
+            for (uint frag = 0; frag < matrix_count; ++frag) {
+                accumulated[frag].thread_elements()[0] = 0.0f;
+                accumulated[frag].thread_elements()[1] = 0.0f;
+            }
+            float row_maximum = -INFINITY;
+            float row_sum = 0.0f;
+
+            for (uint key_block = 0; key_block < BLOCK_COUNT; ++key_block) {
+                uint route_offset = (head * BLOCK_COUNT + query_block) * BLOCK_COUNT + key_block;
+                if (routes[route_offset] == 0) continue;
+                uint key_start = key_block * block_size;
+                uint key_end = key_start + uint(block_sizes[key_block]);
+                for (uint key_tile = key_start; key_tile < key_end; key_tile += matrix_size) {
+                    threadgroup_barrier(mem_flags::mem_threadgroup);
+                    for (uint index = thread_linear;
+                         index < matrix_size * head_dimension;
+                         index += 32 * simdgroup_count) {
+                        uint dimension = index / matrix_size;
+                        uint key_column = index - dimension * matrix_size;
+                        uint token = key_tile + key_column;
+                        key_value_shared[dimension * key_stride + key_column] = token < key_end
+                            ? bfloat(keys[(head * TOKEN_COUNT + token) * head_dimension + dimension])
+                            : bfloat(0.0f);
+                    }
+                    threadgroup_barrier(mem_flags::mem_threadgroup);
+
+                    thread simdgroup_matrix<float, 8, 8> scores;
+                    scores.thread_elements()[0] = 0.0f;
+                    scores.thread_elements()[1] = 0.0f;
+                    for (uint frag = 0; frag < matrix_count; ++frag) {
+                        thread simdgroup_matrix<bfloat, 8, 8> query_fragment;
+                        thread simdgroup_matrix<bfloat, 8, 8> key_fragment;
+                        uint query_dimension = frag * matrix_size + matrix_column;
+                        uint query_row = simd_group * matrix_size + matrix_row;
+                        query_fragment.thread_elements()[0] =
+                            query_shared[query_row * query_stride + query_dimension];
+                        query_fragment.thread_elements()[1] =
+                            query_shared[query_row * query_stride + query_dimension + 1];
+                        uint key_dimension = frag * matrix_size + matrix_row;
+                        key_fragment.thread_elements()[0] =
+                            key_value_shared[key_dimension * key_stride + matrix_column];
+                        key_fragment.thread_elements()[1] =
+                            key_value_shared[key_dimension * key_stride + matrix_column + 1];
+                        thread simdgroup_matrix<float, 8, 8> next_scores;
+                        simdgroup_multiply_accumulate(next_scores, query_fragment, key_fragment, scores);
+                        scores = next_scores;
+                    }
+
+                    float score0 = scores.thread_elements()[0] * attention_scale;
+                    float score1 = scores.thread_elements()[1] * attention_scale;
+                    if (key_tile + matrix_column >= key_end) score0 = -INFINITY;
+                    if (key_tile + matrix_column + 1 >= key_end) score1 = -INFINITY;
+                    float tile_maximum = metal::max(score0, score1);
+                    tile_maximum = metal::max(tile_maximum, simd_shuffle_xor(tile_maximum, ushort(1)));
+                    tile_maximum = metal::max(tile_maximum, simd_shuffle_xor(tile_maximum, ushort(8)));
+                    float new_maximum = metal::max(row_maximum, tile_maximum);
+                    float alpha = metal::fast::exp2(row_maximum - new_maximum);
+                    float probability0 = metal::fast::exp2(score0 - new_maximum);
+                    float probability1 = metal::fast::exp2(score1 - new_maximum);
+                    float probability_sum = probability0 + probability1;
+                    probability_sum += simd_shuffle_xor(probability_sum, ushort(1));
+                    probability_sum += simd_shuffle_xor(probability_sum, ushort(8));
+                    row_sum = row_sum * alpha + probability_sum;
+                    row_maximum = new_maximum;
+
+                    thread simdgroup_matrix<float, 8, 8> probabilities;
+                    probabilities.thread_elements()[0] = probability0;
+                    probabilities.thread_elements()[1] = probability1;
+                    threadgroup_barrier(mem_flags::mem_threadgroup);
+                    for (uint index = thread_linear;
+                         index < matrix_size * head_dimension;
+                         index += 32 * simdgroup_count) {
+                        uint value_row = index / head_dimension;
+                        uint dimension = index - value_row * head_dimension;
+                        uint token = key_tile + value_row;
+                        key_value_shared[value_row * value_stride + dimension] = token < key_end
+                            ? bfloat(values[(head * TOKEN_COUNT + token) * head_dimension + dimension])
+                            : bfloat(0.0f);
+                    }
+                    threadgroup_barrier(mem_flags::mem_threadgroup);
+                    for (uint frag = 0; frag < matrix_count; ++frag) {
+                        accumulated[frag].thread_elements()[0] *= alpha;
+                        accumulated[frag].thread_elements()[1] *= alpha;
+                        thread simdgroup_matrix<bfloat, 8, 8> value_fragment;
+                        uint output_dimension = frag * matrix_size + matrix_column;
+                        value_fragment.thread_elements()[0] =
+                            key_value_shared[matrix_row * value_stride + output_dimension];
+                        value_fragment.thread_elements()[1] =
+                            key_value_shared[matrix_row * value_stride + output_dimension + 1];
+                        thread simdgroup_matrix<float, 8, 8> next_accumulated;
+                        simdgroup_multiply_accumulate(
+                            next_accumulated, probabilities, value_fragment, accumulated[frag]
+                        );
+                        accumulated[frag] = next_accumulated;
+                    }
+                }
+            }
+
+            if (query_valid) {
+                uint output_base = (head * TOKEN_COUNT + local_query) * head_dimension;
+                for (uint frag = 0; frag < matrix_count; ++frag) {
+                    uint output_dimension = frag * matrix_size + matrix_column;
+                    output[output_base + output_dimension] = bfloat(
+                        accumulated[frag].thread_elements()[0] / row_sum
+                    );
+                    output[output_base + output_dimension + 1] = bfloat(
+                        accumulated[frag].thread_elements()[1] / row_sum
+                    );
+                }
+            }
+        """,
+        header: "#include <metal_simdgroup_matrix>\n",
+        ensureRowContiguous: true
+    )
+    #endif
+}

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3FusedKernels.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3FusedKernels.swift
@@ -37,6 +37,43 @@ enum MiniMaxH3FusedKernels {
     private static let affineGroupSize = 64
     private static let feedForwardSize = 14_336
 
+    /// Fuses the first H3 block boundary: RMSNorm followed by the row-indexed
+    /// attention scale and shift. This is the Metal counterpart of FastVideo's
+    /// `fused_rmsnorm_modulate` Triton kernel.
+    static func prepareAttentionInput(
+        input: MLXArray,
+        normWeight: MLXArray,
+        modulation: MLXArray,
+        rowIndices: MLXArray,
+        eps: Float
+    ) -> MLXArray? {
+        #if os(macOS) || os(iOS)
+        guard eps.isFinite,
+              eps > 0,
+              supportsAdaLNShapeContract(
+                  input: input,
+                  normWeight: normWeight,
+                  modulation: modulation,
+                  rowIndices: rowIndices
+              ) else {
+            return nil
+        }
+
+        let kernel = input.dtype == .bfloat16
+            ? attentionAdaLNKernel
+            : attentionAdaLNMixedKernel
+        return kernel(
+            [input, normWeight, modulation, rowIndices, eps],
+            grid: (threadCount, input.dim(1), 1),
+            threadGroup: (threadCount, 1, 1),
+            outputShapes: [input.shape],
+            outputDTypes: [input.dtype]
+        )[0]
+        #else
+        return nil
+        #endif
+    }
+
     static func gateAttentionAndPrepareFeedForward(
         residual: MLXArray,
         attentionOutput: MLXArray,
@@ -416,8 +453,8 @@ enum MiniMaxH3FusedKernels {
     }
 
     /// Matrix-tiled K4a candidate that keeps the gate and up projections in
-    /// registers through the SwiGLU epilogue. This avoids materializing the
-    /// two-wide FC1 output while retaining the managed BF16 QMM boundary.
+    /// registers through the SwiGLU epilogue. Matrix operands and outputs keep
+    /// the residual stream's BF16 or Float32 type, with Float32 accumulation.
     static func projectFeedForwardInputAffineInt8SwiGLUTiled(
         input: MLXArray,
         weightCodes: MLXArray,
@@ -427,7 +464,7 @@ enum MiniMaxH3FusedKernels {
         #if os(macOS) || os(iOS)
         let scaleGroups = hiddenSize / affineGroupSize
         guard Device.defaultDevice().deviceType == .gpu,
-              input.dtype == .bfloat16,
+              [.bfloat16, .float32].contains(input.dtype),
               input.ndim == 3,
               input.dim(0) == 1,
               input.dim(1) > 0,
@@ -446,10 +483,11 @@ enum MiniMaxH3FusedKernels {
         let rowTileCount = (rows + 31) / 32
         return projectFeedForwardInputAffineInt8SwiGLUTiledKernel(
             [input, weightCodes, weightScales, weightBiases],
+            template: [("T", input.dtype)],
             grid: (32 * outputTileCount, 4 * rowTileCount, 1),
             threadGroup: (32, 4, 1),
             outputShapes: [[1, rows, feedForwardSize]],
-            outputDTypes: [.bfloat16]
+            outputDTypes: [input.dtype]
         )[0]
         #else
         return nil
@@ -512,7 +550,7 @@ enum MiniMaxH3FusedKernels {
         #if os(macOS) || os(iOS)
         let scaleGroups = feedForwardSize / affineGroupSize
         guard Device.defaultDevice().deviceType == .gpu,
-              input.dtype == .bfloat16,
+              [.bfloat16, .float32].contains(input.dtype),
               input.ndim == 3,
               input.dim(0) == 1,
               input.dim(1) > 0,
@@ -531,10 +569,11 @@ enum MiniMaxH3FusedKernels {
         let rowTileCount = (rows + 31) / 32
         return projectFeedForwardOutputAffineInt8TiledKernel(
             [input, weightCodes, weightScales, weightBiases],
+            template: [("T", input.dtype)],
             grid: (32 * outputTileCount, 4 * rowTileCount, 1),
             threadGroup: (32, 4, 1),
             outputShapes: [[1, rows, hiddenSize]],
-            outputDTypes: [.bfloat16]
+            outputDTypes: [input.dtype]
         )[0]
         #else
         return nil
@@ -542,19 +581,18 @@ enum MiniMaxH3FusedKernels {
     }
 
     #if os(macOS) || os(iOS)
-    private static func supportsGateAdaLNShapeContract(
-        residual: MLXArray,
-        branch: MLXArray,
+    private static func supportsAdaLNShapeContract(
+        input: MLXArray,
         normWeight: MLXArray,
         modulation: MLXArray,
         rowIndices: MLXArray
     ) -> Bool {
         Device.defaultDevice().deviceType == .gpu
-            && residual.shape == branch.shape
-            && residual.ndim == 3
-            && residual.dim(0) == 1
-            && residual.dim(1) > 0
-            && residual.dim(2) == hiddenSize
+            && [.bfloat16, .float32].contains(input.dtype)
+            && input.ndim == 3
+            && input.dim(0) == 1
+            && input.dim(1) > 0
+            && input.dim(2) == hiddenSize
             && normWeight.dtype == .bfloat16
             && normWeight.shape == [hiddenSize]
             && modulation.dtype == .bfloat16
@@ -562,7 +600,23 @@ enum MiniMaxH3FusedKernels {
             && modulation.dim(0) > 0
             && modulation.dim(1) == modulationPartCount * hiddenSize
             && rowIndices.dtype == .int32
-            && rowIndices.shape == [residual.dim(1)]
+            && rowIndices.shape == [input.dim(1)]
+    }
+
+    private static func supportsGateAdaLNShapeContract(
+        residual: MLXArray,
+        branch: MLXArray,
+        normWeight: MLXArray,
+        modulation: MLXArray,
+        rowIndices: MLXArray
+    ) -> Bool {
+        residual.shape == branch.shape
+            && supportsAdaLNShapeContract(
+                input: residual,
+                normWeight: normWeight,
+                modulation: modulation,
+                rowIndices: rowIndices
+            )
     }
 
     private static func supportsGateAdaLNInputs(
@@ -582,6 +636,134 @@ enum MiniMaxH3FusedKernels {
             && residual.dtype == .bfloat16
             && branch.dtype == .bfloat16
     }
+
+    private static let attentionAdaLNKernel = MLXFast.metalKernel(
+        name: "mere_h3_attention_adaln_bf16_h5376_v1",
+        inputNames: [
+            "input", "norm_weight", "modulation", "row_indices", "epsilon",
+        ],
+        outputNames: ["output"],
+        source: """
+            constexpr uint hidden_size = 5376;
+            constexpr uint modulation_parts = 6;
+            constexpr uint simd_width = 32;
+
+            uint row = threadgroup_position_in_grid.y;
+            uint tid = thread_position_in_threadgroup.x;
+            uint simd_lane = thread_index_in_simdgroup;
+            uint simd_group = simdgroup_index_in_threadgroup;
+            uint row_offset = row * hidden_size;
+            uint modulation_offset = uint(row_indices[row])
+                * modulation_parts * hidden_size;
+
+            threadgroup float partial_sums[simd_width];
+            threadgroup float inverse_rms[1];
+
+            float sum = 0.0f;
+            for (uint dimension = tid; dimension < hidden_size;
+                 dimension += threads_per_threadgroup.x) {
+                float value = float(input[row_offset + dimension]);
+                sum += value * value;
+            }
+
+            sum = simd_sum(sum);
+            if (simd_group == 0) {
+                partial_sums[simd_lane] = 0.0f;
+            }
+            threadgroup_barrier(metal::mem_flags::mem_threadgroup);
+            if (simd_lane == 0) {
+                partial_sums[simd_group] = sum;
+            }
+            threadgroup_barrier(metal::mem_flags::mem_threadgroup);
+            if (simd_group == 0) {
+                sum = simd_sum(partial_sums[simd_lane]);
+                if (simd_lane == 0) {
+                    inverse_rms[0] = metal::precise::rsqrt(
+                        sum / float(hidden_size) + float(epsilon));
+                }
+            }
+            threadgroup_barrier(metal::mem_flags::mem_threadgroup);
+
+            for (uint dimension = tid; dimension < hidden_size;
+                 dimension += threads_per_threadgroup.x) {
+                bfloat16_t normalized = bfloat16_t(
+                    float(input[row_offset + dimension]) * inverse_rms[0]);
+                bfloat16_t weighted = bfloat16_t(
+                    float(norm_weight[dimension]) * float(normalized));
+                bfloat16_t one_plus_scale = bfloat16_t(
+                    1.0f + float(modulation[
+                        modulation_offset + hidden_size + dimension]));
+                bfloat16_t scaled = bfloat16_t(
+                    float(weighted) * float(one_plus_scale));
+                output[row_offset + dimension] = bfloat16_t(
+                    float(scaled) + float(modulation[
+                        modulation_offset + dimension]));
+            }
+        """,
+        ensureRowContiguous: true
+    )
+
+    private static let attentionAdaLNMixedKernel = MLXFast.metalKernel(
+        name: "mere_h3_attention_adaln_mixed_h5376_v1",
+        inputNames: [
+            "input", "norm_weight", "modulation", "row_indices", "epsilon",
+        ],
+        outputNames: ["output"],
+        source: """
+            constexpr uint hidden_size = 5376;
+            constexpr uint modulation_parts = 6;
+            constexpr uint simd_width = 32;
+
+            uint row = threadgroup_position_in_grid.y;
+            uint tid = thread_position_in_threadgroup.x;
+            uint simd_lane = thread_index_in_simdgroup;
+            uint simd_group = simdgroup_index_in_threadgroup;
+            uint row_offset = row * hidden_size;
+            uint modulation_offset = uint(row_indices[row])
+                * modulation_parts * hidden_size;
+
+            threadgroup float partial_sums[simd_width];
+            threadgroup float inverse_rms[1];
+
+            float sum = 0.0f;
+            for (uint dimension = tid; dimension < hidden_size;
+                 dimension += threads_per_threadgroup.x) {
+                float value = float(input[row_offset + dimension]);
+                sum += value * value;
+            }
+
+            sum = simd_sum(sum);
+            if (simd_group == 0) {
+                partial_sums[simd_lane] = 0.0f;
+            }
+            threadgroup_barrier(metal::mem_flags::mem_threadgroup);
+            if (simd_lane == 0) {
+                partial_sums[simd_group] = sum;
+            }
+            threadgroup_barrier(metal::mem_flags::mem_threadgroup);
+            if (simd_group == 0) {
+                sum = simd_sum(partial_sums[simd_lane]);
+                if (simd_lane == 0) {
+                    inverse_rms[0] = metal::precise::rsqrt(
+                        sum / float(hidden_size) + float(epsilon));
+                }
+            }
+            threadgroup_barrier(metal::mem_flags::mem_threadgroup);
+
+            for (uint dimension = tid; dimension < hidden_size;
+                 dimension += threads_per_threadgroup.x) {
+                float weighted = float(input[row_offset + dimension])
+                    * inverse_rms[0] * float(norm_weight[dimension]);
+                bfloat16_t one_plus_scale = bfloat16_t(
+                    1.0f + float(modulation[
+                        modulation_offset + hidden_size + dimension]));
+                output[row_offset + dimension] = weighted
+                    * float(one_plus_scale) + float(modulation[
+                        modulation_offset + dimension]);
+            }
+        """,
+        ensureRowContiguous: true
+    )
 
     private static let gateAdaLNKernel = MLXFast.metalKernel(
         name: "mere_h3_gate_adaln_bf16_h5376_v1",
@@ -1466,7 +1648,7 @@ enum MiniMaxH3FusedKernels {
     )
 
     private static let projectFeedForwardInputAffineInt8SwiGLUTiledKernel = MLXFast.metalKernel(
-        name: "mere_h3_affine_fc1_swiglu_i8g64_tiled_v3",
+        name: "mere_h3_affine_fc1_swiglu_i8g64_tiled_v5",
         inputNames: ["input", "weight_codes", "weight_scales", "weight_biases"],
         outputNames: ["activated"],
         source: """
@@ -1492,13 +1674,13 @@ enum MiniMaxH3FusedKernels {
             uint matrix_row = (quad & 4) + ((lane / 2) % 4);
             uint matrix_column = (quad & 2) * 2 + (lane % 2) * 2;
 
-            threadgroup bfloat gate_weight_tile[
+            threadgroup T gate_weight_tile[
                 output_tile_columns * reduction_tile
             ];
-            threadgroup bfloat up_weight_tile[
+            threadgroup T up_weight_tile[
                 output_tile_columns * reduction_tile
             ];
-            threadgroup bfloat input_tile[row_tile_rows * reduction_tile];
+            threadgroup T input_tile[row_tile_rows * reduction_tile];
 
             thread simdgroup_matrix<float, 8, 8> gate_accumulated[4];
             thread simdgroup_matrix<float, 8, 8> up_accumulated[4];
@@ -1538,34 +1720,34 @@ enum MiniMaxH3FusedKernels {
                 for (uint index = 0; index < 8; ++index) {
                     uint tile_index = local_output * reduction_tile
                         + weight_eight + index;
-                    gate_weight_tile[tile_index] = bfloat(
+                    gate_weight_tile[tile_index] = T(
                         gate_scale * float(gate_values[index]) + gate_bias
                     );
-                    up_weight_tile[tile_index] = bfloat(
+                    up_weight_tile[tile_index] = T(
                         up_scale * float(up_values[index]) + up_bias
                     );
                 }
 
                 uint safe_row = metal::min(local_input_row, valid_rows - 1);
-                const device bfloat16_t* input_values = input
+                const device T* input_values = input
                     + uint64_t(row_start + safe_row) * uint64_t(input_width)
                     + reduction_start + input_eight;
                 #pragma clang loop unroll(full)
                 for (uint index = 0; index < 8; ++index) {
                     input_tile[local_input_row * reduction_tile + input_eight + index]
-                        = bfloat(input_values[index]);
+                        = T(input_values[index]);
                 }
                 threadgroup_barrier(mem_flags::mem_threadgroup);
 
-                threadgroup const bfloat* gate_fragments = gate_weight_tile
+                threadgroup const T* gate_fragments = gate_weight_tile
                     + (simd_group % 2) * 16 * reduction_tile;
-                threadgroup const bfloat* up_fragments = up_weight_tile
+                threadgroup const T* up_fragments = up_weight_tile
                     + (simd_group % 2) * 16 * reduction_tile;
-                threadgroup const bfloat* input_fragments = input_tile
+                threadgroup const T* input_fragments = input_tile
                     + (simd_group / 2) * 16 * reduction_tile;
-                thread simdgroup_matrix<bfloat, 8, 8> gate_weights[2];
-                thread simdgroup_matrix<bfloat, 8, 8> up_weights[2];
-                thread simdgroup_matrix<bfloat, 8, 8> inputs[2];
+                thread simdgroup_matrix<T, 8, 8> gate_weights[2];
+                thread simdgroup_matrix<T, 8, 8> up_weights[2];
+                thread simdgroup_matrix<T, 8, 8> inputs[2];
                 #pragma clang loop unroll(full)
                 for (uint reduction_fragment = 0;
                      reduction_fragment < 4;
@@ -1640,22 +1822,22 @@ enum MiniMaxH3FusedKernels {
                 if (output_row < valid_rows) {
                     uint64_t output_index = uint64_t(row_start + output_row)
                         * uint64_t(output_width) + uint64_t(output_start + output_column);
-                    float gate0 = float(bfloat(
+                    float gate0 = float(T(
                         gate_accumulated[result].thread_elements()[0]
                     ));
-                    float gate1 = float(bfloat(
+                    float gate1 = float(T(
                         gate_accumulated[result].thread_elements()[1]
                     ));
-                    float up0 = float(bfloat(
+                    float up0 = float(T(
                         up_accumulated[result].thread_elements()[0]
                     ));
-                    float up1 = float(bfloat(
+                    float up1 = float(T(
                         up_accumulated[result].thread_elements()[1]
                     ));
                     float sigmoid0 = 1.0f / (1.0f + metal::precise::exp(-gate0));
                     float sigmoid1 = 1.0f / (1.0f + metal::precise::exp(-gate1));
-                    activated[output_index] = bfloat16_t(gate0 * sigmoid0 * up0);
-                    activated[output_index + 1] = bfloat16_t(
+                    activated[output_index] = T(gate0 * sigmoid0 * up0);
+                    activated[output_index + 1] = T(
                         gate1 * sigmoid1 * up1
                     );
                 }
@@ -1929,7 +2111,7 @@ enum MiniMaxH3FusedKernels {
     )
 
     private static let projectFeedForwardOutputAffineInt8TiledKernel = MLXFast.metalKernel(
-        name: "mere_h3_affine_fc2_i8g64_tiled_v3",
+        name: "mere_h3_affine_fc2_i8g64_tiled_v5",
         inputNames: ["input", "weight_codes", "weight_scales", "weight_biases"],
         outputNames: ["projected"],
         source: """
@@ -1956,8 +2138,8 @@ enum MiniMaxH3FusedKernels {
             uint matrix_row = (quad & 4) + ((lane / 2) % 4);
             uint matrix_column = (quad & 2) * 2 + (lane % 2) * 2;
 
-            threadgroup bfloat weight_tile[output_tile_columns * reduction_tile];
-            threadgroup bfloat input_tile[row_tile_rows * reduction_tile];
+            threadgroup T weight_tile[output_tile_columns * reduction_tile];
+            threadgroup T input_tile[row_tile_rows * reduction_tile];
 
             thread simdgroup_matrix<float, 8, 8> accumulated[8];
             #pragma clang loop unroll(full)
@@ -1991,7 +2173,7 @@ enum MiniMaxH3FusedKernels {
                     uint local_x = local_output % 8;
                     uint local_y = index % 8;
                     uint block = 8 * section_x + section_y;
-                    weight_tile[64 * block + 8 * local_y + local_x] = bfloat(
+                    weight_tile[64 * block + 8 * local_y + local_x] = T(
                         scale * float(weight_values[index]) + bias
                     );
                 }
@@ -2001,22 +2183,22 @@ enum MiniMaxH3FusedKernels {
                 uint input_section_y = local_input_row / 8;
                 uint input_local_y = local_input_row % 8;
                 uint input_block = 4 * input_section_x + input_section_y;
-                const device bfloat16_t* input_values = input
+                const device T* input_values = input
                     + uint64_t(row_start + safe_row) * uint64_t(input_width)
                     + reduction_start + input_eight;
                 #pragma clang loop unroll(full)
                 for (uint index = 0; index < 8; ++index) {
                     input_tile[64 * input_block + 8 * input_local_y + index]
-                        = bfloat(input_values[index]);
+                        = T(input_values[index]);
                 }
                 threadgroup_barrier(mem_flags::mem_threadgroup);
 
-                threadgroup const bfloat* weight_fragments = weight_tile
+                threadgroup const T* weight_fragments = weight_tile
                     + 4 * 64 * (simd_group % 2);
-                threadgroup const bfloat* input_fragments = input_tile
+                threadgroup const T* input_fragments = input_tile
                     + 2 * 64 * (simd_group / 2);
-                thread simdgroup_matrix<bfloat, 8, 8> weights[4];
-                thread simdgroup_matrix<bfloat, 8, 8> inputs[2];
+                thread simdgroup_matrix<T, 8, 8> weights[4];
+                thread simdgroup_matrix<T, 8, 8> inputs[2];
                 #pragma clang loop unroll(full)
                 for (uint reduction_fragment = 0;
                      reduction_fragment < 4;
@@ -2072,10 +2254,10 @@ enum MiniMaxH3FusedKernels {
                 if (output_row < valid_rows) {
                     uint64_t output_index = uint64_t(row_start + output_row)
                         * uint64_t(output_width) + uint64_t(output_start + output_column);
-                    projected[output_index] = bfloat16_t(
+                    projected[output_index] = T(
                         accumulated[result].thread_elements()[0]
                     );
-                    projected[output_index + 1] = bfloat16_t(
+                    projected[output_index + 1] = T(
                         accumulated[result].thread_elements()[1]
                     );
                 }

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3FusedKernels.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3FusedKernels.swift
@@ -415,6 +415,47 @@ enum MiniMaxH3FusedKernels {
         #endif
     }
 
+    /// Matrix-tiled K4a candidate that keeps the gate and up projections in
+    /// registers through the SwiGLU epilogue. This avoids materializing the
+    /// two-wide FC1 output while retaining the managed BF16 QMM boundary.
+    static func projectFeedForwardInputAffineInt8SwiGLUTiled(
+        input: MLXArray,
+        weightCodes: MLXArray,
+        weightScales: MLXArray,
+        weightBiases: MLXArray
+    ) -> MLXArray? {
+        #if os(macOS) || os(iOS)
+        let scaleGroups = hiddenSize / affineGroupSize
+        guard Device.defaultDevice().deviceType == .gpu,
+              input.dtype == .bfloat16,
+              input.ndim == 3,
+              input.dim(0) == 1,
+              input.dim(1) > 0,
+              input.dim(2) == hiddenSize,
+              weightCodes.dtype == .uint32,
+              weightCodes.shape == [2 * feedForwardSize, hiddenSize / 4],
+              weightScales.dtype == .bfloat16,
+              weightScales.shape == [2 * feedForwardSize, scaleGroups],
+              weightBiases.dtype == .bfloat16,
+              weightBiases.shape == weightScales.shape else {
+            return nil
+        }
+
+        let rows = input.dim(1)
+        let outputTileCount = feedForwardSize / 32
+        let rowTileCount = (rows + 31) / 32
+        return projectFeedForwardInputAffineInt8SwiGLUTiledKernel(
+            [input, weightCodes, weightScales, weightBiases],
+            grid: (32 * outputTileCount, 4 * rowTileCount, 1),
+            threadGroup: (32, 4, 1),
+            outputShapes: [[1, rows, feedForwardSize]],
+            outputDTypes: [.bfloat16]
+        )[0]
+        #else
+        return nil
+        #endif
+    }
+
     /// K4b applies H3's exact 14336 -> 5376 affine Q8/group-64 FC2 without
     /// relying on a generic shape selection path. It consumes K4a's compact
     /// SwiGLU result directly and preserves the managed artifact arithmetic.
@@ -451,6 +492,49 @@ enum MiniMaxH3FusedKernels {
             threadGroup: (64, 1, 1),
             outputShapes: [[1, rows, hiddenSize]],
             outputDTypes: [input.dtype]
+        )[0]
+        #else
+        return nil
+        #endif
+    }
+
+    /// SIMD-group matrix candidate for K4b. Each workgroup dequantizes one
+    /// 64-output by 32-input weight tile once, shares a 32-row activation
+    /// tile, and accumulates eight 8x8 matrix products per SIMD group.
+    /// The managed FastH3 Q8 recipe selects this after realistic-shape timing
+    /// and installed-checkpoint validation.
+    static func projectFeedForwardOutputAffineInt8Tiled(
+        input: MLXArray,
+        weightCodes: MLXArray,
+        weightScales: MLXArray,
+        weightBiases: MLXArray
+    ) -> MLXArray? {
+        #if os(macOS) || os(iOS)
+        let scaleGroups = feedForwardSize / affineGroupSize
+        guard Device.defaultDevice().deviceType == .gpu,
+              input.dtype == .bfloat16,
+              input.ndim == 3,
+              input.dim(0) == 1,
+              input.dim(1) > 0,
+              input.dim(2) == feedForwardSize,
+              weightCodes.dtype == .uint32,
+              weightCodes.shape == [hiddenSize, feedForwardSize / 4],
+              weightScales.dtype == .bfloat16,
+              weightScales.shape == [hiddenSize, scaleGroups],
+              weightBiases.dtype == .bfloat16,
+              weightBiases.shape == weightScales.shape else {
+            return nil
+        }
+
+        let rows = input.dim(1)
+        let outputTileCount = hiddenSize / 64
+        let rowTileCount = (rows + 31) / 32
+        return projectFeedForwardOutputAffineInt8TiledKernel(
+            [input, weightCodes, weightScales, weightBiases],
+            grid: (32 * outputTileCount, 4 * rowTileCount, 1),
+            threadGroup: (32, 4, 1),
+            outputShapes: [[1, rows, hiddenSize]],
+            outputDTypes: [.bfloat16]
         )[0]
         #else
         return nil
@@ -1381,6 +1465,206 @@ enum MiniMaxH3FusedKernels {
         ensureRowContiguous: true
     )
 
+    private static let projectFeedForwardInputAffineInt8SwiGLUTiledKernel = MLXFast.metalKernel(
+        name: "mere_h3_affine_fc1_swiglu_i8g64_tiled_v3",
+        inputNames: ["input", "weight_codes", "weight_scales", "weight_biases"],
+        outputNames: ["activated"],
+        source: """
+            constexpr uint input_width = 5376;
+            constexpr uint output_width = 14336;
+            constexpr uint group_size = 64;
+            constexpr uint scale_groups = input_width / group_size;
+            constexpr uint output_tile_columns = 32;
+            constexpr uint row_tile_rows = 32;
+            constexpr uint reduction_tile = 32;
+
+            uint output_tile = threadgroup_position_in_grid.x;
+            uint row_tile = threadgroup_position_in_grid.y;
+            uint output_start = output_tile * output_tile_columns;
+            uint row_start = row_tile * row_tile_rows;
+            uint rows = uint(input_shape[1]);
+            uint valid_rows = metal::min(row_tile_rows, rows - row_start);
+            uint thread_linear = thread_position_in_threadgroup.y * 32
+                + thread_position_in_threadgroup.x;
+            uint simd_group = simdgroup_index_in_threadgroup;
+            uint lane = thread_index_in_simdgroup;
+            uint quad = lane / 4;
+            uint matrix_row = (quad & 4) + ((lane / 2) % 4);
+            uint matrix_column = (quad & 2) * 2 + (lane % 2) * 2;
+
+            threadgroup bfloat gate_weight_tile[
+                output_tile_columns * reduction_tile
+            ];
+            threadgroup bfloat up_weight_tile[
+                output_tile_columns * reduction_tile
+            ];
+            threadgroup bfloat input_tile[row_tile_rows * reduction_tile];
+
+            thread simdgroup_matrix<float, 8, 8> gate_accumulated[4];
+            thread simdgroup_matrix<float, 8, 8> up_accumulated[4];
+            #pragma clang loop unroll(full)
+            for (uint index = 0; index < 4; ++index) {
+                gate_accumulated[index].thread_elements()[0] = 0.0f;
+                gate_accumulated[index].thread_elements()[1] = 0.0f;
+                up_accumulated[index].thread_elements()[0] = 0.0f;
+                up_accumulated[index].thread_elements()[1] = 0.0f;
+            }
+
+            const device uint8_t* codes = (const device uint8_t*)weight_codes;
+            uint local_output = thread_linear / 4;
+            uint weight_eight = 8 * (thread_linear % 4);
+            uint local_input_row = thread_linear / 4;
+            uint input_eight = 8 * (thread_linear % 4);
+            for (uint reduction_start = 0;
+                 reduction_start < input_width;
+                 reduction_start += reduction_tile) {
+                threadgroup_barrier(mem_flags::mem_threadgroup);
+
+                uint gate_column = output_start + local_output;
+                uint up_column = gate_column + output_width;
+                uint scale_group = reduction_start / group_size;
+                uint gate_scale_index = gate_column * scale_groups + scale_group;
+                uint up_scale_index = up_column * scale_groups + scale_group;
+                float gate_scale = float(weight_scales[gate_scale_index]);
+                float gate_bias = float(weight_biases[gate_scale_index]);
+                float up_scale = float(weight_scales[up_scale_index]);
+                float up_bias = float(weight_biases[up_scale_index]);
+                uint weight_reduction_start = reduction_start + weight_eight;
+                const device uint8_t* gate_values = codes
+                    + gate_column * input_width + weight_reduction_start;
+                const device uint8_t* up_values = codes
+                    + up_column * input_width + weight_reduction_start;
+                #pragma clang loop unroll(full)
+                for (uint index = 0; index < 8; ++index) {
+                    uint tile_index = local_output * reduction_tile
+                        + weight_eight + index;
+                    gate_weight_tile[tile_index] = bfloat(
+                        gate_scale * float(gate_values[index]) + gate_bias
+                    );
+                    up_weight_tile[tile_index] = bfloat(
+                        up_scale * float(up_values[index]) + up_bias
+                    );
+                }
+
+                uint safe_row = metal::min(local_input_row, valid_rows - 1);
+                const device bfloat16_t* input_values = input
+                    + uint64_t(row_start + safe_row) * uint64_t(input_width)
+                    + reduction_start + input_eight;
+                #pragma clang loop unroll(full)
+                for (uint index = 0; index < 8; ++index) {
+                    input_tile[local_input_row * reduction_tile + input_eight + index]
+                        = bfloat(input_values[index]);
+                }
+                threadgroup_barrier(mem_flags::mem_threadgroup);
+
+                threadgroup const bfloat* gate_fragments = gate_weight_tile
+                    + (simd_group % 2) * 16 * reduction_tile;
+                threadgroup const bfloat* up_fragments = up_weight_tile
+                    + (simd_group % 2) * 16 * reduction_tile;
+                threadgroup const bfloat* input_fragments = input_tile
+                    + (simd_group / 2) * 16 * reduction_tile;
+                thread simdgroup_matrix<bfloat, 8, 8> gate_weights[2];
+                thread simdgroup_matrix<bfloat, 8, 8> up_weights[2];
+                thread simdgroup_matrix<bfloat, 8, 8> inputs[2];
+                #pragma clang loop unroll(full)
+                for (uint reduction_fragment = 0;
+                     reduction_fragment < 4;
+                     ++reduction_fragment) {
+                    simdgroup_barrier(mem_flags::mem_none);
+                    #pragma clang loop unroll(full)
+                    for (uint output_fragment = 0;
+                         output_fragment < 2;
+                         ++output_fragment) {
+                        simdgroup_load(
+                            gate_weights[output_fragment],
+                            gate_fragments
+                                + output_fragment * 8 * reduction_tile
+                                + reduction_fragment * 8,
+                            reduction_tile,
+                            0,
+                            true
+                        );
+                        simdgroup_load(
+                            up_weights[output_fragment],
+                            up_fragments
+                                + output_fragment * 8 * reduction_tile
+                                + reduction_fragment * 8,
+                            reduction_tile,
+                            0,
+                            true
+                        );
+                    }
+                    simdgroup_barrier(mem_flags::mem_none);
+                    #pragma clang loop unroll(full)
+                    for (uint row_fragment = 0; row_fragment < 2; ++row_fragment) {
+                        simdgroup_load(
+                            inputs[row_fragment],
+                            input_fragments
+                                + row_fragment * 8 * reduction_tile
+                                + reduction_fragment * 8,
+                            reduction_tile,
+                            0,
+                            false
+                        );
+                    }
+                    simdgroup_barrier(mem_flags::mem_none);
+                    #pragma clang loop unroll(full)
+                    for (uint result = 0; result < 4; ++result) {
+                        thread simdgroup_matrix<float, 8, 8> next_gate;
+                        thread simdgroup_matrix<float, 8, 8> next_up;
+                        simdgroup_multiply_accumulate(
+                            next_gate,
+                            inputs[result / 2],
+                            gate_weights[result % 2],
+                            gate_accumulated[result]
+                        );
+                        simdgroup_multiply_accumulate(
+                            next_up,
+                            inputs[result / 2],
+                            up_weights[result % 2],
+                            up_accumulated[result]
+                        );
+                        gate_accumulated[result] = next_gate;
+                        up_accumulated[result] = next_up;
+                    }
+                }
+            }
+
+            uint simd_output_start = (simd_group & 1) * 16;
+            uint simd_row_start = (simd_group >> 1) * 16;
+            #pragma clang loop unroll(full)
+            for (uint result = 0; result < 4; ++result) {
+                uint output_row = simd_row_start + (result / 2) * 8 + matrix_row;
+                uint output_column = simd_output_start
+                    + (result % 2) * 8 + matrix_column;
+                if (output_row < valid_rows) {
+                    uint64_t output_index = uint64_t(row_start + output_row)
+                        * uint64_t(output_width) + uint64_t(output_start + output_column);
+                    float gate0 = float(bfloat(
+                        gate_accumulated[result].thread_elements()[0]
+                    ));
+                    float gate1 = float(bfloat(
+                        gate_accumulated[result].thread_elements()[1]
+                    ));
+                    float up0 = float(bfloat(
+                        up_accumulated[result].thread_elements()[0]
+                    ));
+                    float up1 = float(bfloat(
+                        up_accumulated[result].thread_elements()[1]
+                    ));
+                    float sigmoid0 = 1.0f / (1.0f + metal::precise::exp(-gate0));
+                    float sigmoid1 = 1.0f / (1.0f + metal::precise::exp(-gate1));
+                    activated[output_index] = bfloat16_t(gate0 * sigmoid0 * up0);
+                    activated[output_index + 1] = bfloat16_t(
+                        gate1 * sigmoid1 * up1
+                    );
+                }
+            }
+        """,
+        header: "#include <metal_simdgroup_matrix>\n",
+        ensureRowContiguous: true
+    )
+
     private static let projectFeedForwardInputAffineInt8SwiGLUKernel = MLXFast.metalKernel(
         name: "mere_h3_affine_fc1_swiglu_i8g64_v1",
         inputNames: ["input", "weight_codes", "weight_scales", "weight_biases"],
@@ -1641,6 +1925,163 @@ enum MiniMaxH3FusedKernels {
                 }
             }
         """,
+        ensureRowContiguous: true
+    )
+
+    private static let projectFeedForwardOutputAffineInt8TiledKernel = MLXFast.metalKernel(
+        name: "mere_h3_affine_fc2_i8g64_tiled_v3",
+        inputNames: ["input", "weight_codes", "weight_scales", "weight_biases"],
+        outputNames: ["projected"],
+        source: """
+            constexpr uint input_width = 14336;
+            constexpr uint output_width = 5376;
+            constexpr uint group_size = 64;
+            constexpr uint scale_groups = input_width / group_size;
+            constexpr uint output_tile_columns = 64;
+            constexpr uint row_tile_rows = 32;
+            constexpr uint reduction_tile = 32;
+            constexpr uint simdgroups_per_workgroup = 4;
+
+            uint output_tile = threadgroup_position_in_grid.x;
+            uint row_tile = threadgroup_position_in_grid.y;
+            uint output_start = output_tile * output_tile_columns;
+            uint row_start = row_tile * row_tile_rows;
+            uint rows = uint(input_shape[1]);
+            uint valid_rows = metal::min(row_tile_rows, rows - row_start);
+            uint thread_linear = thread_position_in_threadgroup.y * 32
+                + thread_position_in_threadgroup.x;
+            uint simd_group = simdgroup_index_in_threadgroup;
+            uint lane = thread_index_in_simdgroup;
+            uint quad = lane / 4;
+            uint matrix_row = (quad & 4) + ((lane / 2) % 4);
+            uint matrix_column = (quad & 2) * 2 + (lane % 2) * 2;
+
+            threadgroup bfloat weight_tile[output_tile_columns * reduction_tile];
+            threadgroup bfloat input_tile[row_tile_rows * reduction_tile];
+
+            thread simdgroup_matrix<float, 8, 8> accumulated[8];
+            #pragma clang loop unroll(full)
+            for (uint index = 0; index < 8; ++index) {
+                accumulated[index].thread_elements()[0] = 0.0f;
+                accumulated[index].thread_elements()[1] = 0.0f;
+            }
+
+            const device uint8_t* codes = (const device uint8_t*)weight_codes;
+            uint local_output = thread_linear / 2;
+            uint weight_half = thread_linear % 2;
+            uint local_input_row = thread_linear / 4;
+            uint input_eight = 8 * (thread_linear % 4);
+            for (uint reduction_start = 0;
+                 reduction_start < input_width;
+                 reduction_start += reduction_tile) {
+                threadgroup_barrier(mem_flags::mem_threadgroup);
+
+                uint output_column = output_start + local_output;
+                uint scale_index = output_column * scale_groups
+                    + reduction_start / group_size;
+                float scale = float(weight_scales[scale_index]);
+                float bias = float(weight_biases[scale_index]);
+                uint weight_reduction_start = reduction_start + 16 * weight_half;
+                const device uint8_t* weight_values = codes
+                    + output_column * input_width + weight_reduction_start;
+                #pragma clang loop unroll(full)
+                for (uint index = 0; index < 16; ++index) {
+                    uint section_x = 2 * weight_half + index / 8;
+                    uint section_y = local_output / 8;
+                    uint local_x = local_output % 8;
+                    uint local_y = index % 8;
+                    uint block = 8 * section_x + section_y;
+                    weight_tile[64 * block + 8 * local_y + local_x] = bfloat(
+                        scale * float(weight_values[index]) + bias
+                    );
+                }
+
+                uint safe_row = metal::min(local_input_row, valid_rows - 1);
+                uint input_section_x = thread_linear % 4;
+                uint input_section_y = local_input_row / 8;
+                uint input_local_y = local_input_row % 8;
+                uint input_block = 4 * input_section_x + input_section_y;
+                const device bfloat16_t* input_values = input
+                    + uint64_t(row_start + safe_row) * uint64_t(input_width)
+                    + reduction_start + input_eight;
+                #pragma clang loop unroll(full)
+                for (uint index = 0; index < 8; ++index) {
+                    input_tile[64 * input_block + 8 * input_local_y + index]
+                        = bfloat(input_values[index]);
+                }
+                threadgroup_barrier(mem_flags::mem_threadgroup);
+
+                threadgroup const bfloat* weight_fragments = weight_tile
+                    + 4 * 64 * (simd_group % 2);
+                threadgroup const bfloat* input_fragments = input_tile
+                    + 2 * 64 * (simd_group / 2);
+                thread simdgroup_matrix<bfloat, 8, 8> weights[4];
+                thread simdgroup_matrix<bfloat, 8, 8> inputs[2];
+                #pragma clang loop unroll(full)
+                for (uint reduction_fragment = 0;
+                     reduction_fragment < 4;
+                     ++reduction_fragment) {
+                    simdgroup_barrier(mem_flags::mem_none);
+                    #pragma clang loop unroll(full)
+                    for (uint output_fragment = 0;
+                         output_fragment < 4;
+                         ++output_fragment) {
+                        simdgroup_load(
+                            weights[output_fragment],
+                            weight_fragments + 64 * output_fragment,
+                            8,
+                            0,
+                            false
+                        );
+                    }
+                    simdgroup_barrier(mem_flags::mem_none);
+                    #pragma clang loop unroll(full)
+                    for (uint row_fragment = 0; row_fragment < 2; ++row_fragment) {
+                        simdgroup_load(
+                            inputs[row_fragment],
+                            input_fragments + 64 * row_fragment,
+                            8,
+                            0,
+                            false
+                        );
+                    }
+                    simdgroup_barrier(mem_flags::mem_none);
+                    #pragma clang loop unroll(full)
+                    for (uint result = 0; result < 8; ++result) {
+                        thread simdgroup_matrix<float, 8, 8> next;
+                        simdgroup_multiply_accumulate(
+                            next,
+                            inputs[result / 4],
+                            weights[result % 4],
+                            accumulated[result]
+                        );
+                        accumulated[result] = next;
+                    }
+                    weight_fragments += 8 * 64;
+                    input_fragments += 4 * 64;
+                }
+            }
+
+            uint simd_output_start = (simd_group & 1) * 32;
+            uint simd_row_start = (simd_group >> 1) * 16;
+            #pragma clang loop unroll(full)
+            for (uint result = 0; result < 8; ++result) {
+                uint output_row = simd_row_start + (result / 4) * 8 + matrix_row;
+                uint output_column = simd_output_start
+                    + (result % 4) * 8 + matrix_column;
+                if (output_row < valid_rows) {
+                    uint64_t output_index = uint64_t(row_start + output_row)
+                        * uint64_t(output_width) + uint64_t(output_start + output_column);
+                    projected[output_index] = bfloat16_t(
+                        accumulated[result].thread_elements()[0]
+                    );
+                    projected[output_index + 1] = bfloat16_t(
+                        accumulated[result].thread_elements()[1]
+                    );
+                }
+            }
+        """,
+        header: "#include <metal_simdgroup_matrix>\n",
         ensureRowContiguous: true
     )
 

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Generator.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Generator.swift
@@ -42,7 +42,7 @@ extension MiniMaxH3ExactKernelMode {
             false
         case .boundaryLayout:
             sequenceLength > MiniMaxH3DenoiseExecutionPolicy.blockwiseSequenceThreshold
-        case .affineQ8:
+        case .affineQ8, .affineQ8MLP:
             true
         }
     }
@@ -52,12 +52,29 @@ extension MiniMaxH3ExactKernelMode {
         case nil, "", "disabled": .disabled
         case MiniMaxH3ExactKernelMode.boundaryLayout.rawValue: .boundaryLayout
         case MiniMaxH3ExactKernelMode.affineQ8.rawValue: .affineQ8
+        case MiniMaxH3ExactKernelMode.affineQ8MLP.rawValue: .affineQ8MLP
         case .some(let value):
             throw MiniMaxH3GeneratorError.invalidOptions(
                 "MERERUN_H3_EXACT_KERNELS must be disabled, boundary-layout, "
-                    + "or affine-q8, not \(value)"
+                    + "affine-q8, or affine-q8-mlp, not \(value)"
             )
         }
+    }
+
+    static func resolveForRuntime(
+        environmentValue: String?,
+        usesFastH3VSA: Bool,
+        supportsAffineQ8ExactKernels: Bool,
+        usesResidentBF16: Bool
+    ) throws -> Self {
+        let configured = try resolve(environmentValue: environmentValue)
+        if environmentValue == nil,
+           usesFastH3VSA,
+           supportsAffineQ8ExactKernels,
+           !usesResidentBF16 {
+            return .affineQ8MLP
+        }
+        return configured
     }
 }
 
@@ -1128,8 +1145,11 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
         // compiled whole-step transform; very large graphs also stay blockwise
         // to avoid the macOS watchdog.
         let environment = ProcessInfo.processInfo.environment
-        let exactKernelMode = try MiniMaxH3ExactKernelMode.resolve(
-            environmentValue: environment["MERERUN_H3_EXACT_KERNELS"]
+        let exactKernelMode = try MiniMaxH3ExactKernelMode.resolveForRuntime(
+            environmentValue: environment["MERERUN_H3_EXACT_KERNELS"],
+            usesFastH3VSA: transformer.usesFastH3VSA,
+            supportsAffineQ8ExactKernels: transformer.supportsAffineQ8ExactKernels,
+            usesResidentBF16: transformer.usesResidentBF16
         )
         if exactKernelMode != .disabled {
             guard accelerationMode == .quality else {
@@ -1138,11 +1158,11 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
                 )
             }
         }
-        if exactKernelMode == .affineQ8 {
+        if exactKernelMode.usesAffineQ8FeedForward {
             guard transformer.supportsAffineQ8ExactKernels,
                   !transformer.usesResidentBF16 else {
                 throw MiniMaxH3GeneratorError.invalidOptions(
-                    "affine-q8 exact kernels require the unadapted managed Q8/group-64 transformer"
+                    "affine Q8 exact kernels require the managed Q8/group-64 transformer"
                 )
             }
         }

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Generator.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Generator.swift
@@ -867,6 +867,9 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
     ) throws -> (transformer: MiniMaxH3Transformer, adaLNCache: MiniMaxH3AdaLNCache?) {
         let modelSourceIdentity = try resources.adaLNCacheSourceIdentity()
         let adapterInferenceRecipe = adapterURL.map(MiniMaxH3TurboAdapter.inferenceRecipe(for:))
+        let usesPremergedFastH3Student = adapterURL.map(
+            MiniMaxH3TurboAdapter.isPremergedFastH3Artifact
+        ) ?? false
         let cacheKey = DenoisingRuntimeCacheKey(
             modelRoot: resources.rootURL.resolvingSymlinksInPath(),
             modelSourceIdentity: modelSourceIdentity,
@@ -891,10 +894,10 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
         let cachedAdaLNForLoading: MiniMaxH3AdaLNCache?
         if adapterInferenceRecipe?.requiresFastH3VSA == true,
            !resources.usesShardedBF16Transformer {
-            guard try resources.transformerStorage() == .compactBF16,
+            guard try [.compactBF16, .affineQ8].contains(resources.transformerStorage()),
                   let adapterURL else {
                 throw MiniMaxH3GeneratorError.invalidOptions(
-                    "FastH3 VSA requires the compact BF16 or full sharded BF16 MiniMax-H3 transformer"
+                    "FastH3 VSA requires the compact BF16, affine Q8, or full sharded BF16 MiniMax-H3 transformer"
                 )
             }
             let cacheURL = adapterURL.deletingLastPathComponent().appending(
@@ -969,8 +972,10 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
         } else {
             resolvedAdaLNCache = adaLNCache
         }
+        let effectiveWeightMode: MiniMaxH3TransformerWeightMode =
+            usesPremergedFastH3Student && weightMode == .automatic ? .quantized : weightMode
         let shouldMaterialize = try MiniMaxH3ResidentBF16Policy.shouldMaterialize(
-            mode: weightMode,
+            mode: effectiveWeightMode,
             physicalMemoryBytes: ProcessInfo.processInfo.physicalMemory,
             estimatedResidentBytes: transformer.estimatedResidentBF16ByteCount,
             sequenceLength: sequenceLength,
@@ -1197,8 +1202,11 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
             transformer.prepareTokenReduction(context: context)
         }
         let executionMode: MiniMaxH3DenoiseExecutionMode
-        if transformer.usesFastH3VSA
-            || exactKernelMode.requiresEagerExecution(sequenceLength: layout.sequenceLength) {
+        if transformer.usesFastH3VSA {
+            executionMode = environment["MERERUN_H3_EXECUTION_MODE"]?.lowercased() == "eager"
+                ? .eagerStep
+                : .blockwiseCompiled
+        } else if exactKernelMode.requiresEagerExecution(sequenceLength: layout.sequenceLength) {
             executionMode = .eagerStep
         } else if layerThinningPolicy == nil,
                   velocityReusePolicy == nil,
@@ -1239,9 +1247,8 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
         transformer.dynamicSparseAttentionLogHandler = stepProfileLogger
         transformer.usesFusedPostAttention = ProcessInfo.processInfo
             .environment["MERERUN_H3_FUSED_POST_ATTENTION"] == "1"
-        transformer.usesLayerwiseEvaluation = transformer.usesFastH3VSA
-            || executionMode.usesLayerwiseEvaluation
-        transformer.clearsCacheAfterLayerwiseEvaluation = transformer.usesFastH3VSA
+        transformer.usesLayerwiseEvaluation = executionMode.usesLayerwiseEvaluation
+        transformer.clearsCacheAfterLayerwiseEvaluation = executionMode == .eagerStep
         let attentionHeadsPerKernel = transformer.maximumAttentionHeadsPerKernel
             ?? transformer.configuration.attentionHeadCount
         stepProfileLogger?(

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Generator.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Generator.swift
@@ -1075,11 +1075,19 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
             keys: ["MERERUN_H3_PROFILE_BLOCKS"],
             prefix: "[minimax-h3-profile]"
         )
+        let fastVSAProfileLogger = MereRunRuntimeDebug.logger(
+            keys: ["MERERUN_H3_PROFILE_FASTVSA"],
+            prefix: "[minimax-h3-fastvsa-profile]"
+        )
         let stepProfileLogger = MereRunRuntimeDebug.logger(
             keys: ["MERERUN_H3_PROFILE_STEPS"],
             prefix: "[minimax-h3-step-profile]"
         )
         blockProfileLogger?("rows=\(layout.sequenceLength) blocks=\(transformer.configuration.layerCount)")
+        fastVSAProfileLogger?(
+            "rows=\(layout.sequenceLength) blocks=\(transformer.configuration.layerCount) "
+                + "kernel=\(MiniMaxH3FastVSAKernelMode.runtimeDefault.rawValue)"
+        )
         stepProfileLogger?(
             "rows=\(layout.sequenceLength) steps=\(videoSchedule.timesteps.count) "
                 + "resident_bf16=\(transformer.usesResidentBF16)"
@@ -1093,6 +1101,17 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
                     Double(memory.activeMemory) / 1_073_741_824,
                     Double(memory.cacheMemory) / 1_073_741_824,
                     Double(memory.peakMemory) / 1_073_741_824
+                ))
+            }
+        }
+        transformer.fastH3BlockPhaseTimingHandler = fastVSAProfileLogger.map { logger in
+            { index, projection, attention, postAttention in
+                logger(String(
+                    format: "block=%02d projection=%.3f attention=%.3f post_attention=%.3f",
+                    index,
+                    projection,
+                    attention,
+                    postAttention
                 ))
             }
         }
@@ -1254,6 +1273,7 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
         stepProfileLogger?(
             "execution_mode=\(executionMode) acceleration=\(accelerationMode.rawValue) "
                 + "exact_kernels=\(exactKernelMode.rawValue) "
+                + "fastvsa_kernel=\(MiniMaxH3FastVSAKernelMode.runtimeDefault.rawValue) "
                 + "fused_post_attention=\(transformer.usesFusedPostAttention) "
                 + "attention_query_tokens=\(transformer.maximumAttentionQueryTokensPerKernel) "
                 + "attention_heads_per_kernel=\(attentionHeadsPerKernel) "

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Generator.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Generator.swift
@@ -682,6 +682,18 @@ public struct MiniMaxH3GenerationOptions: Sendable, Hashable {
                     )
                 }
             }
+            if adapterInferenceRecipe.requiresTextOnlyConditioning,
+               firstFrameURL != nil || lastFrameURL != nil || !frameInputs.isEmpty {
+                throw MiniMaxH3GeneratorError.invalidOptions(
+                    "FastH3 Preview v1 supports text-to-audio/video only; frame conditioning is unsupported"
+                )
+            }
+            if adapterInferenceRecipe.requiresFastH3VSA,
+               accelerationMode != .quality {
+                throw MiniMaxH3GeneratorError.invalidOptions(
+                    "FastH3 VSA cannot be combined with additional H3 approximation modes; use --h3-acceleration quality"
+                )
+            }
         }
         let resolvedSteps: Int
         if let steps {
@@ -854,6 +866,7 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
         progressHandler: (@Sendable (MiniMaxH3GenerationProgress) -> Void)?
     ) throws -> (transformer: MiniMaxH3Transformer, adaLNCache: MiniMaxH3AdaLNCache?) {
         let modelSourceIdentity = try resources.adaLNCacheSourceIdentity()
+        let adapterInferenceRecipe = adapterURL.map(MiniMaxH3TurboAdapter.inferenceRecipe(for:))
         let cacheKey = DenoisingRuntimeCacheKey(
             modelRoot: resources.rootURL.resolvingSymlinksInPath(),
             modelSourceIdentity: modelSourceIdentity,
@@ -876,7 +889,33 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
         }
         let adaLNCache: MiniMaxH3AdaLNCache?
         let cachedAdaLNForLoading: MiniMaxH3AdaLNCache?
-        if resources.usesShardedBF16Transformer {
+        if adapterInferenceRecipe?.requiresFastH3VSA == true,
+           !resources.usesShardedBF16Transformer {
+            guard try resources.transformerStorage() == .compactBF16,
+                  let adapterURL else {
+                throw MiniMaxH3GeneratorError.invalidOptions(
+                    "FastH3 VSA requires the compact BF16 or full sharded BF16 MiniMax-H3 transformer"
+                )
+            }
+            let cacheURL = adapterURL.deletingLastPathComponent().appending(
+                path: MiniMaxH3TurboAdapter.fastH3AdaLNCacheFilename
+            )
+            guard FileManager.default.fileExists(atPath: cacheURL.path) else {
+                throw MiniMaxH3GeneratorError.invalidOptions(
+                    "FastH3 VSA requires its source-bound AdaLN cache at \(cacheURL.path). "
+                        + "Build it with scripts/model-conversion/prepare_minimax_h3_fasth3_vsa.py."
+                )
+            }
+            let cache = try MiniMaxH3AdaLNCache.load(
+                from: cacheURL,
+                configuration: .init(configuration),
+                videoSchedule: videoSchedule,
+                audioSchedule: audioSchedule,
+                sourceIdentity: MiniMaxH3TurboAdapter.fastH3SourceIdentity
+            )
+            adaLNCache = cache
+            cachedAdaLNForLoading = cache
+        } else if resources.usesShardedBF16Transformer {
             // A legacy full BF16 root retains the schedule-only projections.
             // Build an exact table for the requested run; compact managed roots
             // select their source-bound production cache pack below.
@@ -911,7 +950,6 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
                 ))
             }
         )
-        let adapterInferenceRecipe = adapterURL.map(MiniMaxH3TurboAdapter.inferenceRecipe(for:))
         if let adapterURL, resources.usesShardedBF16Transformer {
             try MiniMaxH3TurboAdapter.install(
                 url: adapterURL,
@@ -1158,24 +1196,26 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
         let tokenReduction = tokenReductionPolicy.map { _ in
             transformer.prepareTokenReduction(context: context)
         }
-        let executionMode = exactKernelMode.requiresEagerExecution(
-            sequenceLength: layout.sequenceLength
-        )
-            ? MiniMaxH3DenoiseExecutionMode.eagerStep
-            : layerThinningPolicy == nil
-            && velocityReusePolicy == nil
-            && tokenReductionPolicy == nil
-            && adaptiveCachePolicy == nil
-            && blockReusePolicy == nil
-            && dynamicSparseAttentionPolicy == nil
-            ? MiniMaxH3DenoiseExecutionPolicy.mode(
+        let executionMode: MiniMaxH3DenoiseExecutionMode
+        if transformer.usesFastH3VSA
+            || exactKernelMode.requiresEagerExecution(sequenceLength: layout.sequenceLength) {
+            executionMode = .eagerStep
+        } else if layerThinningPolicy == nil,
+                  velocityReusePolicy == nil,
+                  tokenReductionPolicy == nil,
+                  adaptiveCachePolicy == nil,
+                  blockReusePolicy == nil,
+                  dynamicSparseAttentionPolicy == nil {
+            executionMode = MiniMaxH3DenoiseExecutionPolicy.mode(
                 usesResidentBF16: transformer.usesResidentBF16,
                 sequenceLength: layout.sequenceLength,
                 usesBlockProfiling: blockProfileLogger != nil,
                 denoiseStepCount: videoSchedule.timesteps.count,
                 profilingOverride: ProcessInfo.processInfo.environment["MERERUN_H3_EXECUTION_MODE"]
             )
-            : .blockwiseCompiled
+        } else {
+            executionMode = .blockwiseCompiled
+        }
         let usesCompiledStep = executionMode == .compiledStep
         transformer.usesBlockwiseCompilation = executionMode == .blockwiseCompiled
         let attentionKernelSchedule = MiniMaxH3DenoiseExecutionPolicy.attentionKernelSchedule(
@@ -1199,8 +1239,9 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
         transformer.dynamicSparseAttentionLogHandler = stepProfileLogger
         transformer.usesFusedPostAttention = ProcessInfo.processInfo
             .environment["MERERUN_H3_FUSED_POST_ATTENTION"] == "1"
-        transformer.usesLayerwiseEvaluation = executionMode.usesLayerwiseEvaluation
-        transformer.clearsCacheAfterLayerwiseEvaluation = false
+        transformer.usesLayerwiseEvaluation = transformer.usesFastH3VSA
+            || executionMode.usesLayerwiseEvaluation
+        transformer.clearsCacheAfterLayerwiseEvaluation = transformer.usesFastH3VSA
         let attentionHeadsPerKernel = transformer.maximumAttentionHeadsPerKernel
             ?? transformer.configuration.attentionHeadCount
         stepProfileLogger?(
@@ -1631,6 +1672,11 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
         let latentWidth = options.internalWidth / 16
         let audioFrames = MiniMaxH3Geometry.audioLatentFrameCount(for: options.numFrames)
         if let continuation {
+            if options.adapterInferenceRecipe?.requiresTextOnlyConditioning == true {
+                throw MiniMaxH3GeneratorError.invalidOptions(
+                    "FastH3 Preview v1 supports text-to-audio/video only; continuation is unsupported"
+                )
+            }
             guard !options.usesReducedRenderCanvas else {
                 throw MiniMaxH3GeneratorError.invalidOptions(
                     "reduced internal rendering does not yet support continuation or sliding windows"
@@ -1765,14 +1811,17 @@ public final class MiniMaxH3Generator: @unchecked Sendable {
             seed: options.seed,
             latentFrames: audioFrames
         )
-        let videoSchedule = try MiniMaxH3Schedule(
-            pointCount: options.steps,
-            shift: options.adapterInferenceRecipe?.videoFlowShift ?? configuration.videoFlowShift
-        )
-        let audioSchedule = try MiniMaxH3Schedule(
-            pointCount: options.steps,
-            shift: options.adapterInferenceRecipe?.audioFlowShift ?? configuration.audioFlowShift
-        )
+        let videoShift = options.adapterInferenceRecipe?.videoFlowShift ?? configuration.videoFlowShift
+        let audioShift = options.adapterInferenceRecipe?.audioFlowShift ?? configuration.audioFlowShift
+        let videoSchedule: MiniMaxH3Schedule
+        let audioSchedule: MiniMaxH3Schedule
+        if let baseSigmas = options.adapterInferenceRecipe?.baseDenoisingSigmas {
+            videoSchedule = try MiniMaxH3Schedule(baseSigmas: baseSigmas, shift: videoShift)
+            audioSchedule = try MiniMaxH3Schedule(baseSigmas: baseSigmas, shift: audioShift)
+        } else {
+            videoSchedule = try MiniMaxH3Schedule(pointCount: options.steps, shift: videoShift)
+            audioSchedule = try MiniMaxH3Schedule(pointCount: options.steps, shift: audioShift)
+        }
 
         progressHandler?(.init(stage: .loadingTransformer, stepIndex: 0, totalSteps: options.steps - 1))
         try withMiniMaxH3AutoreleasePool {

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Generator.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Generator.swift
@@ -42,7 +42,7 @@ extension MiniMaxH3ExactKernelMode {
             false
         case .boundaryLayout:
             sequenceLength > MiniMaxH3DenoiseExecutionPolicy.blockwiseSequenceThreshold
-        case .affineQ8, .affineQ8MLP:
+        case .affineQ8, .affineQ8MLP, .fastH3Metal:
             true
         }
     }
@@ -53,10 +53,11 @@ extension MiniMaxH3ExactKernelMode {
         case MiniMaxH3ExactKernelMode.boundaryLayout.rawValue: .boundaryLayout
         case MiniMaxH3ExactKernelMode.affineQ8.rawValue: .affineQ8
         case MiniMaxH3ExactKernelMode.affineQ8MLP.rawValue: .affineQ8MLP
+        case MiniMaxH3ExactKernelMode.fastH3Metal.rawValue: .fastH3Metal
         case .some(let value):
             throw MiniMaxH3GeneratorError.invalidOptions(
                 "MERERUN_H3_EXACT_KERNELS must be disabled, boundary-layout, "
-                    + "affine-q8, or affine-q8-mlp, not \(value)"
+                    + "affine-q8, affine-q8-mlp, or fasth3-metal, not \(value)"
             )
         }
     }
@@ -72,7 +73,7 @@ extension MiniMaxH3ExactKernelMode {
            usesFastH3VSA,
            supportsAffineQ8ExactKernels,
            !usesResidentBF16 {
-            return .affineQ8MLP
+            return .fastH3Metal
         }
         return configured
     }

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Resources.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Resources.swift
@@ -272,8 +272,8 @@ public struct MiniMaxH3Resources: Sendable {
     public static let compactBF16ArtifactRevision = "4ce4b1d870f7b1b0c75672fd4f2867c1f5df7b5f"
     public static let q8ArtifactRepository = "Sawfwair/MiniMax-H3-FL2VA-MLX-8bit"
     public static let q8ArtifactRevision = "86500cb6ebec22c006597e41840b26ef1099fdd7"
-    public static let fastH3ArtifactRepository = "Sawfwair/MiniMax-H3-FastH3-VSA-DataFree-MLX-BF16"
-    public static let fastH3ArtifactRevision = "4208e52b28074fac87f7639281b1a4d564aba4a1"
+    public static let fastH3ArtifactRepository = "Sawfwair/MiniMax-H3-FastH3-VSA-DataFree-MLX-Q8"
+    public static let fastH3ArtifactRevision = "6068ae3dafafb1e4b2afb29f3109745a16912e07"
     public static let ref2vaArtifactRepository = "Sawfwair/MiniMax-H3-Ref2VA-MLX-8bit"
     public static let ref2vaArtifactRevision = "61dc387ef1a7166425cdacd63c2340598dcc364f"
     public static let bf16TransformerDirectory = "transformer-bf16"
@@ -295,6 +295,9 @@ public struct MiniMaxH3Resources: Sendable {
     public static let fastH3AdaLNCacheSHA256 =
         "d5e98c47a6a8924acbae4cfe34007049f22f56df7e9a4809f8d509320067fbe1"
     public static let fastH3AdaLNCacheByteCount: Int64 = 116_449_540
+    public static let fastH3PremergedGateSHA256 =
+        "4dee9a4fa80cadc13a602d7973b3c43a09bcfa0ef5e0baebe31a4d68a4b51dec"
+    public static let fastH3PremergedGateByteCount: Int64 = 2_047_200_096
 
     public static let requiredFiles = [
         "config.json",
@@ -322,8 +325,10 @@ public struct MiniMaxH3Resources: Sendable {
         "transformer.conversion.json",
         "SHA256SUMS",
     ]
-    public static let fastH3ArtifactFiles = compactBF16AndQ8ArtifactFiles + [
-        "adaln_cache-p5-v6-a3.safetensors",
+    public static let fastH3ArtifactFiles = requiredFiles + [
+        "SOURCE_MANIFEST.json",
+        "transformer.conversion.json",
+        "SHA256SUMS",
         MiniMaxH3TurboAdapter.fastH3VSADataFreeFilename,
         MiniMaxH3TurboAdapter.fastH3AdaLNCacheFilename,
         "FASTH3_SOURCE_MANIFEST.json",
@@ -531,8 +536,13 @@ public struct MiniMaxH3Resources: Sendable {
                 .filter { !fileManager.fileExists(atPath: $0.path) }
         }
         if fileManager.fileExists(atPath: transformerWeightsURL.path),
-           (try? requiresAdaLNCache()) == true {
-            if fileManager.fileExists(atPath: adaLNCachePackIndexURL.path) {
+           let metadata = try? transformerMetadata(),
+           metadata["cache_covered_weights_omitted"] == "true" {
+            let usesFastH3Cache = metadata["fasth3_premerged"] == "true"
+                && fileManager.fileExists(atPath: fastH3AdaLNCacheURL.path)
+            if usesFastH3Cache {
+                return missing
+            } else if fileManager.fileExists(atPath: adaLNCachePackIndexURL.path) {
                 missing += Self.cachePackFiles
                     .map { rootURL.appending(path: $0) }
                     .filter { !fileManager.fileExists(atPath: $0.path) }
@@ -570,8 +580,11 @@ public struct MiniMaxH3Resources: Sendable {
     }
 
     func validateManagedFastH3Artifact(fileManager: FileManager = .default) -> [String] {
-        var issues = validateCompactCachePack(fileManager: fileManager)
+        var issues: [String] = []
         let provenanceFiles = [
+            "SOURCE_MANIFEST.json",
+            "transformer.conversion.json",
+            "SHA256SUMS",
             "FASTH3_SOURCE_MANIFEST.json",
             "FASTH3_CONVERSION.json",
         ]
@@ -582,13 +595,15 @@ public struct MiniMaxH3Resources: Sendable {
         }
         guard issues.isEmpty else { return issues }
 
-        guard let adapter = ManagedAdapterCatalog.spec(
-            for: ManagedAdapterCatalog.miniMaxH3FastH3VSADataFreeID
-        ) else {
-            return ["Missing the pinned FastH3 adapter catalog entry."]
-        }
         do {
-            _ = try adapter.artifact.verify(in: rootURL, fileManager: fileManager)
+            guard MiniMaxH3TurboAdapter.isPremergedFastH3Artifact(fastH3AdapterURL) else {
+                return ["FastH3 package does not contain the premerged Q8 compression-gate artifact."]
+            }
+            _ = try ModelArtifactPin(
+                filename: MiniMaxH3TurboAdapter.fastH3VSADataFreeFilename,
+                byteCount: Self.fastH3PremergedGateByteCount,
+                sha256: Self.fastH3PremergedGateSHA256
+            ).verify(in: rootURL, fileManager: fileManager)
             _ = try ModelArtifactPin(
                 filename: MiniMaxH3TurboAdapter.fastH3AdaLNCacheFilename,
                 byteCount: Self.fastH3AdaLNCacheByteCount,

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Resources.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Resources.swift
@@ -260,6 +260,7 @@ public struct MiniMaxH3Resources: Sendable {
     public static let fl2vaModelID = "video-minimax-h3-fl2va-mlx"
     public static let fl2vaBF16ModelID = "video-minimax-h3-fl2va-bf16-mlx"
     public static let fl2vaQ8ModelID = "video-minimax-h3-fl2va-8bit-mlx"
+    public static let fastH3ModelID = "video-minimax-h3-fasth3-vsa-datafree-mlx"
     public static let ref2vaModelID = "video-minimax-h3-ref2va-mlx"
     public static let sourceRepository = "MiniMaxAI/MiniMax-H3"
     public static let sourceRevision = "ec19cc6daf5d8add9417c18e86b6b58cc6c55027"
@@ -271,6 +272,8 @@ public struct MiniMaxH3Resources: Sendable {
     public static let compactBF16ArtifactRevision = "4ce4b1d870f7b1b0c75672fd4f2867c1f5df7b5f"
     public static let q8ArtifactRepository = "Sawfwair/MiniMax-H3-FL2VA-MLX-8bit"
     public static let q8ArtifactRevision = "86500cb6ebec22c006597e41840b26ef1099fdd7"
+    public static let fastH3ArtifactRepository = "Sawfwair/MiniMax-H3-FastH3-VSA-DataFree-MLX-BF16"
+    public static let fastH3ArtifactRevision = "4208e52b28074fac87f7639281b1a4d564aba4a1"
     public static let ref2vaArtifactRepository = "Sawfwair/MiniMax-H3-Ref2VA-MLX-8bit"
     public static let ref2vaArtifactRevision = "61dc387ef1a7166425cdacd63c2340598dcc364f"
     public static let bf16TransformerDirectory = "transformer-bf16"
@@ -289,6 +292,9 @@ public struct MiniMaxH3Resources: Sendable {
     public static let ref2vaAdaLNCacheByteCount: Int64 = 873_820_740
     public static let ref2vaAdaLNCacheSourceIdentity =
         "sha256:\(ref2vaConvertedSHA256)"
+    public static let fastH3AdaLNCacheSHA256 =
+        "d5e98c47a6a8924acbae4cfe34007049f22f56df7e9a4809f8d509320067fbe1"
+    public static let fastH3AdaLNCacheByteCount: Int64 = 116_449_540
 
     public static let requiredFiles = [
         "config.json",
@@ -315,6 +321,13 @@ public struct MiniMaxH3Resources: Sendable {
         "SOURCE_MANIFEST.json",
         "transformer.conversion.json",
         "SHA256SUMS",
+    ]
+    public static let fastH3ArtifactFiles = compactBF16AndQ8ArtifactFiles + [
+        "adaln_cache-p5-v6-a3.safetensors",
+        MiniMaxH3TurboAdapter.fastH3VSADataFreeFilename,
+        MiniMaxH3TurboAdapter.fastH3AdaLNCacheFilename,
+        "FASTH3_SOURCE_MANIFEST.json",
+        "FASTH3_CONVERSION.json",
     ]
     public static let bf16SupportArtifactFiles = compactArtifactFiles.filter {
         $0 != "transformer.safetensors" && $0 != MiniMaxH3AdaLNCache.filename
@@ -368,6 +381,12 @@ public struct MiniMaxH3Resources: Sendable {
         rootURL.appending(path: MiniMaxH3AdaLNCachePack.filename)
     }
     public var conversionReceiptURL: URL { rootURL.appending(path: "transformer.conversion.json") }
+    public var fastH3AdapterURL: URL {
+        rootURL.appending(path: MiniMaxH3TurboAdapter.fastH3VSADataFreeFilename)
+    }
+    public var fastH3AdaLNCacheURL: URL {
+        rootURL.appending(path: MiniMaxH3TurboAdapter.fastH3AdaLNCacheFilename)
+    }
 
     public func transformerWeightsLayout(fileManager: FileManager = .default) -> TransformerWeightsLayout? {
         if fileManager.fileExists(atPath: bf16TransformerIndexURL.path) {
@@ -548,6 +567,50 @@ public struct MiniMaxH3Resources: Sendable {
         } catch {
             return ["Invalid MiniMax-H3 cache pack: \(error.localizedDescription)"]
         }
+    }
+
+    func validateManagedFastH3Artifact(fileManager: FileManager = .default) -> [String] {
+        var issues = validateCompactCachePack(fileManager: fileManager)
+        let provenanceFiles = [
+            "FASTH3_SOURCE_MANIFEST.json",
+            "FASTH3_CONVERSION.json",
+        ]
+        issues += provenanceFiles.compactMap { filename in
+            fileManager.fileExists(atPath: rootURL.appending(path: filename).path)
+                ? nil
+                : "Missing required FastH3 provenance file: \(filename)"
+        }
+        guard issues.isEmpty else { return issues }
+
+        guard let adapter = ManagedAdapterCatalog.spec(
+            for: ManagedAdapterCatalog.miniMaxH3FastH3VSADataFreeID
+        ) else {
+            return ["Missing the pinned FastH3 adapter catalog entry."]
+        }
+        do {
+            _ = try adapter.artifact.verify(in: rootURL, fileManager: fileManager)
+            _ = try ModelArtifactPin(
+                filename: MiniMaxH3TurboAdapter.fastH3AdaLNCacheFilename,
+                byteCount: Self.fastH3AdaLNCacheByteCount,
+                sha256: Self.fastH3AdaLNCacheSHA256
+            ).verify(in: rootURL, fileManager: fileManager)
+            let recipe = MiniMaxH3TurboAdapter.fastH3VSADataFreeRecipe
+            guard let baseSigmas = recipe.baseDenoisingSigmas,
+                  let videoShift = recipe.videoFlowShift,
+                  let audioShift = recipe.audioFlowShift else {
+                return ["FastH3 recipe is missing its pinned sampler schedule."]
+            }
+            _ = try MiniMaxH3AdaLNCache.load(
+                from: fastH3AdaLNCacheURL,
+                configuration: MiniMaxH3TransformerConfiguration(try loadConfiguration()),
+                videoSchedule: MiniMaxH3Schedule(baseSigmas: baseSigmas, shift: videoShift),
+                audioSchedule: MiniMaxH3Schedule(baseSigmas: baseSigmas, shift: audioShift),
+                sourceIdentity: MiniMaxH3TurboAdapter.fastH3SourceIdentity
+            )
+        } catch {
+            issues.append("Invalid pinned FastH3 artifact: \(error.localizedDescription)")
+        }
+        return issues
     }
 
     public func loadConfiguration() throws -> MiniMaxH3Configuration {

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Scheduler.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Scheduler.swift
@@ -23,6 +23,26 @@ public struct MiniMaxH3Schedule: Sendable {
         self.timesteps = shifted.dropLast().map { 1 - $0 }
     }
 
+    public init(baseSigmas: [Float], shift: Float) throws {
+        guard baseSigmas.count >= 2 else {
+            throw MiniMaxH3LayoutError.invalidGeometry("schedule needs at least two points")
+        }
+        guard shift > 0 else {
+            throw MiniMaxH3LayoutError.invalidGeometry("schedule shift must be positive")
+        }
+        guard baseSigmas.first.map({ $0 > 0 && $0 <= 1 }) == true,
+              baseSigmas.last == 0,
+              zip(baseSigmas, baseSigmas.dropFirst()).allSatisfy({ $0 > $1 }) else {
+            throw MiniMaxH3LayoutError.invalidGeometry(
+                "base sigmas must strictly descend from (0, 1] to 0"
+            )
+        }
+        self.sigmas = baseSigmas.map { base in
+            shift * base / (1 + (shift - 1) * base)
+        }
+        self.timesteps = sigmas.dropLast().map { 1 - $0 }
+    }
+
     public func step(sample: MLXArray, velocity: MLXArray, index: Int) -> MLXArray {
         precondition(index >= 0 && index + 1 < sigmas.count)
         let sigma = sigmas[index]

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Transformer.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Transformer.swift
@@ -17,17 +17,23 @@ enum MiniMaxH3ExactKernelMode: String, Sendable, Equatable {
     case boundaryLayout = "boundary-layout"
     case affineQ8 = "affine-q8"
     case affineQ8MLP = "affine-q8-mlp"
+    case fastH3Metal = "fasth3-metal"
 
     var usesBoundaryLayout: Bool {
-        self == .boundaryLayout || self == .affineQ8
+        self == .boundaryLayout || self == .affineQ8 || self == .fastH3Metal
     }
 
     var usesAffineQ8FeedForward: Bool {
-        self == .affineQ8 || self == .affineQ8MLP
+        self == .affineQ8 || self == .affineQ8MLP || self == .fastH3Metal
+    }
+
+    var usesTiledAffineQ8FeedForward: Bool {
+        self == .affineQ8MLP || self == .fastH3Metal
     }
 }
 
 enum MiniMaxH3ExactKernelStage: String, CaseIterable, Sendable, Hashable {
+    case attentionAdaLN = "k0-attention-adaln"
     case gateAdaLN = "k1-gate-adaln"
     case qkvLayout = "k2a-qkv-layout"
     case qkvProjection = "k2b-qkv-projection"
@@ -560,7 +566,7 @@ private final class MiniMaxH3FeedForward: Module {
         if exactKernelMode.usesAffineQ8FeedForward,
            enabledExactKernelStages.contains(.feedForwardInput) {
             if let weights = miniMaxH3AffineQ8Weights(input) {
-                let projected = exactKernelMode == .affineQ8MLP
+                let projected = exactKernelMode.usesTiledAffineQ8FeedForward
                     ? MiniMaxH3FusedKernels.projectFeedForwardInputAffineInt8SwiGLUTiled(
                         input: value,
                         weightCodes: weights.codes,
@@ -593,7 +599,7 @@ private final class MiniMaxH3FeedForward: Module {
         if exactKernelMode.usesAffineQ8FeedForward,
            enabledExactKernelStages.contains(.feedForwardOutput) {
             if let weights = miniMaxH3AffineQ8Weights(output) {
-                let projected = exactKernelMode == .affineQ8MLP
+                let projected = exactKernelMode.usesTiledAffineQ8FeedForward
                     ? MiniMaxH3FusedKernels.projectFeedForwardOutputAffineInt8Tiled(
                         input: value,
                         weightCodes: weights.codes,
@@ -815,6 +821,37 @@ private final class MiniMaxH3TransformerBlock: Module {
         adaLNWeightsAvailable = false
     }
 
+    private func prepareAttentionInput(
+        _ value: MLXArray,
+        modulation: MLXArray,
+        adaLNIndices: MLXArray
+    ) -> MLXArray {
+        if exactKernelMode.usesBoundaryLayout,
+           enabledExactKernelStages.contains(.attentionAdaLN) {
+            if let prepared = MiniMaxH3FusedKernels.prepareAttentionInput(
+                input: value,
+                normWeight: attentionNorm.weight,
+                modulation: modulation,
+                rowIndices: adaLNIndices,
+                eps: attentionNorm.eps
+            ) {
+                exactKernelDispatchHandler?(.attentionAdaLN)
+                return prepared
+            }
+            exactKernelFallbackHandler?(
+                .attentionAdaLN,
+                "input=\(value.dtype):\(value.shape) "
+                    + "norm=\(attentionNorm.weight.dtype) "
+                    + "modulation=\(modulation.dtype):\(modulation.shape) "
+                    + "indices=\(adaLNIndices.dtype):\(adaLNIndices.shape)"
+            )
+        }
+        let parts = MLX.split(modulation, parts: 6, axis: -1)
+        let shift = MLX.take(parts[0], adaLNIndices, axis: 0).expandedDimensions(axis: 0)
+        let scale = MLX.take(parts[1], adaLNIndices, axis: 0).expandedDimensions(axis: 0)
+        return attentionNorm(value) * (1 + scale) + shift
+    }
+
     func callAsFunction(
         _ value: MLXArray,
         timeEmbedding: MLXArray,
@@ -865,18 +902,11 @@ private final class MiniMaxH3TransformerBlock: Module {
             }
             completeModulation = adaLN.concatenated(timeEmbedding)
         }
-        let modulation = MLX.split(completeModulation, parts: 6, axis: -1)
-        let shiftAttention = MLX.take(
-            modulation[0],
-            adaLNIndices,
-            axis: 0
-        ).expandedDimensions(axis: 0)
-        let scaleAttention = MLX.take(
-            modulation[1],
-            adaLNIndices,
-            axis: 0
-        ).expandedDimensions(axis: 0)
-        let attentionInput = attentionNorm(value) * (1 + scaleAttention) + shiftAttention
+        let attentionInput = prepareAttentionInput(
+            value,
+            modulation: completeModulation,
+            adaLNIndices: adaLNIndices
+        )
         let attentionOutput = attention(attentionInput, rope: rope)
         guard let boundary = MiniMaxH3FusedKernels.gateAttentionAndPrepareFeedForward(
             residual: value,
@@ -908,17 +938,20 @@ private final class MiniMaxH3TransformerBlock: Module {
         rope: MiniMaxH3RotaryEmbedding,
         cachedModulation: MLXArray?
     ) -> MLXArray {
-        let modulation: [MLXArray]
+        let completeModulation: MLXArray
         if let cachedModulation {
-            modulation = MLX.split(cachedModulation, parts: 6, axis: -1)
+            completeModulation = cachedModulation
         } else {
             guard let adaLN else { preconditionFailure("MiniMax-H3 AdaLN cache is required") }
-            modulation = adaLN(timeEmbedding)
+            completeModulation = adaLN.concatenated(timeEmbedding)
         }
-        let shiftAttention = MLX.take(modulation[0], adaLNIndices, axis: 0).expandedDimensions(axis: 0)
-        let scaleAttention = MLX.take(modulation[1], adaLNIndices, axis: 0).expandedDimensions(axis: 0)
+        let modulation = MLX.split(completeModulation, parts: 6, axis: -1)
         let gateAttention = MLX.take(modulation[2], adaLNIndices, axis: 0).expandedDimensions(axis: 0)
-        let attentionInput = attentionNorm(value) * (1 + scaleAttention) + shiftAttention
+        let attentionInput = prepareAttentionInput(
+            value,
+            modulation: completeModulation,
+            adaLNIndices: adaLNIndices
+        )
         return value + gateAttention * attention(attentionInput, rope: rope)
     }
 
@@ -949,17 +982,20 @@ private final class MiniMaxH3TransformerBlock: Module {
         rope: MiniMaxH3RotaryEmbedding,
         cachedModulation: MLXArray?
     ) -> [MLXArray] {
-        let modulation: [MLXArray]
+        let completeModulation: MLXArray
         if let cachedModulation {
-            modulation = MLX.split(cachedModulation, parts: 6, axis: -1)
+            completeModulation = cachedModulation
         } else {
             guard let adaLN else { preconditionFailure("MiniMax-H3 AdaLN cache is required") }
-            modulation = adaLN(timeEmbedding)
+            completeModulation = adaLN.concatenated(timeEmbedding)
         }
-        let shiftAttention = MLX.take(modulation[0], adaLNIndices, axis: 0).expandedDimensions(axis: 0)
-        let scaleAttention = MLX.take(modulation[1], adaLNIndices, axis: 0).expandedDimensions(axis: 0)
+        let modulation = MLX.split(completeModulation, parts: 6, axis: -1)
         let gateAttention = MLX.take(modulation[2], adaLNIndices, axis: 0).expandedDimensions(axis: 0)
-        let attentionInput = attentionNorm(value) * (1 + scaleAttention) + shiftAttention
+        let attentionInput = prepareAttentionInput(
+            value,
+            modulation: completeModulation,
+            adaLNIndices: adaLNIndices
+        )
         return attention.project(attentionInput, rope: rope) + [gateAttention]
     }
 
@@ -991,17 +1027,20 @@ private final class MiniMaxH3TransformerBlock: Module {
         compressionGateStorage: MiniMaxH3FastH3CompressionGate.Storage,
         compressionGateParameters: [MLXArray]
     ) -> [MLXArray] {
-        let modulation: [MLXArray]
+        let completeModulation: MLXArray
         if let cachedModulation {
-            modulation = MLX.split(cachedModulation, parts: 6, axis: -1)
+            completeModulation = cachedModulation
         } else {
             guard let adaLN else { preconditionFailure("MiniMax-H3 AdaLN cache is required") }
-            modulation = adaLN(timeEmbedding)
+            completeModulation = adaLN.concatenated(timeEmbedding)
         }
-        let shiftAttention = MLX.take(modulation[0], adaLNIndices, axis: 0).expandedDimensions(axis: 0)
-        let scaleAttention = MLX.take(modulation[1], adaLNIndices, axis: 0).expandedDimensions(axis: 0)
+        let modulation = MLX.split(completeModulation, parts: 6, axis: -1)
         let gateAttention = MLX.take(modulation[2], adaLNIndices, axis: 0).expandedDimensions(axis: 0)
-        let attentionInput = attentionNorm(value) * (1 + scaleAttention) + shiftAttention
+        let attentionInput = prepareAttentionInput(
+            value,
+            modulation: completeModulation,
+            adaLNIndices: adaLNIndices
+        )
         let projected = attention.project(attentionInput, rope: rope)
         let compressed = MiniMaxH3FastH3CompressionGate.project(
             attentionInput,
@@ -1053,6 +1092,87 @@ private final class MiniMaxH3TransformerBlock: Module {
         gate: MLXArray
     ) -> MLXArray {
         value + gate * attention.projectOutput(attended)
+    }
+
+    func postAttention(
+        _ value: MLXArray,
+        attended: MLXArray,
+        gate: MLXArray,
+        timeEmbedding: MLXArray,
+        adaLNIndices: MLXArray,
+        cachedModulation: MLXArray?
+    ) -> MLXArray {
+        let projected = postAttentionProjection(
+            value,
+            attended: attended,
+            gate: gate,
+            timeEmbedding: timeEmbedding,
+            adaLNIndices: adaLNIndices,
+            cachedModulation: cachedModulation
+        )
+        return feedForwardProjectionResidual(
+            projected[0],
+            projected: projected[1],
+            gate: projected[2]
+        )
+    }
+
+    func postAttentionProjection(
+        _ value: MLXArray,
+        attended: MLXArray,
+        gate: MLXArray,
+        timeEmbedding: MLXArray,
+        adaLNIndices: MLXArray,
+        cachedModulation: MLXArray?
+    ) -> [MLXArray] {
+        let attentionOutput = attention.projectOutput(attended)
+        if exactKernelMode.usesBoundaryLayout,
+           enabledExactKernelStages.contains(.gateAdaLN) {
+            let completeModulation: MLXArray
+            if let cachedModulation {
+                completeModulation = cachedModulation
+            } else {
+                guard let adaLN else {
+                    preconditionFailure("MiniMax-H3 AdaLN cache is required")
+                }
+                completeModulation = adaLN.concatenated(timeEmbedding)
+            }
+            if let boundary = MiniMaxH3FusedKernels.gateAttentionAndPrepareFeedForward(
+                residual: value,
+                attentionOutput: attentionOutput,
+                normWeight: feedForwardNorm.weight,
+                modulation: completeModulation,
+                rowIndices: adaLNIndices,
+                eps: feedForwardNorm.eps
+            ) {
+                exactKernelDispatchHandler?(.gateAdaLN)
+                return [
+                    boundary.residual,
+                    feedForward.project(boundary.feedForwardInput),
+                    boundary.feedForwardGate,
+                ]
+            }
+            exactKernelFallbackHandler?(
+                .gateAdaLN,
+                "residual=\(value.dtype):\(value.shape) "
+                    + "attention=\(attentionOutput.dtype):\(attentionOutput.shape) "
+                    + "norm=\(feedForwardNorm.weight.dtype) "
+                    + "modulation=\(completeModulation.dtype):\(completeModulation.shape) "
+                    + "indices=\(adaLNIndices.dtype):\(adaLNIndices.shape)"
+            )
+        }
+        let attentionResidual = value + gate * attentionOutput
+        let feedForwardParts = feedForwardProjection(
+            attentionResidual,
+            timeEmbedding: timeEmbedding,
+            adaLNIndices: adaLNIndices,
+            cachedModulation: cachedModulation
+        )
+        return [
+            attentionResidual,
+            feedForwardParts[0],
+            feedForwardParts[1],
+        ]
     }
 
     func feedForwardProjection(
@@ -1292,6 +1412,7 @@ private struct MiniMaxH3CompiledBlockForwards {
     let attentionOutput: MiniMaxH3CompiledBlockForward
     let feedForwardProjection: MiniMaxH3CompiledBlockForward
     let feedForwardOutput: MiniMaxH3CompiledBlockForward
+    let postAttentionProjection: MiniMaxH3CompiledBlockForward
     let postAttention: MiniMaxH3CompiledBlockForward
 }
 
@@ -1385,17 +1506,24 @@ final class MiniMaxH3BlockScheduleBenchmark {
             )]
         }
         let postAttention = MLX.compile(inputs: [block]) { inputs in
-            let attended = block.attentionProjectionResidual(
+            [block.postAttention(
                 inputs[0],
                 attended: inputs[1],
-                gate: inputs[2]
-            )
-            return [block.feedForwardResidual(
-                attended,
+                gate: inputs[2],
                 timeEmbedding: inputs[3],
                 adaLNIndices: inputs[4],
                 cachedModulation: inputs[5]
             )]
+        }
+        let postAttentionProjection = MLX.compile(inputs: [block]) { inputs in
+            block.postAttentionProjection(
+                inputs[0],
+                attended: inputs[1],
+                gate: inputs[2],
+                timeEmbedding: inputs[3],
+                adaLNIndices: inputs[4],
+                cachedModulation: inputs[5]
+            )
         }
         self.forwards = MiniMaxH3CompiledBlockForwards(
             attentionProjection: attentionProjection,
@@ -1403,6 +1531,7 @@ final class MiniMaxH3BlockScheduleBenchmark {
             attentionOutput: attentionOutput,
             feedForwardProjection: feedForwardProjection,
             feedForwardOutput: feedForwardOutput,
+            postAttentionProjection: postAttentionProjection,
             postAttention: postAttention
         )
         self.fusedFeedForward = feedForward
@@ -1789,6 +1918,17 @@ public final class MiniMaxH3Transformer: Module {
 
     var supportsAffineQ8ExactKernels: Bool {
         !blocks.isEmpty && blocks.allSatisfy(\.supportsAffineQ8ExactKernels)
+    }
+
+    static func requiresTiledFeedForwardEvaluationBoundary(
+        rowCount: Int,
+        feedForwardSize: Int,
+        itemSize: Int
+    ) -> Bool {
+        precondition(rowCount > 0 && feedForwardSize > 0 && itemSize > 0)
+        return UInt64(rowCount)
+            * UInt64(feedForwardSize)
+            * UInt64(itemSize) > UInt64(UInt32.max)
     }
 
     #if DEBUG
@@ -2425,16 +2565,29 @@ public final class MiniMaxH3Transformer: Module {
                     if let modulation = cachedAdaLN?.blockModulations[index] {
                         postAttentionInputs.append(modulation)
                     }
-                    hidden = compiled.postAttention(postAttentionInputs)[0]
+                    if exactKernelMode.usesTiledAffineQ8FeedForward,
+                       Self.requiresTiledFeedForwardEvaluationBoundary(
+                        rowCount: hidden.dim(1),
+                        feedForwardSize: configuration.feedForwardSize,
+                        itemSize: hidden.itemSize
+                    ) {
+                        // MLX buffers use 32-bit byte offsets. Materialize the
+                        // compact SwiGLU result before compiling the FC2 stage
+                        // when that single activation exceeds 4 GiB.
+                        let feedForwardParts = compiled.postAttentionProjection(
+                            postAttentionInputs
+                        )
+                        MLX.eval(feedForwardParts)
+                        hidden = compiled.feedForwardOutput(feedForwardParts)[0]
+                    } else {
+                        hidden = compiled.postAttention(postAttentionInputs)[0]
+                    }
                     MLX.eval(hidden)
                 } else {
-                    hidden = block.attentionProjectionResidual(
+                    hidden = block.postAttention(
                         hidden,
                         attended: attended,
-                        gate: projectedAttention[3]
-                    )
-                    hidden = block.feedForwardResidual(
-                        hidden,
+                        gate: projectedAttention[3],
                         timeEmbedding: timeEmbedding,
                         adaLNIndices: context.adaLNIndices,
                         cachedModulation: cachedAdaLN?.blockModulations[index]
@@ -2663,14 +2816,23 @@ public final class MiniMaxH3Transformer: Module {
                 gate: inputs[2]
             )]
         }
-        let postAttention = MLX.compile(inputs: [runner]) { (inputs: [MLXArray]) -> [MLXArray] in
-            let attended = runner.attentionProjectionResidual(
+        let postAttentionProjection = MLX.compile(
+            inputs: [runner]
+        ) { (inputs: [MLXArray]) -> [MLXArray] in
+            runner.postAttentionProjection(
                 inputs[0],
                 attended: inputs[1],
-                gate: inputs[2]
+                gate: inputs[2],
+                timeEmbedding: inputs[3],
+                adaLNIndices: inputs[4],
+                cachedModulation: inputs.count == 6 ? inputs[5] : nil
             )
-            return [runner.feedForwardResidual(
-                attended,
+        }
+        let postAttention = MLX.compile(inputs: [runner]) { (inputs: [MLXArray]) -> [MLXArray] in
+            [runner.postAttention(
+                inputs[0],
+                attended: inputs[1],
+                gate: inputs[2],
                 timeEmbedding: inputs[3],
                 adaLNIndices: inputs[4],
                 cachedModulation: inputs.count == 6 ? inputs[5] : nil
@@ -2682,6 +2844,7 @@ public final class MiniMaxH3Transformer: Module {
             attentionOutput: attentionOutput,
             feedForwardProjection: feedForwardProjection,
             feedForwardOutput: feedForwardOutput,
+            postAttentionProjection: postAttentionProjection,
             postAttention: postAttention
         )
         compiledBlockRunner = runner

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Transformer.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Transformer.swift
@@ -16,6 +16,15 @@ enum MiniMaxH3ExactKernelMode: String, Sendable, Equatable {
     case disabled
     case boundaryLayout = "boundary-layout"
     case affineQ8 = "affine-q8"
+    case affineQ8MLP = "affine-q8-mlp"
+
+    var usesBoundaryLayout: Bool {
+        self == .boundaryLayout || self == .affineQ8
+    }
+
+    var usesAffineQ8FeedForward: Bool {
+        self == .affineQ8 || self == .affineQ8MLP
+    }
 }
 
 enum MiniMaxH3ExactKernelStage: String, CaseIterable, Sendable, Hashable {
@@ -393,7 +402,7 @@ private final class MiniMaxH3Attention: Module {
             }
         }
         let globalProjection = queryKeyValue(input)
-        if exactKernelMode != .disabled,
+        if exactKernelMode.usesBoundaryLayout,
            enabledExactKernelStages.contains(.qkvLayout) {
             if let rope {
                 if let projected = MiniMaxH3FusedKernels.prepareHeadMajorQKV(
@@ -548,16 +557,23 @@ private final class MiniMaxH3FeedForward: Module {
     }
 
     func project(_ value: MLXArray) -> MLXArray {
-        if exactKernelMode == .affineQ8,
+        if exactKernelMode.usesAffineQ8FeedForward,
            enabledExactKernelStages.contains(.feedForwardInput) {
             if let weights = miniMaxH3AffineQ8Weights(input) {
-                if let projected = MiniMaxH3FusedKernels
-                    .projectFeedForwardInputAffineInt8SwiGLU(
+                let projected = exactKernelMode == .affineQ8MLP
+                    ? MiniMaxH3FusedKernels.projectFeedForwardInputAffineInt8SwiGLUTiled(
                         input: value,
                         weightCodes: weights.codes,
                         weightScales: weights.scales,
                         weightBiases: weights.biases
-                    ) {
+                    )
+                    : MiniMaxH3FusedKernels.projectFeedForwardInputAffineInt8SwiGLU(
+                        input: value,
+                        weightCodes: weights.codes,
+                        weightScales: weights.scales,
+                        weightBiases: weights.biases
+                    )
+                if let projected {
                     exactKernelDispatchHandler?(.feedForwardInput)
                     return projected
                 }
@@ -574,15 +590,23 @@ private final class MiniMaxH3FeedForward: Module {
     }
 
     func projectOutput(_ value: MLXArray) -> MLXArray {
-        if exactKernelMode == .affineQ8,
+        if exactKernelMode.usesAffineQ8FeedForward,
            enabledExactKernelStages.contains(.feedForwardOutput) {
             if let weights = miniMaxH3AffineQ8Weights(output) {
-                if let projected = MiniMaxH3FusedKernels.projectFeedForwardOutputAffineInt8(
-                    input: value,
-                    weightCodes: weights.codes,
-                    weightScales: weights.scales,
-                    weightBiases: weights.biases
-                ) {
+                let projected = exactKernelMode == .affineQ8MLP
+                    ? MiniMaxH3FusedKernels.projectFeedForwardOutputAffineInt8Tiled(
+                        input: value,
+                        weightCodes: weights.codes,
+                        weightScales: weights.scales,
+                        weightBiases: weights.biases
+                    )
+                    : MiniMaxH3FusedKernels.projectFeedForwardOutputAffineInt8(
+                        input: value,
+                        weightCodes: weights.codes,
+                        weightScales: weights.scales,
+                        weightBiases: weights.biases
+                    )
+                if let projected {
                     exactKernelDispatchHandler?(.feedForwardOutput)
                     return projected
                 }
@@ -769,6 +793,20 @@ private final class MiniMaxH3TransformerBlock: Module {
             && feedForwardNorm.weight.dtype == .bfloat16
     }
 
+    #if DEBUG
+    func feedForwardForBenchmark(_ value: MLXArray) -> MLXArray {
+        feedForward(value)
+    }
+
+    func feedForwardInputForBenchmark(_ value: MLXArray) -> MLXArray {
+        feedForward.project(value)
+    }
+
+    func feedForwardOutputForBenchmark(_ value: MLXArray) -> MLXArray {
+        feedForward.projectOutput(value)
+    }
+    #endif
+
     func discardAdaLNWeights() {
         guard adaLNWeightsAvailable else { return }
         update(modules: ModuleChildren.unflattened([
@@ -784,7 +822,7 @@ private final class MiniMaxH3TransformerBlock: Module {
         rope: MiniMaxH3RotaryEmbedding,
         cachedModulation: MLXArray?
     ) -> MLXArray {
-        if exactKernelMode != .disabled,
+        if exactKernelMode.usesBoundaryLayout,
            enabledExactKernelStages.contains(.gateAdaLN),
            let exact = exactBoundaryCall(
                value,
@@ -1752,6 +1790,23 @@ public final class MiniMaxH3Transformer: Module {
     var supportsAffineQ8ExactKernels: Bool {
         !blocks.isEmpty && blocks.allSatisfy(\.supportsAffineQ8ExactKernels)
     }
+
+    #if DEBUG
+    func feedForwardForBenchmark(_ value: MLXArray, blockIndex: Int) -> MLXArray {
+        precondition(blocks.indices.contains(blockIndex))
+        return blocks[blockIndex].feedForwardForBenchmark(value)
+    }
+
+    func feedForwardInputForBenchmark(_ value: MLXArray, blockIndex: Int) -> MLXArray {
+        precondition(blocks.indices.contains(blockIndex))
+        return blocks[blockIndex].feedForwardInputForBenchmark(value)
+    }
+
+    func feedForwardOutputForBenchmark(_ value: MLXArray, blockIndex: Int) -> MLXArray {
+        precondition(blocks.indices.contains(blockIndex))
+        return blocks[blockIndex].feedForwardOutputForBenchmark(value)
+    }
+    #endif
 
     var affineQ8ExactKernelBlockCount: Int {
         blocks.count(where: \.supportsAffineQ8ExactKernels)

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Transformer.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Transformer.swift
@@ -1732,6 +1732,7 @@ public final class MiniMaxH3Transformer: Module {
     var dynamicSparseAttentionStepCount = 0
     var dynamicSparseAttentionLogHandler: ((String) -> Void)?
     var blockTimingHandler: ((Int, TimeInterval, Memory.Snapshot) -> Void)?
+    var fastH3BlockPhaseTimingHandler: ((Int, TimeInterval, TimeInterval, TimeInterval) -> Void)?
     var activeBlockIndices: Set<Int>?
     @ModuleInfo(key: "video_patch_proj") var videoInput: Linear
     @ModuleInfo(key: "audio_patch_proj") var audioInput: Linear
@@ -2306,6 +2307,8 @@ public final class MiniMaxH3Transformer: Module {
             let block = blocks[index]
             let blockStarted = blockTimingHandler.map { _ in CFAbsoluteTimeGetCurrent() }
             if let compressionGate = fastH3CompressionGates[index] {
+                let phaseTimingHandler = fastH3BlockPhaseTimingHandler
+                let projectionStarted = phaseTimingHandler.map { _ in CFAbsoluteTimeGetCurrent() }
                 let compiled = usesBlockwiseCompilation
                     ? compiledBlockForward(for: block, compressionGate: compressionGate)
                     : nil
@@ -2334,18 +2337,28 @@ public final class MiniMaxH3Transformer: Module {
                     )
                 }
                 MLX.eval(projectedAttention)
+                let projectionSeconds = projectionStarted.map {
+                    CFAbsoluteTimeGetCurrent() - $0
+                }
                 guard let fastVSA = context.fastVSA else {
                     preconditionFailure("FastH3 VSA prepared context is missing")
                 }
+                let attentionStarted = phaseTimingHandler.map { _ in CFAbsoluteTimeGetCurrent() }
                 guard let attended = MiniMaxH3FastVSA.call(
                     queries: projectedAttention[0],
                     keys: projectedAttention[1],
                     values: projectedAttention[2],
                     compressionGate: projectedAttention[4],
-                    prepared: fastVSA
+                    prepared: fastVSA,
+                    kernelMode: .runtimeDefault
                 ) else {
                     preconditionFailure("FastH3 VSA requires batch-one BF16 attention on Metal")
                 }
+                if phaseTimingHandler != nil { MLX.eval(attended) }
+                let attentionSeconds = attentionStarted.map {
+                    CFAbsoluteTimeGetCurrent() - $0
+                }
+                let postAttentionStarted = phaseTimingHandler.map { _ in CFAbsoluteTimeGetCurrent() }
                 if let compiled {
                     var postAttentionInputs = [
                         hidden,
@@ -2370,6 +2383,18 @@ public final class MiniMaxH3Transformer: Module {
                         timeEmbedding: timeEmbedding,
                         adaLNIndices: context.adaLNIndices,
                         cachedModulation: cachedAdaLN?.blockModulations[index]
+                    )
+                }
+                if let phaseTimingHandler,
+                   let projectionSeconds,
+                   let attentionSeconds,
+                   let postAttentionStarted {
+                    MLX.eval(hidden)
+                    phaseTimingHandler(
+                        index,
+                        projectionSeconds,
+                        attentionSeconds,
+                        CFAbsoluteTimeGetCurrent() - postAttentionStarted
                     )
                 }
             } else if usesBlockwiseCompilation {

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Transformer.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Transformer.swift
@@ -33,6 +33,61 @@ private struct MiniMaxH3AffineQ8Weights {
     let biases: MLXArray
 }
 
+struct MiniMaxH3FastH3CompressionGate {
+    enum Storage: Sendable, Equatable {
+        case dense
+        case affineQ8(groupSize: Int, bits: Int)
+    }
+
+    let storage: Storage
+    let parameters: [MLXArray]
+
+    init(weight: MLXArray) {
+        self.storage = .dense
+        self.parameters = [weight]
+    }
+
+    init(
+        codes: MLXArray,
+        scales: MLXArray,
+        biases: MLXArray,
+        groupSize: Int,
+        bits: Int
+    ) {
+        precondition(groupSize > 0 && bits == 8)
+        self.storage = .affineQ8(groupSize: groupSize, bits: bits)
+        self.parameters = [codes, scales, biases]
+    }
+
+    func project(_ input: MLXArray) -> MLXArray {
+        Self.project(input, storage: storage, parameters: parameters)
+    }
+
+    static func project(
+        _ input: MLXArray,
+        storage: Storage,
+        parameters: [MLXArray]
+    ) -> MLXArray {
+        switch storage {
+        case .dense:
+            precondition(parameters.count == 1)
+            let weight = parameters[0]
+            return MLX.matmul(input.asType(weight.dtype), weight.T)
+        case .affineQ8(let groupSize, let bits):
+            precondition(parameters.count == 3)
+            return MLX.quantizedMM(
+                input.asType(parameters[1].dtype),
+                parameters[0],
+                scales: parameters[1],
+                biases: parameters[2],
+                groupSize: groupSize,
+                bits: bits,
+                mode: .affine
+            )
+        }
+    }
+}
+
 private func miniMaxH3AffineQ8Weights(
     _ linear: Linear
 ) -> MiniMaxH3AffineQ8Weights? {
@@ -876,7 +931,27 @@ private final class MiniMaxH3TransformerBlock: Module {
         adaLNIndices: MLXArray,
         rope: MiniMaxH3RotaryEmbedding,
         cachedModulation: MLXArray?,
-        compressionGateWeight: MLXArray
+        compressionGate: MiniMaxH3FastH3CompressionGate
+    ) -> [MLXArray] {
+        fastH3AttentionProjection(
+            value,
+            timeEmbedding: timeEmbedding,
+            adaLNIndices: adaLNIndices,
+            rope: rope,
+            cachedModulation: cachedModulation,
+            compressionGateStorage: compressionGate.storage,
+            compressionGateParameters: compressionGate.parameters
+        )
+    }
+
+    func fastH3AttentionProjection(
+        _ value: MLXArray,
+        timeEmbedding: MLXArray,
+        adaLNIndices: MLXArray,
+        rope: MiniMaxH3RotaryEmbedding,
+        cachedModulation: MLXArray?,
+        compressionGateStorage: MiniMaxH3FastH3CompressionGate.Storage,
+        compressionGateParameters: [MLXArray]
     ) -> [MLXArray] {
         let modulation: [MLXArray]
         if let cachedModulation {
@@ -890,9 +965,10 @@ private final class MiniMaxH3TransformerBlock: Module {
         let gateAttention = MLX.take(modulation[2], adaLNIndices, axis: 0).expandedDimensions(axis: 0)
         let attentionInput = attentionNorm(value) * (1 + scaleAttention) + shiftAttention
         let projected = attention.project(attentionInput, rope: rope)
-        let compressed = MLX.matmul(
-            attentionInput.asType(compressionGateWeight.dtype),
-            compressionGateWeight.T
+        let compressed = MiniMaxH3FastH3CompressionGate.project(
+            attentionInput,
+            storage: compressionGateStorage,
+            parameters: compressionGateParameters
         ).reshaped(
             attentionInput.dim(0),
             attentionInput.dim(1),
@@ -1056,6 +1132,7 @@ struct MiniMaxH3TransformerPreparedContext {
     let adaLNIndices: MLXArray
     let rope: MiniMaxH3RotaryEmbedding
     let layout: MiniMaxH3PackedLayout
+    let fastVSA: MiniMaxH3FastVSAPreparedContext?
 }
 
 struct MiniMaxH3TokenReductionState {
@@ -1173,6 +1250,7 @@ private typealias MiniMaxH3CompiledBlockForward = @Sendable ([MLXArray]) -> [MLX
 
 private struct MiniMaxH3CompiledBlockForwards {
     let attentionProjection: MiniMaxH3CompiledBlockForward
+    let fastH3AttentionProjection: MiniMaxH3CompiledBlockForward?
     let attentionOutput: MiniMaxH3CompiledBlockForward
     let feedForwardProjection: MiniMaxH3CompiledBlockForward
     let feedForwardOutput: MiniMaxH3CompiledBlockForward
@@ -1283,6 +1361,7 @@ final class MiniMaxH3BlockScheduleBenchmark {
         }
         self.forwards = MiniMaxH3CompiledBlockForwards(
             attentionProjection: attentionProjection,
+            fastH3AttentionProjection: nil,
             attentionOutput: attentionOutput,
             feedForwardProjection: feedForwardProjection,
             feedForwardOutput: feedForwardOutput,
@@ -1667,7 +1746,7 @@ public final class MiniMaxH3Transformer: Module {
     private var compiledBlockRunner: MiniMaxH3TransformerBlock?
     private var compiledBlockForwards: MiniMaxH3CompiledBlockForwards?
     private var dynamicSparseAttentionGateResults: [String: Bool] = [:]
-    private var fastH3CompressionGateWeights: [MLXArray?]
+    private var fastH3CompressionGates: [MiniMaxH3FastH3CompressionGate?]
 
     var supportsAffineQ8ExactKernels: Bool {
         !blocks.isEmpty && blocks.allSatisfy(\.supportsAffineQ8ExactKernels)
@@ -1684,7 +1763,7 @@ public final class MiniMaxH3Transformer: Module {
     ) {
         self.adaLNWeightsAvailable = includeAdaLN
         self.configuration = configuration
-        self.fastH3CompressionGateWeights = Array(repeating: nil, count: configuration.layerCount)
+        self.fastH3CompressionGates = Array(repeating: nil, count: configuration.layerCount)
         self._videoInput.wrappedValue = Linear(
             configuration.videoPatchDimension,
             configuration.hiddenSize,
@@ -1733,18 +1812,45 @@ public final class MiniMaxH3Transformer: Module {
     }
 
     var usesFastH3VSA: Bool {
-        !fastH3CompressionGateWeights.isEmpty
-            && fastH3CompressionGateWeights.allSatisfy { $0 != nil }
+        !fastH3CompressionGates.isEmpty
+            && fastH3CompressionGates.allSatisfy { $0 != nil }
     }
 
     func installFastH3CompressionGate(_ weight: MLXArray, blockIndex: Int) {
-        precondition(fastH3CompressionGateWeights.indices.contains(blockIndex))
+        precondition(fastH3CompressionGates.indices.contains(blockIndex))
         precondition(weight.shape == [
             configuration.attentionHeadCount * configuration.attentionHeadDimension,
             configuration.hiddenSize,
         ])
-        fastH3CompressionGateWeights[blockIndex] = weight
+        fastH3CompressionGates[blockIndex] = MiniMaxH3FastH3CompressionGate(weight: weight)
         MLX.eval(weight)
+        compiledBlockRunner = nil
+        compiledBlockForwards = nil
+    }
+
+    func installFastH3QuantizedCompressionGate(
+        codes: MLXArray,
+        scales: MLXArray,
+        biases: MLXArray,
+        groupSize: Int,
+        bits: Int,
+        blockIndex: Int
+    ) {
+        precondition(fastH3CompressionGates.indices.contains(blockIndex))
+        let outputDimension = configuration.attentionHeadCount
+            * configuration.attentionHeadDimension
+        precondition(bits == 8 && groupSize == 64)
+        precondition(codes.shape == [outputDimension, configuration.hiddenSize * bits / 32])
+        precondition(scales.shape == [outputDimension, configuration.hiddenSize / groupSize])
+        precondition(biases.shape == scales.shape)
+        fastH3CompressionGates[blockIndex] = MiniMaxH3FastH3CompressionGate(
+            codes: codes,
+            scales: scales,
+            biases: biases,
+            groupSize: groupSize,
+            bits: bits
+        )
+        MLX.eval(codes, scales, biases)
         compiledBlockRunner = nil
         compiledBlockForwards = nil
     }
@@ -1840,12 +1946,14 @@ public final class MiniMaxH3Transformer: Module {
             Int32(timeIndex * 3) + max(tag, 0)
         })
         let rope = rotaryEmbedding(positions: layout.positions)
+        let fastVSA = usesFastH3VSA ? MiniMaxH3FastVSA.prepare(layout: layout) : nil
         MLX.eval(text, adaLNIndices, rope.cosine, rope.sine)
         return MiniMaxH3TransformerPreparedContext(
             text: text,
             adaLNIndices: adaLNIndices,
             rope: rope,
-            layout: layout
+            layout: layout,
+            fastVSA: fastVSA
         )
     }
 
@@ -1909,7 +2017,8 @@ public final class MiniMaxH3Transformer: Module {
                 text: context.text,
                 adaLNIndices: reducedAdaLNIndices,
                 rope: reducedRope,
-                layout: reducedLayout
+                layout: reducedLayout,
+                fastVSA: nil
             )
         )
     }
@@ -2196,36 +2305,73 @@ public final class MiniMaxH3Transformer: Module {
             if let activeBlockIndices, !activeBlockIndices.contains(index) { continue }
             let block = blocks[index]
             let blockStarted = blockTimingHandler.map { _ in CFAbsoluteTimeGetCurrent() }
-            if let compressionGateWeight = fastH3CompressionGateWeights[index] {
-                let projectedAttention = block.fastH3AttentionProjection(
-                    hidden,
-                    timeEmbedding: timeEmbedding,
-                    adaLNIndices: context.adaLNIndices,
-                    rope: context.rope,
-                    cachedModulation: cachedAdaLN?.blockModulations[index],
-                    compressionGateWeight: compressionGateWeight
-                )
+            if let compressionGate = fastH3CompressionGates[index] {
+                let compiled = usesBlockwiseCompilation
+                    ? compiledBlockForward(for: block, compressionGate: compressionGate)
+                    : nil
+                let projectedAttention: [MLXArray]
+                if let compiled, let fastH3Projection = compiled.fastH3AttentionProjection {
+                    var projectionInputs = [
+                        hidden,
+                        timeEmbedding,
+                        context.adaLNIndices,
+                        context.rope.cosine,
+                        context.rope.sine,
+                    ]
+                    if let modulation = cachedAdaLN?.blockModulations[index] {
+                        projectionInputs.append(modulation)
+                    }
+                    projectionInputs.append(contentsOf: compressionGate.parameters)
+                    projectedAttention = fastH3Projection(projectionInputs)
+                } else {
+                    projectedAttention = block.fastH3AttentionProjection(
+                        hidden,
+                        timeEmbedding: timeEmbedding,
+                        adaLNIndices: context.adaLNIndices,
+                        rope: context.rope,
+                        cachedModulation: cachedAdaLN?.blockModulations[index],
+                        compressionGate: compressionGate
+                    )
+                }
                 MLX.eval(projectedAttention)
+                guard let fastVSA = context.fastVSA else {
+                    preconditionFailure("FastH3 VSA prepared context is missing")
+                }
                 guard let attended = MiniMaxH3FastVSA.call(
                     queries: projectedAttention[0],
                     keys: projectedAttention[1],
                     values: projectedAttention[2],
                     compressionGate: projectedAttention[4],
-                    layout: context.layout
+                    prepared: fastVSA
                 ) else {
                     preconditionFailure("FastH3 VSA requires batch-one BF16 attention on Metal")
                 }
-                hidden = block.attentionProjectionResidual(
-                    hidden,
-                    attended: attended,
-                    gate: projectedAttention[3]
-                )
-                hidden = block.feedForwardResidual(
-                    hidden,
-                    timeEmbedding: timeEmbedding,
-                    adaLNIndices: context.adaLNIndices,
-                    cachedModulation: cachedAdaLN?.blockModulations[index]
-                )
+                if let compiled {
+                    var postAttentionInputs = [
+                        hidden,
+                        attended,
+                        projectedAttention[3],
+                        timeEmbedding,
+                        context.adaLNIndices,
+                    ]
+                    if let modulation = cachedAdaLN?.blockModulations[index] {
+                        postAttentionInputs.append(modulation)
+                    }
+                    hidden = compiled.postAttention(postAttentionInputs)[0]
+                    MLX.eval(hidden)
+                } else {
+                    hidden = block.attentionProjectionResidual(
+                        hidden,
+                        attended: attended,
+                        gate: projectedAttention[3]
+                    )
+                    hidden = block.feedForwardResidual(
+                        hidden,
+                        timeEmbedding: timeEmbedding,
+                        adaLNIndices: context.adaLNIndices,
+                        cachedModulation: cachedAdaLN?.blockModulations[index]
+                    )
+                }
             } else if usesBlockwiseCompilation {
                 var attentionInputs = [
                     hidden,
@@ -2379,7 +2525,8 @@ public final class MiniMaxH3Transformer: Module {
     }
 
     private func compiledBlockForward(
-        for block: MiniMaxH3TransformerBlock
+        for block: MiniMaxH3TransformerBlock,
+        compressionGate: MiniMaxH3FastH3CompressionGate? = nil
     ) -> MiniMaxH3CompiledBlockForwards {
         if let compiledBlockRunner, let compiledBlockForwards {
             updateCompiledBlockRunner(compiledBlockRunner, from: block)
@@ -2396,6 +2543,23 @@ public final class MiniMaxH3Transformer: Module {
                 rope: MiniMaxH3RotaryEmbedding(cosine: inputs[3], sine: inputs[4]),
                 cachedModulation: inputs.count == 6 ? inputs[5] : nil
             )
+        }
+        let fastH3AttentionProjection: MiniMaxH3CompiledBlockForward? = compressionGate.map { gate in
+            let gateStorage = gate.storage
+            let gateParameterCount = gate.parameters.count
+            return MLX.compile(inputs: [runner]) { (inputs: [MLXArray]) -> [MLXArray] in
+                let hasCachedModulation = inputs.count == 6 + gateParameterCount
+                let gateStart = hasCachedModulation ? 6 : 5
+                return runner.fastH3AttentionProjection(
+                    inputs[0],
+                    timeEmbedding: inputs[1],
+                    adaLNIndices: inputs[2],
+                    rope: MiniMaxH3RotaryEmbedding(cosine: inputs[3], sine: inputs[4]),
+                    cachedModulation: hasCachedModulation ? inputs[5] : nil,
+                    compressionGateStorage: gateStorage,
+                    compressionGateParameters: Array(inputs[gateStart...])
+                )
+            }
         }
         let attentionOutput = MLX.compile(inputs: [runner]) { (inputs: [MLXArray]) -> [MLXArray] in
             [runner.attentionProjectionResidual(
@@ -2434,6 +2598,7 @@ public final class MiniMaxH3Transformer: Module {
         }
         let forwards = MiniMaxH3CompiledBlockForwards(
             attentionProjection: attentionProjection,
+            fastH3AttentionProjection: fastH3AttentionProjection,
             attentionOutput: attentionOutput,
             feedForwardProjection: feedForwardProjection,
             feedForwardOutput: feedForwardOutput,

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Transformer.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3Transformer.swift
@@ -870,6 +870,38 @@ private final class MiniMaxH3TransformerBlock: Module {
         return attention.project(attentionInput, rope: rope) + [gateAttention]
     }
 
+    func fastH3AttentionProjection(
+        _ value: MLXArray,
+        timeEmbedding: MLXArray,
+        adaLNIndices: MLXArray,
+        rope: MiniMaxH3RotaryEmbedding,
+        cachedModulation: MLXArray?,
+        compressionGateWeight: MLXArray
+    ) -> [MLXArray] {
+        let modulation: [MLXArray]
+        if let cachedModulation {
+            modulation = MLX.split(cachedModulation, parts: 6, axis: -1)
+        } else {
+            guard let adaLN else { preconditionFailure("MiniMax-H3 AdaLN cache is required") }
+            modulation = adaLN(timeEmbedding)
+        }
+        let shiftAttention = MLX.take(modulation[0], adaLNIndices, axis: 0).expandedDimensions(axis: 0)
+        let scaleAttention = MLX.take(modulation[1], adaLNIndices, axis: 0).expandedDimensions(axis: 0)
+        let gateAttention = MLX.take(modulation[2], adaLNIndices, axis: 0).expandedDimensions(axis: 0)
+        let attentionInput = attentionNorm(value) * (1 + scaleAttention) + shiftAttention
+        let projected = attention.project(attentionInput, rope: rope)
+        let compressed = MLX.matmul(
+            attentionInput.asType(compressionGateWeight.dtype),
+            compressionGateWeight.T
+        ).reshaped(
+            attentionInput.dim(0),
+            attentionInput.dim(1),
+            attention.heads,
+            attention.headDimension
+        ).transposed(0, 2, 1, 3).contiguous()
+        return projected + [gateAttention, compressed]
+    }
+
     func scaledDotProductAttention(
         queries: MLXArray,
         keys: MLXArray,
@@ -1635,6 +1667,7 @@ public final class MiniMaxH3Transformer: Module {
     private var compiledBlockRunner: MiniMaxH3TransformerBlock?
     private var compiledBlockForwards: MiniMaxH3CompiledBlockForwards?
     private var dynamicSparseAttentionGateResults: [String: Bool] = [:]
+    private var fastH3CompressionGateWeights: [MLXArray?]
 
     var supportsAffineQ8ExactKernels: Bool {
         !blocks.isEmpty && blocks.allSatisfy(\.supportsAffineQ8ExactKernels)
@@ -1651,6 +1684,7 @@ public final class MiniMaxH3Transformer: Module {
     ) {
         self.adaLNWeightsAvailable = includeAdaLN
         self.configuration = configuration
+        self.fastH3CompressionGateWeights = Array(repeating: nil, count: configuration.layerCount)
         self._videoInput.wrappedValue = Linear(
             configuration.videoPatchDimension,
             configuration.hiddenSize,
@@ -1696,6 +1730,23 @@ public final class MiniMaxH3Transformer: Module {
 
     var activeBlockCount: Int {
         activeBlockIndices?.count ?? blocks.count
+    }
+
+    var usesFastH3VSA: Bool {
+        !fastH3CompressionGateWeights.isEmpty
+            && fastH3CompressionGateWeights.allSatisfy { $0 != nil }
+    }
+
+    func installFastH3CompressionGate(_ weight: MLXArray, blockIndex: Int) {
+        precondition(fastH3CompressionGateWeights.indices.contains(blockIndex))
+        precondition(weight.shape == [
+            configuration.attentionHeadCount * configuration.attentionHeadDimension,
+            configuration.hiddenSize,
+        ])
+        fastH3CompressionGateWeights[blockIndex] = weight
+        MLX.eval(weight)
+        compiledBlockRunner = nil
+        compiledBlockForwards = nil
     }
 
     /// Expands compact quantized storage into resident bf16 linear weights.
@@ -2145,7 +2196,37 @@ public final class MiniMaxH3Transformer: Module {
             if let activeBlockIndices, !activeBlockIndices.contains(index) { continue }
             let block = blocks[index]
             let blockStarted = blockTimingHandler.map { _ in CFAbsoluteTimeGetCurrent() }
-            if usesBlockwiseCompilation {
+            if let compressionGateWeight = fastH3CompressionGateWeights[index] {
+                let projectedAttention = block.fastH3AttentionProjection(
+                    hidden,
+                    timeEmbedding: timeEmbedding,
+                    adaLNIndices: context.adaLNIndices,
+                    rope: context.rope,
+                    cachedModulation: cachedAdaLN?.blockModulations[index],
+                    compressionGateWeight: compressionGateWeight
+                )
+                MLX.eval(projectedAttention)
+                guard let attended = MiniMaxH3FastVSA.call(
+                    queries: projectedAttention[0],
+                    keys: projectedAttention[1],
+                    values: projectedAttention[2],
+                    compressionGate: projectedAttention[4],
+                    layout: context.layout
+                ) else {
+                    preconditionFailure("FastH3 VSA requires batch-one BF16 attention on Metal")
+                }
+                hidden = block.attentionProjectionResidual(
+                    hidden,
+                    attended: attended,
+                    gate: projectedAttention[3]
+                )
+                hidden = block.feedForwardResidual(
+                    hidden,
+                    timeEmbedding: timeEmbedding,
+                    adaLNIndices: context.adaLNIndices,
+                    cachedModulation: cachedAdaLN?.blockModulations[index]
+                )
+            } else if usesBlockwiseCompilation {
                 var attentionInputs = [
                     hidden,
                     timeEmbedding,

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3TurboAdapter.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3TurboAdapter.swift
@@ -5,9 +5,19 @@ import MLXNN
 public enum MiniMaxH3TurboAdapter {
     public static let format = "minimax-h3-runtime-lora-v1"
     public static let lightX2VFormat = "minimax-h3-peft-fused-lora-v1"
+    public static let fastVideoFormat = "fastvideo-lora-v2"
     public static let expectedPairCount = 259
     public static let lightX2VExpectedPairCount = 312
+    public static let fastVideoExpectedPairCount = 362
     public static let recommendedSchedulePointCount = 5
+    public static let fastH3VSADataFreeFilename =
+        "fastvideo_fasth3_4step_v1_vsa_datafree_rank64.safetensors"
+    public static let fastH3AdaLNCacheFilename = "fastvideo_fasth3_v1_vsa_datafree_adaln_cache.safetensors"
+    public static let fastH3SourceIdentity =
+        "FastVideo/FastVideo-FastH3-4-step-Preview-v1-VSA-DataFree"
+        + "@b65818d41939b5085451074fe8ca8b799f8d4921:transformer"
+    public static let fastVideoExpectedDiffCount = 82
+    public static let fastVideoExpectedCompressionGateCount = 50
 
     public enum Task: String, Sendable, Hashable {
         case fl2va
@@ -22,6 +32,9 @@ public enum MiniMaxH3TurboAdapter {
         public let videoFlowShift: Float?
         public let audioFlowShift: Float?
         public let lightX2VAlpha: Float
+        public let baseDenoisingSigmas: [Float]?
+        public let requiresFastH3VSA: Bool
+        public let requiresTextOnlyConditioning: Bool
 
         public func supports(schedulePointCount: Int) -> Bool {
             supportedSchedulePointCounts.contains(schedulePointCount)
@@ -39,7 +52,10 @@ public enum MiniMaxH3TurboAdapter {
         supportedSchedulePointCounts: [5],
         videoFlowShift: nil,
         audioFlowShift: nil,
-        lightX2VAlpha: 8
+        lightX2VAlpha: 8,
+        baseDenoisingSigmas: nil,
+        requiresFastH3VSA: false,
+        requiresTextOnlyConditioning: false
     )
 
     public static let lightX2VEightStepV1Recipe = InferenceRecipe(
@@ -49,7 +65,10 @@ public enum MiniMaxH3TurboAdapter {
         supportedSchedulePointCounts: [5, 9],
         videoFlowShift: 12,
         audioFlowShift: 3,
-        lightX2VAlpha: 8
+        lightX2VAlpha: 8,
+        baseDenoisingSigmas: nil,
+        requiresFastH3VSA: false,
+        requiresTextOnlyConditioning: false
     )
 
     public static let lightX2VEightStepV1_768pRecipe = InferenceRecipe(
@@ -69,7 +88,10 @@ public enum MiniMaxH3TurboAdapter {
         supportedSchedulePointCounts: [5],
         videoFlowShift: 6,
         audioFlowShift: 3,
-        lightX2VAlpha: 128
+        lightX2VAlpha: 128,
+        baseDenoisingSigmas: nil,
+        requiresFastH3VSA: false,
+        requiresTextOnlyConditioning: false
     )
 
     public static let lightX2VRef2VFourStepV01Recipe = InferenceRecipe(
@@ -79,11 +101,32 @@ public enum MiniMaxH3TurboAdapter {
         supportedSchedulePointCounts: [5],
         videoFlowShift: 12,
         audioFlowShift: 3,
-        lightX2VAlpha: 8
+        lightX2VAlpha: 8,
+        baseDenoisingSigmas: nil,
+        requiresFastH3VSA: false,
+        requiresTextOnlyConditioning: false
+    )
+
+    public static let fastH3VSADataFreeRecipe = InferenceRecipe(
+        name: "fastvideo-fasth3-v1-vsa-datafree",
+        task: .fl2va,
+        defaultSchedulePointCount: 5,
+        supportedSchedulePointCounts: [5],
+        videoFlowShift: 12,
+        audioFlowShift: 3,
+        lightX2VAlpha: 1,
+        baseDenoisingSigmas: [0.999, 0.749, 0.5, 0.25, 0],
+        requiresFastH3VSA: true,
+        requiresTextOnlyConditioning: true
     )
 
     public static func inferenceRecipe(for url: URL) -> InferenceRecipe {
-        inferenceRecipe(filename: url.lastPathComponent)
+        if let metadata = try? SafetensorsStreamingLoader.fileMetadata(url: url),
+           metadata["format"] == fastVideoFormat,
+           metadata["finetuned_model"] == "FastVideo/FastVideo-FastH3-4-step-v1" {
+            return fastH3VSADataFreeRecipe
+        }
+        return inferenceRecipe(filename: url.lastPathComponent)
     }
 
     public static func inferenceRecipe(filename: String) -> InferenceRecipe {
@@ -96,6 +139,8 @@ public enum MiniMaxH3TurboAdapter {
             lightX2VEightStepV1_768pRecipe
         case "minimax_h3_fl2v_turbo_4step_v1.0_768p_bf16.safetensors":
             lightX2VFourStepV1_768pRecipe
+        case fastH3VSADataFreeFilename:
+            fastH3VSADataFreeRecipe
         default:
             fourEvaluationRecipe
         }
@@ -104,6 +149,7 @@ public enum MiniMaxH3TurboAdapter {
     private enum SourceFormat: Equatable {
         case runtime
         case lightX2V
+        case fastVideo
 
         var pairSuffixes: (String, String) {
             switch self {
@@ -111,6 +157,8 @@ public enum MiniMaxH3TurboAdapter {
                 return (".lora_A.weight", ".lora_B.weight")
             case .lightX2V:
                 return (".lora_A.default.weight", ".lora_B.default.weight")
+            case .fastVideo:
+                return (".lora_A.weight", ".lora_B.weight")
             }
         }
 
@@ -120,6 +168,8 @@ public enum MiniMaxH3TurboAdapter {
                 return MiniMaxH3TurboAdapter.expectedPairCount
             case .lightX2V:
                 return MiniMaxH3TurboAdapter.lightX2VExpectedPairCount
+            case .fastVideo:
+                return MiniMaxH3TurboAdapter.fastVideoExpectedPairCount
             }
         }
     }
@@ -157,6 +207,9 @@ public enum MiniMaxH3TurboAdapter {
         case incompleteQKVTarget(String, missing: [QKVBranch])
         case invalidPairShape(String, a: [Int], b: [Int])
         case targetShapeMismatch(String, expected: [Int], actual: [Int])
+        case requiresUnitStrength(Float)
+        case unexpectedAuxiliaryTensorCount(kind: String, expected: Int, actual: Int)
+        case missingTargetParameter(String)
 
         var errorDescription: String? {
             switch self {
@@ -183,6 +236,12 @@ public enum MiniMaxH3TurboAdapter {
                 return "Invalid MiniMax-H3 LoRA pair for \(path): A=\(a), B=\(b)."
             case .targetShapeMismatch(let path, let expected, let actual):
                 return "MiniMax-H3 LoRA target \(path) has shape \(actual); expected \(expected)."
+            case .requiresUnitStrength(let strength):
+                return "FastH3 VSA is a complete student checkpoint and requires adapter strength 1, not \(strength)."
+            case .unexpectedAuxiliaryTensorCount(let kind, let expected, let actual):
+                return "FastH3 VSA \(kind) tensor count mismatch: expected \(expected), found \(actual)."
+            case .missingTargetParameter(let path):
+                return "FastH3 VSA target parameter is missing: \(path)"
             }
         }
     }
@@ -211,8 +270,28 @@ public enum MiniMaxH3TurboAdapter {
         expectedPairCount: Int? = nil
     ) throws -> Installation {
         let sourceFormat = try sourceFormat(at: url)
+        if sourceFormat == .fastVideo, strength != 1 {
+            throw AdapterError.requiresUnitStrength(strength)
+        }
         let inferenceRecipe = inferenceRecipe(for: url)
         let suffixes = sourceFormat.pairSuffixes
+        let usesNativeFastH3Cache = sourceFormat == .fastVideo
+            && adaLNCache?.sourceIdentity == fastH3SourceIdentity
+        if sourceFormat == .fastVideo {
+            let parameterCount = try applyFastVideoDifferences(
+                url: url,
+                to: transformer,
+                strength: strength,
+                omittingCacheCoveredParameters: usesNativeFastH3Cache
+            )
+            guard parameterCount == fastVideoExpectedDiffCount else {
+                throw AdapterError.unexpectedAuxiliaryTensorCount(
+                    kind: "difference",
+                    expected: fastVideoExpectedDiffCount,
+                    actual: parameterCount
+                )
+            }
+        }
         let leafModules = transformer.leafModules().flattened()
         let modulesByPath = Dictionary(uniqueKeysWithValues: leafModules)
         var replacements: [String: Module] = [:]
@@ -241,7 +320,8 @@ public enum MiniMaxH3TurboAdapter {
                 sourceFormat: sourceFormat,
                 lightX2VAlpha: inferenceRecipe.lightX2VAlpha
             )
-            if sourceFormat == .runtime, isAdaLNTarget(target.modulePath) {
+            if isAdaLNTarget(target.modulePath) {
+                if usesNativeFastH3Cache { return }
                 guard adaLNPairs[target.modulePath] == nil else {
                     throw AdapterError.duplicateTarget(target.modulePath)
                 }
@@ -349,12 +429,25 @@ public enum MiniMaxH3TurboAdapter {
         }
 
         applyModuleReplacements(replacements, leafModules: leafModules, to: transformer)
+        if sourceFormat == .fastVideo {
+            let gateCount = try installFastVideoCompressionGates(url: url, into: transformer)
+            guard gateCount == fastVideoExpectedCompressionGateCount else {
+                throw AdapterError.unexpectedAuxiliaryTensorCount(
+                    kind: "compression-gate",
+                    expected: fastVideoExpectedCompressionGateCount,
+                    actual: gateCount
+                )
+            }
+        }
         transformer.exactKernelMode = .disabled
         Memory.clearCache()
         return Installation(pairCount: pairCount, adaLNCache: resolvedAdaLNCache)
     }
 
     private static func sourceFormat(at url: URL) throws -> SourceFormat {
+        if try SafetensorsStreamingLoader.fileMetadata(url: url)["format"] == fastVideoFormat {
+            return .fastVideo
+        }
         let keys = try SafetensorsStreamingLoader.metadata(url: url).keys
         if keys.contains(where: { $0.hasSuffix(".lora_A.default.weight") }) {
             return .lightX2V
@@ -369,7 +462,7 @@ public enum MiniMaxH3TurboAdapter {
         for sourcePath: String,
         sourceFormat: SourceFormat
     ) throws -> LightX2VTarget {
-        guard sourceFormat == .lightX2V else {
+        guard sourceFormat != .runtime else {
             return LightX2VTarget(modulePath: sourcePath, qkvBranch: nil)
         }
 
@@ -401,6 +494,7 @@ public enum MiniMaxH3TurboAdapter {
             (".attn.to_out.0", ".attn.out_proj"),
             (".ff.net.0.proj", ".mlp.fc1"),
             (".ff.net.2", ".mlp.fc2"),
+            (".adaln_proj.linear", ".adaln_proj.linear"),
         ] where normalized.hasSuffix(suffix) {
             return LightX2VTarget(
                 modulePath: String(normalized.dropLast(suffix.count)) + replacement,
@@ -419,6 +513,122 @@ public enum MiniMaxH3TurboAdapter {
         guard sourceFormat == .lightX2V else { return up }
         let scale = MLXArray(lightX2VAlpha / Float(down.dim(0))).asType(up.dtype)
         return up * scale
+    }
+
+    private static func applyFastVideoDifferences(
+        url: URL,
+        to transformer: MiniMaxH3Transformer,
+        strength: Float,
+        omittingCacheCoveredParameters: Bool
+    ) throws -> Int {
+        var seenCount = 0
+        var targetPaths: Set<String> = []
+        let count = try SafetensorsStreamingLoader.forEachTensor(
+            url: url,
+            where: { $0.hasSuffix(".diff") || $0.hasSuffix(".diff_b") }
+        ) { sourceKey, difference in
+            seenCount += 1
+            let targetPath = try fastVideoDifferenceTarget(sourceKey)
+            guard targetPaths.insert(targetPath).inserted else {
+                throw AdapterError.duplicateTarget(targetPath)
+            }
+            if omittingCacheCoveredParameters,
+               (targetPath.hasPrefix("time_embedder.")
+                || (targetPath.hasPrefix("blocks.") && targetPath.contains(".adaln_proj."))
+                || targetPath.hasPrefix("final_layer.adaln_proj.")) {
+                return
+            }
+            let parameters = transformer.parameters().flattened()
+            guard let base = parameters.first(where: { $0.0 == targetPath })?.1 else {
+                throw AdapterError.missingTargetParameter(targetPath)
+            }
+            guard base.shape == difference.shape else {
+                throw AdapterError.targetShapeMismatch(
+                    targetPath,
+                    expected: base.shape,
+                    actual: difference.shape
+                )
+            }
+            let updated = base + difference.asType(base.dtype)
+                * MLXArray(strength).asType(base.dtype)
+            transformer.update(parameters: ModuleParameters.unflattened([(targetPath, updated)]))
+            MLX.eval(updated)
+            Memory.clearCache()
+        }
+        precondition(count == seenCount)
+        return count
+    }
+
+    private static func fastVideoDifferenceTarget(_ sourceKey: String) throws -> String {
+        let suffix: String
+        let parameter: String
+        if sourceKey.hasSuffix(".diff_b") {
+            suffix = ".diff_b"
+            parameter = ".bias"
+        } else if sourceKey.hasSuffix(".diff") {
+            suffix = ".diff"
+            parameter = ".weight"
+        } else {
+            throw AdapterError.unsupportedSourceModule(sourceKey)
+        }
+        let source = String(sourceKey.dropLast(suffix.count))
+        let mapped: String
+        switch source {
+        case "proj_in": mapped = "video_patch_proj"
+        case "audio_proj_in": mapped = "audio_patch_proj"
+        case "context_embedder": mapped = "condition_proj"
+        case "proj_out": mapped = "final_layer.video_out"
+        case "audio_proj_out": mapped = "final_layer.audio_out"
+        case "norm_out.norm": mapped = "final_layer.norm"
+        case "norm_out.linear": mapped = "final_layer.adaln_proj.linear"
+        case "time_embedder.linear_1": mapped = "time_embedder.proj_in"
+        case "time_embedder.linear_2": mapped = "time_embedder.proj_out"
+        default:
+            if source.hasPrefix("transformer_blocks.") {
+                mapped = "blocks." + String(source.dropFirst("transformer_blocks.".count))
+            } else {
+                throw AdapterError.unsupportedSourceModule(sourceKey)
+            }
+        }
+        return mapped + parameter
+    }
+
+    private static func installFastVideoCompressionGates(
+        url: URL,
+        into transformer: MiniMaxH3Transformer
+    ) throws -> Int {
+        var blockIndices: Set<Int> = []
+        return try SafetensorsStreamingLoader.forEachTensor(
+            url: url,
+            where: { $0.hasSuffix(".attn.to_gate_compress.set_weight") }
+        ) { sourceKey, weight in
+            let components = sourceKey.split(separator: ".")
+            guard components.count == 5,
+                  components[0] == "transformer_blocks",
+                  let blockIndex = Int(components[1]),
+                  components[2] == "attn",
+                  components[3] == "to_gate_compress",
+                  components[4] == "set_weight",
+                  (0..<transformer.configuration.layerCount).contains(blockIndex) else {
+                throw AdapterError.unsupportedSourceModule(sourceKey)
+            }
+            guard blockIndices.insert(blockIndex).inserted else {
+                throw AdapterError.duplicateTarget(sourceKey)
+            }
+            let expected = [
+                transformer.configuration.attentionHeadCount
+                    * transformer.configuration.attentionHeadDimension,
+                transformer.configuration.hiddenSize,
+            ]
+            guard weight.shape == expected else {
+                throw AdapterError.targetShapeMismatch(
+                    sourceKey,
+                    expected: expected,
+                    actual: weight.shape
+                )
+            }
+            transformer.installFastH3CompressionGate(weight, blockIndex: blockIndex)
+        }
     }
 
     private static func targetLinear(

--- a/Sources/MereRunCore/MiniMaxH3/MiniMaxH3TurboAdapter.swift
+++ b/Sources/MereRunCore/MiniMaxH3/MiniMaxH3TurboAdapter.swift
@@ -6,6 +6,7 @@ public enum MiniMaxH3TurboAdapter {
     public static let format = "minimax-h3-runtime-lora-v1"
     public static let lightX2VFormat = "minimax-h3-peft-fused-lora-v1"
     public static let fastVideoFormat = "fastvideo-lora-v2"
+    public static let fastH3PremergedFormat = "mere.run.minimax-h3-fasth3-premerged-v1"
     public static let expectedPairCount = 259
     public static let lightX2VExpectedPairCount = 312
     public static let fastVideoExpectedPairCount = 362
@@ -78,7 +79,10 @@ public enum MiniMaxH3TurboAdapter {
         supportedSchedulePointCounts: [9],
         videoFlowShift: 6,
         audioFlowShift: 3,
-        lightX2VAlpha: 8
+        lightX2VAlpha: 8,
+        baseDenoisingSigmas: nil,
+        requiresFastH3VSA: false,
+        requiresTextOnlyConditioning: false
     )
 
     public static let lightX2VFourStepV1_768pRecipe = InferenceRecipe(
@@ -122,11 +126,17 @@ public enum MiniMaxH3TurboAdapter {
 
     public static func inferenceRecipe(for url: URL) -> InferenceRecipe {
         if let metadata = try? SafetensorsStreamingLoader.fileMetadata(url: url),
-           metadata["format"] == fastVideoFormat,
+           (metadata["format"] == fastVideoFormat
+            || metadata["format"] == fastH3PremergedFormat),
            metadata["finetuned_model"] == "FastVideo/FastVideo-FastH3-4-step-v1" {
             return fastH3VSADataFreeRecipe
         }
         return inferenceRecipe(filename: url.lastPathComponent)
+    }
+
+    static func isPremergedFastH3Artifact(_ url: URL) -> Bool {
+        (try? SafetensorsStreamingLoader.fileMetadata(url: url)["format"])
+            == fastH3PremergedFormat
     }
 
     public static func inferenceRecipe(filename: String) -> InferenceRecipe {
@@ -150,6 +160,7 @@ public enum MiniMaxH3TurboAdapter {
         case runtime
         case lightX2V
         case fastVideo
+        case fastH3Premerged
 
         var pairSuffixes: (String, String) {
             switch self {
@@ -157,7 +168,7 @@ public enum MiniMaxH3TurboAdapter {
                 return (".lora_A.weight", ".lora_B.weight")
             case .lightX2V:
                 return (".lora_A.default.weight", ".lora_B.default.weight")
-            case .fastVideo:
+            case .fastVideo, .fastH3Premerged:
                 return (".lora_A.weight", ".lora_B.weight")
             }
         }
@@ -170,6 +181,8 @@ public enum MiniMaxH3TurboAdapter {
                 return MiniMaxH3TurboAdapter.lightX2VExpectedPairCount
             case .fastVideo:
                 return MiniMaxH3TurboAdapter.fastVideoExpectedPairCount
+            case .fastH3Premerged:
+                return 0
             }
         }
     }
@@ -270,8 +283,23 @@ public enum MiniMaxH3TurboAdapter {
         expectedPairCount: Int? = nil
     ) throws -> Installation {
         let sourceFormat = try sourceFormat(at: url)
-        if sourceFormat == .fastVideo, strength != 1 {
+        if (sourceFormat == .fastVideo || sourceFormat == .fastH3Premerged), strength != 1 {
             throw AdapterError.requiresUnitStrength(strength)
+        }
+        if sourceFormat == .fastH3Premerged {
+            let gateCount = try installFastH3QuantizedCompressionGates(
+                url: url,
+                into: transformer
+            )
+            guard gateCount == fastVideoExpectedCompressionGateCount else {
+                throw AdapterError.unexpectedAuxiliaryTensorCount(
+                    kind: "quantized-compression-gate",
+                    expected: fastVideoExpectedCompressionGateCount,
+                    actual: gateCount
+                )
+            }
+            Memory.clearCache()
+            return Installation(pairCount: 0, adaLNCache: adaLNCache)
         }
         let inferenceRecipe = inferenceRecipe(for: url)
         let suffixes = sourceFormat.pairSuffixes
@@ -445,8 +473,12 @@ public enum MiniMaxH3TurboAdapter {
     }
 
     private static func sourceFormat(at url: URL) throws -> SourceFormat {
-        if try SafetensorsStreamingLoader.fileMetadata(url: url)["format"] == fastVideoFormat {
+        let format = try SafetensorsStreamingLoader.fileMetadata(url: url)["format"]
+        if format == fastVideoFormat {
             return .fastVideo
+        }
+        if format == fastH3PremergedFormat {
+            return .fastH3Premerged
         }
         let keys = try SafetensorsStreamingLoader.metadata(url: url).keys
         if keys.contains(where: { $0.hasSuffix(".lora_A.default.weight") }) {
@@ -465,6 +497,7 @@ public enum MiniMaxH3TurboAdapter {
         guard sourceFormat != .runtime else {
             return LightX2VTarget(modulePath: sourcePath, qkvBranch: nil)
         }
+        precondition(sourceFormat != .fastH3Premerged)
 
         let runtimePrefix: String
         let remainder: Substring
@@ -629,6 +662,46 @@ public enum MiniMaxH3TurboAdapter {
             }
             transformer.installFastH3CompressionGate(weight, blockIndex: blockIndex)
         }
+    }
+
+    private static func installFastH3QuantizedCompressionGates(
+        url: URL,
+        into transformer: MiniMaxH3Transformer
+    ) throws -> Int {
+        let metadata = try SafetensorsStreamingLoader.fileMetadata(url: url)
+        guard metadata["gate_quantization"] == "affine 8-bit g64" else {
+            throw AdapterError.unrecognizedFormat(url)
+        }
+        let arrays = try SafetensorsStreamingLoader.loadArrays(
+            url: url,
+            where: { $0.hasPrefix("transformer_blocks.") }
+        )
+        var installed = 0
+        for blockIndex in 0..<transformer.configuration.layerCount {
+            let prefix = "transformer_blocks.\(blockIndex).attn.to_gate_compress"
+            guard let codes = arrays["\(prefix).weight"],
+                  let scales = arrays["\(prefix).scales"],
+                  let biases = arrays["\(prefix).biases"] else {
+                throw AdapterError.missingTargetParameter(prefix)
+            }
+            transformer.installFastH3QuantizedCompressionGate(
+                codes: codes,
+                scales: scales,
+                biases: biases,
+                groupSize: 64,
+                bits: 8,
+                blockIndex: blockIndex
+            )
+            installed += 1
+        }
+        guard arrays.count == installed * 3 else {
+            throw AdapterError.unexpectedAuxiliaryTensorCount(
+                kind: "quantized-compression-gate tensor",
+                expected: installed * 3,
+                actual: arrays.count
+            )
+        }
+        return installed
     }
 
     private static func targetLinear(

--- a/Sources/MereRunCore/MiniMaxH3/README.md
+++ b/Sources/MereRunCore/MiniMaxH3/README.md
@@ -52,6 +52,24 @@ expanded to resident BF16 before the adapter is installed, so this recipe
 requires `resident-bf16` or a memory-qualified automatic selection; forced
 quantized execution is rejected.
 
+The managed `minimax-h3-fasth3-vsa-datafree-4step` release targets only compact
+BF16 FL2VA. It installs FastVideo's 5.3 GB student adapter, applies the exact
+four-evaluation DMD schedule, and runs its VSA-H3 tile routing and learned
+compression gates with MLX Metal. The runtime retains every prefix key tile and
+the highest-scoring 10% of video key tiles for each video query tile. Prefix
+query tiles remain dense.
+
+FastH3 changes the schedule-only AdaLN weights that the compact BF16 model
+omits. The managed `video-minimax-h3-fasth3-vsa-datafree-mlx` package includes a
+source-bound cache beside the adapter, so end users need one model pull and no
+preparation step. Package builders use
+`scripts/model-conversion/prepare_minimax_h3_fasth3_vsa.py --adapter PATH`; the
+script range-reads about 26 GiB from the pinned student transformer but doesn't
+store the 70 GB transformer or the complete 148 GB checkpoint. FastH3 accepts
+text-only FL2VA generation with `--h3-acceleration quality`; it rejects frame
+conditioning, continuation, references, non-unit adapter strength, and other
+H3 approximation modes.
+
 All standard projection pairs execute as activation-space low-rank wrappers
 around the dense or stock MLX quantized base linear. QKV keeps independent
 query, key, and value pairs while preserving the runtime's global-QKV slab

--- a/Sources/MereRunCore/MiniMaxH3/README.md
+++ b/Sources/MereRunCore/MiniMaxH3/README.md
@@ -52,23 +52,23 @@ expanded to resident BF16 before the adapter is installed, so this recipe
 requires `resident-bf16` or a memory-qualified automatic selection; forced
 quantized execution is rejected.
 
-The managed `minimax-h3-fasth3-vsa-datafree-4step` release targets only compact
-BF16 FL2VA. It installs FastVideo's 5.3 GB student adapter, applies the exact
-four-evaluation DMD schedule, and runs its VSA-H3 tile routing and learned
-compression gates with MLX Metal. The runtime retains every prefix key tile and
-the highest-scoring 10% of video key tiles for each video query tile. Prefix
-query tiles remain dense.
+The managed `minimax-h3-fasth3-vsa-datafree-4step` adapter remains available
+for compact BF16 FL2VA package development. The preferred managed model stores
+the student as an affine Q8/group-64 transformer and stores its 50 compression
+gates in Q8. It applies the exact four-evaluation DMD schedule and runs VSA-H3
+with MLX Metal. The runtime retains every prefix key tile and the
+highest-scoring 10% of video key tiles for each video query tile. Prefix query
+tiles remain dense.
 
-FastH3 changes the schedule-only AdaLN weights that the compact BF16 model
-omits. The managed `video-minimax-h3-fasth3-vsa-datafree-mlx` package includes a
-source-bound cache beside the adapter, so end users need one model pull and no
-preparation step. Package builders use
-`scripts/model-conversion/prepare_minimax_h3_fasth3_vsa.py --adapter PATH`; the
-script range-reads about 26 GiB from the pinned student transformer but doesn't
-store the 70 GB transformer or the complete 148 GB checkpoint. FastH3 accepts
-text-only FL2VA generation with `--h3-acceleration quality`; it rejects frame
-conditioning, continuation, references, non-unit adapter strength, and other
-H3 approximation modes.
+FastH3 changes the schedule-only AdaLN weights that the compact base omits. The
+managed `video-minimax-h3-fasth3-vsa-datafree-mlx` package includes its
+source-bound table beside the Q8 compression-gate artifact. End users need one
+model pull and no preparation step. Package builders use
+`prepare_minimax_h3_fasth3_vsa.py` to create the table and
+`merge_minimax_h3_fasth3_q8.py` to create the premerged transformer. FastH3
+accepts text-only FL2VA generation with `--h3-acceleration quality`. It rejects
+frame conditioning, continuation, references, non-unit adapter strength, and
+other H3 approximation modes.
 
 All standard projection pairs execute as activation-space low-rank wrappers
 around the dense or stock MLX quantized base linear. QKV keeps independent

--- a/Sources/MereRunCore/ModelResolver.swift
+++ b/Sources/MereRunCore/ModelResolver.swift
@@ -147,6 +147,7 @@ public struct ModelResolver {
         case miniMaxH3FL2VAMLX = "video-minimax-h3-fl2va-mlx"
         case miniMaxH3FL2VABF16MLX = "video-minimax-h3-fl2va-bf16-mlx"
         case miniMaxH3FL2VAQ8MLX = "video-minimax-h3-fl2va-8bit-mlx"
+        case miniMaxH3FastH3VSADataFreeMLX = "video-minimax-h3-fasth3-vsa-datafree-mlx"
         case miniMaxH3Ref2VAMLX = "video-minimax-h3-ref2va-mlx"
         case cosmos3EdgeMLX = "video-cosmos3-edge-mlx"
         case scail2Video14BMLX = "video-scail2-14b-mlx"

--- a/Sources/MereRunCore/SafetensorsStreamingLoader.swift
+++ b/Sources/MereRunCore/SafetensorsStreamingLoader.swift
@@ -243,6 +243,41 @@ public enum SafetensorsStreamingLoader {
         return pairCount
     }
 
+    /// Reads selected tensors in file order without retaining the complete checkpoint.
+    @discardableResult
+    public static func forEachTensor(
+        url: URL,
+        where shouldInclude: (String) -> Bool,
+        dtype: DType? = nil,
+        body: (_ key: String, _ value: MLXArray) throws -> Void
+    ) throws -> Int {
+        let parsed = try parseHeader(fileURL: url)
+        let tensorMetadata = try parseTensorMetadata(
+            header: parsed.header,
+            dataOffset: parsed.dataOffset,
+            fileDataCount: parsed.fileSize,
+            fileURL: url
+        )
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { try? handle.close() }
+        var count = 0
+        for (key, metadata) in tensorMetadata.sorted(by: {
+            $0.value.startOffset < $1.value.startOffset
+        }) where shouldInclude(key) {
+            try body(
+                key,
+                makeArray(
+                    metadata: metadata,
+                    fileHandle: handle,
+                    fileURL: url,
+                    dtype: dtype
+                )
+            )
+            count += 1
+        }
+        return count
+    }
+
     private static func makeArray(
         metadata: TensorMetadata,
         fileHandle: FileHandle,

--- a/Tests/MereRunCLITests/AdapterCommandTests.swift
+++ b/Tests/MereRunCLITests/AdapterCommandTests.swift
@@ -50,6 +50,16 @@ struct AdapterCommandTests {
         #expect(command.target == ManagedAdapterCatalog.miniMaxH3LightX2VRef2VFourStepV01ID)
     }
 
+    @Test("FastH3 VSA adapter pull parses its canonical id and license acknowledgement")
+    func parsesMiniMaxH3FastH3VSADataFreePull() throws {
+        let command = try AdapterPull.parse([
+            ManagedAdapterCatalog.miniMaxH3FastH3VSADataFreeID,
+            "--accept-license",
+        ])
+        #expect(command.target == ManagedAdapterCatalog.miniMaxH3FastH3VSADataFreeID)
+        #expect(command.acceptLicense)
+    }
+
     @Test("Gated LTX-2.5 DFR adapter pull requires explicit terms acceptance")
     func parsesLTX25DFRAdapterPull() throws {
         let command = try AdapterPull.parse([

--- a/Tests/MereRunCLITests/VideoCommandTests.swift
+++ b/Tests/MereRunCLITests/VideoCommandTests.swift
@@ -803,6 +803,31 @@ final class VideoCommandTests: XCTestCase {
         XCTAssertTrue(action?.command?.argv.contains(missingAdapter.path) == true)
     }
 
+    func testManagedFastH3PreflightUsesEmbeddedAdapterWithoutAnotherDownload() throws {
+        let command = try VideoGenerate.parse([
+            "a red kite crosses a bright coastal sky",
+            "--model", ModelResolver.ModelID.miniMaxH3FastH3VSADataFreeMLX.rawValue,
+        ])
+        XCTAssertNil(command.h3Adapter)
+
+        let envelope = command.makePreflightEnvelope(
+            outputURL: makeTempOutput(name: "h3-fasth3-managed.mp4"),
+            fileManager: .default,
+            now: { Date(timeIntervalSince1970: 0) }
+        )
+        XCTAssertNil(envelope.request.h3Adapter)
+        XCTAssertEqual(envelope.result.plan.resolvedSteps, 5)
+        XCTAssertEqual(
+            envelope.result.plan.h3Adapter,
+            MiniMaxH3TurboAdapter.fastH3VSADataFreeFilename
+        )
+        XCTAssertFalse(envelope.diagnostics.contains { $0.id == "h3_adapter_missing" })
+        let actionArguments = envelope.actions.first {
+            $0.id == "start-video-generation"
+        }?.command?.argv
+        XCTAssertFalse(actionArguments?.contains("--h3-adapter") == true)
+    }
+
     func testMiniMaxH3LightX2VV1PreflightSelectsPublishedEightEvaluations() throws {
         let command = try VideoGenerate.parse([
             "a train crosses a bright alpine valley",

--- a/Tests/MereRunCoreTests/DiTShapeBenchTests.swift
+++ b/Tests/MereRunCoreTests/DiTShapeBenchTests.swift
@@ -78,6 +78,233 @@ final class DiTShapeBenchTests: XCTestCase {
         return best
     }
 
+    /// Compares the previous 32-row FastH3 VSA workgroup with the 64-row
+    /// workgroup used by the released CUDA recipe. This benchmark is isolated
+    /// from model loading so large production geometries can be searched
+    /// without paying for every transformer block. Configure with
+    /// `MERERUN_H3_FASTVSA_BENCH_WIDTH`, `MERERUN_H3_FASTVSA_BENCH_HEIGHT`,
+    /// `MERERUN_H3_FASTVSA_BENCH_FRAMES`, `MERERUN_H3_FASTVSA_BENCH_HEADS`,
+    /// and `MERERUN_H3_FASTVSA_BENCH_ROUNDS`.
+    func testFastVSATileSchedule() throws {
+        let environment = ProcessInfo.processInfo.environment
+        guard environment["MERERUN_H3_FASTVSA_BENCH"] == "1" else {
+            throw XCTSkip("Set MERERUN_H3_FASTVSA_BENCH=1 to run the FastH3 VSA benchmark")
+        }
+        guard Device.defaultDevice().deviceType == .gpu else {
+            throw XCTSkip("The FastH3 VSA benchmark requires a Metal GPU.")
+        }
+        let width = max(
+            64,
+            Int(environment["MERERUN_H3_FASTVSA_BENCH_WIDTH"] ?? "") ?? 1_024
+        )
+        let height = max(
+            64,
+            Int(environment["MERERUN_H3_FASTVSA_BENCH_HEIGHT"] ?? "") ?? 576
+        )
+        let frames = max(
+            5,
+            Int(environment["MERERUN_H3_FASTVSA_BENCH_FRAMES"] ?? "") ?? 22
+        )
+        let heads = max(
+            1,
+            Int(environment["MERERUN_H3_FASTVSA_BENCH_HEADS"] ?? "") ?? 1
+        )
+        let rounds = max(
+            1,
+            Int(environment["MERERUN_H3_FASTVSA_BENCH_ROUNDS"] ?? "") ?? 2
+        )
+        let textTokens = max(
+            1,
+            Int(environment["MERERUN_H3_FASTVSA_BENCH_TEXT_TOKENS"] ?? "") ?? 512
+        )
+        let layout = try MiniMaxH3Geometry.buildFL2VA(
+            textTokenTags: Array(repeating: 1, count: textTokens),
+            videoLatentFrames: MiniMaxH3Geometry.videoLatentFrameCount(for: frames),
+            latentHeight: height / 16,
+            latentWidth: width / 16,
+            audioLatentFrames: MiniMaxH3Geometry.audioLatentFrameCount(for: frames),
+            keyframeAnchors: []
+        )
+        let prepared = MiniMaxH3FastVSA.prepare(layout: layout)
+        let geometry = prepared.geometry
+        let keepVideo = max(
+            1,
+            min(
+                Int(ceil((1 - MiniMaxH3FastVSA.sparsity) * Float(geometry.videoTileCount))),
+                geometry.videoTileCount
+            )
+        )
+        var routeValues: [Int32] = []
+        routeValues.reserveCapacity(heads * geometry.tileCount * keepVideo)
+        for head in 0..<heads {
+            for queryBlock in 0..<geometry.tileCount {
+                let offset = (head * 17 + queryBlock * 31) % geometry.videoTileCount
+                for route in 0..<keepVideo {
+                    routeValues.append(Int32(
+                        geometry.prefixTileCount
+                            + (offset + route * 13) % geometry.videoTileCount
+                    ))
+                }
+            }
+        }
+        let videoRoutes = MLXArray(routeValues).reshaped(
+            1, heads, geometry.tileCount, keepVideo
+        )
+        MLXRandom.seed(2_026_082_9)
+        let shape = [1, heads, layout.sequenceLength, MiniMaxH3FastVSA.headDimension]
+        let queries = (MLXRandom.normal(shape) * Float(0.2)).asType(.bfloat16)
+        let keys = (MLXRandom.normal(shape) * Float(0.2)).asType(.bfloat16)
+        let values = MLXRandom.normal(shape).asType(.bfloat16)
+        let gate = (MLXRandom.normal(shape) * Float(0.05)).asType(.bfloat16)
+        let sentinel = MLXArray.zeros(
+            [1, heads, 1, MiniMaxH3FastVSA.headDimension],
+            dtype: .bfloat16
+        )
+        func tiled(_ value: MLXArray) -> MLXArray {
+            MLX.take(
+                MLX.concatenated([value, sentinel], axis: 2),
+                prepared.paddedIndices,
+                axis: 2
+            )
+        }
+        let tiledQueries = tiled(queries)
+        let tiledKeys = tiled(keys)
+        let tiledValues = tiled(values)
+        MLX.eval(
+            queries, keys, values, gate,
+            tiledQueries, tiledKeys, tiledValues,
+            videoRoutes
+        )
+
+        func sparse(_ mode: MiniMaxH3FastVSAKernelMode) -> MLXArray {
+            MiniMaxH3FastVSA.sparseOutputForTesting(
+                queries: tiledQueries,
+                keys: tiledKeys,
+                values: tiledValues,
+                videoRoutes: videoRoutes,
+                blockSizes: prepared.blockSizes,
+                prefixTileCount: geometry.prefixTileCount,
+                kernelMode: mode
+            )
+        }
+        func complete(_ mode: MiniMaxH3FastVSAKernelMode) -> MLXArray {
+            MiniMaxH3FastVSA.call(
+                queries: queries,
+                keys: keys,
+                values: values,
+                compressionGate: gate,
+                prepared: prepared,
+                kernelMode: mode
+            )!
+        }
+        func elapsed(_ body: () -> MLXArray) -> Double {
+            let started = CFAbsoluteTimeGetCurrent()
+            MLX.eval(body())
+            return CFAbsoluteTimeGetCurrent() - started
+        }
+
+        MLX.eval(sparse(.halfTile), sparse(.fullTile), sparse(.fullTileKV16))
+        let halfTile = sparse(.halfTile).asType(.float32)
+        let fullTile = sparse(.fullTile).asType(.float32)
+        let delta = fullTile - halfTile
+        let maximumAbsoluteError = MLX.max(MLX.abs(delta)).item(Float.self)
+        let relativeL2Error = MLX.sqrt(
+            MLX.sum(delta * delta)
+                / MLX.maximum(MLX.sum(halfTile * halfTile), MLXArray(Float(1e-12)))
+        ).item(Float.self)
+        let fullTileKV16 = sparse(.fullTileKV16).asType(.float32)
+        let kv16Delta = fullTileKV16 - halfTile
+        let kv16MaximumAbsoluteError = MLX.max(MLX.abs(kv16Delta)).item(Float.self)
+        let kv16RelativeL2Error = MLX.sqrt(
+            MLX.sum(kv16Delta * kv16Delta)
+                / MLX.maximum(MLX.sum(halfTile * halfTile), MLXArray(Float(1e-12)))
+        ).item(Float.self)
+
+        var halfSparseTotal = 0.0
+        var fullSparseTotal = 0.0
+        var kv16SparseTotal = 0.0
+        for round in 0..<rounds {
+            switch round % 3 {
+            case 0:
+                halfSparseTotal += elapsed { sparse(.halfTile) }
+                fullSparseTotal += elapsed { sparse(.fullTile) }
+                kv16SparseTotal += elapsed { sparse(.fullTileKV16) }
+            case 1:
+                fullSparseTotal += elapsed { sparse(.fullTile) }
+                kv16SparseTotal += elapsed { sparse(.fullTileKV16) }
+                halfSparseTotal += elapsed { sparse(.halfTile) }
+            default:
+                kv16SparseTotal += elapsed { sparse(.fullTileKV16) }
+                halfSparseTotal += elapsed { sparse(.halfTile) }
+                fullSparseTotal += elapsed { sparse(.fullTile) }
+            }
+        }
+        let halfSparseSeconds = halfSparseTotal / Double(rounds)
+        let fullSparseSeconds = fullSparseTotal / Double(rounds)
+        let kv16SparseSeconds = kv16SparseTotal / Double(rounds)
+
+        MLX.eval(complete(.halfTile), complete(.fullTile), complete(.fullTileKV16))
+        var halfCompleteTotal = 0.0
+        var fullCompleteTotal = 0.0
+        var kv16CompleteTotal = 0.0
+        Memory.peakMemory = 0
+        for round in 0..<rounds {
+            switch round % 3 {
+            case 0:
+                halfCompleteTotal += elapsed { complete(.halfTile) }
+                fullCompleteTotal += elapsed { complete(.fullTile) }
+                kv16CompleteTotal += elapsed { complete(.fullTileKV16) }
+            case 1:
+                fullCompleteTotal += elapsed { complete(.fullTile) }
+                kv16CompleteTotal += elapsed { complete(.fullTileKV16) }
+                halfCompleteTotal += elapsed { complete(.halfTile) }
+            default:
+                kv16CompleteTotal += elapsed { complete(.fullTileKV16) }
+                halfCompleteTotal += elapsed { complete(.halfTile) }
+                fullCompleteTotal += elapsed { complete(.fullTile) }
+            }
+        }
+        let halfCompleteSeconds = halfCompleteTotal / Double(rounds)
+        let fullCompleteSeconds = fullCompleteTotal / Double(rounds)
+        let kv16CompleteSeconds = kv16CompleteTotal / Double(rounds)
+        let peakGiB = Double(Memory.peakMemory) / 1_073_741_824
+        print(String(
+            format: "[h3-fastvsa] %dx%d frames=%d rows=%d padded=%d tiles=%d "
+                + "prefix_tiles=%d video_tiles=%d keep=%d heads=%d "
+                + "sparse_half_ms=%.1f sparse_full_ms=%.1f sparse_kv16_ms=%.1f "
+                + "full_speedup=%.3fx kv16_speedup=%.3fx "
+                + "complete_half_ms=%.1f complete_full_ms=%.1f complete_kv16_ms=%.1f "
+                + "complete_full_speedup=%.3fx complete_kv16_speedup=%.3fx "
+                + "full_max_abs=%.6g full_rel_l2=%.6g "
+                + "kv16_max_abs=%.6g kv16_rel_l2=%.6g peak_gib=%.3f",
+            width,
+            height,
+            frames,
+            layout.sequenceLength,
+            geometry.paddedTokenCount,
+            geometry.tileCount,
+            geometry.prefixTileCount,
+            geometry.videoTileCount,
+            keepVideo,
+            heads,
+            halfSparseSeconds * 1_000,
+            fullSparseSeconds * 1_000,
+            kv16SparseSeconds * 1_000,
+            halfSparseSeconds / fullSparseSeconds,
+            halfSparseSeconds / kv16SparseSeconds,
+            halfCompleteSeconds * 1_000,
+            fullCompleteSeconds * 1_000,
+            kv16CompleteSeconds * 1_000,
+            halfCompleteSeconds / fullCompleteSeconds,
+            halfCompleteSeconds / kv16CompleteSeconds,
+            maximumAbsoluteError,
+            relativeL2Error,
+            kv16MaximumAbsoluteError,
+            kv16RelativeL2Error,
+            peakGiB
+        ))
+    }
+
     /// Measures the fused SDPA dispatch used by a full upstream-equivalent
     /// SCAIL-2 window. This is env-gated because the key/value tensors occupy
     /// about 900 MB and the larger query sizes intentionally stress Metal's

--- a/Tests/MereRunCoreTests/DiTShapeBenchTests.swift
+++ b/Tests/MereRunCoreTests/DiTShapeBenchTests.swift
@@ -750,10 +750,11 @@ final class DiTShapeBenchTests: XCTestCase {
         }
     }
 
-    /// MiniMax-H3's dominant projections at its practical 512-square and
-    /// 768x448 packed row counts. The cached arm models loading a compact
-    /// checkpoint, dequantizing each projection once, and keeping bf16 weights
-    /// resident for the denoising loop.
+    /// MiniMax-H3's dominant projections at its practical packed row counts.
+    /// The cached arm models loading a compact checkpoint, dequantizing each
+    /// projection once, and keeping bf16 weights resident for the denoising
+    /// loop. Set `MERERUN_H3_BENCH_BITS=8` to match the managed FastH3 package
+    /// and `MERERUN_H3_BENCH_INCLUDE_FF1=1` to include its largest projection.
     func testMiniMaxH3QmmVsResidentBF16() throws {
         try benchGate()
 
@@ -790,22 +791,40 @@ final class DiTShapeBenchTests: XCTestCase {
                 .compactMap { Int($0.trimmingCharacters(in: .whitespaces)) }
                 .filter { $0 > 0 } ?? []
             let rowCounts = configuredRows.isEmpty ? [4_608, 12_925] : configuredRows
+            let bits = Int(
+                ProcessInfo.processInfo.environment["MERERUN_H3_BENCH_BITS"] ?? ""
+            ) ?? 4
+            precondition([4, 8].contains(bits))
+            var projections = [
+                ("qkv", 5_376, 21_504),
+                ("attention-out", 7_168, 5_376),
+                ("ff2", 14_336, 5_376),
+            ]
+            if ProcessInfo.processInfo.environment["MERERUN_H3_BENCH_INCLUDE_FF1"] == "1" {
+                projections.insert(("ff1", 5_376, 28_672), at: 1)
+            }
+            let configuredProjections = Set(
+                ProcessInfo.processInfo.environment["MERERUN_H3_BENCH_PROJECTIONS"]?
+                    .split(separator: ",")
+                    .map { String($0.trimmingCharacters(in: .whitespaces)) } ?? []
+            )
+            if !configuredProjections.isEmpty {
+                projections = projections.filter { configuredProjections.contains($0.0) }
+            }
+            precondition(!projections.isEmpty)
             for rows in rowCounts {
-                for (name, inputDimension, outputDimension) in [
-                    ("qkv", 5_376, 21_504),
-                    ("ff2", 14_336, 5_376),
-                ] {
+                for (name, inputDimension, outputDimension) in projections {
                     let input = MLXRandom.normal([1, rows, inputDimension]).asType(.bfloat16)
                     let qmm = QuantizedLinear(
                         inputDimension,
                         outputDimension,
                         bias: false,
                         groupSize: 64,
-                        bits: 4
+                        bits: bits
                     )
                     MLX.eval(input, qmm.parameters())
                     pairedTime(
-                        "rows=\(rows) \(name) \(inputDimension)->\(outputDimension)",
+                        "rows=\(rows) q\(bits) \(name) \(inputDimension)->\(outputDimension)",
                         qmm: qmm,
                         dense: BenchCachedDenseLinear(copying: qmm),
                         input: input
@@ -813,6 +832,106 @@ final class DiTShapeBenchTests: XCTestCase {
                     MLX.Memory.clearCache()
                 }
             }
+        }
+    }
+
+    /// Probes MLX's built-in MXFP8 activation-and-weight path at H3's dense
+    /// projection shapes. Weight quantization is treated as package preparation
+    /// and excluded; each timed QQMM includes MLX's on-the-fly activation
+    /// quantization. This is a research gate, not runtime dispatch.
+    func testMiniMaxH3MXFP8QQMM() throws {
+        try benchGate()
+
+        let environment = ProcessInfo.processInfo.environment
+        let rows = max(1, Int(environment["MERERUN_H3_BENCH_ROWS"] ?? "") ?? 128)
+        let projection = environment["MERERUN_H3_BENCH_PROJECTION"] ?? "ff1-half"
+        let shape: (input: Int, output: Int)
+        switch projection {
+        case "qkv":
+            shape = (5_376, 21_504)
+        case "attention-out":
+            shape = (7_168, 5_376)
+        case "ff1-half":
+            shape = (5_376, 14_336)
+        case "ff2":
+            shape = (14_336, 5_376)
+        default:
+            preconditionFailure("Unsupported H3 MXFP8 projection: \(projection)")
+        }
+        let rounds = max(1, Int(environment["MERERUN_H3_BENCH_ROUNDS"] ?? "") ?? 2)
+        let iterations = max(
+            1,
+            Int(environment["MERERUN_H3_BENCH_ITERATIONS"] ?? "") ?? 2
+        )
+
+        Stream.withNewDefaultStream {
+            MLXRandom.seed(2_026_082_906)
+            let input = MLXRandom.normal([rows, shape.input]).asType(.bfloat16)
+            let denseWeight = MLXRandom.normal([shape.output, shape.input])
+                .asType(.bfloat16)
+            let preparedWeight = MLX.quantized(
+                denseWeight,
+                groupSize: 32,
+                bits: 8,
+                mode: .mxfp8
+            )
+            MLX.eval(input, denseWeight, preparedWeight.wq, preparedWeight.scales)
+
+            func dense() -> MLXArray {
+                MLX.matmul(input, denseWeight.T)
+            }
+            func mxfp8() -> MLXArray {
+                MLX.quantizedQuantizedMM(
+                    input,
+                    preparedWeight.wq,
+                    scales: preparedWeight.scales,
+                    groupSize: 32,
+                    bits: 8,
+                    mode: .mxfp8
+                )
+            }
+            func benchmark(_ body: () -> MLXArray) -> Double {
+                MLX.eval(body())
+                var best = Double.greatestFiniteMagnitude
+                for _ in 0..<rounds {
+                    let started = CFAbsoluteTimeGetCurrent()
+                    for _ in 0..<iterations {
+                        MLX.eval(body())
+                    }
+                    best = min(
+                        best,
+                        (CFAbsoluteTimeGetCurrent() - started) / Double(iterations)
+                    )
+                }
+                return best
+            }
+
+            let reference = dense()
+            let candidate = mxfp8()
+            MLX.eval(reference, candidate)
+            let difference = reference.asType(.float32) - candidate.asType(.float32)
+            let relativeL2 = MLX.sqrt(
+                MLX.sum(difference * difference)
+                    / MLX.maximum(
+                        MLX.sum(reference.asType(.float32) * reference.asType(.float32)),
+                        MLXArray(Float(1e-12))
+                    )
+            ).item(Float.self)
+            let denseSeconds = benchmark(dense)
+            let mxfp8Seconds = benchmark(mxfp8)
+            print(String(
+                format: "[dit-bench] H3 MXFP8 projection=%@ rows=%d shape=%d->%d "
+                    + "dense-bf16=%.3fms mxfp8-qqmm=%.3fms speedup=%.3fx rel_l2=%.6g",
+                projection,
+                rows,
+                shape.input,
+                shape.output,
+                denseSeconds * 1_000,
+                mxfp8Seconds * 1_000,
+                denseSeconds / mxfp8Seconds,
+                relativeL2
+            ))
+            XCTAssertTrue(relativeL2.isFinite)
         }
     }
 

--- a/Tests/MereRunCoreTests/ManagedAdapterCatalogTests.swift
+++ b/Tests/MereRunCoreTests/ManagedAdapterCatalogTests.swift
@@ -129,6 +129,27 @@ struct ManagedAdapterCatalogTests {
         #expect(spec.downloadURL.absoluteString.contains(spec.upstreamRevision!))
     }
 
+    @Test("FastH3 VSA DataFree release is an immutable restricted BF16 pin")
+    func miniMaxH3FastH3VSADataFreeReleaseIsPinned() throws {
+        let spec = try #require(
+            ManagedAdapterCatalog.spec(for: ManagedAdapterCatalog.miniMaxH3FastH3VSADataFreeID)
+        )
+        #expect(spec.version == "bcf40ca6f457")
+        #expect(spec.baseModelID == ModelResolver.ModelID.miniMaxH3FL2VABF16MLX.rawValue)
+        #expect(spec.supports(
+            baseModelID: ModelResolver.ModelID.miniMaxH3FastH3VSADataFreeMLX.rawValue
+        ))
+        #expect(!spec.supports(baseModelID: ModelResolver.ModelID.miniMaxH3FL2VAQ8MLX.rawValue))
+        #expect(spec.format == MiniMaxH3TurboAdapter.fastVideoFormat)
+        #expect(spec.usageRestriction != nil)
+        #expect(spec.upstreamRevision == ManagedAdapterCatalog.miniMaxH3FastH3VSADataFreeRevision)
+        #expect(spec.artifact.filename == MiniMaxH3TurboAdapter.fastH3VSADataFreeFilename)
+        #expect(spec.artifact.byteCount == 5_339_117_712)
+        #expect(spec.artifact.sha256 == "42dc502a2078f166c396a1fa75f29728d1844363652d345d5ef3e2b444ed6470")
+        #expect(spec.downloadURL.host == "huggingface.co")
+        #expect(spec.downloadURL.absoluteString.contains(spec.upstreamRevision!))
+    }
+
     @Test("Catalog ids resolve case-insensitively")
     func normalizedLookup() {
         #expect(ManagedAdapterCatalog.spec(for: " MERE-PLATFORM-ASSISTANT ")?.version == "22")

--- a/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
@@ -192,6 +192,7 @@ final class ManagedModelCatalogTests: XCTestCase {
             "video-minimax-h3-fl2va-mlx",
             "video-minimax-h3-fl2va-bf16-mlx",
             "video-minimax-h3-fl2va-8bit-mlx",
+            "video-minimax-h3-fasth3-vsa-datafree-mlx",
             "video-minimax-h3-ref2va-mlx",
         ])
         let visibleAndCompanionSpecs = ManagedModelCatalog.allSpecs
@@ -1551,6 +1552,11 @@ final class ManagedModelCatalogTests: XCTestCase {
                 .miniMaxH3FL2VAQ8MLX,
                 MiniMaxH3Resources.q8ArtifactRepository,
                 MiniMaxH3Resources.q8ArtifactRevision
+            ),
+            (
+                .miniMaxH3FastH3VSADataFreeMLX,
+                MiniMaxH3Resources.fastH3ArtifactRepository,
+                MiniMaxH3Resources.fastH3ArtifactRevision
             ),
         ]
         for (modelID, repository, revision) in cases {

--- a/Tests/MereRunCoreTests/MiniMaxH3FusedKernelTests.swift
+++ b/Tests/MereRunCoreTests/MiniMaxH3FusedKernelTests.swift
@@ -8,6 +8,59 @@ import XCTest
 
 final class MiniMaxH3FusedKernelTests: MereRunCoreTestCase {
     #if os(macOS)
+    func testPrepareAttentionInputMatchesDecomposedGraph() throws {
+        guard Device.defaultDevice().deviceType == .gpu else {
+            throw XCTSkip(
+                "Set MERERUN_TEST_MLX_DEVICE=gpu to run the H3 attention AdaLN canary."
+            )
+        }
+
+        let rows = 7
+        let hiddenSize = 5_376
+        let modulationRows = 9
+        let epsilon = Float(1e-5)
+        MLXRandom.seed(2_026_082_904)
+        let baseInput = MLXRandom.uniform(-0.5 ..< 0.5, [1, rows, hiddenSize])
+        let normWeight = MLXRandom.uniform(
+            0.8 ..< 1.2,
+            [hiddenSize]
+        ).asType(.bfloat16)
+        let modulation = MLXRandom.uniform(
+            -0.2 ..< 0.2,
+            [modulationRows, 6 * hiddenSize]
+        ).asType(.bfloat16)
+        let rowIndices = MLXArray((0..<rows).map { Int32(($0 * 4) % modulationRows) })
+        let parts = MLX.split(modulation, parts: 6, axis: -1)
+        let shift = MLX.take(parts[0], rowIndices, axis: 0).expandedDimensions(axis: 0)
+        let scale = MLX.take(parts[1], rowIndices, axis: 0).expandedDimensions(axis: 0)
+
+        for dtype in [DType.bfloat16, .float32] {
+            let input = baseInput.asType(dtype)
+            let reference = MLXFast.rmsNorm(
+                input,
+                weight: normWeight,
+                eps: epsilon
+            ) * (1 + scale) + shift
+            let fused = try XCTUnwrap(MiniMaxH3FusedKernels.prepareAttentionInput(
+                input: input,
+                normWeight: normWeight,
+                modulation: modulation,
+                rowIndices: rowIndices,
+                eps: epsilon
+            ))
+            MLX.eval(reference, fused)
+
+            let difference = maximumDifference(fused, reference)
+            print(
+                "[h3-transfer] k0-attention-adaln dtype=\(dtype) "
+                    + "max_abs=\(difference)"
+            )
+            XCTAssertEqual(fused.shape, reference.shape)
+            XCTAssertEqual(fused.dtype, reference.dtype)
+            XCTAssertLessThan(difference, dtype == .bfloat16 ? 0.016 : 1e-4)
+        }
+    }
+
     func testGateAttentionAndPrepareFeedForwardMatchesDecomposedGraph() throws {
         guard Device.defaultDevice().deviceType == .gpu else {
             throw XCTSkip(
@@ -312,6 +365,13 @@ final class MiniMaxH3FusedKernelTests: MereRunCoreTestCase {
             rowIndices: rowIndices,
             eps: 1e-5
         ))
+        XCTAssertNil(MiniMaxH3FusedKernels.prepareAttentionInput(
+            input: residual.asType(.float16),
+            normWeight: normWeight,
+            modulation: modulation,
+            rowIndices: rowIndices,
+            eps: 1e-5
+        ))
         XCTAssertNil(MiniMaxH3FusedKernels.gateAttentionAndQuantizeFeedForward(
             residual: residual,
             attentionOutput: attentionOutput,
@@ -555,6 +615,15 @@ final class MiniMaxH3FusedKernelTests: MereRunCoreTestCase {
         let ropeCosine = MLX.cos(angles)
         let ropeSine = MLX.sin(angles)
 
+        let eagerAttentionInput = try XCTUnwrap(
+            MiniMaxH3FusedKernels.prepareAttentionInput(
+                input: residual,
+                normWeight: normWeight,
+                modulation: modulation,
+                rowIndices: rowIndices,
+                eps: epsilon
+            )
+        )
         let eagerGate = try XCTUnwrap(
             MiniMaxH3FusedKernels.gateAttentionAndPrepareFeedForward(
                 residual: residual,
@@ -574,7 +643,13 @@ final class MiniMaxH3FusedKernelTests: MereRunCoreTestCase {
             eps: epsilon
         ))
         let compiled = MLX.compile { (inputs: [MLXArray]) -> [MLXArray] in
-            guard let gate = MiniMaxH3FusedKernels.gateAttentionAndPrepareFeedForward(
+            guard let attentionInput = MiniMaxH3FusedKernels.prepareAttentionInput(
+                input: inputs[0],
+                normWeight: inputs[2],
+                modulation: inputs[3],
+                rowIndices: inputs[4],
+                eps: epsilon
+            ), let gate = MiniMaxH3FusedKernels.gateAttentionAndPrepareFeedForward(
                 residual: inputs[0],
                 attentionOutput: inputs[1],
                 normWeight: inputs[2],
@@ -592,6 +667,7 @@ final class MiniMaxH3FusedKernelTests: MereRunCoreTestCase {
                 preconditionFailure("compiled H3 boundary contract unexpectedly rejected")
             }
             return [
+                attentionInput,
                 gate.residual,
                 gate.feedForwardInput,
                 gate.feedForwardGate,
@@ -613,6 +689,7 @@ final class MiniMaxH3FusedKernelTests: MereRunCoreTestCase {
             ropeSine,
         ])
         MLX.eval(
+            eagerAttentionInput,
             eagerGate.residual,
             eagerGate.feedForwardInput,
             eagerGate.feedForwardGate,
@@ -624,10 +701,12 @@ final class MiniMaxH3FusedKernelTests: MereRunCoreTestCase {
             compiledOutputs[2],
             compiledOutputs[3],
             compiledOutputs[4],
-            compiledOutputs[5]
+            compiledOutputs[5],
+            compiledOutputs[6]
         )
 
         let eagerOutputs = [
+            eagerAttentionInput,
             eagerGate.residual,
             eagerGate.feedForwardInput,
             eagerGate.feedForwardGate,
@@ -949,6 +1028,31 @@ final class MiniMaxH3FusedKernelTests: MereRunCoreTestCase {
         XCTAssertEqual(tiledCandidate.shape, [1, rows, outputWidth])
         XCTAssertEqual(tiledCandidate.dtype, .bfloat16)
         XCTAssertLessThan(maximumDifference(tiledCandidate, reference), 0.032)
+
+        let floatInput = input.asType(.float32)
+        let floatProjected = MLX.quantizedMM(
+            floatInput,
+            codes,
+            scales: scales,
+            biases: biases,
+            transpose: true,
+            groupSize: groupSize,
+            bits: 8,
+            mode: .affine
+        )
+        let floatParts = MLX.split(floatProjected, parts: 2, axis: -1)
+        let floatReference = MLXNN.silu(floatParts[0]) * floatParts[1]
+        let floatTiled = try XCTUnwrap(
+            MiniMaxH3FusedKernels.projectFeedForwardInputAffineInt8SwiGLUTiled(
+                input: floatInput,
+                weightCodes: codes,
+                weightScales: scales,
+                weightBiases: biases
+            )
+        )
+        MLX.eval(floatReference, floatTiled)
+        XCTAssertEqual(floatTiled.dtype, .float32)
+        XCTAssertLessThan(relativeL2Difference(floatReference, floatTiled), 0.005)
     }
 
     func testProjectFeedForwardOutputAffineInt8MatchesManagedQ8Contract() throws {
@@ -1013,6 +1117,29 @@ final class MiniMaxH3FusedKernelTests: MereRunCoreTestCase {
         XCTAssertEqual(tiledCandidate.shape, [1, rows, outputWidth])
         XCTAssertEqual(tiledCandidate.dtype, .bfloat16)
         XCTAssertLessThan(maximumDifference(tiledCandidate, reference), 0.032)
+
+        let floatInput = input.asType(.float32)
+        let floatReference = MLX.quantizedMM(
+            floatInput,
+            codes,
+            scales: scales,
+            biases: biases,
+            transpose: true,
+            groupSize: groupSize,
+            bits: 8,
+            mode: .affine
+        )
+        let floatTiled = try XCTUnwrap(
+            MiniMaxH3FusedKernels.projectFeedForwardOutputAffineInt8Tiled(
+                input: floatInput,
+                weightCodes: codes,
+                weightScales: scales,
+                weightBiases: biases
+            )
+        )
+        MLX.eval(floatReference, floatTiled)
+        XCTAssertEqual(floatTiled.dtype, .float32)
+        XCTAssertLessThan(relativeL2Difference(floatReference, floatTiled), 0.005)
     }
 
     func testTiledAffineInt8MLPRunsInsideCompiledGraph() throws {
@@ -1030,7 +1157,7 @@ final class MiniMaxH3FusedKernelTests: MereRunCoreTestCase {
         let input = MLXRandom.uniform(
             -0.25 ..< 0.25,
             [1, rows, hiddenSize]
-        ).asType(.bfloat16)
+        )
         let fc1Codes = MLXArray.full(
             [2 * feedForwardSize, hiddenSize / 4],
             values: MLXArray(UInt32(0x0403_0201))
@@ -1249,6 +1376,106 @@ final class MiniMaxH3FusedKernelTests: MereRunCoreTestCase {
         XCTAssertGreaterThan(retainedIncrement, donated.bytes)
     }
 
+    func testPrepareAttentionInputReleaseBenchmark() throws {
+        let environment = ProcessInfo.processInfo.environment
+        guard environment["MERERUN_H3_ATTENTION_ADALN_BENCH"] == "1" else {
+            throw XCTSkip(
+                "Set MERERUN_H3_ATTENTION_ADALN_BENCH=1 and "
+                    + "MERERUN_TEST_MLX_DEVICE=gpu to run the H3 attention AdaLN benchmark."
+            )
+        }
+        guard Device.defaultDevice().deviceType == .gpu else {
+            throw XCTSkip("The H3 attention AdaLN benchmark requires a Metal GPU.")
+        }
+
+        let rows = max(
+            1,
+            Int(environment["MERERUN_H3_BENCH_ROWS"] ?? "") ?? 14_958
+        )
+        let rounds = max(
+            1,
+            Int(environment["MERERUN_H3_BENCH_ROUNDS"] ?? "") ?? 4
+        )
+        let activationDType: DType = environment["MERERUN_H3_BENCH_DTYPE"] == "bfloat16"
+            ? .bfloat16
+            : .float32
+        let hiddenSize = 5_376
+        let modulationRows = 9
+        let epsilon = Float(1e-5)
+        MLXRandom.seed(2_026_082_905)
+        let input = MLXRandom.normal([1, rows, hiddenSize]).asType(activationDType)
+        let normWeight = MLXRandom.uniform(
+            0.8 ..< 1.2,
+            [hiddenSize]
+        ).asType(.bfloat16)
+        let modulation = (
+            MLXRandom.normal([modulationRows, 6 * hiddenSize]) * Float(0.1)
+        ).asType(.bfloat16)
+        let rowIndices = MLXArray((0..<rows).map { Int32($0 % modulationRows) })
+        MLX.eval(input, normWeight, modulation, rowIndices)
+
+        let portable = MLX.compile { (inputs: [MLXArray]) -> [MLXArray] in
+            let parts = MLX.split(inputs[2], parts: 6, axis: -1)
+            let shift = MLX.take(parts[0], inputs[3], axis: 0).expandedDimensions(axis: 0)
+            let scale = MLX.take(parts[1], inputs[3], axis: 0).expandedDimensions(axis: 0)
+            return [MLXFast.rmsNorm(inputs[0], weight: inputs[1], eps: epsilon)
+                * (1 + scale) + shift]
+        }
+        let inputs = [input, normWeight, modulation, rowIndices]
+        func portableRun() -> [MLXArray] {
+            portable(inputs)
+        }
+        func fusedRun() -> [MLXArray] {
+            guard let output = MiniMaxH3FusedKernels.prepareAttentionInput(
+                input: input,
+                normWeight: normWeight,
+                modulation: modulation,
+                rowIndices: rowIndices,
+                eps: epsilon
+            ) else {
+                XCTFail("Expected the H3 attention AdaLN Metal kernel.")
+                return portableRun()
+            }
+            return [output]
+        }
+
+        MLX.eval(portableRun(), fusedRun())
+        var portableSeconds = 0.0
+        var fusedSeconds = 0.0
+        for round in 0..<rounds {
+            if round.isMultiple(of: 2) {
+                portableSeconds += measure(portableRun)
+                fusedSeconds += measure(fusedRun)
+            } else {
+                fusedSeconds += measure(fusedRun)
+                portableSeconds += measure(portableRun)
+            }
+        }
+        portableSeconds /= Double(rounds)
+        fusedSeconds /= Double(rounds)
+
+        let reference = portableRun()[0]
+        let candidate = fusedRun()[0]
+        MLX.eval(reference, candidate)
+        let difference = maximumDifference(reference, candidate)
+        let relativeL2 = relativeL2Difference(reference, candidate)
+        print(String(
+            format: "[h3-transfer] attention-adaln dtype=%@ rows=%d "
+                + "portable_ms=%.3f fused_ms=%.3f speedup=%.3fx "
+                + "max_abs=%.6g rel_l2=%.6g",
+            String(describing: activationDType),
+            rows,
+            portableSeconds * 1_000,
+            fusedSeconds * 1_000,
+            portableSeconds / fusedSeconds,
+            difference,
+            relativeL2
+        ))
+
+        XCTAssertLessThan(difference, activationDType == .bfloat16 ? 0.05 : 1e-4)
+        XCTAssertLessThan(relativeL2, activationDType == .bfloat16 ? 0.001 : 1e-5)
+    }
+
     func testGateAttentionAndPrepareFeedForwardReleaseBenchmark() throws {
         let environment = ProcessInfo.processInfo.environment
         guard environment["MERERUN_H3_FUSED_KERNEL_BENCH"] == "1" else {
@@ -1272,9 +1499,12 @@ final class MiniMaxH3FusedKernelTests: MereRunCoreTestCase {
         let hiddenSize = 5_376
         let modulationRows = 9
         let epsilon = Float(1e-5)
+        let activationDType: DType = environment["MERERUN_H3_BENCH_DTYPE"] == "bfloat16"
+            ? .bfloat16
+            : .float32
         MLXRandom.seed(2_026_081_002)
-        let residual = MLXRandom.normal([1, rows, hiddenSize])
-        let attentionOutput = MLXRandom.normal([1, rows, hiddenSize])
+        let residual = MLXRandom.normal([1, rows, hiddenSize]).asType(activationDType)
+        let attentionOutput = MLXRandom.normal([1, rows, hiddenSize]).asType(activationDType)
         let normWeight = MLXRandom.uniform(
             0.8 ..< 1.2,
             [hiddenSize]
@@ -1334,21 +1564,25 @@ final class MiniMaxH3FusedKernelTests: MereRunCoreTestCase {
         MLX.eval(reference, candidate)
         let residualDifference = maximumDifference(reference[0], candidate[0])
         let inputDifference = maximumDifference(reference[1], candidate[1])
+        let inputRelativeL2 = relativeL2Difference(reference[1], candidate[1])
         let gateDifference = maximumDifference(reference[2], candidate[2])
         print("[h3-transfer] gate-adaln residual_dtype=\(residual.dtype) " + String(
             format: "rows=%d portable_ms=%.3f fused_ms=%.3f "
-                + "speedup=%.3fx residual_max_abs=%.6g input_max_abs=%.6g gate_max_abs=%.6g",
+                + "speedup=%.3fx residual_max_abs=%.6g input_max_abs=%.6g "
+                + "input_rel_l2=%.6g gate_max_abs=%.6g",
             rows,
             portableSeconds * 1_000,
             fusedSeconds * 1_000,
             portableSeconds / fusedSeconds,
             residualDifference,
             inputDifference,
+            inputRelativeL2,
             gateDifference
         ))
 
         XCTAssertLessThanOrEqual(residualDifference, 0.00390625)
-        XCTAssertLessThan(inputDifference, 0.016)
+        XCTAssertLessThan(inputDifference, activationDType == .bfloat16 ? 0.05 : 0.016)
+        XCTAssertLessThan(inputRelativeL2, activationDType == .bfloat16 ? 0.001 : 1e-5)
         XCTAssertEqual(gateDifference, 0)
     }
 
@@ -1487,10 +1721,13 @@ final class MiniMaxH3FusedKernelTests: MereRunCoreTestCase {
         let headDimension = 128
         let rotaryDimension = 96
         let epsilon = Float(1e-5)
+        let activationDType: DType = environment["MERERUN_H3_BENCH_DTYPE"] == "bfloat16"
+            ? .bfloat16
+            : .float32
         MLXRandom.seed(2_026_081_006)
         let projected = MLXRandom.normal(
             [1, rows, 3 * heads * headDimension]
-        )
+        ).asType(activationDType)
         let queryNormWeight = MLXRandom.uniform(
             0.8 ..< 1.2,
             [headDimension]
@@ -1504,7 +1741,8 @@ final class MiniMaxH3FusedKernelTests: MereRunCoreTestCase {
             [1, rows, 1, rotaryDimension]
         )
         let ropeCosine = MLX.cos(angles)
-        let ropeSine = MLX.sin(angles)
+            .asType(activationDType)
+        let ropeSine = MLX.sin(angles).asType(activationDType)
         MLX.eval(
             projected,
             queryNormWeight,
@@ -1568,23 +1806,30 @@ final class MiniMaxH3FusedKernelTests: MereRunCoreTestCase {
         MLX.eval(reference, candidate)
         let queryDifference = maximumDifference(reference[0], candidate[0])
         let keyDifference = maximumDifference(reference[1], candidate[1])
+        let queryRelativeL2 = relativeL2Difference(reference[0], candidate[0])
+        let keyRelativeL2 = relativeL2Difference(reference[1], candidate[1])
         let valueDifference = maximumDifference(reference[2], candidate[2])
         print("[h3-transfer] qkv-layout projection_dtype=\(projected.dtype) "
             + "rope_dtype=\(ropeCosine.dtype) " + String(
             format: "rows=%d portable_ms=%.3f "
                 + "fused_ms=%.3f speedup=%.3fx query_max_abs=%.6g "
-                + "key_max_abs=%.6g value_max_abs=%.6g",
+                + "key_max_abs=%.6g query_rel_l2=%.6g key_rel_l2=%.6g "
+                + "value_max_abs=%.6g",
             rows,
             portableSeconds * 1_000,
             fusedSeconds * 1_000,
             portableSeconds / fusedSeconds,
             queryDifference,
             keyDifference,
+            queryRelativeL2,
+            keyRelativeL2,
             valueDifference
         ))
 
-        XCTAssertLessThan(queryDifference, 0.032)
-        XCTAssertLessThan(keyDifference, 0.032)
+        XCTAssertLessThan(queryDifference, activationDType == .bfloat16 ? 0.0625 : 0.032)
+        XCTAssertLessThan(keyDifference, activationDType == .bfloat16 ? 0.0625 : 0.032)
+        XCTAssertLessThan(queryRelativeL2, activationDType == .bfloat16 ? 0.001 : 1e-5)
+        XCTAssertLessThan(keyRelativeL2, activationDType == .bfloat16 ? 0.001 : 1e-5)
         XCTAssertEqual(valueDifference, 0)
     }
 
@@ -1870,11 +2115,23 @@ final class MiniMaxH3FusedKernelTests: MereRunCoreTestCase {
             1,
             Int(environment["MERERUN_H3_BENCH_ROUNDS"] ?? "") ?? 4
         )
+        let activationDType: DType = environment["MERERUN_H3_BENCH_DTYPE"] == "float32"
+            ? .float32
+            : .bfloat16
         let hiddenSize = 5_376
         let feedForwardSize = 14_336
         let groupSize = 64
+        let portableProjectionBytes = UInt64(rows)
+            * UInt64(2 * feedForwardSize)
+            * UInt64(activationDType.size)
+        guard portableProjectionBytes <= UInt64(UInt32.max) else {
+            throw XCTSkip(
+                "Use the installed affine MLP stage benchmark for rows whose "
+                    + "portable FC1 projection exceeds 4 GiB."
+            )
+        }
         MLXRandom.seed(2_026_081_011)
-        let input = MLXRandom.normal([1, rows, hiddenSize]).asType(.bfloat16)
+        let input = MLXRandom.normal([1, rows, hiddenSize]).asType(activationDType)
         let fc1Codes = MLXArray.full(
             [2 * feedForwardSize, hiddenSize / 4],
             values: MLXArray(UInt32(0x0403_0201))
@@ -1974,11 +2231,14 @@ final class MiniMaxH3FusedKernelTests: MereRunCoreTestCase {
         MLX.eval(reference, candidate)
         let difference = maximumDifference(reference, candidate)
         let relativeL2 = relativeL2Difference(reference, candidate)
-        let avoidedBytes = UInt64(rows) * UInt64(2 * feedForwardSize) * 2
+        let avoidedBytes = UInt64(rows)
+            * UInt64(2 * feedForwardSize)
+            * UInt64(activationDType.size)
         print(String(
-            format: "[h3-transfer] affine-ffn rows=%d portable_ms=%.3f "
+            format: "[h3-transfer] affine-ffn dtype=%@ rows=%d portable_ms=%.3f "
                 + "fused_ms=%.3f speedup=%.3fx max_abs=%.6g rel_l2=%.6g "
                 + "fc1_materialization_avoided_bytes=%llu",
+            String(describing: activationDType),
             rows,
             portableSeconds * 1_000,
             fusedSeconds * 1_000,

--- a/Tests/MereRunCoreTests/MiniMaxH3FusedKernelTests.swift
+++ b/Tests/MereRunCoreTests/MiniMaxH3FusedKernelTests.swift
@@ -892,7 +892,7 @@ final class MiniMaxH3FusedKernelTests: MereRunCoreTestCase {
             )
         }
 
-        let rows = 1
+        let rows = 33
         let inputWidth = 5_376
         let outputWidth = 14_336
         let groupSize = 64
@@ -933,11 +933,22 @@ final class MiniMaxH3FusedKernelTests: MereRunCoreTestCase {
                 weightBiases: biases
             )
         )
-        MLX.eval(reference, candidate)
+        let tiledCandidate = try XCTUnwrap(
+            MiniMaxH3FusedKernels.projectFeedForwardInputAffineInt8SwiGLUTiled(
+                input: input,
+                weightCodes: codes,
+                weightScales: scales,
+                weightBiases: biases
+            )
+        )
+        MLX.eval(reference, candidate, tiledCandidate)
 
         XCTAssertEqual(candidate.shape, [1, rows, outputWidth])
         XCTAssertEqual(candidate.dtype, .bfloat16)
         XCTAssertLessThan(maximumDifference(candidate, reference), 0.032)
+        XCTAssertEqual(tiledCandidate.shape, [1, rows, outputWidth])
+        XCTAssertEqual(tiledCandidate.dtype, .bfloat16)
+        XCTAssertLessThan(maximumDifference(tiledCandidate, reference), 0.032)
     }
 
     func testProjectFeedForwardOutputAffineInt8MatchesManagedQ8Contract() throws {
@@ -947,7 +958,7 @@ final class MiniMaxH3FusedKernelTests: MereRunCoreTestCase {
             )
         }
 
-        let rows = 1
+        let rows = 33
         let inputWidth = 14_336
         let outputWidth = 5_376
         let groupSize = 64
@@ -986,11 +997,113 @@ final class MiniMaxH3FusedKernelTests: MereRunCoreTestCase {
                 weightBiases: biases
             )
         )
-        MLX.eval(reference, candidate)
+        let tiledCandidate = try XCTUnwrap(
+            MiniMaxH3FusedKernels.projectFeedForwardOutputAffineInt8Tiled(
+                input: input,
+                weightCodes: codes,
+                weightScales: scales,
+                weightBiases: biases
+            )
+        )
+        MLX.eval(reference, candidate, tiledCandidate)
 
         XCTAssertEqual(candidate.shape, [1, rows, outputWidth])
         XCTAssertEqual(candidate.dtype, .bfloat16)
         XCTAssertLessThan(maximumDifference(candidate, reference), 0.032)
+        XCTAssertEqual(tiledCandidate.shape, [1, rows, outputWidth])
+        XCTAssertEqual(tiledCandidate.dtype, .bfloat16)
+        XCTAssertLessThan(maximumDifference(tiledCandidate, reference), 0.032)
+    }
+
+    func testTiledAffineInt8MLPRunsInsideCompiledGraph() throws {
+        guard Device.defaultDevice().deviceType == .gpu else {
+            throw XCTSkip(
+                "Set MERERUN_TEST_MLX_DEVICE=gpu to run the compiled tiled H3 MLP canary."
+            )
+        }
+
+        let rows = 33
+        let hiddenSize = 5_376
+        let feedForwardSize = 14_336
+        let groupSize = 64
+        MLXRandom.seed(2_026_082_904)
+        let input = MLXRandom.uniform(
+            -0.25 ..< 0.25,
+            [1, rows, hiddenSize]
+        ).asType(.bfloat16)
+        let fc1Codes = MLXArray.full(
+            [2 * feedForwardSize, hiddenSize / 4],
+            values: MLXArray(UInt32(0x0403_0201))
+        )
+        let fc1Scales = MLXRandom.uniform(
+            0.0005 ..< 0.0025,
+            [2 * feedForwardSize, hiddenSize / groupSize]
+        ).asType(.bfloat16)
+        let fc1Biases = MLXRandom.uniform(
+            -0.01 ..< 0.01,
+            fc1Scales.shape
+        ).asType(.bfloat16)
+        let fc2Codes = MLXArray.full(
+            [hiddenSize, feedForwardSize / 4],
+            values: MLXArray(UInt32(0x0403_0201))
+        )
+        let fc2Scales = MLXRandom.uniform(
+            0.0005 ..< 0.0025,
+            [hiddenSize, feedForwardSize / groupSize]
+        ).asType(.bfloat16)
+        let fc2Biases = MLXRandom.uniform(
+            -0.01 ..< 0.01,
+            fc2Scales.shape
+        ).asType(.bfloat16)
+        let compiled = MLX.compile { inputs in
+            guard let activated = MiniMaxH3FusedKernels
+                .projectFeedForwardInputAffineInt8SwiGLUTiled(
+                    input: inputs[0],
+                    weightCodes: inputs[1],
+                    weightScales: inputs[2],
+                    weightBiases: inputs[3]
+                ),
+                let projected = MiniMaxH3FusedKernels
+                .projectFeedForwardOutputAffineInt8Tiled(
+                    input: activated,
+                    weightCodes: inputs[4],
+                    weightScales: inputs[5],
+                    weightBiases: inputs[6]
+                ) else {
+                return []
+            }
+            return [activated, projected]
+        }
+        let arguments = [
+            input,
+            fc1Codes,
+            fc1Scales,
+            fc1Biases,
+            fc2Codes,
+            fc2Scales,
+            fc2Biases,
+        ]
+        let eagerActivated = try XCTUnwrap(
+            MiniMaxH3FusedKernels.projectFeedForwardInputAffineInt8SwiGLUTiled(
+                input: input,
+                weightCodes: fc1Codes,
+                weightScales: fc1Scales,
+                weightBiases: fc1Biases
+            )
+        )
+        let eagerProjected = try XCTUnwrap(
+            MiniMaxH3FusedKernels.projectFeedForwardOutputAffineInt8Tiled(
+                input: eagerActivated,
+                weightCodes: fc2Codes,
+                weightScales: fc2Scales,
+                weightBiases: fc2Biases
+            )
+        )
+        let compiledOutputs = compiled(arguments)
+        XCTAssertEqual(compiledOutputs.count, 2)
+        MLX.eval(eagerActivated, eagerProjected, compiledOutputs)
+        XCTAssertEqual(maximumDifference(compiledOutputs[0], eagerActivated), 0)
+        XCTAssertEqual(maximumDifference(compiledOutputs[1], eagerProjected), 0)
     }
 
     func testCompiledResidualBoundaryDonatesUnretainedH3Buffer() throws {
@@ -1822,13 +1935,14 @@ final class MiniMaxH3FusedKernelTests: MereRunCoreTestCase {
         }
         func fusedRun() -> [MLXArray] {
             guard let activated = MiniMaxH3FusedKernels
-                .projectFeedForwardInputAffineInt8SwiGLU(
+                .projectFeedForwardInputAffineInt8SwiGLUTiled(
                     input: input,
                     weightCodes: fc1Codes,
                     weightScales: fc1Scales,
                     weightBiases: fc1Biases
                 ),
-                let projected = MiniMaxH3FusedKernels.projectFeedForwardOutputAffineInt8(
+                let projected = MiniMaxH3FusedKernels
+                .projectFeedForwardOutputAffineInt8Tiled(
                     input: activated,
                     weightCodes: fc2Codes,
                     weightScales: fc2Scales,
@@ -1859,17 +1973,116 @@ final class MiniMaxH3FusedKernelTests: MereRunCoreTestCase {
         let candidate = fusedRun()[0]
         MLX.eval(reference, candidate)
         let difference = maximumDifference(reference, candidate)
+        let relativeL2 = relativeL2Difference(reference, candidate)
         let avoidedBytes = UInt64(rows) * UInt64(2 * feedForwardSize) * 2
         print(String(
             format: "[h3-transfer] affine-ffn rows=%d portable_ms=%.3f "
-                + "fused_ms=%.3f speedup=%.3fx max_abs=%.6g "
+                + "fused_ms=%.3f speedup=%.3fx max_abs=%.6g rel_l2=%.6g "
                 + "fc1_materialization_avoided_bytes=%llu",
             rows,
             portableSeconds * 1_000,
             fusedSeconds * 1_000,
             portableSeconds / fusedSeconds,
             difference,
+            relativeL2,
             avoidedBytes
+        ))
+
+        XCTAssertLessThan(relativeL2, 0.005)
+    }
+
+    func testFeedForwardOutputAffineInt8TiledReleaseBenchmark() throws {
+        let environment = ProcessInfo.processInfo.environment
+        guard environment["MERERUN_H3_AFFINE_FC2_TILED_BENCH"] == "1" else {
+            throw XCTSkip(
+                "Set MERERUN_H3_AFFINE_FC2_TILED_BENCH=1 and "
+                    + "MERERUN_TEST_MLX_DEVICE=gpu to run the tiled H3 FC2 benchmark."
+            )
+        }
+        guard Device.defaultDevice().deviceType == .gpu else {
+            throw XCTSkip("The tiled H3 FC2 benchmark requires a Metal GPU.")
+        }
+
+        let rows = max(
+            1,
+            Int(environment["MERERUN_H3_BENCH_ROWS"] ?? "") ?? 14_958
+        )
+        let rounds = max(
+            1,
+            Int(environment["MERERUN_H3_BENCH_ROUNDS"] ?? "") ?? 4
+        )
+        let inputWidth = 14_336
+        let outputWidth = 5_376
+        let groupSize = 64
+        MLXRandom.seed(2_026_082_901)
+        let input = MLXRandom.normal([1, rows, inputWidth]).asType(.bfloat16)
+        let codes = MLXArray.full(
+            [outputWidth, inputWidth / 4],
+            values: MLXArray(UInt32(0x0403_0201))
+        )
+        let scales = MLXRandom.uniform(
+            0.0005 ..< 0.0025,
+            [outputWidth, inputWidth / groupSize]
+        ).asType(.bfloat16)
+        let biases = MLXRandom.uniform(
+            -0.01 ..< 0.01,
+            scales.shape
+        ).asType(.bfloat16)
+        MLX.eval(input, codes, scales, biases)
+
+        func portableRun() -> [MLXArray] {
+            [MLX.quantizedMM(
+                input,
+                codes,
+                scales: scales,
+                biases: biases,
+                transpose: true,
+                groupSize: groupSize,
+                bits: 8,
+                mode: .affine
+            )]
+        }
+        func tiledRun() -> [MLXArray] {
+            guard let output = MiniMaxH3FusedKernels
+                .projectFeedForwardOutputAffineInt8Tiled(
+                    input: input,
+                    weightCodes: codes,
+                    weightScales: scales,
+                    weightBiases: biases
+                ) else {
+                XCTFail("Expected the tiled H3 FC2 kernel.")
+                return []
+            }
+            return [output]
+        }
+
+        MLX.eval(portableRun(), tiledRun())
+        var portableSeconds = 0.0
+        var tiledSeconds = 0.0
+        for round in 0..<rounds {
+            if round.isMultiple(of: 2) {
+                portableSeconds += measure(portableRun)
+                tiledSeconds += measure(tiledRun)
+            } else {
+                tiledSeconds += measure(tiledRun)
+                portableSeconds += measure(portableRun)
+            }
+        }
+        portableSeconds /= Double(rounds)
+        tiledSeconds /= Double(rounds)
+
+        let reference = portableRun()[0]
+        let candidate = tiledRun()[0]
+        MLX.eval(reference, candidate)
+        let difference = maximumDifference(reference, candidate)
+        print(String(
+            format: "[h3-transfer] affine-fc2-tiled rows=%d portable_ms=%.3f "
+                + "tiled_ms=%.3f speedup=%.3fx max_abs=%.6g",
+            rows,
+            portableSeconds * 1_000,
+            tiledSeconds * 1_000,
+            portableSeconds / tiledSeconds,
+            difference
         ))
 
         XCTAssertLessThan(difference, 0.125)
@@ -1878,6 +2091,14 @@ final class MiniMaxH3FusedKernelTests: MereRunCoreTestCase {
 
     private func maximumDifference(_ lhs: MLXArray, _ rhs: MLXArray) -> Float {
         MLX.max(MLX.abs(lhs.asType(.float32) - rhs.asType(.float32))).item(Float.self)
+    }
+
+    private func relativeL2Difference(_ lhs: MLXArray, _ rhs: MLXArray) -> Float {
+        let reference = lhs.asType(.float32)
+        let difference = reference - rhs.asType(.float32)
+        let numerator = MLX.sqrt(MLX.sum(difference * difference))
+        let denominator = MLX.sqrt(MLX.sum(reference * reference))
+        return (numerator / denominator).item(Float.self)
     }
 
     private func measure(_ body: () -> [MLXArray]) -> Double {

--- a/Tests/MereRunCoreTests/MiniMaxH3Tests.swift
+++ b/Tests/MereRunCoreTests/MiniMaxH3Tests.swift
@@ -161,6 +161,232 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
         ))
     }
 
+    func testFastVSAGeometryKeepsPrefixSegmentsPureAndTilesVideoIn3D() throws {
+        let layout = try MiniMaxH3Geometry.buildFL2VA(
+            textTokenTags: Array(repeating: 1, count: 70),
+            videoLatentFrames: 5,
+            latentHeight: 10,
+            latentWidth: 10,
+            audioLatentFrames: 3,
+            keyframeAnchors: []
+        )
+        let geometry = MiniMaxH3FastVSAGeometry(layout: layout)
+
+        XCTAssertEqual(geometry.prefixTileCount, 3)
+        XCTAssertEqual(geometry.videoTileCount, 8)
+        XCTAssertEqual(Array(geometry.blockSizes.prefix(3)), [64, 6, 6])
+        XCTAssertEqual(geometry.blockSizes.reduce(0, { $0 + Int($1) }), layout.sequenceLength)
+        XCTAssertEqual(geometry.originalToPadded.count, layout.sequenceLength)
+        XCTAssertEqual(
+            Set(geometry.originalToPadded).count,
+            layout.sequenceLength
+        )
+        for (original, padded) in geometry.originalToPadded.enumerated() {
+            XCTAssertEqual(geometry.paddedToOriginal[Int(padded)], Int32(original))
+        }
+    }
+
+    func testFastVSARoutingKeepsPrefixDenseAndTopKVideoKeys() {
+        let scores = MLXArray((0..<25).map(Float.init)).reshaped(1, 1, 5, 5)
+        let routes = MiniMaxH3FastVSA.routesForTesting(
+            scores: scores,
+            prefixTileCount: 2,
+            videoTileCount: 3,
+            sparsity: 0.9
+        )
+        MLX.eval(routes)
+        let values = routes.asArray(UInt8.self)
+        for query in 0..<2 {
+            XCTAssertEqual(Array(values[(query * 5)..<(query * 5 + 5)]), [1, 1, 1, 1, 1])
+        }
+        for query in 2..<5 {
+            let row = Array(values[(query * 5)..<(query * 5 + 5)])
+            XCTAssertEqual(Array(row.prefix(2)), [1, 1])
+            XCTAssertEqual(row.suffix(3).reduce(0, +), 1)
+        }
+    }
+
+    func testFastVSAMetalDenseRouteMatchesFusedSDPA() throws {
+        guard Device.defaultDevice().deviceType == .gpu else {
+            throw XCTSkip("FastH3 VSA parity requires a Metal GPU.")
+        }
+        let layout = try MiniMaxH3Geometry.buildFL2VA(
+            textTokenTags: Array(repeating: 1, count: 7),
+            videoLatentFrames: 2,
+            latentHeight: 4,
+            latentWidth: 4,
+            audioLatentFrames: 3,
+            keyframeAnchors: []
+        )
+        MLXRandom.seed(2_026_082_9)
+        let shape = [1, 2, layout.sequenceLength, MiniMaxH3FastVSA.headDimension]
+        let queries = (MLXRandom.normal(shape) * Float(0.2)).asType(.bfloat16)
+        let keys = (MLXRandom.normal(shape) * Float(0.2)).asType(.bfloat16)
+        let values = MLXRandom.normal(shape).asType(.bfloat16)
+        let gate = MLXArray.zeros(shape, dtype: .bfloat16)
+        let candidate = try XCTUnwrap(MiniMaxH3FastVSA.call(
+            queries: queries,
+            keys: keys,
+            values: values,
+            compressionGate: gate,
+            layout: layout,
+            sparsity: 0
+        ))
+        let reference = MLXFast.scaledDotProductAttention(
+            queries: queries,
+            keys: keys,
+            values: values,
+            scale: 1 / sqrt(Float(MiniMaxH3FastVSA.headDimension)),
+            mask: .none
+        )
+        let delta = candidate.asType(.float32) - reference.asType(.float32)
+        let relativeL2 = MLX.sqrt(
+            MLX.sum(delta * delta)
+                / MLX.maximum(
+                    MLX.sum(reference.asType(.float32) * reference.asType(.float32)),
+                    MLXArray(Float(1e-12))
+                )
+        )
+        MLX.eval(candidate, reference, relativeL2)
+        XCTAssertLessThanOrEqual(relativeL2.item(Float.self), 0.005)
+    }
+
+    func testFastVSAMetalAcceptsFP32RotaryQueriesAndKeys() throws {
+        guard Device.defaultDevice().deviceType == .gpu else {
+            throw XCTSkip("FastH3 VSA rotary promotion coverage requires a Metal GPU.")
+        }
+        let layout = try MiniMaxH3Geometry.buildFL2VA(
+            textTokenTags: Array(repeating: 1, count: 7),
+            videoLatentFrames: 2,
+            latentHeight: 4,
+            latentWidth: 4,
+            audioLatentFrames: 3,
+            keyframeAnchors: []
+        )
+        MLXRandom.seed(2_026_083_1)
+        let shape = [1, 2, layout.sequenceLength, MiniMaxH3FastVSA.headDimension]
+        let queries = MLXRandom.normal(shape) * Float(0.2)
+        let keys = MLXRandom.normal(shape) * Float(0.2)
+        let values = MLXRandom.normal(shape).asType(.bfloat16)
+        let gate = MLXArray.zeros(shape, dtype: .bfloat16)
+        let candidate = try XCTUnwrap(MiniMaxH3FastVSA.call(
+            queries: queries,
+            keys: keys,
+            values: values,
+            compressionGate: gate,
+            layout: layout,
+            sparsity: 0
+        ))
+        let expected = try XCTUnwrap(MiniMaxH3FastVSA.call(
+            queries: queries.asType(.bfloat16),
+            keys: keys.asType(.bfloat16),
+            values: values,
+            compressionGate: gate,
+            layout: layout,
+            sparsity: 0
+        ))
+        MLX.eval(candidate, expected)
+        XCTAssertEqual(candidate.dtype, .bfloat16)
+        XCTAssertEqual(candidate.asArray(Float.self), expected.asArray(Float.self))
+    }
+
+    func testFastVSAMetalSparseRouteAndCompressionMatchTensorReference() throws {
+        guard Device.defaultDevice().deviceType == .gpu else {
+            throw XCTSkip("FastH3 sparse VSA parity requires a Metal GPU.")
+        }
+        let layout = try MiniMaxH3Geometry.buildFL2VA(
+            textTokenTags: Array(repeating: 1, count: 7),
+            videoLatentFrames: 5,
+            latentHeight: 10,
+            latentWidth: 10,
+            audioLatentFrames: 3,
+            keyframeAnchors: []
+        )
+        let geometry = MiniMaxH3FastVSAGeometry(layout: layout)
+        MLXRandom.seed(2_026_083_0)
+        let shape = [1, 2, layout.sequenceLength, MiniMaxH3FastVSA.headDimension]
+        let queries = (MLXRandom.normal(shape) * Float(0.2)).asType(.bfloat16)
+        let keys = (MLXRandom.normal(shape) * Float(0.2)).asType(.bfloat16)
+        let values = MLXRandom.normal(shape).asType(.bfloat16)
+        let gate = (MLXRandom.normal(shape) * Float(0.05)).asType(.bfloat16)
+        let candidate = try XCTUnwrap(MiniMaxH3FastVSA.call(
+            queries: queries,
+            keys: keys,
+            values: values,
+            compressionGate: gate,
+            layout: layout
+        ))
+
+        let sentinel = MLXArray.zeros([1, 2, 1, MiniMaxH3FastVSA.headDimension], dtype: .bfloat16)
+        let paddedIndices = MLXArray(geometry.paddedToOriginal)
+        let inverseIndices = MLXArray(geometry.originalToPadded)
+        func tiled(_ value: MLXArray) -> MLXArray {
+            MLX.take(MLX.concatenated([value, sentinel], axis: 2), paddedIndices, axis: 2)
+        }
+        let tiledQueries = tiled(queries)
+        let tiledKeys = tiled(keys)
+        let tiledValues = tiled(values)
+        let tiledGate = tiled(gate)
+        let tileCount = geometry.tileCount
+        let paddedCount = geometry.paddedTokenCount
+        let sizes = MLXArray(geometry.blockSizes).asType(.float32).reshaped(1, 1, tileCount, 1)
+        func pooled(_ value: MLXArray) -> MLXArray {
+            value.asType(.float32)
+                .reshaped(1, 2, tileCount, MiniMaxH3FastVSAGeometry.tileSize, MiniMaxH3FastVSA.headDimension)
+                .sum(axis: 3) / sizes
+        }
+        let pooledQueries = pooled(tiledQueries)
+        let pooledKeys = pooled(tiledKeys)
+        let pooledValues = pooled(tiledValues)
+        let scale = 1 / sqrt(Float(MiniMaxH3FastVSA.headDimension))
+        let routeScores = MLX.matmul(pooledQueries, pooledKeys.transposed(0, 1, 3, 2)) * scale
+        let routes = MiniMaxH3FastVSA.routesForTesting(
+            scores: routeScores,
+            prefixTileCount: geometry.prefixTileCount,
+            videoTileCount: geometry.videoTileCount
+        )
+        let tokenRoutes = MLX.broadcast(
+            routes.reshaped(1, 2, tileCount, 1, tileCount, 1),
+            to: [1, 2, tileCount, 64, tileCount, 64]
+        ).reshaped(1, 2, paddedCount, paddedCount)
+        let validKeys = MLXArray(geometry.paddedToOriginal.map {
+            $0 == Int32(layout.sequenceLength) ? UInt8(0) : UInt8(1)
+        }).reshaped(1, 1, 1, paddedCount)
+        let exactScores = MLX.matmul(
+            tiledQueries.asType(.float32),
+            tiledKeys.asType(.float32).transposed(0, 1, 3, 2)
+        ) * scale
+        let maskedScores = MLX.where(
+            (tokenRoutes * validKeys) .== 1,
+            exactScores,
+            MLXArray(-Float.infinity)
+        )
+        let exact = MLX.matmul(
+            MLX.softmax(maskedScores, axis: -1, precise: true),
+            tiledValues.asType(.float32)
+        )
+        let compressed = MLX.matmul(
+            MLX.softmax(routeScores, axis: -1, precise: true),
+            pooledValues
+        )
+        let referenceTiled = exact.reshaped(
+            1, 2, tileCount, 64, MiniMaxH3FastVSA.headDimension
+        ) + compressed.expandedDimensions(axis: 3)
+            * tiledGate.asType(.float32).reshaped(1, 2, tileCount, 64, MiniMaxH3FastVSA.headDimension)
+        let reference = MLX.take(
+            referenceTiled.reshaped(1, 2, paddedCount, MiniMaxH3FastVSA.headDimension),
+            inverseIndices,
+            axis: 2
+        )
+        let delta = candidate.asType(.float32) - reference
+        let relativeL2 = MLX.sqrt(
+            MLX.sum(delta * delta)
+                / MLX.maximum(MLX.sum(reference * reference), MLXArray(Float(1e-12)))
+        )
+        MLX.eval(candidate, reference, relativeL2)
+        XCTAssertLessThanOrEqual(relativeL2.item(Float.self), 0.01)
+    }
+
     func testDynamicSparseAttentionRoutesAboveAdaptiveThreshold() {
         let queryCentroids = MLXArray([Float(1), 0]).reshaped(1, 1, 1, 2)
         let keyCentroids = MLXArray([
@@ -1347,6 +1573,41 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
         )
     }
 
+    func testManagedFastH3ProfileIsOnePinnedSelfContainedArtifact() throws {
+        let spec = try XCTUnwrap(
+            ManagedModelCatalog.spec(for: MiniMaxH3Resources.fastH3ModelID)
+        )
+        XCTAssertEqual(spec.hubFallback?.repoId, MiniMaxH3Resources.fastH3ArtifactRepository)
+        XCTAssertEqual(spec.hubFallback?.revision, MiniMaxH3Resources.fastH3ArtifactRevision)
+        XCTAssertEqual(spec.hubFallback?.patterns, MiniMaxH3Resources.fastH3ArtifactFiles)
+        XCTAssertEqual(spec.estimatedDownloadBytes, 82_316_599_044)
+        XCTAssertTrue(spec.mountedHubFallbacks.isEmpty)
+        XCTAssertFalse(spec.runtimeAutoDownloadAllowed)
+        XCTAssertTrue(
+            MiniMaxH3Resources.fastH3ArtifactFiles.contains(
+                MiniMaxH3TurboAdapter.fastH3VSADataFreeFilename
+            )
+        )
+        XCTAssertTrue(
+            MiniMaxH3Resources.fastH3ArtifactFiles.contains(
+                MiniMaxH3TurboAdapter.fastH3AdaLNCacheFilename
+            )
+        )
+
+        let manifest = MereRunModelManifest.template(
+            for: .miniMaxH3FastH3VSADataFreeMLX,
+            createdAt: Date(timeIntervalSince1970: 0)
+        )
+        XCTAssertEqual(manifest.precision, .bf16)
+        XCTAssertNil(manifest.quantization)
+        XCTAssertEqual(manifest.defaults?.steps, 5)
+        XCTAssertEqual(
+            manifest.upstreamRepoId,
+            "\(MiniMaxH3Resources.fastH3ArtifactRepository)"
+                + "@\(MiniMaxH3Resources.fastH3ArtifactRevision)"
+        )
+    }
+
     func testManagedRef2VAProfileUsesPinnedPublicEightBitArtifact() throws {
         XCTAssertEqual(
             MiniMaxH3Resources.ref2vaArtifactRepository,
@@ -2352,6 +2613,55 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
         let final = video.step(sample: sample, velocity: velocity, index: video.timesteps.count - 1)
         MLX.eval(final)
         XCTAssertTrue(final.asArray(Float.self).allSatisfy(\.isFinite))
+    }
+
+    func testFastH3DMDJumpScheduleUsesReleasedTrainingPoints() throws {
+        let recipe = MiniMaxH3TurboAdapter.fastH3VSADataFreeRecipe
+        let baseSigmas = try XCTUnwrap(recipe.baseDenoisingSigmas)
+        let video = try MiniMaxH3Schedule(baseSigmas: baseSigmas, shift: 12)
+        let audio = try MiniMaxH3Schedule(baseSigmas: baseSigmas, shift: 3)
+
+        XCTAssertEqual(baseSigmas, [0.999, 0.749, 0.5, 0.25, 0])
+        XCTAssertEqual(video.sigmas.count, 5)
+        XCTAssertEqual(audio.sigmas.count, 5)
+        XCTAssertEqual(video.sigmas.last, 0)
+        XCTAssertEqual(audio.sigmas.last, 0)
+        XCTAssertEqual(video.timesteps.count, 4)
+        XCTAssertEqual(audio.timesteps.count, 4)
+        XCTAssertTrue(recipe.requiresFastH3VSA)
+        XCTAssertTrue(recipe.requiresTextOnlyConditioning)
+        XCTAssertEqual(
+            MiniMaxH3TurboAdapter.inferenceRecipe(
+                filename: MiniMaxH3TurboAdapter.fastH3VSADataFreeFilename
+            ),
+            recipe
+        )
+    }
+
+    func testFastH3RecipeRecognizesOriginalAdapterMetadata() throws {
+        let url = FileManager.default.temporaryDirectory.appending(
+            path: "adapter_model-\(UUID().uuidString).safetensors"
+        )
+        defer { try? FileManager.default.removeItem(at: url) }
+        try MLX.save(
+            arrays: ["probe": MLXArray([Float(1)])],
+            metadata: [
+                "format": MiniMaxH3TurboAdapter.fastVideoFormat,
+                "finetuned_model": "FastVideo/FastVideo-FastH3-4-step-v1",
+            ],
+            url: url
+        )
+
+        XCTAssertEqual(
+            MiniMaxH3TurboAdapter.inferenceRecipe(for: url),
+            MiniMaxH3TurboAdapter.fastH3VSADataFreeRecipe
+        )
+    }
+
+    func testExplicitDMDJumpScheduleRejectsInvalidBaseSigmas() {
+        XCTAssertThrowsError(try MiniMaxH3Schedule(baseSigmas: [1, 0.5], shift: 12))
+        XCTAssertThrowsError(try MiniMaxH3Schedule(baseSigmas: [0.5, 0.75, 0], shift: 12))
+        XCTAssertThrowsError(try MiniMaxH3Schedule(baseSigmas: [0.999, 0], shift: 0))
     }
 
     func testBlockReusePolicyBoundsCacheStepsForPracticalSchedule() throws {

--- a/Tests/MereRunCoreTests/MiniMaxH3Tests.swift
+++ b/Tests/MereRunCoreTests/MiniMaxH3Tests.swift
@@ -300,6 +300,63 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
         XCTAssertEqual(candidate.asArray(Float.self), expected.asArray(Float.self))
     }
 
+    func testFastVSAFullTileKernelMatchesHalfTileKernel() throws {
+        guard Device.defaultDevice().deviceType == .gpu else {
+            throw XCTSkip("FastH3 VSA tile schedule parity requires a Metal GPU.")
+        }
+        let layout = try MiniMaxH3Geometry.buildFL2VA(
+            textTokenTags: Array(repeating: 1, count: 70),
+            videoLatentFrames: 5,
+            latentHeight: 10,
+            latentWidth: 10,
+            audioLatentFrames: 3,
+            keyframeAnchors: []
+        )
+        MLXRandom.seed(2_026_082_9)
+        let shape = [1, 2, layout.sequenceLength, MiniMaxH3FastVSA.headDimension]
+        let queries = (MLXRandom.normal(shape) * Float(0.2)).asType(.bfloat16)
+        let keys = (MLXRandom.normal(shape) * Float(0.2)).asType(.bfloat16)
+        let values = MLXRandom.normal(shape).asType(.bfloat16)
+        let gate = (MLXRandom.normal(shape) * Float(0.05)).asType(.bfloat16)
+        let halfTile = try XCTUnwrap(MiniMaxH3FastVSA.call(
+            queries: queries,
+            keys: keys,
+            values: values,
+            compressionGate: gate,
+            layout: layout,
+            kernelMode: .halfTile
+        ))
+        let fullTile = try XCTUnwrap(MiniMaxH3FastVSA.call(
+            queries: queries,
+            keys: keys,
+            values: values,
+            compressionGate: gate,
+            layout: layout,
+            kernelMode: .fullTile
+        ))
+        let fullTileKV16 = try XCTUnwrap(MiniMaxH3FastVSA.call(
+            queries: queries,
+            keys: keys,
+            values: values,
+            compressionGate: gate,
+            layout: layout,
+            kernelMode: .fullTileKV16
+        ))
+        MLX.eval(halfTile, fullTile, fullTileKV16)
+        XCTAssertEqual(halfTile.asArray(Float.self), fullTile.asArray(Float.self))
+        let reference = halfTile.asType(.float32)
+        let candidate = fullTileKV16.asType(.float32)
+        let delta = candidate - reference
+        let maximumAbsoluteError = MLX.max(MLX.abs(delta))
+        let relativeL2Error = MLX.sqrt(
+            MLX.sum(delta * delta)
+                / MLX.maximum(MLX.sum(reference * reference), MLXArray(Float(1e-12)))
+        )
+        MLX.eval(maximumAbsoluteError, relativeL2Error)
+        XCTAssertLessThanOrEqual(maximumAbsoluteError.item(Float.self), 0.02)
+        XCTAssertLessThanOrEqual(relativeL2Error.item(Float.self), 0.01)
+    }
+
     func testFastVSAMetalSparseRouteAndCompressionMatchTensorReference() throws {
         guard Device.defaultDevice().deviceType == .gpu else {
             throw XCTSkip("FastH3 sparse VSA parity requires a Metal GPU.")

--- a/Tests/MereRunCoreTests/MiniMaxH3Tests.swift
+++ b/Tests/MereRunCoreTests/MiniMaxH3Tests.swift
@@ -28,6 +28,10 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
             try MiniMaxH3ExactKernelMode.resolve(environmentValue: "AFFINE-Q8-MLP"),
             .affineQ8MLP
         )
+        XCTAssertEqual(
+            try MiniMaxH3ExactKernelMode.resolve(environmentValue: "FASTH3-METAL"),
+            .fastH3Metal
+        )
         let threshold = MiniMaxH3DenoiseExecutionPolicy.blockwiseSequenceThreshold
         XCTAssertFalse(MiniMaxH3ExactKernelMode.disabled.requiresEagerExecution(
             sequenceLength: threshold + 1
@@ -44,20 +48,27 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
         XCTAssertTrue(MiniMaxH3ExactKernelMode.affineQ8MLP.requiresEagerExecution(
             sequenceLength: 1
         ))
+        XCTAssertTrue(MiniMaxH3ExactKernelMode.fastH3Metal.requiresEagerExecution(
+            sequenceLength: 1
+        ))
         XCTAssertThrowsError(
             try MiniMaxH3ExactKernelMode.resolve(environmentValue: "automatic")
         ) { error in
             XCTAssertTrue(
                 error.localizedDescription.contains(
-                    "must be disabled, boundary-layout, affine-q8, or affine-q8-mlp"
+                    "must be disabled, boundary-layout, affine-q8, affine-q8-mlp, "
+                        + "or fasth3-metal"
                 )
             )
         }
     }
 
-    func testFastH3AffineQ8MLPAutomaticSelectionAndOptOut() throws {
+    func testFastH3MetalAutomaticSelectionAndOptOut() throws {
         XCTAssertFalse(MiniMaxH3ExactKernelMode.affineQ8MLP.usesBoundaryLayout)
         XCTAssertTrue(MiniMaxH3ExactKernelMode.affineQ8MLP.usesAffineQ8FeedForward)
+        XCTAssertTrue(MiniMaxH3ExactKernelMode.fastH3Metal.usesBoundaryLayout)
+        XCTAssertTrue(MiniMaxH3ExactKernelMode.fastH3Metal.usesAffineQ8FeedForward)
+        XCTAssertTrue(MiniMaxH3ExactKernelMode.fastH3Metal.usesTiledAffineQ8FeedForward)
         XCTAssertEqual(
             try MiniMaxH3ExactKernelMode.resolveForRuntime(
                 environmentValue: nil,
@@ -65,7 +76,7 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
                 supportsAffineQ8ExactKernels: true,
                 usesResidentBF16: false
             ),
-            .affineQ8MLP
+            .fastH3Metal
         )
         XCTAssertEqual(
             try MiniMaxH3ExactKernelMode.resolveForRuntime(
@@ -94,6 +105,31 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
             ),
             .disabled
         )
+    }
+
+    func testFastH3MetalMaterializesLargeFloatFeedForwardActivation() {
+        let feedForwardSize = 14_336
+        let maximumFloatRows = Int(UInt32.max) / (feedForwardSize * 4)
+        XCTAssertFalse(MiniMaxH3Transformer.requiresTiledFeedForwardEvaluationBoundary(
+            rowCount: maximumFloatRows,
+            feedForwardSize: feedForwardSize,
+            itemSize: 4
+        ))
+        XCTAssertTrue(MiniMaxH3Transformer.requiresTiledFeedForwardEvaluationBoundary(
+            rowCount: maximumFloatRows + 1,
+            feedForwardSize: feedForwardSize,
+            itemSize: 4
+        ))
+        XCTAssertTrue(MiniMaxH3Transformer.requiresTiledFeedForwardEvaluationBoundary(
+            rowCount: 89_188,
+            feedForwardSize: feedForwardSize,
+            itemSize: 4
+        ))
+        XCTAssertFalse(MiniMaxH3Transformer.requiresTiledFeedForwardEvaluationBoundary(
+            rowCount: 89_188,
+            feedForwardSize: feedForwardSize,
+            itemSize: 2
+        ))
     }
 
     func testExactKernelModeFallsBackForUnsupportedTransformerContracts() throws {
@@ -2053,6 +2089,9 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
         let rows = max(1, Int(environment["MERERUN_H3_BENCH_ROWS"] ?? "") ?? 37_719)
         let rounds = max(2, Int(environment["MERERUN_H3_BENCH_ROUNDS"] ?? "") ?? 4)
         let measuresTiming = environment["MERERUN_H3_BENCH_TIMING"] != "0"
+        let activationDType: DType = environment["MERERUN_H3_BENCH_DTYPE"] == "float32"
+            ? .float32
+            : .bfloat16
         let resources = MiniMaxH3Resources(
             rootURL: URL(fileURLWithPath: root, isDirectory: true)
         )
@@ -2082,7 +2121,7 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
         MLXRandom.seed(2_026_082_903)
         let input = MLXRandom.normal(
             [1, rows, configuration.hiddenSize]
-        ).asType(.bfloat16)
+        ).asType(activationDType)
         MLX.eval(input)
 
         let portableFC1ChunkRows = 32_768
@@ -2197,12 +2236,13 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
             candidate: fc2Candidate
         )
         print(String(
-            format: "[h3-transfer] real-affine-mlp-stages rows=%d "
+            format: "[h3-transfer] real-affine-mlp-stages dtype=%@ rows=%d "
                 + "fc1_portable_ms=%.3f fc1_tiled_ms=%.3f fc1_speedup=%.3fx "
                 + "fc1_rel_l2=%.6g fc1_worst_chunk_rel_l2=%.6g "
                 + "fc1_worst_chunk_start=%d fc2_portable_ms=%.3f fc2_tiled_ms=%.3f "
                 + "fc2_speedup=%.3fx fc2_rel_l2=%.6g "
                 + "fc2_worst_chunk_rel_l2=%.6g fc2_worst_chunk_start=%d",
+            String(describing: activationDType),
             rows,
             fc1Timing.0 * 1_000,
             fc1Timing.1 * 1_000,
@@ -2241,11 +2281,38 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
             rootURL: URL(fileURLWithPath: root, isDirectory: true)
         )
         let configuration = try resources.loadConfiguration()
-        let transformer = try MiniMaxH3ModelLoader.loadInferenceTransformer(
-            resources: resources,
-            configuration: configuration,
-            cachedAdaLN: nil
-        )
+        let transformer: MiniMaxH3Transformer
+        let loadedAdaLNCache: MiniMaxH3AdaLNCache?
+        do {
+            transformer = try MiniMaxH3ModelLoader.loadInferenceTransformer(
+                resources: resources,
+                configuration: configuration,
+                cachedAdaLN: nil
+            )
+            loadedAdaLNCache = nil
+        } catch MiniMaxH3ModelLoaderError.adaLNCacheRequired {
+            let recipe = MiniMaxH3TurboAdapter.fastH3VSADataFreeRecipe
+            let baseSigmas = try XCTUnwrap(recipe.baseDenoisingSigmas)
+            let cache = try MiniMaxH3AdaLNCache.load(
+                from: resources.fastH3AdaLNCacheURL,
+                configuration: .init(configuration),
+                videoSchedule: MiniMaxH3Schedule(
+                    baseSigmas: baseSigmas,
+                    shift: recipe.videoFlowShift ?? configuration.videoFlowShift
+                ),
+                audioSchedule: MiniMaxH3Schedule(
+                    baseSigmas: baseSigmas,
+                    shift: recipe.audioFlowShift ?? configuration.audioFlowShift
+                ),
+                sourceIdentity: MiniMaxH3TurboAdapter.fastH3SourceIdentity
+            )
+            transformer = try MiniMaxH3ModelLoader.loadInferenceTransformer(
+                resources: resources,
+                configuration: configuration,
+                cachedAdaLN: cache
+            )
+            loadedAdaLNCache = cache
+        }
         XCTAssertTrue(transformer.supportsAffineQ8ExactKernels)
         transformer.usesLayerwiseEvaluation = true
         transformer.clearsCacheAfterLayerwiseEvaluation = false
@@ -2271,6 +2338,19 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
             -0.05 ..< 0.05,
             [1, layout.textRows.count, configuration.textDimension]
         ).asType(.bfloat16)
+        let preparedContext = transformer.prepare(textStates: text, layout: layout)
+        let timesteps = MLXArray([Float(0.2), Float(0.4), Float(0.999)])
+        let cachedAdaLNStep = loadedAdaLNCache?.step(at: 0)
+
+        func runTransformer() -> MiniMaxH3TransformerOutput {
+            transformer(
+                videoRows: video,
+                audioRows: audio,
+                context: preparedContext,
+                timesteps: timesteps,
+                cachedAdaLN: cachedAdaLNStep
+            )
+        }
 
         func metrics(_ value: MLXArray, _ reference: MLXArray) -> (Float, Float) {
             let difference = value.asType(.float32) - reference.asType(.float32)
@@ -2284,28 +2364,14 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
         }
 
         transformer.exactKernelMode = .disabled
-        let baseline = transformer(
-            videoRows: video,
-            audioRows: audio,
-            textStates: text,
-            layout: layout,
-            videoTimestep: 0.2,
-            audioTimestep: 0.4
-        )
+        let baseline = runTransformer()
         MLX.eval(baseline.videoVelocityRows, baseline.audioVelocityRows)
 
         if environment["MERERUN_H3_EXACT_STAGE_DIAGNOSTICS"] == "1" {
             for stage in MiniMaxH3ExactKernelStage.allCases {
                 transformer.enabledExactKernelStages = [stage]
                 transformer.exactKernelMode = .affineQ8
-                let stageCandidate = transformer(
-                    videoRows: video,
-                    audioRows: audio,
-                    textStates: text,
-                    layout: layout,
-                    videoTimestep: 0.2,
-                    audioTimestep: 0.4
-                )
+                let stageCandidate = runTransformer()
                 MLX.eval(
                     stageCandidate.videoVelocityRows,
                     stageCandidate.audioVelocityRows
@@ -2340,14 +2406,7 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
             fallbackCounts["\(stage.rawValue):\(reason)", default: 0] += 1
         }
         transformer.exactKernelMode = .affineQ8
-        let candidate = transformer(
-            videoRows: video,
-            audioRows: audio,
-            textStates: text,
-            layout: layout,
-            videoTimestep: 0.2,
-            audioTimestep: 0.4
-        )
+        let candidate = runTransformer()
         MLX.eval(candidate.videoVelocityRows, candidate.audioVelocityRows)
 
         let videoMetrics = metrics(candidate.videoVelocityRows, baseline.videoVelocityRows)
@@ -2385,17 +2444,14 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
             uniqueKeysWithValues: MiniMaxH3ExactKernelStage.allCases.map { ($0, 0) }
         )
         fallbackCounts = [:]
-        let boundaryStages: Set<MiniMaxH3ExactKernelStage> = [.gateAdaLN, .qkvLayout]
+        let boundaryStages: Set<MiniMaxH3ExactKernelStage> = [
+            .attentionAdaLN,
+            .gateAdaLN,
+            .qkvLayout,
+        ]
         transformer.enabledExactKernelStages = boundaryStages
         transformer.exactKernelMode = .boundaryLayout
-        let boundaryCandidate = transformer(
-            videoRows: video,
-            audioRows: audio,
-            textStates: text,
-            layout: layout,
-            videoTimestep: 0.2,
-            audioTimestep: 0.4
-        )
+        let boundaryCandidate = runTransformer()
         MLX.eval(
             boundaryCandidate.videoVelocityRows,
             boundaryCandidate.audioVelocityRows
@@ -2434,6 +2490,86 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
         XCTAssertTrue(boundaryFallbackReceipt.isEmpty)
         XCTAssertLessThan(boundaryVideoMetrics.1, 0.05)
         XCTAssertLessThan(boundaryAudioMetrics.1, 0.05)
+
+        dispatchCounts = Dictionary(
+            uniqueKeysWithValues: MiniMaxH3ExactKernelStage.allCases.map { ($0, 0) }
+        )
+        fallbackCounts = [:]
+        let fastH3MetalStages: Set<MiniMaxH3ExactKernelStage> = [
+            .attentionAdaLN,
+            .gateAdaLN,
+            .qkvLayout,
+            .feedForwardInput,
+            .feedForwardOutput,
+        ]
+        transformer.enabledExactKernelStages = fastH3MetalStages
+        transformer.exactKernelMode = .fastH3Metal
+        let fastH3MetalCandidate = runTransformer()
+        MLX.eval(
+            fastH3MetalCandidate.videoVelocityRows,
+            fastH3MetalCandidate.audioVelocityRows
+        )
+        let fastH3MetalVideoMetrics = metrics(
+            fastH3MetalCandidate.videoVelocityRows,
+            baseline.videoVelocityRows
+        )
+        let fastH3MetalAudioMetrics = metrics(
+            fastH3MetalCandidate.audioVelocityRows,
+            baseline.audioVelocityRows
+        )
+        let fastH3MetalDispatchReceipt = MiniMaxH3ExactKernelStage.allCases.map { stage in
+            "\(stage.rawValue)=\(dispatchCounts[stage, default: 0])"
+        }.joined(separator: " ")
+        let fastH3MetalFallbackReceipt = fallbackCounts.sorted { $0.key < $1.key }.map { entry in
+            "\(entry.key)=\(entry.value)"
+        }.joined(separator: " | ")
+        print(String(
+            format: "[h3-transfer] real-weight-fasth3-metal blocks=%d rows=%d "
+                + "video_max_abs=%.6g video_rel_l2=%.6g "
+                + "audio_max_abs=%.6g audio_rel_l2=%.6g %@ fallbacks=%@",
+            transformer.affineQ8ExactKernelBlockCount,
+            layout.sequenceLength,
+            fastH3MetalVideoMetrics.0,
+            fastH3MetalVideoMetrics.1,
+            fastH3MetalAudioMetrics.0,
+            fastH3MetalAudioMetrics.1,
+            fastH3MetalDispatchReceipt,
+            fastH3MetalFallbackReceipt
+        ))
+        for stage in MiniMaxH3ExactKernelStage.allCases {
+            let expected = fastH3MetalStages.contains(stage) ? configuration.layerCount : 0
+            XCTAssertEqual(dispatchCounts[stage], expected, stage.rawValue)
+        }
+        XCTAssertTrue(fastH3MetalFallbackReceipt.isEmpty)
+        XCTAssertLessThan(fastH3MetalVideoMetrics.1, 0.01)
+        XCTAssertLessThan(fastH3MetalAudioMetrics.1, 0.01)
+
+        transformer.exactKernelDispatchHandler = nil
+        transformer.exactKernelFallbackHandler = nil
+        transformer.usesBlockwiseCompilation = true
+        let compiledFastH3MetalCandidate = runTransformer()
+        MLX.eval(
+            compiledFastH3MetalCandidate.videoVelocityRows,
+            compiledFastH3MetalCandidate.audioVelocityRows
+        )
+        let compiledFastH3MetalVideoMetrics = metrics(
+            compiledFastH3MetalCandidate.videoVelocityRows,
+            baseline.videoVelocityRows
+        )
+        let compiledFastH3MetalAudioMetrics = metrics(
+            compiledFastH3MetalCandidate.audioVelocityRows,
+            baseline.audioVelocityRows
+        )
+        print(String(
+            format: "[h3-transfer] real-weight-fasth3-metal-compiled "
+                + "blocks=%d rows=%d video_rel_l2=%.6g audio_rel_l2=%.6g",
+            transformer.affineQ8ExactKernelBlockCount,
+            layout.sequenceLength,
+            compiledFastH3MetalVideoMetrics.1,
+            compiledFastH3MetalAudioMetrics.1
+        ))
+        XCTAssertLessThan(compiledFastH3MetalVideoMetrics.1, 0.01)
+        XCTAssertLessThan(compiledFastH3MetalAudioMetrics.1, 0.01)
     }
 
     func testInstalledRef2VAAdaLNCacheMatchesLiveBranchWhenEnabled() throws {

--- a/Tests/MereRunCoreTests/MiniMaxH3Tests.swift
+++ b/Tests/MereRunCoreTests/MiniMaxH3Tests.swift
@@ -24,6 +24,10 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
             try MiniMaxH3ExactKernelMode.resolve(environmentValue: "AFFINE-Q8"),
             .affineQ8
         )
+        XCTAssertEqual(
+            try MiniMaxH3ExactKernelMode.resolve(environmentValue: "AFFINE-Q8-MLP"),
+            .affineQ8MLP
+        )
         let threshold = MiniMaxH3DenoiseExecutionPolicy.blockwiseSequenceThreshold
         XCTAssertFalse(MiniMaxH3ExactKernelMode.disabled.requiresEagerExecution(
             sequenceLength: threshold + 1
@@ -37,15 +41,59 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
         XCTAssertTrue(MiniMaxH3ExactKernelMode.affineQ8.requiresEagerExecution(
             sequenceLength: 1
         ))
+        XCTAssertTrue(MiniMaxH3ExactKernelMode.affineQ8MLP.requiresEagerExecution(
+            sequenceLength: 1
+        ))
         XCTAssertThrowsError(
             try MiniMaxH3ExactKernelMode.resolve(environmentValue: "automatic")
         ) { error in
             XCTAssertTrue(
                 error.localizedDescription.contains(
-                    "must be disabled, boundary-layout, or affine-q8"
+                    "must be disabled, boundary-layout, affine-q8, or affine-q8-mlp"
                 )
             )
         }
+    }
+
+    func testFastH3AffineQ8MLPAutomaticSelectionAndOptOut() throws {
+        XCTAssertFalse(MiniMaxH3ExactKernelMode.affineQ8MLP.usesBoundaryLayout)
+        XCTAssertTrue(MiniMaxH3ExactKernelMode.affineQ8MLP.usesAffineQ8FeedForward)
+        XCTAssertEqual(
+            try MiniMaxH3ExactKernelMode.resolveForRuntime(
+                environmentValue: nil,
+                usesFastH3VSA: true,
+                supportsAffineQ8ExactKernels: true,
+                usesResidentBF16: false
+            ),
+            .affineQ8MLP
+        )
+        XCTAssertEqual(
+            try MiniMaxH3ExactKernelMode.resolveForRuntime(
+                environmentValue: "disabled",
+                usesFastH3VSA: true,
+                supportsAffineQ8ExactKernels: true,
+                usesResidentBF16: false
+            ),
+            .disabled
+        )
+        XCTAssertEqual(
+            try MiniMaxH3ExactKernelMode.resolveForRuntime(
+                environmentValue: nil,
+                usesFastH3VSA: false,
+                supportsAffineQ8ExactKernels: true,
+                usesResidentBF16: false
+            ),
+            .disabled
+        )
+        XCTAssertEqual(
+            try MiniMaxH3ExactKernelMode.resolveForRuntime(
+                environmentValue: nil,
+                usesFastH3VSA: true,
+                supportsAffineQ8ExactKernels: true,
+                usesResidentBF16: true
+            ),
+            .disabled
+        )
     }
 
     func testExactKernelModeFallsBackForUnsupportedTransformerContracts() throws {
@@ -1882,6 +1930,298 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
             configuration.layerCount
         )
         XCTAssertTrue(transformer.supportsAffineQ8ExactKernels)
+    }
+
+    func testInstalledAffineQ8MLPReleaseBenchmark() throws {
+        let environment = ProcessInfo.processInfo.environment
+        guard environment["MERERUN_H3_AFFINE_MLP_REAL_BENCH"] == "1",
+              let root = environment["MERERUN_H3_EXACT_KERNEL_MODEL_ROOT"],
+              !root.isEmpty else {
+            throw XCTSkip(
+                "Set MERERUN_H3_AFFINE_MLP_REAL_BENCH=1 and "
+                    + "MERERUN_H3_EXACT_KERNEL_MODEL_ROOT to run the real-weight MLP benchmark."
+            )
+        }
+        guard Device.defaultDevice().deviceType == .gpu else {
+            throw XCTSkip("The real-weight H3 MLP benchmark requires a Metal GPU.")
+        }
+
+        let rows = max(1, Int(environment["MERERUN_H3_BENCH_ROWS"] ?? "") ?? 37_719)
+        let rounds = max(1, Int(environment["MERERUN_H3_BENCH_ROUNDS"] ?? "") ?? 3)
+        let resources = MiniMaxH3Resources(
+            rootURL: URL(fileURLWithPath: root, isDirectory: true)
+        )
+        let configuration = try resources.loadConfiguration()
+        let recipe = MiniMaxH3TurboAdapter.fastH3VSADataFreeRecipe
+        let baseSigmas = try XCTUnwrap(recipe.baseDenoisingSigmas)
+        let cache = try MiniMaxH3AdaLNCache.load(
+            from: resources.fastH3AdaLNCacheURL,
+            configuration: .init(configuration),
+            videoSchedule: MiniMaxH3Schedule(
+                baseSigmas: baseSigmas,
+                shift: recipe.videoFlowShift ?? configuration.videoFlowShift
+            ),
+            audioSchedule: MiniMaxH3Schedule(
+                baseSigmas: baseSigmas,
+                shift: recipe.audioFlowShift ?? configuration.audioFlowShift
+            ),
+            sourceIdentity: MiniMaxH3TurboAdapter.fastH3SourceIdentity
+        )
+        let transformer = try MiniMaxH3ModelLoader.loadInferenceTransformer(
+            resources: resources,
+            configuration: configuration,
+            cachedAdaLN: cache
+        )
+        XCTAssertTrue(transformer.supportsAffineQ8ExactKernels)
+
+        MLXRandom.seed(2_026_082_902)
+        let input = MLXRandom.normal(
+            [1, rows, configuration.hiddenSize]
+        ).asType(.bfloat16)
+        MLX.eval(input)
+
+        func portableRun() -> [MLXArray] {
+            transformer.exactKernelMode = .disabled
+            return [transformer.feedForwardForBenchmark(input, blockIndex: 0)]
+        }
+        func tiledRun() -> [MLXArray] {
+            transformer.exactKernelMode = .affineQ8MLP
+            return [transformer.feedForwardForBenchmark(input, blockIndex: 0)]
+        }
+        func measure(_ body: () -> [MLXArray]) -> Double {
+            let started = CFAbsoluteTimeGetCurrent()
+            MLX.eval(body())
+            return CFAbsoluteTimeGetCurrent() - started
+        }
+
+        MLX.eval(portableRun(), tiledRun())
+        var portableSeconds = 0.0
+        var tiledSeconds = 0.0
+        for round in 0..<rounds {
+            if round.isMultiple(of: 2) {
+                portableSeconds += measure(portableRun)
+                tiledSeconds += measure(tiledRun)
+            } else {
+                tiledSeconds += measure(tiledRun)
+                portableSeconds += measure(portableRun)
+            }
+        }
+        portableSeconds /= Double(rounds)
+        tiledSeconds /= Double(rounds)
+
+        let reference = portableRun()[0]
+        let candidate = tiledRun()[0]
+        let difference = reference.asType(.float32) - candidate.asType(.float32)
+        let maximum = MLX.max(MLX.abs(difference)).item(Float.self)
+        let numerator = MLX.sum(difference * difference)
+        let denominator = MLX.maximum(
+            MLX.sum(reference.asType(.float32) * reference.asType(.float32)),
+            MLXArray(Float(1e-12))
+        )
+        let relativeL2 = MLX.sqrt(numerator / denominator).item(Float.self)
+        let avoidedBytes = UInt64(rows) * UInt64(2 * configuration.feedForwardSize) * 2
+        print(String(
+            format: "[h3-transfer] real-affine-mlp rows=%d portable_ms=%.3f "
+                + "tiled_ms=%.3f speedup=%.3fx max_abs=%.6g rel_l2=%.6g "
+                + "fc1_materialization_avoided_bytes=%llu",
+            rows,
+            portableSeconds * 1_000,
+            tiledSeconds * 1_000,
+            portableSeconds / tiledSeconds,
+            maximum,
+            relativeL2,
+            avoidedBytes
+        ))
+
+        XCTAssertLessThan(relativeL2, 0.005)
+    }
+
+    func testInstalledAffineQ8MLPStageReleaseBenchmark() throws {
+        let environment = ProcessInfo.processInfo.environment
+        guard environment["MERERUN_H3_AFFINE_MLP_REAL_STAGE_BENCH"] == "1",
+              let root = environment["MERERUN_H3_EXACT_KERNEL_MODEL_ROOT"],
+              !root.isEmpty else {
+            throw XCTSkip(
+                "Set MERERUN_H3_AFFINE_MLP_REAL_STAGE_BENCH=1 and "
+                    + "MERERUN_H3_EXACT_KERNEL_MODEL_ROOT to run real-weight MLP stages."
+            )
+        }
+        guard Device.defaultDevice().deviceType == .gpu else {
+            throw XCTSkip("The real-weight H3 MLP stage benchmark requires a Metal GPU.")
+        }
+
+        let rows = max(1, Int(environment["MERERUN_H3_BENCH_ROWS"] ?? "") ?? 37_719)
+        let rounds = max(2, Int(environment["MERERUN_H3_BENCH_ROUNDS"] ?? "") ?? 4)
+        let measuresTiming = environment["MERERUN_H3_BENCH_TIMING"] != "0"
+        let resources = MiniMaxH3Resources(
+            rootURL: URL(fileURLWithPath: root, isDirectory: true)
+        )
+        let configuration = try resources.loadConfiguration()
+        let recipe = MiniMaxH3TurboAdapter.fastH3VSADataFreeRecipe
+        let baseSigmas = try XCTUnwrap(recipe.baseDenoisingSigmas)
+        let cache = try MiniMaxH3AdaLNCache.load(
+            from: resources.fastH3AdaLNCacheURL,
+            configuration: .init(configuration),
+            videoSchedule: MiniMaxH3Schedule(
+                baseSigmas: baseSigmas,
+                shift: recipe.videoFlowShift ?? configuration.videoFlowShift
+            ),
+            audioSchedule: MiniMaxH3Schedule(
+                baseSigmas: baseSigmas,
+                shift: recipe.audioFlowShift ?? configuration.audioFlowShift
+            ),
+            sourceIdentity: MiniMaxH3TurboAdapter.fastH3SourceIdentity
+        )
+        let transformer = try MiniMaxH3ModelLoader.loadInferenceTransformer(
+            resources: resources,
+            configuration: configuration,
+            cachedAdaLN: cache
+        )
+        XCTAssertTrue(transformer.supportsAffineQ8ExactKernels)
+
+        MLXRandom.seed(2_026_082_903)
+        let input = MLXRandom.normal(
+            [1, rows, configuration.hiddenSize]
+        ).asType(.bfloat16)
+        MLX.eval(input)
+
+        let portableFC1ChunkRows = 32_768
+        func portableFC1() -> [MLXArray] {
+            transformer.exactKernelMode = .disabled
+            return stride(from: 0, to: rows, by: portableFC1ChunkRows).map { start in
+                let end = min(start + portableFC1ChunkRows, rows)
+                return transformer.feedForwardInputForBenchmark(
+                    input[0..., start..<end, 0...],
+                    blockIndex: 0
+                )
+            }
+        }
+        func tiledFC1() -> [MLXArray] {
+            transformer.exactKernelMode = .affineQ8MLP
+            return [transformer.feedForwardInputForBenchmark(input, blockIndex: 0)]
+        }
+        let fc2Input = tiledFC1()[0]
+        MLX.eval(fc2Input)
+        func portableFC2() -> [MLXArray] {
+            transformer.exactKernelMode = .disabled
+            return [transformer.feedForwardOutputForBenchmark(fc2Input, blockIndex: 0)]
+        }
+        func tiledFC2() -> [MLXArray] {
+            transformer.exactKernelMode = .affineQ8MLP
+            return [transformer.feedForwardOutputForBenchmark(fc2Input, blockIndex: 0)]
+        }
+        func measure(_ body: () -> [MLXArray]) -> Double {
+            let started = CFAbsoluteTimeGetCurrent()
+            MLX.eval(body())
+            return CFAbsoluteTimeGetCurrent() - started
+        }
+        func benchmark(
+            _ portable: () -> [MLXArray],
+            _ tiled: () -> [MLXArray]
+        ) -> (Double, Double) {
+            guard measuresTiming else { return (.nan, .nan) }
+            MLX.eval(portable(), tiled())
+            var portableSeconds = 0.0
+            var tiledSeconds = 0.0
+            for round in 0..<rounds {
+                if round.isMultiple(of: 2) {
+                    portableSeconds += measure(portable)
+                    tiledSeconds += measure(tiled)
+                } else {
+                    tiledSeconds += measure(tiled)
+                    portableSeconds += measure(portable)
+                }
+            }
+            return (
+                portableSeconds / Double(rounds),
+                tiledSeconds / Double(rounds)
+            )
+        }
+        func relativeL2(
+            referenceChunks: [MLXArray],
+            candidate: MLXArray
+        ) -> (Float, Float, Int) {
+            var numerator = 0.0
+            var denominator = 0.0
+            var worstRelativeL2: Float = 0
+            var worstStart = 0
+            var start = 0
+            for referenceChunk in referenceChunks {
+                let end = start + referenceChunk.dim(1)
+                let reference = referenceChunk.asType(.float32)
+                let difference = reference - candidate[
+                    0..., start..<end, 0...
+                ].asType(.float32)
+                let chunkNumerator = MLX.sum(difference * difference).item(Float.self)
+                let chunkDenominator = MLX.maximum(
+                    MLX.sum(reference * reference),
+                    MLXArray(Float(1e-12))
+                ).item(Float.self)
+                let chunkRelativeL2 = sqrt(chunkNumerator / chunkDenominator)
+                if chunkRelativeL2 >= 0.005 {
+                    print(String(
+                        format: "[h3-transfer] failing-chunk start=%d end=%d rel_l2=%.6g",
+                        start,
+                        end,
+                        chunkRelativeL2
+                    ))
+                }
+                numerator += Double(chunkNumerator)
+                denominator += Double(chunkDenominator)
+                if chunkRelativeL2 > worstRelativeL2 {
+                    worstRelativeL2 = chunkRelativeL2
+                    worstStart = start
+                }
+                start = end
+            }
+            return (
+                Float(sqrt(numerator / max(denominator, 1e-12))),
+                worstRelativeL2,
+                worstStart
+            )
+        }
+
+        let fc1Timing = benchmark(portableFC1, tiledFC1)
+        let fc2Timing = benchmark(portableFC2, tiledFC2)
+        let fc1References = portableFC1()
+        let fc1Candidate = tiledFC1()[0]
+        let fc2Reference = portableFC2()[0]
+        let fc2Candidate = tiledFC2()[0]
+        MLX.eval(fc1References, [fc1Candidate, fc2Reference, fc2Candidate])
+        let fc1RelativeL2 = relativeL2(
+            referenceChunks: fc1References,
+            candidate: fc1Candidate
+        )
+        let fc2RelativeL2 = relativeL2(
+            referenceChunks: [fc2Reference],
+            candidate: fc2Candidate
+        )
+        print(String(
+            format: "[h3-transfer] real-affine-mlp-stages rows=%d "
+                + "fc1_portable_ms=%.3f fc1_tiled_ms=%.3f fc1_speedup=%.3fx "
+                + "fc1_rel_l2=%.6g fc1_worst_chunk_rel_l2=%.6g "
+                + "fc1_worst_chunk_start=%d fc2_portable_ms=%.3f fc2_tiled_ms=%.3f "
+                + "fc2_speedup=%.3fx fc2_rel_l2=%.6g "
+                + "fc2_worst_chunk_rel_l2=%.6g fc2_worst_chunk_start=%d",
+            rows,
+            fc1Timing.0 * 1_000,
+            fc1Timing.1 * 1_000,
+            fc1Timing.0 / fc1Timing.1,
+            fc1RelativeL2.0,
+            fc1RelativeL2.1,
+            fc1RelativeL2.2,
+            fc2Timing.0 * 1_000,
+            fc2Timing.1 * 1_000,
+            fc2Timing.0 / fc2Timing.1,
+            fc2RelativeL2.0,
+            fc2RelativeL2.1,
+            fc2RelativeL2.2
+        ))
+
+        XCTAssertLessThan(fc1RelativeL2.0, 0.005)
+        XCTAssertLessThan(fc1RelativeL2.1, 0.005)
+        XCTAssertLessThan(fc2RelativeL2.0, 0.005)
+        XCTAssertLessThan(fc2RelativeL2.1, 0.005)
     }
 
     func testInstalledRef2VAExactKernelFullForwardWhenEnabled() throws {

--- a/Tests/MereRunCoreTests/MiniMaxH3Tests.swift
+++ b/Tests/MereRunCoreTests/MiniMaxH3Tests.swift
@@ -204,6 +204,16 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
             XCTAssertEqual(Array(row.prefix(2)), [1, 1])
             XCTAssertEqual(row.suffix(3).reduce(0, +), 1)
         }
+
+        let compact = MiniMaxH3FastVSA.selectedVideoRoutesForTesting(
+            scores: scores,
+            prefixTileCount: 2,
+            videoTileCount: 3,
+            sparsity: 0.9
+        )
+        MLX.eval(compact)
+        XCTAssertEqual(compact.shape, [1, 1, 5, 1])
+        XCTAssertEqual(compact.asArray(Int32.self), [4, 4, 4, 4, 4])
     }
 
     func testFastVSAMetalDenseRouteMatchesFusedSDPA() throws {
@@ -1580,7 +1590,7 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
         XCTAssertEqual(spec.hubFallback?.repoId, MiniMaxH3Resources.fastH3ArtifactRepository)
         XCTAssertEqual(spec.hubFallback?.revision, MiniMaxH3Resources.fastH3ArtifactRevision)
         XCTAssertEqual(spec.hubFallback?.patterns, MiniMaxH3Resources.fastH3ArtifactFiles)
-        XCTAssertEqual(spec.estimatedDownloadBytes, 82_316_599_044)
+        XCTAssertEqual(spec.estimatedDownloadBytes, 57_559_079_710)
         XCTAssertTrue(spec.mountedHubFallbacks.isEmpty)
         XCTAssertFalse(spec.runtimeAutoDownloadAllowed)
         XCTAssertTrue(
@@ -1598,14 +1608,31 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
             for: .miniMaxH3FastH3VSADataFreeMLX,
             createdAt: Date(timeIntervalSince1970: 0)
         )
-        XCTAssertEqual(manifest.precision, .bf16)
-        XCTAssertNil(manifest.quantization)
+        XCTAssertEqual(manifest.precision, .int8)
+        XCTAssertEqual(manifest.quantization?.bits, 8)
+        XCTAssertEqual(manifest.quantization?.groupSize, 64)
+        XCTAssertEqual(manifest.quantization?.scheme, "mlx-affine")
         XCTAssertEqual(manifest.defaults?.steps, 5)
         XCTAssertEqual(
             manifest.upstreamRepoId,
             "\(MiniMaxH3Resources.fastH3ArtifactRepository)"
                 + "@\(MiniMaxH3Resources.fastH3ArtifactRevision)"
         )
+    }
+
+    func testManagedFastH3PackageValidationWhenConfigured() throws {
+        let environment = ProcessInfo.processInfo.environment
+        guard let root = environment["MERERUN_H3_FASTH3_MODEL_ROOT"], !root.isEmpty else {
+            throw XCTSkip(
+                "Set MERERUN_H3_FASTH3_MODEL_ROOT to validate the complete managed FastH3 artifact."
+            )
+        }
+        let rootURL = URL(fileURLWithPath: root, isDirectory: true)
+        let spec = try XCTUnwrap(
+            ManagedModelCatalog.spec(for: MiniMaxH3Resources.fastH3ModelID)
+        )
+        XCTAssertEqual(spec.validationMessages(in: rootURL), [])
+        XCTAssertTrue(spec.isManagedRootComplete(rootURL, fileManager: .default))
     }
 
     func testManagedRef2VAProfileUsesPinnedPublicEightBitArtifact() throws {
@@ -2655,6 +2682,63 @@ final class MiniMaxH3Tests: MereRunCoreTestCase {
         XCTAssertEqual(
             MiniMaxH3TurboAdapter.inferenceRecipe(for: url),
             MiniMaxH3TurboAdapter.fastH3VSADataFreeRecipe
+        )
+    }
+
+    func testFastH3RecipeRecognizesPremergedGateArtifactMetadata() throws {
+        let url = FileManager.default.temporaryDirectory.appending(
+            path: "adapter_model-\(UUID().uuidString).safetensors"
+        )
+        defer { try? FileManager.default.removeItem(at: url) }
+        try MLX.save(
+            arrays: ["probe": MLXArray([Float(1)])],
+            metadata: [
+                "format": MiniMaxH3TurboAdapter.fastH3PremergedFormat,
+                "finetuned_model": "FastVideo/FastVideo-FastH3-4-step-v1",
+            ],
+            url: url
+        )
+
+        XCTAssertTrue(MiniMaxH3TurboAdapter.isPremergedFastH3Artifact(url))
+        XCTAssertEqual(
+            MiniMaxH3TurboAdapter.inferenceRecipe(for: url),
+            MiniMaxH3TurboAdapter.fastH3VSADataFreeRecipe
+        )
+    }
+
+    func testFastH3QuantizedCompressionGateMatchesMLXAffineProjection() throws {
+        let weight = (MLXArray(0..<320).reshaped(5, 64).asType(.bfloat16) - 160) / 64
+        let input = (MLXArray(0..<128).reshaped(2, 64).asType(.bfloat16) - 64) / 32
+        let (codes, scales, optionalBiases) = MLX.quantized(
+            weight,
+            groupSize: 64,
+            bits: 8,
+            mode: .affine
+        )
+        let biases = try XCTUnwrap(optionalBiases)
+        let gate = MiniMaxH3FastH3CompressionGate(
+            codes: codes,
+            scales: scales,
+            biases: biases,
+            groupSize: 64,
+            bits: 8
+        )
+        let candidate = gate.project(input)
+        let reference = MLX.quantizedMM(
+            input,
+            codes,
+            scales: scales,
+            biases: biases,
+            groupSize: 64,
+            bits: 8,
+            mode: .affine
+        )
+        MLX.eval(candidate, reference)
+        XCTAssertEqual(candidate.shape, [2, 5])
+        XCTAssertEqual(
+            MLX.max(MLX.abs(candidate.asType(.float32) - reference.asType(.float32)))
+                .item(Float.self),
+            0
         )
     }
 

--- a/docs/benchmarks/minimax-h3-fasth3-vsa-datafree-m4-max.md
+++ b/docs/benchmarks/minimax-h3-fasth3-vsa-datafree-m4-max.md
@@ -125,3 +125,26 @@ frames and stereo AAC audio. Its SHA-256 is
 Manual contact-sheet inspection confirmed the requested dark circular stage,
 cyan lighting, and multiple dancers. These runs don't prove numerical parity
 with CUDA, long-duration quality, or performance at 1,344 by 768 pixels.
+
+## High-resolution tiled MLP qualification
+
+The managed affine Q8 FastH3 recipe now selects matrix-tiled Metal FC1/SwiGLU
+and FC2 kernels. This qualification isolates those stages with block 0's real
+checkpoint weights at 89,188 rows, the sequence shape for a 1,344 by 768 pixel
+and 294-frame request.
+
+| Stage | Correct portable oracle | Tiled Metal | Speedup | Numerical result |
+| --- | ---: | ---: | ---: | --- |
+| FC1 plus SwiGLU | 3,813.785 ms | 3,445.900 ms | 1.107x | relative L2 0.000767212 |
+| FC2 | 2,176.992 ms | 2,073.032 ms | 1.050x | bit-identical |
+
+The FC1 gate compares against portable calls chunked to at most 32,768 rows.
+An unchunked portable call materializes a 5.11 GiB `[1, 89188, 28672]` BF16
+projection and produces an invalid tail after its 4 GiB byte-offset boundary.
+The tiled kernel fuses SwiGLU and never creates that projection. Its worst
+32,768-row chunk had relative L2 0.000767620.
+
+This is an isolated GPU-stage qualification, not a new end-to-end generation
+timing. A packaged MP4 rerun was stopped before inference by mere.run's 16 GB
+system-disk reserve gate, with 11.45 GB available. The earlier end-to-end
+package and media-closure results above remain the generation evidence.

--- a/docs/benchmarks/minimax-h3-fasth3-vsa-datafree-m4-max.md
+++ b/docs/benchmarks/minimax-h3-fasth3-vsa-datafree-m4-max.md
@@ -182,6 +182,66 @@ inference by mere.run's 16 GB system-disk reserve gate, with 11.45 GB available.
 The earlier package and media-closure results in this document remain the
 generation evidence.
 
+## Output-resolution-preserving reduced-canvas proof
+
+A clean-host release run used the same six-shot dance prompt, 294 frames, seed
+42, and requested 1,344 by 768 output. The run selected an explicit 672 by 384
+internal render canvas. FastH3 retained its exact four-evaluation quality mode;
+the approximation is spatial resolution. DiT and the video VAE operated on the
+smaller canvas, then the pinned high-quality vImage scaler returned decoded RGB
+frames to 1,344 by 768 before muxing.
+
+The packed transformer shape was 23,687 rows: 21,924 target-video rows, 980
+target-audio rows, and 783 prompt rows. A clean real-checkpoint K4 diagnostic at
+that shape measured 627.871 ms for tiled FC1 plus SwiGLU and 487.725 ms for
+tiled FC2. Both results retained the installed Float32 arithmetic contract;
+FC1 measured relative L2 `3.82343e-8` and FC2 was bit-identical to its chunked
+portable oracle.
+
+The complete command used the release binary with SHA-256
+`d1aae95781eda202130a18b49962a149f3bb09c9034b3a0ad110e1a618436c63`.
+Set `VIDEO_PROMPT` to the six-shot dance prompt, then run:
+
+```bash
+mere.run video generate "$VIDEO_PROMPT" \
+  --model video-minimax-h3-fasth3-vsa-datafree-mlx \
+  --model-root /path/to/video-minimax-h3-fasth3-vsa-datafree-q8-mlx \
+  --width 1344 \
+  --height 768 \
+  --h3-render-width 672 \
+  --h3-render-height 384 \
+  --num-frames 294 \
+  --fps 24 \
+  --h3-weight-mode auto \
+  --h3-acceleration quality \
+  --seed 42 \
+  --output fasth3-metal-1344x768-from-672x384x294-seed42.mp4
+```
+
+Phase and step profiling were disabled so their synchronization did not enter
+the measured wall time. The preflight reported no diagnostics. The run
+completed in 1,083.12 seconds, or 18 minutes 3.12 seconds. `/usr/bin/time -l`
+reported a 27,818,442,752-byte maximum resident set, a 45,079,204,600-byte peak
+process footprint, and zero process swaps. System swap was zero before, during,
+and after the run.
+
+The 10,100,029-byte MP4 has SHA-256
+`9f78da1110b9aa43af2bea028032e789ff37c74b225346e782ae7776b0c58056`.
+`ffprobe` reported 294 H.264 frames at 1,344 by 768 and 24 fps, plus stereo AAC
+at 32 kHz; both streams and the container are 12.25 seconds. A complete decode
+to null succeeded. The audio is not silent: `volumedetect` measured -12.5 dB
+mean and 0.0 dB maximum volume. Contact-sheet inspection showed the dark
+circular stage, cyan perimeter lights, multiple dancers, movement, and the
+requested overhead view. This single sample does not prove exact dancer count,
+spoken-word accuracy, or native-1,344-by-768 visual quality.
+
+This is the first complete local M4 Max long-form proof that finished in less
+than 20 minutes, but it does not meet a five-minute target. The earlier
+native-canvas attempt was stopped after 799.66 seconds without finishing its
+first denoise evaluation. The reduced canvas makes the 12.25-second deliverable
+practical by quartering spatial video tokens. Present this result as 672-by-384
+generation upscaled to 1,344 by 768, not as native latent-resolution inference.
+
 ## CUDA comparison boundary
 
 FastVideo reports warm 1,344 by 768 pixel generation after compilation. Its

--- a/docs/benchmarks/minimax-h3-fasth3-vsa-datafree-m4-max.md
+++ b/docs/benchmarks/minimax-h3-fasth3-vsa-datafree-m4-max.md
@@ -126,25 +126,73 @@ Manual contact-sheet inspection confirmed the requested dark circular stage,
 cyan lighting, and multiple dancers. These runs don't prove numerical parity
 with CUDA, long-duration quality, or performance at 1,344 by 768 pixels.
 
-## High-resolution tiled MLP qualification
+## FastH3 Metal fusion qualification
 
-The managed affine Q8 FastH3 recipe now selects matrix-tiled Metal FC1/SwiGLU
-and FC2 kernels. This qualification isolates those stages with block 0's real
-checkpoint weights at 89,188 rows, the sequence shape for a 1,344 by 768 pixel
-and 294-frame request.
+The managed affine Q8 FastH3 recipe selects the combined `fasth3-metal` mode.
+The mode ports FastVideo's three H3 fusion families into the existing compiled
+Metal path:
 
-| Stage | Correct portable oracle | Tiled Metal | Speedup | Numerical result |
+- K0 fuses attention RMSNorm with row-indexed AdaLN scale and shift.
+- K1 fuses the attention residual and gate with feed-forward RMSNorm, scale,
+  and shift.
+- K2a writes head-major QKV and fuses Q/K RMSNorm with rotary embedding.
+- K4a fuses the affine Q8 FC1 projection with SwiGLU.
+- K4b applies the affine Q8 FC2 projection with a matrix tile.
+
+The first tiled K4 candidate accepted only BF16 activations. The live FastH3
+residual and MLP stream is Float32, so that candidate didn't dispatch during
+generation. A mixed candidate narrowed Float32 activations to BF16 matrix
+operands and failed the 50-block quality gate. The selected kernels use
+Float32 SIMD-group operands and accumulation for Float32 inputs.
+
+The installed checkpoint's deterministic seven-row, 50-block gate dispatched
+K0, K1, K2a, K4a, and K4b in every block with no fallback. The combined output
+measured video relative L2 `0.000926183` and audio relative L2 `0.00116363`
+against the decomposed graph. The boundary-only K0, K1, and K2a result measured
+`0.000169663` and `0.000345908`.
+
+The production-shape gate isolates block 0 with 89,188 rows, which is the
+sequence shape for a 1,344 by 768 pixel and 294-frame request. The following
+Float32 results compare the tiled kernels with a portable oracle chunked to at
+most 32,768 rows:
+
+| Stage | Portable oracle | Tiled Metal | Speedup | Numerical result |
 | --- | ---: | ---: | ---: | --- |
-| FC1 plus SwiGLU | 3,813.785 ms | 3,445.900 ms | 1.107x | relative L2 0.000767212 |
-| FC2 | 2,176.992 ms | 2,073.032 ms | 1.050x | bit-identical |
+| FC1 plus SwiGLU | 3,784.052 ms | 3,508.304 ms | 1.079x | relative L2 `3.82194e-8` |
+| FC2 | 2,042.034 ms | 1,881.471 ms | 1.085x | bit-identical |
 
-The FC1 gate compares against portable calls chunked to at most 32,768 rows.
-An unchunked portable call materializes a 5.11 GiB `[1, 89188, 28672]` BF16
-projection and produces an invalid tail after its 4 GiB byte-offset boundary.
-The tiled kernel fuses SwiGLU and never creates that projection. Its worst
-32,768-row chunk had relative L2 0.000767620.
+The timing host had approximately 31 GiB of system swap and another live
+inference service. The timings are exploratory and don't replace a zero-swap,
+clean-host receipt. Numerical parity was checked independently by chunk to
+avoid retaining two complete Float32 FC1 intermediates at once.
 
-This is an isolated GPU-stage qualification, not a new end-to-end generation
-timing. A packaged MP4 rerun was stopped before inference by mere.run's 16 GB
-system-disk reserve gate, with 11.45 GB available. The earlier end-to-end
-package and media-closure results above remain the generation evidence.
+K4a never creates the 9.53 GiB Float32 `[1, 89188, 28672]` FC1 projection.
+This removes the portable path's large intermediate and its 4 GiB addressing
+hazard. The earlier BF16 stage benchmark remains useful for the BF16 diagnostic
+path, but it didn't establish live FastH3 dispatch.
+
+The compact Float32 SwiGLU result is 4.76 GiB at this shape. The block runner
+evaluates K4a before K4b when the compact result exceeds 4 GiB. This boundary
+prevents a lazy compiled graph from applying a 32-bit offset to the K4a output.
+Smaller shapes keep K4a and K4b in one compiled post-attention region.
+
+This is an isolated GPU-stage and full-transformer arithmetic qualification,
+not a new end-to-end generation timing. A packaged MP4 rerun was stopped before
+inference by mere.run's 16 GB system-disk reserve gate, with 11.45 GB available.
+The earlier package and media-closure results in this document remain the
+generation evidence.
+
+## CUDA comparison boundary
+
+FastVideo reports warm 1,344 by 768 pixel generation after compilation. Its
+15-second VSA result is 47.2 seconds on one B200 and 12.88 seconds on eight B200
+GPUs. That runtime combines the four-call student, the `sm100a` tile-64 sparse
+kernel, regional DiT compilation, H3 fusions, FlashAttention 4, compiled video
+VAE decoding, and sequence-parallel VAE decoding on eight GPUs.
+
+The Metal path now matches the transferable model and fusion recipe: four DiT
+calls, 90% VSA, compact tile-64 routing, cached AdaLN, compiled block regions,
+and H3-specific modulation, Q/K, rotary, and SwiGLU kernels. It doesn't match
+B200 sparse-matrix throughput, FlashAttention 4, eight-device parallelism, or
+the CUDA VAE path. The port removes software disparity, but it doesn't imply
+the upstream eight-B200 wall time on one M4 Max.

--- a/docs/benchmarks/minimax-h3-fasth3-vsa-datafree-m4-max.md
+++ b/docs/benchmarks/minimax-h3-fasth3-vsa-datafree-m4-max.md
@@ -1,0 +1,88 @@
+# FastH3 VSA DataFree Metal qualification
+
+This receipt records a bounded native Metal generation for the managed
+`video-minimax-h3-fasth3-vsa-datafree-mlx` package. It proves that the packaged
+base, adapter, AdaLN cache, four-evaluation schedule, VSA-H3 path, video decoder,
+audio decoder, and MP4 muxer complete together. It does not establish general
+output quality or parity with the full upstream checkpoint.
+
+## Environment
+
+- Date: August 29, 2026
+- Hardware: Apple M4 Max with 128 GB unified memory
+- Operating system: macOS 26.5.2 (25F84), arm64
+- mere.run source base: `16cc6bed16974308e6b941bddd8bb05573f6689b`
+- Adapter revision: `bcf40ca6f457ed66f8badf13514943e390205fca`
+- Adapter SHA-256:
+  `42dc502a2078f166c396a1fa75f29728d1844363652d345d5ef3e2b444ed6470`
+- FastH3 AdaLN cache SHA-256:
+  `d5e98c47a6a8924acbae4cfe34007049f22f56df7e9a4809f8d509320067fbe1`
+
+The managed model root used symlinks to the exact package files. This avoided a
+second 82 GB local copy but exercised the same single-root paths and automatic
+embedded-adapter resolution as a completed managed pull.
+
+## Preflight
+
+The preflight resolved a text-to-video plan at 384 by 256 pixels with 22 frames,
+24 fps, synchronized generated audio, seed 7, adapter strength 1, and five
+schedule points for four denoising evaluations. It reported no diagnostics. The
+generated command contained only the managed model ID and did not contain an
+`--h3-adapter` argument.
+
+## Command
+
+```bash
+MERERUN_H3_PROFILE_STEPS=1 \
+MERERUN_H3_PROFILE_PHASES=1 \
+mere.run video generate \
+  "A red kite crosses a bright coastal sky while waves break below, with synchronized wind and surf." \
+  --model video-minimax-h3-fasth3-vsa-datafree-mlx \
+  --width 384 \
+  --height 256 \
+  --num-frames 22 \
+  --seed 7 \
+  --output minimax-h3-fasth3-vsa-datafree-metal-384x256x22.mp4 \
+  --quiet
+```
+
+## Results
+
+| Measurement | Observed value |
+| --- | ---: |
+| End-to-end wall time | 96.37 s |
+| Runtime generation total | 94.478 s |
+| Text encoding | 28.169 s |
+| Denoising | 54.417 s |
+| First evaluation, including Metal compilation | 43.511 s |
+| Second evaluation | 3.104 s |
+| Third evaluation | 3.099 s |
+| Fourth evaluation | 3.121 s |
+| Video decoding | 6.577 s |
+| Audio decoding | 0.961 s |
+| MLX peak memory | 42.15 GiB |
+| Maximum resident set size | 55,709,581,312 bytes |
+| Peak process memory footprint | 56,740,766,160 bytes |
+| Process swaps reported by `/usr/bin/time -l` | 0 |
+
+System-wide swap already existed on the host, and the run did not record a
+before-and-after system swap delta. The process-level observation must not be
+read as a system-wide no-swap qualification.
+
+## Output validation
+
+The generated MP4 is 89,328 bytes with SHA-256
+`e3a86b5a18a94944620dbb3b40bad7cac3689935907c5bf48f8bee181899aabc`.
+`ffprobe` reported:
+
+- H.264 video at 384 by 256 pixels, 24 fps, 22 frames, and 0.916667 seconds.
+- AAC stereo audio at 32 kHz and 0.917 seconds.
+- Container duration 0.917 seconds.
+
+Decoded audio was not silent: `volumedetect` measured -28.8 dB mean volume and
+-14.6 dB maximum volume. A manually inspected middle frame showed the prompted
+red subject above breaking coastal waves against a blue sky.
+
+This single short sample proves execution and media closure only. It does not
+measure prompt adherence across a dataset, temporal quality at longer durations,
+audio semantic accuracy, or behavior on systems with less unified memory.

--- a/docs/benchmarks/minimax-h3-fasth3-vsa-datafree-m4-max.md
+++ b/docs/benchmarks/minimax-h3-fasth3-vsa-datafree-m4-max.md
@@ -86,3 +86,42 @@ red subject above breaking coastal waves against a blue sky.
 This single short sample proves execution and media closure only. It does not
 measure prompt adherence across a dataset, temporal quality at longer durations,
 audio semantic accuracy, or behavior on systems with less unified memory.
+
+## Premerged Q8 and compact-route qualification
+
+A later qualification used the self-contained premerged Q8 package and a
+six-shot dance prompt. The package is pinned at revision
+`6068ae3dafafb1e4b2afb29f3109745a16912e07` and contains the following converted
+artifacts:
+
+- Transformer: 21,352,545,115 bytes, SHA-256
+  `dd29127cbb4b1b81603e565b9783677be2eb868cc53d47be2db8b7ca7ba6045f`.
+- Compression gates: 2,047,200,096 bytes, SHA-256
+  `4dee9a4fa80cadc13a602d7973b3c43a09bcfa0ef5e0baebe31a4d68a4b51dec`.
+- Complete managed download set: 57,559,079,710 bytes.
+
+The 384 by 256 pixel run used 22 frames, seed 42, and release-mode compiled
+blocks. The following comparison changes only VSA route representation and
+prepared geometry reuse:
+
+| Measurement | Dense route mask | Compact route table |
+| --- | ---: | ---: |
+| Runtime generation total | 98.666 s | 91.006 s |
+| Denoising | 57.730 s | 52.162 s |
+| First evaluation with specialization | 17.705 s | 26.021 s |
+| Mean of evaluations 2-4 | 13.187 s | 8.407 s |
+| Peak process memory footprint | 29,749,842,680 bytes | 29,747,860,072 bytes |
+
+Compact routing reduces steady-state evaluation time by approximately 36% in
+this bounded sample. The cold total improves by approximately 9.6% because the
+first run includes a new Metal specialization compile.
+
+A later process generated 512 by 320 pixels and 22 frames in 58.34 s wall
+time. Denoising took 44.685 s, with evaluations between 10.749 s and 11.650 s.
+The peak process footprint was 30,226,551,496 bytes. The MP4 contains 22 H.264
+frames and stereo AAC audio. Its SHA-256 is
+`165f0cf19bda49545b1cea8ed5b3c4828d1ec3de06c81954b295a6074c68bb9f`.
+
+Manual contact-sheet inspection confirmed the requested dark circular stage,
+cyan lighting, and multiple dancers. These runs don't prove numerical parity
+with CUDA, long-duration quality, or performance at 1,344 by 768 pixels.

--- a/docs/benchmarks/minimax-h3-h3c-transfer.md
+++ b/docs/benchmarks/minimax-h3-h3c-transfer.md
@@ -7,16 +7,35 @@ memory, and fallback gates.
 
 ## Promotion conclusion
 
-The portable M4 result is decisive: keep stock MLX's tiled affine-Q8 matrix
-primitive and fuse the elementwise/layout boundaries around it. Promote only
-K1 gated AdaLN and K2a head-major QKV normalization/RoPE for shape-qualified
-evaluation. Do not promote K2b, K3, or K4's scalar-SIMD affine-Q8 matrix cores;
-they are roughly four to five times slower than stock MLX at H3's production
-shapes. MLX's public quantized-matmul primitive does not accept an output
-stride or custom epilogue, so eliminating the remaining projection
-materializations competitively requires an MLX/MLXFast primitive with a tiled
-quantized core and H3-specific epilogue, or an M5 TensorOps implementation. It
-is not achievable by further tuning the standalone scalar kernels.
+The original scalar-SIMD affine-Q8 matrix cores remain rejected: they are
+roughly four to five times slower than stock MLX at H3's production shapes.
+The FastH3 Q8 MLP now uses a separate matrix-tiled Metal schedule. K4a stages a
+32-row by 32-output tile and keeps both FC1 projections in registers through
+the SwiGLU epilogue; K4b stages a 32-row by 64-output tile. Both dequantize each
+Q8/group-64 weight tile once into threadgroup memory and accumulate BF16 matrix
+operands in FP32.
+
+The tiled K4 path is the default only for the managed FastH3 VSA Q8 recipe.
+Other H3 variants retain stock MLX unless `MERERUN_H3_EXACT_KERNELS=affine-q8-mlp`
+is selected explicitly. `MERERUN_H3_EXACT_KERNELS=disabled` opts the FastH3
+recipe out. K2b and K3 remain experimental because their scalar matrix cores
+did not win.
+
+At 89,188 rows on the packaged FastH3 checkpoint, the correct chunked portable
+oracle measured 3,813.785 ms for FC1 plus SwiGLU and 2,176.992 ms for FC2. The
+tiled kernels measured 3,445.900 ms and 2,073.032 ms respectively: 1.107x and
+1.050x. FC1 relative L2 was 0.000767212, with a worst 32,768-row chunk of
+0.000767620; FC2 was bit-identical. K4a also avoids the 5.11 GiB
+`[1, 89188, 28672]` FC1 projection. The unchunked stock path wraps that
+intermediate after its 4 GiB boundary, so high-resolution validation must use
+the chunked oracle rather than treating the corrupt tail as a baseline.
+
+Reproduce the installed-checkpoint stage gate with:
+
+```bash
+MERERUN_H3_EXACT_KERNEL_MODEL_ROOT=/path/to/video-minimax-h3-fasth3-vsa-datafree-mlx \
+  scripts/h3-kernel-lab.sh affine-mlp-real
+```
 
 Resident BF16 has a separate M3/M4 opportunity. The refreshed MLX source has
 a Metal 4 NAX GEMM implementation, but its runtime capability gate
@@ -278,6 +297,11 @@ quantization contract and falls back to the decomposed graph if that individual
 contract is unavailable. K1's activation-INT8 output remains a lab boundary:
 the installed path uses its BF16 sibling until a projection consumes the
 dynamic INT8 rows directly.
+
+`MERERUN_H3_EXACT_KERNELS=affine-q8-mlp` selects only the matrix-tiled K4a and
+K4b kernels. It does not select K1, K2, or K3. The managed FastH3 VSA Q8 recipe
+uses this mode automatically when the environment variable is absent; setting
+the variable to `disabled` retains the portable MLX MLP for diagnostics.
 
 The gated real-weight test can also enable one stage at a time before the
 combined run. On the installed Ref2VA artifact, all five stages selected in all

--- a/docs/benchmarks/minimax-h3-h3c-transfer.md
+++ b/docs/benchmarks/minimax-h3-h3c-transfer.md
@@ -89,6 +89,41 @@ scripts/h3-kernel-lab.sh mpp-projections
 This round deliberately targets the resident-BF16 M3/M4 path; M5-specific
 TensorOps work is out of scope.
 
+### M4 W8A8 and MXFP8 rejection
+
+The MLX Metal backend does not expose a competitive W8A8 path on the M4 Max.
+MLX's `QQMatmul` quantizes and dequantizes the activation, then routes the
+prepared weight through the quantized matrix-vector dispatcher. The NAX path
+requires Apple GPU generation 18 or later. The measured M4 Max is generation
+16.
+
+An env-gated synthetic projection gate prequantized the weight outside the
+timed region and compared MLX MXFP8 QQMM with resident BF16 matrix
+multiplication. The 5,376 to 14,336 half-FC1 shape produced:
+
+| Rows | Resident BF16 | MXFP8 QQMM | Speedup | Relative L2 |
+| ---: | ---: | ---: | ---: | ---: |
+| 128 | 1.671 ms | 5.679 ms | 0.294x | 0.110748 |
+| 1,024 | 10.971 ms | 43.908 ms | 0.250x | 0.110763 |
+
+The 1,024-row result rules out a tiny-matrix artifact: MXFP8 was four times
+slower and already introduced approximately 11% relative L2 error before any
+50-block accumulation. The runtime therefore does not select this path on M4.
+Reproduce the research gate with:
+
+```bash
+MERERUN_H3_BENCH_PROJECTION=ff1-half \
+MERERUN_H3_BENCH_ROWS=1024 \
+  scripts/h3-kernel-lab.sh mxfp8
+```
+
+Resident BF16 cannot close the native-canvas target through software dispatch
+alone either. At 89,459 rows, the real-checkpoint BF16 K4 diagnostic measured
+2,779.228 ms for FC1 plus SwiGLU and 1,808.893 ms for FC2. Its 4.588-second MLP
+floor per block execution is only 1.095x below the 5.024-second Float32 K4
+result and remains 3.6 times above the complete 1.275-second block budget for a
+five-minute 1,344 by 768 request, before attention and the other block phases.
+
 The quality-sensitive algorithm arms remain non-default. Reduced canvas,
 layer thinning, complete velocity reuse, and token reduction all produced
 material same-seed trajectory changes. The three-seed Ref2VA follow-up closed

--- a/docs/benchmarks/minimax-h3-h3c-transfer.md
+++ b/docs/benchmarks/minimax-h3-h3c-transfer.md
@@ -7,28 +7,43 @@ memory, and fallback gates.
 
 ## Promotion conclusion
 
-The original scalar-SIMD affine-Q8 matrix cores remain rejected: they are
-roughly four to five times slower than stock MLX at H3's production shapes.
-The FastH3 Q8 MLP now uses a separate matrix-tiled Metal schedule. K4a stages a
+The original scalar-SIMD affine-Q8 matrix cores remain rejected because they
+are roughly four to five times slower than stock MLX at H3's production shapes.
+The FastH3 Q8 MLP uses a separate matrix-tiled Metal schedule. K4a stages a
 32-row by 32-output tile and keeps both FC1 projections in registers through
-the SwiGLU epilogue; K4b stages a 32-row by 64-output tile. Both dequantize each
-Q8/group-64 weight tile once into threadgroup memory and accumulate BF16 matrix
-operands in FP32.
+the SwiGLU epilogue. K4b stages a 32-row by 64-output tile. Both kernels
+dequantize each Q8/group-64 weight tile once into threadgroup memory.
 
-The tiled K4 path is the default only for the managed FastH3 VSA Q8 recipe.
-Other H3 variants retain stock MLX unless `MERERUN_H3_EXACT_KERNELS=affine-q8-mlp`
-is selected explicitly. `MERERUN_H3_EXACT_KERNELS=disabled` opts the FastH3
-recipe out. K2b and K3 remain experimental because their scalar matrix cores
-did not win.
+The live FastH3 residual and MLP activation stream is Float32. The production
+K4 path therefore uses Float32 SIMD-group matrix operands and accumulators.
+The kernel template retains BF16 operands only when a BF16 diagnostic input
+selects that type. An earlier BF16-only candidate passed an isolated benchmark
+but didn't dispatch in the live transformer. Narrowing the live Float32 stream
+to BF16 caused unacceptable error across 50 blocks and was rejected.
 
-At 89,188 rows on the packaged FastH3 checkpoint, the correct chunked portable
-oracle measured 3,813.785 ms for FC1 plus SwiGLU and 2,176.992 ms for FC2. The
-tiled kernels measured 3,445.900 ms and 2,073.032 ms respectively: 1.107x and
-1.050x. FC1 relative L2 was 0.000767212, with a worst 32,768-row chunk of
-0.000767620; FC2 was bit-identical. K4a also avoids the 5.11 GiB
-`[1, 89188, 28672]` FC1 projection. The unchunked stock path wraps that
-intermediate after its 4 GiB boundary, so high-resolution validation must use
-the chunked oracle rather than treating the corrupt tail as a baseline.
+The managed FastH3 VSA Q8 recipe selects `fasth3-metal` automatically. This
+mode combines attention AdaLN, post-attention gate and AdaLN, Q/K normalization
+and rotary embedding, and the tiled Q8 MLP. Other H3 variants retain stock MLX
+unless you select an exact mode explicitly. Set
+`MERERUN_H3_EXACT_KERNELS=disabled` to compare FastH3 with the portable MLX
+path. K2b and K3 remain experimental because their scalar matrix cores didn't
+win.
+
+At 89,188 rows on the packaged FastH3 checkpoint, the Float32 tiled FC1 plus
+SwiGLU result had relative L2 `3.82194e-8` against the chunked portable oracle.
+FC2 was bit-identical. An exploratory run measured 3,784.052 ms compared with
+3,508.304 ms for FC1 and 2,042.034 ms compared with 1,881.471 ms for FC2. These
+values are `1.079x` and `1.085x`. The host had approximately 31 GiB of system
+swap and another inference service, so these timings are candidate evidence,
+not a clean performance receipt.
+
+K4a also avoids the 9.53 GiB Float32 `[1, 89188, 28672]` FC1 projection. The
+portable oracle remains chunked to 32,768 rows. Evaluating both complete
+89,188-row intermediates together under memory pressure produced an invalid
+comparison, so the production-shape gate compares each chunk independently.
+The compact `[1, 89188, 14336]` result is 4.76 GiB. At shapes where this result
+exceeds 4 GiB, the compiled block runner evaluates K4a before K4b. Smaller
+shapes retain one compiled post-attention region.
 
 Reproduce the installed-checkpoint stage gate with:
 
@@ -36,6 +51,25 @@ Reproduce the installed-checkpoint stage gate with:
 MERERUN_H3_EXACT_KERNEL_MODEL_ROOT=/path/to/video-minimax-h3-fasth3-vsa-datafree-mlx \
   scripts/h3-kernel-lab.sh affine-mlp-real
 ```
+
+## FastH3 CUDA recipe parity
+
+FastVideo's published B200 path combines four independent optimizations:
+
+- The student uses four DiT calls instead of Base H3's 49 calls.
+- VSA-H3 keeps approximately 10% of eligible video-to-video tile-64 attention.
+- H3-specific kernels fuse modulation, Q/K normalization and rotary embedding,
+  and SwiGLU boundaries.
+- The runtime uses regional full-graph DiT compilation, FlashAttention 4,
+  compiled video VAE decoding, and multi-GPU sequence parallelism.
+
+The Metal recipe implements the transferable parts: the four-call schedule,
+compact tile-64 VSA routes, compiled block regions, cached AdaLN, and the same
+three fusion families. The M4 Max doesn't provide the B200 `sm100a`
+block-sparse kernel, FlashAttention 4, eight-GPU parallelism, or the same VAE
+decode throughput. FastVideo's 12.88-second result also uses eight B200 GPUs
+and excludes model loading and compilation after warmup. It isn't a
+single-device latency target for the M4 Max.
 
 Resident BF16 has a separate M3/M4 opportunity. The refreshed MLX source has
 a Metal 4 NAX GEMM implementation, but its runtime capability gate
@@ -246,9 +280,11 @@ immediate SwiGLU into the same dispatch, writing only the compact
 `[1, rows, 14336]` activation. It therefore removes the 28,672-wide FC1 tensor.
 K4b applies the exact `14336 -> 5376` FC2 projection to that compact result.
 Both candidates retain the graph's BF16 or Float32 activation boundary and
-compare independently with MLX `quantizedMM`; they do not yet consume K1's symmetric activation-INT8
-rows. The whole-path isolated release arm alternates the decomposed and fused
-orders and reports the FC1 materialization bytes avoided:
+compare independently with MLX `quantizedMM`. Float32 inputs use Float32
+SIMD-group matrix operands instead of narrowing the live residual stream. The
+kernels don't consume K1's symmetric activation-INT8 rows. The whole-path
+isolated release arm alternates the decomposed and fused orders and reports the
+FC1 materialization bytes avoided:
 
 ```bash
 scripts/h3-kernel-lab.sh affine-ffn
@@ -271,10 +307,10 @@ scripts/h3-kernel-lab.sh buffer-alias
 
 ### Installed-checkpoint exact-kernel dispatch
 
-`MERERUN_H3_EXACT_KERNELS=boundary-layout` enables only the exact candidates
-that won their clean production-shape microbenchmarks: K1 gated AdaLN and K2a
-head-major QKV layout with fused Q/K normalization and RoPE. It retains MLX's
-quantized projections instead of selecting the slower custom affine-Q8 GEMMs.
+`MERERUN_H3_EXACT_KERNELS=boundary-layout` enables only the exact boundary
+candidates: K0 attention AdaLN, K1 gated AdaLN, and K2a head-major QKV layout
+with fused Q/K normalization and RoPE. It retains MLX's quantized projections
+instead of selecting the slower custom affine-Q8 GEMMs.
 The mode remains explicit, requires `--h3-acceleration quality`, and falls back
 per call when the exact H3 shape or dtype contract is unavailable. Sequences at
 or below 12,000 rows retain whole-step compilation. Larger sequences use eager
@@ -289,19 +325,31 @@ transformer block must retain its unadapted affine Q8/group-64 QKV, output, FC1,
 and FC2 linears, and resident-BF16 materialization must be off. The mode forces
 eager block execution so custom-kernel behavior and memory remain attributable.
 
-Within an admitted block, K2b handles QKV projection plus Q/K norm/RoPE, K3
-handles the head-major attention output projection, K1 fuses the attention
-residual into the following feed-forward AdaLN, and K4 handles both feed-forward
-projections. Every custom call still validates its complete shape, dtype, and
-quantization contract and falls back to the decomposed graph if that individual
-contract is unavailable. K1's activation-INT8 output remains a lab boundary:
-the installed path uses its BF16 sibling until a projection consumes the
-dynamic INT8 rows directly.
+Within an admitted block, K0 fuses attention RMSNorm with the row-indexed scale
+and shift. K2b handles QKV projection plus Q/K norm and RoPE. K3 handles the
+head-major attention output projection. K1 fuses the attention residual into
+the following feed-forward AdaLN, and K4 handles both feed-forward projections.
+Every custom call validates its complete shape, dtype, and quantization contract
+and falls back to the decomposed graph if that contract is unavailable. K1's
+activation-INT8 output remains a lab boundary. The installed path uses its
+floating-point sibling until a projection consumes the dynamic INT8 rows
+directly.
 
 `MERERUN_H3_EXACT_KERNELS=affine-q8-mlp` selects only the matrix-tiled K4a and
-K4b kernels. It does not select K1, K2, or K3. The managed FastH3 VSA Q8 recipe
-uses this mode automatically when the environment variable is absent; setting
-the variable to `disabled` retains the portable MLX MLP for diagnostics.
+K4b kernels. It doesn't select K0, K1, K2, or K3.
+
+`MERERUN_H3_EXACT_KERNELS=fasth3-metal` selects K0, K1, K2a, K4a, and K4b.
+The managed FastH3 VSA Q8 recipe uses this mode automatically when the
+environment variable is absent. FastH3 retains release-mode block compilation;
+the custom kernels run inside the compiled projection and post-attention
+regions. Setting the variable to `disabled` retains the portable MLX path for
+diagnostics.
+
+The installed FastH3 50-block gate dispatched all five selected stages in every
+block with no fallback. Against the decomposed graph, the seven-row deterministic
+forward measured video relative L2 `0.000926183` and audio relative L2
+`0.00116363`. The corresponding `boundary-layout` comparison measured
+`0.000169663` and `0.000345908`.
 
 The gated real-weight test can also enable one stage at a time before the
 combined run. On the installed Ref2VA artifact, all five stages selected in all
@@ -368,9 +416,11 @@ K5 buffer donation avoided a 160,841,728-byte retained peak increment. The
 direct QKV and FFN arms also exceeded their synthetic absolute-error envelopes;
 all affine stages nevertheless remained below `0.00044` combined relative L2
 in the installed 50-block Ref2VA arithmetic gate. The speed regressions are
-decisive: K2b/K3/K4 remain research prototypes until their GEMM core uses a
-competitive MLX/Metal matrix path. `boundary-layout` is the only exact mode
-advanced to generated-media evaluation from this run.
+decisive: K2b/K3 and the scalar K4 implementation remain research prototypes
+until their GEMM core uses a competitive MLX/Metal matrix path.
+`boundary-layout` was the only exact mode advanced to generated-media
+evaluation from this historical run. The separate FastH3 tiled K4 schedule was
+qualified later.
 
 ### Clean generated-media result
 
@@ -752,8 +802,9 @@ The portable direction is therefore narrower, not more aggressive: retain the
 exact reference-serving alignment, evaluate a 448 x 224 (87.5%) internal canvas,
 at most one reused middle evaluation, less aggressive token pairing/block
 spans, and true load-time pruning for A2 before another promotion attempt.
-Exact `boundary-layout` remains the only h3.c kernel lane with a supported
-experimental execution policy in this PR.
+For the Ref2VA and FL2VA h3.c comparison in this section, exact
+`boundary-layout` remains the only supported experimental execution policy.
+The dedicated FastH3 recipe uses its separately qualified `fasth3-metal` mode.
 
 ## Acceptance gates
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -2374,6 +2374,7 @@ mere.run adapter pull minimax-h3-lightx2v-8step-v1
 mere.run adapter pull minimax-h3-lightx2v-4step-v1-768p
 mere.run adapter pull minimax-h3-lightx2v-8step-v1-768p
 mere.run adapter pull minimax-h3-lightx2v-ref2v-4step-v0.1
+mere.run adapter pull minimax-h3-fasth3-vsa-datafree-4step --accept-license
 ```
 
 The pull verifies the cataloged byte count and SHA-256 before atomically
@@ -2387,6 +2388,22 @@ adapters support the compact BF16 and affine Q8 FL2VA bases and reject the
 legacy Q4 compatibility package. The Ref2V adapter uses the managed Ref2VA base
 expanded to resident BF16. All bases remain subject to MiniMax-H3 Community
 License acceptance.
+
+The preferred FastH3 path is a single managed model pull:
+
+```bash
+mere.run model pull video-minimax-h3-fasth3-vsa-datafree-mlx \
+  --accept-model-license
+mere.run video generate "a lighthouse in a winter storm" \
+  --model video-minimax-h3-fasth3-vsa-datafree-mlx \
+  --output ./lighthouse-fasth3.mp4
+```
+
+This package contains the compact BF16 base, FastH3 VSA DataFree adapter, and
+source-bound AdaLN cache. It doesn't require a separate download or preparation
+step after the model pull. The lower-level adapter command remains available to
+developers building or verifying the package. FastH3 accepts text-only FL2VA,
+requires adapter strength `1.0`, and uses the quality acceleration mode.
 
 For a cross-command decision guide, see [Benchmarking](./benchmarking.md). The
 following subsections provide the command reference for each benchmark lane.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -2404,7 +2404,9 @@ compression gates, Q8 text encoder, both VAEs, tokenizer, and source-bound
 AdaLN cache. It doesn't require another download or preparation step after the
 model pull. The lower-level adapter command remains available to developers who
 build or verify the package. FastH3 accepts text-only FL2VA, requires adapter
-strength `1.0`, and uses the quality acceleration mode.
+strength `1.0`, and uses the quality acceleration mode. Managed affine Q8
+FastH3 roots automatically use the Metal tiled MLP; developers can set
+`MERERUN_H3_EXACT_KERNELS=disabled` for a portable-path comparison.
 
 For a cross-command decision guide, see [Benchmarking](./benchmarking.md). The
 following subsections provide the command reference for each benchmark lane.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -2399,11 +2399,12 @@ mere.run video generate "a lighthouse in a winter storm" \
   --output ./lighthouse-fasth3.mp4
 ```
 
-This package contains the compact BF16 base, FastH3 VSA DataFree adapter, and
-source-bound AdaLN cache. It doesn't require a separate download or preparation
-step after the model pull. The lower-level adapter command remains available to
-developers building or verifying the package. FastH3 accepts text-only FL2VA,
-requires adapter strength `1.0`, and uses the quality acceleration mode.
+This package contains the premerged affine Q8/group-64 FastH3 student, Q8
+compression gates, Q8 text encoder, both VAEs, tokenizer, and source-bound
+AdaLN cache. It doesn't require another download or preparation step after the
+model pull. The lower-level adapter command remains available to developers who
+build or verify the package. FastH3 accepts text-only FL2VA, requires adapter
+strength `1.0`, and uses the quality acceleration mode.
 
 For a cross-command decision guide, see [Benchmarking](./benchmarking.md). The
 following subsections provide the command reference for each benchmark lane.

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -1384,25 +1384,27 @@ The adapter contains 362 LoRA pairs, 82 direct differences, and 50 VSA-H3
 compression-gate weights. The runtime consumes the released `fastvideo-lora-v2`
 format without producing a fused checkpoint.
 
-The managed `video-minimax-h3-fasth3-vsa-datafree-mlx` package combines that
-adapter and its source-bound AdaLN cache with the compact BF16 FL2VA runtime
-files in `Sawfwair/MiniMax-H3-FastH3-VSA-DataFree-MLX-BF16` at immutable
-revision `4208e52b28074fac87f7639281b1a4d564aba4a1`. One explicit license-accepting
-pull installs every asset used by supported FastH3 inference; the runtime does
-not fetch a second model or adapter during generation.
+The managed `video-minimax-h3-fasth3-vsa-datafree-mlx` package stores a
+premerged affine Q8/group-64 student in
+`Sawfwair/MiniMax-H3-FastH3-VSA-DataFree-MLX-Q8` at immutable revision
+`6068ae3dafafb1e4b2afb29f3109745a16912e07`. The package also includes the Q8
+text encoder, both VAEs, tokenizer, Q8 compression gates, and source-bound AdaLN
+table. One explicit license-accepting pull installs every asset used by
+supported FastH3 inference. The runtime doesn't fetch a second model or adapter
+during generation.
 
-FastH3 changes the base transformer's time and AdaLN projections. For compact
-BF16, the preparation script range-reads the required tensors from
+FastH3 changes the base transformer's time and AdaLN projections. The
+preparation script range-reads the required tensors from
 `FastVideo/FastVideo-FastH3-4-step-Preview-v1-VSA-DataFree` at immutable
 revision `b65818d41939b5085451074fe8ca8b799f8d4921`. The script verifies the
 transformer index SHA-256, evaluates the four released DMD points with MLX
-Metal, and stores the source-bound cache beside the adapter. This workflow
-transfers about 26 GiB but doesn't store the 70 GB student transformer. It is
-not full-checkpoint or output-quality proof. The MiniMax-H3 Community License
-continues to govern the base and student weights.
-The runtime remaps the adapter's fused QKV output rows into the same global
-Q/K/V slab order as the converted base and applies all 362 LoRA pairs as live
-activation deltas, including the schedule-only AdaLN projections.
+Metal, and stores the source-bound cache beside the compression gates. The
+offline merge tool verifies all 362 LoRA pairs, 82 direct differences, and 50
+compression gates. It merges 208 inference linear targets with FP32
+accumulation, rounds once to BF16, and encodes the result as MLX affine
+Q8/group-64. The runtime loads the premerged transformer and doesn't apply live
+LoRA deltas. The MiniMax-H3 Community License continues to govern the base and
+student weights.
 
 Another managed H3 adapter, `minimax-h3-lightx2v-4step`, pins
 `minimax_h3_fl2v_turbo_4step_v0.1.safetensors` from

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -167,6 +167,7 @@ an effective overlay; they are not a second capability catalog.
 | `video` | `video-minimax-h3-fl2va-mlx` |
 | `video` | `video-minimax-h3-fl2va-bf16-mlx` |
 | `video` | `video-minimax-h3-fl2va-8bit-mlx` |
+| `video` | `video-minimax-h3-fasth3-vsa-datafree-mlx` |
 | `video` | `video-minimax-h3-ref2va-mlx` |
 | `video` | `video-cosmos3-edge-mlx` |
 | `video` | `video-scail2-14b-mlx` |
@@ -219,7 +220,7 @@ validates all configured models before downloading any; both accept the same
 | `vision-segment-sam31` | Meta SAM License custom use, trade-control, attribution, and redistribution conditions |
 | `vision-face-buffalo-l` | InsightFace pretrained weights; non-commercial research use |
 | `vision-embed-olmoearth-v12-{nano,tiny,small,base}` | OlmoEarth Artifact License; prohibited military, defense, intelligence, human-surveillance, policing, and listed extractive uses |
-| `video-minimax-h3-fl2va-mlx`, `video-minimax-h3-fl2va-bf16-mlx`, `video-minimax-h3-fl2va-8bit-mlx`, `video-minimax-h3-ref2va-mlx` | MiniMax-H3 Community License; use, distribution, and display are excluded in the United States, European Union, United Kingdom, and Republic of Korea, with downstream notice and safeguard obligations |
+| `video-minimax-h3-fl2va-mlx`, `video-minimax-h3-fl2va-bf16-mlx`, `video-minimax-h3-fl2va-8bit-mlx`, `video-minimax-h3-fasth3-vsa-datafree-mlx`, `video-minimax-h3-ref2va-mlx` | MiniMax-H3 Community License; use, distribution, and display are excluded in the United States, European Union, United Kingdom, and Republic of Korea, with downstream notice and safeguard obligations |
 | `image-3d-trellis2-4b` | the mounted DINOv3 encoder is gated under Meta's custom DINOv3 License |
 | `music-muscriptor-{small,medium,large}` | CC BY-NC 4.0 model weights |
 | `sfx-woosh-*` | CC BY-NC 4.0 Woosh or MMAudio Synchformer weights |
@@ -1372,11 +1373,38 @@ The optional `minimax-h3-turbo-4step` runtime adapter is the EMA checkpoint
 `5a6eeba171cf183020a4ad48774bb2968f29f8168afd6ec17a04987f3528b4ea`.
 The adapter card declares Apache-2.0, but using it does not replace or relax
 the MiniMax-H3 Community License governing the required BF16 base model.
+
+The managed `minimax-h3-fasth3-vsa-datafree-4step` adapter pins
+`vsa-datafree/adapter_model.safetensors` from
+`FastVideo/FastVideo-FastH3-4-step-Preview-v1-LoRA` at immutable revision
+`bcf40ca6f457ed66f8badf13514943e390205fca`. The catalog verifies its exact
+5,339,117,712-byte length and SHA-256
+`42dc502a2078f166c396a1fa75f29728d1844363652d345d5ef3e2b444ed6470`.
+The adapter contains 362 LoRA pairs, 82 direct differences, and 50 VSA-H3
+compression-gate weights. The runtime consumes the released `fastvideo-lora-v2`
+format without producing a fused checkpoint.
+
+The managed `video-minimax-h3-fasth3-vsa-datafree-mlx` package combines that
+adapter and its source-bound AdaLN cache with the compact BF16 FL2VA runtime
+files in `Sawfwair/MiniMax-H3-FastH3-VSA-DataFree-MLX-BF16` at immutable
+revision `4208e52b28074fac87f7639281b1a4d564aba4a1`. One explicit license-accepting
+pull installs every asset used by supported FastH3 inference; the runtime does
+not fetch a second model or adapter during generation.
+
+FastH3 changes the base transformer's time and AdaLN projections. For compact
+BF16, the preparation script range-reads the required tensors from
+`FastVideo/FastVideo-FastH3-4-step-Preview-v1-VSA-DataFree` at immutable
+revision `b65818d41939b5085451074fe8ca8b799f8d4921`. The script verifies the
+transformer index SHA-256, evaluates the four released DMD points with MLX
+Metal, and stores the source-bound cache beside the adapter. This workflow
+transfers about 26 GiB but doesn't store the 70 GB student transformer. It is
+not full-checkpoint or output-quality proof. The MiniMax-H3 Community License
+continues to govern the base and student weights.
 The runtime remaps the adapter's fused QKV output rows into the same global
-Q/K/V slab order as the converted base and applies all 259 LoRA pairs as live
+Q/K/V slab order as the converted base and applies all 362 LoRA pairs as live
 activation deltas, including the schedule-only AdaLN projections.
 
-The second managed H3 adapter, `minimax-h3-lightx2v-4step`, pins
+Another managed H3 adapter, `minimax-h3-lightx2v-4step`, pins
 `minimax_h3_fl2v_turbo_4step_v0.1.safetensors` from
 `lightx2v/Minimax-h3-Turbo` at immutable commit
 `b65e359c0d128b3c5e08e0f5bf2791b794378588`. The catalog verifies its exact

--- a/docs/runtime/video.md
+++ b/docs/runtime/video.md
@@ -64,8 +64,9 @@ are an escape hatch, not the capability contract.
   same conditioner, VAEs, cache pack, and provenance as compact BF16. Q8 is a
   storage and memory option, not an advertised speedup without measurements.
 - `video-minimax-h3-fasth3-vsa-datafree-mlx`: dedicated four-evaluation FastH3
-  package with the compact BF16 base, student adapter, AdaLN sidecar, and Metal
-  VSA-H3 sparse attention in one explicit license-accepting pull.
+  package with a premerged affine Q8/group-64 student, Q8 compression gates,
+  source-bound AdaLN table, and compact Metal VSA-H3 routing in one explicit
+  license-accepting pull.
 - `video-minimax-h3-ref2va-mlx`: explicit-pull 8-bit Ref2VA package. Repeated
   `--reference image:path|video:path|audio:path` options retain request order.
   Video soundtracks are conditioned with their video; a standalone audio
@@ -229,22 +230,26 @@ and 0.001427 RMSE. This proves why the exact table is preferable; it doesn't by
 itself constitute a same-seed visual or audio quality qualification.
 
 `video-minimax-h3-fasth3-vsa-datafree-mlx` is a self-contained FastVideo student
-package. One explicit model pull installs the compact BF16 base, FastH3 adapter,
-and source-bound AdaLN cache. Generation doesn't require another model or
-adapter download. The recipe requires adapter strength `1.0`. Its
+package. One explicit model pull installs the premerged Q8 student, Q8 text
+encoder, both VAEs, tokenizer, Q8 compression gates, and source-bound AdaLN
+table. Generation doesn't require another model or adapter download. The recipe
+requires adapter strength `1.0`. Its
 four denoising evaluations use base sigma points `0.999`, `0.749`, `0.5`, and
 `0.25`, followed by the clean endpoint. MLX Metal runs FastH3's 64-token VSA
 tiles, per-head top-k routes at 90% video-key sparsity, and learned pooled-value
-compression gates. Prefix queries remain dense, and video queries retain every
-prefix key tile. The recipe accepts text-only generation. It rejects frame
-conditioning, continuation, references, and additional H3 approximation modes.
+compression gates. The Metal kernel consumes compact selected-video route
+tables, so video queries don't scan rejected tiles. Prefix queries remain
+dense, and video queries retain every prefix key tile. The recipe accepts
+text-only generation. It rejects frame conditioning, continuation, references,
+and additional H3 approximation modes.
 
 The package build uses
-`scripts/model-conversion/prepare_minimax_h3_fasth3_vsa.py` to reconstruct the
-schedule-only AdaLN values that the compact BF16 base omits. The script verifies
-the adapter, range-reads about 26 GiB from the pinned student transformer, and
-writes only the approximately 120 MB source-bound cache. End users who pull the
-dedicated managed model don't run this build step.
+`scripts/model-conversion/merge_minimax_h3_fasth3_q8.py` after creating the
+source-bound table with `prepare_minimax_h3_fasth3_vsa.py`. The merge script
+verifies all 362 LoRA pairs, 82 direct differences, and 50 compression gates.
+It merges 208 inference linear targets with FP32 accumulation, rounds once to
+BF16, and writes MLX affine Q8/group-64 weights. End users who pull the managed
+model don't run either build step.
 
 `--h3-frame FRAME:PATH` adds an FL2VA keyframe at an exact zero-based output
 frame. Values may be repeated up to the released 12-frame condition limit and

--- a/docs/runtime/video.md
+++ b/docs/runtime/video.md
@@ -243,6 +243,13 @@ dense, and video queries retain every prefix key tile. The recipe accepts
 text-only generation. It rejects frame conditioning, continuation, references,
 and additional H3 approximation modes.
 
+On affine Q8 FastH3 roots, Metal also selects the shape-specific tiled MLP.
+It fuses FC1 with SwiGLU, avoids the two-wide FC1 projection slab, and applies
+FC2 with a separate matrix tile. This keeps the 89,188-row high-resolution path
+below the 4 GiB intermediate boundary. Set
+`MERERUN_H3_EXACT_KERNELS=disabled` only when comparing against the portable
+MLX path.
+
 The package build uses
 `scripts/model-conversion/merge_minimax_h3_fasth3_q8.py` after creating the
 source-bound table with `prepare_minimax_h3_fasth3_vsa.py`. The merge script

--- a/docs/runtime/video.md
+++ b/docs/runtime/video.md
@@ -243,12 +243,21 @@ dense, and video queries retain every prefix key tile. The recipe accepts
 text-only generation. It rejects frame conditioning, continuation, references,
 and additional H3 approximation modes.
 
-On affine Q8 FastH3 roots, Metal also selects the shape-specific tiled MLP.
-It fuses FC1 with SwiGLU, avoids the two-wide FC1 projection slab, and applies
-FC2 with a separate matrix tile. This keeps the 89,188-row high-resolution path
-below the 4 GiB intermediate boundary. Set
+On affine Q8 FastH3 roots, Metal selects the `fasth3-metal` exact-kernel mode.
+This mode fuses attention AdaLN, post-attention gate and AdaLN, Q/K
+normalization and rotary embedding, FC1 and SwiGLU, and FC2. Float32 activation
+streams use Float32 SIMD-group matrix operands and accumulators. The mode runs
+inside FastH3's release-mode compiled block regions.
+
+The fused FC1 writes only the compact SwiGLU result. It doesn't create the
+9.53 GiB Float32 `[1, 89188, 28672]` projection for a 1,344 by 768 pixel,
+294-frame request. The remaining compact result is 4.76 GiB. At shapes where
+that result exceeds 4 GiB, the compiled runner evaluates FC1 and SwiGLU before
+FC2 to preserve 64-bit indexing. Each kernel validates its complete shape,
+dtype, and affine Q8/group-64 contract before dispatch. Set
 `MERERUN_H3_EXACT_KERNELS=disabled` only when comparing against the portable
-MLX path.
+MLX path. To select the combined mode explicitly, set
+`MERERUN_H3_EXACT_KERNELS=fasth3-metal`.
 
 The package build uses
 `scripts/model-conversion/merge_minimax_h3_fasth3_q8.py` after creating the

--- a/docs/runtime/video.md
+++ b/docs/runtime/video.md
@@ -63,6 +63,9 @@ are an escape hatch, not the capability contract.
   uses MLX affine INT8/group-64 for eligible core linears while retaining the
   same conditioner, VAEs, cache pack, and provenance as compact BF16. Q8 is a
   storage and memory option, not an advertised speedup without measurements.
+- `video-minimax-h3-fasth3-vsa-datafree-mlx`: dedicated four-evaluation FastH3
+  package with the compact BF16 base, student adapter, AdaLN sidecar, and Metal
+  VSA-H3 sparse attention in one explicit license-accepting pull.
 - `video-minimax-h3-ref2va-mlx`: explicit-pull 8-bit Ref2VA package. Repeated
   `--reference image:path|video:path|audio:path` options retain request order.
   Video soundtracks are conditioned with their video; a standalone audio
@@ -131,6 +134,14 @@ mere.run adapter pull minimax-h3-lightx2v-4step
 mere.run adapter pull minimax-h3-lightx2v-8step-v1
 mere.run adapter pull minimax-h3-lightx2v-4step-v1-768p
 mere.run adapter pull minimax-h3-lightx2v-ref2v-4step-v0.1
+
+# The dedicated FastH3 package includes its base, adapter, and AdaLN cache.
+mere.run model pull video-minimax-h3-fasth3-vsa-datafree-mlx \
+  --accept-model-license
+mere.run video generate "a lighthouse in a winter storm" \
+  --model video-minimax-h3-fasth3-vsa-datafree-mlx \
+  --output ./lighthouse-fasth3.mp4
+
 mere.run video generate "a superhero waits beneath an umbrella at a bus stop" \
   --model video-minimax-h3-fl2va-8bit-mlx \
   --width 960 --height 544 \
@@ -216,6 +227,24 @@ against the former interpolation path covered 116,444,160 values: 88.40% were
 already exact, while the remaining values reached 0.125 maximum absolute error
 and 0.001427 RMSE. This proves why the exact table is preferable; it doesn't by
 itself constitute a same-seed visual or audio quality qualification.
+
+`video-minimax-h3-fasth3-vsa-datafree-mlx` is a self-contained FastVideo student
+package. One explicit model pull installs the compact BF16 base, FastH3 adapter,
+and source-bound AdaLN cache. Generation doesn't require another model or
+adapter download. The recipe requires adapter strength `1.0`. Its
+four denoising evaluations use base sigma points `0.999`, `0.749`, `0.5`, and
+`0.25`, followed by the clean endpoint. MLX Metal runs FastH3's 64-token VSA
+tiles, per-head top-k routes at 90% video-key sparsity, and learned pooled-value
+compression gates. Prefix queries remain dense, and video queries retain every
+prefix key tile. The recipe accepts text-only generation. It rejects frame
+conditioning, continuation, references, and additional H3 approximation modes.
+
+The package build uses
+`scripts/model-conversion/prepare_minimax_h3_fasth3_vsa.py` to reconstruct the
+schedule-only AdaLN values that the compact BF16 base omits. The script verifies
+the adapter, range-reads about 26 GiB from the pinned student transformer, and
+writes only the approximately 120 MB source-bound cache. End users who pull the
+dedicated managed model don't run this build step.
 
 `--h3-frame FRAME:PATH` adds an FL2VA keyframe at an exact zero-based output
 frame. Values may be repeated up to the released 12-frame condition limit and

--- a/scripts/h3-kernel-lab.sh
+++ b/scripts/h3-kernel-lab.sh
@@ -131,6 +131,13 @@ case "$mode" in
   projections)
     run_release_test DiTShapeBenchTests/testMiniMaxH3QmmVsResidentBF16
     ;;
+  mxfp8)
+    export MERERUN_TEST_MLX_DEVICE=gpu
+    export MERERUN_H3_BENCH_ROWS="${MERERUN_H3_BENCH_ROWS:-128}"
+    export MERERUN_H3_BENCH_ROUNDS="${MERERUN_H3_BENCH_ROUNDS:-2}"
+    export MERERUN_H3_BENCH_ITERATIONS="${MERERUN_H3_BENCH_ITERATIONS:-2}"
+    run_release_test DiTShapeBenchTests/testMiniMaxH3MXFP8QQMM
+    ;;
   mpp-projections)
     export MERERUN_H3_MPP_BENCH=1
     export MERERUN_TEST_MLX_DEVICE=gpu
@@ -281,7 +288,7 @@ case "$mode" in
     run_release_test MiniMaxH3Tests/testInstalledAudioVAEDecodeMatchesReference
     ;;
   *)
-    print -u2 "usage: scripts/h3-kernel-lab.sh [quick|attention|attention-block|projections|mpp-projections|modulation|attention-adaln|gate-adaln|gate-adaln-int8|qkv-layout|qkv-direct|affine-oproj|affine-ffn|buffer-alias|exact-ref2va|block|post|dtype|turnover|boundary|gemm|gemm-block|vae|audio-parity]"
+    print -u2 "usage: scripts/h3-kernel-lab.sh [quick|attention|attention-block|projections|mxfp8|mpp-projections|modulation|attention-adaln|gate-adaln|gate-adaln-int8|qkv-layout|qkv-direct|affine-oproj|affine-ffn|buffer-alias|exact-ref2va|block|post|dtype|turnover|boundary|gemm|gemm-block|vae|audio-parity]"
     exit 64
     ;;
 esac

--- a/scripts/h3-kernel-lab.sh
+++ b/scripts/h3-kernel-lab.sh
@@ -191,6 +191,16 @@ case "$mode" in
     run_release_test \
       MiniMaxH3FusedKernelTests/testFusedFeedForwardAffineInt8ReleaseBenchmark
     ;;
+  affine-mlp-real)
+    default_fast_h3_root="${HOME}/Library/Application Support/MereRun/models/video-minimax-h3-fasth3-vsa-datafree-mlx"
+    export MERERUN_H3_AFFINE_MLP_REAL_STAGE_BENCH=1
+    export MERERUN_TEST_MLX_DEVICE=gpu
+    export MERERUN_H3_EXACT_KERNEL_MODEL_ROOT="${MERERUN_H3_EXACT_KERNEL_MODEL_ROOT:-$default_fast_h3_root}"
+    export MERERUN_H3_BENCH_ROWS="${MERERUN_H3_BENCH_ROWS:-89188}"
+    export MERERUN_H3_BENCH_ROUNDS="${MERERUN_H3_BENCH_ROUNDS:-2}"
+    run_release_test \
+      MiniMaxH3Tests/testInstalledAffineQ8MLPStageReleaseBenchmark
+    ;;
   buffer-alias)
     export MERERUN_H3_BUFFER_DONATION_BENCH=1
     export MERERUN_TEST_MLX_DEVICE=gpu

--- a/scripts/h3-kernel-lab.sh
+++ b/scripts/h3-kernel-lab.sh
@@ -143,6 +143,14 @@ case "$mode" in
     export MERERUN_H3_BENCH_ROWS="${MERERUN_H3_BENCH_ROWS:-29018}"
     run_release_test DiTShapeBenchTests/testMiniMaxH3AdaLNRunModulation
     ;;
+  attention-adaln)
+    export MERERUN_H3_ATTENTION_ADALN_BENCH=1
+    export MERERUN_TEST_MLX_DEVICE=gpu
+    export MERERUN_H3_BENCH_ROWS="${MERERUN_H3_BENCH_ROWS:-14958}"
+    export MERERUN_H3_BENCH_ROUNDS="${MERERUN_H3_BENCH_ROUNDS:-4}"
+    run_release_test \
+      MiniMaxH3FusedKernelTests/testPrepareAttentionInputReleaseBenchmark
+    ;;
   gate-adaln)
     export MERERUN_H3_FUSED_KERNEL_BENCH=1
     export MERERUN_TEST_MLX_DEVICE=gpu
@@ -186,6 +194,7 @@ case "$mode" in
   affine-ffn)
     export MERERUN_H3_AFFINE_FFN_BENCH=1
     export MERERUN_TEST_MLX_DEVICE=gpu
+    export MERERUN_H3_BENCH_DTYPE="${MERERUN_H3_BENCH_DTYPE:-float32}"
     export MERERUN_H3_BENCH_ROWS="${MERERUN_H3_BENCH_ROWS:-14958}"
     export MERERUN_H3_BENCH_ROUNDS="${MERERUN_H3_BENCH_ROUNDS:-4}"
     run_release_test \
@@ -195,6 +204,7 @@ case "$mode" in
     default_fast_h3_root="${HOME}/Library/Application Support/MereRun/models/video-minimax-h3-fasth3-vsa-datafree-mlx"
     export MERERUN_H3_AFFINE_MLP_REAL_STAGE_BENCH=1
     export MERERUN_TEST_MLX_DEVICE=gpu
+    export MERERUN_H3_BENCH_DTYPE="${MERERUN_H3_BENCH_DTYPE:-float32}"
     export MERERUN_H3_EXACT_KERNEL_MODEL_ROOT="${MERERUN_H3_EXACT_KERNEL_MODEL_ROOT:-$default_fast_h3_root}"
     export MERERUN_H3_BENCH_ROWS="${MERERUN_H3_BENCH_ROWS:-89188}"
     export MERERUN_H3_BENCH_ROUNDS="${MERERUN_H3_BENCH_ROUNDS:-2}"
@@ -271,7 +281,7 @@ case "$mode" in
     run_release_test MiniMaxH3Tests/testInstalledAudioVAEDecodeMatchesReference
     ;;
   *)
-    print -u2 "usage: scripts/h3-kernel-lab.sh [quick|attention|attention-block|projections|mpp-projections|modulation|gate-adaln|gate-adaln-int8|qkv-layout|qkv-direct|affine-oproj|affine-ffn|buffer-alias|exact-ref2va|block|post|dtype|turnover|boundary|gemm|gemm-block|vae|audio-parity]"
+    print -u2 "usage: scripts/h3-kernel-lab.sh [quick|attention|attention-block|projections|mpp-projections|modulation|attention-adaln|gate-adaln|gate-adaln-int8|qkv-layout|qkv-direct|affine-oproj|affine-ffn|buffer-alias|exact-ref2va|block|post|dtype|turnover|boundary|gemm|gemm-block|vae|audio-parity]"
     exit 64
     ;;
 esac

--- a/scripts/h3-kernel-suite.sh
+++ b/scripts/h3-kernel-suite.sh
@@ -50,6 +50,7 @@ done
 
 if (( ${#modes} == 0 )); then
   modes=(
+    attention-adaln
     gate-adaln
     gate-adaln-int8
     qkv-layout

--- a/scripts/model-conversion/merge_minimax_h3_fasth3_q8.py
+++ b/scripts/model-conversion/merge_minimax_h3_fasth3_q8.py
@@ -1,0 +1,865 @@
+#!/usr/bin/env python3
+"""Build a self-contained premerged Q8 FastH3 package from audited local inputs.
+
+This is offline release tooling, not a runtime sidecar. It consumes mere.run's
+compact BF16 MiniMax-H3 package and the exact finalized FastVideo adapter. The
+208 inference core linears are merged with FP32 accumulation, rounded once to
+BF16, and encoded with MLX affine Q8/group-64. The 50 VSA compression gates are
+encoded with the same quantizer. Cache-covered AdaLN parameters remain omitted;
+the source-bound FastH3 AdaLN table is copied into the output package.
+
+Example::
+
+    python merge_minimax_h3_fasth3_q8.py \
+      --base-root /Volumes/MODELS/video-minimax-h3-fl2va-bf16-mlx \
+      --adapter /path/to/fastvideo_fasth3_4step_v1_vsa_datafree_rank64.safetensors \
+      --fast-h3-cache /path/to/fastvideo_fasth3_v1_vsa_datafree_adaln_cache.safetensors \
+      --conversion-location "CA, Canada" \
+      --output /Volumes/MODELS/video-minimax-h3-fasth3-vsa-datafree-q8-mlx
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import hashlib
+import importlib.metadata as importlib_metadata
+import json
+import os
+import platform
+import shutil
+import sys
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+GROUP_SIZE = 64
+BITS = 8
+BASE_TRANSFORMER_FORMAT = "mere.run.minimax-h3-inference-transformer"
+SOURCE_ADAPTER_FORMAT = "fastvideo-lora-v2"
+OUTPUT_ADAPTER_FORMAT = "mere.run.minimax-h3-fasth3-premerged-v1"
+FAST_H3_MODEL = "FastVideo/FastVideo-FastH3-4-step-v1"
+FAST_H3_SOURCE_IDENTITY = (
+    "FastVideo/FastVideo-FastH3-4-step-Preview-v1-VSA-DataFree"
+    "@b65818d41939b5085451074fe8ca8b799f8d4921:transformer"
+)
+ADAPTER_FILENAME = "fastvideo_fasth3_4step_v1_vsa_datafree_rank64.safetensors"
+FAST_H3_CACHE_FILENAME = "fastvideo_fasth3_v1_vsa_datafree_adaln_cache.safetensors"
+EXPECTED_LORA_PAIRS = 362
+EXPECTED_CORE_PAIRS = 312
+EXPECTED_CORE_TARGETS = 208
+EXPECTED_DIFFS = 82
+EXPECTED_GATES = 50
+
+QUANTIZED_SUFFIXES = (
+    ".attn.qkv_proj.weight",
+    ".attn.out_proj.weight",
+    ".mlp.fc1.weight",
+    ".mlp.fc2.weight",
+)
+
+
+@dataclass(frozen=True)
+class AdapterTarget:
+    module: str
+    branch: str | None
+
+
+def utc_now() -> str:
+    return dt.datetime.now(dt.timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(16 * 1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def atomic_json(path: Path, value: Any) -> None:
+    temporary = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
+    temporary.write_text(
+        json.dumps(value, indent=2, sort_keys=True) + "\n",
+        encoding="utf-8",
+    )
+    os.replace(temporary, path)
+
+
+def atomic_text(path: Path, value: str) -> None:
+    temporary = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp")
+    temporary.write_text(value, encoding="utf-8")
+    os.replace(temporary, path)
+
+
+def atomic_safetensors(path: Path, arrays: dict[str, Any], metadata: dict[str, str]) -> None:
+    import mlx.core as mx
+
+    temporary = path.with_name(f".{path.name}.{uuid.uuid4().hex}.tmp.safetensors")
+    try:
+        mx.save_safetensors(str(temporary), dict(sorted(arrays.items())), metadata=metadata)
+        os.replace(temporary, path)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def safetensors_header(path: Path) -> tuple[dict[str, Any], dict[str, str]]:
+    with path.open("rb") as handle:
+        raw_length = handle.read(8)
+        if len(raw_length) != 8:
+            raise ValueError(f"{path} has no safetensors header")
+        header_length = int.from_bytes(raw_length, "little")
+        if not 0 < header_length <= 64 * 1024 * 1024:
+            raise ValueError(f"{path} has an invalid safetensors header")
+        raw_header = handle.read(header_length)
+    if len(raw_header) != header_length:
+        raise ValueError(f"{path} has a truncated safetensors header")
+    header = json.loads(raw_header)
+    metadata = header.pop("__metadata__", {})
+    if not isinstance(metadata, dict):
+        raise ValueError(f"{path} metadata is not an object")
+    return header, metadata
+
+
+def adapter_target(source_module: str) -> AdapterTarget:
+    if source_module.startswith("transformer_blocks."):
+        normalized = "blocks." + source_module.removeprefix("transformer_blocks.")
+    elif source_module.startswith("token_refiner.refiner_blocks."):
+        normalized = (
+            "token_refiner.blocks."
+            + source_module.removeprefix("token_refiner.refiner_blocks.")
+        )
+    else:
+        raise ValueError(f"Unsupported FastH3 LoRA module: {source_module}")
+
+    for suffix, branch in (
+        (".attn.to_q", "query"),
+        (".attn.to_k", "key"),
+        (".attn.to_v", "value"),
+    ):
+        if normalized.endswith(suffix):
+            return AdapterTarget(
+                normalized.removesuffix(suffix) + ".attn.qkv_proj",
+                branch,
+            )
+    for suffix, replacement in (
+        (".attn.to_out.0", ".attn.out_proj"),
+        (".ff.net.0.proj", ".mlp.fc1"),
+        (".ff.net.2", ".mlp.fc2"),
+        (".adaln_proj.linear", ".adaln_proj.linear"),
+    ):
+        if normalized.endswith(suffix):
+            return AdapterTarget(normalized.removesuffix(suffix) + replacement, None)
+    raise ValueError(f"Unsupported FastH3 LoRA module: {source_module}")
+
+
+def difference_target(source_key: str) -> str:
+    if source_key.endswith(".diff_b"):
+        source = source_key.removesuffix(".diff_b")
+        parameter = ".bias"
+    elif source_key.endswith(".diff"):
+        source = source_key.removesuffix(".diff")
+        parameter = ".weight"
+    else:
+        raise ValueError(f"Unsupported FastH3 difference: {source_key}")
+    aliases = {
+        "proj_in": "video_patch_proj",
+        "audio_proj_in": "audio_patch_proj",
+        "context_embedder": "condition_proj",
+        "proj_out": "final_layer.video_out",
+        "audio_proj_out": "final_layer.audio_out",
+        "norm_out.norm": "final_layer.norm",
+        "norm_out.linear": "final_layer.adaln_proj.linear",
+        "time_embedder.linear_1": "time_embedder.proj_in",
+        "time_embedder.linear_2": "time_embedder.proj_out",
+    }
+    if source in aliases:
+        mapped = aliases[source]
+    elif source.startswith("transformer_blocks."):
+        mapped = "blocks." + source.removeprefix("transformer_blocks.")
+    else:
+        raise ValueError(f"Unsupported FastH3 difference: {source_key}")
+    return mapped + parameter
+
+
+def is_cache_covered(parameter: str) -> bool:
+    return (
+        parameter.startswith("time_embedder.")
+        or parameter.startswith("final_layer.adaln_proj.")
+        or (parameter.startswith("blocks.") and ".adaln_proj." in parameter)
+    )
+
+
+def adapter_inventory(header: dict[str, Any], metadata: dict[str, str]) -> dict[str, Any]:
+    if metadata.get("format") != SOURCE_ADAPTER_FORMAT:
+        raise ValueError("FastH3 adapter does not have the finalized fastvideo-lora-v2 format")
+    if metadata.get("finetuned_model") != FAST_H3_MODEL:
+        raise ValueError("FastH3 adapter belongs to another student model")
+    down_keys = sorted(key for key in header if key.endswith(".lora_A.weight"))
+    up_keys = sorted(key for key in header if key.endswith(".lora_B.weight"))
+    diff_keys = sorted(
+        key for key in header if key.endswith(".diff") or key.endswith(".diff_b")
+    )
+    gate_keys = sorted(key for key in header if key.endswith(".set_weight"))
+    if (len(down_keys), len(up_keys), len(diff_keys), len(gate_keys)) != (
+        EXPECTED_LORA_PAIRS,
+        EXPECTED_LORA_PAIRS,
+        EXPECTED_DIFFS,
+        EXPECTED_GATES,
+    ):
+        raise ValueError(
+            "Unexpected FastH3 adapter closure: "
+            f"A={len(down_keys)} B={len(up_keys)} diffs={len(diff_keys)} "
+            f"gates={len(gate_keys)}"
+        )
+
+    core_pairs = 0
+    cache_pairs = 0
+    core_targets: set[str] = set()
+    for key in down_keys:
+        module = key.removesuffix(".lora_A.weight")
+        if f"{module}.lora_B.weight" not in header:
+            raise ValueError(f"FastH3 adapter is missing the B matrix for {module}")
+        target = adapter_target(module)
+        if is_cache_covered(target.module):
+            cache_pairs += 1
+        else:
+            core_pairs += 1
+            core_targets.add(target.module)
+    if (core_pairs, cache_pairs, len(core_targets)) != (
+        EXPECTED_CORE_PAIRS,
+        EXPECTED_LORA_PAIRS - EXPECTED_CORE_PAIRS,
+        EXPECTED_CORE_TARGETS,
+    ):
+        raise ValueError(
+            "Unexpected FastH3 merge closure: "
+            f"core_pairs={core_pairs} cache_pairs={cache_pairs} "
+            f"core_targets={len(core_targets)}"
+        )
+    return {
+        "lora_pair_count": len(down_keys),
+        "core_lora_pair_count": core_pairs,
+        "cache_covered_lora_pair_count": cache_pairs,
+        "core_target_count": len(core_targets),
+        "direct_difference_count": len(diff_keys),
+        "compression_gate_count": len(gate_keys),
+    }
+
+
+def quantize_weight(value: Any) -> tuple[Any, Any, Any]:
+    import mlx.core as mx
+
+    if value.ndim != 2 or value.shape[-1] % GROUP_SIZE:
+        raise ValueError(f"Cannot quantize shape {value.shape} at group size {GROUP_SIZE}")
+    packed, scales, biases = mx.quantize(
+        value,
+        group_size=GROUP_SIZE,
+        bits=BITS,
+        mode="affine",
+    )
+    mx.eval(packed, scales, biases)
+    if scales.dtype != mx.bfloat16 or biases.dtype != mx.bfloat16:
+        raise ValueError("FastH3 exact Metal kernels require BF16 Q8 scales and biases")
+    return packed, scales, biases
+
+
+def build_merge_targets(adapter_header: dict[str, Any]) -> dict[str, list[tuple[str | None, str]]]:
+    targets: dict[str, list[tuple[str | None, str]]] = {}
+    for key in sorted(adapter_header):
+        if not key.endswith(".lora_A.weight"):
+            continue
+        source = key.removesuffix(".lora_A.weight")
+        target = adapter_target(source)
+        if is_cache_covered(target.module):
+            continue
+        targets.setdefault(target.module, []).append((target.branch, source))
+    if len(targets) != EXPECTED_CORE_TARGETS:
+        raise ValueError(f"Expected {EXPECTED_CORE_TARGETS} core targets; found {len(targets)}")
+    return targets
+
+
+def merge_core_weight(
+    base: Any,
+    entries: list[tuple[str | None, str]],
+    adapter_arrays: dict[str, Any],
+) -> Any:
+    import mlx.core as mx
+
+    branch_order = {"query": 0, "key": 1, "value": 2}
+    if any(branch is not None for branch, _ in entries):
+        if {branch for branch, _ in entries} != set(branch_order):
+            raise ValueError("Fused QKV target does not contain exactly Q, K, and V")
+        if base.shape[0] % 3:
+            raise ValueError(f"Fused QKV output width is not divisible by three: {base.shape}")
+        rows = base.shape[0] // 3
+        merged_branches = []
+        for branch, source in sorted(entries, key=lambda entry: branch_order[entry[0]]):
+            down = adapter_arrays[f"{source}.lora_A.weight"]
+            up = adapter_arrays[f"{source}.lora_B.weight"]
+            start = branch_order[branch] * rows
+            merged_branches.append(
+                base[start : start + rows].astype(mx.float32)
+                + mx.matmul(up.astype(mx.float32), down.astype(mx.float32))
+            )
+        merged = mx.concatenate(merged_branches, axis=0)
+    else:
+        if len(entries) != 1:
+            raise ValueError(f"Dense target has {len(entries)} LoRA pairs instead of one")
+        source = entries[0][1]
+        down = adapter_arrays[f"{source}.lora_A.weight"]
+        up = adapter_arrays[f"{source}.lora_B.weight"]
+        merged = base.astype(mx.float32) + mx.matmul(
+            up.astype(mx.float32),
+            down.astype(mx.float32),
+        )
+    # The exact kernels require BF16 scale/bias tables. Accumulate in FP32,
+    # then make one explicit BF16 rounding before MLX affine quantization.
+    return merged.astype(mx.bfloat16)
+
+
+def convert_transformer(base_path: Path, adapter_path: Path, output: Path) -> dict[str, Any]:
+    import mlx.core as mx
+
+    base_header, base_metadata = safetensors_header(base_path)
+    adapter_header, adapter_metadata = safetensors_header(adapter_path)
+    if base_metadata.get("format") != BASE_TRANSFORMER_FORMAT:
+        raise ValueError("Base transformer is not a mere.run compact MiniMax-H3 transformer")
+    if base_metadata.get("precision") != "bf16" or base_metadata.get("quantization") != "none":
+        raise ValueError("FastH3 Q8 merge requires the compact BF16 base transformer")
+    if base_metadata.get("qkv_layout") != "global-qkv-slabs":
+        raise ValueError("FastH3 QKV merge requires the global-qkv-slabs base layout")
+    if len(base_header) != 428:
+        raise ValueError(f"Expected 428 compact BF16 base tensors; found {len(base_header)}")
+    inventory = adapter_inventory(adapter_header, adapter_metadata)
+    merge_targets = build_merge_targets(adapter_header)
+    differences = {
+        difference_target(key): key
+        for key in adapter_header
+        if key.endswith(".diff") or key.endswith(".diff_b")
+    }
+
+    base_arrays = mx.load(str(base_path))
+    adapter_arrays = mx.load(str(adapter_path))
+    converted: dict[str, Any] = {}
+    consumed_targets: set[str] = set()
+    applied_differences: set[str] = set()
+    quantized = copied = changed_dense = 0
+    for index, key in enumerate(sorted(base_arrays), start=1):
+        value = base_arrays[key]
+        if key.endswith(QUANTIZED_SUFFIXES):
+            module = key.removesuffix(".weight")
+            entries = merge_targets.get(module)
+            if entries is None:
+                raise ValueError(f"FastH3 adapter has no merge target for {module}")
+            merged = merge_core_weight(value, entries, adapter_arrays)
+            packed, scales, biases = quantize_weight(merged)
+            prefix = key.removesuffix(".weight")
+            converted[key] = packed
+            converted[f"{prefix}.scales"] = scales
+            converted[f"{prefix}.biases"] = biases
+            consumed_targets.add(module)
+            quantized += 1
+            del merged
+        elif key in differences:
+            difference = adapter_arrays[differences[key]]
+            updated = (
+                value.astype(mx.float32) + difference.astype(mx.float32)
+            ).astype(value.dtype)
+            mx.eval(updated)
+            converted[key] = updated
+            applied_differences.add(key)
+            changed_dense += 1
+        else:
+            mx.eval(value)
+            converted[key] = value
+            copied += 1
+        if index % 10 == 0 or index == len(base_arrays):
+            print(
+                f"transformer [{index}/{len(base_arrays)}] q8={quantized} "
+                f"changed_dense={changed_dense}",
+                flush=True,
+            )
+        mx.clear_cache()
+
+    if consumed_targets != set(merge_targets):
+        missing = sorted(set(merge_targets) - consumed_targets)
+        raise ValueError(f"Base transformer did not consume FastH3 targets: {missing}")
+    expected_applied_differences = {
+        target for target in differences if not is_cache_covered(target)
+    }
+    if applied_differences != expected_applied_differences:
+        missing = sorted(expected_applied_differences - applied_differences)
+        raise ValueError(f"Base transformer did not consume FastH3 differences: {missing}")
+    if (quantized, copied + changed_dense, len(converted)) != (208, 220, 844):
+        raise ValueError(
+            "Unexpected premerged transformer closure: "
+            f"q8={quantized} dense={copied + changed_dense} arrays={len(converted)}"
+        )
+
+    output_metadata = dict(base_metadata)
+    output_metadata.update(
+        {
+            "precision": "q8",
+            "quantization": "affine 8-bit g64",
+            "adaln_cache_source_identity": FAST_H3_SOURCE_IDENTITY,
+            "fasth3_premerged": "true",
+            "fasth3_adapter_sha256": sha256_file(adapter_path),
+            "merge_accumulation": "fp32 then bf16 before quantization",
+        }
+    )
+    atomic_safetensors(output, converted, output_metadata)
+    del base_arrays, adapter_arrays
+    converted.clear()
+    mx.clear_cache()
+    return {
+        **inventory,
+        "input_tensors": len(base_header),
+        "output_tensors": 844,
+        "quantized_linears": quantized,
+        "copied_dense_tensors": copied,
+        "updated_dense_tensors": changed_dense,
+        "applied_difference_count": len(applied_differences),
+        "cache_covered_difference_count": len(differences) - len(applied_differences),
+        "precision": "q8",
+        "quantization": {"bits": BITS, "group_size": GROUP_SIZE, "mode": "affine"},
+        "merge_accumulation": "fp32 then bf16 before quantization",
+    }
+
+
+def convert_gates(adapter_path: Path, output: Path) -> dict[str, Any]:
+    import mlx.core as mx
+
+    header, metadata = safetensors_header(adapter_path)
+    adapter_inventory(header, metadata)
+    arrays = mx.load(str(adapter_path))
+    converted: dict[str, Any] = {}
+    for block_index in range(EXPECTED_GATES):
+        source = f"transformer_blocks.{block_index}.attn.to_gate_compress.set_weight"
+        if source not in arrays:
+            raise ValueError(f"FastH3 adapter is missing compression gate {block_index}")
+        packed, scales, biases = quantize_weight(arrays[source])
+        prefix = f"transformer_blocks.{block_index}.attn.to_gate_compress"
+        converted[f"{prefix}.weight"] = packed
+        converted[f"{prefix}.scales"] = scales
+        converted[f"{prefix}.biases"] = biases
+        print(f"compression gate [{block_index + 1}/{EXPECTED_GATES}]", flush=True)
+        mx.clear_cache()
+    if len(converted) != 150:
+        raise ValueError(f"Expected 150 quantized gate tensors; found {len(converted)}")
+    atomic_safetensors(
+        output,
+        converted,
+        {
+            "format": OUTPUT_ADAPTER_FORMAT,
+            "finetuned_model": FAST_H3_MODEL,
+            "gate_quantization": "affine 8-bit g64",
+            "source_adapter_format": SOURCE_ADAPTER_FORMAT,
+            "source_adapter_sha256": sha256_file(adapter_path),
+            "compression_gate_count": str(EXPECTED_GATES),
+            "student_weights": "premerged into transformer.safetensors",
+        },
+    )
+    del arrays
+    converted.clear()
+    mx.clear_cache()
+    return {
+        "input_compression_gates": EXPECTED_GATES,
+        "output_tensors": 150,
+        "quantization": {"bits": BITS, "group_size": GROUP_SIZE, "mode": "affine"},
+    }
+
+
+def link_or_copy(source: Path, destination: Path) -> str:
+    try:
+        os.link(source, destination)
+        return "hardlink"
+    except OSError:
+        shutil.copy2(source, destination)
+        return "copy"
+
+
+def prepare_support_files(
+    base_root: Path,
+    output: Path,
+    adapter_path: Path,
+    cache_path: Path,
+) -> dict[str, str]:
+    excluded = {
+        "transformer.safetensors",
+        "config.json",
+        "mererun_model.json",
+        "MODIFICATIONS.md",
+        "README.md",
+        "SHA256SUMS",
+        "transformer.conversion.json",
+    }
+    methods: dict[str, str] = {}
+    for source in sorted(base_root.iterdir()):
+        if (
+            not source.is_file()
+            or source.name in excluded
+            or source.name.startswith("adaln_cache")
+        ):
+            continue
+        methods[source.name] = link_or_copy(source, output / source.name)
+    methods[FAST_H3_CACHE_FILENAME] = link_or_copy(
+        cache_path,
+        output / FAST_H3_CACHE_FILENAME,
+    )
+    if adapter_path.name != ADAPTER_FILENAME:
+        print(
+            f"warning: source adapter is named {adapter_path.name}; output uses {ADAPTER_FILENAME}",
+            flush=True,
+        )
+    return methods
+
+
+def write_package_metadata(base_root: Path, output: Path) -> None:
+    config = json.loads((base_root / "config.json").read_text(encoding="utf-8"))
+    config["quantization"] = {"bits": BITS, "group_size": GROUP_SIZE, "mode": "affine"}
+    atomic_json(output / "config.json", config)
+
+    model = json.loads((base_root / "mererun_model.json").read_text(encoding="utf-8"))
+    model.update(
+        {
+            "id": "video-minimax-h3-fasth3-vsa-datafree-mlx",
+            "precision": "int8",
+            "variant": "distilled",
+            "defaults": {"cfg": 1, "sigma_shift": 12, "steps": 5},
+            "upstreamRepoId": "Sawfwair/MiniMax-H3-FastH3-VSA-DataFree-MLX-Q8",
+            "sources": [
+                {
+                    "repository": "Sawfwair/MiniMax-H3-FastH3-VSA-DataFree-MLX-Q8",
+                    "revision": "local-unpublished",
+                    "role": "primary",
+                }
+            ],
+        }
+    )
+    atomic_json(output / "mererun_model.json", model)
+
+    atomic_text(
+        output / "README.md",
+        """---
+license: other
+license_name: minimax-h3-community-license
+license_link: https://huggingface.co/MiniMaxAI/MiniMax-H3/blob/ec19cc6daf5d8add9417c18e86b6b58cc6c55027/LICENSE
+library_name: mlx
+pipeline_tag: text-to-video
+tags:
+  - audio-video
+  - apple-silicon
+  - fastvideo
+  - metal
+  - mlx
+  - minimax-h3
+---
+
+# MiniMax-H3 FastH3 VSA DataFree MLX Q8
+
+This is a self-contained Apple Silicon inference package for FastVideo's
+four-evaluation FastH3 VSA DataFree MiniMax-H3 student. It includes the Q8
+transformer, Q8 text encoder, both VAEs, tokenizer, VSA compression gates,
+and all AdaLN tables required by mere.run. Inference does not download another
+base model, adapter, text encoder, or cache.
+
+## License notice
+
+These are modified MiniMax-H3 weights governed by the included MiniMax-H3
+Community License Agreement (`LICENSE`) and notice (`NOTICE`). The license
+excludes use, distribution, and display in the United States, European Union,
+United Kingdom, and Republic of Korea and imposes downstream notice and safety
+obligations. Downloading this ungated repository does not waive those terms.
+
+## Conversion
+
+The finalized FastH3 low-rank updates and direct differences were merged into
+the compact BF16 student with FP32 accumulation. The 208 inference core linear
+weights were rounded once to BF16 and encoded as MLX affine Q8/group-64. The 50
+VSA compression gates use the same encoding. Cache-covered AdaLN updates remain
+in the source-bound inference table. See `MODIFICATIONS.md`,
+`FASTH3_SOURCE_MANIFEST.json`, `FASTH3_CONVERSION.json`, and `SHA256SUMS` for
+the complete provenance and integrity receipts.
+
+## Run with mere.run
+
+Use a mere.run build that includes premerged FastH3 Q8 support:
+
+```bash
+mere.run video generate \
+  "A lighthouse in a winter storm with synchronized wind and surf." \
+  --model-root /path/to/this/package \
+  --h3-adapter /path/to/this/package/fastvideo_fasth3_4step_v1_vsa_datafree_rank64.safetensors \
+  --width 512 --height 320 --num-frames 22 \
+  --output lighthouse.mp4
+```
+
+The public managed model ID is
+`video-minimax-h3-fasth3-vsa-datafree-mlx`. It selects the released schedule,
+unit adapter strength, compiled block execution, 64-token VSA tiles, per-head
+top-k routing at 90% video-key sparsity, and learned pooled-value compression.
+""",
+    )
+
+    atomic_text(
+        output / "MODIFICATIONS.md",
+        """# Modifications to MiniMax H3
+
+These files are MODIFIED versions of the MiniMax H3 Works, redistributed under
+the MiniMax H3 Community License Agreement in `LICENSE` and `NOTICE`.
+
+Modified by: Sawfwair (https://github.com/sawfwair/mere-run)
+
+* The finalized FastH3 VSA DataFree low-rank updates and direct differences
+  were merged into the compact MiniMax-H3 student with FP32 accumulation.
+  Cache-covered timestep and AdaLN updates are represented by the included
+  source-bound FastH3 AdaLN inference table.
+* The 208 merged transformer and token-refiner core linear weights were rounded
+  once to BF16 and quantized to MLX affine 8-bit, group size 64. Dense input,
+  normalization, and output precision islands retain their source dtype.
+* The 50 VSA compression-gate matrices were quantized to MLX affine 8-bit,
+  group size 64 and packaged in the FastH3 adapter filename. That file contains
+  no remaining LoRA matrices; the student weights are already merged.
+* The Q8 text encoder, video VAE, audio VAE, tokenizer, license, notice, and
+  production cache pack are unchanged from the audited base package.
+
+`FASTH3_SOURCE_MANIFEST.json` and `FASTH3_CONVERSION.json` record the exact
+inputs, numeric transformations, and output hashes. No additional model
+downloads are required at inference time.
+""",
+    )
+
+
+def base_sha256sums(base_root: Path) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for line in (base_root / "SHA256SUMS").read_text(encoding="utf-8").splitlines():
+        digest, filename = line.split("  ", maxsplit=1)
+        result[filename] = digest
+    return result
+
+
+def write_sha256sums(output: Path, inherited: dict[str, str]) -> dict[str, str]:
+    excluded = {"SHA256SUMS", "README.md"}
+    hashes: dict[str, str] = {}
+    for path in sorted(value for value in output.iterdir() if value.is_file()):
+        if path.name in excluded or path.name.startswith("."):
+            continue
+        hashes[path.name] = inherited.get(path.name) or sha256_file(path)
+    atomic_text(
+        output / "SHA256SUMS",
+        "".join(f"{digest}  {name}\n" for name, digest in sorted(hashes.items())),
+    )
+    return hashes
+
+
+def write_transformer_receipt(
+    output: Path,
+    base_transformer: Path,
+    converter_sha256: str,
+    completed_at: str,
+) -> None:
+    transformer = output / "transformer.safetensors"
+    atomic_json(
+        output / "transformer.conversion.json",
+        {
+            "schema_version": 1,
+            "format": "mere.run.minimax-h3-fasth3-q8-transformer-receipt",
+            "converter": "scripts/model-conversion/merge_minimax_h3_fasth3_q8.py",
+            "converter_version": 2,
+            "converter_sha256": converter_sha256,
+            "completed_at": completed_at,
+            "input": {
+                "filename": base_transformer.name,
+                "byte_count": base_transformer.stat().st_size,
+                "sha256": sha256_file(base_transformer),
+            },
+            "output": {
+                "filename": transformer.name,
+                "byte_count": transformer.stat().st_size,
+                "sha256": sha256_file(transformer),
+                "precision": "q8",
+                "quantization": {
+                    "bits": BITS,
+                    "group_size": GROUP_SIZE,
+                    "mode": "affine",
+                },
+                "tensor_count": 844,
+            },
+            "full_receipt": "FASTH3_CONVERSION.json",
+        },
+    )
+
+
+def hardware_receipt() -> dict[str, Any]:
+    receipt: dict[str, Any] = {
+        "platform": platform.platform(),
+        "machine": platform.machine(),
+        "python": sys.version.split()[0],
+    }
+    if sys.platform == "darwin":
+        import subprocess
+
+        for key, command in (
+            ("chip", ["sysctl", "-n", "machdep.cpu.brand_string"]),
+            ("unified_memory_bytes", ["sysctl", "-n", "hw.memsize"]),
+        ):
+            try:
+                receipt[key] = subprocess.check_output(command, text=True).strip()
+            except Exception as error:
+                receipt[f"{key}_error"] = str(error)
+    return receipt
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-root", required=True, type=Path)
+    parser.add_argument("--adapter", required=True, type=Path)
+    parser.add_argument("--fast-h3-cache", required=True, type=Path)
+    parser.add_argument("--output", required=True, type=Path)
+    parser.add_argument("--conversion-location", required=True)
+    parser.add_argument("--validate-only", action="store_true")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    base_root = args.base_root.expanduser().resolve()
+    adapter_path = args.adapter.expanduser().resolve()
+    cache_path = args.fast_h3_cache.expanduser().resolve()
+    output = args.output.expanduser().resolve()
+    required = [
+        base_root / "transformer.safetensors",
+        base_root / "config.json",
+        base_root / "mererun_model.json",
+        base_root / "SHA256SUMS",
+        adapter_path,
+        cache_path,
+    ]
+    missing = [str(path) for path in required if not path.is_file()]
+    if missing:
+        raise ValueError(f"Missing conversion inputs: {missing}")
+    adapter_header, adapter_metadata = safetensors_header(adapter_path)
+    inventory = adapter_inventory(adapter_header, adapter_metadata)
+    if args.validate_only:
+        print(json.dumps(inventory, indent=2, sort_keys=True))
+        return 0
+    if output.exists() and any(output.iterdir()):
+        raise ValueError(f"Output directory is not empty: {output}")
+    output.mkdir(parents=True, exist_ok=True)
+    started_at = utc_now()
+    base_transformer = base_root / "transformer.safetensors"
+    base_source_manifest = json.loads(
+        (base_root / "SOURCE_MANIFEST.json").read_text(encoding="utf-8")
+    )
+    base_transformer_sha = sha256_file(base_transformer)
+    adapter_sha = sha256_file(adapter_path)
+    cache_sha = sha256_file(cache_path)
+
+    methods = prepare_support_files(
+        base_root,
+        output,
+        adapter_path,
+        cache_path,
+    )
+    write_package_metadata(base_root, output)
+    transformer_stats = convert_transformer(
+        base_transformer,
+        adapter_path,
+        output / "transformer.safetensors",
+    )
+    gate_stats = convert_gates(adapter_path, output / ADAPTER_FILENAME)
+
+    source_manifest = {
+        "schema_version": 1,
+        "artifact": {
+            "format": "mere.run.minimax-h3-fasth3-vsa-datafree-mlx-q8-premerged",
+            "repository": "Sawfwair/MiniMax-H3-FastH3-VSA-DataFree-MLX-Q8",
+            "partition": "fl2va",
+            "task": "text-to-video-with-audio",
+        },
+        "base": {
+            "repository": base_source_manifest.get("repository"),
+            "revision": base_source_manifest.get("revision"),
+            "transformer_sha256": base_transformer_sha,
+            "source_manifest_sha256": sha256_file(base_root / "SOURCE_MANIFEST.json"),
+        },
+        "adapter": {
+            "filename": adapter_path.name,
+            "sha256": adapter_sha,
+            **inventory,
+        },
+        "adaln_cache": {
+            "path": FAST_H3_CACHE_FILENAME,
+            "source_identity": FAST_H3_SOURCE_IDENTITY,
+            "sha256": cache_sha,
+        },
+    }
+    atomic_json(output / "FASTH3_SOURCE_MANIFEST.json", source_manifest)
+
+    receipt = {
+        "schema_version": 1,
+        "converter": "scripts/model-conversion/merge_minimax_h3_fasth3_q8.py",
+        "converter_version": 2,
+        "converter_sha256": sha256_file(Path(__file__).resolve()),
+        "started_at": started_at,
+        "completed_at": utc_now(),
+        "declared_conversion_location": args.conversion_location,
+        "software": {
+            "mlx": importlib_metadata.version("mlx"),
+            "numpy": importlib_metadata.version("numpy"),
+            "safetensors": importlib_metadata.version("safetensors"),
+        },
+        "hardware": hardware_receipt(),
+        "inputs": {
+            "base_transformer": {
+                "filename": base_transformer.name,
+                "byte_count": base_transformer.stat().st_size,
+                "sha256": base_transformer_sha,
+            },
+            "adapter": {
+                "filename": adapter_path.name,
+                "byte_count": adapter_path.stat().st_size,
+                "sha256": adapter_sha,
+            },
+            "fast_h3_adaln_cache": {
+                "filename": cache_path.name,
+                "byte_count": cache_path.stat().st_size,
+                "sha256": cache_sha,
+            },
+        },
+        "transformer": transformer_stats,
+        "compression_gates": gate_stats,
+        "support_file_materialization": methods,
+        "outputs": {
+            "transformer.safetensors": {
+                "byte_count": (output / "transformer.safetensors").stat().st_size,
+                "sha256": sha256_file(output / "transformer.safetensors"),
+            },
+            ADAPTER_FILENAME: {
+                "byte_count": (output / ADAPTER_FILENAME).stat().st_size,
+                "sha256": sha256_file(output / ADAPTER_FILENAME),
+            },
+        },
+    }
+    atomic_json(output / "FASTH3_CONVERSION.json", receipt)
+    write_transformer_receipt(
+        output,
+        base_transformer,
+        receipt["converter_sha256"],
+        receipt["completed_at"],
+    )
+    inherited_hashes = {
+        name: digest
+        for name, digest in base_sha256sums(base_root).items()
+        if methods.get(name) == "hardlink"
+    }
+    hashes = write_sha256sums(output, inherited_hashes)
+    print(json.dumps(receipt, indent=2, sort_keys=True), flush=True)
+    print(f"complete: {output} ({len(hashes)} checksummed files)", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/model-conversion/prepare_minimax_h3_fasth3_vsa.py
+++ b/scripts/model-conversion/prepare_minimax_h3_fasth3_vsa.py
@@ -1,0 +1,405 @@
+#!/usr/bin/env python3
+"""Build the compact FastH3 AdaLN sidecar from the pinned student checkpoint.
+
+The managed MiniMax-H3 BF16 bundle omits the 13B schedule-only AdaLN weights.
+FastH3 changes those weights, so its adapter cannot reuse the base bundle's
+cache. This tool range-reads only the 106 required tensors from the immutable
+FastH3 transformer, evaluates the released four-step schedule with MLX Metal,
+and writes the roughly 120 MB source-bound sidecar expected by mere.run.
+
+The remote range reads transfer about 26 GB but never materialize the 70 GB
+transformer or the 148 GB complete model on disk. Install requirements:
+
+    python -m pip install 'mlx==0.29.3' 'numpy==2.2.6'
+
+Example:
+
+    python scripts/model-conversion/prepare_minimax_h3_fasth3_vsa.py \
+      --adapter "$HOME/Library/Application Support/MereRun/adapters/\
+minimax-h3-fasth3-vsa-datafree-4step/bcf40ca6f45/\
+fastvideo_fasth3_4step_v1_vsa_datafree_rank64.safetensors"
+"""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import tempfile
+import urllib.parse
+import urllib.request
+import uuid
+from pathlib import Path
+from typing import Any
+
+
+SOURCE_REPOSITORY = "FastVideo/FastVideo-FastH3-4-step-Preview-v1-VSA-DataFree"
+SOURCE_REVISION = "b65818d41939b5085451074fe8ca8b799f8d4921"
+SOURCE_INDEX = "transformer/diffusion_pytorch_model.safetensors.index.json"
+SOURCE_INDEX_SHA256 = "5be1367650e2faf79edf1f106a8354d1a7ef2e3ff45df40c4514b4ae97e1136b"
+SOURCE_IDENTITY = f"{SOURCE_REPOSITORY}@{SOURCE_REVISION}:transformer"
+ADAPTER_BYTES = 5_339_117_712
+ADAPTER_SHA256 = "42dc502a2078f166c396a1fa75f29728d1844363652d345d5ef3e2b444ed6470"
+ADAPTER_FORMAT = "fastvideo-lora-v2"
+OUTPUT_FILENAME = "fastvideo_fasth3_v1_vsa_datafree_adaln_cache.safetensors"
+BASE_SIGMAS = (0.999, 0.749, 0.5, 0.25, 0.0)
+VIDEO_SHIFT = 12.0
+AUDIO_SHIFT = 3.0
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(16 * 1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def read_safetensors_header(path: Path) -> tuple[dict[str, Any], dict[str, str]]:
+    with path.open("rb") as handle:
+        raw_length = handle.read(8)
+        if len(raw_length) != 8:
+            raise ValueError(f"{path} has no safetensors header")
+        header_length = int.from_bytes(raw_length, "little")
+        if not 0 < header_length <= 64 * 1024 * 1024:
+            raise ValueError(f"{path} has an invalid safetensors header")
+        raw_header = handle.read(header_length)
+    if len(raw_header) != header_length:
+        raise ValueError(f"{path} has a truncated safetensors header")
+    header = json.loads(raw_header)
+    metadata = header.pop("__metadata__", {})
+    if not isinstance(metadata, dict):
+        raise ValueError(f"{path} metadata is not an object")
+    return header, metadata
+
+
+def verify_adapter(path: Path) -> None:
+    if path.stat().st_size != ADAPTER_BYTES:
+        raise ValueError(f"FastH3 adapter has {path.stat().st_size} bytes; expected {ADAPTER_BYTES}")
+    digest = sha256_file(path)
+    if digest != ADAPTER_SHA256:
+        raise ValueError(f"FastH3 adapter SHA-256 differs: {digest}")
+    header, metadata = read_safetensors_header(path)
+    if metadata.get("format") != ADAPTER_FORMAT:
+        raise ValueError("FastH3 adapter metadata has an unexpected format")
+    pair_count = sum(key.endswith(".lora_A.weight") for key in header)
+    difference_count = sum(key.endswith((".diff", ".diff_b")) for key in header)
+    gate_count = sum(key.endswith(".attn.to_gate_compress.set_weight") for key in header)
+    if (pair_count, difference_count, gate_count) != (362, 82, 50):
+        raise ValueError(
+            "FastH3 adapter tensor closure differs: "
+            f"pairs={pair_count}, differences={difference_count}, gates={gate_count}"
+        )
+
+
+class RangeTensorSource:
+    def __init__(self, temporary: Path, token: str | None) -> None:
+        self.temporary = temporary
+        self.token = token
+        self.headers: dict[str, tuple[int, dict[str, Any]]] = {}
+        self.transferred_bytes = 0
+
+    def source_url(self, relative_path: str) -> str:
+        encoded = urllib.parse.quote(relative_path, safe="/")
+        return (
+            f"https://huggingface.co/{SOURCE_REPOSITORY}/resolve/"
+            f"{SOURCE_REVISION}/{encoded}"
+        )
+
+    def request(self, url: str, start: int | None = None, end: int | None = None) -> Any:
+        headers = {"Accept-Encoding": "identity"}
+        if self.token:
+            headers["Authorization"] = f"Bearer {self.token}"
+        if start is not None and end is not None:
+            headers["Range"] = f"bytes={start}-{end}"
+        return urllib.request.urlopen(urllib.request.Request(url, headers=headers), timeout=300)
+
+    def range_bytes(self, url: str, start: int, end: int) -> bytes:
+        with self.request(url, start, end) as response:
+            if response.status != 206:
+                raise ValueError(f"Server ignored byte range {start}-{end} (HTTP {response.status})")
+            value = response.read()
+        if len(value) != end - start + 1:
+            raise ValueError(f"Truncated byte range {start}-{end}")
+        self.transferred_bytes += len(value)
+        return value
+
+    def shard_header(self, shard: str) -> tuple[int, dict[str, Any]]:
+        if shard in self.headers:
+            return self.headers[shard]
+        url = self.source_url(f"transformer/{shard}")
+        header_length = int.from_bytes(self.range_bytes(url, 0, 7), "little")
+        if not 0 < header_length <= 64 * 1024 * 1024:
+            raise ValueError(f"{shard} has an invalid safetensors header")
+        header = json.loads(self.range_bytes(url, 8, 7 + header_length))
+        header.pop("__metadata__", None)
+        self.headers[shard] = (header_length, header)
+        return self.headers[shard]
+
+    def tensor_extent(self, shard: str, key: str) -> int:
+        _, header = self.shard_header(shard)
+        entry = header.get(key)
+        if entry is None:
+            raise ValueError(f"{shard} does not contain {key}")
+        start, end = map(int, entry["data_offsets"])
+        return end - start
+
+    def load_tensor(self, shard: str, key: str) -> tuple[Any, Path]:
+        import mlx.core as mx
+
+        header_length, header = self.shard_header(shard)
+        entry = header.get(key)
+        if entry is None:
+            raise ValueError(f"{shard} does not contain {key}")
+        start, end = map(int, entry["data_offsets"])
+        if start < 0 or end <= start:
+            raise ValueError(f"{shard}:{key} has invalid data offsets")
+        standalone_entry = {
+            key: {
+                "dtype": entry["dtype"],
+                "shape": entry["shape"],
+                "data_offsets": [0, end - start],
+            }
+        }
+        raw_header = json.dumps(standalone_entry, separators=(",", ":")).encode("utf-8")
+        raw_header += b" " * ((8 - len(raw_header) % 8) % 8)
+        output = self.temporary / f"tensor-{uuid.uuid4().hex}.safetensors"
+        with output.open("wb") as handle:
+            handle.write(len(raw_header).to_bytes(8, "little"))
+            handle.write(raw_header)
+            url = self.source_url(f"transformer/{shard}")
+            absolute_start = 8 + header_length + start
+            absolute_end = 8 + header_length + end - 1
+            with self.request(url, absolute_start, absolute_end) as response:
+                if response.status != 206:
+                    raise ValueError(
+                        f"Server ignored {shard}:{key} byte range (HTTP {response.status})"
+                    )
+                observed = 0
+                while chunk := response.read(16 * 1024 * 1024):
+                    handle.write(chunk)
+                    observed += len(chunk)
+            if observed != end - start:
+                raise ValueError(f"Truncated tensor {shard}:{key}")
+            self.transferred_bytes += observed
+        arrays = mx.load(str(output))
+        value = arrays[key]
+        mx.eval(value)
+        return value, output
+
+
+def fetch_index(source: RangeTensorSource) -> dict[str, Any]:
+    with source.request(source.source_url(SOURCE_INDEX)) as response:
+        raw = response.read()
+    if hashlib.sha256(raw).hexdigest() != SOURCE_INDEX_SHA256:
+        raise ValueError("Pinned FastH3 transformer index SHA-256 differs")
+    index = json.loads(raw)
+    weight_map = index.get("weight_map")
+    if not isinstance(weight_map, dict) or len(weight_map) != 688:
+        raise ValueError("Pinned FastH3 transformer index closure differs")
+    return index
+
+
+def shifted_schedule(shift: float) -> tuple[list[float], list[float]]:
+    import numpy as np
+
+    shift32 = np.float32(shift)
+    one = np.float32(1)
+    sigmas = []
+    for raw in BASE_SIGMAS:
+        base = np.float32(raw)
+        sigma = shift32 * base / (one + (shift32 - one) * base)
+        sigmas.append(float(sigma))
+    timesteps = [float(np.float32(one - np.float32(value))) for value in sigmas[:-1]]
+    return sigmas, timesteps
+
+
+def linear(value: Any, weight: Any, bias: Any) -> Any:
+    import mlx.core as mx
+
+    return mx.addmm(bias, value.astype(weight.dtype), weight.T)
+
+
+def load_group(
+    source: RangeTensorSource,
+    weight_map: dict[str, str],
+    keys: tuple[str, ...],
+) -> tuple[dict[str, Any], list[Path]]:
+    values: dict[str, Any] = {}
+    paths: list[Path] = []
+    for key in keys:
+        shard = weight_map.get(key)
+        if shard is None:
+            raise ValueError(f"Pinned FastH3 transformer is missing {key}")
+        value, path = source.load_tensor(shard, key)
+        values[key] = value
+        paths.append(path)
+    return values, paths
+
+
+def release_group(values: dict[str, Any], paths: list[Path]) -> None:
+    import mlx.core as mx
+
+    values.clear()
+    mx.clear_cache()
+    for path in paths:
+        path.unlink(missing_ok=True)
+
+
+def build_cache(source: RangeTensorSource, index: dict[str, Any], output: Path) -> None:
+    import mlx.core as mx
+    import mlx.nn as nn
+    import numpy as np
+
+    weight_map: dict[str, str] = index["weight_map"]
+    video_sigmas, video_timesteps = shifted_schedule(VIDEO_SHIFT)
+    audio_sigmas, audio_timesteps = shifted_schedule(AUDIO_SHIFT)
+    flat_timesteps: list[np.float32] = []
+    condition = np.float32(0.999)
+    for video, audio in zip(video_timesteps, audio_timesteps, strict=True):
+        video32 = np.float32(video)
+        flat_timesteps.extend((video32, np.float32(audio), max(video32, condition)))
+
+    time_keys = (
+        "time_embedder.linear_1.weight",
+        "time_embedder.linear_1.bias",
+        "time_embedder.linear_2.weight",
+        "time_embedder.linear_2.bias",
+    )
+    time_weights, time_paths = load_group(source, weight_map, time_keys)
+    frequency_indices = np.arange(128, dtype=np.float32)
+    frequencies = np.exp(
+        -np.log(np.float32(10_000)) * frequency_indices / np.float32(128)
+    ).astype(np.float32)
+    arguments = mx.array(np.asarray(flat_timesteps, dtype=np.float32)).reshape(-1, 1) \
+        * mx.array(frequencies).reshape(1, -1)
+    sinusoidal = mx.concatenate([mx.cos(arguments), mx.sin(arguments)], axis=-1)
+    time_embeddings = linear(
+        nn.silu(linear(
+            sinusoidal.astype(mx.float32),
+            time_weights["time_embedder.linear_1.weight"],
+            time_weights["time_embedder.linear_1.bias"],
+        )),
+        time_weights["time_embedder.linear_2.weight"],
+        time_weights["time_embedder.linear_2.bias"],
+    ).reshape(4, 3, 2_688)
+    mx.eval(time_embeddings)
+    release_group(time_weights, time_paths)
+
+    activated = nn.silu(time_embeddings.reshape(12, 2_688)).astype(mx.bfloat16)
+    mx.eval(activated)
+    block_modulations: list[Any] = []
+    for block in range(50):
+        prefix = f"transformer_blocks.{block}.adaln_proj.linear"
+        keys = (f"{prefix}.weight", f"{prefix}.bias")
+        values, paths = load_group(source, weight_map, keys)
+        projected = linear(activated, values[keys[0]], values[keys[1]])
+        modulation = projected.reshape(4, 9, 32_256).astype(mx.bfloat16)
+        mx.eval(modulation)
+        block_modulations.append(modulation)
+        release_group(values, paths)
+        transferred = source.transferred_bytes / (1024 ** 3)
+        print(f"AdaLN block {block + 1}/50 ({transferred:.2f} GiB transferred)", flush=True)
+
+    final_keys = ("norm_out.linear.weight", "norm_out.linear.bias")
+    final_weights, final_paths = load_group(source, weight_map, final_keys)
+    final_modulations = linear(
+        activated,
+        final_weights[final_keys[0]],
+        final_weights[final_keys[1]],
+    ).reshape(4, 3, 10_752).astype(mx.bfloat16)
+    mx.eval(final_modulations)
+    release_group(final_weights, final_paths)
+
+    arrays: dict[str, Any] = {
+        "audio_sigmas": mx.array(audio_sigmas, dtype=mx.float32),
+        "final_modulations": final_modulations,
+        "time_embeddings": time_embeddings,
+        "video_sigmas": mx.array(video_sigmas, dtype=mx.float32),
+    }
+    for block, modulation in enumerate(block_modulations):
+        arrays[f"blocks.{block}.modulations"] = modulation
+    temporary = output.with_name(f".{output.name}.{uuid.uuid4().hex}.tmp.safetensors")
+    try:
+        mx.save_safetensors(
+            str(temporary),
+            dict(sorted(arrays.items())),
+            metadata={
+                "schema_version": "2",
+                "format": "mere.run.minimax-h3-adaln-cache",
+                "source_identity": SOURCE_IDENTITY,
+            },
+        )
+        os.replace(temporary, output)
+    finally:
+        temporary.unlink(missing_ok=True)
+
+
+def required_remote_bytes(source: RangeTensorSource, index: dict[str, Any]) -> int:
+    weight_map: dict[str, str] = index["weight_map"]
+    keys = [
+        "time_embedder.linear_1.weight",
+        "time_embedder.linear_1.bias",
+        "time_embedder.linear_2.weight",
+        "time_embedder.linear_2.bias",
+        "norm_out.linear.weight",
+        "norm_out.linear.bias",
+    ]
+    for block in range(50):
+        prefix = f"transformer_blocks.{block}.adaln_proj.linear"
+        keys.extend((f"{prefix}.weight", f"{prefix}.bias"))
+    return sum(source.tensor_extent(weight_map[key], key) for key in keys)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--adapter",
+        type=Path,
+        required=True,
+        help="Verified FastH3 VSA DataFree managed adapter path.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        help=f"Output sidecar (default: adapter directory/{OUTPUT_FILENAME}).",
+    )
+    parser.add_argument("--force", action="store_true", help="Replace an existing verified sidecar.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    adapter = args.adapter.expanduser().resolve()
+    output = (args.output or adapter.with_name(OUTPUT_FILENAME)).expanduser().resolve()
+    if output.exists() and not args.force:
+        raise ValueError(f"Output already exists: {output} (use --force to replace it)")
+    output.parent.mkdir(parents=True, exist_ok=True)
+    verify_adapter(adapter)
+    if shutil.disk_usage(output.parent).free < 2 * 1024 ** 3:
+        raise ValueError("At least 2 GiB of free temporary disk space is required")
+
+    token = os.environ.get("HF_TOKEN") or os.environ.get("HUGGING_FACE_HUB_TOKEN")
+    with tempfile.TemporaryDirectory(prefix="mere-run-fasth3-adaln-") as raw_temporary:
+        source = RangeTensorSource(Path(raw_temporary), token)
+        index = fetch_index(source)
+        remote_bytes = required_remote_bytes(source, index)
+        print(
+            f"Verified adapter. The pinned range-read closure is {remote_bytes / (1024 ** 3):.2f} GiB; "
+            "the complete checkpoint will not be downloaded.",
+            flush=True,
+        )
+        build_cache(source, index, output)
+
+    header, metadata = read_safetensors_header(output)
+    if len(header) != 54 or metadata.get("source_identity") != SOURCE_IDENTITY:
+        raise ValueError("Generated FastH3 AdaLN sidecar failed closure validation")
+    print(f"Wrote {output}", flush=True)
+    print(f"SHA-256 {sha256_file(output)}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/model-conversion/tests/test_merge_minimax_h3_fasth3_q8.py
+++ b/scripts/model-conversion/tests/test_merge_minimax_h3_fasth3_q8.py
@@ -1,0 +1,85 @@
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+SCRIPT = Path(__file__).parents[1] / "merge_minimax_h3_fasth3_q8.py"
+SPEC = importlib.util.spec_from_file_location("merge_minimax_h3_fasth3_q8", SCRIPT)
+assert SPEC is not None and SPEC.loader is not None
+CONVERTER = importlib.util.module_from_spec(SPEC)
+sys.modules[SPEC.name] = CONVERTER
+SPEC.loader.exec_module(CONVERTER)
+
+
+class MiniMaxH3FastH3Q8MergeTests(unittest.TestCase):
+    def test_adapter_targets_match_runtime_global_qkv_layout(self) -> None:
+        self.assertEqual(
+            CONVERTER.adapter_target("transformer_blocks.17.attn.to_q"),
+            CONVERTER.AdapterTarget("blocks.17.attn.qkv_proj", "query"),
+        )
+        self.assertEqual(
+            CONVERTER.adapter_target("transformer_blocks.17.attn.to_out.0"),
+            CONVERTER.AdapterTarget("blocks.17.attn.out_proj", None),
+        )
+        self.assertEqual(
+            CONVERTER.adapter_target(
+                "token_refiner.refiner_blocks.1.ff.net.0.proj"
+            ),
+            CONVERTER.AdapterTarget("token_refiner.blocks.1.mlp.fc1", None),
+        )
+
+    def test_difference_targets_match_compact_runtime_parameters(self) -> None:
+        self.assertEqual(
+            CONVERTER.difference_target("proj_in.diff"),
+            "video_patch_proj.weight",
+        )
+        self.assertEqual(
+            CONVERTER.difference_target("transformer_blocks.9.norm2.diff"),
+            "blocks.9.norm2.weight",
+        )
+        self.assertTrue(
+            CONVERTER.is_cache_covered(
+                CONVERTER.difference_target("time_embedder.linear_1.diff")
+            )
+        )
+
+    def test_inventory_requires_exact_fast_h3_tensor_closure(self) -> None:
+        header = {}
+        modules = []
+        for prefix, count in (("transformer_blocks", 50), ("token_refiner.refiner_blocks", 2)):
+            for index in range(count):
+                block = f"{prefix}.{index}"
+                modules.extend(
+                    [
+                        f"{block}.attn.to_q",
+                        f"{block}.attn.to_k",
+                        f"{block}.attn.to_v",
+                        f"{block}.attn.to_out.0",
+                        f"{block}.ff.net.0.proj",
+                        f"{block}.ff.net.2",
+                    ]
+                )
+                if prefix == "transformer_blocks":
+                    modules.append(f"{block}.adaln_proj.linear")
+                    header[f"{block}.attn.to_gate_compress.set_weight"] = {}
+        for module in modules:
+            header[f"{module}.lora_A.weight"] = {}
+            header[f"{module}.lora_B.weight"] = {}
+        for index in range(CONVERTER.EXPECTED_DIFFS):
+            header[f"transformer_blocks.{index % 50}.synthetic_{index}.diff"] = {}
+        inventory = CONVERTER.adapter_inventory(
+            header,
+            {
+                "format": CONVERTER.SOURCE_ADAPTER_FORMAT,
+                "finetuned_model": CONVERTER.FAST_H3_MODEL,
+            },
+        )
+        self.assertEqual(inventory["lora_pair_count"], 362)
+        self.assertEqual(inventory["core_lora_pair_count"], 312)
+        self.assertEqual(inventory["core_target_count"], 208)
+        self.assertEqual(inventory["compression_gate_count"], 50)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add the FastH3 VSA DataFree four-call runtime for MiniMax H3 on Apple Silicon
- port the fused FastVSA, post-attention, and high-resolution Q8 MLP recipe to MLX Metal custom kernels
- add a self-contained premerged Q8 managed package, conversion tooling, runtime controls, and documentation
- qualify the reduced-canvas Metal proof and record the remaining high-resolution throughput boundary

## Validation

- focused MiniMax H3 runtime and fused-kernel tests
- conversion-tool tests
- real-checkpoint reduced-canvas video proof on M4 Max
- full repository gate is being rerun while hosted CI executes

## Scope

The MLX dependency itself is unchanged. The Metal kernels and FastH3 recipe are owned by mere.run.