### PR TITLE
Add native FLUX.1 and FLUX.2 dev support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,27 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+### Image
+
+- added the gated `image-flux1-dev` managed model with a separate Swift and MLX
+  FLUX.1 runtime. The runtime loads the pinned BFL transformer, CLIP-L,
+  T5-XXL, VAE, tokenizer, and scheduler components, uses the published
+  28-step flow-matching profile, and requires explicit acceptance of the
+  FLUX.1 dev Non-Commercial License v1.1.1.
+- added ordered, independently scaled FLUX.1 LoRA stacks. The loader supports
+  Diffusers and BFL target names and preserves FLUX.1 single-block projection
+  targets, while incompatible FLUX.2 and Klein adapters fail shape validation.
+- added the gated `image-flux2-dev` managed model for native Swift and MLX
+  generation with FLUX.2-dev LoRAs. The install pins the authoritative BFL
+  transformer, VAE, tokenizer, and scheduler, mounts a compatible 4-bit
+  Mistral Small 3.2 text encoder, requires explicit acceptance of the FLUX
+  Non-Commercial License and BFL Acceptable Use Policy, and uses the published
+  embedded-guidance and empirical scheduler behavior.
+- added ordered, independently scaled FLUX.2 LoRA stacks and the gated,
+  checksum-pinned `flux2-dev-turbo-8step` adapter. Selecting the managed Turbo
+  adapter applies its published eight-step sigma schedule and guidance default,
+  so it can run alongside a local FLUX.2-dev style or subject LoRA.
+
 ## 0.50.0 - 2026-09-01
 
 This release adds native DiffusionGemma text generation and image-conditioned

--- a/Package.swift
+++ b/Package.swift
@@ -358,6 +358,7 @@ targets.append(contentsOf: [
       "DepthAnything3/README.md",
       "FaceAnalysis/README.md",
       "FalconPerception/README.md",
+      "Flux1/README.md",
       "Flux2Klein/README.md",
       "Flux2Klein/Model/Transformer/README.md",
       "Gemma4/README.md",

--- a/Sources/MereRunCLI/Commands/APIServeCommand.swift
+++ b/Sources/MereRunCLI/Commands/APIServeCommand.swift
@@ -5278,12 +5278,14 @@ actor CodeGenServer {
         let resolved = try resolveImageModel(plan.modelID)
         let effectiveSteps = plan.steps
             ?? ((resolved.manifest.family == .hidream || resolved.manifest.family == .senseNova
-                    || resolved.manifest.family == .krea || resolved.manifest.family == .ideogram)
+                    || resolved.manifest.family == .krea || resolved.manifest.family == .ideogram
+                    || resolved.manifest.family == .flux1)
                 ? (resolved.manifest.defaults?.steps ?? 4)
                 : 4)
         let effectiveCFG = plan.guidanceScale
             ?? ((resolved.manifest.family == .hidream || resolved.manifest.family == .senseNova
-                    || resolved.manifest.family == .krea || resolved.manifest.family == .ideogram)
+                    || resolved.manifest.family == .krea || resolved.manifest.family == .ideogram
+                    || resolved.manifest.family == .flux1)
                 ? (resolved.manifest.defaults?.cfg ?? 1.0)
                 : 1.0)
         let outputURL = try temporaryOutputURL(directoryName: "mere-run-api-images", extension: "png")
@@ -5309,6 +5311,13 @@ actor CodeGenServer {
         )
 
         switch resolved.manifest.family {
+        case .flux1:
+            _ = try await sidecarPool.generateImage(
+                kind: .flux1,
+                modelID: resolved.modelID,
+                modelPath: resolved.rootURL.path,
+                request: request
+            )
         case .klein:
             _ = try await sidecarPool.generateImage(
                 kind: .flux2Klein,

--- a/Sources/MereRunCLI/Commands/ImageGenerateCommand.swift
+++ b/Sources/MereRunCLI/Commands/ImageGenerateCommand.swift
@@ -31,6 +31,12 @@ struct ImageGenerate: AsyncParsableCommand {
     @Option(name: [.customLong("sigma-shift")], help: "Sigma shift for the FlowMatch schedule (i2L recommends 8).")
     var sigmaShift: Double?
 
+    @Option(
+        name: [.customLong("sigmas")],
+        help: "Pre-shifted descending sigma values. A terminal zero is optional."
+    )
+    var sigmaList: String?
+
     @Option(name: [.customShort("o"), .long], help: "Output PNG path (default: ./mererun-image-<timestamp>.png).")
     var output: String?
 
@@ -106,10 +112,15 @@ struct ImageGenerate: AsyncParsableCommand {
     @Option(name: [.customLong("structured-prompt-output")], help: "Write the generated structured JSON caption to this path.")
     var structuredPromptOutput: String?
 
-    @Option(name: [.customShort("l"), .long], help: "LoRA safetensors file path.")
-    var lora: String?
+    @Option(
+        name: [.customShort("l"), .customLong("lora")],
+        help: "LoRA as PATH_OR_ID[=SCALE]. Repeat to stack FLUX.1 or FLUX.2 adapters."
+    )
+    var loraArguments: [String] = []
 
-    @Option(name: [.long], help: "LoRA scale (default: 1.0).")
+    var lora: String? { loraArguments.first }
+
+    @Option(name: [.long], help: "Default scale for --lora values without an inline scale.")
     var loraScale: Double = 1.0
 
     @Option(
@@ -150,6 +161,11 @@ struct ImageGenerate: AsyncParsableCommand {
         let kreaConditioningRebalance = try Self.resolveKreaConditioningRebalance(
             multiplier: kreaConditioningMultiplier,
             layerWeights: kreaConditioningLayerWeights
+        )
+        let explicitSigmas = try Self.parseSigmaList(sigmaList)
+        let parsedLoRAs = try Self.parseLoRAArguments(
+            loraArguments,
+            defaultScale: loraScale
         )
 
         let outputURL = CLIOutput.resolveOutputURL(output, defaultPrefix: "mererun-image", defaultExtension: "png")
@@ -245,18 +261,23 @@ struct ImageGenerate: AsyncParsableCommand {
             }
         }
 
-        let loraConfig: LoRA?
-        if let loraPath = lora {
-            let loraURL = URL(fileURLWithPath: loraPath).standardizedFileURL
-            guard FileManager.default.fileExists(atPath: loraURL.path) else {
-                throw ValidationError("LoRA file not found: \(loraPath)")
-            }
-            loraConfig = .local(path: loraURL.path, scale: loraScale)
-        } else {
-            loraConfig = nil
-        }
-
         let manifest = try MereRunModelManifest.loadRequired(from: URL(fileURLWithPath: resolvedModel!))
+        if parsedLoRAs.count > 1, manifest.family != .klein, manifest.family != .flux1 {
+            throw ValidationError("Stacked image LoRAs are supported only for FLUX.1 and FLUX.2 models.")
+        }
+        if explicitSigmas != nil, manifest.family != .klein {
+            throw ValidationError("--sigmas is supported only for FLUX.2 models.")
+        }
+        let loraConfigs = try Self.resolveLoRAs(
+            parsedLoRAs,
+            baseModelID: manifest.id
+        )
+        let usesTurboRecipe = parsedLoRAs.contains {
+            ManagedAdapterCatalog.spec(for: $0.reference)?.id
+                == ManagedAdapterCatalog.flux2DevTurboEightStepID
+        }
+        let effectiveSigmas = explicitSigmas
+            ?? (usesTurboRecipe ? Flux2DevTurboRecipe.sigmas : nil)
         if kreaBaseQuantizationBits != nil, manifest.family != .krea {
             throw ValidationError("--krea-base-quantization-bits is only supported for Krea 2 generation")
         }
@@ -269,11 +290,20 @@ struct ImageGenerate: AsyncParsableCommand {
         let usesManifestImageDefaults = manifest.engine == .qwenImageEdit
             || manifest.family == .hidream || manifest.family == .senseNova
             || manifest.family == .krea || manifest.family == .ideogram
+            || manifest.family == .klein || manifest.family == .flux1
         let effectiveSteps = steps
+            ?? effectiveSigmas?.count
             ?? (usesManifestImageDefaults
                 ? (manifest.defaults?.steps ?? 4)
                 : 4)
+        if let effectiveSigmas, effectiveSigmas.count != effectiveSteps {
+            throw ValidationError(
+                "--steps must equal the number of non-terminal --sigmas values "
+                    + "(\(effectiveSigmas.count))."
+            )
+        }
         let effectiveCFG = cfgScale
+            ?? (usesTurboRecipe ? Flux2DevTurboRecipe.guidanceScale : nil)
             ?? (usesManifestImageDefaults
                 ? (manifest.defaults?.cfg ?? 1.0)
                 : 1.0)
@@ -287,6 +317,7 @@ struct ImageGenerate: AsyncParsableCommand {
             effectiveSteps: effectiveSteps,
             effectiveCFGScale: effectiveCFG,
             effectiveSigmaShift: effectiveSigmaShift,
+            effectiveSigmas: effectiveSigmas,
             inputMode: Self.inputMode(
                 family: manifest.family,
                 inputImage: inputURL,
@@ -347,13 +378,15 @@ struct ImageGenerate: AsyncParsableCommand {
                 outputURL: outputURL,
                 model: resolvedModel,
                 maxSequenceLength: effectiveMaxSequenceLength,
-                lora: loraConfig,
+                lora: loraConfigs.first,
+                loras: loraConfigs,
                 enhancePrompt: false,
                 inputImage: conditioning.inputImage,
                 strength: conditioning.strength,
                 keepOriginalAspect: keepOriginalAspect,
                 useBetaSigmas: false,
                 sigmaShift: effectiveSigmaShift,
+                sigmas: effectiveSigmas,
                 kreaConditioningRebalance: kreaConditioningRebalance,
                 kreaBaseQuantizationBits: kreaBaseQuantizationBits
             )
@@ -372,6 +405,9 @@ struct ImageGenerate: AsyncParsableCommand {
 
             let result: GenerationResult
             switch manifest.family {
+            case .flux1:
+                let generator = Flux1Generator()
+                result = try await generator.generate(request, progressHandler: progressHandler)
             case .klein:
                 let generator = Flux2KleinGenerator()
                 result = try await generator.generate(request, progressHandler: progressHandler)
@@ -448,6 +484,93 @@ struct ImageGenerate: AsyncParsableCommand {
         if let kreaBaseQuantizationBits, kreaBaseQuantizationBits != 4, kreaBaseQuantizationBits != 8 {
             throw ValidationError("--krea-base-quantization-bits must be 4 or 8")
         }
+        guard loraScale.isFinite else {
+            throw ValidationError("--lora-scale must be finite")
+        }
+        if sigmaList != nil, sigmaShift != nil {
+            throw ValidationError("--sigmas cannot be combined with --sigma-shift")
+        }
+    }
+
+    struct LoRAArgument: Equatable {
+        let raw: String
+        let reference: String
+        let scale: Double
+    }
+
+    static func parseLoRAArguments(
+        _ arguments: [String],
+        defaultScale: Double
+    ) throws -> [LoRAArgument] {
+        guard defaultScale.isFinite else {
+            throw ValidationError("--lora-scale must be finite")
+        }
+        return try arguments.map { raw in
+            let separator = raw.lastIndex(of: "=")
+            let reference: String
+            let scale: Double
+            if let separator {
+                reference = String(raw[..<separator])
+                let rawScale = String(raw[raw.index(after: separator)...])
+                guard let parsed = Double(rawScale), parsed.isFinite else {
+                    throw ValidationError("--lora scale must be finite (got \(rawScale)).")
+                }
+                scale = parsed
+            } else {
+                reference = raw
+                scale = defaultScale
+            }
+            guard !reference.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                throw ValidationError("--lora must be PATH_OR_ID[=SCALE].")
+            }
+            return LoRAArgument(raw: raw, reference: reference, scale: scale)
+        }
+    }
+
+    static func resolveLoRAs(
+        _ arguments: [LoRAArgument],
+        baseModelID: String,
+        fileManager: FileManager = .default
+    ) throws -> [LoRA] {
+        var resolvedPaths = Set<String>()
+        return try arguments.map { argument in
+            let resolved = try ManagedAdapterArgumentResolver.resolve(
+                argument.reference,
+                baseModelID: baseModelID,
+                fileManager: fileManager
+            ) ?? argument.reference
+            let url = URL(fileURLWithPath: resolved).standardizedFileURL
+            guard fileManager.fileExists(atPath: url.path) else {
+                throw ValidationError("LoRA file not found: \(url.path)")
+            }
+            guard resolvedPaths.insert(url.path).inserted else {
+                throw ValidationError("Duplicate LoRA adapter: \(url.path)")
+            }
+            return .local(path: url.path, scale: argument.scale)
+        }
+    }
+
+    static func parseSigmaList(_ raw: String?) throws -> [Float]? {
+        guard let raw else { return nil }
+        var values = try raw.split(separator: ",", omittingEmptySubsequences: false).map { item in
+            let trimmed = item.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard let value = Float(trimmed), value.isFinite else {
+                throw ValidationError("--sigmas must contain finite comma-separated values.")
+            }
+            return value
+        }
+        if values.last == 0 {
+            values.removeLast()
+        }
+        guard !values.isEmpty else {
+            throw ValidationError("--sigmas must include at least one non-terminal value.")
+        }
+        do {
+            try Flux2EulerScheduler.validateCustomSigmas(values, expectedSteps: values.count)
+        } catch {
+            throw ValidationError(error.localizedDescription)
+        }
+        return values
     }
 
     func makePreflightEnvelope(
@@ -473,13 +596,14 @@ struct ImageGenerate: AsyncParsableCommand {
             strength: strength,
             cfgScale: cfgScale,
             sigmaShift: sigmaShift,
+            sigmaList: sigmaList,
             maxSequenceLength: maxSequenceLength,
             structuredPrompt: structuredPrompt,
             structuredPromptModel: structuredPromptModel,
             structuredPromptModelRoot: structuredPromptModelRoot,
             structuredPromptMaxTokens: structuredPromptMaxTokens,
             structuredPromptOutput: structuredPromptOutput,
-            lora: lora,
+            loras: loraArguments,
             loraScale: loraScale,
             kreaConditioningMultiplier: kreaConditioningMultiplier,
             kreaConditioningLayerWeights: kreaConditioningLayerWeights,
@@ -520,6 +644,9 @@ struct ImageGenerate: AsyncParsableCommand {
         }
         if let sigmaShift {
             args += ["--sigma-shift", String(sigmaShift)]
+        }
+        if let sigmaList {
+            args += ["--sigmas", sigmaList]
         }
         if let steps {
             args += ["--steps", String(steps)]
@@ -569,7 +696,7 @@ struct ImageGenerate: AsyncParsableCommand {
         if let structuredPromptOutput {
             args += ["--structured-prompt-output", structuredPromptOutput]
         }
-        if let lora {
+        for lora in loraArguments {
             args += ["--lora", lora]
         }
         if loraScale != 1.0 {
@@ -607,6 +734,7 @@ struct ImageGenerate: AsyncParsableCommand {
         effectiveSteps: Int,
         effectiveCFGScale: Double,
         effectiveSigmaShift: Float?,
+        effectiveSigmas: [Float]? = nil,
         inputMode: String
     ) throws -> LoRATrainingEventLogger? {
         guard let materializedPlanURL = materializedPlanURL(for: outputURL) else {
@@ -636,15 +764,18 @@ struct ImageGenerate: AsyncParsableCommand {
         if let effectiveSigmaShift {
             metadata["sigma_shift"] = String(effectiveSigmaShift)
         }
+        if let effectiveSigmas {
+            metadata["sigmas"] = effectiveSigmas.map { String($0) }.joined(separator: ",")
+        }
         if let input {
             metadata["input"] = input
         }
         if !referenceImages.isEmpty {
             metadata["reference_images"] = referenceImages.joined(separator: "\n")
         }
-        if let lora {
-            metadata["lora"] = lora
-            metadata["lora_scale"] = String(loraScale)
+        if !loraArguments.isEmpty {
+            metadata["loras"] = loraArguments.joined(separator: "\n")
+            metadata["lora_default_scale"] = String(loraScale)
         }
         try logger.record(
             type: "run_started",

--- a/Sources/MereRunCLI/Commands/ImageRunPlanCommand.swift
+++ b/Sources/MereRunCLI/Commands/ImageRunPlanCommand.swift
@@ -576,9 +576,10 @@ struct ImageRunPlan: AsyncParsableCommand {
         if !plan.arguments.referenceImages.isEmpty {
             configSnapshot["reference_images"] = plan.arguments.referenceImages.joined(separator: "\n")
         }
-        if let lora = plan.arguments.lora {
-            configSnapshot["lora"] = lora
-            configSnapshot["lora_scale"] = String(plan.arguments.loraScale)
+        let loras = plan.arguments.loras ?? plan.arguments.lora.map { [$0] } ?? []
+        if !loras.isEmpty {
+            configSnapshot["loras"] = loras.joined(separator: "\n")
+            configSnapshot["lora_default_scale"] = String(plan.arguments.loraScale)
         }
 
         let manifest = LoRATrainingRunManifest(

--- a/Sources/MereRunCLI/Support/APISidecarModelPool.swift
+++ b/Sources/MereRunCLI/Support/APISidecarModelPool.swift
@@ -531,6 +531,7 @@ actor APISidecarResidentSlot<Key: Equatable & Sendable, Value: Sendable> {
 }
 
 enum APISidecarImageKind: String, Hashable, Sendable {
+    case flux1
     case flux2Klein
     case zImageTurbo
     case hiDreamO1
@@ -666,6 +667,7 @@ enum APISidecarEvictionPlanner {
 /// Non-actor image generators are safe here because the resident slot holds an
 /// exclusive lease for their entire lifetime of use.
 private enum APISidecarImageGenerator: @unchecked Sendable {
+    case flux1(Flux1Generator)
     case flux2Klein(Flux2KleinGenerator)
     case zImageTurbo(ZImageTurboGenerator)
     case hiDreamO1(HiDreamO1Generator)
@@ -793,6 +795,8 @@ struct APISidecarModelPool: Sendable, CLIASRTranscriptionExecutor {
                 },
                 make: {
                     switch kind {
+                    case .flux1:
+                        return .flux1(Flux1Generator())
                     case .flux2Klein:
                         return .flux2Klein(Flux2KleinGenerator())
                     case .zImageTurbo:
@@ -811,6 +815,8 @@ struct APISidecarModelPool: Sendable, CLIASRTranscriptionExecutor {
                 },
                 unload: { generator in
                     switch generator {
+                    case .flux1(let generator):
+                        await generator.unload()
                     case .flux2Klein(let generator):
                         await generator.unload()
                     case .zImageTurbo(let generator):
@@ -829,6 +835,8 @@ struct APISidecarModelPool: Sendable, CLIASRTranscriptionExecutor {
                 },
                 operation: { generator in
                     switch generator {
+                    case .flux1(let generator):
+                        return try await generator.generate(request, progressHandler: nil)
                     case .flux2Klein(let generator):
                         return try await generator.generate(request, progressHandler: nil)
                     case .zImageTurbo(let generator):
@@ -1449,6 +1457,8 @@ struct APISidecarModelPool: Sendable, CLIASRTranscriptionExecutor {
 
     private static func unloadImage(_ generator: APISidecarImageGenerator) async {
         switch generator {
+        case .flux1(let generator):
+            await generator.unload()
         case .flux2Klein(let generator):
             await generator.unload()
         case .zImageTurbo(let generator):
@@ -1545,6 +1555,8 @@ struct APISidecarModelPool: Sendable, CLIASRTranscriptionExecutor {
 
     private static func imageBaseLoadBytes(for kind: APISidecarImageKind) -> UInt64 {
         switch kind {
+        case .flux1:
+            return 40 * gibibyte
         case .flux2Klein:
             return 10 * gibibyte
         case .zImageTurbo:
@@ -1568,7 +1580,7 @@ struct APISidecarModelPool: Sendable, CLIASRTranscriptionExecutor {
                 height: height
             )
             return (resolution.width, resolution.height)
-        case .flux2Klein, .zImageTurbo, .senseNovaU15, .krea2, .ideogram4, .qwenImageEdit:
+        case .flux1, .flux2Klein, .zImageTurbo, .senseNovaU15, .krea2, .ideogram4, .qwenImageEdit:
             return (width, height)
         }
     }

--- a/Sources/MereRunCLI/Support/ImageGenerationPreflight.swift
+++ b/Sources/MereRunCLI/Support/ImageGenerationPreflight.swift
@@ -20,13 +20,14 @@ struct ImageGenerationPreflightInput {
     let strength: Double?
     let cfgScale: Double?
     let sigmaShift: Double?
+    let sigmaList: String?
     let maxSequenceLength: Int
     let structuredPrompt: Bool
     let structuredPromptModel: String
     let structuredPromptModelRoot: String?
     let structuredPromptMaxTokens: Int
     let structuredPromptOutput: String?
-    let lora: String?
+    let loras: [String]
     let loraScale: Double
     let kreaConditioningMultiplier: Double?
     let kreaConditioningLayerWeights: String?
@@ -53,13 +54,14 @@ struct ImageGenerationPreflightRequest: Codable, Equatable {
     let strength: Double?
     let cfgScale: Double?
     let sigmaShift: Double?
+    let sigmaList: String?
     let maxSequenceLength: Int
     let structuredPrompt: Bool
     let structuredPromptModel: String
     let structuredPromptModelRoot: String?
     let structuredPromptMaxTokens: Int
     let structuredPromptOutput: String?
-    let lora: String?
+    let loras: [String]
     let loraScale: Double
     let kreaConditioningMultiplier: Double?
     let kreaConditioningLayerWeights: String?
@@ -83,13 +85,14 @@ struct ImageGenerationPreflightRequest: Codable, Equatable {
         case strength
         case cfgScale = "cfg_scale"
         case sigmaShift = "sigma_shift"
+        case sigmaList = "sigmas"
         case maxSequenceLength = "max_sequence_length"
         case structuredPrompt = "structured_prompt"
         case structuredPromptModel = "structured_prompt_model"
         case structuredPromptModelRoot = "structured_prompt_model_root"
         case structuredPromptMaxTokens = "structured_prompt_max_tokens"
         case structuredPromptOutput = "structured_prompt_output"
-        case lora
+        case loras
         case loraScale = "lora_scale"
         case kreaConditioningMultiplier = "krea_conditioning_multiplier"
         case kreaConditioningLayerWeights = "krea_conditioning_layer_weights"
@@ -102,6 +105,7 @@ struct ImageGenerationPreflightResult: Codable, Equatable {
     let output: ImageGenerationOutputPreflightSummary
     let inputs: ImageGenerationInputPreflightSummary
     let lora: ImageGenerationLoRAPreflightSummary?
+    let loras: [ImageGenerationLoRAPreflightSummary]
     let structuredPrompt: ImageGenerationStructuredPromptPreflightSummary
     let plan: ImageGenerationPlanPreflightSummary
     let runPlan: ImageGenerationRunPlan
@@ -111,6 +115,7 @@ struct ImageGenerationPreflightResult: Codable, Equatable {
         case output
         case inputs
         case lora
+        case loras
         case structuredPrompt = "structured_prompt"
         case plan
         case runPlan = "run_plan"
@@ -237,6 +242,8 @@ struct ImageGenerationPlanPreflightSummary: Codable, Equatable {
     let effectiveCFGScale: Double?
     let requestedSigmaShift: Double?
     let effectiveSigmaShift: Double?
+    let requestedSigmas: String?
+    let effectiveSigmas: [Float]?
     let maxSequenceLength: Int
     let effectiveMaxSequenceLength: Int
     let inputMode: String
@@ -251,6 +258,8 @@ struct ImageGenerationPlanPreflightSummary: Codable, Equatable {
         case effectiveCFGScale = "effective_cfg_scale"
         case requestedSigmaShift = "requested_sigma_shift"
         case effectiveSigmaShift = "effective_sigma_shift"
+        case requestedSigmas = "requested_sigmas"
+        case effectiveSigmas = "effective_sigmas"
         case maxSequenceLength = "max_sequence_length"
         case effectiveMaxSequenceLength = "effective_max_sequence_length"
         case inputMode = "input_mode"
@@ -281,6 +290,7 @@ struct ImageGenerationPreflightAnalyzer {
         var diagnostics: [PreflightDiagnostic] = []
         let createdAt = now()
         validatePrompt(diagnostics: &diagnostics)
+        validateSampling(diagnostics: &diagnostics)
         let model = modelSummary(diagnostics: &diagnostics)
         let output = outputSummary(
             for: input.outputURL,
@@ -291,12 +301,12 @@ struct ImageGenerationPreflightAnalyzer {
             diagnostics: &diagnostics
         )
         let inputs = inputSummary(diagnostics: &diagnostics)
-        let lora = loraSummary(diagnostics: &diagnostics)
+        let loras = loraSummaries(model: model, diagnostics: &diagnostics)
         let structuredPrompt = structuredPromptSummary(diagnostics: &diagnostics)
         let plan = planSummary(model: model)
         let runPlan = runPlan(resolved: plan, createdAt: createdAt)
         let status = StructuredRunOutput.status(for: diagnostics)
-        let actions = actions(status: status, model: model, output: output, inputs: inputs, lora: lora)
+        let actions = actions(status: status, model: model, output: output, inputs: inputs, loras: loras)
 
         return ImageGenerationPreflightEnvelope(
             schemaVersion: 1,
@@ -312,7 +322,8 @@ struct ImageGenerationPreflightAnalyzer {
                 model: model,
                 output: output,
                 inputs: inputs,
-                lora: lora,
+                lora: loras.first,
+                loras: loras,
                 structuredPrompt: structuredPrompt,
                 plan: plan,
                 runPlan: runPlan
@@ -341,13 +352,14 @@ struct ImageGenerationPreflightAnalyzer {
             strength: input.strength,
             cfgScale: input.cfgScale,
             sigmaShift: input.sigmaShift,
+            sigmaList: input.sigmaList,
             maxSequenceLength: input.maxSequenceLength,
             structuredPrompt: input.structuredPrompt,
             structuredPromptModel: input.structuredPromptModel,
             structuredPromptModelRoot: input.structuredPromptModelRoot,
             structuredPromptMaxTokens: input.structuredPromptMaxTokens,
             structuredPromptOutput: input.structuredPromptOutput,
-            lora: input.lora,
+            loras: input.loras,
             loraScale: input.loraScale,
             kreaConditioningMultiplier: input.kreaConditioningMultiplier,
             kreaConditioningLayerWeights: input.kreaConditioningLayerWeights,
@@ -367,6 +379,43 @@ struct ImageGenerationPreflightAnalyzer {
                     severity: .blocker,
                     title: "Prompt is empty",
                     message: "--prompt must include non-whitespace text."
+                )
+            )
+        }
+    }
+
+    private func validateSampling(diagnostics: inout [PreflightDiagnostic]) {
+        if input.sigmaList != nil, input.sigmaShift != nil {
+            diagnostics.append(
+                PreflightDiagnostic(
+                    id: "sigma_options_conflict",
+                    severity: .blocker,
+                    title: "Sigma options conflict",
+                    message: "--sigmas cannot be combined with --sigma-shift."
+                )
+            )
+        }
+        do {
+            _ = try ImageGenerate.parseSigmaList(input.sigmaList)
+        } catch {
+            diagnostics.append(
+                PreflightDiagnostic(
+                    id: "sigma_schedule_invalid",
+                    severity: .blocker,
+                    title: "Sigma schedule is invalid",
+                    message: error.localizedDescription
+                )
+            )
+        }
+        if let sigmas = resolvedSigmas(),
+           let steps = input.steps,
+           steps != sigmas.count {
+            diagnostics.append(
+                PreflightDiagnostic(
+                    id: "sigma_step_count_mismatch",
+                    severity: .blocker,
+                    title: "Sigma count doesn't match the step count",
+                    message: "--steps must equal the number of non-terminal --sigmas values."
                 )
             )
         }
@@ -559,39 +608,96 @@ struct ImageGenerationPreflightAnalyzer {
         )
     }
 
-    private func loraSummary(
+    private func loraSummaries(
+        model: ImageGenerationModelPreflightSummary,
         diagnostics: inout [PreflightDiagnostic]
-    ) -> ImageGenerationLoRAPreflightSummary? {
-        guard let lora = input.lora else { return nil }
-        let summary = pathSummary(requested: lora)
-        if !summary.exists {
+    ) -> [ImageGenerationLoRAPreflightSummary] {
+        let parsed: [ImageGenerate.LoRAArgument]
+        do {
+            parsed = try ImageGenerate.parseLoRAArguments(
+                input.loras,
+                defaultScale: input.loraScale
+            )
+        } catch {
             diagnostics.append(
                 PreflightDiagnostic(
-                    id: "lora_missing",
+                    id: "lora_argument_invalid",
                     severity: .blocker,
-                    title: "LoRA missing",
-                    message: "LoRA file not found: \(summary.path)",
-                    locations: [.init(kind: "file", path: summary.path)]
+                    title: "LoRA argument is invalid",
+                    message: error.localizedDescription
                 )
             )
-        } else if summary.isDirectory {
+            return []
+        }
+
+        if parsed.count > 1,
+           model.family != MereRunModelManifest.Family.klein.rawValue,
+           model.family != MereRunModelManifest.Family.flux1.rawValue {
             diagnostics.append(
                 PreflightDiagnostic(
-                    id: "lora_is_directory",
+                    id: "lora_stack_model_unsupported",
                     severity: .blocker,
-                    title: "LoRA path is a directory",
-                    message: "LoRA path is a directory: \(summary.path)",
-                    locations: [.init(kind: "directory", path: summary.path)]
+                    title: "Model doesn't support stacked LoRAs",
+                    message: "Stacked image LoRAs require a FLUX.1 or FLUX.2 model."
                 )
             )
         }
-        return ImageGenerationLoRAPreflightSummary(
-            requested: lora,
-            path: summary.path,
-            exists: summary.exists,
-            isDirectory: summary.isDirectory,
-            scale: input.loraScale
-        )
+
+        let baseModelID = model.id ?? model.requested
+        return parsed.enumerated().map { index, argument in
+            let resolved: String
+            do {
+                resolved = try ManagedAdapterArgumentResolver.resolve(
+                    argument.reference,
+                    baseModelID: baseModelID,
+                    fileManager: fileManager,
+                    requireInstalled: false
+                ) ?? argument.reference
+            } catch {
+                diagnostics.append(
+                    PreflightDiagnostic(
+                        id: "lora_base_model_incompatible",
+                        severity: .blocker,
+                        title: "LoRA base model is incompatible",
+                        message: error.localizedDescription
+                    )
+                )
+                resolved = argument.reference
+            }
+            let summary = pathSummary(requested: resolved)
+            if !summary.exists {
+                let managed = ManagedAdapterCatalog.spec(for: argument.reference)
+                diagnostics.append(
+                    PreflightDiagnostic(
+                        id: managed == nil ? "lora_missing" : "managed_lora_missing",
+                        severity: .blocker,
+                        title: managed == nil ? "LoRA missing" : "Managed LoRA missing",
+                        message: managed == nil
+                            ? "LoRA file not found: \(summary.path)"
+                            : "Adapter \(argument.reference) is not installed. Pull it before generation.",
+                        locations: [.init(kind: "file", path: summary.path)],
+                        suggestedActionIDs: managed == nil ? [] : ["pull-adapter-\(index + 1)"]
+                    )
+                )
+            } else if summary.isDirectory {
+                diagnostics.append(
+                    PreflightDiagnostic(
+                        id: "lora_is_directory",
+                        severity: .blocker,
+                        title: "LoRA path is a directory",
+                        message: "LoRA path is a directory: \(summary.path)",
+                        locations: [.init(kind: "directory", path: summary.path)]
+                    )
+                )
+            }
+            return ImageGenerationLoRAPreflightSummary(
+                requested: argument.reference,
+                path: summary.path,
+                exists: summary.exists,
+                isDirectory: summary.isDirectory,
+                scale: argument.scale
+            )
+        }
     }
 
     private func structuredPromptSummary(
@@ -662,6 +768,7 @@ struct ImageGenerationPreflightAnalyzer {
         let effectiveSteps = effectiveSteps(for: family, modelPath: model.path)
         let effectiveCFG = effectiveCFGScale(for: family, modelPath: model.path)
         let effectiveSigma = input.sigmaShift ?? manifestDefaultSigmaShift(modelPath: model.path)
+        let effectiveSigmas = resolvedSigmas()
         let effectiveMaxSequenceLength = input.structuredPrompt
             ? max(input.maxSequenceLength, StructuredImagePromptAdapter.recommendedImagePromptTokens)
             : input.maxSequenceLength
@@ -676,6 +783,8 @@ struct ImageGenerationPreflightAnalyzer {
             effectiveCFGScale: effectiveCFG,
             requestedSigmaShift: input.sigmaShift,
             effectiveSigmaShift: effectiveSigma,
+            requestedSigmas: input.sigmaList,
+            effectiveSigmas: effectiveSigmas,
             maxSequenceLength: input.maxSequenceLength,
             effectiveMaxSequenceLength: effectiveMaxSequenceLength,
             inputMode: inputMode(family: family)
@@ -707,13 +816,15 @@ struct ImageGenerationPreflightAnalyzer {
                 strength: input.strength,
                 cfgScale: input.cfgScale,
                 sigmaShift: input.sigmaShift,
+                sigmaList: input.sigmaList,
                 maxSequenceLength: input.maxSequenceLength,
                 structuredPrompt: input.structuredPrompt,
                 structuredPromptModel: input.structuredPromptModel,
                 structuredPromptModelRoot: input.structuredPromptModelRoot,
                 structuredPromptMaxTokens: input.structuredPromptMaxTokens,
                 structuredPromptOutput: input.structuredPromptOutput,
-                lora: input.lora,
+                lora: input.loras.first,
+                loras: input.loras,
                 loraScale: input.loraScale,
                 kreaConditioningMultiplier: input.kreaConditioningMultiplier,
                 kreaConditioningLayerWeights: input.kreaConditioningLayerWeights,
@@ -729,7 +840,7 @@ struct ImageGenerationPreflightAnalyzer {
         model: ImageGenerationModelPreflightSummary,
         output: ImageGenerationOutputPreflightSummary,
         inputs: ImageGenerationInputPreflightSummary,
-        lora: ImageGenerationLoRAPreflightSummary?
+        loras: [ImageGenerationLoRAPreflightSummary]
     ) -> [DeclarativeAction] {
         var actions: [DeclarativeAction] = []
         let blocked = status == .blocked
@@ -782,17 +893,32 @@ struct ImageGenerationPreflightAnalyzer {
             actions.append(action)
         }
 
-        if let lora {
+        for (index, lora) in loras.enumerated() {
             actions.append(
                 DeclarativeAction(
-                    id: "reveal-lora",
-                    label: "Reveal LoRA",
+                    id: "reveal-lora-\(index + 1)",
+                    label: "Reveal LoRA \(index + 1)",
                     kind: .revealFile,
                     style: .link,
                     enabled: lora.exists && !lora.isDirectory,
                     path: lora.path
                 )
             )
+            if let managed = ManagedAdapterCatalog.spec(for: lora.requested), !lora.exists {
+                actions.append(
+                    DeclarativeAction(
+                        id: "pull-adapter-\(index + 1)",
+                        label: "Pull \(managed.id)",
+                        kind: .command,
+                        style: .secondary,
+                        command: DeclarativeCommand(
+                            argv: ["mere.run", "adapter", "pull", managed.id],
+                            cwd: input.cwd,
+                            commandPath: ["adapter", "pull"]
+                        )
+                    )
+                )
+            }
         }
 
         return actions
@@ -909,6 +1035,7 @@ struct ImageGenerationPreflightAnalyzer {
 
     private func effectiveSteps(for family: MereRunModelManifest.Family?, modelPath: String?) -> Int? {
         if let steps = input.steps { return steps }
+        if let sigmas = resolvedSigmas() { return sigmas.count }
         guard let family else { return nil }
         if Self.familyUsesManifestDefaults(family) {
             return manifestDefaults(modelPath: modelPath)?.steps ?? 4
@@ -918,6 +1045,7 @@ struct ImageGenerationPreflightAnalyzer {
 
     private func effectiveCFGScale(for family: MereRunModelManifest.Family?, modelPath: String?) -> Double? {
         if let cfgScale = input.cfgScale { return cfgScale }
+        if usesTurboRecipe { return Flux2DevTurboRecipe.guidanceScale }
         guard let family else { return nil }
         if Self.familyUsesManifestDefaults(family) {
             return manifestDefaults(modelPath: modelPath)?.cfg ?? 1.0
@@ -928,6 +1056,21 @@ struct ImageGenerationPreflightAnalyzer {
     private func manifestDefaultSigmaShift(modelPath: String?) -> Double? {
         guard let modelPath else { return nil }
         return manifestDefaults(modelPath: modelPath)?.sigmaShift
+    }
+
+    private var usesTurboRecipe: Bool {
+        (try? ImageGenerate.parseLoRAArguments(input.loras, defaultScale: input.loraScale))?
+            .contains {
+                ManagedAdapterCatalog.spec(for: $0.reference)?.id
+                    == ManagedAdapterCatalog.flux2DevTurboEightStepID
+            } == true
+    }
+
+    private func resolvedSigmas() -> [Float]? {
+        if let parsed = try? ImageGenerate.parseSigmaList(input.sigmaList) {
+            return parsed
+        }
+        return usesTurboRecipe ? Flux2DevTurboRecipe.sigmas : nil
     }
 
     private func manifestDefaults(modelPath: String?) -> MereRunModelManifest.Defaults? {
@@ -954,7 +1097,8 @@ struct ImageGenerationPreflightAnalyzer {
     }
 
     private static func familyUsesManifestDefaults(_ family: MereRunModelManifest.Family) -> Bool {
-        family == .hidream || family == .krea || family == .qwen || family == .ideogram || family == .senseNova
+        family == .hidream || family == .krea || family == .qwen || family == .ideogram
+            || family == .senseNova || family == .klein || family == .flux1
     }
 
     private static func supportsImageGeneration(_ manifest: MereRunModelManifest) -> Bool {
@@ -965,6 +1109,7 @@ struct ImageGenerationPreflightAnalyzer {
     }
 
     private static let supportedImageFamilies: Set<MereRunModelManifest.Family?> = [
+        .flux1,
         .klein,
         .zimage,
         .hidream,

--- a/Sources/MereRunCLI/Support/ImageGenerationRunPlan.swift
+++ b/Sources/MereRunCLI/Support/ImageGenerationRunPlan.swift
@@ -82,6 +82,7 @@ struct ImageGenerationRunPlanArguments: Codable, Equatable {
     let strength: Double?
     let cfgScale: Double?
     let sigmaShift: Double?
+    let sigmaList: String?
     let maxSequenceLength: Int
     let structuredPrompt: Bool
     let structuredPromptModel: String
@@ -89,6 +90,7 @@ struct ImageGenerationRunPlanArguments: Codable, Equatable {
     let structuredPromptMaxTokens: Int
     let structuredPromptOutput: String?
     let lora: String?
+    let loras: [String]?
     let loraScale: Double
     let kreaConditioningMultiplier: Double?
     let kreaConditioningLayerWeights: String?
@@ -110,6 +112,7 @@ struct ImageGenerationRunPlanArguments: Codable, Equatable {
         case strength
         case cfgScale = "cfg_scale"
         case sigmaShift = "sigma_shift"
+        case sigmaList = "sigmas"
         case maxSequenceLength = "max_sequence_length"
         case structuredPrompt = "structured_prompt"
         case structuredPromptModel = "structured_prompt_model"
@@ -117,6 +120,7 @@ struct ImageGenerationRunPlanArguments: Codable, Equatable {
         case structuredPromptMaxTokens = "structured_prompt_max_tokens"
         case structuredPromptOutput = "structured_prompt_output"
         case lora
+        case loras
         case loraScale = "lora_scale"
         case kreaConditioningMultiplier = "krea_conditioning_multiplier"
         case kreaConditioningLayerWeights = "krea_conditioning_layer_weights"
@@ -151,6 +155,7 @@ struct ImageGenerationRunPlanArguments: Codable, Equatable {
             strength: strength,
             cfgScale: cfgScale,
             sigmaShift: sigmaShift,
+            sigmaList: sigmaList,
             maxSequenceLength: maxSequenceLength,
             structuredPrompt: structuredPrompt,
             structuredPromptModel: structuredPromptModel,
@@ -158,6 +163,7 @@ struct ImageGenerationRunPlanArguments: Codable, Equatable {
             structuredPromptMaxTokens: structuredPromptMaxTokens,
             structuredPromptOutput: structuredPromptOutput,
             lora: lora,
+            loras: loras,
             loraScale: loraScale,
             kreaConditioningMultiplier: kreaConditioningMultiplier,
             kreaConditioningLayerWeights: kreaConditioningLayerWeights,
@@ -177,6 +183,7 @@ struct ImageGenerationRunPlanArguments: Codable, Equatable {
         appendOption("--negative-prompt", negativePrompt, to: &args)
         appendOption("--cfg", cfgScale, to: &args)
         appendOption("--sigma-shift", sigmaShift, to: &args)
+        appendOption("--sigmas", sigmaList, to: &args)
         appendOption("--steps", steps, to: &args)
         appendOption("--seed", seed, to: &args)
         appendOption("--input", input, to: &args)
@@ -191,7 +198,10 @@ struct ImageGenerationRunPlanArguments: Codable, Equatable {
         appendOption("--structured-prompt-model-root", structuredPromptModelRoot, to: &args)
         args += ["--structured-prompt-max-tokens", String(structuredPromptMaxTokens)]
         appendOption("--structured-prompt-output", structuredPromptOutput, to: &args)
-        appendOption("--lora", lora, to: &args)
+        let adapterArguments = loras ?? lora.map { [$0] } ?? []
+        for adapter in adapterArguments {
+            args += ["--lora", adapter]
+        }
         args += ["--lora-scale", String(loraScale)]
         appendOption("--krea-conditioning-multiplier", kreaConditioningMultiplier, to: &args)
         appendOption("--krea-conditioning-layer-weights", kreaConditioningLayerWeights, to: &args)

--- a/Sources/MereRunCLI/Support/InstalledModelGateSupport.swift
+++ b/Sources/MereRunCLI/Support/InstalledModelGateSupport.swift
@@ -170,7 +170,7 @@ enum InstalledModelSmokePlans {
         installedIDs: Set<String>
     ) -> InstalledModelSmokePlan? {
         switch spec.validationKind {
-        case .flux2Klein, .bonsaiImage, .zimageTurbo, .hidreamO1, .senseNovaU15, .krea2, .ideogram4SDNQ:
+        case .flux1, .flux2Klein, .bonsaiImage, .zimageTurbo, .hidreamO1, .senseNovaU15, .krea2, .ideogram4SDNQ:
             return direct(spec, route: "image generate") { runner in
                 try await runner.installedImageCheck(model: spec.id)
             }

--- a/Sources/MereRunCore/Flux1/Flux1Configs.swift
+++ b/Sources/MereRunCore/Flux1/Flux1Configs.swift
@@ -1,0 +1,220 @@
+import Foundation
+
+public struct Flux1TransformerConfiguration: Decodable, Sendable, Hashable {
+    public let attentionHeadDim: Int
+    public let axesDimsRope: [Int]
+    public let guidanceEmbeds: Bool
+    public let inChannels: Int
+    public let jointAttentionDim: Int
+    public let numAttentionHeads: Int
+    public let numLayers: Int
+    public let numSingleLayers: Int
+    public let patchSize: Int
+    public let pooledProjectionDim: Int
+
+    public var hiddenSize: Int { attentionHeadDim * numAttentionHeads }
+    public var outChannels: Int { inChannels }
+
+    private enum CodingKeys: String, CodingKey {
+        case attentionHeadDim = "attention_head_dim"
+        case axesDimsRope = "axes_dims_rope"
+        case guidanceEmbeds = "guidance_embeds"
+        case inChannels = "in_channels"
+        case jointAttentionDim = "joint_attention_dim"
+        case numAttentionHeads = "num_attention_heads"
+        case numLayers = "num_layers"
+        case numSingleLayers = "num_single_layers"
+        case patchSize = "patch_size"
+        case pooledProjectionDim = "pooled_projection_dim"
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.attentionHeadDim = try container.decode(Int.self, forKey: .attentionHeadDim)
+        self.axesDimsRope = try container.decodeIfPresent([Int].self, forKey: .axesDimsRope) ?? [16, 56, 56]
+        self.guidanceEmbeds = try container.decode(Bool.self, forKey: .guidanceEmbeds)
+        self.inChannels = try container.decode(Int.self, forKey: .inChannels)
+        self.jointAttentionDim = try container.decode(Int.self, forKey: .jointAttentionDim)
+        self.numAttentionHeads = try container.decode(Int.self, forKey: .numAttentionHeads)
+        self.numLayers = try container.decode(Int.self, forKey: .numLayers)
+        self.numSingleLayers = try container.decode(Int.self, forKey: .numSingleLayers)
+        self.patchSize = try container.decode(Int.self, forKey: .patchSize)
+        self.pooledProjectionDim = try container.decode(Int.self, forKey: .pooledProjectionDim)
+    }
+}
+
+public struct Flux1VAEConfiguration: Decodable, Sendable, Hashable {
+    public let blockOutChannels: [Int]
+    public let inChannels: Int
+    public let latentChannels: Int
+    public let layersPerBlock: Int
+    public let normNumGroups: Int
+    public let outChannels: Int
+    public let scalingFactor: Float
+    public let shiftFactor: Float
+
+    private enum CodingKeys: String, CodingKey {
+        case blockOutChannels = "block_out_channels"
+        case inChannels = "in_channels"
+        case latentChannels = "latent_channels"
+        case layersPerBlock = "layers_per_block"
+        case normNumGroups = "norm_num_groups"
+        case outChannels = "out_channels"
+        case scalingFactor = "scaling_factor"
+        case shiftFactor = "shift_factor"
+    }
+
+    public var coreConfiguration: VAEConfig {
+        VAEConfig(
+            inChannels: inChannels,
+            outChannels: outChannels,
+            latentChannels: latentChannels,
+            scalingFactor: scalingFactor,
+            shiftFactor: shiftFactor,
+            blockOutChannels: blockOutChannels,
+            layersPerBlock: layersPerBlock,
+            normNumGroups: normNumGroups
+        )
+    }
+}
+
+public struct Flux1CLIPConfiguration: Decodable, Sendable, Hashable {
+    public let hiddenSize: Int
+    public let intermediateSize: Int
+    public let layerNormEps: Float
+    public let maxPositionEmbeddings: Int
+    public let numAttentionHeads: Int
+    public let numHiddenLayers: Int
+    public let projectionDim: Int
+    public let vocabSize: Int
+
+    private enum CodingKeys: String, CodingKey {
+        case hiddenSize = "hidden_size"
+        case intermediateSize = "intermediate_size"
+        case layerNormEps = "layer_norm_eps"
+        case maxPositionEmbeddings = "max_position_embeddings"
+        case numAttentionHeads = "num_attention_heads"
+        case numHiddenLayers = "num_hidden_layers"
+        case projectionDim = "projection_dim"
+        case vocabSize = "vocab_size"
+    }
+}
+
+public struct Flux1T5Configuration: Decodable, Sendable, Hashable {
+    public let dFF: Int
+    public let dKV: Int
+    public let dModel: Int
+    public let layerNormEpsilon: Float
+    public let numHeads: Int
+    public let numLayers: Int
+    public let relativeAttentionNumBuckets: Int
+    public let vocabSize: Int
+
+    private enum CodingKeys: String, CodingKey {
+        case dFF = "d_ff"
+        case dKV = "d_kv"
+        case dModel = "d_model"
+        case layerNormEpsilon = "layer_norm_epsilon"
+        case numHeads = "num_heads"
+        case numLayers = "num_layers"
+        case relativeAttentionNumBuckets = "relative_attention_num_buckets"
+        case vocabSize = "vocab_size"
+    }
+
+    public var wanConfiguration: Wan2TextEncoderConfiguration {
+        Wan2TextEncoderConfiguration(
+            vocabularySize: vocabSize,
+            hiddenSize: dModel,
+            attentionSize: dKV * numHeads,
+            feedForwardSize: dFF,
+            headCount: numHeads,
+            layerCount: numLayers,
+            relativePositionBuckets: relativeAttentionNumBuckets
+        )
+    }
+}
+
+public struct Flux1SchedulerConfiguration: Decodable, Sendable, Hashable {
+    public let baseImageSequenceLength: Int
+    public let baseShift: Float
+    public let maxImageSequenceLength: Int
+    public let maxShift: Float
+    public let numTrainTimesteps: Int
+    public let shift: Float
+    public let useDynamicShifting: Bool
+
+    private enum CodingKeys: String, CodingKey {
+        case baseImageSequenceLength = "base_image_seq_len"
+        case baseShift = "base_shift"
+        case maxImageSequenceLength = "max_image_seq_len"
+        case maxShift = "max_shift"
+        case numTrainTimesteps = "num_train_timesteps"
+        case shift
+        case useDynamicShifting = "use_dynamic_shifting"
+    }
+}
+
+public struct Flux1Resources: Sendable, Hashable {
+    public static let modelID = "image-flux1-dev"
+    public static let upstreamRepoID = "black-forest-labs/FLUX.1-dev"
+    public static let upstreamRevision = "3de623fc3c33e44ffbe2bad470d0f45bccf2eb21"
+    public static let estimatedDownloadBytes: Int64 = 34_000_000_000
+    public static let snapshotPatterns = [
+        "LICENSE*",
+        "README.md",
+        "model_index.json",
+        "scheduler/**",
+        "text_encoder/**",
+        "text_encoder_2/**",
+        "tokenizer/**",
+        "tokenizer_2/**",
+        "transformer/**",
+        "vae/**",
+    ]
+
+    public let rootURL: URL
+
+    public init(rootURL: URL) {
+        self.rootURL = rootURL
+    }
+
+    public var transformerDirectoryURL: URL { rootURL.appendingPathComponent("transformer", isDirectory: true) }
+    public var transformerConfigURL: URL { transformerDirectoryURL.appendingPathComponent("config.json") }
+    public var transformerWeightsIndexURL: URL {
+        transformerDirectoryURL.appendingPathComponent("diffusion_pytorch_model.safetensors.index.json")
+    }
+    public var clipDirectoryURL: URL { rootURL.appendingPathComponent("text_encoder", isDirectory: true) }
+    public var clipConfigURL: URL { clipDirectoryURL.appendingPathComponent("config.json") }
+    public var clipWeightsURL: URL { clipDirectoryURL.appendingPathComponent("model.safetensors") }
+    public var clipTokenizerURL: URL { rootURL.appendingPathComponent("tokenizer", isDirectory: true) }
+    public var clipTokenizerVocabURL: URL { clipTokenizerURL.appendingPathComponent("vocab.json") }
+    public var clipTokenizerMergesURL: URL { clipTokenizerURL.appendingPathComponent("merges.txt") }
+    public var t5DirectoryURL: URL { rootURL.appendingPathComponent("text_encoder_2", isDirectory: true) }
+    public var t5ConfigURL: URL { t5DirectoryURL.appendingPathComponent("config.json") }
+    public var t5WeightsIndexURL: URL { t5DirectoryURL.appendingPathComponent("model.safetensors.index.json") }
+    public var t5TokenizerURL: URL { rootURL.appendingPathComponent("tokenizer_2", isDirectory: true) }
+    public var vaeDirectoryURL: URL { rootURL.appendingPathComponent("vae", isDirectory: true) }
+    public var vaeConfigURL: URL { vaeDirectoryURL.appendingPathComponent("config.json") }
+    public var vaeWeightsURL: URL { vaeDirectoryURL.appendingPathComponent("diffusion_pytorch_model.safetensors") }
+    public var schedulerConfigURL: URL {
+        rootURL.appendingPathComponent("scheduler", isDirectory: true).appendingPathComponent("scheduler_config.json")
+    }
+
+    public func validate(fileManager: FileManager = .default) -> [URL] {
+        [
+            transformerConfigURL,
+            transformerWeightsIndexURL,
+            clipConfigURL,
+            clipWeightsURL,
+            clipTokenizerURL.appendingPathComponent("tokenizer_config.json"),
+            clipTokenizerVocabURL,
+            clipTokenizerMergesURL,
+            t5ConfigURL,
+            t5WeightsIndexURL,
+            t5TokenizerURL.appendingPathComponent("tokenizer.json"),
+            vaeConfigURL,
+            vaeWeightsURL,
+            schedulerConfigURL,
+        ].filter { !fileManager.fileExists(atPath: $0.path) }
+    }
+}

--- a/Sources/MereRunCore/Flux1/Flux1Generator.swift
+++ b/Sources/MereRunCore/Flux1/Flux1Generator.swift
@@ -1,0 +1,353 @@
+import Foundation
+import MLX
+import MLXRandom
+
+public enum Flux1Error: LocalizedError {
+    case missingFiles([URL])
+    case modelNotFound(String)
+    case unsupportedMode(String)
+    case invalidConfiguration(String)
+    case incompatibleAdapter(path: String, actual: [Int], expected: [Int])
+
+    public var errorDescription: String? {
+        switch self {
+        case .missingFiles(let files):
+            return "Missing FLUX.1 model files: \(files.map(\.path).joined(separator: ", "))"
+        case .modelNotFound(let model):
+            return "FLUX.1 model not found: \(model)"
+        case .unsupportedMode(let mode):
+            return "FLUX.1-dev native generation does not support \(mode)."
+        case .invalidConfiguration(let message):
+            return "Invalid FLUX.1 configuration: \(message)"
+        case .incompatibleAdapter(let path, let actual, let expected):
+            return "FLUX.1 adapter target \(path) has shape \(actual); expected \(expected). "
+                + "Verify that the adapter was trained for FLUX.1-dev, not FLUX.2 or Klein."
+        }
+    }
+}
+
+public actor Flux1Generator: ImageGenerator {
+    public init() {}
+
+    public func unload() {
+        Memory.clearCache()
+    }
+
+    public func generate(
+        _ request: GenerationRequest,
+        progressHandler: (@Sendable (GenerationProgress) -> Void)?
+    ) async throws -> GenerationResult {
+        guard request.referenceImages.isEmpty else {
+            throw Flux1Error.unsupportedMode("reference images")
+        }
+        guard request.inputImage == nil else {
+            throw Flux1Error.unsupportedMode("image-to-image")
+        }
+        guard request.negativePrompt?.isEmpty != false else {
+            throw Flux1Error.unsupportedMode("negative prompts")
+        }
+
+        let rootURL = try resolveModelRoot(request.model)
+        let resources = Flux1Resources(rootURL: rootURL)
+        let missing = resources.validate()
+        guard missing.isEmpty else { throw Flux1Error.missingFiles(missing) }
+        let configurations = try loadConfigurations(resources: resources)
+        try validate(configurations: configurations)
+
+        progressHandler?(GenerationProgress(stage: .loadingEncoder, stepIndex: 0, totalSteps: 2))
+        let pooled = try encodeCLIP(
+            prompt: request.prompt,
+            resources: resources,
+            configuration: configurations.clip
+        )
+        progressHandler?(GenerationProgress(stage: .loadingEncoder, stepIndex: 1, totalSteps: 2))
+        Memory.clearCache()
+
+        let context = try encodeT5(
+            prompt: request.prompt,
+            maximumLength: min(max(request.maxSequenceLength, 1), 512),
+            resources: resources,
+            configuration: configurations.t5
+        )
+        progressHandler?(GenerationProgress(stage: .loadingEncoder, stepIndex: 2, totalSteps: 2))
+        progressHandler?(GenerationProgress(stage: .encodingText, stepIndex: 1, totalSteps: 1))
+        Memory.clearCache()
+
+        progressHandler?(GenerationProgress(stage: .loadingTransformer, stepIndex: 0, totalSteps: 3))
+        let transformer = Flux1Transformer(configuration: configurations.transformer)
+        try HFSafetensorsWeightsLoader.applyShardedWeights(
+            indexURL: resources.transformerWeightsIndexURL,
+            to: transformer,
+            dtype: .bfloat16,
+            verify: [.shapeMismatch],
+            mapper: Flux1TransformerWeightMapper.map,
+            progressHandler: { progress in
+                progressHandler?(GenerationProgress(
+                    stage: .loadingTransformer,
+                    stepIndex: progress.shardIndex + 1,
+                    totalSteps: progress.shardCount
+                ))
+            }
+        )
+        try await applyAdapters(request.loras, to: transformer, progressHandler: progressHandler)
+        progressHandler?(GenerationProgress(stage: .loadingTransformer, stepIndex: 3, totalSteps: 3))
+
+        let seed = request.seed ?? deterministicSeed(prompt: request.prompt)
+        let resolution = Flux1SampleBuilder.alignedResolution(width: request.width, height: request.height)
+        let latentHeight = resolution.height / Flux1SampleBuilder.vaeCompression
+        let latentWidth = resolution.width / Flux1SampleBuilder.vaeCompression
+        let noise = MLXRandom.normal(
+            [1, configurations.vae.latentChannels, latentHeight, latentWidth],
+            key: MLXRandom.key(seed)
+        ).asType(.bfloat16)
+        var tokens = Flux1SampleBuilder.pack(noise)
+        let imageIDs = Flux1SampleBuilder.imageIDs(height: latentHeight, width: latentWidth)
+        let textIDs = Flux1SampleBuilder.textIDs(length: context.dim(1))
+        let scheduler = Flux1Scheduler(
+            steps: request.steps,
+            imageSequenceLength: tokens.dim(1),
+            configuration: configurations.scheduler
+        )
+        let guidance = configurations.transformer.guidanceEmbeds
+            ? MLXArray([Float(request.guidanceScale)]).asType(.bfloat16)
+            : nil
+
+        for index in 0..<max(request.steps, 1) {
+            try Task.checkCancellation()
+            progressHandler?(GenerationProgress(
+                stage: .denoising,
+                stepIndex: index,
+                totalSteps: max(request.steps, 1)
+            ))
+            let prediction = transformer(
+                image: tokens,
+                context: context,
+                pooledProjection: pooled,
+                timestep: MLXArray([scheduler.sigmas[index]]).asType(.bfloat16),
+                imageIDs: imageIDs,
+                textIDs: textIDs,
+                guidance: guidance
+            )
+            tokens = scheduler.step(modelOutput: prediction, index: index, sample: tokens)
+            MLX.eval(tokens)
+        }
+        progressHandler?(GenerationProgress(
+            stage: .denoising,
+            stepIndex: max(request.steps, 1),
+            totalSteps: max(request.steps, 1)
+        ))
+
+        let latents = Flux1SampleBuilder.unpack(tokens, height: latentHeight, width: latentWidth)
+        MLX.eval(latents)
+        Memory.clearCache()
+
+        progressHandler?(GenerationProgress(stage: .loadingVAE, stepIndex: 0, totalSteps: 1))
+        let vae = AutoencoderKL(configuration: configurations.vae.coreConfiguration)
+        try HFSafetensorsWeightsLoader.applyWeights(
+            url: resources.vaeWeightsURL,
+            to: vae,
+            dtype: .bfloat16,
+            verify: [.shapeMismatch],
+            mapper: { key, value in
+                let mapped = value.ndim == 4 && key.contains("conv")
+                    ? HFSafetensorsWeightsLoader.convWeightOIHWToOHWI(value)
+                    : value
+                return [(key, mapped)]
+            }
+        )
+        progressHandler?(GenerationProgress(stage: .loadingVAE, stepIndex: 1, totalSteps: 1))
+        progressHandler?(GenerationProgress(stage: .decoding, stepIndex: 0, totalSteps: 1))
+        let (decoded, _) = vae.decode(latents)
+        var image = MLX.clip(QwenImageIO.denormalizeFromDecoder(decoded), min: 0, max: 1)
+        if resolution.width != request.width || resolution.height != request.height {
+            image = image[0..., 0..., 0..<request.height, 0..<request.width]
+        }
+        MLX.eval(image)
+        progressHandler?(GenerationProgress(stage: .decoding, stepIndex: 1, totalSteps: 1))
+
+        progressHandler?(GenerationProgress(stage: .saving, stepIndex: 0, totalSteps: 1))
+        let outputDirectory = request.outputURL.deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: outputDirectory, withIntermediateDirectories: true)
+        try QwenImageIO.saveImage(array: image, to: request.outputURL)
+        progressHandler?(GenerationProgress(stage: .saving, stepIndex: 1, totalSteps: 1))
+        Memory.clearCache()
+        return GenerationResult(outputURL: request.outputURL, seed: seed)
+    }
+
+    private struct Configurations {
+        let transformer: Flux1TransformerConfiguration
+        let clip: Flux1CLIPConfiguration
+        let t5: Flux1T5Configuration
+        let vae: Flux1VAEConfiguration
+        let scheduler: Flux1SchedulerConfiguration
+    }
+
+    private func loadConfigurations(resources: Flux1Resources) throws -> Configurations {
+        let decoder = JSONDecoder()
+        return try Configurations(
+            transformer: decoder.decode(
+                Flux1TransformerConfiguration.self,
+                from: Data(contentsOf: resources.transformerConfigURL)
+            ),
+            clip: decoder.decode(
+                Flux1CLIPConfiguration.self,
+                from: Data(contentsOf: resources.clipConfigURL)
+            ),
+            t5: decoder.decode(
+                Flux1T5Configuration.self,
+                from: Data(contentsOf: resources.t5ConfigURL)
+            ),
+            vae: decoder.decode(
+                Flux1VAEConfiguration.self,
+                from: Data(contentsOf: resources.vaeConfigURL)
+            ),
+            scheduler: decoder.decode(
+                Flux1SchedulerConfiguration.self,
+                from: Data(contentsOf: resources.schedulerConfigURL)
+            )
+        )
+    }
+
+    private func validate(configurations: Configurations) throws {
+        guard configurations.transformer.hiddenSize == 3_072,
+              configurations.transformer.inChannels == 64,
+              configurations.transformer.axesDimsRope == [16, 56, 56] else {
+            throw Flux1Error.invalidConfiguration("expected the FLUX.1-dev transformer shape")
+        }
+        guard configurations.clip.hiddenSize == 768,
+              configurations.t5.dModel == 4_096,
+              configurations.vae.latentChannels == 16 else {
+            throw Flux1Error.invalidConfiguration("expected CLIP-L, T5-XXL, and the 16-channel FLUX.1 VAE")
+        }
+    }
+
+    private func encodeCLIP(
+        prompt: String,
+        resources: Flux1Resources,
+        configuration: Flux1CLIPConfiguration
+    ) throws -> MLXArray {
+        let tokenizer = try Flux1Tokenizer.load(
+            from: resources.clipTokenizerURL,
+            maximumLength: configuration.maxPositionEmbeddings,
+            fallbackPadTokenID: 49_407
+        )
+        let encoded = tokenizer.encode(prompt)
+        let inputIDs = MLXArray(encoded.ids.map(Int32.init)).reshaped(1, encoded.ids.count)
+        let model = try Flux1TextEncoderLoader.loadCLIP(resources: resources, configuration: configuration)
+        let pooled = model.pooled(inputIDs: inputIDs, index: encoded.pooledIndex).asType(.bfloat16)
+        MLX.eval(pooled)
+        return pooled
+    }
+
+    private func encodeT5(
+        prompt: String,
+        maximumLength: Int,
+        resources: Flux1Resources,
+        configuration: Flux1T5Configuration
+    ) throws -> MLXArray {
+        let tokenizer = try Flux1Tokenizer.load(
+            from: resources.t5TokenizerURL,
+            maximumLength: maximumLength,
+            fallbackPadTokenID: 0
+        )
+        let encoded = tokenizer.encode(prompt)
+        let inputIDs = MLXArray(encoded.ids.map(Int32.init)).reshaped(1, encoded.ids.count)
+        let mask = MLXArray(encoded.mask.map(Int32.init)).reshaped(1, encoded.mask.count)
+        let model = try Flux1TextEncoderLoader.loadT5(
+            resources: resources,
+            configuration: configuration
+        )
+        let context = model(tokenIDs: inputIDs, mask: mask).asType(.bfloat16)
+        MLX.eval(context)
+        return context
+    }
+
+    private func applyAdapters(
+        _ adapters: [LoRA],
+        to transformer: Flux1Transformer,
+        progressHandler: (@Sendable (GenerationProgress) -> Void)?
+    ) async throws {
+        guard !adapters.isEmpty else { return }
+        var inputs: [Flux2LoRAStackInput] = []
+        for (index, adapter) in adapters.enumerated() {
+            let weights = try await LoRAWeightLoader.load(from: adapter, architecture: .flux1)
+            inputs.append(Flux2LoRAStackInput(
+                label: Self.adapterLabel(adapter),
+                scale: Self.adapterScale(adapter),
+                weights: weights
+            ))
+            progressHandler?(GenerationProgress(
+                stage: .loadingLoRA,
+                stepIndex: index + 1,
+                totalSteps: adapters.count
+            ))
+        }
+        let stacked = try Flux2LoRAStacker.stack(inputs)
+        let layers = try Flux2LoRAInjector.inject(
+            into: transformer,
+            rank: stacked.rank,
+            targetRanks: stacked.targetRanks,
+            zeroInitUp: true
+        )
+        var applied = 0
+        for (path, layer) in layers {
+            guard let weights = stacked.weights[path] else { continue }
+            guard weights.down.shape == layer.loraDown.shape else {
+                throw Flux1Error.incompatibleAdapter(
+                    path: path,
+                    actual: weights.down.shape,
+                    expected: layer.loraDown.shape
+                )
+            }
+            guard weights.up.shape == layer.loraUp.shape else {
+                throw Flux1Error.incompatibleAdapter(
+                    path: path,
+                    actual: weights.up.shape,
+                    expected: layer.loraUp.shape
+                )
+            }
+            layer.loraDown = weights.down.asType(.bfloat16)
+            layer.loraUp = weights.up.asType(.bfloat16)
+            layer.isActive = true
+            applied += 1
+        }
+        guard applied > 0 else {
+            throw LoRAError.invalidFormat("No FLUX.1 transformer layers matched this adapter.")
+        }
+    }
+
+    private func resolveModelRoot(_ model: String?) throws -> URL {
+        let spec = model ?? Flux1Resources.modelID
+        let localURL = URL(fileURLWithPath: spec).standardizedFileURL
+        var isDirectory: ObjCBool = false
+        if FileManager.default.fileExists(atPath: localURL.path, isDirectory: &isDirectory), isDirectory.boolValue {
+            return localURL
+        }
+        if let modelID = ModelResolver.ModelID(rawValue: spec) {
+            return try ModelResolver().resolve(modelID).rootURL
+        }
+        throw Flux1Error.modelNotFound(spec)
+    }
+
+    private func deterministicSeed(prompt: String) -> UInt64 {
+        var hash: UInt64 = 0xcbf2_9ce4_8422_2325
+        for byte in prompt.utf8 {
+            hash ^= UInt64(byte)
+            hash &*= 0x0000_0100_0000_01b3
+        }
+        return hash
+    }
+
+    private static func adapterScale(_ adapter: LoRA) -> Float {
+        switch adapter {
+        case .local(_, let scale), .remote(_, let scale): return Float(scale)
+        }
+    }
+
+    private static func adapterLabel(_ adapter: LoRA) -> String {
+        switch adapter {
+        case .local(let path, _): return path
+        case .remote(let reference, _): return reference
+        }
+    }
+}

--- a/Sources/MereRunCore/Flux1/Flux1Scheduler.swift
+++ b/Sources/MereRunCore/Flux1/Flux1Scheduler.swift
@@ -1,0 +1,85 @@
+import Foundation
+import MLX
+
+public struct Flux1Scheduler: Sendable, Hashable {
+    public let sigmas: [Float]
+
+    public init(
+        steps: Int,
+        imageSequenceLength: Int,
+        configuration: Flux1SchedulerConfiguration
+    ) {
+        let count = max(steps, 1)
+        let base = (0..<count).map { 1 - Float($0) / Float(count) }
+        if configuration.useDynamicShifting {
+            let slope = (configuration.maxShift - configuration.baseShift)
+                / Float(configuration.maxImageSequenceLength - configuration.baseImageSequenceLength)
+            let intercept = configuration.baseShift
+                - slope * Float(configuration.baseImageSequenceLength)
+            let mu = slope * Float(imageSequenceLength) + intercept
+            let exponential = exp(mu)
+            self.sigmas = base.map { sigma in
+                exponential / (exponential + (1 / sigma - 1))
+            } + [0]
+        } else {
+            self.sigmas = base.map { sigma in
+                configuration.shift * sigma / (1 + (configuration.shift - 1) * sigma)
+            } + [0]
+        }
+    }
+
+    public func step(modelOutput: MLXArray, index: Int, sample: MLXArray) -> MLXArray {
+        sample + modelOutput.asType(sample.dtype) * MLXArray(sigmas[index + 1] - sigmas[index])
+    }
+}
+
+enum Flux1SampleBuilder {
+    static let vaeCompression = 8
+    static let patch = 2
+
+    static func alignedResolution(width: Int, height: Int) -> (width: Int, height: Int) {
+        let divisor = vaeCompression * patch
+        return (
+            max(divisor, width / divisor * divisor),
+            max(divisor, height / divisor * divisor)
+        )
+    }
+
+    static func pack(_ latents: MLXArray) -> MLXArray {
+        let batch = latents.dim(0)
+        let channels = latents.dim(1)
+        let height = latents.dim(2)
+        let width = latents.dim(3)
+        return latents
+            .reshaped(batch, channels, height / 2, 2, width / 2, 2)
+            .transposed(0, 2, 4, 1, 3, 5)
+            .reshaped(batch, height / 2 * width / 2, channels * 4)
+    }
+
+    static func unpack(_ tokens: MLXArray, height: Int, width: Int) -> MLXArray {
+        let batch = tokens.dim(0)
+        let channels = tokens.dim(2) / 4
+        return tokens
+            .reshaped(batch, height / 2, width / 2, channels, 2, 2)
+            .transposed(0, 3, 1, 4, 2, 5)
+            .reshaped(batch, channels, height, width)
+    }
+
+    static func textIDs(length: Int) -> MLXArray {
+        MLX.zeros([length, 3], dtype: .float32)
+    }
+
+    static func imageIDs(height: Int, width: Int) -> MLXArray {
+        let tokenHeight = height / 2
+        let tokenWidth = width / 2
+        var values = [Float](repeating: 0, count: tokenHeight * tokenWidth * 3)
+        for y in 0..<tokenHeight {
+            for x in 0..<tokenWidth {
+                let offset = (y * tokenWidth + x) * 3
+                values[offset + 1] = Float(y)
+                values[offset + 2] = Float(x)
+            }
+        }
+        return MLXArray(values).reshaped(tokenHeight * tokenWidth, 3)
+    }
+}

--- a/Sources/MereRunCore/Flux1/Flux1TextEncoders.swift
+++ b/Sources/MereRunCore/Flux1/Flux1TextEncoders.swift
@@ -1,0 +1,421 @@
+import Foundation
+@preconcurrency import Hub
+import MLX
+import MLXFast
+import MLXNN
+@preconcurrency import Tokenizers
+
+final class Flux1Tokenizer: @unchecked Sendable {
+    private let tokenizer: any Tokenizer
+    let maximumLength: Int
+    let padTokenID: Int
+    let eosTokenID: Int?
+
+    private init(tokenizer: any Tokenizer, maximumLength: Int, padTokenID: Int) {
+        self.tokenizer = tokenizer
+        self.maximumLength = maximumLength
+        self.padTokenID = padTokenID
+        self.eosTokenID = tokenizer.eosTokenId
+    }
+
+    static func load(
+        from directory: URL,
+        maximumLength: Int,
+        fallbackPadTokenID: Int,
+        hubAPI: HubApi = .shared
+    ) throws -> Flux1Tokenizer {
+        let configURL = directory.appendingPathComponent("tokenizer_config.json")
+        let dataURL = directory.appendingPathComponent("tokenizer.json")
+        let tokenizerConfig = try hubAPI.configuration(fileURL: configURL)
+        let tokenizerData: Config
+        let effectiveTokenizerConfig: Config
+        if FileManager.default.fileExists(atPath: dataURL.path) {
+            tokenizerData = try hubAPI.configuration(fileURL: dataURL)
+            effectiveTokenizerConfig = tokenizerConfig
+        } else {
+            tokenizerData = try makeBPETokenizerData(
+                vocabURL: directory.appendingPathComponent("vocab.json"),
+                mergesURL: directory.appendingPathComponent("merges.txt")
+            )
+            effectiveTokenizerConfig = Config([
+                "tokenizer_class": Config("GPT2Tokenizer"),
+                "bos_token": Config("<|startoftext|>"),
+                "eos_token": Config("<|endoftext|>"),
+                "unk_token": Config("<|endoftext|>"),
+                "pad_token": Config("<|endoftext|>"),
+                "model_max_length": Config(maximumLength),
+                "clean_up_tokenization_spaces": Config(true),
+            ])
+        }
+        let tokenizer = try AutoTokenizer.from(
+            tokenizerConfig: effectiveTokenizerConfig,
+            tokenizerData: tokenizerData,
+            strict: false
+        )
+        return Flux1Tokenizer(
+            tokenizer: tokenizer,
+            maximumLength: maximumLength,
+            padTokenID: tokenizer.convertTokenToId("<pad>") ?? tokenizer.eosTokenId ?? fallbackPadTokenID
+        )
+    }
+
+    private static func makeBPETokenizerData(vocabURL: URL, mergesURL: URL) throws -> Config {
+        let vocabData = try Data(contentsOf: vocabURL)
+        let vocab = try JSONDecoder().decode([String: Int].self, from: vocabData)
+        let merges = try String(contentsOf: mergesURL, encoding: .utf8)
+            .components(separatedBy: .newlines)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty && !$0.hasPrefix("#") }
+        let data = try JSONEncoder().encode(Flux1BPETokenizerData(vocab: vocab, merges: merges))
+        return try JSONDecoder().decode(Config.self, from: data)
+    }
+
+    func encode(_ text: String) -> (ids: [Int], mask: [Int], pooledIndex: Int) {
+        var ids = tokenizer.encode(text: text, addSpecialTokens: true)
+        if ids.count > maximumLength {
+            ids = Array(ids.prefix(maximumLength))
+            if let eosTokenID {
+                ids[maximumLength - 1] = eosTokenID
+            }
+        }
+        let pooledIndex = eosTokenID.flatMap { ids.firstIndex(of: $0) } ?? max(ids.count - 1, 0)
+        let activeCount = ids.count
+        ids.append(contentsOf: repeatElement(padTokenID, count: maximumLength - activeCount))
+        return (
+            ids,
+            Array(repeating: 1, count: activeCount) + Array(repeating: 0, count: maximumLength - activeCount),
+            pooledIndex
+        )
+    }
+}
+
+private struct Flux1BPETokenizerData: Encodable {
+    let model: Model
+    let addedTokens = [
+        AddedToken(id: 49_406, content: "<|startoftext|>"),
+        AddedToken(id: 49_407, content: "<|endoftext|>"),
+    ]
+    let normalizer = LowercaseNormalizer()
+    let preTokenizer = ByteLevelPreTokenizer()
+    let postProcessor = TemplatePostProcessor()
+    let decoder = ByteLevelDecoder()
+
+    init(vocab: [String: Int], merges: [String]) {
+        self.model = Model(vocab: vocab, merges: merges)
+    }
+
+    struct Model: Encodable {
+        let vocab: [String: Int]
+        let merges: [String]
+    }
+
+    struct AddedToken: Encodable {
+        let id: Int
+        let content: String
+        let lstrip = false
+        let rstrip = false
+        let normalized = false
+        let singleWord = false
+        let special = true
+    }
+
+    struct LowercaseNormalizer: Encodable {
+        let type = "Lowercase"
+    }
+
+    struct ByteLevelPreTokenizer: Encodable {
+        let type = "ByteLevel"
+        let addPrefixSpace = false
+        let trimOffsets = true
+        let useRegex = true
+    }
+
+    struct ByteLevelDecoder: Encodable {
+        let type = "ByteLevel"
+    }
+
+    struct TemplatePostProcessor: Encodable {
+        let type = "TemplateProcessing"
+        let single = [
+            Item(specialToken: "<|startoftext|>"),
+            Item(sequence: "A"),
+            Item(specialToken: "<|endoftext|>"),
+        ]
+        let pair = [
+            Item(specialToken: "<|startoftext|>"),
+            Item(sequence: "A"),
+            Item(specialToken: "<|endoftext|>"),
+            Item(sequence: "B", typeID: 1),
+            Item(specialToken: "<|endoftext|>", typeID: 1),
+        ]
+
+        struct Item: Encodable {
+            let specialToken: Payload?
+            let sequence: Payload?
+
+            init(specialToken: String, typeID: Int = 0) {
+                self.specialToken = Payload(id: specialToken, typeID: typeID)
+                self.sequence = nil
+            }
+
+            init(sequence: String, typeID: Int = 0) {
+                self.specialToken = nil
+                self.sequence = Payload(id: sequence, typeID: typeID)
+            }
+
+            enum CodingKeys: String, CodingKey {
+                case specialToken = "SpecialToken"
+                case sequence = "Sequence"
+            }
+        }
+
+        struct Payload: Encodable {
+            let id: String
+            let typeID: Int
+        }
+    }
+}
+
+final class Flux1CLIPAttention: Module {
+    let headCount: Int
+    let headSize: Int
+    @ModuleInfo(key: "q_proj") var query: Linear
+    @ModuleInfo(key: "k_proj") var key: Linear
+    @ModuleInfo(key: "v_proj") var value: Linear
+    @ModuleInfo(key: "out_proj") var output: Linear
+
+    init(configuration: Flux1CLIPConfiguration) {
+        self.headCount = configuration.numAttentionHeads
+        self.headSize = configuration.hiddenSize / configuration.numAttentionHeads
+        self._query.wrappedValue = Linear(configuration.hiddenSize, configuration.hiddenSize, bias: true)
+        self._key.wrappedValue = Linear(configuration.hiddenSize, configuration.hiddenSize, bias: true)
+        self._value.wrappedValue = Linear(configuration.hiddenSize, configuration.hiddenSize, bias: true)
+        self._output.wrappedValue = Linear(configuration.hiddenSize, configuration.hiddenSize, bias: true)
+        super.init()
+    }
+
+    func callAsFunction(_ input: MLXArray, mask: MLXArray) -> MLXArray {
+        let batch = input.dim(0)
+        let length = input.dim(1)
+        func heads(_ value: MLXArray) -> MLXArray {
+            value.reshaped(batch, length, headCount, headSize).transposed(0, 2, 1, 3)
+        }
+        let attended = MLXFast.scaledDotProductAttention(
+            queries: heads(query(input)),
+            keys: heads(key(input)),
+            values: heads(value(input)),
+            scale: 1 / sqrt(Float(headSize)),
+            mask: mask
+        )
+        return output(attended.transposed(0, 2, 1, 3).reshaped(batch, length, headCount * headSize))
+    }
+}
+
+final class Flux1CLIPMLP: Module {
+    @ModuleInfo(key: "fc1") var input: Linear
+    @ModuleInfo(key: "fc2") var output: Linear
+
+    init(configuration: Flux1CLIPConfiguration) {
+        self._input.wrappedValue = Linear(configuration.hiddenSize, configuration.intermediateSize, bias: true)
+        self._output.wrappedValue = Linear(configuration.intermediateSize, configuration.hiddenSize, bias: true)
+        super.init()
+    }
+
+    func callAsFunction(_ value: MLXArray) -> MLXArray {
+        let projected = input(value)
+        return output(projected * MLX.sigmoid(projected * 1.702))
+    }
+}
+
+final class Flux1CLIPLayer: Module {
+    @ModuleInfo(key: "self_attn") var attention: Flux1CLIPAttention
+    @ModuleInfo(key: "layer_norm1") var attentionNorm: LayerNorm
+    @ModuleInfo(key: "mlp") var mlp: Flux1CLIPMLP
+    @ModuleInfo(key: "layer_norm2") var mlpNorm: LayerNorm
+
+    init(configuration: Flux1CLIPConfiguration) {
+        self._attention.wrappedValue = Flux1CLIPAttention(configuration: configuration)
+        self._attentionNorm.wrappedValue = LayerNorm(
+            dimensions: configuration.hiddenSize,
+            eps: configuration.layerNormEps
+        )
+        self._mlp.wrappedValue = Flux1CLIPMLP(configuration: configuration)
+        self._mlpNorm.wrappedValue = LayerNorm(
+            dimensions: configuration.hiddenSize,
+            eps: configuration.layerNormEps
+        )
+        super.init()
+    }
+
+    func callAsFunction(_ input: MLXArray, mask: MLXArray) -> MLXArray {
+        let attended = input + attention(attentionNorm(input), mask: mask)
+        return attended + mlp(mlpNorm(attended))
+    }
+}
+
+final class Flux1CLIPEmbeddings: Module {
+    @ModuleInfo(key: "token_embedding") var tokenEmbedding: Embedding
+    @ModuleInfo(key: "position_embedding") var positionEmbedding: Embedding
+
+    init(configuration: Flux1CLIPConfiguration) {
+        self._tokenEmbedding.wrappedValue = Embedding(
+            embeddingCount: configuration.vocabSize,
+            dimensions: configuration.hiddenSize
+        )
+        self._positionEmbedding.wrappedValue = Embedding(
+            embeddingCount: configuration.maxPositionEmbeddings,
+            dimensions: configuration.hiddenSize
+        )
+        super.init()
+    }
+
+    func callAsFunction(_ inputIDs: MLXArray) -> MLXArray {
+        let positionIDs = MLXArray(0..<inputIDs.dim(1)).asType(.int32)
+        return tokenEmbedding(inputIDs) + positionEmbedding(positionIDs)
+    }
+}
+
+final class Flux1CLIPEncoder: Module {
+    @ModuleInfo(key: "layers") var layers: [Flux1CLIPLayer]
+
+    init(configuration: Flux1CLIPConfiguration) {
+        self._layers.wrappedValue = (0..<configuration.numHiddenLayers).map { _ in
+            Flux1CLIPLayer(configuration: configuration)
+        }
+        super.init()
+    }
+
+    func callAsFunction(_ input: MLXArray, mask: MLXArray) -> MLXArray {
+        var hidden = input
+        for layer in layers {
+            hidden = layer(hidden, mask: mask)
+        }
+        return hidden
+    }
+}
+
+final class Flux1CLIPTextModel: Module {
+    @ModuleInfo(key: "embeddings") var embeddings: Flux1CLIPEmbeddings
+    @ModuleInfo(key: "encoder") var encoder: Flux1CLIPEncoder
+    @ModuleInfo(key: "final_layer_norm") var finalNorm: LayerNorm
+
+    init(configuration: Flux1CLIPConfiguration) {
+        self._embeddings.wrappedValue = Flux1CLIPEmbeddings(configuration: configuration)
+        self._encoder.wrappedValue = Flux1CLIPEncoder(configuration: configuration)
+        self._finalNorm.wrappedValue = LayerNorm(
+            dimensions: configuration.hiddenSize,
+            eps: configuration.layerNormEps
+        )
+        super.init()
+    }
+
+    func callAsFunction(_ inputIDs: MLXArray) -> MLXArray {
+        let length = inputIDs.dim(1)
+        let hidden = embeddings(inputIDs)
+        var values = [Float](repeating: 0, count: length * length)
+        for row in 0..<length {
+            for column in (row + 1)..<length {
+                values[row * length + column] = -1e9
+            }
+        }
+        let mask = MLXArray(values, [1, 1, length, length]).asType(hidden.dtype)
+        return finalNorm(encoder(hidden, mask: mask))
+    }
+}
+
+final class Flux1CLIPModel: Module {
+    @ModuleInfo(key: "text_model") var textModel: Flux1CLIPTextModel
+
+    init(configuration: Flux1CLIPConfiguration) {
+        self._textModel.wrappedValue = Flux1CLIPTextModel(configuration: configuration)
+        super.init()
+    }
+
+    func pooled(inputIDs: MLXArray, index: Int) -> MLXArray {
+        textModel(inputIDs)[0..., index, 0...]
+    }
+}
+
+enum Flux1TextEncoderLoader {
+    static func loadCLIP(
+        resources: Flux1Resources,
+        configuration: Flux1CLIPConfiguration
+    ) throws -> Flux1CLIPModel {
+        let model = Flux1CLIPModel(configuration: configuration)
+        try HFSafetensorsWeightsLoader.applyWeights(
+            url: resources.clipWeightsURL,
+            to: model,
+            dtype: .bfloat16,
+            verify: [.shapeMismatch]
+        )
+        return model
+    }
+
+    static func loadT5(
+        resources: Flux1Resources,
+        configuration: Flux1T5Configuration,
+        progressHandler: (@Sendable (HFSafetensorsWeightsLoader.ShardProgress) -> Void)? = nil
+    ) throws -> Wan2TextEncoderModel {
+        let model = Wan2TextEncoderModel(configuration: configuration.wanConfiguration)
+        try HFSafetensorsWeightsLoader.applyShardedWeights(
+            indexURL: resources.t5WeightsIndexURL,
+            to: model,
+            dtype: .bfloat16,
+            verify: [.shapeMismatch],
+            mapper: { key, value in
+                mapT5Weight(
+                    key: key,
+                    value: value,
+                    layerCount: configuration.numLayers
+                )
+            },
+            progressHandler: progressHandler
+        )
+        return model
+    }
+
+    static func mapT5Weight(key: String, value: MLXArray, layerCount: Int) -> [(String, MLXArray)] {
+        if key == "shared.weight" {
+            return [("token_embedding.weight", value)]
+        }
+        if key == "encoder.final_layer_norm.weight" {
+            return [("norm.weight", value)]
+        }
+        if key == "encoder.block.0.layer.0.SelfAttention.relative_attention_bias.weight" {
+            return (0..<layerCount).map { ("blocks.\($0).pos_embedding.embedding.weight", value) }
+        }
+
+        let components = key.split(separator: ".").map(String.init)
+        guard components.count >= 6,
+              components[0] == "encoder",
+              components[1] == "block",
+              let layerIndex = Int(components[2]),
+              components[3] == "layer" else {
+            return []
+        }
+        let remainder = components.dropFirst(5).joined(separator: ".")
+        let prefix = "blocks.\(layerIndex)"
+        switch (components[4], remainder) {
+        case ("0", "SelfAttention.q.weight"):
+            return [("\(prefix).attn.q.weight", value)]
+        case ("0", "SelfAttention.k.weight"):
+            return [("\(prefix).attn.k.weight", value)]
+        case ("0", "SelfAttention.v.weight"):
+            return [("\(prefix).attn.v.weight", value)]
+        case ("0", "SelfAttention.o.weight"):
+            return [("\(prefix).attn.o.weight", value)]
+        case ("0", "layer_norm.weight"):
+            return [("\(prefix).norm1.weight", value)]
+        case ("1", "DenseReluDense.wi_0.weight"):
+            return [("\(prefix).ffn.gate_proj.weight", value)]
+        case ("1", "DenseReluDense.wi_1.weight"):
+            return [("\(prefix).ffn.fc1.weight", value)]
+        case ("1", "DenseReluDense.wo.weight"):
+            return [("\(prefix).ffn.fc2.weight", value)]
+        case ("1", "layer_norm.weight"):
+            return [("\(prefix).norm2.weight", value)]
+        default:
+            return []
+        }
+    }
+}

--- a/Sources/MereRunCore/Flux1/Flux1Transformer.swift
+++ b/Sources/MereRunCore/Flux1/Flux1Transformer.swift
@@ -1,0 +1,444 @@
+import Foundation
+import MLX
+import MLXFast
+import MLXNN
+
+private func flux1LayerNorm(_ value: MLXArray, epsilon: Float = 1e-6) -> MLXArray {
+    let source = value.asType(.float32)
+    let mean = source.mean(axis: -1, keepDims: true)
+    let centered = source - mean
+    let variance = (centered * centered).mean(axis: -1, keepDims: true)
+    return (centered / MLX.sqrt(variance + epsilon)).asType(value.dtype)
+}
+
+final class Flux1TimestepEmbedding: Module {
+    @ModuleInfo(key: "linear_1") var linear1: Linear
+    @ModuleInfo(key: "linear_2") var linear2: Linear
+
+    init(inputSize: Int, hiddenSize: Int) {
+        self._linear1.wrappedValue = Linear(inputSize, hiddenSize, bias: true)
+        self._linear2.wrappedValue = Linear(hiddenSize, hiddenSize, bias: true)
+        super.init()
+    }
+
+    func callAsFunction(_ value: MLXArray) -> MLXArray {
+        linear2(silu(linear1(value)))
+    }
+}
+
+final class Flux1TimeTextEmbedding: Module {
+    @ModuleInfo(key: "timestep_embedder") var timestepEmbedder: Flux1TimestepEmbedding
+    @ModuleInfo(key: "guidance_embedder") var guidanceEmbedder: Flux1TimestepEmbedding?
+    @ModuleInfo(key: "text_embedder") var textEmbedder: Flux1TimestepEmbedding
+
+    init(hiddenSize: Int, pooledProjectionSize: Int, guidanceEmbeds: Bool) {
+        self._timestepEmbedder.wrappedValue = Flux1TimestepEmbedding(inputSize: 256, hiddenSize: hiddenSize)
+        self._guidanceEmbedder.wrappedValue = guidanceEmbeds
+            ? Flux1TimestepEmbedding(inputSize: 256, hiddenSize: hiddenSize)
+            : nil
+        self._textEmbedder.wrappedValue = Flux1TimestepEmbedding(
+            inputSize: pooledProjectionSize,
+            hiddenSize: hiddenSize
+        )
+        super.init()
+    }
+
+    func callAsFunction(
+        timestep: MLXArray,
+        guidance: MLXArray?,
+        pooledProjection: MLXArray
+    ) -> MLXArray {
+        var embedding = timestepEmbedder(Self.sinusoidal(timestep))
+        if let guidance, let guidanceEmbedder {
+            embedding = embedding + guidanceEmbedder(Self.sinusoidal(guidance))
+        }
+        return embedding + textEmbedder(pooledProjection)
+    }
+
+    private static func sinusoidal(_ values: MLXArray) -> MLXArray {
+        let half = 128
+        let indices = MLXArray(0..<half).asType(.float32)
+        let frequencies = MLX.exp(-log(Float(10_000)) * indices / Float(half))
+        let angles = values.asType(.float32).expandedDimensions(axis: -1) * frequencies
+        return MLX.concatenated([MLX.cos(angles), MLX.sin(angles)], axis: -1)
+    }
+}
+
+final class Flux1AdaLayerNormZero: Module {
+    @ModuleInfo(key: "linear") var linear: Linear
+
+    init(hiddenSize: Int) {
+        self._linear.wrappedValue = Linear(hiddenSize, hiddenSize * 6, bias: true)
+        super.init()
+    }
+
+    func callAsFunction(
+        _ value: MLXArray,
+        embedding: MLXArray
+    ) -> (
+        normalized: MLXArray,
+        attentionGate: MLXArray,
+        mlpShift: MLXArray,
+        mlpScale: MLXArray,
+        mlpGate: MLXArray
+    ) {
+        let chunks = MLX.split(linear(silu(embedding)), parts: 6, axis: -1)
+        let shift = chunks[0].expandedDimensions(axis: 1)
+        let scale = chunks[1].expandedDimensions(axis: 1)
+        return (
+            flux1LayerNorm(value) * (1 + scale) + shift,
+            chunks[2].expandedDimensions(axis: 1),
+            chunks[3].expandedDimensions(axis: 1),
+            chunks[4].expandedDimensions(axis: 1),
+            chunks[5].expandedDimensions(axis: 1)
+        )
+    }
+}
+
+final class Flux1AdaLayerNormZeroSingle: Module {
+    @ModuleInfo(key: "linear") var linear: Linear
+
+    init(hiddenSize: Int) {
+        self._linear.wrappedValue = Linear(hiddenSize, hiddenSize * 3, bias: true)
+        super.init()
+    }
+
+    func callAsFunction(_ value: MLXArray, embedding: MLXArray) -> (MLXArray, MLXArray) {
+        let chunks = MLX.split(linear(silu(embedding)), parts: 3, axis: -1)
+        let shift = chunks[0].expandedDimensions(axis: 1)
+        let scale = chunks[1].expandedDimensions(axis: 1)
+        let gate = chunks[2].expandedDimensions(axis: 1)
+        return (flux1LayerNorm(value) * (1 + scale) + shift, gate)
+    }
+}
+
+final class Flux1AdaLayerNormContinuous: Module {
+    @ModuleInfo(key: "linear") var linear: Linear
+
+    init(hiddenSize: Int) {
+        self._linear.wrappedValue = Linear(hiddenSize, hiddenSize * 2, bias: true)
+        super.init()
+    }
+
+    func callAsFunction(_ value: MLXArray, embedding: MLXArray) -> MLXArray {
+        let chunks = MLX.split(linear(silu(embedding)), parts: 2, axis: -1)
+        let scale = chunks[0].expandedDimensions(axis: 1)
+        let shift = chunks[1].expandedDimensions(axis: 1)
+        return flux1LayerNorm(value) * (1 + scale) + shift
+    }
+}
+
+final class Flux1GELUProjection: Module {
+    @ModuleInfo(key: "proj") var projection: Linear
+
+    init(inputSize: Int, outputSize: Int) {
+        self._projection.wrappedValue = Linear(inputSize, outputSize, bias: true)
+        super.init()
+    }
+
+    func callAsFunction(_ value: MLXArray) -> MLXArray {
+        MLXNN.geluApproximate(projection(value))
+    }
+}
+
+final class Flux1FeedForward: Module {
+    @ModuleInfo(key: "input") var input: Flux1GELUProjection
+    @ModuleInfo(key: "output") var output: Linear
+
+    init(hiddenSize: Int) {
+        self._input.wrappedValue = Flux1GELUProjection(inputSize: hiddenSize, outputSize: hiddenSize * 4)
+        self._output.wrappedValue = Linear(hiddenSize * 4, hiddenSize, bias: true)
+        super.init()
+    }
+
+    func callAsFunction(_ value: MLXArray) -> MLXArray {
+        output(input(value))
+    }
+}
+
+final class Flux1JointAttention: Module {
+    let headCount: Int
+    let headSize: Int
+
+    @ModuleInfo(key: "to_q") var query: Linear
+    @ModuleInfo(key: "to_k") var key: Linear
+    @ModuleInfo(key: "to_v") var value: Linear
+    @ModuleInfo(key: "norm_q") var queryNorm: RMSNorm
+    @ModuleInfo(key: "norm_k") var keyNorm: RMSNorm
+    @ModuleInfo(key: "to_out") var output: [Linear]
+
+    @ModuleInfo(key: "add_q_proj") var contextQuery: Linear
+    @ModuleInfo(key: "add_k_proj") var contextKey: Linear
+    @ModuleInfo(key: "add_v_proj") var contextValue: Linear
+    @ModuleInfo(key: "norm_added_q") var contextQueryNorm: RMSNorm
+    @ModuleInfo(key: "norm_added_k") var contextKeyNorm: RMSNorm
+    @ModuleInfo(key: "to_add_out") var contextOutput: Linear
+
+    init(hiddenSize: Int, headCount: Int, headSize: Int) {
+        self.headCount = headCount
+        self.headSize = headSize
+        self._query.wrappedValue = Linear(hiddenSize, hiddenSize, bias: true)
+        self._key.wrappedValue = Linear(hiddenSize, hiddenSize, bias: true)
+        self._value.wrappedValue = Linear(hiddenSize, hiddenSize, bias: true)
+        self._queryNorm.wrappedValue = RMSNorm(dimensions: headSize, eps: 1e-6)
+        self._keyNorm.wrappedValue = RMSNorm(dimensions: headSize, eps: 1e-6)
+        self._output.wrappedValue = [Linear(hiddenSize, hiddenSize, bias: true)]
+        self._contextQuery.wrappedValue = Linear(hiddenSize, hiddenSize, bias: true)
+        self._contextKey.wrappedValue = Linear(hiddenSize, hiddenSize, bias: true)
+        self._contextValue.wrappedValue = Linear(hiddenSize, hiddenSize, bias: true)
+        self._contextQueryNorm.wrappedValue = RMSNorm(dimensions: headSize, eps: 1e-6)
+        self._contextKeyNorm.wrappedValue = RMSNorm(dimensions: headSize, eps: 1e-6)
+        self._contextOutput.wrappedValue = Linear(hiddenSize, hiddenSize, bias: true)
+        super.init()
+    }
+
+    func callAsFunction(
+        image: MLXArray,
+        context: MLXArray,
+        rotary: (MLXArray, MLXArray)
+    ) -> (image: MLXArray, context: MLXArray) {
+        let batch = image.dim(0)
+        let imageLength = image.dim(1)
+        let contextLength = context.dim(1)
+
+        func heads(_ value: MLXArray) -> MLXArray {
+            value.reshaped(batch, -1, headCount, headSize).transposed(0, 2, 1, 3)
+        }
+
+        let imageQuery = queryNorm(heads(query(image)))
+        let imageKey = keyNorm(heads(key(image)))
+        let imageValue = heads(value(image))
+        let textQuery = contextQueryNorm(heads(contextQuery(context)))
+        let textKey = contextKeyNorm(heads(contextKey(context)))
+        let textValue = heads(contextValue(context))
+
+        let jointQuery = Flux2PosEmbed.applyRotaryEmb(
+            MLX.concatenated([textQuery, imageQuery], axis: 2),
+            freqs: rotary
+        )
+        let jointKey = Flux2PosEmbed.applyRotaryEmb(
+            MLX.concatenated([textKey, imageKey], axis: 2),
+            freqs: rotary
+        )
+        let jointValue = MLX.concatenated([textValue, imageValue], axis: 2)
+        let attended = MLXFast.scaledDotProductAttention(
+            queries: jointQuery,
+            keys: jointKey,
+            values: jointValue,
+            scale: 1 / sqrt(Float(headSize)),
+            mask: .none
+        ).transposed(0, 2, 1, 3).reshaped(batch, contextLength + imageLength, headCount * headSize)
+        let text = attended[0..., 0..<contextLength, 0...]
+        let image = attended[0..., contextLength..., 0...]
+        return (output[0](image), contextOutput(text))
+    }
+}
+
+final class Flux1TransformerBlock: Module {
+    @ModuleInfo(key: "norm1") var imageNorm: Flux1AdaLayerNormZero
+    @ModuleInfo(key: "norm1_context") var contextNorm: Flux1AdaLayerNormZero
+    @ModuleInfo(key: "attn") var attention: Flux1JointAttention
+    @ModuleInfo(key: "ff") var imageFeedForward: Flux1FeedForward
+    @ModuleInfo(key: "ff_context") var contextFeedForward: Flux1FeedForward
+
+    init(configuration: Flux1TransformerConfiguration) {
+        let hiddenSize = configuration.hiddenSize
+        self._imageNorm.wrappedValue = Flux1AdaLayerNormZero(hiddenSize: hiddenSize)
+        self._contextNorm.wrappedValue = Flux1AdaLayerNormZero(hiddenSize: hiddenSize)
+        self._attention.wrappedValue = Flux1JointAttention(
+            hiddenSize: hiddenSize,
+            headCount: configuration.numAttentionHeads,
+            headSize: configuration.attentionHeadDim
+        )
+        self._imageFeedForward.wrappedValue = Flux1FeedForward(hiddenSize: hiddenSize)
+        self._contextFeedForward.wrappedValue = Flux1FeedForward(hiddenSize: hiddenSize)
+        super.init()
+    }
+
+    func callAsFunction(
+        image: MLXArray,
+        context: MLXArray,
+        embedding: MLXArray,
+        rotary: (MLXArray, MLXArray)
+    ) -> (context: MLXArray, image: MLXArray) {
+        let imageModulation = imageNorm(image, embedding: embedding)
+        let contextModulation = contextNorm(context, embedding: embedding)
+        let attended = attention(
+            image: imageModulation.normalized,
+            context: contextModulation.normalized,
+            rotary: rotary
+        )
+
+        var nextImage = image + imageModulation.attentionGate * attended.image
+        var nextContext = context + contextModulation.attentionGate * attended.context
+        let normalizedImage = flux1LayerNorm(nextImage)
+            * (1 + imageModulation.mlpScale) + imageModulation.mlpShift
+        let normalizedContext = flux1LayerNorm(nextContext)
+            * (1 + contextModulation.mlpScale) + contextModulation.mlpShift
+        nextImage = nextImage + imageModulation.mlpGate * imageFeedForward(normalizedImage)
+        nextContext = nextContext + contextModulation.mlpGate * contextFeedForward(normalizedContext)
+        return (nextContext, nextImage)
+    }
+}
+
+final class Flux1SelfAttention: Module {
+    let headCount: Int
+    let headSize: Int
+
+    @ModuleInfo(key: "to_q") var query: Linear
+    @ModuleInfo(key: "to_k") var key: Linear
+    @ModuleInfo(key: "to_v") var value: Linear
+    @ModuleInfo(key: "norm_q") var queryNorm: RMSNorm
+    @ModuleInfo(key: "norm_k") var keyNorm: RMSNorm
+
+    init(hiddenSize: Int, headCount: Int, headSize: Int) {
+        self.headCount = headCount
+        self.headSize = headSize
+        self._query.wrappedValue = Linear(hiddenSize, hiddenSize, bias: true)
+        self._key.wrappedValue = Linear(hiddenSize, hiddenSize, bias: true)
+        self._value.wrappedValue = Linear(hiddenSize, hiddenSize, bias: true)
+        self._queryNorm.wrappedValue = RMSNorm(dimensions: headSize, eps: 1e-6)
+        self._keyNorm.wrappedValue = RMSNorm(dimensions: headSize, eps: 1e-6)
+        super.init()
+    }
+
+    func callAsFunction(_ input: MLXArray, rotary: (MLXArray, MLXArray)) -> MLXArray {
+        let batch = input.dim(0)
+        func heads(_ value: MLXArray) -> MLXArray {
+            value.reshaped(batch, -1, headCount, headSize).transposed(0, 2, 1, 3)
+        }
+        let q = Flux2PosEmbed.applyRotaryEmb(queryNorm(heads(query(input))), freqs: rotary)
+        let k = Flux2PosEmbed.applyRotaryEmb(keyNorm(heads(key(input))), freqs: rotary)
+        let v = heads(value(input))
+        return MLXFast.scaledDotProductAttention(
+            queries: q,
+            keys: k,
+            values: v,
+            scale: 1 / sqrt(Float(headSize)),
+            mask: .none
+        ).transposed(0, 2, 1, 3).reshaped(batch, -1, headCount * headSize)
+    }
+}
+
+final class Flux1SingleTransformerBlock: Module {
+    @ModuleInfo(key: "norm") var norm: Flux1AdaLayerNormZeroSingle
+    @ModuleInfo(key: "proj_mlp") var mlpProjection: Linear
+    @ModuleInfo(key: "attn") var attention: Flux1SelfAttention
+    @ModuleInfo(key: "proj_out") var outputProjection: Linear
+
+    init(configuration: Flux1TransformerConfiguration) {
+        let hiddenSize = configuration.hiddenSize
+        self._norm.wrappedValue = Flux1AdaLayerNormZeroSingle(hiddenSize: hiddenSize)
+        self._mlpProjection.wrappedValue = Linear(hiddenSize, hiddenSize * 4, bias: true)
+        self._attention.wrappedValue = Flux1SelfAttention(
+            hiddenSize: hiddenSize,
+            headCount: configuration.numAttentionHeads,
+            headSize: configuration.attentionHeadDim
+        )
+        self._outputProjection.wrappedValue = Linear(hiddenSize * 5, hiddenSize, bias: true)
+        super.init()
+    }
+
+    func callAsFunction(
+        _ input: MLXArray,
+        embedding: MLXArray,
+        rotary: (MLXArray, MLXArray)
+    ) -> MLXArray {
+        let (normalized, gate) = norm(input, embedding: embedding)
+        let attended = attention(normalized, rotary: rotary)
+        let mlp = MLXNN.geluApproximate(mlpProjection(normalized))
+        return input + gate * outputProjection(MLX.concatenated([attended, mlp], axis: -1))
+    }
+}
+
+public final class Flux1Transformer: Module {
+    public let configuration: Flux1TransformerConfiguration
+
+    @ModuleInfo(key: "x_embedder") var imageEmbedder: Linear
+    @ModuleInfo(key: "context_embedder") var contextEmbedder: Linear
+    @ModuleInfo(key: "time_text_embed") var timeTextEmbedder: Flux1TimeTextEmbedding
+    @ModuleInfo(key: "transformer_blocks") var transformerBlocks: [Flux1TransformerBlock]
+    @ModuleInfo(key: "single_transformer_blocks") var singleTransformerBlocks: [Flux1SingleTransformerBlock]
+    @ModuleInfo(key: "norm_out") var outputNorm: Flux1AdaLayerNormContinuous
+    @ModuleInfo(key: "proj_out") var outputProjection: Linear
+    private let positionEmbedder: Flux2PosEmbed
+
+    public init(configuration: Flux1TransformerConfiguration) {
+        self.configuration = configuration
+        self._imageEmbedder.wrappedValue = Linear(
+            configuration.inChannels,
+            configuration.hiddenSize,
+            bias: true
+        )
+        self._contextEmbedder.wrappedValue = Linear(
+            configuration.jointAttentionDim,
+            configuration.hiddenSize,
+            bias: true
+        )
+        self._timeTextEmbedder.wrappedValue = Flux1TimeTextEmbedding(
+            hiddenSize: configuration.hiddenSize,
+            pooledProjectionSize: configuration.pooledProjectionDim,
+            guidanceEmbeds: configuration.guidanceEmbeds
+        )
+        self._transformerBlocks.wrappedValue = (0..<configuration.numLayers).map { _ in
+            Flux1TransformerBlock(configuration: configuration)
+        }
+        self._singleTransformerBlocks.wrappedValue = (0..<configuration.numSingleLayers).map { _ in
+            Flux1SingleTransformerBlock(configuration: configuration)
+        }
+        self._outputNorm.wrappedValue = Flux1AdaLayerNormContinuous(hiddenSize: configuration.hiddenSize)
+        self._outputProjection.wrappedValue = Linear(
+            configuration.hiddenSize,
+            configuration.patchSize * configuration.patchSize * configuration.outChannels,
+            bias: true
+        )
+        self.positionEmbedder = Flux2PosEmbed(theta: 10_000, axesDim: configuration.axesDimsRope)
+        super.init()
+    }
+
+    public func callAsFunction(
+        image: MLXArray,
+        context: MLXArray,
+        pooledProjection: MLXArray,
+        timestep: MLXArray,
+        imageIDs: MLXArray,
+        textIDs: MLXArray,
+        guidance: MLXArray?
+    ) -> MLXArray {
+        var imageHidden = imageEmbedder(image)
+        var contextHidden = contextEmbedder(context)
+        let embedding = timeTextEmbedder(
+            timestep: timestep.asType(imageHidden.dtype) * 1_000,
+            guidance: guidance.map { $0.asType(imageHidden.dtype) * 1_000 },
+            pooledProjection: pooledProjection
+        )
+        let ids = MLX.concatenated([textIDs, imageIDs], axis: 0)
+        let rotary = positionEmbedder(ids)
+        for block in transformerBlocks {
+            (contextHidden, imageHidden) = block(
+                image: imageHidden,
+                context: contextHidden,
+                embedding: embedding,
+                rotary: rotary
+            )
+        }
+        let textLength = contextHidden.dim(1)
+        var combined = MLX.concatenated([contextHidden, imageHidden], axis: 1)
+        for block in singleTransformerBlocks {
+            combined = block(combined, embedding: embedding, rotary: rotary)
+        }
+        imageHidden = combined[0..., textLength..., 0...]
+        return outputProjection(outputNorm(imageHidden, embedding: embedding))
+    }
+}
+
+enum Flux1TransformerWeightMapper {
+    static func map(key: String, value: MLXArray) -> [(String, MLXArray)] {
+        var target = key
+        target = target.replacingOccurrences(of: ".ff.net.0.proj", with: ".ff.input.proj")
+        target = target.replacingOccurrences(of: ".ff.net.2", with: ".ff.output")
+        target = target.replacingOccurrences(of: ".ff_context.net.0.proj", with: ".ff_context.input.proj")
+        target = target.replacingOccurrences(of: ".ff_context.net.2", with: ".ff_context.output")
+        return [(target, value)]
+    }
+}

--- a/Sources/MereRunCore/Flux1/README.md
+++ b/Sources/MereRunCore/Flux1/README.md
@@ -1,0 +1,14 @@
+# FLUX.1
+
+Native FLUX.1 text-to-image inference for the gated `FLUX.1-dev` Diffusers
+checkpoint.
+
+- `Flux1Generator.swift`: component loading, prompt encoding, denoising, and decode.
+- `Flux1Transformer.swift`: FLUX.1 dual-stream and single-stream transformer.
+- `Flux1TextEncoders.swift`: CLIP-L pooled and T5-XXL sequence conditioning.
+- `Flux1Configs.swift`: typed Diffusers configuration and checkpoint resources.
+- `Flux1Scheduler.swift`: flow-match schedule and latent packing.
+
+FLUX.1 and FLUX.2 adapters are architecture-specific. Keep this runtime and
+its manifest family separate from `Flux2Klein` even though both use FLUX-style
+block names.

--- a/Sources/MereRunCore/Flux2Klein/Flux2DevTurboRecipe.swift
+++ b/Sources/MereRunCore/Flux2Klein/Flux2DevTurboRecipe.swift
@@ -1,0 +1,14 @@
+public enum Flux2DevTurboRecipe {
+    public static let steps = 8
+    public static let guidanceScale: Double = 2.5
+    public static let sigmas: [Float] = [
+        1.0,
+        0.6509,
+        0.4374,
+        0.2932,
+        0.1893,
+        0.1108,
+        0.0495,
+        0.00031,
+    ]
+}

--- a/Sources/MereRunCore/Flux2Klein/Flux2EulerScheduler.swift
+++ b/Sources/MereRunCore/Flux2Klein/Flux2EulerScheduler.swift
@@ -17,13 +17,17 @@ public struct Flux2EulerScheduler {
     ///   - imageSeqLen: Number of latent tokens (height * width after patchify)
     ///   - isDistilled: If true, uses terminal stretch + mu=1.0 (distilled models).
     ///                  If false, uses linear 1→0 schedule with dynamic mu (base models).
+    ///   - usesEmpiricalMu: Use the published FLUX.2-dev step- and sequence-aware shift.
     ///   - sigmaShift: Optional scalar FlowMatch shift override.
+    ///   - customSigmas: Optional pre-shifted sigma value for each denoising step.
     public init(
         numInferenceSteps: Int = 4,
         numTrainTimesteps: Int = 1000,
         imageSeqLen: Int,
         isDistilled: Bool = true,
-        sigmaShift: Float? = nil
+        usesEmpiricalMu: Bool = false,
+        sigmaShift: Float? = nil,
+        customSigmas: [Float]? = nil
     ) {
         self.numInferenceSteps = max(numInferenceSteps, 1)
         let steps = self.numInferenceSteps
@@ -31,7 +35,9 @@ public struct Flux2EulerScheduler {
 
         let sigmasFinal: [Float]
 
-        if isDistilled {
+        if let customSigmas {
+            sigmasFinal = customSigmas
+        } else if isDistilled {
             // Distilled mode: terminal stretch to 0.02, mu=1.0 (mflux behavior)
             let sigmaMin = 1.0 / numTrainTimestepsF
             let sigmaMax: Float = 1.0
@@ -57,16 +63,16 @@ public struct Flux2EulerScheduler {
                 sigmasLinear.append(1.0 - Float(i) / Float(steps))
             }
 
-            // Dynamic mu based on image sequence length (ai-toolkit formula)
-            // Linear interpolation: y1=0.5 at x1=256, y2=1.15 at x2=4096
-            let mu = Self.computeDynamicMu(imageSeqLen: imageSeqLen)
+            let mu = usesEmpiricalMu
+                ? Self.computeEmpiricalMu(imageSeqLen: imageSeqLen, numSteps: steps)
+                : Self.computeDynamicMu(imageSeqLen: imageSeqLen)
             sigmasFinal = sigmasLinear.map { Self.timeShiftExponentialScalar(mu: mu, sigmaPower: 1.0, t: $0) }
             // NO terminal stretch for base model - schedule goes to 0
         }
 
-        let shiftedSigmas = sigmaShift.map {
-            Self.applyScalarSigmaShift(sigmas: sigmasFinal, shift: $0)
-        } ?? sigmasFinal
+        let shiftedSigmas = customSigmas == nil
+            ? sigmaShift.map { Self.applyScalarSigmaShift(sigmas: sigmasFinal, shift: $0) } ?? sigmasFinal
+            : sigmasFinal
 
         // Convert to timesteps
         let timestepsArr = shiftedSigmas.map { $0 * numTrainTimestepsF }
@@ -78,12 +84,47 @@ public struct Flux2EulerScheduler {
         self.timesteps = MLXArray(timestepsArr).asType(.float32)
     }
 
+    public static func validateCustomSigmas(_ sigmas: [Float], expectedSteps: Int) throws {
+        guard expectedSteps > 0, sigmas.count == expectedSteps else {
+            throw Flux2Error.invalidSigmaSchedule(
+                "Expected \(expectedSteps) sigma values, found \(sigmas.count)."
+            )
+        }
+        guard sigmas.allSatisfy({ $0.isFinite && $0 > 0 && $0 <= 1 }) else {
+            throw Flux2Error.invalidSigmaSchedule(
+                "Sigma values must be finite and greater than 0 through 1."
+            )
+        }
+        for index in 1..<sigmas.count where sigmas[index] >= sigmas[index - 1] {
+            throw Flux2Error.invalidSigmaSchedule("Sigma values must be strictly descending.")
+        }
+    }
+
     /// Compute dynamic mu based on image sequence length (ai-toolkit formula)
     /// Linear interpolation: y1=0.5 at x1=256, y2=1.15 at x2=4096
     private static func computeDynamicMu(imageSeqLen: Int) -> Float {
         let m: Float = (1.15 - 0.5) / Float(4096 - 256)
         let b: Float = 0.5 - m * 256
         return m * Float(imageSeqLen) + b
+    }
+
+    /// Published FLUX.2-dev schedule fit used by the reference Diffusers pipeline.
+    static func computeEmpiricalMu(imageSeqLen: Int, numSteps: Int) -> Float {
+        let a1: Float = 8.73809524e-05
+        let b1: Float = 1.89833333
+        let a2: Float = 0.00016927
+        let b2: Float = 0.45666666
+        let sequenceLength = Float(imageSeqLen)
+
+        if imageSeqLen > 4_300 {
+            return a2 * sequenceLength + b2
+        }
+
+        let muAt200Steps = a2 * sequenceLength + b2
+        let muAt10Steps = a1 * sequenceLength + b1
+        let slope = (muAt200Steps - muAt10Steps) / 190
+        let intercept = muAt200Steps - 200 * slope
+        return slope * Float(numSteps) + intercept
     }
 
     /// Stretch sigmas so final sigma lands at shiftTerminal (0.02)

--- a/Sources/MereRunCore/Flux2Klein/Flux2KleinConfigs.swift
+++ b/Sources/MereRunCore/Flux2Klein/Flux2KleinConfigs.swift
@@ -6,7 +6,8 @@ public struct Flux2TransformerConfig: Decodable, Sendable {
     public let attentionHeadDim: Int
     public let axesDimsRope: [Int]
     public let eps: Float
-    public let guidanceEmbeds: Bool
+    /// Diffusers defaults this to `true`; older Klein configs persist `false` explicitly.
+    public let guidanceEmbeds: Bool?
     public let inChannels: Int
     public let jointAttentionDim: Int
     public let mlpRatio: Float
@@ -37,6 +38,7 @@ public struct Flux2TransformerConfig: Decodable, Sendable {
 
     public var hiddenSize: Int { numAttentionHeads * attentionHeadDim }
     public var mlpHiddenSize: Int { Int(Float(hiddenSize) * mlpRatio) }
+    public var resolvedGuidanceEmbeds: Bool { guidanceEmbeds ?? true }
 }
 
 // MARK: - Scheduler Config
@@ -106,9 +108,15 @@ public struct Flux2VAEConfig: Decodable, Sendable {
     }
 }
 
-// MARK: - Text Encoder Config (Qwen3)
+// MARK: - Text Encoder Config
 
 public struct Flux2TextEncoderConfig: Decodable, Sendable {
+    public enum Architecture: Equatable, Sendable {
+        case qwen3
+        case mistral3
+    }
+
+    public let architecture: Architecture
     public let hiddenSize: Int
     public let intermediateSize: Int
     public let numHiddenLayers: Int
@@ -122,6 +130,8 @@ public struct Flux2TextEncoderConfig: Decodable, Sendable {
     public let quantizationConfig: QuantizationConfig?
 
     enum CodingKeys: String, CodingKey {
+        case modelType = "model_type"
+        case textConfig = "text_config"
         case hiddenSize = "hidden_size"
         case intermediateSize = "intermediate_size"
         case numHiddenLayers = "num_hidden_layers"
@@ -132,7 +142,65 @@ public struct Flux2TextEncoderConfig: Decodable, Sendable {
         case ropeTheta = "rope_theta"
         case vocabSize = "vocab_size"
         case maxPositionEmbeddings = "max_position_embeddings"
+        case quantization
         case quantizationConfig = "quantization_config"
+    }
+
+    private struct TextConfig: Decodable {
+        let hiddenSize: Int
+        let intermediateSize: Int
+        let numHiddenLayers: Int
+        let numAttentionHeads: Int
+        let numKeyValueHeads: Int
+        let headDim: Int
+        let rmsNormEps: Float
+        let ropeTheta: Float
+        let vocabSize: Int
+        let maxPositionEmbeddings: Int
+
+        enum CodingKeys: String, CodingKey {
+            case hiddenSize = "hidden_size"
+            case intermediateSize = "intermediate_size"
+            case numHiddenLayers = "num_hidden_layers"
+            case numAttentionHeads = "num_attention_heads"
+            case numKeyValueHeads = "num_key_value_heads"
+            case headDim = "head_dim"
+            case rmsNormEps = "rms_norm_eps"
+            case ropeTheta = "rope_theta"
+            case vocabSize = "vocab_size"
+            case maxPositionEmbeddings = "max_position_embeddings"
+        }
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        if let nested = try container.decodeIfPresent(TextConfig.self, forKey: .textConfig) {
+            architecture = .mistral3
+            hiddenSize = nested.hiddenSize
+            intermediateSize = nested.intermediateSize
+            numHiddenLayers = nested.numHiddenLayers
+            numAttentionHeads = nested.numAttentionHeads
+            numKeyValueHeads = nested.numKeyValueHeads
+            headDim = nested.headDim
+            rmsNormEps = nested.rmsNormEps
+            ropeTheta = nested.ropeTheta
+            vocabSize = nested.vocabSize
+            maxPositionEmbeddings = nested.maxPositionEmbeddings
+        } else {
+            architecture = .qwen3
+            hiddenSize = try container.decode(Int.self, forKey: .hiddenSize)
+            intermediateSize = try container.decode(Int.self, forKey: .intermediateSize)
+            numHiddenLayers = try container.decode(Int.self, forKey: .numHiddenLayers)
+            numAttentionHeads = try container.decode(Int.self, forKey: .numAttentionHeads)
+            numKeyValueHeads = try container.decode(Int.self, forKey: .numKeyValueHeads)
+            headDim = try container.decode(Int.self, forKey: .headDim)
+            rmsNormEps = try container.decode(Float.self, forKey: .rmsNormEps)
+            ropeTheta = try container.decode(Float.self, forKey: .ropeTheta)
+            vocabSize = try container.decode(Int.self, forKey: .vocabSize)
+            maxPositionEmbeddings = try container.decode(Int.self, forKey: .maxPositionEmbeddings)
+        }
+        quantizationConfig = try container.decodeIfPresent(QuantizationConfig.self, forKey: .quantizationConfig)
+            ?? container.decodeIfPresent(QuantizationConfig.self, forKey: .quantization)
     }
 
     public struct QuantizationConfig: Decodable, Sendable {

--- a/Sources/MereRunCore/Flux2Klein/Flux2KleinGenerator+Generation.swift
+++ b/Sources/MereRunCore/Flux2Klein/Flux2KleinGenerator+Generation.swift
@@ -23,7 +23,7 @@ extension Flux2KleinGenerator {
             try await loadModels(from: modelPath, progressHandler: progressHandler)
         }
 
-        try await applyLoRAIfNeeded(request.lora, progressHandler: progressHandler)
+        try await applyLoRAIfNeeded(request.loras, progressHandler: progressHandler)
 
         guard let transformer = transformer,
               let textEncoder = textEncoder,
@@ -54,12 +54,18 @@ extension Flux2KleinGenerator {
             throw Flux2Error.invalidManifest("Missing manifest.variant")
         }
         let isDistilled = variant == .distilled
+        let usesEmbeddedGuidance = transformer.config.guidanceEmbeds
+        if let sigmas = request.sigmas {
+            try Flux2EulerScheduler.validateCustomSigmas(sigmas, expectedSteps: request.steps)
+        }
 
         // CFG behavior differs between distilled and base models:
         // - Distilled: CFG only if user explicitly provides negative prompt (mflux behavior)
         // - Base: CFG required when guidance > 1.0, uses empty string as unconditional
         let useCFG: Bool
-        if isDistilled {
+        if usesEmbeddedGuidance {
+            useCFG = false
+        } else if isDistilled {
             let hasNegativePrompt = request.negativePrompt.map {
                 !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
             } ?? false
@@ -196,7 +202,9 @@ extension Flux2KleinGenerator {
             numTrainTimesteps: 1000,
             imageSeqLen: seqLen,
             isDistilled: isDistilled,
-            sigmaShift: request.sigmaShift
+            usesEmpiricalMu: usesEmbeddedGuidance,
+            sigmaShift: request.sigmaShift,
+            customSigmas: request.sigmas
         )
 
         // Note: FLUX.2 Klein does NOT scale initial latents (unlike SD3/etc)
@@ -265,7 +273,8 @@ extension Flux2KleinGenerator {
                     encoderHiddenStates: promptEmbeds,
                     timestep: timestepTensor,
                     imgIds: imgIds,
-                    txtIds: txtIds
+                    txtIds: txtIds,
+                    guidance: usesEmbeddedGuidance ? MLXArray([Float(request.guidanceScale)]) : nil
                 )
             }
 
@@ -402,12 +411,23 @@ extension Flux2KleinGenerator {
         textEncoder: QwenTextEncoder,
         debugLog: ((String) -> Void)?
     ) throws -> (MLXArray, MLXArray) {
-        // Tokenize using FLUX.2 chat template (matching mflux with enable_thinking=False)
-        // Template (from `chat_template.jinja`): <|im_start|>user\n{prompt}<|im_end|>\n<|im_start|>assistant\n<think>\n\n</think>\n\n
+        // Klein uses Qwen3 conditioning; FLUX.2-dev uses Mistral Small 3.2.
         //
         // Important: we must NOT use `QwenTokenizer.encode(...)` here because it applies the
         // Z-Image system prefix/suffix (image-editing instructions), which breaks FLUX.2 prompts.
-        let promptWithTemplate = "<|im_start|>user\n\(prompt)<|im_end|>\n<|im_start|>assistant\n<think>\n\n</think>\n\n"
+        let usesMistral = !textEncoder.configuration.useQKNorm
+        let promptWithTemplate: String
+        if usesMistral {
+            let cleanedPrompt = prompt.replacingOccurrences(of: "[IMG]", with: "")
+            let systemPrompt = """
+            You are an AI that reasons about image descriptions. You give structured responses focusing on object relationships, object
+            attribution and actions without speculation.
+            """
+            promptWithTemplate = "<s>[SYSTEM_PROMPT]\(systemPrompt)[/SYSTEM_PROMPT]"
+                + "[INST]\(cleanedPrompt)[/INST]"
+        } else {
+            promptWithTemplate = "<|im_start|>user\n\(prompt)<|im_end|>\n<|im_start|>assistant\n<think>\n\n</think>\n\n"
+        }
         let encoded = tokenizer.encodePlain(prompts: [promptWithTemplate], maxLength: 512)
 
         if let debugLog {
@@ -415,35 +435,36 @@ extension Flux2KleinGenerator {
             debugLog("Tokenized \(tokens.count) tokens: \(tokens.prefix(20))...")
         }
 
-        // Get hidden states - diffusers uses indices 9, 18, 27 directly
-        // These are the outputs of layers 8, 17, 26 (0-indexed from transformers convention)
+        // Diffusers selects three architecture-specific intermediate hidden states.
         let result = textEncoder.forwardWithHiddenStates(
             inputIds: encoded.inputIds,
             attentionMask: encoded.attentionMask
         )
 
-        guard let hiddenStates = result.hiddenStates, hiddenStates.count >= 28 else {
+        let hiddenStateIndices = usesMistral ? [10, 20, 30] : [9, 18, 27]
+        guard let hiddenStates = result.hiddenStates,
+              let lastIndex = hiddenStateIndices.last,
+              hiddenStates.count > lastIndex else {
             throw Flux2Error.insufficientHiddenStates
         }
 
-        // Use direct indices 9, 18, 27 matching diffusers exactly.
-        // No RMSNorm: diffusers uses raw hidden states.
+        // Diffusers concatenates the raw states without applying RMSNorm.
         if let debugLog {
             debugLog("=== Hidden States Debug ===")
             debugLog("Total hidden states: \(hiddenStates.count)")
         }
 
-        let h1 = hiddenStates[9]   // hidden_states[9]
-        let h2 = hiddenStates[18]  // hidden_states[18]
-        let h3 = hiddenStates[27]  // hidden_states[27]
+        let h1 = hiddenStates[hiddenStateIndices[0]]
+        let h2 = hiddenStates[hiddenStateIndices[1]]
+        let h3 = hiddenStates[hiddenStateIndices[2]]
 
         if let debugLog {
-            debugLog("h1 (idx 9): shape=\(h1.shape), mean=\(h1.mean().item(Float.self)), std=\(sqrt((h1 * h1).mean().item(Float.self)))")
-            debugLog("h2 (idx 18): shape=\(h2.shape), mean=\(h2.mean().item(Float.self)), std=\(sqrt((h2 * h2).mean().item(Float.self)))")
-            debugLog("h3 (idx 27): shape=\(h3.shape), mean=\(h3.mean().item(Float.self)), std=\(sqrt((h3 * h3).mean().item(Float.self)))")
+            debugLog("h1 (idx \(hiddenStateIndices[0])): shape=\(h1.shape), mean=\(h1.mean().item(Float.self)), std=\(sqrt((h1 * h1).mean().item(Float.self)))")
+            debugLog("h2 (idx \(hiddenStateIndices[1])): shape=\(h2.shape), mean=\(h2.mean().item(Float.self)), std=\(sqrt((h2 * h2).mean().item(Float.self)))")
+            debugLog("h3 (idx \(hiddenStateIndices[2])): shape=\(h3.shape), mean=\(h3.mean().item(Float.self)), std=\(sqrt((h3 * h3).mean().item(Float.self)))")
         }
 
-        // Concatenate along feature dimension: [batch, seq, 2560*3 = 7680]
+        // Concatenate the three states along the feature dimension.
         let promptEmbeds = concatenated([h1, h2, h3], axis: -1)
 
         if let debugLog {

--- a/Sources/MereRunCore/Flux2Klein/Flux2KleinGenerator+ModelLoading.swift
+++ b/Sources/MereRunCore/Flux2Klein/Flux2KleinGenerator+ModelLoading.swift
@@ -20,6 +20,7 @@ extension Flux2KleinGenerator {
         let textEncoderComponent = try componentResolver.resolveDirectory(for: .textEncoder, fallbackLocalPath: "text_encoder")
         let tokenizerComponent = try componentResolver.resolveDirectory(for: .tokenizer, fallbackLocalPath: "tokenizer")
         let quantization = try ModelWeightsLoader.QuantizationParams.fromManifest(textEncoderComponent.sourceManifest)
+            ?? loadTextEncoderQuantization(from: textEncoderComponent.directoryURL)
 
         // Load text encoder
         progressHandler?(ChatProgress(stage: .loadingModel, message: "Loading text encoder"))
@@ -72,7 +73,8 @@ extension Flux2KleinGenerator {
             ropeTheta: rawConfig.ropeTheta,
             maxPositionEmbeddings: rawConfig.maxPositionEmbeddings,
             rmsNormEps: rawConfig.rmsNormEps,
-            headDim: rawConfig.headDim
+            headDim: rawConfig.headDim,
+            useQKNorm: rawConfig.architecture == .qwen3
         )
 
         textEncoder = QwenTextEncoder(configuration: config)
@@ -154,6 +156,7 @@ extension Flux2KleinGenerator {
 
         let transformerQuantization = try ModelWeightsLoader.QuantizationParams.fromManifest(transformerComponent.sourceManifest)
         let textEncoderQuantization = try ModelWeightsLoader.QuantizationParams.fromManifest(textEncoderComponent.sourceManifest)
+            ?? loadTextEncoderQuantization(from: textEncoderComponent.directoryURL)
 
         // Load transformer
         // Shared shard discovery resolves symlinked component directories before listing them.
@@ -180,7 +183,10 @@ extension Flux2KleinGenerator {
         let vaeConfig = try loadVAEConfig(from: vaeComponent.directoryURL)
         vae = AutoencoderKL(configuration: vaeConfig)
 
-        let vaeWeightsURL = vaeComponent.directoryURL.appendingPathComponent("diffusion_pytorch_model.safetensors").resolvingSymlinksInPath()
+        let vaeWeightsURL = Self.checkpointFileURL(
+            in: vaeComponent.directoryURL,
+            filename: "diffusion_pytorch_model.safetensors"
+        )
 
         // First, load BN running stats directly from safetensors
         let bnWeights = try loadBatchNormStats(from: vaeWeightsURL)
@@ -208,7 +214,7 @@ extension Flux2KleinGenerator {
         loadedModelPath = path
         loadedManifest = manifest
         loadedQuantization = transformerQuantization
-        currentLoRA = nil
+        currentLoRAs = []
         transformerLoRALayers = nil
         transformerLoRARankSignature = nil
         compiledTransformer = nil
@@ -216,42 +222,57 @@ extension Flux2KleinGenerator {
     }
 
     func applyLoRAIfNeeded(
-        _ lora: LoRA?,
+        _ loras: [LoRA],
         progressHandler: (@Sendable (GenerationProgress) -> Void)?
     ) async throws {
-        guard lora != currentLoRA else { return }
+        guard loras != currentLoRAs else { return }
         guard transformer != nil else { return }
 
-        // Clearing LoRA (keep injected wrappers but disable them).
-        guard let lora else {
+        // Clearing LoRAs keeps injected wrappers resident but disables every contribution.
+        guard !loras.isEmpty else {
             if let layers = transformerLoRALayers {
                 for layer in layers.values {
-                    layer.isActive = false
+                    Self.setAllLoRAContributions(in: layer, active: false)
                 }
             }
-            currentLoRA = nil
+            currentLoRAs = []
             progressHandler?(GenerationProgress(stage: .loadingLoRA, stepIndex: 1, totalSteps: 1))
             return
         }
 
-        progressHandler?(GenerationProgress(stage: .loadingLoRA, stepIndex: 0, totalSteps: 1))
-        let loraWeights = try await LoRAWeightLoader.load(from: lora)
+        progressHandler?(GenerationProgress(stage: .loadingLoRA, stepIndex: 0, totalSteps: loras.count))
+        var stackInputs: [Flux2LoRAStackInput] = []
+        stackInputs.reserveCapacity(loras.count)
+        for (index, lora) in loras.enumerated() {
+            let weights = try await LoRAWeightLoader.load(from: lora)
+            stackInputs.append(
+                Flux2LoRAStackInput(
+                    label: Self.loraLabel(for: lora),
+                    scale: Self.loraScale(for: lora),
+                    weights: weights
+                )
+            )
+            progressHandler?(
+                GenerationProgress(stage: .loadingLoRA, stepIndex: index + 1, totalSteps: loras.count)
+            )
+        }
+        let loraWeights = try Flux2LoRAStacker.stack(stackInputs)
         let targetRank = loraWeights.rank
-        let targetRanks = loraWeights.targetRanks.isEmpty ? nil : loraWeights.targetRanks
+        let targetRanks = loraWeights.targetRanks
         let targetRankSignature = Self.loraRankSignature(defaultRank: targetRank, targetRanks: targetRanks)
 
         if transformerLoRALayers == nil {
             transformerLoRALayers = try Flux2LoRAInjector.inject(
                 into: transformer!,
                 rank: targetRank,
-                alpha: loraWeights.alpha,
+                alpha: nil,
                 targetRanks: targetRanks,
                 zeroInitUp: true
             )
             transformerLoRARankSignature = targetRankSignature
             if let layers = transformerLoRALayers {
                 for layer in layers.values {
-                    layer.isActive = false
+                    Self.setAllLoRAContributions(in: layer, active: false)
                 }
             }
 
@@ -262,7 +283,7 @@ extension Flux2KleinGenerator {
             transformerLoRALayers = try Flux2LoRAInjector.inject(
                 into: transformer!,
                 rank: targetRank,
-                alpha: loraWeights.alpha,
+                alpha: nil,
                 targetRanks: targetRanks,
                 zeroInitUp: true,
                 allowReinjection: true
@@ -270,7 +291,7 @@ extension Flux2KleinGenerator {
             transformerLoRARankSignature = targetRankSignature
             if let layers = transformerLoRALayers {
                 for layer in layers.values {
-                    layer.isActive = false
+                    Self.setAllLoRAContributions(in: layer, active: false)
                 }
             }
 
@@ -286,31 +307,28 @@ extension Flux2KleinGenerator {
         var applied = 0
         for (path, layer) in layers {
             guard let weights = loraWeights.weights[path] else {
-                layer.isActive = false
+                Self.setAllLoRAContributions(in: layer, active: false)
                 continue
             }
 
-            layer.loraDown = weights.down.asType(.float32)
-            layer.loraUp = weights.up.asType(.float32)
+            try Self.validateLoRAWeightShapes(
+                path: path,
+                down: weights.down,
+                up: weights.up,
+                expectedDown: layer.loraDown.shape,
+                expectedUp: layer.loraUp.shape
+            )
+            layer.loraDown = weights.down
+            layer.loraUp = weights.up
             layer.isActive = true
             applied += 1
         }
-
-        // Apply user scale by scaling lora_down (delta scales linearly).
-        let userScale = Self.loraScale(for: lora)
-        if userScale != 1 {
-            let s = MLXArray(userScale)
-            for layer in layers.values where layer.isActive {
-                layer.loraDown = layer.loraDown * s
-            }
-        }
-        progressHandler?(GenerationProgress(stage: .loadingLoRA, stepIndex: 1, totalSteps: 1))
 
         guard applied > 0 else {
             throw LoRAError.invalidFormat(Self.noMatchingTransformerLayersMessage)
         }
 
-        currentLoRA = lora
+        currentLoRAs = loras
     }
 
     private static func loraScale(for lora: LoRA) -> Float {
@@ -319,6 +337,44 @@ extension Flux2KleinGenerator {
             return Float(scale)
         case .remote(_, let scale):
             return Float(scale)
+        }
+    }
+
+    private static func loraLabel(for lora: LoRA) -> String {
+        switch lora {
+        case .local(let path, _):
+            return path
+        case .remote(let reference, _):
+            return reference
+        }
+    }
+
+    static func validateLoRAWeightShapes(
+        path: String,
+        down: MLXArray,
+        up: MLXArray,
+        expectedDown: [Int],
+        expectedUp: [Int]
+    ) throws {
+        guard down.shape == expectedDown, up.shape == expectedUp else {
+            throw LoRAError.invalidFormat(
+                "LoRA target \(path) has down/up shapes \(down.shape)/\(up.shape); "
+                    + "the loaded FLUX.2 model requires \(expectedDown)/\(expectedUp). "
+                    + "Verify that every adapter was trained for this exact FLUX.2 base, not FLUX.1 or Klein."
+            )
+        }
+    }
+
+    private static func setAllLoRAContributions(
+        in layer: TrainableLoRALayer,
+        active: Bool
+    ) {
+        if let fused = layer as? FusedLoRALinear {
+            for contribution in fused.loras {
+                contribution.isActive = active
+            }
+        } else {
+            layer.isActive = active
         }
     }
 
@@ -347,16 +403,17 @@ extension Flux2KleinGenerator {
         encoderHiddenStates: MLXArray,
         timestep: MLXArray,
         imgIds: MLXArray,
-        txtIds: MLXArray
+        txtIds: MLXArray,
+        guidance: MLXArray? = nil
     ) -> MLXArray {
-        guard Self.compileEnabled else {
+        guard Self.compileEnabled, guidance == nil else {
             return transformer(
                 hiddenStates: hiddenStates,
                 encoderHiddenStates: encoderHiddenStates,
                 timestep: timestep,
                 imgIds: imgIds,
                 txtIds: txtIds,
-                guidance: nil
+                guidance: guidance
             )
         }
 
@@ -409,14 +466,13 @@ extension Flux2KleinGenerator {
             mlpRatio: config.mlpRatio,
             eps: config.eps,
             ropeTheta: config.ropeTheta,
-            axesDimsRope: config.axesDimsRope
+            axesDimsRope: config.axesDimsRope,
+            guidanceEmbeds: config.resolvedGuidanceEmbeds
         )
     }
 
     private func loadTextEncoderConfig(from textEncoderDir: URL) throws -> QwenTextEncoderConfiguration {
-        let configURL = textEncoderDir.appendingPathComponent("config.json")
-        let data = try Data(contentsOf: configURL)
-        let config = try JSONDecoder().decode(Flux2TextEncoderConfig.self, from: data)
+        let config = try loadRawTextEncoderConfig(from: textEncoderDir)
 
         return QwenTextEncoderConfiguration(
             vocabSize: config.vocabSize,
@@ -428,8 +484,27 @@ extension Flux2KleinGenerator {
             ropeTheta: config.ropeTheta,
             maxPositionEmbeddings: config.maxPositionEmbeddings,
             rmsNormEps: config.rmsNormEps,
-            headDim: config.headDim
+            headDim: config.headDim,
+            useQKNorm: config.architecture == .qwen3
         )
+    }
+
+    private func loadRawTextEncoderConfig(from textEncoderDir: URL) throws -> Flux2TextEncoderConfig {
+        let configURL = textEncoderDir.appendingPathComponent("config.json")
+        let data = try Data(contentsOf: configURL)
+        return try JSONDecoder().decode(Flux2TextEncoderConfig.self, from: data)
+    }
+
+    private func loadTextEncoderQuantization(
+        from textEncoderDir: URL
+    ) throws -> ModelWeightsLoader.QuantizationParams? {
+        let config = try loadRawTextEncoderConfig(from: textEncoderDir)
+        guard let quantization = config.quantizationConfig,
+              let bits = quantization.bits,
+              let groupSize = quantization.groupSize else {
+            return nil
+        }
+        return ModelWeightsLoader.QuantizationParams(bits: bits, groupSize: groupSize)
     }
 
     private func loadVAEConfig(from vaeDir: URL) throws -> VAEConfig {
@@ -519,30 +594,14 @@ extension Flux2KleinGenerator {
         let singleFileURL = url.appendingPathComponent("model.safetensors")
 
         let mapper: (String, MLXArray) -> [(String, MLXArray)] = { key, value in
-            // The Qwen3 text encoder used as an embedder only needs hidden states; the
-            // language-model output head (lm_head.*) is not part of the encoder and ships
-            // in some checkpoints (e.g. FLUX.2-klein-9B's 8B Qwen3 embedder). Drop it so
-            // Module.update(verify: .noUnusedKeys) doesn't reject the load.
-            if key == "lm_head" || key.hasPrefix("lm_head.") || key.hasPrefix("model.lm_head") {
-                return []
-            }
-            var mappedKey = key
-            if key.hasPrefix("model.") {
-                mappedKey = key.replacingOccurrences(of: "model.", with: "encoder.")
-            } else if !key.hasPrefix("encoder.") {
-                mappedKey = "encoder." + key
-            }
+            // Image conditioning needs hidden states, not language-model or vision outputs.
+            guard !key.hasPrefix("__discard__."),
+                  let mappedKey = Self.mapTextEncoderWeightKey(key) else { return [] }
             return [(mappedKey, value)]
         }
 
         let keyMapper: (String) -> String = { key in
-            if key.hasPrefix("model.") {
-                return "encoder." + String(key.dropFirst("model.".count))
-            }
-            if key.hasPrefix("encoder.") {
-                return key
-            }
-            return "encoder." + key
+            Self.mapTextEncoderWeightKey(key) ?? "__discard__.\(key)"
         }
 
         let fm = FileManager.default
@@ -574,6 +633,27 @@ extension Flux2KleinGenerator {
             keyMapper: keyMapper,
             quantization: quantization
         )
+    }
+
+    static func mapTextEncoderWeightKey(_ key: String) -> String? {
+        if key.hasPrefix("language_model.lm_head")
+            || key.hasPrefix("vision_tower.")
+            || key.hasPrefix("multi_modal_projector.") {
+            return nil
+        }
+        if key.hasPrefix("language_model.model.") {
+            return "encoder." + String(key.dropFirst("language_model.model.".count))
+        }
+        if key == "lm_head" || key.hasPrefix("lm_head.") || key.hasPrefix("model.lm_head") {
+            return nil
+        }
+        if key.hasPrefix("model.") {
+            return "encoder." + String(key.dropFirst("model.".count))
+        }
+        if key.hasPrefix("encoder.") {
+            return key
+        }
+        return "encoder." + key
     }
 
     private func loadTokenizer(from url: URL) throws -> QwenTokenizer {

--- a/Sources/MereRunCore/Flux2Klein/Flux2KleinGenerator.swift
+++ b/Sources/MereRunCore/Flux2Klein/Flux2KleinGenerator.swift
@@ -19,7 +19,7 @@ public actor Flux2KleinGenerator: ImageGenerator {
     var loadedModelPath: String?
     var loadedManifest: MereRunModelManifest?
     var loadedQuantization: ModelWeightsLoader.QuantizationParams?
-    var currentLoRA: LoRA?
+    var currentLoRAs: [LoRA] = []
     var currentTextLoRA: LoRA?
     var transformerLoRALayers: [String: TrainableLoRALayer]?
     var transformerLoRARankSignature: String?
@@ -27,6 +27,12 @@ public actor Flux2KleinGenerator: ImageGenerator {
     var compiledTransformerNeedsWarmup: Bool = true
 
     public init() {}
+
+    /// Preserve the checkpoint filename when its payload is a content-addressed symlink.
+    /// MLX selects the loader from the visible `.safetensors` extension.
+    static func checkpointFileURL(in directoryURL: URL, filename: String) -> URL {
+        directoryURL.appendingPathComponent(filename)
+    }
 
     // MARK: - Memory Management
 
@@ -41,7 +47,7 @@ public actor Flux2KleinGenerator: ImageGenerator {
         loadedModelPath = nil
         loadedManifest = nil
         loadedQuantization = nil
-        currentLoRA = nil
+        currentLoRAs = []
         transformerLoRALayers = nil
         transformerLoRARankSignature = nil
         currentTextLoRA = nil
@@ -95,6 +101,7 @@ public enum Flux2Error: LocalizedError {
     case referenceImageNotFound(URL)
     case referenceImageDecodeFailed(URL)
     case invalidManifest(String)
+    case invalidSigmaSchedule(String)
 
     public var errorDescription: String? {
         switch self {
@@ -118,6 +125,8 @@ public enum Flux2Error: LocalizedError {
             return "Failed to decode reference image: \(url.path)"
         case .invalidManifest(let message):
             return "Invalid model manifest: \(message)"
+        case .invalidSigmaSchedule(let message):
+            return "Invalid FLUX.2 sigma schedule: \(message)"
         }
     }
 }

--- a/Sources/MereRunCore/Flux2Klein/Flux2KleinLoRATrainer.swift
+++ b/Sources/MereRunCore/Flux2Klein/Flux2KleinLoRATrainer.swift
@@ -471,7 +471,10 @@ public enum Flux2KleinLoRATrainer {
 
         let vaeConfig = try loadVAEConfig(from: vaeComponent.directoryURL)
         let vae = AutoencoderKL(configuration: vaeConfig)
-        let vaeWeightsURL = vaeComponent.directoryURL.appendingPathComponent("diffusion_pytorch_model.safetensors").resolvingSymlinksInPath()
+        let vaeWeightsURL = Flux2KleinGenerator.checkpointFileURL(
+            in: vaeComponent.directoryURL,
+            filename: "diffusion_pytorch_model.safetensors"
+        )
         let (bnMean, bnVar) = try loadBatchNormStats(from: vaeWeightsURL)
         try loadVAEWeights(from: vaeWeightsURL, to: vae)
 

--- a/Sources/MereRunCore/Flux2Klein/Model/Transformer/Flux2Transformer.swift
+++ b/Sources/MereRunCore/Flux2Klein/Model/Transformer/Flux2Transformer.swift
@@ -17,7 +17,7 @@ public struct Flux2TransformerConfiguration: Sendable {
     public let eps: Float                // 1e-6
     public let ropeTheta: Float          // 2000
     public let axesDimsRope: [Int]       // [32, 32, 32, 32]
-    public let guidanceEmbeds: Bool      // false for base models
+    public let guidanceEmbeds: Bool      // true for FLUX.2-dev, false for Klein
     public let quantized: Bool           // true to use QuantizedLinear layers
 
     public init(
@@ -107,9 +107,13 @@ final class Flux2TimestepEmbedder: Module {
 
 final class Flux2TimeGuidanceEmbed: Module {
     @ModuleInfo(key: "timestep_embedder") var timestepEmbedder: Flux2TimestepEmbedder
+    @ModuleInfo(key: "guidance_embedder") var guidanceEmbedder: Flux2TimestepEmbedder?
 
-    init(hiddenSize: Int = 3072) {
+    init(hiddenSize: Int = 3072, guidanceEmbeds: Bool = false) {
         self._timestepEmbedder.wrappedValue = Flux2TimestepEmbedder(inDim: 256, hiddenSize: hiddenSize)
+        self._guidanceEmbedder.wrappedValue = guidanceEmbeds
+            ? Flux2TimestepEmbedder(inDim: 256, hiddenSize: hiddenSize)
+            : nil
         super.init()
     }
 
@@ -117,10 +121,9 @@ final class Flux2TimeGuidanceEmbed: Module {
         let timestepProj = Self.timestepProjection(timestep, dim: 256)
         let timestepEmb = timestepEmbedder(timestepProj)
 
-        // FLUX.2 Klein 4B doesn't have guidance layers (guidance_embeds=false)
-        // mflux always passes guidance=None for this model
-        // Only models with guidance_embeds=true use the guidance parameter
-        return timestepEmb
+        guard let guidance, let guidanceEmbedder else { return timestepEmb }
+        let guidanceProj = Self.timestepProjection(guidance * 1000, dim: 256)
+        return timestepEmb + guidanceEmbedder(guidanceProj)
     }
 
     /// Sinusoidal timestep projection (flip_sin_to_cos=True, downscale_freq_shift=0)
@@ -819,7 +822,10 @@ public final class Flux2Transformer2DModel: Module {
 
         self._xEmbedder.wrappedValue = Linear(config.inChannels, config.hiddenSize, bias: false)
         self._contextEmbedder.wrappedValue = Linear(config.contextDim, config.hiddenSize, bias: false)
-        self._timeGuidanceEmbed.wrappedValue = Flux2TimeGuidanceEmbed(hiddenSize: config.hiddenSize)
+        self._timeGuidanceEmbed.wrappedValue = Flux2TimeGuidanceEmbed(
+            hiddenSize: config.hiddenSize,
+            guidanceEmbeds: config.guidanceEmbeds
+        )
 
         // Modulation: 2 param sets for double stream (MSA + MLP), 1 for single
         self._doubleStreamModImg.wrappedValue = Flux2Modulation(hiddenSize: config.hiddenSize, modParamSets: 2)
@@ -853,7 +859,10 @@ public final class Flux2Transformer2DModel: Module {
         // Placeholder Linear layers - will be replaced
         self._xEmbedder.wrappedValue = Linear(1, 1, bias: false)
         self._contextEmbedder.wrappedValue = Linear(1, 1, bias: false)
-        self._timeGuidanceEmbed.wrappedValue = Flux2TimeGuidanceEmbed(hiddenSize: config.hiddenSize)
+        self._timeGuidanceEmbed.wrappedValue = Flux2TimeGuidanceEmbed(
+            hiddenSize: config.hiddenSize,
+            guidanceEmbeds: config.guidanceEmbeds
+        )
 
         self._doubleStreamModImg.wrappedValue = Flux2Modulation(hiddenSize: config.hiddenSize, modParamSets: 2)
         self._doubleStreamModTxt.wrappedValue = Flux2Modulation(hiddenSize: config.hiddenSize, modParamSets: 2)

--- a/Sources/MereRunCore/Flux2Klein/README.md
+++ b/Sources/MereRunCore/Flux2Klein/README.md
@@ -1,6 +1,6 @@
 # Flux2Klein
 
-FLUX.2 Klein image generation and LoRA training runtime.
+FLUX.2 Dev and Klein image generation runtime, with Klein LoRA training.
 
 - `Flux2KleinGenerator*.swift`: loading, prompt/reference encoding, denoising,
   decode, and generation support.

--- a/Sources/MereRunCore/Generation.swift
+++ b/Sources/MereRunCore/Generation.swift
@@ -30,7 +30,12 @@ public struct GenerationRequest: Sendable, Hashable {
     public var outputURL: URL
     public var model: String?
     public var maxSequenceLength: Int
-    public var lora: LoRA?
+    /// Ordered image LoRA adapters. Runtimes that support only one adapter use the first value.
+    public var loras: [LoRA]
+    public var lora: LoRA? {
+        get { loras.first }
+        set { loras = newValue.map { [$0] } ?? [] }
+    }
     public var enhancePrompt: Bool
     public var inputImage: URL?
     public var strength: Double
@@ -38,6 +43,8 @@ public struct GenerationRequest: Sendable, Hashable {
     public var keepOriginalAspect: Bool
     public var useBetaSigmas: Bool
     public var sigmaShift: Float?
+    /// Optional pre-shifted denoising sigmas. The scheduler appends the terminal zero.
+    public var sigmas: [Float]?
     public var kreaConditioningRebalance: Krea2ConditioningRebalance?
     public var kreaBaseQuantizationBits: Int?
 
@@ -55,12 +62,14 @@ public struct GenerationRequest: Sendable, Hashable {
         model: String? = nil,
         maxSequenceLength: Int = 512,
         lora: LoRA? = nil,
+        loras: [LoRA] = [],
         enhancePrompt: Bool = false,
         inputImage: URL? = nil,
         strength: Double = 0.75,
         keepOriginalAspect: Bool = false,
         useBetaSigmas: Bool = false,
         sigmaShift: Float? = nil,
+        sigmas: [Float]? = nil,
         kreaConditioningRebalance: Krea2ConditioningRebalance? = nil,
         kreaBaseQuantizationBits: Int? = nil
     ) {
@@ -76,13 +85,14 @@ public struct GenerationRequest: Sendable, Hashable {
         self.outputURL = outputURL
         self.model = model
         self.maxSequenceLength = maxSequenceLength
-        self.lora = lora
+        self.loras = loras.isEmpty ? lora.map { [$0] } ?? [] : loras
         self.enhancePrompt = enhancePrompt
         self.inputImage = inputImage
         self.strength = strength
         self.keepOriginalAspect = keepOriginalAspect
         self.useBetaSigmas = useBetaSigmas
         self.sigmaShift = sigmaShift
+        self.sigmas = sigmas
         self.kreaConditioningRebalance = kreaConditioningRebalance
         self.kreaBaseQuantizationBits = kreaBaseQuantizationBits
     }

--- a/Sources/MereRunCore/LoRA/Flux1LoRAKeyMapper.swift
+++ b/Sources/MereRunCore/LoRA/Flux1LoRAKeyMapper.swift
@@ -1,0 +1,126 @@
+import Foundation
+import MLX
+
+enum Flux1LoRAKeyMapper {
+    static func map(
+        baseKey: String,
+        down: MLXArray,
+        up: MLXArray
+    ) -> [String: (down: MLXArray, up: MLXArray)] {
+        let key = normalize(baseKey)
+        if let global = globalKey(key) {
+            return [global: (down, up)]
+        }
+        if let mapped = bflDoubleBlock(key, down: down, up: up) {
+            return mapped
+        }
+        return [standardKey(key): (down, up)]
+    }
+
+    private static func normalize(_ key: String) -> String {
+        var result = key
+        for prefix in ["base_model.model.", "diffusion_model.", "lora_unet_", "transformer.", "model."]
+        where result.hasPrefix(prefix) {
+            result = String(result.dropFirst(prefix.count))
+            break
+        }
+        if result.hasSuffix(".weight") {
+            result = String(result.dropLast(".weight".count))
+        }
+        return result
+    }
+
+    private static func standardKey(_ key: String) -> String {
+        key
+            .replacingOccurrences(of: ".ff.net.0.proj", with: ".ff.input.proj")
+            .replacingOccurrences(of: ".ff.net.2", with: ".ff.output")
+            .replacingOccurrences(of: ".ff_context.net.0.proj", with: ".ff_context.input.proj")
+            .replacingOccurrences(of: ".ff_context.net.2", with: ".ff_context.output")
+    }
+
+    private static func globalKey(_ key: String) -> String? {
+        let mappings = [
+            "img_in": "x_embedder",
+            "txt_in": "context_embedder",
+            "time_in.in_layer": "time_text_embed.timestep_embedder.linear_1",
+            "time_in.out_layer": "time_text_embed.timestep_embedder.linear_2",
+            "guidance_in.in_layer": "time_text_embed.guidance_embedder.linear_1",
+            "guidance_in.out_layer": "time_text_embed.guidance_embedder.linear_2",
+            "vector_in.in_layer": "time_text_embed.text_embedder.linear_1",
+            "vector_in.out_layer": "time_text_embed.text_embedder.linear_2",
+            "final_layer.adaLN_modulation.1": "norm_out.linear",
+            "final_layer.linear": "proj_out",
+        ]
+        return mappings[key]
+    }
+
+    private static func bflDoubleBlock(
+        _ key: String,
+        down: MLXArray,
+        up: MLXArray
+    ) -> [String: (down: MLXArray, up: MLXArray)]? {
+        guard let parsed = parseBlock(key, prefix: "double_blocks_")
+                ?? parseDottedBlock(key, prefix: "double_blocks") else {
+            return nil
+        }
+        let prefix = "transformer_blocks.\(parsed.index)"
+        switch parsed.remainder {
+        case "img_attn_qkv":
+            return splitQKV(down: down, up: up, prefix: "\(prefix).attn.to_")
+        case "txt_attn_qkv":
+            return splitQKV(down: down, up: up, prefix: "\(prefix).attn.add_")
+        case "img_attn_proj":
+            return ["\(prefix).attn.to_out.0": (down, up)]
+        case "txt_attn_proj":
+            return ["\(prefix).attn.to_add_out": (down, up)]
+        case "img_mlp_0":
+            return ["\(prefix).ff.input.proj": (down, up)]
+        case "img_mlp_2":
+            return ["\(prefix).ff.output": (down, up)]
+        case "txt_mlp_0":
+            return ["\(prefix).ff_context.input.proj": (down, up)]
+        case "txt_mlp_2":
+            return ["\(prefix).ff_context.output": (down, up)]
+        default:
+            return [:]
+        }
+    }
+
+    private static func parseBlock(_ key: String, prefix: String) -> (index: Int, remainder: String)? {
+        guard key.hasPrefix(prefix) else { return nil }
+        let tail = key.dropFirst(prefix.count)
+        guard let separator = tail.firstIndex(of: "_"),
+              let index = Int(tail[..<separator]) else { return nil }
+        return (index, String(tail[tail.index(after: separator)...]))
+    }
+
+    private static func parseDottedBlock(_ key: String, prefix: String) -> (index: Int, remainder: String)? {
+        let components = key.split(separator: ".")
+        guard components.count >= 3,
+              components[0] == prefix,
+              let index = Int(components[1]) else { return nil }
+        return (index, components.dropFirst(2).joined(separator: "_"))
+    }
+
+    private static func splitQKV(
+        down: MLXArray,
+        up: MLXArray,
+        prefix: String
+    ) -> [String: (down: MLXArray, up: MLXArray)] {
+        guard down.ndim == 2, up.ndim == 2, up.dim(0) % 3 == 0 else { return [:] }
+        let outputSize = up.dim(0) / 3
+        let rank = up.dim(1)
+        let upParts = (0..<3).map { up[$0 * outputSize..<($0 + 1) * outputSize, 0...] }
+        let downParts: [MLXArray]
+        if down.dim(0) == rank {
+            downParts = [down, down, down]
+        } else if down.dim(0) == rank * 3 {
+            downParts = (0..<3).map { down[$0 * rank..<($0 + 1) * rank, 0...] }
+        } else {
+            return [:]
+        }
+        return Dictionary(uniqueKeysWithValues: zip(["q", "k", "v"], zip(downParts, upParts)).map {
+            ("\(prefix)\($0.0)", (down: $0.1.0, up: $0.1.1))
+        })
+    }
+}

--- a/Sources/MereRunCore/LoRA/Flux2LoRAInjector.swift
+++ b/Sources/MereRunCore/LoRA/Flux2LoRAInjector.swift
@@ -48,7 +48,7 @@ public enum Flux2LoRAInjector {
     ]
 
     public static func inject(
-        into transformer: Flux2Transformer2DModel,
+        into transformer: Module,
         rank: Int,
         alpha: Float? = nil,
         targetMode: TargetMode = .suffix,
@@ -162,7 +162,7 @@ public enum Flux2LoRAInjector {
     }
 
     public static func resolveTargetRanks(
-        in transformer: Flux2Transformer2DModel,
+        in transformer: Module,
         defaultRank: Int,
         targetSuffixes: [String] = defaultTargetSuffixes,
         targetRankSuffixes: [String: Int]

--- a/Sources/MereRunCore/LoRA/Flux2LoRAStacker.swift
+++ b/Sources/MereRunCore/LoRA/Flux2LoRAStacker.swift
@@ -1,0 +1,114 @@
+import Foundation
+import MLX
+
+struct Flux2LoRAStackInput: @unchecked Sendable {
+    let label: String
+    let scale: Float
+    let weights: LoRAWeights
+}
+
+enum Flux2LoRAStacker {
+    enum StackError: LocalizedError, Equatable {
+        case empty
+        case invalidScale(label: String, scale: Float)
+        case invalidPair(label: String, path: String, down: [Int], up: [Int])
+        case incompatiblePair(
+            label: String,
+            path: String,
+            expectedInput: Int,
+            actualInput: Int,
+            expectedOutput: Int,
+            actualOutput: Int
+        )
+
+        var errorDescription: String? {
+            switch self {
+            case .empty:
+                return "At least one FLUX.2 LoRA is required."
+            case .invalidScale(let label, let scale):
+                return "FLUX.2 LoRA scale must be finite for \(label) (got \(scale))."
+            case .invalidPair(let label, let path, let down, let up):
+                return "Invalid FLUX.2 LoRA pair in \(label) for \(path): down=\(down), up=\(up)."
+            case .incompatiblePair(
+                let label,
+                let path,
+                let expectedInput,
+                let actualInput,
+                let expectedOutput,
+                let actualOutput
+            ):
+                return "Incompatible stacked FLUX.2 LoRA in \(label) for \(path): "
+                    + "expected input/output \(expectedInput)/\(expectedOutput), "
+                    + "found \(actualInput)/\(actualOutput)."
+            }
+        }
+    }
+
+    /// Combines an ordered adapter stack into one mathematically equivalent low-rank update.
+    /// Each source alpha and user scale is folded into its down matrix before concatenation.
+    static func stack(_ inputs: [Flux2LoRAStackInput]) throws -> LoRAWeights {
+        guard !inputs.isEmpty else { throw StackError.empty }
+
+        var combined: [String: (down: MLXArray, up: MLXArray)] = [:]
+        for input in inputs {
+            guard input.scale.isFinite else {
+                throw StackError.invalidScale(label: input.label, scale: input.scale)
+            }
+            for (path, pair) in input.weights.weights {
+                let downShape = pair.down.shape
+                let upShape = pair.up.shape
+                guard downShape.count == 2,
+                      upShape.count == 2,
+                      downShape[0] > 0,
+                      downShape[0] == upShape[1] else {
+                    throw StackError.invalidPair(
+                        label: input.label,
+                        path: path,
+                        down: downShape,
+                        up: upShape
+                    )
+                }
+
+                let pairScale = input.scale * input.weights.alpha / Float(downShape[0])
+                let scaledDown = pairScale == 1
+                    ? pair.down.asType(.float32)
+                    : pair.down.asType(.float32) * MLXArray(pairScale)
+                let up = pair.up.asType(.float32)
+
+                if let existing = combined[path] {
+                    let expectedInput = existing.down.shape[1]
+                    let expectedOutput = existing.up.shape[0]
+                    guard downShape[1] == expectedInput,
+                          upShape[0] == expectedOutput else {
+                        throw StackError.incompatiblePair(
+                            label: input.label,
+                            path: path,
+                            expectedInput: expectedInput,
+                            actualInput: downShape[1],
+                            expectedOutput: expectedOutput,
+                            actualOutput: upShape[0]
+                        )
+                    }
+                    combined[path] = (
+                        down: MLX.concatenated([existing.down, scaledDown], axis: 0),
+                        up: MLX.concatenated([existing.up, up], axis: 1)
+                    )
+                } else {
+                    combined[path] = (down: scaledDown, up: up)
+                }
+            }
+        }
+
+        guard !combined.isEmpty else { throw LoRAError.noWeightPairs }
+        let targetRanks = combined.mapValues { $0.down.shape[0] }
+        let defaultRank = targetRanks.sorted { $0.key < $1.key }.first?.value ?? 1
+        // The injector uses alpha == target rank for every combined layer. Source alpha
+        // values are already included in the scaled down matrices.
+        return LoRAWeights(
+            weights: combined,
+            rank: defaultRank,
+            alpha: Float(defaultRank),
+            targetRanks: targetRanks
+        )
+    }
+}

--- a/Sources/MereRunCore/LoRA/LoRAWeightLoader.swift
+++ b/Sources/MereRunCore/LoRA/LoRAWeightLoader.swift
@@ -7,6 +7,11 @@ import Glibc
 #endif
 import MLX
 
+public enum LoRAWeightArchitecture: Sendable, Hashable {
+    case flux2Klein
+    case flux1
+}
+
 public enum LoRAWeightLoader {
     private static let remoteCacheDirName = "lora"
     private static let defaultTrainingAdapterRepoId = "ostris/zimage_turbo_training_adapter"
@@ -17,9 +22,12 @@ public enum LoRAWeightLoader {
         (".lora_A.", ".lora_B."),
     ]
 
-    public static func load(from lora: LoRA) async throws -> LoRAWeights {
+    public static func load(
+        from lora: LoRA,
+        architecture: LoRAWeightArchitecture = .flux2Klein
+    ) async throws -> LoRAWeights {
         let url = try await resolveURL(for: lora)
-        return try load(from: url)
+        return try load(from: url, architecture: architecture)
     }
 
     public static func resolveURL(for lora: LoRA) async throws -> URL {
@@ -60,7 +68,10 @@ public enum LoRAWeightLoader {
         )
     }
 
-    public static func load(from url: URL) throws -> LoRAWeights {
+    public static func load(
+        from url: URL,
+        architecture: LoRAWeightArchitecture = .flux2Klein
+    ) throws -> LoRAWeights {
         guard FileManager.default.fileExists(atPath: url.path) else {
             throw LoRAError.fileNotFound(url.path)
         }
@@ -79,7 +90,12 @@ public enum LoRAWeightLoader {
                 continue
             }
 
-            if isKrea2NativeBaseKey(baseKey) {
+            if architecture == .flux1 {
+                let mapped = Flux1LoRAKeyMapper.map(baseKey: baseKey, down: downWeight, up: upWeight)
+                for (mappedKey, pair) in mapped {
+                    loraWeights[mappedKey] = pair
+                }
+            } else if isKrea2NativeBaseKey(baseKey) {
                 loraWeights[baseKey] = (down: downWeight, up: upWeight)
             } else if let mapped = Krea2LoRAKeyMapper.map(baseKey: baseKey) {
                 loraWeights[mapped] = (down: downWeight, up: upWeight)

--- a/Sources/MereRunCore/ManagedAdapterCatalog.swift
+++ b/Sources/MereRunCore/ManagedAdapterCatalog.swift
@@ -87,6 +87,9 @@ public struct ManagedAdapterSpec: Equatable, Sendable {
 
 public enum ManagedAdapterCatalog {
     public static let merePlatformAssistantID = "mere-platform-assistant"
+    public static let flux2DevTurboEightStepID = "flux2-dev-turbo-8step"
+    public static let flux2DevTurboEightStepRevision = "9ee51cd87578162cf8d02355a870bc5f4570045c"
+    public static let flux2DevLoRAFormat = "diffusers.flux2.transformer-lora"
     public static let scail2LightX2VFourStepID = "scail2-lightx2v-4step"
     public static let scail2LightX2VFourStepRevision = "27ae38da91014b947dd39cc3fa78b97cd7b386dd"
     public static let miniMaxH3TurboFourStepID = "minimax-h3-turbo-4step"
@@ -124,6 +127,53 @@ public enum ManagedAdapterCatalog {
                 filename: "mere-platform-assistant-v22.safetensors",
                 byteCount: 128_131_022,
                 sha256: "c4fec5979631b4031196c1e21c0b990437a26c5ebc52aec32f89338d64063290"
+            )
+        ),
+        ManagedAdapterSpec(
+            id: flux2DevTurboEightStepID,
+            title: "FLUX.2-dev Turbo 8-step",
+            version: String(flux2DevTurboEightStepRevision.prefix(12)),
+            summary: "Eight-step distilled LoRA and published sigma recipe for FLUX.2-dev.",
+            baseModelID: ModelResolver.ModelID.flux2Dev.rawValue,
+            format: flux2DevLoRAFormat,
+            license: "FLUX Non-Commercial License",
+            upstreamRevision: flux2DevTurboEightStepRevision,
+            usageRestriction: ManagedModelUsageRestriction(
+                summary: "The Turbo adapter inherits the non-commercial, "
+                    + "non-production FLUX.2-dev license and BFL Acceptable Use Policy.",
+                terms: [
+                    ManagedModelUsageTerm(
+                        component: "FLUX.2-dev Turbo adapter and base model",
+                        license: "FLUX Non-Commercial License",
+                        summary: "Weights are limited to non-commercial, non-production use; "
+                            + "commercial use requires a separate BFL license.",
+                        sourceRepoId: "fal/FLUX.2-dev-Turbo",
+                        sourceRevision: flux2DevTurboEightStepRevision,
+                        licenseURL: "https://huggingface.co/black-forest-labs/FLUX.2-dev/"
+                            + "blob/26afe3a78bb242c0a8bb181dcc8937bb16e5c66c/LICENSE.md"
+                    ),
+                    ManagedModelUsageTerm(
+                        component: "FLUX.2-dev Turbo use",
+                        license: "BFL Acceptable Use Policy",
+                        summary: "BFL's prohibited-use conditions apply independently of the non-commercial license.",
+                        sourceRepoId: "fal/FLUX.2-dev-Turbo",
+                        sourceRevision: flux2DevTurboEightStepRevision,
+                        licenseURL: "https://bfl.ai/legal/usage-policy"
+                    ),
+                ]
+            ),
+            releaseManifestURL: URL(
+                string: "https://huggingface.co/fal/FLUX.2-dev-Turbo/commit/\(flux2DevTurboEightStepRevision)"
+            )!,
+            downloadURL: URL(
+                string: "https://huggingface.co/fal/FLUX.2-dev-Turbo/"
+                    + "resolve/\(flux2DevTurboEightStepRevision)/"
+                    + "flux.2-turbo-lora.safetensors?download=true"
+            )!,
+            artifact: ModelArtifactPin(
+                filename: "flux.2-turbo-lora.safetensors",
+                byteCount: 2_760_818_216,
+                sha256: "f76cf9c2cc546ddca878799136434a1098477af3f4b0adff2cfd79f2ebe4aa01"
             )
         ),
         ManagedAdapterSpec(

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -504,6 +504,7 @@ public enum ManagedModelInstallShape: Hashable, Sendable {
 }
 
 public enum ManagedModelValidationKind: String, Hashable, Sendable {
+    case flux1
     case flux2Klein
     case bonsaiImage
     case zimageTurbo
@@ -718,6 +719,15 @@ public enum ManagedModelCatalog {
         "model_index.json",
         "transformer/*",
     ]
+    private static let flux2DevSnapshotPatterns = [
+        "LICENSE*",
+        "README.md",
+        "model_index.json",
+        "tokenizer/*",
+        "transformer/*",
+        "vae/*",
+        "scheduler/*",
+    ]
     private static let kleinNanoSnapshotPatterns = [
         "model_index.json",
         "scheduler/scheduler_config.json",
@@ -759,6 +769,9 @@ public enum ManagedModelCatalog {
     private static let zImageNanoUpstreamRevision = "b3a8f31115a11f2f9e2fa0bfbc8d78dcc3e6568b"
     private static let klein9BUpstreamRevision = "b0f0826a36667ec7c58253e50557ba76f8c0255e"
     private static let kleinBase9BUpstreamRevision = "32773329fbe7e81a90ef971740e8ba4b0364ecf3"
+    private static let flux2DevUpstreamRevision = "26afe3a78bb242c0a8bb181dcc8937bb16e5c66c"
+    private static let flux2DevTextEncoderRepoId = "mlx-community/Mistral-Small-3.2-24B-Instruct-2506-4bit"
+    private static let flux2DevTextEncoderRevision = "2a1d5eabfc504747bdc24178394821a1efc0edde"
     private static let sam31MLXRevision = "a992e302ea9b0f03f41dfd93414a4fd0e818f65b"
     private static let sam31TokenizerRevision = "694239a1479aab8fd1317c87c433c58acd7c6eab"
     private static let wooshWeightsRevision = "f7b524db359f95b2b0bdc4afce12120b72e68bff"
@@ -950,6 +963,36 @@ public enum ManagedModelCatalog {
             terms: [term] + additionalTerms
         )
     }
+
+    private static let flux2DevUsageRestriction = ManagedModelUsageRestriction(
+        summary: "FLUX.2-dev is limited to non-commercial, non-production use; BFL also requires filters or manual review and compliance with its Acceptable Use Policy.",
+        terms: [
+            ManagedModelUsageTerm(
+                component: "FLUX.2-dev transformer, VAE, and tokenizer",
+                license: "FLUX Non-Commercial License",
+                summary: "Weights are limited to non-commercial, non-production use; commercial use requires a separate BFL license, and generated content requires filters or manual review.",
+                sourceRepoId: "black-forest-labs/FLUX.2-dev",
+                sourceRevision: flux2DevUpstreamRevision,
+                licenseURL: "https://huggingface.co/black-forest-labs/FLUX.2-dev/blob/\(flux2DevUpstreamRevision)/LICENSE.md"
+            ),
+            ManagedModelUsageTerm(
+                component: "FLUX.2-dev use",
+                license: "BFL Acceptable Use Policy",
+                summary: "BFL's prohibited-use conditions apply independently of the non-commercial license.",
+                sourceRepoId: "black-forest-labs/FLUX.2-dev",
+                sourceRevision: flux2DevUpstreamRevision,
+                licenseURL: "https://bfl.ai/legal/usage-policy"
+            ),
+        ]
+    )
+
+    private static let flux1DevUsageRestriction = usageRestriction(
+        summary: "FLUX.1-dev weights and derivatives are limited to non-commercial, non-production use; content filtering or review and the license's prohibited-use conditions also apply.",
+        license: "FLUX.1 dev Non-Commercial License v1.1.1",
+        sourceRepoId: Flux1Resources.upstreamRepoID,
+        sourceRevision: Flux1Resources.upstreamRevision,
+        licenseURL: "https://huggingface.co/black-forest-labs/FLUX.1-dev/blob/\(Flux1Resources.upstreamRevision)/LICENSE.md"
+    )
 
     private static func krea2UsageRestriction(
         sourceRepoId: String,
@@ -1269,6 +1312,59 @@ public enum ManagedModelCatalog {
             installShape: .directoryRoot,
             validationKind: .flux2Klein,
             runtimeAutoDownloadAllowed: false
+        ),
+        ManagedModelSpec(
+            // Keep the gated, LoRA-compatible FLUX.2-dev image stack authoritative while
+            // replacing only its identical Mistral Small 3.2 text encoder with a pinned
+            // Apple-Silicon 4-bit conversion. This avoids about 35 GB of resident and
+            // downloaded weights without changing the transformer targeted by Dev LoRAs.
+            id: "image-flux2-dev",
+            category: .image,
+            installShape: .directoryRoot,
+            hubFallback: HubFallbackConfig(
+                repoId: "black-forest-labs/FLUX.2-dev",
+                revision: flux2DevUpstreamRevision,
+                patterns: flux2DevSnapshotPatterns
+            ),
+            mountedHubFallbacks: [
+                MountedHubFallbackConfig(
+                    destinationPath: "text_encoder",
+                    hubFallback: HubFallbackConfig(
+                        repoId: flux2DevTextEncoderRepoId,
+                        revision: flux2DevTextEncoderRevision,
+                        patterns: [
+                            "README.md",
+                            "config.json",
+                            "model-*.safetensors",
+                            "model.safetensors.index.json",
+                        ]
+                    )
+                ),
+            ],
+            upstreamRepoId: "black-forest-labs/FLUX.2-dev",
+            upstreamRevision: flux2DevUpstreamRevision,
+            usageRestriction: flux2DevUsageRestriction,
+            validationKind: .flux2Klein,
+            runtimeAutoDownloadAllowed: false,
+            estimatedDownloadBytes: 78_100_000_000,
+            defaultCLICommands: ["image generate"]
+        ),
+        ManagedModelSpec(
+            id: Flux1Resources.modelID,
+            category: .image,
+            installShape: .directoryRoot,
+            hubFallback: HubFallbackConfig(
+                repoId: Flux1Resources.upstreamRepoID,
+                revision: Flux1Resources.upstreamRevision,
+                patterns: Flux1Resources.snapshotPatterns
+            ),
+            upstreamRepoId: Flux1Resources.upstreamRepoID,
+            upstreamRevision: Flux1Resources.upstreamRevision,
+            usageRestriction: flux1DevUsageRestriction,
+            validationKind: .flux1,
+            runtimeAutoDownloadAllowed: false,
+            estimatedDownloadBytes: Flux1Resources.estimatedDownloadBytes,
+            defaultCLICommands: ["image generate"]
         ),
         ManagedModelSpec(
             id: "image-bonsai-binary",
@@ -4176,6 +4272,8 @@ public extension ManagedModelSpec {
 
     private func missingPathsWithoutNormalization(in rootURL: URL, fileManager: FileManager = .default) -> [URL] {
         switch validationKind {
+        case .flux1:
+            return Flux1Resources(rootURL: rootURL).validate(fileManager: fileManager)
         case .flux2Klein:
             return Self.missingDiffusersImagePaths(in: rootURL, fileManager: fileManager)
         case .bonsaiImage:

--- a/Sources/MereRunCore/ManagedModelSupport.swift
+++ b/Sources/MereRunCore/ManagedModelSupport.swift
@@ -238,6 +238,20 @@ public enum ManagedModelCapabilityCatalog {
                 recommended: 32
             ),
             descriptor(
+                "image-flux2-dev",
+                "Image, FLUX.2-dev LoRA",
+                "Installs gated FLUX.2-dev with a compatible 4-bit Mistral conditioner for high-quality generation and existing Dev LoRAs.",
+                minimum: 96,
+                recommended: 128
+            ),
+            descriptor(
+                Flux1Resources.modelID,
+                "Image, FLUX.1-dev LoRA",
+                "Installs gated FLUX.1-dev for native text-to-image generation and existing FLUX.1 adapters.",
+                minimum: 48,
+                recommended: 64
+            ),
+            descriptor(
                 "image-klein-shared",
                 "Shared Klein components",
                 "Represents shared FLUX.2 Klein components resolved from another installed Klein image model.",

--- a/Sources/MereRunCore/MereRunModelManifest.swift
+++ b/Sources/MereRunCore/MereRunModelManifest.swift
@@ -14,6 +14,8 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
     public static let filename: String = "mererun_model.json"
 
     public enum Engine: String, Codable, CaseIterable, Hashable, Sendable {
+        /// FLUX.1 Diffusers family.
+        case flux1 = "flux1"
         /// MereRun family (FLUX.2 Klein based).
         case flux2Klein = "flux2-klein"
         /// Zeta family (Z-Image Turbo based).
@@ -121,6 +123,7 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
     }
 
     public enum Family: String, Codable, CaseIterable, Hashable, Sendable {
+        case flux1
         case klein
         case zimage
         case hidream
@@ -787,6 +790,34 @@ public struct MereRunModelManifest: Codable, Hashable, Sendable {
                 precision: .unknown,
                 supports: [.txt2img, .referenceEdit, .loraInference],
                 components: kleinSharedComponents,
+                createdAt: createdAt
+            )
+        case .flux2Dev:
+            return MereRunModelManifest(
+                id: modelID.rawValue,
+                engine: .flux2Klein,
+                family: .klein,
+                tier: .max,
+                variant: .standard,
+                precision: .bf16,
+                defaults: Defaults(steps: 50, cfg: 4.0),
+                supports: [.txt2img, .referenceEdit, .loraInference],
+                components: defaultComponents,
+                upstreamRepoId: "black-forest-labs/FLUX.2-dev",
+                createdAt: createdAt
+            )
+        case .flux1Dev:
+            return MereRunModelManifest(
+                id: modelID.rawValue,
+                engine: .flux1,
+                family: .flux1,
+                tier: .max,
+                variant: .standard,
+                precision: .bf16,
+                defaults: Defaults(steps: 28, cfg: 3.5),
+                supports: [.txt2img, .loraInference],
+                components: defaultComponents,
+                upstreamRepoId: "\(Flux1Resources.upstreamRepoID)@\(Flux1Resources.upstreamRevision)",
                 createdAt: createdAt
             )
         case .bonsaiBinary:

--- a/Sources/MereRunCore/MereRunModelValidator.swift
+++ b/Sources/MereRunCore/MereRunModelValidator.swift
@@ -440,6 +440,8 @@ public enum MereRunModelValidator {
 
         if let family = manifest.family, let engine = manifest.engine {
             switch family {
+            case .flux1 where engine != .flux1:
+                warnings.append("Manifest engine mismatch: family=flux1 expects flux1.")
             case .klein where engine != .flux2Klein:
                 warnings.append("Manifest engine mismatch: family=klein expects flux2-klein.")
             case .zimage where engine != .zimageTurbo:
@@ -616,7 +618,7 @@ public enum MereRunModelValidator {
 
     private static func manifestRequiresInlineQuantization(_ manifest: MereRunModelManifest) -> Bool {
         switch manifest.engine {
-        case .flux2Klein?, .zimageTurbo?, .ideogram4?, .qwen35HybridMoE?, .laguna?:
+        case .flux1?, .flux2Klein?, .zimageTurbo?, .ideogram4?, .qwen35HybridMoE?, .laguna?:
             return true
         default:
             return false
@@ -624,7 +626,9 @@ public enum MereRunModelValidator {
     }
 
     private static func inferFamily(from modelId: String) -> MereRunModelManifest.Family? {
+        if modelId.hasPrefix("image-flux1-") { return .flux1 }
         if modelId.hasPrefix("image-klein-") { return .klein }
+        if modelId.hasPrefix("image-flux2-") { return .klein }
         if modelId.hasPrefix("image-zimage-") { return .zimage }
         if modelId.hasPrefix("image-hidream-") { return .hidream }
         if modelId.hasPrefix("image-sensenova-") { return .senseNova }

--- a/Sources/MereRunCore/ModelResolver.swift
+++ b/Sources/MereRunCore/ModelResolver.swift
@@ -15,6 +15,8 @@ public struct ModelResolver {
         case kleinBase9B = "image-klein-base-9b"
         case kleinBase = "image-klein-base"
         case kleinShared = "image-klein-shared"
+        case flux2Dev = "image-flux2-dev"
+        case flux1Dev = "image-flux1-dev"
         case bonsaiBinary = "image-bonsai-binary"
         case bonsaiTernary = "image-bonsai-ternary"
         case zetaNano = "image-zimage-nano"

--- a/Sources/MereRunCore/Quantization/QuantizedModelManifestWriter.swift
+++ b/Sources/MereRunCore/Quantization/QuantizedModelManifestWriter.swift
@@ -21,7 +21,9 @@ public enum QuantizedModelManifestWriter {
             : outputModelRoot.lastPathComponent
 
         func inferFamily(from id: String) -> MereRunModelManifest.Family? {
+            if id.hasPrefix("image-flux1-") { return .flux1 }
             if id.hasPrefix("image-klein-") { return .klein }
+            if id.hasPrefix("image-flux2-") { return .klein }
             if id.hasPrefix("image-zimage-") { return .zimage }
             if id.hasPrefix("image-hidream-") { return .hidream }
             if id.hasPrefix("image-krea2-") { return .krea }
@@ -53,6 +55,7 @@ public enum QuantizedModelManifestWriter {
 
         let family = baseManifest.family ?? inferFamily(from: id) ?? {
             switch engine {
+            case .flux1: return .flux1
             case .flux2Klein: return .klein
             case .zimageTurbo: return .zimage
             case .hidreamO1: return .hidream
@@ -116,6 +119,8 @@ public enum QuantizedModelManifestWriter {
         let supports: [MereRunModelManifest.Capability] = {
             let baseline: [MereRunModelManifest.Capability] = baseManifest.supports ?? {
                 switch engine {
+                case .flux1:
+                    return [.txt2img, .loraInference]
                 case .flux2Klein:
                     return [.txt2img, .referenceEdit, .loraInference]
                 case .zimageTurbo:
@@ -256,6 +261,8 @@ public enum QuantizedModelManifestWriter {
         // If we couldn't infer defaults from the base manifest, set reasonable engine defaults.
         if manifest.defaults == nil {
             switch engine {
+            case .flux1:
+                manifest.defaults = MereRunModelManifest.Defaults(steps: 28, cfg: 3.5)
             case .flux2Klein:
                 manifest.defaults = MereRunModelManifest.Defaults(steps: 4, cfg: 1.0)
             case .zimageTurbo:

--- a/Sources/MereRunCore/RuntimeModelSettings.swift
+++ b/Sources/MereRunCore/RuntimeModelSettings.swift
@@ -421,7 +421,7 @@ public extension ManagedModelSpec {
 
     var isAPISidecarRuntimeModel: Bool {
         switch validationKind {
-        case .flux2Klein, .zimageTurbo, .hidreamO1, .krea2, .ideogram4SDNQ,
+        case .flux1, .flux2Klein, .zimageTurbo, .hidreamO1, .krea2, .ideogram4SDNQ,
              .qwen3TTS, .qwen3ASR, .parakeet, .qwen3Embedding:
             return true
         default:

--- a/Tests/MereRunCLITests/AdapterCommandTests.swift
+++ b/Tests/MereRunCLITests/AdapterCommandTests.swift
@@ -18,6 +18,16 @@ struct AdapterCommandTests {
         #expect(command.quiet)
     }
 
+    @Test("FLUX.2-dev Turbo pull parses explicit license acceptance")
+    func parsesFlux2DevTurboPull() throws {
+        let command = try AdapterPull.parse([
+            ManagedAdapterCatalog.flux2DevTurboEightStepID,
+            "--accept-license",
+        ])
+        #expect(command.target == ManagedAdapterCatalog.flux2DevTurboEightStepID)
+        #expect(command.acceptLicense)
+    }
+
     @Test("SCAIL-2 distilled adapter pull parses its canonical id")
     func parsesSCAIL2Pull() throws {
         let command = try AdapterPull.parse([

--- a/Tests/MereRunCLITests/ImageGenerateCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/ImageGenerateCommandParsingTests.swift
@@ -41,6 +41,43 @@ final class ImageGenerateCommandParsingTests: XCTestCase {
         XCTAssertEqual(cmd.cfgScale, 1.0)
     }
 
+    func testParsesOrderedLoRAStackWithIndependentScales() throws {
+        let cmd = try ImageGenerate.parse([
+            "--prompt", "a studio portrait",
+            "--lora", "flux2-dev-turbo-8step=1.0",
+            "--lora", "/tmp/style.safetensors=0.65",
+            "--lora-scale", "0.8",
+        ])
+
+        XCTAssertEqual(
+            cmd.loraArguments,
+            ["flux2-dev-turbo-8step=1.0", "/tmp/style.safetensors=0.65"]
+        )
+        XCTAssertEqual(cmd.lora, "flux2-dev-turbo-8step=1.0")
+        XCTAssertEqual(
+            try ImageGenerate.parseLoRAArguments(
+                cmd.loraArguments,
+                defaultScale: cmd.loraScale
+            ),
+            [
+                .init(raw: "flux2-dev-turbo-8step=1.0", reference: "flux2-dev-turbo-8step", scale: 1),
+                .init(raw: "/tmp/style.safetensors=0.65", reference: "/tmp/style.safetensors", scale: 0.65),
+            ]
+        )
+    }
+
+    func testParsesTurboSigmaScheduleWithOptionalTerminalZero() throws {
+        let cmd = try ImageGenerate.parse([
+            "--prompt", "a studio portrait",
+            "--sigmas", "1, 0.6509, 0.4374, 0",
+        ])
+
+        XCTAssertEqual(
+            try ImageGenerate.parseSigmaList(cmd.sigmaList),
+            [1, 0.6509, 0.4374]
+        )
+    }
+
     func testParsesOptionalImageStrength() throws {
         let cmd = try ImageGenerate.parse([
             "--prompt", "a brass camera",
@@ -408,6 +445,118 @@ final class ImageGenerateCommandParsingTests: XCTestCase {
         XCTAssertEqual(commandFromPlan.seed, 42)
         XCTAssertFalse(commandFromPlan.preflight)
         XCTAssertFalse(commandFromPlan.json)
+    }
+
+    func testImageGenerationPreflightRoundTripsStackedLocalLoRAs() throws {
+        let temp = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: temp) }
+
+        let model = temp.appendingPathComponent("model", isDirectory: true)
+        try writeManifest(id: "image-flux2-dev", family: .klein, to: model)
+        let turbo = temp.appendingPathComponent("turbo.safetensors")
+        let style = temp.appendingPathComponent("style.safetensors")
+        try Data("turbo".utf8).write(to: turbo)
+        try Data("style".utf8).write(to: style)
+
+        let command = try ImageGenerate.parse([
+            "--prompt", "TRIGGER_TOKEN a studio portrait",
+            "--model", model.path,
+            "--lora", "\(turbo.path)=1.0",
+            "--lora", "\(style.path)=0.7",
+            "--preflight",
+            "--json",
+        ])
+        let envelope = command.makePreflightEnvelope(
+            outputURL: temp.appendingPathComponent("stacked.png")
+        )
+
+        XCTAssertEqual(envelope.status, .ok)
+        XCTAssertEqual(envelope.result.loras.map(\.path), [turbo.path, style.path])
+        XCTAssertEqual(envelope.result.loras.map(\.scale), [1, 0.7])
+        XCTAssertEqual(
+            envelope.result.runPlan.arguments.loras,
+            ["\(turbo.path)=1.0", "\(style.path)=0.7"]
+        )
+
+        let runPlan = try ImageRunPlan.parse(["/tmp/unused-plan.json"])
+        let replay = try runPlan.makeGenerateCommand(from: envelope.result.runPlan)
+        XCTAssertEqual(
+            replay.loraArguments,
+            ["\(turbo.path)=1.0", "\(style.path)=0.7"]
+        )
+    }
+
+    func testFlux1PreflightAcceptsStackedLoRAsAndUsesManifestDefaults() throws {
+        let temp = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: temp) }
+
+        let model = temp.appendingPathComponent("model", isDirectory: true)
+        try FileManager.default.createDirectory(at: model, withIntermediateDirectories: true)
+        let manifest = MereRunModelManifest(
+            id: Flux1Resources.modelID,
+            engine: .flux1,
+            family: .flux1,
+            variant: .standard,
+            precision: .bf16,
+            defaults: .init(steps: 28, cfg: 3.5),
+            supports: [.txt2img, .loraInference]
+        )
+        try manifest.write(to: model)
+        let fast = temp.appendingPathComponent("fast.safetensors")
+        let style = temp.appendingPathComponent("style.safetensors")
+        try Data("fast".utf8).write(to: fast)
+        try Data("style".utf8).write(to: style)
+
+        let command = try ImageGenerate.parse([
+            "--prompt", "a studio portrait",
+            "--model", model.path,
+            "--lora", "\(fast.path)=0.9",
+            "--lora", "\(style.path)=0.65",
+            "--preflight",
+            "--json",
+        ])
+        let envelope = command.makePreflightEnvelope(
+            outputURL: temp.appendingPathComponent("flux1.png")
+        )
+
+        XCTAssertEqual(envelope.status, .ok)
+        XCTAssertEqual(envelope.result.model.family, MereRunModelManifest.Family.flux1.rawValue)
+        XCTAssertEqual(envelope.result.plan.effectiveSteps, 28)
+        XCTAssertEqual(envelope.result.plan.effectiveCFGScale, 3.5)
+        XCTAssertEqual(envelope.result.loras.map(\.scale), [0.9, 0.65])
+        XCTAssertFalse(envelope.diagnostics.contains { $0.id == "lora_stack_model_unsupported" })
+    }
+
+    func testFlux2DevTurboPreflightAppliesPublishedRecipe() throws {
+        let temp = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: temp) }
+
+        let model = temp.appendingPathComponent("model", isDirectory: true)
+        try writeManifest(id: "image-flux2-dev", family: .klein, to: model)
+        let command = try ImageGenerate.parse([
+            "--prompt", "a studio portrait",
+            "--model", model.path,
+            "--lora", ManagedAdapterCatalog.flux2DevTurboEightStepID,
+            "--preflight",
+            "--json",
+        ])
+        let envelope = command.makePreflightEnvelope(
+            outputURL: temp.appendingPathComponent("turbo.png")
+        )
+
+        XCTAssertEqual(envelope.result.plan.effectiveSteps, Flux2DevTurboRecipe.steps)
+        XCTAssertEqual(envelope.result.plan.effectiveCFGScale, Flux2DevTurboRecipe.guidanceScale)
+        XCTAssertEqual(envelope.result.plan.effectiveSigmas, Flux2DevTurboRecipe.sigmas)
+        let turbo = try XCTUnwrap(envelope.result.loras.first)
+        XCTAssertEqual(turbo.requested, ManagedAdapterCatalog.flux2DevTurboEightStepID)
+        if turbo.exists {
+            XCTAssertEqual(envelope.status, .ok)
+            XCTAssertFalse(envelope.diagnostics.contains { $0.id == "managed_lora_missing" })
+        } else {
+            XCTAssertEqual(envelope.status, .blocked)
+            XCTAssertTrue(envelope.diagnostics.contains { $0.id == "managed_lora_missing" })
+            XCTAssertTrue(envelope.actions.contains { $0.id == "pull-adapter-1" })
+        }
     }
 
     func testImageRunPlanMaterializesGenerationRunDirectory() throws {

--- a/Tests/MereRunCoreTests/Flux1RuntimeTests.swift
+++ b/Tests/MereRunCoreTests/Flux1RuntimeTests.swift
@@ -1,0 +1,204 @@
+import MLX
+import XCTest
+@testable import MereRunCore
+
+final class Flux1RuntimeTests: MereRunCoreTestCase {
+    func testOfficialComponentConfigurationsDecodeExpectedArchitecture() throws {
+        let transformer = try decode(
+            Flux1TransformerConfiguration.self,
+            """
+            {
+              "attention_head_dim": 128,
+              "guidance_embeds": true,
+              "in_channels": 64,
+              "joint_attention_dim": 4096,
+              "num_attention_heads": 24,
+              "num_layers": 19,
+              "num_single_layers": 38,
+              "patch_size": 1,
+              "pooled_projection_dim": 768
+            }
+            """
+        )
+        let clip = try decode(
+            Flux1CLIPConfiguration.self,
+            """
+            {
+              "hidden_size": 768,
+              "intermediate_size": 3072,
+              "layer_norm_eps": 0.00001,
+              "max_position_embeddings": 77,
+              "num_attention_heads": 12,
+              "num_hidden_layers": 12,
+              "projection_dim": 768,
+              "vocab_size": 49408
+            }
+            """
+        )
+        let t5 = try decode(
+            Flux1T5Configuration.self,
+            """
+            {
+              "d_ff": 10240,
+              "d_kv": 64,
+              "d_model": 4096,
+              "layer_norm_epsilon": 0.000001,
+              "num_heads": 64,
+              "num_layers": 24,
+              "relative_attention_num_buckets": 32,
+              "vocab_size": 32128
+            }
+            """
+        )
+        let vae = try decode(
+            Flux1VAEConfiguration.self,
+            """
+            {
+              "block_out_channels": [128, 256, 512, 512],
+              "in_channels": 3,
+              "latent_channels": 16,
+              "layers_per_block": 2,
+              "norm_num_groups": 32,
+              "out_channels": 3,
+              "scaling_factor": 0.3611,
+              "shift_factor": 0.1159
+            }
+            """
+        )
+
+        XCTAssertEqual(transformer.hiddenSize, 3_072)
+        XCTAssertEqual(transformer.outChannels, 64)
+        XCTAssertEqual(transformer.axesDimsRope, [16, 56, 56])
+        XCTAssertEqual(transformer.axesDimsRope.reduce(0, +), transformer.attentionHeadDim)
+        XCTAssertTrue(transformer.guidanceEmbeds)
+        XCTAssertEqual(clip.maxPositionEmbeddings, 77)
+        XCTAssertEqual(t5.wanConfiguration.attentionSize, 4_096)
+        XCTAssertEqual(t5.wanConfiguration.layerCount, 24)
+        XCTAssertEqual(vae.coreConfiguration.latentChannels, 16)
+        XCTAssertEqual(vae.coreConfiguration.scalingFactor, 0.3611, accuracy: 0.00001)
+        XCTAssertEqual(vae.coreConfiguration.shiftFactor, 0.1159, accuracy: 0.00001)
+    }
+
+    func testFlowMatchScheduleUsesDynamicImageShiftAndTerminalZero() throws {
+        let configuration = try decode(
+            Flux1SchedulerConfiguration.self,
+            """
+            {
+              "base_image_seq_len": 256,
+              "base_shift": 0.5,
+              "max_image_seq_len": 4096,
+              "max_shift": 1.15,
+              "num_train_timesteps": 1000,
+              "shift": 1.0,
+              "use_dynamic_shifting": true
+            }
+            """
+        )
+        let scheduler = Flux1Scheduler(
+            steps: 4,
+            imageSequenceLength: 1_024,
+            configuration: configuration
+        )
+
+        XCTAssertEqual(scheduler.sigmas.count, 5)
+        XCTAssertEqual(scheduler.sigmas.first, 1)
+        XCTAssertEqual(scheduler.sigmas.last, 0)
+        XCTAssertTrue(zip(scheduler.sigmas, scheduler.sigmas.dropFirst()).allSatisfy(>))
+    }
+
+    func testLatentPackingRoundTripsSixteenChannelGrid() {
+        let latents = MLXArray(0..<256).asType(.float32).reshaped(1, 16, 4, 4)
+        let packed = Flux1SampleBuilder.pack(latents)
+        let unpacked = Flux1SampleBuilder.unpack(packed, height: 4, width: 4)
+
+        XCTAssertEqual(packed.shape, [1, 4, 64])
+        XCTAssertEqual(unpacked.shape, latents.shape)
+        XCTAssertEqual(unpacked.asArray(Float.self), latents.asArray(Float.self))
+    }
+
+    func testT5WeightMapperReplicatesSharedRelativeBias() {
+        let relativeBias = MLXArray.zeros([32, 64], dtype: .float32)
+        let mapped = Flux1TextEncoderLoader.mapT5Weight(
+            key: "encoder.block.0.layer.0.SelfAttention.relative_attention_bias.weight",
+            value: relativeBias,
+            layerCount: 24
+        )
+
+        XCTAssertEqual(mapped.count, 24)
+        XCTAssertEqual(mapped.first?.0, "blocks.0.pos_embedding.embedding.weight")
+        XCTAssertEqual(mapped.last?.0, "blocks.23.pos_embedding.embedding.weight")
+    }
+
+    func testTransformerWeightMapperPreservesOfficialProjectionNames() {
+        let value = MLXArray.zeros([4, 4], dtype: .float32)
+        XCTAssertEqual(
+            Flux1TransformerWeightMapper.map(
+                key: "single_transformer_blocks.0.proj_out.weight",
+                value: value
+            ).first?.0,
+            "single_transformer_blocks.0.proj_out.weight"
+        )
+        XCTAssertEqual(
+            Flux1TransformerWeightMapper.map(
+                key: "transformer_blocks.0.ff.net.0.proj.weight",
+                value: value
+            ).first?.0,
+            "transformer_blocks.0.ff.input.proj.weight"
+        )
+    }
+
+    func testResourcesRequireOfficialCLIPBPEFilesInsteadOfTokenizerJSON() throws {
+        let root = try TestFileSystem.makeTempDir(prefix: "flux1-resources")
+        defer { try? FileManager.default.removeItem(at: root) }
+        let resources = Flux1Resources(rootURL: root)
+        let required = [
+            resources.transformerConfigURL,
+            resources.transformerWeightsIndexURL,
+            resources.clipConfigURL,
+            resources.clipWeightsURL,
+            resources.clipTokenizerURL.appendingPathComponent("tokenizer_config.json"),
+            resources.clipTokenizerVocabURL,
+            resources.clipTokenizerMergesURL,
+            resources.t5ConfigURL,
+            resources.t5WeightsIndexURL,
+            resources.t5TokenizerURL.appendingPathComponent("tokenizer.json"),
+            resources.vaeConfigURL,
+            resources.vaeWeightsURL,
+            resources.schedulerConfigURL,
+        ]
+        for url in required {
+            try TestFileSystem.writeFile(url)
+        }
+
+        XCTAssertTrue(resources.validate().isEmpty)
+        XCTAssertFalse(required.contains(resources.clipTokenizerURL.appendingPathComponent("tokenizer.json")))
+    }
+
+    func testCLIPBPEFallbackAddsReferenceSpecialTokens() throws {
+        let root = try TestFileSystem.makeTempDir(prefix: "flux1-clip-tokenizer")
+        defer { try? FileManager.default.removeItem(at: root) }
+        try TestFileSystem.writeFile(
+            root.appendingPathComponent("tokenizer_config.json"),
+            contents: Data(#"{"tokenizer_class":"CLIPTokenizer"}"#.utf8)
+        )
+        try TestFileSystem.writeFile(
+            root.appendingPathComponent("vocab.json"),
+            contents: Data(#"{"<|startoftext|>":49406,"<|endoftext|>":49407}"#.utf8)
+        )
+        try TestFileSystem.writeFile(
+            root.appendingPathComponent("merges.txt"),
+            contents: Data("#version: 0.2\n".utf8)
+        )
+
+        let tokenizer = try Flux1Tokenizer.load(from: root, maximumLength: 4, fallbackPadTokenID: 49_407)
+        let encoded = tokenizer.encode("")
+
+        XCTAssertEqual(encoded.ids, [49_406, 49_407, 49_407, 49_407])
+        XCTAssertEqual(encoded.mask, [1, 1, 0, 0])
+        XCTAssertEqual(encoded.pooledIndex, 1)
+    }
+
+    private func decode<Value: Decodable>(_ type: Value.Type, _ json: String) throws -> Value {
+        try JSONDecoder().decode(type, from: Data(json.utf8))
+    }
+}

--- a/Tests/MereRunCoreTests/Flux2DevConfigTests.swift
+++ b/Tests/MereRunCoreTests/Flux2DevConfigTests.swift
@@ -1,0 +1,93 @@
+import Foundation
+import XCTest
+@testable import MereRunCore
+
+final class Flux2DevConfigTests: XCTestCase {
+    func testTransformerConfigUsesDiffusersGuidanceDefaultWhenFieldIsAbsent() throws {
+        let data = Data("""
+        {
+          "attention_head_dim": 128,
+          "axes_dims_rope": [32, 32, 32, 32],
+          "eps": 0.000001,
+          "in_channels": 128,
+          "joint_attention_dim": 15360,
+          "mlp_ratio": 3,
+          "num_attention_heads": 48,
+          "num_layers": 8,
+          "num_single_layers": 48,
+          "patch_size": 1,
+          "rope_theta": 2000,
+          "timestep_guidance_channels": 256
+        }
+        """.utf8)
+
+        let config = try JSONDecoder().decode(Flux2TransformerConfig.self, from: data)
+        XCTAssertNil(config.guidanceEmbeds)
+        XCTAssertTrue(config.resolvedGuidanceEmbeds)
+        XCTAssertEqual(config.hiddenSize, 6_144)
+    }
+
+    func testNestedMistralConfigCarriesArchitectureAndQuantization() throws {
+        let data = Data("""
+        {
+          "model_type": "mistral3",
+          "quantization": {"group_size": 64, "bits": 4},
+          "text_config": {
+            "hidden_size": 5120,
+            "intermediate_size": 32768,
+            "num_hidden_layers": 40,
+            "num_attention_heads": 32,
+            "num_key_value_heads": 8,
+            "head_dim": 128,
+            "rms_norm_eps": 0.00001,
+            "rope_theta": 1000000000,
+            "vocab_size": 131072,
+            "max_position_embeddings": 131072
+          }
+        }
+        """.utf8)
+
+        let config = try JSONDecoder().decode(Flux2TextEncoderConfig.self, from: data)
+        XCTAssertEqual(config.architecture, .mistral3)
+        XCTAssertEqual(config.hiddenSize, 5_120)
+        XCTAssertEqual(config.numHiddenLayers, 40)
+        XCTAssertEqual(config.quantizationConfig?.bits, 4)
+        XCTAssertEqual(config.quantizationConfig?.groupSize, 64)
+    }
+
+    func testMistralWeightMapperDropsUnusedMultimodalHeads() {
+        XCTAssertEqual(
+            Flux2KleinGenerator.mapTextEncoderWeightKey(
+                "language_model.model.layers.0.self_attn.q_proj.weight"
+            ),
+            "encoder.layers.0.self_attn.q_proj.weight"
+        )
+        XCTAssertNil(
+            Flux2KleinGenerator.mapTextEncoderWeightKey("language_model.lm_head.weight")
+        )
+        XCTAssertNil(Flux2KleinGenerator.mapTextEncoderWeightKey("vision_tower.patch_conv.weight"))
+        XCTAssertNil(
+            Flux2KleinGenerator.mapTextEncoderWeightKey("multi_modal_projector.linear_1.weight")
+        )
+    }
+
+    func testCheckpointFileURLPreservesSafetensorsExtensionForContentAddressedSymlink() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        let component = root.appendingPathComponent("vae", isDirectory: true)
+        let blob = root.appendingPathComponent("content-addressed-blob")
+        try FileManager.default.createDirectory(at: component, withIntermediateDirectories: true)
+        try Data().write(to: blob)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let alias = component.appendingPathComponent("diffusion_pytorch_model.safetensors")
+        try FileManager.default.createSymbolicLink(at: alias, withDestinationURL: blob)
+
+        let loaderURL = Flux2KleinGenerator.checkpointFileURL(
+            in: component,
+            filename: "diffusion_pytorch_model.safetensors"
+        )
+        XCTAssertEqual(loaderURL.pathExtension, "safetensors")
+        XCTAssertEqual(loaderURL.resolvingSymlinksInPath().pathExtension, "")
+    }
+}

--- a/Tests/MereRunCoreTests/Flux2EulerSchedulerTests.swift
+++ b/Tests/MereRunCoreTests/Flux2EulerSchedulerTests.swift
@@ -87,4 +87,47 @@ final class Flux2EulerSchedulerTests: MereRunCoreTestCase {
         XCTAssertFalse(sigma.isNaN)
         XCTAssertFalse(sigma.isInfinite)
     }
+
+    func testFlux2DevEmpiricalMuMatchesPublishedFit() {
+        XCTAssertEqual(
+            Flux2EulerScheduler.computeEmpiricalMu(imageSeqLen: 4_096, numSteps: 50),
+            2.02335,
+            accuracy: 0.00001
+        )
+        XCTAssertEqual(
+            Flux2EulerScheduler.computeEmpiricalMu(imageSeqLen: 5_000, numSteps: 50),
+            1.3030167,
+            accuracy: 0.00001
+        )
+    }
+
+    func testCustomSigmasArePreservedAndReceiveTerminalZero() throws {
+        let custom: [Float] = [1, 0.6509, 0.4374, 0.00031]
+        try Flux2EulerScheduler.validateCustomSigmas(custom, expectedSteps: 4)
+        let scheduler = Flux2EulerScheduler(
+            numInferenceSteps: 4,
+            imageSeqLen: 4_096,
+            isDistilled: false,
+            sigmaShift: 8,
+            customSigmas: custom
+        )
+
+        XCTAssertEqual(scheduler.sigmas.asArray(Float.self), custom + [0])
+        XCTAssertEqual(
+            scheduler.timesteps.asArray(Float.self),
+            custom.map { $0 * 1_000 }
+        )
+    }
+
+    func testCustomSigmaValidationRejectsWrongCountAndOrder() {
+        XCTAssertThrowsError(
+            try Flux2EulerScheduler.validateCustomSigmas([1, 0.5], expectedSteps: 3)
+        )
+        XCTAssertThrowsError(
+            try Flux2EulerScheduler.validateCustomSigmas([1, 0.5, 0.5], expectedSteps: 3)
+        )
+        XCTAssertThrowsError(
+            try Flux2EulerScheduler.validateCustomSigmas([1, 0, -0.5], expectedSteps: 3)
+        )
+    }
 }

--- a/Tests/MereRunCoreTests/LoRAWeightLoaderTests.swift
+++ b/Tests/MereRunCoreTests/LoRAWeightLoaderTests.swift
@@ -4,6 +4,168 @@ import XCTest
 @testable import MereRunCore
 
 final class LoRAWeightLoaderTests: MereRunCoreTestCase {
+    func testFlux2LoRAStackerCombinesOrderedScaledUpdates() throws {
+        let first = LoRAWeights(
+            weights: [
+                "transformer_blocks.0.attn.to_q": (
+                    down: MLXArray([1, 2, 3, 4] as [Float]).reshaped([2, 2]),
+                    up: MLXArray([1, 2, 3, 4, 5, 6] as [Float]).reshaped([3, 2])
+                ),
+            ],
+            rank: 2,
+            alpha: 4
+        )
+        let second = LoRAWeights(
+            weights: [
+                "transformer_blocks.0.attn.to_q": (
+                    down: MLXArray([8, 12] as [Float]).reshaped([1, 2]),
+                    up: MLXArray([10, 20, 30] as [Float]).reshaped([3, 1])
+                ),
+            ],
+            rank: 1,
+            alpha: 1
+        )
+
+        let stacked = try Flux2LoRAStacker.stack([
+            Flux2LoRAStackInput(label: "turbo", scale: 0.5, weights: first),
+            Flux2LoRAStackInput(label: "style", scale: 0.25, weights: second),
+        ])
+        let pair = try XCTUnwrap(stacked.weights["transformer_blocks.0.attn.to_q"])
+
+        XCTAssertEqual(pair.down.shape, [3, 2])
+        XCTAssertEqual(pair.up.shape, [3, 3])
+        XCTAssertEqual(pair.down.asArray(Float.self), [1, 2, 3, 4, 2, 3])
+        XCTAssertEqual(pair.up.asArray(Float.self), [1, 2, 10, 3, 4, 20, 5, 6, 30])
+        XCTAssertEqual(stacked.targetRanks["transformer_blocks.0.attn.to_q"], 3)
+        XCTAssertEqual(stacked.alpha, 3)
+    }
+
+    func testFlux2LoRAStackerRejectsIncompatibleLayerDimensions() {
+        let first = LoRAWeights(
+            weights: [
+                "transformer_blocks.0.attn.to_q": (
+                    down: MLXArray.zeros([2, 4], dtype: .float32),
+                    up: MLXArray.zeros([6, 2], dtype: .float32)
+                ),
+            ],
+            rank: 2
+        )
+        let second = LoRAWeights(
+            weights: [
+                "transformer_blocks.0.attn.to_q": (
+                    down: MLXArray.zeros([1, 5], dtype: .float32),
+                    up: MLXArray.zeros([6, 1], dtype: .float32)
+                ),
+            ],
+            rank: 1
+        )
+
+        XCTAssertThrowsError(
+            try Flux2LoRAStacker.stack([
+                Flux2LoRAStackInput(label: "first", scale: 1, weights: first),
+                Flux2LoRAStackInput(label: "second", scale: 1, weights: second),
+            ])
+        ) { error in
+            XCTAssertEqual(
+                error as? Flux2LoRAStacker.StackError,
+                .incompatiblePair(
+                    label: "second",
+                    path: "transformer_blocks.0.attn.to_q",
+                    expectedInput: 4,
+                    actualInput: 5,
+                    expectedOutput: 6,
+                    actualOutput: 6
+                )
+            )
+        }
+    }
+
+    func testFlux2DevLoRAValidationRejectsFlux1HiddenWidth() {
+        XCTAssertThrowsError(
+            try Flux2KleinGenerator.validateLoRAWeightShapes(
+                path: "single_transformer_blocks.0.attn.to_q",
+                down: MLXArray.zeros([16, 3_072], dtype: .float32),
+                up: MLXArray.zeros([3_072, 16], dtype: .float32),
+                expectedDown: [16, 6_144],
+                expectedUp: [6_144, 16]
+            )
+        ) { error in
+            XCTAssertTrue(error.localizedDescription.contains("not FLUX.1"))
+            XCTAssertTrue(error.localizedDescription.contains("6144"))
+            XCTAssertTrue(error.localizedDescription.contains("3072"))
+        }
+    }
+
+    func testExternalFlux2DevLoRAWhenConfigured() throws {
+        guard let path = ProcessInfo.processInfo.environment["MERERUN_TEST_FLUX2_DEV_LORA"] else {
+            throw XCTSkip("Set MERERUN_TEST_FLUX2_DEV_LORA to inspect a real FLUX.2-dev adapter.")
+        }
+
+        let weights = try LoRAWeightLoader.load(from: URL(fileURLWithPath: path))
+        let pair = try XCTUnwrap(weights.weights["transformer_blocks.0.attn.to_q"])
+        XCTAssertEqual(pair.down.shape[1], 6_144)
+        XCTAssertEqual(pair.up.shape[0], 6_144)
+    }
+
+    func testExternalFlux1LoRAIsRejectedWhenConfigured() throws {
+        guard let path = ProcessInfo.processInfo.environment["MERERUN_TEST_FLUX1_LORA"] else {
+            throw XCTSkip("Set MERERUN_TEST_FLUX1_LORA to inspect a FLUX.1 adapter.")
+        }
+
+        let weights = try LoRAWeightLoader.load(from: URL(fileURLWithPath: path))
+        let pair = try XCTUnwrap(weights.weights["single_transformer_blocks.0.attn.to_q"])
+        XCTAssertThrowsError(
+            try Flux2KleinGenerator.validateLoRAWeightShapes(
+                path: "single_transformer_blocks.0.attn.to_q",
+                down: pair.down,
+                up: pair.up,
+                expectedDown: [pair.down.shape[0], 6_144],
+                expectedUp: [6_144, pair.up.shape[1]]
+            )
+        ) { error in
+            XCTAssertTrue(error.localizedDescription.contains("not FLUX.1"))
+        }
+    }
+
+    func testFlux1ArchitecturePreservesDiffusersSingleBlockOutputTarget() throws {
+        let temp = try TestFileSystem.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: temp) }
+
+        let adapterURL = temp.appendingPathComponent("flux1.safetensors")
+        try MLX.save(
+            arrays: [
+                "transformer.single_transformer_blocks.0.proj_out.lora_A.weight":
+                    MLXArray.zeros([16, 15_360], dtype: .float32),
+                "transformer.single_transformer_blocks.0.proj_out.lora_B.weight":
+                    MLXArray.zeros([3_072, 16], dtype: .float32),
+            ],
+            url: adapterURL
+        )
+
+        let weights = try LoRAWeightLoader.load(from: adapterURL, architecture: .flux1)
+        let pair = try XCTUnwrap(weights.weights["single_transformer_blocks.0.proj_out"])
+        XCTAssertEqual(pair.down.shape, [16, 15_360])
+        XCTAssertEqual(pair.up.shape, [3_072, 16])
+        XCTAssertNil(weights.weights["single_transformer_blocks.0.attn.to_out"])
+    }
+
+    func testExternalFlux1LoRALoadsWithNativeTargetsWhenConfigured() throws {
+        guard let path = ProcessInfo.processInfo.environment["MERERUN_TEST_FLUX1_LORA"] else {
+            throw XCTSkip("Set MERERUN_TEST_FLUX1_LORA to inspect a real FLUX.1 adapter.")
+        }
+
+        let weights = try LoRAWeightLoader.load(
+            from: URL(fileURLWithPath: path),
+            architecture: .flux1
+        )
+        let query = try XCTUnwrap(weights.weights["single_transformer_blocks.0.attn.to_q"])
+        let projection = try XCTUnwrap(weights.weights["single_transformer_blocks.0.proj_out"])
+        XCTAssertEqual(query.down.shape, [16, 3_072])
+        XCTAssertEqual(query.up.shape, [3_072, 16])
+        XCTAssertEqual(projection.down.shape, [16, 15_360])
+        XCTAssertEqual(projection.up.shape, [3_072, 16])
+    }
+
     func testLoadInfersPerLayerRanks() throws {
         let temp = try TestFileSystem.makeTempDir()
         defer { try? FileManager.default.removeItem(at: temp) }

--- a/Tests/MereRunCoreTests/ManagedAdapterCatalogTests.swift
+++ b/Tests/MereRunCoreTests/ManagedAdapterCatalogTests.swift
@@ -4,6 +4,23 @@ import Testing
 
 @Suite("Managed adapter catalog")
 struct ManagedAdapterCatalogTests {
+    @Test("FLUX.2-dev Turbo is an immutable gated eight-step pin")
+    func flux2DevTurboIsPinned() throws {
+        let spec = try #require(
+            ManagedAdapterCatalog.spec(for: ManagedAdapterCatalog.flux2DevTurboEightStepID)
+        )
+        #expect(spec.version == "9ee51cd87578")
+        #expect(spec.baseModelID == ModelResolver.ModelID.flux2Dev.rawValue)
+        #expect(spec.format == ManagedAdapterCatalog.flux2DevLoRAFormat)
+        #expect(spec.upstreamRevision == ManagedAdapterCatalog.flux2DevTurboEightStepRevision)
+        #expect(spec.usageRestriction != nil)
+        #expect(spec.artifact.filename == "flux.2-turbo-lora.safetensors")
+        #expect(spec.artifact.byteCount == 2_760_818_216)
+        #expect(spec.artifact.sha256 == "f76cf9c2cc546ddca878799136434a1098477af3f4b0adff2cfd79f2ebe4aa01")
+        #expect(spec.downloadURL.host == "huggingface.co")
+        #expect(spec.downloadURL.absoluteString.contains(spec.upstreamRevision!))
+    }
+
     @Test("Mere platform assistant release is pinned")
     func releaseIsPinned() throws {
         let spec = try #require(

--- a/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
@@ -144,6 +144,8 @@ final class ManagedModelCatalogTests: XCTestCase {
 
     func testRestrictedModelInventoryIsCompleteAndCannotAutoDownload() throws {
         let expected = Set([
+            "image-flux1-dev",
+            "image-flux2-dev",
             "image-klein-9b",
             "image-klein-base-9b",
             "image-krea2-raw",
@@ -282,6 +284,8 @@ final class ManagedModelCatalogTests: XCTestCase {
 
     func testImageModelsHaveManagedDownloadSources() {
         let expectedPullableImageIDs = [
+            "image-flux1-dev",
+            "image-flux2-dev",
             "image-klein-nano",
             "image-klein-base",
             "image-klein-base-9b",
@@ -495,6 +499,40 @@ final class ManagedModelCatalogTests: XCTestCase {
         XCTAssertEqual(mounted["tokenizer"], "mlx-community/FLUX.2-klein-9B")
         XCTAssertEqual(mounted["vae"], "mlx-community/FLUX.2-klein-9B")
         XCTAssertEqual(mounted["scheduler"], "mlx-community/FLUX.2-klein-9B")
+    }
+
+    func testFlux2DevUsesPinnedGatedWeightsAndQuantizedMistralConditioner() throws {
+        let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: "image-flux2-dev"))
+
+        XCTAssertEqual(spec.hubFallback?.repoId, "black-forest-labs/FLUX.2-dev")
+        XCTAssertEqual(spec.hubFallback?.revision, "26afe3a78bb242c0a8bb181dcc8937bb16e5c66c")
+        XCTAssertEqual(spec.hubFallback?.patterns.contains("text_encoder/*"), false)
+        XCTAssertEqual(spec.runtimeAutoDownloadAllowed, false)
+        XCTAssertEqual(spec.usageRestriction?.terms.count, 2)
+
+        let textEncoder = try XCTUnwrap(spec.mountedHubFallbacks.first)
+        XCTAssertEqual(textEncoder.destinationPath, "text_encoder")
+        XCTAssertEqual(
+            textEncoder.hubFallback.repoId,
+            "mlx-community/Mistral-Small-3.2-24B-Instruct-2506-4bit"
+        )
+        XCTAssertEqual(textEncoder.hubFallback.revision, "2a1d5eabfc504747bdc24178394821a1efc0edde")
+    }
+
+    func testFlux1DevUsesPinnedGatedDiffusersComponents() throws {
+        let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: Flux1Resources.modelID))
+
+        XCTAssertEqual(spec.hubFallback?.repoId, Flux1Resources.upstreamRepoID)
+        XCTAssertEqual(spec.hubFallback?.revision, Flux1Resources.upstreamRevision)
+        XCTAssertEqual(spec.hubFallback?.patterns, Flux1Resources.snapshotPatterns)
+        XCTAssertEqual(spec.upstreamRevision, Flux1Resources.upstreamRevision)
+        XCTAssertEqual(spec.validationKind, .flux1)
+        XCTAssertEqual(spec.runtimeAutoDownloadAllowed, false)
+        XCTAssertEqual(spec.usageRestriction?.terms.first?.license, "FLUX.1 dev Non-Commercial License v1.1.1")
+        XCTAssertEqual(spec.estimatedDownloadBytes, Flux1Resources.estimatedDownloadBytes)
+        XCTAssertTrue(Flux1Resources.snapshotPatterns.contains("text_encoder/**"))
+        XCTAssertTrue(Flux1Resources.snapshotPatterns.contains("text_encoder_2/**"))
+        XCTAssertFalse(Flux1Resources.snapshotPatterns.contains("flux1-dev.safetensors"))
     }
 
     func testSAM31ManagedInstallMountsTokenizerForTextPrompts() throws {

--- a/Tests/MereRunCoreTests/MereRunModelManifestTests.swift
+++ b/Tests/MereRunCoreTests/MereRunModelManifestTests.swift
@@ -126,6 +126,45 @@ final class MereRunModelManifestTests: MereRunCoreTestCase {
         XCTAssertEqual(loaded.supports?.contains(.referenceEdit), true)
     }
 
+    func testFlux2DevTemplateKeepsGuidanceAndLicenseAcceptanceExplicit() {
+        let manifest = MereRunModelManifest.template(
+            for: .flux2Dev,
+            createdAt: Date(timeIntervalSince1970: 0)
+        )
+
+        XCTAssertEqual(manifest.id, "image-flux2-dev")
+        XCTAssertEqual(manifest.engine, .flux2Klein)
+        XCTAssertEqual(manifest.family, .klein)
+        XCTAssertEqual(manifest.variant, .standard)
+        XCTAssertEqual(manifest.defaults?.steps, 50)
+        XCTAssertEqual(manifest.defaults?.cfg, 4.0)
+        XCTAssertEqual(manifest.supports, [.txt2img, .referenceEdit, .loraInference])
+        XCTAssertEqual(manifest.sources?.count, 2)
+        XCTAssertEqual(manifest.usageTerms?.count, 2)
+        XCTAssertNil(manifest.usageTermsAcknowledged)
+    }
+
+    func testFlux1DevTemplateUsesSeparateArchitectureAndOfficialDefaults() {
+        let manifest = MereRunModelManifest.template(
+            for: .flux1Dev,
+            createdAt: Date(timeIntervalSince1970: 0)
+        )
+
+        XCTAssertEqual(manifest.id, Flux1Resources.modelID)
+        XCTAssertEqual(manifest.engine, .flux1)
+        XCTAssertEqual(manifest.family, .flux1)
+        XCTAssertEqual(manifest.variant, .standard)
+        XCTAssertEqual(manifest.defaults?.steps, 28)
+        XCTAssertEqual(manifest.defaults?.cfg, 3.5)
+        XCTAssertEqual(manifest.supports, [.txt2img, .loraInference])
+        XCTAssertEqual(
+            manifest.upstreamRepoId,
+            "\(Flux1Resources.upstreamRepoID)@\(Flux1Resources.upstreamRevision)"
+        )
+        XCTAssertEqual(manifest.usageTerms?.count, 1)
+        XCTAssertNil(manifest.usageTermsAcknowledged)
+    }
+
     func testWriteTemplateIfKnownOverwritesInvalidJSON() throws {
         let temp = try TestFileSystem.makeTempDir()
         defer { try? FileManager.default.removeItem(at: temp) }

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -238,7 +238,7 @@ See [`model-sources.md`](./model-sources.md) for the full source story,
 including which IDs are pullable from Hugging Face. The most common managed IDs
 are:
 
-- Images: `image-klein-nano`, `image-klein-base`, `image-klein-base-9b`, `image-klein-max`,
+- Images: `image-flux1-dev`, `image-flux2-dev`, `image-klein-nano`, `image-klein-base`, `image-klein-base-9b`, `image-klein-max`,
   `image-bonsai-binary`, `image-bonsai-ternary`, `image-zimage-nano`, `image-zimage-base`, `image-zimage-max`,
   `image-hidream-o1`, `image-hidream-o1-dev`, `image-sensenova-u1-5-8b-mot`, `image-krea2-raw`,
   `image-krea2-turbo`,
@@ -487,7 +487,11 @@ Key options:
 - `--structured-prompt`, `--json-prompt`: expand the prompt into a structured JSON caption with a local text chat model before image generation
 - `--structured-prompt-model`: text chat model id for the adapter; defaults to `text-chat-gemma4-12b-4bit`
 - `--structured-prompt-output`: write the generated structured JSON caption to a file
-- `--lora`, `--lora-scale`
+- `--lora PATH_OR_ID[=SCALE]`: load an image LoRA. Repeat it to stack ordered,
+  independently scaled FLUX.1 or FLUX.2 adapters.
+- `--lora-scale`: default scale for `--lora` values without an inline scale
+- `--sigmas`: pre-shifted, descending FLUX.2 sigma values; a terminal zero is
+  optional
 - `--krea-base-quantization-bits 4|8`: quantize the frozen Krea transformer and
   load the text encoder, transformer, and VAE sequentially to reduce peak memory
 - `--preflight`: inspect the generation request without loading the model or writing an image
@@ -2386,6 +2390,7 @@ List the built-in public adapter catalog or install one immutable release:
 mere.run adapter list
 mere.run adapter list --json
 mere.run adapter pull mere-platform-assistant
+mere.run adapter pull flux2-dev-turbo-8step --accept-license
 mere.run adapter pull scail2-lightx2v-4step
 mere.run adapter pull minimax-h3-turbo-4step
 mere.run adapter pull minimax-h3-lightx2v-4step
@@ -2399,9 +2404,15 @@ mere.run adapter pull minimax-h3-fasth3-vsa-datafree-4step --accept-license
 The pull verifies the cataloged byte count and SHA-256 before atomically
 installing the adapter. Stdout contains only the installed path; progress and
 verification diagnostics go to stderr. Use the adapter id directly with
-`text chat --lora`, `api serve --lora`, or the matching SCAIL
-`video animate --distilled-adapter` option. `video animate --profile fast`
-selects `scail2-lightx2v-4step` and its fixed four-step schedule.
+`image generate --lora`, `text chat --lora`, `api serve --lora`, or the
+matching SCAIL `video animate --distilled-adapter` option. `video animate
+--profile fast` selects `scail2-lightx2v-4step` and its fixed four-step
+schedule.
+`image generate --lora flux2-dev-turbo-8step` selects the Turbo adapter's
+eight-step schedule and guidance default for `image-flux2-dev`. Repeat
+`--lora PATH_OR_ID[=SCALE]` to add local FLUX.2-dev adapters to the same run.
+For `image-flux1-dev`, repeat the same option to stack compatible FLUX.1
+adapters. FLUX.1, FLUX.2-dev, and Klein adapters aren't interchangeable.
 Use the MiniMax-H3 adapter ids with `video generate --h3-adapter`. FL2VA
 adapters support the compact BF16 and affine Q8 FL2VA bases and reject the
 legacy Q4 compatibility package. The Ref2V adapter uses the managed Ref2VA base

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -54,6 +54,8 @@ an effective overlay; they are not a second capability catalog.
 | `image` | `image-klein-base` |
 | `image` | `image-klein-base-9b` |
 | `image` | `image-klein-shared` |
+| `image` | `image-flux2-dev` |
+| `image` | `image-flux1-dev` |
 | `image` | `image-bonsai-binary` |
 | `image` | `image-bonsai-ternary` |
 | `image` | `image-zimage-nano` |
@@ -213,6 +215,8 @@ validates all configured models before downloading any; both accept the same
 
 | Models | Upstream terms that require acceptance |
 | --- | --- |
+| `image-flux1-dev` | FLUX.1 dev Non-Commercial License v1.1.1; non-commercial, non-production use |
+| `image-flux2-dev` | FLUX Non-Commercial License and BFL Acceptable Use Policy; non-commercial, non-production use |
 | `image-klein-9b`, `image-klein-base-9b` | FLUX Non-Commercial License v2.1; non-commercial, non-production use |
 | `image-krea2-raw`, `image-krea2-turbo` | Krea 2 Community License; commercial use is limited to entities below USD 1M trailing annual revenue, plus use/distribution conditions |
 | `image-sensenova-u1-5-8b-mot` | Apache License 2.0 |
@@ -669,6 +673,83 @@ Useful environment variables for that path:
 larger distilled Klein generation and reference-image workflows. It is distinct
 from `image-klein-base-9b`, which pulls the undistilled Base 9B transformer plus
 shared 9B components for higher-capacity LoRA training and research workflows.
+
+`image-flux1-dev` installs the gated Diffusers layout from
+`black-forest-labs/FLUX.1-dev` at revision
+`3de623fc3c33e44ffbe2bad470d0f45bccf2eb21`. The approximately 34 GB managed
+download includes the FLUX.1 transformer, CLIP-L and T5-XXL text encoders,
+tokenizers, VAE, and flow-matching scheduler. The managed patterns exclude the
+duplicate root checkpoint files.
+
+Before you pull the model, accept its access terms on Hugging Face and
+configure a Hugging Face token in mere.run. The pull also requires explicit
+local acceptance of the FLUX.1 dev Non-Commercial License v1.1.1:
+
+```bash
+swift run mere.run model pull image-flux1-dev --accept-model-license
+swift run mere.run image generate \
+  --model image-flux1-dev \
+  --prompt "TRIGGER_TOKEN a portrait in a glass conservatory" \
+  --lora ./flux1-subject.safetensors=0.8 \
+  --output ./flux1-subject.png
+```
+
+The runtime defaults to 28 denoising steps and embedded guidance scale 3.5.
+Repeat `--lora PATH_OR_ID[=SCALE]` to apply ordered FLUX.1 adapters with
+independent scales. Each adapter must target FLUX.1-dev. FLUX.2 and Klein
+adapters use different transformer dimensions and fail tensor-shape validation.
+
+The model license limits the weights and derivatives to non-commercial,
+non-production use. It also requires filters or manual review for generated
+content. The mere.run acceptance record doesn't determine whether a workflow
+complies with those requirements.
+
+`image-flux2-dev` installs the gated FLUX.2-dev transformer, variational
+autoencoder (VAE), tokenizer, and scheduler from
+`black-forest-labs/FLUX.2-dev`. The install mounts a pinned 4-bit MLX conversion
+of the matching Mistral Small 3.2 24B text encoder. This layout reduces the
+managed download from approximately 113 GB to 78 GB without changing the
+transformer that a FLUX.2-dev LoRA targets.
+
+Before you pull the model, accept its access terms on Hugging Face, and
+configure a Hugging Face token in mere.run. The pull also requires explicit
+local acceptance because the FLUX Non-Commercial License limits the weights to
+non-commercial, non-production use, and the BFL Acceptable Use Policy applies:
+
+```bash
+swift run mere.run model pull image-flux2-dev --accept-model-license
+swift run mere.run adapter pull flux2-dev-turbo-8step --accept-license
+swift run mere.run image generate \
+  --model image-flux2-dev \
+  --prompt "a ceramic vessel on dark linen, precise studio lighting" \
+  --lora flux2-dev-turbo-8step=1.0 \
+  --lora ./flux2-dev-style.safetensors=0.8 \
+  --output ./flux2-dev-style.png
+```
+
+The managed Turbo adapter is the `fal/FLUX.2-dev-Turbo` artifact pinned at
+revision `9ee51cd87578162cf8d02355a870bc5f4570045c`. mere.run verifies its
+2,760,818,216-byte safetensors file against SHA-256
+`f76cf9c2cc546ddca878799136434a1098477af3f4b0adff2cfd79f2ebe4aa01`.
+The separate adapter pull requires explicit acceptance because the adapter
+inherits the FLUX.2-dev noncommercial terms and BFL Acceptable Use Policy.
+
+Selecting `flux2-dev-turbo-8step` applies the publisher's eight-step,
+guidance-2.5 sigma recipe. Repeated `--lora PATH_OR_ID[=SCALE]` values preserve
+their order and combine the Turbo update with local FLUX.2-dev style or subject
+adapters. FLUX.1-dev adapters are structurally incompatible and are rejected by
+the runtime's tensor-shape validation.
+
+The license treats generated outputs separately and permits personal,
+scientific, and commercial output use subject to its terms. It also requires
+filters or manual review for generated content. The mere.run acceptance record
+does not provide legal clearance or certify that a workflow satisfies those
+requirements.
+
+The default profile uses 50 denoising steps and embedded guidance scale 4.0.
+The capability catalog requires at least 96 GB of unified memory and recommends
+128 GB. Real-checkpoint qualification remains separate from catalog and
+synthetic runtime tests.
 
 `image-bonsai-binary` and `image-bonsai-ternary` map to PrismML Apple Silicon
 Bonsai Image snapshots:

--- a/docs/runtime/image.md
+++ b/docs/runtime/image.md
@@ -3,8 +3,9 @@
 Use the image runtime to generate an image from a prompt, train a low-rank
 adaptation (LoRA) on your own pictures, replay a generation from a saved plan,
 or convert one photo into a textured three-dimensional (3D) mesh. The runtime
-supports local model families from compact ZImage checkpoints through FLUX.2
-Klein, HiDream O1, SenseNova U1.5, Krea 2, Qwen Image Edit 2511, and Ideogram 4.
+supports local model families from compact ZImage checkpoints through FLUX.1
+Dev, FLUX.2 Dev and Klein, HiDream O1, SenseNova U1.5, Krea 2, Qwen Image Edit
+2511, and Ideogram 4.
 
 ## Commands
 
@@ -59,6 +60,8 @@ shared contract tests keep every form flag aligned with ArgumentParser help.
 The public image families are:
 
 - `image-klein-*`: Klein image family
+- `image-flux1-dev`: gated FLUX.1-dev generation and LoRA inference
+- `image-flux2-dev`: gated FLUX.2-dev generation and LoRA inference
 - `image-bonsai-binary`: PrismML Bonsai binary FLUX.2 Klein deployment
 - `image-bonsai-ternary`: PrismML Bonsai ternary FLUX.2 Klein deployment
 - `image-zimage-*`: ZImage image family
@@ -72,6 +75,8 @@ The public image families are:
 
 Common managed IDs:
 
+- `image-flux1-dev`
+- `image-flux2-dev`
 - `image-klein-nano`
 - `image-klein-base`
 - `image-klein-base-9b`
@@ -165,6 +170,103 @@ swift run mere.run image generate \
 The base download is about 57.7 GB. Hardware-specific memory, quality, and
 performance qualification remains required before treating either lane as a
 released default.
+
+### Generate with FLUX.1-dev LoRAs
+
+FLUX.1-dev runs through a dedicated Swift and MLX runtime. The managed package
+pins the official Diffusers transformer, CLIP-L and T5-XXL text encoders,
+tokenizers, VAE, and flow-matching scheduler. The download is approximately
+34 GB.
+
+To install the model, accept access on Hugging Face, configure a Hugging Face
+token, and acknowledge the FLUX.1 dev Non-Commercial License v1.1.1:
+
+```bash
+swift run mere.run model pull image-flux1-dev --accept-model-license
+```
+
+To run one or more FLUX.1 adapters, repeat `--lora`. Each value accepts an
+independent inline scale as `PATH_OR_ID=SCALE`:
+
+```bash
+swift run mere.run image generate \
+  --model image-flux1-dev \
+  --prompt "TRIGGER_TOKEN a glass sculpture in a quiet museum" \
+  --lora ./flux1-fast.safetensors=1.0 \
+  --lora ./flux1-style.safetensors=0.8 \
+  --output ./flux1-fast-style.png
+```
+
+The model defaults to 28 denoising steps and embedded guidance scale 3.5.
+FLUX.1 adapters target a 3,072-wide transformer. FLUX.2-dev uses a 6,144-wide
+transformer, and Klein uses a separate architecture. mere.run rejects adapters
+that don't match the selected model before denoising.
+
+The license limits the weights and derivatives to non-commercial,
+non-production use. It also requires filters or manual review for generated
+content. The local acceptance record doesn't certify that a workflow complies
+with the license.
+
+### Generate with FLUX.2-dev LoRAs
+
+FLUX.2-dev runs through the shared Swift and MLX FLUX.2 runtime. The managed
+layout keeps the gated BFL transformer unchanged and uses a pinned 4-bit
+Mistral Small 3.2 text encoder. Existing FLUX.2-dev transformer LoRAs remain
+compatible with this layout.
+
+To install the model, accept access on Hugging Face, configure a Hugging Face
+token, and acknowledge the FLUX Non-Commercial License and BFL Acceptable Use
+Policy:
+
+```bash
+swift run mere.run model pull image-flux2-dev --accept-model-license
+```
+
+To run an adapter, pass its local safetensors file to `--lora`. Repeat the
+option to stack adapters in order. Each value accepts an inline scale as
+`PATH_OR_ID=SCALE`; `--lora-scale` remains the default for values without an
+inline scale.
+
+```bash
+swift run mere.run image generate \
+  --model image-flux2-dev \
+  --prompt "TRIGGER_TOKEN a glass sculpture in a quiet museum" \
+  --lora ./flux2-dev-style.safetensors \
+  --lora-scale 1.0 \
+  --output ./flux2-dev-style.png
+```
+
+For the fast path, pull the checksum-pinned `fal/FLUX.2-dev-Turbo` adapter after
+reviewing and accepting its inherited FLUX.2-dev terms:
+
+```bash
+swift run mere.run adapter pull flux2-dev-turbo-8step --accept-license
+swift run mere.run image generate \
+  --model image-flux2-dev \
+  --prompt "TRIGGER_TOKEN a glass sculpture in a quiet museum" \
+  --lora flux2-dev-turbo-8step=1.0 \
+  --lora ./flux2-dev-style.safetensors=0.8 \
+  --output ./flux2-dev-turbo-style.png
+```
+
+Selecting the managed Turbo adapter defaults to eight steps, guidance scale
+2.5, and the publisher's pre-shifted sigma schedule. An explicit `--cfg`
+overrides the guidance default. An explicit `--sigmas` overrides the recipe;
+when you also pass `--steps`, its value must equal the number of nonterminal
+sigma values. Don't combine `--sigmas` with `--sigma-shift`.
+
+Every adapter in a stack must target the exact loaded architecture. In
+particular, FLUX.1-dev adapters use a 3,072-wide transformer and aren't
+compatible with the 6,144-wide FLUX.2-dev transformer. mere.run rejects these
+shape mismatches before denoising.
+
+The model defaults to 50 steps and embedded guidance scale 4.0. The managed
+download is approximately 78 GB. The capability catalog requires 96 GB of
+unified memory and recommends 128 GB.
+
+The license requires filters or manual review for generated content. The local
+acceptance record does not certify that a workflow satisfies the license or the
+BFL Acceptable Use Policy.
 
 ### Klein generation and LoRA training
 

--- a/docs/runtime/model-management.md
+++ b/docs/runtime/model-management.md
@@ -103,7 +103,7 @@ a download.
 
 The following list shows representative canonical IDs by modality:
 
-- images: `image-klein-nano`, `image-bonsai-binary`, `image-bonsai-ternary`, `image-zimage-nano`, `image-klein-max`, `image-zimage-max`
+- images: `image-flux1-dev`, `image-flux2-dev`, `image-klein-nano`, `image-bonsai-binary`, `image-bonsai-ternary`, `image-zimage-nano`, `image-klein-max`, `image-zimage-max`
 - text, chat, and embeddings: `text-chat-gemma4`, `text-chat-laguna-s-2-1`, `text-chat-laguna-xs-2-1`, `text-chat-nemotron-35-lightning`, `omni-chat-nemotron3-nano-30b-a3b-bf16`, `text-chat-q36-nano`, `vision-chat-q38-27b`, `vision-chat-q38-27b-4bit`, `vision-chat-q38-flash-next-mixed`, `vision-chat-q38-flash-next-3bit`, `vision-chat-q38-flash-next-3bit-native-ple`, `vision-chat-q38-flash-next-4bit`, `text-chat-bonsai-27b-1bit`, `text-chat-bonsai-27b-2bit`, `text-chat-lfm25-1.2b-bf16`, `text-chat-lfm25-1.2b-qad-4bit`, `text-chat-lfm25-2.6b-4bit`, `text-chat-lfm25-2.6b-bf16`, `text-chat-lfm25-2.6b-qad-4bit`, `text-chat-lfm25-a1b-8bit`, `text-chat-lfm25-a1b-bf16`, `vision-chat-lfm25-3b-8bit`, `text-agent-deepseek-v4-flash`, `text-agent-qwen35-9b`, `text-agent-ornith-9b`, `text-agent-ornith-35b-mlx-4bit`, `text-agent-ornith-35b-mlx-6bit`, `text-agent-ornith-35b-mlx-8bit`, `text-agent-ornith-35b-mlx`, `vision-chat-ornith-35b`, `text-agent-ornith-35b`, `text-code-north-mini`, `text-code-qwen3`, `text-embed-qwen3-0.6b`, `vision-embed-qwen3-vl-2b`
 
 Pulling an exact BF16 LFM2.5 DSpark target also pulls its pinned `*-dspark` companion after
@@ -237,6 +237,16 @@ does not determine whether your intended use is
 permitted. The complete inventory is in
 [`model-sources.md`](../model-sources.md#restricted-model-downloads).
 
+For example, the FLUX.1-dev package is gated and noncommercial. To keep its
+approximately 34 GB payload on an external volume, provide both acceptance and
+the cache directory:
+
+```bash
+mere.run model pull image-flux1-dev \
+  --accept-model-license \
+  --cache-dir /Volumes/Models/mere-run-cache
+```
+
 Laguna XS 2.1 is released under the permissive OpenMDW-1.1 license, and its
 public Hugging Face repository is not gated. It therefore installs without a
 separate acceptance flag while retaining the upstream license file:
@@ -284,12 +294,14 @@ Adapters use a separate checksum-pinned catalog and install under:
 ```
 
 Catalog entries include the promoted Mere Platform Assistant v22 and the
-remote-only Apache-2.0 LightX2V Wan 2.1 I2V four-step adapter:
+gated FLUX.2-dev Turbo and remote-only Apache-2.0 LightX2V Wan 2.1 I2V
+adapters:
 
 ```bash
 mere.run model pull text-chat-gemma4-12b-4bit
 mere.run adapter list
 mere.run adapter pull mere-platform-assistant
+mere.run adapter pull flux2-dev-turbo-8step --accept-license
 mere.run adapter pull scail2-lightx2v-4step
 mere.run adapter pull minimax-h3-lightx2v-ref2v-4step-v0.1
 mere.run text chat \
@@ -301,9 +313,11 @@ mere.run text chat \
 `adapter pull` downloads the immutable upstream artifact, verifies its exact
 byte count and SHA-256, and prints the installed adapter path on stdout.
 Catalog IDs are accepted by `text chat --lora`, `api serve --lora`, and the
-compatible SCAIL `video animate --distilled-adapter` surface; local paths
-remain supported. The default `video animate --profile fast` selects the SCAIL
-adapter ID and its published four-step schedule automatically.
+compatible image and SCAIL video adapter surfaces; local paths remain
+supported. `image generate --lora flux2-dev-turbo-8step` applies its published
+eight-step FLUX.2-dev recipe and can be combined with repeated local
+`--lora PATH[=SCALE]` values. The default `video animate --profile fast`
+selects the SCAIL adapter ID and its published four-step schedule automatically.
 
 ### `mere.run setup`
 


### PR DESCRIPTION
## Summary

- add gated, revision-pinned managed installs for FLUX.1-dev and FLUX.2-dev with explicit license acceptance and validation
- add a separate native FLUX.1 Swift/MLX runtime for CLIP-L, T5-XXL, 16-channel VAE generation, and FLUX.1 LoRAs
- extend the FLUX.2 runtime for Dev guidance, its Mistral conditioner, published scheduling, and architecture-aware adapter checks
- support ordered, independently scaled LoRA stacks, including the checksum-pinned FLUX.2 Turbo eight-step adapter alongside local Dev adapters
- document the model, adapter, storage, and CLI contracts

## Validation

- `./scripts/check.sh`
  - strict SwiftLint: 0 violations
  - build and documentation/hygiene checks passed
  - 3,433 tests passed with 285 expected opt-in or asset-dependent skips and 0 failures
- real adapter compatibility suite: 12 tests passed using the installed 2.6 GB FLUX.2 Turbo adapter and a 164 MB FLUX.1 adapter
- manual installed-checkpoint renders completed during development for FLUX.2 Turbo and FLUX.1 plus LoRA; these prove load and render paths, not image-quality qualification

## Scope

This PR does not add concept distillation or cross-family adapter conversion. FLUX.1 and FLUX.2 remain separate architectures, and incompatible adapters fail closed. Generated canary images are not committed. Residual Turbo ghosting and FLUX.1 anatomy quality remain explicit visual-quality follow-up items.