### PR TITLE
Synchronize Studio-managed CLI after app updates

### DIFF
--- a/apps/macos/MereRunStudio/CLIBootstrapInstaller.swift
+++ b/apps/macos/MereRunStudio/CLIBootstrapInstaller.swift
@@ -1,64 +1,108 @@
+import Darwin
 import Foundation
 
 enum CLIBootstrapInstallError: LocalizedError {
     case missingBinary(String)
+    case invalidPayload(String)
+    case unwritableDestination(String)
+    case validationFailed(String)
+    case atomicActivationFailed(String)
 
     var errorDescription: String? {
         switch self {
         case .missingBinary(let path):
             return "Bundled CLI binary not found at \(path)."
+        case .invalidPayload(let message):
+            return "Bundled CLI payload is invalid: \(message)"
+        case .unwritableDestination(let path):
+            return "The CLI destination is not writable: \(path). Choose a writable bin directory or update its permissions."
+        case .validationFailed(let message):
+            return "The staged CLI did not pass validation: \(message)"
+        case .atomicActivationFailed(let message):
+            return "The CLI could not be activated atomically: \(message)"
         }
     }
 }
 
-enum CLIBootstrapInstallOutcome: Equatable {
-    case installed(URL)
-    case skippedNoBundledCLI
-    case failed(String)
+struct CLIManagedInstallation: Equatable, Sendable {
+    let destinationURL: URL
+    let payloadURL: URL
+    let receipt: CLIInstallationReceipt
+    let installedVersion: String
 }
 
 enum CLIBootstrapInstaller {
-    static func installBundledCLI(
-        fileManager fm: FileManager = .default,
-        bundle: Bundle = .main
-    ) -> CLIBootstrapInstallOutcome {
-        guard let payloadURL = bundledPayloadURL(fileManager: fm, bundle: bundle) else {
-            return .skippedNoBundledCLI
-        }
-
-        let destinationURL = CLIResolver.existingInstalledCLI(fileManager: fm)
-            ?? preferredAutomaticInstallURL(fileManager: fm)
-        do {
-            try installBundledCLI(from: payloadURL, to: destinationURL, fileManager: fm)
-            return .installed(destinationURL)
-        } catch {
-            return .failed(error.localizedDescription)
-        }
-    }
-
-    static func installBundledCLI(
+    static func installManagedPayload(
         from payloadURL: URL,
         to destinationURL: URL,
+        paths: CLIInstallationPaths,
+        studioBuild: CLIStudioBuild,
+        installationDate: Date = Date(),
         fileManager fm: FileManager = .default
-    ) throws {
-        let binaryURL = payloadURL.appendingPathComponent("mere.run", isDirectory: false)
-        guard fm.isExecutableFile(atPath: binaryURL.path) else {
-            throw CLIBootstrapInstallError.missingBinary(binaryURL.path)
+    ) throws -> CLIManagedInstallation {
+        let bundledBinaryURL = payloadURL.appendingPathComponent("mere.run", isDirectory: false)
+        guard fm.isExecutableFile(atPath: bundledBinaryURL.path) else {
+            throw CLIBootstrapInstallError.missingBinary(bundledBinaryURL.path)
         }
 
-        let destinationDirectoryURL = destinationURL.deletingLastPathComponent()
-        try fm.createDirectory(at: destinationDirectoryURL, withIntermediateDirectories: true)
+        let manifest = try CLIPayloadManifestBuilder.manifest(at: payloadURL, fileManager: fm)
+        guard manifest.assetNames.contains("mere.run") else {
+            throw CLIBootstrapInstallError.invalidPayload("the top-level executable is absent")
+        }
+        guard destinationDirectoryIsWritable(destinationURL, fileManager: fm) else {
+            throw CLIBootstrapInstallError.unwritableDestination(destinationURL.deletingLastPathComponent().path)
+        }
 
-        for assetURL in supportAssetURLs(in: payloadURL, fileManager: fm) {
-            try copyReplacingItem(
-                at: assetURL,
-                to: destinationDirectoryURL.appendingPathComponent(assetURL.lastPathComponent),
+        let oldReceipt = try? CLIInstallationReceipt.read(from: paths.receiptURL)
+        try fm.createDirectory(at: paths.payloadRoot, withIntermediateDirectories: true)
+        let targetURL = try stagedPayloadURL(
+            for: payloadURL,
+            manifest: manifest,
+            paths: paths,
+            studioBuild: studioBuild,
+            fileManager: fm
+        )
+        let installedBinaryURL = targetURL.appendingPathComponent("mere.run", isDirectory: false)
+        let installedVersion = try validatedVersion(executableURL: installedBinaryURL)
+
+        let receipt = CLIInstallationReceipt(
+            destinationPath: destinationURL.standardizedFileURL.path,
+            payloadPath: targetURL.standardizedFileURL.path,
+            studioVersion: studioBuild.version,
+            studioBuild: studioBuild.build,
+            payloadFingerprint: manifest.fingerprint,
+            installedAssetNames: manifest.assetNames,
+            installationTimestamp: installationDate
+        )
+
+        let backup = try activateSymlink(
+            destinationURL: destinationURL,
+            executableURL: installedBinaryURL,
+            fileManager: fm
+        )
+        do {
+            try receipt.write(to: paths.receiptURL, fileManager: fm)
+        } catch {
+            try? restoreDestination(backup, destinationURL: destinationURL, fileManager: fm)
+            throw error
+        }
+        discardDestinationBackup(backup, fileManager: fm)
+
+        if let oldReceipt {
+            removePreviouslyOwnedPayloadIfSafe(
+                oldReceipt,
+                replacingWith: receipt,
+                paths: paths,
                 fileManager: fm
             )
         }
 
-        try copyReplacingItem(at: binaryURL, to: destinationURL, fileManager: fm)
-        try fm.setAttributes([.posixPermissions: 0o755], ofItemAtPath: destinationURL.path)
+        return CLIManagedInstallation(
+            destinationURL: destinationURL,
+            payloadURL: targetURL,
+            receipt: receipt,
+            installedVersion: installedVersion
+        )
     }
 
     static func bundledPayloadURL(
@@ -93,7 +137,7 @@ enum CLIBootstrapInstaller {
         fileManager fm: FileManager = .default,
         installDirectoryCandidates: [URL]
     ) -> URL {
-        for candidate in installDirectoryCandidates where candidate.isWritableDirectory(fileManager: fm) {
+        for candidate in installDirectoryCandidates where directoryIsWritable(candidate, fileManager: fm) {
             return candidate.appendingPathComponent("mere.run", isDirectory: false)
         }
         return fm.homeDirectoryForCurrentUser
@@ -102,37 +146,250 @@ enum CLIBootstrapInstaller {
             .appendingPathComponent("mere.run", isDirectory: false)
     }
 
-    private static func supportAssetURLs(in payloadURL: URL, fileManager fm: FileManager) -> [URL] {
-        let contents = (try? fm.contentsOfDirectory(
-            at: payloadURL,
-            includingPropertiesForKeys: [.isDirectoryKey],
-            options: [.skipsHiddenFiles]
-        )) ?? []
-
-        return contents
-            .filter { url in
-                url.pathExtension == "framework"
-                    || url.pathExtension == "bundle"
-                    || url.pathExtension == "dylib"
-                    || url.lastPathComponent == "Resources"
-                    || url.lastPathComponent == "mlx.metallib"
-            }
-            .sorted { $0.lastPathComponent < $1.lastPathComponent }
+    static func existingInstallationCandidate(
+        paths: CLIInstallationPaths,
+        fileManager fm: FileManager = .default
+    ) -> URL? {
+        paths.destinationCandidates.first { itemExistsIncludingSymbolicLink($0, fileManager: fm) }
     }
 
-    private static func copyReplacingItem(at sourceURL: URL, to destinationURL: URL, fileManager fm: FileManager) throws {
-        if fm.fileExists(atPath: destinationURL.path) {
-            try fm.removeItem(at: destinationURL)
+    static func itemExistsIncludingSymbolicLink(_ url: URL, fileManager fm: FileManager = .default) -> Bool {
+        fm.fileExists(atPath: url.path) || (try? fm.destinationOfSymbolicLink(atPath: url.path)) != nil
+    }
+
+    static func resolvedSymbolicLink(at url: URL, fileManager fm: FileManager = .default) -> URL? {
+        guard let destination = try? fm.destinationOfSymbolicLink(atPath: url.path) else { return nil }
+        let destinationURL: URL
+        if destination.hasPrefix("/") {
+            destinationURL = URL(fileURLWithPath: destination)
+        } else {
+            destinationURL = url.deletingLastPathComponent().appendingPathComponent(destination)
         }
-        try fm.copyItem(at: sourceURL, to: destinationURL)
+        return destinationURL.standardizedFileURL.resolvingSymlinksInPath()
     }
-}
 
-private extension URL {
-    func isWritableDirectory(fileManager fm: FileManager) -> Bool {
+    static func validatedVersion(executableURL: URL) throws -> String {
+        guard FileManager.default.isExecutableFile(atPath: executableURL.path) else {
+            throw CLIBootstrapInstallError.validationFailed("\(executableURL.path) is not executable")
+        }
+
+        let process = Process()
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.executableURL = executableURL
+        process.arguments = ["--version"]
+        process.currentDirectoryURL = executableURL.resolvingSymlinksInPath().deletingLastPathComponent()
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+        do {
+            try process.run()
+        } catch {
+            throw CLIBootstrapInstallError.validationFailed(error.localizedDescription)
+        }
+        process.waitUntilExit()
+        let stdout = String(decoding: stdoutPipe.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let stderr = String(decoding: stderrPipe.fileHandleForReading.readDataToEndOfFile(), as: UTF8.self)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard process.terminationStatus == 0, !stdout.isEmpty else {
+            let message = stderr.isEmpty ? "`--version` exited with status \(process.terminationStatus)" : stderr
+            throw CLIBootstrapInstallError.validationFailed(message)
+        }
+        return stdout
+    }
+
+    static func payloadMatches(
+        receipt: CLIInstallationReceipt,
+        paths: CLIInstallationPaths,
+        fileManager fm: FileManager = .default
+    ) -> Bool {
+        let payloadURL = URL(fileURLWithPath: receipt.payloadPath, isDirectory: true)
+        guard payloadURL != paths.payloadRoot,
+              payloadURL.isContained(in: paths.payloadRoot),
+              fm.isExecutableFile(atPath: payloadURL.appendingPathComponent("mere.run").path),
+              let manifest = try? CLIPayloadManifestBuilder.manifest(at: payloadURL, fileManager: fm) else {
+            return false
+        }
+        return manifest.fingerprint == receipt.payloadFingerprint
+            && manifest.assetNames == receipt.installedAssetNames
+    }
+
+    static func destinationIsWritable(_ destinationURL: URL, fileManager fm: FileManager = .default) -> Bool {
+        destinationDirectoryIsWritable(destinationURL, fileManager: fm)
+    }
+
+    private static func stagedPayloadURL(
+        for payloadURL: URL,
+        manifest: CLIPayloadManifest,
+        paths: CLIInstallationPaths,
+        studioBuild: CLIStudioBuild,
+        fileManager fm: FileManager
+    ) throws -> URL {
+        let baseName = "\(safePathComponent(studioBuild.build))-\(manifest.fingerprint.prefix(12))"
+        var targetURL = paths.payloadRoot.appendingPathComponent(baseName, isDirectory: true)
+        if fm.fileExists(atPath: targetURL.path) {
+            if let existingManifest = try? CLIPayloadManifestBuilder.manifest(at: targetURL, fileManager: fm),
+               existingManifest == manifest,
+               (try? validatedVersion(executableURL: targetURL.appendingPathComponent("mere.run"))) != nil {
+                return targetURL
+            }
+            targetURL = paths.payloadRoot.appendingPathComponent(
+                "\(baseName)-repair-\(UUID().uuidString)",
+                isDirectory: true
+            )
+        }
+
+        let stagingURL = paths.payloadRoot.appendingPathComponent(
+            ".stage-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        do {
+            try fm.createDirectory(at: stagingURL, withIntermediateDirectories: false)
+            for assetURL in try fm.contentsOfDirectory(at: payloadURL, includingPropertiesForKeys: nil) {
+                try fm.copyItem(
+                    at: assetURL,
+                    to: stagingURL.appendingPathComponent(assetURL.lastPathComponent)
+                )
+            }
+            let stagedManifest = try CLIPayloadManifestBuilder.manifest(at: stagingURL, fileManager: fm)
+            guard stagedManifest == manifest else {
+                throw CLIBootstrapInstallError.invalidPayload("the staged payload fingerprint changed during copy")
+            }
+            _ = try validatedVersion(executableURL: stagingURL.appendingPathComponent("mere.run"))
+            try fm.moveItem(at: stagingURL, to: targetURL)
+            return targetURL
+        } catch {
+            try? fm.removeItem(at: stagingURL)
+            throw error
+        }
+    }
+
+    private enum DestinationBackup {
+        case missing
+        case symbolicLink(String)
+        case copied(URL)
+    }
+
+    private static func activateSymlink(
+        destinationURL: URL,
+        executableURL: URL,
+        fileManager fm: FileManager
+    ) throws -> DestinationBackup {
+        let destinationDirectoryURL = destinationURL.deletingLastPathComponent()
+        try fm.createDirectory(at: destinationDirectoryURL, withIntermediateDirectories: true)
+        guard destinationDirectoryIsWritable(destinationURL, fileManager: fm) else {
+            throw CLIBootstrapInstallError.unwritableDestination(destinationDirectoryURL.path)
+        }
+
+        let backup: DestinationBackup
+        if let symbolicDestination = try? fm.destinationOfSymbolicLink(atPath: destinationURL.path) {
+            backup = .symbolicLink(symbolicDestination)
+        } else if fm.fileExists(atPath: destinationURL.path) {
+            var isDirectory: ObjCBool = false
+            guard fm.fileExists(atPath: destinationURL.path, isDirectory: &isDirectory), !isDirectory.boolValue else {
+                throw CLIBootstrapInstallError.atomicActivationFailed("\(destinationURL.path) is a directory")
+            }
+            let backupURL = destinationDirectoryURL.appendingPathComponent(
+                ".mere.run-backup-\(UUID().uuidString)",
+                isDirectory: false
+            )
+            try fm.copyItem(at: destinationURL, to: backupURL)
+            backup = .copied(backupURL)
+        } else {
+            backup = .missing
+        }
+
+        let temporaryLinkURL = destinationDirectoryURL.appendingPathComponent(
+            ".mere.run-link-\(UUID().uuidString)",
+            isDirectory: false
+        )
+        do {
+            try fm.createSymbolicLink(at: temporaryLinkURL, withDestinationURL: executableURL)
+            try renameAtomically(from: temporaryLinkURL, to: destinationURL)
+            return backup
+        } catch {
+            try? fm.removeItem(at: temporaryLinkURL)
+            discardDestinationBackup(backup, fileManager: fm)
+            throw error
+        }
+    }
+
+    private static func restoreDestination(
+        _ backup: DestinationBackup,
+        destinationURL: URL,
+        fileManager fm: FileManager
+    ) throws {
+        switch backup {
+        case .missing:
+            try? fm.removeItem(at: destinationURL)
+        case .symbolicLink(let target):
+            let restoreURL = destinationURL.deletingLastPathComponent().appendingPathComponent(
+                ".mere.run-restore-\(UUID().uuidString)"
+            )
+            try fm.createSymbolicLink(atPath: restoreURL.path, withDestinationPath: target)
+            try renameAtomically(from: restoreURL, to: destinationURL)
+        case .copied(let backupURL):
+            try renameAtomically(from: backupURL, to: destinationURL)
+        }
+    }
+
+    private static func discardDestinationBackup(_ backup: DestinationBackup, fileManager fm: FileManager) {
+        if case .copied(let backupURL) = backup {
+            try? fm.removeItem(at: backupURL)
+        }
+    }
+
+    private static func renameAtomically(from sourceURL: URL, to destinationURL: URL) throws {
+        let result = sourceURL.path.withCString { sourcePath in
+            destinationURL.path.withCString { destinationPath in
+                Darwin.rename(sourcePath, destinationPath)
+            }
+        }
+        guard result == 0 else {
+            throw CLIBootstrapInstallError.atomicActivationFailed(String(cString: strerror(errno)))
+        }
+    }
+
+    private static func removePreviouslyOwnedPayloadIfSafe(
+        _ oldReceipt: CLIInstallationReceipt,
+        replacingWith newReceipt: CLIInstallationReceipt,
+        paths: CLIInstallationPaths,
+        fileManager fm: FileManager
+    ) {
+        guard oldReceipt.payloadPath != newReceipt.payloadPath,
+              oldReceipt.destinationPath == newReceipt.destinationPath,
+              payloadMatches(receipt: oldReceipt, paths: paths, fileManager: fm) else {
+            return
+        }
+        try? fm.removeItem(at: URL(fileURLWithPath: oldReceipt.payloadPath, isDirectory: true))
+    }
+
+    private static func destinationDirectoryIsWritable(_ destinationURL: URL, fileManager fm: FileManager) -> Bool {
+        directoryIsWritable(destinationURL.deletingLastPathComponent(), fileManager: fm)
+    }
+
+    private static func directoryIsWritable(_ directoryURL: URL, fileManager fm: FileManager) -> Bool {
+        var candidateURL = directoryURL
+        while !fm.fileExists(atPath: candidateURL.path) {
+            let parentURL = candidateURL.deletingLastPathComponent()
+            guard parentURL.path != candidateURL.path else { return false }
+            candidateURL = parentURL
+        }
         var isDirectory: ObjCBool = false
-        return fm.fileExists(atPath: path, isDirectory: &isDirectory)
-            && isDirectory.boolValue
-            && fm.isWritableFile(atPath: path)
+        guard fm.fileExists(atPath: candidateURL.path, isDirectory: &isDirectory),
+              isDirectory.boolValue,
+              let attributes = try? fm.attributesOfItem(atPath: candidateURL.path),
+              let permissions = attributes[.posixPermissions] as? NSNumber,
+              permissions.intValue & 0o222 != 0 else {
+            return false
+        }
+        return fm.isWritableFile(atPath: candidateURL.path)
+    }
+
+    private static func safePathComponent(_ value: String) -> String {
+        let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-._"))
+        let scalars = value.unicodeScalars.map { allowed.contains($0) ? Character(String($0)) : "-" }
+        let component = String(scalars)
+        return component.isEmpty ? "dev" : component
     }
 }

--- a/apps/macos/MereRunStudio/CLIInstallationReceipt.swift
+++ b/apps/macos/MereRunStudio/CLIInstallationReceipt.swift
@@ -1,0 +1,201 @@
+import CryptoKit
+import Foundation
+
+enum CLIInstallationReceiptError: LocalizedError, Equatable {
+    case unsupportedSchemaVersion(Int)
+    case payloadOutsideManagedRoot(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .unsupportedSchemaVersion(let version):
+            return "Unsupported Studio CLI installation receipt schema version \(version)."
+        case .payloadOutsideManagedRoot(let path):
+            return "The Studio CLI receipt points outside the managed payload directory: \(path)."
+        }
+    }
+}
+
+struct CLIInstallationReceipt: Codable, Equatable, Sendable {
+    static let currentSchemaVersion = 1
+
+    let schemaVersion: Int
+    let destinationPath: String
+    let payloadPath: String
+    let studioVersion: String
+    let studioBuild: String
+    let payloadFingerprint: String
+    let installedAssetNames: [String]
+    let installationTimestamp: Date
+
+    init(
+        schemaVersion: Int = Self.currentSchemaVersion,
+        destinationPath: String,
+        payloadPath: String,
+        studioVersion: String,
+        studioBuild: String,
+        payloadFingerprint: String,
+        installedAssetNames: [String],
+        installationTimestamp: Date
+    ) {
+        self.schemaVersion = schemaVersion
+        self.destinationPath = destinationPath
+        self.payloadPath = payloadPath
+        self.studioVersion = studioVersion
+        self.studioBuild = studioBuild
+        self.payloadFingerprint = payloadFingerprint
+        self.installedAssetNames = installedAssetNames
+        self.installationTimestamp = installationTimestamp
+    }
+
+    static func read(from url: URL) throws -> Self {
+        let data = try Data(contentsOf: url)
+        let receipt = try decoder.decode(Self.self, from: data)
+        guard receipt.schemaVersion == currentSchemaVersion else {
+            throw CLIInstallationReceiptError.unsupportedSchemaVersion(receipt.schemaVersion)
+        }
+        return receipt
+    }
+
+    func write(to url: URL, fileManager fm: FileManager = .default) throws {
+        try fm.createDirectory(at: url.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try Self.encoder.encode(self).write(to: url, options: .atomic)
+    }
+
+    private static var encoder: JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        return encoder
+    }
+
+    private static var decoder: JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }
+}
+
+struct CLIStudioBuild: Equatable, Sendable {
+    let version: String
+    let build: String
+
+    static func current(bundle: Bundle = .main) -> Self {
+        let version = bundle.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+        let build = bundle.object(forInfoDictionaryKey: "CFBundleVersion") as? String
+        return Self(version: version ?? "dev", build: build ?? "dev")
+    }
+}
+
+struct CLIInstallationPaths: Equatable, Sendable {
+    let applicationSupportRoot: URL
+    let payloadRoot: URL
+    let receiptURL: URL
+    let destinationCandidates: [URL]
+
+    init(applicationSupportRoot: URL, destinationCandidates: [URL]) {
+        self.applicationSupportRoot = applicationSupportRoot
+        payloadRoot = applicationSupportRoot.appendingPathComponent("cli", isDirectory: true)
+        receiptURL = applicationSupportRoot.appendingPathComponent(
+            "studio-cli-install.json",
+            isDirectory: false
+        )
+        self.destinationCandidates = destinationCandidates
+    }
+
+    static func current(fileManager fm: FileManager = .default) -> Self {
+        let supportRoot = fm.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
+            .appendingPathComponent("mere.run", isDirectory: true)
+        return Self(
+            applicationSupportRoot: supportRoot,
+            destinationCandidates: CLIResolver.installedCandidates(fileManager: fm)
+        )
+    }
+}
+
+struct CLIPayloadManifest: Equatable, Sendable {
+    let fingerprint: String
+    let assetNames: [String]
+}
+
+enum CLIPayloadManifestBuilder {
+    static func manifest(at rootURL: URL, fileManager fm: FileManager = .default) throws -> CLIPayloadManifest {
+        let assetURLs = try fm.contentsOfDirectory(
+            at: rootURL,
+            includingPropertiesForKeys: [.isDirectoryKey, .isRegularFileKey, .isSymbolicLinkKey],
+            options: []
+        ).sorted { $0.lastPathComponent < $1.lastPathComponent }
+
+        var entries = assetURLs
+        if let enumerator = fm.enumerator(
+            at: rootURL,
+            includingPropertiesForKeys: [.isDirectoryKey, .isRegularFileKey, .isSymbolicLinkKey],
+            options: []
+        ) {
+            for case let entryURL as URL in enumerator {
+                if !assetURLs.contains(entryURL) {
+                    entries.append(entryURL)
+                }
+            }
+        }
+        entries.sort { relativePath(for: $0, rootURL: rootURL) < relativePath(for: $1, rootURL: rootURL) }
+
+        var hasher = SHA256()
+        for entryURL in entries {
+            let relativePath = relativePath(for: entryURL, rootURL: rootURL)
+            let values = try entryURL.resourceValues(forKeys: [
+                .fileSizeKey,
+                .isDirectoryKey,
+                .isRegularFileKey,
+                .isSymbolicLinkKey,
+            ])
+            if values.isSymbolicLink == true {
+                update(&hasher, marker: "link", path: relativePath)
+                let destination = try fm.destinationOfSymbolicLink(atPath: entryURL.path)
+                updateLength(destination.utf8.count, hasher: &hasher)
+                hasher.update(data: Data(destination.utf8))
+            } else if values.isDirectory == true {
+                update(&hasher, marker: "directory", path: relativePath)
+            } else if values.isRegularFile == true {
+                update(&hasher, marker: "file", path: relativePath)
+                updateLength(values.fileSize ?? 0, hasher: &hasher)
+                let handle = try FileHandle(forReadingFrom: entryURL)
+                defer { try? handle.close() }
+                while let chunk = try handle.read(upToCount: 1024 * 1024), !chunk.isEmpty {
+                    hasher.update(data: chunk)
+                }
+            }
+        }
+
+        return CLIPayloadManifest(
+            fingerprint: hasher.finalize().map { String(format: "%02x", $0) }.joined(),
+            assetNames: assetURLs.map(\.lastPathComponent)
+        )
+    }
+
+    private static func relativePath(for url: URL, rootURL: URL) -> String {
+        let rootPath = rootURL.standardizedFileURL.path
+        let path = url.standardizedFileURL.path
+        guard path.hasPrefix(rootPath + "/") else { return url.lastPathComponent }
+        return String(path.dropFirst(rootPath.count + 1))
+    }
+
+    private static func update(_ hasher: inout SHA256, marker: String, path: String) {
+        hasher.update(data: Data(marker.utf8))
+        hasher.update(data: Data([0]))
+        hasher.update(data: Data(path.utf8))
+        hasher.update(data: Data([0]))
+    }
+
+    private static func updateLength(_ length: Int, hasher: inout SHA256) {
+        hasher.update(data: Data(String(length).utf8))
+        hasher.update(data: Data([0]))
+    }
+}
+
+extension URL {
+    func isContained(in rootURL: URL) -> Bool {
+        let rootPath = rootURL.standardizedFileURL.path
+        let candidatePath = standardizedFileURL.path
+        return candidatePath == rootPath || candidatePath.hasPrefix(rootPath + "/")
+    }
+}

--- a/apps/macos/MereRunStudio/CLIInstallationSynchronizer.swift
+++ b/apps/macos/MereRunStudio/CLIInstallationSynchronizer.swift
@@ -1,0 +1,485 @@
+import Foundation
+
+enum CLIInstallationKind: Equatable, Sendable {
+    case none
+    case studioManaged
+    case bundledSymlink
+    case unowned
+    case externallyManaged
+    case custom
+}
+
+enum CLIInstallationPhase: Equatable, Sendable {
+    case install
+    case upToDate
+    case update
+    case repair
+    case externallyManaged
+    case synchronizing
+}
+
+struct CLIInstallationStatus: Equatable, Sendable {
+    let phase: CLIInstallationPhase
+    let kind: CLIInstallationKind
+    let resolvedPath: String?
+    let installedVersion: String?
+    let bundledVersion: String?
+    let detail: String
+    let lastSynchronizationError: String?
+    let allowsManualAction: Bool
+
+    static let checking = Self(
+        phase: .synchronizing,
+        kind: .none,
+        resolvedPath: nil,
+        installedVersion: nil,
+        bundledVersion: nil,
+        detail: "Checking the Terminal CLI installation…",
+        lastSynchronizationError: nil,
+        allowsManualAction: false
+    )
+
+    var title: String {
+        switch phase {
+        case .install: "Install CLI"
+        case .upToDate: "CLI is up to date"
+        case .update: "Update CLI"
+        case .repair: "Repair CLI"
+        case .externallyManaged: "CLI managed externally"
+        case .synchronizing: "Synchronizing CLI…"
+        }
+    }
+
+    var actionTitle: String? {
+        guard allowsManualAction else { return nil }
+        return switch phase {
+        case .install: "Install CLI"
+        case .update: "Update CLI"
+        case .repair, .upToDate: "Repair CLI"
+        case .externallyManaged, .synchronizing: nil
+        }
+    }
+}
+
+struct CLIInstallationContext: Equatable, Sendable {
+    let bundledPayloadURL: URL?
+    let paths: CLIInstallationPaths
+    let studioBuild: CLIStudioBuild
+    let customCLIPath: String
+
+    static func current(
+        customCLIPath: String,
+        fileManager fm: FileManager = .default,
+        bundle: Bundle = .main
+    ) -> Self {
+        Self(
+            bundledPayloadURL: CLIBootstrapInstaller.bundledPayloadURL(fileManager: fm, bundle: bundle),
+            paths: .current(fileManager: fm),
+            studioBuild: .current(bundle: bundle),
+            customCLIPath: customCLIPath
+        )
+    }
+}
+
+private struct CLIInstallationInspection {
+    let status: CLIInstallationStatus
+    let destinationURL: URL?
+    let automaticUpdateAllowed: Bool
+}
+
+enum CLIInstallationSynchronizer {
+    static func inspect(
+        context: CLIInstallationContext,
+        fileManager fm: FileManager = .default
+    ) -> CLIInstallationStatus {
+        inspection(context: context, fileManager: fm).status
+    }
+
+    static func synchronizeAfterLaunch(
+        context: CLIInstallationContext,
+        fileManager fm: FileManager = .default
+    ) -> CLIInstallationStatus {
+        let current = inspection(context: context, fileManager: fm)
+        guard current.automaticUpdateAllowed,
+              let payloadURL = context.bundledPayloadURL,
+              let destinationURL = current.destinationURL else {
+            return current.status
+        }
+
+        do {
+            _ = try CLIBootstrapInstaller.installManagedPayload(
+                from: payloadURL,
+                to: destinationURL,
+                paths: context.paths,
+                studioBuild: context.studioBuild,
+                fileManager: fm
+            )
+            return inspection(context: context, fileManager: fm).status
+        } catch {
+            return failedStatus(from: current.status, error: error)
+        }
+    }
+
+    static func performManualAction(
+        context: CLIInstallationContext,
+        fileManager fm: FileManager = .default
+    ) -> CLIInstallationStatus {
+        let current = inspection(context: context, fileManager: fm)
+        guard current.status.allowsManualAction else { return current.status }
+        guard let payloadURL = context.bundledPayloadURL else {
+            return failedStatus(
+                from: current.status,
+                error: CLIBootstrapInstallError.invalidPayload("the app does not contain a bundled CLI")
+            )
+        }
+
+        let destinationURL = current.destinationURL ?? preferredDestination(
+            paths: context.paths,
+            fileManager: fm
+        )
+        do {
+            _ = try CLIBootstrapInstaller.installManagedPayload(
+                from: payloadURL,
+                to: destinationURL,
+                paths: context.paths,
+                studioBuild: context.studioBuild,
+                fileManager: fm
+            )
+            return inspection(context: context, fileManager: fm).status
+        } catch {
+            return failedStatus(from: current.status, error: error)
+        }
+    }
+
+    private static func inspection(
+        context: CLIInstallationContext,
+        fileManager fm: FileManager
+    ) -> CLIInstallationInspection {
+        let bundled = bundledInformation(context: context, fileManager: fm)
+        let customPath = NSString(string: context.customCLIPath).expandingTildeInPath
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if !customPath.isEmpty {
+            let customURL = URL(fileURLWithPath: customPath, isDirectory: false)
+            return CLIInstallationInspection(
+                status: CLIInstallationStatus(
+                    phase: .externallyManaged,
+                    kind: .custom,
+                    resolvedPath: customURL.path,
+                    installedVersion: try? CLIBootstrapInstaller.validatedVersion(executableURL: customURL),
+                    bundledVersion: bundled.version,
+                    detail: "Studio will not replace the explicitly configured CLI path.",
+                    lastSynchronizationError: nil,
+                    allowsManualAction: false
+                ),
+                destinationURL: customURL,
+                automaticUpdateAllowed: false
+            )
+        }
+
+        var receipt: CLIInstallationReceipt?
+        var receiptError: String?
+        if CLIBootstrapInstaller.itemExistsIncludingSymbolicLink(context.paths.receiptURL, fileManager: fm) {
+            do {
+                receipt = try CLIInstallationReceipt.read(from: context.paths.receiptURL)
+            } catch {
+                receiptError = error.localizedDescription
+            }
+        }
+
+        let receiptDestinationURL = receipt.map {
+            URL(fileURLWithPath: $0.destinationPath, isDirectory: false)
+        }
+        let destinationURL = receiptDestinationURL
+            ?? CLIBootstrapInstaller.existingInstallationCandidate(paths: context.paths, fileManager: fm)
+
+        guard let destinationURL else {
+            let bundledMissing = context.bundledPayloadURL == nil
+            return CLIInstallationInspection(
+                status: CLIInstallationStatus(
+                    phase: .install,
+                    kind: .none,
+                    resolvedPath: nil,
+                    installedVersion: nil,
+                    bundledVersion: bundled.version,
+                    detail: bundledMissing
+                        ? "This build does not contain a bundled CLI payload."
+                        : "No Terminal CLI is installed in a supported command location.",
+                    lastSynchronizationError: bundled.error,
+                    allowsManualAction: !bundledMissing
+                ),
+                destinationURL: nil,
+                automaticUpdateAllowed: false
+            )
+        }
+
+        if receipt != nil, !isSupportedDestination(destinationURL, paths: context.paths) {
+            return CLIInstallationInspection(
+                status: CLIInstallationStatus(
+                    phase: .externallyManaged,
+                    kind: .custom,
+                    resolvedPath: destinationURL.path,
+                    installedVersion: try? CLIBootstrapInstaller.validatedVersion(executableURL: destinationURL),
+                    bundledVersion: bundled.version,
+                    detail: "The receipt names a destination outside Studio's supported command locations.",
+                    lastSynchronizationError: "Studio won't replace this custom CLI destination.",
+                    allowsManualAction: false
+                ),
+                destinationURL: destinationURL,
+                automaticUpdateAllowed: false
+            )
+        }
+
+        let resolvedLinkURL = CLIBootstrapInstaller.resolvedSymbolicLink(at: destinationURL, fileManager: fm)
+        if let bundledBinaryURL = context.bundledPayloadURL?.appendingPathComponent("mere.run"),
+           resolvedLinkURL == bundledBinaryURL.standardizedFileURL.resolvingSymlinksInPath() {
+            let installedVersion = try? CLIBootstrapInstaller.validatedVersion(executableURL: destinationURL)
+            let isValid = installedVersion != nil
+            return CLIInstallationInspection(
+                status: CLIInstallationStatus(
+                    phase: isValid ? .upToDate : .repair,
+                    kind: .bundledSymlink,
+                    resolvedPath: destinationURL.path,
+                    installedVersion: installedVersion,
+                    bundledVersion: bundled.version,
+                    detail: isValid
+                        ? "The command resolves directly into this Studio app bundle; no copy is required."
+                        : "The command points into this Studio app bundle but does not pass `--version`.",
+                    lastSynchronizationError: isValid ? nil : "The bundled CLI symlink could not be validated.",
+                    allowsManualAction: false
+                ),
+                destinationURL: destinationURL,
+                automaticUpdateAllowed: false
+            )
+        }
+
+        if let receipt {
+            return inspectOwnedInstallation(
+                receipt: receipt,
+                destinationURL: destinationURL,
+                resolvedLinkURL: resolvedLinkURL,
+                bundled: bundled,
+                context: context,
+                fileManager: fm
+            )
+        }
+
+        if let receiptError {
+            return CLIInstallationInspection(
+                status: CLIInstallationStatus(
+                    phase: .repair,
+                    kind: .unowned,
+                    resolvedPath: destinationURL.path,
+                    installedVersion: try? CLIBootstrapInstaller.validatedVersion(executableURL: destinationURL),
+                    bundledVersion: bundled.version,
+                    detail: "Studio cannot prove ownership because the installation receipt is invalid. Explicit repair is required.",
+                    lastSynchronizationError: receiptError,
+                    allowsManualAction: context.bundledPayloadURL != nil
+                ),
+                destinationURL: destinationURL,
+                automaticUpdateAllowed: false
+            )
+        }
+
+        if let resolvedLinkURL, !resolvedLinkURL.isContained(in: context.paths.payloadRoot) {
+            return CLIInstallationInspection(
+                status: CLIInstallationStatus(
+                    phase: .externallyManaged,
+                    kind: .externallyManaged,
+                    resolvedPath: destinationURL.path,
+                    installedVersion: try? CLIBootstrapInstaller.validatedVersion(executableURL: destinationURL),
+                    bundledVersion: bundled.version,
+                    detail: "This command is a symlink managed outside Studio. Update it with its package manager or owner.",
+                    lastSynchronizationError: nil,
+                    allowsManualAction: false
+                ),
+                destinationURL: destinationURL,
+                automaticUpdateAllowed: false
+            )
+        }
+
+        let installedVersion = try? CLIBootstrapInstaller.validatedVersion(executableURL: destinationURL)
+        let matchesBundledBinary = context.bundledPayloadURL.map {
+            filesMatch(
+                destinationURL,
+                $0.appendingPathComponent("mere.run", isDirectory: false)
+            )
+        } ?? false
+        let detail = if matchesBundledBinary && installedVersion != nil {
+            "The CLI matches this Studio build but has no ownership receipt. Update once to adopt the managed layout."
+        } else {
+            "This unmarked CLI will not be changed automatically. Update explicitly to migrate it into Studio management."
+        }
+        return CLIInstallationInspection(
+            status: CLIInstallationStatus(
+                phase: .update,
+                kind: .unowned,
+                resolvedPath: destinationURL.path,
+                installedVersion: installedVersion,
+                bundledVersion: bundled.version,
+                detail: detail,
+                lastSynchronizationError: nil,
+                allowsManualAction: context.bundledPayloadURL != nil
+            ),
+            destinationURL: destinationURL,
+            automaticUpdateAllowed: false
+        )
+    }
+
+    private static func inspectOwnedInstallation(
+        receipt: CLIInstallationReceipt,
+        destinationURL: URL,
+        resolvedLinkURL: URL?,
+        bundled: (manifest: CLIPayloadManifest?, version: String?, error: String?),
+        context: CLIInstallationContext,
+        fileManager fm: FileManager
+    ) -> CLIInstallationInspection {
+        let receiptDestinationPath = URL(fileURLWithPath: receipt.destinationPath).standardizedFileURL.path
+        let expectedExecutableURL = URL(fileURLWithPath: receipt.payloadPath, isDirectory: true)
+            .appendingPathComponent("mere.run", isDirectory: false)
+            .standardizedFileURL
+            .resolvingSymlinksInPath()
+        let ownershipMatches = destinationURL.standardizedFileURL.path == receiptDestinationPath
+            && resolvedLinkURL == expectedExecutableURL
+            && CLIBootstrapInstaller.payloadMatches(receipt: receipt, paths: context.paths, fileManager: fm)
+        let installedVersion = ownershipMatches
+            ? try? CLIBootstrapInstaller.validatedVersion(executableURL: destinationURL)
+            : nil
+
+        guard ownershipMatches, installedVersion != nil else {
+            return CLIInstallationInspection(
+                status: CLIInstallationStatus(
+                    phase: .repair,
+                    kind: .studioManaged,
+                    resolvedPath: destinationURL.path,
+                    installedVersion: installedVersion,
+                    bundledVersion: bundled.version,
+                    detail: "The installed destination or payload no longer matches Studio's ownership receipt.",
+                    lastSynchronizationError: "Automatic replacement was blocked because the installed CLI changed after Studio installed it.",
+                    allowsManualAction: context.bundledPayloadURL != nil
+                ),
+                destinationURL: destinationURL,
+                automaticUpdateAllowed: false
+            )
+        }
+
+        guard let bundledManifest = bundled.manifest else {
+            return CLIInstallationInspection(
+                status: CLIInstallationStatus(
+                    phase: .repair,
+                    kind: .studioManaged,
+                    resolvedPath: destinationURL.path,
+                    installedVersion: installedVersion,
+                    bundledVersion: bundled.version,
+                    detail: "The managed CLI is intact, but this app does not contain a valid replacement payload.",
+                    lastSynchronizationError: bundled.error,
+                    allowsManualAction: false
+                ),
+                destinationURL: destinationURL,
+                automaticUpdateAllowed: false
+            )
+        }
+
+        if receipt.payloadFingerprint == bundledManifest.fingerprint {
+            return CLIInstallationInspection(
+                status: CLIInstallationStatus(
+                    phase: .upToDate,
+                    kind: .studioManaged,
+                    resolvedPath: destinationURL.path,
+                    installedVersion: installedVersion,
+                    bundledVersion: bundled.version,
+                    detail: "Studio owns this versioned CLI payload and its runtime assets match the app bundle.",
+                    lastSynchronizationError: nil,
+                    allowsManualAction: true
+                ),
+                destinationURL: destinationURL,
+                automaticUpdateAllowed: false
+            )
+        }
+
+        guard CLIBootstrapInstaller.destinationIsWritable(destinationURL, fileManager: fm) else {
+            return CLIInstallationInspection(
+                status: CLIInstallationStatus(
+                    phase: .repair,
+                    kind: .studioManaged,
+                    resolvedPath: destinationURL.path,
+                    installedVersion: installedVersion,
+                    bundledVersion: bundled.version,
+                    detail: "A newer bundled CLI is available, but Studio cannot write the command destination.",
+                    lastSynchronizationError: "Make \(destinationURL.deletingLastPathComponent().path) writable, then choose Repair CLI.",
+                    allowsManualAction: true
+                ),
+                destinationURL: destinationURL,
+                automaticUpdateAllowed: false
+            )
+        }
+
+        return CLIInstallationInspection(
+            status: CLIInstallationStatus(
+                phase: .update,
+                kind: .studioManaged,
+                resolvedPath: destinationURL.path,
+                installedVersion: installedVersion,
+                bundledVersion: bundled.version,
+                detail: "Studio will synchronize its managed CLI payload with this app build.",
+                lastSynchronizationError: nil,
+                allowsManualAction: true
+            ),
+            destinationURL: destinationURL,
+            automaticUpdateAllowed: true
+        )
+    }
+
+    private static func bundledInformation(
+        context: CLIInstallationContext,
+        fileManager fm: FileManager
+    ) -> (manifest: CLIPayloadManifest?, version: String?, error: String?) {
+        guard let payloadURL = context.bundledPayloadURL else {
+            return (nil, nil, "Bundled CLI payload was not found.")
+        }
+        do {
+            let manifest = try CLIPayloadManifestBuilder.manifest(at: payloadURL, fileManager: fm)
+            let version = try CLIBootstrapInstaller.validatedVersion(
+                executableURL: payloadURL.appendingPathComponent("mere.run", isDirectory: false)
+            )
+            return (manifest, version, nil)
+        } catch {
+            return (nil, nil, error.localizedDescription)
+        }
+    }
+
+    private static func preferredDestination(paths: CLIInstallationPaths, fileManager fm: FileManager) -> URL {
+        for candidate in paths.destinationCandidates
+        where CLIBootstrapInstaller.destinationIsWritable(candidate, fileManager: fm) {
+            return candidate
+        }
+        return paths.destinationCandidates.last
+            ?? fm.homeDirectoryForCurrentUser
+                .appendingPathComponent(".local/bin/mere.run", isDirectory: false)
+    }
+
+    private static func isSupportedDestination(_ destinationURL: URL, paths: CLIInstallationPaths) -> Bool {
+        let path = destinationURL.standardizedFileURL.path
+        return paths.destinationCandidates.contains { $0.standardizedFileURL.path == path }
+    }
+
+    private static func filesMatch(_ firstURL: URL, _ secondURL: URL) -> Bool {
+        guard let first = try? Data(contentsOf: firstURL, options: .mappedIfSafe),
+              let second = try? Data(contentsOf: secondURL, options: .mappedIfSafe) else {
+            return false
+        }
+        return first == second
+    }
+
+    private static func failedStatus(from status: CLIInstallationStatus, error: Error) -> CLIInstallationStatus {
+        CLIInstallationStatus(
+            phase: status.phase == .install ? .install : .repair,
+            kind: status.kind,
+            resolvedPath: status.resolvedPath,
+            installedVersion: status.installedVersion,
+            bundledVersion: status.bundledVersion,
+            detail: status.detail,
+            lastSynchronizationError: error.localizedDescription,
+            allowsManualAction: status.kind != .externallyManaged && status.kind != .custom
+        )
+    }
+}

--- a/apps/macos/MereRunStudio/MereRunApp.swift
+++ b/apps/macos/MereRunStudio/MereRunApp.swift
@@ -55,6 +55,9 @@ struct MereRunApp: App {
                         }
                     }
                 }
+                .task {
+                    await controller.synchronizeCLIInstallationAfterLaunch()
+                }
                 .onOpenURL(perform: openDeepLink)
                 .alert(
                     "Couldn’t open MereRun link",

--- a/apps/macos/MereRunStudio/MereRunController.swift
+++ b/apps/macos/MereRunStudio/MereRunController.swift
@@ -175,7 +175,7 @@ enum CLIResolver {
         ]
     }
 
-    private static func installedCandidates(fileManager fm: FileManager) -> [URL] {
+    static func installedCandidates(fileManager fm: FileManager) -> [URL] {
         [
             "/usr/local/bin/mere.run",
             "/opt/homebrew/bin/mere.run",
@@ -560,6 +560,7 @@ final class MereRunController: ObservableObject {
     /// the foreground canvas.
     @Published private(set) var progressByRequestID: [UUID: StudioRunProgress] = [:]
     @Published private(set) var cliVersion: String?
+    @Published private(set) var cliInstallationStatus = CLIInstallationStatus.checking
 
     /// The app's own version, read from the bundle for the version handshake display.
     var appVersion: String {
@@ -580,6 +581,7 @@ final class MereRunController: ObservableObject {
     private let processRunner: MereRunProcessRunning
     private let fileSystem: MereRunFileProbing
     private let cliResolve: (String) -> MereRunLaunch
+    private var didSynchronizeCLIInstallationAfterLaunch = false
     private var utilityProcesses: [UUID: MereRunRunningProcess] = [:]
     private var readinessProcesses: [StudioMode: MereRunRunningProcess] = [:]
     private var readinessRequests: [StudioMode: ReadinessRequest] = [:]
@@ -881,9 +883,26 @@ final class MereRunController: ObservableObject {
     }
 
     func installTerminalCLI() {
-        let outcome = CLIBootstrapInstaller.installBundledCLI()
-        handleCLIInstall(outcome)
-        refreshResolvedCLI()
+        guard cliInstallationStatus.phase != .synchronizing else { return }
+        let context = CLIInstallationContext.current(customCLIPath: cliPath)
+        cliInstallationStatus = synchronizingCLIStatus(from: cliInstallationStatus)
+        Task { @MainActor in
+            let nextStatus = await Task.detached(priority: .utility) {
+                CLIInstallationSynchronizer.performManualAction(context: context)
+            }.value
+            publishCLIInstallationStatus(nextStatus, automatic: false)
+        }
+    }
+
+    func synchronizeCLIInstallationAfterLaunch() async {
+        guard !didSynchronizeCLIInstallationAfterLaunch else { return }
+        didSynchronizeCLIInstallationAfterLaunch = true
+        let context = CLIInstallationContext.current(customCLIPath: cliPath)
+        cliInstallationStatus = synchronizingCLIStatus(from: cliInstallationStatus)
+        let nextStatus = await Task.detached(priority: .utility) {
+            CLIInstallationSynchronizer.synchronizeAfterLaunch(context: context)
+        }.value
+        publishCLIInstallationStatus(nextStatus, automatic: true)
     }
 
     func installCodexSkills() {
@@ -1825,17 +1844,34 @@ final class MereRunController: ObservableObject {
         }
     }
 
-    private func handleCLIInstall(_ outcome: CLIBootstrapInstallOutcome) {
-        switch outcome {
-        case .installed(let url):
+    private func synchronizingCLIStatus(from current: CLIInstallationStatus) -> CLIInstallationStatus {
+        CLIInstallationStatus(
+            phase: .synchronizing,
+            kind: current.kind,
+            resolvedPath: current.resolvedPath,
+            installedVersion: current.installedVersion,
+            bundledVersion: current.bundledVersion,
+            detail: "Validating and staging the complete CLI payload…",
+            lastSynchronizationError: nil,
+            allowsManualAction: false
+        )
+    }
+
+    private func publishCLIInstallationStatus(_ nextStatus: CLIInstallationStatus, automatic: Bool) {
+        cliInstallationStatus = nextStatus
+        refreshResolvedCLI()
+        refreshCLIVersion()
+
+        if let message = nextStatus.lastSynchronizationError {
+            if !automatic {
+                status = "CLI synchronization needs attention"
+            }
+            append("Terminal CLI synchronization: \(message)", stream: .stderr)
+        } else if !automatic, nextStatus.phase == .upToDate {
             status = "CLI installed"
-            append("Installed Terminal CLI at \(url.abbreviatedForDisplay).", stream: .system)
-        case .failed(let message):
-            status = "CLI install failed"
-            append("Terminal CLI install failed: \(message)", stream: .stderr)
-        case .skippedNoBundledCLI:
-            status = "No bundled CLI"
-            append("Terminal CLI install skipped: bundled CLI payload was not found.", stream: .stderr)
+            if let path = nextStatus.resolvedPath {
+                append("Installed Terminal CLI at \(URL(fileURLWithPath: path).abbreviatedForDisplay).", stream: .system)
+            }
         }
     }
 

--- a/apps/macos/MereRunStudio/MereRunRootView.swift
+++ b/apps/macos/MereRunStudio/MereRunRootView.swift
@@ -5447,13 +5447,51 @@ struct MereRunSettingsView: View {
                     .foregroundStyle(MereRunTheme.textMuted)
             }
             EditorSection("Install") {
-                HStack(spacing: 10) {
-                    Button {
-                        controller.installTerminalCLI()
-                    } label: {
-                        Label("Install CLI", systemImage: "terminal")
+                VStack(alignment: .leading, spacing: 8) {
+                    Label(
+                        controller.cliInstallationStatus.title,
+                        systemImage: controller.cliInstallationStatus.phase == .upToDate
+                            ? "checkmark.circle.fill"
+                            : "terminal"
+                    )
+                    .font(MereRunTheme.bodyFont.weight(.semibold))
+
+                    Text(controller.cliInstallationStatus.detail)
+                        .font(MereRunTheme.captionFont)
+                        .foregroundStyle(MereRunTheme.textMuted)
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    if let path = controller.cliInstallationStatus.resolvedPath {
+                        Text("Path: \(path)")
+                            .font(MereRunTheme.monoFont)
+                            .foregroundStyle(MereRunTheme.textMuted)
+                            .textSelection(.enabled)
                     }
-                    .buttonStyle(.borderedProminent)
+
+                    HStack(spacing: 14) {
+                        Text("Installed: \(controller.cliInstallationStatus.installedVersion ?? "—")")
+                        Text("Bundled: \(controller.cliInstallationStatus.bundledVersion ?? "—")")
+                    }
+                    .font(MereRunTheme.captionFont)
+                    .foregroundStyle(MereRunTheme.textMuted)
+
+                    if let error = controller.cliInstallationStatus.lastSynchronizationError {
+                        Text(error)
+                            .font(MereRunTheme.captionFont)
+                            .foregroundStyle(MereRunTheme.yellow)
+                            .fixedSize(horizontal: false, vertical: true)
+                    }
+                }
+
+                HStack(spacing: 10) {
+                    if let actionTitle = controller.cliInstallationStatus.actionTitle {
+                        Button {
+                            controller.installTerminalCLI()
+                        } label: {
+                            Label(actionTitle, systemImage: "terminal")
+                        }
+                        .buttonStyle(.borderedProminent)
+                    }
 
                     Button {
                         controller.installCodexSkills()
@@ -5462,7 +5500,7 @@ struct MereRunSettingsView: View {
                     }
                     .buttonStyle(.bordered)
                 }
-                Text("CLI installs from the app bundle without sudo. Skill install copies the bundled `use-mere-run` Codex skill to `~/.codex/skills`.")
+                Text("Studio-managed CLI payloads keep every runtime asset in Application Support and activate the command with an atomic symlink. Skill install copies the bundled `use-mere-run` Codex skill to `~/.codex/skills`.")
                     .font(MereRunTheme.captionFont)
                     .foregroundStyle(MereRunTheme.textMuted)
             }

--- a/apps/macos/MereRunStudioTests/CLIBootstrapInstallerTests.swift
+++ b/apps/macos/MereRunStudioTests/CLIBootstrapInstallerTests.swift
@@ -3,128 +3,406 @@ import XCTest
 
 final class CLIBootstrapInstallerTests: XCTestCase {
     func testPreferredAutomaticInstallURLUsesFirstWritableCandidate() throws {
-        let rootURL = try temporaryDirectory()
-        defer { try? FileManager.default.removeItem(at: rootURL) }
-
-        let firstCandidateURL = rootURL.appendingPathComponent("first-bin", isDirectory: true)
-        let secondCandidateURL = rootURL.appendingPathComponent("second-bin", isDirectory: true)
-        try FileManager.default.createDirectory(at: firstCandidateURL, withIntermediateDirectories: true)
+        let layout = try makeLayout()
+        defer { try? FileManager.default.removeItem(at: layout.rootURL) }
+        let secondCandidateURL = layout.rootURL.appendingPathComponent("second-bin", isDirectory: true)
         try FileManager.default.createDirectory(at: secondCandidateURL, withIntermediateDirectories: true)
 
         let installURL = CLIBootstrapInstaller.preferredAutomaticInstallURL(
-            installDirectoryCandidates: [
-                firstCandidateURL,
-                secondCandidateURL,
-            ]
+            installDirectoryCandidates: [layout.binURL, secondCandidateURL]
         )
 
-        XCTAssertEqual(installURL, firstCandidateURL.appendingPathComponent("mere.run", isDirectory: false))
+        XCTAssertEqual(installURL, layout.destinationURL)
     }
 
-    func testCopiesBundledPayloadToDestination() throws {
-        let rootURL = try temporaryDirectory()
-        defer { try? FileManager.default.removeItem(at: rootURL) }
+    func testReceiptRoundTripsAndRejectsUnknownSchema() throws {
+        let layout = try makeLayout()
+        defer { try? FileManager.default.removeItem(at: layout.rootURL) }
+        let timestamp = Date(timeIntervalSince1970: 1_700_000_000)
+        let receipt = CLIInstallationReceipt(
+            destinationPath: layout.destinationURL.path,
+            payloadPath: layout.paths.payloadRoot.appendingPathComponent("42-deadbeef").path,
+            studioVersion: "1.2.3",
+            studioBuild: "42",
+            payloadFingerprint: "deadbeef",
+            installedAssetNames: ["Resources", "mere.run"],
+            installationTimestamp: timestamp
+        )
 
-        let payloadURL = rootURL.appendingPathComponent("payload", isDirectory: true)
-        let destinationURL = rootURL
-            .appendingPathComponent("install", isDirectory: true)
-            .appendingPathComponent("bin", isDirectory: true)
-            .appendingPathComponent("mere.run", isDirectory: false)
+        try receipt.write(to: layout.paths.receiptURL)
+        XCTAssertEqual(try CLIInstallationReceipt.read(from: layout.paths.receiptURL), receipt)
 
-        try makePayload(at: payloadURL)
+        let unsupported = CLIInstallationReceipt(
+            schemaVersion: 99,
+            destinationPath: receipt.destinationPath,
+            payloadPath: receipt.payloadPath,
+            studioVersion: receipt.studioVersion,
+            studioBuild: receipt.studioBuild,
+            payloadFingerprint: receipt.payloadFingerprint,
+            installedAssetNames: receipt.installedAssetNames,
+            installationTimestamp: timestamp
+        )
+        try unsupported.write(to: layout.paths.receiptURL)
+        XCTAssertThrowsError(try CLIInstallationReceipt.read(from: layout.paths.receiptURL)) { error in
+            XCTAssertEqual(error as? CLIInstallationReceiptError, .unsupportedSchemaVersion(99))
+        }
+    }
+
+    func testManagedInstallStagesCompletePayloadAndWritesReceipt() throws {
+        let layout = try makeLayout()
+        defer { try? FileManager.default.removeItem(at: layout.rootURL) }
+        try makePayload(at: layout.payloadURL, version: "1.0.0")
+        try "leave me".write(
+            to: layout.binURL.appendingPathComponent("unrelated-tool"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let installation = try CLIBootstrapInstaller.installManagedPayload(
+            from: layout.payloadURL,
+            to: layout.destinationURL,
+            paths: layout.paths,
+            studioBuild: CLIStudioBuild(version: "1.0.0", build: "100")
+        )
+
+        XCTAssertEqual(installation.installedVersion, "mere.run 1.0.0")
+        XCTAssertTrue(installation.payloadURL.isContained(in: layout.paths.payloadRoot))
+        XCTAssertEqual(
+            CLIBootstrapInstaller.resolvedSymbolicLink(at: layout.destinationURL),
+            installation.payloadURL.appendingPathComponent("mere.run").resolvingSymlinksInPath()
+        )
+        XCTAssertEqual(try CLIBootstrapInstaller.validatedVersion(executableURL: layout.destinationURL), "mere.run 1.0.0")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: installation.payloadURL.appendingPathComponent("llama.framework").path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: installation.payloadURL.appendingPathComponent("mlx-swift_Cmlx.bundle").path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: installation.payloadURL.appendingPathComponent("libonnxruntime.dylib").path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: installation.payloadURL.appendingPathComponent("Resources/default.metallib").path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: installation.payloadURL.appendingPathComponent("vendor/ds4/helper").path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: layout.binURL.appendingPathComponent("unrelated-tool").path))
+
+        let receipt = try CLIInstallationReceipt.read(from: layout.paths.receiptURL)
+        XCTAssertEqual(receipt.destinationPath, layout.destinationURL.path)
+        XCTAssertEqual(receipt.payloadPath, installation.payloadURL.path)
+        XCTAssertEqual(receipt.studioVersion, "1.0.0")
+        XCTAssertEqual(receipt.studioBuild, "100")
+        XCTAssertEqual(receipt.installedAssetNames, [
+            "Resources",
+            "libonnxruntime.dylib",
+            "llama.framework",
+            "mere.run",
+            "mlx-swift_Cmlx.bundle",
+            "vendor",
+        ])
+    }
+
+    func testUnownedCopiedCLIRequiresExplicitMigration() throws {
+        let layout = try makeLayout()
+        defer { try? FileManager.default.removeItem(at: layout.rootURL) }
+        try makePayload(at: layout.payloadURL, version: "2.0.0")
+        try makeLegacyCopiedInstallation(from: layout.payloadURL, in: layout.binURL)
+        let context = makeContext(layout: layout, version: "2.0.0", build: "200")
+
+        let before = CLIInstallationSynchronizer.synchronizeAfterLaunch(context: context)
+        XCTAssertEqual(before.phase, .update)
+        XCTAssertEqual(before.kind, .unowned)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: layout.paths.receiptURL.path))
+        XCTAssertNil(CLIBootstrapInstaller.resolvedSymbolicLink(at: layout.destinationURL))
+
+        let after = CLIInstallationSynchronizer.performManualAction(context: context)
+        XCTAssertEqual(after.phase, .upToDate)
+        XCTAssertEqual(after.kind, .studioManaged)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: layout.paths.receiptURL.path))
+        XCTAssertNotNil(CLIBootstrapInstaller.resolvedSymbolicLink(at: layout.destinationURL))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: layout.binURL.appendingPathComponent("Resources/default.metallib").path))
+    }
+
+    func testMatchingManagedBuildIsANoOp() throws {
+        let layout = try makeLayout()
+        defer { try? FileManager.default.removeItem(at: layout.rootURL) }
+        try makePayload(at: layout.payloadURL, version: "3.0.0")
+        let context = makeContext(layout: layout, version: "3.0.0", build: "300")
+        XCTAssertEqual(CLIInstallationSynchronizer.performManualAction(context: context).phase, .upToDate)
+        let receiptData = try Data(contentsOf: layout.paths.receiptURL)
+        let payloads = try FileManager.default.contentsOfDirectory(atPath: layout.paths.payloadRoot.path)
+
+        let status = CLIInstallationSynchronizer.synchronizeAfterLaunch(context: context)
+
+        XCTAssertEqual(status.phase, .upToDate)
+        XCTAssertEqual(try Data(contentsOf: layout.paths.receiptURL), receiptData)
+        XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: layout.paths.payloadRoot.path), payloads)
+    }
+
+    func testStartupSynchronizerUpdatesOwnedPayloadAndPreservesUnrelatedFiles() throws {
+        let layout = try makeLayout()
+        defer { try? FileManager.default.removeItem(at: layout.rootURL) }
+        try makePayload(at: layout.payloadURL, version: "4.0.0")
+        let firstContext = makeContext(layout: layout, version: "4.0.0", build: "400")
+        XCTAssertEqual(CLIInstallationSynchronizer.performManualAction(context: firstContext).phase, .upToDate)
+        let oldReceipt = try CLIInstallationReceipt.read(from: layout.paths.receiptURL)
+        let oldPayloadURL = URL(fileURLWithPath: oldReceipt.payloadPath, isDirectory: true)
+        let unmanagedPayloadURL = layout.paths.payloadRoot.appendingPathComponent("do-not-delete", isDirectory: true)
+        try FileManager.default.createDirectory(at: unmanagedPayloadURL, withIntermediateDirectories: true)
+        let unrelatedURL = layout.binURL.appendingPathComponent("unrelated-tool")
+        try "unrelated".write(to: unrelatedURL, atomically: true, encoding: .utf8)
+
+        try FileManager.default.removeItem(at: layout.payloadURL)
+        try makePayload(at: layout.payloadURL, version: "4.1.0")
+        let updateContext = makeContext(layout: layout, version: "4.1.0", build: "401")
+        let status = CLIInstallationSynchronizer.synchronizeAfterLaunch(context: updateContext)
+
+        XCTAssertEqual(status.phase, .upToDate)
+        XCTAssertEqual(status.kind, .studioManaged)
+        XCTAssertEqual(try CLIBootstrapInstaller.validatedVersion(executableURL: layout.destinationURL), "mere.run 4.1.0")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: oldPayloadURL.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: unmanagedPayloadURL.path))
+        XCTAssertEqual(try String(contentsOf: unrelatedURL, encoding: .utf8), "unrelated")
+    }
+
+    func testDamagedOwnedPayloadRequiresExplicitRepair() throws {
+        let layout = try makeLayout()
+        defer { try? FileManager.default.removeItem(at: layout.rootURL) }
+        try makePayload(at: layout.payloadURL, version: "5.0.0")
+        let context = makeContext(layout: layout, version: "5.0.0", build: "500")
+        XCTAssertEqual(CLIInstallationSynchronizer.performManualAction(context: context).phase, .upToDate)
+        let receipt = try CLIInstallationReceipt.read(from: layout.paths.receiptURL)
+        let damagedAssetURL = URL(fileURLWithPath: receipt.payloadPath, isDirectory: true)
+            .appendingPathComponent("Resources/default.metallib")
+        try FileManager.default.removeItem(at: damagedAssetURL)
+
+        let automatic = CLIInstallationSynchronizer.synchronizeAfterLaunch(context: context)
+        XCTAssertEqual(automatic.phase, .repair)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: damagedAssetURL.path))
+
+        let repaired = CLIInstallationSynchronizer.performManualAction(context: context)
+        XCTAssertEqual(repaired.phase, .upToDate)
+        let repairedReceipt = try CLIInstallationReceipt.read(from: layout.paths.receiptURL)
+        XCTAssertNotEqual(repairedReceipt.payloadPath, receipt.payloadPath)
+        XCTAssertTrue(
+            FileManager.default.fileExists(
+                atPath: URL(fileURLWithPath: repairedReceipt.payloadPath)
+                    .appendingPathComponent("Resources/default.metallib")
+                    .path
+            )
+        )
+    }
+
+    func testFailedStagedVersionValidationPreservesWorkingInstallation() throws {
+        let layout = try makeLayout()
+        defer { try? FileManager.default.removeItem(at: layout.rootURL) }
+        try makePayload(at: layout.payloadURL, version: "6.0.0")
+        _ = try CLIBootstrapInstaller.installManagedPayload(
+            from: layout.payloadURL,
+            to: layout.destinationURL,
+            paths: layout.paths,
+            studioBuild: CLIStudioBuild(version: "6.0.0", build: "600")
+        )
+        let originalTarget = CLIBootstrapInstaller.resolvedSymbolicLink(at: layout.destinationURL)
+
+        try FileManager.default.removeItem(at: layout.payloadURL)
+        try makePayload(at: layout.payloadURL, version: "6.1.0", exitsSuccessfully: false)
+        XCTAssertThrowsError(
+            try CLIBootstrapInstaller.installManagedPayload(
+                from: layout.payloadURL,
+                to: layout.destinationURL,
+                paths: layout.paths,
+                studioBuild: CLIStudioBuild(version: "6.1.0", build: "601")
+            )
+        )
+        XCTAssertEqual(CLIBootstrapInstaller.resolvedSymbolicLink(at: layout.destinationURL), originalTarget)
+        XCTAssertEqual(try CLIBootstrapInstaller.validatedVersion(executableURL: layout.destinationURL), "mere.run 6.0.0")
+    }
+
+    func testUnwritableDestinationReportsRecoveryWithoutReplacement() throws {
+        let layout = try makeLayout()
+        defer { try? FileManager.default.setAttributes([.posixPermissions: 0o755], ofItemAtPath: layout.binURL.path) }
+        defer { try? FileManager.default.removeItem(at: layout.rootURL) }
+        try makePayload(at: layout.payloadURL, version: "7.0.0")
+        try makeLegacyCopiedInstallation(from: layout.payloadURL, in: layout.binURL)
+        try FileManager.default.setAttributes([.posixPermissions: 0o555], ofItemAtPath: layout.binURL.path)
+
+        let status = CLIInstallationSynchronizer.performManualAction(
+            context: makeContext(layout: layout, version: "7.0.0", build: "700")
+        )
+
+        XCTAssertEqual(status.phase, .repair)
+        XCTAssertTrue(status.lastSynchronizationError?.contains("not writable") == true)
+        XCTAssertNil(CLIBootstrapInstaller.resolvedSymbolicLink(at: layout.destinationURL))
+    }
+
+    func testBrokenExternalSymlinkAndCustomPathRemainExternal() throws {
+        let layout = try makeLayout()
+        defer { try? FileManager.default.removeItem(at: layout.rootURL) }
+        try makePayload(at: layout.payloadURL, version: "8.0.0")
+        let externalTargetURL = layout.rootURL.appendingPathComponent("external/mere.run")
+        try FileManager.default.createSymbolicLink(at: layout.destinationURL, withDestinationURL: externalTargetURL)
+        let regularContext = makeContext(layout: layout, version: "8.0.0", build: "800")
+
+        let external = CLIInstallationSynchronizer.synchronizeAfterLaunch(context: regularContext)
+        XCTAssertEqual(external.phase, .externallyManaged)
+        XCTAssertEqual(external.kind, .externallyManaged)
+        XCTAssertFalse(external.allowsManualAction)
+
+        let customContext = CLIInstallationContext(
+            bundledPayloadURL: layout.payloadURL,
+            paths: layout.paths,
+            studioBuild: CLIStudioBuild(version: "8.0.0", build: "800"),
+            customCLIPath: externalTargetURL.path
+        )
+        let custom = CLIInstallationSynchronizer.synchronizeAfterLaunch(context: customContext)
+        XCTAssertEqual(custom.phase, .externallyManaged)
+        XCTAssertEqual(custom.kind, .custom)
+        XCTAssertFalse(custom.allowsManualAction)
+    }
+
+    func testReceiptCannotAuthorizeAPathOutsideSupportedDestinations() throws {
+        let layout = try makeLayout()
+        defer { try? FileManager.default.removeItem(at: layout.rootURL) }
+        try makePayload(at: layout.payloadURL, version: "8.1.0")
+        let unsupportedDestinationURL = layout.rootURL.appendingPathComponent("custom/mere.run")
         try FileManager.default.createDirectory(
-            at: destinationURL.deletingLastPathComponent(),
+            at: unsupportedDestinationURL.deletingLastPathComponent(),
             withIntermediateDirectories: true
         )
-        try "stale".write(to: destinationURL, atomically: true, encoding: .utf8)
+        try FileManager.default.createSymbolicLink(
+            at: unsupportedDestinationURL,
+            withDestinationURL: layout.payloadURL.appendingPathComponent("mere.run")
+        )
+        let manifest = try CLIPayloadManifestBuilder.manifest(at: layout.payloadURL)
+        let receipt = CLIInstallationReceipt(
+            destinationPath: unsupportedDestinationURL.path,
+            payloadPath: layout.payloadURL.path,
+            studioVersion: "8.1.0",
+            studioBuild: "810",
+            payloadFingerprint: manifest.fingerprint,
+            installedAssetNames: manifest.assetNames,
+            installationTimestamp: Date(timeIntervalSince1970: 1_700_000_000)
+        )
+        try receipt.write(to: layout.paths.receiptURL)
 
-        try CLIBootstrapInstaller.installBundledCLI(from: payloadURL, to: destinationURL)
+        let status = CLIInstallationSynchronizer.synchronizeAfterLaunch(
+            context: makeContext(layout: layout, version: "8.1.0", build: "810")
+        )
 
-        XCTAssertTrue(FileManager.default.isExecutableFile(atPath: destinationURL.path))
-        XCTAssertEqual(try String(contentsOf: destinationURL, encoding: .utf8), "#!/usr/bin/env bash\n")
-        XCTAssertTrue(
-            FileManager.default.fileExists(
-                atPath: destinationURL
-                    .deletingLastPathComponent()
-                    .appendingPathComponent("llama.framework", isDirectory: true)
-                    .path
-            )
-        )
-        XCTAssertTrue(
-            FileManager.default.fileExists(
-                atPath: destinationURL
-                    .deletingLastPathComponent()
-                    .appendingPathComponent("mlx-swift_Cmlx.bundle", isDirectory: true)
-                    .path
-            )
-        )
-        XCTAssertTrue(
-            FileManager.default.fileExists(
-                atPath: destinationURL
-                    .deletingLastPathComponent()
-                    .appendingPathComponent("libonnxruntime.1.20.1.dylib", isDirectory: false)
-                    .path
-            )
-        )
-        XCTAssertTrue(
-            FileManager.default.fileExists(
-                atPath: destinationURL
-                    .deletingLastPathComponent()
-                    .appendingPathComponent("Resources/default.metallib", isDirectory: false)
-                    .path
-            )
-        )
-        XCTAssertFalse(
-            FileManager.default.fileExists(
-                atPath: destinationURL
-                    .deletingLastPathComponent()
-                    .appendingPathComponent("mererun-model-source-base-url.txt", isDirectory: false)
-                    .path
-            )
+        XCTAssertEqual(status.phase, .externallyManaged)
+        XCTAssertEqual(status.kind, .custom)
+        XCTAssertFalse(status.allowsManualAction)
+        XCTAssertEqual(
+            CLIBootstrapInstaller.resolvedSymbolicLink(at: unsupportedDestinationURL),
+            layout.payloadURL.appendingPathComponent("mere.run").resolvingSymlinksInPath()
         )
     }
 
-    private func makePayload(at payloadURL: URL) throws {
-        let fm = FileManager.default
-        try fm.createDirectory(at: payloadURL, withIntermediateDirectories: true)
+    func testSymlinkIntoBundledPayloadNeedsNoReceiptOrCopy() throws {
+        let layout = try makeLayout()
+        defer { try? FileManager.default.removeItem(at: layout.rootURL) }
+        try makePayload(at: layout.payloadURL, version: "9.0.0")
+        try FileManager.default.createSymbolicLink(
+            at: layout.destinationURL,
+            withDestinationURL: layout.payloadURL.appendingPathComponent("mere.run")
+        )
 
-        let binaryURL = payloadURL.appendingPathComponent("mere.run", isDirectory: false)
-        try "#!/usr/bin/env bash\n".write(to: binaryURL, atomically: true, encoding: .utf8)
-        try fm.setAttributes([.posixPermissions: 0o755], ofItemAtPath: binaryURL.path)
+        let status = CLIInstallationSynchronizer.synchronizeAfterLaunch(
+            context: makeContext(layout: layout, version: "9.0.0", build: "900")
+        )
 
-        try fm.createDirectory(
-            at: payloadURL.appendingPathComponent("llama.framework", isDirectory: true),
-            withIntermediateDirectories: true
-        )
-        try fm.createDirectory(
-            at: payloadURL.appendingPathComponent("mlx-swift_Cmlx.bundle", isDirectory: true),
-            withIntermediateDirectories: true
-        )
-        try fm.createDirectory(
-            at: payloadURL.appendingPathComponent("Resources", isDirectory: true),
-            withIntermediateDirectories: true
-        )
-        try "fake".write(
-            to: payloadURL.appendingPathComponent("libonnxruntime.1.20.1.dylib", isDirectory: false),
-            atomically: true,
-            encoding: .utf8
-        )
-        try "fake".write(
-            to: payloadURL.appendingPathComponent("Resources/default.metallib", isDirectory: false),
-            atomically: true,
-            encoding: .utf8
-        )
-        try "https://models.example.com/\n".write(
-            to: payloadURL.appendingPathComponent("mererun-model-source-base-url.txt", isDirectory: false),
-            atomically: true,
-            encoding: .utf8
-        )
+        XCTAssertEqual(status.phase, .upToDate)
+        XCTAssertEqual(status.kind, .bundledSymlink)
+        XCTAssertFalse(status.allowsManualAction)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: layout.paths.receiptURL.path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: layout.paths.payloadRoot.path))
     }
 
-    private func temporaryDirectory() throws -> URL {
+    private struct Layout {
+        let rootURL: URL
+        let payloadURL: URL
+        let binURL: URL
+        let destinationURL: URL
+        let paths: CLIInstallationPaths
+    }
+
+    private func makeLayout() throws -> Layout {
         let rootURL = FileManager.default.temporaryDirectory
             .appendingPathComponent("CLIBootstrapInstallerTests-\(UUID().uuidString)", isDirectory: true)
-        try FileManager.default.createDirectory(at: rootURL, withIntermediateDirectories: true)
-        return rootURL
+        let payloadURL = rootURL.appendingPathComponent("bundled-payload", isDirectory: true)
+        let binURL = rootURL.appendingPathComponent("bin", isDirectory: true)
+        let destinationURL = binURL.appendingPathComponent("mere.run", isDirectory: false)
+        try FileManager.default.createDirectory(at: binURL, withIntermediateDirectories: true)
+        let paths = CLIInstallationPaths(
+            applicationSupportRoot: rootURL.appendingPathComponent("Application Support/mere.run", isDirectory: true),
+            destinationCandidates: [destinationURL]
+        )
+        return Layout(
+            rootURL: rootURL,
+            payloadURL: payloadURL,
+            binURL: binURL,
+            destinationURL: destinationURL,
+            paths: paths
+        )
+    }
+
+    private func makeContext(layout: Layout, version: String, build: String) -> CLIInstallationContext {
+        CLIInstallationContext(
+            bundledPayloadURL: layout.payloadURL,
+            paths: layout.paths,
+            studioBuild: CLIStudioBuild(version: version, build: build),
+            customCLIPath: ""
+        )
+    }
+
+    private func makePayload(
+        at payloadURL: URL,
+        version: String,
+        exitsSuccessfully: Bool = true
+    ) throws {
+        let fm = FileManager.default
+        try fm.createDirectory(at: payloadURL, withIntermediateDirectories: true)
+        try fm.createDirectory(at: payloadURL.appendingPathComponent("llama.framework"), withIntermediateDirectories: true)
+        try fm.createDirectory(at: payloadURL.appendingPathComponent("mlx-swift_Cmlx.bundle"), withIntermediateDirectories: true)
+        try fm.createDirectory(at: payloadURL.appendingPathComponent("Resources"), withIntermediateDirectories: true)
+        try fm.createDirectory(at: payloadURL.appendingPathComponent("vendor/ds4"), withIntermediateDirectories: true)
+        try "framework".write(
+            to: payloadURL.appendingPathComponent("llama.framework/runtime"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try "bundle".write(
+            to: payloadURL.appendingPathComponent("mlx-swift_Cmlx.bundle/resource"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try "dylib".write(
+            to: payloadURL.appendingPathComponent("libonnxruntime.dylib"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try "metal".write(
+            to: payloadURL.appendingPathComponent("Resources/default.metallib"),
+            atomically: true,
+            encoding: .utf8
+        )
+        try "helper".write(
+            to: payloadURL.appendingPathComponent("vendor/ds4/helper"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        let script = exitsSuccessfully
+            ? "#!/bin/sh\n"
+                + "[ -f Resources/default.metallib ] || exit 70\n"
+                + "[ -d llama.framework ] || exit 70\n"
+                + "[ -d mlx-swift_Cmlx.bundle ] || exit 70\n"
+                + "[ -f libonnxruntime.dylib ] || exit 70\n"
+                + "[ -f vendor/ds4/helper ] || exit 70\n"
+                + "printf 'mere.run \(version)\\n'\n"
+            : "#!/bin/sh\necho 'fixture validation failed' >&2\nexit 71\n"
+        let binaryURL = payloadURL.appendingPathComponent("mere.run", isDirectory: false)
+        try script.write(to: binaryURL, atomically: true, encoding: .utf8)
+        try fm.setAttributes([.posixPermissions: 0o755], ofItemAtPath: binaryURL.path)
+    }
+
+    private func makeLegacyCopiedInstallation(from payloadURL: URL, in binURL: URL) throws {
+        let fm = FileManager.default
+        for assetURL in try fm.contentsOfDirectory(at: payloadURL, includingPropertiesForKeys: nil) {
+            try fm.copyItem(at: assetURL, to: binURL.appendingPathComponent(assetURL.lastPathComponent))
+        }
     }
 }

--- a/apps/macos/README.md
+++ b/apps/macos/README.md
@@ -214,3 +214,16 @@ menu. Release builds use the stable HTTPS appcast, automatic daily discovery,
 an Ed25519-signed archive and feed, Developer ID verification, and
 pre-extraction signature validation. Sparkle updates the complete app bundle,
 including its embedded CLI, as one atomic unit.
+
+Studio installs the Terminal CLI as a complete, versioned payload under
+`~/Library/Application Support/mere.run/cli/`. The public `mere.run` command is
+an atomic symlink to that payload. Studio records the destination, app build,
+payload fingerprint, and installed assets in the
+`~/Library/Application Support/mere.run/studio-cli-install.json` file.
+
+After Studio starts, it synchronizes only an installation that still matches
+this ownership receipt. Studio doesn't replace custom paths, package-manager
+symlinks, or unmarked CLI copies. In **Settings**, use **Update CLI** to adopt
+an unmarked copy or use **Repair CLI** after an owned payload changes. Studio
+validates the staged command with `mere.run --version` before it updates the
+public symlink.


### PR DESCRIPTION
## Summary

- record a typed ownership receipt and fingerprint the complete bundled CLI payload
- stage versioned payloads, validate them before atomic symlink activation, and preserve rollback behavior
- synchronize owned Studio installations at startup while protecting external and unowned CLI installations
- expose Install, Update, and Repair states in Settings and document the managed-install behavior

## Validation

- `swift test --filter CLIBootstrapInstallerTests` (12 passed)
- `./scripts/check.sh` (passed; 3,341 XCTest tests with 278 expected environment/checkpoint skips, plus 33 Swift Testing tests)
- `./scripts/build_mere_run_app.sh debug` (passed; packaged app signed and complete helper assets verified)
- packaged `Contents/Helpers/mere.run --version` (`0.48.0`)

## Remaining release validation

- A signed Sparkle upgrade smoke was not run in this checkout. It requires Developer ID-signed previous/current application artifacts and a release appcast.
