### PR TITLE
Add native DiffusionGemma text generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+### Text
+
+- added native Swift/MLX text generation and OpenAI-compatible serving for the
+  pinned DiffusionGemma 26B-A4B OptiQ snapshot. The dedicated runtime performs
+  causal prompt caching and 48-step bidirectional block denoising, preserves
+  the checkpoint's mixed 4-bit and 8-bit affine weights, and keeps image input
+  disabled until the separate vision path receives real-checkpoint
+  qualification. Diffusion generation now supports deterministic seeds,
+  revision-aware progressive unmasking, denoising-step and work-throughput
+  diagnostics, sorted expert routing, selected-token confidence without a full
+  probability tensor, and resident graph warmup in API serving.
+
 ## 0.49.0 - 2026-08-31
 
 This release adds native attention QLoRA training for LFM2.5, a complete

--- a/Package.swift
+++ b/Package.swift
@@ -354,6 +354,7 @@ targets.append(contentsOf: [
       "Cosmos3/README.md",
       "Decode/README.md",
       "DeepseekV4Flash/README.md",
+      "DiffusionGemma/README.md",
       "DepthAnything3/README.md",
       "FaceAnalysis/README.md",
       "FalconPerception/README.md",

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ of updating all model weights.
 
 | Area | Commands | Capabilities |
 | --- | --- | --- |
-| [Text, code, and agents](./docs/runtime/text.md) | `text chat`, `text code`, `text embed`, `text anonymize`, `agent` | Chat, code generation, tool calls, structured responses, embeddings, and personal information redaction. Models include Gemma 4, Qwen3.8, LFM2.5, Laguna, Inkling, Nemotron Lightning, DeepSeek V4 Flash, and Ornith. |
+| [Text, code, and agents](./docs/runtime/text.md) | `text chat`, `text code`, `text embed`, `text anonymize`, `agent` | Chat, code generation, tool calls, structured responses, embeddings, and personal information redaction. Models include Gemma 4, DiffusionGemma, Qwen3.8, LFM2.5, Laguna, Inkling, Nemotron Lightning, DeepSeek V4 Flash, and Ornith. |
 | [Multimodal chat](./docs/runtime/text.md) | `text chat`, `vision caption`, `vision inspect`, `vision embed` | Image understanding with Gemma, Qwen, LFM, Bonsai, and Muse Glimmer. Nemotron Nano Omni also supports audio and video understanding. Shared text and image embeddings support retrieval. |
 | [Images](./docs/runtime/image.md) | `image generate` | Generation and editing with Klein, ZImage, HiDream O1, SenseNova U1.5, Krea 2, Qwen Image Edit 2511, Ideogram 4, and Bonsai. Controls include ordered references, structured prompts, and LoRA adapters. |
 | [Video](./docs/runtime/video.md) | `video generate`, `video session`, `video animate`, `video prepare-masks` | Synchronized audio and video with LTX 2.5 and 2.3. MiniMax-H3 supports keyframes and ordered media references. Other workflows include Wan 2.2 generation and SCAIL-2 subject animation with SAM masks. |

--- a/Sources/MereRunCLI/Commands/APIServeCommand.swift
+++ b/Sources/MereRunCLI/Commands/APIServeCommand.swift
@@ -48,6 +48,9 @@ struct APIServe: AsyncParsableCommand {
           # Start a Gemma 4 text-chat server
           mere.run api serve --engine text-chat-gemma4
 
+          # Start a DiffusionGemma block-diffusion text server
+          mere.run api serve --engine text-chat-diffusiongemma
+
           # Start a Qwen3.6 text-chat server with an explicit model root
           mere.run api serve --engine text-chat-q36 -m ~/Models/text-chat-q36-nano
 
@@ -149,10 +152,10 @@ struct APIServe: AsyncParsableCommand {
     @Option(name: [.long], help: "Host to bind to.")
     var host: String = "127.0.0.1"
 
-    @Option(name: [.customShort("m"), .long, .customLong("model-path")], help: "Model path. For --engine text-code, pass a GGUF file. For --engine text-chat-klein, pass a Klein-root text chat model. For --engine text-chat-gemma4, pass a Gemma 4 model root or repo ID. For --engine text-chat-laguna, pass text-chat-laguna-s-2-1, text-chat-laguna-xs-2-1, or an installed Laguna MLX root. For --engine text-chat-q36, pass a Qwen3.6 text chat model root. For --engine text-chat-lfm2, pass an LFM2 MLX model root or repo ID. For --engine text-chat-deepseek-v4-flash, pass a DS4 GGUF file or managed model root. For --engine text-chat-muse-glimmer, pass vision-chat-muse-glimmer-30b or an installed Muse Glimmer MLX root. For --engine text-chat-nemotron-omni, pass omni-chat-nemotron3-nano-30b-a3b-bf16 or its installed wrapper root.")
+    @Option(name: [.customShort("m"), .long, .customLong("model-path")], help: "Model path. For --engine text-code, pass a GGUF file. For --engine text-chat-klein, pass a Klein-root text chat model. For --engine text-chat-gemma4, pass a Gemma 4 model root or repo ID. For --engine text-chat-diffusiongemma, pass text-chat-diffusiongemma-26b-optiq-4bit or its installed MLX root. For --engine text-chat-laguna, pass text-chat-laguna-s-2-1, text-chat-laguna-xs-2-1, or an installed Laguna MLX root. For --engine text-chat-q36, pass a Qwen3.6 text chat model root. For --engine text-chat-lfm2, pass an LFM2 MLX model root or repo ID. For --engine text-chat-deepseek-v4-flash, pass a DS4 GGUF file or managed model root. For --engine text-chat-muse-glimmer, pass vision-chat-muse-glimmer-30b or an installed Muse Glimmer MLX root. For --engine text-chat-nemotron-omni, pass omni-chat-nemotron3-nano-30b-a3b-bf16 or its installed wrapper root.")
     var model: String?
 
-    @Option(name: [.long], help: "Serving engine: text-chat-q36 (default; serves text-chat-q36-nano), text-code, text-chat-klein, text-chat-gemma4, text-chat-laguna, text-chat-lfm2, text-chat-deepseek-v4-flash, text-chat-muse-glimmer, text-chat-nemotron-h, or text-chat-nemotron-omni.")
+    @Option(name: [.long], help: "Serving engine: text-chat-q36 (default; serves text-chat-q36-nano), text-code, text-chat-klein, text-chat-gemma4, text-chat-diffusiongemma, text-chat-laguna, text-chat-lfm2, text-chat-deepseek-v4-flash, text-chat-muse-glimmer, text-chat-nemotron-h, or text-chat-nemotron-omni.")
     var engine: APIEngine = .textChatQ36
 
     @Option(name: [.long], help: "Default cataloged adapter id or local LoRA path for all requests.")
@@ -265,6 +268,8 @@ struct APIServe: AsyncParsableCommand {
             return ModelResolver.ModelID.mebot.rawValue
         case .textChatGemma4:
             return ModelResolver.ModelID.gemma4.rawValue
+        case .textChatDiffusionGemma:
+            return DiffusionGemmaResources.modelID
         case .textChatLaguna:
             return LagunaResources.modelID
         case .textChatQ36, .textChatQ35:
@@ -315,6 +320,13 @@ struct APIServe: AsyncParsableCommand {
                 return resolved.rootURL.path
             }
             return nil
+        case .textChatDiffusionGemma:
+            if let explicit = model {
+                return explicit
+            }
+            return ManagedModelResolver.resolveInstalledModel(
+                id: DiffusionGemmaResources.modelID
+            )?.path
         case .textChatLaguna:
             if let explicit = model {
                 if LagunaResources.isManagedIdentifier(explicit) {
@@ -520,6 +532,7 @@ enum APIEngine: String, ExpressibleByArgument {
     case textCode = "text-code"
     case textChatKlein = "text-chat-klein"
     case textChatGemma4 = "text-chat-gemma4"
+    case textChatDiffusionGemma = "text-chat-diffusiongemma"
     case textChatLaguna = "text-chat-laguna"
     case textChatQ36 = "text-chat-q36"
     case textChatQ35 = "text-chat-q35"
@@ -537,6 +550,8 @@ enum APIEngine: String, ExpressibleByArgument {
             return .textChatKlein
         case .textChatGemma4:
             return .textChatGemma4
+        case .textChatDiffusionGemma:
+            return .textChatDiffusionGemma
         case .textChatLaguna:
             return .textChatLaguna
         case .textChatQ36:
@@ -2592,6 +2607,20 @@ enum APIServerContract {
         } else {
             logprobCapture = .none
         }
+        if openaiRequest.mere_show_unmasking == true {
+            guard laneModelID == DiffusionGemmaResources.modelID else {
+                throw APIRequestValidationError.invalidField(
+                    "mere_show_unmasking",
+                    "progressive unmasking is supported only by \(DiffusionGemmaResources.modelID)"
+                )
+            }
+            guard openaiRequest.stream == true else {
+                throw APIRequestValidationError.invalidField(
+                    "mere_show_unmasking",
+                    "requires stream=true"
+                )
+            }
+        }
 
         return ChatRequest(
             messages: messages,
@@ -2610,6 +2639,7 @@ enum APIServerContract {
             minP: openaiRequest.min_p == nil && isLaguna
                 ? LagunaResources.recommendedMinP
                 : minP,
+            seed: openaiRequest.seed.map(UInt64.init),
             reasoningEffort: reasoningEffort,
             showThinking: requiresJSON
                 ? false
@@ -2622,7 +2652,8 @@ enum APIServerContract {
             parallelToolCalls: parallelToolCalls,
             stopSequences: openaiRequest.stop?.values ?? [],
             maxContextTokens: contextSize,
-            logprobCapture: logprobCapture
+            logprobCapture: logprobCapture,
+            showUnmasking: openaiRequest.mere_show_unmasking == true
         )
     }
 
@@ -2829,6 +2860,9 @@ enum APIServerContract {
         }
         if request.seed != nil, !capabilities.supportsSeed {
             throw APIRequestValidationError.invalidField("seed", "deterministic seeds are not supported by this engine")
+        }
+        if let seed = request.seed, seed < 0 {
+            throw APIRequestValidationError.invalidField("seed", "must be an unsigned integer")
         }
         if let penalty = request.presence_penalty, penalty != 0, !capabilities.supportsPenalties {
             throw APIRequestValidationError.invalidField("presence_penalty", "presence penalties are not supported by this engine")
@@ -5108,7 +5142,8 @@ actor CodeGenServer {
                             logprobs: OpenAIChatLogprobs(result.logprobs)
                         )
                     ],
-                    usage: Self.openAIUsage(for: result)
+                    usage: Self.openAIUsage(for: result),
+                    mere_diffusion: result.diffusion
                 )
                 let data = try JSONEncoder().encode(response)
                 var trailers = Self.openAITimingHeaders(for: result)
@@ -5771,6 +5806,28 @@ actor CodeGenServer {
                 let result = try await lease.chat(request) { progress in
                     admissionLease.observe(progress)
                     guard !shouldBufferForToolCalls else { return }
+                    if let diffusion = progress.diffusion {
+                        let chunk = OpenAIChatResponse(
+                            id: id,
+                            object: "chat.completion.chunk",
+                            created: Int(Date().timeIntervalSince1970),
+                            model: modelID,
+                            choices: [
+                                OpenAIChatChoice(
+                                    index: 0,
+                                    delta: OpenAIChatDelta(
+                                        mere_diffusion_draft: OpenAIDiffusionDraft(diffusion)
+                                    ),
+                                    finish_reason: nil
+                                )
+                            ]
+                        )
+                        if let data = try? encoder.encode(chunk),
+                           let json = String(data: data, encoding: .utf8) {
+                            continuation.yield(ByteBuffer(string: "data: \(json)\n\n"))
+                        }
+                        return
+                    }
                     if progress.stage == .generating,
                        let token = progress.message,
                        !token.isEmpty,
@@ -5860,7 +5917,8 @@ actor CodeGenServer {
                                 hasToolCalls: responseToolCalls?.isEmpty == false
                             )
                         )
-                    ]
+                    ],
+                    mere_diffusion: result.diffusion
                 )
                 if let data = try? encoder.encode(finalChunk),
                    let json = String(data: data, encoding: .utf8) {
@@ -6011,6 +6069,18 @@ actor CodeGenServer {
         }
         if let kvCache = timing.decodeKVCache {
             headers["x-mere-kv-cache"] = kvCache
+        }
+        if let diffusion = result.diffusion {
+            headers["x-mere-diffusion-seed"] = String(diffusion.seed)
+            headers["x-mere-diffusion-canvas-tokens"] = String(diffusion.canvasTokens)
+            headers["x-mere-diffusion-denoising-steps"] = String(diffusion.denoisingSteps)
+            headers["x-mere-diffusion-work-tokens"] = String(diffusion.workTokens)
+            headers["x-mere-diffusion-work-tokens-per-second"] = fixedPrecision(
+                diffusion.workTokensPerSecond
+            )
+            if let firstDraftSeconds = diffusion.firstDraftSeconds {
+                headers["x-mere-diffusion-first-draft-seconds"] = fixedPrecision(firstDraftSeconds)
+            }
         }
         return headers
     }

--- a/Sources/MereRunCLI/Commands/ModelBenchmarkVLMCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelBenchmarkVLMCommand.swift
@@ -326,6 +326,8 @@ struct ModelBenchmarkVLM: AsyncParsableCommand {
         switch engine.canonical {
         case .textChatGemma4:
             return .textChatGemma4
+        case .textChatDiffusionGemma:
+            return .textChatDiffusionGemma
         case .textChatLaguna:
             return .textChatLaguna
         case .textChatQ35:

--- a/Sources/MereRunCLI/Commands/OpenWebUICommand.swift
+++ b/Sources/MereRunCLI/Commands/OpenWebUICommand.swift
@@ -935,6 +935,8 @@ private extension APIEngine {
             self = .textChatKlein
         case .textChatGemma4:
             self = .textChatGemma4
+        case .textChatDiffusionGemma:
+            self = .textChatDiffusionGemma
         case .textChatLaguna:
             self = .textChatLaguna
         case .textChatQ36:

--- a/Sources/MereRunCLI/Commands/TextChatCommand.swift
+++ b/Sources/MereRunCLI/Commands/TextChatCommand.swift
@@ -40,6 +40,7 @@ struct TextChat: AsyncParsableCommand {
           - text-chat-gemma4 (Gemma 4 31B; large/slow, kept for compatibility)
           - text-chat-gemma4-max (Gemma 4 31B native Swift runtime)
           - text-chat-gemma4-nano (Gemma 4 4B native Swift runtime)
+          - text-chat-diffusiongemma-26b-optiq-4bit (DiffusionGemma 26B-A4B OptiQ native Swift runtime)
           - text-chat-laguna-s-2-1 (Poolside Laguna S 2.1 118B-A8B NVFP4 with DFlash)
           - text-chat-laguna-xs-2-1 (Poolside Laguna XS 2.1 33B-A3B NVFP4)
           - text-chat-nemotron-35-lightning (NVIDIA Nemotron 3.5 Lightning 30B-A3B NVFP4 with DSpark)
@@ -167,7 +168,7 @@ struct TextChat: AsyncParsableCommand {
             + firstTokenSeconds
     }
 
-    @Option(name: [.long], help: "Canonical model id. Default: text-chat-gemma4-12b-4bit (Apple Silicon) / text-chat-q36-nano-gguf (Linux CUDA). Others include omni-chat-nemotron3-nano-30b-a3b-bf16, vision-chat-muse-glimmer-30b, text-chat-nemotron-35-lightning, text-chat-laguna-s-2-1, text-chat-inkling-small, text-chat-bonsai-27b-1bit, text-chat-q36-nano, text-agent-ornith-9b, text-chat-gemma4[-12b|-12b-4bit|-turbo|-max|-nano], text-chat-lfm25-{1.2b,2.6b,a1b}-bf16, and text-chat-lfm25-a1b-8bit.")
+    @Option(name: [.long], help: "Canonical model id. Default: text-chat-gemma4-12b-4bit (Apple Silicon) / text-chat-q36-nano-gguf (Linux CUDA). Others include text-chat-diffusiongemma-26b-optiq-4bit, omni-chat-nemotron3-nano-30b-a3b-bf16, vision-chat-muse-glimmer-30b, text-chat-nemotron-35-lightning, text-chat-laguna-s-2-1, text-chat-inkling-small, text-chat-bonsai-27b-1bit, text-chat-q36-nano, text-agent-ornith-9b, text-chat-gemma4[-12b|-12b-4bit|-turbo|-max|-nano], text-chat-lfm25-{1.2b,2.6b,a1b}-bf16, and text-chat-lfm25-a1b-8bit.")
     var model: String = TextChat.defaultChatModelId
 
     @Option(
@@ -192,8 +193,17 @@ struct TextChat: AsyncParsableCommand {
     @Flag(name: [.customLong("stats")], help: "Print generation timing and tokens/sec.")
     var stats: Bool = false
 
+    @Option(name: [.customLong("seed")], help: "Deterministic DiffusionGemma canvas seed.")
+    var seed: UInt64?
+
     @Flag(name: [.customLong("stream")], help: "Stream generated text to stdout as tokens arrive.")
     var stream: Bool = false
+
+    @Flag(
+        name: [.customLong("show-unmasking")],
+        help: "Show revision-aware DiffusionGemma canvas drafts on stderr."
+    )
+    var showUnmasking: Bool = false
 
     @Option(name: [.customLong("tools")], help: "Comma-separated built-in tool names: write_file, shell_exec.")
     var tools: String?
@@ -229,6 +239,11 @@ struct TextChat: AsyncParsableCommand {
         let normalizedModelId = model.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         try Self.validate(responseFormat: responseFormat, modelID: normalizedModelId)
         try Self.validateReasoningEffort(reasoningEffort, modelID: normalizedModelId)
+        try Self.validateDiffusionOptions(
+            seed: seed,
+            showUnmasking: showUnmasking,
+            modelID: normalizedModelId
+        )
         let installedModelPath = resolvedInstalledModelPath(modelID: normalizedModelId)
         if preflight {
             try emitPreflight(modelID: normalizedModelId, installedModelPath: installedModelPath)
@@ -371,13 +386,15 @@ struct TextChat: AsyncParsableCommand {
             topP: resolvedTopP,
             topK: resolvedTopK,
             minP: resolvedMinP,
+            seed: seed,
             reasoningEffort: reasoningEffort,
             showThinking: resolvedShowThinking,
             lora: lora,
             requiresJSON: requiresJSON,
             tools: toolDefs,
             kvCacheMode: q35KVCacheMode,
-            maxContextTokens: contextSize
+            maxContextTokens: contextSize,
+            showUnmasking: showUnmasking
         )
 
         let streamingOutput = StreamingChatOutput(enabled: stream)
@@ -416,6 +433,13 @@ struct TextChat: AsyncParsableCommand {
             if normalizedModelId == Psi3ChatResources.defaultModelId {
                 let generator = Psi3ChatGenerator(modelId: Psi3ChatResources.defaultModelId)
                 return try await generator.chat(req, modelPath: runtimeModelRoot, progressHandler: progressHandler)
+            } else if normalizedModelId == DiffusionGemmaResources.modelID {
+                let generator = DiffusionGemmaGenerator(modelID: normalizedModelId)
+                return try await generator.chat(
+                    req,
+                    modelPath: runtimeModelRoot,
+                    progressHandler: progressHandler
+                )
             } else if Gemma4Resources.handles(modelSpec: normalizedModelId) {
                 let effectiveModelId = normalizedModelId.isEmpty ? Gemma4Resources.defaultModelId : normalizedModelId
                 let kvQuantization = try self.resolveGemma4KVCacheQuantization(for: effectiveModelId)
@@ -604,6 +628,20 @@ struct TextChat: AsyncParsableCommand {
                     if let firstToken = timing.firstTokenSeconds,
                        let ttft = Self.ttftSeconds(for: timing) {
                         line += String(format: " ttft_s=%.3f first_token_s=%.3f", ttft, firstToken)
+                    }
+                    if let diffusion = result.diffusion {
+                        line += String(
+                            format: " seed=%llu canvas_tokens=%d denoise_steps=%d work_tokens=%d canvas_tps=%.2f work_tps=%.2f",
+                            diffusion.seed,
+                            diffusion.canvasTokens,
+                            diffusion.denoisingSteps,
+                            diffusion.workTokens,
+                            diffusion.canvasTokensPerSecond,
+                            diffusion.workTokensPerSecond
+                        )
+                        if let firstDraftSeconds = diffusion.firstDraftSeconds {
+                            line += String(format: " first_draft_s=%.3f", firstDraftSeconds)
+                        }
                     }
                     CLIStderr.write("\(line)\n")
                     if let mtp = lastGemma4MTPStats {
@@ -885,6 +923,19 @@ struct TextChat: AsyncParsableCommand {
         }
     }
 
+    static func validateDiffusionOptions(
+        seed: UInt64?,
+        showUnmasking: Bool,
+        modelID: String
+    ) throws {
+        guard seed != nil || showUnmasking else { return }
+        guard modelID == DiffusionGemmaResources.modelID else {
+            throw ValidationError(
+                "--seed and --show-unmasking are currently supported only by \(DiffusionGemmaResources.modelID)."
+            )
+        }
+    }
+
     func cleanResponse(_ response: String, showThinking: Bool) -> String {
         guard !showThinking else { return response }
         return ChatReasoningMarkup.splitThinkBlocks(in: response).visibleContent
@@ -1006,6 +1057,17 @@ enum TextChatProgressHandler {
         }
 
         return { progress in
+            if let diffusion = progress.diffusion {
+                guard !quiet else { return }
+                let terminator = diffusion.blockComplete ? "\n" : "\r"
+                diagnosticWriter(
+                    "[unmasking canvas=\(diffusion.canvasIndex) step=\(diffusion.step)/\(diffusion.totalSteps)] "
+                        + diffusion.draftText
+                        + "\u{001B}[K"
+                        + terminator
+                )
+                return
+            }
             if streamingOutput.write(progress: progress) {
                 return
             }

--- a/Sources/MereRunCLI/Support/InstalledModelGateSupport.swift
+++ b/Sources/MereRunCLI/Support/InstalledModelGateSupport.swift
@@ -195,7 +195,7 @@ enum InstalledModelSmokePlans {
                 try await runner.installedTextCheck(model: spec.id)
             }
 
-        case .laguna, .lfm2, .inkling, .nemotronH, .codegenGGUF, .hfTextChat:
+        case .diffusionGemma, .laguna, .lfm2, .inkling, .nemotronH, .codegenGGUF, .hfTextChat:
             return direct(spec, route: "text chat") { runner in
                 try await runner.installedTextCheck(model: spec.id)
             }

--- a/Sources/MereRunCLI/Support/RuntimeModelPool.swift
+++ b/Sources/MereRunCLI/Support/RuntimeModelPool.swift
@@ -1089,6 +1089,7 @@ actor RuntimeModelPool {
         )
         if warmup, Self.shouldWarmDefaultModel(modelID: resolved.id, engine: resolved.engine) {
             let isQwen4Exp = Self.isQwen4ExpWarmupModel(resolved.id)
+            let isDiffusionGemma = resolved.engine == .textChatDiffusionGemma
             let warmupStart = currentDate()
             let response = try await loaded.chat(
                 ChatRequest(
@@ -1101,6 +1102,7 @@ actor RuntimeModelPool {
                     maxTokens: isQwen4Exp ? 8 : 1,
                     temperature: 0,
                     topP: 1,
+                    seed: isDiffusionGemma ? 0 : nil,
                     showThinking: false
                 ),
                 progressHandler: nil
@@ -1112,7 +1114,7 @@ actor RuntimeModelPool {
                 warmupPrefillSeconds: timing?.prefillSeconds,
                 warmupDecodeSeconds: timing?.decodeSeconds,
                 warmupTimeToFirstTokenSeconds: timing.map(Self.timeToFirstToken),
-                graphCompilationAccounting: isQwen4Exp
+                graphCompilationAccounting: isQwen4Exp || isDiffusionGemma
                     ? "included_in_warmup_prefill_and_decode"
                     : "included_in_warmup_prefill",
                 completedAt: currentDate()
@@ -1127,6 +1129,10 @@ actor RuntimeModelPool {
         modelID: String,
         engine: RuntimeServingEngine
     ) -> Bool {
+        if engine == .textChatDiffusionGemma,
+           modelID == DiffusionGemmaResources.modelID {
+            return true
+        }
         if engine == .textChatGemma4,
            Gemma4Resources.usesTurboDefaults(modelSpec: modelID) {
             return true
@@ -1802,6 +1808,11 @@ actor RuntimeModelPool {
                 ),
                 modelPath: resolved.installPath
             )
+        case .textChatDiffusionGemma:
+            return .textChatDiffusionGemma(
+                DiffusionGemmaGenerator(modelID: resolved.id),
+                modelPath: resolved.installPath
+            )
         case .textChatLaguna:
             return .textChatLaguna(
                 LagunaGenerator(
@@ -2081,6 +2092,7 @@ actor RuntimeModelPool {
             return ManagedModelCategory.textCode.rawValue
         case .textChatKlein,
              .textChatGemma4,
+             .textChatDiffusionGemma,
              .textChatLaguna,
              .textChatQ36,
              .textChatQ35,
@@ -2582,6 +2594,7 @@ enum RuntimeLoadedModel: Sendable {
     case textCode(CodeGenGenerator, modelPath: String?)
     case textChatKlein(Flux2KleinGenerator, modelPath: String?, useStandalone: Bool)
     case textChatGemma4(Gemma4Generator, modelPath: String?)
+    case textChatDiffusionGemma(DiffusionGemmaGenerator, modelPath: String?)
     case textChatLaguna(LagunaGenerator, modelPath: String?)
     case textChatQ35(Q35Generator, modelPath: String?)
     case textChatLFM2(LFM2Generator, modelPath: String?)
@@ -2604,6 +2617,8 @@ enum RuntimeLoadedModel: Sendable {
                 progressHandler: progressHandler
             )
         case .textChatGemma4(let generator, let modelPath):
+            try await generator.prepare(modelPath: modelPath, progressHandler: progressHandler)
+        case .textChatDiffusionGemma(let generator, let modelPath):
             try await generator.prepare(modelPath: modelPath, progressHandler: progressHandler)
         case .textChatLaguna(let generator, let modelPath):
             guard let modelPath else {
@@ -2633,6 +2648,8 @@ enum RuntimeLoadedModel: Sendable {
             await generator.unload()
         case .textChatGemma4(let generator, _):
             await generator.unload()
+        case .textChatDiffusionGemma(let generator, _):
+            await generator.unload()
         case .textChatLaguna(let generator, _):
             await generator.unload()
         case .textChatQ35(let generator, _):
@@ -2658,7 +2675,7 @@ enum RuntimeLoadedModel: Sendable {
             return await generator.prefixKVCacheStats()
         case .textChatLFM2(let generator, _):
             return await generator.prefixKVCacheStats()
-        case .textCode, .textChatKlein, .textChatLaguna, .textChatDeepseekV4Flash,
+        case .textCode, .textChatKlein, .textChatDiffusionGemma, .textChatLaguna, .textChatDeepseekV4Flash,
              .textChatMuseGlimmer, .textChatNemotronH, .textChatNemotronOmni:
             return nil
         }
@@ -2674,7 +2691,7 @@ enum RuntimeLoadedModel: Sendable {
             return await generator.continuousBatchingStats()
         case .textChatLFM2(let generator, _):
             return await generator.continuousBatchingStats()
-        case .textCode, .textChatKlein, .textChatDeepseekV4Flash, .textChatMuseGlimmer,
+        case .textCode, .textChatKlein, .textChatDiffusionGemma, .textChatDeepseekV4Flash, .textChatMuseGlimmer,
              .textChatNemotronH, .textChatNemotronOmni:
             return nil
         }
@@ -2684,7 +2701,7 @@ enum RuntimeLoadedModel: Sendable {
         switch self {
         case .textChatGemma4(let generator, _):
             return await generator.mtpStats()
-        case .textCode, .textChatKlein, .textChatLaguna, .textChatQ35, .textChatLFM2,
+        case .textCode, .textChatKlein, .textChatDiffusionGemma, .textChatLaguna, .textChatQ35, .textChatLFM2,
              .textChatDeepseekV4Flash, .textChatMuseGlimmer, .textChatNemotronH,
              .textChatNemotronOmni:
             return nil
@@ -2711,6 +2728,8 @@ enum RuntimeLoadedModel: Sendable {
             }
             return try await generator.chat(request, modelPath: modelPath, progressHandler: progressHandler)
         case .textChatGemma4(let generator, let modelPath):
+            return try await generator.chat(request, modelPath: modelPath, progressHandler: progressHandler)
+        case .textChatDiffusionGemma(let generator, let modelPath):
             return try await generator.chat(request, modelPath: modelPath, progressHandler: progressHandler)
         case .textChatLaguna(let generator, let modelPath):
             guard let modelPath else {
@@ -2745,7 +2764,7 @@ enum RuntimeLoadedModel: Sendable {
                 modelPath: modelPath,
                 progressHandler: progressHandler
             )
-        case .textCode, .textChatKlein, .textChatGemma4, .textChatLaguna, .textChatQ35,
+        case .textCode, .textChatKlein, .textChatGemma4, .textChatDiffusionGemma, .textChatLaguna, .textChatQ35,
              .textChatLFM2, .textChatMuseGlimmer, .textChatNemotronH,
              .textChatNemotronOmni:
             throw RuntimeModelPoolError.rawProxyUnavailable("")

--- a/Sources/MereRunCore/CodeGen/OpenAITypes.swift
+++ b/Sources/MereRunCore/CodeGen/OpenAITypes.swift
@@ -113,6 +113,7 @@ public struct OpenAIChatRequest: Codable, Sendable {
     public var think: Bool?
     public var thinking: OpenAIJSONValue?
     public var lora: String?
+    public var mere_show_unmasking: Bool?
     public var unknownFields: [String: OpenAIJSONValue]
 
     private enum CodingKeys: String, CodingKey, CaseIterable {
@@ -147,6 +148,7 @@ public struct OpenAIChatRequest: Codable, Sendable {
         case think
         case thinking
         case lora
+        case mere_show_unmasking
     }
 
     public init(
@@ -180,7 +182,8 @@ public struct OpenAIChatRequest: Codable, Sendable {
         prediction: OpenAIJSONValue? = nil,
         think: Bool? = nil,
         thinking: OpenAIJSONValue? = nil,
-        lora: String? = nil
+        lora: String? = nil,
+        mere_show_unmasking: Bool? = nil
     ) {
         self.model = model
         self.messages = messages
@@ -213,6 +216,7 @@ public struct OpenAIChatRequest: Codable, Sendable {
         self.think = think
         self.thinking = thinking
         self.lora = lora
+        self.mere_show_unmasking = mere_show_unmasking
         self.unknownFields = [:]
     }
 
@@ -249,6 +253,7 @@ public struct OpenAIChatRequest: Codable, Sendable {
         think = try container.decodeIfPresent(Bool.self, forKey: .think)
         thinking = try container.decodeIfPresent(OpenAIJSONValue.self, forKey: .thinking)
         lora = try container.decodeIfPresent(String.self, forKey: .lora)
+        mere_show_unmasking = try container.decodeIfPresent(Bool.self, forKey: .mere_show_unmasking)
 
         let knownKeys = Set(CodingKeys.allCases.map(\.rawValue))
         let dynamic = try decoder.container(keyedBy: OpenAIDynamicCodingKey.self)
@@ -292,6 +297,7 @@ public struct OpenAIChatRequest: Codable, Sendable {
         try container.encodeIfPresent(think, forKey: .think)
         try container.encodeIfPresent(thinking, forKey: .thinking)
         try container.encodeIfPresent(lora, forKey: .lora)
+        try container.encodeIfPresent(mere_show_unmasking, forKey: .mere_show_unmasking)
 
         var dynamic = encoder.container(keyedBy: OpenAIDynamicCodingKey.self)
         for (key, value) in unknownFields {
@@ -732,6 +738,7 @@ public struct OpenAIChatResponse: Codable, Sendable {
     public var model: String
     public var choices: [OpenAIChatChoice]
     public var usage: OpenAIUsage?
+    public var mere_diffusion: ChatDiffusionDiagnostics?
 
     public init(
         id: String,
@@ -739,7 +746,8 @@ public struct OpenAIChatResponse: Codable, Sendable {
         created: Int,
         model: String,
         choices: [OpenAIChatChoice],
-        usage: OpenAIUsage? = nil
+        usage: OpenAIUsage? = nil,
+        mere_diffusion: ChatDiffusionDiagnostics? = nil
     ) {
         self.id = id
         self.object = object
@@ -747,6 +755,7 @@ public struct OpenAIChatResponse: Codable, Sendable {
         self.model = model
         self.choices = choices
         self.usage = usage
+        self.mere_diffusion = mere_diffusion
     }
 }
 
@@ -839,17 +848,36 @@ public struct OpenAIChatDelta: Codable, Sendable {
     public var content: String?
     public var reasoning_content: String?
     public var tool_calls: [OpenAIChatToolCallDelta]?
+    public var mere_diffusion_draft: OpenAIDiffusionDraft?
 
     public init(
         role: String? = nil,
         content: String? = nil,
         reasoning_content: String? = nil,
-        tool_calls: [OpenAIChatToolCallDelta]? = nil
+        tool_calls: [OpenAIChatToolCallDelta]? = nil,
+        mere_diffusion_draft: OpenAIDiffusionDraft? = nil
     ) {
         self.role = role
         self.content = content
         self.reasoning_content = reasoning_content
         self.tool_calls = tool_calls
+        self.mere_diffusion_draft = mere_diffusion_draft
+    }
+}
+
+public struct OpenAIDiffusionDraft: Codable, Hashable, Sendable {
+    public var text: String
+    public var step: Int
+    public var total_steps: Int
+    public var canvas_index: Int
+    public var block_complete: Bool
+
+    public init(_ progress: ChatDiffusionProgress) {
+        self.text = progress.draftText
+        self.step = progress.step
+        self.total_steps = progress.totalSteps
+        self.canvas_index = progress.canvasIndex
+        self.block_complete = progress.blockComplete
     }
 }
 

--- a/Sources/MereRunCore/DiffusionGemma/DiffusionGemmaConfig.swift
+++ b/Sources/MereRunCore/DiffusionGemma/DiffusionGemmaConfig.swift
@@ -1,0 +1,176 @@
+import Foundation
+
+public struct DiffusionGemmaQuantizationParameters: Decodable, Sendable, Hashable {
+    public let groupSize: Int
+    public let bits: Int
+
+    private enum CodingKeys: String, CodingKey {
+        case groupSize = "group_size"
+        case bits
+    }
+}
+public struct DiffusionGemmaQuantizationConfig: Decodable, Sendable, Hashable {
+    public let groupSize: Int
+    public let bits: Int
+    public let mode: String
+    public let overrides: [String: DiffusionGemmaQuantizationParameters]
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: DiffusionGemmaCodingKey.self)
+        groupSize = try container.decode(Int.self, forKey: .init("group_size"))
+        bits = try container.decode(Int.self, forKey: .init("bits"))
+        mode = try container.decode(String.self, forKey: .init("mode"))
+
+        let reserved = Set(["group_size", "bits", "mode"])
+        var decoded: [String: DiffusionGemmaQuantizationParameters] = [:]
+        for key in container.allKeys where !reserved.contains(key.stringValue) {
+            decoded[key.stringValue] = try container.decode(
+                DiffusionGemmaQuantizationParameters.self,
+                forKey: key
+            )
+        }
+        overrides = decoded
+    }
+
+    public func parameters(for path: String) -> DiffusionGemmaQuantizationParameters {
+        overrides[path] ?? DiffusionGemmaQuantizationParameters(
+            groupSize: groupSize,
+            bits: bits
+        )
+    }
+}
+
+public struct DiffusionGemmaTextConfig: Decodable, Sendable, Hashable {
+    public let modelType: String
+    public let vocabSize: Int
+    public let hiddenSize: Int
+    public let intermediateSize: Int
+    public let moeIntermediateSize: Int
+    public let numHiddenLayers: Int
+    public let numAttentionHeads: Int
+    public let numKeyValueHeads: Int
+    public let numGlobalKeyValueHeads: Int
+    public let headDim: Int
+    public let globalHeadDim: Int
+    public let rmsNormEps: Float
+    public let maxPositionEmbeddings: Int
+    public let padTokenId: Int
+    public let slidingWindow: Int
+    public let layerTypes: [String]
+    public let finalLogitSoftcapping: Float
+    public let numExperts: Int
+    public let topKExperts: Int
+    public let ropeParameters: [String: Gemma4TextRopeParameters]
+
+    private enum CodingKeys: String, CodingKey {
+        case modelType = "model_type"
+        case vocabSize = "vocab_size"
+        case hiddenSize = "hidden_size"
+        case intermediateSize = "intermediate_size"
+        case moeIntermediateSize = "moe_intermediate_size"
+        case numHiddenLayers = "num_hidden_layers"
+        case numAttentionHeads = "num_attention_heads"
+        case numKeyValueHeads = "num_key_value_heads"
+        case numGlobalKeyValueHeads = "num_global_key_value_heads"
+        case headDim = "head_dim"
+        case globalHeadDim = "global_head_dim"
+        case rmsNormEps = "rms_norm_eps"
+        case maxPositionEmbeddings = "max_position_embeddings"
+        case padTokenId = "pad_token_id"
+        case slidingWindow = "sliding_window"
+        case layerTypes = "layer_types"
+        case finalLogitSoftcapping = "final_logit_softcapping"
+        case numExperts = "num_experts"
+        case topKExperts = "top_k_experts"
+        case ropeParameters = "rope_parameters"
+    }
+}
+
+public struct DiffusionGemmaConfig: Decodable, Sendable, Hashable {
+    public let modelType: String
+    public let architectures: [String]
+    public let canvasLength: Int
+    public let eosTokenIds: [Int]
+    public let imageTokenId: Int?
+    public let boiTokenId: Int?
+    public let eoiTokenId: Int?
+    public let textConfig: DiffusionGemmaTextConfig
+    public let quantization: DiffusionGemmaQuantizationConfig
+
+    private enum CodingKeys: String, CodingKey {
+        case modelType = "model_type"
+        case architectures
+        case canvasLength = "canvas_length"
+        case eosTokenId = "eos_token_id"
+        case imageTokenId = "image_token_id"
+        case boiTokenId = "boi_token_id"
+        case eoiTokenId = "eoi_token_id"
+        case textConfig = "text_config"
+        case quantization
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        modelType = try container.decode(String.self, forKey: .modelType)
+        architectures = try container.decodeIfPresent([String].self, forKey: .architectures) ?? []
+        canvasLength = try container.decode(Int.self, forKey: .canvasLength)
+        imageTokenId = try container.decodeIfPresent(Int.self, forKey: .imageTokenId)
+        boiTokenId = try container.decodeIfPresent(Int.self, forKey: .boiTokenId)
+        eoiTokenId = try container.decodeIfPresent(Int.self, forKey: .eoiTokenId)
+        textConfig = try container.decode(DiffusionGemmaTextConfig.self, forKey: .textConfig)
+        quantization = try container.decode(DiffusionGemmaQuantizationConfig.self, forKey: .quantization)
+        if let ids = try? container.decode([Int].self, forKey: .eosTokenId) {
+            eosTokenIds = ids
+        } else {
+            eosTokenIds = [try container.decode(Int.self, forKey: .eosTokenId)]
+        }
+    }
+}
+
+public struct DiffusionGemmaGenerationConfig: Decodable, Sendable, Hashable {
+    public let confidenceThreshold: Float
+    public let eosTokenIds: [Int]
+    public let maxDenoisingSteps: Int
+    public let maxNewTokens: Int
+    public let stabilityThreshold: Int
+    public let minimumTemperature: Float
+    public let maximumTemperature: Float
+
+    private enum CodingKeys: String, CodingKey {
+        case confidenceThreshold = "confidence_threshold"
+        case eosTokenId = "eos_token_id"
+        case maxDenoisingSteps = "max_denoising_steps"
+        case maxNewTokens = "max_new_tokens"
+        case stabilityThreshold = "stability_threshold"
+        case minimumTemperature = "t_min"
+        case maximumTemperature = "t_max"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        confidenceThreshold = try container.decode(Float.self, forKey: .confidenceThreshold)
+        eosTokenIds = try container.decode([Int].self, forKey: .eosTokenId)
+        maxDenoisingSteps = try container.decode(Int.self, forKey: .maxDenoisingSteps)
+        maxNewTokens = try container.decode(Int.self, forKey: .maxNewTokens)
+        stabilityThreshold = try container.decode(Int.self, forKey: .stabilityThreshold)
+        minimumTemperature = try container.decode(Float.self, forKey: .minimumTemperature)
+        maximumTemperature = try container.decode(Float.self, forKey: .maximumTemperature)
+    }
+}
+
+private struct DiffusionGemmaCodingKey: CodingKey {
+    let stringValue: String
+    let intValue: Int? = nil
+
+    init(_ stringValue: String) {
+        self.stringValue = stringValue
+    }
+
+    init?(stringValue: String) {
+        self.init(stringValue)
+    }
+
+    init?(intValue: Int) {
+        return nil
+    }
+}

--- a/Sources/MereRunCore/DiffusionGemma/DiffusionGemmaGenerator.swift
+++ b/Sources/MereRunCore/DiffusionGemma/DiffusionGemmaGenerator.swift
@@ -1,0 +1,613 @@
+import Foundation
+import MLX
+import MLXNN
+import MLXRandom
+@preconcurrency import Hub
+
+private struct DiffusionGemmaRandomKeyStream {
+    private var key: MLXArray
+
+    init(seed: UInt64) {
+        key = MLXRandom.key(seed)
+    }
+
+    mutating func next() -> MLXArray {
+        let (nextKey, sampleKey) = MLXRandom.split(key: key)
+        key = nextKey
+        return sampleKey
+    }
+}
+
+public actor DiffusionGemmaGenerator: ChatGenerator {
+    private static let minimumCanvasLength = 64
+    private static let transferThreshold: Float = 0.9
+    private static let maximumUnmaskingCharacters = 160
+
+    private let modelID: String
+    private var model: DiffusionGemmaLanguageModel?
+    private var tokenizerAndTemplate: Gemma4TokenizerAndTemplate?
+    private var generationConfig: DiffusionGemmaGenerationConfig?
+    private var loadedModelPath: String?
+
+    public init(modelID: String = DiffusionGemmaResources.modelID) {
+        self.modelID = modelID
+    }
+
+    public func chat(
+        _ request: ChatRequest,
+        progressHandler: (@Sendable (ChatProgress) -> Void)?
+    ) async throws -> ChatResponse {
+        try await chat(request, modelPath: nil, progressHandler: progressHandler)
+    }
+
+    public func chat(
+        _ request: ChatRequest,
+        modelPath: String?,
+        progressHandler: (@Sendable (ChatProgress) -> Void)?
+    ) async throws -> ChatResponse {
+        try await Stream.withNewDefaultStream {
+            try validate(request)
+            let loadStart = Date()
+            let rootURL = try await resolveModelRoot(
+                modelPath: modelPath,
+                progressHandler: progressHandler
+            )
+            try await ensureLoaded(rootURL: rootURL, progressHandler: progressHandler)
+            let loadSeconds = Date().timeIntervalSince(loadStart)
+            var response = try generate(request, progressHandler: progressHandler)
+            if var timing = response.timing {
+                timing.loadSeconds = loadSeconds
+                response.timing = timing
+            }
+            return response
+        }
+    }
+
+    public func prepare(
+        modelPath: String? = nil,
+        progressHandler: (@Sendable (ChatProgress) -> Void)? = nil
+    ) async throws {
+        try await Stream.withNewDefaultStream {
+            let rootURL = try await resolveModelRoot(
+                modelPath: modelPath,
+                progressHandler: progressHandler
+            )
+            try await ensureLoaded(rootURL: rootURL, progressHandler: progressHandler)
+        }
+    }
+
+    public func unload() {
+        model = nil
+        tokenizerAndTemplate = nil
+        generationConfig = nil
+        loadedModelPath = nil
+        Memory.clearCache()
+    }
+
+    private func validate(_ request: ChatRequest) throws {
+        if request.messages.contains(where: {
+            $0.imageUrl != nil || $0.audioUrl != nil || $0.videoUrl != nil
+        }) {
+            throw DiffusionGemmaError.unsupportedConfiguration(
+                "DiffusionGemma image, audio, and video inputs are not qualified in this runtime."
+            )
+        }
+        if request.lora != nil {
+            throw DiffusionGemmaError.unsupportedConfiguration(
+                "DiffusionGemma does not support LoRA adapters."
+            )
+        }
+        if request.requiresJSON {
+            throw DiffusionGemmaError.unsupportedConfiguration(
+                "DiffusionGemma does not support constrained JSON decoding."
+            )
+        }
+        if request.logprobCapture != .none {
+            throw DiffusionGemmaError.unsupportedConfiguration(
+                "DiffusionGemma does not expose autoregressive token logprobs."
+            )
+        }
+        if request.maxTokens < 0 {
+            throw DiffusionGemmaError.unsupportedConfiguration("maxTokens must not be negative.")
+        }
+    }
+
+    private func ensureLoaded(
+        rootURL: URL,
+        progressHandler: (@Sendable (ChatProgress) -> Void)?
+    ) async throws {
+        let normalizedRoot = rootURL.standardizedFileURL
+        if loadedModelPath == normalizedRoot.path,
+           model != nil,
+           tokenizerAndTemplate != nil,
+           generationConfig != nil {
+            return
+        }
+
+        let resources = DiffusionGemmaResources(rootURL: normalizedRoot)
+        let missing = resources.validate()
+        guard missing.isEmpty else {
+            throw DiffusionGemmaError.missingFiles(missing.map(\.lastPathComponent))
+        }
+
+        progressHandler?(ChatProgress(stage: .loadingModel, message: "Loading DiffusionGemma config"))
+        let config = try JSONDecoder().decode(
+            DiffusionGemmaConfig.self,
+            from: Data(contentsOf: resources.configURL)
+        )
+        guard config.modelType == "diffusion_gemma",
+              config.architectures.contains("DiffusionGemmaForBlockDiffusion") else {
+            throw DiffusionGemmaError.unsupportedConfiguration(
+                "The selected checkpoint is not a DiffusionGemma block-diffusion model."
+            )
+        }
+        guard config.canvasLength > 0,
+              config.canvasLength <= DiffusionGemmaResources.maximumCanvasLength else {
+            throw DiffusionGemmaError.unsupportedConfiguration(
+                "Unsupported DiffusionGemma canvas length \(config.canvasLength)."
+            )
+        }
+
+        let decodedGenerationConfig = try JSONDecoder().decode(
+            DiffusionGemmaGenerationConfig.self,
+            from: Data(contentsOf: resources.generationConfigURL)
+        )
+        progressHandler?(ChatProgress(stage: .loadingModel, message: "Loading DiffusionGemma tokenizer"))
+        let tokenizer = try await Gemma4TokenizerAndTemplate.load(
+            from: normalizedRoot,
+            maxLengthOverride: min(
+                DiffusionGemmaResources.defaultContextLength,
+                config.textConfig.maxPositionEmbeddings
+            )
+        )
+
+        progressHandler?(ChatProgress(stage: .loadingModel, message: "Loading DiffusionGemma OptiQ weights"))
+        let loadedModel = DiffusionGemmaLanguageModel(config: config)
+        try HFSafetensorsWeightsLoader.applyQuantizedWeights(
+            indexURL: resources.modelIndexURL,
+            to: loadedModel,
+            groupSize: config.quantization.groupSize,
+            bits: config.quantization.bits,
+            quantizedModuleResolver: { _, _, _, _, _, groupSize, bits in
+                (groupSize: groupSize, bits: bits, mode: .affine)
+            }
+        )
+        Memory.clearCache()
+
+        model = loadedModel
+        tokenizerAndTemplate = tokenizer
+        generationConfig = decodedGenerationConfig
+        loadedModelPath = normalizedRoot.path
+    }
+
+    private func generate(
+        _ request: ChatRequest,
+        progressHandler: (@Sendable (ChatProgress) -> Void)?
+    ) throws -> ChatResponse {
+        guard let model, let tokenizerAndTemplate, let generationConfig else {
+            throw DiffusionGemmaError.unsupportedConfiguration("DiffusionGemma is not loaded.")
+        }
+
+        progressHandler?(ChatProgress(stage: .encoding, message: "Encoding DiffusionGemma prompt"))
+        let contextLimit = min(
+            request.maxContextTokens ?? DiffusionGemmaResources.defaultContextLength,
+            model.config.textConfig.maxPositionEmbeddings
+        )
+        let promptTokens = try tokenizerAndTemplate.encodeForGeneration(
+            messages: request.messages,
+            tools: request.tools,
+            includeThinking: request.showThinking,
+            maxLength: contextLimit
+        )
+        guard !promptTokens.isEmpty else {
+            throw DiffusionGemmaError.unsupportedConfiguration("The rendered prompt is empty.")
+        }
+
+        let tokenBudget = min(
+            request.maxTokens,
+            generationConfig.maxNewTokens,
+            max(0, contextLimit - promptTokens.count)
+        )
+        guard tokenBudget > 0 else {
+            return ChatResponse(
+                response: "",
+                tokensGenerated: 0,
+                timing: ChatTiming(),
+                promptTokens: promptTokens.count,
+                finishReason: .length
+            )
+        }
+
+        let caches = model.makeCaches()
+        let promptArray = MLXArray(promptTokens.map(Int32.init)).reshaped(1, promptTokens.count)
+        let prefillStart = Date()
+        model.updateCache(promptArray, caches: caches)
+        evaluateGemma4CacheStorage(caches)
+        let prefillSeconds = Date().timeIntervalSince(prefillStart)
+
+        progressHandler?(ChatProgress(stage: .generating, message: "Generating..."))
+        let decodeStart = Date()
+        let effectiveSeed = request.seed ?? UInt64.random(in: UInt64.min...UInt64.max)
+        var randomKeys = DiffusionGemmaRandomKeyStream(seed: effectiveSeed)
+        var generated: [Int] = []
+        generated.reserveCapacity(tokenBudget)
+        let eos = Set(generationConfig.eosTokenIds + model.config.eosTokenIds + tokenizerAndTemplate.stopTokenIds)
+        var finishReason: ChatFinishReason = .length
+        var canvasCount = 0
+        var canvasTokens = 0
+        var denoisingSteps = 0
+        var workTokens = 0
+        var firstDraftSeconds: Double?
+
+        while generated.count < tokenBudget {
+            canvasCount += 1
+            let remaining = tokenBudget - generated.count
+            let canvasLength = min(
+                model.config.canvasLength,
+                max(remaining, Self.minimumCanvasLength)
+            )
+            canvasTokens += canvasLength
+            var canvas = MLXRandom.randInt(
+                Int32(0)..<Int32(model.config.textConfig.vocabSize),
+                [1, canvasLength],
+                key: randomKeys.next()
+            )
+            var revealed = MLXArray.zeros([1, canvasLength], dtype: .bool)
+            var accepted = canvas
+            var selfConditioningLogits: MLXArray?
+            var finalCanvas = canvas
+            var stabilityHistory: [MLXArray] = []
+            var denoisingStepsThisCanvas = 0
+
+            for step in stride(from: generationConfig.maxDenoisingSteps, through: 1, by: -1) {
+                denoisingSteps += 1
+                denoisingStepsThisCanvas += 1
+                workTokens += canvasLength
+                var logits = model.canvasLogits(
+                    canvas,
+                    caches: caches,
+                    selfConditioningLogits: selfConditioningLogits
+                )
+                let fraction = Float(step) / Float(generationConfig.maxDenoisingSteps)
+                let scheduledTemperature = generationConfig.minimumTemperature
+                    + (generationConfig.maximumTemperature - generationConfig.minimumTemperature) * fraction
+                logits = logits / MLXArray(scheduledTemperature).asType(logits.dtype)
+
+                let argmaxCanvas = argMax(logits, axis: -1).asType(.int32)
+                finalCanvas = argmaxCanvas
+                if step == 1 {
+                    break
+                }
+
+                let denoised: MLXArray
+                if request.temperature <= 0 {
+                    denoised = argmaxCanvas
+                } else {
+                    denoised = MLXRandom.categorical(
+                        logits / MLXArray(Float(request.temperature)).asType(logits.dtype),
+                        axis: -1,
+                        key: randomKeys.next()
+                    ).asType(.int32)
+                }
+                let confidence = Self.tokenProbability(logits: logits, tokenIDs: denoised)
+                let unrevealed = revealed .== MLXArray(false)
+                var transfer = unrevealed .&& (
+                    confidence .>= MLXArray(Self.transferThreshold).asType(confidence.dtype)
+                )
+                let eligibleConfidence = MLX.where(
+                    unrevealed,
+                    confidence,
+                    MLXArray(-Float.infinity).asType(confidence.dtype)
+                )
+                let best = argMax(eligibleConfidence, axis: -1)
+                let positions = MLXArray(Int32(0)..<Int32(canvasLength)).reshaped(1, canvasLength)
+                let forced = positions .== MLX.expandedDimensions(best, axis: -1)
+                transfer = MLX.where(MLX.any(transfer), transfer, forced)
+
+                accepted = MLX.where(transfer, denoised, accepted)
+                revealed = revealed .|| transfer
+                let randomCanvas = MLXRandom.randInt(
+                    Int32(0)..<Int32(model.config.textConfig.vocabSize),
+                    [1, canvasLength],
+                    key: randomKeys.next()
+                )
+                canvas = MLX.where(revealed, accepted, randomCanvas)
+                selfConditioningLogits = logits
+
+                if request.showUnmasking {
+                    Self.emitUnmaskingProgress(
+                        tokens: accepted,
+                        revealed: revealed,
+                        tokenizerAndTemplate: tokenizerAndTemplate,
+                        step: generationConfig.maxDenoisingSteps - step + 1,
+                        totalSteps: generationConfig.maxDenoisingSteps,
+                        canvasIndex: canvasCount,
+                        blockComplete: false,
+                        showThinking: request.showThinking,
+                        progressHandler: progressHandler
+                    )
+                    if firstDraftSeconds == nil {
+                        firstDraftSeconds = Date().timeIntervalSince(decodeStart)
+                    }
+                }
+
+                if MLX.all(revealed).item(Bool.self) {
+                    break
+                }
+                if stableAndConfident(
+                    argmaxCanvas,
+                    logits: logits,
+                    history: &stabilityHistory,
+                    generationConfig: generationConfig
+                ) {
+                    break
+                }
+            }
+
+            MLX.eval(finalCanvas)
+            let block = finalCanvas.asArray(Int32.self).map(Int.init)
+            if request.showUnmasking {
+                let finalDraft = Self.maskedDraft(
+                    tokens: block,
+                    revealed: Array(repeating: true, count: block.count),
+                    skipTokenIDs: eos,
+                    decode: tokenizerAndTemplate.decode(tokens:)
+                )
+                progressHandler?(ChatProgress(
+                    stage: .generating,
+                    diffusion: ChatDiffusionProgress(
+                        draftText: Self.cleanedResponse(
+                            finalDraft,
+                            showThinking: request.showThinking
+                        ),
+                        step: denoisingStepsThisCanvas,
+                        totalSteps: generationConfig.maxDenoisingSteps,
+                        canvasIndex: canvasCount,
+                        blockComplete: true
+                    )
+                ))
+                if firstDraftSeconds == nil {
+                    firstDraftSeconds = Date().timeIntervalSince(decodeStart)
+                }
+            }
+            var stopped = false
+            for token in block.prefix(remaining) {
+                if request.stopOnEOS, eos.contains(token) {
+                    finishReason = .stop
+                    stopped = true
+                    break
+                }
+                generated.append(token)
+            }
+            if stopped || generated.count >= tokenBudget {
+                break
+            }
+            model.updateCache(finalCanvas, caches: caches)
+            evaluateGemma4CacheStorage(caches)
+            Memory.clearCache()
+        }
+
+        let decodeSeconds = Date().timeIntervalSince(decodeStart)
+        let decodedRaw = tokenizerAndTemplate.decode(tokens: generated)
+        let trimmed = TextGenerationStopSequences.trimming(
+            decodedRaw,
+            sequences: TextGenerationStopSequences.merged(
+                request.stopSequences + TextGenerationStopSequences.defaultRenderedChatStops
+            )
+        )
+        if trimmed.matchedSequence != nil {
+            finishReason = .stopSequence
+        }
+        let reasoning = ChatReasoningMarkup.splitThinkBlocks(in: trimmed.text)
+        let response = Self.cleanedResponse(
+            request.showThinking ? trimmed.text : reasoning.visibleContent,
+            showThinking: request.showThinking
+        )
+        let parsedToolCalls = request.tools?.isEmpty == false
+            ? Gemma4ToolParser.parseToolCalls(response)
+            : []
+        let diffusion = ChatDiffusionDiagnostics(
+            seed: effectiveSeed,
+            canvasTokens: canvasTokens,
+            denoisingSteps: denoisingSteps,
+            workTokens: workTokens,
+            canvasTokensPerSecond: decodeSeconds > 0
+                ? Double(canvasTokens) / decodeSeconds
+                : 0,
+            workTokensPerSecond: decodeSeconds > 0
+                ? Double(workTokens) / decodeSeconds
+                : 0,
+            firstDraftSeconds: firstDraftSeconds
+        )
+
+        return ChatResponse(
+            response: response,
+            tokensGenerated: generated.count,
+            timing: ChatTiming(
+                prefillSeconds: prefillSeconds,
+                decodeSeconds: decodeSeconds,
+                firstTokenSeconds: decodeSeconds,
+                prefillKVCache: "native-hybrid",
+                decodeKVCache: "native-hybrid",
+                prefillTokensPerSecond: prefillSeconds > 0
+                    ? Double(promptTokens.count) / prefillSeconds
+                    : nil,
+                decodeTokensPerSecond: decodeSeconds > 0
+                    ? Double(generated.count) / decodeSeconds
+                    : nil
+            ),
+            toolCalls: parsedToolCalls.isEmpty ? nil : parsedToolCalls,
+            promptTokens: promptTokens.count,
+            finishReason: finishReason,
+            reasoningContent: reasoning.reasoningContent,
+            hasIncompleteReasoning: reasoning.hasIncompleteReasoning,
+            reasoningBlockCount: reasoning.reasoningBlockCount,
+            hasReopenedReasoning: reasoning.hasReopenedReasoning,
+            diffusion: diffusion
+        )
+    }
+
+    nonisolated static func tokenProbability(
+        logits: MLXArray,
+        tokenIDs: MLXArray
+    ) -> MLXArray {
+        let floatLogits = logits.asType(.float32)
+        let selected = takeAlong(
+            floatLogits,
+            MLX.expandedDimensions(tokenIDs.asType(.int32), axis: -1),
+            axis: -1
+        ).squeezed(axis: -1)
+        return MLX.exp(selected - logSumExp(floatLogits, axis: -1))
+    }
+
+    nonisolated static func maskedDraft(
+        tokens: [Int],
+        revealed: [Bool],
+        skipTokenIDs: Set<Int> = [],
+        maximumCharacters: Int = maximumUnmaskingCharacters,
+        decode: ([Int]) -> String
+    ) -> String {
+        precondition(tokens.count == revealed.count)
+        var pieces: [String] = []
+        var pending: [Int] = []
+
+        func flushPending() {
+            guard !pending.isEmpty else { return }
+            pieces.append(decode(pending))
+            pending.removeAll(keepingCapacity: true)
+        }
+
+        for (token, isRevealed) in zip(tokens, revealed) {
+            if isRevealed {
+                if !skipTokenIDs.contains(token) {
+                    pending.append(token)
+                }
+            } else {
+                flushPending()
+                pieces.append("[Mask]")
+            }
+        }
+        flushPending()
+
+        let text = pieces
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+            .replacingOccurrences(of: "\r", with: "\\r")
+            .replacingOccurrences(of: "\n", with: "\\n")
+        return String(text.prefix(max(0, maximumCharacters)))
+    }
+
+    private nonisolated static func emitUnmaskingProgress(
+        tokens: MLXArray,
+        revealed: MLXArray,
+        tokenizerAndTemplate: Gemma4TokenizerAndTemplate,
+        step: Int,
+        totalSteps: Int,
+        canvasIndex: Int,
+        blockComplete: Bool,
+        showThinking: Bool,
+        progressHandler: (@Sendable (ChatProgress) -> Void)?
+    ) {
+        MLX.eval(tokens, revealed)
+        let tokenValues = tokens.asArray(Int32.self).map(Int.init)
+        let revealValues = revealed.asArray(Bool.self)
+        let draft = maskedDraft(
+            tokens: tokenValues,
+            revealed: revealValues,
+            decode: tokenizerAndTemplate.decode(tokens:)
+        )
+        progressHandler?(ChatProgress(
+            stage: .generating,
+            diffusion: ChatDiffusionProgress(
+                draftText: cleanedResponse(draft, showThinking: showThinking),
+                step: step,
+                totalSteps: totalSteps,
+                canvasIndex: canvasIndex,
+                blockComplete: blockComplete
+            )
+        ))
+    }
+
+    nonisolated static func cleanedResponse(_ response: String, showThinking: Bool) -> String {
+        Gemma4Generator.cleanedResponse(response, showThinking: showThinking)
+    }
+
+    private func stableAndConfident(
+        _ canvas: MLXArray,
+        logits: MLXArray,
+        history: inout [MLXArray],
+        generationConfig: DiffusionGemmaGenerationConfig
+    ) -> Bool {
+        let historyLength = max(1, generationConfig.stabilityThreshold)
+        let stable = history.count == historyLength && history.allSatisfy {
+            MLX.all(canvas .== $0).item(Bool.self)
+        }
+        history.append(canvas)
+        if history.count > historyLength {
+            history.removeFirst(history.count - historyLength)
+        }
+        guard stable else { return false }
+
+        let logProbabilities = logSoftmax(logits.asType(.float32), axis: -1)
+        let entropy = (MLXArray(0) - MLX.exp(logProbabilities) * logProbabilities)
+            .sum(axis: -1)
+            .mean()
+        return entropy.item(Float.self) < generationConfig.confidenceThreshold
+    }
+
+    private func resolveModelRoot(
+        modelPath: String?,
+        progressHandler: (@Sendable (ChatProgress) -> Void)?
+    ) async throws -> URL {
+        if let modelPath = modelPath?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !modelPath.isEmpty {
+            if let canonicalID = ModelResolver.ModelID(rawValue: modelPath),
+               canonicalID.rawValue == DiffusionGemmaResources.modelID {
+                if let resolved = ModelResolver().resolveIfPresent(canonicalID) {
+                    return resolved.rootURL
+                }
+                if let installed = ManagedModelResolver.resolveInstalledModel(id: modelPath) {
+                    return installed
+                }
+            } else {
+                let url = URL(fileURLWithPath: modelPath).standardizedFileURL
+                guard FileManager.default.fileExists(atPath: url.path) else {
+                    throw DiffusionGemmaError.unsupportedModelLocation(modelPath)
+                }
+                return url
+            }
+        }
+
+        if let modelID = ModelResolver.ModelID(rawValue: modelID),
+           let resolved = ModelResolver().resolveIfPresent(modelID) {
+            return resolved.rootURL
+        }
+        if let installed = ManagedModelResolver.resolveInstalledModel(id: modelID) {
+            return installed
+        }
+
+        do {
+            let resolution = try await ManagedModelResolver.resolveForRuntime(
+                requestedModel: modelID,
+                defaultModelID: DiffusionGemmaResources.modelID,
+                progress: { event in
+                    switch event {
+                    case .downloading(let percent):
+                        progressHandler?(ChatProgress(
+                            stage: .loadingModel,
+                            message: "Downloading DiffusionGemma... \(percent)%"
+                        ))
+                    case .extracting:
+                        progressHandler?(ChatProgress(
+                            stage: .loadingModel,
+                            message: "Finalizing DiffusionGemma..."
+                        ))
+                    }
+                }
+            )
+            return resolution.url.standardizedFileURL
+        } catch {
+            throw DiffusionGemmaError.downloadFailed(error.localizedDescription)
+        }
+    }
+}

--- a/Sources/MereRunCore/DiffusionGemma/DiffusionGemmaModel.swift
+++ b/Sources/MereRunCore/DiffusionGemma/DiffusionGemmaModel.swift
@@ -1,0 +1,622 @@
+import Foundation
+import MLX
+import MLXFast
+import MLXNN
+import MLXRandom
+
+final class DiffusionGemmaSwitchLinear: Module {
+    @ModuleInfo(key: "weight") var weight: MLXArray
+    @ModuleInfo(key: "scales") var scales: MLXArray
+    @ModuleInfo(key: "biases") var biases: MLXArray
+
+    private let groupSize: Int
+    private let bits: Int
+
+    init(
+        inputDims: Int,
+        outputDims: Int,
+        numExperts: Int,
+        parameters: DiffusionGemmaQuantizationParameters
+    ) {
+        groupSize = parameters.groupSize
+        bits = parameters.bits
+        let packedInput = max(1, (inputDims * parameters.bits + 31) / 32)
+        let groups = max(1, (inputDims + parameters.groupSize - 1) / parameters.groupSize)
+        _weight.wrappedValue = MLXArray.zeros(
+            [numExperts, outputDims, packedInput],
+            dtype: .uint32
+        )
+        _scales.wrappedValue = MLXArray.zeros(
+            [numExperts, outputDims, groups],
+            dtype: .bfloat16
+        )
+        _biases.wrappedValue = MLXArray.zeros(
+            [numExperts, outputDims, groups],
+            dtype: .bfloat16
+        )
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray, indices: MLXArray) -> MLXArray {
+        let batchTokens = x.dim(0) * x.dim(1)
+        let topK = indices.dim(2)
+        let inputDim = x.dim(-1)
+        if x.ndim == 4 && x.dim(2) == topK {
+            let flat = x.reshaped([batchTokens * topK, 1, inputDim])
+            let flatIndices = indices.reshaped([batchTokens * topK])
+            let output = applyFlat(flat, indices: flatIndices, sortedIndices: false)
+            return output.reshaped([x.dim(0), x.dim(1), topK, output.dim(-1)])
+        }
+        let expanded = MLX.expandedDimensions(x, axes: [-2, -3])
+        return applyFlat(expanded, indices: indices, sortedIndices: false).squeezed(axis: -2)
+    }
+
+    func applyFlat(
+        _ x: MLXArray,
+        indices: MLXArray,
+        sortedIndices: Bool
+    ) -> MLXArray {
+        portableGatherQuantizedMM(
+            x,
+            weight,
+            scales: scales,
+            biases: biases,
+            rhsIndices: indices,
+            transpose: true,
+            groupSize: groupSize,
+            bits: bits,
+            mode: .affine,
+            sortedIndices: sortedIndices
+        )
+    }
+}
+
+enum DiffusionGemmaExpertRouting {
+    static let minimumSortedRouteCount = 64
+
+    struct Plan {
+        let order: MLXArray
+        let inverseOrder: MLXArray
+        let sortedIndices: MLXArray
+        let tokenOrder: MLXArray
+    }
+
+    static func shouldSort(routeCount: Int) -> Bool {
+        routeCount >= minimumSortedRouteCount
+    }
+
+    static func sortedPlan(indices: MLXArray, topK: Int) -> Plan {
+        let flatIndices = indices.reshaped([indices.size])
+        let order = argSort(flatIndices, axis: 0)
+        return Plan(
+            order: order,
+            inverseOrder: argSort(order, axis: 0),
+            sortedIndices: take(flatIndices, order, axis: 0),
+            tokenOrder: order.floorDivide(topK)
+        )
+    }
+}
+
+final class DiffusionGemmaExperts: Module {
+    @ModuleInfo(key: "gate_up_proj") var gateUpProj: DiffusionGemmaSwitchLinear
+    @ModuleInfo(key: "down_proj") var downProj: DiffusionGemmaSwitchLinear
+
+    private let intermediateSize: Int
+
+    init(
+        config: DiffusionGemmaTextConfig,
+        quantization: DiffusionGemmaQuantizationConfig,
+        layerIndex: Int
+    ) {
+        intermediateSize = config.moeIntermediateSize
+        let prefix = "model.decoder.layers.\(layerIndex).experts"
+        _gateUpProj.wrappedValue = DiffusionGemmaSwitchLinear(
+            inputDims: config.hiddenSize,
+            outputDims: 2 * config.moeIntermediateSize,
+            numExperts: config.numExperts,
+            parameters: quantization.parameters(for: "\(prefix).gate_up_proj")
+        )
+        _downProj.wrappedValue = DiffusionGemmaSwitchLinear(
+            inputDims: config.moeIntermediateSize,
+            outputDims: config.hiddenSize,
+            numExperts: config.numExperts,
+            parameters: quantization.parameters(for: "\(prefix).down_proj")
+        )
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray, indices: MLXArray, weights: MLXArray) -> MLXArray {
+        let batchTokens = x.dim(0) * x.dim(1)
+        let topK = indices.dim(2)
+        let routeCount = batchTokens * topK
+        guard DiffusionGemmaExpertRouting.shouldSort(routeCount: routeCount) else {
+            let gateUp = gateUpProj(x, indices: indices)
+            let gate = gateUp[.ellipsis, ..<intermediateSize]
+            let up = gateUp[.ellipsis, intermediateSize...]
+            let routed = downProj(geluApproximate(gate) * up, indices: indices)
+            return (routed * MLX.expandedDimensions(weights, axis: weights.ndim)).sum(axis: -2)
+        }
+
+        let inputDim = x.dim(-1)
+        let plan = DiffusionGemmaExpertRouting.sortedPlan(indices: indices, topK: topK)
+        let sortedInput = take(
+            x.reshaped([batchTokens, inputDim]),
+            plan.tokenOrder,
+            axis: 0
+        ).reshaped([routeCount, 1, inputDim])
+        let gateUp = gateUpProj.applyFlat(
+            sortedInput,
+            indices: plan.sortedIndices,
+            sortedIndices: true
+        )
+        let gate = gateUp[.ellipsis, ..<intermediateSize]
+        let up = gateUp[.ellipsis, intermediateSize...]
+        let sortedRouted = downProj.applyFlat(
+            geluApproximate(gate) * up,
+            indices: plan.sortedIndices,
+            sortedIndices: true
+        )
+        let routed = take(sortedRouted, plan.inverseOrder, axis: 0).reshaped([
+            x.dim(0),
+            x.dim(1),
+            topK,
+            sortedRouted.dim(-1),
+        ])
+        return (routed * MLX.expandedDimensions(weights, axis: weights.ndim)).sum(axis: -2)
+    }
+}
+
+final class DiffusionGemmaMLP: Module {
+    @ModuleInfo(key: "gate_proj") var gateProj: Linear
+    @ModuleInfo(key: "up_proj") var upProj: Linear
+    @ModuleInfo(key: "down_proj") var downProj: Linear
+
+    init(config: DiffusionGemmaTextConfig) {
+        _gateProj.wrappedValue = Linear(config.hiddenSize, config.intermediateSize, bias: false)
+        _upProj.wrappedValue = Linear(config.hiddenSize, config.intermediateSize, bias: false)
+        _downProj.wrappedValue = Linear(config.intermediateSize, config.hiddenSize, bias: false)
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> MLXArray {
+        downProj(geluApproximate(gateProj(x)) * upProj(x))
+    }
+}
+
+final class DiffusionGemmaRouter: Module {
+    @ModuleInfo(key: "proj") var proj: Linear
+    @ParameterInfo(key: "scale") var scale: MLXArray
+    @ParameterInfo(key: "per_expert_scale") var perExpertScale: MLXArray
+
+    private let topK: Int
+    private let eps: Float
+    private let rootSize: Float
+
+    init(config: DiffusionGemmaTextConfig) {
+        topK = config.topKExperts
+        eps = config.rmsNormEps
+        rootSize = pow(Float(config.hiddenSize), -0.5)
+        _proj.wrappedValue = Linear(config.hiddenSize, config.numExperts, bias: false)
+        _scale.wrappedValue = MLXArray.ones([config.hiddenSize])
+        _perExpertScale.wrappedValue = MLXArray.ones([config.numExperts])
+        super.init()
+    }
+
+    func callAsFunction(_ x: MLXArray) -> (indices: MLXArray, weights: MLXArray) {
+        let normWeight = scale * MLXArray(rootSize).asType(scale.dtype)
+        let scores = proj(MLXFast.rmsNorm(x, weight: normWeight, eps: eps))
+        let k = min(topK, scores.dim(-1))
+        let indices = argPartition(-scores, kth: k - 1, axis: -1)[.ellipsis, 0..<k]
+        var weights = softmax(takeAlong(scores, indices, axis: -1), axis: -1)
+        weights = weights * take(perExpertScale, indices, axis: 0)
+        return (indices, weights)
+    }
+}
+
+final class DiffusionGemmaAttention: Module {
+    @ModuleInfo(key: "q_proj") var qProj: Linear
+    @ModuleInfo(key: "k_proj") var kProj: Linear
+    @ModuleInfo(key: "v_proj") var vProj: Linear?
+    @ModuleInfo(key: "o_proj") var oProj: Linear
+    @ModuleInfo(key: "q_norm") var qNorm: RMSNorm
+    @ModuleInfo(key: "k_norm") var kNorm: RMSNorm
+
+    let layerType: String
+    private let numHeads: Int
+    private let numKVHeads: Int
+    private let headDim: Int
+    private let slidingWindow: Int
+    private let rope: any OffsetLayer
+    private let eps: Float
+
+    init(config: DiffusionGemmaTextConfig, layerIndex: Int) {
+        layerType = config.layerTypes[layerIndex]
+        let full = layerType == "full_attention"
+        numHeads = config.numAttentionHeads
+        numKVHeads = full ? config.numGlobalKeyValueHeads : config.numKeyValueHeads
+        headDim = full ? config.globalHeadDim : config.headDim
+        slidingWindow = config.slidingWindow
+        eps = config.rmsNormEps
+
+        let ropeConfig = config.ropeParameters[layerType]
+        if ropeConfig?.ropeType == "proportional" {
+            rope = Gemma4ProportionalRoPE(
+                dims: headDim,
+                base: ropeConfig?.ropeTheta ?? 1_000_000,
+                partialRotaryFactor: ropeConfig?.partialRotaryFactor ?? 0.25
+            )
+        } else {
+            rope = RoPE(
+                dimensions: headDim,
+                traditional: false,
+                base: ropeConfig?.ropeTheta ?? 10_000
+            )
+        }
+
+        _qProj.wrappedValue = Linear(config.hiddenSize, numHeads * headDim, bias: false)
+        _kProj.wrappedValue = Linear(config.hiddenSize, numKVHeads * headDim, bias: false)
+        _vProj.wrappedValue = full ? nil : Linear(config.hiddenSize, numKVHeads * headDim, bias: false)
+        _oProj.wrappedValue = Linear(numHeads * headDim, config.hiddenSize, bias: false)
+        _qNorm.wrappedValue = RMSNorm(dimensions: headDim, eps: config.rmsNormEps)
+        _kNorm.wrappedValue = RMSNorm(dimensions: headDim, eps: config.rmsNormEps)
+        super.init()
+    }
+
+    func causal(_ x: MLXArray, cache: Gemma4AttentionCache) -> MLXArray {
+        let queryOffset = cache.offset
+        let projected = project(x, offset: queryOffset)
+        guard let state = cache.attentionState(appending: projected.keys, values: projected.values) else {
+            preconditionFailure("DiffusionGemma cache failed to retain appended state.")
+        }
+        let mask = causalMask(
+            queryLength: x.dim(1),
+            queryOffset: queryOffset,
+            keyLength: state.0.dim(2),
+            dtype: x.dtype
+        )
+        return attend(projected.queries, keys: state.0, values: state.1, mask: mask, input: x)
+    }
+
+    func canvas(_ x: MLXArray, cache: Gemma4AttentionCache) -> MLXArray {
+        let projected = project(x, offset: cache.offset)
+        var prefix = cache.currentState()
+        if layerType == "sliding_attention", let state = prefix {
+            let keep = max(0, slidingWindow - 1)
+            if state.0.dim(2) > keep {
+                let start = state.0.dim(2) - keep
+                prefix = (
+                    state.0[0..., 0..., start..., 0...],
+                    state.1[0..., 0..., start..., 0...]
+                )
+            }
+        }
+        let keys = prefix.map { concatenated([$0.0, projected.keys], axis: 2) } ?? projected.keys
+        let values = prefix.map { concatenated([$0.1, projected.values], axis: 2) } ?? projected.values
+        return attend(projected.queries, keys: keys, values: values, mask: .none, input: x)
+    }
+
+    private func project(_ x: MLXArray, offset: Int) -> (
+        queries: MLXArray,
+        keys: MLXArray,
+        values: MLXArray
+    ) {
+        let batch = x.dim(0)
+        let length = x.dim(1)
+        var queries = qNorm(qProj(x).reshaped(batch, length, numHeads, headDim))
+            .transposed(0, 2, 1, 3)
+        queries = rope(queries, offset: offset)
+        let rawKeys = kProj(x)
+        var keys = kNorm(rawKeys.reshaped(batch, length, numKVHeads, headDim))
+            .transposed(0, 2, 1, 3)
+        keys = rope(keys, offset: offset)
+        let rawValues = vProj?(x) ?? rawKeys
+        let values = gemma4RMSNormNoScale(
+            rawValues.reshaped(batch, length, numKVHeads, headDim),
+            eps: eps
+        ).transposed(0, 2, 1, 3)
+        return (queries, keys, values)
+    }
+
+    private func attend(
+        _ queries: MLXArray,
+        keys: MLXArray,
+        values: MLXArray,
+        mask: MLXFast.ScaledDotProductAttentionMaskMode,
+        input: MLXArray
+    ) -> MLXArray {
+        let attended = MLXFast.scaledDotProductAttention(
+            queries: queries,
+            keys: keys,
+            values: values,
+            scale: 1,
+            mask: mask
+        )
+        return oProj(attended.transposed(0, 2, 1, 3).reshaped(
+            input.dim(0),
+            input.dim(1),
+            numHeads * headDim
+        ))
+    }
+
+    private func causalMask(
+        queryLength: Int,
+        queryOffset: Int,
+        keyLength: Int,
+        dtype: DType
+    ) -> MLXFast.ScaledDotProductAttentionMaskMode {
+        guard queryLength > 1 else { return .none }
+        let keyStart = max(0, queryOffset + queryLength - keyLength)
+        let queries = MLXArray(Int32(queryOffset)..<Int32(queryOffset + queryLength)).reshaped(queryLength, 1)
+        let keys = MLXArray(Int32(keyStart)..<Int32(keyStart + keyLength)).reshaped(1, keyLength)
+        var allowed = keys .<= queries
+        if layerType == "sliding_attention" {
+            allowed = allowed .&& (keys .> (queries - Int32(slidingWindow)))
+        }
+        let typed = allowed.asType(dtype).reshaped(1, 1, queryLength, keyLength)
+        let zeros = MLXArray.zeros(typed.shape, dtype: dtype)
+        let negative = zeros + MLXArray(-1e9).asType(dtype)
+        return .array(MLX.where(typed .> MLXArray(0).asType(dtype), zeros, negative))
+    }
+}
+
+final class DiffusionGemmaDecoderLayer: Module {
+    @ModuleInfo(key: "self_attn") var selfAttention: DiffusionGemmaAttention
+    @ModuleInfo(key: "mlp") var mlp: DiffusionGemmaMLP
+    @ModuleInfo(key: "router") var router: DiffusionGemmaRouter
+    @ModuleInfo(key: "experts") var experts: DiffusionGemmaExperts
+    @ModuleInfo(key: "input_layernorm") var inputLayerNorm: RMSNorm
+    @ModuleInfo(key: "post_attention_layernorm") var postAttentionLayerNorm: RMSNorm
+    @ModuleInfo(key: "pre_feedforward_layernorm") var preFeedforwardLayerNorm: RMSNorm
+    @ModuleInfo(key: "post_feedforward_layernorm") var postFeedforwardLayerNorm: RMSNorm
+    @ModuleInfo(key: "pre_feedforward_layernorm_2") var preFeedforwardLayerNorm2: RMSNorm
+    @ModuleInfo(key: "post_feedforward_layernorm_1") var postFeedforwardLayerNorm1: RMSNorm
+    @ModuleInfo(key: "post_feedforward_layernorm_2") var postFeedforwardLayerNorm2: RMSNorm
+    @ParameterInfo(key: "layer_scalar") var layerScalar: MLXArray
+
+    init(
+        config: DiffusionGemmaTextConfig,
+        quantization: DiffusionGemmaQuantizationConfig,
+        layerIndex: Int
+    ) {
+        _selfAttention.wrappedValue = DiffusionGemmaAttention(config: config, layerIndex: layerIndex)
+        _mlp.wrappedValue = DiffusionGemmaMLP(config: config)
+        _router.wrappedValue = DiffusionGemmaRouter(config: config)
+        _experts.wrappedValue = DiffusionGemmaExperts(
+            config: config,
+            quantization: quantization,
+            layerIndex: layerIndex
+        )
+        _inputLayerNorm.wrappedValue = RMSNorm(dimensions: config.hiddenSize, eps: config.rmsNormEps)
+        _postAttentionLayerNorm.wrappedValue = RMSNorm(dimensions: config.hiddenSize, eps: config.rmsNormEps)
+        _preFeedforwardLayerNorm.wrappedValue = RMSNorm(dimensions: config.hiddenSize, eps: config.rmsNormEps)
+        _postFeedforwardLayerNorm.wrappedValue = RMSNorm(dimensions: config.hiddenSize, eps: config.rmsNormEps)
+        _preFeedforwardLayerNorm2.wrappedValue = RMSNorm(dimensions: config.hiddenSize, eps: config.rmsNormEps)
+        _postFeedforwardLayerNorm1.wrappedValue = RMSNorm(dimensions: config.hiddenSize, eps: config.rmsNormEps)
+        _postFeedforwardLayerNorm2.wrappedValue = RMSNorm(dimensions: config.hiddenSize, eps: config.rmsNormEps)
+        _layerScalar.wrappedValue = MLXArray.ones([1])
+        super.init()
+    }
+
+    func callAsFunction(
+        _ x: MLXArray,
+        cache: Gemma4AttentionCache,
+        decoder: Bool,
+        scalar: MLXArray? = nil
+    ) -> MLXArray {
+        let attentionResidual = x
+        var hidden = inputLayerNorm(x)
+        hidden = decoder
+            ? selfAttention.canvas(hidden, cache: cache)
+            : selfAttention.causal(hidden, cache: cache)
+        hidden = attentionResidual + postAttentionLayerNorm(hidden)
+
+        let feedForwardResidual = hidden
+        var dense = mlp(preFeedforwardLayerNorm(hidden))
+        dense = postFeedforwardLayerNorm1(dense)
+
+        let route = router(hidden)
+        var sparse = experts(
+            preFeedforwardLayerNorm2(hidden),
+            indices: route.indices,
+            weights: route.weights
+        )
+        sparse = postFeedforwardLayerNorm2(sparse)
+
+        hidden = feedForwardResidual + postFeedforwardLayerNorm(dense + sparse)
+        return hidden * (scalar ?? layerScalar)
+    }
+}
+
+final class DiffusionGemmaSelfConditioning: Module {
+    @ModuleInfo(key: "pre_norm") var preNorm: RMSNorm
+    @ModuleInfo(key: "post_norm") var postNorm: RMSNorm
+    @ModuleInfo(key: "gate_proj") var gateProj: Linear
+    @ModuleInfo(key: "up_proj") var upProj: Linear
+    @ModuleInfo(key: "down_proj") var downProj: Linear
+
+    private let eps: Float
+
+    init(config: DiffusionGemmaTextConfig) {
+        eps = config.rmsNormEps
+        _preNorm.wrappedValue = RMSNorm(dimensions: config.hiddenSize, eps: config.rmsNormEps)
+        _postNorm.wrappedValue = RMSNorm(dimensions: config.hiddenSize, eps: config.rmsNormEps)
+        _gateProj.wrappedValue = Linear(config.hiddenSize, config.intermediateSize, bias: false)
+        _upProj.wrappedValue = Linear(config.hiddenSize, config.intermediateSize, bias: false)
+        _downProj.wrappedValue = Linear(config.intermediateSize, config.hiddenSize, bias: false)
+        super.init()
+    }
+
+    func callAsFunction(_ embeddings: MLXArray, signal: MLXArray) -> MLXArray {
+        let normed = preNorm(signal)
+        let projected = downProj(geluApproximate(gateProj(normed)) * upProj(normed))
+        return gemma4RMSNormNoScale(embeddings + projected, eps: eps)
+    }
+}
+
+final class DiffusionGemmaDecoder: Module {
+    @ModuleInfo(key: "embed_tokens") var embedTokens: Embedding
+    @ModuleInfo(key: "layers") var layers: [DiffusionGemmaDecoderLayer]
+    @ModuleInfo(key: "norm") var norm: RMSNorm
+    @ModuleInfo(key: "self_conditioning") var selfConditioning: DiffusionGemmaSelfConditioning
+
+    let config: DiffusionGemmaTextConfig
+    private let embedScale: Float
+
+    init(config: DiffusionGemmaConfig) {
+        self.config = config.textConfig
+        embedScale = sqrt(Float(config.textConfig.hiddenSize))
+        _embedTokens.wrappedValue = Embedding(
+            embeddingCount: config.textConfig.vocabSize,
+            dimensions: config.textConfig.hiddenSize
+        )
+        _layers.wrappedValue = (0..<config.textConfig.numHiddenLayers).map {
+            DiffusionGemmaDecoderLayer(
+                config: config.textConfig,
+                quantization: config.quantization,
+                layerIndex: $0
+            )
+        }
+        _norm.wrappedValue = RMSNorm(
+            dimensions: config.textConfig.hiddenSize,
+            eps: config.textConfig.rmsNormEps
+        )
+        _selfConditioning.wrappedValue = DiffusionGemmaSelfConditioning(config: config.textConfig)
+        super.init()
+    }
+
+    func embeddings(_ tokenIds: MLXArray) -> MLXArray {
+        embedTokens(tokenIds.asType(.int32)) * MLXArray(embedScale).asType(embedTokens.weight.dtype)
+    }
+
+    func causal(
+        _ tokenIds: MLXArray,
+        caches: [Gemma4AttentionCache],
+        encoderScalars: [MLXArray]
+    ) {
+        var hidden = embeddings(tokenIds)
+        for index in layers.indices {
+            hidden = layers[index](
+                hidden,
+                cache: caches[index],
+                decoder: false,
+                scalar: encoderScalars[index]
+            )
+        }
+        _ = norm(hidden)
+    }
+
+    func canvasLogits(
+        _ tokenIds: MLXArray,
+        caches: [Gemma4AttentionCache],
+        selfConditioningLogits: MLXArray?
+    ) -> MLXArray {
+        var hidden = embeddings(tokenIds)
+        if let selfConditioningLogits,
+           let quantizedEmbedding = embedTokens as? PreQuantizedEmbedding {
+            let probabilities = softmax(selfConditioningLogits, axis: -1)
+            let signal = quantizedMM(
+                probabilities.asType(hidden.dtype),
+                quantizedEmbedding.weight,
+                scales: quantizedEmbedding.scales,
+                biases: quantizedEmbedding.biases,
+                transpose: false,
+                groupSize: quantizedEmbedding.groupSize,
+                bits: quantizedEmbedding.bits,
+                mode: quantizedEmbedding.mode
+            ) * MLXArray(embedScale).asType(hidden.dtype)
+            hidden = selfConditioning(hidden, signal: signal)
+        } else {
+            hidden = selfConditioning(hidden, signal: MLXArray.zeros(hidden.shape, dtype: hidden.dtype))
+        }
+        for index in layers.indices {
+            hidden = layers[index](hidden, cache: caches[index], decoder: true)
+        }
+        var logits = embedTokens.asLinear(norm(hidden))
+        let softcap = MLXArray(config.finalLogitSoftcapping).asType(.float32)
+        logits = tanh(logits.asType(.float32) / softcap) * softcap
+        return logits
+    }
+
+    func makeCaches() -> [Gemma4AttentionCache] {
+        config.layerTypes.map { layerType -> Gemma4AttentionCache in
+            if layerType == "full_attention" {
+                return Gemma4FullKVCache()
+            }
+            return Gemma4SlidingKVCache(maxSize: config.slidingWindow)
+        }
+    }
+}
+
+final class DiffusionGemmaEncoderScalar: Module {
+    @ParameterInfo(key: "layer_scalar") var layerScalar: MLXArray
+
+    override init() {
+        _layerScalar.wrappedValue = MLXArray.ones([1])
+        super.init()
+    }
+}
+
+final class DiffusionGemmaEncoderLanguageModel: Module {
+    @ModuleInfo(key: "layers") var layers: [DiffusionGemmaEncoderScalar]
+
+    init(layerCount: Int) {
+        _layers.wrappedValue = (0..<layerCount).map { _ in DiffusionGemmaEncoderScalar() }
+        super.init()
+    }
+}
+
+final class DiffusionGemmaEncoder: Module {
+    @ModuleInfo(key: "language_model") var languageModel: DiffusionGemmaEncoderLanguageModel
+
+    init(layerCount: Int) {
+        _languageModel.wrappedValue = DiffusionGemmaEncoderLanguageModel(layerCount: layerCount)
+        super.init()
+    }
+}
+
+final class DiffusionGemmaBackbone: Module {
+    @ModuleInfo(key: "decoder") var decoder: DiffusionGemmaDecoder
+    @ModuleInfo(key: "encoder") var encoder: DiffusionGemmaEncoder
+
+    init(config: DiffusionGemmaConfig) {
+        _decoder.wrappedValue = DiffusionGemmaDecoder(config: config)
+        _encoder.wrappedValue = DiffusionGemmaEncoder(layerCount: config.textConfig.numHiddenLayers)
+        super.init()
+    }
+}
+
+public final class DiffusionGemmaLanguageModel: Module, @unchecked Sendable {
+    @ModuleInfo(key: "model") var model: DiffusionGemmaBackbone
+
+    public let config: DiffusionGemmaConfig
+
+    public init(config: DiffusionGemmaConfig) {
+        self.config = config
+        _model.wrappedValue = DiffusionGemmaBackbone(config: config)
+        super.init()
+    }
+
+    func makeCaches() -> [Gemma4AttentionCache] {
+        model.decoder.makeCaches()
+    }
+
+    func updateCache(_ tokenIds: MLXArray, caches: [Gemma4AttentionCache]) {
+        model.decoder.causal(
+            tokenIds,
+            caches: caches,
+            encoderScalars: model.encoder.languageModel.layers.map(\.layerScalar)
+        )
+    }
+
+    func canvasLogits(
+        _ tokenIds: MLXArray,
+        caches: [Gemma4AttentionCache],
+        selfConditioningLogits: MLXArray?
+    ) -> MLXArray {
+        model.decoder.canvasLogits(
+            tokenIds,
+            caches: caches,
+            selfConditioningLogits: selfConditioningLogits
+        )
+    }
+}

--- a/Sources/MereRunCore/DiffusionGemma/DiffusionGemmaResources.swift
+++ b/Sources/MereRunCore/DiffusionGemma/DiffusionGemmaResources.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+public struct DiffusionGemmaResources: Sendable, Hashable {
+    public static let modelID = "text-chat-diffusiongemma-26b-optiq-4bit"
+    public static let upstreamModelID = "mlx-community/diffusiongemma-26B-A4B-it-OptiQ-4bit"
+    public static let upstreamRevision = "30f3c7c7746bf41cfd1a290155cc3b777ab588b9"
+    public static let estimatedDownloadBytes: Int64 = 17_852_058_816
+    public static let defaultContextLength = 32_768
+    public static let maximumCanvasLength = 256
+    public static let snapshotPatterns = [
+        ".gitattributes",
+        "README.md",
+        "chat_template.jinja",
+        "config.json",
+        "generation_config.json",
+        "model.safetensors.index.json",
+        "*.safetensors",
+        "optiq/optiq_vision.safetensors",
+        "optiq_metadata.json",
+        "processor_config.json",
+        "tokenizer.json",
+        "tokenizer_config.json",
+    ]
+
+    public let rootURL: URL
+
+    public init(rootURL: URL) {
+        self.rootURL = rootURL.standardizedFileURL
+    }
+
+    public var configURL: URL { rootURL.appending(path: "config.json") }
+    public var generationConfigURL: URL { rootURL.appending(path: "generation_config.json") }
+    public var chatTemplateURL: URL { rootURL.appending(path: "chat_template.jinja") }
+    public var modelIndexURL: URL { rootURL.appending(path: "model.safetensors.index.json") }
+    public var tokenizerURL: URL { rootURL.appending(path: "tokenizer.json") }
+    public var tokenizerConfigURL: URL { rootURL.appending(path: "tokenizer_config.json") }
+    public var visionWeightsURL: URL { rootURL.appending(path: "optiq/optiq_vision.safetensors") }
+
+    public var modelShardURLs: [URL] {
+        (1...4).map {
+            rootURL.appending(path: String(format: "model-%05d-of-00004.safetensors", $0))
+        }
+    }
+
+    public func validate(fileManager: FileManager = .default, requireVision: Bool = false) -> [URL] {
+        var required = [
+            chatTemplateURL,
+            configURL,
+            generationConfigURL,
+            modelIndexURL,
+            tokenizerURL,
+            tokenizerConfigURL,
+        ] + modelShardURLs
+        if requireVision {
+            required.append(visionWeightsURL)
+        }
+        return required.filter { !fileManager.fileExists(atPath: $0.path) }
+    }
+}
+
+public enum DiffusionGemmaError: LocalizedError {
+    case missingFiles([String])
+    case unsupportedConfiguration(String)
+    case unsupportedModelLocation(String)
+    case downloadFailed(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .missingFiles(let files):
+            return "Missing required DiffusionGemma files: \(files.joined(separator: ", "))"
+        case .unsupportedConfiguration(let message):
+            return message
+        case .unsupportedModelLocation(let location):
+            return "Could not resolve DiffusionGemma model location: \(location)"
+        case .downloadFailed(let message):
+            return "DiffusionGemma download failed: \(message)"
+        }
+    }
+}

--- a/Sources/MereRunCore/DiffusionGemma/README.md
+++ b/Sources/MereRunCore/DiffusionGemma/README.md
@@ -1,0 +1,17 @@
+# DiffusionGemma
+
+This module describes the native MLX text-generation runtime for contributors
+working on DiffusionGemma checkpoints.
+DiffusionGemma uses a causal encoder to cache the prompt and completed blocks,
+then denoises a bidirectional token canvas in parallel. It is not compatible
+with the autoregressive Gemma4 runtime.
+
+The managed checkpoint is the revision-pinned OptiQ 4-bit conversion. Its
+ordinary projections and shared embedding are loaded through mere.run's
+portable affine quantization path. Routed experts keep their fused
+`gate_up_proj` and `down_proj` layout and use gather-quantized matrix
+multiplication directly.
+
+The runtime supports text generation. The checkpoint's separate BF16 vision
+sidecar is downloaded and validated, but the runtime rejects image input
+because that path has no real-checkpoint qualification.

--- a/Sources/MereRunCore/Gemma4/Gemma4Model.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4Model.swift
@@ -6,7 +6,7 @@ import MLXRandom
 import Cmlx
 
 @inline(__always)
-private func gemma4RMSNormNoScale(_ x: MLXArray, eps: Float) -> MLXArray {
+func gemma4RMSNormNoScale(_ x: MLXArray, eps: Float) -> MLXArray {
     let noWeight = MLXArray.mlxNone
     let stream = StreamOrDevice.default
     var result = mlx_array_new()
@@ -17,7 +17,7 @@ private func gemma4RMSNormNoScale(_ x: MLXArray, eps: Float) -> MLXArray {
 }
 
 @inline(__always)
-private func gemma4RMSNormNoScale(_ x: MLXArray, weight: MLXArray, eps: Float) -> MLXArray {
+func gemma4RMSNormNoScale(_ x: MLXArray, weight: MLXArray, eps: Float) -> MLXArray {
     MLXFast.rmsNorm(x, weight: weight, eps: eps)
 }
 

--- a/Sources/MereRunCore/Generation.swift
+++ b/Sources/MereRunCore/Generation.swift
@@ -469,6 +469,8 @@ public struct ChatRequest: Sendable, Hashable {
     public var topK: Int?
     /// Min-p sampling cutoff relative to the most likely token; zero disables it.
     public var minP: Double
+    /// Optional deterministic seed for runtimes with an explicit random canvas or sampler.
+    public var seed: UInt64?
     /// Model-specific reasoning budget. Inkling-Small accepts values from 0 through 0.99.
     public var reasoningEffort: Double?
     public var showThinking: Bool
@@ -489,6 +491,8 @@ public struct ChatRequest: Sendable, Hashable {
     /// Optional semantic region for visible generated tokens. Reasoning and
     /// protocol markup detected by the runtime override this hint.
     public var logprobRegionHint: ChatLogprobRegion?
+    /// Emit revision-aware masked-diffusion drafts through `ChatProgress`.
+    public var showUnmasking: Bool
 
     public init(
         messages: [ChatMessage],
@@ -497,6 +501,7 @@ public struct ChatRequest: Sendable, Hashable {
         topP: Double = 0.9,
         topK: Int? = nil,
         minP: Double = 0,
+        seed: UInt64? = nil,
         reasoningEffort: Double? = nil,
         showThinking: Bool = true,
         lora: LoRA? = nil,
@@ -510,7 +515,8 @@ public struct ChatRequest: Sendable, Hashable {
         kvCacheMode: RuntimeKVCacheMode? = nil,
         maxContextTokens: Int? = nil,
         logprobCapture: ChatLogprobCapture = .none,
-        logprobRegionHint: ChatLogprobRegion? = nil
+        logprobRegionHint: ChatLogprobRegion? = nil,
+        showUnmasking: Bool = false
     ) {
         self.messages = messages
         self.maxTokens = maxTokens
@@ -518,6 +524,7 @@ public struct ChatRequest: Sendable, Hashable {
         self.topP = topP
         self.topK = topK
         self.minP = minP
+        self.seed = seed
         self.reasoningEffort = reasoningEffort
         self.showThinking = showThinking
         self.lora = lora
@@ -532,6 +539,35 @@ public struct ChatRequest: Sendable, Hashable {
         self.maxContextTokens = maxContextTokens
         self.logprobCapture = logprobCapture
         self.logprobRegionHint = logprobRegionHint
+        self.showUnmasking = showUnmasking
+    }
+}
+
+public struct ChatDiffusionDiagnostics: Codable, Sendable, Hashable {
+    public let seed: UInt64
+    public let canvasTokens: Int
+    public let denoisingSteps: Int
+    public let workTokens: Int
+    public let canvasTokensPerSecond: Double
+    public let workTokensPerSecond: Double
+    public let firstDraftSeconds: Double?
+
+    public init(
+        seed: UInt64,
+        canvasTokens: Int,
+        denoisingSteps: Int,
+        workTokens: Int,
+        canvasTokensPerSecond: Double,
+        workTokensPerSecond: Double,
+        firstDraftSeconds: Double? = nil
+    ) {
+        self.seed = seed
+        self.canvasTokens = canvasTokens
+        self.denoisingSteps = denoisingSteps
+        self.workTokens = workTokens
+        self.canvasTokensPerSecond = canvasTokensPerSecond
+        self.workTokensPerSecond = workTokensPerSecond
+        self.firstDraftSeconds = firstDraftSeconds
     }
 }
 
@@ -613,6 +649,7 @@ public struct ChatResponse: Sendable, Hashable {
     public var hasReopenedReasoning: Bool
     public var logprobs: ChatLogprobDiagnostics?
     public var acceleration: ChatAccelerationDiagnostics?
+    public var diffusion: ChatDiffusionDiagnostics?
 
     public init(
         response: String,
@@ -626,7 +663,8 @@ public struct ChatResponse: Sendable, Hashable {
         reasoningBlockCount: Int = 0,
         hasReopenedReasoning: Bool = false,
         logprobs: ChatLogprobDiagnostics? = nil,
-        acceleration: ChatAccelerationDiagnostics? = nil
+        acceleration: ChatAccelerationDiagnostics? = nil,
+        diffusion: ChatDiffusionDiagnostics? = nil
     ) {
         self.response = response
         self.tokensGenerated = tokensGenerated
@@ -641,6 +679,7 @@ public struct ChatResponse: Sendable, Hashable {
         self.hasReopenedReasoning = hasReopenedReasoning
         self.logprobs = logprobs
         self.acceleration = acceleration
+        self.diffusion = diffusion
     }
 
     public init(
@@ -652,7 +691,8 @@ public struct ChatResponse: Sendable, Hashable {
         promptTokens: Int? = nil,
         finishReason: ChatFinishReason? = nil,
         logprobs: ChatLogprobDiagnostics? = nil,
-        acceleration: ChatAccelerationDiagnostics? = nil
+        acceleration: ChatAccelerationDiagnostics? = nil,
+        diffusion: ChatDiffusionDiagnostics? = nil
     ) {
         let split = ChatReasoningMarkup.splitThinkBlocks(in: generatedText)
         let visibleResponse = showThinking
@@ -670,7 +710,8 @@ public struct ChatResponse: Sendable, Hashable {
             reasoningBlockCount: split.reasoningBlockCount,
             hasReopenedReasoning: split.hasReopenedReasoning,
             logprobs: logprobs,
-            acceleration: acceleration
+            acceleration: acceleration,
+            diffusion: diffusion
         )
     }
 }
@@ -841,13 +882,41 @@ public enum ChatStage: String, Sendable, Hashable {
     case generating
 }
 
+public struct ChatDiffusionProgress: Sendable, Hashable {
+    public let draftText: String
+    public let step: Int
+    public let totalSteps: Int
+    public let canvasIndex: Int
+    public let blockComplete: Bool
+
+    public init(
+        draftText: String,
+        step: Int,
+        totalSteps: Int,
+        canvasIndex: Int,
+        blockComplete: Bool = false
+    ) {
+        self.draftText = draftText
+        self.step = step
+        self.totalSteps = totalSteps
+        self.canvasIndex = canvasIndex
+        self.blockComplete = blockComplete
+    }
+}
+
 public struct ChatProgress: Sendable, Hashable {
     public let stage: ChatStage
     public let message: String?
+    public let diffusion: ChatDiffusionProgress?
 
-    public init(stage: ChatStage, message: String? = nil) {
+    public init(
+        stage: ChatStage,
+        message: String? = nil,
+        diffusion: ChatDiffusionProgress? = nil
+    ) {
         self.stage = stage
         self.message = message
+        self.diffusion = diffusion
     }
 }
 

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -212,6 +212,17 @@ public extension ManagedModelAPIProfile {
         )
     }
 
+    static func diffusionGemma() -> ManagedModelAPIProfile {
+        chat(
+            servingEngine: .textChatDiffusionGemma,
+            contextWindow: DiffusionGemmaResources.defaultContextLength,
+            maximumOutputTokens: DiffusionGemmaResources.maximumCanvasLength,
+            toolCall: true,
+            supportsStopSequences: true,
+            supportsSeed: true
+        )
+    }
+
     static func laguna(contextWindow: Int = LagunaResources.defaultContextLength) -> ManagedModelAPIProfile {
         chat(
             servingEngine: .textChatLaguna,
@@ -366,6 +377,8 @@ public extension ManagedModelAPIProfile {
             return .klein()
         case .textChatGemma4:
             return .gemma4()
+        case .textChatDiffusionGemma:
+            return .diffusionGemma()
         case .textChatLaguna:
             return .laguna()
         case .textChatQ36, .textChatQ35:
@@ -500,6 +513,7 @@ public enum ManagedModelValidationKind: String, Hashable, Sendable {
     case qwenImageEdit
     case ideogram4SDNQ
     case gemma4
+    case diffusionGemma
     case gemma4Unified
     case gemma4MTPAssistant
     case laguna
@@ -1560,6 +1574,22 @@ public enum ManagedModelCatalog {
             estimatedDownloadBytes: 62_578_654_199,
             defaultCLICommands: ["text chat", "text train-lora", "api serve"],
             apiProfile: .gemma4()
+        ),
+        ManagedModelSpec(
+            id: DiffusionGemmaResources.modelID,
+            category: .textChat,
+            installShape: .directoryRoot,
+            hubFallback: HubFallbackConfig(
+                repoId: DiffusionGemmaResources.upstreamModelID,
+                revision: DiffusionGemmaResources.upstreamRevision,
+                patterns: DiffusionGemmaResources.snapshotPatterns
+            ),
+            upstreamRepoId: DiffusionGemmaResources.upstreamModelID,
+            upstreamRevision: DiffusionGemmaResources.upstreamRevision,
+            validationKind: .diffusionGemma,
+            estimatedDownloadBytes: DiffusionGemmaResources.estimatedDownloadBytes,
+            defaultCLICommands: ["text chat", "api serve"],
+            apiProfile: .diffusionGemma()
         ),
         ManagedModelSpec(
             id: Gemma4Resources.turboModelId,
@@ -4183,6 +4213,11 @@ public extension ManagedModelSpec {
             return Ideogram4Resources(rootURL: rootURL).validate(fileManager: fileManager)
         case .gemma4:
             return Gemma4Resources(rootURL: rootURL).validate(fileManager: fileManager)
+        case .diffusionGemma:
+            return DiffusionGemmaResources(rootURL: rootURL).validate(
+                fileManager: fileManager,
+                requireVision: true
+            )
         case .gemma4Unified:
             return Gemma4Resources(rootURL: rootURL).validate(
                 fileManager: fileManager,

--- a/Sources/MereRunCore/ManagedModelSupport.swift
+++ b/Sources/MereRunCore/ManagedModelSupport.swift
@@ -358,6 +358,13 @@ public enum ManagedModelCapabilityCatalog {
                 recommended: 64
             ),
             descriptor(
+                DiffusionGemmaResources.modelID,
+                "DiffusionGemma 26B-A4B OptiQ",
+                "Runs the mixed 4-bit and 8-bit DiffusionGemma checkpoint through native Swift/MLX parallel block denoising.",
+                minimum: 48,
+                recommended: 64
+            ),
+            descriptor(
                 Gemma4Resources.turboModelId,
                 "Gemma 4 NVFP4 MoE",
                 "Installs the MLX NVFP4 Gemma 4 26B-A4B-it MoE snapshot for the native Swift 32 GB tier.",

--- a/Sources/MereRunCore/MereRunModelManifest.swift
+++ b/Sources/MereRunCore/MereRunModelManifest.swift
@@ -887,6 +887,22 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
                 upstreamRepoId: Gemma4Resources.turboUpstreamModelId,
                 createdAt: createdAt
             )
+        case .diffusionGemma26BOptiQ4Bit:
+            return MereRunModelManifest(
+                id: modelID.rawValue,
+                engine: .gemma4,
+                family: .gemma,
+                tier: .max,
+                variant: .standard,
+                precision: .int4,
+                quantization: Quantization(bits: 4, groupSize: 64, scheme: "optiq-mixed-affine"),
+                defaults: nil,
+                supports: [.chat, .codeGeneration],
+                components: gemma4TextComponents,
+                upstreamRepoId: DiffusionGemmaResources.upstreamModelID
+                    + "@\(DiffusionGemmaResources.upstreamRevision)",
+                createdAt: createdAt
+            )
         case .gemma4TwelveB:
             return MereRunModelManifest(
                 id: modelID.rawValue,

--- a/Sources/MereRunCore/ModelResolver.swift
+++ b/Sources/MereRunCore/ModelResolver.swift
@@ -34,6 +34,7 @@ public struct ModelResolver {
         case gemma4Nano = "text-chat-gemma4-nano"
         case gemma4Max = "text-chat-gemma4-max"
         case gemma4Turbo = "text-chat-gemma4-turbo"
+        case diffusionGemma26BOptiQ4Bit = "text-chat-diffusiongemma-26b-optiq-4bit"
         case gemma4TwelveB = "text-chat-gemma4-12b"
         case gemma4TwelveB4Bit = "text-chat-gemma4-12b-4bit"
         case gemma4VisionTwelveB = "vision-chat-gemma4-12b"

--- a/Sources/MereRunCore/RuntimeModelSettings.swift
+++ b/Sources/MereRunCore/RuntimeModelSettings.swift
@@ -4,6 +4,7 @@ public enum RuntimeServingEngine: String, Codable, CaseIterable, Hashable, Senda
     case textCode = "text-code"
     case textChatKlein = "text-chat-klein"
     case textChatGemma4 = "text-chat-gemma4"
+    case textChatDiffusionGemma = "text-chat-diffusiongemma"
     case textChatLaguna = "text-chat-laguna"
     case textChatQ36 = "text-chat-q36"
     case textChatQ35 = "text-chat-q35"

--- a/Tests/MereRunCLITests/APIServeCommandTests.swift
+++ b/Tests/MereRunCLITests/APIServeCommandTests.swift
@@ -110,6 +110,20 @@ final class APIServeCommandTests: XCTestCase {
         XCTAssertFalse(cmd.engine.openAICompatibility.supportsStructuredOutputs)
     }
 
+    func testAPIServeParsesDiffusionGemmaEngine() throws {
+        let cmd = try APIServe.parse([
+            "--engine", "text-chat-diffusiongemma",
+            "--model", DiffusionGemmaResources.modelID,
+        ])
+
+        XCTAssertEqual(cmd.engine, .textChatDiffusionGemma)
+        XCTAssertEqual(cmd.model, DiffusionGemmaResources.modelID)
+        XCTAssertEqual(cmd.defaultRuntimeModelID(modelPath: nil), DiffusionGemmaResources.modelID)
+        XCTAssertTrue(cmd.engine.openAICompatibility.supportsTools)
+        XCTAssertFalse(cmd.engine.openAICompatibility.supportsVisionContentParts)
+        XCTAssertFalse(cmd.engine.openAICompatibility.supportsStructuredOutputs)
+    }
+
     func testAPIServeParsesNemotronHNativeEngine() throws {
         let cmd = try APIServe.parse([
             "--engine", "text-chat-nemotron-h",
@@ -2876,6 +2890,73 @@ final class APIServeCommandTests: XCTestCase {
         }
     }
 
+    func testDiffusionGemmaRequestMapsSeedAndProgressiveUnmasking() throws {
+        let profile = try XCTUnwrap(
+            ManagedModelCatalog.apiProfile(for: DiffusionGemmaResources.modelID)
+        )
+        let request = OpenAIChatRequest(
+            model: DiffusionGemmaResources.modelID,
+            messages: [OpenAIChatMessage(role: "user", content: "hello")],
+            max_tokens: 128,
+            stream: true,
+            seed: 123,
+            mere_show_unmasking: true
+        )
+
+        let chatRequest = try APIServerContract.chatRequest(
+            from: request,
+            fallbackLoraPath: nil,
+            contextSize: DiffusionGemmaResources.defaultContextLength,
+            capabilities: .catalog(profile),
+            servedModelID: DiffusionGemmaResources.modelID,
+            apiProfile: profile
+        )
+
+        XCTAssertEqual(chatRequest.seed, 123)
+        XCTAssertTrue(chatRequest.showUnmasking)
+    }
+
+    func testDiffusionGemmaRequestRejectsNegativeSeed() throws {
+        let profile = try XCTUnwrap(
+            ManagedModelCatalog.apiProfile(for: DiffusionGemmaResources.modelID)
+        )
+        let request = OpenAIChatRequest(
+            model: DiffusionGemmaResources.modelID,
+            messages: [OpenAIChatMessage(role: "user", content: "hello")],
+            seed: -1
+        )
+
+        XCTAssertThrowsError(try APIServerContract.chatRequest(
+            from: request,
+            fallbackLoraPath: nil,
+            contextSize: DiffusionGemmaResources.defaultContextLength,
+            capabilities: .catalog(profile),
+            servedModelID: DiffusionGemmaResources.modelID,
+            apiProfile: profile
+        )) { error in
+            XCTAssertTrue(error.localizedDescription.contains("unsigned"))
+        }
+    }
+
+    func testDiffusionDraftEncodesAsRevisionAwareDeltaExtension() throws {
+        let delta = OpenAIChatDelta(
+            mere_diffusion_draft: OpenAIDiffusionDraft(ChatDiffusionProgress(
+                draftText: "A [Mask] draft",
+                step: 4,
+                totalSteps: 48,
+                canvasIndex: 1
+            ))
+        )
+
+        let object = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: JSONEncoder().encode(delta)) as? [String: Any]
+        )
+        let draft = try XCTUnwrap(object["mere_diffusion_draft"] as? [String: Any])
+        XCTAssertEqual(draft["text"] as? String, "A [Mask] draft")
+        XCTAssertEqual(draft["step"] as? Int, 4)
+        XCTAssertEqual(draft["total_steps"] as? Int, 48)
+    }
+
     func testQ38LogprobRequestMapsToTopCapture() throws {
         let profile = try XCTUnwrap(
             ManagedModelCatalog.apiProfile(for: Q35Resources.q38TwentySevenB4BitModelId)
@@ -3132,7 +3213,16 @@ final class APIServeCommandTests: XCTestCase {
                 prefillTokensPerSecond: 100,
                 decodeTokensPerSecond: 2
             ),
-            promptTokens: 200
+            promptTokens: 200,
+            diffusion: ChatDiffusionDiagnostics(
+                seed: 123,
+                canvasTokens: 128,
+                denoisingSteps: 17,
+                workTokens: 2_176,
+                canvasTokensPerSecond: 42.7,
+                workTokensPerSecond: 726.1,
+                firstDraftSeconds: 0.3
+            )
         )
 
         let headers = CodeGenServer.openAITimingHeaders(for: result)
@@ -3142,6 +3232,11 @@ final class APIServeCommandTests: XCTestCase {
         XCTAssertEqual(headers["x-mere-prefill-tokens-per-second"], "100.000")
         XCTAssertEqual(headers["x-mere-decode-tokens-per-second"], "2.000")
         XCTAssertEqual(headers["x-mere-kv-cache"], "full-precision")
+        XCTAssertEqual(headers["x-mere-diffusion-seed"], "123")
+        XCTAssertEqual(headers["x-mere-diffusion-denoising-steps"], "17")
+        XCTAssertEqual(headers["x-mere-diffusion-work-tokens"], "2176")
+        XCTAssertEqual(headers["x-mere-diffusion-work-tokens-per-second"], "726.100")
+        XCTAssertEqual(headers["x-mere-diffusion-first-draft-seconds"], "0.300")
         XCTAssertEqual(
             headers["server-timing"],
             "model_load;dur=250.000, prefill;dur=2000.000, kv_pack;dur=125.000, "

--- a/Tests/MereRunCLITests/RuntimeModelPoolTests.swift
+++ b/Tests/MereRunCLITests/RuntimeModelPoolTests.swift
@@ -6,7 +6,11 @@ import XCTest
 final class RuntimeModelPoolTests: XCTestCase {
     private let gib = UInt64(1024 * 1024 * 1024)
 
-    func testDefaultWarmupCoversGemmaTurboAndQwen4ExpOnly() {
+    func testDefaultWarmupCoversDiffusionGemmaGemmaTurboAndQwen4Exp() {
+        XCTAssertTrue(RuntimeModelPool.shouldWarmDefaultModel(
+            modelID: DiffusionGemmaResources.modelID,
+            engine: .textChatDiffusionGemma
+        ))
         XCTAssertTrue(RuntimeModelPool.shouldWarmDefaultModel(
             modelID: Gemma4Resources.turboModelId,
             engine: .textChatGemma4

--- a/Tests/MereRunCLITests/TextChatCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/TextChatCommandParsingTests.swift
@@ -45,6 +45,61 @@ final class TextChatCommandParsingTests: XCTestCase {
         XCTAssertTrue(cmd.stream)
     }
 
+    func testTextChatParsesDiffusionGemmaModel() throws {
+        let cmd = try TextChat.parse([
+            "--model", DiffusionGemmaResources.modelID,
+            "--max-tokens", "256",
+            "--seed", "123",
+            "--show-unmasking",
+            "--prompt", "Explain block diffusion.",
+        ])
+
+        XCTAssertEqual(cmd.model, DiffusionGemmaResources.modelID)
+        XCTAssertEqual(cmd.maxTokens, DiffusionGemmaResources.maximumCanvasLength)
+        XCTAssertEqual(cmd.seed, 123)
+        XCTAssertTrue(cmd.showUnmasking)
+        XCTAssertNoThrow(try TextChat.validateDiffusionOptions(
+            seed: cmd.seed,
+            showUnmasking: cmd.showUnmasking,
+            modelID: cmd.model
+        ))
+    }
+
+    func testTextChatRejectsDiffusionOptionsForOtherModels() {
+        XCTAssertThrowsError(try TextChat.validateDiffusionOptions(
+            seed: 123,
+            showUnmasking: false,
+            modelID: Gemma4Resources.nanoModelId
+        ))
+    }
+
+    func testDiffusionDraftProgressUsesStderrWithoutMarkingFinalOutputStreamed() throws {
+        let stdout = TextOutputRecorder()
+        let stderr = TextOutputRecorder()
+        let streamingOutput = StreamingChatOutput(enabled: true, writer: stdout.write)
+        let progressHandler = try XCTUnwrap(TextChatProgressHandler.make(
+            quiet: false,
+            streamingOutput: streamingOutput,
+            diagnosticWriter: stderr.write
+        ))
+
+        progressHandler(ChatProgress(
+            stage: .generating,
+            diffusion: ChatDiffusionProgress(
+                draftText: "The [Mask] answer",
+                step: 2,
+                totalSteps: 48,
+                canvasIndex: 1,
+                blockComplete: true
+            )
+        ))
+
+        XCTAssertEqual(stdout.value, "")
+        XCTAssertFalse(streamingOutput.hasWritten)
+        XCTAssertTrue(stderr.value.contains("canvas=1 step=2/48"))
+        XCTAssertTrue(stderr.value.contains("The [Mask] answer"))
+    }
+
     func testQuietStreamingKeepsGeneratingCallbackAndSuppressesDiagnostics() throws {
         let stdout = TextOutputRecorder()
         let stderr = TextOutputRecorder()

--- a/Tests/MereRunCoreTests/DiffusionGemmaTests.swift
+++ b/Tests/MereRunCoreTests/DiffusionGemmaTests.swift
@@ -1,0 +1,156 @@
+import Foundation
+import MLX
+import Testing
+import XCTest
+@testable import MereRunCore
+
+@Suite("DiffusionGemma", .serialized)
+struct DiffusionGemmaTests {
+    @Test("decodes dynamic mixed-bit OptiQ overrides without untyped dictionaries")
+    func decodesQuantizationOverrides() throws {
+        let data = Data(
+            """
+            {
+              "model_type": "diffusion_gemma",
+              "architectures": ["DiffusionGemmaForBlockDiffusion"],
+              "canvas_length": 256,
+              "eos_token_id": [1, 106],
+              "text_config": {
+                "model_type": "diffusion_gemma_text",
+                "vocab_size": 262144,
+                "hidden_size": 2816,
+                "intermediate_size": 2112,
+                "moe_intermediate_size": 704,
+                "num_hidden_layers": 1,
+                "num_attention_heads": 16,
+                "num_key_value_heads": 8,
+                "num_global_key_value_heads": 2,
+                "head_dim": 256,
+                "global_head_dim": 512,
+                "rms_norm_eps": 0.000001,
+                "max_position_embeddings": 262144,
+                "pad_token_id": 0,
+                "sliding_window": 1024,
+                "layer_types": ["sliding_attention"],
+                "final_logit_softcapping": 30.0,
+                "num_experts": 128,
+                "top_k_experts": 8,
+                "rope_parameters": {
+                  "sliding_attention": {"rope_theta": 10000.0, "rope_type": "default"}
+                }
+              },
+              "quantization": {
+                "group_size": 64,
+                "bits": 4,
+                "mode": "affine",
+                "model.decoder.embed_tokens": {"group_size": 64, "bits": 8}
+              }
+            }
+            """.utf8
+        )
+
+        let config = try JSONDecoder().decode(DiffusionGemmaConfig.self, from: data)
+        #expect(config.canvasLength == 256)
+        #expect(config.textConfig.numExperts == 128)
+        #expect(config.quantization.parameters(for: "model.decoder.embed_tokens").bits == 8)
+        #expect(config.quantization.parameters(for: "model.decoder.layers.0.experts.gate_up_proj").bits == 4)
+    }
+
+    @Test("catalog pins the exact OptiQ revision and dedicated runtime")
+    func catalogSpecIsPinnedAndAdditive() throws {
+        let spec = try #require(ManagedModelCatalog.spec(for: DiffusionGemmaResources.modelID))
+        #expect(spec.upstreamRepoId == DiffusionGemmaResources.upstreamModelID)
+        #expect(spec.upstreamRevision == DiffusionGemmaResources.upstreamRevision)
+        #expect(spec.validationKind == .diffusionGemma)
+        #expect(spec.defaultRuntimeServingEngine == .textChatDiffusionGemma)
+        #expect(spec.apiProfile?.inputModalities == [.text])
+        #expect(spec.apiProfile?.supportsSeed == true)
+        #expect(spec.estimatedDownloadBytes == 17_852_058_816)
+    }
+
+    @Test("masked drafts preserve revealed islands and mask unrevealed positions")
+    func maskedDraftPreservesRevealedIslands() {
+        let draft = DiffusionGemmaGenerator.maskedDraft(
+            tokens: [10, 11, 12, 13],
+            revealed: [true, false, true, false],
+            decode: { $0.map(String.init).joined(separator: ",") }
+        )
+
+        #expect(draft == "10 [Mask] 12 [Mask]")
+    }
+
+    @Test("resource validation can separately require the vision sidecar")
+    func resourceValidationSeparatesVision() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appending(path: "diffusiongemma-test-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        for relativePath in [
+            "chat_template.jinja",
+            "config.json",
+            "generation_config.json",
+            "model-00001-of-00004.safetensors",
+            "model-00002-of-00004.safetensors",
+            "model-00003-of-00004.safetensors",
+            "model-00004-of-00004.safetensors",
+            "model.safetensors.index.json",
+            "tokenizer.json",
+            "tokenizer_config.json",
+        ] {
+            FileManager.default.createFile(
+                atPath: root.appending(path: relativePath).path,
+                contents: Data()
+            )
+        }
+
+        let resources = DiffusionGemmaResources(rootURL: root)
+        #expect(resources.validate().isEmpty)
+        #expect(resources.validate(requireVision: true) == [resources.visionWeightsURL])
+    }
+
+    @Test("hidden thinking removes Gemma channel markers")
+    func hiddenThinkingRemovesChannelMarkers() {
+        let decoded = "<|channel>thought\n<channel|>DiffusionGemma is running locally."
+
+        #expect(
+            DiffusionGemmaGenerator.cleanedResponse(decoded, showThinking: false)
+                == "DiffusionGemma is running locally."
+        )
+    }
+}
+
+final class DiffusionGemmaKernelTests: MereRunCoreTestCase {
+    func testSelectedLogitConfidenceMatchesFullSoftmax() {
+        let logits = MLXArray([
+            Float(0), 1, 2, 3,
+            4, 3, 2, 1,
+        ]).reshaped(1, 2, 4)
+        let tokenIDs = MLXArray([Int32(3), 0]).reshaped(1, 2)
+        let expected = takeAlong(
+            softmax(logits, axis: -1),
+            tokenIDs.expandedDimensions(axis: -1),
+            axis: -1
+        ).squeezed(axis: -1)
+        let actual = DiffusionGemmaGenerator.tokenProbability(
+            logits: logits,
+            tokenIDs: tokenIDs
+        )
+
+        XCTAssertTrue(MLX.allClose(actual, expected, rtol: 1e-6, atol: 1e-6).item(Bool.self))
+    }
+
+    func testSortedExpertRoutingRestoresOriginalOrder() {
+        XCTAssertFalse(DiffusionGemmaExpertRouting.shouldSort(routeCount: 63))
+        XCTAssertTrue(DiffusionGemmaExpertRouting.shouldSort(routeCount: 64))
+
+        let indices = MLXArray([Int32(3), 1, 3, 0, 2, 1, 0, 2]).reshaped(1, 2, 4)
+        let plan = DiffusionGemmaExpertRouting.sortedPlan(indices: indices, topK: 4)
+        MLX.eval(plan.order, plan.inverseOrder, plan.sortedIndices, plan.tokenOrder)
+
+        XCTAssertEqual(plan.sortedIndices.asArray(Int32.self), [0, 0, 1, 1, 2, 2, 3, 3])
+        XCTAssertEqual(
+            take(plan.sortedIndices, plan.inverseOrder, axis: 0).asArray(Int32.self),
+            indices.reshaped([indices.size]).asArray(Int32.self)
+        )
+    }
+}

--- a/Tests/MereRunCoreTests/ManagedModelSupportTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelSupportTests.swift
@@ -76,6 +76,24 @@ final class ManagedModelSupportTests: XCTestCase {
         XCTAssertEqual(report.reasons, [])
     }
 
+    func testDiffusionGemmaRequiresFortyEightGBAndRecommendsSixtyFourGB() throws {
+        let spec = try XCTUnwrap(
+            ManagedModelCatalog.spec(for: DiffusionGemmaResources.modelID)
+        )
+        let machine = MereRunMachineProfile(
+            physicalMemoryBytes: 48 * 1_073_741_824,
+            processorName: "M4 Max",
+            isAppleSiliconMac: true
+        )
+
+        let report = ManagedModelCapabilityCatalog.support(for: spec, on: machine)
+
+        XCTAssertTrue(report.isSupported)
+        XCTAssertEqual(report.descriptor.minimumUnifiedMemoryGB, 48)
+        XCTAssertEqual(report.descriptor.recommendedUnifiedMemoryGB, 64)
+        XCTAssertFalse(report.descriptor.isRecommendedForSetup)
+    }
+
     func testDenseGemma4IsRejectedOnThirtyTwoGB() throws {
         let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: Gemma4Resources.defaultModelId))
         let machine = MereRunMachineProfile(

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -243,7 +243,7 @@ are:
   `image-hidream-o1`, `image-hidream-o1-dev`, `image-sensenova-u1-5-8b-mot`, `image-krea2-raw`,
   `image-krea2-turbo`,
   `image-ideogram4-sdnq-uint4`
-- Text chat: `text-chat-gemma4`, `text-chat-mebot`, `text-chat-psi-agent`, `text-chat-q36-nano`, `vision-chat-q38-27b`, `vision-chat-q38-27b-4bit`, `text-agent-ornith-35b-mlx-4bit`, `vision-chat-ornith-35b`, `text-chat-lfm25-2.6b-4bit`, `text-chat-lfm25-a1b-8bit`, `vision-chat-lfm25-3b-8bit`
+- Text chat: `text-chat-gemma4`, `text-chat-diffusiongemma-26b-optiq-4bit`, `text-chat-mebot`, `text-chat-psi-agent`, `text-chat-q36-nano`, `vision-chat-q38-27b`, `vision-chat-q38-27b-4bit`, `text-agent-ornith-35b-mlx-4bit`, `vision-chat-ornith-35b`, `text-chat-lfm25-2.6b-4bit`, `text-chat-lfm25-a1b-8bit`, `vision-chat-lfm25-3b-8bit`
 - Text code / agents: `text-agent-qwen35-9b`, `text-agent-ornith-9b`, `text-agent-ornith-35b-mlx-4bit`, `text-agent-ornith-35b-mlx-6bit`, `text-agent-ornith-35b-mlx-8bit`, `text-agent-ornith-35b-mlx`, `text-agent-ornith-35b`, `text-code-north-mini`, `text-code-qwen3`
 - Text embed: `text-embed-qwen3-0.6b`
 - Multimodal embed: `vision-embed-qwen3-vl-2b`
@@ -812,8 +812,8 @@ Key options:
 
 ### `mere.run text chat`
 
-Run local text chat with the Gemma 4, Laguna 2.1, Inkling-Small, Qwen3.6/Qwen3.8/Bonsai,
-LFM2, or Psi family.
+Run local text chat with the Gemma 4, DiffusionGemma, Laguna 2.1,
+Inkling-Small, Qwen3.6/Qwen3.8/Bonsai, LFM2, or Psi family.
 
 ```bash
 swift run mere.run text chat --prompt "<text>" [options]
@@ -870,6 +870,7 @@ Examples:
 
 ```bash
 swift run mere.run text chat --prompt "What is classifier-free guidance?"
+swift run mere.run text chat --model text-chat-diffusiongemma-26b-optiq-4bit --max-tokens 256 --prompt "Explain block diffusion."
 swift run mere.run text chat --model vision-chat-q38-27b --image ./diagram.png --prompt "Explain this diagram."
 swift run mere.run text chat --model vision-chat-q38-flash-next-3bit-native-ple --context-size 32768 --max-tokens 256 --prompt "Explain sparse attention."
 swift run mere.run text chat --model text-agent-ornith-35b-mlx-4bit --image ./screenshot.png --prompt "Describe this interface."
@@ -2879,6 +2880,7 @@ Engine values:
 - `text-code`
 - `text-chat-klein`
 - `text-chat-gemma4`
+- `text-chat-diffusiongemma`
 - `text-chat-q36`
 - `text-chat-lfm2`
 - `text-chat-deepseek-v4-flash`
@@ -2933,6 +2935,7 @@ Examples:
 swift run mere.run api serve
 swift run mere.run api serve --preflight --json
 swift run mere.run api serve --engine text-chat-gemma4
+swift run mere.run api serve --engine text-chat-diffusiongemma --model text-chat-diffusiongemma-26b-optiq-4bit
 swift run mere.run api serve --engine text-chat-lfm2
 swift run mere.run api serve --engine text-code --model ./Qwen3-Coder-Next-Q4_K_M.gguf
 swift run mere.run api serve --host 0.0.0.0 --preflight --json

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -70,6 +70,7 @@ an effective overlay; they are not a second capability catalog.
 | `text-chat` | `text-chat-mebot` |
 | `text-chat` | `text-chat-psi-agent` |
 | `text-chat` | `text-chat-gemma4` |
+| `text-chat` | `text-chat-diffusiongemma-26b-optiq-4bit` |
 | `text-chat` | `text-chat-gemma4-turbo` |
 | `text-chat` | `text-chat-gemma4-12b` |
 | `text-chat` | `text-chat-gemma4-12b-4bit` |
@@ -570,6 +571,17 @@ managed Gemma 12B chat tier. Sawfwair's package is independently converted
 from Google's verified dense checkpoint, includes `MERERUN_CONVERSION.json`
 with source and emitted artifact hashes, and is published as the user-facing
 `v1.0.0` release.
+
+`text-chat-diffusiongemma-26b-optiq-4bit` pins the public Apache-2.0
+`mlx-community/diffusiongemma-26B-A4B-it-OptiQ-4bit` snapshot at revision
+`30f3c7c7746bf41cfd1a290155cc3b777ab588b9`. The 17.85 GB snapshot stores the
+ordinary projections and shared embedding in mixed 4-bit and 8-bit affine MLX
+tensors. Its separate `optiq/optiq_vision.safetensors` file retains the vision
+tower in BF16. The native Swift runtime consumes the OptiQ tensors in place,
+uses a causal prompt cache plus a bidirectional denoising canvas, and supports
+text and function-tool output with at most 256 generated tokens. The text
+runtime validates the vision sidecar but rejects image input because that path
+has no real-checkpoint qualification.
 
 `text-chat-lfm25-a1b-8bit` uses the public
 `LiquidAI/LFM2.5-8B-A1B-MLX-8bit` snapshot at the pinned catalog revision. It is

--- a/docs/runtime/api-server.md
+++ b/docs/runtime/api-server.md
@@ -102,6 +102,40 @@ swift run mere.run api serve \
   --model vision-chat-gemma4-12b
 ```
 
+For DiffusionGemma text chat:
+
+```bash
+swift run mere.run model pull text-chat-diffusiongemma-26b-optiq-4bit
+swift run mere.run api serve \
+  --engine text-chat-diffusiongemma \
+  --model text-chat-diffusiongemma-26b-optiq-4bit
+```
+
+This engine serves text and function tools with a maximum output budget of 256
+tokens. It rejects image content parts even though the managed checkpoint
+includes a validated BF16 vision sidecar. The resident model pool runs one
+seeded denoising warmup after loading so the first user request does not pay the
+initial MLX graph-compilation cost.
+
+OpenAI-compatible requests accept `seed`. Streaming requests can also set the
+Mere extension `mere_show_unmasking: true`; revision-aware drafts arrive in
+`delta.mere_diffusion_draft`, while the final response remains in
+`delta.content`. Completion responses expose diffusion diagnostics in
+`mere_diffusion`, and response headers include the seed, canvas tokens,
+denoising steps, work tokens, work tokens per second, and first-draft latency.
+
+```json
+{
+  "model": "text-chat-diffusiongemma-26b-optiq-4bit",
+  "messages": [{"role": "user", "content": "Explain block diffusion."}],
+  "max_tokens": 128,
+  "temperature": 0,
+  "seed": 123,
+  "stream": true,
+  "mere_show_unmasking": true
+}
+```
+
 For Muse Glimmer multimodal agent chat (explicit 21.38 GB Q4 target plus the
 5.54 GB DFlash2 assistant):
 
@@ -509,6 +543,9 @@ Engine compatibility:
   `ds4-server`, preserving DS4's OpenAI-compatible behavior.
 - `text-chat-gemma4`: accepts function tools and emits OpenAI tool-call
   responses when the model generates a tool call.
+- `text-chat-diffusiongemma`: accepts text and function tools, then generates
+  each block through parallel token denoising. It rejects image content parts,
+  structured JSON mode, LoRA adapters, and log-probability capture.
 - `text-chat-nemotron-h`: accepts function tools using the checkpoint's native
   Qwen-style XML envelope. Both final-target and DSpark decode stop at the first
   structurally complete envelope when parallel calls are disabled; malformed

--- a/docs/runtime/text.md
+++ b/docs/runtime/text.md
@@ -38,6 +38,7 @@ help in the repository gate.
 - `text-chat-gemma4-12b` (managed dense Google Gemma 4 12B-it snapshot)
 - `text-chat-gemma4-12b-4bit` (managed MLX 4-bit Gemma 4 12B-it snapshot)
 - `text-chat-gemma4-turbo` (managed MLX NVFP4 Gemma 4 26B-A4B MoE snapshot)
+- `text-chat-diffusiongemma-26b-optiq-4bit` (managed mixed-bit MLX DiffusionGemma 26B-A4B snapshot)
 - `vision-chat-muse-glimmer-30b` (pinned Sawfwair selective MLX Q4 conversion of Meta Muse Glimmer 30B)
 - `text-chat-laguna-s-2-1` (managed Poolside Laguna S 2.1 118B-A8B NVFP4 target plus DFlash)
 - `text-chat-laguna-xs-2-1` (managed Poolside Laguna XS 2.1 33B-A3B NVFP4 target)
@@ -116,6 +117,50 @@ fallback state.
 Loading performs one target and DFlash warmup before the first user-visible
 decode, so lazy MLX graph compilation is reported in `loadSeconds` and a
 persistent CLI/API model session pays that cost once.
+
+### DiffusionGemma block diffusion
+
+`text-chat-diffusiongemma-26b-optiq-4bit` runs the pinned MLX OptiQ conversion
+through a dedicated native Swift runtime. The runtime caches the causal prompt,
+then denoises a bidirectional token canvas in parallel instead of decoding one
+token at a time. It supports output budgets from 1 through 256 tokens and uses
+up to 48 denoising steps per canvas. Set both `--temperature 0` and `--seed`
+when you need a repeatable run.
+
+```bash
+mere.run model pull text-chat-diffusiongemma-26b-optiq-4bit
+mere.run text chat \
+  --model text-chat-diffusiongemma-26b-optiq-4bit \
+  --max-tokens 256 \
+  --seed 123 \
+  --stats \
+  --prompt "Explain block diffusion in one paragraph."
+```
+
+Diffusion stats distinguish conventional output throughput from the actual
+parallel work performed by the model. `decode_tps` counts returned tokens,
+`canvas_tps` counts canvas tokens, and `work_tps` counts one canvas token for
+every denoising step. The same line includes `seed`, `denoise_steps`, and
+`work_tokens`, making fixed-seed performance comparisons reproducible.
+
+Use `--show-unmasking` to render revision-aware canvas drafts on stderr while
+keeping the final answer on stdout:
+
+```bash
+mere.run text chat \
+  --model text-chat-diffusiongemma-26b-optiq-4bit \
+  --max-tokens 128 \
+  --seed 123 \
+  --show-unmasking \
+  --prompt "Explain why diffusion generation revises tokens."
+```
+
+Progressive drafts are observability output, not an append-only token stream:
+later steps can replace text shown by earlier steps.
+
+The managed snapshot includes and validates its separate BF16 vision sidecar,
+but this runtime supports text input only. It rejects `--image`, `--audio`, and
+`--video` rather than claiming an unqualified multimodal path.
 
 DFlash2 adds two-phase grouped dynamic causal convolution and predecessor-aware
 sparse candidate selection. It is installed and preferred automatically; an


### PR DESCRIPTION
## Summary

- add a dedicated native Swift/MLX DiffusionGemma 26B-A4B runtime for the pinned OptiQ mixed-bit checkpoint
- support deterministic seeds, denoising-step and work-TPS telemetry, progressive unmasking, and OpenAI-compatible serving
- add sorted expert routing, selected-token confidence without a full softmax tensor, and resident graph warmup
- register the managed model, hardware admission, manifests, documentation, and focused CLI/core/API tests

## Validation

- `./scripts/check.sh` on the rebased head
  - SwiftLint: 0 violations
  - XCTest: 3,376 executed, 279 expected skips, 0 failures
  - Swift Testing: 38 tests across 5 suites, 0 failures
- real OptiQ checkpoint at `/Volumes/MODELS/text-chat-diffusiongemma-26b-optiq-4bit`
  - deterministic seed 123 reproduced identical output
  - 128-token canvas converged in 10 denoising steps
  - repeated contention-bound samples: 36.0–39.4 output TPS and 360–394 work-TPS
  - resident API load, warmup, non-streaming response, progressive SSE drafts, and diffusion telemetry verified

## Performance boundary

The real-checkpoint throughput samples overlapped an unrelated LFM inference job, so they are operational smoke evidence rather than an uncontended performance ceiling. The new work-TPS and step counters make a clean follow-up comparison reproducible.