### PR TITLE
Bundle Ornith Q4 vision and MTP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ The format is based on Keep a Changelog.
 
 ### Text
 
+- consolidated the recommended Ornith 1.5 35B-A3B Q4 target, authoritative
+  BF16 vision shard, and BF16 MTP draft head into one pinned
+  `Sawfwair/Ornith-1.5-35B-A3B-MLX-4bit-Vision-MTP` snapshot. The Q4 managed
+  pull no longer installs separate vision or MTP companions; validation now
+  requires both embedded components.
 - added image-conditioned LoRA training for `vision-chat-gemma4-12b` through
   `text train-lora`. The first target freezes the Gemma 4 vision stack and base
   language weights, then trains q/k/v/o language-attention adapters with

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -2073,22 +2073,11 @@ public enum ManagedModelCatalog {
             category: .visionChat,
             installShape: .directoryRoot,
             hubFallback: Q35Resources.profile(for: Q35Resources.ornith35BMLX4BitModelId)?.hubFallbackConfig,
-            mountedHubFallbacks: [
-                MountedHubFallbackConfig(
-                    destinationPath: Q35Resources.ornith35BVisionComponentPath,
-                    hubFallback: HubFallbackConfig(
-                        repoId: Q35Resources.ornith35BVisionUpstreamRepoId,
-                        revision: Q35Resources.ornith35BVisionUpstreamRevision,
-                        patterns: Q35Resources.ornith35BVisionComponentSnapshotPatterns
-                    )
-                ),
-            ],
-            upstreamRepoId: Q35Resources.ornith35BMLX4BitUpstreamRepoId,
-            upstreamRevision: Q35Resources.ornith35BMLX4BitUpstreamRevision,
+            upstreamRepoId: Q35Resources.ornith35BMLX4BitBundleRepoId,
+            upstreamRevision: Q35Resources.ornith35BMLX4BitBundleRevision,
             validationKind: .q35,
             runtimeAutoDownloadAllowed: false,
-            estimatedDownloadBytes: Q35Resources.ornith35BMLX4BitEstimatedDownloadBytes
-                + Q35Resources.ornith35BVisionComponentEstimatedDownloadBytes,
+            estimatedDownloadBytes: Q35Resources.ornith35BMLX4BitBundleEstimatedDownloadBytes,
             defaultCLICommands: [
                 "text chat",
                 "api serve",
@@ -2097,7 +2086,6 @@ public enum ManagedModelCatalog {
                 "model benchmark code",
                 "model benchmark vlm",
             ],
-            companionModelIDs: [Q35Resources.ornith35BMTPModelId],
             apiProfile: .q36(
                 contextWindow: Q35Resources.ornith35BMLXContextLength,
                 fixedReasoning: true
@@ -4246,6 +4234,7 @@ public extension ManagedModelSpec {
             }
             if id == Q35Resources.ornith35BMLX4BitModelId {
                 missing.append(contentsOf: resources.validateOrnithVisionComponent(fileManager: fileManager))
+                missing.append(contentsOf: resources.validateOrnithMTPComponent(fileManager: fileManager))
             }
             return missing
         case .q35MTPAssistant:

--- a/Sources/MereRunCore/ManagedModelSupport.swift
+++ b/Sources/MereRunCore/ManagedModelSupport.swift
@@ -560,7 +560,7 @@ public enum ManagedModelCapabilityCatalog {
             descriptor(
                 Q35Resources.ornith35BMLX4BitModelId,
                 "Ornith 1.5 35B-A3B 4-bit vision agent",
-                "Runs the official 4-bit Ornith target with its BF16 vision tower and shared MTP companion.",
+                "Runs the official 4-bit Ornith target with its BF16 vision tower and MTP head in one bundle.",
                 minimum: 32,
                 recommended: 48
             ),

--- a/Sources/MereRunCore/MereRunModelManifest.swift
+++ b/Sources/MereRunCore/MereRunModelManifest.swift
@@ -1478,8 +1478,8 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
                 modelID: modelID,
                 precision: .int4,
                 bits: 4,
-                upstreamRepoId: Q35Resources.ornith35BMLX4BitUpstreamRepoId,
-                upstreamRevision: Q35Resources.ornith35BMLX4BitUpstreamRevision,
+                upstreamRepoId: Q35Resources.ornith35BMLX4BitBundleRepoId,
+                upstreamRevision: Q35Resources.ornith35BMLX4BitBundleRevision,
                 supports: [.chat, .codeGeneration, .visionChat],
                 createdAt: createdAt
             )

--- a/Sources/MereRunCore/Q35/Q35Resources.swift
+++ b/Sources/MereRunCore/Q35/Q35Resources.swift
@@ -168,6 +168,9 @@ public struct Q35Resources: Sendable, Hashable {
     public static let ornith35BMLX4BitUpstreamRepoId = "ornith-ai/Ornith-1.5-35B-A3B-MLX-4bit"
     public static let ornith35BMLX4BitUpstreamRevision = "19504d912fa8fc7622bf6b1de3db5d5d890b1f02"
     public static let ornith35BMLX4BitEstimatedDownloadBytes: Int64 = 19_530_936_278
+    public static let ornith35BMLX4BitBundleRepoId = "Sawfwair/Ornith-1.5-35B-A3B-MLX-4bit-Vision-MTP"
+    public static let ornith35BMLX4BitBundleRevision = "2323acfa0fd0a01c452c89991558e6bbd86f0f05"
+    public static let ornith35BMLX4BitBundleEstimatedDownloadBytes: Int64 = 28_652_830_929
     public static let ornith35BMLX6BitUpstreamRepoId = "ornith-ai/Ornith-1.5-35B-A3B-MLX-6bit"
     public static let ornith35BMLX6BitUpstreamRevision = "585b7867b0517980293ece857b26d64e84491352"
     public static let ornith35BMLX6BitEstimatedDownloadBytes: Int64 = 28_190_535_198
@@ -188,6 +191,7 @@ public struct Q35Resources: Sendable, Hashable {
     public static let ornith35BVisionComponentEstimatedDownloadBytes: Int64 = 4_744_402_377
     public static let ornith35BMTPUpstreamRepoId = "ornith-ai/Ornith-1.5-35B-A3B"
     public static let ornith35BMTPUpstreamRevision = "e4dfb35a93d4b6822a811a7676f3488514abe7e2"
+    public static let ornith35BMTPComponentPath = q38MTPComponentPath
     public static let ornith35BMTPShardFilename = "model-00016-of-00016.safetensors"
     public static let ornith35BMTPSnapshotPatterns = [
         "README.md",
@@ -195,6 +199,13 @@ public struct Q35Resources: Sendable, Hashable {
         ornith35BMTPShardFilename,
     ]
     public static let ornith35BMTPEstimatedDownloadBytes: Int64 = 4_379_189_705
+    public static let ornith35BMLX4BitBundleSnapshotPatterns = snapshotPatterns + [
+        "generation_config.json",
+        "README.md",
+        "mererun_model.json",
+        "SHA256SUMS",
+    ] + ornith35BVisionComponentSnapshotPatterns.map { "\(ornith35BVisionComponentPath)/\($0)" }
+        + ornith35BMTPSnapshotPatterns.map { "\(ornith35BMTPComponentPath)/\($0)" }
     public static let ornith35BMLXContextLength = 262_144
     public static let infinityParser2ProUpstreamRepoId = "infly/Infinity-Parser2-Pro"
     public static let infinityParser2ProUpstreamRevision = "1d070df7db5acca0ffa75596229070a047704f89"
@@ -305,9 +316,9 @@ public struct Q35Resources: Sendable, Hashable {
         ),
         ornith35BMLX4BitModelId: Profile(
             modelId: ornith35BMLX4BitModelId,
-            upstreamRepoId: ornith35BMLX4BitUpstreamRepoId,
-            upstreamRevision: ornith35BMLX4BitUpstreamRevision,
-            snapshotPatterns: snapshotPatterns + ["generation_config.json", "README.md"]
+            upstreamRepoId: ornith35BMLX4BitBundleRepoId,
+            upstreamRevision: ornith35BMLX4BitBundleRevision,
+            snapshotPatterns: ornith35BMLX4BitBundleSnapshotPatterns
         ),
         ornith35BMLX6BitModelId: Profile(
             modelId: ornith35BMLX6BitModelId,
@@ -492,6 +503,17 @@ public struct Q35Resources: Sendable, Hashable {
         return Self.ornith35BVisionComponentSnapshotPatterns
             .map { componentRoot.appendingPathComponent($0, isDirectory: false) }
             .filter { !fileManager.fileExists(atPath: $0.path) }
+    }
+
+    public func validateOrnithMTPComponent(fileManager: FileManager = .default) -> [URL] {
+        let componentRoot = rootURL.appendingPathComponent(
+            Self.ornith35BMTPComponentPath,
+            isDirectory: true
+        )
+        return [
+            componentRoot.appendingPathComponent("model.safetensors.index.json", isDirectory: false),
+            componentRoot.appendingPathComponent(Self.ornith35BMTPShardFilename, isDirectory: false),
+        ].filter { !fileManager.fileExists(atPath: $0.path) }
     }
 
     public func validateQ38VisionComponent(fileManager: FileManager = .default) -> [URL] {

--- a/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
@@ -851,34 +851,19 @@ final class ManagedModelCatalogTests: XCTestCase {
         XCTAssertEqual(pixelBounds.maximum, 65_536)
     }
 
-    func testOrnith35BMLX4BitUsesQuantizedTargetWithVisionAndMTPCompanions() throws {
+    func testOrnith35BMLX4BitUsesSingleVisionMTPBundle() throws {
         let spec = try XCTUnwrap(
             ManagedModelCatalog.spec(for: Q35Resources.ornith35BMLX4BitModelId)
         )
 
         XCTAssertEqual(ModelResolver.ModelID.ornith35BMLX4Bit.rawValue, spec.id)
         XCTAssertEqual(spec.category, .visionChat)
-        XCTAssertEqual(spec.hubFallback?.repoId, Q35Resources.ornith35BMLX4BitUpstreamRepoId)
-        XCTAssertEqual(spec.hubFallback?.revision, Q35Resources.ornith35BMLX4BitUpstreamRevision)
-        XCTAssertEqual(spec.mountedHubFallbacks.count, 1)
-        XCTAssertEqual(
-            spec.mountedHubFallbacks.first?.destinationPath,
-            Q35Resources.ornith35BVisionComponentPath
-        )
-        XCTAssertEqual(
-            spec.mountedHubFallbacks.first?.hubFallback.repoId,
-            Q35Resources.ornith35BVisionUpstreamRepoId
-        )
-        XCTAssertEqual(
-            spec.mountedHubFallbacks.first?.hubFallback.revision,
-            Q35Resources.ornith35BVisionUpstreamRevision
-        )
-        XCTAssertEqual(
-            spec.mountedHubFallbacks.first?.hubFallback.patterns,
-            Q35Resources.ornith35BVisionComponentSnapshotPatterns
-        )
-        XCTAssertEqual(spec.companionModelIDs, [Q35Resources.ornith35BMTPModelId])
-        XCTAssertEqual(spec.estimatedDownloadBytes, 24_275_338_655)
+        XCTAssertEqual(spec.hubFallback?.repoId, Q35Resources.ornith35BMLX4BitBundleRepoId)
+        XCTAssertEqual(spec.hubFallback?.revision, Q35Resources.ornith35BMLX4BitBundleRevision)
+        XCTAssertEqual(spec.hubFallback?.patterns, Q35Resources.ornith35BMLX4BitBundleSnapshotPatterns)
+        XCTAssertTrue(spec.mountedHubFallbacks.isEmpty)
+        XCTAssertTrue(spec.companionModelIDs.isEmpty)
+        XCTAssertEqual(spec.estimatedDownloadBytes, Q35Resources.ornith35BMLX4BitBundleEstimatedDownloadBytes)
         XCTAssertFalse(spec.runtimeAutoDownloadAllowed)
         XCTAssertTrue(spec.defaultCLICommands.contains("model benchmark code"))
         XCTAssertTrue(spec.defaultCLICommands.contains("model benchmark vlm"))
@@ -999,6 +984,47 @@ final class ManagedModelCatalogTests: XCTestCase {
         XCTAssertEqual(q4.hubFallback?.revision, Q35Resources.q38FlashNext4BitUpstreamRevision)
         XCTAssertEqual(q4.estimatedDownloadBytes, 104_742_357_706)
         XCTAssertNotNil(q4.usageRestriction)
+    }
+
+    func testOrnith35BMLX4BitValidationRequiresBundledVisionAndMTP() throws {
+        let spec = try XCTUnwrap(
+            ManagedModelCatalog.spec(for: Q35Resources.ornith35BMLX4BitModelId)
+        )
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        for filename in ["config.json", "model.safetensors", "tokenizer.json", "tokenizer_config.json"] {
+            try Data().write(to: root.appendingPathComponent(filename))
+        }
+
+        let missing = Set(spec.missingPaths(in: root).map {
+            $0.path.replacingOccurrences(of: root.path + "/", with: "")
+        })
+        let expectedVision = Q35Resources.ornith35BVisionComponentSnapshotPatterns.map {
+            "\(Q35Resources.ornith35BVisionComponentPath)/\($0)"
+        }
+        let expectedMTP = [
+            "\(Q35Resources.ornith35BMTPComponentPath)/model.safetensors.index.json",
+            "\(Q35Resources.ornith35BMTPComponentPath)/\(Q35Resources.ornith35BMTPShardFilename)",
+        ]
+        XCTAssertEqual(missing, Set(expectedVision + expectedMTP))
+
+        for (directory, filenames) in [
+            (
+                Q35Resources.ornith35BVisionComponentPath,
+                Q35Resources.ornith35BVisionComponentSnapshotPatterns
+            ),
+            (
+                Q35Resources.ornith35BMTPComponentPath,
+                ["model.safetensors.index.json", Q35Resources.ornith35BMTPShardFilename]
+            ),
+        ] {
+            let componentRoot = root.appendingPathComponent(directory, isDirectory: true)
+            try FileManager.default.createDirectory(at: componentRoot, withIntermediateDirectories: true)
+            for filename in filenames {
+                try Data().write(to: componentRoot.appendingPathComponent(filename))
+            }
+        }
+        XCTAssertTrue(spec.missingPaths(in: root).isEmpty)
     }
 
     func testQ38TwentySevenB4BitValidationRequiresMountedComponents() throws {
@@ -1126,30 +1152,32 @@ final class ManagedModelCatalogTests: XCTestCase {
         XCTAssertEqual(spec.companionModelIDs, [Q35Resources.ornith35BMTPModelId])
     }
 
-    func testOrnith35BMLXQuantizedVariantsUsePinnedOfficialSourcesAndMTPCompanion() throws {
-        let expected: [(String, String, String, Int64)] = [
+    func testOrnith35BMLXQuantizedVariantsUsePinnedSources() throws {
+        let expected: [(String, String, String, Int64, [String])] = [
             (
                 Q35Resources.ornith35BMLX4BitModelId,
-                Q35Resources.ornith35BMLX4BitUpstreamRepoId,
-                Q35Resources.ornith35BMLX4BitUpstreamRevision,
-                Q35Resources.ornith35BMLX4BitEstimatedDownloadBytes
-                    + Q35Resources.ornith35BVisionComponentEstimatedDownloadBytes
+                Q35Resources.ornith35BMLX4BitBundleRepoId,
+                Q35Resources.ornith35BMLX4BitBundleRevision,
+                Q35Resources.ornith35BMLX4BitBundleEstimatedDownloadBytes,
+                []
             ),
             (
                 Q35Resources.ornith35BMLX6BitModelId,
                 Q35Resources.ornith35BMLX6BitUpstreamRepoId,
                 Q35Resources.ornith35BMLX6BitUpstreamRevision,
-                Q35Resources.ornith35BMLX6BitEstimatedDownloadBytes
+                Q35Resources.ornith35BMLX6BitEstimatedDownloadBytes,
+                [Q35Resources.ornith35BMTPModelId]
             ),
             (
                 Q35Resources.ornith35BMLX8BitModelId,
                 Q35Resources.ornith35BMLX8BitUpstreamRepoId,
                 Q35Resources.ornith35BMLX8BitUpstreamRevision,
-                Q35Resources.ornith35BMLX8BitEstimatedDownloadBytes
+                Q35Resources.ornith35BMLX8BitEstimatedDownloadBytes,
+                [Q35Resources.ornith35BMTPModelId]
             ),
         ]
 
-        for (modelID, repoID, revision, downloadBytes) in expected {
+        for (modelID, repoID, revision, downloadBytes, companions) in expected {
             let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: modelID))
             XCTAssertEqual(spec.hubFallback?.repoId, repoID)
             XCTAssertEqual(spec.hubFallback?.revision, revision)
@@ -1157,7 +1185,7 @@ final class ManagedModelCatalogTests: XCTestCase {
             XCTAssertEqual(spec.upstreamRevision, revision)
             XCTAssertEqual(spec.validationKind, .q35)
             XCTAssertEqual(spec.estimatedDownloadBytes, downloadBytes)
-            XCTAssertEqual(spec.companionModelIDs, [Q35Resources.ornith35BMTPModelId])
+            XCTAssertEqual(spec.companionModelIDs, companions)
         }
 
         let companion = try XCTUnwrap(ManagedModelCatalog.spec(for: Q35Resources.ornith35BMTPModelId))

--- a/Tests/MereRunCoreTests/MereRunModelManifestTests.swift
+++ b/Tests/MereRunCoreTests/MereRunModelManifestTests.swift
@@ -486,7 +486,7 @@ final class MereRunModelManifestTests: MereRunCoreTestCase {
         )
     }
 
-    func testOrnith35BMLX4BitTemplateRecordsTargetAndVisionSources() throws {
+    func testOrnith35BMLX4BitTemplateRecordsSingleBundleSource() throws {
         let manifest = MereRunModelManifest.template(
             for: .ornith35BMLX4Bit,
             createdAt: Date(timeIntervalSince1970: 0)
@@ -499,21 +499,17 @@ final class MereRunModelManifestTests: MereRunCoreTestCase {
         XCTAssertEqual(manifest.quantization?.groupSize, 64)
         XCTAssertEqual(manifest.quantization?.scheme, "mlx-affine")
         XCTAssertEqual(Set(manifest.supports ?? []), Set([.chat, .codeGeneration, .visionChat]))
-        XCTAssertEqual(manifest.sources?.count, 2)
+        XCTAssertEqual(manifest.sources?.count, 1)
         XCTAssertEqual(manifest.sources?.first?.role, "primary")
         XCTAssertEqual(
             manifest.sources?.first?.repository,
-            Q35Resources.ornith35BMLX4BitUpstreamRepoId
-        )
-        XCTAssertEqual(manifest.sources?.last?.role, "component")
-        XCTAssertEqual(
-            manifest.sources?.last?.repository,
-            Q35Resources.ornith35BVisionUpstreamRepoId
+            Q35Resources.ornith35BMLX4BitBundleRepoId
         )
         XCTAssertEqual(
-            manifest.sources?.last?.destinationPath,
-            Q35Resources.ornith35BVisionComponentPath
+            manifest.sources?.first?.revision,
+            Q35Resources.ornith35BMLX4BitBundleRevision
         )
+        XCTAssertNil(manifest.sources?.first?.destinationPath)
     }
 
     func testOrnith35BMLXQuantizedTemplatesPinOfficialConversions() throws {
@@ -531,8 +527,8 @@ final class MereRunModelManifestTests: MereRunCoreTestCase {
                 Q35Resources.ornith35BMLX4BitModelId,
                 .int4,
                 4,
-                Q35Resources.ornith35BMLX4BitUpstreamRepoId,
-                Q35Resources.ornith35BMLX4BitUpstreamRevision
+                Q35Resources.ornith35BMLX4BitBundleRepoId,
+                Q35Resources.ornith35BMLX4BitBundleRevision
             ),
             (
                 .ornith35BMLX6Bit,

--- a/Tests/MereRunCoreTests/OrnithVisionCheckpointTests.swift
+++ b/Tests/MereRunCoreTests/OrnithVisionCheckpointTests.swift
@@ -17,7 +17,7 @@ final class OrnithVisionCheckpointTests: MereRunCoreTestCase {
             )
         }
         let rootURL = URL(fileURLWithPath: root, isDirectory: true)
-        Self.report("validating 4-bit target, MTP companion, and vision tensors")
+        Self.report("validating bundled 4-bit target, MTP head, and vision tensors")
         try validatePublishedConfigurationAndVisionWeights(primaryRootURL: rootURL)
         Self.report("vision tensor validation complete")
         Memory.clearCache()
@@ -81,8 +81,9 @@ final class OrnithVisionCheckpointTests: MereRunCoreTestCase {
         XCTAssertEqual(primaryConfig.quantization?.bits, 4)
         XCTAssertNil(primaryConfig.visionConfig)
 
-        let mtpRoot = try XCTUnwrap(
-            ManagedModelResolver.resolveInstalledModel(id: Q35Resources.ornith35BMTPModelId)
+        let mtpRoot = primaryRootURL.appendingPathComponent(
+            Q35Resources.ornith35BMTPComponentPath,
+            isDirectory: true
         )
         XCTAssertTrue(Q35Resources(rootURL: mtpRoot).validateOrnith35BMTPCompanion().isEmpty)
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -987,8 +987,10 @@ swift run mere.run model pull text-agent-ornith-35b
 swift run mere.run text code --model text-agent-ornith-35b --prompt "Sketch a small Swift Result helper."
 ```
 
-Ornith 1.5's native Swift/MLX lane has official Q4/Q6/Q8 ids plus the BF16
-compatibility id `text-agent-ornith-35b-mlx`. Use `model capabilities` to pick
+Ornith 1.5's native Swift/MLX lane has Q4/Q6/Q8 ids plus the BF16 compatibility
+id `text-agent-ornith-35b-mlx`. Q4 is a single packaging snapshot containing
+the official Q4 target, authoritative vision shard, and MTP head. Use
+`model capabilities` to pick
 the speed, balanced, or quality tier for this machine. Pull it explicitly;
 runtime auto-download is disabled for these large checkpoints:
 

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -317,20 +317,23 @@ The Ornith 1.5 native family pins the official
 `text-agent-ornith-35b-mlx-4bit`, `-6bit`, `-8bit`, and
 `text-agent-ornith-35b-mlx`. The 35B-parameter MoE activates about 3B
 parameters per token, advertises a 262,144-token context, and runs through the
-native Qwen-family runtime. Runtime auto-download remains disabled. Every pull
-also installs the final safetensors shard and index containing `mtp.*` from the
-pinned authoritative base checkpoint as the shared
-`text-agent-ornith-35b-mtp` companion. The authoritative
+native Qwen-family runtime. Runtime auto-download remains disabled. Q6, Q8,
+and BF16 pulls also install the final safetensors shard and index containing
+`mtp.*` from the pinned authoritative base checkpoint as the shared
+`text-agent-ornith-35b-mtp` companion. The Q4 lane instead pulls the pinned
+`Sawfwair/Ornith-1.5-35B-A3B-MLX-4bit-Vision-MTP` packaging snapshot, which
+contains its target, vision, and MTP files together. The authoritative
 [`ornith-ai/Ornith-1.5-35B-A3B`](https://huggingface.co/ornith-ai/Ornith-1.5-35B-A3B)
 base checkpoint declares the model under the MIT license in its model-card
 metadata; the MLX conversion repository does not duplicate the license file.
 
-`text-agent-ornith-35b-mlx-4bit` is the recommended local multimodal lane. It
-combines the official `Ornith-1.5-35B-A3B-MLX-4bit` text target with the
+`text-agent-ornith-35b-mlx-4bit` is the recommended local multimodal lane. Its
+single packaging snapshot combines the official
+`Ornith-1.5-35B-A3B-MLX-4bit` text target with the
 authoritative base checkpoint's `model-00001-of-00016.safetensors` vision
-shard, vision configuration, processor metadata, and the shared BF16 MTP
-companion. The primary and vision payloads total about 22.6 GiB; the shared MTP
-companion adds about 4.1 GiB when it is not already installed. Image requests
+shard, vision configuration, processor metadata, and BF16 MTP head. The
+complete snapshot is about 26.7 GiB and records every packaged file in
+`SHA256SUMS`. Image requests
 use target-only decoding because MTP speculation is disabled when image
 embeddings are present; text and code requests retain verified MTP.
 

--- a/docs/runtime/model-management.md
+++ b/docs/runtime/model-management.md
@@ -321,17 +321,18 @@ The `text-code` API lane rejects tool calls, so these models are not Pi setup
 agents.
 `text-agent-ornith-9b` can be pulled, inspected, and run through the native
 Qwen-family MLX/OptiQ runtime for coding-agent comparisons.
-Ornith 1.5 35B-A3B has four official native MLX targets:
+Ornith 1.5 35B-A3B has four native MLX targets:
 `text-agent-ornith-35b-mlx-4bit`, `text-agent-ornith-35b-mlx-6bit`,
 `text-agent-ornith-35b-mlx-8bit`, and the unquantized BF16 compatibility id
-`text-agent-ornith-35b-mlx`. All require an explicit `model pull`; each pull
-also installs one shared, pinned BF16 MTP head from the authoritative base
-checkpoint. Use `model capabilities` for the current machine's explicit
+`text-agent-ornith-35b-mlx`. All require an explicit `model pull`. Q6, Q8, and
+BF16 pulls also install one shared, pinned BF16 MTP head from the authoritative
+base checkpoint. Q4 pulls one Sawfwair packaging snapshot with its target,
+vision shard, and MTP head embedded. Use `model capabilities` for the current machine's explicit
 speed/balanced/quality choices. The conservative tiers are Q4 at 32 GB, Q6 at
 48 GB, Q8 at 64 GB, and BF16 at 96 GB; 128 GB is recommended for BF16.
-The recommended `text-agent-ornith-35b-mlx-4bit` explicit-pull lane reuses the Q4
-target, mounts the authoritative base vision shard, and installs the shared MTP
-companion. It has a 32 GB minimum and 48 GB recommendation. The full
+The recommended `text-agent-ornith-35b-mlx-4bit` explicit-pull lane installs
+its Q4 target, authoritative base vision shard, and MTP head from one pinned
+snapshot. It has a 32 GB minimum and 48 GB recommendation. The full
 `vision-chat-ornith-35b` BF16 quality reference has a 96 GB minimum and
 128 GB recommendation.
 

--- a/docs/runtime/text.md
+++ b/docs/runtime/text.md
@@ -57,7 +57,7 @@ help in the repository gate.
 - `text-chat-lfm25-a1b-bf16` (managed LiquidAI LFM2.5 8B-A1B BF16 target plus DSpark)
 - `vision-chat-lfm25-3b-8bit` (managed LiquidAI LFM2.5-VL 3B MLX 8-bit vision-language snapshot)
 - `text-agent-ornith-9b` (experimental native MLX/OptiQ coding-agent snapshot)
-- `text-agent-ornith-35b-mlx-4bit` (recommended Ornith 1.5 Q4 coding and vision composite)
+- `text-agent-ornith-35b-mlx-4bit` (recommended self-contained Ornith 1.5 Q4 coding and vision bundle)
 - `text-agent-ornith-35b-mlx-6bit` (Ornith 1.5 balanced tier)
 - `text-agent-ornith-35b-mlx-8bit` (Ornith 1.5 quantized quality tier)
 - `text-agent-ornith-35b-mlx` (Ornith 1.5 35B-A3B BF16 MLX coding-agent snapshot)


### PR DESCRIPTION
## Summary

- Point text-agent-ornith-35b-mlx-4bit at the pinned Sawfwair self-contained bundle.
- Require embedded vision and MTP components and remove separate companion downloads for the Q4 profile.
- Update manifests, documentation, and tests for the single-root layout.

## Validation

- swift test --filter Ornith: 39 tests, 1 expected checkpoint skip, 0 failures.
- ./scripts/check.sh: 3,394 XCTest cases, 282 expected opt-in skips, 0 failures; 38 Swift Testing cases passed.
- pnpm docs:build passed.
- Real local MTP-enabled inference against the bundled root returned bundle-ok.
- All 20 bundle SHA-256 entries matched.