### PR TITLE
Release v0.48.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,45 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+## 0.48.0 - 2026-08-31
+
+This release makes every public CLI capability first class in macOS Studio,
+including geospatial workflows, model-location management, benchmarks, live
+transcription, vision serving, and signed-plugin operations. It also makes the
+terminal CLI installer self-repairing for app releases whose runtime payload
+was incomplete.
+
 ### macOS
 
+- expanded Studio's exhaustive command contract from 101 to 127 commands and
+  added dedicated surfaces for Geospatial Lab, model-store locations, the full
+  benchmark family, Listen Live, Vision Grounding serving, and signed-plugin
+  details, execution, and rollback. New diagnostics exports remain bounded and
+  secret-safe, while local MetricKit crash capture is opt-in.
 - fixed Studio's Install CLI action to copy the bundled ONNX Runtime dylib
   alongside `mere.run` and to replace an existing CLI install, so rerunning the
   action repairs incomplete terminal payloads from earlier app releases.
+
+### CLI
+
+- exposed the 26 newly cataloged commands through `mere.run catalog --json`
+  and let `mere.run vision serve` read `MERERUN_API_KEY` when `--api-key` is
+  omitted, while preserving explicit-argument precedence.
+
+### Documentation and release quality
+
+- moved version-specific release history out of the README and added a guard
+  that keeps the project overview evergreen.
+- generalized signed-plugin acceptance coverage to derive each test bundle
+  from its verified release manifest, then install, relocate, run, and validate
+  that bundle through the production plugin store.
+
+### Included pull requests
+
+- exact release range: [#382](https://github.com/sawfwair/mere-run/pull/382),
+  [#383](https://github.com/sawfwair/mere-run/pull/383),
+  [#384](https://github.com/sawfwair/mere-run/pull/384), and
+  [#385](https://github.com/sawfwair/mere-run/pull/385).
 
 ## 0.47.0 - 2026-08-29
 

--- a/Sources/MereRunRelayKit/MereRunCLIVersion.swift
+++ b/Sources/MereRunRelayKit/MereRunCLIVersion.swift
@@ -2,7 +2,7 @@
 /// contract version floors, worker probes, and the built-in node catalog
 /// identity.
 public enum MereRunCLIVersion {
-    public static let current = "0.47.0"
+    public static let current = "0.48.0"
 }
 
 /// Lenient three-component version-floor comparison used by worker

--- a/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
+++ b/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
@@ -130,7 +130,7 @@ final class CLIModelStoreBootstrapTests: XCTestCase {
     }
 
     func testMereRunCLIExposesReleaseVersion() {
-        XCTAssertEqual(MereRunCLIVersion.current, "0.47.0")
+        XCTAssertEqual(MereRunCLIVersion.current, "0.48.0")
         XCTAssertEqual(MereRunCLI.configuration.version, MereRunCLIVersion.current)
     }
 

--- a/scripts/build_mere_run_app.sh
+++ b/scripts/build_mere_run_app.sh
@@ -15,7 +15,7 @@ cd "$repo_root"
 
 # Version/build derive from git when not provided, so the bundle has a single source of
 # truth in CI. Fall back to a pinned value when git metadata is unavailable.
-default_version="0.47.0"
+default_version="0.48.0"
 if git_version="$(git describe --tags --exact-match 2>/dev/null)"; then
   default_version="${git_version#v}"
 fi


### PR DESCRIPTION
## Summary

- bump the public CLI and macOS bundle fallback version to 0.48.0
- document the exact post-v0.47.0 release range: #382, #383, #384, and #385
- call out the expanded macOS Studio capability catalog and the self-repairing CLI installer

## Validation

- `./scripts/check.sh`
  - strict SwiftLint: 0 violations across 1,403 files
  - XCTest: 3,331 tests, 278 expected skips, 0 failures
  - Swift Testing: 33 tests, 0 failures
  - build, CLI help sweep, documentation, and hygiene checks passed
- `git diff --check`

## Release boundary

This PR only prepares the source tree. The annotated `v0.48.0` tag will be created from the exact merged commit after required checks pass. Signed, notarized macOS/Sparkle artifacts and Linux CUDA artifacts will then be built from that tag and published only after their release gates pass.