### PR TITLE
CI: reuse Swift build for debug app bundle

### DIFF
--- a/Tests/MereRunCLITests/LinuxNativeBridgeTests.swift
+++ b/Tests/MereRunCLITests/LinuxNativeBridgeTests.swift
@@ -210,6 +210,29 @@ final class LinuxNativeBridgeTests: XCTestCase {
         XCTAssertTrue(script.contains(#"if [[ "$identity" == "-" ]]"#))
         XCTAssertTrue(script.contains(#"-ffile-prefix-map=${source_path_map}"#))
         XCTAssertTrue(script.contains(#"-Xswiftc -file-prefix-map"#))
+        let releaseBuildGuard = try XCTUnwrap(
+            script.range(
+                of: #"""
+                if [[ "$configuration" == "release" ]]; then
+                  # Only distributable builds need checkout-path sanitization.
+                """#
+            )
+        )
+        let releaseBuildEnd = try XCTUnwrap(
+            script.range(
+                of: #"""
+                fi
+
+                swift "${swift_app_args[@]}"
+                """#,
+                range: releaseBuildGuard.lowerBound..<script.endIndex
+            )
+        )
+        let releaseBuildBlock = script[releaseBuildGuard.lowerBound..<releaseBuildEnd.upperBound]
+        XCTAssertTrue(releaseBuildBlock.contains(#"-ffile-prefix-map=${source_path_map}"#))
+        XCTAssertTrue(releaseBuildBlock.contains(#"-Xswiftc -file-prefix-map"#))
+        XCTAssertTrue(releaseBuildBlock.contains(#"swift_app_args+=(--configuration release)"#))
+        XCTAssertEqual(script.components(separatedBy: #"swift_app_args+=("${swift_path_map_args[@]}")"#).count, 2)
         XCTAssertTrue(script.contains("MERERUN_SWIFT_SCRATCH_PATH"))
         XCTAssertTrue(script.contains(#"${swift_scratch_path}=/src/mere-run/.build"#))
         XCTAssertTrue(script.contains("verify_private_build_path_absent"))

--- a/scripts/build_mere_run_app.sh
+++ b/scripts/build_mere_run_app.sh
@@ -57,23 +57,26 @@ if [[ -n "$swift_scratch_path" && "$swift_scratch_path" != "${repo_root}/.build"
   source_path_maps+=("${swift_scratch_path}=/src/mere-run/.build")
 fi
 swift_path_map_args=()
-for source_path_map in "${source_path_maps[@]}"; do
-  swift_path_map_args+=(
-    -Xcc "-ffile-prefix-map=${source_path_map}"
-    -Xcxx "-ffile-prefix-map=${source_path_map}"
-    -Xswiftc -file-prefix-map
-    -Xswiftc "$source_path_map"
-  )
-done
-swift_app_args+=("${swift_path_map_args[@]}")
-swift_cli_args+=("${swift_path_map_args[@]}")
-swift_bin_path_args+=("${swift_path_map_args[@]}")
 if [[ "${MERERUN_SWIFT_DISABLE_INDEX_STORE:-0}" == "1" ]]; then
   swift_app_args+=(--disable-index-store)
   swift_cli_args+=(--disable-index-store)
   swift_bin_path_args+=(--disable-index-store)
 fi
 if [[ "$configuration" == "release" ]]; then
+  # Only distributable builds need checkout-path sanitization. Keeping debug
+  # builds on the same command line as scripts/check.sh lets CI reuse the warm
+  # SwiftPM build directory instead of recompiling MereRunCore for the bundle.
+  for source_path_map in "${source_path_maps[@]}"; do
+    swift_path_map_args+=(
+      -Xcc "-ffile-prefix-map=${source_path_map}"
+      -Xcxx "-ffile-prefix-map=${source_path_map}"
+      -Xswiftc -file-prefix-map
+      -Xswiftc "$source_path_map"
+    )
+  done
+  swift_app_args+=("${swift_path_map_args[@]}")
+  swift_cli_args+=("${swift_path_map_args[@]}")
+  swift_bin_path_args+=("${swift_path_map_args[@]}")
   swift_app_args+=(--configuration release)
   swift_cli_args+=(--configuration release)
   swift_bin_path_args+=(--configuration release)


### PR DESCRIPTION
## Summary

- apply checkout-path sanitization flags only to release app bundles
- keep debug bundle compiler arguments aligned with scripts/check.sh so SwiftPM can reuse the warm build directory
- add regression coverage that keeps release path sanitization inside the release-only branch

## Why

PR CI currently runs scripts/check.sh and then recompiles MereRunCore and MereRunCLI during the debug app-bundle step because the path-map compiler flags differ. Recent runs spend roughly 10 extra minutes in that second compile.

## Validation

- MERERUN_SWIFT_DISABLE_INDEX_STORE=1 ./scripts/check.sh
- focused LinuxNativeBridgeTests regression passed
- warm debug bundle completed in 25 seconds
- asserted the warm bundle output contained no MereRunCore or MereRunCLI compilation

Release bundles retain the existing path sanitization and private-checkout-path verification.