### PR TITLE
Release v0.50.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+## 0.50.0 - 2026-09-01
+
+This release adds native DiffusionGemma text generation and image-conditioned
+Gemma 4 VLM LoRA training. It consolidates Ornith Q4 vision and MTP into one
+managed bundle and moves Nemotron Omni to a standalone native checkpoint. It
+also restores native Qwen Image Edit 2511 inference and fixes Studio video
+playback and model-aware music admission.
+
 ### Runtime
 
 - changed the managed Nemotron 3 Nano Omni BF16 installation to one standalone
@@ -44,6 +52,22 @@ The format is based on Keep a Changelog.
   revision-aware progressive unmasking, denoising-step and work-throughput
   diagnostics, sorted expert routing, selected-token confidence without a full
   probability tensor, and resident graph warmup in API serving.
+
+### Image
+
+- fixed native `image-qwen-edit-2511-lightning` inference by admitting its
+  manifest during image-generation preflight, aligning the Qwen 2.5 VL encoder
+  with the checkpoint, removing duplicate vision-tower registration, and
+  applying the required 1,000 timestep scale before sinusoidal embedding.
+
+### Included pull requests
+
+- exact release range: [#393](https://github.com/sawfwair/mere-run/pull/393),
+  [#396](https://github.com/sawfwair/mere-run/pull/396),
+  [#397](https://github.com/sawfwair/mere-run/pull/397),
+  [#399](https://github.com/sawfwair/mere-run/pull/399),
+  [#400](https://github.com/sawfwair/mere-run/pull/400), and
+  [#401](https://github.com/sawfwair/mere-run/pull/401).
 
 ## 0.49.0 - 2026-08-31
 

--- a/Sources/MereRunRelayKit/MereRunCLIVersion.swift
+++ b/Sources/MereRunRelayKit/MereRunCLIVersion.swift
@@ -2,7 +2,7 @@
 /// contract version floors, worker probes, and the built-in node catalog
 /// identity.
 public enum MereRunCLIVersion {
-    public static let current = "0.49.0"
+    public static let current = "0.50.0"
 }
 
 /// Lenient three-component version-floor comparison used by worker

--- a/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
+++ b/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
@@ -130,7 +130,7 @@ final class CLIModelStoreBootstrapTests: XCTestCase {
     }
 
     func testMereRunCLIExposesReleaseVersion() {
-        XCTAssertEqual(MereRunCLIVersion.current, "0.49.0")
+        XCTAssertEqual(MereRunCLIVersion.current, "0.50.0")
         XCTAssertEqual(MereRunCLI.configuration.version, MereRunCLIVersion.current)
     }
 

--- a/scripts/build_mere_run_app.sh
+++ b/scripts/build_mere_run_app.sh
@@ -15,7 +15,7 @@ cd "$repo_root"
 
 # Version/build derive from git when not provided, so the bundle has a single source of
 # truth in CI. Fall back to a pinned value when git metadata is unavailable.
-default_version="0.49.0"
+default_version="0.50.0"
 if git_version="$(git describe --tags --exact-match 2>/dev/null)"; then
   default_version="${git_version#v}"
 fi


### PR DESCRIPTION
## Summary

- release native DiffusionGemma text generation and image-conditioned Gemma 4 VLM LoRA training
- publish bundled Ornith Q4 vision/MTP and standalone native Nemotron Omni checkpoint support
- include native Qwen Image Edit 2511, Studio video playback, and model-aware music admission fixes
- bump the CLI and app fallback version to 0.50.0

## Included pull requests

- #393
- #396
- #397
- #399
- #400
- #401

## Validation

- `./scripts/check.sh`
- `git diff --check`
