### PR TITLE
Fix Studio video playback and model-aware music admission

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+### Runtime
+
+- made machine-wide music admission use managed checkpoint size: models at or
+  below 16 GiB, including ACE-Step and Magenta RT2, now use the 6 GiB small-work
+  headroom floor instead of the fixed 16 GiB standard floor. Larger music
+  checkpoints and training retain their stricter admission classes.
+
+### macOS
+
+- linked AVKit explicitly into Studio so opening a generated or saved video no
+  longer aborts while resolving `AVPlayerView`.
+
 ### Text
 
 - added native Swift/MLX text generation and OpenAI-compatible serving for the

--- a/Package.swift
+++ b/Package.swift
@@ -536,6 +536,7 @@ if !isLinuxPackage {
       ],
       path: "apps/macos/MereRunStudio",
       linkerSettings: [
+        .linkedFramework("AVKit"),
         .unsafeFlags([
           "-Xlinker", "-rpath",
           "-Xlinker", "@loader_path/../Frameworks"

--- a/Sources/MereRunCLI/Support/MachineInferenceAdmission.swift
+++ b/Sources/MereRunCLI/Support/MachineInferenceAdmission.swift
@@ -557,6 +557,7 @@ final class MachineInferenceLease: @unchecked Sendable {
 }
 
 enum CLIInferenceAdmissionClassifier {
+    private static let smallModelBytes = Int64(16 * 1_073_741_824)
     private static let largeModelBytes = Int64(48 * 1_073_741_824)
 
     static func request(arguments: [String]) -> MachineInferenceRequest? {
@@ -588,7 +589,8 @@ enum CLIInferenceAdmissionClassifier {
         }) {
             return MachineInferenceRequest(label: label, resourceClass: .large)
         }
-        if modelIdentifiers(in: tokens).contains(where: isLargeModel) {
+        let selectedModelIdentifiers = modelIdentifiers(in: tokens)
+        if selectedModelIdentifiers.contains(where: isLargeModel) {
             return MachineInferenceRequest(label: label, resourceClass: .large)
         }
 
@@ -617,7 +619,13 @@ enum CLIInferenceAdmissionClassifier {
                 "depth-video",
             ].contains(subcommand)
             return MachineInferenceRequest(label: label, resourceClass: large ? .large : .standard)
-        case "music", "sfx":
+        case "music":
+            let large = ["train-adapter"].contains(subcommand)
+            let resourceClass = large
+                ? MachineInferenceClass.large
+                : musicResourceClass(modelIdentifiers: selectedModelIdentifiers)
+            return MachineInferenceRequest(label: label, resourceClass: resourceClass)
+        case "sfx":
             let large = ["train-adapter"].contains(subcommand)
             return MachineInferenceRequest(label: label, resourceClass: large ? .large : .standard)
         case "video", "world":
@@ -661,17 +669,32 @@ enum CLIInferenceAdmissionClassifier {
     }
 
     private static func isLargeModel(_ identifier: String?) -> Bool {
-        guard let identifier, !identifier.isEmpty else { return false }
+        estimatedModelBytes(identifier).map { $0 >= largeModelBytes } ?? false
+    }
+
+    private static func musicResourceClass(modelIdentifiers: [String]) -> MachineInferenceClass {
+        let identifiers = modelIdentifiers.isEmpty
+            ? [ModelResolver.ModelID.aceStep.rawValue]
+            : modelIdentifiers
+        return identifiers.allSatisfy(isSmallModel) ? .small : .standard
+    }
+
+    private static func isSmallModel(_ identifier: String) -> Bool {
+        estimatedModelBytes(identifier).map { $0 <= smallModelBytes } ?? false
+    }
+
+    private static func estimatedModelBytes(_ identifier: String?) -> Int64? {
+        guard let identifier, !identifier.isEmpty else { return nil }
         if let estimatedBytes = ManagedModelCatalog.spec(for: identifier)?.estimatedDownloadBytes {
-            return estimatedBytes >= largeModelBytes
+            return estimatedBytes
         }
         let fileURL = URL(fileURLWithPath: identifier)
         guard let values = try? fileURL.resourceValues(forKeys: [.isRegularFileKey, .fileSizeKey]),
               values.isRegularFile == true,
               let fileSize = values.fileSize else {
-            return false
+            return nil
         }
-        return Int64(fileSize) >= largeModelBytes
+        return Int64(fileSize)
     }
 
     private static func commandPath(_ tokens: [String]) -> [String] {

--- a/Tests/MereRunCLITests/MachineInferenceAdmissionTests.swift
+++ b/Tests/MereRunCLITests/MachineInferenceAdmissionTests.swift
@@ -273,6 +273,28 @@ final class MachineInferenceAdmissionTests: XCTestCase {
         }
     }
 
+    func testSmallMusicModelsAdmitWithLessThanStandardHeadroom() async throws {
+        for (offset, modelID) in ["music-acestep", "music-magenta-rt2-small"].enumerated() {
+            let directory = try temporaryDirectory()
+            let coordinator = makeCoordinator(
+                directory: directory,
+                processID: Int32(107 + offset),
+                physicalMemoryBytes: 24 * gibibyte,
+                availableMemoryBytes: 14 * gibibyte
+            )
+            let request = try XCTUnwrap(
+                CLIInferenceAdmissionClassifier.request(
+                    arguments: ["mere.run", "music", "generate", "test", "--model", modelID]
+                )
+            )
+
+            let lease = try await coordinator.acquire(request)
+            XCTAssertEqual(request.resourceClass, .small, modelID)
+            XCTAssertEqual(try coordinator.snapshot().activePermits, 1, modelID)
+            lease.release()
+        }
+    }
+
     func testCLIClassifierProtectsMediaAndLeavesLightweightCommandsFree() {
         XCTAssertEqual(
             CLIInferenceAdmissionClassifier.request(
@@ -285,6 +307,42 @@ final class MachineInferenceAdmissionTests: XCTestCase {
                 arguments: ["mere.run", "speech", "synthesize", "hello"]
             ),
             MachineInferenceRequest(label: "speech synthesize", resourceClass: .small)
+        )
+        XCTAssertEqual(
+            CLIInferenceAdmissionClassifier.request(
+                arguments: ["mere.run", "music", "generate", "test"]
+            ),
+            MachineInferenceRequest(label: "music generate", resourceClass: .small)
+        )
+        XCTAssertEqual(
+            CLIInferenceAdmissionClassifier.request(
+                arguments: [
+                    "mere.run", "music", "generate", "test", "--model", "music-magenta-rt2-small",
+                ]
+            ),
+            MachineInferenceRequest(label: "music generate", resourceClass: .small)
+        )
+        XCTAssertEqual(
+            CLIInferenceAdmissionClassifier.request(
+                arguments: [
+                    "mere.run", "music", "generate", "test", "--model", "music-acestep-xl-sft",
+                ]
+            ),
+            MachineInferenceRequest(label: "music generate", resourceClass: .standard)
+        )
+        XCTAssertEqual(
+            CLIInferenceAdmissionClassifier.request(
+                arguments: [
+                    "mere.run", "music", "generate", "test", "--model", "music-minimax-music3",
+                ]
+            ),
+            MachineInferenceRequest(label: "music generate", resourceClass: .standard)
+        )
+        XCTAssertEqual(
+            CLIInferenceAdmissionClassifier.request(
+                arguments: ["mere.run", "music", "train-adapter", "dataset.jsonl"]
+            ),
+            MachineInferenceRequest(label: "music train-adapter", resourceClass: .large)
         )
         XCTAssertEqual(
             CLIInferenceAdmissionClassifier.request(
@@ -391,6 +449,7 @@ final class MachineInferenceAdmissionTests: XCTestCase {
         directory: URL,
         processID: Int32,
         bootSessionID: String = "test-boot",
+        physicalMemoryBytes: UInt64 = 128 * 1_073_741_824,
         availableMemoryBytes: UInt64? = 96 * 1_073_741_824,
         availableDiskBytes: UInt64? = 100 * 1_073_741_824,
         processIsAlive: @escaping @Sendable (Int32) -> Bool = { _ in true }
@@ -402,7 +461,7 @@ final class MachineInferenceAdmissionTests: XCTestCase {
             currentDate: { Date() },
             hostSnapshot: {
                 MachineInferenceHostSnapshot(
-                    physicalMemoryBytes: 128 * 1_073_741_824,
+                    physicalMemoryBytes: physicalMemoryBytes,
                     availableMemoryBytes: availableMemoryBytes,
                     memoryPressure: .nominal,
                     availableDiskBytes: availableDiskBytes

--- a/apps/macos/MereRunStudioTests/StudioMediaPreviewTests.swift
+++ b/apps/macos/MereRunStudioTests/StudioMediaPreviewTests.swift
@@ -1,7 +1,21 @@
+import AppKit
 @testable import MereRunApp
+import SwiftUI
 import XCTest
 
 final class StudioMediaPreviewTests: XCTestCase {
+    @MainActor
+    func testVideoPlayerViewCanBeHosted() {
+        let url = URL(fileURLWithPath: "/tmp/mere-run-video-player-linkage-smoke.mp4")
+        let hostingView = NSHostingView(rootView: StudioVideoPlayerView(url: url))
+        hostingView.frame = NSRect(x: 0, y: 0, width: 320, height: 180)
+
+        hostingView.layoutSubtreeIfNeeded()
+        hostingView.displayIfNeeded()
+
+        XCTAssertEqual(hostingView.frame.size, NSSize(width: 320, height: 180))
+    }
+
     func testMovieOutputsAreNotReadAsTextPreviews() throws {
         let url = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -179,13 +179,15 @@ concurrency. Lightweight inspection and management commands such as `status`,
 `model list`, and `--help` do not consume permits.
 
 Capacity scales with physical memory: one permit below 48 GiB, two below 96
-GiB, four below 192 GiB, and six on larger hosts. Speech and lightweight audio
-use one permit; ordinary image, text, music, and vision work use two; video,
-world generation, model training/benchmarks, geometry/3D, and DeepSeek V4 Flash
-use the entire capacity. Any selected catalog model estimated at 48 GiB or
-larger, and an explicit local model file of that size, is also promoted to the
-exclusive class. FIFO ordering prevents a stream of small jobs from starving
-an earlier large job.
+GiB, four below 192 GiB, and six on larger hosts. Speech, lightweight audio,
+and managed music models estimated at 16 GiB or smaller use one permit and
+require 6 GiB of reclaimable memory. Ordinary image, text, vision, and larger
+music models use two permits and require 16 GiB. Video, world generation, model
+training/benchmarks, geometry/3D, and DeepSeek V4 Flash use the entire capacity
+and require 32 GiB. Any selected catalog model estimated at 48 GiB or larger,
+and an explicit local model file of that size, is also promoted to the exclusive
+class. FIFO ordering prevents a stream of small jobs from starving an earlier
+large job.
 
 Before it registers and admits a command, the coordinator checks reclaimable
 memory and preserves free disk for swap and temporary files. The disk floor is one


### PR DESCRIPTION
## Summary

- link AVKit directly into the macOS Studio executable so SwiftUI VideoPlayer can materialize without a runtime superclass-demangling abort
- classify normal music commands by estimated managed-model size, allowing ACE-Step and Magenta RT2 Small to use the 6 GiB headroom tier while retaining stricter admission for larger models and training
- add regression coverage for hosting the Studio video player and for both small music models on a simulated 24 GiB machine with 14 GiB reclaimable
- document the model-aware admission thresholds and record both fixes in the changelog

Closes #394
Closes #395

## Validation

- [x] `./scripts/check.sh` — 3,378 XCTest tests, 279 expected skips, 0 failures; 38 Swift Testing tests passed
- [x] focused tests for the changed area — 6 Studio media-preview tests and 15 machine-admission tests passed
- [x] release `mere.run.app` build; `otool -L` confirms a direct `AVKit.framework` load command
- [x] valid 320×180 H.264 MP4 host/layout/display smoke passed
- [x] docs updated for the public admission behavior
- [x] `git diff --check`
- [x] no vendored artifacts or package pins changed; `THIRD_PARTY_NOTICES.md` is unchanged