### PR TITLE
Add Ornith 1.5 4-bit vision support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ The format is based on Keep a Changelog.
   external, mere.run verifies and stages only the 33 PLE-bearing safetensors on
   the internal SSD, then reuses that cache while all remaining files stay in
   the configured model store.
+### Vision
+
+- Added vision support to `text-agent-ornith-35b-mlx-4bit` by combining its
+  official 4-bit MLX target with the authoritative base checkpoint's 4.42 GiB
+  vision shard and shared BF16 MTP companion. It is the recommended local lane
+  for local image chat, API serving, agent use, and VLM, chat, and code
+  benchmarks. Image requests remain target-only; text and code retain verified
+  MTP speculation. The optional `vision-chat-ornith-35b` full-BF16 reference lane
+  remains available. Both resize inputs to a watchdog-safe 65,536-pixel budget.
 
 ### Text training
 

--- a/Sources/MereRunCLI/Commands/ModelBenchmarkCodeCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelBenchmarkCodeCommand.swift
@@ -424,7 +424,7 @@ struct ModelBenchmarkCode: AsyncParsableCommand {
 
     static func supportsCodingBenchmark(_ spec: ManagedModelSpec) -> Bool {
         spec.category == .textCode
-            || Q35Resources.isQ38ModelId(spec.id)
+            || spec.defaultCLICommands.contains("model benchmark code")
     }
 
     static func scoredCodeResponse(_ response: ChatResponse) -> String {

--- a/Sources/MereRunCLI/Commands/ModelBenchmarkCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelBenchmarkCommand.swift
@@ -92,6 +92,7 @@ struct ModelBenchmarkQ36MTP: AsyncParsableCommand {
             Q35Resources.ornith35BMLX6BitModelId,
             Q35Resources.ornith35BMLX8BitModelId,
             Q35Resources.ornith35BMLXModelId,
+            Q35Resources.ornith35BVisionModelId,
         ]
         guard supportedModels.contains(model) else {
             throw ValidationError(

--- a/Sources/MereRunCore/AgentModelResources.swift
+++ b/Sources/MereRunCore/AgentModelResources.swift
@@ -196,6 +196,7 @@ public enum MereRunAgentModelCatalog {
             ornith35BMLX6Bit(),
             ornith35BMLX8Bit(),
             ornith35BMLX(),
+            ornith35BVision(),
             q36Nano(),
             q38TwentySevenB4Bit(),
             q38TwentySevenB(),
@@ -312,12 +313,27 @@ public enum MereRunAgentModelCatalog {
         )
     }
 
+    private static func ornith35BVision() -> MereRunAgentModelRecommendation {
+        MereRunAgentModelRecommendation(
+            id: Q35Resources.ornith35BVisionModelId,
+            displayName: "Ornith 1.5 35B-A3B Vision",
+            summary: "Full BF16 Ornith coding and vision agent for native Swift Qwen-family workflows.",
+            minimumUnifiedMemoryGB: 96,
+            recommendedUnifiedMemoryGB: 128,
+            servingEngine: .textChatQ35,
+            managedModelID: Q35Resources.ornith35BVisionModelId
+        )
+    }
+
     private static func ornith35BMLX4Bit() -> MereRunAgentModelRecommendation {
-        ornith35BMLXQuantized(
+        MereRunAgentModelRecommendation(
             id: Q35Resources.ornith35BMLX4BitModelId,
-            label: "4-bit",
-            minimum: 32,
-            recommended: 48
+            displayName: "Ornith 1.5 35B-A3B 4-bit Vision",
+            summary: "Recommended Q4 Ornith target with the BF16 vision tower and shared MTP companion.",
+            minimumUnifiedMemoryGB: 32,
+            recommendedUnifiedMemoryGB: 48,
+            servingEngine: .textChatQ35,
+            managedModelID: Q35Resources.ornith35BMLX4BitModelId
         )
     }
 

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -2040,15 +2040,33 @@ public enum ManagedModelCatalog {
         ),
         ManagedModelSpec(
             id: Q35Resources.ornith35BMLX4BitModelId,
-            category: .textCode,
+            category: .visionChat,
             installShape: .directoryRoot,
             hubFallback: Q35Resources.profile(for: Q35Resources.ornith35BMLX4BitModelId)?.hubFallbackConfig,
+            mountedHubFallbacks: [
+                MountedHubFallbackConfig(
+                    destinationPath: Q35Resources.ornith35BVisionComponentPath,
+                    hubFallback: HubFallbackConfig(
+                        repoId: Q35Resources.ornith35BVisionUpstreamRepoId,
+                        revision: Q35Resources.ornith35BVisionUpstreamRevision,
+                        patterns: Q35Resources.ornith35BVisionComponentSnapshotPatterns
+                    )
+                ),
+            ],
             upstreamRepoId: Q35Resources.ornith35BMLX4BitUpstreamRepoId,
             upstreamRevision: Q35Resources.ornith35BMLX4BitUpstreamRevision,
             validationKind: .q35,
             runtimeAutoDownloadAllowed: false,
-            estimatedDownloadBytes: Q35Resources.ornith35BMLX4BitEstimatedDownloadBytes,
-            defaultCLICommands: ["chat", "api serve", "agent start", "model benchmark code"],
+            estimatedDownloadBytes: Q35Resources.ornith35BMLX4BitEstimatedDownloadBytes
+                + Q35Resources.ornith35BVisionComponentEstimatedDownloadBytes,
+            defaultCLICommands: [
+                "text chat",
+                "api serve",
+                "agent start",
+                "model benchmark chat",
+                "model benchmark code",
+                "model benchmark vlm",
+            ],
             companionModelIDs: [Q35Resources.ornith35BMTPModelId],
             apiProfile: .q36(
                 contextWindow: Q35Resources.ornith35BMLXContextLength,
@@ -2101,6 +2119,29 @@ public enum ManagedModelCatalog {
             estimatedDownloadBytes: Q35Resources.ornith35BMLXEstimatedDownloadBytes,
             defaultCLICommands: ["chat", "api serve", "agent start", "model benchmark code"],
             companionModelIDs: [Q35Resources.ornith35BMTPModelId],
+            apiProfile: .q36(
+                contextWindow: Q35Resources.ornith35BMLXContextLength,
+                fixedReasoning: true
+            )
+        ),
+        ManagedModelSpec(
+            id: Q35Resources.ornith35BVisionModelId,
+            category: .visionChat,
+            installShape: .directoryRoot,
+            hubFallback: Q35Resources.profile(for: Q35Resources.ornith35BVisionModelId)?.hubFallbackConfig,
+            upstreamRepoId: Q35Resources.ornith35BVisionUpstreamRepoId,
+            upstreamRevision: Q35Resources.ornith35BVisionUpstreamRevision,
+            validationKind: .q35,
+            runtimeAutoDownloadAllowed: false,
+            estimatedDownloadBytes: Q35Resources.ornith35BVisionEstimatedDownloadBytes,
+            defaultCLICommands: [
+                "text chat",
+                "api serve",
+                "agent start",
+                "model benchmark chat",
+                "model benchmark code",
+                "model benchmark vlm",
+            ],
             apiProfile: .q36(
                 contextWindow: Q35Resources.ornith35BMLXContextLength,
                 fixedReasoning: true
@@ -4167,6 +4208,9 @@ public extension ManagedModelSpec {
                         missing.append(url)
                     }
                 }
+            }
+            if id == Q35Resources.ornith35BMLX4BitModelId {
+                missing.append(contentsOf: resources.validateOrnithVisionComponent(fileManager: fileManager))
             }
             return missing
         case .q35MTPAssistant:

--- a/Sources/MereRunCore/ManagedModelSupport.swift
+++ b/Sources/MereRunCore/ManagedModelSupport.swift
@@ -552,8 +552,8 @@ public enum ManagedModelCapabilityCatalog {
             ),
             descriptor(
                 Q35Resources.ornith35BMLX4BitModelId,
-                "Ornith 1.5 35B-A3B MLX 4-bit",
-                "Fastest official Ornith 35B MLX tier with the shared BF16 MTP companion for verified speculative decode.",
+                "Ornith 1.5 35B-A3B 4-bit vision agent",
+                "Runs the official 4-bit Ornith target with its BF16 vision tower and shared MTP companion.",
                 minimum: 32,
                 recommended: 48
             ),
@@ -575,6 +575,13 @@ public enum ManagedModelCapabilityCatalog {
                 Q35Resources.ornith35BMLXModelId,
                 "Ornith 1.5 35B-A3B MLX BF16",
                 "Runs Ornith's official unquantized BF16 coding agent with the shared BF16 MTP companion.",
+                minimum: 96,
+                recommended: 128
+            ),
+            descriptor(
+                Q35Resources.ornith35BVisionModelId,
+                "Ornith 1.5 35B-A3B vision agent",
+                "Runs Ornith's full BF16 agentic coding and vision checkpoint through the native Qwen-family runtime.",
                 minimum: 96,
                 recommended: 128
             ),
@@ -1468,7 +1475,8 @@ public enum ManagedModelCapabilityCatalog {
             CodeGenResources.defaultModelId,
         ].filter { modelID in
             guard let spec = ManagedModelCatalog.spec(for: modelID),
-                  spec.category == .textCode else {
+                  spec.category == .textCode
+                    || spec.defaultCLICommands.contains("model benchmark code") else {
                 return false
             }
             return support(for: spec, on: machine).isSupported

--- a/Sources/MereRunCore/MereRunModelManifest.swift
+++ b/Sources/MereRunCore/MereRunModelManifest.swift
@@ -1464,6 +1464,7 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
                 bits: 4,
                 upstreamRepoId: Q35Resources.ornith35BMLX4BitUpstreamRepoId,
                 upstreamRevision: Q35Resources.ornith35BMLX4BitUpstreamRevision,
+                supports: [.chat, .codeGeneration, .visionChat],
                 createdAt: createdAt
             )
         case .ornith35BMLX6Bit:
@@ -1498,6 +1499,22 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
                 components: q35TextComponents,
                 upstreamRepoId: "\(Q35Resources.ornith35BMLXUpstreamRepoId)"
                     + "@\(Q35Resources.ornith35BMLXUpstreamRevision)",
+                createdAt: createdAt
+            )
+        case .ornith35BVision:
+            return MereRunModelManifest(
+                id: modelID.rawValue,
+                engine: .qwen35HybridMoE,
+                family: .code,
+                tier: .large,
+                variant: .standard,
+                precision: .bf16,
+                quantization: nil,
+                defaults: nil,
+                supports: [.chat, .codeGeneration, .visionChat],
+                components: q35TextComponents,
+                upstreamRepoId: "\(Q35Resources.ornith35BVisionUpstreamRepoId)"
+                    + "@\(Q35Resources.ornith35BVisionUpstreamRevision)",
                 createdAt: createdAt
             )
         case .ornith35BMTP:
@@ -2649,6 +2666,7 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
         bits: Int,
         upstreamRepoId: String,
         upstreamRevision: String,
+        supports: [Capability] = [.chat, .codeGeneration],
         createdAt: Date
     ) -> MereRunModelManifest {
         MereRunModelManifest(
@@ -2660,7 +2678,7 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
             precision: precision,
             quantization: Quantization(bits: bits, groupSize: 64, scheme: "mlx-affine"),
             defaults: nil,
-            supports: [.chat, .codeGeneration],
+            supports: supports,
             components: Components(
                 tokenizer: .local(path: "."),
                 textEncoder: .local(path: "."),

--- a/Sources/MereRunCore/ModelResolver.swift
+++ b/Sources/MereRunCore/ModelResolver.swift
@@ -75,6 +75,7 @@ public struct ModelResolver {
         case ornith35BMLX6Bit = "text-agent-ornith-35b-mlx-6bit"
         case ornith35BMLX8Bit = "text-agent-ornith-35b-mlx-8bit"
         case ornith35BMLX = "text-agent-ornith-35b-mlx"
+        case ornith35BVision = "vision-chat-ornith-35b"
         case ornith35BMTP = "text-agent-ornith-35b-mtp"
         case northMiniCode = "text-code-north-mini"
         case q36NanoGGUF = "text-chat-q36-nano-gguf"

--- a/Sources/MereRunCore/Q35/Q35Generator.swift
+++ b/Sources/MereRunCore/Q35/Q35Generator.swift
@@ -514,6 +514,14 @@ public actor Q35Generator: ChatGenerator {
                 throw Q35Error.generationFailed("Qwen3.8 4-bit vision companion does not include a vision config.")
             }
             visionConfigAndResources = (companionConfig, companionResources)
+        } else if modelId == Q35Resources.ornith35BMLX4BitModelId {
+            let companionResources = primaryResources.ornithVisionComponentResources
+            let companionConfigData = try Data(contentsOf: companionResources.configURL)
+            let companionConfig = try JSONDecoder().decode(Q35Config.self, from: companionConfigData)
+            guard companionConfig.visionConfig != nil else {
+                throw Q35Error.generationFailed("Ornith 4-bit vision companion does not include a vision config.")
+            }
+            visionConfigAndResources = (companionConfig, companionResources)
         } else {
             visionConfigAndResources = nil
         }
@@ -953,7 +961,7 @@ public actor Q35Generator: ChatGenerator {
     }
 
     static func defaultMTPMinimumPromptTokens(modelId: String, usesMoE: Bool) -> Int {
-        if Q35Resources.isOrnith35BMLXModelId(modelId) {
+        if Q35Resources.isOrnith35BModelId(modelId) {
             return 0
         }
         if modelId == Q35Resources.q38FlashNextMixedModelId
@@ -2919,6 +2927,7 @@ public actor Q35Generator: ChatGenerator {
 
         progressHandler?(ChatProgress(stage: .loadingModel, message: "Loading Qwen-family vision tower"))
         try visionTower.loadWeights(from: loadedVisionResources)
+        progressHandler?(ChatProgress(stage: .loadingModel, message: "Loaded Qwen-family vision tower"))
     }
 
     private func buildVisionReplacements(

--- a/Sources/MereRunCore/Q35/Q35MTP.swift
+++ b/Sources/MereRunCore/Q35/Q35MTP.swift
@@ -62,20 +62,20 @@ final class Q35MTPExperts: Module {
         let flatX = expanded.reshaped([batchTokens * topK, 1, inputDim])
         let flatIndices = indices.reshaped([batchTokens * topK])
 
-        let gateUp = gatherMM(
+        let gateUp = q35DenseExpertMM(
             flatX,
-            gateUpProj.swappedAxes(-1, -2),
-            rhsIndices: flatIndices,
+            weight: gateUpProj,
+            indices: flatIndices,
             sortedIndices: false
         )
         let gate = gateUp[.ellipsis, 0..<intermediateSize]
         let up = gateUp[.ellipsis, intermediateSize...]
         let activated = q35MTPSwiglu(gate, up)
 
-        let output = gatherMM(
+        let output = q35DenseExpertMM(
             activated,
-            downProj.swappedAxes(-1, -2),
-            rhsIndices: flatIndices,
+            weight: downProj,
+            indices: flatIndices,
             sortedIndices: false
         )
         let outDim = output.dim(2)

--- a/Sources/MereRunCore/Q35/Q35MoE.swift
+++ b/Sources/MereRunCore/Q35/Q35MoE.swift
@@ -13,6 +13,27 @@ private func q35Swiglu(_ gate: MLXArray, _ up: MLXArray) -> MLXArray {
     q35SwigluCompiled(gate, up)
 }
 
+/// MLX `gatherMM` currently accepts dense float32 expert banks only. Preserve
+/// native BF16 checkpoints by gathering just the routed expert matrices and
+/// applying the regular batched matmul path, which supports BF16 on Metal.
+func q35DenseExpertMM(
+    _ x: MLXArray,
+    weight: MLXArray,
+    indices: MLXArray,
+    sortedIndices: Bool
+) -> MLXArray {
+    if weight.dtype == .float32 {
+        return gatherMM(
+            x,
+            weight.swappedAxes(-1, -2),
+            rhsIndices: indices,
+            sortedIndices: sortedIndices
+        )
+    }
+    let selected = weight.take(indices, axis: 0)
+    return MLX.matmul(x, selected.swappedAxes(-1, -2))
+}
+
 enum Q35FusedSwitchGLUPolicy {
     /// Kill switch: MERERUN_Q35_FUSED_SWITCH_GLU=0 disables the stacked
     /// gate+up expert matmul. The fusion halves the gather-matmul launches per
@@ -134,10 +155,10 @@ class Q35SwitchLinear: Module {
                 sortedIndices: sortedIndices
             )
         } else {
-            output = gatherMM(
+            output = q35DenseExpertMM(
                 x,
-                weight.swappedAxes(-1, -2),
-                rhsIndices: indices,
+                weight: weight,
+                indices: indices,
                 sortedIndices: sortedIndices
             )
         }
@@ -417,10 +438,10 @@ final class Q35SwitchGLU: Module {
                 sortedIndices: sortedIndices
             )
         } else {
-            output = gatherMM(
+            output = q35DenseExpertMM(
                 x,
-                fused.weight.swappedAxes(-1, -2),
-                rhsIndices: indices,
+                weight: fused.weight,
+                indices: indices,
                 sortedIndices: sortedIndices
             )
         }

--- a/Sources/MereRunCore/Q35/Q35Model.swift
+++ b/Sources/MereRunCore/Q35/Q35Model.swift
@@ -274,11 +274,13 @@ final class Q35Transformer: Module {
     @ModuleInfo(key: "hyper_connection_mixer") var hyperConnectionMixer: Q38GatedResidual?
 
     private let isQwen4Exp: Bool
+    private let usesMoE: Bool
     private let hyperConnectionCount: Int
 
     init(config: Q35Config) {
         let text = config.textConfig
         self.isQwen4Exp = text.isQwen4Exp
+        self.usesMoE = text.usesMoE
         self.hyperConnectionCount = text.hyperConnectionCount
         self._embedTokens.wrappedValue = Embedding(
             embeddingCount: text.vocabSize,
@@ -365,11 +367,12 @@ final class Q35Transformer: Module {
                 // the exact dequantized embeddings.
                 MLX.asyncEval(hidden)
             }
-            if isQwen4Exp,
+            if (isQwen4Exp || usesMoE),
                (index + 1).isMultiple(of: 4) || index + 1 == layers.count {
-                // Qwen4Exp adds two hyper-connection projections per block.
-                // Materialize each four-layer hybrid block so a 48-layer
+                // Materialize each four-layer hybrid block so a deep MoE
                 // prefill is not submitted as one watchdog-sized lazy graph.
+                // This is also required by full-BF16 Qwen3.5 checkpoints;
+                // Qwen4Exp adds two hyper-connection projections per block.
                 MLX.eval(hidden)
             }
             Q35DebugLayerDump.record(stage: "layer\(index)", hidden)

--- a/Sources/MereRunCore/Q35/Q35Resources.swift
+++ b/Sources/MereRunCore/Q35/Q35Resources.swift
@@ -43,6 +43,7 @@ public struct Q35Resources: Sendable, Hashable {
     public static let ornith35BMLX8BitModelId = "text-agent-ornith-35b-mlx-8bit"
     /// Compatibility id for the official unquantized BF16 MLX snapshot.
     public static let ornith35BMLXModelId = "text-agent-ornith-35b-mlx"
+    public static let ornith35BVisionModelId = "vision-chat-ornith-35b"
     public static let ornith35BMTPModelId = "text-agent-ornith-35b-mtp"
     public static let infinityParser2ProModelId = "vision-ocr-infinity-pro"
     public static let infinityParser2ProInt8ModelId = "vision-ocr-infinity-pro-int8"
@@ -56,7 +57,7 @@ public struct Q35Resources: Sendable, Hashable {
         isQ38ModelId(modelId)
             || isBonsai27BModelId(modelId)
             || modelId == ornith9BModelId
-            || isOrnith35BMLXModelId(modelId)
+            || isOrnith35BModelId(modelId)
     }
 
     public static func isBonsai27BModelId(_ modelId: String) -> Bool {
@@ -101,7 +102,8 @@ public struct Q35Resources: Sendable, Hashable {
              ornith35BMLX4BitModelId,
              ornith35BMLX6BitModelId,
              ornith35BMLX8BitModelId,
-             ornith35BMLXModelId:
+             ornith35BMLXModelId,
+             ornith35BVisionModelId:
             return RecommendedSampling(temperature: 1.0, topP: 0.95, topK: 20)
         default:
             return nil
@@ -148,6 +150,7 @@ public struct Q35Resources: Sendable, Hashable {
     public static let q38TwentySevenBContextLength = 262_144
     public static let q38TwentySevenBVisionMinPixels = 65_536
     public static let q38TwentySevenBVisionMaxPixels = 16_777_216
+    public static let ornith35BVisionMaxPixels = 65_536
     public static let bonsai27B1BitUpstreamRepoId = "prism-ml/Bonsai-27B-mlx-1bit"
     public static let bonsai27B1BitUpstreamRevision = "ef22f239c670078e1507f9769bcaa66657332b96"
     public static let bonsai27B1BitEstimatedDownloadBytes: Int64 = 5_128_837_600
@@ -171,6 +174,18 @@ public struct Q35Resources: Sendable, Hashable {
     public static let ornith35BMLX8BitUpstreamRepoId = "ornith-ai/Ornith-1.5-35B-A3B-MLX-8bit"
     public static let ornith35BMLX8BitUpstreamRevision = "02440c39bdf7365c494a7f55f2a8b104ba87562f"
     public static let ornith35BMLX8BitEstimatedDownloadBytes: Int64 = 36_850_134_639
+    public static let ornith35BVisionUpstreamRepoId = "ornith-ai/Ornith-1.5-35B-A3B"
+    public static let ornith35BVisionUpstreamRevision = "10fbf86fed7ecee4a061f8b499a618f46001cac1"
+    public static let ornith35BVisionEstimatedDownloadBytes: Int64 = 71_926_980_382
+    public static let ornith35BVisionComponentPath = "vision"
+    public static let ornith35BVisionComponentSnapshotPatterns = [
+        "config.json",
+        "model.safetensors.index.json",
+        "model-00001-of-00016.safetensors",
+        "preprocessor_config.json",
+        "video_preprocessor_config.json",
+    ]
+    public static let ornith35BVisionComponentEstimatedDownloadBytes: Int64 = 4_744_402_377
     public static let ornith35BMTPUpstreamRepoId = "ornith-ai/Ornith-1.5-35B-A3B"
     public static let ornith35BMTPUpstreamRevision = "e4dfb35a93d4b6822a811a7676f3488514abe7e2"
     public static let ornith35BMTPShardFilename = "model-00016-of-00016.safetensors"
@@ -306,6 +321,19 @@ public struct Q35Resources: Sendable, Hashable {
             upstreamRevision: ornith35BMLX8BitUpstreamRevision,
             snapshotPatterns: snapshotPatterns + ["generation_config.json", "README.md"]
         ),
+        ornith35BVisionModelId: Profile(
+            modelId: ornith35BVisionModelId,
+            upstreamRepoId: ornith35BVisionUpstreamRepoId,
+            upstreamRevision: ornith35BVisionUpstreamRevision,
+            snapshotPatterns: snapshotPatterns + [
+                "generation_config.json",
+                "preprocessor_config.json",
+                "video_preprocessor_config.json",
+                "merges.txt",
+                "vocab.json",
+                "README.md",
+            ]
+        ),
         infinityParser2ProModelId: Profile(
             modelId: infinityParser2ProModelId,
             upstreamRepoId: infinityParser2ProUpstreamRepoId,
@@ -345,7 +373,8 @@ public struct Q35Resources: Sendable, Hashable {
         case ornith35BMLX4BitModelId,
              ornith35BMLX6BitModelId,
              ornith35BMLX8BitModelId,
-             ornith35BMLXModelId:
+             ornith35BMLXModelId,
+             ornith35BVisionModelId:
             ornith35BMLXContextLength
         default:
             defaultContextLength
@@ -353,6 +382,9 @@ public struct Q35Resources: Sendable, Hashable {
     }
 
     public static func visionPixelBounds(forModelId modelId: String) -> (minimum: Int, maximum: Int) {
+        if modelId == ornith35BMLX4BitModelId || modelId == ornith35BVisionModelId {
+            return (q38TwentySevenBVisionMinPixels, ornith35BVisionMaxPixels)
+        }
         if isQ38ModelId(modelId) {
             return (q38TwentySevenBVisionMinPixels, q38TwentySevenBVisionMaxPixels)
         }
@@ -373,6 +405,10 @@ public struct Q35Resources: Sendable, Hashable {
             || modelId == ornith35BMLX6BitModelId
             || modelId == ornith35BMLX8BitModelId
             || modelId == ornith35BMLXModelId
+    }
+
+    public static func isOrnith35BModelId(_ modelId: String) -> Bool {
+        isOrnith35BMLXModelId(modelId) || modelId == ornith35BVisionModelId
     }
 
     public static let snapshotPatterns = [
@@ -442,6 +478,20 @@ public struct Q35Resources: Sendable, Hashable {
             Self.q38VisionComponentPath,
             isDirectory: true
         ))
+    }
+
+    public var ornithVisionComponentResources: Q35Resources {
+        Q35Resources(rootURL: rootURL.appendingPathComponent(
+            Self.ornith35BVisionComponentPath,
+            isDirectory: true
+        ))
+    }
+
+    public func validateOrnithVisionComponent(fileManager: FileManager = .default) -> [URL] {
+        let componentRoot = ornithVisionComponentResources.rootURL
+        return Self.ornith35BVisionComponentSnapshotPatterns
+            .map { componentRoot.appendingPathComponent($0, isDirectory: false) }
+            .filter { !fileManager.fileExists(atPath: $0.path) }
     }
 
     public func validateQ38VisionComponent(fileManager: FileManager = .default) -> [URL] {

--- a/Sources/MereRunCore/Q35/Q35VisionTower.swift
+++ b/Sources/MereRunCore/Q35/Q35VisionTower.swift
@@ -93,6 +93,14 @@ public final class Q35VisionTower: Module {
             try update(parameters: ModuleParameters.unflattened(mapped), verify: [.shapeMismatch])
         }
 
+        // A managed model may be backed by an external-volume snapshot. Page
+        // weights in through bounded command buffers before the first vision
+        // forward so disk I/O cannot turn that forward into a Metal timeout.
+        let values = parameters().flattened().map(\.1)
+        for start in stride(from: 0, to: values.count, by: 8) {
+            MLX.eval(Array(values[start..<min(start + 8, values.count)]))
+            Stream.gpu.synchronize()
+        }
         isLoaded = true
     }
 
@@ -117,6 +125,8 @@ public final class Q35VisionTower: Module {
         if let projection = visionProjection {
             embeds = projection(embeds)
         }
+        MLX.eval(embeds)
+        Stream.gpu.synchronize()
         return embeds
     }
 

--- a/Sources/MereRunCore/Q35/README.md
+++ b/Sources/MereRunCore/Q35/README.md
@@ -89,6 +89,16 @@ place, and insufficient internal free space falls back to the original shards.
 Four-layer evaluation boundaries keep the 48-layer lazy graph below
 the macOS Metal watchdog while preserving each hybrid block.
 
+The same four-layer evaluation boundaries keep other deep MoE lazy graphs below
+the macOS Metal watchdog while preserving each decoder block. Full-precision BF16 expert
+weights use selected batched matrix multiplication because MLX's dense
+`gatherMM` kernel accepts only FP32 weights.
+
+Qwen3 learned-position vision towers materialize checkpoint weights in bounded
+batches and synchronize after each vision block and final projection. This
+keeps external-volume page-in and the full BF16 Ornith vision graph below the
+macOS Metal watchdog without changing the checkpoint tensors.
+
 QSA indexers run in every full-attention layer. Raw index keys are mean-pooled
 in four-token blocks in FP32, normalized, and rotated at the block's first
 position. Normalized/rotated index queries score those blocks by summed ReLU

--- a/Sources/MereRunCore/ZImageTurbo/Model/TextEncoder/Vision/QwenVisionTower.swift
+++ b/Sources/MereRunCore/ZImageTurbo/Model/TextEncoder/Vision/QwenVisionTower.swift
@@ -321,6 +321,11 @@ final class QwenVisionTower: Module {
         attentionMask: nil,
         cuSeqlens: cuSeqlensArray
       )
+      // Full-BF16 learned-position towers can exceed the macOS Metal watchdog
+      // when several blocks share one command buffer. Materialize each block;
+      // image encoding is a one-time prefill cost and remains deterministic.
+      MLX.eval(hiddenStates)
+      Stream.gpu.synchronize()
 
       // Capture deepstack features at intermediate layers
       if let mergerIdx = deepstackVisualIndexes.firstIndex(of: layerIdx) {

--- a/Tests/MereRunCLITests/ModelBenchmarkCommandTests.swift
+++ b/Tests/MereRunCLITests/ModelBenchmarkCommandTests.swift
@@ -250,6 +250,17 @@ final class ModelBenchmarkCommandTests: XCTestCase {
         }
     }
 
+    func testCodeBenchmarkAcceptsOrnithVisionAgentLane() throws {
+        for modelID in [
+            Q35Resources.ornith35BMLX4BitModelId,
+            Q35Resources.ornith35BVisionModelId,
+        ] {
+            let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: modelID))
+            XCTAssertEqual(spec.category, .visionChat)
+            XCTAssertTrue(ModelBenchmarkCode.supportsCodingBenchmark(spec))
+        }
+    }
+
     func testCodeBenchmarkScoresOnlyVisibleCodeAfterImplicitThinkingPrefix() {
         let response = ChatResponse(
             response: """
@@ -537,6 +548,7 @@ final class ModelBenchmarkCommandTests: XCTestCase {
             Q35Resources.ornith35BMLX4BitModelId,
             Q35Resources.ornith35BMLX6BitModelId,
             Q35Resources.ornith35BMLX8BitModelId,
+            Q35Resources.ornith35BVisionModelId,
         ] {
             let cmd = try ModelBenchmarkQ36MTP.parse(["--model", modelId])
             XCTAssertNoThrow(try cmd.validate())

--- a/Tests/MereRunCLITests/SetupCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/SetupCommandParsingTests.swift
@@ -148,6 +148,39 @@ final class SetupCommandParsingTests: XCTestCase {
         XCTAssertEqual(runtime.recommendation.servingEngine, .textChatQ36)
     }
 
+    func testOrnithVisionProviderUsesNativeQwenRuntime() throws {
+        let runtime = try SetupAgentRuntime.runtime(
+            forManagedModelID: Q35Resources.ornith35BVisionModelId
+        )
+        let providerModel = runtime.providerModel
+
+        XCTAssertEqual(runtime.engine, .textChatQ36)
+        XCTAssertEqual(providerModel.id, Q35Resources.ornith35BVisionModelId)
+        XCTAssertEqual(providerModel.contextWindow, Q35Resources.ornith35BMLXContextLength)
+        XCTAssertEqual(providerModel.maxTokens, 4_096)
+        XCTAssertTrue(providerModel.reasoning)
+        XCTAssertTrue(providerModel.toolCall)
+        XCTAssertTrue(providerModel.inputModalities.contains("image"))
+        XCTAssertTrue(runtime.recommendation.isStartableByMereRun)
+        XCTAssertEqual(runtime.recommendation.servingEngine, .textChatQ35)
+    }
+
+    func testOrnithMLX4BitVisionProviderUsesNativeQwenRuntime() throws {
+        let runtime = try SetupAgentRuntime.runtime(
+            forManagedModelID: Q35Resources.ornith35BMLX4BitModelId
+        )
+        let providerModel = runtime.providerModel
+
+        XCTAssertEqual(runtime.engine, .textChatQ36)
+        XCTAssertEqual(providerModel.id, Q35Resources.ornith35BMLX4BitModelId)
+        XCTAssertEqual(providerModel.contextWindow, Q35Resources.ornith35BMLXContextLength)
+        XCTAssertTrue(providerModel.reasoning)
+        XCTAssertTrue(providerModel.toolCall)
+        XCTAssertTrue(providerModel.inputModalities.contains("image"))
+        XCTAssertTrue(runtime.recommendation.isStartableByMereRun)
+        XCTAssertEqual(runtime.recommendation.servingEngine, .textChatQ35)
+    }
+
     func testOrnith35BProviderUsesNativeManagedModelID() throws {
         let recommendation = try XCTUnwrap(
             MereRunAgentModelCatalog

--- a/Tests/MereRunCLITests/TextChatCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/TextChatCommandParsingTests.swift
@@ -416,6 +416,8 @@ final class TextChatCommandParsingTests: XCTestCase {
 
     func testQwenAgentAndQ38LanesDefaultToThinkingAndRecommendedSampling() {
         XCTAssertTrue(Q35Resources.thinkingDefault(forModelId: Q35Resources.ornith35BMLXModelId))
+        XCTAssertTrue(Q35Resources.thinkingDefault(forModelId: Q35Resources.ornith35BMLX4BitModelId))
+        XCTAssertTrue(Q35Resources.thinkingDefault(forModelId: Q35Resources.ornith35BVisionModelId))
         XCTAssertTrue(Q35Resources.thinkingDefault(forModelId: Q35Resources.ornith9BModelId))
         XCTAssertTrue(Q35Resources.thinkingDefault(forModelId: Q35Resources.q38TwentySevenBModelId))
         XCTAssertTrue(Q35Resources.thinkingDefault(forModelId: Q35Resources.q38TwentySevenB4BitModelId))
@@ -426,6 +428,14 @@ final class TextChatCommandParsingTests: XCTestCase {
         XCTAssertEqual(sampling?.temperature, 1.0)
         XCTAssertEqual(sampling?.topP, 0.95)
         XCTAssertEqual(sampling?.topK, 20)
+        XCTAssertEqual(
+            Q35Resources.recommendedSampling(forModelId: Q35Resources.ornith35BMLX4BitModelId),
+            sampling
+        )
+        XCTAssertEqual(
+            Q35Resources.recommendedSampling(forModelId: Q35Resources.ornith35BVisionModelId),
+            sampling
+        )
         let q38Sampling = Q35Resources.recommendedSampling(forModelId: Q35Resources.q38TwentySevenBModelId)
         XCTAssertEqual(q38Sampling?.temperature, 1.0)
         XCTAssertEqual(q38Sampling?.topP, 0.95)

--- a/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
@@ -821,6 +821,72 @@ final class ManagedModelCatalogTests: XCTestCase {
         XCTAssertEqual(spec.apiProfile?.compatibility.supportsReasoningEffort, true)
     }
 
+    func testOrnith35BVisionUsesPinnedOfficialMultimodalSource() throws {
+        let spec = try XCTUnwrap(
+            ManagedModelCatalog.spec(for: Q35Resources.ornith35BVisionModelId)
+        )
+
+        XCTAssertEqual(ModelResolver.ModelID.ornith35BVision.rawValue, spec.id)
+        XCTAssertEqual(spec.category, .visionChat)
+        XCTAssertEqual(spec.installShape, .directoryRoot)
+        XCTAssertEqual(spec.hubFallback?.repoId, Q35Resources.ornith35BVisionUpstreamRepoId)
+        XCTAssertEqual(spec.hubFallback?.revision, Q35Resources.ornith35BVisionUpstreamRevision)
+        XCTAssertEqual(spec.upstreamRepoId, Q35Resources.ornith35BVisionUpstreamRepoId)
+        XCTAssertEqual(spec.upstreamRevision, Q35Resources.ornith35BVisionUpstreamRevision)
+        XCTAssertEqual(spec.validationKind, .q35)
+        XCTAssertEqual(spec.defaultRuntimeServingEngine, .textChatQ36)
+        XCTAssertEqual(spec.estimatedDownloadBytes, 71_926_980_382)
+        XCTAssertFalse(spec.runtimeAutoDownloadAllowed)
+        XCTAssertTrue(spec.defaultCLICommands.contains("agent start"))
+        XCTAssertTrue(spec.defaultCLICommands.contains("model benchmark code"))
+        XCTAssertTrue(spec.defaultCLICommands.contains("model benchmark vlm"))
+        XCTAssertEqual(spec.hubFallback?.patterns.contains("generation_config.json"), true)
+        XCTAssertEqual(spec.hubFallback?.patterns.contains("preprocessor_config.json"), true)
+        XCTAssertEqual(spec.hubFallback?.patterns.contains("video_preprocessor_config.json"), true)
+        XCTAssertEqual(spec.apiProfile?.inputModalities, [.text, .image])
+        XCTAssertEqual(spec.apiProfile?.thinkingLevels, [.high])
+        let pixelBounds = Q35Resources.visionPixelBounds(forModelId: spec.id)
+        XCTAssertEqual(pixelBounds.minimum, 65_536)
+        XCTAssertEqual(pixelBounds.maximum, 65_536)
+    }
+
+    func testOrnith35BMLX4BitUsesQuantizedTargetWithVisionAndMTPCompanions() throws {
+        let spec = try XCTUnwrap(
+            ManagedModelCatalog.spec(for: Q35Resources.ornith35BMLX4BitModelId)
+        )
+
+        XCTAssertEqual(ModelResolver.ModelID.ornith35BMLX4Bit.rawValue, spec.id)
+        XCTAssertEqual(spec.category, .visionChat)
+        XCTAssertEqual(spec.hubFallback?.repoId, Q35Resources.ornith35BMLX4BitUpstreamRepoId)
+        XCTAssertEqual(spec.hubFallback?.revision, Q35Resources.ornith35BMLX4BitUpstreamRevision)
+        XCTAssertEqual(spec.mountedHubFallbacks.count, 1)
+        XCTAssertEqual(
+            spec.mountedHubFallbacks.first?.destinationPath,
+            Q35Resources.ornith35BVisionComponentPath
+        )
+        XCTAssertEqual(
+            spec.mountedHubFallbacks.first?.hubFallback.repoId,
+            Q35Resources.ornith35BVisionUpstreamRepoId
+        )
+        XCTAssertEqual(
+            spec.mountedHubFallbacks.first?.hubFallback.revision,
+            Q35Resources.ornith35BVisionUpstreamRevision
+        )
+        XCTAssertEqual(
+            spec.mountedHubFallbacks.first?.hubFallback.patterns,
+            Q35Resources.ornith35BVisionComponentSnapshotPatterns
+        )
+        XCTAssertEqual(spec.companionModelIDs, [Q35Resources.ornith35BMTPModelId])
+        XCTAssertEqual(spec.estimatedDownloadBytes, 24_275_338_655)
+        XCTAssertFalse(spec.runtimeAutoDownloadAllowed)
+        XCTAssertTrue(spec.defaultCLICommands.contains("model benchmark code"))
+        XCTAssertTrue(spec.defaultCLICommands.contains("model benchmark vlm"))
+        XCTAssertEqual(spec.apiProfile?.inputModalities, [.text, .image])
+        let pixelBounds = Q35Resources.visionPixelBounds(forModelId: spec.id)
+        XCTAssertEqual(pixelBounds.minimum, 65_536)
+        XCTAssertEqual(pixelBounds.maximum, 65_536)
+    }
+
     func testQ38TwentySevenB4BitUsesCrownedTargetWithMTPAndVisionComponents() throws {
         let spec = try XCTUnwrap(
             ManagedModelCatalog.spec(for: Q35Resources.q38TwentySevenB4BitModelId)
@@ -1066,6 +1132,7 @@ final class ManagedModelCatalogTests: XCTestCase {
                 Q35Resources.ornith35BMLX4BitUpstreamRepoId,
                 Q35Resources.ornith35BMLX4BitUpstreamRevision,
                 Q35Resources.ornith35BMLX4BitEstimatedDownloadBytes
+                    + Q35Resources.ornith35BVisionComponentEstimatedDownloadBytes
             ),
             (
                 Q35Resources.ornith35BMLX6BitModelId,

--- a/Tests/MereRunCoreTests/ManagedModelSupportTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelSupportTests.swift
@@ -263,6 +263,68 @@ final class ManagedModelSupportTests: XCTestCase {
         XCTAssertEqual(recommendedReport.descriptor.recommendedUnifiedMemoryGB, 48)
     }
 
+    func testOrnith35BVisionRequiresNinetySixGBAndRecommendsOneTwentyEightGB() throws {
+        let spec = try XCTUnwrap(
+            ManagedModelCatalog.spec(for: Q35Resources.ornith35BVisionModelId)
+        )
+        let undersized = MereRunMachineProfile(
+            physicalMemoryBytes: 64 * 1_073_741_824,
+            processorName: "M4 Max",
+            isAppleSiliconMac: true
+        )
+        let recommended = MereRunMachineProfile(
+            physicalMemoryBytes: 128 * 1_073_741_824,
+            processorName: "M4 Max",
+            isAppleSiliconMac: true
+        )
+
+        let rejected = ManagedModelCapabilityCatalog.support(for: spec, on: undersized)
+        let accepted = ManagedModelCapabilityCatalog.support(for: spec, on: recommended)
+
+        XCTAssertFalse(rejected.isSupported)
+        XCTAssertTrue(rejected.reasons.joined(separator: " ").contains("Requires at least 96 GB"))
+        XCTAssertTrue(accepted.isSupported)
+        XCTAssertTrue(accepted.meetsRecommendedMemory)
+        XCTAssertEqual(accepted.descriptor.minimumUnifiedMemoryGB, 96)
+        XCTAssertEqual(accepted.descriptor.recommendedUnifiedMemoryGB, 128)
+        let recommendation = try XCTUnwrap(
+            MereRunAgentModelCatalog.allTierRecommendations(on: recommended)
+                .first { $0.id == Q35Resources.ornith35BVisionModelId }
+        )
+        XCTAssertTrue(recommendation.isStartableByMereRun)
+        XCTAssertEqual(recommendation.servingEngine, .textChatQ35)
+    }
+
+    func testOrnith35BMLX4BitVisionRequiresThirtyTwoGBAndRecommendsFortyEightGB() throws {
+        let spec = try XCTUnwrap(
+            ManagedModelCatalog.spec(for: Q35Resources.ornith35BMLX4BitModelId)
+        )
+        let undersized = MereRunMachineProfile(
+            physicalMemoryBytes: 24 * 1_073_741_824,
+            processorName: "M4 Max",
+            isAppleSiliconMac: true
+        )
+        let recommended = MereRunMachineProfile(
+            physicalMemoryBytes: 48 * 1_073_741_824,
+            processorName: "M4 Max",
+            isAppleSiliconMac: true
+        )
+
+        let rejected = ManagedModelCapabilityCatalog.support(for: spec, on: undersized)
+        XCTAssertFalse(rejected.isSupported)
+        let accepted = ManagedModelCapabilityCatalog.support(for: spec, on: recommended)
+        XCTAssertTrue(accepted.isSupported)
+        XCTAssertTrue(accepted.meetsRecommendedMemory)
+        XCTAssertEqual(accepted.descriptor.minimumUnifiedMemoryGB, 32)
+        XCTAssertEqual(accepted.descriptor.recommendedUnifiedMemoryGB, 48)
+        let recommendation = try XCTUnwrap(
+            MereRunAgentModelCatalog.allTierRecommendations(on: recommended)
+                .first { $0.id == Q35Resources.ornith35BMLX4BitModelId }
+        )
+        XCTAssertTrue(recommendation.isStartableByMereRun)
+        XCTAssertEqual(recommendation.servingEngine, .textChatQ35)
+    }
+
     func testBonsai27BIsSupportedOnSixteenGB() throws {
         let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: Q35Resources.bonsai27B1BitModelId))
         let machine = MereRunMachineProfile(

--- a/Tests/MereRunCoreTests/MereRunModelManifestTests.swift
+++ b/Tests/MereRunCoreTests/MereRunModelManifestTests.swift
@@ -465,6 +465,57 @@ final class MereRunModelManifestTests: MereRunCoreTestCase {
         )
     }
 
+    func testOrnith35BVisionTemplateHasExpectedMetadata() throws {
+        let manifest = MereRunModelManifest.template(
+            for: .ornith35BVision,
+            createdAt: Date(timeIntervalSince1970: 0)
+        )
+
+        XCTAssertEqual(manifest.id, Q35Resources.ornith35BVisionModelId)
+        XCTAssertEqual(manifest.engine, .qwen35HybridMoE)
+        XCTAssertEqual(manifest.family, .code)
+        XCTAssertEqual(manifest.tier, .large)
+        XCTAssertEqual(manifest.variant, .standard)
+        XCTAssertEqual(manifest.precision, .bf16)
+        XCTAssertNil(manifest.quantization)
+        XCTAssertEqual(Set(manifest.supports ?? []), Set([.chat, .codeGeneration, .visionChat]))
+        XCTAssertEqual(
+            manifest.upstreamRepoId,
+            "\(Q35Resources.ornith35BVisionUpstreamRepoId)"
+                + "@\(Q35Resources.ornith35BVisionUpstreamRevision)"
+        )
+    }
+
+    func testOrnith35BMLX4BitTemplateRecordsTargetAndVisionSources() throws {
+        let manifest = MereRunModelManifest.template(
+            for: .ornith35BMLX4Bit,
+            createdAt: Date(timeIntervalSince1970: 0)
+        )
+
+        XCTAssertEqual(manifest.id, Q35Resources.ornith35BMLX4BitModelId)
+        XCTAssertEqual(manifest.engine, .qwen35HybridMoE)
+        XCTAssertEqual(manifest.precision, .int4)
+        XCTAssertEqual(manifest.quantization?.bits, 4)
+        XCTAssertEqual(manifest.quantization?.groupSize, 64)
+        XCTAssertEqual(manifest.quantization?.scheme, "mlx-affine")
+        XCTAssertEqual(Set(manifest.supports ?? []), Set([.chat, .codeGeneration, .visionChat]))
+        XCTAssertEqual(manifest.sources?.count, 2)
+        XCTAssertEqual(manifest.sources?.first?.role, "primary")
+        XCTAssertEqual(
+            manifest.sources?.first?.repository,
+            Q35Resources.ornith35BMLX4BitUpstreamRepoId
+        )
+        XCTAssertEqual(manifest.sources?.last?.role, "component")
+        XCTAssertEqual(
+            manifest.sources?.last?.repository,
+            Q35Resources.ornith35BVisionUpstreamRepoId
+        )
+        XCTAssertEqual(
+            manifest.sources?.last?.destinationPath,
+            Q35Resources.ornith35BVisionComponentPath
+        )
+    }
+
     func testOrnith35BMLXQuantizedTemplatesPinOfficialConversions() throws {
         let createdAt = Date(timeIntervalSince1970: 0)
         let cases: [(
@@ -511,7 +562,10 @@ final class MereRunModelManifestTests: MereRunCoreTestCase {
             XCTAssertEqual(manifest.quantization?.bits, bits)
             XCTAssertEqual(manifest.quantization?.groupSize, 64)
             XCTAssertEqual(manifest.quantization?.scheme, "mlx-affine")
-            XCTAssertEqual(Set(manifest.supports ?? []), Set([.chat, .codeGeneration]))
+            let expectedSupports: Set<MereRunModelManifest.Capability> = bits == 4
+                ? [.chat, .codeGeneration, .visionChat]
+                : [.chat, .codeGeneration]
+            XCTAssertEqual(Set(manifest.supports ?? []), expectedSupports)
             XCTAssertEqual(manifest.upstreamRepoId, "\(repoID)@\(revision)")
         }
     }

--- a/Tests/MereRunCoreTests/OrnithVisionCheckpointTests.swift
+++ b/Tests/MereRunCoreTests/OrnithVisionCheckpointTests.swift
@@ -1,0 +1,154 @@
+#if os(macOS)
+import CoreGraphics
+import Foundation
+import ImageIO
+import MLX
+import XCTest
+import UniformTypeIdentifiers
+@testable import MereRunCore
+
+final class OrnithVisionCheckpointTests: MereRunCoreTestCase {
+    func testInstalledFourBitCompositeLoadsEveryVisionTensorAndAnswersImage() async throws {
+        guard let root = ProcessInfo.processInfo.environment[
+            "MERERUN_TEST_ORNITH_VISION_4BIT_MODEL_ROOT"
+        ] else {
+            throw XCTSkip(
+                "Set MERERUN_TEST_ORNITH_VISION_4BIT_MODEL_ROOT for installed Ornith 4-bit vision qualification."
+            )
+        }
+        let rootURL = URL(fileURLWithPath: root, isDirectory: true)
+        Self.report("validating 4-bit target, MTP companion, and vision tensors")
+        try validatePublishedConfigurationAndVisionWeights(primaryRootURL: rootURL)
+        Self.report("vision tensor validation complete")
+        Memory.clearCache()
+
+        let fixtureDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mere-run-ornith-vision-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: fixtureDirectory) }
+        let fixture = try Self.makeFixture(in: fixtureDirectory)
+        let generator = Q35Generator(
+            modelId: Q35Resources.ornith35BMLX4BitModelId,
+            prefixKVCacheEnabled: true,
+            continuousBatchingEnabled: false
+        )
+        let started = Date()
+        do {
+            Self.report("starting full model load and image answer")
+            let response = try await generator.chat(
+                ChatRequest(
+                    messages: [ChatMessage(
+                        role: .user,
+                        content: "Describe the two shapes from left to right, giving each shape's color and shape.",
+                        imageUrl: fixture.path
+                    )],
+                    maxTokens: 128,
+                    temperature: 0,
+                    topP: 1,
+                    showThinking: false,
+                    maxContextTokens: 8_192
+                ),
+                modelPath: root,
+                progressHandler: { progress in
+                    Self.report("\(progress.stage.rawValue): \(progress.message ?? "")")
+                }
+            )
+            Self.report("image answer complete")
+            let output = response.response.lowercased()
+            XCTAssertTrue(output.contains("red") && output.contains("circle"), output)
+            XCTAssertTrue(output.contains("blue") && output.contains("square"), output)
+            XCTAssertEqual(response.acceleration?.route, "final-target-pipelined")
+            XCTAssertNil(response.acceleration?.acceptedDraftTokens)
+            print("[ornith-vision] elapsed_seconds=\(Date().timeIntervalSince(started)) "
+                + "prompt_tokens=\(response.promptTokens ?? 0) output_tokens=\(response.tokensGenerated) "
+                + "text=\(String(reflecting: response.response))")
+        } catch {
+            await generator.unload()
+            throw error
+        }
+        await generator.unload()
+    }
+
+    private static func report(_ message: String) {
+        FileHandle.standardError.write(Data("[ornith-vision] \(message)\n".utf8))
+    }
+
+    private func validatePublishedConfigurationAndVisionWeights(primaryRootURL: URL) throws {
+        let primaryConfig = try JSONDecoder().decode(
+            Q35Config.self,
+            from: Data(contentsOf: primaryRootURL.appendingPathComponent("config.json"))
+        )
+        XCTAssertEqual(primaryConfig.modelType, "qwen3_5_moe")
+        XCTAssertEqual(primaryConfig.quantization?.bits, 4)
+        XCTAssertNil(primaryConfig.visionConfig)
+
+        let mtpRoot = try XCTUnwrap(
+            ManagedModelResolver.resolveInstalledModel(id: Q35Resources.ornith35BMTPModelId)
+        )
+        XCTAssertTrue(Q35Resources(rootURL: mtpRoot).validateOrnith35BMTPCompanion().isEmpty)
+
+        let resources = Q35Resources(rootURL: primaryRootURL).ornithVisionComponentResources
+        let config = try JSONDecoder().decode(
+            Q35Config.self,
+            from: Data(contentsOf: resources.configURL)
+        )
+        let vision = try XCTUnwrap(config.visionConfig)
+        XCTAssertEqual(config.modelType, "qwen3_5_moe")
+        XCTAssertEqual(config.textConfig.numHiddenLayers, 40)
+        XCTAssertEqual(config.textConfig.numExperts, 256)
+        XCTAssertEqual(vision.depth, 27)
+        XCTAssertEqual(vision.hiddenSize, 1_152)
+        XCTAssertEqual(vision.outHiddenSize, 2_048)
+        XCTAssertEqual(vision.numPositionEmbeddings, 2_304)
+        XCTAssertEqual(vision.patchSize, 16)
+        XCTAssertEqual(vision.temporalPatchSize, 2)
+
+        let index = try JSONDecoder().decode(
+            HFSafetensorsIndex.self,
+            from: Data(contentsOf: resources.modelIndexURL)
+        )
+        let expected = Set(index.weightMap.keys.flatMap {
+            Q35VisionTower.mapVisionWeight($0, MLXArray.zeros([1])).map(\.0)
+        })
+        let tower = Q35VisionTower(config: config)
+        try tower.loadWeights(from: resources)
+        let parameters = tower.parameters().flattened()
+        XCTAssertEqual(expected, Set(parameters.map(\.0)))
+        print("[ornith-vision-weights] checkpoint_tensors=\(expected.count) runtime_tensors=\(parameters.count)")
+
+        Self.report("starting isolated 256x256 vision forward")
+        let embeddings = try tower.encodeImage(
+            pixelValues: MLXArray.zeros([1, 3, 256, 256], dtype: .float32),
+            gridTHW: (1, 16, 16)
+        )
+        XCTAssertEqual(embeddings.shape, [64, config.textConfig.hiddenSize])
+        Self.report("isolated vision forward complete")
+    }
+
+    private static func makeFixture(in directory: URL) throws -> URL {
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let context = try XCTUnwrap(CGContext(
+            data: nil,
+            width: 512,
+            height: 384,
+            bitsPerComponent: 8,
+            bytesPerRow: 512 * 4,
+            space: CGColorSpaceCreateDeviceRGB(),
+            bitmapInfo: CGImageAlphaInfo.premultipliedLast.rawValue
+        ))
+        context.setFillColor(CGColor(gray: 1, alpha: 1))
+        context.fill(CGRect(x: 0, y: 0, width: 512, height: 384))
+        context.setFillColor(CGColor(red: 0.9, green: 0.05, blue: 0.05, alpha: 1))
+        context.fillEllipse(in: CGRect(x: 55, y: 117, width: 150, height: 150))
+        context.setFillColor(CGColor(red: 0.05, green: 0.15, blue: 0.9, alpha: 1))
+        context.fill(CGRect(x: 307, y: 117, width: 150, height: 150))
+
+        let url = directory.appendingPathComponent("red-circle-blue-square.png")
+        let destination = try XCTUnwrap(
+            CGImageDestinationCreateWithURL(url as CFURL, UTType.png.identifier as CFString, 1, nil)
+        )
+        CGImageDestinationAddImage(destination, try XCTUnwrap(context.makeImage()), nil)
+        XCTAssertTrue(CGImageDestinationFinalize(destination))
+        return url
+    }
+}
+#endif

--- a/Tests/MereRunCoreTests/PortableQuantizedMatmulTests.swift
+++ b/Tests/MereRunCoreTests/PortableQuantizedMatmulTests.swift
@@ -225,6 +225,38 @@ final class PortableQuantizedMatmulTests: MereRunCoreTestCase {
         XCTAssertLessThan(maxDiff, 0.0001)
     }
 
+    func testQ35SwitchLinearDenseBF16ExpertPathUsesSelectedBatchedMatmul() throws {
+        let weight = MLXArray([
+            1.0, 2.0, 3.0,
+            4.0, 5.0, 6.0,
+            -1.0, 0.5, 2.0,
+            0.0, -2.0, 1.0,
+        ] as [Float], [2, 2, 3]).asType(.bfloat16)
+        let x = MLXArray([
+            0.5, 1.0, -1.0,
+            2.0, -0.5, 1.5,
+        ] as [Float], [1, 2, 3]).asType(.bfloat16)
+        let indices = MLXArray([0, 1] as [Int32], [1, 2, 1])
+        let layer = Q35SwitchLinear(
+            inputDims: 3,
+            outputDims: 2,
+            numExperts: 2,
+            groupSize: 64,
+            bits: 4,
+            quantized: false,
+            bias: false
+        )
+        try layer.update(parameters: ModuleParameters.unflattened([("weight", weight)]), verify: .none)
+
+        let actual = layer(x, indices: indices).asType(.float32)
+        MLX.eval(actual)
+
+        let expected: [Float] = [-0.5, 1.0, 0.75, 2.5]
+        for (value, reference) in zip(actual.asArray(Float.self), expected) {
+            XCTAssertEqual(value, reference, accuracy: 0.02)
+        }
+    }
+
     func testQ35SwitchLinearInfersMixedPrecisionExpertBits() throws {
         let weightValues = (0..<384).map { Float($0 % 19) / 18.0 - 0.5 }
         let denseWeight = MLXArray(weightValues, [3, 4, 32])

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -280,6 +280,14 @@ Use the synthetic suite for quick regression checks:
 swift run mere.run model benchmark vlm --json
 ```
 
+To benchmark the recommended installed Ornith 4-bit vision lane directly:
+
+```bash
+swift run mere.run model benchmark vlm \
+  --models text-agent-ornith-35b-mlx-4bit \
+  --json
+```
+
 Use the external lane when you want existing dataset coverage. Start with
 `--dry-run` so the command prints the exact `lmms-eval` invocation before it
 starts servers or runs datasets:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -243,7 +243,7 @@ are:
   `image-hidream-o1`, `image-hidream-o1-dev`, `image-sensenova-u1-5-8b-mot`, `image-krea2-raw`,
   `image-krea2-turbo`,
   `image-ideogram4-sdnq-uint4`
-- Text chat: `text-chat-gemma4`, `text-chat-mebot`, `text-chat-psi-agent`, `text-chat-q36-nano`, `vision-chat-q38-27b`, `vision-chat-q38-27b-4bit`, `text-chat-lfm25-2.6b-4bit`, `text-chat-lfm25-a1b-8bit`, `vision-chat-lfm25-3b-8bit`
+- Text chat: `text-chat-gemma4`, `text-chat-mebot`, `text-chat-psi-agent`, `text-chat-q36-nano`, `vision-chat-q38-27b`, `vision-chat-q38-27b-4bit`, `text-agent-ornith-35b-mlx-4bit`, `vision-chat-ornith-35b`, `text-chat-lfm25-2.6b-4bit`, `text-chat-lfm25-a1b-8bit`, `vision-chat-lfm25-3b-8bit`
 - Text code / agents: `text-agent-qwen35-9b`, `text-agent-ornith-9b`, `text-agent-ornith-35b-mlx-4bit`, `text-agent-ornith-35b-mlx-6bit`, `text-agent-ornith-35b-mlx-8bit`, `text-agent-ornith-35b-mlx`, `text-agent-ornith-35b`, `text-code-north-mini`, `text-code-qwen3`
 - Text embed: `text-embed-qwen3-0.6b`
 - Multimodal embed: `vision-embed-qwen3-vl-2b`
@@ -872,6 +872,7 @@ Examples:
 swift run mere.run text chat --prompt "What is classifier-free guidance?"
 swift run mere.run text chat --model vision-chat-q38-27b --image ./diagram.png --prompt "Explain this diagram."
 swift run mere.run text chat --model vision-chat-q38-flash-next-3bit-native-ple --context-size 32768 --max-tokens 256 --prompt "Explain sparse attention."
+swift run mere.run text chat --model text-agent-ornith-35b-mlx-4bit --image ./screenshot.png --prompt "Describe this interface."
 swift run mere.run text chat --model vision-chat-q38-flash-next-3bit --context-size 32768 --max-tokens 256 --prompt "Explain sparse attention."
 swift run mere.run text chat --model vision-chat-q38-flash-next-mixed --context-size 32768 --max-tokens 256 --prompt "Explain sparse attention."
 swift run mere.run text chat --model text-chat-bonsai-27b-1bit --context-size 262144 --kv-bits 4 --prompt "Plan a long-context repository review."
@@ -2642,6 +2643,10 @@ swift run mere.run model benchmark vlm --json
 The default synthetic suite compares `vision-chat-gemma4-12b` with the existing
 `vision-inspect-qwen3-vl-2b` backend on deterministic color, location, and
 counting fixtures.
+
+Pass `--models text-agent-ornith-35b-mlx-4bit` to exercise the recommended Ornith
+Q4 target plus BF16 vision companion against the same fixtures. Use
+`vision-chat-ornith-35b` for the optional full-BF16 reference lane.
 
 For existing datasets, install or check out `lmms-eval`, then start with a
 dry-run:

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -92,10 +92,11 @@ an effective overlay; they are not a second capability catalog.
 | `text-chat` | `text-chat-bonsai-27b-1bit` |
 | `text-chat` | `text-chat-bonsai-27b-2bit` |
 | `text-code` | `text-agent-ornith-9b` |
-| `text-code` | `text-agent-ornith-35b-mlx-4bit` |
+| `vision-chat` | `text-agent-ornith-35b-mlx-4bit` |
 | `text-code` | `text-agent-ornith-35b-mlx-6bit` |
 | `text-code` | `text-agent-ornith-35b-mlx-8bit` |
 | `text-code` | `text-agent-ornith-35b-mlx` |
+| `vision-chat` | `vision-chat-ornith-35b` |
 | `text-code` | `text-agent-qwen35-9b` |
 | `text-code` | `text-code-north-mini` |
 | `text-code` | `text-agent-ornith-35b` |
@@ -322,6 +323,27 @@ pinned authoritative base checkpoint as the shared
 [`ornith-ai/Ornith-1.5-35B-A3B`](https://huggingface.co/ornith-ai/Ornith-1.5-35B-A3B)
 base checkpoint declares the model under the MIT license in its model-card
 metadata; the MLX conversion repository does not duplicate the license file.
+
+`text-agent-ornith-35b-mlx-4bit` is the recommended local multimodal lane. It
+combines the official `Ornith-1.5-35B-A3B-MLX-4bit` text target with the
+authoritative base checkpoint's `model-00001-of-00016.safetensors` vision
+shard, vision configuration, processor metadata, and the shared BF16 MTP
+companion. The primary and vision payloads total about 22.6 GiB; the shared MTP
+companion adds about 4.1 GiB when it is not already installed. Image requests
+use target-only decoding because MTP speculation is disabled when image
+embeddings are present; text and code requests retain verified MTP.
+
+`vision-chat-ornith-35b` installs the authoritative full BF16 base checkpoint
+at immutable revision `10fbf86fed7ecee4a061f8b499a618f46001cac1`. Unlike
+the text-only MLX conversions, the 67.0 GiB snapshot includes Ornith's Qwen3.5
+vision tower, processor metadata, and embedded `mtp.*` tensors. It accepts
+local images through `text chat` and the OpenAI-compatible API, retains the
+262,144-token advertised context, and is available to the VLM, chat, and code
+benchmark commands. Runtime auto-download remains disabled; the catalog
+requires 96 GB unified memory and recommends 128 GB. Use it as the optional
+quality reference instead of the recommended Q4 lane. The source processor
+advertises images up to 16,777,216 pixels, but this full-BF16 local lane caps
+the encoded input at 65,536 pixels to remain below the macOS Metal watchdog.
 
 `text-agent-ornith-35b` installs DeepReinforce's public
 `deepreinforce-ai/Ornith-1.0-35B-GGUF` Q4_K_M file at the pinned catalog

--- a/docs/runtime/api-server.md
+++ b/docs/runtime/api-server.md
@@ -545,7 +545,13 @@ Engine compatibility:
   `text-agent-ornith-35b-mlx`: use the Qwen-family serving engine for Ornith's
   official 1.5 35B-A3B MLX family. Install a RAM-appropriate tier explicitly,
   then pass that id to `api serve --engine text-chat-q36 --model`.
-- Both Ornith lanes serve with thinking-enabled generation by default (the
+- `text-agent-ornith-35b-mlx-4bit`: the recommended lane, using Ornith's official
+  Q4 target with the authoritative base vision shard and shared MTP companion.
+  `vision-chat-ornith-35b` remains the full-BF16 quality reference. Both
+  accept one local/base64 image content part per message, advertise text and
+  image input modalities, and resize inputs to a watchdog-safe 65,536-pixel
+  budget before encoding. Image requests decode target-only.
+- The Ornith lanes serve with thinking-enabled generation by default (the
   models degenerate without it); the reasoning arrives in the response's
   `reasoning_content` field while `content` carries only the visible answer.
   When a request sets no explicit `temperature`/`top_p`/`min_p`, these lanes

--- a/docs/runtime/model-management.md
+++ b/docs/runtime/model-management.md
@@ -104,7 +104,7 @@ a download.
 The following list shows representative canonical IDs by modality:
 
 - images: `image-klein-nano`, `image-bonsai-binary`, `image-bonsai-ternary`, `image-zimage-nano`, `image-klein-max`, `image-zimage-max`
-- text, chat, and embeddings: `text-chat-gemma4`, `text-chat-laguna-s-2-1`, `text-chat-laguna-xs-2-1`, `text-chat-nemotron-35-lightning`, `omni-chat-nemotron3-nano-30b-a3b-bf16`, `text-chat-q36-nano`, `vision-chat-q38-27b`, `vision-chat-q38-27b-4bit`, `vision-chat-q38-flash-next-mixed`, `vision-chat-q38-flash-next-3bit`, `vision-chat-q38-flash-next-3bit-native-ple`, `vision-chat-q38-flash-next-4bit`, `text-chat-bonsai-27b-1bit`, `text-chat-bonsai-27b-2bit`, `text-chat-lfm25-1.2b-bf16`, `text-chat-lfm25-1.2b-qad-4bit`, `text-chat-lfm25-2.6b-4bit`, `text-chat-lfm25-2.6b-bf16`, `text-chat-lfm25-2.6b-qad-4bit`, `text-chat-lfm25-a1b-8bit`, `text-chat-lfm25-a1b-bf16`, `vision-chat-lfm25-3b-8bit`, `text-agent-deepseek-v4-flash`, `text-agent-qwen35-9b`, `text-agent-ornith-9b`, `text-agent-ornith-35b-mlx-4bit`, `text-agent-ornith-35b-mlx-6bit`, `text-agent-ornith-35b-mlx-8bit`, `text-agent-ornith-35b-mlx`, `text-agent-ornith-35b`, `text-code-north-mini`, `text-code-qwen3`, `text-embed-qwen3-0.6b`, `vision-embed-qwen3-vl-2b`
+- text, chat, and embeddings: `text-chat-gemma4`, `text-chat-laguna-s-2-1`, `text-chat-laguna-xs-2-1`, `text-chat-nemotron-35-lightning`, `omni-chat-nemotron3-nano-30b-a3b-bf16`, `text-chat-q36-nano`, `vision-chat-q38-27b`, `vision-chat-q38-27b-4bit`, `vision-chat-q38-flash-next-mixed`, `vision-chat-q38-flash-next-3bit`, `vision-chat-q38-flash-next-3bit-native-ple`, `vision-chat-q38-flash-next-4bit`, `text-chat-bonsai-27b-1bit`, `text-chat-bonsai-27b-2bit`, `text-chat-lfm25-1.2b-bf16`, `text-chat-lfm25-1.2b-qad-4bit`, `text-chat-lfm25-2.6b-4bit`, `text-chat-lfm25-2.6b-bf16`, `text-chat-lfm25-2.6b-qad-4bit`, `text-chat-lfm25-a1b-8bit`, `text-chat-lfm25-a1b-bf16`, `vision-chat-lfm25-3b-8bit`, `text-agent-deepseek-v4-flash`, `text-agent-qwen35-9b`, `text-agent-ornith-9b`, `text-agent-ornith-35b-mlx-4bit`, `text-agent-ornith-35b-mlx-6bit`, `text-agent-ornith-35b-mlx-8bit`, `text-agent-ornith-35b-mlx`, `vision-chat-ornith-35b`, `text-agent-ornith-35b`, `text-code-north-mini`, `text-code-qwen3`, `text-embed-qwen3-0.6b`, `vision-embed-qwen3-vl-2b`
 
 Pulling an exact BF16 LFM2.5 DSpark target also pulls its pinned `*-dspark` companion after
 the same LFM Open License acknowledgement. Companions remain separately
@@ -329,6 +329,12 @@ also installs one shared, pinned BF16 MTP head from the authoritative base
 checkpoint. Use `model capabilities` for the current machine's explicit
 speed/balanced/quality choices. The conservative tiers are Q4 at 32 GB, Q6 at
 48 GB, Q8 at 64 GB, and BF16 at 96 GB; 128 GB is recommended for BF16.
+The recommended `text-agent-ornith-35b-mlx-4bit` explicit-pull lane reuses the Q4
+target, mounts the authoritative base vision shard, and installs the shared MTP
+companion. It has a 32 GB minimum and 48 GB recommendation. The full
+`vision-chat-ornith-35b` BF16 quality reference has a 96 GB minimum and
+128 GB recommendation.
+
 `text-agent-ornith-35b` is the larger GGUF Ornith eval target and runs through
 the native `text-code`/llama.cpp path.
 

--- a/docs/runtime/text.md
+++ b/docs/runtime/text.md
@@ -56,10 +56,11 @@ help in the repository gate.
 - `text-chat-lfm25-a1b-bf16` (managed LiquidAI LFM2.5 8B-A1B BF16 target plus DSpark)
 - `vision-chat-lfm25-3b-8bit` (managed LiquidAI LFM2.5-VL 3B MLX 8-bit vision-language snapshot)
 - `text-agent-ornith-9b` (experimental native MLX/OptiQ coding-agent snapshot)
-- `text-agent-ornith-35b-mlx-4bit` (Ornith 1.5 speed tier)
+- `text-agent-ornith-35b-mlx-4bit` (recommended Ornith 1.5 Q4 coding and vision composite)
 - `text-agent-ornith-35b-mlx-6bit` (Ornith 1.5 balanced tier)
 - `text-agent-ornith-35b-mlx-8bit` (Ornith 1.5 quantized quality tier)
 - `text-agent-ornith-35b-mlx` (Ornith 1.5 35B-A3B BF16 MLX coding-agent snapshot)
+- `vision-chat-ornith-35b` (Ornith 1.5 full BF16 coding and vision reference)
 - `text-agent-deepseek-v4-flash` (API/agent serving)
 - `text-chat-mebot` (API serving; not a `text chat` dispatch lane)
 - `text-chat-psi-agent`
@@ -407,7 +408,28 @@ authoritative base checkpoint; target verification remains authoritative for
 every emitted speculative token. Ornith enables that verified MTP path from
 short prompts; Qwen3.6 retains its separate 6,144-token adaptive threshold.
 
-Both Ornith lanes are R1-style reasoning tunes and generate with thinking
+The recommended `text-agent-ornith-35b-mlx-4bit` ID combines the official 4-bit
+text target with the authoritative base checkpoint's vision shard and the
+shared MTP head. Pull it explicitly on a 32 GB-or-larger Apple Silicon Mac;
+48 GB is the conservative recommendation:
+
+```bash
+swift run mere.run model pull text-agent-ornith-35b-mlx-4bit
+swift run mere.run text chat \
+  --model text-agent-ornith-35b-mlx-4bit \
+  --image ./screenshot.png \
+  --prompt "Describe the interface and identify the most likely next action."
+```
+
+Image requests are resized to a 65,536-pixel runtime budget and disable
+MTP speculation, so vision output remains target-only. The pinned processor
+metadata still records its published 16,777,216-pixel upper bound; the lower
+local cap prevents Metal watchdog failures. Text-only requests use the shared
+verified MTP companion. `vision-chat-ornith-35b` remains the explicit-pull full
+BF16 quality reference for systems with at least 96 GB. The recommended memory
+for this reference lane is 128 GB.
+
+The Ornith lanes are R1-style reasoning tunes and generate with thinking
 enabled by default in `text chat` and `api serve` — without it the models
 degenerate into repetition loops or signature echo on constrained prompts.
 The reasoning stays hidden in `text chat` unless `--thinking` is passed;


### PR DESCRIPTION
## Summary

- add vision chat to the existing text-agent-ornith-35b-mlx-4bit managed model without duplicating its Q4 target
- mount the pinned authoritative Ornith base vision configuration, processor metadata, and vision shard alongside the Q4 text target
- retain the shared verified MTP companion for text and code; image requests intentionally use target-only decode
- keep vision-chat-ornith-35b as an optional full-BF16 quality reference
- add the VLM benchmark surface, runtime watchdog boundaries, manifest and catalog metadata, docs, and real-checkpoint qualification coverage

## Validation

- ./scripts/check.sh: 3,366 tests, 279 expected skips, zero failures; 33 Swift Testing tests passed
- real installed GPU qualification loaded all 333 checkpoint vision tensors, completed an isolated 256 x 256 vision forward, and correctly identified a red circle followed by a blue square
- image answer generation took 23.08 seconds; the complete cold qualification took 55.89 seconds
- installed-model preflight reports both the Q4 target and shared MTP companion runtime-ready with zero download bytes required

## Benchmark boundary

The scored VLM harness was attempted but machine admission queued it while an existing Nemotron API service held 2 of 4 permits. Only the queued benchmark was canceled. This PR therefore claims real-checkpoint vision runtime proof, not a scored VLM quality result.