### PR TITLE
Add native LFM2.5 attention QLoRA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+### Text training
+
+- added attention-only QLoRA training and adapter loading for
+  `text-chat-lfm25-a1b-8bit`, using a frozen affine 8-bit LFM2.5 base and the
+  `mererun.lfm2.text-lora` manifest. The v1 target surface is limited to
+  q/k/v/output attention projections and keeps convolution and MoE expert
+  matrices frozen.
+
 ## 0.48.0 - 2026-08-31
 
 This release makes every public CLI capability first class in macOS Studio,

--- a/Sources/MereRunCLI/Commands/TextTrainLoRACommand.swift
+++ b/Sources/MereRunCLI/Commands/TextTrainLoRACommand.swift
@@ -9,7 +9,7 @@ struct TextTrainLoRA: AsyncParsableCommand {
         discussion: """
         This is the native mere.run text fine-tuning entrypoint. It accepts OpenAI-style chat
         JSONL records with system/user/assistant messages and trains Gemma 4, Laguna XS 2.1,
-        or Inkling-Small.
+        Inkling-Small, or the LFM2.5 A1B 8-bit text model.
         It writes a model-family-specific MereRun adapter manifest beside the safetensors file.
         Use --dry-run to validate data, create manifests, and prepare a reproducible run.
         """
@@ -65,7 +65,7 @@ struct TextTrainLoRA: AsyncParsableCommand {
 
     @Option(
         name: [.customLong("target-modules")],
-        help: "Comma-separated LoRA target suffixes. Defaults to attention for Gemma/Laguna and attention, MLP, experts, and unembedding for Inkling."
+        help: "Comma-separated LoRA target suffixes. Defaults to attention for Gemma, Laguna, and LFM2.5; Inkling also includes MLP, expert, and unembedding targets."
     )
     var targetModules: String?
 
@@ -175,6 +175,28 @@ struct TextTrainLoRA: AsyncParsableCommand {
                             trainingConfig: config,
                             maxSequenceLength: maxSequenceLength,
                             reasoningEffort: reasoningEffort,
+                            rank: rank,
+                            alpha: alpha ?? Float(rank),
+                            targetSuffixes: resolvedTargetModules(),
+                            metadata: metadata
+                        ),
+                        progressHandler: makeChatProgressHandler(
+                            eventLogger: visualization?.logger
+                        ),
+                        trainingProgressHandler: makeTrainingProgressHandler(
+                            eventLogger: visualization?.logger
+                        )
+                    )
+                case .lfm2A1B:
+                    report = try await LFM2TextLoRATrainingPipeline.train(
+                        LFM2TextLoRATrainingPipelineRequest(
+                            modelId: model,
+                            modelPath: modelPath,
+                            examples: examples,
+                            evaluationExamples: evaluationExamples,
+                            outputURL: outputURL,
+                            trainingConfig: config,
+                            maxSequenceLength: maxSequenceLength,
                             rank: rank,
                             alpha: alpha ?? Float(rank),
                             targetSuffixes: resolvedTargetModules(),
@@ -339,6 +361,9 @@ struct TextTrainLoRA: AsyncParsableCommand {
         if InklingResources.handles(modelSpec: model) {
             return InklingTextLoRAInjector.defaultTargetSuffixes
         }
+        if LFM2Resources.supportsTextLoRATraining(modelSpec: model) {
+            return LFM2TextLoRAInjector.defaultTargetSuffixes
+        }
         return ["q_proj", "k_proj", "v_proj", "o_proj"]
     }
 
@@ -353,8 +378,12 @@ struct TextTrainLoRA: AsyncParsableCommand {
         if InklingResources.handles(modelSpec: model) {
             return .inkling
         }
+        if LFM2Resources.supportsTextLoRATraining(modelSpec: model) {
+            return .lfm2A1B
+        }
         throw ValidationError(
-            "--model must be a supported Gemma 4 text model, \(LagunaResources.xsModelID), or \(InklingResources.modelID)."
+            "--model must be a supported Gemma 4 text model, \(LagunaResources.xsModelID), "
+                + "\(InklingResources.modelID), or \(LFM2Resources.defaultModelId)."
         )
     }
 
@@ -524,6 +553,7 @@ private enum NativeTextLoRATrainingFamily {
     case gemma4
     case lagunaXS
     case inkling
+    case lfm2A1B
 
     var manifestFormat: String {
         switch self {
@@ -533,6 +563,8 @@ private enum NativeTextLoRATrainingFamily {
             TextLoRATrainingManifest.lagunaFormat
         case .inkling:
             TextLoRATrainingManifest.inklingFormat
+        case .lfm2A1B:
+            TextLoRATrainingManifest.lfm2Format
         }
     }
 }

--- a/Sources/MereRunCLI/Guides/text-chat.md
+++ b/Sources/MereRunCLI/Guides/text-chat.md
@@ -58,6 +58,7 @@ mere.run model pull text-chat-gemma4-12b-4bit
 mere.run model pull text-chat-lfm25-1.2b-qad-4bit --accept-model-license
 mere.run model pull text-chat-lfm25-2.6b-4bit --accept-model-license
 mere.run model pull vision-chat-lfm25-3b-8bit --accept-model-license
+mere.run model pull text-chat-lfm25-a1b-8bit --accept-model-license
 mere.run model pull text-chat-laguna-s-2-1
 mere.run model pull text-chat-laguna-xs-2-1
 mere.run text chat --help
@@ -97,6 +98,24 @@ mere.run text train-lora \
   --model text-chat-gemma4-12b-4bit \
   --visualize
 ```
+
+For an LFM2.5 A1B canary, use the same reviewed dataset format and a 10-step
+attention-only run:
+
+```bash
+mere.run text train-lora \
+  --data ./copper-finch-canary.jsonl \
+  --eval ./copper-finch-heldout.jsonl \
+  --output ./copper-finch-lfm25.safetensors \
+  --model text-chat-lfm25-a1b-8bit \
+  --training-steps 10 \
+  --rank 16 \
+  --alpha 32
+```
+
+The command writes a `mererun.lfm2.text-lora` manifest and keeps convolution
+and MoE expert matrices frozen. The LFM Open License v1.0 applies to the base
+model and derived adapters.
 
 ## Parameters
 

--- a/Sources/MereRunCore/LFM2/LFM2Config.swift
+++ b/Sources/MereRunCore/LFM2/LFM2Config.swift
@@ -157,6 +157,7 @@ public enum LFM2Error: LocalizedError {
     case unsupportedModelId(String)
     case missingFiles([String])
     case downloadFailed(String)
+    case adapterSwitchDuringActiveGeneration
     case generationFailed(String)
 
     public var errorDescription: String? {
@@ -169,6 +170,8 @@ public enum LFM2Error: LocalizedError {
             return "Missing required LFM2 files: \(files.joined(separator: ", "))"
         case .downloadFailed(let message):
             return "LFM2 download failed: \(message)"
+        case .adapterSwitchDuringActiveGeneration:
+            return "LFM2 cannot switch text LoRA adapters while batched generation is active."
         case .generationFailed(let message):
             return message
         }

--- a/Sources/MereRunCore/LFM2/LFM2Generator.swift
+++ b/Sources/MereRunCore/LFM2/LFM2Generator.swift
@@ -168,6 +168,7 @@ public actor LFM2Generator: ChatGenerator {
     private var loadedConfig: LFM2Config?
     private var loadedVisionConfig: LFM2VLConfig?
     private var loadedVisionProcessorConfig: LFM2VLProcessorConfig?
+    private var loadedTextLoRASignature: String?
 
     private let modelId: String
 
@@ -212,7 +213,15 @@ public actor LFM2Generator: ChatGenerator {
                 progressHandler: progressHandler
             )
             let loadStart = Date()
+            let requestedLoRASignature = Self.loraSignature(request.lora)
+            if loadedTextLoRASignature != requestedLoRASignature {
+                guard !hasActiveGeneration else {
+                    throw LFM2Error.adapterSwitchDuringActiveGeneration
+                }
+                beginResidencyTransition()
+            }
             try await ensureLoaded(rootURL: rootURL, progressHandler: progressHandler)
+            try await applyTextLoRAIfNeeded(request.lora, progressHandler: progressHandler)
             let loadSeconds = Date().timeIntervalSince(loadStart)
 
             var response = try await generate(request, progressHandler: progressHandler)
@@ -704,6 +713,45 @@ public actor LFM2Generator: ChatGenerator {
             promptTokens: promptTokens.count,
             acceleration: decodeResult.acceleration
         )
+    }
+
+    private func applyTextLoRAIfNeeded(
+        _ lora: LoRA?,
+        progressHandler: (@Sendable (ChatProgress) -> Void)?
+    ) async throws {
+        guard let lora else {
+            loadedTextLoRASignature = nil
+            return
+        }
+        let signature = Self.loraSignature(lora)
+        guard loadedTextLoRASignature != signature else { return }
+        guard let model, let loadedConfig else {
+            throw LFM2Error.modelNotLoaded
+        }
+        guard loadedVisionConfig == nil,
+              loadedConfig.modelType == "lfm2_moe",
+              loadedConfig.quantization?.bits == 8 else {
+            throw LFM2Error.generationFailed(
+                "Native LFM2 text LoRA adapters v1 require the affine 8-bit LFM2.5 A1B text runtime."
+            )
+        }
+        progressHandler?(ChatProgress(
+            stage: .loadingModel,
+            message: "Loading LFM2 text LoRA"
+        ))
+        _ = try await LFM2TextLoRAAdapter.apply(lora, to: model)
+        loadedTextLoRASignature = signature
+        prefixKVCache.removeAll(keepingCapacity: false)
+    }
+
+    private static func loraSignature(_ lora: LoRA?) -> String? {
+        guard let lora else { return nil }
+        switch lora {
+        case .local(let path, let scale):
+            return "local:\(URL(fileURLWithPath: path).standardizedFileURL.path):\(scale)"
+        case .remote(let reference, let scale):
+            return "remote:\(reference):\(scale)"
+        }
     }
 
     private func decodeTokens(
@@ -1321,6 +1369,12 @@ public actor LFM2Generator: ChatGenerator {
         }
     }
 
+    private var hasActiveGeneration: Bool {
+        decodeLoopEpochState.runningEpoch != nil
+            || !decodeQueue.isEmpty
+            || !activeDecodeRows.isEmpty
+    }
+
     private func cacheMode(for caches: [LFM2LayerCache?]) -> RuntimeKVCacheMode {
         caches.contains { entry in
             guard case .attention(let cache)? = entry else { return false }
@@ -1349,6 +1403,7 @@ public actor LFM2Generator: ChatGenerator {
         loadedConfig = nil
         loadedVisionConfig = nil
         loadedVisionProcessorConfig = nil
+        loadedTextLoRASignature = nil
         prefixKVCache.removeAll(keepingCapacity: false)
         Memory.clearCache()
         return epoch

--- a/Sources/MereRunCore/LFM2/LFM2Model.swift
+++ b/Sources/MereRunCore/LFM2/LFM2Model.swift
@@ -454,15 +454,24 @@ final class LFM2SwitchGLU: Module {
         super.init()
     }
 
-    func callAsFunction(_ x: MLXArray, indices: MLXArray) -> MLXArray {
-        return unsorted(x, indices: indices)
+    func callAsFunction(
+        _ x: MLXArray,
+        indices: MLXArray,
+        useCustomKernels: Bool = true
+    ) -> MLXArray {
+        return unsorted(x, indices: indices, useCustomKernels: useCustomKernels)
     }
 
-    private func unsorted(_ x: MLXArray, indices: MLXArray) -> MLXArray {
+    private func unsorted(
+        _ x: MLXArray,
+        indices: MLXArray,
+        useCustomKernels: Bool
+    ) -> MLXArray {
         let batch = x.dim(0)
         let sequenceLength = x.dim(1)
         let topK = indices.dim(2)
-        if LFM2MoEAccelerationPolicy.fusedAffine8MoEEnabled,
+        if useCustomKernels,
+           LFM2MoEAccelerationPolicy.fusedAffine8MoEEnabled,
            gateProj.groupSize == upProj.groupSize,
            gateProj.bits == upProj.bits,
            let gateScales = gateProj.scales,
@@ -537,7 +546,7 @@ final class LFM2FeedForward: Module {
         super.init()
     }
 
-    func callAsFunction(_ x: MLXArray) -> MLXArray {
+    func callAsFunction(_ x: MLXArray, useCustomKernels: Bool = true) -> MLXArray {
         if usesDenseWeightNames, let w1, let w2, let w3 {
             return w2(lfm2Swiglu(w1(x), w3(x)))
         }
@@ -553,14 +562,22 @@ final class LFM2FeedForward: Module {
             scores = scores + expertBias
         }
 
-        let indices = argPartition(-scores, kth: topK - 1, axis: -1)[.ellipsis, 0..<topK]
+        // Expert selection is discrete. Preserve gradients through the
+        // selected scores, but do not request a VJP for integer indices.
+        let indices = stopGradient(
+            argPartition(-scores, kth: topK - 1, axis: -1)[.ellipsis, 0..<topK]
+        )
         scores = takeAlong(scores, indices, axis: -1)
         if normTopKProb, topK > 1 {
             scores = scores / (scores.sum(axis: -1, keepDims: true) + MLXArray(1e-20))
         }
         scores = scores.asType(x.dtype)
 
-        let switched = switchMLP(x, indices: indices)
+        let switched = switchMLP(
+            x,
+            indices: indices,
+            useCustomKernels: useCustomKernels
+        )
         var routed = switched * MLX.expandedDimensions(scores, axis: scores.ndim)
         routed = routed.sum(axis: -2)
         return routed
@@ -593,7 +610,8 @@ final class LFM2DecoderLayer: Module {
         _ x: MLXArray,
         attentionMask: MLXFast.ScaledDotProductAttentionMaskMode,
         cache: LFM2LayerCache?,
-        captureSpeculativeState: Bool = false
+        captureSpeculativeState: Bool = false,
+        useCustomKernels: Bool = true
     ) -> MLXArray {
         let normed = operatorNorm(x)
         let operatorOut: MLXArray
@@ -626,7 +644,10 @@ final class LFM2DecoderLayer: Module {
         }
 
         let hidden = x + operatorOut
-        return hidden + feedForward(ffnNorm(hidden))
+        return hidden + feedForward(
+            ffnNorm(hidden),
+            useCustomKernels: useCustomKernels
+        )
     }
 }
 
@@ -670,7 +691,8 @@ final class LFM2Transformer: Module {
         cache: [LFM2LayerCache?]?,
         inputEmbeddings: MLXArray? = nil,
         captureLayerIndices: Set<Int> = [],
-        captureSpeculativeState: Bool = false
+        captureSpeculativeState: Bool = false,
+        useCustomKernels: Bool = true
     ) -> (hidden: MLXArray, captures: [Int: MLXArray]) {
         var hidden = inputEmbeddings ?? embeddings(for: inputIds)
         let attentionMask = createAttentionMask(h: hidden, cache: firstAttentionCache(from: cache))
@@ -681,7 +703,8 @@ final class LFM2Transformer: Module {
                 hidden,
                 attentionMask: attentionMask,
                 cache: cache?[index] ?? nil,
-                captureSpeculativeState: captureSpeculativeState
+                captureSpeculativeState: captureSpeculativeState,
+                useCustomKernels: useCustomKernels
             )
             if captureLayerIndices.contains(index) {
                 captures[index] = hidden
@@ -733,14 +756,16 @@ public final class LFM2Model: Module, @unchecked Sendable {
         cache: [LFM2LayerCache?]?,
         inputEmbeddings: MLXArray? = nil,
         captureLayerIndices: Set<Int> = [],
-        captureSpeculativeState: Bool = false
+        captureSpeculativeState: Bool = false,
+        useCustomKernels: Bool = true
     ) -> LFM2ForwardOutput {
         let output = model.forward(
             inputIds,
             cache: cache,
             inputEmbeddings: inputEmbeddings,
             captureLayerIndices: captureLayerIndices,
-            captureSpeculativeState: captureSpeculativeState
+            captureSpeculativeState: captureSpeculativeState,
+            useCustomKernels: useCustomKernels
         )
         return LFM2ForwardOutput(
             hidden: output.hidden,
@@ -776,6 +801,38 @@ public final class LFM2Model: Module, @unchecked Sendable {
             logits: logits(from: hidden),
             capturedHiddenStates: output.captures
         )
+    }
+
+    /// Projects only loss-bearing token positions through the tied vocabulary
+    /// head while retaining the full differentiable LFM2 graph. The native
+    /// affine-8 fused MoE kernel is inference-only and does not define a VJP.
+    func trainingLogits(
+        inputIDs: MLXArray,
+        flatTargetPositions: MLXArray
+    ) -> MLXArray {
+        let hidden = model.forward(
+            inputIDs,
+            cache: nil,
+            useCustomKernels: false
+        ).hidden
+        let flattened = hidden.reshaped([-1, hidden.dim(-1)])
+        let selected = take(
+            flattened,
+            flatTargetPositions.asType(.int32),
+            axis: 0
+        )
+        return logits(from: selected)
+    }
+
+    /// Full-vocabulary fallback for training configurations that disable the
+    /// gathered assistant-token loss.
+    func trainingForward(_ inputIDs: MLXArray) -> MLXArray {
+        let hidden = model.forward(
+            inputIDs,
+            cache: nil,
+            useCustomKernels: false
+        ).hidden
+        return logits(from: hidden)
     }
 
     func forkCache(_ cache: [LFM2LayerCache?]) -> [LFM2LayerCache?] {

--- a/Sources/MereRunCore/LFM2/LFM2Resources.swift
+++ b/Sources/MereRunCore/LFM2/LFM2Resources.swift
@@ -122,6 +122,12 @@ public struct LFM2Resources: Sendable, Hashable {
             || normalized.contains("liquidai/")
     }
 
+    public static func supportsTextLoRATraining(modelSpec: String) -> Bool {
+        let normalized = modelSpec.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return normalized == defaultModelId.lowercased()
+            || normalized == upstreamRepoId.lowercased()
+    }
+
     public var rootURL: URL
 
     public init(rootURL: URL) {

--- a/Sources/MereRunCore/LFM2/LFM2TextLoRAAdapter.swift
+++ b/Sources/MereRunCore/LFM2/LFM2TextLoRAAdapter.swift
@@ -1,0 +1,74 @@
+import Foundation
+import MLX
+
+enum LFM2TextLoRAAdapterError: Error, LocalizedError, Sendable {
+    case noMatchingWeights([String])
+
+    var errorDescription: String? {
+        switch self {
+        case .noMatchingWeights(let keys):
+            return "LFM2 text LoRA adapter did not match injected attention layers. "
+                + "Weight keys: \(keys.prefix(8).joined(separator: ", "))"
+        }
+    }
+}
+
+struct LFM2TextLoRAApplyReport: Sendable, Equatable {
+    let matchedLayerCount: Int
+    let injectedLayerCount: Int
+}
+
+enum LFM2TextLoRAAdapter {
+    static func apply(
+        _ lora: LoRA,
+        to model: LFM2Model,
+        targetSuffixes: [String]? = nil
+    ) async throws -> LFM2TextLoRAApplyReport {
+        let weights = try await LoRAWeightLoader.load(from: lora)
+        let resolvedTargets = targetSuffixes ?? weights.weights.keys.sorted()
+        let layers = try LFM2TextLoRAInjector.inject(
+            into: model,
+            rank: weights.rank,
+            alpha: weights.alpha * scale(for: lora),
+            targetSuffixes: resolvedTargets,
+            zeroInitUp: true
+        )
+        let layersByAdapterKey = Dictionary(uniqueKeysWithValues: layers.map { path, layer in
+            (adapterKey(for: path), layer)
+        })
+
+        var matched = 0
+        for (path, pair) in weights.weights {
+            guard let layer = layersByAdapterKey[adapterKey(for: path)] else { continue }
+            layer.loraDown = pair.down.asType(.float32)
+            layer.loraUp = pair.up.asType(.float32)
+            layer.role = .assistant
+            layer.isActive = true
+            matched += 1
+        }
+        guard matched > 0 else {
+            throw LFM2TextLoRAAdapterError.noMatchingWeights(weights.weights.keys.sorted())
+        }
+
+        eval(layers.values.flatMap { [$0.loraDown, $0.loraUp] })
+        return LFM2TextLoRAApplyReport(
+            matchedLayerCount: matched,
+            injectedLayerCount: layers.count
+        )
+    }
+
+    static func adapterKey(for modulePath: String) -> String {
+        var key = modulePath
+        while key.hasPrefix("model.") {
+            key = String(key.dropFirst("model.".count))
+        }
+        return key.replacingOccurrences(of: ".self_attn.o_proj", with: ".self_attn.out_proj")
+    }
+
+    private static func scale(for lora: LoRA) -> Float {
+        switch lora {
+        case .local(_, let scale), .remote(_, let scale):
+            return Float(scale)
+        }
+    }
+}

--- a/Sources/MereRunCore/LFM2/LFM2TextLoRAInjector.swift
+++ b/Sources/MereRunCore/LFM2/LFM2TextLoRAInjector.swift
@@ -1,0 +1,196 @@
+import Foundation
+import MLXNN
+
+public enum LFM2TextLoRAInjectionError: Error, LocalizedError, Sendable {
+    case invalidRank(Int)
+    case noMatchingLayers([String])
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidRank(let rank):
+            return "LoRA rank must be >= 1 (got \(rank))."
+        case .noMatchingLayers(let suffixes):
+            return "No matching LFM2 attention Linear layers found for LoRA injection. "
+                + "Target suffixes: \(suffixes.joined(separator: ","))"
+        }
+    }
+}
+
+public enum LFM2TextLoRAInjector {
+    public static let defaultTargetSuffixes = [
+        "q_proj",
+        "k_proj",
+        "v_proj",
+        "out_proj",
+    ]
+
+    public static func inject(
+        into model: Module,
+        rank: Int,
+        alpha: Float? = nil,
+        targetSuffixes: [String] = defaultTargetSuffixes,
+        zeroInitUp: Bool = true
+    ) throws -> [String: TrainableLoRALayer] {
+        guard rank >= 1 else {
+            throw LFM2TextLoRAInjectionError.invalidRank(rank)
+        }
+        let suffixes = targetSuffixes
+            .map(canonicalTargetSuffix)
+            .filter { !$0.isEmpty }
+        let alphaValue = alpha ?? Float(rank)
+
+        if let lfm2Model = model as? LFM2Model {
+            return try injectIntoNativeModel(
+                lfm2Model,
+                rank: rank,
+                alpha: alphaValue,
+                suffixes: suffixes,
+                zeroInitUp: zeroInitUp
+            )
+        }
+
+        var replacements: [String: Module] = [:]
+        var loraLayers: [String: TrainableLoRALayer] = [:]
+
+        for (path, module) in model.leafModules().flattened() {
+            guard shouldTarget(path: path, suffixes: suffixes) else { continue }
+            if let injected = makeLoRALayer(
+                from: module,
+                rank: rank,
+                alpha: alphaValue,
+                zeroInitUp: zeroInitUp
+            ) {
+                if let replacement = injected.replacement {
+                    replacements[path] = replacement
+                }
+                loraLayers[path] = injected.layer
+            }
+        }
+
+        guard !loraLayers.isEmpty else {
+            throw LFM2TextLoRAInjectionError.noMatchingLayers(suffixes)
+        }
+        if !replacements.isEmpty {
+            let updates = replacements.map { (path: $0.key, module: $0.value) }
+            model.update(modules: ModuleChildren.unflattened(updates))
+        }
+        return loraLayers
+    }
+
+    private static func injectIntoNativeModel(
+        _ model: LFM2Model,
+        rank: Int,
+        alpha: Float,
+        suffixes: [String],
+        zeroInitUp: Bool
+    ) throws -> [String: TrainableLoRALayer] {
+        var loraLayers: [String: TrainableLoRALayer] = [:]
+
+        for (layerIndex, decoderLayer) in model.model.layers.enumerated() {
+            guard let attention = decoderLayer.selfAttention else { continue }
+            var replacements: [String: Module] = [:]
+            for (localPath, module) in attention.leafModules().flattened() {
+                let fullPath = "model.layers.\(layerIndex).self_attn.\(localPath)"
+                guard shouldTarget(path: fullPath, suffixes: suffixes) else { continue }
+                guard let injected = makeLoRALayer(
+                    from: module,
+                    rank: rank,
+                    alpha: alpha,
+                    zeroInitUp: zeroInitUp
+                ) else { continue }
+                if let replacement = injected.replacement {
+                    replacements[localPath] = replacement
+                }
+                loraLayers[fullPath] = injected.layer
+            }
+            if !replacements.isEmpty {
+                let updates = replacements.map { (path: $0.key, module: $0.value) }
+                attention.update(modules: ModuleChildren.unflattened(updates))
+            }
+        }
+
+        guard !loraLayers.isEmpty else {
+            throw LFM2TextLoRAInjectionError.noMatchingLayers(suffixes)
+        }
+        return loraLayers
+    }
+
+    private static func makeLoRALayer(
+        from module: Module,
+        rank: Int,
+        alpha: Float,
+        zeroInitUp: Bool
+    ) -> (replacement: Module?, layer: TrainableLoRALayer)? {
+        if let fused = module as? FusedLoRALinear {
+            let newLoRA = LoRALinear(
+                base: Linear(weight: fused.weight, bias: fused.bias),
+                rank: rank,
+                alpha: alpha,
+                zeroInitUp: zeroInitUp
+            )
+            newLoRA.role = .train
+            for lora in fused.loras where lora.role == .train {
+                lora.role = .assistant
+            }
+            fused.loras.append(newLoRA)
+            return (nil, fused)
+        }
+        if let existing = module as? LoRAQuantizedLinear {
+            let fused = FusedLoRALinear(
+                existingLoRA: existing,
+                newRank: rank,
+                newAlpha: alpha,
+                zeroInitUp: zeroInitUp
+            )
+            return (fused, fused)
+        }
+        if let existing = module as? LoRALinear {
+            let fused = FusedLoRALinear(
+                existingLoRA: existing,
+                newRank: rank,
+                newAlpha: alpha,
+                zeroInitUp: zeroInitUp
+            )
+            return (fused, fused)
+        }
+        if let quantized = module as? QuantizedLinear {
+            let wrapped = LoRAQuantizedLinear(
+                base: quantized,
+                rank: rank,
+                alpha: alpha,
+                zeroInitUp: zeroInitUp
+            )
+            return (wrapped, wrapped)
+        }
+        if let linear = module as? Linear {
+            let wrapped = LoRALinear(
+                base: linear,
+                rank: rank,
+                alpha: alpha,
+                zeroInitUp: zeroInitUp
+            )
+            return (wrapped, wrapped)
+        }
+        return nil
+    }
+
+    static func shouldTarget(path: String, suffixes: [String]) -> Bool {
+        guard path.hasPrefix("self_attn.") || path.contains(".self_attn.") else {
+            return false
+        }
+        return suffixes.map(canonicalTargetSuffix).contains { suffix in
+            path == suffix || path.hasSuffix(".\(suffix)")
+        }
+    }
+
+    private static func canonicalTargetSuffix(_ value: String) -> String {
+        let suffix = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        if suffix == "o_proj" {
+            return "out_proj"
+        }
+        if suffix.hasSuffix(".o_proj") {
+            return String(suffix.dropLast("o_proj".count)) + "out_proj"
+        }
+        return suffix
+    }
+}

--- a/Sources/MereRunCore/LFM2/LFM2TextLoRATrainingPipeline.swift
+++ b/Sources/MereRunCore/LFM2/LFM2TextLoRATrainingPipeline.swift
@@ -1,0 +1,114 @@
+import Foundation
+import MLX
+
+public struct LFM2TextLoRATrainingPipelineRequest: Sendable {
+    public let modelId: String
+    public let modelPath: String?
+    public let examples: [TextSFTExample]
+    public let evaluationExamples: [TextSFTExample]
+    public let outputURL: URL
+    public let trainingConfig: TextLoRATrainingConfig
+    public let maxSequenceLength: Int
+    public let rank: Int
+    public let alpha: Float
+    public let targetSuffixes: [String]
+    public let metadata: [String: String]
+
+    public init(
+        modelId: String,
+        modelPath: String? = nil,
+        examples: [TextSFTExample],
+        evaluationExamples: [TextSFTExample] = [],
+        outputURL: URL,
+        trainingConfig: TextLoRATrainingConfig,
+        maxSequenceLength: Int,
+        rank: Int,
+        alpha: Float,
+        targetSuffixes: [String],
+        metadata: [String: String] = [:]
+    ) {
+        self.modelId = modelId
+        self.modelPath = modelPath
+        self.examples = examples
+        self.evaluationExamples = evaluationExamples
+        self.outputURL = outputURL
+        self.trainingConfig = trainingConfig
+        self.maxSequenceLength = maxSequenceLength
+        self.rank = rank
+        self.alpha = alpha
+        self.targetSuffixes = targetSuffixes
+        self.metadata = metadata
+    }
+}
+
+public enum LFM2TextLoRATrainingPipeline {
+    public static func train(
+        _ request: LFM2TextLoRATrainingPipelineRequest,
+        progressHandler: (@Sendable (ChatProgress) -> Void)? = nil,
+        trainingProgressHandler: (@Sendable (TextLoRATrainingProgress) -> Void)? = nil
+    ) async throws -> TextLoRATrainingReport {
+        try await Stream.withNewDefaultStream {
+            try await trainOnCurrentStream(
+                request,
+                progressHandler: progressHandler,
+                trainingProgressHandler: trainingProgressHandler
+            )
+        }
+    }
+
+    private static func trainOnCurrentStream(
+        _ request: LFM2TextLoRATrainingPipelineRequest,
+        progressHandler: (@Sendable (ChatProgress) -> Void)?,
+        trainingProgressHandler: (@Sendable (TextLoRATrainingProgress) -> Void)?
+    ) async throws -> TextLoRATrainingReport {
+        let loaded = try await LFM2TextModelLoader.load(
+            modelId: request.modelId,
+            modelPath: request.modelPath,
+            maxContextLength: request.maxSequenceLength,
+            progressHandler: progressHandler
+        )
+        progressHandler?(ChatProgress(stage: .encoding, message: "Tokenizing LFM2 SFT examples"))
+        let tokenized = try LFM2TextSFTTokenizer.tokenize(
+            request.examples,
+            tokenizerAndTemplate: loaded.tokenizerAndTemplate,
+            maxSequenceLength: request.maxSequenceLength
+        )
+        let tokenizedEvaluation = try LFM2TextSFTTokenizer.tokenize(
+            request.evaluationExamples,
+            tokenizerAndTemplate: loaded.tokenizerAndTemplate,
+            maxSequenceLength: request.maxSequenceLength
+        )
+        progressHandler?(ChatProgress(stage: .loadingModel, message: "Injecting LFM2 attention LoRA layers"))
+        let layers = try LFM2TextLoRAInjector.inject(
+            into: loaded.model,
+            rank: request.rank,
+            alpha: request.alpha,
+            targetSuffixes: request.targetSuffixes
+        )
+        var metadata = request.metadata
+        metadata["base_model"] = request.modelId
+        metadata["model_root"] = loaded.rootURL.path
+        metadata["format"] = TextLoRATrainingManifest.lfm2Format
+        metadata["max_sequence_length"] = String(request.maxSequenceLength)
+
+        progressHandler?(ChatProgress(stage: .generating, message: "Training LFM2 attention LoRA adapter"))
+        return try TextLoRATrainer.train(
+            model: loaded.model,
+            loraLayers: layers,
+            examples: tokenized,
+            evaluationExamples: tokenizedEvaluation,
+            config: request.trainingConfig,
+            outputURL: request.outputURL,
+            metadata: metadata,
+            progressHandler: trainingProgressHandler,
+            gatheredForward: { model, inputIDs, targetPositions in
+                model.trainingLogits(
+                    inputIDs: inputIDs,
+                    flatTargetPositions: targetPositions
+                )
+            }
+        ) { model, inputIDs in
+            model.trainingForward(inputIDs)
+        }
+    }
+}

--- a/Sources/MereRunCore/LFM2/LFM2TextModelLoader.swift
+++ b/Sources/MereRunCore/LFM2/LFM2TextModelLoader.swift
@@ -1,0 +1,137 @@
+import Foundation
+import MLX
+
+struct LFM2LoadedTextModel: Sendable {
+    let model: LFM2Model
+    let tokenizerAndTemplate: LFM2TokenizerAndTemplate
+    let config: LFM2Config
+    let rootURL: URL
+}
+
+enum LFM2TextModelLoader {
+    static func load(
+        modelId: String,
+        modelPath: String? = nil,
+        maxContextLength: Int? = nil,
+        progressHandler: (@Sendable (ChatProgress) -> Void)? = nil
+    ) async throws -> LFM2LoadedTextModel {
+        guard LFM2Resources.supportsTextLoRATraining(modelSpec: modelId) else {
+            throw LFM2Error.unsupportedModelId(modelId)
+        }
+        let rootURL = try await resolveModelRoot(
+            modelId: modelId,
+            modelPath: modelPath,
+            progressHandler: progressHandler
+        )
+        let normalized = LFM2Resources.normalizedRootURL(rootURL)
+        let resources = LFM2Resources(rootURL: normalized)
+        let missing = resources.validate()
+        guard missing.isEmpty else {
+            throw LFM2Error.missingFiles(missing.map(\.lastPathComponent))
+        }
+
+        progressHandler?(ChatProgress(stage: .loadingModel, message: "Loading LFM2 config"))
+        let config = try JSONDecoder().decode(
+            LFM2Config.self,
+            from: Data(contentsOf: resources.configURL)
+        )
+        guard config.modelType == "lfm2_moe",
+              config.quantization?.bits == 8,
+              config.quantization?.mode == "affine" else {
+            throw LFM2Error.generationFailed(
+                "Native LFM2 text LoRA training v1 requires the affine 8-bit LFM2.5 A1B checkpoint."
+            )
+        }
+
+        progressHandler?(ChatProgress(stage: .loadingModel, message: "Loading LFM2 tokenizer"))
+        let tokenizer = try await LFM2TokenizerAndTemplate.load(
+            from: normalized,
+            maxLengthOverride: min(
+                maxContextLength ?? LFM2Resources.defaultContextLength,
+                config.maxPositionEmbeddings
+            )
+        )
+
+        progressHandler?(ChatProgress(stage: .loadingModel, message: "Loading LFM2 weights"))
+        let model = LFM2Model(config: config)
+        let groupSize = config.quantization?.groupSize ?? 64
+        let bits = config.quantization?.bits ?? 8
+        if FileManager.default.fileExists(atPath: resources.modelIndexURL.path) {
+            try HFSafetensorsWeightsLoader.applyQuantizedWeights(
+                indexURL: resources.modelIndexURL,
+                to: model,
+                groupSize: groupSize,
+                bits: bits,
+                mapper: LFM2Resources.mapWeight(key:value:),
+                progressHandler: { progress in
+                    progressHandler?(ChatProgress(
+                        stage: .loadingModel,
+                        message: "Loading LFM2 shard \(progress.shardIndex + 1)/\(progress.shardCount)"
+                    ))
+                }
+            )
+        } else {
+            let arrays = try MLX.loadArrays(url: resources.modelWeightsURL)
+            try HFSafetensorsWeightsLoader.applyQuantizedWeightsFromArrays(
+                arrays,
+                to: model,
+                groupSize: groupSize,
+                bits: bits,
+                mapper: LFM2Resources.mapWeight(key:value:)
+            )
+        }
+        try Task.checkCancellation()
+        return LFM2LoadedTextModel(
+            model: model,
+            tokenizerAndTemplate: tokenizer,
+            config: config,
+            rootURL: normalized
+        )
+    }
+
+    private static func resolveModelRoot(
+        modelId: String,
+        modelPath: String?,
+        progressHandler: (@Sendable (ChatProgress) -> Void)?
+    ) async throws -> URL {
+        if let explicit = modelPath?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !explicit.isEmpty {
+            let rootURL = URL(fileURLWithPath: explicit).standardizedFileURL
+            guard FileManager.default.fileExists(atPath: rootURL.path) else {
+                throw LFM2Error.downloadFailed("LFM2 model path does not exist: \(rootURL.path)")
+            }
+            return rootURL
+        }
+
+        let requested = modelId.trimmingCharacters(in: .whitespacesAndNewlines)
+        if FileManager.default.fileExists(atPath: requested) {
+            return URL(fileURLWithPath: requested).standardizedFileURL
+        }
+        if let installed = ManagedModelResolver.resolveInstalledModel(id: LFM2Resources.defaultModelId) {
+            return installed.standardizedFileURL
+        }
+        do {
+            let resolution = try await ManagedModelResolver.resolveForRuntime(
+                requestedModel: LFM2Resources.defaultModelId,
+                defaultModelID: LFM2Resources.defaultModelId,
+                progress: { event in
+                    switch event {
+                    case .downloading(let percent):
+                        progressHandler?(ChatProgress(
+                            stage: .loadingModel,
+                            message: "Downloading LFM2... \(percent)%"
+                        ))
+                    case .extracting:
+                        progressHandler?(ChatProgress(
+                            stage: .loadingModel,
+                            message: "Extracting LFM2..."
+                        ))
+                    }
+                }
+            )
+            return resolution.url.standardizedFileURL
+        } catch let error as ManagedModelResolver.ResolverError {
+            throw LFM2Error.downloadFailed(error.localizedDescription)
+        }
+    }
+}

--- a/Sources/MereRunCore/LFM2/LFM2TextSFTTokenizer.swift
+++ b/Sources/MereRunCore/LFM2/LFM2TextSFTTokenizer.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+public enum LFM2TextSFTTokenizer {
+    public static func tokenize(
+        _ examples: [TextSFTExample],
+        tokenizerAndTemplate: LFM2TokenizerAndTemplate,
+        maxSequenceLength: Int
+    ) throws -> [TextSFTTokenizedExample] {
+        try examples.map { example in
+            guard let assistant = example.messages.last,
+                  assistant.role == .assistant else {
+                throw LFM2TextSFTTokenizerError.lastMessageMustBeAssistant
+            }
+            guard assistant.toolCalls?.isEmpty != false else {
+                throw LFM2TextSFTTokenizerError.assistantToolCallsUnsupported
+            }
+            let prefixTokens = try tokenizerAndTemplate.encodeForGeneration(
+                messages: Array(example.messages.dropLast()),
+                tools: example.tools,
+                addGenerationPrompt: true,
+                includeThinking: false,
+                maxLength: tokenizerAndTemplate.maxLength
+            )
+            var targetTokens = tokenizerAndTemplate.encodeRaw(
+                assistantTargetText(
+                    content: assistant.content,
+                    reasoningContent: assistant.reasoningContent,
+                    generationPromptSuffix: tokenizerAndTemplate.generationPromptSuffix
+                ),
+                addSpecialTokens: false
+            )
+            if let imEndTokenId = tokenizerAndTemplate.imEndTokenId {
+                targetTokens.append(imEndTokenId)
+            } else if let eosTokenId = tokenizerAndTemplate.eosTokenId {
+                targetTokens.append(eosTokenId)
+            }
+            return try TextSFTTrainingBatchBuilder.shiftedTargetExample(
+                prefixTokenIds: prefixTokens,
+                targetTokenIds: targetTokens,
+                maxSequenceLength: maxSequenceLength
+            )
+        }
+    }
+
+    static func assistantTargetText(
+        content: String,
+        reasoningContent: String?,
+        generationPromptSuffix: String
+    ) -> String {
+        var visible = content.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard generationPromptSuffix == "<think>" else { return visible }
+
+        if visible.lowercased().hasPrefix("<think>") {
+            visible = String(visible.dropFirst("<think>".count))
+        }
+        if visible.localizedCaseInsensitiveContains("</think>") {
+            return visible
+        }
+        if let reasoning = reasoningContent?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !reasoning.isEmpty {
+            return "\(reasoning)</think>\n\(visible)"
+        }
+        return "</think>\n\(visible)"
+    }
+}
+
+public enum LFM2TextSFTTokenizerError: Error, LocalizedError, Sendable {
+    case lastMessageMustBeAssistant
+    case assistantToolCallsUnsupported
+
+    public var errorDescription: String? {
+        switch self {
+        case .lastMessageMustBeAssistant:
+            return "LFM2 text SFT tokenization requires the last message to be assistant."
+        case .assistantToolCallsUnsupported:
+            return "LFM2 text LoRA training v1 supports assistant text targets, not assistant tool-call targets."
+        }
+    }
+}

--- a/Sources/MereRunCore/LFM2/LFM2TokenizerAndTemplate.swift
+++ b/Sources/MereRunCore/LFM2/LFM2TokenizerAndTemplate.swift
@@ -75,6 +75,10 @@ public final class LFM2TokenizerAndTemplate: @unchecked Sendable {
         tokenizer.decode(tokens: tokens)
     }
 
+    public func encodeRaw(_ text: String, addSpecialTokens: Bool = false) -> [Int] {
+        tokenizer.encode(text: text, addSpecialTokens: addSpecialTokens)
+    }
+
     public func decode(token: Int) -> String {
         tokenizer.decode(tokens: [token])
     }

--- a/Sources/MereRunCore/LFM2/README.md
+++ b/Sources/MereRunCore/LFM2/README.md
@@ -52,6 +52,13 @@ applies sharded safetensor weights with `HFSafetensorsWeightsLoader`, pre-fills
 in cancellable chunks, then uses either the pipelined serial loop or the
 row-compacting continuous decode scheduler selected by the serving runtime.
 
+The A1B 8-bit text model also supports attention-only low-rank adaptation
+(LoRA) training and loading. `LFM2TextLoRAInjector.swift` wraps only the
+`q_proj`, `k_proj`, `v_proj`, and `out_proj` modules under `self_attn`.
+Convolution output projections and MoE expert matrices remain frozen. The
+training path turns off the inference-only fused affine-8 MoE kernel so that
+MLX can differentiate through the frozen base graph.
+
 For text targets, the managed catalog also installs the matching pinned
 `*-dspark` companion. `LFM2DSpark.swift` projects hidden states captured at
 the inputs to the checkpoint's five configured target layers into a five-layer,
@@ -75,6 +82,10 @@ fall back to MLX's portable gather path.
 ## Notes
 
 - This runtime is Swift-native and does not bridge to Python.
+- LFM2 text adapters use the `mererun.lfm2.text-lora` manifest. The
+  `text-chat-lfm25-a1b-8bit` model remains subject to the LFM Open License
+  v1.0 acceptance gate. The license also applies to adapters derived from the
+  model.
 - The QAD checkpoints keep Q4_0 projection nibbles and scales exactly in MLX
   affine group-32 tensors. Their Q6_K tied embeddings are decoded and
   requantized to MLX affine 6-bit/group-64; the published conversion receipts

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -2169,7 +2169,7 @@ public enum ManagedModelCatalog {
             validationKind: .lfm2,
             runtimeAutoDownloadAllowed: false,
             estimatedDownloadBytes: 10 * 1_073_741_824,
-            defaultCLICommands: ["text chat", "api serve"],
+            defaultCLICommands: ["text chat", "text train-lora", "api serve"],
             apiProfile: .lfm2()
         ),
         ManagedModelSpec(

--- a/Sources/MereRunCore/TextLoRATrainingManifest.swift
+++ b/Sources/MereRunCore/TextLoRATrainingManifest.swift
@@ -5,6 +5,7 @@ public struct TextLoRATrainingManifest: Codable, Sendable, Hashable {
     public static let gemma4Format = "mererun.gemma4.text-lora"
     public static let lagunaFormat = "mererun.laguna.text-lora"
     public static let inklingFormat = "mererun.inkling.text-lora"
+    public static let lfm2Format = "mererun.lfm2.text-lora"
     /// Compatibility alias for the first native text adapter format.
     public static let format = gemma4Format
 

--- a/Tests/MereRunCLITests/TextTrainLoRACommandParsingTests.swift
+++ b/Tests/MereRunCLITests/TextTrainLoRACommandParsingTests.swift
@@ -91,6 +91,20 @@ final class TextTrainLoRACommandParsingTests: XCTestCase {
         )
     }
 
+    func testTrainLoRAParsesLFM25A1BModel() throws {
+        let command = try TextTrainLoRA.parse([
+            "--data", "pairs.jsonl",
+            "--output", "lfm25-support.safetensors",
+            "--model", LFM2Resources.defaultModelId,
+        ])
+
+        XCTAssertEqual(command.model, LFM2Resources.defaultModelId)
+        XCTAssertEqual(
+            command.resolvedTargetModules(),
+            ["q_proj", "k_proj", "v_proj", "out_proj"]
+        )
+    }
+
     func testInklingReceptivityFixturesAreHeldOutParaphrases() throws {
         let fixtureRoot = URL(fileURLWithPath: #filePath)
             .deletingLastPathComponent()

--- a/Tests/MereRunCoreTests/LFM2ConfigAndModelTests.swift
+++ b/Tests/MereRunCoreTests/LFM2ConfigAndModelTests.swift
@@ -432,6 +432,111 @@ final class LFM2ConfigAndModelTests: MereRunCoreTestCase {
         XCTAssertTrue(MLX.max(MLX.abs(logits.asType(.float32))).item(Float.self).isFinite)
     }
 
+    func testTrainingLogitsMatchFullProjectionAtSelectedPositions() throws {
+        MLXRandom.seed(73)
+        let config = try makeTinyConfig()
+        let model = LFM2Model(config: config)
+        let input = MLXArray([Int32(1), 2, 3, 4, 5, 6]).reshaped(2, 3)
+        let positions = MLXArray([Int32(1), Int32(3), Int32(5)])
+        let full = model.trainingForward(input).reshaped(-1, config.vocabSize)
+        let expected = take(full, positions, axis: 0)
+        let gathered = model.trainingLogits(
+            inputIDs: input,
+            flatTargetPositions: positions
+        )
+        MLX.eval(expected, gathered)
+
+        XCTAssertEqual(gathered.shape, [3, config.vocabSize])
+        XCTAssertEqual(
+            MLX.max(MLX.abs(expected - gathered)).item(Float.self),
+            0,
+            accuracy: 1e-6
+        )
+    }
+
+    func testNativeLFM2TrainerUpdatesAttentionLoRA() throws {
+        MLXRandom.seed(74)
+        let model = LFM2Model(config: try makeTinyConfig())
+        let layers = try LFM2TextLoRAInjector.inject(into: model, rank: 2)
+        let inputTokenIDs = (0..<40).map { ($0 % 8) + 1 }
+        let labelTokenIDs = Array(inputTokenIDs.dropFirst()) + [1]
+
+        let report = try TextLoRATrainer.train(
+            model: model,
+            loraLayers: layers,
+            examples: [
+                TextSFTTokenizedExample(
+                    inputTokenIds: inputTokenIDs,
+                    labelTokenIds: labelTokenIDs,
+                    lossMask: [0] + Array(repeating: 1, count: 39)
+                ),
+            ],
+            config: TextLoRATrainingConfig(
+                trainingSteps: 2,
+                batchSize: 1,
+                learningRate: 0.01
+            ),
+            gatheredForward: { model, inputIDs, positions in
+                model.trainingLogits(
+                    inputIDs: inputIDs,
+                    flatTargetPositions: positions
+                )
+            }
+        ) { model, inputIDs in
+            model.trainingForward(inputIDs)
+        }
+
+        XCTAssertEqual(report.steps, 2)
+        XCTAssertEqual(report.layerCount, 8)
+        XCTAssertTrue(report.finalLoss?.isFinite == true)
+        XCTAssertTrue(layers.values.contains {
+            MLX.sum(MLX.abs($0.loraUp)).item(Float.self) > 0
+        })
+    }
+
+    func testNativeLFM2AdapterReloadsSavedTrainingWeights() async throws {
+        MLXRandom.seed(75)
+        let config = try makeTinyConfig()
+        let source = LFM2Model(config: config)
+        let sourceLayers = try LFM2TextLoRAInjector.inject(
+            into: source,
+            rank: 2,
+            alpha: 4
+        )
+        for layer in sourceLayers.values {
+            layer.loraDown = MLXArray.ones(like: layer.loraDown) * 0.125
+            layer.loraUp = MLXArray.ones(like: layer.loraUp) * 0.25
+        }
+
+        let directory = try TestFileSystem.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let adapterURL = directory.appendingPathComponent("lfm2-attention.safetensors")
+        try LoRASafetensorsWriter.save(
+            loraLayers: sourceLayers,
+            to: adapterURL,
+            metadata: ["format": TextLoRATrainingManifest.lfm2Format]
+        )
+
+        MLXRandom.seed(75)
+        let target = LFM2Model(config: config)
+        let input = MLXArray([Int32(1), 2, 3]).reshaped(1, 3)
+        let baseline = target.trainingForward(input)
+        MLX.eval(baseline)
+        let report = try await LFM2TextLoRAAdapter.apply(
+            .local(path: adapterURL.path, scale: 1),
+            to: target
+        )
+        let adapted = target.trainingForward(input)
+        MLX.eval(adapted)
+
+        XCTAssertEqual(report.matchedLayerCount, sourceLayers.count)
+        XCTAssertEqual(report.injectedLayerCount, sourceLayers.count)
+        XCTAssertGreaterThan(
+            MLX.max(MLX.abs(adapted - baseline)).item(Float.self),
+            0
+        )
+    }
+
     func testTinyDenseLFM2ForwardUsesOfficialWeightNames() throws {
         MLXRandom.seed(43)
         let config = try makeTinyDenseConfig()

--- a/Tests/MereRunCoreTests/LFM2TextLoRAInjectorTests.swift
+++ b/Tests/MereRunCoreTests/LFM2TextLoRAInjectorTests.swift
@@ -1,0 +1,104 @@
+import MLXNN
+import XCTest
+@testable import MereRunCore
+
+final class LFM2TextLoRAInjectorTests: MereRunCoreTestCase {
+    func testTargetMatcherAcceptsOfficialOutputAliasOnlyUnderAttention() {
+        XCTAssertTrue(LFM2TextLoRAInjector.shouldTarget(
+            path: "model.layers.2.self_attn.out_proj",
+            suffixes: ["o_proj"]
+        ))
+        XCTAssertFalse(LFM2TextLoRAInjector.shouldTarget(
+            path: "model.layers.0.conv.out_proj",
+            suffixes: ["out_proj"]
+        ))
+    }
+
+    func testInjectsOnlyAttentionProjections() throws {
+        let module = ToyLFM2Layer()
+        let layers = try LFM2TextLoRAInjector.inject(
+            into: module,
+            rank: 2,
+            targetSuffixes: ["q_proj", "o_proj"]
+        )
+
+        XCTAssertEqual(
+            Set(layers.keys),
+            ["self_attn.q_proj", "self_attn.out_proj"]
+        )
+        XCTAssertTrue(module.namedModules().contains { path, child in
+            path == "self_attn.q_proj" && child is LoRALinear
+        })
+        XCTAssertTrue(module.namedModules().contains { path, child in
+            path == "self_attn.out_proj" && child is LoRALinear
+        })
+        XCTAssertTrue(module.namedModules().contains { path, child in
+            path == "conv.out_proj" && child is Linear
+        })
+    }
+
+    func testAdapterKeyNormalizesWriterAndPEFTPrefixes() {
+        XCTAssertEqual(
+            LFM2TextLoRAAdapter.adapterKey(
+                for: "model.layers.2.self_attn.out_proj"
+            ),
+            "layers.2.self_attn.out_proj"
+        )
+        XCTAssertEqual(
+            LFM2TextLoRAAdapter.adapterKey(
+                for: "model.model.layers.2.self_attn.o_proj"
+            ),
+            "layers.2.self_attn.out_proj"
+        )
+    }
+
+    func testAssistantTargetClosesA1BThinkingPrefix() {
+        XCTAssertEqual(
+            LFM2TextSFTTokenizer.assistantTargetText(
+                content: "Copper Finch prefers direct answers.",
+                reasoningContent: nil,
+                generationPromptSuffix: "<think>"
+            ),
+            "</think>\nCopper Finch prefers direct answers."
+        )
+        XCTAssertEqual(
+            LFM2TextSFTTokenizer.assistantTargetText(
+                content: "Copper Finch prefers direct answers.",
+                reasoningContent: "Apply the persona instruction.",
+                generationPromptSuffix: "<think>"
+            ),
+            "Apply the persona instruction.</think>\nCopper Finch prefers direct answers."
+        )
+    }
+}
+
+private final class ToyLFM2Layer: Module {
+    @ModuleInfo(key: "self_attn") var selfAttention: ToyLFM2Attention
+    @ModuleInfo(key: "conv") var convolution: ToyLFM2Convolution
+
+    override init() {
+        self._selfAttention.wrappedValue = ToyLFM2Attention()
+        self._convolution.wrappedValue = ToyLFM2Convolution()
+        super.init()
+    }
+}
+
+private final class ToyLFM2Attention: Module {
+    @ModuleInfo(key: "q_proj") var qProj: Linear
+    @ModuleInfo(key: "out_proj") var outProj: Linear
+
+    override init() {
+        self._qProj.wrappedValue = Linear(4, 4, bias: false)
+        self._outProj.wrappedValue = Linear(4, 4, bias: false)
+        super.init()
+    }
+}
+
+private final class ToyLFM2Convolution: Module {
+    @ModuleInfo(key: "out_proj") var outProj: Linear
+
+    override init() {
+        self._outProj.wrappedValue = Linear(4, 4, bias: false)
+        super.init()
+    }
+}

--- a/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
@@ -681,11 +681,15 @@ final class ManagedModelCatalogTests: XCTestCase {
         let inkling = try XCTUnwrap(
             ManagedModelCatalog.spec(for: InklingResources.modelID)
         )
+        let lfm2A1B = try XCTUnwrap(
+            ManagedModelCatalog.spec(for: LFM2Resources.defaultModelId)
+        )
 
         XCTAssertTrue(gemma.defaultCLICommands.contains("text train-lora"))
         XCTAssertTrue(lagunaXS.defaultCLICommands.contains("text train-lora"))
         XCTAssertFalse(lagunaS.defaultCLICommands.contains("text train-lora"))
         XCTAssertTrue(inkling.defaultCLICommands.contains("text train-lora"))
+        XCTAssertTrue(lfm2A1B.defaultCLICommands.contains("text train-lora"))
     }
 
     func testLagunaUsesPinnedOfficialTargetAndCompanion() throws {

--- a/apps/macos/MereRunStudio/MereRunRootView.swift
+++ b/apps/macos/MereRunStudio/MereRunRootView.swift
@@ -1928,6 +1928,7 @@ private struct TextLoRATrainingOptions: View {
                     Text("Gemma 4 12B").tag("text-chat-gemma4-12b-4bit")
                     Text("Laguna XS 2.1").tag("text-chat-laguna-xs-2-1")
                     Text("Inkling-Small").tag("text-chat-inkling-small")
+                    Text("LFM2.5 A1B").tag("text-chat-lfm25-a1b-8bit")
                 }
                 .pickerStyle(.segmented)
                 PathField(

--- a/apps/macos/MereRunStudio/StudioTrainingView.swift
+++ b/apps/macos/MereRunStudio/StudioTrainingView.swift
@@ -674,6 +674,7 @@ struct StudioTrainingSheet: View {
                 Text("Gemma 4").tag("text-chat-gemma4-12b-4bit")
                 Text("Laguna XS 2.1").tag("text-chat-laguna-xs-2-1")
                 Text("Inkling-Small").tag("text-chat-inkling-small")
+                Text("LFM2.5 A1B").tag("text-chat-lfm25-a1b-8bit")
             }
             .pickerStyle(.segmented)
             labeledTextField("Base model", placeholder: "Managed text model", text: $textDraft.model)
@@ -696,7 +697,7 @@ struct StudioTrainingSheet: View {
                 placeholder: "Model-family defaults",
                 text: $textDraft.targetModules
             )
-            Text("Leave target modules empty for the native family recipe. Inkling includes attention, MLP, routed/shared experts, and unembedding.")
+            Text("Leave target modules empty for the native family recipe. LFM2.5 v1 is attention-only; Inkling also includes MLP, expert, and unembedding targets.")
                 .font(MereRunTheme.captionFont)
                 .foregroundStyle(MereRunTheme.textMuted)
             if textDraft.model.localizedCaseInsensitiveContains("inkling") {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -69,6 +69,15 @@ Krea 2 generation and LoRA training:
   - `Sources/MereRunCore/Krea2/Krea2ModelLoader.swift`
   - `Sources/MereRunCore/Krea2/Krea2SampleBuilder.swift`
 
+LFM2.5 text generation and LoRA training:
+
+- Runtime entry point: `Sources/MereRunCore/LFM2/LFM2Generator.swift`
+- Read next:
+  - `Sources/MereRunCore/LFM2/LFM2Model.swift`
+  - `Sources/MereRunCore/LFM2/LFM2TextModelLoader.swift`
+  - `Sources/MereRunCore/LFM2/LFM2TextLoRAInjector.swift`
+  - `Sources/MereRunCore/LFM2/LFM2TextLoRATrainingPipeline.swift`
+
 Shared text encoder stack used by image models:
 
 - Public entry point:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -862,7 +862,7 @@ generated text still arrives incrementally on stdout while diagnostics remain
 suppressed.
 
 `--lora` accepts a compatible local adapter file or cataloged adapter id.
-Native Gemma 4, Laguna XS 2.1, and Inkling-Small adapters produced by
+Native Gemma 4, Laguna XS 2.1, Inkling-Small, and LFM2.5 A1B adapters produced by
 `text train-lora` load directly in their matching runtime; `--lora-scale`
 scales the adapter.
 
@@ -895,9 +895,9 @@ Apple Silicon for this release.
 
 ### `mere.run text train-lora`
 
-Train a native LoRA from reviewed chat-style SFT JSONL. Supported
-families are Gemma 4 text models, `text-chat-laguna-xs-2-1`, and
-`text-chat-inkling-small`.
+Train a native LoRA from reviewed chat-style SFT JSONL. Supported families are
+Gemma 4 text models, `text-chat-laguna-xs-2-1`, `text-chat-inkling-small`, and
+`text-chat-lfm25-a1b-8bit`.
 
 ```bash
 swift run mere.run text train-lora \
@@ -919,12 +919,18 @@ checks include the complete conversation state and schemas, so successive
 tool-loop states may repeat a user question. `--dry-run --json` validates and
 fingerprints the dataset and writes the family-specific manifest without
 loading the model. Gemma 4 and Laguna default to
-`q_proj,k_proj,v_proj,o_proj`. Inkling defaults to those attention projections
-plus `gate_proj,up_proj,down_proj,lm_head`; expert MLPs use shared-outer factors
-to keep the 256-expert adapter tractable. Inkling `--reasoning-effort` accepts
+`q_proj,k_proj,v_proj,o_proj`. LFM2.5 defaults to
+`q_proj,k_proj,v_proj,out_proj` under attention only. Inkling defaults to its
+attention projections plus `gate_proj,up_proj,down_proj,lm_head`; expert MLPs
+use shared-outer factors to keep the 256-expert adapter tractable. Inkling
+`--reasoning-effort` accepts
 0 through 0.99 and is recorded in the training manifest. Use the same value for
 inference. See [Text Runtime](/runtime/text) for the full dataset,
 training-artifact, and behavioral validation flow.
+
+Before you train LFM2.5, install the model with
+`model pull text-chat-lfm25-a1b-8bit --accept-model-license`. The LFM Open
+License v1.0 applies to the base model and derived adapters.
 
 ### `mere.run text code`
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -419,11 +419,11 @@ cadence.
 ### `MERERUN_TEXT_LORA_TRAIN_GATHERED_LOSS`
 
 Native text LoRA training (`text train-lora`) projects only loss-masked
-target positions through the 262k-vocabulary lm_head and computes cross
-entropy as logSumExp-minus-gather, instead of materializing full-sequence
+target positions through the model's vocabulary head and computes cross
+entropy as logSumExp-minus-gather instead of materializing full-sequence
 logits plus a second full-vocabulary log-probability tensor. Gradients are
 identical to the full path. Prompt and padding rows do not contribute loss, so
-so this is on by default; set `0`, `false`, or `off` to restore the legacy
+this optimization is on by default. Set `0`, `false`, or `off` to restore the
 full-logits loss. The trainer prints its decision at startup
 (`gathered_loss=` on stderr).
 

--- a/docs/runtime/text.md
+++ b/docs/runtime/text.md
@@ -547,10 +547,11 @@ repeat a question after an assistant tool call and tool result, while an exact
 duplicate controller state remains invalid.
 
 Without `--dry-run`, the command resolves a supported Gemma 4 text model,
-`text-chat-laguna-xs-2-1`, or `text-chat-inkling-small` through the same managed
-model store as chat, applies that family's released chat template, masks loss
-to assistant tokens, injects native LoRA layers into the family-specific target
-surface, and writes a `.safetensors` adapter plus a family-specific manifest. Add
+`text-chat-laguna-xs-2-1`, `text-chat-inkling-small`, or
+`text-chat-lfm25-a1b-8bit` through the same managed model store as chat. The
+command applies the model's chat template, masks loss to assistant tokens,
+injects LoRA layers into the family-specific target surface, and writes a
+`.safetensors` adapter plus a family-specific manifest. Add
 `--visualize` to start the same loopback LoRA training dashboard used by image
 training; text runs write `run.json`, `*.events.jsonl`, `*.loss.csv`, and
 `*.loss.html` beside the adapter so loss and training events can be inspected
@@ -575,8 +576,9 @@ Core hyperparameters (defaults are tuned for local Gemma4 SFT):
 - `--reasoning-effort` — Inkling renderer effort from `0` through `0.99`
   (default `0.9`; use the same value for inference)
 - `--seed` — random seed (default `42`)
-- `--target-modules` — comma-separated LoRA target suffixes (Gemma/Laguna
-  default to q/k/v/o attention; Inkling also defaults to MLPs and `lm_head`)
+- `--target-modules` — comma-separated LoRA target suffixes. Gemma and Laguna
+  default to q/k/v/o attention. LFM2.5 defaults to q/k/v/output attention.
+  Inkling also defaults to MLPs and `lm_head`.
 - `--adapter-name` — adapter display name (default `local-assistant`)
 
 This list is deliberately not exhaustive; run
@@ -656,6 +658,36 @@ Inkling adapters write `mererun.inkling.text-lora` in their manifest. The
 training graph uses a differentiable MLX mask path and treats discrete expert
 selection indices as non-differentiable while retaining gradients through the
 selected router scores and quantized expert computation.
+
+LFM2.5 A1B uses a frozen affine 8-bit base and adapts only the four attention
+projections. This first target surface excludes short-convolution blocks,
+dense feed-forward layers, routers, and expert matrices. The native module
+name is `out_proj`; the injector also accepts the upstream LoRA alias
+`o_proj`.
+
+```bash
+mere.run model pull text-chat-lfm25-a1b-8bit --accept-model-license
+
+mere.run text train-lora \
+  --model text-chat-lfm25-a1b-8bit \
+  --data ./copper-finch-canary.jsonl \
+  --eval ./copper-finch-heldout.jsonl \
+  --output ./copper-finch-lfm25.safetensors \
+  --training-steps 10 \
+  --rank 16 \
+  --alpha 32
+
+mere.run text chat \
+  --model text-chat-lfm25-a1b-8bit \
+  --lora ./copper-finch-lfm25.safetensors \
+  --prompt "Introduce yourself in two sentences."
+```
+
+LFM2.5 adapters write `mererun.lfm2.text-lora` in their manifest. The LFM
+Open License v1.0 applies to the base model and derived adapters. You must
+accept the model license before installation. Commercial use by a legal entity
+with annual revenue of at least USD 10 million isn't licensed under the
+community terms.
 
 Loss improvement is diagnostic, not a behavioral acceptance gate. The repository
 includes a deterministic codebook task with 32 train examples and four unseen
@@ -746,11 +778,12 @@ plain redacted text or structured JSON spans.
 
 ### `mere.run text train-lora`
 
-Use this to prepare and train Gemma-family, Laguna XS 2.1, or Inkling-Small text
-LoRA adapters from reviewed chat SFT data. The Laguna lane is
+Use this to prepare and train Gemma-family, Laguna XS 2.1, Inkling-Small, or
+LFM2.5 A1B 8-bit text LoRA adapters from reviewed chat SFT data. The Laguna lane is
 `text-chat-laguna-xs-2-1`; Laguna S and DFlash are inference-only here. The
 Inkling lane is `text-chat-inkling-small` and trains against its pinned native
 mixed-precision MLX artifact.
+The LFM2.5 lane is `text-chat-lfm25-a1b-8bit` and uses attention-only QLoRA.
 
 ## Reading the code
 


### PR DESCRIPTION
## Summary

- add native assistant-only LoRA training for `text-chat-lfm25-a1b-8bit`
- target only `q_proj`, `k_proj`, `v_proj`, and `out_proj` under LFM2 attention while keeping convolution and MoE expert matrices frozen
- use a differentiable fallback for the frozen affine-8 MoE graph during training
- add the `mererun.lfm2.text-lora` manifest, adapter load/switch lifecycle, CLI and Studio exposure, tests, and operator documentation
- retain the existing LFM Open License acceptance boundary for the base model and derived adapters

Companion Identity Tools registration: https://github.com/a-github-name/autotrainer/pull/19

## Validation

- `./scripts/check.sh`
  - SwiftLint strict: passed
  - build and CLI help sweep: passed
  - 3,339 XCTest tests: passed with 278 expected skips
  - Swift Testing: 33 tests across 4 suites passed
  - docs and hygiene contracts: passed
- real installed `text-chat-lfm25-a1b-8bit` canary on MLX/Metal
  - 24 attention LoRA layers, rank 16 / alpha 32, 10 updates
  - training loss improved from 4.6451 to 2.5845
  - held-out loss improved from 5.3905 to 4.8765
  - the saved adapter reloaded through `text chat --lora` and entered native token generation

## Validation boundary

The one-pair canary proves training, serialization, reload, and inference mechanics. It is not personality-quality evidence. A reviewed 100–200-pair curriculum and four-arm behavioral evaluation remain follow-up qualification work.
