### PR TITLE
Rebuild Music ▸ Realtime as the Session archetype

### DIFF
--- a/apps/macos/MereRunStudio/StudioRealtimeMusicView.swift
+++ b/apps/macos/MereRunStudio/StudioRealtimeMusicView.swift
@@ -1,34 +1,67 @@
 import AppKit
 import SwiftUI
 
-/// A native transport/control surface for the CLI's long-lived Magenta RT2 session.
-/// The CLI remains the source of truth; controls are sent over its documented stdin protocol.
+// F1 token: the text/glyph color on an accent fill. Moves to MereRunTheme with the other v2 tokens.
+private let onAccent = MereRunTheme.dynamic(light: "FFFFFF", dark: "1B160A")
+
+/// Music ▸ Realtime: the Session archetype for the CLI's long-lived Magenta RT2 process.
+///
+/// One column of panels — transport, waveform, steering, session log — over a job bar. The CLI
+/// remains the source of truth: launch options become `music realtime` arguments, steering is
+/// sent over the documented stdin protocol, the clock and log are read back from the run. The
+/// view re-attaches to a session that is already running when the user navigates back to it.
 struct StudioRealtimeMusicView: View {
     @EnvironmentObject private var controller: MereRunController
     @EnvironmentObject private var library: StudioLibraryStore
+    @Environment(\.studioRealtimeSteeringSeed) private var steeringSeed
 
-    @State private var prompt: String
+    // Launch options (fixed once a session starts; edits apply to the next session).
     @State private var model: String
     @State private var duration = 300.0
     @State private var capturesAudio = true
     @State private var playsAudio = true
     @State private var outputPath: String
-    @State private var temperature = 1.0
-    @State private var topK = 100
-    @State private var cfgMusicCoCa = 3.0
-    @State private var cfgNotes = 5.0
-    @State private var cfgDrums = 1.0
-    @State private var drumless = false
-    @State private var style = "streaming"
     @State private var midiInputs: [String] = []
     @State private var midiInput = ""
     @State private var midiChannel = "all"
+
+    // Steering (sent live over stdin; also the initial controls at launch).
+    @State private var promptA: String
+    @State private var promptB = ""
+    @State private var blend = 0.0
+    @State private var temperature = 1.0
+    @State private var topK = 100
+    @State private var guidance = 3.0
+    @State private var noteGuidance = 5.0
+    @State private var drumGuidance = 1.0
+    @State private var drumless = false
+    @State private var style = "streaming"
+
+    // Session
     @State private var requestID: UUID?
-    @State private var startedAt: Date?
-    @State private var statusMessage: String?
+    @State private var peaks: [Float] = []
+    @State private var banner: Banner?
+    @State private var showsSessionOptions = false
+    @State private var showsMIDIOptions = false
+    @State private var showsLog = false
+    @State private var showsMoreSteering = false
+    @State private var didSeedSteering = false
+
+    private struct Banner: Equatable {
+        let severity: MereBanner.Severity
+        let text: String
+
+        static func == (lhs: Banner, rhs: Banner) -> Bool {
+            lhs.text == rhs.text
+        }
+    }
+
+    private static let contentWidth: CGFloat = 672
+    private static let logLineHeight: CGFloat = 17.8
+    private static let logHeight: CGFloat = 120
 
     init(initialDraft: StudioDraft) {
-        _prompt = State(initialValue: initialDraft.prompt)
+        _promptA = State(initialValue: initialDraft.prompt)
         _model = State(initialValue: Self.preferredModel(from: initialDraft.model))
         let directory = FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent("Music/MereRun", isDirectory: true)
@@ -48,6 +81,8 @@ struct StudioRealtimeMusicView: View {
             : "music-magenta-rt2-small"
     }
 
+    // MARK: - Derived session state
+
     private var item: StudioLibraryItem? {
         guard let requestID else { return nil }
         return library.items.first { $0.id == requestID }
@@ -58,269 +93,592 @@ struct StudioRealtimeMusicView: View {
         return controller.canSteerRealtimeMusic(requestID: requestID)
     }
 
-    private var isSessionPending: Bool {
-        item?.status == .queued || item?.status == .running
+    private var phase: StudioRealtimeJobBar.Phase {
+        guard let item else { return .idle }
+        if isLive { return .live }
+        switch item.status {
+        case .queued: return .queued
+        case .running: return .live
+        case .completed, .failed: return .ended(exitCode: item.exitCode)
+        }
     }
+
+    private var isPending: Bool {
+        switch phase {
+        case .queued, .live: return true
+        case .idle, .ended: return false
+        }
+    }
+
+    private var startedAt: Date? { item?.createdAt }
+
+    private var sessionModel: String { item?.commandDraft?.model ?? model }
+
+    private var renderedSeconds: TimeInterval? {
+        guard let requestID else { return nil }
+        return StudioRealtimeTransport.renderedSeconds(from: controller.progressByRequestID[requestID])
+    }
+
+    private var sessionDuration: Double {
+        item?.commandDraft?.durationSeconds ?? duration
+    }
+
+    private var recordingURL: URL? {
+        let path = item?.commandDraft?.outputPath ?? (capturesAudio ? outputPath : "")
+        return path.isBlank ? nil : URL(fileURLWithPath: path)
+    }
+
+    private var logLines: [String] {
+        guard let requestID, let startedAt else { return [] }
+        return StudioRealtimeSessionLog.lines(controller.logs(for: requestID), startedAt: startedAt)
+    }
+
+    private var blendedPrompt: String {
+        StudioRealtimeSteering.blendedPrompt(a: promptA, b: promptB, blend: blend)
+    }
+
+    // MARK: - Body
 
     var body: some View {
         VStack(spacing: 0) {
-            HStack(spacing: 0) {
-                transport
-                    .frame(minWidth: 300, idealWidth: 380, maxWidth: 380)
-                Divider().overlay(MereRunTheme.border.opacity(0.5))
-                liveControls
-                    .frame(maxWidth: .infinity)
+            ScrollView {
+                VStack(spacing: 14) {
+                    if let banner {
+                        MereBanner(severity: banner.severity, text: banner.text) {
+                            self.banner = nil
+                        }
+                    }
+                    transportPanel
+                    waveformPanel
+                    steeringPanel
+                    logPanel
+                }
+                .frame(maxWidth: Self.contentWidth)
+                .padding(EdgeInsets(top: 22, leading: 24, bottom: 20, trailing: 24))
+                .frame(maxWidth: .infinity)
             }
-            Divider().overlay(MereRunTheme.border.opacity(0.5))
-            footer
+            jobBar
         }
         .background(MereRunTheme.background)
         .foregroundStyle(MereRunTheme.textPrimary)
+        .onAppear(perform: attachToRunningSession)
         .task {
             midiInputs = await controller.loadMIDIInputs()
         }
-    }
-
-    private var liveBadge: some View {
-        HStack(spacing: 7) {
-            Circle()
-                .fill(isLive ? MereRunTheme.green : MereRunTheme.textMuted)
-                .frame(width: 8, height: 8)
-            Text(isLive ? "LIVE" : item?.status.rawValue.uppercased() ?? "READY")
-                .font(.system(size: 10.5, weight: .bold))
-                .kerning(0.7)
+        .task(id: "\(requestID?.uuidString ?? "none")-\(isLive)") {
+            await pollPeaks()
         }
-        .padding(.horizontal, 10)
-        .padding(.vertical, 6)
-        .background { Capsule().fill((isLive ? MereRunTheme.green : MereRunTheme.surfaceRaised).opacity(0.16)) }
     }
 
-    private var transport: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: MereRunTheme.Spacing.lg) {
-                Text("Session")
-                    .font(MereRunTheme.sectionFont)
+    // MARK: - Transport
 
-                VStack(alignment: .leading, spacing: 5) {
-                    Text("Starting prompt")
-                        .font(MereRunTheme.captionFont)
-                        .foregroundStyle(MereRunTheme.textMuted)
-                    TextField("Describe the music", text: $prompt, axis: .vertical)
-                        .lineLimit(2...5)
-                        .mereField()
+    private var transportPanel: some View {
+        HStack(spacing: 14) {
+            Button(action: toggleSession) {
+                ZStack {
+                    Circle().fill(MereRunTheme.accent)
+                    TransportGlyph(stop: isPending)
+                        .stroke(onAccent, style: StrokeStyle(lineWidth: 1.15, lineCap: .round, lineJoin: .round))
+                        .frame(width: 16, height: 16)
                 }
-
-                VStack(alignment: .leading, spacing: 5) {
-                    Text("Model")
-                        .font(MereRunTheme.captionFont)
-                        .foregroundStyle(MereRunTheme.textMuted)
-                    TextField("music-magenta-rt2-small", text: $model)
-                        .mereField()
-                }
-
-                Stepper(
-                    "Maximum duration \(Int(duration))s",
-                    value: $duration,
-                    in: 5...3_600,
-                    step: 5
-                )
-                .font(MereRunTheme.captionFont)
-
-                Toggle("Play through default output", isOn: $playsAudio)
-                    .font(MereRunTheme.captionFont)
-                Toggle("Record WAV", isOn: $capturesAudio)
-                    .font(MereRunTheme.captionFont)
-
-                if capturesAudio {
-                    VStack(alignment: .leading, spacing: 5) {
-                        Text("Recording")
-                            .font(MereRunTheme.captionFont)
-                            .foregroundStyle(MereRunTheme.textMuted)
-                        HStack(spacing: 7) {
-                            TextField("Output WAV", text: $outputPath)
-                                .mereField()
-                            Button("Choose…", action: chooseOutput)
-                                .controlSize(.small)
-                        }
-                    }
-                }
-
-                Divider().overlay(MereRunTheme.border.opacity(0.5))
-
-                VStack(alignment: .leading, spacing: 8) {
-                    Text("MIDI input")
-                        .font(MereRunTheme.sectionFont)
-                    Picker("Device", selection: $midiInput) {
-                        Text("None").tag("")
-                        ForEach(midiInputs, id: \.self) { Text($0).tag($0) }
-                    }
-                    Picker("Channel", selection: $midiChannel) {
-                        Text("All").tag("all")
-                        ForEach(1...16, id: \.self) { Text("\($0)").tag(String($0)) }
-                    }
-                    .disabled(midiInput.isEmpty)
-                    if midiInputs.isEmpty {
-                        Text("No CoreMIDI input sources detected.")
-                            .font(MereRunTheme.captionFont)
-                            .foregroundStyle(MereRunTheme.textMuted)
-                    }
-                }
-
-                if let progress = activeProgress {
-                    VStack(alignment: .leading, spacing: 5) {
-                        ProgressView(value: progress.fractionCompleted)
-                            .tint(MereRunTheme.accent)
-                        Text(progress.detail ?? progress.label)
-                            .font(MereRunTheme.captionFont)
-                            .foregroundStyle(MereRunTheme.textMuted)
-                    }
-                } else if let startedAt, isLive {
-                    TimelineView(.periodic(from: startedAt, by: 1)) { context in
-                        let elapsed = context.date.timeIntervalSince(startedAt)
-                        VStack(alignment: .leading, spacing: 5) {
-                            ProgressView(value: min(1, elapsed / duration))
-                                .tint(MereRunTheme.accent)
-                            Text("\(Int(elapsed))s of \(Int(duration))s")
-                                .font(MereRunTheme.captionFont)
-                                .foregroundStyle(MereRunTheme.textMuted)
-                        }
-                    }
-                }
-
-                if let statusMessage {
-                    Text(statusMessage)
-                        .font(MereRunTheme.captionFont)
-                        .foregroundStyle(MereRunTheme.textMuted)
-                }
+                .frame(width: 40, height: 40)
+                .contentShape(Circle())
             }
-            .padding(20)
+            .buttonStyle(.plain)
+            .disabled(phase == .queued)
+            .accessibilityLabel(isPending ? "Stop session" : "Start session")
+
+            VStack(alignment: .leading, spacing: 2) {
+                HStack(spacing: 8) {
+                    statusBadge
+                    Text(StudioRealtimeTransport.engineLabel(model: sessionModel))
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundStyle(MereRunTheme.textSecondary)
+                }
+                transportClock
+            }
+
+            Spacer(minLength: 8)
+
+            SessionSecondaryButton("Record to file") { showsSessionOptions.toggle() }
+                .popover(isPresented: $showsSessionOptions, arrowEdge: .bottom) { sessionOptions }
+            SessionSecondaryButton(midiInput.isEmpty ? "MIDI in: none" : "MIDI in: \(midiInput)") {
+                showsMIDIOptions.toggle()
+            }
+            .popover(isPresented: $showsMIDIOptions, arrowEdge: .bottom) { midiOptions }
+        }
+        .padding(EdgeInsets(top: 14, leading: 18, bottom: 14, trailing: 18))
+        .sessionPanel()
+    }
+
+    @ViewBuilder
+    private var statusBadge: some View {
+        switch phase {
+        case .idle:
+            EmptyView()
+        case .queued:
+            SessionBadge(text: "QUEUED", color: MereRunTheme.yellow)
+        case .live:
+            SessionBadge(text: "LIVE", color: MereRunTheme.red)
+        case .ended(let exitCode):
+            if let exitCode, exitCode != 0 {
+                SessionBadge(text: "FAILED", color: MereRunTheme.red)
+            } else {
+                SessionBadge(text: "ENDED", color: MereRunTheme.textMuted)
+            }
         }
     }
 
-    private var liveControls: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: MereRunTheme.Spacing.lg) {
-                HStack {
-                    Text("Live steering")
-                        .font(MereRunTheme.sectionFont)
-                    Spacer()
-                    Button("Apply controls", action: applyControls)
-                        .buttonStyle(.borderedProminent)
-                        .tint(MereRunTheme.accent)
-                        .disabled(!isLive)
-                }
+    @ViewBuilder
+    private var transportClock: some View {
+        if phase == .live, let startedAt {
+            TimelineView(.periodic(from: startedAt, by: 1)) { context in
+                clockText(
+                    StudioRealtimeTransport.statusLine(
+                        wallElapsed: context.date.timeIntervalSince(startedAt),
+                        rendered: renderedSeconds
+                    )
+                )
+            }
+        } else {
+            clockText(staticClockLine)
+        }
+    }
 
-                VStack(alignment: .leading, spacing: 5) {
-                    Text("Next musical direction")
-                        .font(MereRunTheme.captionFont)
-                        .foregroundStyle(MereRunTheme.textMuted)
-                    HStack(spacing: 8) {
-                        TextField("Shift the performance…", text: $prompt)
-                            .mereField()
-                        Button("Send prompt") {
-                            send("prompt \(prompt)")
+    private var staticClockLine: String {
+        switch phase {
+        case .idle:
+            return "00:00 · ready to start"
+        case .queued:
+            return "00:00 · queued behind the active job"
+        case .live:
+            return "00:00 · loading model"
+        case .ended:
+            let ran = renderedSeconds ?? item.map { $0.updatedAt.timeIntervalSince($0.createdAt) } ?? 0
+            return "\(StudioRealtimeTransport.timestamp(ran)) · session ended"
+        }
+    }
+
+    private func clockText(_ text: String) -> some View {
+        Text(text)
+            .font(.system(size: 12.5, weight: .medium, design: .monospaced))
+            .foregroundStyle(MereRunTheme.textPrimary)
+            .lineLimit(1)
+    }
+
+    // MARK: - Waveform
+
+    private var waveformPanel: some View {
+        SessionWaveform(peaks: peaks, played: playedFraction)
+            .frame(height: 60)
+            .padding(EdgeInsets(top: 14, leading: 16, bottom: 14, trailing: 16))
+            .sessionPanel()
+    }
+
+    private var playedFraction: Double {
+        switch phase {
+        case .idle, .queued:
+            return 0
+        case .live:
+            guard let startedAt, sessionDuration > 0 else { return 0 }
+            let playback = StudioRealtimeTransport.playbackPosition(
+                wallElapsed: Date().timeIntervalSince(startedAt),
+                rendered: renderedSeconds
+            )
+            return min(1, playback / sessionDuration)
+        case .ended:
+            return peaks.isEmpty ? 0 : 1
+        }
+    }
+
+    // MARK: - Steering
+
+    private var steeringPanel: some View {
+        VStack(spacing: 0) {
+            HStack {
+                Text("Steering")
+                    .font(.system(size: 12.5, weight: .semibold))
+                Spacer()
+                Text("changes blend in over 4 bars")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(MereRunTheme.textMuted)
+            }
+            .padding(EdgeInsets(top: 12, leading: 16, bottom: 12, trailing: 16))
+            SessionHairline()
+            VStack(spacing: 16) {
+                HStack(alignment: .bottom, spacing: 12) {
+                    promptField("Prompt A", text: $promptA)
+                    promptField("Prompt B", text: $promptB)
+                }
+                SessionSlider(
+                    label: "Blend A ↔ B",
+                    value: $blend,
+                    range: 0...1,
+                    display: StudioRealtimeSteering.formatBlend,
+                    onCommit: sendPrompt
+                )
+                HStack(spacing: 16) {
+                    SessionSlider(
+                        label: "Temperature",
+                        value: $temperature,
+                        range: 0.1...2,
+                        display: { String(format: "%.1f", $0) },
+                        onCommit: { send("temp \(StudioRealtimeSteering.format(temperature))") }
+                    )
+                    SessionSlider(
+                        label: "Top-k",
+                        value: Binding(get: { Double(topK) }, set: { topK = Int($0.rounded()) }),
+                        range: 0...512,
+                        display: { String(Int($0.rounded())) },
+                        onCommit: { send("topk \(topK)") }
+                    )
+                    SessionSlider(
+                        label: "Guidance",
+                        value: $guidance,
+                        range: 0...10,
+                        display: { String(format: "%.1f", $0) },
+                        onCommit: { send("mc \(StudioRealtimeSteering.format(guidance))") }
+                    )
+                }
+                moreSteering
+            }
+            .padding(EdgeInsets(top: 14, leading: 16, bottom: 14, trailing: 16))
+        }
+        .sessionPanel()
+    }
+
+    private func promptField(_ label: String, text: Binding<String>) -> some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(label)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(MereRunTheme.textSecondary)
+            TextField("", text: text)
+                .textFieldStyle(.plain)
+                .font(.system(size: 13))
+                .foregroundStyle(MereRunTheme.textPrimary)
+                .padding(.horizontal, 10)
+                .frame(minHeight: 32)
+                .background {
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(MereRunTheme.surface)
+                        .overlay {
+                            RoundedRectangle(cornerRadius: 8)
+                                .strokeBorder(MereRunTheme.border.opacity(0.8), lineWidth: 1)
                         }
-                        .disabled(!isLive || prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-                    }
                 }
+                .onSubmit(sendPrompt)
+                .accessibilityLabel(label)
+        }
+        .frame(maxWidth: .infinity)
+    }
 
+    /// The rest of the stdin protocol: style conditioning, the note and drum guidance, the
+    /// drumless switch, a playable octave, and reset. Folded so the panel reads like the mockup.
+    private var moreSteering: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Button {
+                withAnimation(MereRunTheme.Motion.quick) { showsMoreSteering.toggle() }
+            } label: {
+                HStack(spacing: 4) {
+                    Text("More steering")
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 8, weight: .bold))
+                        .rotationEffect(.degrees(showsMoreSteering ? 90 : 0))
+                }
+                .font(.system(size: 11.5, weight: .medium))
+                .foregroundStyle(MereRunTheme.textMuted)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel(showsMoreSteering ? "Hide more steering" : "Show more steering")
+
+            if showsMoreSteering {
                 Picker("Style conditioning", selection: $style) {
                     Text("Streaming").tag("streaming")
                     Text("Full").tag("full")
                 }
                 .pickerStyle(.segmented)
+                .labelsHidden()
+                .onChange(of: style) { _, newValue in send("style \(newValue)") }
 
-                controlSlider("Temperature", value: $temperature, range: 0.1...2, format: "%.2f")
-                Stepper("Top-k \(topK)", value: $topK, in: 0...512)
-                    .font(MereRunTheme.captionFont)
-                controlSlider("MusicCoCa guidance", value: $cfgMusicCoCa, range: 0...10, format: "%.1f")
-                controlSlider("Note guidance", value: $cfgNotes, range: 0...12, format: "%.1f")
-                controlSlider("Drum guidance", value: $cfgDrums, range: 0...8, format: "%.1f")
+                HStack(spacing: 16) {
+                    SessionSlider(
+                        label: "Note guidance",
+                        value: $noteGuidance,
+                        range: 0...12,
+                        display: { String(format: "%.1f", $0) },
+                        onCommit: { send("notes \(StudioRealtimeSteering.format(noteGuidance))") }
+                    )
+                    SessionSlider(
+                        label: "Drum guidance",
+                        value: $drumGuidance,
+                        range: 0...8,
+                        display: { String(format: "%.1f", $0) },
+                        onCommit: { send("drums \(StudioRealtimeSteering.format(drumGuidance))") }
+                    )
+                }
+
                 Toggle("Drumless", isOn: $drumless)
-                    .font(MereRunTheme.captionFont)
+                    .font(.system(size: 12, weight: .medium))
+                    .onChange(of: drumless) { _, newValue in send("drumless \(newValue ? "on" : "off")") }
 
-                Divider().overlay(MereRunTheme.border.opacity(0.5))
-
-                Text("Playable notes")
-                    .font(MereRunTheme.sectionFont)
-                Text("Tap a note to inject a short MIDI gesture without a controller.")
-                    .font(MereRunTheme.captionFont)
-                    .foregroundStyle(MereRunTheme.textMuted)
-                LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 6), count: 8), spacing: 6) {
-                    ForEach(Array(60...75), id: \.self) { note in
-                        Button(noteName(note)) { playNote(note) }
-                            .buttonStyle(.bordered)
-                            .disabled(!isLive)
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("Playable notes")
+                        .font(.system(size: 12, weight: .medium))
+                        .foregroundStyle(MereRunTheme.textSecondary)
+                    LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 6), count: 8), spacing: 6) {
+                        ForEach(Array(60...75), id: \.self) { note in
+                            SessionSecondaryButton(Self.noteName(note)) { playNote(note) }
+                                .disabled(!isLive)
+                        }
                     }
                 }
 
-                HStack(spacing: 9) {
-                    Button("Reset state") { send("reset") }
+                HStack(spacing: 8) {
+                    SessionSecondaryButton("Reset state") { send("reset") }
                         .disabled(!isLive)
-                    Button("Stop session", role: .destructive) { send("quit") }
+                    SessionSecondaryButton("Apply all controls", action: applyControls)
                         .disabled(!isLive)
                 }
             }
-            .padding(20)
         }
     }
 
-    private var footer: some View {
-        HStack {
-            liveBadge
-            if let url = item?.outputURL {
-                Button {
-                    QuickLookCoordinator.shared.preview(url)
-                } label: {
-                    Label("Preview recording", systemImage: "play.circle")
-                }
-            }
-            Spacer()
-            Button(
-                isLive ? "Running" : (item?.status == .queued ? "Queued" : "Start session"),
-                action: start
-            )
-                .buttonStyle(.borderedProminent)
-                .tint(MereRunTheme.accent)
-                .disabled(
-                    isSessionPending
-                        || prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
-                        || (!playsAudio && !capturesAudio)
-                )
-        }
-        .padding(16)
-    }
+    // MARK: - Session log
 
-    private var activeProgress: StudioRunProgress? {
-        guard let requestID, controller.activeRunRequestID == requestID else { return nil }
-        return controller.currentProgress
-    }
-
-    private func controlSlider(
-        _ title: String,
-        value: Binding<Double>,
-        range: ClosedRange<Double>,
-        format: String
-    ) -> some View {
-        VStack(alignment: .leading, spacing: 4) {
+    private var logPanel: some View {
+        VStack(spacing: 0) {
             HStack {
-                Text(title)
+                Text("Session log")
+                    .font(.system(size: 12, weight: .semibold))
                 Spacer()
-                Text(String(format: format, value.wrappedValue))
+                Button("Copy", action: copyLog)
+                    .buttonStyle(.plain)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(MereRunTheme.textMuted)
+                    .accessibilityLabel("Copy session log")
+            }
+            .padding(EdgeInsets(top: 10, leading: 14, bottom: 10, trailing: 14))
+            SessionHairline()
+            VStack(alignment: .leading, spacing: 0) {
+                let visible = StudioRealtimeSessionLog.visibleTail(
+                    logLines, height: Self.logHeight, lineHeight: Self.logLineHeight
+                )
+                if visible.isEmpty {
+                    logLine(phase == .idle ? "Press play to start a session." : "Waiting for the first line…")
+                }
+                ForEach(Array(visible.enumerated()), id: \.offset) { _, line in
+                    logLine(line)
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .topLeading)
+            .frame(height: Self.logHeight, alignment: .top)
+            .clipped()
+            .padding(EdgeInsets(top: 10, leading: 14, bottom: 10, trailing: 14))
+            .accessibilityElement(children: .combine)
+            .accessibilityLabel("Session log")
+        }
+        .sessionPanel()
+    }
+
+    private func logLine(_ text: String) -> some View {
+        Text(text)
+            .font(.system(size: 11.5, design: .monospaced))
+            .foregroundStyle(MereRunTheme.textSecondary)
+            .lineLimit(1)
+            .frame(height: Self.logLineHeight, alignment: .leading)
+    }
+
+    // MARK: - Job bar
+
+    private var jobBar: some View {
+        HStack(spacing: 12) {
+            Circle()
+                .fill(StudioRealtimeJobBar.dotColor(phase: phase))
+                .frame(width: 8, height: 8)
+            Text("Music · Realtime")
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(MereRunTheme.textPrimary)
+            Text(StudioRealtimeJobBar.detail(phase: phase, startedAt: startedAt, model: sessionModel))
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(MereRunTheme.textMuted)
+                .lineLimit(1)
+            Spacer(minLength: 8)
+            if case .ended = phase, let url = item?.outputURL {
+                SessionSecondaryButton("Preview recording") {
+                    QuickLookCoordinator.shared.preview(url)
+                }
+            }
+            SessionSecondaryButton("Cancel", action: cancelSession)
+                .disabled(!isLive)
+            SessionSecondaryButton("Log") { showsLog.toggle() }
+                .popover(isPresented: $showsLog, arrowEdge: .top) { logPopover }
+        }
+        .padding(.horizontal, 16)
+        .frame(height: 40)
+        .frame(maxWidth: .infinity)
+        .background(MereRunTheme.background)
+        .overlay(alignment: .top) {
+            Rectangle().fill(MereRunTheme.border.opacity(0.53)).frame(height: 1)
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Job bar")
+    }
+
+    private var logPopover: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("Session log")
+                    .font(.system(size: 12, weight: .semibold))
+                Spacer()
+                Button("Copy", action: copyLog)
+                    .controlSize(.small)
+            }
+            ScrollView {
+                Text(logLines.isEmpty ? "No session output yet." : StudioRealtimeSessionLog.copyText(logLines))
+                    .font(.system(size: 11.5, design: .monospaced))
+                    .foregroundStyle(MereRunTheme.textSecondary)
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+        .padding(14)
+        .frame(width: 560, height: 340)
+    }
+
+    // MARK: - Popovers
+
+    private var sessionOptions: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Session")
+                .font(MereRunTheme.sectionFont)
+            if isPending {
+                Text("These options apply to the next session.")
+                    .font(MereRunTheme.captionFont)
                     .foregroundStyle(MereRunTheme.textMuted)
             }
-            .font(MereRunTheme.captionFont)
-            Slider(value: value, in: range)
+            VStack(alignment: .leading, spacing: 5) {
+                Text("Model")
+                    .font(MereRunTheme.captionFont)
+                    .foregroundStyle(MereRunTheme.textMuted)
+                TextField("music-magenta-rt2-small", text: $model)
+                    .mereField()
+            }
+            Stepper("Maximum duration \(Int(duration)) s", value: $duration, in: 5...3_600, step: 5)
+                .font(MereRunTheme.captionFont)
+            Toggle("Play through default output", isOn: $playsAudio)
+                .font(MereRunTheme.captionFont)
+            Toggle("Record to a WAV file", isOn: $capturesAudio)
+                .font(MereRunTheme.captionFont)
+            if capturesAudio {
+                VStack(alignment: .leading, spacing: 5) {
+                    Text("Recording")
+                        .font(MereRunTheme.captionFont)
+                        .foregroundStyle(MereRunTheme.textMuted)
+                    HStack(spacing: 7) {
+                        TextField("Output WAV", text: $outputPath)
+                            .mereField()
+                        Button("Choose…", action: chooseOutput)
+                            .controlSize(.small)
+                    }
+                }
+            }
+            if !playsAudio && !capturesAudio {
+                MereBanner(severity: .warning, text: "Enable playback or recording before starting.")
+            }
+        }
+        .padding(16)
+        .frame(width: 360)
+    }
+
+    private var midiOptions: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("MIDI input")
+                .font(MereRunTheme.sectionFont)
+            if isPending {
+                Text("The input binds when a session starts; this applies to the next one.")
+                    .font(MereRunTheme.captionFont)
+                    .foregroundStyle(MereRunTheme.textMuted)
+            }
+            Picker("Device", selection: $midiInput) {
+                Text("None").tag("")
+                ForEach(midiInputs, id: \.self) { Text($0).tag($0) }
+            }
+            Picker("Channel", selection: $midiChannel) {
+                Text("All").tag("all")
+                ForEach(1...16, id: \.self) { Text("\($0)").tag(String($0)) }
+            }
+            .disabled(midiInput.isEmpty)
+            if midiInputs.isEmpty {
+                Text("No CoreMIDI input sources detected.")
+                    .font(MereRunTheme.captionFont)
+                    .foregroundStyle(MereRunTheme.textMuted)
+            }
+        }
+        .padding(16)
+        .frame(width: 320)
+    }
+
+    // MARK: - Actions
+
+    private func attachToRunningSession() {
+        if requestID == nil {
+            let running = controller.runningRequestID(for: .musicRealtime)
+                ?? library.items.first {
+                    $0.templateID == .musicRealtime && ($0.status == .running || $0.status == .queued)
+                }?.id
+            if let running {
+                requestID = running
+                if let draft = library.items.first(where: { $0.id == running })?.commandDraft {
+                    if promptA.isBlank { promptA = draft.prompt }
+                    model = draft.model.isBlank ? model : draft.model
+                    duration = draft.durationSeconds
+                    playsAudio = draft.musicPlay
+                    capturesAudio = !draft.outputPath.isBlank
+                    if capturesAudio { outputPath = draft.outputPath }
+                    temperature = draft.musicTemperature
+                    topK = draft.musicTopK
+                    guidance = draft.musicCFGMusicCoCa
+                    noteGuidance = draft.musicCFGNotes
+                    drumGuidance = draft.musicCFGDrums
+                    drumless = draft.musicDrumless
+                    style = draft.musicStyleConditioning
+                    midiInput = draft.musicMIDIInput
+                    midiChannel = draft.musicMIDIChannel
+                }
+            }
+        }
+        if let steeringSeed, !didSeedSteering {
+            didSeedSteering = true
+            promptA = steeringSeed.promptA
+            promptB = steeringSeed.promptB
+            blend = steeringSeed.blend
+        }
+    }
+
+    private func toggleSession() {
+        if isPending {
+            send("quit")
+        } else {
+            start()
         }
     }
 
     private func start() {
         guard let template = CommandCatalog.template(id: .musicRealtime) else {
-            statusMessage = "Realtime music template is unavailable."
+            banner = Banner(severity: .error, text: "The realtime music command is unavailable in this build.")
+            return
+        }
+        let prompt = blendedPrompt
+        guard !prompt.isEmpty else {
+            banner = Banner(severity: .error, text: "Describe the music in Prompt A before starting.")
+            return
+        }
+        guard playsAudio || capturesAudio else {
+            banner = Banner(severity: .error, text: "Enable playback or recording (Record to file) before starting.")
             return
         }
         var draft = template.defaultDraft()
-        draft.prompt = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        draft.prompt = prompt
         draft.model = model.trimmingCharacters(in: .whitespacesAndNewlines)
         draft.durationSeconds = duration
         draft.musicPlay = playsAudio
@@ -329,9 +687,9 @@ struct StudioRealtimeMusicView: View {
         draft.musicStyleConditioning = style
         draft.musicTemperature = temperature
         draft.musicTopK = topK
-        draft.musicCFGMusicCoCa = cfgMusicCoCa
-        draft.musicCFGNotes = cfgNotes
-        draft.musicCFGDrums = cfgDrums
+        draft.musicCFGMusicCoCa = guidance
+        draft.musicCFGNotes = noteGuidance
+        draft.musicCFGDrums = drumGuidance
         draft.musicDrumless = drumless
         draft.musicMIDIInput = midiInput
         draft.musicMIDIChannel = midiChannel
@@ -348,26 +706,45 @@ struct StudioRealtimeMusicView: View {
             : .running
         library.start(request: request, commandPreview: preview, status: status)
         requestID = request.id
-        startedAt = Date()
-        statusMessage = status == .queued ? "Queued behind the active job." : "Starting Magenta RT2…"
-        _ = controller.run(studio: request)
+        peaks = []
+        banner = nil
+        if !controller.run(studio: request) {
+            banner = Banner(severity: .error, text: "The session could not be started. Check the CLI path in Settings.")
+        }
+    }
+
+    private func cancelSession() {
+        guard let requestID else { return }
+        if !controller.cancel(requestID: requestID) {
+            banner = Banner(severity: .warning, text: "There is no running session to cancel.")
+        }
+    }
+
+    private func sendPrompt() {
+        guard isLive else { return }
+        let prompt = blendedPrompt
+        guard !prompt.isEmpty else { return }
+        send("prompt \(prompt)")
     }
 
     private func applyControls() {
-        send("style \(style)")
-        send("temp \(temperature)")
-        send("topk \(topK)")
-        send("mc \(cfgMusicCoCa)")
-        send("notes \(cfgNotes)")
-        send("drums \(cfgDrums)")
-        send("drumless \(drumless ? "on" : "off")")
-        statusMessage = "Live controls queued."
+        for command in StudioRealtimeSteering.controlCommands(
+            temperature: temperature,
+            topK: topK,
+            guidance: guidance,
+            noteGuidance: noteGuidance,
+            drumGuidance: drumGuidance,
+            style: style,
+            drumless: drumless
+        ) {
+            send(command)
+        }
     }
 
     private func send(_ command: String) {
-        guard let requestID else { return }
+        guard let requestID, isLive else { return }
         if !controller.submitRealtimeMusicCommand(command, requestID: requestID) {
-            statusMessage = "The realtime process is not ready for live control."
+            banner = Banner(severity: .warning, text: "The realtime process is not ready for live control.")
         }
     }
 
@@ -379,9 +756,15 @@ struct StudioRealtimeMusicView: View {
         }
     }
 
-    private func noteName(_ midi: Int) -> String {
+    private static func noteName(_ midi: Int) -> String {
         let names = ["C", "C♯", "D", "D♯", "E", "F", "F♯", "G", "G♯", "A", "A♯", "B"]
         return "\(names[midi % 12])\(midi / 12 - 1)"
+    }
+
+    private func copyLog() {
+        let pasteboard = NSPasteboard.general
+        pasteboard.clearContents()
+        pasteboard.setString(StudioRealtimeSessionLog.copyText(logLines), forType: .string)
     }
 
     private func chooseOutput() {
@@ -393,5 +776,248 @@ struct StudioRealtimeMusicView: View {
                 ? url.path
                 : url.appendingPathExtension("wav").path
         }
+    }
+
+    /// Live audio is played by the CLI, not the app, so the waveform reads the recording the CLI
+    /// is writing (a growing WAV) while the session runs, and the finished file afterwards.
+    private func pollPeaks() async {
+        while !Task.isCancelled {
+            refreshPeaks()
+            guard isLive else { return }
+            try? await Task.sleep(for: .seconds(2))
+        }
+    }
+
+    private func refreshPeaks() {
+        guard requestID != nil else {
+            peaks = []
+            return
+        }
+        let url: URL?
+        if case .ended = phase {
+            url = item?.outputURL ?? recordingURL
+        } else {
+            url = recordingURL
+        }
+        guard let url else { return }
+        let loaded = isLive
+            ? StudioWaveformLoader.growingWAVPeaks(url: url)
+            : (StudioWaveformLoader.peaks(url: url) ?? StudioWaveformLoader.growingWAVPeaks(url: url))
+        if let loaded {
+            peaks = loaded
+        }
+    }
+}
+
+// MARK: - Pieces
+
+private extension View {
+    /// `panel()`: surface fill, hairline border, radius 10.
+    func sessionPanel() -> some View {
+        frame(maxWidth: .infinity)
+            .background {
+                RoundedRectangle(cornerRadius: 10)
+                    .fill(MereRunTheme.surface)
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 10)
+                            .strokeBorder(MereRunTheme.border.opacity(0.8), lineWidth: 1)
+                    }
+            }
+    }
+}
+
+private struct SessionHairline: View {
+    var body: some View {
+        Rectangle()
+            .fill(MereRunTheme.border.opacity(0.4))
+            .frame(height: 1)
+    }
+}
+
+/// `btnSecondary`: 26pt, raised fill, hairline border, 11.5pt medium.
+private struct SessionSecondaryButton: View {
+    let label: String
+    let action: () -> Void
+    @Environment(\.isEnabled) private var isEnabled
+
+    init(_ label: String, action: @escaping () -> Void) {
+        self.label = label
+        self.action = action
+    }
+
+    var body: some View {
+        Button(action: action) {
+            Text(label)
+                .font(.system(size: 11.5, weight: .medium))
+                .foregroundStyle(isEnabled ? MereRunTheme.textPrimary : MereRunTheme.textMuted)
+                .lineLimit(1)
+                .padding(.horizontal, 10)
+                .frame(height: 26)
+                .background {
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(MereRunTheme.surfaceRaised)
+                        .overlay {
+                            RoundedRectangle(cornerRadius: 6)
+                                .strokeBorder(MereRunTheme.border.opacity(0.6), lineWidth: 1)
+                        }
+                }
+                .contentShape(RoundedRectangle(cornerRadius: 6))
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+/// The LIVE pill: tinted fill, dot, 10.5pt bold tracked caps.
+private struct SessionBadge: View {
+    let text: String
+    let color: Color
+
+    var body: some View {
+        HStack(spacing: 5) {
+            Circle().fill(color).frame(width: 8, height: 8)
+            Text(text)
+                .font(.system(size: 10.5, weight: .bold))
+                .tracking(0.63)
+        }
+        .foregroundStyle(color)
+        .padding(.horizontal, 7)
+        .frame(height: 18)
+        .background(Capsule().fill(color.opacity(0.13)))
+        .accessibilityElement(children: .combine)
+    }
+}
+
+/// Stroke-only stop square / play triangle on the 24-unit icon grid the mockup uses.
+private struct TransportGlyph: Shape {
+    let stop: Bool
+
+    func path(in rect: CGRect) -> Path {
+        let unit = rect.width / 24
+        var path = Path()
+        if stop {
+            path.addRoundedRect(
+                in: CGRect(x: rect.minX + 6 * unit, y: rect.minY + 6 * unit, width: 12 * unit, height: 12 * unit),
+                cornerSize: CGSize(width: 2 * unit, height: 2 * unit)
+            )
+        } else {
+            path.move(to: CGPoint(x: rect.minX + 7 * unit, y: rect.minY + 5 * unit))
+            path.addLine(to: CGPoint(x: rect.minX + 19 * unit, y: rect.minY + 12 * unit))
+            path.addLine(to: CGPoint(x: rect.minX + 7 * unit, y: rect.minY + 19 * unit))
+            path.closeSubpath()
+        }
+        return path
+    }
+}
+
+/// The session waveform: 4pt bars on a 7pt pitch, radius 2, played bars in accent and upcoming
+/// bars in the border color. Peaks are resampled to however many bars fit the width.
+private struct SessionWaveform: View {
+    let peaks: [Float]
+    let played: Double
+
+    var body: some View {
+        Canvas { context, size in
+            let pitch: CGFloat = 7
+            let barWidth: CGFloat = 4
+            let count = max(1, Int((size.width + (pitch - barWidth)) / pitch))
+            let playedBars = Int((played * Double(count)).rounded())
+            for index in 0..<count {
+                let amplitude: CGFloat
+                if peaks.isEmpty {
+                    amplitude = 0
+                } else {
+                    let source = min(peaks.count - 1, index * peaks.count / count)
+                    amplitude = CGFloat(peaks[source])
+                }
+                let height = min(size.height, 8 + amplitude * (size.height - 12))
+                let rect = CGRect(
+                    x: CGFloat(index) * pitch,
+                    y: (size.height - height) / 2,
+                    width: barWidth,
+                    height: height
+                )
+                let color = index < playedBars ? MereRunTheme.accent : MereRunTheme.border
+                context.fill(Path(roundedRect: rect, cornerRadius: 2), with: .color(color))
+            }
+        }
+        .accessibilityElement()
+        .accessibilityLabel("Session waveform")
+        .accessibilityValue("\(Int((played * 100).rounded())) percent played")
+    }
+}
+
+/// `slider()`: 4pt track, accent fill, 14pt surface thumb with hairline and a small shadow, mono
+/// value on the right. Commits when the drag ends so a steer is one stdin line, not hundreds.
+private struct SessionSlider: View {
+    let label: String
+    @Binding var value: Double
+    let range: ClosedRange<Double>
+    let display: (Double) -> String
+    let onCommit: () -> Void
+
+    private var fraction: CGFloat {
+        let span = range.upperBound - range.lowerBound
+        guard span > 0 else { return 0 }
+        return CGFloat(min(1, max(0, (value - range.lowerBound) / span)))
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text(label)
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(MereRunTheme.textSecondary)
+                Spacer()
+                Text(display(value))
+                    .font(.system(size: 12, weight: .medium, design: .monospaced))
+                    .foregroundStyle(MereRunTheme.textPrimary)
+            }
+            GeometryReader { proxy in
+                let width = proxy.size.width
+                ZStack(alignment: .leading) {
+                    RoundedRectangle(cornerRadius: 2)
+                        .fill(MereRunTheme.surfaceRaised)
+                        .frame(height: 4)
+                    RoundedRectangle(cornerRadius: 2)
+                        .fill(MereRunTheme.accent)
+                        .frame(width: max(0, width * fraction), height: 4)
+                    Circle()
+                        .fill(MereRunTheme.surface)
+                        .overlay { Circle().strokeBorder(MereRunTheme.border, lineWidth: 1) }
+                        .mereShadow(radius: 1, y: 1)
+                        .frame(width: 14, height: 14)
+                        .offset(x: width * fraction - 7)
+                }
+                .frame(height: 16)
+                .contentShape(Rectangle())
+                .gesture(
+                    DragGesture(minimumDistance: 0)
+                        .onChanged { drag in set(fractionAt: drag.location.x, width: width) }
+                        .onEnded { drag in
+                            set(fractionAt: drag.location.x, width: width)
+                            onCommit()
+                        }
+                )
+            }
+            .frame(height: 16)
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(label)
+        .accessibilityValue(display(value))
+        .accessibilityAdjustableAction { direction in
+            let step = (range.upperBound - range.lowerBound) / 20
+            switch direction {
+            case .increment: value = min(range.upperBound, value + step)
+            case .decrement: value = max(range.lowerBound, value - step)
+            @unknown default: break
+            }
+            onCommit()
+        }
+    }
+
+    private func set(fractionAt x: CGFloat, width: CGFloat) {
+        guard width > 0 else { return }
+        let clamped = min(1, max(0, x / width))
+        value = range.lowerBound + Double(clamped) * (range.upperBound - range.lowerBound)
     }
 }

--- a/apps/macos/MereRunStudio/StudioRealtimeSession.swift
+++ b/apps/macos/MereRunStudio/StudioRealtimeSession.swift
@@ -1,0 +1,208 @@
+import Foundation
+import SwiftUI
+
+/// Pure view-model logic for Music ▸ Realtime: the transport clock, the prompt blend, the
+/// stdin steering commands, the session log, and the job-bar copy. Everything here is derived
+/// from what the CLI reports (progress lines, log lines, exit state); nothing is invented.
+enum StudioRealtimeTransport {
+    /// Magenta RT2 renders 25 frames per second of audio (`MagentaRT2Resources.frameRate`).
+    static let frameRate = 25.0
+    /// Magenta RT2 output sample rate (`MagentaRT2Resources.sampleRate`).
+    static let sampleRateHz = 48_000
+
+    /// `04:12` — minutes always two digits so the mono line keeps a stable width.
+    static func timestamp(_ seconds: TimeInterval) -> String {
+        guard seconds.isFinite, seconds > 0 else { return "00:00" }
+        let total = Int(seconds.rounded(.down))
+        return String(format: "%02d:%02d", total / 60, total % 60)
+    }
+
+    /// Seconds of audio rendered so far, from the `Realtime frame N/T` progress the CLI writes
+    /// (parsed into "Step N of T" by `StudioProgressParser`). Nil until the first frame.
+    static func renderedSeconds(from progress: StudioRunProgress?) -> TimeInterval? {
+        guard let progress, progress.label == "Realtime music", let detail = progress.detail else {
+            return nil
+        }
+        let scanner = Scanner(string: detail)
+        guard scanner.scanString("Step") != nil, let frames = scanner.scanInt() else { return nil }
+        return Double(frames) / frameRate
+    }
+
+    /// Where playback is, given how long the session has run and how much audio exists. The
+    /// CLI paces frames to wall-clock time, so playback can never be ahead of what is rendered.
+    static func playbackPosition(wallElapsed: TimeInterval, rendered: TimeInterval?) -> TimeInterval {
+        let elapsed = max(0, wallElapsed)
+        guard let rendered else { return 0 }
+        return min(elapsed, rendered)
+    }
+
+    /// `04:12 · 2.1 s ahead of playback`. Before the first frame the session is still loading.
+    static func statusLine(wallElapsed: TimeInterval, rendered: TimeInterval?) -> String {
+        guard let rendered else {
+            return "\(timestamp(wallElapsed)) · loading model"
+        }
+        let playback = playbackPosition(wallElapsed: wallElapsed, rendered: rendered)
+        let lead = rendered - playback
+        return "\(timestamp(playback)) · \(String(format: "%.1f", max(0, lead))) s ahead of playback"
+    }
+
+    /// `Magenta RT2 · 48 kHz` for any Magenta RT2 checkpoint; other ids are shown verbatim.
+    static func engineLabel(model: String) -> String {
+        let trimmed = model.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.isEmpty || trimmed.localizedCaseInsensitiveContains("magenta-rt2") {
+            return "Magenta RT2 · \(sampleRateHz / 1_000) kHz"
+        }
+        return trimmed
+    }
+}
+
+/// Prompt A / Prompt B and the blend slider map onto the CLI's single `prompt <text>` steering
+/// command. Magenta RT2 conditions on one text prompt, so the blend chooses which prompt leads:
+/// the endpoints send one prompt alone, everything in between sends both with the dominant
+/// prompt first. Embedding-level interpolation is a CLI feature; when it lands the same slider
+/// drives it.
+enum StudioRealtimeSteering {
+    static func blendedPrompt(a: String, b: String, blend: Double) -> String {
+        let promptA = a.trimmingCharacters(in: .whitespacesAndNewlines)
+        let promptB = b.trimmingCharacters(in: .whitespacesAndNewlines)
+        if promptB.isEmpty { return promptA }
+        if promptA.isEmpty { return promptB }
+        let clamped = min(1, max(0, blend))
+        if clamped <= 0.05 { return promptA }
+        if clamped >= 0.95 { return promptB }
+        return clamped < 0.5 ? "\(promptA), \(promptB)" : "\(promptB), \(promptA)"
+    }
+
+    static func formatBlend(_ blend: Double) -> String {
+        String(format: "%.2f", min(1, max(0, blend)))
+    }
+
+    /// The stdin lines for the slider row and the extended controls, in the CLI's own words
+    /// (`MagentaRT2LiveControlQueue`). Guidance is the MusicCoCa classifier-free guidance.
+    static func controlCommands(
+        temperature: Double,
+        topK: Int,
+        guidance: Double,
+        noteGuidance: Double,
+        drumGuidance: Double,
+        style: String,
+        drumless: Bool
+    ) -> [String] {
+        [
+            "style \(style)",
+            "temp \(format(temperature))",
+            "topk \(topK)",
+            "mc \(format(guidance))",
+            "notes \(format(noteGuidance))",
+            "drums \(format(drumGuidance))",
+            "drumless \(drumless ? "on" : "off")"
+        ]
+    }
+
+    static func format(_ value: Double) -> String {
+        let text = String(format: "%.2f", value)
+        guard text.contains(".") else { return text }
+        var trimmed = Substring(text)
+        while trimmed.hasSuffix("0") { trimmed = trimmed.dropLast() }
+        if trimmed.hasSuffix(".") { trimmed = trimmed.dropLast() }
+        return String(trimmed)
+    }
+}
+
+/// The session log is the CLI's own stderr plus the live-control lines the controller records,
+/// stamped with the session clock.
+enum StudioRealtimeSessionLog {
+    static func lines(_ logs: [LogLine], startedAt: Date) -> [String] {
+        logs.map { line in
+            let stamp = StudioRealtimeTransport.timestamp(line.date.timeIntervalSince(startedAt))
+            return "\(stamp)  \(line.text)"
+        }
+    }
+
+    static func copyText(_ lines: [String]) -> String {
+        lines.joined(separator: "\n")
+    }
+
+    /// The newest lines that fit a box of `height` points at `lineHeight` points per line.
+    static func visibleTail(_ lines: [String], height: CGFloat, lineHeight: CGFloat) -> [String] {
+        guard lineHeight > 0 else { return lines }
+        let capacity = max(1, Int(height / lineHeight))
+        return Array(lines.suffix(capacity))
+    }
+}
+
+/// Copy and color for the job bar under the session.
+enum StudioRealtimeJobBar {
+    enum Phase: Equatable {
+        case idle
+        case queued
+        case live
+        case ended(exitCode: Int32?)
+    }
+
+    /// `rt2-medium` from `music-magenta-rt2-medium`; other ids keep their last dashed segments.
+    static func residentName(model: String) -> String {
+        let trimmed = model.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return "rt2-small" }
+        for prefix in ["music-magenta-", "magenta-"] where trimmed.hasPrefix(prefix) {
+            return String(trimmed.dropFirst(prefix.count))
+        }
+        return trimmed
+    }
+
+    static func detail(phase: Phase, startedAt: Date?, model: String, now: Date = Date()) -> String {
+        let resident = "\(residentName(model: model)) resident"
+        switch phase {
+        case .idle:
+            return "No session · press play to start · \(residentName(model: model))"
+        case .queued:
+            return "Queued behind the active job · \(residentName(model: model))"
+        case .live:
+            let started = startedAt.map { " · started \(startTimeFormatter.string(from: $0))" } ?? ""
+            return "Session running\(started) · \(resident)"
+        case .ended(let exitCode):
+            let ran = startedAt.map { " · ran \(StudioRealtimeTransport.timestamp(now.timeIntervalSince($0)))" } ?? ""
+            if let exitCode, exitCode != 0 {
+                return "Session failed · exit \(exitCode)\(ran)"
+            }
+            return "Session ended\(ran) · \(residentName(model: model))"
+        }
+    }
+
+    static func dotColor(phase: Phase) -> Color {
+        switch phase {
+        case .idle: return MereRunTheme.textMuted
+        case .queued: return MereRunTheme.yellow
+        case .live: return MereRunTheme.green
+        case .ended(let exitCode):
+            return exitCode == 0 || exitCode == nil ? MereRunTheme.textMuted : MereRunTheme.red
+        }
+    }
+
+    private static let startTimeFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "h:mm a"
+        return formatter
+    }()
+}
+
+/// Test seam for the steering panel: when set in the environment the fields start from these
+/// values instead of empty, so the snapshot harness can show a mid-session steer without a
+/// user typing. Production never sets it.
+struct StudioRealtimeSteeringSeed: Equatable {
+    var promptA: String
+    var promptB: String
+    var blend: Double
+}
+
+private struct StudioRealtimeSteeringSeedKey: EnvironmentKey {
+    static let defaultValue: StudioRealtimeSteeringSeed? = nil
+}
+
+extension EnvironmentValues {
+    var studioRealtimeSteeringSeed: StudioRealtimeSteeringSeed? {
+        get { self[StudioRealtimeSteeringSeedKey.self] }
+        set { self[StudioRealtimeSteeringSeedKey.self] = newValue }
+    }
+}

--- a/apps/macos/MereRunStudio/StudioWaveform.swift
+++ b/apps/macos/MereRunStudio/StudioWaveform.swift
@@ -112,3 +112,83 @@ struct StudioWaveformView: View {
         onSeek(min(1, max(0, locationX / width)))
     }
 }
+
+extension StudioWaveformLoader {
+    /// Peaks for a WAV that is still being written. The realtime recorder (`StreamingWAVWriter`)
+    /// patches the RIFF and data sizes only when it closes the file, so `AVAudioFile` reports zero
+    /// frames mid-session. This reads the `fmt ` chunk itself and treats every byte after the
+    /// `data` chunk header as samples, so a growing file yields a growing waveform. Supports the
+    /// recorder's float32 PCM and plain 16-bit PCM; returns nil for anything else.
+    static func growingWAVPeaks(url: URL, barCount: Int = 96) -> [Float]? {
+        guard barCount > 0, let data = try? Data(contentsOf: url, options: .mappedIfSafe) else {
+            return nil
+        }
+        guard data.count >= 12,
+              data[0..<4].elementsEqual("RIFF".utf8),
+              data[8..<12].elementsEqual("WAVE".utf8) else {
+            return nil
+        }
+
+        func uint16(_ offset: Int) -> Int {
+            Int(data[offset]) | Int(data[offset + 1]) << 8
+        }
+        func uint32(_ offset: Int) -> Int {
+            uint16(offset) | uint16(offset + 2) << 16
+        }
+
+        var offset = 12
+        var formatCode = 0
+        var channelCount = 0
+        var bitsPerSample = 0
+        var samplesStart: Int?
+        while offset + 8 <= data.count {
+            let chunkID = data[offset..<offset + 4]
+            let chunkSize = uint32(offset + 4)
+            let body = offset + 8
+            if chunkID.elementsEqual("fmt ".utf8), body + 16 <= data.count {
+                formatCode = uint16(body)
+                channelCount = uint16(body + 2)
+                bitsPerSample = uint16(body + 14)
+            } else if chunkID.elementsEqual("data".utf8) {
+                samplesStart = body
+                break
+            }
+            offset = body + chunkSize + (chunkSize % 2)
+        }
+
+        guard let samplesStart, channelCount > 0 else { return nil }
+        let bytesPerSample: Int
+        switch (formatCode, bitsPerSample) {
+        case (3, 32): bytesPerSample = 4
+        case (1, 16): bytesPerSample = 2
+        default: return nil
+        }
+        let frameBytes = channelCount * bytesPerSample
+        let totalFrames = (data.count - samplesStart) / frameBytes
+        guard totalFrames > 0 else { return [Float](repeating: 0, count: barCount) }
+
+        let framesPerBar = max(1, totalFrames / barCount)
+        let sampleStride = max(1, framesPerBar / 128)
+        var peaks = [Float](repeating: 0, count: barCount)
+        data.withUnsafeBytes { raw in
+            guard let base = raw.baseAddress?.advanced(by: samplesStart) else { return }
+            for frame in stride(from: 0, to: totalFrames, by: sampleStride) {
+                var amplitude: Float = 0
+                for channel in 0..<channelCount {
+                    let pointer = base.advanced(by: (frame * channelCount + channel) * bytesPerSample)
+                    let value: Float
+                    if bytesPerSample == 4 {
+                        value = Float(bitPattern: UInt32(littleEndian: pointer.loadUnaligned(as: UInt32.self)))
+                    } else {
+                        value = Float(Int16(littleEndian: pointer.loadUnaligned(as: Int16.self))) / Float(Int16.max)
+                    }
+                    amplitude = max(amplitude, abs(value))
+                }
+                let bar = min(barCount - 1, frame / framesPerBar)
+                peaks[bar] = max(peaks[bar], amplitude)
+            }
+        }
+        guard let maxPeak = peaks.max(), maxPeak > 0 else { return peaks }
+        return peaks.map { $0 / maxPeak }
+    }
+}

--- a/apps/macos/MereRunStudioTests/StudioRealtimeSessionTests.swift
+++ b/apps/macos/MereRunStudioTests/StudioRealtimeSessionTests.swift
@@ -1,0 +1,177 @@
+@testable import MereRunApp
+import Foundation
+import XCTest
+
+final class StudioRealtimeSessionTests: XCTestCase {
+    // MARK: Transport clock
+
+    func testTimestampUsesTwoDigitMinutes() {
+        XCTAssertEqual(StudioRealtimeTransport.timestamp(0), "00:00")
+        XCTAssertEqual(StudioRealtimeTransport.timestamp(252.9), "04:12")
+        XCTAssertEqual(StudioRealtimeTransport.timestamp(3_601), "60:01")
+        XCTAssertEqual(StudioRealtimeTransport.timestamp(-4), "00:00")
+        XCTAssertEqual(StudioRealtimeTransport.timestamp(.nan), "00:00")
+    }
+
+    func testRenderedSecondsReadsRealtimeFrameProgress() throws {
+        let progress = StudioProgressParser.parse("Realtime frame 6353/7500")
+        XCTAssertEqual(progress?.label, "Realtime music")
+        XCTAssertEqual(
+            try XCTUnwrap(StudioRealtimeTransport.renderedSeconds(from: progress)),
+            254.12,
+            accuracy: 0.001
+        )
+
+        XCTAssertNil(StudioRealtimeTransport.renderedSeconds(from: nil))
+        XCTAssertNil(
+            StudioRealtimeTransport.renderedSeconds(
+                from: StudioRunProgress(label: "Training", fractionCompleted: 0.5, detail: "Step 2 of 4")
+            )
+        )
+    }
+
+    func testStatusLineReportsLeadOverPlayback() {
+        XCTAssertEqual(
+            StudioRealtimeTransport.statusLine(wallElapsed: 252, rendered: 254.12),
+            "04:12 · 2.1 s ahead of playback"
+        )
+        // Playback can never run ahead of the rendered audio, so the lead floors at zero.
+        XCTAssertEqual(
+            StudioRealtimeTransport.statusLine(wallElapsed: 300, rendered: 254.12),
+            "04:14 · 0.0 s ahead of playback"
+        )
+        XCTAssertEqual(
+            StudioRealtimeTransport.statusLine(wallElapsed: 7, rendered: nil),
+            "00:07 · loading model"
+        )
+    }
+
+    func testEngineLabelNamesMagentaRT2WithSampleRate() {
+        XCTAssertEqual(StudioRealtimeTransport.engineLabel(model: "music-magenta-rt2-medium"), "Magenta RT2 · 48 kHz")
+        XCTAssertEqual(StudioRealtimeTransport.engineLabel(model: ""), "Magenta RT2 · 48 kHz")
+        XCTAssertEqual(StudioRealtimeTransport.engineLabel(model: "/models/custom-rt"), "/models/custom-rt")
+    }
+
+    // MARK: Blend
+
+    func testBlendedPromptPicksEndpointsAndOrdersTheMiddle() {
+        let promptA = "slow-burn synthwave, hopeful bridge"
+        let promptB = "brushed drums, dusty piano"
+        XCTAssertEqual(StudioRealtimeSteering.blendedPrompt(a: promptA, b: promptB, blend: 0), promptA)
+        XCTAssertEqual(StudioRealtimeSteering.blendedPrompt(a: promptA, b: promptB, blend: 1), promptB)
+        XCTAssertEqual(
+            StudioRealtimeSteering.blendedPrompt(a: promptA, b: promptB, blend: 0.35),
+            "\(promptA), \(promptB)"
+        )
+        XCTAssertEqual(
+            StudioRealtimeSteering.blendedPrompt(a: promptA, b: promptB, blend: 0.8),
+            "\(promptB), \(promptA)"
+        )
+    }
+
+    func testBlendedPromptIgnoresAnEmptySide() {
+        XCTAssertEqual(StudioRealtimeSteering.blendedPrompt(a: "  ambient  ", b: "", blend: 0.9), "ambient")
+        XCTAssertEqual(StudioRealtimeSteering.blendedPrompt(a: "", b: "piano", blend: 0), "piano")
+        XCTAssertEqual(StudioRealtimeSteering.blendedPrompt(a: "", b: "", blend: 0.5), "")
+    }
+
+    func testFormatBlendAndControlValues() {
+        XCTAssertEqual(StudioRealtimeSteering.formatBlend(0.35), "0.35")
+        XCTAssertEqual(StudioRealtimeSteering.formatBlend(1.4), "1.00")
+        XCTAssertEqual(StudioRealtimeSteering.format(1.1), "1.1")
+        XCTAssertEqual(StudioRealtimeSteering.format(4.0), "4")
+        XCTAssertEqual(StudioRealtimeSteering.format(0.25), "0.25")
+    }
+
+    func testControlCommandsSpeakTheCLIProtocol() {
+        XCTAssertEqual(
+            StudioRealtimeSteering.controlCommands(
+                temperature: 1.1,
+                topK: 40,
+                guidance: 4,
+                noteGuidance: 5,
+                drumGuidance: 1.5,
+                style: "full",
+                drumless: true
+            ),
+            ["style full", "temp 1.1", "topk 40", "mc 4", "notes 5", "drums 1.5", "drumless on"]
+        )
+    }
+
+    // MARK: Session log
+
+    func testLogLinesAreStampedWithTheSessionClock() {
+        // LogLine stamps itself at creation; the session started 248.5 s before these lines.
+        let startedAt = Date().addingTimeInterval(-248.5)
+        let logs = [
+            LogLine(stream: .stderr, text: "Realtime frame 6326/7500"),
+            LogLine(stream: .system, text: "Live control → prompt brushed drums")
+        ]
+        XCTAssertEqual(
+            StudioRealtimeSessionLog.lines(logs, startedAt: startedAt),
+            ["04:08  Realtime frame 6326/7500", "04:08  Live control → prompt brushed drums"]
+        )
+
+        XCTAssertEqual(
+            StudioRealtimeSessionLog.copyText(["04:08  a", "04:10  b"]),
+            "04:08  a\n04:10  b"
+        )
+    }
+
+    func testVisibleTailKeepsTheNewestLinesThatFit() {
+        let lines = (1...10).map { "line \($0)" }
+        XCTAssertEqual(
+            StudioRealtimeSessionLog.visibleTail(lines, height: 120, lineHeight: 17.8),
+            ["line 5", "line 6", "line 7", "line 8", "line 9", "line 10"]
+        )
+        XCTAssertEqual(StudioRealtimeSessionLog.visibleTail(lines, height: 10, lineHeight: 17.8), ["line 10"])
+        XCTAssertEqual(StudioRealtimeSessionLog.visibleTail(["only"], height: 120, lineHeight: 17.8), ["only"])
+    }
+
+    // MARK: Job bar
+
+    func testJobBarDetailNamesTheResidentModel() {
+        XCTAssertEqual(StudioRealtimeJobBar.residentName(model: "music-magenta-rt2-medium"), "rt2-medium")
+        XCTAssertEqual(StudioRealtimeJobBar.residentName(model: ""), "rt2-small")
+        XCTAssertEqual(StudioRealtimeJobBar.residentName(model: "custom"), "custom")
+
+        var components = DateComponents()
+        components.year = 2026
+        components.month = 9
+        components.day = 3
+        components.hour = 13
+        components.minute = 27
+        let startedAt = Calendar.current.date(from: components)!
+
+        XCTAssertEqual(
+            StudioRealtimeJobBar.detail(phase: .live, startedAt: startedAt, model: "music-magenta-rt2-medium"),
+            "Session running · started 1:27 PM · rt2-medium resident"
+        )
+        XCTAssertEqual(
+            StudioRealtimeJobBar.detail(phase: .idle, startedAt: nil, model: "music-magenta-rt2-small"),
+            "No session · press play to start · rt2-small"
+        )
+        XCTAssertEqual(
+            StudioRealtimeJobBar.detail(phase: .queued, startedAt: nil, model: "music-magenta-rt2-small"),
+            "Queued behind the active job · rt2-small"
+        )
+        XCTAssertEqual(
+            StudioRealtimeJobBar.detail(
+                phase: .ended(exitCode: 0),
+                startedAt: startedAt,
+                model: "music-magenta-rt2-small",
+                now: startedAt.addingTimeInterval(298)
+            ),
+            "Session ended · ran 04:58 · rt2-small"
+        )
+        XCTAssertEqual(
+            StudioRealtimeJobBar.detail(
+                phase: .ended(exitCode: 64),
+                startedAt: startedAt,
+                model: "music-magenta-rt2-small",
+                now: startedAt.addingTimeInterval(3)
+            ),
+            "Session failed · exit 64 · ran 00:03"
+        )
+    }
+}

--- a/apps/macos/MereRunStudioTests/StudioSnapshotTests.swift
+++ b/apps/macos/MereRunStudioTests/StudioSnapshotTests.swift
@@ -24,6 +24,8 @@ final class StudioSnapshotTests: XCTestCase {
         width: StudioLayoutPolicy.defaultWindowWidth,
         height: StudioLayoutPolicy.defaultWindowHeight
     )
+    /// The size the v2 mockups are drawn at.
+    static let fidelitySize = CGSize(width: 1_440, height: 900)
     static let consoleSize = CGSize(width: 1_260, height: 780)
     static let settingsSize = CGSize(width: 560, height: 640)
 
@@ -67,6 +69,45 @@ final class StudioSnapshotTests: XCTestCase {
                 )
             }
         }
+    }
+
+    /// Music ▸ Realtime mid-session: a Magenta RT2 run held open by the process seam (no CLI
+    /// starts), the CLI's own frame progress and steering echoes fed back as stderr, and the
+    /// recording it would be writing synthesized on disk so the waveform has peaks. Rendered at
+    /// the mockup size, light and dark, plus the default window size.
+    func testMusicRealtimeSessionSnapshots() throws {
+        let requestID = try fixture.seedLiveRealtimeSession()
+        let seed = StudioRealtimeSteeringSeed(
+            promptA: "slow-burn synthwave, hopeful bridge",
+            promptB: "brushed drums, dusty piano",
+            blend: 0.35
+        )
+        let renders: [(name: String, size: CGSize, appearance: StudioSnapshotAppearance)] = [
+            ("f7-realtime-light", Self.fidelitySize, .light),
+            ("f7-realtime-dark", Self.fidelitySize, .dark),
+            ("f7-realtime-compact-light", Self.shellSize, .light)
+        ]
+        for render in renders {
+            let navigation = NavigationModel()
+            let view = StudioRootView()
+                .environmentObject(fixture.controller)
+                .environmentObject(fixture.library)
+                .environmentObject(navigation)
+                .environment(\.studioRealtimeSteeringSeed, seed)
+                .frame(width: render.size.width, height: render.size.height)
+            try fixture.write(
+                view,
+                size: render.size,
+                appearance: render.appearance,
+                name: render.name,
+                settle: 2.0,
+                afterAppear: {
+                    navigation.open(task: .musicRealtime)
+                    self.fixture.steerLiveRealtimeSession(requestID: requestID)
+                }
+            )
+        }
+        XCTAssertTrue(fixture.controller.canSteerRealtimeMusic(requestID: requestID))
     }
 
     /// The Settings scene content at the width the app gives it.
@@ -306,6 +347,98 @@ private final class SnapshotFixture {
         }
     }
 
+    // MARK: Live realtime session
+
+    /// Starts a Magenta RT2 session through the real controller and Library paths. The process
+    /// seam holds the launch open instead of refusing it, so `canSteerRealtimeMusic` is true and
+    /// the view re-attaches on appear exactly as it would to a session the user started. The run
+    /// is backdated so the transport clock reads minutes in, and the recording the CLI would be
+    /// streaming to disk is synthesized with the writer's unpatched (zero-length) header.
+    func seedLiveRealtimeSession() throws -> UUID {
+        guard let template = CommandCatalog.template(id: .musicRealtime) else {
+            throw StudioSnapshotError.noContentView
+        }
+        let recordingURL = root.appendingPathComponent("realtime-session.wav", isDirectory: false)
+        try Self.writeGrowingFloatWAV(to: recordingURL, seconds: 254)
+
+        var draft = template.defaultDraft()
+        draft.prompt = "slow-burn synthwave, hopeful bridge, brushed drums, dusty piano"
+        draft.model = "music-magenta-rt2-medium"
+        draft.durationSeconds = 300
+        draft.outputPath = recordingURL.path
+        draft.musicPlay = true
+        draft.musicInteractive = true
+        draft.musicTemperature = 1.1
+        draft.musicTopK = 40
+        draft.musicCFGMusicCoCa = 4
+
+        let request = StudioRunRequest(
+            mode: .music,
+            templateID: .musicRealtime,
+            template: template,
+            draft: draft,
+            createdAt: Date().addingTimeInterval(-249)
+        )
+        let preview = controller.commandPreview(template: template, draft: draft, masksSecrets: true)
+        library.start(request: request, commandPreview: preview, status: .running)
+
+        processRunner.liveSessionMarker = "--interactive"
+        guard controller.run(studio: request), let live = processRunner.liveStarts.last else {
+            throw StudioSnapshotError.noContentView
+        }
+        live.stderr("Starting Magenta RT2 realtime model music-magenta-rt2-medium\n")
+        live.stderr("Interactive steering enabled. Commands: prompt <text> | temp | topk | mc | quit\n")
+        live.stderr("Realtime frame 6226/7500\n")
+        live.stderr("Realtime frame 6251/7500\n")
+        return request.id
+    }
+
+    /// What the user has done so far in the session: one prompt steer and the frames since.
+    func steerLiveRealtimeSession(requestID: UUID) {
+        guard let live = processRunner.liveStarts.last else { return }
+        controller.submitRealtimeMusicCommand(
+            "prompt slow-burn synthwave, hopeful bridge, brushed drums, dusty piano",
+            requestID: requestID
+        )
+        live.stderr("queued prompt\n")
+        live.stderr("Realtime frame 6301/7500\n")
+        live.stderr("Realtime frame 6326/7500\n")
+        live.stderr("Realtime frame 6353/7500\n")
+    }
+
+    /// A float32 mono WAV whose RIFF and data sizes are still zero, as `StreamingWAVWriter`
+    /// leaves them until it closes. The envelope changes slower than one waveform bar
+    /// (~2.6 s of a 96-bar view) so the bars swell and breathe instead of all peaking.
+    private static func writeGrowingFloatWAV(to url: URL, seconds: Int) throws {
+        let sampleRate = 8_000
+        let frames = sampleRate * seconds
+        let secondsPerBar = Float(seconds) / 96
+        var data = Data(capacity: 44 + frames * 4)
+        func appendLE32(_ value: UInt32) { withUnsafeBytes(of: value.littleEndian) { data.append(contentsOf: $0) } }
+        func appendLE16(_ value: UInt16) { withUnsafeBytes(of: value.littleEndian) { data.append(contentsOf: $0) } }
+        data.append(contentsOf: Array("RIFF".utf8))
+        appendLE32(36)
+        data.append(contentsOf: Array("WAVE".utf8))
+        data.append(contentsOf: Array("fmt ".utf8))
+        appendLE32(16)
+        appendLE16(3)
+        appendLE16(1)
+        appendLE32(UInt32(sampleRate))
+        appendLE32(UInt32(sampleRate * 4))
+        appendLE16(4)
+        appendLE16(32)
+        data.append(contentsOf: Array("data".utf8))
+        appendLE32(0)
+        for index in 0..<frames {
+            let time = Float(index) / Float(sampleRate)
+            let bar = time / secondsPerBar
+            let envelope = 0.15 + 0.85 * abs(sin(bar * 0.37) * 0.7 + sin(bar * 1.3) * 0.3)
+            let value = sin(time * 2 * .pi * 220) * envelope
+            withUnsafeBytes(of: value.bitPattern.littleEndian) { data.append(contentsOf: $0) }
+        }
+        try data.write(to: url, options: .atomic)
+    }
+
     /// A soft two-tone gradient with a horizon line, so the canvas visibly shows an image.
     private static func writeFixturePNG(to url: URL, size: CGSize) throws {
         let width = Int(size.width)
@@ -381,14 +514,46 @@ private final class SnapshotFixture {
 
 /// Refuses every launch: reports one stderr line and a non-zero exit asynchronously so readiness
 /// and status probes settle to their "could not check" states without a CLI ever running.
+///
+/// The one exception is a launch whose arguments contain `liveSessionMarker`: that is held open
+/// as a live session (never terminated, stdin recorded) so Session-archetype views can be
+/// rendered mid-run. The test feeds it the lines the CLI would have written.
 private final class SnapshotProcessRunner: MereRunProcessRunning, @unchecked Sendable {
+    struct LiveStart {
+        let configuration: MereRunProcessConfiguration
+        let stdout: @Sendable (String) -> Void
+        let stderr: @Sendable (String) -> Void
+        let process: SnapshotLiveProcess
+    }
+
     private let lock = NSLock()
     private var refusedLaunches = 0
+    private var _liveStarts: [LiveStart] = []
+    private var _liveSessionMarker: String?
 
     var refusedLaunchCount: Int {
         lock.lock()
         defer { lock.unlock() }
         return refusedLaunches
+    }
+
+    var liveSessionMarker: String? {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return _liveSessionMarker
+        }
+        set {
+            lock.lock()
+            _liveSessionMarker = newValue
+            lock.unlock()
+        }
+    }
+
+    var liveStarts: [LiveStart] {
+        lock.lock()
+        defer { lock.unlock() }
+        return _liveStarts
     }
 
     func start(
@@ -398,6 +563,12 @@ private final class SnapshotProcessRunner: MereRunProcessRunning, @unchecked Sen
         termination: @escaping @Sendable (Int32) -> Void
     ) throws -> MereRunRunningProcess {
         lock.lock()
+        if let marker = _liveSessionMarker, configuration.arguments.contains(marker) {
+            let process = SnapshotLiveProcess()
+            _liveStarts.append(LiveStart(configuration: configuration, stdout: stdout, stderr: stderr, process: process))
+            lock.unlock()
+            return process
+        }
         refusedLaunches += 1
         lock.unlock()
         DispatchQueue.global().asyncAfter(deadline: .now() + .milliseconds(30)) {
@@ -410,4 +581,24 @@ private final class SnapshotProcessRunner: MereRunProcessRunning, @unchecked Sen
 
 private final class SnapshotRefusedProcess: MereRunRunningProcess {
     func terminate() {}
+}
+
+/// A session the harness holds open: nothing to terminate, stdin lines kept for assertions.
+private final class SnapshotLiveProcess: MereRunRunningProcess, @unchecked Sendable {
+    private let lock = NSLock()
+    private var _standardInputs: [String] = []
+
+    var standardInputs: [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return _standardInputs
+    }
+
+    func terminate() {}
+
+    func sendStandardInput(_ text: String) throws {
+        lock.lock()
+        _standardInputs.append(text)
+        lock.unlock()
+    }
 }

--- a/apps/macos/MereRunStudioTests/StudioWaveformTests.swift
+++ b/apps/macos/MereRunStudioTests/StudioWaveformTests.swift
@@ -61,4 +61,54 @@ final class StudioWaveformTests: XCTestCase {
 
         XCTAssertNil(StudioWaveformLoader.peaks(url: url, barCount: 0))
     }
+
+    /// The realtime recorder leaves the RIFF/data sizes at zero until it closes the file, which
+    /// makes `AVAudioFile` see no frames. The growing-file reader ignores the declared sizes.
+    func testGrowingWAVPeaksReadPastAZeroLengthHeader() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("waveform-growing-\(UUID().uuidString).wav")
+        defer { try? FileManager.default.removeItem(at: url) }
+
+        var data = Data()
+        func appendLE32(_ value: UInt32) { withUnsafeBytes(of: value.littleEndian) { data.append(contentsOf: $0) } }
+        func appendLE16(_ value: UInt16) { withUnsafeBytes(of: value.littleEndian) { data.append(contentsOf: $0) } }
+        data.append(contentsOf: Array("RIFF".utf8))
+        appendLE32(36)
+        data.append(contentsOf: Array("WAVE".utf8))
+        data.append(contentsOf: Array("fmt ".utf8))
+        appendLE32(16)
+        appendLE16(3) // IEEE float
+        appendLE16(1)
+        appendLE32(48_000)
+        appendLE32(48_000 * 4)
+        appendLE16(4)
+        appendLE16(32)
+        data.append(contentsOf: Array("data".utf8))
+        appendLE32(0) // not yet patched by the writer
+        let frames = 4_000
+        for frame in 0..<frames {
+            let value: Float = frame < frames / 2 ? 0.8 * sin(Float(frame) * 0.3) : 0
+            withUnsafeBytes(of: value.bitPattern.littleEndian) { data.append(contentsOf: $0) }
+        }
+        try data.write(to: url)
+
+        XCTAssertNil(StudioWaveformLoader.peaks(url: url), "AVAudioFile should see zero frames")
+        let peaks = try XCTUnwrap(StudioWaveformLoader.growingWAVPeaks(url: url, barCount: 8))
+        XCTAssertEqual(peaks.count, 8)
+        XCTAssertEqual(peaks.max(), 1.0)
+        for bar in 0..<3 {
+            XCTAssertGreaterThan(peaks[bar], 0.7, "bar \(bar) should carry the sine")
+        }
+        for bar in 5..<8 {
+            XCTAssertEqual(peaks[bar], 0, "bar \(bar) should be silence")
+        }
+    }
+
+    func testGrowingWAVPeaksRejectsNonWAVData() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("waveform-notwav-\(UUID().uuidString).bin")
+        defer { try? FileManager.default.removeItem(at: url) }
+        try Data(repeating: 7, count: 256).write(to: url)
+        XCTAssertNil(StudioWaveformLoader.growingWAVPeaks(url: url))
+    }
 }

--- a/apps/macos/README.md
+++ b/apps/macos/README.md
@@ -109,7 +109,11 @@ candidate ranking, LM planning, adapter stacks, stems, LRC, recipes, and DAW
 delivery. Music ▸ Analyze adds standalone ACE-Step understanding with structured
 results and Music ▸ Transcribe MuScriptor transcription with an embedded MIDI
 piano roll; the resident ACE-Step server's health and lifecycle live under
-Server ▸ Music server. Music ▸ Realtime is the Magenta RT2 workspace;
+Server ▸ Music server. Music ▸ Realtime is the Magenta RT2 session: a transport
+with the live clock, the recording's waveform, Prompt A/B steering with a blend
+slider, temperature, top-k, and guidance sent over the CLI's stdin protocol as
+you release each control, the session log, and a job bar with Cancel and Log;
+it re-attaches to a running session when you navigate back to it.
 Music ▸ Train is the shared LoRA/LoKr trainer with dataset audio previews and live
 loss events. The Command Console retains the complete raw command surface.
 Audio ▸ Enhance and Audio ▸ Separate (also reachable as Music ▸ Separate) are


### PR DESCRIPTION
## What changed

Music ▸ Realtime is rebuilt to the approved v2 mockup (`sessionBoard()` / `jobBar()` in the Studio v2 mockup generator): one centered column (672pt content, 22pt top, 14pt gaps) of `surface` panels with hairline borders and radius 10, over a 40pt job bar.

- **Transport panel**: 40pt accent circle with a stroked stop/play glyph in `onAccent`, LIVE badge (red @13% fill, 10.5pt bold, 0.06em tracking, red dot) while the session is steerable, `Magenta RT2 · 48 kHz`, and a mono 12.5pt clock `04:12 · 2.1 s ahead of playback`. `Record to file` opens the launch options (model, max duration, play-through, record + output path with the save panel); `MIDI in: …` opens the CoreMIDI device/channel picker. Both are the real options the launch argv is built from.
- **Waveform panel**: 60pt bars, 4pt wide on a 7pt pitch, radius 2; played bars in accent, upcoming in `border`.
- **Steering panel**: header + "changes blend in over 4 bars"; Prompt A / Prompt B side by side; `Blend A ↔ B`; Temperature / Top-k / Guidance sliders in a row, each a 4pt track with a 14pt hairline thumb and a mono value.
- **Session log panel**: header + Copy; 11.5pt mono, 120pt tall, `textSecondary`, newest lines.
- **Job bar**: green dot when live, `Music · Realtime`, `Session running · started 1:27 PM · rt2-medium resident`, Cancel + Log (full log popover).

Nothing shown is invented. The clock reads the CLI's `Realtime frame N/T` progress (already parsed by `StudioProgressParser`) for rendered seconds and clamps playback to it; the waveform reads the WAV the CLI is streaming; the log is the run's stderr plus the controller's live-control lines; the job bar names the resident model from the run's draft.

Every previous capability survives: start/stop (transport button sends `quit`; Cancel terminates), MIDI input, record/save panel, and the whole stdin protocol. Style conditioning, note and drum guidance, drumless, the playable octave, reset, and apply-all fold under a collapsed **More steering** row at the bottom of the Steering panel. Errors surface as `MereBanner`. The Close/Start footer and two-column form are gone.

New: the view re-attaches to a running or queued realtime session on appear (`controller.runningRequestID(for: .musicRealtime)` / the Library row), so navigating away and back no longer orphans the session.

`apps/macos/README.md` describes the new surface.

## Decisions the reviewer should know

- **Blend maps onto the CLI's single `prompt <text>`.** Magenta RT2 conditions on one text prompt and the stdin protocol has no two-prompt command. The blend picks the ordering: ≤0.05 sends Prompt A alone, ≥0.95 sends B alone, in between sends both with the dominant prompt first. When the CLI gains embedding-level interpolation, the same slider drives it. (`StudioRealtimeSteering.blendedPrompt`.)
- **Apply semantics.** Each slider sends its own command (`temp`, `topk`, `mc`, …) when the drag ends; prompt fields send on submit. `Apply all controls` under More steering still batches the full set the way the old sheet did.
- **"ahead of playback" is derived, not reported.** The CLI paces frames to wall-clock and does not report its buffer depth, so playback = min(wall elapsed, rendered) and lead = rendered − playback. It reads as a small positive number while the renderer is ahead of the pacing and 0.0 s otherwise. If the CLI later reports the ring-buffer depth, the same field shows it.
- **Waveform mid-session.** Live audio is played by the CLI, not the app, so the panel reads the recording being written. `StreamingWAVWriter` leaves the RIFF/data sizes at zero until close, which makes `AVAudioFile` see zero frames; `StudioWaveformLoader.growingWAVPeaks` parses the header itself and reads to end of file, polled every 2 s while live. With recording off, the bars stay flat.
- **`onAccent`** is file-private with the `// F1 token:` comment, as instructed; `MereRunTheme.swift` is untouched.
- Branch is named `studio-v2/f7-realtime-session` because `studio-v2/f7-realtime` was already checked out in another worktree.

## Snapshot harness

`SnapshotProcessRunner` gains a live-session mode (a launch whose argv contains a marker is held open instead of refused). `testMusicRealtimeSessionSnapshots` starts a Magenta RT2 run through the real controller and Library paths, backdated four minutes, feeds it the CLI's frame progress and steering echoes, synthesizes the recording it would be streaming (unpatched header), seeds the steering fields through a `studioRealtimeSteeringSeed` environment value, and renders 1440×900 light + dark and 1280×820. Renders are written only when `MERERUN_STUDIO_SNAPSHOT_DIR` is set; nothing is committed.

## Verification

- `swiftlint --strict` clean.
- `swift test --filter MereRunAppTests`: 283 tests, 0 failures. New `StudioRealtimeSessionTests` (clock, blend, commands, log stamping and tail, job-bar copy) and two `StudioWaveformTests` for the growing-WAV reader.
- `./scripts/check.sh`: 3472 tests, 0 failures.
- `./scripts/build_mere_run_app.sh debug` builds and validates the bundle.
- Fidelity renders compared side by side with `Session.png`; remaining differences are shell-level (toolbar task control, sidebar and Library row styling: F1/other steps), the deliberate `More steering` row, and real log content in place of the mockup's sample lines.
