### PR TITLE
Add native MLX Cosmos3-Super text-to-image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ The format is based on Keep a Changelog.
 
 ### Image
 
+- added native Swift/MLX inference and resumable conversion tooling for
+  NVIDIA Cosmos3-Super Text2Image 4-Step. The Q4 artifact pins the source
+  revision, preserves the BF16 VAE and small projections, removes unused sound
+  and language heads, records checksums and conversion provenance, and enforces
+  the checkpoint's fixed stochastic four-step, no-CFG recipe.
 - added the gated `image-flux1-dev` managed model with a separate Swift and MLX
   FLUX.1 runtime. The runtime loads the pinned BFL transformer, CLIP-L,
   T5-XXL, VAE, tokenizer, and scheduler components, uses the published

--- a/Sources/MereRunCLI/Commands/VideoCosmos3Command.swift
+++ b/Sources/MereRunCLI/Commands/VideoCosmos3Command.swift
@@ -39,7 +39,7 @@ enum Cosmos3CLISchedule: String, CaseIterable, ExpressibleByArgument {
 struct VideoCosmos3: AsyncParsableCommand {
     static let configuration = CommandConfiguration(
         commandName: "cosmos3",
-        abstract: "Run native NVIDIA Cosmos3-Edge generation and action modes."
+        abstract: "Run native NVIDIA Cosmos3 generation and action modes."
     )
 
     @Argument(help: "Text prompt or action task description.")
@@ -48,7 +48,7 @@ struct VideoCosmos3: AsyncParsableCommand {
     @Option(name: [.long], help: "Cosmos3 mode.")
     var mode: Cosmos3CLIMode = .textToVideo
 
-    @Option(name: [.customShort("m"), .long], help: "Managed model id or local Cosmos3-Edge root.")
+    @Option(name: [.customShort("m"), .long], help: "Managed model id or local Cosmos3 model root.")
     var model = Cosmos3Resources.modelID
 
     @Option(name: [.customShort("o"), .long], help: "Output PNG or MP4 path.")
@@ -182,9 +182,16 @@ struct VideoCosmos3: AsyncParsableCommand {
         let missing = resources.validate()
         guard missing.isEmpty else {
             throw ValidationError(
-                "Cosmos3-Edge resources are incomplete: "
+                "Cosmos3 resources are incomplete: "
                     + missing.map(\.path).joined(separator: ", ")
             )
+        }
+        let distilled = try resources.loadDistilledConfiguration()
+        if distilled != nil, shift != nil {
+            throw ValidationError("The distilled Cosmos3-Super checkpoint does not accept --shift.")
+        }
+        if distilled != nil, schedule != .nvidia {
+            throw ValidationError("The distilled Cosmos3-Super checkpoint does not accept --schedule overrides.")
         }
         let options = try Cosmos3GenerationOptions(
             prompt: trimmedPrompt,
@@ -198,17 +205,20 @@ struct VideoCosmos3: AsyncParsableCommand {
             width: width,
             height: height,
             numFrames: resolvedFrames,
-            steps: steps,
-            guidanceScale: guidanceScale,
+            steps: steps ?? distilled?.sigmas.count,
+            guidanceScale: guidanceScale ?? (distilled == nil ? nil : 1),
             shift: shift,
             schedule: schedule.value,
             seed: UInt64(bitPattern: Int64(seed)),
             fps: fps
         )
         if !quiet {
-            CLIStderr.write("Engine: native Cosmos3-Edge MLX\n")
+            CLIStderr.write("Engine: native Cosmos3 MLX\n")
             CLIStderr.write("Model root: \(root.path)\n")
             CLIStderr.write("Mode: \(mode.rawValue)\n")
+            if distilled != nil, !negativePrompt.isEmpty {
+                CLIStderr.write("Warning: the distilled checkpoint ignores --negative-prompt.\n")
+            }
         }
         let reportsProgress = !quiet
         let generator = Cosmos3EdgeGenerator()

--- a/Sources/MereRunCLI/Guides/video-cosmos3.md
+++ b/Sources/MereRunCLI/Guides/video-cosmos3.md
@@ -20,6 +20,27 @@ The managed model pins `nvidia/Cosmos3-Edge` at revision
 OpenMDW-1.1. The public pull retains `LICENSE.md` and does not add a separate
 mere.run acceptance gate.
 
+For distilled text-to-image generation, download the native MLX Q4
+`Sawfwair/Cosmos3-Super-Text2Image-4Step-MLX-4bit` repository and pass its local
+root explicitly:
+
+```bash
+mere.run video cosmos3 "a glass observatory above a glowing ocean" \
+  --mode text-to-image \
+  --model /path/to/Cosmos3-Super-Text2Image-4Step-MLX-4bit \
+  --width 768 --height 768 \
+  -o observatory.png
+```
+
+The Super checkpoint supports text-to-image only. It requires its published
+four-step stochastic schedule and a guidance scale of 1; the command selects
+both defaults from `modular_model_index.json`. The runtime rejects incompatible
+mode, step, guidance, flow-shift, and scheduler overrides. It ignores negative
+prompts because the distilled model has no unconditional branch. This native
+path does not bundle or run NVIDIA's separate Cosmos guardrail; add
+application-appropriate prompt and output safety checks before showing
+generated images to users.
+
 ## Generation Modes
 
 ```bash
@@ -135,6 +156,7 @@ decoding.
 ## Sources
 
 - https://huggingface.co/nvidia/Cosmos3-Edge
+- https://huggingface.co/nvidia/Cosmos3-Super-Text2Image-4Step
 - https://github.com/NVIDIA/Cosmos
 - https://github.com/sawfwair/mere-run/blob/main/Sources/MereRunCore/Cosmos3
 - https://github.com/sawfwair/mere-run/blob/main/Sources/MereRunCLI/Commands/VideoCosmos3Command.swift

--- a/Sources/MereRunCore/Cosmos3/Cosmos3EdgeGenerator.swift
+++ b/Sources/MereRunCore/Cosmos3/Cosmos3EdgeGenerator.swift
@@ -19,6 +19,9 @@ public enum Cosmos3EdgeGeneratorError: LocalizedError, Sendable {
     case invalidFrameCount(Int)
     case invalidFPS(Int)
     case invalidStepCount(Int)
+    case distilledModeRequiresTextToImage(Cosmos3GenerationMode)
+    case distilledStepCount(expected: Int, received: Int)
+    case distilledGuidanceScale(Float)
     case conflictingConditioning
     case missingFile(URL)
     case emptyVideo(URL)
@@ -34,6 +37,12 @@ public enum Cosmos3EdgeGeneratorError: LocalizedError, Sendable {
             return "Cosmos3 frames per second must be positive; received \(fps)."
         case .invalidStepCount(let count):
             return "Cosmos3 denoising steps must be positive; received \(count)."
+        case .distilledModeRequiresTextToImage(let mode):
+            return "The distilled Cosmos3-Super checkpoint supports text-to-image only; received \(mode.rawValue)."
+        case .distilledStepCount(let expected, let received):
+            return "The distilled Cosmos3-Super checkpoint requires exactly \(expected) steps; received \(received)."
+        case .distilledGuidanceScale(let scale):
+            return "The distilled Cosmos3-Super checkpoint requires --guidance-scale 1; received \(scale)."
         case .conflictingConditioning:
             return "Cosmos3 accepts either image, video, or action conditioning in one request."
         case .missingFile(let url):
@@ -252,6 +261,21 @@ public final class Cosmos3EdgeGenerator: @unchecked Sendable {
         guard missing.isEmpty else {
             throw Cosmos3EdgeGeneratorError.missingModelFiles(missing)
         }
+        let distilled = try resources.loadDistilledConfiguration()
+        if let distilled {
+            guard options.mode == .textToImage else {
+                throw Cosmos3EdgeGeneratorError.distilledModeRequiresTextToImage(options.mode)
+            }
+            guard options.steps == distilled.sigmas.count else {
+                throw Cosmos3EdgeGeneratorError.distilledStepCount(
+                    expected: distilled.sigmas.count,
+                    received: options.steps
+                )
+            }
+            guard options.guidanceScale == 1 else {
+                throw Cosmos3EdgeGeneratorError.distilledGuidanceScale(options.guidanceScale)
+            }
+        }
         try await prepare(resources: resources)
         MLXRandom.seed(options.seed)
         let effectiveFrames = options.action.map { $0.chunkSize + 1 } ?? options.numFrames
@@ -276,7 +300,7 @@ public final class Cosmos3EdgeGenerator: @unchecked Sendable {
             width: conditioning.width,
             fps: Float(options.fps),
             action: options.action,
-            useSystemPrompt: options.useSystemPrompt
+            useSystemPrompt: options.useSystemPrompt || distilled != nil
         )
         let conditionalTokens = MLXArray(promptPair.conditionalTokenIDs.map(Int32.init))
         let unconditionalTokens = MLXArray(promptPair.unconditionalTokenIDs.map(Int32.init))
@@ -307,17 +331,21 @@ public final class Cosmos3EdgeGenerator: @unchecked Sendable {
         eval(visionLatents)
         if let actionLatents { eval(actionLatents) }
 
-        var visionScheduler = Cosmos3UniPCScheduler(
+        var visionScheduler = distilled == nil ? Cosmos3UniPCScheduler(
             steps: options.steps,
             shift: options.shift,
             schedule: options.schedule
-        )
+        ) : nil
+        var distilledScheduler = distilled.map {
+            Cosmos3DistilledEulerScheduler(sigmas: $0.sigmas)
+        }
         var actionScheduler = Cosmos3UniPCScheduler(
             steps: options.steps,
             shift: options.shift,
             schedule: options.schedule
         )
-        for (stepIndex, timestep) in visionScheduler.timesteps.enumerated() {
+        let timesteps = distilledScheduler?.timesteps ?? visionScheduler!.timesteps
+        for (stepIndex, timestep) in timesteps.enumerated() {
             try Task.checkCancellation()
             progressHandler?(GenerationProgress(
                 stage: .denoising,
@@ -361,10 +389,19 @@ public final class Cosmos3EdgeGenerator: @unchecked Sendable {
                         + options.guidanceScale * (conditionalAction - unconditionalAction)
                 }
             }
-            visionLatents = visionScheduler.step(
-                modelOutput: visionVelocity,
-                sample: visionLatents
-            )
+            if var scheduler = distilledScheduler {
+                visionLatents = scheduler.step(
+                    modelOutput: visionVelocity,
+                    sample: visionLatents,
+                    noise: MLXRandom.normal(visionLatents.shape)
+                )
+                distilledScheduler = scheduler
+            } else {
+                visionLatents = visionScheduler!.step(
+                    modelOutput: visionVelocity,
+                    sample: visionLatents
+                )
+            }
             visionLatents = visionConditionMask * conditioning.cleanVision
                 + (1 - visionConditionMask) * visionLatents
             if let velocity = actionVelocity,

--- a/Sources/MereRunCore/Cosmos3/Cosmos3Generation.swift
+++ b/Sources/MereRunCore/Cosmos3/Cosmos3Generation.swift
@@ -271,8 +271,8 @@ extension Cosmos3OmniTransformerModel {
             let domainIDs = MLXArray(
                 Array(repeating: Int32(actionDomain.domainID), count: actionCount)
             )
-            var actionHidden = actionInputProjection(actionLatents, domainIDs: domainIDs)
-                + actionModalityEmbedding
+            var actionHidden = actionInputProjection!(actionLatents, domainIDs: domainIDs)
+                + actionModalityEmbedding!
             if !noisyActionIndexes.isEmpty {
                 let timestepValues = MLX.full(
                     [noisyActionIndexes.count],
@@ -332,7 +332,7 @@ extension Cosmos3OmniTransformerModel {
                 let domainIDs = MLXArray(
                     Array(repeating: Int32(actionDomain.domainID), count: noisyActionIndexes.count)
                 )
-                var predictions = actionOutputProjection(
+                var predictions = actionOutputProjection!(
                     noisyHidden,
                     domainIDs: domainIDs
                 )

--- a/Sources/MereRunCore/Cosmos3/Cosmos3ModelLoader.swift
+++ b/Sources/MereRunCore/Cosmos3/Cosmos3ModelLoader.swift
@@ -10,7 +10,7 @@ public enum Cosmos3ModelLoaderError: LocalizedError, Sendable {
         case .checkpointInventoryMismatch(let missing, let unexpected):
             let missingText = missing.prefix(8).joined(separator: ", ")
             let unexpectedText = unexpected.prefix(8).joined(separator: ", ")
-            return "Cosmos3-Edge checkpoint inventory mismatch"
+            return "Cosmos3 checkpoint inventory mismatch"
                 + " (missing: [\(missingText)], unexpected: [\(unexpectedText)])."
         }
     }
@@ -22,7 +22,6 @@ public enum Cosmos3CheckpointInventory {
             "embed_tokens.weight",
             "norm.weight",
             "norm_moe_gen.weight",
-            "lm_head.weight",
             "proj_in.weight",
             "proj_in.bias",
             "proj_out.weight",
@@ -32,6 +31,9 @@ public enum Cosmos3CheckpointInventory {
             "time_embedder.linear_2.weight",
             "time_embedder.linear_2.bias",
         ]
+        if configuration.includesLanguageModelHead {
+            keys.insert("lm_head.weight")
+        }
         if configuration.generatesActions {
             keys.formUnion([
                 "action_modality_embed",
@@ -62,10 +64,36 @@ public enum Cosmos3CheckpointInventory {
                 prefix + "self_attn.to_add_out.weight",
                 prefix + "self_attn.norm_added_q.weight",
                 prefix + "self_attn.norm_added_k.weight",
-                prefix + "self_attn.k_norm_und_for_gen.weight",
             ])
+            if configuration.feedForwardActivation == .siluGated {
+                keys.formUnion([
+                    prefix + "mlp.gate_proj.weight",
+                    prefix + "mlp_moe_gen.gate_proj.weight",
+                ])
+            }
+            if configuration.normalizesUnderstandingQueriesAndKeys {
+                keys.formUnion([
+                    prefix + "self_attn.norm_q.weight",
+                    prefix + "self_attn.norm_k.weight",
+                ])
+            }
+            if configuration.normalizesUnderstandingKeysForGeneration {
+                keys.insert(prefix + "self_attn.k_norm_und_for_gen.weight")
+            }
         }
         return keys
+    }
+
+    private static func logicalKey(for storedKey: String) -> String {
+        for suffix in [".scales", ".biases"] where storedKey.hasSuffix(suffix) {
+            return String(storedKey.dropLast(suffix.count)) + ".weight"
+        }
+        return storedKey
+    }
+
+    static func isUnusedSoundKey(_ key: String) -> Bool {
+        key == "audio_modality_embed" || key.hasPrefix("audio_proj_in.")
+            || key.hasPrefix("audio_proj_out.")
     }
 
     public static func validateTransformerIndex(
@@ -73,7 +101,7 @@ public enum Cosmos3CheckpointInventory {
         configuration: Cosmos3TransformerConfiguration
     ) throws {
         let expected = transformerKeys(configuration: configuration)
-        let actual = Set(index.weightMap.keys)
+        let actual = Set(index.weightMap.keys.filter { !isUnusedSoundKey($0) }.map(logicalKey))
         let missing = expected.subtracting(actual).sorted()
         let unexpected = actual.subtracting(expected).sorted()
         guard missing.isEmpty, unexpected.isEmpty else {
@@ -125,16 +153,33 @@ public enum Cosmos3ModelLoader {
             index,
             configuration: configuration
         )
-        progress?("Loading Cosmos3-Edge transformer")
+        progress?("Loading Cosmos3 transformer")
         let model = Cosmos3OmniTransformerModel(configuration: configuration)
+        if let quantization = configuration.quantization {
+            try HFSafetensorsWeightsLoader.applyQuantizedWeights(
+                indexURL: resources.transformerIndexURL,
+                to: model,
+                groupSize: quantization.groupSize,
+                bits: quantization.bits,
+                progressHandler: { shard in
+                    progress?(
+                        "Loading Cosmos3 transformer shard "
+                            + "\(shard.shardIndex + 1)/\(shard.shardCount)"
+                    )
+                }
+            )
+            eval(model.parameters().flattened().map(\.1))
+            return model
+        }
         let shardNames = index.shardFilenames
         for (index, shardName) in shardNames.enumerated() {
-            progress?("Loading Cosmos3-Edge transformer shard \(index + 1)/\(shardNames.count)")
+            progress?("Loading Cosmos3 transformer shard \(index + 1)/\(shardNames.count)")
             try SafetensorsStreamingLoader.applyWeightsStreaming(
                 url: resources.transformerRootURL.appendingPathComponent(shardName),
                 to: model,
                 dtype: dtype,
                 verify: .none,
+                include: { !Cosmos3CheckpointInventory.isUnusedSoundKey($0) },
                 batchSize: 8
             )
         }

--- a/Sources/MereRunCore/Cosmos3/Cosmos3Reasoner.swift
+++ b/Sources/MereRunCore/Cosmos3/Cosmos3Reasoner.swift
@@ -413,7 +413,7 @@ public final class Cosmos3Reasoner: @unchecked Sendable {
                 inputEmbeddings: embeddings,
                 positionIDs: positions
             )
-            let logits = transformer!.languageModelHead(hidden[hidden.dim(0) - 1])
+            let logits = transformer!.languageModelHead!(hidden[hidden.dim(0) - 1])
             let next: Int
             if request.temperature <= 0 {
                 next = Int(MLX.argMax(logits).item(Int32.self))

--- a/Sources/MereRunCore/Cosmos3/Cosmos3Resources.swift
+++ b/Sources/MereRunCore/Cosmos3/Cosmos3Resources.swift
@@ -6,15 +6,33 @@ public enum Cosmos3ResourcesError: LocalizedError, Sendable {
     public var errorDescription: String? {
         switch self {
         case .invalidConfiguration(let url, let reason):
-            return "Invalid Cosmos3-Edge configuration at \(url.path): \(reason)"
+            return "Invalid Cosmos3 configuration at \(url.path): \(reason)"
         }
     }
 }
 
-public struct Cosmos3TransformerConfiguration: Codable, Hashable, Sendable {
+public enum Cosmos3FeedForwardActivation: String, Codable, Hashable, Sendable {
+    case reluSquared = "relu2"
+    case siluGated = "silu"
+}
+
+public struct Cosmos3QuantizationConfiguration: Codable, Hashable, Sendable {
+    public let bits: Int
+    public let groupSize: Int
+    public let mode: String
+
+    enum CodingKeys: String, CodingKey {
+        case bits
+        case groupSize = "group_size"
+        case mode
+    }
+}
+
+public struct Cosmos3TransformerConfiguration: Decodable, Hashable, Sendable {
     public let actionDimension: Int?
     public let generatesActions: Bool
     public let attentionBias: Bool
+    public let feedForwardActivation: Cosmos3FeedForwardActivation
     public let baseFPS: Int
     public let enablesFPSModulation: Bool
     public let headDimension: Int
@@ -36,6 +54,8 @@ public struct Cosmos3TransformerConfiguration: Codable, Hashable, Sendable {
     public let temporalCompressionFactor: Int
     public let timestepScale: Float
     public let normalizesUnderstandingKeysForGeneration: Bool
+    public let quantization: Cosmos3QuantizationConfiguration?
+    public let includesLanguageModelHead: Bool
     public let resetsSpatialPositionIDs: Bool
     public let temporalModalityMargin: Int
     public let vocabularySize: Int
@@ -44,6 +64,7 @@ public struct Cosmos3TransformerConfiguration: Codable, Hashable, Sendable {
         case actionDimension = "action_dim"
         case generatesActions = "action_gen"
         case attentionBias = "attention_bias"
+        case feedForwardActivation = "hidden_act"
         case baseFPS = "base_fps"
         case enablesFPSModulation = "enable_fps_modulation"
         case headDimension = "head_dim"
@@ -65,6 +86,9 @@ public struct Cosmos3TransformerConfiguration: Codable, Hashable, Sendable {
         case temporalCompressionFactor = "temporal_compression_factor"
         case timestepScale = "timestep_scale"
         case normalizesUnderstandingKeysForGeneration = "use_und_k_norm_for_gen"
+        case quantization
+        case quantizationConfig = "quantization_config"
+        case textToImageOnly = "mererun_text_to_image_only"
         case resetsSpatialPositionIDs = "unified_3d_mrope_reset_spatial_ids"
         case temporalModalityMargin = "unified_3d_mrope_temporal_modality_margin"
         case vocabularySize = "vocab_size"
@@ -74,6 +98,7 @@ public struct Cosmos3TransformerConfiguration: Codable, Hashable, Sendable {
         actionDimension: Int? = 64,
         generatesActions: Bool = true,
         attentionBias: Bool = false,
+        feedForwardActivation: Cosmos3FeedForwardActivation = .reluSquared,
         baseFPS: Int = 24,
         enablesFPSModulation: Bool = true,
         headDimension: Int = 128,
@@ -95,6 +120,8 @@ public struct Cosmos3TransformerConfiguration: Codable, Hashable, Sendable {
         temporalCompressionFactor: Int = 4,
         timestepScale: Float = 0.001,
         normalizesUnderstandingKeysForGeneration: Bool = true,
+        quantization: Cosmos3QuantizationConfiguration? = nil,
+        includesLanguageModelHead: Bool = true,
         resetsSpatialPositionIDs: Bool = true,
         temporalModalityMargin: Int = 15_000,
         vocabularySize: Int = 131_072
@@ -102,6 +129,7 @@ public struct Cosmos3TransformerConfiguration: Codable, Hashable, Sendable {
         self.actionDimension = actionDimension
         self.generatesActions = generatesActions
         self.attentionBias = attentionBias
+        self.feedForwardActivation = feedForwardActivation
         self.baseFPS = baseFPS
         self.enablesFPSModulation = enablesFPSModulation
         self.headDimension = headDimension
@@ -123,16 +151,73 @@ public struct Cosmos3TransformerConfiguration: Codable, Hashable, Sendable {
         self.temporalCompressionFactor = temporalCompressionFactor
         self.timestepScale = timestepScale
         self.normalizesUnderstandingKeysForGeneration = normalizesUnderstandingKeysForGeneration
+        self.quantization = quantization
+        self.includesLanguageModelHead = includesLanguageModelHead
         self.resetsSpatialPositionIDs = resetsSpatialPositionIDs
         self.temporalModalityMargin = temporalModalityMargin
         self.vocabularySize = vocabularySize
     }
 
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.actionDimension = try container.decodeIfPresent(Int.self, forKey: .actionDimension)
+        self.generatesActions = try container.decodeIfPresent(Bool.self, forKey: .generatesActions) ?? false
+        self.attentionBias = try container.decodeIfPresent(Bool.self, forKey: .attentionBias) ?? false
+        self.baseFPS = try container.decodeIfPresent(Int.self, forKey: .baseFPS) ?? 24
+        self.enablesFPSModulation = try container.decodeIfPresent(Bool.self, forKey: .enablesFPSModulation) ?? true
+        self.headDimension = try container.decode(Int.self, forKey: .headDimension)
+        self.hiddenSize = try container.decode(Int.self, forKey: .hiddenSize)
+        self.intermediateSize = try container.decode(Int.self, forKey: .intermediateSize)
+        self.latentChannels = try container.decode(Int.self, forKey: .latentChannels)
+        self.latentPatchSize = try container.decode(Int.self, forKey: .latentPatchSize)
+        self.attentionHeadCount = try container.decode(Int.self, forKey: .attentionHeadCount)
+        self.embodimentDomainCount = try container.decodeIfPresent(Int.self, forKey: .embodimentDomainCount) ?? 32
+        self.layerCount = try container.decode(Int.self, forKey: .layerCount)
+        self.keyValueHeadCount = try container.decode(Int.self, forKey: .keyValueHeadCount)
+        self.patchLatentDimension = try container.decode(Int.self, forKey: .patchLatentDimension)
+        self.normalizesUnderstandingQueriesAndKeys = try container.decodeIfPresent(
+            Bool.self,
+            forKey: .normalizesUnderstandingQueriesAndKeys
+        ) ?? true
+        self.feedForwardActivation = try container.decodeIfPresent(
+            Cosmos3FeedForwardActivation.self,
+            forKey: .feedForwardActivation
+        ) ?? (normalizesUnderstandingQueriesAndKeys ? .siluGated : .reluSquared)
+        self.rmsNormEpsilon = try container.decode(Float.self, forKey: .rmsNormEpsilon)
+        self.ropeAxesDimensions = try container.decode([Int].self, forKey: .ropeAxesDimensions)
+        self.ropeTheta = try container.decode(Float.self, forKey: .ropeTheta)
+        self.soundDimension = try container.decodeIfPresent(Int.self, forKey: .soundDimension)
+        self.generatesSound = try container.decodeIfPresent(Bool.self, forKey: .generatesSound) ?? false
+        self.temporalCompressionFactor = try container.decodeIfPresent(
+            Int.self,
+            forKey: .temporalCompressionFactor
+        ) ?? 4
+        self.timestepScale = try container.decodeIfPresent(Float.self, forKey: .timestepScale) ?? 0.001
+        self.normalizesUnderstandingKeysForGeneration = try container.decodeIfPresent(
+            Bool.self,
+            forKey: .normalizesUnderstandingKeysForGeneration
+        ) ?? false
+        self.quantization = try container.decodeIfPresent(
+            Cosmos3QuantizationConfiguration.self,
+            forKey: .quantizationConfig
+        ) ?? container.decodeIfPresent(Cosmos3QuantizationConfiguration.self, forKey: .quantization)
+        self.includesLanguageModelHead = !(try container.decodeIfPresent(
+            Bool.self,
+            forKey: .textToImageOnly
+        ) ?? false)
+        self.resetsSpatialPositionIDs = try container.decodeIfPresent(
+            Bool.self,
+            forKey: .resetsSpatialPositionIDs
+        ) ?? true
+        self.temporalModalityMargin = try container.decodeIfPresent(
+            Int.self,
+            forKey: .temporalModalityMargin
+        ) ?? 15_000
+        self.vocabularySize = try container.decode(Int.self, forKey: .vocabularySize)
+    }
+
     public func validationIssues() -> [String] {
         var issues: [String] = []
-        if hiddenSize != attentionHeadCount * headDimension {
-            issues.append("hidden_size must equal num_attention_heads * head_dim")
-        }
         if attentionHeadCount % keyValueHeadCount != 0 {
             issues.append("num_attention_heads must be divisible by num_key_value_heads")
         }
@@ -148,15 +233,54 @@ public struct Cosmos3TransformerConfiguration: Codable, Hashable, Sendable {
         if generatesSound && soundDimension == nil {
             issues.append("sound_dim is required when sound_gen is true")
         }
-        if normalizesUnderstandingQueriesAndKeys {
-            issues.append("Cosmos3-Edge requires qk_norm_for_text=false")
+        if normalizesUnderstandingQueriesAndKeys == normalizesUnderstandingKeysForGeneration {
+            issues.append(
+                "exactly one understanding key-normalization path must be enabled"
+            )
         }
-        if !normalizesUnderstandingKeysForGeneration {
-            issues.append("Cosmos3-Edge requires use_und_k_norm_for_gen=true")
+        if feedForwardActivation == .reluSquared && normalizesUnderstandingQueriesAndKeys {
+            issues.append("relu2 checkpoints require qk_norm_for_text=false")
+        }
+        if feedForwardActivation == .siluGated && !normalizesUnderstandingQueriesAndKeys {
+            issues.append("silu checkpoints require qk_norm_for_text=true")
+        }
+        if let quantization {
+            if !(2...8).contains(quantization.bits) {
+                issues.append("quantization bits must be between 2 and 8")
+            }
+            if quantization.groupSize < 1 {
+                issues.append("quantization group_size must be positive")
+            }
+            if quantization.mode != "affine" {
+                issues.append("Cosmos3 MLX checkpoints require affine quantization")
+            }
         }
         if layerCount < 1 { issues.append("num_hidden_layers must be positive") }
         if embodimentDomainCount < 1 { issues.append("num_embodiment_domains must be positive") }
         if temporalCompressionFactor < 1 { issues.append("temporal_compression_factor must be positive") }
+        return issues
+    }
+}
+
+public struct Cosmos3DistilledConfiguration: Decodable, Hashable, Sendable {
+    public let isDistilled: Bool
+    public let sigmas: [Float]
+
+    enum CodingKeys: String, CodingKey {
+        case isDistilled = "is_distilled"
+        case sigmas = "distilled_sigmas"
+    }
+
+    public func validationIssues() -> [String] {
+        var issues: [String] = []
+        if !isDistilled { issues.append("is_distilled must be true") }
+        if sigmas.isEmpty { issues.append("distilled_sigmas must not be empty") }
+        if sigmas.contains(where: { !$0.isFinite || $0 <= 0 || $0 > 1 }) {
+            issues.append("distilled_sigmas must contain values in (0, 1]")
+        }
+        if zip(sigmas, sigmas.dropFirst()).contains(where: { pair in pair.0 <= pair.1 }) {
+            issues.append("distilled_sigmas must be strictly descending")
+        }
         return issues
     }
 }
@@ -296,6 +420,8 @@ public struct Cosmos3Resources: Hashable, Sendable {
     public static let modelID = "video-cosmos3-edge-mlx"
     public static let officialRepoID = "nvidia/Cosmos3-Edge"
     public static let officialRevision = "6f58f6b4c91288838e60b6bcb2cc45d997e961de"
+    public static let superTextToImageRepository = "nvidia/Cosmos3-Super-Text2Image-4Step"
+    public static let superTextToImageRevision = "aa0d5a57b7b045d68daa60fbacd84ec723c7cb7b"
     public static let snapshotPatterns = [
         "LICENSE*",
         "README.md",
@@ -371,6 +497,9 @@ public struct Cosmos3Resources: Hashable, Sendable {
     public var schedulerConfigURL: URL {
         rootURL.appendingPathComponent("scheduler").appendingPathComponent("scheduler_config.json")
     }
+    public var modularModelIndexURL: URL {
+        rootURL.appendingPathComponent("modular_model_index.json")
+    }
     public var tokenizerConfigURL: URL {
         tokenizerRootURL.appendingPathComponent("tokenizer_config.json")
     }
@@ -428,6 +557,17 @@ public struct Cosmos3Resources: Hashable, Sendable {
         try Self.loadConfiguration(
             Cosmos3VAEConfiguration.self,
             from: vaeConfigURL,
+            validate: { $0.validationIssues() }
+        )
+    }
+
+    public func loadDistilledConfiguration() throws -> Cosmos3DistilledConfiguration? {
+        guard FileManager.default.fileExists(atPath: modularModelIndexURL.path) else {
+            return nil
+        }
+        return try Self.loadConfiguration(
+            Cosmos3DistilledConfiguration.self,
+            from: modularModelIndexURL,
             validate: { $0.validationIssues() }
         )
     }

--- a/Sources/MereRunCore/Cosmos3/Cosmos3Scheduler.swift
+++ b/Sources/MereRunCore/Cosmos3/Cosmos3Scheduler.swift
@@ -67,3 +67,35 @@ public struct Cosmos3UniPCScheduler {
         solver.step(modelOutput: modelOutput, sample: sample)
     }
 }
+
+/// The stochastic four-step Euler sampler published with the distilled
+/// Cosmos3-Super text-to-image checkpoint.
+public struct Cosmos3DistilledEulerScheduler {
+    public let timesteps: [Float]
+    public let sigmas: [Float]
+    private var stepIndex = 0
+
+    public init(sigmas: [Float], trainTimesteps: Int = 1_000) {
+        precondition(!sigmas.isEmpty)
+        precondition(trainTimesteps > 0)
+        precondition(sigmas.allSatisfy { $0 > 0 && $0 <= 1 })
+        precondition(zip(sigmas, sigmas.dropFirst()).allSatisfy { pair in pair.0 > pair.1 })
+        self.timesteps = sigmas.map { $0 * Float(trainTimesteps) }
+        self.sigmas = sigmas + [0]
+    }
+
+    public mutating func step(
+        modelOutput: MLXArray,
+        sample: MLXArray,
+        noise: MLXArray
+    ) -> MLXArray {
+        precondition(stepIndex < timesteps.count)
+        precondition(noise.shape == sample.shape)
+        let sigma = sigmas[stepIndex]
+        let nextSigma = sigmas[stepIndex + 1]
+        stepIndex += 1
+        let prediction = sample.asType(.float32) - sigma * modelOutput.asType(.float32)
+        let next = (1 - nextSigma) * prediction + nextSigma * noise.asType(.float32)
+        return next.asType(modelOutput.dtype)
+    }
+}

--- a/Sources/MereRunCore/Cosmos3/Cosmos3Transformer.swift
+++ b/Sources/MereRunCore/Cosmos3/Cosmos3Transformer.swift
@@ -95,17 +95,32 @@ public final class Cosmos3DomainAwareLinear: Module {
 }
 
 final class Cosmos3MLP: Module {
+    let activation: Cosmos3FeedForwardActivation
+    @ModuleInfo(key: "gate_proj") var gateProjection: Linear?
     @ModuleInfo(key: "up_proj") var upProjection: Linear
     @ModuleInfo(key: "down_proj") var downProjection: Linear
 
-    init(hiddenSize: Int, intermediateSize: Int) {
+    init(
+        hiddenSize: Int,
+        intermediateSize: Int,
+        activation: Cosmos3FeedForwardActivation
+    ) {
+        self.activation = activation
+        self._gateProjection.wrappedValue = activation == .siluGated
+            ? Linear(hiddenSize, intermediateSize, bias: false)
+            : nil
         self._upProjection.wrappedValue = Linear(hiddenSize, intermediateSize, bias: false)
         self._downProjection.wrappedValue = Linear(intermediateSize, hiddenSize, bias: false)
     }
 
     func callAsFunction(_ input: MLXArray) -> MLXArray {
-        let activated = MLX.maximum(upProjection(input), MLXArray(0))
-        return downProjection(activated * activated)
+        switch activation {
+        case .reluSquared:
+            let activated = MLX.maximum(upProjection(input), MLXArray(0))
+            return downProjection(activated * activated)
+        case .siluGated:
+            return downProjection(MLXNN.silu(gateProjection!(input)) * upProjection(input))
+        }
     }
 }
 
@@ -119,13 +134,15 @@ final class Cosmos3PackedAttention: Module {
     @ModuleInfo(key: "to_k") var understandingKey: Linear
     @ModuleInfo(key: "to_v") var understandingValue: Linear
     @ModuleInfo(key: "to_out") var understandingOutput: Linear
+    @ModuleInfo(key: "norm_q") var understandingQueryNorm: RMSNorm?
+    @ModuleInfo(key: "norm_k") var understandingKeyNorm: RMSNorm?
     @ModuleInfo(key: "add_q_proj") var generationQuery: Linear
     @ModuleInfo(key: "add_k_proj") var generationKey: Linear
     @ModuleInfo(key: "add_v_proj") var generationValue: Linear
     @ModuleInfo(key: "to_add_out") var generationOutput: Linear
     @ModuleInfo(key: "norm_added_q") var generationQueryNorm: RMSNorm
     @ModuleInfo(key: "norm_added_k") var generationKeyNorm: RMSNorm
-    @ModuleInfo(key: "k_norm_und_for_gen") var understandingKeyNormForGeneration: RMSNorm
+    @ModuleInfo(key: "k_norm_und_for_gen") var understandingKeyNormForGeneration: RMSNorm?
 
     init(configuration: Cosmos3TransformerConfiguration) {
         self.attentionHeads = configuration.attentionHeadCount
@@ -140,6 +157,12 @@ final class Cosmos3PackedAttention: Module {
         self._understandingKey.wrappedValue = Linear(hidden, kvSize, bias: bias)
         self._understandingValue.wrappedValue = Linear(hidden, kvSize, bias: bias)
         self._understandingOutput.wrappedValue = Linear(qSize, hidden, bias: bias)
+        self._understandingQueryNorm.wrappedValue = configuration.normalizesUnderstandingQueriesAndKeys
+            ? RMSNorm(dimensions: configuration.headDimension, eps: configuration.rmsNormEpsilon)
+            : nil
+        self._understandingKeyNorm.wrappedValue = configuration.normalizesUnderstandingQueriesAndKeys
+            ? RMSNorm(dimensions: configuration.headDimension, eps: configuration.rmsNormEpsilon)
+            : nil
         self._generationQuery.wrappedValue = Linear(hidden, qSize, bias: bias)
         self._generationKey.wrappedValue = Linear(hidden, kvSize, bias: bias)
         self._generationValue.wrappedValue = Linear(hidden, kvSize, bias: bias)
@@ -152,10 +175,13 @@ final class Cosmos3PackedAttention: Module {
             dimensions: configuration.headDimension,
             eps: configuration.rmsNormEpsilon
         )
-        self._understandingKeyNormForGeneration.wrappedValue = RMSNorm(
-            dimensions: configuration.headDimension,
-            eps: configuration.rmsNormEpsilon
-        )
+        self._understandingKeyNormForGeneration.wrappedValue =
+            configuration.normalizesUnderstandingKeysForGeneration
+                ? RMSNorm(
+                    dimensions: configuration.headDimension,
+                    eps: configuration.rmsNormEpsilon
+                )
+                : nil
     }
 
     func callAsFunction(
@@ -181,7 +207,12 @@ final class Cosmos3PackedAttention: Module {
         let vGeneration = generationValue(generation)
             .reshaped(-1, keyValueHeads, headDimension)
 
-        let understandingKeyForGeneration = understandingKeyNormForGeneration(kUnderstanding)
+        if let understandingQueryNorm, let understandingKeyNorm {
+            qUnderstanding = understandingQueryNorm(qUnderstanding)
+            kUnderstanding = understandingKeyNorm(kUnderstanding)
+        }
+        let understandingKeyForGeneration = understandingKeyNormForGeneration?(kUnderstanding)
+            ?? kUnderstanding
         qUnderstanding = Cosmos3RotaryEmbedding.apply(
             qUnderstanding,
             cosine: rotary.understandingCosine,
@@ -237,6 +268,10 @@ final class Cosmos3PackedAttention: Module {
             .reshaped(-1, keyValueHeads, headDimension)
         let values = understandingValue(understanding)
             .reshaped(-1, keyValueHeads, headDimension)
+        if let understandingQueryNorm, let understandingKeyNorm {
+            queries = understandingQueryNorm(queries)
+            keys = understandingKeyNorm(keys)
+        }
         queries = Cosmos3RotaryEmbedding.apply(
             queries,
             cosine: cosine,
@@ -301,11 +336,13 @@ final class Cosmos3DecoderLayer: Module {
         self._attention.wrappedValue = Cosmos3PackedAttention(configuration: configuration)
         self._understandingMLP.wrappedValue = Cosmos3MLP(
             hiddenSize: configuration.hiddenSize,
-            intermediateSize: configuration.intermediateSize
+            intermediateSize: configuration.intermediateSize,
+            activation: configuration.feedForwardActivation
         )
         self._generationMLP.wrappedValue = Cosmos3MLP(
             hiddenSize: configuration.hiddenSize,
-            intermediateSize: configuration.intermediateSize
+            intermediateSize: configuration.intermediateSize,
+            activation: configuration.feedForwardActivation
         )
         self._understandingInputNorm.wrappedValue = RMSNorm(
             dimensions: configuration.hiddenSize,
@@ -392,18 +429,16 @@ public final class Cosmos3OmniTransformerModel: Module {
     @ModuleInfo(key: "layers") var layers: [Cosmos3DecoderLayer]
     @ModuleInfo(key: "norm") var understandingNorm: RMSNorm
     @ModuleInfo(key: "norm_moe_gen") var generationNorm: RMSNorm
-    @ModuleInfo(key: "lm_head") var languageModelHead: Linear
+    @ModuleInfo(key: "lm_head") var languageModelHead: Linear?
     @ModuleInfo(key: "proj_in") var visionInputProjection: Linear
     @ModuleInfo(key: "proj_out") var visionOutputProjection: Linear
     @ModuleInfo(key: "time_embedder") var timestepEmbedding: Cosmos3TimestepEmbedding
-    @ModuleInfo(key: "action_proj_in") var actionInputProjection: Cosmos3DomainAwareLinear
-    @ModuleInfo(key: "action_proj_out") var actionOutputProjection: Cosmos3DomainAwareLinear
-    @ModuleInfo(key: "action_modality_embed") var actionModalityEmbedding: MLXArray
+    @ModuleInfo(key: "action_proj_in") var actionInputProjection: Cosmos3DomainAwareLinear?
+    @ModuleInfo(key: "action_proj_out") var actionOutputProjection: Cosmos3DomainAwareLinear?
+    @ModuleInfo(key: "action_modality_embed") var actionModalityEmbedding: MLXArray?
 
     public init(configuration: Cosmos3TransformerConfiguration = Cosmos3TransformerConfiguration()) {
         precondition(configuration.validationIssues().isEmpty)
-        precondition(configuration.generatesActions)
-        let actionDimension = configuration.actionDimension!
         self.configuration = configuration
         self.rotaryEmbedding = Cosmos3RotaryEmbedding(
             headDimension: configuration.headDimension,
@@ -425,11 +460,13 @@ public final class Cosmos3OmniTransformerModel: Module {
             dimensions: configuration.hiddenSize,
             eps: configuration.rmsNormEpsilon
         )
-        self._languageModelHead.wrappedValue = Linear(
-            configuration.hiddenSize,
-            configuration.vocabularySize,
-            bias: false
-        )
+        self._languageModelHead.wrappedValue = configuration.includesLanguageModelHead
+            ? Linear(
+                configuration.hiddenSize,
+                configuration.vocabularySize,
+                bias: false
+            )
+            : nil
         self._visionInputProjection.wrappedValue = Linear(
             configuration.patchLatentDimension,
             configuration.hiddenSize,
@@ -443,17 +480,23 @@ public final class Cosmos3OmniTransformerModel: Module {
         self._timestepEmbedding.wrappedValue = Cosmos3TimestepEmbedding(
             hiddenSize: configuration.hiddenSize
         )
-        self._actionInputProjection.wrappedValue = Cosmos3DomainAwareLinear(
-            inputSize: actionDimension,
-            outputSize: configuration.hiddenSize,
-            domainCount: configuration.embodimentDomainCount
-        )
-        self._actionOutputProjection.wrappedValue = Cosmos3DomainAwareLinear(
-            inputSize: configuration.hiddenSize,
-            outputSize: actionDimension,
-            domainCount: configuration.embodimentDomainCount
-        )
-        self._actionModalityEmbedding.wrappedValue = MLX.zeros([configuration.hiddenSize])
+        self._actionInputProjection.wrappedValue = configuration.generatesActions
+            ? Cosmos3DomainAwareLinear(
+                inputSize: configuration.actionDimension!,
+                outputSize: configuration.hiddenSize,
+                domainCount: configuration.embodimentDomainCount
+            )
+            : nil
+        self._actionOutputProjection.wrappedValue = configuration.generatesActions
+            ? Cosmos3DomainAwareLinear(
+                inputSize: configuration.hiddenSize,
+                outputSize: configuration.actionDimension!,
+                domainCount: configuration.embodimentDomainCount
+            )
+            : nil
+        self._actionModalityEmbedding.wrappedValue = configuration.generatesActions
+            ? MLX.zeros([configuration.hiddenSize])
+            : nil
     }
 
     public func embedText(tokenIDs: MLXArray) -> MLXArray {
@@ -471,8 +514,9 @@ public final class Cosmos3OmniTransformerModel: Module {
         domainIDs: MLXArray,
         timesteps: MLXArray?
     ) -> MLXArray {
-        var projected = actionInputProjection(actions, domainIDs: domainIDs)
-            + actionModalityEmbedding
+        precondition(configuration.generatesActions)
+        var projected = actionInputProjection!(actions, domainIDs: domainIDs)
+            + actionModalityEmbedding!
         if let timesteps {
             projected = projected + timestepEmbedding(
                 timesteps.asType(.float32) * configuration.timestepScale
@@ -516,7 +560,8 @@ public final class Cosmos3OmniTransformerModel: Module {
     }
 
     public func actionPredictions(_ hidden: MLXArray, domainIDs: MLXArray) -> MLXArray {
-        actionOutputProjection(hidden, domainIDs: domainIDs)
+        precondition(configuration.generatesActions)
+        return actionOutputProjection!(hidden, domainIDs: domainIDs)
     }
 
     public func reasonerHidden(
@@ -549,7 +594,8 @@ public final class Cosmos3OmniTransformerModel: Module {
             Array(repeating: MLXArray(0..<tokens.size), count: 3),
             axis: 0
         )
-        return languageModelHead(reasonerHidden(
+        precondition(configuration.includesLanguageModelHead)
+        return languageModelHead!(reasonerHidden(
             inputEmbeddings: embedText(tokenIDs: tokens),
             positionIDs: positions
         ))

--- a/Sources/MereRunCore/Cosmos3/README.md
+++ b/Sources/MereRunCore/Cosmos3/README.md
@@ -1,9 +1,10 @@
-# Cosmos3-Edge native runtime
+# Cosmos3 native runtime
 
-This directory contains the native Swift/MLX port of NVIDIA Cosmos3-Edge. It
-uses the official, immutable `nvidia/Cosmos3-Edge` Diffusers snapshot directly;
-there is no Python subprocess, converted runtime checkpoint, or remote
-inference dependency.
+This directory contains the native Swift/MLX ports of NVIDIA Cosmos3-Edge and
+the distilled Cosmos3-Super text-to-image model. Cosmos3-Edge uses the official,
+immutable Diffusers snapshot directly. Cosmos3-Super uses a publishable MLX Q4
+artifact converted from an immutable NVIDIA revision. Neither runtime launches
+Python or uses remote inference.
 
 ## Reading order
 
@@ -14,13 +15,14 @@ inference dependency.
 3. `Cosmos3Sequence.swift` implements text, vision, and action packing plus
    multimodal rotary position IDs.
 4. `Cosmos3Transformer.swift` implements the shared omnimodal
-   generation/understanding transformer and Edge mixture-of-transformers
-   blocks.
+   generation/understanding transformer, including the Edge ReLU-squared path
+   and the Super gated-SiLU path.
 5. `Cosmos3ModelLoader.swift` maps the official Diffusers checkpoint into the
    native transformer and shared Wan VAE.
 6. `Cosmos3Tokenizer.swift` reproduces the published generation prompts and
    multimodal metadata.
-7. `Cosmos3Scheduler.swift` implements NVIDIA's shifted-flow UniPC schedule.
+7. `Cosmos3Scheduler.swift` implements NVIDIA's shifted-flow UniPC schedule and
+   the stochastic four-step Euler schedule published with Cosmos3-Super.
 8. `Cosmos3EdgeGenerator.swift` owns text/image/video generation, image
    editing, action-conditioned forward dynamics, policy generation, inverse
    dynamics, decode, and output.
@@ -47,8 +49,8 @@ inference dependency.
 
 ## Parity evidence
 
-`Tests/MereRunCoreTests/Cosmos3EdgeTests.swift` covers published configuration,
-checkpoint inventory, action layouts, prompt templates, sequence geometry,
-mode defaults, warm-world continuity, and deterministic numerical fixtures
-exported from the pinned NVIDIA source by
-`scripts/export-cosmos3-edge-parity.py`.
+`Tests/MereRunCoreTests/Cosmos3EdgeTests.swift` covers both transformer families,
+published configuration and checkpoint inventories, the distilled schedule,
+action layouts, prompt templates, sequence geometry, mode defaults, warm-world
+continuity, and deterministic Edge fixtures exported from the pinned NVIDIA
+source by `scripts/export-cosmos3-edge-parity.py`.

--- a/Tests/MereRunCoreTests/Cosmos3EdgeTests.swift
+++ b/Tests/MereRunCoreTests/Cosmos3EdgeTests.swift
@@ -365,6 +365,22 @@ final class Cosmos3EdgeTests: MereRunCoreTestCase {
         }
     }
 
+    func testDistilledEulerScheduleMatchesPublishedFourStepUpdate() {
+        var scheduler = Cosmos3DistilledEulerScheduler(
+            sigmas: [1, 0.9375, 0.8333333333333334, 0.625]
+        )
+        XCTAssertEqual(scheduler.timesteps, [1_000, 937.5, 833.3333, 625])
+        XCTAssertEqual(scheduler.sigmas, [1, 0.9375, 0.8333333, 0.625, 0])
+
+        let result = scheduler.step(
+            modelOutput: MLXArray([Float(0.25)]),
+            sample: MLXArray([Float(1)]),
+            noise: MLXArray([Float(0.5)])
+        )
+        eval(result)
+        XCTAssertEqual(result.item(Float.self), 0.515625, accuracy: 1e-6)
+    }
+
     func testPromptMetadataAndActionJSONMatchPublishedTemplates() throws {
         let text = try Cosmos3Tokenizer.renderPrompts(
             prompt: "A quiet station.",
@@ -427,6 +443,107 @@ final class Cosmos3EdgeTests: MereRunCoreTestCase {
         XCTAssertTrue(keys.contains("layers.27.mlp_moe_gen.up_proj.weight"))
         XCTAssertFalse(keys.contains("layers.0.mlp.gate_proj.weight"))
         XCTAssertFalse(keys.contains("layers.0.self_attn.norm_q.weight"))
+    }
+
+    func testDecodesCosmos3SuperTextToImageConfiguration() throws {
+        let configuration = try JSONDecoder().decode(
+            Cosmos3TransformerConfiguration.self,
+            from: Data(Self.superTransformerConfigJSON.utf8)
+        )
+
+        XCTAssertEqual(configuration.hiddenSize, 5_120)
+        XCTAssertEqual(configuration.intermediateSize, 25_600)
+        XCTAssertEqual(configuration.layerCount, 64)
+        XCTAssertEqual(configuration.feedForwardActivation, .siluGated)
+        XCTAssertTrue(configuration.normalizesUnderstandingQueriesAndKeys)
+        XCTAssertFalse(configuration.normalizesUnderstandingKeysForGeneration)
+        XCTAssertFalse(configuration.generatesActions)
+        XCTAssertFalse(configuration.generatesSound)
+        XCTAssertFalse(configuration.includesLanguageModelHead)
+        XCTAssertEqual(configuration.quantization?.bits, 4)
+        XCTAssertEqual(configuration.quantization?.groupSize, 64)
+        XCTAssertTrue(configuration.validationIssues().isEmpty)
+    }
+
+    func testCosmos3SuperTextToImageInventoryHasExactTensorCount() throws {
+        let configuration = try JSONDecoder().decode(
+            Cosmos3TransformerConfiguration.self,
+            from: Data(Self.superTransformerConfigJSON.utf8)
+        )
+        let keys = Cosmos3CheckpointInventory.transformerKeys(configuration: configuration)
+
+        XCTAssertEqual(keys.count, 1_419)
+        XCTAssertTrue(keys.contains("layers.0.mlp.gate_proj.weight"))
+        XCTAssertTrue(keys.contains("layers.63.self_attn.norm_q.weight"))
+        XCTAssertFalse(keys.contains("layers.0.self_attn.k_norm_und_for_gen.weight"))
+        XCTAssertFalse(keys.contains("lm_head.weight"))
+    }
+
+    func testCosmos3SuperQuantizedInventoryMapsPackedWeightsAndIgnoresSoundHeads() throws {
+        let configuration = try JSONDecoder().decode(
+            Cosmos3TransformerConfiguration.self,
+            from: Data(Self.superTransformerConfigJSON.utf8)
+        )
+        let expected = Cosmos3CheckpointInventory.transformerKeys(configuration: configuration)
+        var weightMap = Dictionary(uniqueKeysWithValues: expected.map { ($0, "model.safetensors") })
+        let base = "layers.0.mlp.up_proj"
+        weightMap[base + ".scales"] = "model.safetensors"
+        weightMap[base + ".biases"] = "model.safetensors"
+        weightMap["audio_modality_embed"] = "model.safetensors"
+        weightMap["audio_proj_in.weight"] = "model.safetensors"
+        weightMap["audio_proj_in.bias"] = "model.safetensors"
+        weightMap["audio_proj_out.weight"] = "model.safetensors"
+        weightMap["audio_proj_out.bias"] = "model.safetensors"
+
+        try Cosmos3CheckpointInventory.validateTransformerIndex(
+            HFSafetensorsIndex(metadata: nil, weightMap: weightMap),
+            configuration: configuration
+        )
+    }
+
+    func testTinyCosmos3SuperBackboneIsFiniteWithoutActionOrLanguageHeads() {
+        let configuration = Cosmos3TransformerConfiguration(
+            actionDimension: nil,
+            generatesActions: false,
+            feedForwardActivation: .siluGated,
+            headDimension: 8,
+            hiddenSize: 16,
+            intermediateSize: 32,
+            latentChannels: 2,
+            latentPatchSize: 2,
+            attentionHeadCount: 2,
+            embodimentDomainCount: 3,
+            layerCount: 1,
+            keyValueHeadCount: 1,
+            patchLatentDimension: 8,
+            normalizesUnderstandingQueriesAndKeys: true,
+            ropeAxesDimensions: [2, 1, 1],
+            normalizesUnderstandingKeysForGeneration: false,
+            includesLanguageModelHead: false,
+            vocabularySize: 32
+        )
+        let model = Cosmos3OmniTransformerModel(configuration: configuration)
+        let text = model.embedText(tokenIDs: MLXArray([Int32(1), 2]))
+        let vision = model.projectVision(
+            MLX.zeros([2, 8]),
+            timesteps: MLXArray([Float(1_000), 1_000])
+        )
+        let positionIDs = Cosmos3PositionIDs(
+            temporal: [0, 1, 15_002, 15_002],
+            height: [0, 1, 0, 0],
+            width: [0, 1, 0, 1],
+            nextTemporalOffset: 15_003
+        ).mlxArray
+        let output = model(understanding: text, generation: vision, positionIDs: positionIDs)
+        eval(output.understanding, output.generation)
+
+        let parameterKeys = Set(model.parameters().flattened().map(\.0))
+        XCTAssertTrue(parameterKeys.contains("layers.0.mlp.gate_proj.weight"))
+        XCTAssertTrue(parameterKeys.contains("layers.0.self_attn.norm_q.weight"))
+        XCTAssertFalse(parameterKeys.contains("lm_head.weight"))
+        XCTAssertFalse(parameterKeys.contains("action_modality_embed"))
+        XCTAssertTrue(output.understanding.asArray(Float.self).allSatisfy(\.isFinite))
+        XCTAssertTrue(output.generation.asArray(Float.self).allSatisfy(\.isFinite))
     }
 
     func testDiffusersWanVAEKeysMapToNativeWanLayout() {
@@ -1001,6 +1118,40 @@ final class Cosmos3EdgeTests: MereRunCoreTestCase {
     private func maxAbsoluteError(_ lhs: MLXArray, _ rhs: MLXArray) -> Float {
         MLX.max(MLX.abs(lhs.asType(.float32) - rhs.asType(.float32))).item(Float.self)
     }
+
+    private static let superTransformerConfigJSON = """
+    {
+      "action_dim": 32,
+      "action_gen": false,
+      "attention_bias": false,
+      "base_fps": 24,
+      "enable_fps_modulation": true,
+      "head_dim": 128,
+      "hidden_act": "silu",
+      "hidden_size": 5120,
+      "intermediate_size": 25600,
+      "latent_channel": 48,
+      "latent_patch_size": 2,
+      "mererun_text_to_image_only": true,
+      "num_attention_heads": 64,
+      "num_embodiment_domains": 32,
+      "num_hidden_layers": 64,
+      "num_key_value_heads": 8,
+      "patch_latent_dim": 192,
+      "quantization_config": {"bits": 4, "group_size": 64, "mode": "affine"},
+      "rms_norm_eps": 0.000001,
+      "rope_axes_dim": [24, 20, 20],
+      "rope_theta": 5000000,
+      "sound_dim": 64,
+      "sound_gen": false,
+      "temporal_compression_factor": 4,
+      "timestep_scale": 0.001,
+      "use_und_k_norm_for_gen": false,
+      "unified_3d_mrope_reset_spatial_ids": true,
+      "unified_3d_mrope_temporal_modality_margin": 15000,
+      "vocab_size": 151936
+    }
+    """
 
     private static let transformerConfigJSON = """
     {

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -102,7 +102,7 @@ Public tree:
     - `mere.run sfx video generate` — Generate an 8-second sound effect from a video or Synchformer features.
 - [`mere.run video`](/runtime/video) — Generate and understand video with native Swift/MLX pipelines.
   - `mere.run video animate` — Animate or replace a masked subject with native Swift/MLX SCAIL-2.
-  - `mere.run video cosmos3` — Run native NVIDIA Cosmos3-Edge generation and action modes.
+  - `mere.run video cosmos3` — Run native NVIDIA Cosmos3 generation and action modes.
   - `mere.run video dub-it` — Generate synchronized video and audio identity from one LTX 2.5 IC-LoRA reference.
   - `mere.run video export-latents` — Run native Swift/MLX distilled LTX denoising and export final latents.
   - `mere.run video generate` — Generate MP4 video with native Swift/MLX video models.

--- a/docs/runtime/video.md
+++ b/docs/runtime/video.md
@@ -11,7 +11,7 @@ resident to render multiple takes without reloading it.
 | Command | What it does |
 | --- | --- |
 | `mere.run video generate` | Generate MP4 video with native Swift/MLX video models. |
-| `mere.run video cosmos3` | Run native NVIDIA Cosmos3-Edge generation and action modes. |
+| `mere.run video cosmos3` | Run native NVIDIA Cosmos3 generation and action modes. |
 | `mere.run video animate` | Animate or replace a masked subject with native Swift/MLX SCAIL-2. |
 | `mere.run video prepare-masks` | Prepare reviewable, palette-safe SCAIL-2 masks with native SAM 3.1. |
 | `mere.run video session` | Keep an LTX 2.3 or LTX 2.5 runtime resident for JSONL generation requests. |
@@ -374,6 +374,10 @@ mere.run video cosmos3 "Identify safe routes through the room." \
 Use `mere.run guide video-cosmos3` for the full mode matrix and action-domain
 contract. The same runtime powers `world serve --backend cosmos3`, which keeps
 the transformer, VAE, and terminal latent resident across transitions.
+
+The native runtime also accepts the local MLX Q4 Cosmos3-Super Text2Image
+4-Step artifact for `--mode text-to-image`. It reads the fixed four-step
+stochastic schedule from the model root and disables classifier-free guidance.
 
 ### SCAIL-2 subject animation and replacement
 

--- a/scripts/model-conversion/convert_cosmos3_super_t2i_mlx.py
+++ b/scripts/model-conversion/convert_cosmos3_super_t2i_mlx.py
@@ -1,0 +1,514 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.12,<3.13"
+# dependencies = [
+#   "huggingface-hub==1.28.0",
+#   "mlx==0.32.2; sys_platform == 'darwin'",
+#   "numpy==2.5.2",
+#   "safetensors==0.8.0",
+# ]
+# ///
+"""Build the native MLX Q4 Cosmos3-Super text-to-image artifact.
+
+The conversion is resumable and processes one transformer shard at a time.
+The source revision and tensor inventory are immutable release inputs.
+"""
+
+from __future__ import annotations
+
+import argparse
+from datetime import datetime, timezone
+import hashlib
+import importlib.metadata
+import json
+import os
+from pathlib import Path
+import platform
+import shutil
+from typing import Any
+from urllib.request import urlopen
+
+
+SOURCE_REPOSITORY = "nvidia/Cosmos3-Super-Text2Image-4Step"
+SOURCE_REVISION = "aa0d5a57b7b045d68daa60fbacd84ec723c7cb7b"
+TARGET_REPOSITORY = "Sawfwair/Cosmos3-Super-Text2Image-4Step-MLX-4bit"
+SOURCE_TRANSFORMER_BYTES = 127_997_188_608
+SOURCE_TENSOR_COUNT = 1_425
+SOURCE_SHARD_COUNT = 27
+BITS = 4
+GROUP_SIZE = 64
+MODE = "affine"
+STATE_VERSION = 1
+STATE_FILENAME = ".mererun-conversion-state.json"
+LICENSE_URL = "https://openmdw.ai/license/1-1/"
+
+SOURCE_PATTERNS = [
+    "BIAS.md",
+    "EXPLAINABILITY.md",
+    "PRIVACY.md",
+    "README.md",
+    "SAFETY.md",
+    "model_index.json",
+    "modular_model_index.json",
+    "scheduler/*",
+    "text_tokenizer/*",
+    "transformer/config.json",
+    "transformer/diffusion_pytorch_model*.safetensors*",
+    "vae/*",
+]
+
+COPY_PATHS = [
+    "BIAS.md",
+    "EXPLAINABILITY.md",
+    "PRIVACY.md",
+    "SAFETY.md",
+    "model_index.json",
+    "modular_model_index.json",
+    "scheduler",
+    "text_tokenizer",
+    "vae",
+]
+
+
+def utc_now() -> str:
+    return datetime.now(timezone.utc).isoformat()
+
+
+def sha256_file(path: Path) -> str:
+    digest = hashlib.sha256()
+    with path.open("rb") as handle:
+        while chunk := handle.read(16 * 1024 * 1024):
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def atomic_json(path: Path, value: Any) -> None:
+    temporary = path.with_name(f".{path.name}.tmp")
+    temporary.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+    os.replace(temporary, path)
+
+
+def verify_environment() -> None:
+    expected = {
+        "huggingface-hub": "1.28.0",
+        "mlx": "0.32.2",
+        "numpy": "2.5.2",
+        "safetensors": "0.8.0",
+    }
+    for package, version in expected.items():
+        actual = importlib.metadata.version(package)
+        if actual != version:
+            raise RuntimeError(f"{package} {actual} is installed; expected {version}")
+
+
+def download_source(destination: Path, workers: int) -> Path:
+    from huggingface_hub import snapshot_download
+
+    destination.mkdir(parents=True, exist_ok=True)
+    return Path(snapshot_download(
+        repo_id=SOURCE_REPOSITORY,
+        revision=SOURCE_REVISION,
+        local_dir=destination,
+        allow_patterns=SOURCE_PATTERNS,
+        max_workers=workers,
+    ))
+
+
+def remote_manifest() -> dict[str, dict[str, int | str]]:
+    from huggingface_hub import HfApi
+
+    result: dict[str, dict[str, int | str]] = {}
+    for entry in HfApi().list_repo_tree(
+        repo_id=SOURCE_REPOSITORY,
+        revision=SOURCE_REVISION,
+        recursive=True,
+        expand=True,
+    ):
+        path = getattr(entry, "path", None)
+        if not isinstance(path, str):
+            continue
+        record: dict[str, int | str] = {"byte_count": int(getattr(entry, "size", 0) or 0)}
+        lfs = getattr(entry, "lfs", None)
+        digest = getattr(lfs, "sha256", None)
+        if isinstance(digest, str):
+            record["sha256"] = digest
+        result[path] = record
+    return result
+
+
+def load_source_index(source: Path) -> dict[str, Any]:
+    path = source / "transformer" / "diffusion_pytorch_model.safetensors.index.json"
+    index = json.loads(path.read_text(encoding="utf-8"))
+    weight_map = index.get("weight_map")
+    metadata = index.get("metadata")
+    if not isinstance(weight_map, dict) or not isinstance(metadata, dict):
+        raise ValueError("Pinned transformer index is malformed")
+    if len(weight_map) != SOURCE_TENSOR_COUNT:
+        raise ValueError(f"Pinned transformer has {len(weight_map)} tensors; expected {SOURCE_TENSOR_COUNT}")
+    if int(metadata.get("total_size", -1)) != SOURCE_TRANSFORMER_BYTES:
+        raise ValueError("Pinned transformer total_size does not match the audited revision")
+    shards = set(weight_map.values())
+    if len(shards) != SOURCE_SHARD_COUNT:
+        raise ValueError(f"Pinned transformer has {len(shards)} shards; expected {SOURCE_SHARD_COUNT}")
+    return index
+
+
+def omitted_tensor(key: str) -> bool:
+    return key == "lm_head.weight" or key == "audio_modality_embed" or key.startswith("audio_proj_")
+
+
+def should_quantize(key: str, value: Any) -> bool:
+    if not key.endswith(".weight") or value.ndim != 2:
+        return False
+    if int(value.shape[-1]) % GROUP_SIZE:
+        return False
+    return key == "embed_tokens.weight" or key.startswith("layers.")
+
+
+def transform_tensor(key: str, value: Any, mx: Any) -> dict[str, Any]:
+    if omitted_tensor(key):
+        return {}
+    if not should_quantize(key, value):
+        return {key: value}
+    base = key.removesuffix(".weight")
+    packed = mx.quantize(value, group_size=GROUP_SIZE, bits=BITS, mode=MODE)
+    if len(packed) != 3:
+        raise RuntimeError(f"MLX affine quantization emitted no biases for {key}")
+    return {
+        key: packed[0],
+        f"{base}.scales": packed[1],
+        f"{base}.biases": packed[2],
+    }
+
+
+def initial_state() -> dict[str, Any]:
+    return {
+        "schema_version": STATE_VERSION,
+        "source": {"repository": SOURCE_REPOSITORY, "revision": SOURCE_REVISION},
+        "quantization": {"bits": BITS, "group_size": GROUP_SIZE, "mode": MODE},
+        "started_at": utc_now(),
+        "completed_shards": {},
+    }
+
+
+def load_state(output: Path) -> dict[str, Any]:
+    path = output / STATE_FILENAME
+    if not path.exists():
+        return initial_state()
+    state = json.loads(path.read_text(encoding="utf-8"))
+    if state.get("schema_version") != STATE_VERSION:
+        raise ValueError(f"Unsupported conversion state: {path}")
+    if state.get("source") != initial_state()["source"]:
+        raise ValueError(f"Conversion source mismatch: {path}")
+    return state
+
+
+def save_shard(path: Path, arrays: dict[str, Any], mx: Any) -> None:
+    temporary = path.with_name(f".{path.stem}.tmp{path.suffix}")
+    mx.eval(*arrays.values())
+    mx.save_safetensors(str(temporary), arrays, metadata={
+        "format": "mlx",
+        "source_repository": SOURCE_REPOSITORY,
+        "source_revision": SOURCE_REVISION,
+    })
+    os.replace(temporary, path)
+
+
+def convert_shards(
+    source: Path,
+    output: Path,
+    source_index: dict[str, Any],
+    manifest: dict[str, dict[str, int | str]],
+) -> tuple[dict[str, str], int]:
+    import mlx.core as mx
+
+    output_transformer = output / "transformer"
+    output_transformer.mkdir(parents=True, exist_ok=True)
+    state = load_state(output)
+    source_weight_map: dict[str, str] = source_index["weight_map"]
+    source_shards = sorted(set(source_weight_map.values()))
+
+    for position, shard_name in enumerate(source_shards, start=1):
+        destination = output_transformer / shard_name
+        prior = state["completed_shards"].get(shard_name)
+        if prior and destination.is_file() and destination.stat().st_size == prior.get("byte_count"):
+            print(f"[{position}/{len(source_shards)}] resume {shard_name}", flush=True)
+            continue
+
+        source_path = source / "transformer" / shard_name
+        remote = manifest.get(f"transformer/{shard_name}")
+        if not remote:
+            raise ValueError(f"Remote manifest is missing transformer/{shard_name}")
+        if source_path.stat().st_size != int(remote["byte_count"]):
+            raise ValueError(f"Downloaded shard size mismatch: {source_path}")
+        source_digest = sha256_file(source_path)
+        if remote.get("sha256") and source_digest != remote["sha256"]:
+            raise ValueError(f"Downloaded shard SHA-256 mismatch: {source_path}")
+
+        source_arrays = mx.load(str(source_path))
+        converted: dict[str, Any] = {}
+        quantized_modules = 0
+        for key in sorted(source_arrays):
+            arrays = transform_tensor(key, source_arrays[key], mx)
+            if f"{key.removesuffix('.weight')}.scales" in arrays:
+                quantized_modules += 1
+            overlap = set(converted).intersection(arrays)
+            if overlap:
+                raise ValueError(f"Duplicate converted keys: {sorted(overlap)}")
+            converted.update(arrays)
+        save_shard(destination, converted, mx)
+        state["completed_shards"][shard_name] = {
+            "byte_count": destination.stat().st_size,
+            "sha256": sha256_file(destination),
+            "source_byte_count": source_path.stat().st_size,
+            "source_sha256": source_digest,
+            "output_keys": sorted(converted),
+            "quantized_modules": quantized_modules,
+        }
+        atomic_json(output / STATE_FILENAME, state)
+        del converted, source_arrays
+        mx.clear_cache()
+        print(f"[{position}/{len(source_shards)}] converted {shard_name}", flush=True)
+
+    weight_map: dict[str, str] = {}
+    module_count = 0
+    for shard_name in source_shards:
+        record = state["completed_shards"].get(shard_name)
+        if not record:
+            raise ValueError(f"Conversion is incomplete: {shard_name}")
+        module_count += int(record["quantized_modules"])
+        for key in record["output_keys"]:
+            if key in weight_map:
+                raise ValueError(f"Duplicate output tensor: {key}")
+            weight_map[key] = shard_name
+    return dict(sorted(weight_map.items())), module_count
+
+
+def logical_bytes(output: Path, weight_map: dict[str, str]) -> int:
+    from safetensors import safe_open
+
+    item_bytes = {
+        "BOOL": 1, "I8": 1, "U8": 1, "I16": 2, "U16": 2, "F16": 2, "BF16": 2,
+        "I32": 4, "U32": 4, "F32": 4, "I64": 8, "U64": 8, "F64": 8,
+    }
+    total = 0
+    for filename in sorted(set(weight_map.values())):
+        with safe_open(output / "transformer" / filename, framework="numpy") as archive:
+            actual = set(archive.keys())
+            expected = {key for key, shard in weight_map.items() if shard == filename}
+            if actual != expected:
+                raise ValueError(f"Output inventory mismatch in {filename}")
+            for key in actual:
+                view = archive.get_slice(key)
+                elements = 1
+                for dimension in view.get_shape():
+                    elements *= int(dimension)
+                total += elements * item_bytes[view.get_dtype()]
+    return total
+
+
+def copy_metadata(source: Path, output: Path) -> None:
+    for relative in COPY_PATHS:
+        source_path = source / relative
+        destination = output / relative
+        if source_path.is_dir():
+            shutil.copytree(source_path, destination, dirs_exist_ok=True)
+        else:
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source_path, destination)
+    shutil.copy2(source / "README.md", output / "UPSTREAM_MODEL_CARD.md")
+
+
+def write_transformed_config(source: Path, output: Path) -> None:
+    config = json.loads((source / "transformer" / "config.json").read_text(encoding="utf-8"))
+    config.update({
+        "hidden_act": "silu",
+        "sound_gen": False,
+        "mererun_text_to_image_only": True,
+        "quantization": {"bits": BITS, "group_size": GROUP_SIZE, "mode": MODE},
+        "quantization_config": {"bits": BITS, "group_size": GROUP_SIZE, "mode": MODE},
+        "mererun_conversion": {
+            "converter": "scripts/model-conversion/convert_cosmos3_super_t2i_mlx.py",
+            "source_repository": SOURCE_REPOSITORY,
+            "source_revision": SOURCE_REVISION,
+        },
+    })
+    atomic_json(output / "transformer" / "config.json", config)
+
+
+def write_license(output: Path) -> None:
+    with urlopen(LICENSE_URL, timeout=60) as response:
+        contents = response.read()
+    (output / "OPENMDW-1.1-LICENSE.html").write_bytes(contents)
+
+
+def write_checksums(output: Path) -> None:
+    files = sorted(
+        path for path in output.rglob("*")
+        if path.is_file() and path.name not in {"SHA256SUMS", STATE_FILENAME}
+    )
+    lines = [f"{sha256_file(path)}  {path.relative_to(output).as_posix()}" for path in files]
+    (output / "SHA256SUMS").write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def remove_platform_metadata(output: Path) -> None:
+    for path in output.rglob("*"):
+        if path.is_file() and (path.name.startswith("._") or path.name == ".DS_Store"):
+            path.unlink()
+
+
+def model_card_path() -> Path:
+    return Path(__file__).resolve().parent / "model-cards" / "cosmos3-super-t2i-4step-mlx-4bit.md"
+
+
+def finalize(
+    source: Path,
+    output: Path,
+    source_index: dict[str, Any],
+    source_manifest: dict[str, dict[str, int | str]],
+    weight_map: dict[str, str],
+    module_count: int,
+) -> None:
+    copy_metadata(source, output)
+    write_transformed_config(source, output)
+    total_size = logical_bytes(output, weight_map)
+    atomic_json(output / "transformer" / "diffusion_pytorch_model.safetensors.index.json", {
+        "metadata": {"total_size": total_size},
+        "weight_map": weight_map,
+    })
+    atomic_json(output / "SOURCE_MANIFEST.json", {
+        "repository": SOURCE_REPOSITORY,
+        "revision": SOURCE_REVISION,
+        "transformer_index_metadata": source_index["metadata"],
+        "files": source_manifest,
+    })
+    shutil.copy2(model_card_path(), output / "README.md")
+    write_license(output)
+    receipt = {
+        "schema_version": 1,
+        "completed_at": utc_now(),
+        "converter": "scripts/model-conversion/convert_cosmos3_super_t2i_mlx.py",
+        "converter_sha256": sha256_file(Path(__file__).resolve()),
+        "source": {"repository": SOURCE_REPOSITORY, "revision": SOURCE_REVISION},
+        "target_repository": TARGET_REPOSITORY,
+        "quantization": {"bits": BITS, "group_size": GROUP_SIZE, "mode": MODE},
+        "omitted_weights": ["lm_head.weight", "audio_modality_embed", "audio_proj_in.*", "audio_proj_out.*"],
+        "transformer": {
+            "logical_bytes": total_size,
+            "tensor_count": len(weight_map),
+            "quantized_module_count": module_count,
+            "shard_count": len(set(weight_map.values())),
+        },
+        "software": {
+            package: importlib.metadata.version(package)
+            for package in ["huggingface-hub", "mlx", "numpy", "safetensors"]
+        },
+        "hardware": {"machine": platform.machine(), "platform": platform.platform()},
+    }
+    atomic_json(output / "CONVERSION.json", receipt)
+    remove_platform_metadata(output)
+    write_checksums(output)
+    state_path = output / STATE_FILENAME
+    if state_path.exists():
+        state_path.unlink()
+    print(json.dumps(receipt, indent=2, sort_keys=True), flush=True)
+
+
+def upload(output: Path, private: bool) -> None:
+    from huggingface_hub import HfApi
+
+    remove_platform_metadata(output)
+    write_checksums(output)
+    api = HfApi()
+    api.create_repo(TARGET_REPOSITORY, repo_type="model", private=private, exist_ok=True)
+    api.upload_folder(
+        repo_id=TARGET_REPOSITORY,
+        repo_type="model",
+        folder_path=output,
+        commit_message="Add native MLX Q4 Cosmos3-Super text-to-image checkpoint",
+        ignore_patterns=["._*", "**/._*", ".DS_Store", "**/.DS_Store", STATE_FILENAME],
+    )
+
+
+def self_test() -> None:
+    import mlx.core as mx
+
+    source = mx.arange(256, dtype=mx.float32).reshape(4, 64) / 255
+    converted = transform_tensor("layers.0.mlp.up_proj.weight", source, mx)
+    expected = {
+        "layers.0.mlp.up_proj.weight",
+        "layers.0.mlp.up_proj.scales",
+        "layers.0.mlp.up_proj.biases",
+    }
+    if set(converted) != expected:
+        raise AssertionError(f"Q4 self-test emitted {sorted(converted)}")
+    restored = mx.dequantize(
+        converted["layers.0.mlp.up_proj.weight"],
+        converted["layers.0.mlp.up_proj.scales"],
+        converted["layers.0.mlp.up_proj.biases"],
+        group_size=GROUP_SIZE,
+        bits=BITS,
+        mode=MODE,
+    )
+    error = float(mx.max(mx.abs(restored - source)).item())
+    if error <= 0 or error >= 0.05:
+        raise AssertionError(f"Q4 self-test error is outside the expected range: {error}")
+    if transform_tensor("lm_head.weight", source, mx):
+        raise AssertionError("Language-model head was not omitted")
+    if transform_tensor("audio_proj_in.weight", source, mx):
+        raise AssertionError("Sound projection was not omitted")
+    print(json.dumps({"q4_max_absolute_error": error, "status": "passed"}, sort_keys=True))
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Convert pinned Cosmos3-Super Text2Image 4-Step weights to native MLX Q4."
+    )
+    parser.add_argument("--workspace", type=Path, help="Large-volume conversion workspace.")
+    parser.add_argument("--workers", type=int, default=4, help="Concurrent Hugging Face downloads.")
+    parser.add_argument("--upload", action="store_true", help=f"Upload to {TARGET_REPOSITORY} after validation.")
+    parser.add_argument(
+        "--upload-only",
+        action="store_true",
+        help=f"Upload an already completed artifact to {TARGET_REPOSITORY} without reconverting it.",
+    )
+    parser.add_argument("--public", action="store_true", help="Create the target repository as public; private is default.")
+    parser.add_argument("--self-test", action="store_true", help="Run a small MLX quantizer contract test and exit.")
+    return parser.parse_args()
+
+
+def main() -> int:
+    args = parse_args()
+    if args.workers < 1:
+        raise ValueError("--workers must be positive")
+    verify_environment()
+    if args.self_test:
+        self_test()
+        return 0
+    if args.workspace is None:
+        raise ValueError("--workspace is required unless --self-test is used")
+    workspace = args.workspace.expanduser().resolve()
+    source = workspace / "source"
+    output = workspace / "Cosmos3-Super-Text2Image-4Step-MLX-4bit"
+    if args.upload_only:
+        required = [output / "CONVERSION.json", output / "SHA256SUMS", output / "README.md"]
+        missing = [path for path in required if not path.is_file()]
+        if missing:
+            raise ValueError(f"Completed artifact is missing required files: {missing}")
+        upload(output, private=not args.public)
+        print(f"uploaded: https://huggingface.co/{TARGET_REPOSITORY}", flush=True)
+        return 0
+    output.mkdir(parents=True, exist_ok=True)
+    manifest = remote_manifest()
+    source = download_source(source, args.workers)
+    source_index = load_source_index(source)
+    weight_map, module_count = convert_shards(source, output, source_index, manifest)
+    finalize(source, output, source_index, manifest, weight_map, module_count)
+    if args.upload:
+        upload(output, private=not args.public)
+    print(f"complete: {output}", flush=True)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/model-conversion/model-cards/cosmos3-super-t2i-4step-mlx-4bit.md
+++ b/scripts/model-conversion/model-cards/cosmos3-super-t2i-4step-mlx-4bit.md
@@ -1,0 +1,106 @@
+---
+license: other
+license_name: openmdw-1.1
+license_link: https://openmdw.ai/license/1-1/
+base_model: nvidia/Cosmos3-Super-Text2Image-4Step
+pipeline_tag: text-to-image
+library_name: mlx
+tags:
+  - mlx
+  - apple-silicon
+  - cosmos3
+  - text-to-image
+  - quantized
+---
+
+# Cosmos3-Super Text2Image 4-Step MLX 4-bit
+
+This repository is a native MLX conversion of
+[`nvidia/Cosmos3-Super-Text2Image-4Step`](https://huggingface.co/nvidia/Cosmos3-Super-Text2Image-4Step),
+pinned at revision `aa0d5a57b7b045d68daa60fbacd84ec723c7cb7b`.
+
+The 64-billion-parameter mixture-of-transformers backbone uses 4-bit affine
+group quantization with a group size of 64. The VAE and normalization,
+projection, and time-embedding tensors retain their source precision. The
+unused sound projections and language-model head are omitted because this
+artifact supports text-to-image generation only.
+
+## Use with mere.run
+
+Use the native Cosmos3 command and pass the downloaded repository as a local
+model root:
+
+```bash
+mere.run video cosmos3 \
+  "A glass observatory above a bioluminescent ocean at blue hour" \
+  --mode text-to-image \
+  --model /path/to/Cosmos3-Super-Text2Image-4Step-MLX-4bit \
+  --width 768 \
+  --height 768 \
+  --seed 42 \
+  --output cosmos3-super.png
+```
+
+The distilled checkpoint has a fixed four-step stochastic schedule and does
+not use classifier-free guidance. `mere.run` selects four steps and a guidance
+scale of 1 automatically for this artifact. Flow-shift and scheduler overrides
+are not supported, and negative prompts are ignored.
+
+This native path does not bundle or run NVIDIA's separate Cosmos guardrail.
+Add prompt and output safety checks appropriate to your application before
+showing generated images to users.
+
+## Conversion and provenance
+
+The conversion is deterministic at the tensor level and was produced by
+`scripts/model-conversion/convert_cosmos3_super_t2i_mlx.py` in the `mere.run`
+repository. See `CONVERSION.json` for the converter digest, package versions,
+hardware record, tensor counts, and quantization settings. See
+`SOURCE_MANIFEST.json` for the pinned source inventory and `SHA256SUMS` for the
+published artifact checksums.
+
+The following source tensors are intentionally omitted:
+
+- `lm_head.weight`
+- `audio_modality_embed`
+- `audio_proj_in.*`
+- `audio_proj_out.*`
+
+The upstream model card is retained as `UPSTREAM_MODEL_CARD.md`.
+
+## Validation status
+
+Tensor inventory, configuration decoding, native module construction, and the
+published distilled scheduler are covered by automated tests. Conversion does
+not by itself establish visual-quality parity with NVIDIA's BF16 checkpoint.
+Record device, prompt, seed, output digest, peak memory, and elapsed time when
+qualifying a generated image.
+
+### Native qualification
+
+The published artifact completed an end-to-end 768x768 native generation on an
+Apple M4 Max MacBook Pro with 128 GB of unified memory and macOS 26.5.2. The
+command used a debug build of `mere.run`, four steps, seed 42, and this prompt:
+
+> A glass observatory above a bioluminescent ocean at blue hour
+
+| Measurement | Result |
+| --- | --- |
+| Wall time | 60.85 seconds |
+| Maximum resident memory | 38,657,916,928 bytes |
+| Peak memory footprint | 53,394,599,464 bytes |
+| Swaps | 0 |
+| Output SHA-256 | `006a73d23850c1ab6ae9c05e5521109a8a2678f69e42fe362cd3a837d77c7495` |
+
+This is native runtime smoke evidence, not a BF16 parity or broad visual-quality
+evaluation.
+
+![Native MLX qualification output](https://huggingface.co/Sawfwair/Cosmos3-Super-Text2Image-4Step-MLX-4bit/resolve/main/examples/qualification-768-seed42.png)
+
+## License
+
+This model is distributed under the
+[NVIDIA Open Model Development and Weight License 1.1](https://openmdw.ai/license/1-1/).
+The artifact includes an archived copy in `OPENMDW-1.1-LICENSE.html`. Review the
+license and the upstream use restrictions before downloading or redistributing
+the weights.


### PR DESCRIPTION
## Summary

- add native Swift/MLX support for NVIDIA Cosmos3-Super Text2Image 4-Step
- add a resumable, pinned affine-Q4 conversion and publishing workflow
- enforce the fixed stochastic four-step, guidance-1 distilled contract and document safety and qualification boundaries

## Published artifact

- https://huggingface.co/Sawfwair/Cosmos3-Super-Text2Image-4Step-MLX-4bit
- verified artifact revision: `4ef3565cbc05bf3e2867ced9c2cb761df52c6105`
- 3,213 tensors across 27 transformer shards; 897 affine-Q4 group-64 modules

## Validation

- `./scripts/check.sh`
- `swift test --filter Cosmos3EdgeTests` (38 tests passed)
- converter Q4 self-test passed with max absolute error `0.008235305547714233`
- complete local `SHA256SUMS` verification
- exact Hugging Face readback for the receipt, model card, tensor index, checksum manifest, preview, and sampled weight shard
- native 768x768 generation on Apple M4 Max / 128 GB: 60.85 s wall time, 38,657,916,928-byte max RSS, 53,394,599,464-byte peak footprint, zero swaps

## Qualification boundary

The native generation is runtime smoke evidence, not BF16 visual-parity or broad quality qualification. This path does not bundle the separate NVIDIA Cosmos guardrail; the model card and guide call that out explicitly.