### PR TITLE
Fix native Qwen Image Edit 2511 inference

### DIFF
--- a/Sources/MereRunCLI/Support/ImageGenerationPreflight.swift
+++ b/Sources/MereRunCLI/Support/ImageGenerationPreflight.swift
@@ -880,7 +880,7 @@ struct ImageGenerationPreflightAnalyzer {
     ) -> MereRunModelManifest? {
         do {
             let manifest = try MereRunModelManifest.loadRequired(from: modelRoot, fileManager: fileManager)
-            if !Self.supportedImageFamilies.contains(manifest.family) {
+            if !Self.supportsImageGeneration(manifest) {
                 let family = manifest.family?.rawValue ?? "unknown"
                 diagnostics.append(
                     PreflightDiagnostic(
@@ -954,7 +954,14 @@ struct ImageGenerationPreflightAnalyzer {
     }
 
     private static func familyUsesManifestDefaults(_ family: MereRunModelManifest.Family) -> Bool {
-        family == .hidream || family == .krea || family == .ideogram || family == .senseNova
+        family == .hidream || family == .krea || family == .qwen || family == .ideogram || family == .senseNova
+    }
+
+    private static func supportsImageGeneration(_ manifest: MereRunModelManifest) -> Bool {
+        if manifest.family == .qwen {
+            return manifest.engine == .qwenImageEdit
+        }
+        return supportedImageFamilies.contains(manifest.family)
     }
 
     private static let supportedImageFamilies: Set<MereRunModelManifest.Family?> = [

--- a/Sources/MereRunCore/QwenImageEdit/Model/Encoder/Qwen25VLEncoder.swift
+++ b/Sources/MereRunCore/QwenImageEdit/Model/Encoder/Qwen25VLEncoder.swift
@@ -30,9 +30,6 @@ public final class Qwen25VLEncoder: Module {
             )
         }
         super.init()
-
-        // Connect vision tower to text encoder
-        textEncoder.setVisionTower(visionTower)
     }
 
     /// Access underlying text encoder for weight loading
@@ -248,7 +245,9 @@ extension Qwen25VLEncoder {
             promptDropIndex: 0,
             headDim: textEncoderConfig.headDim ?? (textEncoderConfig.hiddenSize / textEncoderConfig.numAttentionHeads),
             mropeSection: textEncoderConfig.ropeScaling?.mropeSection,
-            mropeInterleaved: false
+            mropeInterleaved: false,
+            attentionBias: textEncoderConfig.attentionBias ?? true,
+            useQKNorm: false
         )
 
         // Create vision config from nested config or defaults
@@ -267,7 +266,8 @@ extension Qwen25VLEncoder {
                 inChannels: 3,
                 outHiddenDim: vc.outHiddenSize ?? textEncoderConfig.hiddenSize,
                 windowSize: vc.windowSize ?? 112,
-                fullAttentionBlockIndices: vc.fullattBlockIndexes ?? [7, 15, 23, 31]
+                fullAttentionBlockIndices: vc.fullattBlockIndexes ?? [7, 15, 23, 31],
+                normBias: false
             )
         } else {
             // Default Qwen2.5-VL vision config
@@ -284,7 +284,8 @@ extension Qwen25VLEncoder {
                 inChannels: 3,
                 outHiddenDim: textEncoderConfig.hiddenSize,
                 windowSize: 112,
-                fullAttentionBlockIndices: [7, 15, 23, 31]
+                fullAttentionBlockIndices: [7, 15, 23, 31],
+                normBias: false
             )
         }
 

--- a/Sources/MereRunCore/QwenImageEdit/Model/Transformer/MMDiT.swift
+++ b/Sources/MereRunCore/QwenImageEdit/Model/Transformer/MMDiT.swift
@@ -217,14 +217,27 @@ public final class TimestepEmbedder: Module {
     }
 
     public func callAsFunction(_ timestep: MLXArray) -> MLXArray {
+        let embedding = Self.sinusoidalEmbedding(
+            timestep,
+            frequencyDim: frequencyDim
+        )
+        return mlp.1(MLXNN.silu(mlp.0(embedding)))
+    }
+
+    static func sinusoidalEmbedding(
+        _ timestep: MLXArray,
+        frequencyDim: Int,
+        scale: Float = 1_000
+    ) -> MLXArray {
         let halfDimension = frequencyDim / 2
         let exponent = -MLXArray(Float.log(10_000))
             * MLXArray(0..<halfDimension).asType(.float32)
             / MLXArray(Float(halfDimension))
         let frequencies = MLX.exp(exponent)
-        let arguments = timestep.asType(.float32)[.ellipsis, .newAxis] * frequencies[.newAxis]
-        let embedding = MLX.concatenated([MLX.cos(arguments), MLX.sin(arguments)], axis: -1)
-        return mlp.1(MLXNN.silu(mlp.0(embedding)))
+        let arguments = timestep.asType(.float32)[.ellipsis, .newAxis]
+            * MLXArray(scale)
+            * frequencies[.newAxis]
+        return MLX.concatenated([MLX.cos(arguments), MLX.sin(arguments)], axis: -1)
     }
 }
 

--- a/Sources/MereRunCore/QwenImageEdit/QwenImageEditGenerator+ModelLoading.swift
+++ b/Sources/MereRunCore/QwenImageEdit/QwenImageEditGenerator+ModelLoading.swift
@@ -356,6 +356,9 @@ extension QwenImageEditGenerator {
     ) -> (String, MLXArray) -> [(String, MLXArray)] {
         return { rawKey, value in
             guard let key = textEncoderWeightKey(rawKey) else { return [] }
+            if key == "visionTower.patch_embed.proj.weight", value.ndim == 5 {
+                return [(key, value.transposed(0, 2, 3, 4, 1))]
+            }
             return [(key, value)]
         }
     }

--- a/Sources/MereRunCore/VLM/QwenVLEncoder.swift
+++ b/Sources/MereRunCore/VLM/QwenVLEncoder.swift
@@ -164,7 +164,6 @@ public final class QwenVLEncoder: Module {
             self._visionProjection.wrappedValue = Linear(visionConfig.outHiddenDim, textEncoderConfig.hiddenSize)
         }
         super.init()
-        textEncoder.setVisionTower(visionTower)
     }
 
     public static func imageTokenCount(

--- a/Sources/MereRunCore/ZImageTurbo/Model/TextEncoder/TextEncoder+Blocks.swift
+++ b/Sources/MereRunCore/ZImageTurbo/Model/TextEncoder/TextEncoder+Blocks.swift
@@ -20,8 +20,8 @@ public final class QwenAttention: Module {
   @ModuleInfo(key: "k_proj") var kProj: Linear
   @ModuleInfo(key: "v_proj") var vProj: Linear
   @ModuleInfo(key: "o_proj") var oProj: Linear
-  @ModuleInfo(key: "q_norm") var qNorm: RMSNorm
-  @ModuleInfo(key: "k_norm") var kNorm: RMSNorm
+  @ModuleInfo(key: "q_norm") var qNorm: RMSNorm?
+  @ModuleInfo(key: "k_norm") var kNorm: RMSNorm?
 
   private var usesFusedProjections = false
 
@@ -44,13 +44,18 @@ public final class QwenAttention: Module {
       self.cachedDecodeAttentionMode = configuration.cachedDecodeAttentionMode
     }
 
-    self._qProj.wrappedValue = Linear(hiddenSize, numAttentionHeads * headDim, bias: false)
-    self._kProj.wrappedValue = Linear(hiddenSize, numKeyValueHeads * headDim, bias: false)
-    self._vProj.wrappedValue = Linear(hiddenSize, numKeyValueHeads * headDim, bias: false)
+    self._qProj.wrappedValue = Linear(hiddenSize, numAttentionHeads * headDim, bias: configuration.attentionBias)
+    self._kProj.wrappedValue = Linear(hiddenSize, numKeyValueHeads * headDim, bias: configuration.attentionBias)
+    self._vProj.wrappedValue = Linear(hiddenSize, numKeyValueHeads * headDim, bias: configuration.attentionBias)
     self._oProj.wrappedValue = Linear(numAttentionHeads * headDim, hiddenSize, bias: false)
 
-    self._qNorm.wrappedValue = RMSNorm(dimensions: headDim, eps: configuration.rmsNormEps)
-    self._kNorm.wrappedValue = RMSNorm(dimensions: headDim, eps: configuration.rmsNormEps)
+    if configuration.useQKNorm {
+      self._qNorm.wrappedValue = RMSNorm(dimensions: headDim, eps: configuration.rmsNormEps)
+      self._kNorm.wrappedValue = RMSNorm(dimensions: headDim, eps: configuration.rmsNormEps)
+    } else {
+      self._qNorm.wrappedValue = nil
+      self._kNorm.wrappedValue = nil
+    }
 
     if let mropeSection = configuration.mropeSection, !mropeSection.isEmpty {
       self.mropeSection = mropeSection
@@ -111,8 +116,12 @@ public final class QwenAttention: Module {
         print("[Attn] K pre-norm: std=\(MLX.std(keys).item(Float.self))")
     }
 
-    queries = qNorm(queries.reshaped(B, L, numAttentionHeads, headDim)).transposed(0, 2, 1, 3)
-    keys = kNorm(keys.reshaped(B, L, numKeyValueHeads, headDim)).transposed(0, 2, 1, 3)
+    queries = queries.reshaped(B, L, numAttentionHeads, headDim)
+    keys = keys.reshaped(B, L, numKeyValueHeads, headDim)
+    if let qNorm { queries = qNorm(queries) }
+    if let kNorm { keys = kNorm(keys) }
+    queries = queries.transposed(0, 2, 1, 3)
+    keys = keys.transposed(0, 2, 1, 3)
     values = values.reshaped(B, L, numKeyValueHeads, headDim).transposed(0, 2, 1, 3)
 
     if debug {

--- a/Sources/MereRunCore/ZImageTurbo/Model/TextEncoder/TextEncoder.swift
+++ b/Sources/MereRunCore/ZImageTurbo/Model/TextEncoder/TextEncoder.swift
@@ -8,7 +8,6 @@ import MLXNN
 // through architecture internals.
 
 enum QwenTextEncoderError: Error {
-  case visionTowerUnavailable
   case mismatchedVisionTokenCount
 }
 
@@ -37,6 +36,8 @@ public struct QwenTextEncoderConfiguration {
   public var headDim: Int
   public var mropeSection: [Int]?
   public var mropeInterleaved: Bool
+  public var attentionBias: Bool
+  public var useQKNorm: Bool
   public var useFloat32Activations: Bool
   public var cachedDecodeAttentionMode: QwenCachedDecodeAttentionMode
 
@@ -54,6 +55,8 @@ public struct QwenTextEncoderConfiguration {
     headDim: Int = 128,
     mropeSection: [Int]? = nil,
     mropeInterleaved: Bool = false,
+    attentionBias: Bool = false,
+    useQKNorm: Bool = true,
     useFloat32Activations: Bool = false,
     cachedDecodeAttentionMode: QwenCachedDecodeAttentionMode = .automatic
   ) {
@@ -70,6 +73,8 @@ public struct QwenTextEncoderConfiguration {
     self.headDim = headDim
     self.mropeSection = mropeSection
     self.mropeInterleaved = mropeInterleaved
+    self.attentionBias = attentionBias
+    self.useQKNorm = useQKNorm
     self.useFloat32Activations = useFloat32Activations
     self.cachedDecodeAttentionMode = cachedDecodeAttentionMode
   }
@@ -79,15 +84,10 @@ public final class QwenTextEncoder: Module {
 
   public let configuration: QwenTextEncoderConfiguration
   @ModuleInfo(key: "encoder") var encoder: QwenEncoder
-  private var visionTower: QwenVisionTower?
 
   public init(configuration: QwenTextEncoderConfiguration = .init()) {
     self.configuration = configuration
     self._encoder.wrappedValue = QwenEncoder(configuration: configuration)
-  }
-
-  func setVisionTower(_ tower: QwenVisionTower) {
-    self.visionTower = tower
   }
 
   public func callAsFunction(

--- a/Sources/MereRunCore/ZImageTurbo/Model/TextEncoder/Vision/QwenVisionBlock.swift
+++ b/Sources/MereRunCore/ZImageTurbo/Model/TextEncoder/Vision/QwenVisionBlock.swift
@@ -11,8 +11,18 @@ final class QwenVisionBlock: Module {
 
   init(configuration: QwenVisionConfiguration, blockIndex: Int) {
     self.blockIndex = blockIndex
-    self._norm1.wrappedValue = LayerNorm(dimensions: configuration.embedDim, eps: configuration.eps, affine: true)
-    self._norm2.wrappedValue = LayerNorm(dimensions: configuration.embedDim, eps: configuration.eps, affine: true)
+    self._norm1.wrappedValue = LayerNorm(
+      dimensions: configuration.embedDim,
+      eps: configuration.eps,
+      affine: true,
+      bias: configuration.normBias
+    )
+    self._norm2.wrappedValue = LayerNorm(
+      dimensions: configuration.embedDim,
+      eps: configuration.eps,
+      affine: true,
+      bias: configuration.normBias
+    )
     self._attention.wrappedValue = QwenVisionAttention(embedDim: configuration.embedDim, numHeads: configuration.numHeads)
     let hiddenDim = configuration.mlpHiddenDim
     self._mlp.wrappedValue = QwenVisionMLP(

--- a/Sources/MereRunCore/ZImageTurbo/Model/TextEncoder/Vision/QwenVisionConfiguration.swift
+++ b/Sources/MereRunCore/ZImageTurbo/Model/TextEncoder/Vision/QwenVisionConfiguration.swift
@@ -21,6 +21,7 @@ public struct QwenVisionConfiguration {
   public var windowSize: Int
   public var fullAttentionBlockIndices: [Int]
   public var patchEmbedBias: Bool
+  public var normBias: Bool
   /// Qwen3-VL: number of learned position embeddings (e.g. 2304 = 48*48)
   public var numPositionEmbeddings: Int?
   /// Qwen3-VL: use learned position embeddings + rotary (vs rotary-only for Qwen2-VL)
@@ -49,6 +50,7 @@ public struct QwenVisionConfiguration {
     windowSize: Int = 112,
     fullAttentionBlockIndices: [Int] = [7, 15, 23, 31],
     patchEmbedBias: Bool = false,
+    normBias: Bool = true,
     numPositionEmbeddings: Int? = nil,
     useLearnedPosEmbed: Bool = false,
     deepstackVisualIndexes: [Int] = []
@@ -68,6 +70,7 @@ public struct QwenVisionConfiguration {
     self.windowSize = windowSize
     self.fullAttentionBlockIndices = fullAttentionBlockIndices
     self.patchEmbedBias = patchEmbedBias
+    self.normBias = normBias
     self.numPositionEmbeddings = numPositionEmbeddings
     self.useLearnedPosEmbed = useLearnedPosEmbed
     self.deepstackVisualIndexes = deepstackVisualIndexes

--- a/Sources/MereRunCore/ZImageTurbo/Model/TextEncoder/Vision/QwenVisionPatchMerger.swift
+++ b/Sources/MereRunCore/ZImageTurbo/Model/TextEncoder/Vision/QwenVisionPatchMerger.swift
@@ -16,7 +16,13 @@ final class QwenVisionPatchMerger: Module {
   @ModuleInfo(key: "mlp_0") private var mlpInput: Linear
   @ModuleInfo(key: "mlp_2") private var mlpOutput: Linear
 
-  init(contextDim: Int, outputDim: Int, spatialMergeSize: Int, usePostshuffleNorm: Bool = false) {
+  init(
+    contextDim: Int,
+    outputDim: Int,
+    spatialMergeSize: Int,
+    usePostshuffleNorm: Bool = false,
+    normBias: Bool = true
+  ) {
     self.contextDim = contextDim
     self.outputDim = outputDim
     self.spatialMergeSize = spatialMergeSize
@@ -26,7 +32,12 @@ final class QwenVisionPatchMerger: Module {
 
     // For deepstack (postshuffle norm), the norm operates on hiddenDim instead of contextDim
     let normDim = usePostshuffleNorm ? contextDim * mergeUnit : contextDim
-    self._norm.wrappedValue = LayerNorm(dimensions: normDim, eps: 1e-6, affine: true)
+    self._norm.wrappedValue = LayerNorm(
+      dimensions: normDim,
+      eps: 1e-6,
+      affine: true,
+      bias: normBias
+    )
     self._mlpInput.wrappedValue = Linear(hiddenDim, hiddenDim)
     self._mlpOutput.wrappedValue = Linear(hiddenDim, outputDim)
   }

--- a/Sources/MereRunCore/ZImageTurbo/Model/TextEncoder/Vision/QwenVisionTower.swift
+++ b/Sources/MereRunCore/ZImageTurbo/Model/TextEncoder/Vision/QwenVisionTower.swift
@@ -92,7 +92,8 @@ final class QwenVisionTower: Module {
     self._patchMerger.wrappedValue = QwenVisionPatchMerger(
       contextDim: configuration.embedDim,
       outputDim: configuration.outHiddenDim,
-      spatialMergeSize: configuration.spatialMergeSize
+      spatialMergeSize: configuration.spatialMergeSize,
+      normBias: configuration.normBias
     )
 
     // Qwen3-VL: deepstack mergers (with postshuffle norm)
@@ -101,7 +102,8 @@ final class QwenVisionTower: Module {
         contextDim: configuration.embedDim,
         outputDim: configuration.outHiddenDim,
         spatialMergeSize: configuration.spatialMergeSize,
-        usePostshuffleNorm: true
+        usePostshuffleNorm: true,
+        normBias: configuration.normBias
       )
     }
 

--- a/Tests/MereRunCLITests/ImageGenerateCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/ImageGenerateCommandParsingTests.swift
@@ -585,6 +585,71 @@ final class ImageGenerateCommandParsingTests: XCTestCase {
         XCTAssertTrue(envelope.diagnostics.contains { $0.id == "model_family_unsupported" })
     }
 
+    func testImageGenerationPreflightAcceptsQwenImageEditAndUsesManifestDefaults() throws {
+        let temp = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: temp) }
+
+        let model = temp.appendingPathComponent("model", isDirectory: true)
+        try writeManifest(
+            id: "local-qwen-edit",
+            family: .qwen,
+            engine: .qwenImageEdit,
+            defaults: .init(steps: 40, cfg: 4),
+            to: model
+        )
+        let input = temp.appendingPathComponent("input.png")
+        try Data("input".utf8).write(to: input)
+        let output = temp.appendingPathComponent("render.png")
+
+        let cmd = try ImageGenerate.parse([
+            "--prompt", "remove the truck",
+            "--model", model.path,
+            "--input", input.path,
+            "--output", output.path,
+            "--preflight",
+            "--json",
+        ])
+        let envelope = cmd.makePreflightEnvelope(
+            outputURL: output,
+            now: { Date(timeIntervalSince1970: 0) }
+        )
+
+        XCTAssertEqual(envelope.status, .ok)
+        XCTAssertEqual(envelope.result.model.family, "qwen")
+        XCTAssertEqual(envelope.result.plan.effectiveSteps, 40)
+        XCTAssertEqual(envelope.result.plan.effectiveCFGScale, 4)
+        XCTAssertEqual(envelope.result.plan.inputMode, "image_to_image")
+        XCTAssertTrue(try XCTUnwrap(envelope.actions.first { $0.id == "start-generation" }).enabled)
+    }
+
+    func testImageGenerationPreflightRejectsNonImageQwenEngine() throws {
+        let temp = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: temp) }
+
+        let model = temp.appendingPathComponent("model", isDirectory: true)
+        try writeManifest(
+            id: "local-qwen-text",
+            family: .qwen,
+            engine: .qwen35HybridMoE,
+            to: model
+        )
+        let output = temp.appendingPathComponent("render.png")
+        let cmd = try ImageGenerate.parse([
+            "--prompt", "a clean product render",
+            "--model", model.path,
+            "--output", output.path,
+            "--preflight",
+            "--json",
+        ])
+        let envelope = cmd.makePreflightEnvelope(
+            outputURL: output,
+            now: { Date(timeIntervalSince1970: 0) }
+        )
+
+        XCTAssertEqual(envelope.status, .blocked)
+        XCTAssertTrue(envelope.diagnostics.contains { $0.id == "model_family_unsupported" })
+    }
+
     func testStructuredPromptAdapterValidatesPaperSchema() throws {
         let caption = try StructuredImagePromptAdapter.validateCaptionJSON(Self.validStructuredCaptionJSON)
 
@@ -752,14 +817,18 @@ final class ImageGenerateCommandParsingTests: XCTestCase {
     private func writeManifest(
         id: String,
         family: MereRunModelManifest.Family,
+        engine: MereRunModelManifest.Engine? = nil,
+        defaults: MereRunModelManifest.Defaults? = nil,
         to directory: URL
     ) throws {
         try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         let manifest = MereRunModelManifest(
             id: id,
+            engine: engine,
             family: family,
             variant: .distilled,
             precision: .bf16,
+            defaults: defaults,
             supports: []
         )
         let encoder = JSONEncoder()

--- a/Tests/MereRunCoreTests/QwenImageEditRepositoryTests.swift
+++ b/Tests/MereRunCoreTests/QwenImageEditRepositoryTests.swift
@@ -1,9 +1,65 @@
 import Foundation
+import MediaIO
 import MLX
 import XCTest
 @testable import MereRunCore
 
 final class QwenImageEditRepositoryTests: MereRunCoreTestCase {
+    func testInstalledQwenImageEditVAERoundTripWhenRequested() throws {
+        let env = ProcessInfo.processInfo.environment
+        guard let root = env["MERERUN_TEST_QWEN_EDIT_ROOT"], !root.isEmpty else {
+            throw XCTSkip("Set MERERUN_TEST_QWEN_EDIT_ROOT to test an installed Qwen Image Edit VAE.")
+        }
+        guard let input = env["MERERUN_TEST_QWEN_EDIT_IMAGE"], !input.isEmpty else {
+            throw XCTSkip("Set MERERUN_TEST_QWEN_EDIT_IMAGE to test an installed Qwen Image Edit VAE.")
+        }
+
+        let output = env["MERERUN_TEST_QWEN_EDIT_VAE_OUTPUT"] ?? "/tmp/qwen-image-edit-vae-round-trip.png"
+        let resources = QwenImageEditResources(rootURL: URL(fileURLWithPath: root))
+        let configs = try QwenImageEditModelConfigs.load(from: resources)
+        let vae = QwenImageEditVAE(config: configs.vae)
+        try QwenImageEditGenerator.validateVAECheckpointCoverage(
+            rawKeys: Set(try SafetensorsStreamingLoader.metadata(url: resources.vaeWeightsURL).keys),
+            model: vae
+        )
+        try HFSafetensorsWeightsLoader.applyWeights(
+            url: resources.vaeWeightsURL,
+            to: vae.underlyingVAE,
+            dtype: .bfloat16,
+            verify: [.shapeMismatch],
+            mapper: QwenImageEditVAE.weightMapper
+        )
+        MLX.eval(vae)
+
+        let decodedInput = try MediaImageIO.decode(URL(fileURLWithPath: input))
+        let source = try QwenImageIO.resizedCenterCropPixelArray(
+            from: decodedInput,
+            width: 256,
+            height: 256,
+            dtype: .float32
+        )
+        let normalized = QwenImageIO.normalizeForEncoder(source)
+        let latents = vae.encodeConditioning(normalized)
+        let reconstruction = MLX.clip(
+            QwenImageIO.denormalizeFromDecoder(vae.decodeGenerated(latents)).asType(.float32),
+            min: 0,
+            max: 1
+        )
+        MLX.eval(source, latents, reconstruction)
+        try QwenImageIO.saveImage(
+            array: reconstruction,
+            to: URL(fileURLWithPath: output)
+        )
+
+        let meanAbsoluteError = MLX.mean(MLX.abs(reconstruction - source)).item(Float.self)
+        FileHandle.standardError.write(
+            "qwen_image_edit_vae_round_trip mae=\(meanAbsoluteError) "
+                .appending("latent_shape=\(latents.shape) output=\(output)\n")
+                .data(using: .utf8)!
+        )
+        XCTAssertLessThan(meanAbsoluteError, 0.25, "The installed VAE should reconstruct the source image.")
+    }
+
     func testRepositoryIdentitiesKeepLegacyAnd2511Separate() {
         XCTAssertEqual(
             QwenImageEditRepository.canonicalModelId(for: "Qwen/Qwen-Image-Edit"),
@@ -138,6 +194,20 @@ final class QwenImageEditRepositoryTests: MereRunCoreTestCase {
         XCTAssertTrue(config.zeroCondT)
     }
 
+    func testQwenTimestepEmbeddingUsesOfficialThousandScale() {
+        let embedding = TimestepEmbedder.sinusoidalEmbedding(
+            MLXArray([Float(0.5)]),
+            frequencyDim: 4
+        )
+        MLX.eval(embedding)
+
+        let values = embedding.asArray(Float.self)
+        XCTAssertEqual(values[0], cos(500), accuracy: 0.000_01)
+        XCTAssertEqual(values[1], cos(5), accuracy: 0.000_01)
+        XCTAssertEqual(values[2], sin(500), accuracy: 0.000_01)
+        XCTAssertEqual(values[3], sin(5), accuracy: 0.000_01)
+    }
+
     func testTransformerCheckpointCoverageRejectsMissingAndUnexpectedKeys() throws {
         let json = #"""
         {
@@ -189,6 +259,8 @@ final class QwenImageEditRepositoryTests: MereRunCoreTestCase {
           "num_key_value_heads": 1,
           "intermediate_size": 32,
           "vocab_size": 128,
+          "model_type": "qwen2_5_vl",
+          "attention_bias": true,
           "rope_scaling": {"mrope_section": [1, 1, 2]},
           "vision_config": {
             "depth": 1,
@@ -215,6 +287,17 @@ final class QwenImageEditRepositoryTests: MereRunCoreTestCase {
         XCTAssertTrue(modelKeys.contains("visionTower.blocks.0.mlp.down_proj.weight"))
         XCTAssertFalse(modelKeys.contains("visionTower.blocks.0.mlp.fc1.weight"))
         XCTAssertEqual(encoder.textEncoder.configuration.mropeSection, [1, 1, 2])
+        XCTAssertTrue(encoder.textEncoder.configuration.attentionBias)
+        XCTAssertFalse(encoder.textEncoder.configuration.useQKNorm)
+        XCTAssertTrue(modelKeys.contains("textEncoder.encoder.layers.0.self_attn.q_proj.bias"))
+        XCTAssertTrue(modelKeys.contains("textEncoder.encoder.layers.0.self_attn.k_proj.bias"))
+        XCTAssertTrue(modelKeys.contains("textEncoder.encoder.layers.0.self_attn.v_proj.bias"))
+        XCTAssertFalse(modelKeys.contains("textEncoder.encoder.layers.0.self_attn.q_norm.weight"))
+        XCTAssertFalse(modelKeys.contains("textEncoder.encoder.layers.0.self_attn.k_norm.weight"))
+        XCTAssertFalse(modelKeys.contains { $0.hasPrefix("textEncoder.visionTower.") })
+        XCTAssertFalse(modelKeys.contains("visionTower.blocks.0.norm1.bias"))
+        XCTAssertFalse(modelKeys.contains("visionTower.blocks.0.norm2.bias"))
+        XCTAssertFalse(modelKeys.contains("visionTower.patch_merger.ln_q.bias"))
 
         var rawKeys = Set(modelKeys.map(Self.inverseTextEncoderCheckpointKey))
         rawKeys.insert("lm_head.weight")
@@ -229,6 +312,25 @@ final class QwenImageEditRepositoryTests: MereRunCoreTestCase {
             rawKeys: rawKeys,
             model: encoder
         ))
+    }
+
+    func testQwen25VLEncoderTransposesPyTorchPatchEmbeddingWeightForMLX() throws {
+        let json = #"""
+        {
+          "hidden_size": 16,
+          "num_hidden_layers": 1,
+          "num_attention_heads": 2,
+          "intermediate_size": 32,
+          "vocab_size": 128
+        }
+        """#
+        let config = try JSONDecoder().decode(QwenImageEditTextEncoderConfig.self, from: Data(json.utf8))
+        let mapper = QwenImageEditGenerator.textEncoderWeightMapper(config: config)
+        let weight = MLXArray.zeros([8, 3, 2, 4, 4])
+        let mapped = try XCTUnwrap(mapper("visual.patch_embed.proj.weight", weight).first)
+
+        XCTAssertEqual(mapped.0, "visionTower.patch_embed.proj.weight")
+        XCTAssertEqual(mapped.1.shape, [8, 2, 4, 4, 3])
     }
 
     func testQwen25VLMultimodalPositionsTrackEachOrderedPictureGrid() {


### PR DESCRIPTION
## Summary

- allow Qwen Image Edit manifests through image-generation preflight while rejecting unrelated Qwen engines
- align the Qwen 2.5 VL encoder with the 2511 checkpoint's attention biases, QK normalization, vision normalization, and patch-embedding layout
- remove duplicate vision-tower registration that breaks strict checkpoint coverage
- apply Qwen's required 1,000 timestep scale before the sinusoidal embedding
- add preflight, checkpoint-coverage, timestep-parity, and opt-in installed-VAE regression tests

## Why

The installed `image-qwen-edit-2511-lightning` model was blocked during preflight and rejected during encoder loading. Fixing checkpoint compatibility allowed inference to run, but the four-step Lightning output remained noise. A real-checkpoint VAE round trip passed, isolating the remaining problem to denoising. Comparing the native transformer with the official Diffusers implementation found that the native timestep embedding omitted Qwen's required 1,000 scale.

## Validation

- `./scripts/check.sh`
- `swift test --filter QwenImageEditRepositoryTests` — 28 tests, with the installed-model test skipped by default
- opt-in installed 2511 VAE round trip — passed with mean absolute error 0.03178171
- `swift test --filter ImageGenerateCommandParsingTests` — 40 passed
- native 1024 × 1024 Lightning canary at 4 steps, CFG 1, seed 610102 — passed; the requested object was removed while the surrounding scene remained coherent
- `gitnexus detect-changes --scope compare --base-ref origin/main` — 13 files, 51 symbols, 0 affected processes, low final risk
- `git diff --check`
