### PR TITLE
Deduplicate Qwen image edit references

### DIFF
--- a/Sources/MereRunCore/QwenImageEdit/QwenImageEditGenerator.swift
+++ b/Sources/MereRunCore/QwenImageEdit/QwenImageEditGenerator.swift
@@ -86,7 +86,10 @@ public actor QwenImageEditGenerator: ImageGenerator {
         _ request: GenerationRequest,
         progressHandler: (@Sendable (GenerationProgress) -> Void)?
     ) async throws -> GenerationResult {
-        let referenceURLs = [request.inputImage].compactMap { $0 } + request.referenceImages
+        let referenceURLs = Self.deduplicatedReferenceURLs(
+            inputImage: request.inputImage,
+            referenceImages: request.referenceImages
+        )
         guard !referenceURLs.isEmpty else {
             throw GeneratorError.inputImageRequired
         }
@@ -291,6 +294,14 @@ public actor QwenImageEditGenerator: ImageGenerator {
 
         Memory.clearCache()
         return GenerationResult(outputURL: request.outputURL, seed: seed)
+    }
+
+    static func deduplicatedReferenceURLs(inputImage: URL?, referenceImages: [URL]) -> [URL] {
+        var seen = Set<String>()
+        return ([inputImage].compactMap { $0 } + referenceImages).filter { url in
+            let identity = url.standardizedFileURL.resolvingSymlinksInPath().path
+            return seen.insert(identity).inserted
+        }
     }
 
     func ensureOutputDirectory(_ outputURL: URL) throws {

--- a/Tests/MereRunCoreTests/QwenImageEditRepositoryTests.swift
+++ b/Tests/MereRunCoreTests/QwenImageEditRepositoryTests.swift
@@ -5,6 +5,18 @@ import XCTest
 @testable import MereRunCore
 
 final class QwenImageEditRepositoryTests: MereRunCoreTestCase {
+    func testQwenImageEditDeduplicatesInputAndReferenceURLs() {
+        let input = URL(fileURLWithPath: "/tmp/qwen-edit/source.png")
+        let second = URL(fileURLWithPath: "/tmp/qwen-edit/second.png")
+
+        let resolved = QwenImageEditGenerator.deduplicatedReferenceURLs(
+            inputImage: input,
+            referenceImages: [input, second, input]
+        )
+
+        XCTAssertEqual(resolved, [input, second])
+    }
+
     func testInstalledQwenImageEditVAERoundTripWhenRequested() throws {
         let env = ProcessInfo.processInfo.environment
         guard let root = env["MERERUN_TEST_QWEN_EDIT_ROOT"], !root.isEmpty else {


### PR DESCRIPTION
## Summary

- Deduplicate Qwen image-edit reference URLs while preserving their first-seen order.
- Prevent an input image repeated as `--ref-image` from conditioning the edit twice.
- Add focused regression coverage for repeated input and reference paths.

## Validation

- `swift test --filter QwenImageEditRepositoryTests/testQwenImageEditDeduplicatesInputAndReferenceURLs`
- `./scripts/check.sh`
- Checkpoint-backed four-step Qwen Image Edit 2511 Lightning run at CFG 1.0 with a masked input
- `npx gitnexus detect-changes --scope compare --base-ref main --repo /Users/nerd/mere/mere-run-qwen-edit-input-dedupe-20260902` (low risk, no affected processes)
