### PR TITLE
Rebuild the composer with an attachment well and chip strip

### DIFF
--- a/apps/macos/MereRunStudio/StudioComposer.swift
+++ b/apps/macos/MereRunStudio/StudioComposer.swift
@@ -3,380 +3,538 @@ import MereRunContract
 import SwiftUI
 import UniformTypeIdentifiers
 
-/// The floating command bar at the bottom of the canvas: one field, one run button, and the
-/// depth (attachment, model, options) folded into quiet affordances around it.
+// F1 token: the text/glyph color on an accent fill. Moves to MereRunTheme with the other v2 tokens.
+private let onAccent = MereRunTheme.dynamic(light: "FFFFFF", dark: "1B160A")
+
+/// The composer pinned under the canvas: the attachment well, the prompt, and a strip of the
+/// mode's essential parameters as chips, with Run on the right. Slots and chips come from
+/// `StudioComposerSchema.swift`; the remaining depth stays behind the options popover.
 struct StudioComposer: View {
     let mode: StudioMode
-    var isCompact = false
     @Binding var draft: StudioDraft
     @Binding var showOptions: Bool
     let isRunning: Bool
     let queuedCount: Int
     let readiness: ModelReadinessState
     var sendBlocked: Bool = false
-    let installedModels: [StudioModelInventoryRow]
+    /// Every row of `model list`, installed or not; the model chip filters it to the mode.
+    let modelInventory: [StudioModelInventoryRow]
+    /// The seed of the mode's most recent run, for "Reuse last".
+    var lastSeed: String?
     var promptFocus: FocusState<Bool>.Binding
     let onRun: () -> Void
     let onStop: () -> Void
-    let onAttach: () -> Void
-    let onPaste: () -> Void
     let onShowModels: () -> Void
     let onShowAdapters: () -> Void
     let onShowRealtimeMusic: () -> Void
 
-    /// Whether the clipboard currently holds an image, so the paste affordance only
-    /// appears when it can actually do something (refreshed on appear + on focus).
-    @State private var clipboardHasImage = false
+    @EnvironmentObject private var controller: MereRunController
+    @State private var editingChip: StudioComposerChipKind?
+
+    private enum Metrics {
+        static let outerInsets = EdgeInsets(top: 12, leading: 24, bottom: 20, trailing: 24)
+        static let innerInsets = EdgeInsets(top: 14, leading: 16, bottom: 12, trailing: 16)
+        static let cornerRadius: CGFloat = 18
+        static let rowSpacing: CGFloat = 12
+        static let sendDiameter: CGFloat = 32
+    }
 
     var body: some View {
-        VStack(spacing: MereRunTheme.Spacing.xs) {
-            if !draft.inputPath.isBlank {
-                attachmentChip
-                    .transition(.opacity.combined(with: .move(edge: .bottom)))
+        VStack(alignment: .leading, spacing: Metrics.rowSpacing) {
+            if mode.showsAttachmentWell(for: draft) {
+                attachmentWell
+                    .transition(.opacity.combined(with: .move(edge: .top)))
             }
-
-            composerBar
-
-            if mode.requiresAttachment && draft.inputPath.isBlank {
-                Label(attachmentHint, systemImage: "arrow.down.doc")
-                    .font(MereRunTheme.captionFont)
-                    .foregroundStyle(MereRunTheme.textMuted)
-                    .padding(.leading, 4)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-            }
+            promptEntry
+            chipStrip
         }
-        .animation(MereRunTheme.Motion.standard, value: draft.inputPath.isBlank)
-        .onAppear(perform: refreshClipboardImageState)
-        .onChange(of: promptFocus.wrappedValue) { _, focused in
-            if focused { refreshClipboardImageState() }
-        }
-    }
-
-    private func refreshClipboardImageState() {
-        clipboardHasImage = NSPasteboard.general.canReadObject(forClasses: [NSImage.self], options: nil)
-    }
-
-    private var attachmentChip: some View {
-        HStack(spacing: MereRunTheme.Spacing.xs) {
-            attachmentThumbnail
-                .frame(width: 30, height: 26)
-                .background(MereRunTheme.surface)
-                .clipShape(RoundedRectangle(cornerRadius: MereRunTheme.Radius.sm))
-                .overlay {
-                    RoundedRectangle(cornerRadius: MereRunTheme.Radius.sm)
-                        .strokeBorder(MereRunTheme.border.opacity(0.6), lineWidth: 1)
-                }
-
-            Text(URL(fileURLWithPath: draft.inputPath).lastPathComponent)
-                .font(MereRunTheme.captionFont)
-                .foregroundStyle(MereRunTheme.textSecondary)
-                .lineLimit(1)
-                .truncationMode(.middle)
-
-            Button {
-                draft.inputPath = ""
-            } label: {
-                Image(systemName: "xmark.circle.fill")
-                    .font(.system(size: 12))
-                    .padding(2)
-            }
-            .buttonStyle(.mereIcon(tint: MereRunTheme.textMuted))
-            .help("Remove attachment")
-            .accessibilityLabel("Remove attachment")
-        }
-        .padding(.horizontal, MereRunTheme.Spacing.xs)
-        .padding(.vertical, 5)
+        .padding(Metrics.innerInsets)
         .background {
-            Capsule()
-                .fill(MereRunTheme.surface.opacity(0.85))
-                .overlay {
-                    Capsule().strokeBorder(MereRunTheme.border.opacity(0.6), lineWidth: 1)
-                }
-        }
-        .frame(maxWidth: .infinity, alignment: .leading)
-    }
-
-    @ViewBuilder
-    private var attachmentThumbnail: some View {
-        let url = URL(fileURLWithPath: draft.inputPath)
-        if StudioOutputFileKind.classify(url) == .image {
-            StudioAsyncImagePreview(
-                url: url,
-                maxPixelSize: 120,
-                contentMode: .fill,
-                fallbackSystemImage: "photo"
-            )
-        } else {
-            Image(systemName: attachmentIcon(for: url))
-                .font(.system(size: 11, weight: .semibold))
-                .foregroundStyle(MereRunTheme.accent)
-        }
-    }
-
-    private var composerBar: some View {
-        Group {
-            if isCompact {
-                compactComposerContent
-            } else {
-                regularComposerContent
-            }
-        }
-        .padding(.horizontal, isCompact ? MereRunTheme.Spacing.sm : MereRunTheme.Spacing.md)
-        .padding(.vertical, MereRunTheme.Spacing.sm)
-        .background {
-            RoundedRectangle(cornerRadius: MereRunTheme.Radius.xxl)
+            RoundedRectangle(cornerRadius: Metrics.cornerRadius)
                 .fill(MereRunTheme.surface)
                 .overlay {
-                    RoundedRectangle(cornerRadius: MereRunTheme.Radius.xxl)
-                        .strokeBorder(MereRunTheme.border.opacity(0.75), lineWidth: 1)
+                    RoundedRectangle(cornerRadius: Metrics.cornerRadius)
+                        .strokeBorder(MereRunTheme.border.opacity(promptFocus.wrappedValue ? 0 : 1), lineWidth: 1)
                 }
-                .mereShadow(radius: 18, y: 8)
+                .mereShadow(radius: 12, y: 8)
         }
-        .mereFocusRing(promptFocus.wrappedValue, cornerRadius: MereRunTheme.Radius.xxl)
+        .mereFocusRing(promptFocus.wrappedValue, cornerRadius: Metrics.cornerRadius)
+        .padding(Metrics.outerInsets)
+        .animation(MereRunTheme.Motion.standard, value: mode.showsAttachmentWell(for: draft))
     }
 
-    private var regularComposerContent: some View {
-        HStack(spacing: MereRunTheme.Spacing.sm) {
-            attachmentControls
-            promptEntry
+    // MARK: - Attachment well
 
-            HStack(spacing: 6) {
-                modelMenu
-                optionsButton
-                if isRunning { stopButton }
-                sendButton
-            }
-        }
+    private var visibleSlots: [StudioAttachmentSlot] {
+        mode.attachmentSlots.filter { !$0.isTransient || $0.isFilled(in: draft) }
     }
 
-    private var compactComposerContent: some View {
-        VStack(spacing: 5) {
-            HStack(spacing: MereRunTheme.Spacing.xs) {
-                promptEntry
-                sendButton
+    private var attachmentWell: some View {
+        HStack(alignment: .center, spacing: 8) {
+            ForEach(visibleSlots) { slot in
+                StudioAttachmentSlotView(slot: slot, draft: $draft, onPick: { pickFiles(for: slot) })
             }
-
-            HStack(spacing: 4) {
-                attachmentControls
-                modelMenu
-                Spacer(minLength: 0)
-                optionsButton
-                if isRunning { stopButton }
-            }
-        }
-    }
-
-    private var attachmentControls: some View {
-        HStack(spacing: 2) {
-            Button(action: onAttach) {
-                Image(systemName: mode.requiresAttachment ? "paperclip.badge.ellipsis" : "paperclip")
-                    .font(.system(size: 16, weight: .semibold))
-                    .frame(width: 30, height: 30)
-            }
-            .buttonStyle(.mereIcon)
-            .disabled(mode.acceptedTypes.isEmpty)
-            .opacity(mode.acceptedTypes.isEmpty ? 0.35 : 1)
-            .help(mode.requiresAttachment ? "Attach required input" : "Attach reference")
-            .accessibilityLabel(mode.requiresAttachment ? "Attach required input" : "Attach reference")
-
-            if mode.acceptedTypes.contains(.image), clipboardHasImage {
-                Button(action: onPaste) {
-                    Image(systemName: "doc.on.clipboard")
-                        .font(.system(size: 14, weight: .semibold))
-                        .frame(width: 30, height: 30)
+            VStack(alignment: .leading, spacing: 1) {
+                ForEach(visibleSlots) { slot in
+                    Text(slot.caption(in: draft))
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(MereRunTheme.textMuted)
+                        .lineLimit(1)
+                        .truncationMode(.middle)
                 }
-                .buttonStyle(.mereIcon)
-                .help("Paste image from clipboard (⌘V)")
-                .accessibilityLabel("Paste image from clipboard")
-                .transition(.opacity.combined(with: .scale(scale: 0.8)))
             }
+            .padding(.leading, 4)
+            Spacer(minLength: 0)
         }
-        .animation(MereRunTheme.Motion.quick, value: clipboardHasImage)
     }
+
+    private func pickFiles(for slot: StudioAttachmentSlot) {
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = true
+        panel.canChooseDirectories = false
+        panel.allowsMultipleSelection = slot.allowsMultiple
+        panel.allowedContentTypes = slot.acceptedTypes
+        guard panel.runModal() == .OK else { return }
+        slot.attach(panel.urls, to: &draft)
+    }
+
+    // MARK: - Prompt
 
     @ViewBuilder
     private var promptEntry: some View {
         if mode == .listen {
             Text(mode.promptPlaceholder)
-                .font(.system(size: 15, weight: .medium))
+                .font(.system(size: 15))
                 .foregroundStyle(MereRunTheme.textMuted)
-                .frame(maxWidth: .infinity, alignment: .leading)
+                .frame(maxWidth: .infinity, minHeight: 22, alignment: .leading)
         } else {
-            TextField(mode.promptPlaceholder, text: $draft.prompt, axis: .vertical)
-                .textFieldStyle(.plain)
-                .font(.system(size: 15, weight: .medium))
-                .lineLimit(1...5)
-                .focused(promptFocus)
-                .onSubmit(onRun)
-        }
-    }
-
-    private var optionsButton: some View {
-        Button {
-            showOptions.toggle()
-        } label: {
-            Image(systemName: "slider.horizontal.3")
-                .font(.system(size: 14, weight: .semibold))
-                .foregroundStyle(showOptions ? MereRunTheme.accent : MereRunTheme.textSecondary)
-                .frame(width: 30, height: 30)
-        }
-        .buttonStyle(.mereIcon)
-        .help("Options")
-        .accessibilityLabel("Options")
-        .popover(isPresented: $showOptions, arrowEdge: .top) {
-            StudioOptionsPanel(
-                mode: mode,
-                draft: $draft,
-                onShowAdapters: onShowAdapters,
-                onShowRealtimeMusic: onShowRealtimeMusic
+            TextField(
+                "",
+                text: $draft.prompt,
+                prompt: Text(mode.promptPlaceholder).foregroundStyle(MereRunTheme.textMuted),
+                axis: .vertical
             )
+            .textFieldStyle(.plain)
+            .font(.system(size: 15))
+            .lineSpacing(3)
+            .foregroundStyle(MereRunTheme.textPrimary)
+            .lineLimit(1...5)
+            .frame(minHeight: 22, alignment: .leading)
+            .focused(promptFocus)
+            .onSubmit(onRun)
+            .accessibilityLabel(mode.promptPlaceholder)
         }
     }
 
-    private var stopButton: some View {
-        Button(action: onStop) {
-            Image(systemName: "stop.fill")
-                .font(.system(size: 12, weight: .bold))
-                .frame(width: 30, height: 30)
-        }
-        .buttonStyle(.mereIcon(tint: MereRunTheme.red))
-        .help("Stop current run (⌘.)")
-        .accessibilityLabel("Stop current run")
-    }
+    // MARK: - Chip strip
 
-    private var sendButton: some View {
-        Button(action: onRun) {
-            ZStack {
-                Circle()
-                    .fill(sendEnabled ? MereRunTheme.accent : MereRunTheme.surfaceRaised)
-                Image(systemName: "arrow.up")
-                    .font(.system(size: 14, weight: .bold))
-                    .foregroundStyle(sendEnabled ? MereRunTheme.background : MereRunTheme.textMuted)
+    private var chipStrip: some View {
+        HStack(alignment: .center, spacing: 6) {
+            ForEach(mode.composerChips) { kind in
+                chip(for: kind)
             }
-            .frame(width: 34, height: 34)
-            .overlay(alignment: .topTrailing) {
-                if queuedCount > 0 {
-                    Text("\(queuedCount)")
-                        .font(.system(size: 9, weight: .bold))
-                        .foregroundStyle(MereRunTheme.background)
-                        .padding(.horizontal, 4)
-                        .frame(height: 13)
-                        .background { Capsule().fill(MereRunTheme.yellow) }
-                        .offset(x: 4, y: -3)
-                        .accessibilityHidden(true)
+            Spacer(minLength: 8)
+            HStack(spacing: 8) {
+                optionsButton
+                if showsPaperclip { paperclipButton }
+                if isRunning { stopButton } else { sendButton }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func chip(for kind: StudioComposerChipKind) -> some View {
+        switch kind {
+        case .dimensions: dimensionsChip
+        case .duration: durationChip
+        case .steps: stepsChip
+        case .seed: seedChip
+        case .threshold: thresholdChip
+        case .readImageAction: readImageActionChip
+        case .voiceMode: voiceModeChip
+        case .thinking: thinkingChip
+        case .model: modelChip
+        }
+    }
+
+    private var dimensionsChip: some View {
+        chipMenu(
+            title: StudioComposerPresets.dimensionsTitle(draft),
+            accessibilityLabel: "Size",
+            kind: .dimensions
+        ) {
+            ForEach(StudioAspectPreset.presets(for: mode)) { preset in
+                Toggle(isOn: Binding(get: { preset.matches(draft) }, set: { _ in preset.apply(to: &draft) })) {
+                    Text("\(preset.label) · \(preset.width) × \(preset.height)")
                 }
             }
+            Divider()
+            Button("Swap width and height") {
+                let width = draft.width
+                draft.width = draft.height
+                draft.height = width
+            }
+            Button("Custom size…") { editingChip = .dimensions }
+        } editor: {
+            HStack(spacing: MereRunTheme.Spacing.xs) {
+                numberField("Width", value: $draft.width, range: 64...4096)
+                Text("×").foregroundStyle(MereRunTheme.textMuted)
+                numberField("Height", value: $draft.height, range: 64...4096)
+            }
         }
-        .buttonStyle(.plain)
-        .disabled(!sendEnabled)
-        .help(sendHelp)
-        .accessibilityLabel(isRunning ? "Queue run" : "Run")
-        .accessibilityHint(accessibilityRunHint)
-        .keyboardShortcut(.return, modifiers: .command)
     }
 
-    private var sendEnabled: Bool {
-        !readiness.blocksRun && !sendBlocked
-    }
-
-    private var sendHelp: String {
-        if sendBlocked { return "Waiting for the current reply…" }
-        if readiness.blocksRun { return readiness.message }
-        if isRunning {
-            return queuedCount == 0 ? "Queue run" : "Queue run (\(queuedCount) waiting)"
-        }
-        return "Run (⌘↩)"
-    }
-
-    /// Spoken explanation of why Run is disabled, so the blocked state is not color-only.
-    private var accessibilityRunHint: String {
-        if sendBlocked { return "Waiting for the current reply to finish" }
-        if readiness.blocksRun { return readiness.message }
-        return ""
-    }
-
-    // MARK: - Model quick-picker
-
-    private var modelMenu: some View {
-        Menu {
-            if installedModels.isEmpty {
-                Text("No local models yet")
-            } else {
-                ForEach(groupedModelCategories, id: \.category) { group in
-                    Section(group.category.capitalized) {
-                        ForEach(group.rows) { row in
-                            Button {
-                                draft.model = row.id
-                            } label: {
-                                if row.id == draft.model {
-                                    Label(row.id, systemImage: "checkmark")
-                                } else {
-                                    Text(row.id)
-                                }
-                            }
-                        }
+    private var durationChip: some View {
+        chipMenu(
+            title: StudioComposerPresets.durationTitle(draft, mode: mode),
+            accessibilityLabel: "Length",
+            kind: .duration
+        ) {
+            if mode == .music {
+                Toggle(isOn: Binding(get: { !draft.useDuration }, set: { _ in draft.useDuration = false })) {
+                    Text("Preset length")
+                }
+                Divider()
+            }
+            ForEach(StudioComposerPresets.durations(for: mode), id: \.self) { seconds in
+                Toggle(isOn: Binding(
+                    get: { usesSeconds && draft.durationSeconds == seconds },
+                    set: { _ in setDuration(seconds: seconds) }
+                )) {
+                    Text("\(StudioComposerPresets.secondsText(seconds)) s")
+                }
+            }
+            if mode == .video {
+                Divider()
+                ForEach(StudioComposerPresets.videoFrameCounts, id: \.self) { frames in
+                    Toggle(isOn: Binding(
+                        get: { !draft.useDuration && draft.numFrames == frames },
+                        set: { _ in draft.useDuration = false; draft.numFrames = frames }
+                    )) {
+                        Text("\(frames) frames")
                     }
                 }
             }
             Divider()
-            Button("Use mode default") { draft.model = "" }
-                .disabled(draft.model.isBlank)
-            Button("Browse Models…", action: onShowModels)
-        } label: {
-            HStack(spacing: 5) {
-                Image(systemName: "cpu")
-                    .font(.system(size: 10, weight: .semibold))
-                    .foregroundStyle(MereRunTheme.accent)
-                Text(modelLabel)
-                    .font(.system(size: 11, weight: .medium))
-                    .foregroundStyle(MereRunTheme.textSecondary)
-                    .lineLimit(1)
-                    .truncationMode(.middle)
-                    .frame(maxWidth: 130)
-                    .fixedSize(horizontal: true, vertical: false)
-                Image(systemName: "chevron.up.chevron.down")
-                    .font(.system(size: 7.5, weight: .semibold))
-                    .foregroundStyle(MereRunTheme.textMuted)
-            }
-            .padding(.horizontal, 8)
-            .frame(height: 26)
-            .background {
-                Capsule()
-                    .fill(MereRunTheme.surfaceRaised.opacity(0.8))
-                    .overlay {
-                        Capsule().strokeBorder(MereRunTheme.border.opacity(0.55), lineWidth: 1)
+            Button("Custom length…") { editingChip = .duration }
+        } editor: {
+            HStack(spacing: MereRunTheme.Spacing.xs) {
+                if mode == .video {
+                    Picker("Count", selection: $draft.useDuration) {
+                        Text("Frames").tag(false)
+                        Text("Seconds").tag(true)
                     }
+                    .pickerStyle(.segmented)
+                    .labelsHidden()
+                }
+                if mode == .video, !draft.useDuration {
+                    numberField("Frames", value: $draft.numFrames, range: 1...600)
+                } else {
+                    decimalField("Seconds", value: Binding(
+                        get: { draft.durationSeconds },
+                        set: { setDuration(seconds: max(0.1, $0)) }
+                    ))
+                }
             }
         }
-        .menuStyle(.borderlessButton)
-        .menuIndicator(.hidden)
-        .fixedSize()
-        .help(rawModelID.isEmpty ? "Auto — the mode's default model" : "Model: \(rawModelID)")
-        .accessibilityLabel("Model")
-        .accessibilityValue(rawModelID.isEmpty ? "Automatic" : rawModelID)
     }
 
-    /// The resolved model id for this run: the explicit draft model, else the
-    /// mode's template default, else empty (Auto).
+    private var usesSeconds: Bool {
+        mode == .sfx || draft.useDuration
+    }
+
+    private func setDuration(seconds: Double) {
+        draft.durationSeconds = seconds
+        if mode != .sfx { draft.useDuration = true }
+    }
+
+    private var stepsChip: some View {
+        chipMenu(
+            title: StudioComposerPresets.stepsTitle(draft, mode: mode),
+            accessibilityLabel: "Steps",
+            kind: .steps
+        ) {
+            if mode == .music {
+                Toggle(isOn: Binding(get: { !draft.musicOverrideSteps }, set: { _ in draft.musicOverrideSteps = false })) {
+                    Text("Preset steps")
+                }
+                Divider()
+            }
+            ForEach(StudioComposerPresets.steps(for: mode), id: \.self) { steps in
+                Toggle(isOn: Binding(
+                    get: { stepsAreExplicit && draft.steps == steps },
+                    set: { _ in setSteps(steps) }
+                )) {
+                    Text(steps == 1 ? "1 step" : "\(steps) steps")
+                }
+            }
+            Divider()
+            Button("Custom steps…") { editingChip = .steps }
+        } editor: {
+            numberField("Steps", value: Binding(get: { draft.steps }, set: { setSteps($0) }), range: 1...200)
+        }
+    }
+
+    private var stepsAreExplicit: Bool {
+        mode != .music || draft.musicOverrideSteps
+    }
+
+    private func setSteps(_ steps: Int) {
+        draft.steps = steps
+        if mode == .music { draft.musicOverrideSteps = true }
+    }
+
+    private var seedChip: some View {
+        let seedMode = StudioSeedMode(draft: draft)
+        return chipMenu(title: seedMode.chipTitle, accessibilityLabel: "Seed", kind: .seed) {
+            Toggle(isOn: Binding(get: { seedMode == .random }, set: { _ in StudioSeedMode.random.apply(to: &draft) })) {
+                Text("Random")
+            }
+            Button("Enter a seed…") { editingChip = .seed }
+            Divider()
+            Button("Reuse last\(lastSeed.map { " (\($0))" } ?? "")") {
+                if let lastSeed { draft.seed = lastSeed }
+            }
+            .disabled(lastSeed == nil)
+        } editor: {
+            HStack(spacing: MereRunTheme.Spacing.xs) {
+                TextField("Seed", text: $draft.seed)
+                    .frame(width: 120)
+                    .mereField(cornerRadius: MereRunTheme.Radius.sm)
+                Button("Random") { StudioSeedMode.random.apply(to: &draft) }
+                    .buttonStyle(.mereSecondary)
+            }
+        }
+    }
+
+    private var thresholdChip: some View {
+        chipMenu(
+            title: StudioComposerPresets.thresholdTitle(draft),
+            accessibilityLabel: "Threshold",
+            kind: .threshold
+        ) {
+            ForEach(StudioComposerPresets.thresholds, id: \.self) { threshold in
+                Toggle(isOn: Binding(
+                    get: { draft.visionThreshold == threshold },
+                    set: { _ in draft.visionThreshold = threshold }
+                )) {
+                    Text(StudioComposerPresets.decimalText(threshold))
+                }
+            }
+            Divider()
+            Button("Custom threshold…") { editingChip = .threshold }
+        } editor: {
+            decimalField("Threshold", value: Binding(
+                get: { draft.visionThreshold },
+                set: { draft.visionThreshold = min(max($0, 0), 1) }
+            ))
+        }
+    }
+
+    private var readImageActionChip: some View {
+        chipMenu(title: draft.readImageAction.title, accessibilityLabel: "Task", kind: .readImageAction) {
+            ForEach(StudioReadImageAction.allCases) { action in
+                Toggle(isOn: Binding(
+                    get: { draft.readImageAction == action },
+                    set: { _ in draft.readImageAction = action }
+                )) {
+                    Text(action.title)
+                }
+                .disabled(readImageActionUnavailableMessage(action) != nil)
+                .help(readImageActionUnavailableMessage(action) ?? action.title)
+            }
+        }
+    }
+
+    /// Why a Read Image variant cannot run on this machine, from the capability report.
+    private func readImageActionUnavailableMessage(_ action: StudioReadImageAction) -> String? {
+        guard mode == .readImage else { return nil }
+        var candidateDraft = draft
+        candidateDraft.readImageAction = action
+        switch StudioCommandAdapter.capabilityRequirement(for: .readImage, draft: candidateDraft) {
+        case .unavailable(let message):
+            return message
+        case .managedModel(let modelID):
+            return controller.modelCapabilitiesByID[modelID]?.unavailableMessage
+        case nil:
+            return nil
+        }
+    }
+
+    private var voiceModeChip: some View {
+        chipMenu(title: StudioComposerPresets.voiceModeTitle(draft), accessibilityLabel: "Voice", kind: .voiceMode) {
+            Toggle(isOn: Binding(get: { draft.voiceMode != "clone" }, set: { _ in draft.voiceMode = "style" })) {
+                Text("Preset voice")
+            }
+            Toggle(isOn: Binding(get: { draft.voiceMode == "clone" }, set: { _ in draft.voiceMode = "clone" })) {
+                Text("Cloned voice")
+            }
+        }
+    }
+
+    private var thinkingChip: some View {
+        chipMenu(
+            title: StudioComposerPresets.thinkingTitle(draft.thinkingMode),
+            accessibilityLabel: "Thinking",
+            kind: .thinking
+        ) {
+            ForEach(TextThinkingMode.allCases, id: \.self) { thinking in
+                Toggle(isOn: Binding(
+                    get: { draft.thinkingMode == thinking },
+                    set: { _ in draft.thinkingMode = thinking }
+                )) {
+                    Text(StudioComposerPresets.thinkingTitle(thinking))
+                }
+            }
+        }
+    }
+
+    /// A chip that opens a menu, with an optional popover for values the menu cannot type.
+    private func chipMenu<Items: View, Editor: View>(
+        title: String,
+        accessibilityLabel: String,
+        kind: StudioComposerChipKind,
+        @ViewBuilder items: () -> Items,
+        @ViewBuilder editor: () -> Editor
+    ) -> some View {
+        let editorView = editor()
+        return Menu(content: items) {
+            StudioComposerChipLabel(title: title)
+        }
+        .menuStyle(.button)
+        .buttonStyle(.plain)
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .accessibilityLabel(accessibilityLabel)
+        .accessibilityValue(title)
+        .popover(
+            isPresented: Binding(get: { editingChip == kind }, set: { if !$0 { editingChip = nil } }),
+            arrowEdge: .top
+        ) {
+            editorView
+                .padding(MereRunTheme.Spacing.md)
+                .background(MereRunTheme.background)
+                .foregroundStyle(MereRunTheme.textPrimary)
+        }
+    }
+
+    private func chipMenu<Items: View>(
+        title: String,
+        accessibilityLabel: String,
+        kind: StudioComposerChipKind,
+        @ViewBuilder items: () -> Items
+    ) -> some View {
+        chipMenu(title: title, accessibilityLabel: accessibilityLabel, kind: kind, items: items) { EmptyView() }
+    }
+
+    private func numberField(_ label: String, value: Binding<Int>, range: ClosedRange<Int>) -> some View {
+        TextField(
+            label,
+            value: Binding(get: { value.wrappedValue }, set: { value.wrappedValue = min(max($0, range.lowerBound), range.upperBound) }),
+            format: .number
+        )
+        .frame(width: 72)
+        .mereField(cornerRadius: MereRunTheme.Radius.sm)
+        .accessibilityLabel(label)
+    }
+
+    private func decimalField(_ label: String, value: Binding<Double>) -> some View {
+        TextField(label, value: value, format: .number)
+            .frame(width: 84)
+            .mereField(cornerRadius: MereRunTheme.Radius.sm)
+            .accessibilityLabel(label)
+    }
+
+    // MARK: - Model chip
+
+    private var modelChip: some View {
+        Menu {
+            Toggle(isOn: Binding(get: { draft.model.isBlank }, set: { _ in draft.model = "" })) {
+                Text(defaultModelID.isEmpty ? "Auto" : "Auto · \(Self.displayModelName(defaultModelID))")
+            }
+            let choices = mode.modelChoices(from: modelInventory)
+            let installed = choices.filter(\.isInstalled)
+            let downloadable = choices.filter { !$0.isInstalled }
+            if !installed.isEmpty {
+                Section("Installed") {
+                    ForEach(installed) { row in modelRow(row) }
+                }
+            }
+            if !downloadable.isEmpty {
+                Section("Needs download") {
+                    ForEach(downloadable) { row in modelRow(row) }
+                }
+            }
+            if choices.isEmpty {
+                Text("No \(mode.title.lowercased()) models listed yet")
+            }
+            Divider()
+            Button("Browse Models…", action: onShowModels)
+        } label: {
+            StudioComposerChipLabel(title: modelLabel, leadingSystemImage: modelStatusGlyph)
+        }
+        .menuStyle(.button)
+        .buttonStyle(.plain)
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .help(modelHelp)
+        .accessibilityLabel("Model")
+        .accessibilityValue(modelAccessibilityValue)
+    }
+
+    private func modelRow(_ row: StudioModelInventoryRow) -> some View {
+        Toggle(isOn: Binding(get: { row.id == draft.model }, set: { _ in draft.model = row.id })) {
+            Label(Self.displayModelName(row.id), systemImage: row.isInstalled ? "internaldrive" : "arrow.down.circle")
+        }
+    }
+
+    /// The mode's template default, shown as "Auto".
+    private var defaultModelID: String {
+        CommandCatalog.template(id: mode.defaultTemplateID)?.defaultModel ?? ""
+    }
+
+    /// The resolved model id for this run: the explicit draft model, else the mode's default.
     private var rawModelID: String {
         let current = draft.model.trimmingCharacters(in: .whitespacesAndNewlines)
-        if !current.isEmpty { return current }
-        return CommandCatalog.template(id: mode.defaultTemplateID)?.defaultModel ?? ""
+        return current.isEmpty ? defaultModelID : current
     }
 
     private var modelLabel: String {
         rawModelID.isEmpty ? "Auto" : Self.displayModelName(rawModelID)
     }
 
+    /// A glyph before the model name when the model is not ready: missing locally, or unsupported.
+    private var modelStatusGlyph: String? {
+        switch readiness {
+        case .missingModel: return "arrow.down.circle"
+        case .unsupported: return "exclamationmark.triangle"
+        case .checking, .ready, .unknown: return nil
+        }
+    }
+
+    private var modelHelp: String {
+        let identity = rawModelID.isEmpty ? "Auto — the mode's default model" : "Model: \(rawModelID)"
+        switch readiness {
+        case .ready, .unknown: return identity
+        default: return "\(identity) · \(readiness.message)"
+        }
+    }
+
+    private var modelAccessibilityValue: String {
+        let identity = rawModelID.isEmpty ? "Automatic" : rawModelID
+        return "\(identity), \(readiness.title)"
+    }
+
     /// A human-facing label for a model id: drop the modality/category prefix and
     /// title-case the distinctive remainder ("text-agent-deepseek-v4-flash" →
-    /// "Deepseek V4 Flash"). The exact id stays in the pill's tooltip, so the
+    /// "Deepseek V4 Flash"). The exact id stays in the chip's tooltip, so the
     /// friendly name never hides what the CLI actually expects.
     static func displayModelName(_ id: String) -> String {
         let leaf = id.components(separatedBy: "/").last ?? id
         let prefixes = [
             "text-chat-", "text-agent-", "text-embed-", "text-code-",
-            "image-", "video-", "music-", "sfx-", "speech-", "embed-", "vision-", "text-"
+            "image-", "video-", "music-", "sfx-", "speech-tts-", "speech-asr-", "speech-",
+            "embed-", "vision-ground-", "vision-segment-", "vision-chat-", "vision-ocr-", "vision-", "text-"
         ]
         var core = leaf
         for prefix in prefixes where core.hasPrefix(prefix) {
@@ -391,26 +549,258 @@ struct StudioComposer: View {
         return label.isEmpty ? leaf : label
     }
 
-    private var groupedModelCategories: [(category: String, rows: [StudioModelInventoryRow])] {
-        Dictionary(grouping: installedModels, by: \.category)
-            .map { (category: $0.key, rows: $0.value.sorted { $0.id < $1.id }) }
-            .sorted { $0.category < $1.category }
-    }
+    // MARK: - Right cluster
 
-    private var attachmentHint: String {
-        switch mode {
-        case .listen: return "Attach an audio file to begin — or drop it anywhere"
-        case .track: return "Attach a video to begin — or drop it anywhere"
-        default: return "Attach an image to begin — or drop it anywhere"
+    private var optionsButton: some View {
+        Button {
+            showOptions.toggle()
+        } label: {
+            Image(systemName: "slider.horizontal.3")
+                .font(.system(size: 14, weight: .semibold))
+                .foregroundStyle(showOptions ? MereRunTheme.accent : MereRunTheme.textMuted)
+                .frame(width: 28, height: 28)
+        }
+        .buttonStyle(.mereIcon)
+        .help("More options")
+        .accessibilityLabel("More options")
+        .popover(isPresented: $showOptions, arrowEdge: .top) {
+            StudioOptionsPanel(
+                mode: mode,
+                draft: $draft,
+                onShowAdapters: onShowAdapters,
+                onShowRealtimeMusic: onShowRealtimeMusic
+            )
         }
     }
 
-    private func attachmentIcon(for url: URL) -> String {
+    /// Only a collapsed well (Chat's per-turn image) needs the paperclip; declared slots pick
+    /// from the well itself.
+    private var showsPaperclip: Bool {
+        !mode.attachmentSlots.isEmpty && !mode.showsAttachmentWell(for: draft)
+    }
+
+    private var paperclipButton: some View {
+        Button {
+            if let slot = mode.attachmentSlots.first { pickFiles(for: slot) }
+        } label: {
+            Image(systemName: "paperclip")
+                .font(.system(size: 15, weight: .medium))
+                .foregroundStyle(MereRunTheme.textMuted)
+                .frame(width: 28, height: 28)
+        }
+        .buttonStyle(.mereIcon)
+        .help("Attach an image to this turn")
+        .accessibilityLabel("Attach image")
+    }
+
+    private var stopButton: some View {
+        Button(action: onStop) {
+            ZStack {
+                Circle().fill(MereRunTheme.surfaceRaised)
+                Image(systemName: "stop.fill")
+                    .font(.system(size: 11, weight: .bold))
+                    .foregroundStyle(MereRunTheme.textPrimary)
+            }
+            .frame(width: Metrics.sendDiameter, height: Metrics.sendDiameter)
+        }
+        .buttonStyle(.plain)
+        .help(queuedCount == 0 ? "Stop (⌘.) · ⌘↩ queues another run" : "Stop (⌘.) · \(queuedCount) queued")
+        .accessibilityLabel("Stop current run")
+    }
+
+    private var sendButton: some View {
+        Button(action: onRun) {
+            ZStack {
+                Circle().fill(sendEnabled ? MereRunTheme.accent : MereRunTheme.surfaceRaised)
+                Image(systemName: "arrow.up")
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(sendEnabled ? onAccent : MereRunTheme.textMuted)
+            }
+            .frame(width: Metrics.sendDiameter, height: Metrics.sendDiameter)
+        }
+        .buttonStyle(.plain)
+        .disabled(!sendEnabled)
+        .help(sendHelp)
+        .accessibilityLabel("Run")
+        .accessibilityHint(accessibilityRunHint)
+        .keyboardShortcut(.return, modifiers: .command)
+    }
+
+    private var sendEnabled: Bool {
+        !readiness.blocksRun && !sendBlocked
+    }
+
+    private var sendHelp: String {
+        if sendBlocked { return "Waiting for the current reply…" }
+        if readiness.blocksRun { return readiness.message }
+        return "Run (⌘↩)"
+    }
+
+    /// Spoken explanation of why Run is disabled, so the blocked state is not color-only.
+    private var accessibilityRunHint: String {
+        if sendBlocked { return "Waiting for the current reply to finish" }
+        if readiness.blocksRun { return readiness.message }
+        return ""
+    }
+}
+
+/// The chip body: 24pt tall on `surfaceRaised`, 11.5pt medium, a muted chevron when it opens a menu.
+struct StudioComposerChipLabel: View {
+    let title: String
+    var leadingSystemImage: String?
+    var menu = true
+
+    var body: some View {
+        HStack(spacing: 4) {
+            if let leadingSystemImage {
+                Image(systemName: leadingSystemImage)
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundStyle(MereRunTheme.accent)
+            }
+            Text(title)
+                .font(.system(size: 11.5, weight: .medium))
+                .foregroundStyle(MereRunTheme.textPrimary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .frame(maxWidth: 180)
+                .fixedSize(horizontal: true, vertical: false)
+            if menu {
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 8, weight: .semibold))
+                    .foregroundStyle(MereRunTheme.textMuted)
+            }
+        }
+        .padding(.horizontal, 9)
+        .frame(height: 24)
+        .background {
+            RoundedRectangle(cornerRadius: MereRunTheme.Radius.sm)
+                .fill(MereRunTheme.surfaceRaised)
+        }
+        .contentShape(RoundedRectangle(cornerRadius: MereRunTheme.Radius.sm))
+    }
+}
+
+/// One 48×48 slot of the attachment well. Empty: a dashed outline with a plus. Filled: the
+/// file's thumbnail (or a kind glyph for audio and video) with a hover-revealed remove button.
+/// Accepts a drop, a paste (⌘V while focused), and a click to pick.
+struct StudioAttachmentSlotView: View {
+    let slot: StudioAttachmentSlot
+    @Binding var draft: StudioDraft
+    let onPick: () -> Void
+
+    @State private var isDropTargeted = false
+    @State private var hovering = false
+
+    private static let side: CGFloat = 48
+    private static let cornerRadius: CGFloat = MereRunTheme.Radius.base
+
+    private var paths: [String] { slot.paths(in: draft) }
+    private var isFilled: Bool { !paths.isEmpty }
+
+    var body: some View {
+        Button(action: onPick) {
+            ZStack {
+                if let first = paths.first {
+                    thumbnail(for: URL(fileURLWithPath: first))
+                } else {
+                    Image(systemName: "plus")
+                        .font(.system(size: 15, weight: .medium))
+                        .foregroundStyle(MereRunTheme.textMuted)
+                }
+            }
+            .frame(width: Self.side, height: Self.side)
+            .clipShape(RoundedRectangle(cornerRadius: Self.cornerRadius))
+            .overlay { outline }
+            .overlay(alignment: .topTrailing) {
+                if isFilled, hovering {
+                    Button {
+                        slot.clear(in: &draft)
+                    } label: {
+                        Image(systemName: "xmark.circle.fill")
+                            .font(.system(size: 13))
+                            .symbolRenderingMode(.palette)
+                            .foregroundStyle(MereRunTheme.surface, MereRunTheme.textPrimary)
+                    }
+                    .buttonStyle(.plain)
+                    .padding(3)
+                    .help("Remove")
+                    .accessibilityLabel("Remove \(slot.label.lowercased())")
+                }
+            }
+            .contentShape(RoundedRectangle(cornerRadius: Self.cornerRadius))
+        }
+        .buttonStyle(.plain)
+        .focusable()
+        .onHover { hovering = $0 }
+        .dropDestination(for: URL.self) { urls, _ in
+            let accepted = urls.filter(slot.accepts)
+            guard !accepted.isEmpty else { return false }
+            slot.attach(accepted, to: &draft)
+            return true
+        } isTargeted: { targeted in
+            withAnimation(MereRunTheme.Motion.quick) { isDropTargeted = targeted }
+        }
+        .onPasteCommand(of: [.fileURL, .image]) { _ in paste() }
+        .contextMenu {
+            Button("Choose…", action: onPick)
+            if isFilled {
+                Button("Reveal in Finder") {
+                    NSWorkspace.shared.activateFileViewerSelecting(paths.map { URL(fileURLWithPath: $0) })
+                }
+                Button("Remove") { slot.clear(in: &draft) }
+            }
+        }
+        .help(isFilled ? paths.joined(separator: "\n") : "Drop, paste, or click to add \(slot.label.lowercased())")
+        .accessibilityLabel(slot.label)
+        .accessibilityValue(isFilled ? slot.caption(in: draft) : "Empty")
+        .accessibilityHint("Drop a file, paste with Command-V, or click to choose")
+    }
+
+    @ViewBuilder
+    private var outline: some View {
+        let shape = RoundedRectangle(cornerRadius: Self.cornerRadius)
+        if isDropTargeted {
+            shape.strokeBorder(MereRunTheme.accent, style: StrokeStyle(lineWidth: 2, dash: [5, 4]))
+        } else if isFilled {
+            shape.strokeBorder(MereRunTheme.border, lineWidth: 1)
+        } else {
+            shape.strokeBorder(MereRunTheme.border, style: StrokeStyle(lineWidth: 1, dash: [4, 3]))
+        }
+    }
+
+    @ViewBuilder
+    private func thumbnail(for url: URL) -> some View {
         switch StudioOutputFileKind.classify(url) {
-        case .audio: return "waveform"
-        case .video: return "film"
-        default: return "doc"
+        case .image:
+            StudioAsyncImagePreview(url: url, maxPixelSize: 160, contentMode: .fill, fallbackSystemImage: "photo")
+        case .audio:
+            kindGlyph("waveform")
+        case .video:
+            kindGlyph("film")
+        default:
+            kindGlyph("doc")
         }
+    }
+
+    private func kindGlyph(_ systemImage: String) -> some View {
+        ZStack {
+            MereRunTheme.surfaceRaised
+            Image(systemName: systemImage)
+                .font(.system(size: 16, weight: .medium))
+                .foregroundStyle(MereRunTheme.accent)
+        }
+    }
+
+    private func paste() {
+        let pasteboard = NSPasteboard.general
+        let urls = StudioAttachmentPasteboard.fileURLs(from: pasteboard, for: slot)
+        if !urls.isEmpty {
+            slot.attach(urls, to: &draft)
+            return
+        }
+        guard slot.acceptedTypes.contains(where: { UTType.image.conforms(to: $0) }),
+              let url = try? StudioAttachmentPasteboard.writePastedImage(from: pasteboard) else { return }
+        slot.attach([url], to: &draft)
     }
 }
 
@@ -433,19 +823,6 @@ struct StudioOptionsPanel: View {
                     .font(MereRunTheme.sectionFont)
                     .foregroundStyle(MereRunTheme.textMuted)
 
-                if mode == .readImage {
-                    Picker("Task", selection: $draft.readImageAction) {
-                        ForEach(StudioReadImageAction.allCases) { action in
-                            Text(action.title)
-                                .tag(action)
-                                .disabled(readImageActionUnavailableMessage(action) != nil)
-                                .help(readImageActionUnavailableMessage(action) ?? action.title)
-                        }
-                    }
-                    .pickerStyle(.segmented)
-                    .labelsHidden()
-                }
-
                 if let secondaryLabel {
                     VStack(alignment: .leading, spacing: 4) {
                         Text(secondaryLabel)
@@ -455,14 +832,6 @@ struct StudioOptionsPanel: View {
                             .lineLimit(1...4)
                             .mereField()
                     }
-                }
-
-                VStack(alignment: .leading, spacing: 4) {
-                    Text("Model")
-                        .font(MereRunTheme.captionFont)
-                        .foregroundStyle(MereRunTheme.textMuted)
-                    TextField("Model", text: $draft.model)
-                        .mereField()
                 }
 
                 if mode == .speak {
@@ -485,40 +854,6 @@ struct StudioOptionsPanel: View {
                     musicOptions
                 }
 
-                if [.createImage, .video].contains(mode) {
-                    HStack(spacing: MereRunTheme.Spacing.sm) {
-                        Stepper("Width \(draft.width)", value: $draft.width, in: 64...4096, step: 64)
-                        Stepper("Height \(draft.height)", value: $draft.height, in: 64...4096, step: 64)
-                    }
-                    .font(MereRunTheme.captionFont)
-                }
-
-                if [.createImage, .sfx].contains(mode) {
-                    Stepper("Steps \(draft.steps)", value: $draft.steps, in: 1...80, step: 1)
-                        .font(MereRunTheme.captionFont)
-                }
-
-                if mode == .sfx {
-                    HStack {
-                        Text("Duration seconds")
-                            .font(MereRunTheme.captionFont)
-                        Spacer()
-                        TextField("Seconds", value: $draft.durationSeconds, format: .number)
-                            .frame(width: 80)
-                            .mereField(cornerRadius: MereRunTheme.Radius.sm)
-                    }
-                }
-
-                if [.createImage, .music, .video, .sfx].contains(mode) {
-                    HStack {
-                        Text("Seed")
-                            .font(MereRunTheme.captionFont)
-                        Spacer()
-                        TextField("Random", text: $draft.seed)
-                            .frame(width: 110)
-                            .mereField(cornerRadius: MereRunTheme.Radius.sm)
-                    }
-                }
 
                 if !visibleOptionFields.isEmpty {
                     Divider().overlay(MereRunTheme.border.opacity(0.4))
@@ -1306,25 +1641,6 @@ struct StudioOptionsPanel: View {
         panel.canChooseDirectories = false
         if panel.runModal() == .OK {
             draft.musicAdapterPaths = panel.urls.map(\.path).joined(separator: "\n")
-        }
-    }
-
-    private func readImageActionUnavailableMessage(_ action: StudioReadImageAction) -> String? {
-        guard mode == .readImage else { return nil }
-        var candidateDraft = draft
-        candidateDraft.readImageAction = action
-        let requirement = StudioCommandAdapter.capabilityRequirement(
-            for: .readImage,
-            draft: candidateDraft
-        )
-
-        switch requirement {
-        case .unavailable(let message):
-            return message
-        case .managedModel(let modelID):
-            return controller.modelCapabilitiesByID[modelID]?.unavailableMessage
-        case nil:
-            return nil
         }
     }
 

--- a/apps/macos/MereRunStudio/StudioComposerSchema.swift
+++ b/apps/macos/MereRunStudio/StudioComposerSchema.swift
@@ -1,0 +1,431 @@
+import AppKit
+import MereRunContract
+import UniformTypeIdentifiers
+
+// The composer's declarative surface: which attachment slots and which parameter chips each
+// prompt mode shows, and how each maps onto `StudioDraft`. The views in `StudioComposer.swift`
+// render from these declarations, so a mode's essentials live in one place and are testable
+// without SwiftUI.
+
+// MARK: - Attachment slots
+
+/// One slot in the composer's attachment well, bound to a draft field.
+struct StudioAttachmentSlot: Identifiable, Equatable {
+    enum Storage: Equatable {
+        /// One path in one draft field; attaching replaces it.
+        case path(WritableKeyPath<StudioDraft, String>)
+        /// Newline-separated paths in one draft field; attaching appends, the slot previews the first.
+        case pathList(WritableKeyPath<StudioDraft, String>)
+    }
+
+    let id: String
+    /// The empty slot's caption ("Reference"); a filled slot shows its file name instead.
+    let label: String
+    let acceptedTypes: [UTType]
+    let storage: Storage
+    /// The task cannot run without this slot filled.
+    var isRequired = false
+    /// A per-turn attachment (Chat's image): the well stays collapsed to the paperclip until
+    /// something is attached, so an empty slot never sits above every message.
+    var isTransient = false
+
+    var allowsMultiple: Bool {
+        if case .pathList = storage { return true }
+        return false
+    }
+
+    /// The paths this slot currently holds, in order.
+    func paths(in draft: StudioDraft) -> [String] {
+        switch storage {
+        case .path(let keyPath):
+            let value = draft[keyPath: keyPath].trimmingCharacters(in: .whitespacesAndNewlines)
+            return value.isEmpty ? [] : [value]
+        case .pathList(let keyPath):
+            return Self.separatedPaths(draft[keyPath: keyPath])
+        }
+    }
+
+    func isFilled(in draft: StudioDraft) -> Bool {
+        !paths(in: draft).isEmpty
+    }
+
+    /// The caption shown beside the slot: the file name when filled, the slot label otherwise.
+    func caption(in draft: StudioDraft) -> String {
+        let paths = paths(in: draft)
+        guard let first = paths.first else { return label }
+        let name = URL(fileURLWithPath: first).lastPathComponent
+        return paths.count > 1 ? "\(name) +\(paths.count - 1)" : name
+    }
+
+    /// Whether a dropped or pasted file belongs in this slot.
+    func accepts(_ url: URL) -> Bool {
+        guard url.isFileURL else { return false }
+        guard let type = UTType(filenameExtension: url.pathExtension) else { return false }
+        return acceptedTypes.contains { type.conforms(to: $0) }
+    }
+
+    /// Stores `urls` in the slot: a single-path slot keeps the first, a list slot appends them all.
+    func attach(_ urls: [URL], to draft: inout StudioDraft) {
+        let incoming = urls.filter(accepts).map(\.path)
+        guard !incoming.isEmpty else { return }
+        switch storage {
+        case .path(let keyPath):
+            draft[keyPath: keyPath] = incoming[0]
+        case .pathList(let keyPath):
+            let existing = Self.separatedPaths(draft[keyPath: keyPath])
+            draft[keyPath: keyPath] = (existing + incoming.filter { !existing.contains($0) })
+                .joined(separator: "\n")
+        }
+        draft.didAttach(to: self)
+    }
+
+    func clear(in draft: inout StudioDraft) {
+        switch storage {
+        case .path(let keyPath), .pathList(let keyPath):
+            draft[keyPath: keyPath] = ""
+        }
+    }
+
+    static func separatedPaths(_ raw: String) -> [String] {
+        raw.components(separatedBy: .newlines)
+            .flatMap { $0.split(separator: ",", omittingEmptySubsequences: true) }
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+    }
+}
+
+extension StudioMode {
+    /// The attachment slots this mode's composer declares, in well order.
+    var attachmentSlots: [StudioAttachmentSlot] {
+        switch self {
+        case .createImage:
+            return [
+                StudioAttachmentSlot(id: "input", label: "Input", acceptedTypes: [.image], storage: .path(\.inputPath)),
+                StudioAttachmentSlot(
+                    id: "references", label: "Reference", acceptedTypes: [.image],
+                    storage: .pathList(\.referenceImagePaths)
+                ),
+            ]
+        case .video:
+            return [
+                StudioAttachmentSlot(id: "startFrame", label: "Start frame", acceptedTypes: [.image], storage: .path(\.inputPath)),
+                StudioAttachmentSlot(id: "endFrame", label: "End frame", acceptedTypes: [.image], storage: .path(\.endImagePath)),
+                StudioAttachmentSlot(id: "audio", label: "Audio", acceptedTypes: [.audio], storage: .path(\.audioPath)),
+            ]
+        case .music:
+            return [
+                StudioAttachmentSlot(id: "source", label: "Source", acceptedTypes: [.audio], storage: .path(\.musicSourceAudio)),
+                StudioAttachmentSlot(
+                    id: "timbre", label: "Timbre reference", acceptedTypes: [.audio],
+                    storage: .pathList(\.musicReferenceAudioPaths)
+                ),
+            ]
+        case .speak:
+            return [
+                StudioAttachmentSlot(id: "referenceAudio", label: "Reference audio", acceptedTypes: [.audio], storage: .path(\.refAudioPath)),
+            ]
+        case .chat:
+            return [
+                StudioAttachmentSlot(
+                    id: "image", label: "Image", acceptedTypes: [.image], storage: .path(\.inputPath),
+                    isTransient: true
+                ),
+            ]
+        case .readImage, .findObjects, .segment:
+            return [
+                StudioAttachmentSlot(id: "input", label: "Image", acceptedTypes: [.image], storage: .path(\.inputPath), isRequired: true),
+            ]
+        case .track:
+            return [
+                StudioAttachmentSlot(
+                    id: "input", label: "Video", acceptedTypes: [.movie, .video, .audiovisualContent],
+                    storage: .path(\.inputPath), isRequired: true
+                ),
+            ]
+        case .listen:
+            return [
+                StudioAttachmentSlot(id: "input", label: "Audio", acceptedTypes: [.audio], storage: .path(\.inputPath), isRequired: true),
+            ]
+        case .code, .sfx:
+            return []
+        }
+    }
+
+    /// Whether the composer shows the well: any non-transient slot, or a transient one that is filled.
+    func showsAttachmentWell(for draft: StudioDraft) -> Bool {
+        attachmentSlots.contains { !$0.isTransient || $0.isFilled(in: draft) }
+    }
+
+    /// The slot a file dropped on the canvas or pasted with ⌘V lands in: the first empty slot
+    /// that accepts it, else the first slot that accepts it.
+    func attachmentSlot(for url: URL, in draft: StudioDraft) -> StudioAttachmentSlot? {
+        let accepting = attachmentSlots.filter { $0.accepts(url) }
+        return accepting.first { !$0.isFilled(in: draft) } ?? accepting.first
+    }
+
+    /// The slot a pasted bitmap (no file on the pasteboard) lands in.
+    func pastedImageSlot(in draft: StudioDraft) -> StudioAttachmentSlot? {
+        let accepting = attachmentSlots.filter { slot in slot.acceptedTypes.contains { UTType.image.conforms(to: $0) } }
+        return accepting.first { !$0.isFilled(in: draft) } ?? accepting.first
+    }
+}
+
+extension StudioDraft {
+    /// Routes each dropped file to the slot it belongs in. Returns whether anything was attached.
+    @discardableResult
+    mutating func attach(dropped urls: [URL], for mode: StudioMode) -> Bool {
+        var attached = false
+        for url in urls {
+            guard let slot = mode.attachmentSlot(for: url, in: self) else { continue }
+            slot.attach([url], to: &self)
+            attached = true
+        }
+        return attached
+    }
+
+    /// Settings that follow an attachment so the slot is never silently ignored: LTX audio
+    /// needs the audio+video output, and a cloned voice needs clone mode.
+    fileprivate mutating func didAttach(to slot: StudioAttachmentSlot) {
+        switch slot.id {
+        case "audio" where slot.storage == .path(\.audioPath):
+            videoQuality = .final
+            videoOutputMode = .audioVideo
+        case "referenceAudio":
+            voiceMode = "clone"
+        default:
+            break
+        }
+    }
+}
+
+/// Reads attachments off the pasteboard: file URLs first, else a pasted bitmap saved as PNG.
+enum StudioAttachmentPasteboard {
+    /// File URLs on the pasteboard that `slot` accepts.
+    static func fileURLs(from pasteboard: NSPasteboard, for slot: StudioAttachmentSlot) -> [URL] {
+        let urls = pasteboard.readObjects(
+            forClasses: [NSURL.self],
+            options: [.urlReadingFileURLsOnly: true]
+        ) as? [URL] ?? []
+        return urls.filter(slot.accepts)
+    }
+
+    /// Writes a pasted bitmap to a PNG in the temporary directory; nil when there is no image.
+    static func writePastedImage(from pasteboard: NSPasteboard) throws -> URL? {
+        guard let image = NSImage(pasteboard: pasteboard),
+              let tiff = image.tiffRepresentation,
+              let bitmap = NSBitmapImageRep(data: tiff),
+              let data = bitmap.representation(using: .png, properties: [:]) else {
+            return nil
+        }
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("pasted-\(UUID().uuidString).png")
+        try data.write(to: url)
+        return url
+    }
+}
+
+// MARK: - Chips
+
+/// One essential parameter shown as an editable chip under the prompt.
+enum StudioComposerChipKind: String, CaseIterable, Identifiable {
+    case dimensions
+    case duration
+    case steps
+    case seed
+    case threshold
+    case readImageAction
+    case voiceMode
+    case thinking
+    case model
+
+    var id: String { rawValue }
+}
+
+extension StudioMode {
+    /// The two to four essentials this mode shows as chips, in strip order. Everything else stays
+    /// in the options popover until the inspector replaces it.
+    var composerChips: [StudioComposerChipKind] {
+        switch self {
+        case .createImage: return [.dimensions, .steps, .seed, .model]
+        case .video, .music, .sfx: return [.duration, .steps, .seed, .model]
+        case .speak: return [.voiceMode, .model]
+        case .chat: return [.model, .thinking]
+        case .code, .listen: return [.model]
+        case .readImage: return [.readImageAction, .model]
+        case .findObjects: return [.model]
+        case .segment, .track: return [.threshold, .model]
+        }
+    }
+
+    /// The `model list` categories whose rows the model chip offers for this mode.
+    var modelCategories: Set<String> {
+        switch self {
+        case .createImage: return ["image"]
+        case .chat: return ["text-chat", "vision-chat", "omni-chat"]
+        case .code: return ["text-code", "text-chat"]
+        case .speak: return ["speech-tts"]
+        case .listen: return ["speech-asr"]
+        case .readImage: return ["vision-chat", "omni-chat", "vision-ocr"]
+        case .findObjects: return ["vision-ground"]
+        case .segment, .track: return ["vision-segment"]
+        case .music: return ["music"]
+        case .video: return ["video"]
+        case .sfx: return ["sfx"]
+        }
+    }
+
+    /// Inventory rows the model chip lists: this mode's categories, installed first.
+    func modelChoices(from inventory: [StudioModelInventoryRow]) -> [StudioModelInventoryRow] {
+        inventory
+            .filter { modelCategories.contains($0.category) }
+            .sorted { lhs, rhs in
+                if lhs.isInstalled != rhs.isInstalled { return lhs.isInstalled }
+                return lhs.id < rhs.id
+            }
+    }
+}
+
+/// A named aspect ratio with the pixel size it means for one mode.
+struct StudioAspectPreset: Identifiable, Equatable {
+    let label: String
+    let width: Int
+    let height: Int
+
+    var id: String { label }
+
+    func matches(_ draft: StudioDraft) -> Bool {
+        draft.width == width && draft.height == height
+    }
+
+    func apply(to draft: inout StudioDraft) {
+        draft.width = width
+        draft.height = height
+    }
+
+    /// Image sizes are the 1024² family; video sizes stay multiples of 32 around LTX's 768×512.
+    static func presets(for mode: StudioMode) -> [StudioAspectPreset] {
+        switch mode {
+        case .video:
+            return [
+                StudioAspectPreset(label: "3:2", width: 768, height: 512),
+                StudioAspectPreset(label: "16:9", width: 832, height: 480),
+                StudioAspectPreset(label: "1:1", width: 512, height: 512),
+                StudioAspectPreset(label: "9:16", width: 480, height: 832),
+                StudioAspectPreset(label: "2:3", width: 512, height: 768),
+            ]
+        default:
+            return [
+                StudioAspectPreset(label: "1:1", width: 1024, height: 1024),
+                StudioAspectPreset(label: "3:2", width: 1216, height: 832),
+                StudioAspectPreset(label: "2:3", width: 832, height: 1216),
+                StudioAspectPreset(label: "16:9", width: 1344, height: 768),
+                StudioAspectPreset(label: "9:16", width: 768, height: 1344),
+                StudioAspectPreset(label: "4:3", width: 1152, height: 896),
+                StudioAspectPreset(label: "3:4", width: 896, height: 1152),
+            ]
+        }
+    }
+}
+
+/// How the seed chip reads the draft's free-text seed.
+enum StudioSeedMode: Equatable {
+    case random
+    case fixed(Int)
+
+    init(draft: StudioDraft) {
+        let trimmed = draft.seed.trimmingCharacters(in: .whitespacesAndNewlines)
+        if let value = Int(trimmed) {
+            self = .fixed(value)
+        } else {
+            self = .random
+        }
+    }
+
+    func apply(to draft: inout StudioDraft) {
+        switch self {
+        case .random: draft.seed = ""
+        case .fixed(let value): draft.seed = String(value)
+        }
+    }
+
+    var chipTitle: String {
+        switch self {
+        case .random: return "Seed random"
+        case .fixed(let value): return "Seed \(value)"
+        }
+    }
+}
+
+/// Preset values and titles for the chips whose menus list numbers.
+enum StudioComposerPresets {
+    static func steps(for mode: StudioMode) -> [Int] {
+        switch mode {
+        case .video: return [20, 30, 40, 50]
+        case .music: return [8, 27, 60]
+        case .sfx: return [4, 8, 16, 32, 50]
+        default: return [1, 2, 4, 8, 12, 20, 28, 50]
+        }
+    }
+
+    /// Seconds for the duration chip.
+    static func durations(for mode: StudioMode) -> [Double] {
+        switch mode {
+        case .music: return [30, 60, 120, 180, 240]
+        case .video: return [2, 3, 5, 8]
+        default: return [2, 5, 10, 15, 30]
+        }
+    }
+
+    /// Frame counts for Video's duration chip when it counts frames rather than seconds.
+    static let videoFrameCounts = [33, 65, 97, 129, 161]
+
+    static let thresholds = [0.05, 0.1, 0.2, 0.3, 0.5]
+
+    static func dimensionsTitle(_ draft: StudioDraft) -> String {
+        "\(draft.width) × \(draft.height)"
+    }
+
+    static func stepsTitle(_ draft: StudioDraft, mode: StudioMode) -> String {
+        if mode == .music, !draft.musicOverrideSteps { return "Preset steps" }
+        return draft.steps == 1 ? "1 step" : "\(draft.steps) steps"
+    }
+
+    static func durationTitle(_ draft: StudioDraft, mode: StudioMode) -> String {
+        switch mode {
+        case .video where !draft.useDuration:
+            return "\(draft.numFrames) frames"
+        case .music where !draft.useDuration:
+            return "Preset length"
+        default:
+            return "\(secondsText(draft.durationSeconds)) s"
+        }
+    }
+
+    static func thresholdTitle(_ draft: StudioDraft) -> String {
+        "Threshold \(decimalText(draft.visionThreshold))"
+    }
+
+    static func thinkingTitle(_ mode: TextThinkingMode) -> String {
+        switch mode {
+        case .automatic: return "Thinking auto"
+        case .show: return "Thinking on"
+        case .hide: return "Thinking off"
+        }
+    }
+
+    static func voiceModeTitle(_ draft: StudioDraft) -> String {
+        draft.voiceMode == "clone" ? "Cloned voice" : "Preset voice"
+    }
+
+    static func secondsText(_ seconds: Double) -> String {
+        seconds.rounded() == seconds ? String(Int(seconds)) : decimalText(seconds)
+    }
+
+    static func decimalText(_ value: Double) -> String {
+        let formatter = NumberFormatter()
+        formatter.minimumFractionDigits = 0
+        formatter.maximumFractionDigits = 2
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        return formatter.string(from: NSNumber(value: value)) ?? String(value)
+    }
+}

--- a/apps/macos/MereRunStudio/StudioRootView.swift
+++ b/apps/macos/MereRunStudio/StudioRootView.swift
@@ -32,12 +32,19 @@ struct StudioRootView: View {
     @State private var pendingPullRefresh: StudioReadinessRefresh?
     @State private var pendingRestrictedPull: StudioRunRequest?
     @State private var studioError: String?
-    /// Locally installed models feeding the composer's quick-picker.
-    @State private var installedModels: [StudioModelInventoryRow] = []
+    /// Every `model list` row, installed or not, feeding the composer's model chip.
+    @State private var modelInventory: [StudioModelInventoryRow] = []
     @State private var modelUsageTermsByID: [String: StudioModelUsageTerms] = [:]
     @State private var imageDatasetTask: StudioUtilityTask = .datasetDiscovery
     @AppStorage("mererun.app.hasCompletedWelcome") private var hasCompletedWelcome = false
     @FocusState private var promptFocused: Bool
+    /// Drafts a prompt mode starts with instead of its defaults. The snapshot harness stages
+    /// sample content this way; the app passes nothing.
+    private let seededDrafts: [StudioMode: StudioDraft]
+
+    init(seededDrafts: [StudioMode: StudioDraft] = [:]) {
+        self.seededDrafts = seededDrafts
+    }
 
     private var destination: StudioDestination { navigation.destination }
 
@@ -89,6 +96,14 @@ struct StudioRootView: View {
 
     private var readiness: ModelReadinessState {
         controller.readinessByMode[mode] ?? .unknown("Readiness has not been checked yet.")
+    }
+
+    /// The seed the mode's most recent run was queued with, for the seed chip's "Reuse last".
+    private var lastSeed: String? {
+        library.items.lazy
+            .filter { $0.mode == mode }
+            .compactMap { $0.commandDraft?.seed.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .first { !$0.isEmpty }
     }
 
     private var selectedCapabilityRequirement: StudioCapabilityRequirement? {
@@ -540,8 +555,6 @@ struct StudioRootView: View {
             canvas
 
             composer
-                .padding(.horizontal, MereRunTheme.Spacing.xl)
-                .padding(.bottom, MereRunTheme.Spacing.xl)
         }
         .frame(minWidth: StudioLayoutPolicy.minimumCanvasWidth)
         .background {
@@ -560,15 +573,13 @@ struct StudioRootView: View {
             .ignoresSafeArea()
         }
         .dropDestination(for: URL.self) { urls, _ in
-            guard !mode.acceptedTypes.isEmpty, let url = urls.first(where: \.isFileURL) else {
-                return false
-            }
-            draft.inputPath = url.path
+            // A file dropped anywhere on the canvas lands in the first well slot that takes it.
+            guard draft.attach(dropped: urls, for: mode) else { return false }
             studioError = nil
             return true
         } isTargeted: { targeted in
             withAnimation(MereRunTheme.Motion.quick) {
-                isDropTargeted = targeted && !mode.acceptedTypes.isEmpty
+                isDropTargeted = targeted && !mode.attachmentSlots.isEmpty
             }
         }
         .overlay {
@@ -626,12 +637,11 @@ struct StudioRootView: View {
             queuedCount: controller.queuedRunCount,
             readiness: readiness,
             sendBlocked: mode.isConversational && activeConversationRunning,
-            installedModels: installedModels,
+            modelInventory: modelInventory,
+            lastSeed: lastSeed,
             promptFocus: $promptFocused,
             onRun: runStudioCommand,
             onStop: controller.cancel,
-            onAttach: chooseAttachment,
-            onPaste: pasteImageFromClipboard,
             onShowModels: { navigation.open(task: .modelsInstalled) },
             onShowAdapters: {
                 showOptions = false
@@ -881,7 +891,7 @@ struct StudioRootView: View {
     /// otherwise opens the most recent item or thread of the mode.
     private func activateMode(_ newMode: StudioMode) {
         activatedMode = newMode
-        var nextDraft = freshDraft(for: newMode)
+        var nextDraft = seededDrafts[newMode] ?? freshDraft(for: newMode)
         studioError = nil
         let preferred = navigation.selectedLibraryID.flatMap { id in
             library.items.first { $0.id == id && $0.mode == newMode }
@@ -1276,13 +1286,13 @@ struct StudioRootView: View {
         controller.checkReadiness(for: mode, draft: draft)
     }
 
-    /// Refreshes the composer's installed-model quick-picker from `model list`.
+    /// Refreshes the composer's model chip from `model list`.
     private func refreshInstalledModels() {
         Task {
             let result = await controller.utilityCommandResult(args: ["model", "list"])
             guard result.exitCode == 0 else { return }
             let rows = StudioModelInventoryParser.rows(from: result.stdout)
-            installedModels = rows.filter(\.isInstalled)
+            modelInventory = rows
             modelUsageTermsByID = Dictionary(
                 uniqueKeysWithValues: rows.compactMap { row in
                     row.usageTerms.map { (row.id, $0) }
@@ -1305,31 +1315,24 @@ struct StudioRootView: View {
         }
     }
 
-    /// Pastes an image from the clipboard into the attachment (Edit ▸ Paste / ⌘V when the canvas,
-    /// not a text field, holds focus). Prefers a pasted image file; otherwise writes the pasted
-    /// bitmap to a temporary PNG. Only acts in modes that accept an image.
+    /// Pastes an image from the clipboard into the well (Edit ▸ Paste / ⌘V when the canvas, not a
+    /// text field, holds focus): the first empty image slot, else the first image slot. Prefers a
+    /// pasted image file; otherwise writes the pasted bitmap to a temporary PNG.
     private func pasteImageFromClipboard() {
-        guard mode.acceptedTypes.contains(.image) else { return }
+        guard let slot = mode.pastedImageSlot(in: draft) else { return }
         let pasteboard = NSPasteboard.general
-
-        if let urls = pasteboard.readObjects(
-            forClasses: [NSURL.self],
-            options: [.urlReadingFileURLsOnly: true]
-        ) as? [URL], let imageURL = urls.first(where: { StudioOutputFileKind.classify($0) == .image }) {
-            draft.inputPath = imageURL.path
+        let urls = StudioAttachmentPasteboard.fileURLs(from: pasteboard, for: slot)
+        if !urls.isEmpty {
+            slot.attach(urls, to: &draft)
             studioError = nil
             return
         }
-
-        guard let image = NSImage(pasteboard: pasteboard), let data = image.pngDataRepresentation() else {
-            studioError = "The clipboard has no image to paste."
-            return
-        }
-        let url = FileManager.default.temporaryDirectory
-            .appendingPathComponent("pasted-\(UUID().uuidString).png")
         do {
-            try data.write(to: url)
-            draft.inputPath = url.path
+            guard let url = try StudioAttachmentPasteboard.writePastedImage(from: pasteboard) else {
+                studioError = "The clipboard has no image to paste."
+                return
+            }
+            slot.attach([url], to: &draft)
             studioError = nil
         } catch {
             studioError = "Could not paste image: \(error.localizedDescription)"
@@ -1365,14 +1368,5 @@ private extension String {
         var words = ShellWords.split(self)
         words = words.maskingSecrets()
         return words.shellQuoted()
-    }
-}
-
-private extension NSImage {
-    /// PNG encoding of the image (for persisting a pasted bitmap to a temp file).
-    func pngDataRepresentation() -> Data? {
-        guard let tiff = tiffRepresentation,
-              let bitmap = NSBitmapImageRep(data: tiff) else { return nil }
-        return bitmap.representation(using: .png, properties: [:])
     }
 }

--- a/apps/macos/MereRunStudio/StudioTypes.swift
+++ b/apps/macos/MereRunStudio/StudioTypes.swift
@@ -265,6 +265,8 @@ struct StudioDraft: Codable, Equatable {
     var seed = ""
     var durationSeconds = 10.0
     var readImageAction: StudioReadImageAction = .inspect
+    /// Mask confidence floor for Segment and Track (the CLI `--threshold`); Find has none.
+    var visionThreshold = 0.05
     // Speak voice cloning (Studio surface). "style" uses the voice description; "clone" uses a
     // saved profile or reference audio.
     var voiceMode = "style"
@@ -390,6 +392,7 @@ struct StudioDraft: Codable, Equatable {
         seed = ""
         durationSeconds = 10
         readImageAction = .inspect
+        visionThreshold = base?.visionThreshold ?? 0.05
         voiceMode = "style"
         voiceProfile = ""
         refAudioPath = ""
@@ -748,6 +751,7 @@ enum StudioCommandAdapter {
             draft.prompt = prompt
             draft.inputPath = studioDraft.inputPath
             draft.model = studioDraft.model.isBlank ? draft.model : studioDraft.model
+            draft.visionThreshold = studioDraft.visionThreshold
 
         case .music:
             draft.prompt = prompt

--- a/apps/macos/MereRunStudioTests/StudioComposerSchemaTests.swift
+++ b/apps/macos/MereRunStudioTests/StudioComposerSchemaTests.swift
@@ -1,0 +1,302 @@
+@testable import MereRunApp
+import Foundation
+import MereRunContract
+import UniformTypeIdentifiers
+import XCTest
+
+final class StudioComposerSchemaTests: XCTestCase {
+    // MARK: - Slots
+
+    func testEveryPromptModeDeclaresItsSlotsAndTheyMapToRealDraftFields() {
+        let expectedSlotIDs: [StudioMode: [String]] = [
+            .createImage: ["input", "references"],
+            .video: ["startFrame", "endFrame", "audio"],
+            .music: ["source", "timbre"],
+            .speak: ["referenceAudio"],
+            .chat: ["image"],
+            .code: [],
+            .readImage: ["input"],
+            .findObjects: ["input"],
+            .segment: ["input"],
+            .track: ["input"],
+            .listen: ["input"],
+            .sfx: [],
+        ]
+        for mode in StudioMode.allCases {
+            let slots = mode.attachmentSlots
+            XCTAssertEqual(slots.map(\.id), expectedSlotIDs[mode], "\(mode) slot declaration drifted")
+            XCTAssertEqual(Set(slots.map(\.id)).count, slots.count, "\(mode) declares a duplicate slot id")
+            for slot in slots {
+                XCTAssertFalse(slot.acceptedTypes.isEmpty, "\(mode).\(slot.id) accepts nothing")
+                var draft = StudioDraft()
+                draft.reset(for: mode)
+                XCTAssertFalse(slot.isFilled(in: draft), "\(mode).\(slot.id) starts filled")
+                let url = URL(fileURLWithPath: "/tmp/sample.\(Self.sampleExtension(for: slot))")
+                slot.attach([url], to: &draft)
+                XCTAssertEqual(slot.paths(in: draft), [url.path], "\(mode).\(slot.id) did not store the attachment")
+                XCTAssertEqual(slot.caption(in: draft), url.lastPathComponent)
+                slot.clear(in: &draft)
+                XCTAssertFalse(slot.isFilled(in: draft), "\(mode).\(slot.id) did not clear")
+            }
+        }
+    }
+
+    func testRequiredSlotsMatchTheModesThatRequireAnAttachment() {
+        for mode in StudioMode.allCases {
+            let hasRequiredSlot = mode.attachmentSlots.contains(where: \.isRequired)
+            XCTAssertEqual(hasRequiredSlot, mode.requiresAttachment, "\(mode) required-slot flag drifted")
+        }
+    }
+
+    func testSlotsFeedTheCommandTheModeBuilds() throws {
+        var image = StudioDraft()
+        image.reset(for: .createImage)
+        image.prompt = "a mug"
+        let slots = StudioMode.createImage.attachmentSlots
+        slots[0].attach([URL(fileURLWithPath: "/tmp/in.png")], to: &image)
+        slots[1].attach([URL(fileURLWithPath: "/tmp/ref-a.png"), URL(fileURLWithPath: "/tmp/ref-b.jpg")], to: &image)
+        let request = try StudioCommandAdapter.makeRequest(mode: .createImage, draft: image)
+        let arguments = request.template.arguments(from: request.draft)
+        XCTAssertTrue(arguments.contains("/tmp/in.png"))
+        XCTAssertTrue(arguments.contains("/tmp/ref-a.png"))
+        XCTAssertTrue(arguments.contains("/tmp/ref-b.jpg"))
+
+        var find = StudioDraft()
+        find.reset(for: .findObjects)
+        find.prompt = "every coffee cup"
+        StudioMode.findObjects.attachmentSlots[0].attach([URL(fileURLWithPath: "/tmp/mug.png")], to: &find)
+        let findRequest = try StudioCommandAdapter.makeRequest(mode: .findObjects, draft: find)
+        let findArguments = findRequest.template.arguments(from: findRequest.draft)
+        XCTAssertTrue(findArguments.contains("/tmp/mug.png"))
+        XCTAssertFalse(findArguments.contains("--threshold"), "vision ground has no threshold flag")
+
+        var segment = StudioDraft()
+        segment.reset(for: .segment)
+        segment.prompt = "the cup"
+        segment.visionThreshold = 0.3
+        StudioMode.segment.attachmentSlots[0].attach([URL(fileURLWithPath: "/tmp/mug.png")], to: &segment)
+        let segmentRequest = try StudioCommandAdapter.makeRequest(mode: .segment, draft: segment)
+        let segmentArguments = segmentRequest.template.arguments(from: segmentRequest.draft)
+        let thresholdIndex = try XCTUnwrap(segmentArguments.firstIndex(of: "--threshold"))
+        XCTAssertEqual(segmentArguments[thresholdIndex + 1], "0.3")
+    }
+
+    func testListSlotAppendsWithoutDuplicatesAndSingleSlotReplaces() {
+        var draft = StudioDraft()
+        draft.reset(for: .music)
+        let slots = StudioMode.music.attachmentSlots
+        let source = slots[0]
+        let timbre = slots[1]
+        source.attach([URL(fileURLWithPath: "/tmp/a.wav")], to: &draft)
+        source.attach([URL(fileURLWithPath: "/tmp/b.wav")], to: &draft)
+        XCTAssertEqual(draft.musicSourceAudio, "/tmp/b.wav")
+        timbre.attach([URL(fileURLWithPath: "/tmp/t1.wav")], to: &draft)
+        timbre.attach([URL(fileURLWithPath: "/tmp/t1.wav"), URL(fileURLWithPath: "/tmp/t2.mp3")], to: &draft)
+        XCTAssertEqual(timbre.paths(in: draft), ["/tmp/t1.wav", "/tmp/t2.mp3"])
+        XCTAssertEqual(timbre.caption(in: draft), "t1.wav +1")
+    }
+
+    func testSlotsRejectFilesOfTheWrongKind() {
+        var draft = StudioDraft()
+        draft.reset(for: .video)
+        let audio = StudioMode.video.attachmentSlots[2]
+        audio.attach([URL(fileURLWithPath: "/tmp/frame.png")], to: &draft)
+        XCTAssertTrue(draft.audioPath.isEmpty)
+        audio.attach([URL(fileURLWithPath: "/tmp/track.wav")], to: &draft)
+        XCTAssertEqual(draft.audioPath, "/tmp/track.wav")
+        // Attaching LTX audio keeps the run producing audio + video, as the popover picker did.
+        XCTAssertEqual(draft.videoOutputMode, .audioVideo)
+        XCTAssertEqual(draft.videoQuality, .final)
+    }
+
+    func testReferenceVoiceSwitchesSpeakToCloneMode() {
+        var draft = StudioDraft()
+        draft.reset(for: .speak)
+        XCTAssertEqual(draft.voiceMode, "style")
+        StudioMode.speak.attachmentSlots[0].attach([URL(fileURLWithPath: "/tmp/me.wav")], to: &draft)
+        XCTAssertEqual(draft.voiceMode, "clone")
+        XCTAssertEqual(draft.refAudioPath, "/tmp/me.wav")
+    }
+
+    func testCanvasDropRoutesToTheFirstEmptySlotThatAcceptsTheFile() {
+        var draft = StudioDraft()
+        draft.reset(for: .createImage)
+        XCTAssertTrue(draft.attach(dropped: [URL(fileURLWithPath: "/tmp/one.png")], for: .createImage))
+        XCTAssertEqual(draft.inputPath, "/tmp/one.png")
+        XCTAssertTrue(draft.attach(dropped: [URL(fileURLWithPath: "/tmp/two.png")], for: .createImage))
+        XCTAssertEqual(draft.inputPath, "/tmp/one.png")
+        XCTAssertEqual(draft.referenceImagePaths, "/tmp/two.png")
+        XCTAssertFalse(draft.attach(dropped: [URL(fileURLWithPath: "/tmp/song.wav")], for: .createImage))
+
+        var code = StudioDraft()
+        code.reset(for: .code)
+        XCTAssertFalse(code.attach(dropped: [URL(fileURLWithPath: "/tmp/one.png")], for: .code))
+    }
+
+    func testChatImageSlotCollapsesToThePaperclipUntilFilled() {
+        var draft = StudioDraft()
+        draft.reset(for: .chat)
+        XCTAssertFalse(StudioMode.chat.showsAttachmentWell(for: draft))
+        StudioMode.chat.attachmentSlots[0].attach([URL(fileURLWithPath: "/tmp/photo.png")], to: &draft)
+        XCTAssertTrue(StudioMode.chat.showsAttachmentWell(for: draft))
+
+        var image = StudioDraft()
+        image.reset(for: .createImage)
+        XCTAssertTrue(StudioMode.createImage.showsAttachmentWell(for: image))
+        var sfx = StudioDraft()
+        sfx.reset(for: .sfx)
+        XCTAssertFalse(StudioMode.sfx.showsAttachmentWell(for: sfx))
+    }
+
+    // MARK: - Chips
+
+    func testEveryPromptModeShowsTwoToFourChipsEndingWithOrIncludingTheModel() {
+        for mode in StudioMode.allCases {
+            let chips = mode.composerChips
+            XCTAssertTrue((1...4).contains(chips.count), "\(mode) shows \(chips.count) chips")
+            XCTAssertTrue(chips.contains(.model), "\(mode) has no model chip")
+            XCTAssertEqual(Set(chips).count, chips.count, "\(mode) repeats a chip")
+        }
+        XCTAssertEqual(StudioMode.createImage.composerChips, [.dimensions, .steps, .seed, .model])
+        XCTAssertEqual(StudioMode.chat.composerChips, [.model, .thinking])
+        XCTAssertEqual(StudioMode.findObjects.composerChips, [.model], "vision ground has no threshold")
+        XCTAssertEqual(StudioMode.segment.composerChips, [.threshold, .model])
+    }
+
+    func testAspectPresetsRoundTripThroughTheDraft() throws {
+        var draft = StudioDraft()
+        draft.reset(for: .createImage)
+        let presets = StudioAspectPreset.presets(for: .createImage)
+        let square = try XCTUnwrap(presets.first { $0.label == "1:1" })
+        XCTAssertTrue(square.matches(draft))
+
+        let wide = try XCTUnwrap(presets.first { $0.label == "16:9" })
+        wide.apply(to: &draft)
+        XCTAssertEqual(draft.width, 1344)
+        XCTAssertEqual(draft.height, 768)
+        XCTAssertTrue(wide.matches(draft))
+        XCTAssertEqual(StudioComposerPresets.dimensionsTitle(draft), "1344 × 768")
+        XCTAssertFalse(square.matches(draft))
+
+        for preset in StudioAspectPreset.presets(for: .video) {
+            XCTAssertEqual(preset.width % 32, 0, "\(preset.label) video width is not a multiple of 32")
+            XCTAssertEqual(preset.height % 32, 0, "\(preset.label) video height is not a multiple of 32")
+        }
+        var video = StudioDraft()
+        video.reset(for: .video)
+        XCTAssertTrue(StudioAspectPreset.presets(for: .video).contains { $0.matches(video) })
+    }
+
+    func testSeedModesReadAndWriteTheDraftSeed() {
+        var draft = StudioDraft()
+        draft.reset(for: .createImage)
+        XCTAssertEqual(StudioSeedMode(draft: draft), .random)
+        XCTAssertEqual(StudioSeedMode(draft: draft).chipTitle, "Seed random")
+
+        StudioSeedMode.fixed(8812).apply(to: &draft)
+        XCTAssertEqual(draft.seed, "8812")
+        XCTAssertEqual(StudioSeedMode(draft: draft), .fixed(8812))
+        XCTAssertEqual(StudioSeedMode(draft: draft).chipTitle, "Seed 8812")
+
+        draft.seed = " 42 "
+        XCTAssertEqual(StudioSeedMode(draft: draft), .fixed(42))
+        draft.seed = "random"
+        XCTAssertEqual(StudioSeedMode(draft: draft), .random)
+
+        StudioSeedMode.random.apply(to: &draft)
+        XCTAssertEqual(draft.seed, "")
+    }
+
+    func testChipTitlesFollowTheDraft() {
+        var image = StudioDraft()
+        image.reset(for: .createImage)
+        XCTAssertEqual(StudioComposerPresets.stepsTitle(image, mode: .createImage), "4 steps")
+        image.steps = 1
+        XCTAssertEqual(StudioComposerPresets.stepsTitle(image, mode: .createImage), "1 step")
+
+        var music = StudioDraft()
+        music.reset(for: .music)
+        XCTAssertEqual(StudioComposerPresets.stepsTitle(music, mode: .music), "Preset steps")
+        XCTAssertEqual(StudioComposerPresets.durationTitle(music, mode: .music), "Preset length")
+        music.useDuration = true
+        music.durationSeconds = 90
+        XCTAssertEqual(StudioComposerPresets.durationTitle(music, mode: .music), "90 s")
+
+        var video = StudioDraft()
+        video.reset(for: .video)
+        XCTAssertEqual(StudioComposerPresets.durationTitle(video, mode: .video), "65 frames")
+
+        var sfx = StudioDraft()
+        sfx.reset(for: .sfx)
+        XCTAssertEqual(StudioComposerPresets.durationTitle(sfx, mode: .sfx), "10 s")
+        sfx.durationSeconds = 2.5
+        XCTAssertEqual(StudioComposerPresets.durationTitle(sfx, mode: .sfx), "2.5 s")
+
+        var segment = StudioDraft()
+        segment.reset(for: .segment)
+        XCTAssertEqual(StudioComposerPresets.thresholdTitle(segment), "Threshold 0.05")
+        segment.visionThreshold = 0.3
+        XCTAssertEqual(StudioComposerPresets.thresholdTitle(segment), "Threshold 0.3")
+
+        XCTAssertEqual(StudioComposerPresets.thinkingTitle(.hide), "Thinking off")
+        XCTAssertEqual(StudioComposerPresets.thinkingTitle(.automatic), "Thinking auto")
+    }
+
+    // MARK: - Model chip
+
+    func testModelChoicesAreFilteredToTheModeCategoryWithInstalledFirst() {
+        let inventory = [
+            row("image-zimage-nano", category: "image", status: "installed"),
+            row("image-flux2-klein", category: "image", status: "missing"),
+            row("text-chat-qwen3.6-4b", category: "text-chat", status: "installed"),
+            row("vision-chat-qwen3.6-vl-4b", category: "vision-chat", status: "installed"),
+            row("vision-ground-falcon-perception", category: "vision-ground", status: "missing"),
+            row("speech-tts-qwen3-nano", category: "speech-tts", status: "installed"),
+            row("music-acestep", category: "music", status: "installed"),
+        ]
+
+        XCTAssertEqual(
+            StudioMode.createImage.modelChoices(from: inventory).map(\.id),
+            ["image-zimage-nano", "image-flux2-klein"]
+        )
+        XCTAssertEqual(
+            StudioMode.chat.modelChoices(from: inventory).map(\.id),
+            ["text-chat-qwen3.6-4b", "vision-chat-qwen3.6-vl-4b"]
+        )
+        XCTAssertEqual(StudioMode.findObjects.modelChoices(from: inventory).map(\.id), ["vision-ground-falcon-perception"])
+        XCTAssertEqual(StudioMode.speak.modelChoices(from: inventory).map(\.id), ["speech-tts-qwen3-nano"])
+        XCTAssertEqual(StudioMode.music.modelChoices(from: inventory).map(\.id), ["music-acestep"])
+        XCTAssertTrue(StudioMode.video.modelChoices(from: inventory).isEmpty)
+    }
+
+    func testEveryModeDefaultModelFallsInsideItsOwnCategories() throws {
+        for mode in StudioMode.allCases {
+            let template = try XCTUnwrap(CommandCatalog.template(id: mode.defaultTemplateID))
+            guard !template.defaultModel.isEmpty else { continue }
+            // Managed model ids start with their `model list` category ("image-", "vision-ground-").
+            XCTAssertTrue(
+                mode.modelCategories.contains { template.defaultModel.hasPrefix($0 + "-") },
+                "\(mode) default model \(template.defaultModel) is outside its chip categories"
+            )
+        }
+    }
+
+    func testDisplayModelNameDropsCategoryPrefixes() {
+        XCTAssertEqual(StudioComposer.displayModelName("image-zimage-nano"), "Zimage Nano")
+        XCTAssertEqual(StudioComposer.displayModelName("vision-ground-falcon-perception"), "Falcon Perception")
+        XCTAssertEqual(StudioComposer.displayModelName("speech-tts-qwen3-nano"), "Qwen3 Nano")
+        XCTAssertEqual(StudioComposer.displayModelName("text-agent-deepseek-v4-flash"), "Deepseek V4 Flash")
+    }
+
+    // MARK: - Helpers
+
+    private static func sampleExtension(for slot: StudioAttachmentSlot) -> String {
+        if slot.acceptedTypes.contains(where: { UTType.png.conforms(to: $0) }) { return "png" }
+        if slot.acceptedTypes.contains(where: { UTType.wav.conforms(to: $0) }) { return "wav" }
+        return "mp4"
+    }
+
+    private func row(_ id: String, category: String, status: String) -> StudioModelInventoryRow {
+        StudioModelInventoryRow(id: id, category: category, status: status, size: "1 GB", usageTerms: nil)
+    }
+}

--- a/apps/macos/MereRunStudioTests/StudioSnapshotTests.swift
+++ b/apps/macos/MereRunStudioTests/StudioSnapshotTests.swift
@@ -24,6 +24,8 @@ final class StudioSnapshotTests: XCTestCase {
         width: StudioLayoutPolicy.defaultWindowWidth,
         height: StudioLayoutPolicy.defaultWindowHeight
     )
+    /// The size the v2 mockups were drawn at; fidelity renders use it so they overlay 1:1.
+    static let fidelitySize = CGSize(width: 1_440, height: 900)
     static let consoleSize = CGSize(width: 1_260, height: 780)
     static let settingsSize = CGSize(width: 560, height: 640)
 
@@ -64,6 +66,43 @@ final class StudioSnapshotTests: XCTestCase {
                     name: "shell-\(domain.rawValue)-\(appearance.rawValue)",
                     settle: 2.0,
                     afterAppear: { navigation.open(destination: domain.defaultDestination) }
+                )
+            }
+        }
+    }
+
+    /// The composer at mockup size with the mockup's sample content: Image ▸ Generate with an
+    /// empty well and the sample prompt, and Vision ▸ Find with `mug.png` attached, so the
+    /// renders line up with the v2 mockups for review.
+    func testComposerFidelitySnapshots() throws {
+        var image = StudioDraft()
+        image.reset(for: .createImage)
+        image.prompt = "a ceramic coffee mug in soft morning light"
+
+        var find = StudioDraft()
+        find.reset(for: .findObjects)
+        find.prompt = "every coffee cup and what it sits on"
+        find.inputPath = fixture.mugURL.path
+
+        let scenes: [(name: String, destination: StudioDestination, drafts: [StudioMode: StudioDraft])] = [
+            ("composer-image-generate", StudioTask.imageGenerate.destination, [.createImage: image]),
+            ("composer-vision-find", StudioTask.visionFind.destination, [.findObjects: find]),
+        ]
+        for scene in scenes {
+            for appearance in StudioSnapshotAppearance.allCases {
+                let navigation = NavigationModel()
+                let view = StudioRootView(seededDrafts: scene.drafts)
+                    .environmentObject(fixture.controller)
+                    .environmentObject(fixture.library)
+                    .environmentObject(navigation)
+                    .frame(width: Self.fidelitySize.width, height: Self.fidelitySize.height)
+                try fixture.write(
+                    view,
+                    size: Self.fidelitySize,
+                    appearance: appearance,
+                    name: "\(scene.name)-\(appearance.rawValue)",
+                    settle: 2.0,
+                    afterAppear: { navigation.open(destination: scene.destination) }
                 )
             }
         }
@@ -121,6 +160,8 @@ private final class SnapshotFixture {
     let controller: MereRunController
     let library: StudioLibraryStore
     let crashReporter = StudioCrashReporter()
+    /// A placeholder "mug.png" for the attachment well, drawn in-test.
+    let mugURL: URL
     private let processRunner = SnapshotProcessRunner()
 
     init(outputDirectory: URL) throws {
@@ -129,6 +170,8 @@ private final class SnapshotFixture {
             .appendingPathComponent("StudioSnapshotTests-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
         try FileManager.default.createDirectory(at: outputDirectory, withIntermediateDirectories: true)
+        mugURL = root.appendingPathComponent("mug.png", isDirectory: false)
+        try Self.writeMugPNG(to: mugURL, side: 512)
 
         // The first-run banner is dismissed state in the volatile registration domain only, so the
         // shell renders as a returning user sees it without writing to any persistent defaults.
@@ -337,6 +380,51 @@ private final class SnapshotFixture {
         CGRect(x: width * 2 / 3, y: height / 3, width: 18, height: height / 3).fill()
         NSColor(calibratedRed: 1.0, green: 0.93, blue: 0.62, alpha: 1).setFill()
         NSBezierPath(ovalIn: CGRect(x: width * 2 / 3 - 6, y: height * 2 / 3 - 6, width: 30, height: 30)).fill()
+        NSGraphicsContext.restoreGraphicsState()
+        guard let data = rep.representation(using: .png, properties: [:]) else {
+            throw StudioSnapshotError.pngEncodingFailed
+        }
+        try data.write(to: url, options: .atomic)
+    }
+
+    /// A white mug with a handle on a warm grey ground, so the well's thumbnail reads as a photo.
+    private static func writeMugPNG(to url: URL, side: Int) throws {
+        guard let rep = NSBitmapImageRep(
+            bitmapDataPlanes: nil,
+            pixelsWide: side,
+            pixelsHigh: side,
+            bitsPerSample: 8,
+            samplesPerPixel: 4,
+            hasAlpha: true,
+            isPlanar: false,
+            colorSpaceName: .deviceRGB,
+            bytesPerRow: 0,
+            bitsPerPixel: 0
+        ), let context = NSGraphicsContext(bitmapImageRep: rep) else {
+            throw StudioSnapshotError.noBitmap
+        }
+        NSGraphicsContext.saveGraphicsState()
+        NSGraphicsContext.current = context
+        let unit = CGFloat(side)
+        let ground = NSGradient(
+            starting: NSColor(calibratedRed: 0.86, green: 0.84, blue: 0.80, alpha: 1),
+            ending: NSColor(calibratedRed: 0.62, green: 0.60, blue: 0.57, alpha: 1)
+        )
+        ground?.draw(in: CGRect(x: 0, y: 0, width: unit, height: unit), angle: 75)
+        NSColor(calibratedWhite: 0.3, alpha: 0.18).setFill()
+        NSBezierPath(ovalIn: CGRect(x: unit * 0.18, y: unit * 0.14, width: unit * 0.62, height: unit * 0.12)).fill()
+        NSColor(calibratedWhite: 0.97, alpha: 1).setFill()
+        NSBezierPath(
+            roundedRect: CGRect(x: unit * 0.26, y: unit * 0.2, width: unit * 0.42, height: unit * 0.5),
+            xRadius: unit * 0.05,
+            yRadius: unit * 0.05
+        ).fill()
+        let handle = NSBezierPath(ovalIn: CGRect(x: unit * 0.6, y: unit * 0.3, width: unit * 0.22, height: unit * 0.26))
+        handle.lineWidth = unit * 0.05
+        NSColor(calibratedWhite: 0.95, alpha: 1).setStroke()
+        handle.stroke()
+        NSColor(calibratedRed: 0.80, green: 0.70, blue: 0.55, alpha: 1).setFill()
+        CGRect(x: unit * 0.26, y: unit * 0.2, width: unit * 0.42, height: unit * 0.1).fill()
         NSGraphicsContext.restoreGraphicsState()
         guard let data = rep.representation(using: .png, properties: [:]) else {
             throw StudioSnapshotError.pngEncodingFailed

--- a/apps/macos/README.md
+++ b/apps/macos/README.md
@@ -41,6 +41,21 @@ the full width. It is filtered to the current domain by default with an All
 segment — a row is filed under its command's domain (`CommandTemplateID.studioDomain`),
 so 3D meshes land under 3D and benchmark reports under Models — and picking a
 row from another domain switches the destination to it.
+
+The **composer** under the canvas is one surface for every prompt mode
+(`StudioComposer.swift`, declarations in `StudioComposerSchema.swift`). An
+**attachment well** shows the mode's slots — Image: input and reference images;
+Video: start frame, end frame, audio; Music: source and timbre references;
+Voice: reference audio; Vision and Audio tasks: their required input; Chat: a
+per-turn image that stays behind the paperclip until attached — and every slot
+takes a drop, a paste (⌘V), or a click to pick, storing straight into the draft
+field the CLI flag reads. Under the prompt, a **chip strip** shows the mode's two
+to four essentials (size, steps, seed, length, threshold, thinking) as menus, and
+the **model chip** is the only model control: it lists `model list` rows filtered
+to the mode's category, installed first, with "Auto" for the mode's default. The
+remaining depth stays in the options popover behind the sliders button until the
+inspector replaces it.
+
 Menus follow macOS convention: File ▸ New Chat (⌘N) and Import Receipt…, View ▸
 Show Library (⌥⌘L), Command Console (⌥⌘C), and the system sidebar toggle, Go ▸
 every domain (⌘1–⌘9, then ⌥⌘1…) plus the current domain's tasks, Run ▸ Run


### PR DESCRIPTION
## What changed

The composer is rebuilt to the Studio v2 mockup (`composer()` in the mockup generator): a
declared **attachment well**, the prompt, and a **chip strip** of each mode's essentials,
with one model control.

- **Chrome**: 12/24/20 outer padding, 18pt radius on `surface`, hairline `border` at rest and
  the 1.5pt accent ring + glow (`mereFocusRing`) when the prompt has focus, `mereShadow`;
  14/16/12 inner padding, 12pt row gap; 15pt prompt at ~1.4 line height, muted placeholder,
  1–5 lines as before.
- **Attachment well** (`StudioComposerSchema.swift`): slots are declared per mode and bound
  to real draft fields — Image: input + references; Video: start frame, end frame, audio;
  Music: source + timbre references; Voice: reference audio; Chat: per-turn image (collapsed
  behind the paperclip until attached); Read/Find/Segment: image; Track: video; Listen:
  audio. Every slot is a 48pt drop target (dashed accent highlight), takes ⌘V while focused,
  and opens the picker on click; a hover ✕ and a context menu remove. The canvas-wide drop
  and ⌘V route through the same slots (first empty slot that accepts the file, else the
  first), keeping the existing dashed canvas highlight. Attaching LTX audio still switches to
  audio+video output; attaching a reference voice switches Speak to clone mode.
- **Chip strip**: 24pt chips on `surfaceRaised`, 11.5pt medium, muted chevron. Per mode:
  Image `size · steps · seed · model`; Video/Music/Sound `length · steps · seed · model`;
  Voice `voice · model`; Chat `model · thinking`; Code/Listen `model`; Read Image
  `task · model`; Segment/Track `threshold · model`; Find `model` (vision ground has no
  `--threshold` in the contract, so it shows none). Size offers aspect presets + swap +
  custom; seed offers Random / enter a number / Reuse last (from the mode's last queued
  command); custom values open a small popover from the chip.
- **Model chip** is the only model control: rows from `model list` filtered to the mode's
  categories, split into Installed / Needs download, "Auto · <default>" on top, Browse
  Models… at the bottom. The free-text Model field is gone from the options popover, so
  nothing fires a readiness probe per keystroke any more.
- The options popover keeps everything else, minus the controls that became chips (size,
  steps, seed, sound duration, Read Image task); its sliders button moved to the right
  cluster beside Run. Run is a 32pt accent circle with an on-accent arrow; while a run is in
  flight it becomes a `surfaceRaised` stop circle (⌘↩ still queues).
- `StudioDraft.visionThreshold` is new and mapped for Segment and Track, so the threshold chip
  drives the real `--threshold` flag.
- `StudioRootView(seededDrafts:)` lets the snapshot harness stage sample content; the app
  passes nothing.

## Verification

- `swiftlint --strict`, `swift build`, `swift test --filter MereRunAppTests` (285 tests),
  `./scripts/check.sh`, and `./scripts/build_mere_run_app.sh debug`.
- New `StudioComposerSchemaTests` (15): every mode's slot declaration and draft round trip,
  slots feeding the built command, list-slot append/dedupe, wrong-kind rejection, drop
  routing, chat collapse, chip declarations, aspect-preset and seed-mode round trips, chip
  titles, model filtering by category with installed first, default models inside their
  categories, display names.
- `StudioSnapshotTests.testComposerFidelitySnapshots` renders Image ▸ Generate and
  Vision ▸ Find at 1440×900 in light and dark with the mockup's sample prompt, chips, and an
  in-test `mug.png` attached (`MERERUN_STUDIO_SNAPSHOT_DIR=… swift test --filter
  StudioSnapshotTests/testComposerFidelitySnapshots`).

## Reviewer notes

- Differences from the mockup that are deliberate or outside this step: Image shows both
  Input and Reference slots (the plan declares both); the right cluster carries the options
  sliders instead of the mockup's paperclip (the paperclip only appears for Chat's collapsed
  image slot); Find has no threshold chip; the composer spans the canvas width until the feed
  column and inspector land.
- In the harness Run renders disabled because readiness cannot be checked without the CLI,
  and the prompt shows a select-all highlight because focusing a pre-filled field selects it.
- `onAccent` is defined file-private in `StudioComposer.swift` (marked `F1 token:`) until the
  theme tokens PR lands.
