### PR TITLE
Release v0.47.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+## 0.47.0 - 2026-08-29
+
+This release brings FastH3 VSA DataFree to Apple Silicon with a self-contained
+managed Q8 package and a fused MLX Metal execution recipe. It also moves LTX
+2.5 to immutable inference-only native packages and adds the pinned MiniMax-H3
+LightX2V 8-step adapter with source-bound AdaLN caching.
+
 ### Video
 
 - moved both managed LTX 2.5 downloads to immutable inference-only MLX
@@ -44,6 +51,12 @@ The format is based on Keep a Changelog.
   4 GiB. The installed 50-block gate dispatched all five selected stages
   without fallback and stayed below `0.0012` relative L2 for both output
   modalities.
+
+### Included pull requests
+
+- exact release range: [#378](https://github.com/sawfwair/mere-run/pull/378),
+  [#379](https://github.com/sawfwair/mere-run/pull/379), and
+  [#380](https://github.com/sawfwair/mere-run/pull/380).
 
 ## 0.46.1 - 2026-08-29
 

--- a/Sources/MereRunRelayKit/MereRunCLIVersion.swift
+++ b/Sources/MereRunRelayKit/MereRunCLIVersion.swift
@@ -2,7 +2,7 @@
 /// contract version floors, worker probes, and the built-in node catalog
 /// identity.
 public enum MereRunCLIVersion {
-    public static let current = "0.46.1"
+    public static let current = "0.47.0"
 }
 
 /// Lenient three-component version-floor comparison used by worker

--- a/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
+++ b/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
@@ -130,7 +130,7 @@ final class CLIModelStoreBootstrapTests: XCTestCase {
     }
 
     func testMereRunCLIExposesReleaseVersion() {
-        XCTAssertEqual(MereRunCLIVersion.current, "0.46.1")
+        XCTAssertEqual(MereRunCLIVersion.current, "0.47.0")
         XCTAssertEqual(MereRunCLI.configuration.version, MereRunCLIVersion.current)
     }
 

--- a/scripts/build_mere_run_app.sh
+++ b/scripts/build_mere_run_app.sh
@@ -15,7 +15,7 @@ cd "$repo_root"
 
 # Version/build derive from git when not provided, so the bundle has a single source of
 # truth in CI. Fall back to a pinned value when git metadata is unavailable.
-default_version="0.46.1"
+default_version="0.47.0"
 if git_version="$(git describe --tags --exact-match 2>/dev/null)"; then
   default_version="${git_version#v}"
 fi


### PR DESCRIPTION
## Summary

- release FastH3 VSA DataFree Metal support from #380
- include the immutable LTX 2.5 packages from #378
- include the MiniMax-H3 LightX2V 8-step adapter and AdaLN cache from #379
- bump the CLI and app fallback version to 0.47.0

## Exact release range

- #378
- #379
- #380

## Validation

- `./scripts/check.sh`
- SwiftLint: 1,399 files, 0 violations
- XCTest: 3,323 tests passed, 278 expected skips, 0 failures
- Swift Testing: 32 tests in 4 suites passed