### PR TITLE
Fix macOS CLI installer runtime assets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+### macOS
+
+- fixed Studio's Install CLI action to copy the bundled ONNX Runtime dylib
+  alongside `mere.run` and to replace an existing CLI install, so rerunning the
+  action repairs incomplete terminal payloads from earlier app releases.
+
 ## 0.47.0 - 2026-08-29
 
 This release brings FastH3 VSA DataFree to Apple Silicon with a self-contained

--- a/apps/macos/MereRunStudio/CLIBootstrapInstaller.swift
+++ b/apps/macos/MereRunStudio/CLIBootstrapInstaller.swift
@@ -13,25 +13,21 @@ enum CLIBootstrapInstallError: LocalizedError {
 
 enum CLIBootstrapInstallOutcome: Equatable {
     case installed(URL)
-    case alreadyInstalled(URL)
     case skippedNoBundledCLI
     case failed(String)
 }
 
 enum CLIBootstrapInstaller {
-    static func installBundledCLIIfNeeded(
+    static func installBundledCLI(
         fileManager fm: FileManager = .default,
         bundle: Bundle = .main
     ) -> CLIBootstrapInstallOutcome {
-        if let installed = CLIResolver.existingInstalledCLI(fileManager: fm) {
-            return .alreadyInstalled(installed)
-        }
-
         guard let payloadURL = bundledPayloadURL(fileManager: fm, bundle: bundle) else {
             return .skippedNoBundledCLI
         }
 
-        let destinationURL = preferredAutomaticInstallURL(fileManager: fm)
+        let destinationURL = CLIResolver.existingInstalledCLI(fileManager: fm)
+            ?? preferredAutomaticInstallURL(fileManager: fm)
         do {
             try installBundledCLI(from: payloadURL, to: destinationURL, fileManager: fm)
             return .installed(destinationURL)
@@ -52,8 +48,6 @@ enum CLIBootstrapInstaller {
 
         let destinationDirectoryURL = destinationURL.deletingLastPathComponent()
         try fm.createDirectory(at: destinationDirectoryURL, withIntermediateDirectories: true)
-        try copyReplacingItem(at: binaryURL, to: destinationURL, fileManager: fm)
-        try fm.setAttributes([.posixPermissions: 0o755], ofItemAtPath: destinationURL.path)
 
         for assetURL in supportAssetURLs(in: payloadURL, fileManager: fm) {
             try copyReplacingItem(
@@ -62,6 +56,9 @@ enum CLIBootstrapInstaller {
                 fileManager: fm
             )
         }
+
+        try copyReplacingItem(at: binaryURL, to: destinationURL, fileManager: fm)
+        try fm.setAttributes([.posixPermissions: 0o755], ofItemAtPath: destinationURL.path)
     }
 
     static func bundledPayloadURL(
@@ -116,6 +113,7 @@ enum CLIBootstrapInstaller {
             .filter { url in
                 url.pathExtension == "framework"
                     || url.pathExtension == "bundle"
+                    || url.pathExtension == "dylib"
                     || url.lastPathComponent == "Resources"
                     || url.lastPathComponent == "mlx.metallib"
             }

--- a/apps/macos/MereRunStudio/MereRunController.swift
+++ b/apps/macos/MereRunStudio/MereRunController.swift
@@ -881,7 +881,7 @@ final class MereRunController: ObservableObject {
     }
 
     func installTerminalCLI() {
-        let outcome = CLIBootstrapInstaller.installBundledCLIIfNeeded()
+        let outcome = CLIBootstrapInstaller.installBundledCLI()
         handleCLIInstall(outcome)
         refreshResolvedCLI()
     }
@@ -1833,9 +1833,6 @@ final class MereRunController: ObservableObject {
         case .failed(let message):
             status = "CLI install failed"
             append("Terminal CLI install failed: \(message)", stream: .stderr)
-        case .alreadyInstalled(let url):
-            status = "CLI already installed"
-            append("Terminal CLI already installed at \(url.abbreviatedForDisplay).", stream: .system)
         case .skippedNoBundledCLI:
             status = "No bundled CLI"
             append("Terminal CLI install skipped: bundled CLI payload was not found.", stream: .stderr)

--- a/apps/macos/MereRunStudioTests/CLIBootstrapInstallerTests.swift
+++ b/apps/macos/MereRunStudioTests/CLIBootstrapInstallerTests.swift
@@ -32,10 +32,16 @@ final class CLIBootstrapInstallerTests: XCTestCase {
             .appendingPathComponent("mere.run", isDirectory: false)
 
         try makePayload(at: payloadURL)
+        try FileManager.default.createDirectory(
+            at: destinationURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try "stale".write(to: destinationURL, atomically: true, encoding: .utf8)
 
         try CLIBootstrapInstaller.installBundledCLI(from: payloadURL, to: destinationURL)
 
         XCTAssertTrue(FileManager.default.isExecutableFile(atPath: destinationURL.path))
+        XCTAssertEqual(try String(contentsOf: destinationURL, encoding: .utf8), "#!/usr/bin/env bash\n")
         XCTAssertTrue(
             FileManager.default.fileExists(
                 atPath: destinationURL
@@ -49,6 +55,14 @@ final class CLIBootstrapInstallerTests: XCTestCase {
                 atPath: destinationURL
                     .deletingLastPathComponent()
                     .appendingPathComponent("mlx-swift_Cmlx.bundle", isDirectory: true)
+                    .path
+            )
+        )
+        XCTAssertTrue(
+            FileManager.default.fileExists(
+                atPath: destinationURL
+                    .deletingLastPathComponent()
+                    .appendingPathComponent("libonnxruntime.1.20.1.dylib", isDirectory: false)
                     .path
             )
         )
@@ -89,6 +103,11 @@ final class CLIBootstrapInstallerTests: XCTestCase {
         try fm.createDirectory(
             at: payloadURL.appendingPathComponent("Resources", isDirectory: true),
             withIntermediateDirectories: true
+        )
+        try "fake".write(
+            to: payloadURL.appendingPathComponent("libonnxruntime.1.20.1.dylib", isDirectory: false),
+            atomically: true,
+            encoding: .utf8
         )
         try "fake".write(
             to: payloadURL.appendingPathComponent("Resources/default.metallib", isDirectory: false),


### PR DESCRIPTION
## Summary
- copy the bundled ONNX Runtime dylib with the terminal CLI payload
- make Install CLI replace an existing installation so affected users can repair incomplete installs
- stage support assets before replacing the executable and cover the repair path in tests

## Validation
- ./scripts/check.sh
- focused CLIBootstrapInstallerTests
- strict SwiftLint on touched Swift files
- git diff --check
- artifact simulation from the installed v0.47.0 app verified that the copied CLI runs mere.run status --json and includes libonnxruntime.1.20.1.dylib