### PR TITLE
Use standalone native Nemotron Omni checkpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ The format is based on Keep a Changelog.
 
 ### Runtime
 
+- changed the managed Nemotron 3 Nano Omni BF16 installation to one standalone
+  native MLX checkpoint. The published artifact stores every parameter once,
+  includes a byte-level conversion receipt, and removes the first-run 58.75 GB
+  expert-cache build while retaining compatibility with legacy local caches.
 - made machine-wide music admission use managed checkpoint size: models at or
   below 16 GiB, including ACE-Step and Magenta RT2, now use the 6 GiB small-work
   headroom floor instead of the fixed 16 GiB standard floor. Larger music

--- a/Sources/MereRunCLI/Commands/ModelOptimizeCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelOptimizeCommand.swift
@@ -20,6 +20,12 @@ struct ModelOptimize: ParsableCommand {
     )
     var textEncoderOnly: Bool = false
 
+    @Option(
+        name: [.customLong("output")],
+        help: "For Nemotron Omni, write a standalone native checkpoint to this directory."
+    )
+    var output: String?
+
     @Flag(name: [.long], help: "Emit the result as JSON.")
     var json: Bool = false
 
@@ -27,7 +33,44 @@ struct ModelOptimize: ParsableCommand {
         let rootURL = try resolveRootURL()
         let artifacts: [URL]
         let optimization: String
-        if isLTX25ModelRoot(rootURL) {
+        if NemotronOmniNativeCheckpoint.isValid(rootURL: rootURL) {
+            throw ValidationError(
+                "Nemotron Omni model root is already a standalone native checkpoint."
+            )
+        } else if NemotronOmniResources.validationMessages(rootURL: rootURL).isEmpty {
+            guard !textEncoderOnly else {
+                throw ValidationError("--text-encoder-only requires an LTX 2.5 model.")
+            }
+            guard let output, !output.isEmpty else {
+                throw ValidationError(
+                    "Nemotron Omni standalone optimization requires --output <directory>."
+                )
+            }
+            let result = try NemotronOmniNativeCheckpoint.export(
+                sourceRootURL: rootURL,
+                destinationRootURL: URL(fileURLWithPath: output),
+                replacing: force,
+                progressHandler: { phase, completed, total in
+                    if completed == total || completed.isMultiple(of: 32) {
+                        CLIStderr.write(
+                            "Nemotron Omni native \(phase): \(completed)/\(total)\n"
+                        )
+                    }
+                }
+            )
+            artifacts = [result.expertPackURL]
+                + result.nonExpertShardURLs
+                + [
+                    result.indexURL,
+                    NemotronOmniNativeCheckpoint.manifestURL(
+                        rootURL: result.outputRootURL
+                    ),
+                ]
+            optimization = NemotronOmniNativeCheckpoint.format
+        } else if isLTX25ModelRoot(rootURL) {
+            guard output == nil else {
+                throw ValidationError("--output is supported only for Nemotron Omni.")
+            }
             let resources = LTX25Resources(rootURL: rootURL)
             if textEncoderOnly {
                 let hasTextSource = FileManager.default.fileExists(
@@ -113,6 +156,9 @@ struct ModelOptimize: ParsableCommand {
             artifacts = ltxArtifacts
             optimization = "ltx25-native-model-pack+text-q4-v1"
         } else {
+            guard output == nil else {
+                throw ValidationError("--output is supported only for Nemotron Omni.")
+            }
             if textEncoderOnly {
                 throw ValidationError("--text-encoder-only requires an LTX 2.5 model.")
             }
@@ -195,8 +241,11 @@ struct ModelOptimize: ParsableCommand {
                 || modelID == .miniMaxH3FL2VAQ8MLX
                 || modelID == .miniMaxH3Ref2VAMLX
                 || modelID == .ltxVideo25DistilledBF16
-                || modelID == .ltxVideo25FullBF16 else {
-            throw ValidationError("Model optimization supports MiniMax-H3 MLX and LTX 2.5 models.")
+                || modelID == .ltxVideo25FullBF16
+                || modelID == .nemotron3NanoOmni30BA3BBF16 else {
+            throw ValidationError(
+                "Model optimization supports MiniMax-H3 MLX, LTX 2.5, and Nemotron Omni models."
+            )
         }
         do {
             return try ModelResolver().resolve(modelID).rootURL

--- a/Sources/MereRunCore/HFSafetensorsIndex.swift
+++ b/Sources/MereRunCore/HFSafetensorsIndex.swift
@@ -5,6 +5,10 @@ public struct HFSafetensorsIndex: Codable, Sendable, Hashable {
     public struct Metadata: Codable, Sendable, Hashable {
         public let totalSize: Int64?
 
+        public init(totalSize: Int64?) {
+            self.totalSize = totalSize
+        }
+
         enum CodingKeys: String, CodingKey {
             case totalSize = "total_size"
         }

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -1787,8 +1787,8 @@ public enum ManagedModelCatalog {
             category: .omniChat,
             installShape: .directoryRoot,
             hubFallback: HubFallbackConfig(
-                repoId: NemotronOmniResources.upstreamRepoID,
-                revision: NemotronOmniResources.upstreamRevision,
+                repoId: NemotronOmniResources.nativeRepoID,
+                revision: NemotronOmniResources.nativeRevision,
                 patterns: NemotronOmniResources.snapshotPatterns
             ),
             upstreamRepoId: NemotronOmniResources.upstreamRepoID,

--- a/Sources/MereRunCore/NemotronOmni/NemotronOmniExpertPack.swift
+++ b/Sources/MereRunCore/NemotronOmni/NemotronOmniExpertPack.swift
@@ -32,53 +32,86 @@ public enum NemotronOmniExpertPackError: LocalizedError {
 /// model tensor is converted, rounded, or materialized in unified memory.
 public enum NemotronOmniExpertPack {
     public static let format = "mere-run-nemotron-omni-experts-v1"
+    public static let publishedFilename = "experts-bf16.safetensors"
     public static let relativePath = ".mere-run/nemotron-omni-experts-v1/experts-bf16.safetensors"
+
+    public static func publishedURL(
+        rootURL: URL,
+        fileManager: FileManager = .default
+    ) throws -> URL {
+        try artifactRootURL(rootURL: rootURL, fileManager: fileManager)
+            .appendingPathComponent(publishedFilename)
+    }
 
     public static func outputURL(
         rootURL: URL,
         fileManager: FileManager = .default
     ) throws -> URL {
+        try artifactRootURL(rootURL: rootURL, fileManager: fileManager)
+            .appendingPathComponent(relativePath)
+    }
+
+    private static func artifactRootURL(
+        rootURL: URL,
+        fileManager: FileManager
+    ) throws -> URL {
         let standardized = rootURL.standardizedFileURL
         let configURL = standardized.appendingPathComponent("config.json")
-        let base: URL
         if let destination = try? fileManager.destinationOfSymbolicLink(atPath: configURL.path) {
             let destinationURL = URL(fileURLWithPath: destination)
             let absolute = destinationURL.path.hasPrefix("/")
                 ? destinationURL
                 : configURL.deletingLastPathComponent().appendingPathComponent(destination)
-            base = absolute.deletingLastPathComponent()
-        } else {
-            base = standardized
+            return absolute.deletingLastPathComponent()
         }
-        return base.appendingPathComponent(relativePath)
+        return standardized
     }
 
     public static func optimizedURLIfValid(
         rootURL: URL,
         fileManager: FileManager = .default
     ) -> URL? {
-        guard let url = try? outputURL(rootURL: rootURL, fileManager: fileManager),
-              fileManager.fileExists(atPath: url.path),
+        let candidates = [
+            try? publishedURL(rootURL: rootURL, fileManager: fileManager),
+            try? outputURL(rootURL: rootURL, fileManager: fileManager),
+        ].compactMap { $0 }
+        return candidates.first {
+            isValid(url: $0, fileManager: fileManager)
+        }
+    }
+
+    public static func isValid(
+        url: URL,
+        fileManager: FileManager = .default
+    ) -> Bool {
+        guard fileManager.fileExists(atPath: url.path),
               let metadata = try? SafetensorsStreamingLoader.fileMetadata(url: url),
               metadata["format"] == format,
               metadata["source_revision"] == NemotronOmniResources.upstreamRevision,
               metadata["payload_bytes"] == String(NemotronOmniResources.packedExpertWeightBytes),
               let tensors = try? SafetensorsStreamingLoader.metadata(url: url),
               tensors.count == 46 else {
-            return nil
+            return false
         }
-        return url
+        return true
     }
 
     @discardableResult
     public static func optimize(
         rootURL: URL,
+        destinationURL: URL? = nil,
         replacing: Bool = false,
         progressHandler: ((Int, Int) -> Void)? = nil,
         fileManager: FileManager = .default
     ) throws -> URL {
         let rootURL = rootURL.standardizedFileURL
-        let outputURL = try outputURL(rootURL: rootURL, fileManager: fileManager)
+        let resolvedOutputURL: URL
+        if let destinationURL {
+            resolvedOutputURL = destinationURL.standardizedFileURL
+        } else {
+            resolvedOutputURL = try outputURL(rootURL: rootURL, fileManager: fileManager)
+        }
+        let outputURL = resolvedOutputURL
         if fileManager.fileExists(atPath: outputURL.path), !replacing {
             throw NemotronOmniExpertPackError.outputExists(outputURL)
         }
@@ -269,7 +302,7 @@ public enum NemotronOmniExpertPack {
             try fileManager.removeItem(at: outputURL)
         }
         try fileManager.moveItem(at: temporaryURL, to: outputURL)
-        guard optimizedURLIfValid(rootURL: rootURL, fileManager: fileManager) == outputURL else {
+        guard isValid(url: outputURL, fileManager: fileManager) else {
             throw NemotronOmniExpertPackError.invalidOutput(outputURL)
         }
         return outputURL

--- a/Sources/MereRunCore/NemotronOmni/NemotronOmniLanguageModel.swift
+++ b/Sources/MereRunCore/NemotronOmni/NemotronOmniLanguageModel.swift
@@ -86,6 +86,36 @@ final class NemotronOmniMoE: NemotronHMixer {
         _ input: MLXArray,
         cache: NemotronHLayerCache?
     ) -> MLXArray {
+        let tokenCount = input.ndim == 3 ? input.dim(1) : 1
+        let ranges = Self.prefillRanges(tokenCount: tokenCount)
+        guard ranges.count > 1 else {
+            return mixedOutput(input)
+        }
+
+        // BF16 gather matmul selects routed matrices with `take` because
+        // MLX's native gatherMM path is float32-only. Evaluating an entire
+        // prompt at once can therefore page several gigabytes of selected
+        // expert rows into one Metal command buffer and trip the macOS GPU
+        // watchdog. Materialize small token runs independently; decode keeps
+        // the original single-token path.
+        var pieces: [MLXArray] = []
+        pieces.reserveCapacity(ranges.count)
+        for range in ranges {
+            let piece = mixedOutput(input[0..., range, 0...])
+            MLX.eval(piece)
+            pieces.append(piece)
+        }
+        return MLX.concatenated(pieces, axis: 1)
+    }
+
+    static func prefillRanges(tokenCount: Int, chunkSize: Int = 4) -> [Range<Int>] {
+        precondition(tokenCount > 0 && chunkSize > 0)
+        return stride(from: 0, to: tokenCount, by: chunkSize).map { start in
+            start..<min(start + chunkSize, tokenCount)
+        }
+    }
+
+    private func mixedOutput(_ input: MLXArray) -> MLXArray {
         let route = gate(input)
         let routed = (
             experts(input, indices: route.indices)

--- a/Sources/MereRunCore/NemotronOmni/NemotronOmniNativeCheckpoint.swift
+++ b/Sources/MereRunCore/NemotronOmni/NemotronOmniNativeCheckpoint.swift
@@ -1,0 +1,372 @@
+import Foundation
+
+public struct NemotronOmniNativeCheckpointManifest: Codable, Sendable, Hashable {
+    public let schemaVersion: Int
+    public let format: String
+    public let sourceRepository: String
+    public let sourceRevision: String
+    public let totalWeightBytes: Int64
+    public let expertWeightBytes: Int64
+    public let nonExpertWeightBytes: Int64
+    public let nonExpertShardCount: Int
+}
+
+public struct NemotronOmniNativeCheckpointResult: Sendable, Hashable {
+    public let outputRootURL: URL
+    public let expertPackURL: URL
+    public let indexURL: URL
+    public let nonExpertShardURLs: [URL]
+    public let totalWeightBytes: Int64
+}
+
+public enum NemotronOmniNativeCheckpointError: LocalizedError {
+    case invalidSource([String])
+    case outputExists(URL)
+    case insufficientDisk(required: Int64, available: Int64)
+    case missingSupportFile(URL)
+    case unexpectedNonExpertBytes(expected: Int64, actual: Int64)
+    case invalidOutput([String])
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidSource(let messages):
+            "Nemotron Omni source checkpoint is invalid: \(messages.joined(separator: "; "))"
+        case .outputExists(let url):
+            "Nemotron Omni native checkpoint already exists: \(url.path)"
+        case .insufficientDisk(let required, let available):
+            "Nemotron Omni native export requires \(required) bytes but only \(available) bytes are available."
+        case .missingSupportFile(let url):
+            "Nemotron Omni native export is missing support file: \(url.path)"
+        case .unexpectedNonExpertBytes(let expected, let actual):
+            "Nemotron Omni native export expected \(expected) non-expert bytes but wrote \(actual)."
+        case .invalidOutput(let messages):
+            "Nemotron Omni native checkpoint failed validation: \(messages.joined(separator: "; "))"
+        }
+    }
+}
+
+/// Produces a standalone native checkpoint with each parameter stored once.
+/// Non-expert tensors retain their upstream keys and payload bytes, while the
+/// routed experts are stacked into the physical layout used by the MLX model.
+public enum NemotronOmniNativeCheckpoint {
+    public static let format = "mere-run-nemotron-omni-native-v1"
+    public static let manifestFilename = "mere-run-native-checkpoint.json"
+
+    public static let supportFilenames = [
+        "bias.md",
+        "chat_template.jinja",
+        "config.json",
+        "explainability.md",
+        "generation_config.json",
+        "preprocessor_config.json",
+        "privacy.md",
+        "safety.md",
+        "special_tokens_map.json",
+        "tokenizer.json",
+        "tokenizer_config.json",
+    ]
+
+    public static func manifestURL(rootURL: URL) -> URL {
+        rootURL.appendingPathComponent(manifestFilename)
+    }
+
+    public static func validationMessages(
+        rootURL: URL,
+        fileManager: FileManager = .default
+    ) -> [String] {
+        var messages: [String] = []
+        for filename in supportFilenames {
+            let url = rootURL.appendingPathComponent(filename)
+            if !fileManager.fileExists(atPath: url.path) {
+                messages.append("Missing required file: \(url.path)")
+            }
+        }
+        let manifest: NemotronOmniNativeCheckpointManifest?
+        do {
+            manifest = try JSONDecoder().decode(
+                NemotronOmniNativeCheckpointManifest.self,
+                from: Data(contentsOf: manifestURL(rootURL: rootURL))
+            )
+        } catch {
+            messages.append("Invalid \(manifestFilename): \(error.localizedDescription)")
+            manifest = nil
+        }
+        if let manifest,
+           manifest.schemaVersion != 1
+            || manifest.format != format
+            || manifest.sourceRepository != NemotronOmniResources.upstreamRepoID
+            || manifest.sourceRevision != NemotronOmniResources.upstreamRevision
+            || manifest.totalWeightBytes != NemotronOmniResources.checkpointWeightBytes
+            || manifest.expertWeightBytes != NemotronOmniResources.packedExpertWeightBytes
+            || manifest.nonExpertWeightBytes != NemotronOmniResources.nativeNonExpertWeightBytes
+            || manifest.nonExpertShardCount != NemotronOmniResources.checkpointShardCount {
+            messages.append("Native checkpoint manifest does not match the pinned format.")
+        }
+
+        let expertURL = rootURL.appendingPathComponent(
+            NemotronOmniExpertPack.publishedFilename
+        )
+        if !NemotronOmniExpertPack.isValid(url: expertURL, fileManager: fileManager) {
+            messages.append("Published native expert shard is missing or invalid.")
+        }
+
+        let indexURL = rootURL.appendingPathComponent("model.safetensors.index.json")
+        do {
+            let index = try JSONDecoder().decode(
+                HFSafetensorsIndex.self,
+                from: Data(contentsOf: indexURL)
+            )
+            let expectedShards = (1...NemotronOmniResources.checkpointShardCount).map {
+                String(
+                    format: "model-%05d-of-%05d.safetensors",
+                    $0,
+                    NemotronOmniResources.checkpointShardCount
+                )
+            }
+            if index.metadata?.totalSize != NemotronOmniResources.nativeNonExpertWeightBytes {
+                messages.append("Native non-expert index reports the wrong payload size.")
+            }
+            if index.shardFilenames != expectedShards {
+                messages.append("Native non-expert index reports the wrong shard inventory.")
+            }
+            if index.weightMap.keys.contains(where: {
+                NemotronOmniExpertWeightKey(checkpointKey: $0) != nil
+            }) {
+                messages.append("Native non-expert index still contains routed expert tensors.")
+            }
+            for filename in expectedShards {
+                let url = rootURL.appendingPathComponent(filename)
+                if !fileManager.fileExists(atPath: url.path) {
+                    messages.append("Missing required file: \(url.path)")
+                }
+            }
+        } catch {
+            messages.append("Invalid native safetensors index: \(error.localizedDescription)")
+        }
+        return messages
+    }
+
+    public static func isValid(
+        rootURL: URL,
+        fileManager: FileManager = .default
+    ) -> Bool {
+        validationMessages(rootURL: rootURL, fileManager: fileManager).isEmpty
+    }
+
+    public static func export(
+        sourceRootURL: URL,
+        destinationRootURL: URL,
+        replacing: Bool = false,
+        progressHandler: ((String, Int, Int) -> Void)? = nil,
+        fileManager: FileManager = .default
+    ) throws -> NemotronOmniNativeCheckpointResult {
+        let sourceRootURL = sourceRootURL.standardizedFileURL
+        let destinationRootURL = destinationRootURL.standardizedFileURL
+        guard !fileManager.fileExists(
+            atPath: manifestURL(rootURL: sourceRootURL).path
+        ) else {
+            throw NemotronOmniNativeCheckpointError.invalidSource([
+                "Source is already a standalone native checkpoint.",
+            ])
+        }
+        let sourceMessages = NemotronOmniResources.validationMessages(
+            rootURL: sourceRootURL,
+            fileManager: fileManager
+        )
+        guard sourceMessages.isEmpty else {
+            throw NemotronOmniNativeCheckpointError.invalidSource(sourceMessages)
+        }
+        if fileManager.fileExists(atPath: destinationRootURL.path), !replacing {
+            throw NemotronOmniNativeCheckpointError.outputExists(destinationRootURL)
+        }
+
+        let parentURL = destinationRootURL.deletingLastPathComponent()
+        try fileManager.createDirectory(at: parentURL, withIntermediateDirectories: true)
+        let available = try NemotronOmniExpertPack.availableCapacity(
+            at: parentURL,
+            fileManager: fileManager
+        )
+        let reserve: Int64 = 8 * 1_073_741_824
+        let required = NemotronOmniResources.checkpointWeightBytes + reserve
+        guard available <= 0 || available >= required else {
+            throw NemotronOmniNativeCheckpointError.insufficientDisk(
+                required: required,
+                available: available
+            )
+        }
+
+        let stagingRootURL = parentURL.appendingPathComponent(
+            ".\(destinationRootURL.lastPathComponent).\(UUID().uuidString).tmp",
+            isDirectory: true
+        )
+        try fileManager.createDirectory(at: stagingRootURL, withIntermediateDirectories: true)
+        do {
+            try copySupportFiles(
+                sourceRootURL: sourceRootURL,
+                destinationRootURL: stagingRootURL,
+                fileManager: fileManager
+            )
+            let sourceIndex = try JSONDecoder().decode(
+                HFSafetensorsIndex.self,
+                from: Data(
+                    contentsOf: sourceRootURL.appendingPathComponent(
+                        "model.safetensors.index.json"
+                    )
+                )
+            )
+            let expertPackURL = stagingRootURL.appendingPathComponent(
+                NemotronOmniExpertPack.publishedFilename
+            )
+            try NemotronOmniExpertPack.optimize(
+                rootURL: sourceRootURL,
+                destinationURL: expertPackURL,
+                progressHandler: { completed, total in
+                    progressHandler?("experts", completed, total)
+                },
+                fileManager: fileManager
+            )
+
+            let nativeWeightMap = sourceIndex.weightMap.filter {
+                NemotronOmniExpertWeightKey(checkpointKey: $0.key) == nil
+            }
+            var nonExpertBytes: Int64 = 0
+            var nonExpertShardURLs: [URL] = []
+            let shardFilenames = sourceIndex.shardFilenames
+            for (shardIndex, filename) in shardFilenames.enumerated() {
+                let sourceURL = sourceRootURL.appendingPathComponent(filename)
+                let destinationURL = stagingRootURL.appendingPathComponent(filename)
+                let result = try SafetensorsSubsetWriter.write(
+                    sourceURL: sourceURL,
+                    destinationURL: destinationURL,
+                    fileMetadata: [
+                        "format": format,
+                        "source_filename": filename,
+                        "source_repository": NemotronOmniResources.upstreamRepoID,
+                        "source_revision": NemotronOmniResources.upstreamRevision,
+                    ],
+                    include: { nativeWeightMap[$0] == filename },
+                    fileManager: fileManager
+                )
+                nonExpertBytes += result.payloadBytes
+                nonExpertShardURLs.append(destinationURL)
+                progressHandler?("non-expert-shards", shardIndex + 1, shardFilenames.count)
+            }
+            guard nonExpertBytes == NemotronOmniResources.nativeNonExpertWeightBytes else {
+                throw NemotronOmniNativeCheckpointError.unexpectedNonExpertBytes(
+                    expected: NemotronOmniResources.nativeNonExpertWeightBytes,
+                    actual: nonExpertBytes
+                )
+            }
+
+            let nativeIndex = HFSafetensorsIndex(
+                metadata: HFSafetensorsIndex.Metadata(totalSize: nonExpertBytes),
+                weightMap: nativeWeightMap
+            )
+            let indexURL = stagingRootURL.appendingPathComponent(
+                "model.safetensors.index.json"
+            )
+            try writeJSON(nativeIndex, to: indexURL)
+            let manifest = NemotronOmniNativeCheckpointManifest(
+                schemaVersion: 1,
+                format: format,
+                sourceRepository: NemotronOmniResources.upstreamRepoID,
+                sourceRevision: NemotronOmniResources.upstreamRevision,
+                totalWeightBytes: NemotronOmniResources.checkpointWeightBytes,
+                expertWeightBytes: NemotronOmniResources.packedExpertWeightBytes,
+                nonExpertWeightBytes: nonExpertBytes,
+                nonExpertShardCount: nonExpertShardURLs.count
+            )
+            try writeJSON(manifest, to: manifestURL(rootURL: stagingRootURL))
+
+            let messages = validationMessages(
+                rootURL: stagingRootURL,
+                fileManager: fileManager
+            )
+            guard messages.isEmpty else {
+                throw NemotronOmniNativeCheckpointError.invalidOutput(messages)
+            }
+            try installStagingRoot(
+                stagingRootURL,
+                at: destinationRootURL,
+                replacing: replacing,
+                fileManager: fileManager
+            )
+        } catch {
+            try? fileManager.removeItem(at: stagingRootURL)
+            throw error
+        }
+
+        let indexURL = destinationRootURL.appendingPathComponent(
+            "model.safetensors.index.json"
+        )
+        let index = try JSONDecoder().decode(
+            HFSafetensorsIndex.self,
+            from: Data(contentsOf: indexURL)
+        )
+        return NemotronOmniNativeCheckpointResult(
+            outputRootURL: destinationRootURL,
+            expertPackURL: destinationRootURL.appendingPathComponent(
+                NemotronOmniExpertPack.publishedFilename
+            ),
+            indexURL: indexURL,
+            nonExpertShardURLs: index.shardFilenames.map {
+                destinationRootURL.appendingPathComponent($0)
+            },
+            totalWeightBytes: NemotronOmniResources.checkpointWeightBytes
+        )
+    }
+
+    private static func copySupportFiles(
+        sourceRootURL: URL,
+        destinationRootURL: URL,
+        fileManager: FileManager
+    ) throws {
+        for filename in supportFilenames {
+            let sourceURL = sourceRootURL.appendingPathComponent(filename)
+            guard fileManager.fileExists(atPath: sourceURL.path) else {
+                throw NemotronOmniNativeCheckpointError.missingSupportFile(sourceURL)
+            }
+            try fileManager.copyItem(
+                at: sourceURL,
+                to: destinationRootURL.appendingPathComponent(filename)
+            )
+        }
+    }
+
+    private static func writeJSON<T: Encodable>(_ value: T, to url: URL) throws {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        var data = try encoder.encode(value)
+        data.append(0x0A)
+        try data.write(to: url, options: .atomic)
+    }
+
+    private static func installStagingRoot(
+        _ stagingRootURL: URL,
+        at destinationRootURL: URL,
+        replacing: Bool,
+        fileManager: FileManager
+    ) throws {
+        guard fileManager.fileExists(atPath: destinationRootURL.path) else {
+            try fileManager.moveItem(at: stagingRootURL, to: destinationRootURL)
+            return
+        }
+        guard replacing else {
+            throw NemotronOmniNativeCheckpointError.outputExists(destinationRootURL)
+        }
+        let backupURL = destinationRootURL.deletingLastPathComponent().appendingPathComponent(
+            ".\(destinationRootURL.lastPathComponent).\(UUID().uuidString).backup",
+            isDirectory: true
+        )
+        try fileManager.moveItem(at: destinationRootURL, to: backupURL)
+        do {
+            try fileManager.moveItem(at: stagingRootURL, to: destinationRootURL)
+            try fileManager.removeItem(at: backupURL)
+        } catch {
+            if !fileManager.fileExists(atPath: destinationRootURL.path) {
+                try? fileManager.moveItem(at: backupURL, to: destinationRootURL)
+            }
+            throw error
+        }
+    }
+}

--- a/Sources/MereRunCore/NemotronOmni/NemotronOmniResources.swift
+++ b/Sources/MereRunCore/NemotronOmni/NemotronOmniResources.swift
@@ -24,19 +24,20 @@ public enum NemotronOmniError: LocalizedError {
 }
 
 /// Pinned artifacts and runtime limits for NVIDIA Nemotron 3 Nano Omni.
-///
-/// The upstream repository contains executable Python reference code. mere.run
-/// downloads it only as provenance for the published checkpoint contract; the
-/// native runtime never imports or executes repository code.
 public enum NemotronOmniResources {
     public static let modelID = "omni-chat-nemotron3-nano-30b-a3b-bf16"
+    public static let nativeRepoID =
+        "Sawfwair/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16-MLX-Native"
+    public static let nativeRevision = "9256528c67910cc390c3286157b1527eac44ef04"
     public static let upstreamRepoID =
         "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16"
     public static let upstreamRevision = "24e67ea000b7c2837fc8f9488aa2008524fac8ba"
-    public static let estimatedDownloadBytes: Int64 = 66_059_015_328
+    public static let estimatedDownloadBytes: Int64 = 66_049_002_038
     public static let checkpointWeightBytes: Int64 = 66_031_270_520
     public static let checkpointShardCount = 17
     public static let packedExpertWeightBytes: Int64 = 58_749_616_128
+    public static let nativeNonExpertWeightBytes =
+        checkpointWeightBytes - packedExpertWeightBytes
 
     /// The composed checkpoint advertises 131,072 tokens even though the
     /// underlying Nemotron-H text backbone has 262,144 positional slots.
@@ -56,6 +57,10 @@ public enum NemotronOmniResources {
 
     public static let snapshotPatterns = [
         "README.md",
+        "LICENSE.pdf",
+        "NOTICE",
+        "NEMOTRON_OMNI_NATIVE_VALIDATION.json",
+        "SHA256SUMS",
         "bias.md",
         "explainability.md",
         "privacy.md",
@@ -67,29 +72,19 @@ public enum NemotronOmniResources {
         "special_tokens_map.json",
         "tokenizer.json",
         "tokenizer_config.json",
+        NemotronOmniNativeCheckpoint.manifestFilename,
+        NemotronOmniExpertPack.publishedFilename,
         "model.safetensors.index.json",
         "model-*.safetensors",
-        // Reference implementation files are retained for pinned provenance.
-        "__init__.py",
-        "audio_model.py",
-        "configuration.py",
-        "configuration_nemotron_h.py",
-        "configuration_radio.py",
-        "evs.py",
-        "image_processing.py",
-        "modeling.py",
-        "modeling_nemotron_h.py",
-        "processing.py",
-        "processing_utils.py",
-        "video_io.py",
-        "video_processing.py",
     ]
 
     public static func handles(modelSpec raw: String) -> Bool {
         let normalized = raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
         let localName = URL(fileURLWithPath: normalized).lastPathComponent
         return normalized == modelID
+            || normalized == nativeRepoID.lowercased()
             || normalized == upstreamRepoID.lowercased()
+            || localName == nativeRepoID.split(separator: "/").last?.lowercased()
             || localName == upstreamRepoID.split(separator: "/").last?.lowercased()
     }
 
@@ -126,6 +121,14 @@ public enum NemotronOmniResources {
         rootURL: URL,
         fileManager: FileManager = .default
     ) -> [String] {
+        if fileManager.fileExists(
+            atPath: NemotronOmniNativeCheckpoint.manifestURL(rootURL: rootURL).path
+        ) {
+            return NemotronOmniNativeCheckpoint.validationMessages(
+                rootURL: rootURL,
+                fileManager: fileManager
+            )
+        }
         let missing = missingTargetFiles(rootURL: rootURL, fileManager: fileManager)
         guard missing.isEmpty else {
             return missing.map { "Missing required file: \($0.path)" }

--- a/Sources/MereRunCore/NemotronOmni/README.md
+++ b/Sources/MereRunCore/NemotronOmni/README.md
@@ -1,9 +1,9 @@
 # Nemotron Omni runtime
 
-This module is the native Swift/MLX execution engine for NVIDIA's pinned
-Nemotron 3 Nano Omni 30B-A3B Reasoning BF16 checkpoint. It accepts text,
+This module is the native Swift/MLX execution engine for the pinned standalone
+Nemotron 3 Nano Omni 30B-A3B Reasoning BF16 MLX checkpoint. It accepts text,
 images, local audio, and local video and generates text without Python,
-Transformers, vLLM, or an intermediate model conversion.
+Transformers, vLLM, or a first-run model conversion.
 
 The runtime has four layers:
 
@@ -15,17 +15,18 @@ The runtime has four layers:
 - `NemotronOmniSoundModel` and the audio processor implement the Parakeet
   log-Mel frontend, convolutional subsampling, and conformer encoder.
 - `NemotronOmniLanguageModel` implements the BF16 Nemotron-H hybrid
-  attention/Mamba/MoE backbone. `NemotronOmniExpertPack` creates one
-  source-bound, stacked expert cache beside the source snapshot so the 46
-  routed expert tensors do not require 17-shard gathers on every launch.
+  attention/Mamba/MoE backbone. `NemotronOmniExpertPack` loads the published
+  stacked expert shard directly so the 46 routed expert tensors do not require
+  17-shard gathers on every launch. The non-expert shards retain their upstream
+  keys, shapes, dtypes, and payload bytes.
   Multitoken prefill evaluates at layer boundaries to keep every Metal command
   buffer below the macOS watchdog; one-token decode remains fused.
 
-Managed installation remains explicit because the upstream checkpoint uses
-the NVIDIA Open Model Agreement. The small internal MereRun wrapper may point
-at an immutable snapshot on external storage; the 66 GB source checkpoint and
-58 GB derived expert cache must not be duplicated merely to make the catalog
-entry visible.
+Managed installation remains explicit because the checkpoint uses the NVIDIA
+Open Model Agreement. The managed pull downloads one approximately 66 GB
+artifact containing every model parameter exactly once. A legacy source
+snapshot with a locally generated expert cache remains readable, but is no
+longer the managed installation path.
 
 Media inputs are decoded locally. Image and video URLs passed to this runtime
 must be local paths or `file:` URLs. Audio uses the shared local audio loader.

--- a/Sources/MereRunCore/SafetensorsSubsetWriter.swift
+++ b/Sources/MereRunCore/SafetensorsSubsetWriter.swift
@@ -1,0 +1,207 @@
+import Foundation
+import MLX
+
+struct SafetensorsSubsetWriteResult: Sendable, Hashable {
+    let outputURL: URL
+    let tensorCount: Int
+    let payloadBytes: Int64
+}
+
+enum SafetensorsSubsetWriterError: LocalizedError {
+    case outputExists(URL)
+    case emptySelection(URL)
+    case unsupportedDType(DType)
+    case truncatedTensor(String)
+    case invalidOutput(URL)
+
+    var errorDescription: String? {
+        switch self {
+        case .outputExists(let url):
+            "Safetensors output already exists: \(url.path)"
+        case .emptySelection(let url):
+            "Safetensors selection is empty: \(url.path)"
+        case .unsupportedDType(let dtype):
+            "Safetensors subset writer cannot preserve dtype \(dtype)."
+        case .truncatedTensor(let key):
+            "Safetensors source ended while copying tensor \(key)."
+        case .invalidOutput(let url):
+            "Safetensors subset output failed validation: \(url.path)"
+        }
+    }
+}
+
+/// Rewrites a filtered safetensors file without materializing tensor values.
+/// Payload bytes, shapes, dtypes, and source ordering are preserved exactly.
+enum SafetensorsSubsetWriter {
+    static func write(
+        sourceURL: URL,
+        destinationURL: URL,
+        replacing: Bool = false,
+        fileMetadata: [String: String] = [:],
+        include: (String) -> Bool,
+        progressHandler: ((Int, Int) -> Void)? = nil,
+        fileManager: FileManager = .default
+    ) throws -> SafetensorsSubsetWriteResult {
+        if fileManager.fileExists(atPath: destinationURL.path), !replacing {
+            throw SafetensorsSubsetWriterError.outputExists(destinationURL)
+        }
+        let sourceMetadata = try SafetensorsStreamingLoader.metadata(url: sourceURL)
+        let tensors = try sourceMetadata
+            .filter { include($0.key) }
+            .map { key, metadata in
+                SafetensorsSubsetTensor(
+                    key: key,
+                    metadata: metadata,
+                    dtype: try safetensorsDType(metadata.dtype)
+                )
+            }
+            .sorted { $0.metadata.startOffset < $1.metadata.startOffset }
+        guard !tensors.isEmpty else {
+            throw SafetensorsSubsetWriterError.emptySelection(sourceURL)
+        }
+
+        var runningOffset = 0
+        var headers: [String: SafetensorsSubsetTensorHeader] = [:]
+        headers.reserveCapacity(tensors.count)
+        for tensor in tensors {
+            let byteCount = tensor.metadata.endOffset - tensor.metadata.startOffset
+            headers[tensor.key] = SafetensorsSubsetTensorHeader(
+                dtype: tensor.dtype,
+                shape: tensor.metadata.shape,
+                dataOffsets: [runningOffset, runningOffset + byteCount]
+            )
+            runningOffset += byteCount
+        }
+
+        let header = SafetensorsSubsetHeader(
+            tensors: headers,
+            metadata: fileMetadata
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        var headerData = try encoder.encode(header)
+        let padding = (8 - (headerData.count % 8)) % 8
+        if padding > 0 {
+            headerData.append(Data(repeating: 0x20, count: padding))
+        }
+
+        try fileManager.createDirectory(
+            at: destinationURL.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        let temporaryURL = destinationURL.deletingLastPathComponent().appendingPathComponent(
+            ".\(destinationURL.lastPathComponent).\(UUID().uuidString).tmp"
+        )
+        _ = fileManager.createFile(atPath: temporaryURL.path, contents: nil)
+        do {
+            let source = try FileHandle(forReadingFrom: sourceURL)
+            let output = try FileHandle(forWritingTo: temporaryURL)
+            defer {
+                try? source.close()
+                try? output.close()
+            }
+            var headerLength = UInt64(headerData.count).littleEndian
+            try withUnsafeBytes(of: &headerLength) { bytes in
+                try output.write(contentsOf: bytes)
+            }
+            try output.write(contentsOf: headerData)
+            for (index, tensor) in tensors.enumerated() {
+                try source.seek(toOffset: UInt64(tensor.metadata.startOffset))
+                var remaining = tensor.metadata.endOffset - tensor.metadata.startOffset
+                while remaining > 0 {
+                    let requested = min(remaining, 8 * 1_024 * 1_024)
+                    #if canImport(ObjectiveC)
+                    let data = try autoreleasepool {
+                        try source.read(upToCount: requested)
+                    }
+                    #else
+                    let data = try source.read(upToCount: requested)
+                    #endif
+                    guard let data, data.count == requested else {
+                        throw SafetensorsSubsetWriterError.truncatedTensor(tensor.key)
+                    }
+                    try output.write(contentsOf: data)
+                    remaining -= data.count
+                }
+                progressHandler?(index + 1, tensors.count)
+            }
+            try output.synchronize()
+        } catch {
+            try? fileManager.removeItem(at: temporaryURL)
+            throw error
+        }
+
+        if fileManager.fileExists(atPath: destinationURL.path) {
+            try fileManager.removeItem(at: destinationURL)
+        }
+        try fileManager.moveItem(at: temporaryURL, to: destinationURL)
+        guard let outputMetadata = try? SafetensorsStreamingLoader.metadata(url: destinationURL),
+              outputMetadata.count == tensors.count,
+              outputMetadata.keys.allSatisfy({ headers[$0] != nil }) else {
+            throw SafetensorsSubsetWriterError.invalidOutput(destinationURL)
+        }
+        return SafetensorsSubsetWriteResult(
+            outputURL: destinationURL,
+            tensorCount: tensors.count,
+            payloadBytes: Int64(runningOffset)
+        )
+    }
+
+    private static func safetensorsDType(_ dtype: DType) throws -> String {
+        switch dtype {
+        case .float32: "F32"
+        case .float16: "F16"
+        case .bfloat16: "BF16"
+        case .int64: "I64"
+        case .int32: "I32"
+        case .int16: "I16"
+        case .int8: "I8"
+        case .uint8: "U8"
+        case .uint32: "U32"
+        case .bool: "BOOL"
+        default: throw SafetensorsSubsetWriterError.unsupportedDType(dtype)
+        }
+    }
+}
+
+private struct SafetensorsSubsetTensor {
+    let key: String
+    let metadata: SafetensorsStreamingLoader.TensorMetadata
+    let dtype: String
+}
+
+private struct SafetensorsSubsetTensorHeader: Encodable {
+    let dtype: String
+    let shape: [Int]
+    let dataOffsets: [Int]
+
+    private enum CodingKeys: String, CodingKey {
+        case dtype
+        case shape
+        case dataOffsets = "data_offsets"
+    }
+}
+
+private struct SafetensorsSubsetHeader: Encodable {
+    let tensors: [String: SafetensorsSubsetTensorHeader]
+    let metadata: [String: String]
+
+    func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: SafetensorsSubsetCodingKey.self)
+        if !metadata.isEmpty {
+            try container.encode(metadata, forKey: SafetensorsSubsetCodingKey("__metadata__"))
+        }
+        for (key, tensor) in tensors {
+            try container.encode(tensor, forKey: SafetensorsSubsetCodingKey(key))
+        }
+    }
+}
+
+private struct SafetensorsSubsetCodingKey: CodingKey {
+    let stringValue: String
+    let intValue: Int? = nil
+
+    init(_ stringValue: String) { self.stringValue = stringValue }
+    init?(stringValue: String) { self.init(stringValue) }
+    init?(intValue: Int) { return nil }
+}

--- a/Tests/MereRunCLITests/ModelOptimizeCommandTests.swift
+++ b/Tests/MereRunCLITests/ModelOptimizeCommandTests.swift
@@ -12,11 +12,13 @@ final class ModelOptimizeCommandTests: XCTestCase {
             "video-minimax-h3-fl2va-mlx",
             "--force",
             "--text-encoder-only",
+            "--output", "/tmp/native-model",
             "--json",
         ])
         XCTAssertEqual(command.target, "video-minimax-h3-fl2va-mlx")
         XCTAssertTrue(command.force)
         XCTAssertTrue(command.textEncoderOnly)
+        XCTAssertEqual(command.output, "/tmp/native-model")
         XCTAssertTrue(command.json)
     }
 }

--- a/Tests/MereRunCoreTests/NemotronOmniTests.swift
+++ b/Tests/MereRunCoreTests/NemotronOmniTests.swift
@@ -12,6 +12,44 @@ final class NemotronOmniTests: MereRunCoreTestCase {
         XCTAssertGreaterThan(capacity, 0)
     }
 
+    func testPublishedExpertPackTakesPrecedenceOverLegacyCache() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "nemotron-published-pack-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let publishedURL = root.appendingPathComponent(
+            NemotronOmniExpertPack.publishedFilename
+        )
+        let tensors = Dictionary(uniqueKeysWithValues: (0..<46).map {
+            ("tensor.\($0)", MLXArray([UInt8($0)]))
+        })
+        try MLX.save(
+            arrays: tensors,
+            metadata: [
+                "format": NemotronOmniExpertPack.format,
+                "source_revision": NemotronOmniResources.upstreamRevision,
+                "payload_bytes": String(NemotronOmniResources.packedExpertWeightBytes),
+            ],
+            url: publishedURL
+        )
+
+        XCTAssertEqual(
+            NemotronOmniExpertPack.optimizedURLIfValid(rootURL: root),
+            publishedURL
+        )
+    }
+
+    func testNativeRepositoryAndLocalRootAreRecognized() {
+        XCTAssertTrue(NemotronOmniResources.handles(
+            modelSpec: NemotronOmniResources.nativeRepoID
+        ))
+        XCTAssertTrue(NemotronOmniResources.handles(
+            modelSpec: "/models/\(NemotronOmniResources.nativeRepoID.split(separator: "/").last!)"
+        ))
+    }
+
     func testPinnedOmniConfigDecodesAllThreeMediaTowers() throws {
         let config = try JSONDecoder().decode(
             NemotronOmniConfig.self,
@@ -123,6 +161,14 @@ final class NemotronOmniTests: MereRunCoreTestCase {
         )
     }
 
+    func testMoEPrefillPlanBoundsWatchdogSafeTokenBatches() {
+        XCTAssertEqual(
+            NemotronOmniMoE.prefillRanges(tokenCount: 10),
+            [0..<4, 4..<8, 8..<10]
+        )
+        XCTAssertEqual(NemotronOmniMoE.prefillRanges(tokenCount: 1), [0..<1])
+    }
+
     func testBF16ExpertWeightKeyDecodesExactCheckpointNamespace() throws {
         let key = try XCTUnwrap(NemotronOmniExpertWeightKey(
             checkpointKey:
@@ -173,9 +219,14 @@ final class NemotronOmniTests: MereRunCoreTestCase {
 
         XCTAssertEqual(spec.category, .omniChat)
         XCTAssertEqual(spec.validationKind, .nemotronOmni)
-        XCTAssertEqual(spec.hubFallback?.repoId, NemotronOmniResources.upstreamRepoID)
-        XCTAssertEqual(spec.hubFallback?.revision, NemotronOmniResources.upstreamRevision)
-        XCTAssertEqual(spec.estimatedDownloadBytes, 66_059_015_328)
+        XCTAssertEqual(spec.hubFallback?.repoId, NemotronOmniResources.nativeRepoID)
+        XCTAssertEqual(spec.hubFallback?.revision, NemotronOmniResources.nativeRevision)
+        XCTAssertEqual(spec.upstreamRepoId, NemotronOmniResources.upstreamRepoID)
+        XCTAssertEqual(spec.upstreamRevision, NemotronOmniResources.upstreamRevision)
+        XCTAssertEqual(
+            spec.estimatedDownloadBytes,
+            NemotronOmniResources.estimatedDownloadBytes
+        )
         XCTAssertFalse(spec.runtimeAutoDownloadAllowed)
         XCTAssertEqual(spec.defaultRuntimeServingEngine, .textChatNemotronOmni)
         XCTAssertEqual(profile.inputModalities, [.text, .image, .audio, .video])
@@ -299,6 +350,74 @@ final class NemotronOmniTests: MereRunCoreTestCase {
                     + "66031270520-byte checkpoint contract.",
             ]
         )
+    }
+
+    func testStructuralValidationAcceptsStandaloneNativeCheckpoint() throws {
+        let root = try TestFileSystem.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+        for filename in NemotronOmniNativeCheckpoint.supportFilenames {
+            try Data().write(to: root.appendingPathComponent(filename))
+        }
+        let manifest = NemotronOmniNativeCheckpointManifest(
+            schemaVersion: 1,
+            format: NemotronOmniNativeCheckpoint.format,
+            sourceRepository: NemotronOmniResources.upstreamRepoID,
+            sourceRevision: NemotronOmniResources.upstreamRevision,
+            totalWeightBytes: NemotronOmniResources.checkpointWeightBytes,
+            expertWeightBytes: NemotronOmniResources.packedExpertWeightBytes,
+            nonExpertWeightBytes: NemotronOmniResources.nativeNonExpertWeightBytes,
+            nonExpertShardCount: NemotronOmniResources.checkpointShardCount
+        )
+        try JSONEncoder().encode(manifest).write(
+            to: NemotronOmniNativeCheckpoint.manifestURL(rootURL: root)
+        )
+        let expertArrays = Dictionary(uniqueKeysWithValues: (0..<46).map {
+            ("tensor.\($0)", MLXArray([UInt8($0)]))
+        })
+        try MLX.save(
+            arrays: expertArrays,
+            metadata: [
+                "format": NemotronOmniExpertPack.format,
+                "source_revision": NemotronOmniResources.upstreamRevision,
+                "payload_bytes": String(NemotronOmniResources.packedExpertWeightBytes),
+            ],
+            url: root.appendingPathComponent(NemotronOmniExpertPack.publishedFilename)
+        )
+        var weightMap: [String: String] = [:]
+        for index in 1...NemotronOmniResources.checkpointShardCount {
+            let filename = String(
+                format: "model-%05d-of-%05d.safetensors",
+                index,
+                NemotronOmniResources.checkpointShardCount
+            )
+            weightMap["tensor.\(index)"] = filename
+            try Data([0]).write(to: root.appendingPathComponent(filename))
+        }
+        let nativeIndex = HFSafetensorsIndex(
+            metadata: .init(totalSize: NemotronOmniResources.nativeNonExpertWeightBytes),
+            weightMap: weightMap
+        )
+        try JSONEncoder().encode(nativeIndex).write(
+            to: root.appendingPathComponent("model.safetensors.index.json")
+        )
+
+        XCTAssertEqual(NemotronOmniResources.validationMessages(rootURL: root), [])
+    }
+
+    func testNativeExporterRejectsAnAlreadyNativeSource() throws {
+        let root = try TestFileSystem.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try Data().write(to: NemotronOmniNativeCheckpoint.manifestURL(rootURL: root))
+
+        XCTAssertThrowsError(try NemotronOmniNativeCheckpoint.export(
+            sourceRootURL: root,
+            destinationRootURL: root.appendingPathComponent("output")
+        )) { error in
+            guard case NemotronOmniNativeCheckpointError.invalidSource(let messages) = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+            XCTAssertEqual(messages, ["Source is already a standalone native checkpoint."])
+        }
     }
 
     func testOpenAIContentRoundTripsImageAudioAndVideoURLs() throws {

--- a/Tests/MereRunCoreTests/SafetensorsSubsetWriterTests.swift
+++ b/Tests/MereRunCoreTests/SafetensorsSubsetWriterTests.swift
@@ -1,0 +1,58 @@
+import Foundation
+import MLX
+import XCTest
+@testable import MereRunCore
+
+final class SafetensorsSubsetWriterTests: MereRunCoreTestCase {
+    func testWriterCopiesSelectedTensorPayloadWithoutMaterializingConversion() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(
+            "safetensors-subset-\(UUID().uuidString)",
+            isDirectory: true
+        )
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let sourceURL = root.appendingPathComponent("source.safetensors")
+        let destinationURL = root.appendingPathComponent("subset.safetensors")
+        try MLX.save(
+            arrays: [
+                "drop.weight": MLXArray([Float(1), Float(2)]),
+                "keep.bias": MLXArray([Int32(7), Int32(8), Int32(9)]),
+                "keep.weight": MLXArray([Float(3), Float(4), Float(5), Float(6)])
+                    .asType(.bfloat16),
+            ],
+            metadata: ["source": "fixture"],
+            url: sourceURL
+        )
+
+        let result = try SafetensorsSubsetWriter.write(
+            sourceURL: sourceURL,
+            destinationURL: destinationURL,
+            fileMetadata: ["format": "fixture-v1"],
+            include: { $0.hasPrefix("keep.") }
+        )
+
+        let sourceMetadata = try SafetensorsStreamingLoader.metadata(url: sourceURL)
+        let outputMetadata = try SafetensorsStreamingLoader.metadata(url: destinationURL)
+        XCTAssertEqual(Set(outputMetadata.keys), ["keep.bias", "keep.weight"])
+        XCTAssertEqual(result.tensorCount, 2)
+        XCTAssertEqual(
+            result.payloadBytes,
+            Int64(
+                sourceMetadata["keep.bias"]!.endOffset
+                    - sourceMetadata["keep.bias"]!.startOffset
+                    + sourceMetadata["keep.weight"]!.endOffset
+                    - sourceMetadata["keep.weight"]!.startOffset
+            )
+        )
+        XCTAssertEqual(
+            try SafetensorsStreamingLoader.fileMetadata(url: destinationURL)["format"],
+            "fixture-v1"
+        )
+        let arrays = try MLX.loadArrays(url: destinationURL)
+        XCTAssertEqual(arrays["keep.bias"]?.asArray(Int32.self), [7, 8, 9])
+        XCTAssertEqual(
+            arrays["keep.weight"]?.asType(.float32).asArray(Float.self),
+            [3, 4, 5, 6]
+        )
+    }
+}

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -526,13 +526,20 @@ OpenMDW-1.1 license and upstream model cards, never download implicitly, and do
 not require an additional mere.run acceptance gate solely because the public
 repositories use a custom license identifier.
 
-`omni-chat-nemotron3-nano-30b-a3b-bf16` stages NVIDIA's official
-`Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16` snapshot at immutable revision
-`24e67ea000b7c2837fc8f9488aa2008524fac8ba`. The 66.06 GB checkpoint accepts
-text, images, audio, and video and produces reasoning text. Its document
-examples render PDF pages to images before prompting; PDF is not a separate raw
-input modality. The catalog pins all 17 BF16 weight shards, typed
-Nemotron-H/C-RADIO v4-H/Parakeet configuration contracts, tokenizer and media
+`omni-chat-nemotron3-nano-30b-a3b-bf16` stages one standalone native MLX
+checkpoint derived losslessly from NVIDIA's
+`Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16` source revision
+`24e67ea000b7c2837fc8f9488aa2008524fac8ba`. The native artifact is pinned at
+revision `9256528c67910cc390c3286157b1527eac44ef04`. Its approximately 66 GB
+download stores every BF16 parameter once: 17 slim shards retain the non-expert tensor
+keys and payload bytes, while one published shard stacks the routed experts in
+the physical layout used by MLX. No first-run conversion or second 58.75 GB
+expert cache is required.
+
+The checkpoint accepts text, images, audio, and video and produces reasoning
+text. Its document examples render PDF pages to images before prompting; PDF is
+not a separate raw input modality. The catalog pins the native artifact,
+byte-level conversion receipt, configuration contracts, tokenizer and media
 processor metadata, NVIDIA Open Model Agreement terms, 131,072-token composed
 context, and 20,480-token maximum output.
 
@@ -551,11 +558,10 @@ mere.run text chat \
   --prompt "Summarize the clip."
 ```
 
-The runtime consumes the 17 upstream BF16 shards in place and creates a
-source-bound stacked expert cache. A lightweight managed-model wrapper may
-point at an immutable snapshot on external storage, avoiding a second copy of
-the checkpoint while keeping it visible to `model list`, `text chat`, and
-`api serve`.
+The runtime consumes the published native shards in place. A lightweight
+managed-model wrapper may point at an immutable snapshot on external storage,
+keeping it visible to `model list`, `text chat`, and `api serve` without
+duplicating model weights.
 
 `text-chat-gemma4-12b` and `vision-chat-gemma4-12b` share Google's dense Gemma
 4 12B-it checkpoint; the text id uses the native chat path, while the vision id

--- a/scripts/model-conversion/README.md
+++ b/scripts/model-conversion/README.md
@@ -1,5 +1,35 @@
 # Native model conversion
 
+## NVIDIA Nemotron 3 Nano Omni BF16 native layout
+
+`mere.run model optimize` can stream NVIDIA's pinned 17-shard Nemotron Omni
+BF16 checkpoint into a standalone native layout. The output keeps every tensor
+payload exactly once: non-expert tensors retain their upstream keys across 17
+slim shards, while 5,888 routed-expert tensors become 46 stacked MLX expert
+tensors. No tensor value is quantized, rounded, or materialized during the
+conversion.
+
+```bash
+mere.run model optimize /path/to/upstream-checkpoint \
+  --output /path/to/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16-MLX-Native
+```
+
+Before publication, run the byte-for-byte validator. It compares every one of
+the 7,349 source tensor payloads with the native partition and writes a
+machine-readable verification receipt:
+
+```bash
+python3 scripts/model-conversion/validate_nemotron_omni_native.py \
+  --source /path/to/upstream-checkpoint \
+  --native /path/to/native-checkpoint \
+  --output /path/to/native-checkpoint/NEMOTRON_OMNI_NATIVE_VALIDATION.json
+```
+
+The publishable artifact must also include the NVIDIA Open Model Agreement,
+attribution notice, source revision, model card, and upstream safety documents.
+The conversion is release tooling; inference downloads only the standalone
+native checkpoint and never rebuilds an expert cache locally.
+
 ## Qwen3.8-Flash-Next MLX quantization
 
 `convert_qwen38_flash_next_mlx.py` downloads Qwen's exact immutable BF16

--- a/scripts/model-conversion/validate_nemotron_omni_native.py
+++ b/scripts/model-conversion/validate_nemotron_omni_native.py
@@ -1,0 +1,314 @@
+#!/usr/bin/env python3
+"""Verify a native Nemotron Omni checkpoint against its pinned BF16 source."""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+import hashlib
+import json
+from pathlib import Path
+import re
+import struct
+import tempfile
+from typing import BinaryIO, Iterable
+
+
+SOURCE_REPOSITORY = "nvidia/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16"
+SOURCE_REVISION = "24e67ea000b7c2837fc8f9488aa2008524fac8ba"
+FORMAT = "mere-run-nemotron-omni-native-v1"
+EXPERT_FORMAT = "mere-run-nemotron-omni-experts-v1"
+TOTAL_WEIGHT_BYTES = 66_031_270_520
+EXPERT_WEIGHT_BYTES = 58_749_616_128
+NON_EXPERT_WEIGHT_BYTES = 7_281_654_392
+SOURCE_EXPERT_RE = re.compile(
+    r"^language_model\.backbone\.layers\.(?P<layer>\d+)\.mixer\.experts\."
+    r"(?P<expert>\d+)\.(?P<projection>up_proj|down_proj)\.weight$"
+)
+PACKED_EXPERT_RE = re.compile(
+    r"^backbone\.layers\.(?P<layer>\d+)\.mixer\.experts\."
+    r"(?P<projection>up_proj|down_proj)\.weight$"
+)
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--source", type=Path, required=True)
+    parser.add_argument("--native", type=Path, required=True)
+    parser.add_argument("--output", type=Path, required=True)
+    return parser.parse_args()
+
+
+def load_index(root: Path) -> dict:
+    return json.loads((root / "model.safetensors.index.json").read_text())
+
+
+def load_safetensors_header(path: Path) -> tuple[dict[str, str], dict[str, dict]]:
+    with path.open("rb") as handle:
+        length_data = handle.read(8)
+        if len(length_data) != 8:
+            raise ValueError(f"Safetensors file is too small: {path}")
+        header_length = struct.unpack("<Q", length_data)[0]
+        header_data = handle.read(header_length)
+        if len(header_data) != header_length:
+            raise ValueError(f"Safetensors header is truncated: {path}")
+    header = json.loads(header_data)
+    file_metadata = header.pop("__metadata__", {})
+    data_start = 8 + header_length
+    tensors = {}
+    for key, value in header.items():
+        start, end = value["data_offsets"]
+        tensors[key] = {
+            "dtype": value["dtype"],
+            "shape": value["shape"],
+            "start": data_start + start,
+            "end": data_start + end,
+        }
+    return file_metadata, tensors
+
+
+def update_range(
+    digest: hashlib._Hash,
+    handle: BinaryIO,
+    start: int,
+    end: int,
+) -> int:
+    handle.seek(start)
+    remaining = end - start
+    total = remaining
+    while remaining:
+        chunk = handle.read(min(8 * 1024 * 1024, remaining))
+        if not chunk:
+            raise ValueError("Safetensors payload ended unexpectedly")
+        digest.update(chunk)
+        remaining -= len(chunk)
+    return total
+
+
+def digest_ranges(
+    ranges: Iterable[tuple[Path, int, int]],
+    handles: dict[Path, BinaryIO],
+) -> tuple[str, int]:
+    digest = hashlib.sha256()
+    total = 0
+    for path, start, end in ranges:
+        handle = handles.get(path)
+        if handle is None:
+            handle = path.open("rb")
+            handles[path] = handle
+        total += update_range(digest, handle, start, end)
+    return digest.hexdigest(), total
+
+
+def metadata_cache(root: Path, filenames: Iterable[str]) -> dict[str, dict[str, dict]]:
+    return {
+        filename: load_safetensors_header(root / filename)[1]
+        for filename in sorted(set(filenames))
+    }
+
+
+def verify_non_experts(
+    source: Path,
+    native: Path,
+    source_index: dict,
+    native_index: dict,
+    source_headers: dict[str, dict[str, dict]],
+    native_headers: dict[str, dict[str, dict]],
+    handles: dict[Path, BinaryIO],
+) -> tuple[list[dict], int]:
+    source_map = source_index["weight_map"]
+    native_map = native_index["weight_map"]
+    expected_keys = {key for key in source_map if SOURCE_EXPERT_RE.match(key) is None}
+    if set(native_map) != expected_keys:
+        raise ValueError("Native non-expert index does not exactly partition source keys")
+    results = []
+    total = 0
+    for filename in sorted(set(native_map.values())):
+        source_keys = sorted(
+            (key for key in expected_keys if source_map[key] == filename),
+            key=lambda key: source_headers[filename][key]["start"],
+        )
+        native_keys = sorted(
+            (key for key, shard in native_map.items() if shard == filename),
+            key=lambda key: native_headers[filename][key]["start"],
+        )
+        if native_keys != source_keys:
+            raise ValueError(f"Tensor order changed in {filename}")
+        source_ranges = [
+            (
+                source / filename,
+                source_headers[filename][key]["start"],
+                source_headers[filename][key]["end"],
+            )
+            for key in source_keys
+        ]
+        native_ranges = [
+            (
+                native / filename,
+                native_headers[filename][key]["start"],
+                native_headers[filename][key]["end"],
+            )
+            for key in native_keys
+        ]
+        source_digest, source_bytes = digest_ranges(source_ranges, handles)
+        native_digest, native_bytes = digest_ranges(native_ranges, handles)
+        if source_bytes != native_bytes or source_digest != native_digest:
+            raise ValueError(f"Non-expert payload mismatch in {filename}")
+        total += native_bytes
+        results.append(
+            {
+                "filename": filename,
+                "tensor_count": len(native_keys),
+                "payload_bytes": native_bytes,
+                "sha256": native_digest,
+            }
+        )
+        print(f"verified non-expert shard {len(results)}/17: {filename}", flush=True)
+    return results, total
+
+
+def verify_experts(
+    source: Path,
+    native: Path,
+    source_index: dict,
+    source_headers: dict[str, dict[str, dict]],
+    handles: dict[Path, BinaryIO],
+) -> tuple[list[dict], int, int]:
+    source_map = source_index["weight_map"]
+    pack_path = native / "experts-bf16.safetensors"
+    pack_metadata, pack_header = load_safetensors_header(pack_path)
+    expected_metadata = {
+        "format": EXPERT_FORMAT,
+        "source_repo": SOURCE_REPOSITORY,
+        "source_revision": SOURCE_REVISION,
+        "payload_bytes": str(EXPERT_WEIGHT_BYTES),
+    }
+    if pack_metadata != expected_metadata:
+        raise ValueError("Packed expert metadata does not match the pinned source")
+    groups: dict[tuple[int, str], list[tuple[int, str]]] = {}
+    for key in source_map:
+        match = SOURCE_EXPERT_RE.match(key)
+        if match is None:
+            continue
+        group = (int(match["layer"]), match["projection"])
+        groups.setdefault(group, []).append((int(match["expert"]), key))
+    if len(groups) != 46:
+        raise ValueError(f"Expected 46 expert groups; found {len(groups)}")
+
+    results = []
+    total = 0
+    tensor_count = 0
+    for layer, projection in sorted(groups):
+        source_keys = sorted(groups[(layer, projection)])
+        if [expert for expert, _key in source_keys] != list(range(128)):
+            raise ValueError(f"Expert inventory is incomplete for layer {layer} {projection}")
+        output_key = f"backbone.layers.{layer}.mixer.experts.{projection}.weight"
+        match = PACKED_EXPERT_RE.match(output_key)
+        if match is None or output_key not in pack_header:
+            raise ValueError(f"Packed expert tensor is missing: {output_key}")
+        source_ranges = []
+        for _expert, key in source_keys:
+            filename = source_map[key]
+            metadata = source_headers[filename][key]
+            source_ranges.append(
+                (source / filename, metadata["start"], metadata["end"])
+            )
+        output_metadata = pack_header[output_key]
+        source_digest, source_bytes = digest_ranges(source_ranges, handles)
+        output_digest, output_bytes = digest_ranges(
+            [(pack_path, output_metadata["start"], output_metadata["end"])],
+            handles,
+        )
+        if source_bytes != output_bytes or source_digest != output_digest:
+            raise ValueError(f"Expert payload mismatch for {output_key}")
+        total += output_bytes
+        tensor_count += len(source_keys)
+        results.append(
+            {
+                "tensor": output_key,
+                "source_tensor_count": len(source_keys),
+                "payload_bytes": output_bytes,
+                "sha256": output_digest,
+            }
+        )
+        print(f"verified expert group {len(results)}/46: {output_key}", flush=True)
+    return results, total, tensor_count
+
+
+def write_json_atomic(path: Path, value: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with tempfile.NamedTemporaryFile(
+        "w", encoding="utf-8", dir=path.parent, delete=False
+    ) as handle:
+        json.dump(value, handle, indent=2, sort_keys=True)
+        handle.write("\n")
+        temporary = Path(handle.name)
+    temporary.replace(path)
+
+
+def main() -> None:
+    args = parse_args()
+    source = args.source.resolve()
+    native = args.native.resolve()
+    source_index = load_index(source)
+    native_index = load_index(native)
+    source_headers = metadata_cache(source, source_index["weight_map"].values())
+    native_headers = metadata_cache(native, native_index["weight_map"].values())
+    handles: dict[Path, BinaryIO] = {}
+    try:
+        non_expert_results, non_expert_bytes = verify_non_experts(
+            source,
+            native,
+            source_index,
+            native_index,
+            source_headers,
+            native_headers,
+            handles,
+        )
+        expert_results, expert_bytes, expert_source_tensors = verify_experts(
+            source,
+            native,
+            source_index,
+            source_headers,
+            handles,
+        )
+    finally:
+        for handle in handles.values():
+            handle.close()
+    if non_expert_bytes != NON_EXPERT_WEIGHT_BYTES:
+        raise ValueError(f"Wrong non-expert byte count: {non_expert_bytes}")
+    if expert_bytes != EXPERT_WEIGHT_BYTES:
+        raise ValueError(f"Wrong expert byte count: {expert_bytes}")
+    if non_expert_bytes + expert_bytes != TOTAL_WEIGHT_BYTES:
+        raise ValueError("Native payload does not exactly partition the source checkpoint")
+
+    receipt = {
+        "schema_version": 1,
+        "status": "verified",
+        "verified_at": datetime.now(timezone.utc).isoformat(),
+        "format": FORMAT,
+        "source_repository": SOURCE_REPOSITORY,
+        "source_revision": SOURCE_REVISION,
+        "source_tensor_count": len(source_index["weight_map"]),
+        "native_non_expert_tensor_count": len(native_index["weight_map"]),
+        "source_expert_tensor_count": expert_source_tensors,
+        "native_expert_tensor_count": len(expert_results),
+        "total_weight_bytes": TOTAL_WEIGHT_BYTES,
+        "non_expert_weight_bytes": non_expert_bytes,
+        "expert_weight_bytes": expert_bytes,
+        "non_expert_shards": non_expert_results,
+        "expert_groups": expert_results,
+    }
+    write_json_atomic(args.output, receipt)
+    print(json.dumps({key: receipt[key] for key in [
+        "status",
+        "source_tensor_count",
+        "native_non_expert_tensor_count",
+        "source_expert_tensor_count",
+        "native_expert_tensor_count",
+        "total_weight_bytes",
+    ]}, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- switch the managed Nemotron Omni BF16 install from the upstream snapshot plus a first-run derived expert cache to one standalone native MLX checkpoint
- add a streaming, exact-byte checkpoint exporter and a source-to-native verification tool
- load the published expert shard directly while preserving legacy local-cache compatibility
- bound BF16 routed-expert prefill work into watchdog-safe token batches

## Published artifact

- repository: https://huggingface.co/Sawfwair/Nemotron-3-Nano-Omni-30B-A3B-Reasoning-BF16-MLX-Native
- pinned revision: `9256528c67910cc390c3286157b1527eac44ef04`
- 36 artifact files, 66,049,002,038 bytes
- 66,031,270,520 bytes of model payload verified against source revision `24e67ea000b7c2837fc8f9488aa2008524fac8ba`
- remote inventory, checksum ledger, and verification receipt match the local validated artifact

## Validation

- `./scripts/check.sh`
  - SwiftLint: 0 violations
  - XCTest: 3,400 executed, 282 checkpoint/device-dependent skips, 0 failures
  - Swift Testing: 38 passed
- focused exporter, catalog, CLI, and runtime tests: 22 passed
- real 128 GB Apple Silicon checkpoint canary on commit `252b105d70e57738d662146ef4f754a2107ba24f`
  - loaded all 17 slim shards and the published expert shard
  - prefilled 22/22 tokens and generated 16 tokens
  - exited successfully without a cache build or Metal watchdog failure
