### PR TITLE
Rebuild Models ▸ Installed to the Studio v2 Manage design

### DIFF
--- a/apps/macos/MereRunStudio/StudioModelsPresentation.swift
+++ b/apps/macos/MereRunStudio/StudioModelsPresentation.swift
@@ -1,0 +1,462 @@
+import Foundation
+import SwiftUI
+
+/// The display family a managed model category belongs to: the vocabulary of the Installed
+/// page's chip row and the first word of every row's meta line ("Image · 2.1 GB").
+enum StudioModelFamily: String, CaseIterable, Identifiable {
+    case image
+    case video
+    case music
+    case sound
+    case voice
+    case audio
+    case chat
+    case text
+    case vision
+    case threeD
+    case other
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .image: return "Image"
+        case .video: return "Video"
+        case .music: return "Music"
+        case .sound: return "Sound"
+        case .voice: return "Voice"
+        case .audio: return "Audio"
+        case .chat: return "Chat"
+        case .text: return "Text"
+        case .vision: return "Vision"
+        case .threeD: return "3D"
+        case .other: return "Other"
+        }
+    }
+
+    /// The CLI's `ManagedModelCategory` raw values, grouped the way the sidebar groups domains.
+    static func from(category: String) -> StudioModelFamily {
+        switch category.lowercased() {
+        case "image": return .image
+        case "image-3d": return .threeD
+        case "video": return .video
+        case "music": return .music
+        case "sfx": return .sound
+        case "speech-tts": return .voice
+        case "speech-asr", "speech-diarization", "audio": return .audio
+        case "text-chat", "text-code", "omni-chat": return .chat
+        case let value where value.hasPrefix("text-"): return .text
+        case let value where value.hasPrefix("vision-"): return .vision
+        default: return .other
+        }
+    }
+
+    /// The LoRA/adapter training template for models of this family, when the app has one.
+    var trainingTemplateID: CommandTemplateID? {
+        switch self {
+        case .image: return .imageTrainLoRA
+        case .chat: return .textTrainLoRA
+        case .music: return .musicTrainAdapter
+        default: return nil
+        }
+    }
+}
+
+/// What the Models toolbar subtitle reports: installed count and the managed store's size.
+struct StudioModelInventorySummary: Equatable {
+    let installedCount: Int
+    let storageBytes: Int64?
+
+    var subtitle: String {
+        guard installedCount > 0 else { return "No models installed" }
+        let count = "\(installedCount) installed"
+        guard let storageBytes, storageBytes > 0 else { return count }
+        return "\(count) · \(StudioModelsPresenter.bytes(storageBytes)) on this Mac"
+    }
+}
+
+/// The state dot in front of a list row.
+enum StudioModelRowStatus: Equatable {
+    case installed
+    case attention
+    case pulling(Double?)
+    case missing
+
+    var color: Color {
+        switch self {
+        case .installed: return MereRunTheme.green
+        case .attention: return MereRunTheme.yellow
+        case .pulling: return MereRunTheme.accent
+        case .missing: return MereRunTheme.textMuted
+        }
+    }
+
+    var accessibilityDescription: String {
+        switch self {
+        case .installed: return "installed"
+        case .attention: return "needs attention"
+        case .pulling(let fraction):
+            guard let fraction else { return "pulling" }
+            return "pulling \(Int((fraction * 100).rounded())) percent"
+        case .missing: return "not installed"
+        }
+    }
+}
+
+/// A Models-domain job the page's job bar reports: a pull, an optimization, or a storage
+/// clean-up. Pulls started from the composer arrive as running `.modelPull` Library rows; the
+/// page's own pulls, optimizations, and clean-ups are tracked locally.
+struct StudioModelsJob: Equatable {
+    enum Kind: Equatable {
+        case pull
+        case optimize
+        case cleanup
+
+        var verb: String {
+            switch self {
+            case .pull: return "Pull"
+            case .optimize: return "Optimize"
+            case .cleanup: return "Clean up"
+            }
+        }
+    }
+
+    let kind: Kind
+    let modelID: String?
+    let subject: String
+    let progress: StudioRunProgress?
+    let isCancelling: Bool
+    /// The Library row backing a composer-initiated pull, so Cancel routes to the controller.
+    let libraryItemID: UUID?
+
+    init(
+        kind: Kind,
+        modelID: String?,
+        subject: String,
+        progress: StudioRunProgress? = nil,
+        isCancelling: Bool = false,
+        libraryItemID: UUID? = nil
+    ) {
+        self.kind = kind
+        self.modelID = modelID
+        self.subject = subject
+        self.progress = progress
+        self.isCancelling = isCancelling
+        self.libraryItemID = libraryItemID
+    }
+
+    var label: String {
+        "Models · \(kind.verb) \(subject)"
+    }
+
+    var detail: String? {
+        if isCancelling { return "Cancelling…" }
+        return progress?.detail
+    }
+
+    var fraction: Double? {
+        progress?.fractionCompleted
+    }
+}
+
+/// Facts parsed from `mere.run model info <id> --components` for the detail column.
+struct StudioModelInfoFacts: Equatable {
+    var root: String?
+    var quantization: String?
+    var hasManifest: Bool?
+    var isValid: Bool?
+
+    /// The "Verified" row: nil until the info output has been read.
+    var verifiedLine: String? {
+        switch (hasManifest, isValid) {
+        case (false, _): return "manifest missing"
+        case (true, true): return "manifest ok · validation passed"
+        case (true, false): return "manifest ok · validation failed"
+        case (nil, true): return "validation passed"
+        case (nil, false): return "validation failed"
+        case (true, nil), (nil, nil): return nil
+        }
+    }
+
+    var isEmpty: Bool {
+        root == nil && quantization == nil && hasManifest == nil && isValid == nil
+    }
+}
+
+/// How a model has been used from this Mac, from the Library.
+struct StudioModelUsageSummary: Equatable {
+    let lastUsed: Date
+    let runs: Int
+}
+
+/// Pure presentation rules for the Installed page: filtering, the row meta line, chips,
+/// Library-derived facts, and the job bar. Everything here is unit-testable without a view.
+enum StudioModelsPresenter {
+    static func displayName(_ row: StudioModelInventoryRow) -> String {
+        row.title ?? row.id
+    }
+
+    static func family(of row: StudioModelInventoryRow) -> StudioModelFamily {
+        StudioModelFamily.from(category: row.category)
+    }
+
+    /// The families that have at least one row, in sidebar order.
+    static func families(in rows: [StudioModelInventoryRow]) -> [StudioModelFamily] {
+        let present = Set(rows.map(family(of:)))
+        return StudioModelFamily.allCases.filter(present.contains)
+    }
+
+    static func filter(
+        _ rows: [StudioModelInventoryRow],
+        family: StudioModelFamily?,
+        query: String
+    ) -> [StudioModelInventoryRow] {
+        let trimmed = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return rows.filter { row in
+            if let family, self.family(of: row) != family { return false }
+            guard !trimmed.isEmpty else { return true }
+            return row.id.lowercased().contains(trimmed)
+                || displayName(row).lowercased().contains(trimmed)
+                || row.category.lowercased().contains(trimmed)
+                || self.family(of: row).title.lowercased().contains(trimmed)
+        }
+    }
+
+    /// Installed rows plus any row that is being pulled right now, so a pull shows up in the
+    /// list the moment it starts.
+    static func listRows(
+        _ rows: [StudioModelInventoryRow],
+        pullingIDs: Set<String>
+    ) -> [StudioModelInventoryRow] {
+        rows.filter { $0.isInstalled || pullingIDs.contains($0.id) }
+    }
+
+    static func status(of row: StudioModelInventoryRow, job: StudioModelsJob?) -> StudioModelRowStatus {
+        if let job, job.kind == .pull, job.modelID == row.id {
+            return .pulling(job.fraction)
+        }
+        guard row.isInstalled else { return .missing }
+        if row.supported == false { return .attention }
+        return .installed
+    }
+
+    /// "Image · 2.1 GB", "Vision · pulling 25%", "Chat · 4.8 GB download".
+    static func meta(for row: StudioModelInventoryRow, status: StudioModelRowStatus) -> String {
+        let family = family(of: row).title
+        switch status {
+        case .pulling(let fraction):
+            guard let fraction else { return "\(family) · pulling…" }
+            return "\(family) · pulling \(Int((fraction * 100).rounded()))%"
+        case .missing:
+            let size = row.displayedSize
+            return size == "—" ? "\(family) · not installed" : "\(family) · \(size) download"
+        case .installed, .attention:
+            let size = row.size
+            guard !size.isEmpty, size != "—", size != "not measured" else { return family }
+            return "\(family) · \(size)"
+        }
+    }
+
+    /// "Q4 · 2.1 GB" for the detail chip row; the quantization comes from `model info`.
+    static func sizeChip(for row: StudioModelInventoryRow, facts: StudioModelInfoFacts?) -> String? {
+        var parts: [String] = []
+        if let quantization = facts?.quantization { parts.append(quantization) }
+        let size = row.isInstalled ? row.size : row.displayedSize
+        if !size.isEmpty, size != "—", size != "not measured" { parts.append(size) }
+        return parts.isEmpty ? nil : parts.joined(separator: " · ")
+    }
+
+    /// Domain titles whose prompt task defaults to this model ("Default for Image").
+    static func defaultDomainTitles(for modelID: String) -> [String] {
+        var titles: [String] = []
+        for task in StudioTask.allCases {
+            guard let mode = task.mode,
+                  let template = CommandCatalog.template(id: mode.defaultTemplateID),
+                  template.defaultModel == modelID else { continue }
+            let title = task.domain.title
+            if !titles.contains(title) { titles.append(title) }
+        }
+        return titles
+    }
+
+    /// Runs from the Library that used this model: conversation threads record it directly,
+    /// other runs carry it in their draft or `--model` argument.
+    static func usage(of modelID: String, in items: [StudioLibraryItem]) -> StudioModelUsageSummary? {
+        let matches = items.filter { uses(modelID, item: $0) }
+        guard let latest = matches.map(\.updatedAt).max() else { return nil }
+        return StudioModelUsageSummary(lastUsed: latest, runs: matches.count)
+    }
+
+    static func uses(_ modelID: String, item: StudioLibraryItem) -> Bool {
+        if item.model == modelID || item.commandDraft?.model == modelID { return true }
+        let tokens = item.commandPreview.split(whereSeparator: \.isWhitespace).map(String.init)
+        guard let flag = tokens.firstIndex(where: { $0 == "--model" || $0 == "-m" }),
+              flag + 1 < tokens.count else {
+            return tokens.contains { $0 == "--model=\(modelID)" }
+        }
+        return tokens[flag + 1] == modelID
+    }
+
+    /// "1:31 PM · 214 runs" today, "Aug 30 · 3 runs" otherwise.
+    static func usageLine(_ usage: StudioModelUsageSummary, now: Date = Date(), calendar: Calendar = .current) -> String {
+        let when: String
+        if calendar.isDate(usage.lastUsed, inSameDayAs: now) {
+            when = usage.lastUsed.formatted(date: .omitted, time: .shortened)
+        } else {
+            when = shortDate(usage.lastUsed)
+        }
+        return "\(when) · \(usage.runs) \(usage.runs == 1 ? "run" : "runs")"
+    }
+
+    /// Wall-clock length of the latest completed run with this model ("3.4 s").
+    static func lastRunDuration(for modelID: String, in items: [StudioLibraryItem]) -> String? {
+        let completed = items
+            .filter { uses(modelID, item: $0) && $0.status == .completed && !$0.isConversation }
+            .sorted { $0.updatedAt > $1.updatedAt }
+        guard let latest = completed.first else { return nil }
+        let seconds = latest.updatedAt.timeIntervalSince(latest.createdAt)
+        guard seconds > 0 else { return nil }
+        return duration(seconds)
+    }
+
+    /// The latest quality-gate run: "Quality gate passed · Aug 30".
+    static func gateLine(in items: [StudioLibraryItem]) -> (text: String, ok: Bool)? {
+        guard let latest = items
+            .filter({ $0.templateID == .qualityGate })
+            .sorted(by: { $0.updatedAt > $1.updatedAt })
+            .first else { return nil }
+        switch latest.status {
+        case .completed:
+            return ("Quality gate passed · \(shortDate(latest.updatedAt))", true)
+        case .failed:
+            return ("Quality gate failed · \(shortDate(latest.updatedAt))", false)
+        case .running, .queued:
+            return ("Quality gate running", true)
+        }
+    }
+
+    /// The latest completed benchmark: "Aug 30 · Lite suite".
+    static func benchmarkLine(in items: [StudioLibraryItem]) -> String? {
+        guard let latest = items
+            .filter({ $0.templateID == .modelBenchmarkFused || $0.templateID == .modelBenchmarkFusedFixture })
+            .filter({ $0.status == .completed })
+            .sorted(by: { $0.updatedAt > $1.updatedAt })
+            .first else { return nil }
+        var line = shortDate(latest.updatedAt)
+        if let suite = latest.commandDraft?.benchmarkSuite, !suite.isBlank {
+            line += " · \(suite.capitalized) suite"
+        }
+        return line
+    }
+
+    /// Composer-initiated pulls show up as running `.modelPull` Library rows.
+    static func libraryPullJob(
+        in items: [StudioLibraryItem],
+        rows: [StudioModelInventoryRow],
+        progressByRequestID: [UUID: StudioRunProgress]
+    ) -> StudioModelsJob? {
+        guard let item = items.first(where: { $0.templateID == .modelPull && $0.status == .running }) else {
+            return nil
+        }
+        let modelID = item.commandDraft?.model ?? item.model ?? pulledModelID(fromPreview: item.commandPreview)
+        let subject = rows.first { $0.id == modelID }.map(displayName) ?? modelID ?? "model"
+        return StudioModelsJob(
+            kind: .pull,
+            modelID: modelID,
+            subject: subject,
+            progress: progressByRequestID[item.id],
+            libraryItemID: item.id
+        )
+    }
+
+    static func pulledModelID(fromPreview preview: String) -> String? {
+        let tokens = preview.split(whereSeparator: \.isWhitespace).map(String.init)
+        guard let pull = tokens.firstIndex(of: "pull"), pull + 1 < tokens.count,
+              pull > 0, tokens[pull - 1] == "model" else { return nil }
+        return tokens[pull + 1]
+    }
+
+    static func facts(fromInfo output: String) -> StudioModelInfoFacts {
+        var facts = StudioModelInfoFacts()
+        var precision: String?
+        for rawLine in output.components(separatedBy: .newlines) {
+            let line = rawLine.trimmingCharacters(in: .whitespaces)
+            if line.hasPrefix("Model Root:") {
+                let path = line.dropFirst("Model Root:".count).trimmingCharacters(in: .whitespaces)
+                if !path.isEmpty { facts.root = path }
+            } else if line.hasPrefix("Manifest: (missing)") {
+                facts.hasManifest = false
+            } else if line.hasPrefix("Manifest (") {
+                facts.hasManifest = true
+            } else if line.hasPrefix("quantization:"), facts.quantization == nil {
+                if let bits = value(of: "bits", in: line) { facts.quantization = "Q\(bits)" }
+            } else if line.hasPrefix("precision:"), precision == nil {
+                let value = line.dropFirst("precision:".count).trimmingCharacters(in: .whitespaces)
+                if !value.isEmpty { precision = value }
+            } else if line.hasPrefix("isValid:") {
+                let flag = line.dropFirst("isValid:".count).trimmingCharacters(in: .whitespaces)
+                facts.isValid = flag == "true"
+            }
+        }
+        // Quantized checkpoints report both; the bit width is the fact users recognize.
+        if facts.quantization == nil { facts.quantization = precision }
+        return facts
+    }
+
+    /// "~/Library/Application Support/MereRun/models" for the Store row.
+    static func abbreviatedPath(_ path: String, home: String = NSHomeDirectory()) -> String {
+        guard !home.isEmpty, path.hasPrefix(home) else { return path }
+        return "~" + path.dropFirst(home.count)
+    }
+
+    static func sourceLine(for row: StudioModelInventoryRow) -> String? {
+        guard let repository = row.sourceRepository, !repository.isBlank else { return nil }
+        return "huggingface.co/\(repository)"
+    }
+
+    static func memoryLine(for row: StudioModelInventoryRow) -> String? {
+        switch (row.minimumUnifiedMemoryGB, row.recommendedUnifiedMemoryGB) {
+        case let (minimum?, recommended?) where recommended > minimum:
+            return "\(minimum) GB min · \(recommended) GB recommended"
+        case let (minimum?, _):
+            return "\(minimum) GB min"
+        case let (nil, recommended?):
+            return "\(recommended) GB recommended"
+        case (nil, nil):
+            return nil
+        }
+    }
+
+    /// "LoRA · 48 MB · v2" under an adapter's name.
+    static func adapterMeta(format: String, byteCount: Int64, version: String, installed: Bool) -> String {
+        var parts = [format.lowercased() == "lora" ? "LoRA" : format.uppercased()]
+        if byteCount > 0 { parts.append(bytes(byteCount)) }
+        if !version.isBlank { parts.append("v\(version)") }
+        if !installed { parts.append("not pulled") }
+        return parts.joined(separator: " · ")
+    }
+
+    static func bytes(_ count: Int64) -> String {
+        ByteCountFormatter.string(fromByteCount: count, countStyle: .file)
+    }
+
+    static func shortDate(_ date: Date) -> String {
+        date.formatted(.dateTime.month(.abbreviated).day())
+    }
+
+    static func duration(_ seconds: TimeInterval) -> String {
+        if seconds < 60 { return String(format: "%.1f s", seconds) }
+        let minutes = Int(seconds) / 60
+        let rest = Int(seconds) % 60
+        return "\(minutes) min \(rest) s"
+    }
+
+    private static func value(of key: String, in line: String) -> String? {
+        for token in line.split(separator: " ") {
+            let pair = token.split(separator: "=", maxSplits: 1)
+            guard pair.count == 2, pair[0] == Substring(key) else { continue }
+            return String(pair[1])
+        }
+        return nil
+    }
+}

--- a/apps/macos/MereRunStudio/StudioModelsView.swift
+++ b/apps/macos/MereRunStudio/StudioModelsView.swift
@@ -329,18 +329,56 @@ enum StudioModelInventoryParser {
     }
 }
 
+
+// F1 token: text on an accent fill (mockup `onAccent`); light #FFFFFF, dark #1B160A.
+private let onAccent = MereRunTheme.dynamic(light: "FFFFFF", dark: "1B160A")
+
+private enum ModelsMetrics {
+    static let listWidth: CGFloat = 320
+    static let rowHeight: CGFloat = 40
+    static let dot: CGFloat = 8
+    static let jobBarHeight: CGFloat = 40
+    static let detailPadding = EdgeInsets(top: 22, leading: 24, bottom: 22, trailing: 24)
+    static let panelRadius: CGFloat = 10
+}
+
+/// Models ▸ Installed: a 320pt list of installed (and in-flight) models beside a detail column
+/// of facts, health, performance, and the adapters that target the model, with a job bar for
+/// pulls, optimizations, and storage clean-ups pinned to the page bottom.
 struct StudioModelsView: View {
     @EnvironmentObject private var controller: MereRunController
     @EnvironmentObject private var library: StudioLibraryStore
+    @EnvironmentObject private var navigation: NavigationModel
 
     let onModelsChanged: () -> Void
+    /// Reports installed count and store size so the toolbar subtitle can show them.
+    let onInventoryChanged: (StudioModelInventorySummary) -> Void
+    /// The domain an adapter is applied to ("Image" in "Use in Image").
+    let adapterTargetTitle: String
+    let onUseAdapter: (StudioAdapterRow) -> Void
+    let onTrain: (CommandTemplateID) -> Void
+
+    init(
+        onModelsChanged: @escaping () -> Void,
+        onInventoryChanged: @escaping (StudioModelInventorySummary) -> Void = { _ in },
+        adapterTargetTitle: String = "Image",
+        onUseAdapter: @escaping (StudioAdapterRow) -> Void = { _ in },
+        onTrain: @escaping (CommandTemplateID) -> Void = { _ in }
+    ) {
+        self.onModelsChanged = onModelsChanged
+        self.onInventoryChanged = onInventoryChanged
+        self.adapterTargetTitle = adapterTargetTitle
+        self.onUseAdapter = onUseAdapter
+        self.onTrain = onTrain
+    }
 
     @State private var rows: [StudioModelInventoryRow] = []
+    @State private var adapters: [StudioAdapterRow] = []
     @State private var selectedID: String?
     @State private var detailText = ""
-    @State private var statusMessage = "Loading models"
-    @State private var showAll = false
+    @State private var statusMessage = ""
     @State private var searchText = ""
+    @State private var selectedFamily: StudioModelFamily?
     @State private var isRefreshing = false
     @State private var loadingInfoID: String?
     @State private var loadingRuntimeID: String?
@@ -351,9 +389,12 @@ struct StudioModelsView: View {
     @State private var cancellingDownloadID: String?
     @State private var removingID: String?
     @State private var optimizingID: String?
+    @State private var optimizeCommandID: UUID?
+    @State private var cleanupCommandID: UUID?
     @State private var pendingAlert: StudioModelsAlert?
     @State private var storageReport: StudioModelStorageReport?
     @State private var isCleaningStorage = false
+    @State private var infoFactsByID: [String: StudioModelInfoFacts] = [:]
     @State private var runtimeSettingsByID: [String: StudioRuntimeSettings] = [:]
     @State private var runtimeAlias = ""
     @State private var runtimeTTL = ""
@@ -363,18 +404,59 @@ struct StudioModelsView: View {
     @State private var runtimeTopP = ""
     @State private var runtimeMinP = ""
     @State private var runtimePinned = false
+    @State private var showPullSheet = false
+    @State private var showJobLog = false
+    @State private var showRuntimeSettings = false
+    @State private var showDetails = false
+    @State private var jobLog = ""
 
     private var installedRows: [StudioModelInventoryRow] {
         rows.filter(\.isInstalled)
     }
 
-    private var visibleRows: [StudioModelInventoryRow] {
-        let scoped = showAll ? rows : installedRows
-        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        guard !query.isEmpty else { return scoped }
-        return scoped.filter { row in
-            row.id.lowercased().contains(query) || row.category.lowercased().contains(query)
+    private var missingRows: [StudioModelInventoryRow] {
+        rows.filter { !$0.isInstalled && $0.id != downloadingID }
+    }
+
+    /// The page's own job first; otherwise a composer-initiated pull from the Library.
+    private var activeJob: StudioModelsJob? {
+        if let downloadingID {
+            return StudioModelsJob(
+                kind: .pull,
+                modelID: downloadingID,
+                subject: displayName(for: downloadingID),
+                progress: downloadProgress,
+                isCancelling: cancellingDownloadID == downloadingID
+            )
         }
+        if let optimizingID {
+            return StudioModelsJob(kind: .optimize, modelID: optimizingID, subject: displayName(for: optimizingID))
+        }
+        if isCleaningStorage {
+            return StudioModelsJob(kind: .cleanup, modelID: nil, subject: "model storage")
+        }
+        return StudioModelsPresenter.libraryPullJob(
+            in: library.items,
+            rows: rows,
+            progressByRequestID: controller.progressByRequestID
+        )
+    }
+
+    private var pullingIDs: Set<String> {
+        guard let job = activeJob, job.kind == .pull, let modelID = job.modelID else { return [] }
+        return [modelID]
+    }
+
+    private var families: [StudioModelFamily] {
+        StudioModelsPresenter.families(in: StudioModelsPresenter.listRows(rows, pullingIDs: pullingIDs))
+    }
+
+    private var visibleRows: [StudioModelInventoryRow] {
+        StudioModelsPresenter.filter(
+            StudioModelsPresenter.listRows(rows, pullingIDs: pullingIDs),
+            family: selectedFamily,
+            query: searchText
+        )
     }
 
     private var selectedRow: StudioModelInventoryRow? {
@@ -383,20 +465,27 @@ struct StudioModelsView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            header
-
-            Divider()
-                .overlay(MereRunTheme.border.opacity(0.6))
-
             HStack(spacing: 0) {
-                modelList
-                    .frame(minWidth: 280, idealWidth: 360, maxWidth: 360)
+                listColumn
+                    .frame(width: ModelsMetrics.listWidth)
+                    .overlay(alignment: .trailing) {
+                        Rectangle()
+                            .fill(MereRunTheme.border.opacity(0.4))
+                            .frame(width: 1)
+                    }
 
-                Divider()
-                    .overlay(MereRunTheme.border.opacity(0.6))
-
-                detailPane
+                detailColumn
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
+            }
+
+            if let job = activeJob {
+                StudioModelsJobBar(
+                    job: job,
+                    onCancel: { cancel(job) },
+                    onLog: { showJobLog.toggle() },
+                    showLog: $showJobLog,
+                    log: log(for: job)
+                )
             }
         }
         .background(MereRunTheme.background)
@@ -404,10 +493,8 @@ struct StudioModelsView: View {
         .task {
             await refresh()
         }
-        .onChange(of: showAll) {
-            if let selectedID, visibleRows.contains(where: { $0.id == selectedID }) {
-                return
-            }
+        .onChange(of: visibleRows.map(\.id)) { _, ids in
+            if let selectedID, ids.contains(selectedID) { return }
             guard let first = visibleRows.first else {
                 selectedID = nil
                 detailText = ""
@@ -415,22 +502,28 @@ struct StudioModelsView: View {
             }
             select(first)
         }
+        .sheet(isPresented: $showPullSheet) {
+            StudioModelPullSheet(rows: missingRows) { row in
+                showPullSheet = false
+                requestDownload(row)
+            }
+        }
         .alert(item: $pendingAlert) { pending in
             switch pending {
             case .download(let row):
                 Alert(
                     title: Text("Accept third-party model terms"),
                     message: Text(downloadTermsMessage(row)),
-                    primaryButton: .default(Text("Accept & Download")) {
+                    primaryButton: .default(Text("Accept & Pull")) {
                         Task { await download(row, acknowledgingUsageTerms: true) }
                     },
                     secondaryButton: .cancel()
                 )
             case .removal(let row):
                 Alert(
-                    title: Text("Purge \(row.id)?"),
+                    title: Text("Remove \(displayName(for: row.id))?"),
                     message: Text(removalMessage(row)),
-                    primaryButton: .destructive(Text("Purge")) {
+                    primaryButton: .destructive(Text("Remove")) {
                         Task { await purge(row) }
                     },
                     secondaryButton: .cancel()
@@ -451,122 +544,74 @@ struct StudioModelsView: View {
         }
     }
 
-    private var header: some View {
-        HStack(spacing: 14) {
-            Text(statusMessage)
-                .font(MereRunTheme.captionFont)
-                .foregroundStyle(MereRunTheme.textMuted)
-                .lineLimit(1)
+    // MARK: - List column
 
-            Spacer()
-
-            Picker("Scope", selection: $showAll) {
-                Text("Downloaded").tag(false)
-                Text("All").tag(true)
-            }
-            .pickerStyle(.segmented)
-            .frame(width: 230)
-
-            Button {
-                revealStore()
-            } label: {
-                Label("Files", systemImage: "folder")
-            }
-            .buttonStyle(.bordered)
-            .help("Open model storage in Finder")
-
-            Button {
-                Task { await previewStorageCleanup() }
-            } label: {
-                Label("Clean Up", systemImage: "externaldrive.badge.minus")
-            }
-            .buttonStyle(.bordered)
-            .disabled(isRefreshing || isCleaningStorage)
-            .help("Preview unreferenced payloads and partial downloads before deleting them")
-
-            Button {
-                Task { await refresh() }
-            } label: {
-                Label("Refresh", systemImage: "arrow.clockwise")
-            }
-            .buttonStyle(.bordered)
-            .disabled(isRefreshing)
-        }
-        .padding(.horizontal, 18)
-        .padding(.vertical, 12)
-    }
-
-    private var modelList: some View {
+    private var listColumn: some View {
         VStack(alignment: .leading, spacing: 0) {
-            searchField
-                .padding(.horizontal, 12)
-                .padding(.top, 12)
-                .padding(.bottom, 8)
+            HStack(spacing: 8) {
+                StudioModelsSearchPill(
+                    text: $searchText,
+                    placeholder: "Search \(installedRows.count) \(installedRows.count == 1 ? "model" : "models")"
+                )
 
-            HStack {
-                Text(showAll ? "All known models" : "Downloaded")
-                    .font(.system(size: 10.5, weight: .semibold))
-                    .kerning(0.5)
-                    .textCase(.uppercase)
-                    .foregroundStyle(MereRunTheme.textMuted)
-                Spacer()
-                Text("\(visibleRows.count)")
-                    .font(MereRunTheme.captionFont)
-                    .foregroundStyle(MereRunTheme.textMuted)
+                Button("Pull…") {
+                    showPullSheet = true
+                }
+                .buttonStyle(ModelsPrimaryButtonStyle())
+                .disabled(isRefreshing)
+                .help("Pull a model into managed storage")
             }
-            .padding(.horizontal, 16)
-            .padding(.bottom, 6)
+            .padding(EdgeInsets(top: 14, leading: 14, bottom: 8, trailing: 14))
+
+            familyChips
+                .padding(EdgeInsets(top: 0, leading: 14, bottom: 10, trailing: 14))
 
             if visibleRows.isEmpty {
                 emptyList
             } else {
                 ScrollView {
-                    LazyVStack(spacing: 4) {
+                    LazyVStack(spacing: 1) {
                         ForEach(visibleRows) { row in
                             StudioModelListRow(
-                                row: row,
-                                isSelected: selectedID == row.id,
-                                runtime: runtimeSettingsByID[row.id]
+                                name: displayName(for: row.id),
+                                meta: StudioModelsPresenter.meta(for: row, status: status(of: row)),
+                                status: status(of: row),
+                                isSelected: selectedID == row.id
                             ) {
                                 select(row)
                             }
                         }
                     }
-                    .padding(.horizontal, 10)
-                    .padding(.bottom, 14)
+                    .padding(.horizontal, 8)
+                    .padding(.bottom, 12)
                 }
+            }
+
+            if !statusMessage.isEmpty {
+                Text(statusMessage)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(MereRunTheme.textMuted)
+                    .lineLimit(2)
+                    .padding(EdgeInsets(top: 6, leading: 14, bottom: 10, trailing: 14))
+                    .accessibilityAddTraits(.updatesFrequently)
             }
         }
     }
 
-    private var searchField: some View {
-        HStack(spacing: 7) {
-            Image(systemName: "magnifyingglass")
-                .font(.system(size: 12, weight: .medium))
-                .foregroundStyle(MereRunTheme.textMuted)
-            TextField("Search models", text: $searchText)
-                .textFieldStyle(.plain)
-                .font(.system(size: 12.5))
-            if !searchText.isEmpty {
-                Button {
-                    searchText = ""
-                } label: {
-                    Image(systemName: "xmark.circle.fill")
-                        .font(.system(size: 11))
+    private var familyChips: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 6) {
+                StudioModelsChip(title: "All", isSelected: selectedFamily == nil) {
+                    selectedFamily = nil
                 }
-                .buttonStyle(.mereIcon(tint: MereRunTheme.textMuted))
-                .accessibilityLabel("Clear search")
+                ForEach(families) { family in
+                    StudioModelsChip(title: family.title, isSelected: selectedFamily == family) {
+                        selectedFamily = selectedFamily == family ? nil : family
+                    }
+                }
             }
         }
-        .padding(.horizontal, MereRunTheme.Spacing.sm)
-        .frame(height: 30)
-        .background {
-            Capsule()
-                .fill(MereRunTheme.surface)
-                .overlay {
-                    Capsule().strokeBorder(MereRunTheme.border.opacity(0.7), lineWidth: 1)
-                }
-        }
+        .accessibilityLabel("Model family")
     }
 
     private var emptyList: some View {
@@ -584,329 +629,388 @@ struct StudioModelsView: View {
     }
 
     private var emptyListMessage: String {
+        if isRefreshing, rows.isEmpty { return "Loading models…" }
         if !searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             return "No models match the search."
         }
-        return showAll ? "No models reported." : "No downloaded models yet."
+        if selectedFamily != nil { return "No installed models in this family." }
+        return "No models installed yet. Pull one to get started."
     }
 
-    private var detailPane: some View {
-        VStack(alignment: .leading, spacing: 14) {
+    // MARK: - Detail column
+
+    private var detailColumn: some View {
+        Group {
             if let selectedRow {
-                selectedHeader(selectedRow)
-
                 ScrollView {
-                    Text(detailBody(for: selectedRow))
-                        .font(MereRunTheme.monoFont)
-                        .foregroundStyle(MereRunTheme.textSecondary)
-                        .textSelection(.enabled)
-                        .frame(maxWidth: .infinity, alignment: .topLeading)
-                        .padding(14)
-                }
-                .merePanel()
-            } else {
-                Spacer()
-                emptyDetail
-                Spacer()
-            }
-        }
-        .padding(18)
-    }
-
-    private func selectedHeader(_ row: StudioModelInventoryRow) -> some View {
-        VStack(alignment: .leading, spacing: 12) {
-            HStack(alignment: .top, spacing: 12) {
-                VStack(alignment: .leading, spacing: 4) {
-                    Text(row.title ?? row.id)
-                        .font(.system(size: 18, weight: .semibold))
-                    Text(modelStatusLine(row))
-                        .font(MereRunTheme.captionFont)
-                        .foregroundStyle(MereRunTheme.textMuted)
-                    if let summary = row.summary {
-                        Text(summary)
-                            .font(MereRunTheme.bodyFont)
-                            .foregroundStyle(MereRunTheme.textSecondary)
-                            .fixedSize(horizontal: false, vertical: true)
-                    }
-                    modelFacts(row)
-                    if row.supported == false, !row.supportReasons.isEmpty {
-                        Text(row.supportReasons.joined(separator: " "))
-                            .font(MereRunTheme.captionFont)
-                            .foregroundStyle(MereRunTheme.yellow)
-                            .fixedSize(horizontal: false, vertical: true)
-                    }
-                    if let usageTerms = row.usageTerms {
-                        Text("Third-party usage terms · acceptance required for new downloads")
-                            .font(MereRunTheme.captionFont)
-                            .foregroundStyle(MereRunTheme.yellow)
-                        Text(usageTerms.summary)
-                            .font(MereRunTheme.captionFont)
-                            .foregroundStyle(MereRunTheme.textMuted)
-                        HStack(spacing: 8) {
-                            ForEach(Array(usageTerms.links.enumerated()), id: \.offset) { index, url in
-                                Link("Review terms \(index + 1)", destination: url)
-                                    .font(MereRunTheme.captionFont)
+                    VStack(alignment: .leading, spacing: 14) {
+                        detailHeader(selectedRow)
+                        factsPanel(selectedRow)
+                        if selectedRow.isInstalled {
+                            HStack(alignment: .top, spacing: 14) {
+                                healthPanel(selectedRow)
+                                performancePanel(selectedRow)
                             }
+                            .fixedSize(horizontal: false, vertical: true)
+                            adaptersPanel(selectedRow)
+                            runtimePanel(selectedRow)
+                            detailsPanel(selectedRow)
+                        } else {
+                            pullPanel(selectedRow)
                         }
                     }
+                    .padding(ModelsMetrics.detailPadding)
+                    .frame(maxWidth: .infinity, alignment: .topLeading)
                 }
+            } else {
+                emptyDetail
+            }
+        }
+    }
 
-                Spacer()
+    private func detailHeader(_ row: StudioModelInventoryRow) -> some View {
+        HStack(alignment: .top, spacing: 14) {
+            VStack(alignment: .leading, spacing: 4) {
+                Text(displayName(for: row.id))
+                    .font(.system(size: 20, weight: .semibold))
+                    .foregroundStyle(MereRunTheme.textPrimary)
+                    .lineLimit(1)
+                    .accessibilityAddTraits(.isHeader)
 
-                if loadingInfoID == row.id || downloadingID == row.id || removingID == row.id
-                    || optimizingID == row.id {
-                    ProgressView()
-                        .controlSize(.small)
+                HStack(spacing: 6) {
+                    StudioModelsTag(title: StudioModelsPresenter.family(of: row).title)
+                    if let size = StudioModelsPresenter.sizeChip(for: row, facts: infoFactsByID[row.id]) {
+                        StudioModelsTag(title: size)
+                    }
+                    ForEach(StudioModelsPresenter.defaultDomainTitles(for: row.id), id: \.self) { domain in
+                        StudioModelsTag(title: "Default for \(domain)", accent: true)
+                    }
+                    if row.supported == false {
+                        StudioModelsTag(title: "Needs attention", accent: true)
+                    }
                 }
             }
+
+            Spacer(minLength: 14)
 
             if row.isInstalled {
-                installedModelActions(row)
-                runtimeSettingsEditor(row)
-                installedModelFilesActions(row)
-            } else {
-                missingModelActions(row)
+                headerActions(row)
+            } else if downloadingID == row.id || pullingIDs.contains(row.id) {
+                ProgressView()
+                    .controlSize(.small)
             }
         }
     }
 
-    private func modelStatusLine(_ row: StudioModelInventoryRow) -> String {
-        let sizeDescription = row.isInstalled
-            ? "\(row.size) referenced"
-            : "\(row.displayedSize) estimated download"
-        return "\(row.id) · \(row.category) · \(row.status) · \(sizeDescription)"
-    }
+    private func headerActions(_ row: StudioModelInventoryRow) -> some View {
+        HStack(spacing: 8) {
+            if loadingInfoID == row.id || removingID == row.id || optimizingID == row.id {
+                ProgressView()
+                    .controlSize(.small)
+            }
 
-    private func modelFacts(_ row: StudioModelInventoryRow) -> some View {
-        HStack(spacing: 12) {
-            if let estimatedDownloadBytes = row.estimatedDownloadBytes {
-                Label(
-                    "Checkpoint \(Self.bytes(estimatedDownloadBytes))",
-                    systemImage: "externaldrive"
-                )
-            }
-            if let minimumUnifiedMemoryGB = row.minimumUnifiedMemoryGB {
-                Label("\(minimumUnifiedMemoryGB) GB RAM minimum", systemImage: "memorychip")
-            }
-            if let sourceRepository = row.sourceRepository,
-               let sourceURL = URL(string: "https://huggingface.co/\(sourceRepository)") {
-                Link(destination: sourceURL) {
-                    Label("By \(row.publisher ?? sourceRepository)", systemImage: "person.crop.circle")
-                }
-            } else if let publisher = row.publisher {
-                Label("By \(publisher)", systemImage: "person.crop.circle")
-            }
-        }
-        .font(MereRunTheme.captionFont)
-        .foregroundStyle(MereRunTheme.textMuted)
-    }
-
-    private func installedModelActions(_ row: StudioModelInventoryRow) -> some View {
-        HStack(spacing: 10) {
-            Button {
-                Task { await runtimeLoad(row) }
-            } label: {
-                Label("Load", systemImage: "play.fill")
-            }
-            .buttonStyle(.bordered)
-            .disabled(loadingRuntimeID != nil)
-
-            Button {
-                Task { await runtimeUnload(row) }
-            } label: {
-                Label("Unload", systemImage: "stop.fill")
-            }
-            .buttonStyle(.bordered)
-            .disabled(loadingRuntimeID != nil)
-
-            Button {
-                Task { await saveRuntimeSettings(for: row, pinned: true) }
-            } label: {
-                Label("Pin", systemImage: "pin")
-            }
-            .buttonStyle(.bordered)
-            .disabled(loadingRuntimeID != nil)
-
-            Button {
-                Task { await saveRuntimeSettings(for: row, pinned: false) }
-            } label: {
-                Label("Unpin", systemImage: "pin.slash")
-            }
-            .buttonStyle(.bordered)
-            .disabled(loadingRuntimeID != nil)
-        }
-    }
-
-    private func installedModelFilesActions(_ row: StudioModelInventoryRow) -> some View {
-        HStack(spacing: 10) {
-            Button {
-                Task { await loadInfo(for: row) }
-            } label: {
-                Label("Inspect", systemImage: "info.circle")
-            }
-            .buttonStyle(.bordered)
-            .disabled(loadingInfoID != nil)
-
-            Button {
+            Button("Reveal") {
                 Task { await reveal(row) }
-            } label: {
-                Label("Finder", systemImage: "magnifyingglass")
             }
-            .buttonStyle(.bordered)
+            .buttonStyle(ModelsSecondaryButtonStyle())
             .disabled(loadingInfoID != nil)
-            .help("Reveal this model's source folder in Finder")
+            .help("Reveal this model's folder in Finder")
 
             if StudioModelOptimizationCommand.supports(modelID: row.id) {
-                Button {
+                Button("Optimize") {
                     Task { await optimize(row, replacing: false) }
-                } label: {
-                    Label("Optimize", systemImage: "bolt.badge.clock")
                 }
-                .buttonStyle(.borderedProminent)
-                .tint(MereRunTheme.accent)
+                .buttonStyle(ModelsSecondaryButtonStyle())
                 .disabled(optimizingID != nil)
                 .help("Build the inference-only MiniMax-H3 AdaLN cache")
+            }
 
-                Menu {
+            Button("Remove…") {
+                pendingAlert = .removal(row)
+            }
+            .buttonStyle(ModelsSecondaryButtonStyle())
+            .disabled(removingID != nil)
+
+            Menu {
+                Button("Refresh inventory") {
+                    Task { await refresh() }
+                }
+                .disabled(isRefreshing)
+                Button("Inspect manifest and components") {
+                    showDetails = true
+                    Task { await loadInfo(for: row) }
+                }
+                .disabled(loadingInfoID != nil)
+                if StudioModelOptimizationCommand.supports(modelID: row.id) {
                     Button("Rebuild optimization cache") {
                         Task { await optimize(row, replacing: true) }
                     }
-                } label: {
-                    Image(systemName: "ellipsis.circle")
+                    .disabled(optimizingID != nil)
                 }
-                .disabled(optimizingID != nil)
-            }
-
-            Button(role: .destructive) {
-                pendingAlert = .removal(row)
+                Divider()
+                Button("Open model store in Finder") {
+                    revealStore()
+                }
+                Button("Clean up storage…") {
+                    Task { await previewStorageCleanup() }
+                }
+                .disabled(isRefreshing || isCleaningStorage)
             } label: {
-                Label("Purge", systemImage: "trash")
+                Image(systemName: "ellipsis")
+                    .font(.system(size: 12, weight: .semibold))
+                    .frame(width: 26, height: 26)
             }
-            .buttonStyle(.bordered)
-            .disabled(removingID != nil)
+            .menuStyle(.borderlessButton)
+            .menuIndicator(.hidden)
+            .fixedSize()
+            .frame(width: 26, height: 26)
+            .background {
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(MereRunTheme.surfaceRaised)
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 6)
+                            .strokeBorder(MereRunTheme.border.opacity(0.6), lineWidth: 1)
+                    }
+            }
+            .accessibilityLabel("More model actions")
         }
     }
 
-    private func missingModelActions(_ row: StudioModelInventoryRow) -> some View {
-        VStack(alignment: .leading, spacing: MereRunTheme.Spacing.sm) {
-            Text("Download this model into Mere's managed model storage. The CLI checks hardware, disk space, and the pinned source before transferring weights.")
-                .font(MereRunTheme.bodyFont)
-                .foregroundStyle(MereRunTheme.textSecondary)
+    private func factsPanel(_ row: StudioModelInventoryRow) -> some View {
+        let facts = infoFactsByID[row.id]
+        let usage = StudioModelsPresenter.usage(of: row.id, in: library.items)
+        return VStack(spacing: 0) {
+            if row.isInstalled {
+                StudioModelsKeyValueRow(
+                    key: "Store",
+                    value: StudioModelsPresenter.abbreviatedPath(storePath(for: facts)),
+                    mono: true
+                )
+            }
+            if let source = StudioModelsPresenter.sourceLine(for: row) {
+                StudioModelsKeyValueRow(key: "Source", value: source, mono: true)
+            } else if let publisher = row.publisher, !publisher.isBlank {
+                StudioModelsKeyValueRow(key: "Publisher", value: publisher, mono: false)
+            }
+            if let usage {
+                StudioModelsKeyValueRow(key: "Last used", value: StudioModelsPresenter.usageLine(usage), mono: false)
+            }
+            if row.isInstalled, let verified = facts?.verifiedLine {
+                StudioModelsKeyValueRow(key: "Verified", value: verified, mono: false)
+            }
+            if !row.isInstalled, row.displayedSize != "—" {
+                StudioModelsKeyValueRow(key: "Download", value: row.displayedSize, mono: true)
+            }
+            if let summary = row.summary, !summary.isBlank {
+                Text(summary)
+                    .font(.system(size: 12))
+                    .foregroundStyle(MereRunTheme.textSecondary)
+                    .fixedSize(horizontal: false, vertical: true)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.vertical, 6)
+            }
+        }
+        .padding(EdgeInsets(top: 4, leading: 16, bottom: 4, trailing: 16))
+        .modelsPanel()
+    }
 
-            HStack(spacing: MereRunTheme.Spacing.sm) {
-                Button {
-                    requestDownload(row)
-                } label: {
-                    if downloadingID == row.id {
-                        HStack(spacing: 7) {
-                            ProgressView()
-                                .controlSize(.small)
-                            Text(cancellingDownloadID == row.id ? "Cancelling…" : "Downloading…")
-                        }
-                    } else {
-                        Label("Download", systemImage: "arrow.down.circle.fill")
-                    }
-                }
-                .buttonStyle(.borderedProminent)
-                .tint(MereRunTheme.accent)
-                .disabled(downloadingID != nil || isRefreshing)
+    private func healthPanel(_ row: StudioModelInventoryRow) -> some View {
+        let gate = StudioModelsPresenter.gateLine(in: library.items)
+        let facts = infoFactsByID[row.id]
+        return VStack(alignment: .leading, spacing: 8) {
+            Text("Health")
+                .font(.system(size: 12.5, weight: .semibold))
+                .foregroundStyle(MereRunTheme.textPrimary)
 
-                if downloadingID == row.id {
-                    Button("Cancel", role: .cancel) {
-                        cancelDownload()
-                    }
-                    .buttonStyle(.bordered)
-                    .disabled(cancellingDownloadID == row.id)
-                }
-
-                Spacer()
-
-                if row.displayedSize != "—" {
-                    Text("\(row.displayedSize) download")
-                        .font(MereRunTheme.monoFont)
-                        .foregroundStyle(MereRunTheme.textMuted)
+            if let gate {
+                StudioModelsStatusLine(text: gate.text, color: gate.ok ? MereRunTheme.green : MereRunTheme.red)
+            }
+            if let facts, let hasManifest = facts.hasManifest {
+                if !hasManifest {
+                    StudioModelsStatusLine(text: "Manifest missing", color: MereRunTheme.yellow)
+                } else if facts.isValid == false {
+                    StudioModelsStatusLine(text: "Validation failed", color: MereRunTheme.red)
+                } else {
+                    StudioModelsStatusLine(text: "Manifest audit clean", color: MereRunTheme.green)
                 }
             }
-
-            if downloadingID == row.id, let progress = downloadProgress {
-                VStack(alignment: .leading, spacing: 5) {
-                    if let fraction = progress.fractionCompleted {
-                        ProgressView(value: fraction)
-                            .progressViewStyle(.linear)
-                    } else {
-                        ProgressView()
-                            .controlSize(.small)
-                    }
-                    HStack(spacing: 6) {
-                        Text(progress.label)
-                        if let detail = progress.detail {
-                            Text("· \(detail)")
-                        }
-                    }
-                    .font(MereRunTheme.captionFont)
+            if row.supported == false {
+                StudioModelsStatusLine(
+                    text: row.supportReasons.first ?? "Not supported on this Mac",
+                    color: MereRunTheme.yellow
+                )
+            }
+            if gate == nil, facts?.hasManifest == nil, row.supported != false {
+                Text("No checks recorded yet")
+                    .font(.system(size: 12.5, weight: .medium))
                     .foregroundStyle(MereRunTheme.textMuted)
-                    .lineLimit(1)
-                }
             }
 
-            if row.usageTerms != nil {
-                Text("Review the linked terms above. Download requires explicit acceptance.")
-                    .font(MereRunTheme.captionFont)
-                    .foregroundStyle(MereRunTheme.yellow)
+            HStack(spacing: 6) {
+                Button("Run gate") {
+                    navigation.open(task: .modelsHealth)
+                }
+                .buttonStyle(ModelsSecondaryButtonStyle())
+                Button("Benchmark…") {
+                    navigation.open(task: .modelsBenchmarks)
+                }
+                .buttonStyle(ModelsSecondaryButtonStyle())
             }
+            .padding(.top, 4)
         }
-        .padding(MereRunTheme.Spacing.md)
-        .merePanel()
+        .padding(EdgeInsets(top: 14, leading: 16, bottom: 14, trailing: 16))
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .modelsPanel()
     }
 
-    private func runtimeSettingsEditor(_ row: StudioModelInventoryRow) -> some View {
-        VStack(alignment: .leading, spacing: MereRunTheme.Spacing.sm) {
-            Text("Runtime settings")
-                .font(.system(size: 10.5, weight: .semibold))
-                .kerning(0.5)
-                .textCase(.uppercase)
-                .foregroundStyle(MereRunTheme.textMuted)
+    private func performancePanel(_ row: StudioModelInventoryRow) -> some View {
+        let lastRun = StudioModelsPresenter.lastRunDuration(for: row.id, in: library.items)
+        let memory = StudioModelsPresenter.memoryLine(for: row)
+        let benchmark = StudioModelsPresenter.benchmarkLine(in: library.items)
+        return VStack(alignment: .leading, spacing: 8) {
+            Text("Performance")
+                .font(.system(size: 12.5, weight: .semibold))
+                .foregroundStyle(MereRunTheme.textPrimary)
 
-            Grid(alignment: .leading, horizontalSpacing: MereRunTheme.Spacing.sm, verticalSpacing: 8) {
-                GridRow {
-                    runtimeField("Alias", text: $runtimeAlias, width: 150)
-                    runtimeField("TTL seconds", text: $runtimeTTL, width: 100)
-                    runtimeField("Context", text: $runtimeMaxContext, width: 100)
-                }
-                GridRow {
-                    runtimeField("Max tokens", text: $runtimeMaxTokens, width: 150)
-                    runtimeField("Temperature", text: $runtimeTemperature, width: 100)
-                    runtimeField("Top P", text: $runtimeTopP, width: 100)
-                }
-                GridRow {
-                    runtimeField("Min P", text: $runtimeMinP, width: 150)
-                }
+            if let lastRun {
+                StudioModelsKeyValueRow(key: "Last run", value: lastRun, mono: true)
             }
-
-            HStack(spacing: MereRunTheme.Spacing.sm) {
-                Toggle("Pinned", isOn: $runtimePinned)
-                    .toggleStyle(.checkbox)
-                    .font(MereRunTheme.captionFont)
-
-                Spacer()
-
-                Button {
-                    Task { await saveRuntimeSettings(for: row, pinned: runtimePinned) }
-                } label: {
-                    Label("Save settings", systemImage: "checkmark")
-                }
-                .buttonStyle(.merePrimary)
-                .disabled(!row.isInstalled || loadingRuntimeID != nil)
+            if let memory {
+                StudioModelsKeyValueRow(key: "Unified memory", value: memory, mono: true)
+            }
+            if let benchmark {
+                StudioModelsKeyValueRow(key: "Last benchmark", value: benchmark, mono: false)
+            }
+            if lastRun == nil, memory == nil, benchmark == nil {
+                Text("No runs recorded yet")
+                    .font(.system(size: 12.5, weight: .medium))
+                    .foregroundStyle(MereRunTheme.textMuted)
             }
         }
-        .padding(MereRunTheme.Spacing.md)
-        .background {
-            RoundedRectangle(cornerRadius: MereRunTheme.Radius.lg)
-                .fill(MereRunTheme.surface.opacity(0.55))
-                .overlay {
-                    RoundedRectangle(cornerRadius: MereRunTheme.Radius.lg)
-                        .strokeBorder(MereRunTheme.border.opacity(0.5), lineWidth: 1)
+        .padding(EdgeInsets(top: 14, leading: 16, bottom: 14, trailing: 16))
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .modelsPanel()
+    }
+
+    private func adaptersPanel(_ row: StudioModelInventoryRow) -> some View {
+        let using = adapters.filter { $0.baseModelID == row.id }
+        let training = StudioModelsPresenter.family(of: row).trainingTemplateID
+        return VStack(spacing: 0) {
+            HStack {
+                Text("Adapters using this model")
+                    .font(.system(size: 12.5, weight: .semibold))
+                    .foregroundStyle(MereRunTheme.textPrimary)
+                Spacer()
+                if let training {
+                    Button("Train new…") {
+                        onTrain(training)
+                    }
+                    .buttonStyle(.plain)
+                    .font(.system(size: 11.5, weight: .medium))
+                    .foregroundStyle(MereRunTheme.accent)
                 }
+            }
+            .padding(EdgeInsets(top: 12, leading: 16, bottom: 12, trailing: 16))
+            .overlay(alignment: .bottom) {
+                Rectangle().fill(MereRunTheme.border.opacity(0.4)).frame(height: 1)
+            }
+
+            if using.isEmpty {
+                Text("No adapters target this model yet.")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(MereRunTheme.textMuted)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(EdgeInsets(top: 10, leading: 16, bottom: 12, trailing: 16))
+            } else {
+                ForEach(using) { adapter in
+                    HStack(spacing: 10) {
+                        VStack(alignment: .leading, spacing: 1) {
+                            Text(adapter.id)
+                                .font(.system(size: 12.5, weight: .medium, design: .monospaced))
+                                .foregroundStyle(MereRunTheme.textPrimary)
+                                .lineLimit(1)
+                            Text(adapterMeta(adapter))
+                                .font(.system(size: 11, weight: .medium))
+                                .foregroundStyle(MereRunTheme.textMuted)
+                                .lineLimit(1)
+                        }
+                        Spacer(minLength: 10)
+                        Button("Use in \(adapterTargetTitle)") {
+                            onUseAdapter(adapter)
+                        }
+                        .buttonStyle(ModelsSecondaryButtonStyle())
+                        .disabled(!adapter.installed)
+                        .help(adapter.installed ? "Apply this adapter to the composer" : "Pull the adapter first")
+                    }
+                    .padding(EdgeInsets(top: 10, leading: 16, bottom: 10, trailing: 16))
+                    .overlay(alignment: .bottom) {
+                        Rectangle().fill(MereRunTheme.border.opacity(0.27)).frame(height: 1)
+                    }
+                }
+            }
+        }
+        .modelsPanel()
+    }
+
+    private func adapterMeta(_ adapter: StudioAdapterRow) -> String {
+        StudioModelsPresenter.adapterMeta(
+            format: adapter.format,
+            byteCount: adapter.byteCount,
+            version: adapter.version,
+            installed: adapter.installed
+        )
+    }
+
+    private func runtimePanel(_ row: StudioModelInventoryRow) -> some View {
+        StudioModelsDisclosurePanel(title: "Runtime settings", isExpanded: $showRuntimeSettings) {
+            VStack(alignment: .leading, spacing: MereRunTheme.Spacing.sm) {
+                HStack(spacing: 6) {
+                    Button("Load") {
+                        Task { await runtimeLoad(row) }
+                    }
+                    .buttonStyle(ModelsSecondaryButtonStyle())
+                    Button("Unload") {
+                        Task { await runtimeUnload(row) }
+                    }
+                    .buttonStyle(ModelsSecondaryButtonStyle())
+                    Button(runtimePinned ? "Unpin" : "Pin") {
+                        Task { await saveRuntimeSettings(for: row, pinned: !runtimePinned) }
+                    }
+                    .buttonStyle(ModelsSecondaryButtonStyle())
+                    if loadingRuntimeID == row.id {
+                        ProgressView().controlSize(.small)
+                    }
+                }
+                .disabled(loadingRuntimeID != nil)
+
+                Grid(alignment: .leading, horizontalSpacing: MereRunTheme.Spacing.sm, verticalSpacing: 8) {
+                    GridRow {
+                        runtimeField("Alias", text: $runtimeAlias, width: 150)
+                        runtimeField("TTL seconds", text: $runtimeTTL, width: 100)
+                        runtimeField("Context", text: $runtimeMaxContext, width: 100)
+                    }
+                    GridRow {
+                        runtimeField("Max tokens", text: $runtimeMaxTokens, width: 150)
+                        runtimeField("Temperature", text: $runtimeTemperature, width: 100)
+                        runtimeField("Top P", text: $runtimeTopP, width: 100)
+                    }
+                    GridRow {
+                        runtimeField("Min P", text: $runtimeMinP, width: 150)
+                    }
+                }
+
+                HStack(spacing: MereRunTheme.Spacing.sm) {
+                    Toggle("Pinned", isOn: $runtimePinned)
+                        .toggleStyle(.checkbox)
+                        .font(MereRunTheme.captionFont)
+                    Spacer()
+                    Button("Save settings") {
+                        Task { await saveRuntimeSettings(for: row, pinned: runtimePinned) }
+                    }
+                    .buttonStyle(ModelsPrimaryButtonStyle())
+                    .disabled(loadingRuntimeID != nil)
+                }
+            }
         }
     }
 
@@ -922,31 +1026,135 @@ struct StudioModelsView: View {
         }
     }
 
+    private func detailsPanel(_ row: StudioModelInventoryRow) -> some View {
+        StudioModelsDisclosurePanel(title: "Details", isExpanded: $showDetails) {
+            Text(detailBody(for: row))
+                .font(.system(size: 11.5, design: .monospaced))
+                .foregroundStyle(MereRunTheme.textSecondary)
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, alignment: .topLeading)
+        }
+    }
+
+    private func pullPanel(_ row: StudioModelInventoryRow) -> some View {
+        VStack(alignment: .leading, spacing: MereRunTheme.Spacing.sm) {
+            if let usageTerms = row.usageTerms {
+                Text("Third-party usage terms · acceptance required before pulling")
+                    .font(MereRunTheme.captionFont)
+                    .foregroundStyle(MereRunTheme.yellow)
+                Text(usageTerms.summary)
+                    .font(MereRunTheme.captionFont)
+                    .foregroundStyle(MereRunTheme.textMuted)
+                    .fixedSize(horizontal: false, vertical: true)
+                HStack(spacing: 8) {
+                    ForEach(Array(usageTerms.links.enumerated()), id: \.offset) { index, url in
+                        Link("Review terms \(index + 1)", destination: url)
+                            .font(MereRunTheme.captionFont)
+                    }
+                }
+            }
+            if row.supported == false, !row.supportReasons.isEmpty {
+                Text(row.supportReasons.joined(separator: " "))
+                    .font(MereRunTheme.captionFont)
+                    .foregroundStyle(MereRunTheme.yellow)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            HStack(spacing: 8) {
+                if downloadingID == row.id {
+                    Button("Cancel pull") {
+                        cancelDownload()
+                    }
+                    .buttonStyle(ModelsSecondaryButtonStyle())
+                    .disabled(cancellingDownloadID == row.id)
+                } else if pullingIDs.contains(row.id) {
+                    Text("Pulling from the composer")
+                        .font(MereRunTheme.captionFont)
+                        .foregroundStyle(MereRunTheme.textMuted)
+                } else {
+                    Button("Pull") {
+                        requestDownload(row)
+                    }
+                    .buttonStyle(ModelsPrimaryButtonStyle())
+                    .disabled(downloadingID != nil || isRefreshing)
+                }
+            }
+
+            if !detailText.isEmpty {
+                Text(detailText)
+                    .font(.system(size: 11.5, design: .monospaced))
+                    .foregroundStyle(MereRunTheme.textSecondary)
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .topLeading)
+            }
+        }
+        .padding(EdgeInsets(top: 14, leading: 16, bottom: 14, trailing: 16))
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .modelsPanel()
+    }
+
     private var emptyDetail: some View {
         VStack(spacing: 10) {
-            Image(systemName: "info.circle")
+            Image(systemName: "shippingbox")
                 .font(.system(size: 28, weight: .medium))
                 .foregroundStyle(MereRunTheme.textMuted)
-            Text("Select a downloaded model to inspect, reveal, or purge it.")
+            Text(rows.isEmpty && isRefreshing ? "Loading models…" : "Select a model to see its facts, health, and adapters.")
                 .font(MereRunTheme.bodyFont)
                 .foregroundStyle(MereRunTheme.textMuted)
         }
-        .frame(maxWidth: .infinity)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    // MARK: - Presentation helpers
+
+    /// The store that holds the model: its resolved root's parent when `model info` has reported
+    /// one (external stores included), otherwise the configured managed store.
+    private func storePath(for facts: StudioModelInfoFacts?) -> String {
+        guard let root = facts?.root else { return modelStoreURL.path }
+        return URL(fileURLWithPath: root, isDirectory: true).deletingLastPathComponent().path
+    }
+
+    private func displayName(for modelID: String) -> String {
+        rows.first { $0.id == modelID }.map(StudioModelsPresenter.displayName) ?? modelID
+    }
+
+    private func status(of row: StudioModelInventoryRow) -> StudioModelRowStatus {
+        StudioModelsPresenter.status(of: row, job: activeJob)
     }
 
     private func detailBody(for row: StudioModelInventoryRow) -> String {
-        if !row.isInstalled {
-            return detailText.isEmpty ? "\(row.id) is not downloaded." : detailText
-        }
         if detailText.isEmpty {
-            return "Select Inspect to load manifest, validation, and component paths."
+            return loadingInfoID == row.id ? "Loading manifest, validation, and component paths…" : "No details loaded."
         }
         return detailText
     }
 
+    private func log(for job: StudioModelsJob) -> String {
+        if let itemID = job.libraryItemID {
+            let item = library.items.first { $0.id == itemID }
+            return item?.outputText ?? "Pull started from the composer. Its log is in the Library row."
+        }
+        return jobLog.isEmpty ? "Waiting for output…" : jobLog
+    }
+
+    private func cancel(_ job: StudioModelsJob) {
+        if let itemID = job.libraryItemID {
+            _ = controller.cancel(requestID: itemID)
+            return
+        }
+        switch job.kind {
+        case .pull:
+            cancelDownload()
+        case .optimize:
+            if let optimizeCommandID { _ = controller.cancelUtilityCommand(optimizeCommandID) }
+        case .cleanup:
+            if let cleanupCommandID { _ = controller.cancelUtilityCommand(cleanupCommandID) }
+        }
+    }
+
     private func select(_ row: StudioModelInventoryRow) {
         selectedID = row.id
-        detailText = row.isInstalled ? "" : "\(row.id) is not downloaded."
+        detailText = ""
         guard row.isInstalled else { return }
         Task { await loadInfo(for: row) }
         Task { await loadRuntimeSettings(for: row) }
@@ -960,6 +1168,8 @@ struct StudioModelsView: View {
         }
     }
 
+    // MARK: - Commands
+
     @MainActor
     private func download(_ row: StudioModelInventoryRow, acknowledgingUsageTerms: Bool) async {
         let modelID = row.id
@@ -967,10 +1177,12 @@ struct StudioModelsView: View {
         cancellingDownloadID = nil
         downloadProgress = nil
         downloadProgressOutput = ""
+        jobLog = ""
         let commandID = UUID()
         downloadCommandID = commandID
-        statusMessage = "Downloading \(modelID)…"
-        detailText = "Starting managed download for \(modelID)…\n"
+        statusMessage = ""
+        selectedID = modelID
+        detailText = ""
 
         let result = await controller.utilityCommandResult(
             args: StudioModelDownloadCommand.arguments(
@@ -986,8 +1198,7 @@ struct StudioModelsView: View {
                 if let progress = StudioModelDownloadCommand.latestProgress(in: downloadProgressOutput) {
                     downloadProgress = progress
                 }
-                guard selectedID == modelID else { return }
-                detailText = StudioModelDownloadCommand.appendingOutput(chunk, to: detailText)
+                jobLog = StudioModelDownloadCommand.appendingOutput(chunk, to: jobLog)
             }
         )
 
@@ -1002,17 +1213,11 @@ struct StudioModelsView: View {
             detailText = result.outputText
         }
         if wasCancelled {
-            statusMessage = "Cancelled download for \(modelID)"
-            if selectedID == modelID {
-                detailText = StudioModelDownloadCommand.appendingOutput(
-                    "\nDownload cancelled. Its resumable partial payload remains available to the next pull.\n",
-                    to: detailText
-                )
-            }
+            statusMessage = "Cancelled pull for \(displayName(for: modelID)). The partial payload resumes on the next pull."
             return
         }
         guard result.exitCode == 0 else {
-            statusMessage = "Could not download \(modelID)"
+            statusMessage = "Could not pull \(displayName(for: modelID))"
             return
         }
 
@@ -1022,7 +1227,6 @@ struct StudioModelsView: View {
         if keepSelection, let installed = rows.first(where: { $0.id == modelID }) {
             select(installed)
         }
-        statusMessage = "Downloaded \(modelID)"
     }
 
     private func cancelDownload() {
@@ -1032,7 +1236,6 @@ struct StudioModelsView: View {
             return
         }
         cancellingDownloadID = modelID
-        statusMessage = "Cancelling download for \(modelID)…"
     }
 
     private func downloadTermsMessage(_ row: StudioModelInventoryRow) -> String {
@@ -1048,7 +1251,6 @@ struct StudioModelsView: View {
     @MainActor
     private func refresh() async {
         isRefreshing = true
-        statusMessage = "Refreshing model inventory..."
         let result = await controller.utilityCommandResult(args: ["model", "list"])
 
         guard result.exitCode == 0 else {
@@ -1075,8 +1277,18 @@ struct StudioModelsView: View {
             storageReport = report
             applyStorageUsage(report)
         }
+        let adapterResult = await controller.utilityCommandResult(args: ["adapter", "list", "--json"])
+        if adapterResult.exitCode == 0,
+           let data = StudioOperationsJSON.objectData(adapterResult.stdout),
+           let payload = try? JSONDecoder().decode(StudioAdapterCatalogPayload.self, from: data) {
+            adapters = payload.adapters
+        }
         isRefreshing = false
-        updateStatusMessage()
+        statusMessage = ""
+        onInventoryChanged(StudioModelInventorySummary(
+            installedCount: installedRows.count,
+            storageBytes: storageReport?.applicationSupportBytes
+        ))
         if let selectedID, visibleRows.contains(where: { $0.id == selectedID }) {
             return
         }
@@ -1118,17 +1330,17 @@ struct StudioModelsView: View {
     @MainActor
     private func saveRuntimeSettings(for row: StudioModelInventoryRow, pinned: Bool) async {
         loadingRuntimeID = row.id
-        statusMessage = "Saving runtime settings for \(row.id)..."
         var args = ["model", "runtime", "set", row.id, pinned ? "--pinned" : "--unpinned"]
         appendRuntimeSettingArgs(to: &args)
         let result = await controller.utilityCommandResult(args: args)
         loadingRuntimeID = nil
         if result.exitCode == 0 {
-            statusMessage = "Saved runtime settings for \(row.id)"
+            statusMessage = "Saved runtime settings for \(displayName(for: row.id))"
             await loadRuntimeSettings(for: row)
         } else {
-            statusMessage = "Could not save runtime settings for \(row.id)"
+            statusMessage = "Could not save runtime settings for \(displayName(for: row.id))"
             detailText = result.outputText
+            showDetails = true
         }
     }
 
@@ -1179,7 +1391,7 @@ struct StudioModelsView: View {
     @MainActor
     private func runtimeServerAction(_ row: StudioModelInventoryRow, action: String) async {
         loadingRuntimeID = row.id
-        statusMessage = "\(action.capitalized)ing \(row.id)..."
+        let name = displayName(for: row.id)
         do {
             var request = URLRequest(url: controller.runtimeURL(path: "/runtime/models/\(row.id)/\(action)"))
             request.httpMethod = "POST"
@@ -1189,7 +1401,7 @@ struct StudioModelsView: View {
             let (_, response) = try await URLSession.shared.data(for: request)
             let http = response as? HTTPURLResponse
             if (200..<300).contains(http?.statusCode ?? 500) {
-                statusMessage = "\(action.capitalized)ed \(row.id)"
+                statusMessage = "\(action.capitalized)ed \(name)"
             } else {
                 statusMessage = "Runtime \(action) returned HTTP \(http?.statusCode ?? 0)"
             }
@@ -1203,85 +1415,91 @@ struct StudioModelsView: View {
     private func loadInfo(for row: StudioModelInventoryRow) async {
         guard row.isInstalled else { return }
         loadingInfoID = row.id
-        statusMessage = "Inspecting \(row.id)..."
         let result = await controller.utilityCommandResult(args: ["model", "info", row.id, "--components"])
         loadingInfoID = nil
-        detailText = result.outputText
-        statusMessage = result.exitCode == 0 ? "\(installedRows.count) downloaded · \(rows.count) known" : "Could not inspect \(row.id)"
+        if result.exitCode == 0 {
+            infoFactsByID[row.id] = StudioModelsPresenter.facts(fromInfo: result.stdout)
+        } else {
+            statusMessage = "Could not inspect \(displayName(for: row.id))"
+        }
+        if selectedID == row.id {
+            detailText = result.outputText
+        }
     }
 
     @MainActor
     private func reveal(_ row: StudioModelInventoryRow) async {
         guard row.isInstalled else { return }
-        loadingInfoID = row.id
-        statusMessage = "Resolving \(row.id) folder..."
-
-        let info: String
-        if let root = StudioModelInventoryParser.modelRoot(from: detailText) {
-            reveal(url: root)
-            loadingInfoID = nil
-            statusMessage = "\(installedRows.count) downloaded · \(rows.count) known"
+        if let root = infoFactsByID[row.id]?.root {
+            reveal(url: URL(fileURLWithPath: root, isDirectory: true))
             return
-        } else {
-            let result = await controller.utilityCommandResult(args: ["model", "info", row.id])
-            info = result.outputText
         }
-
+        loadingInfoID = row.id
+        let result = await controller.utilityCommandResult(args: ["model", "info", row.id])
         loadingInfoID = nil
-        guard let root = StudioModelInventoryParser.modelRoot(from: info) else {
-            statusMessage = "Could not resolve \(row.id) folder"
-            detailText = info
+        guard let root = StudioModelInventoryParser.modelRoot(from: result.outputText) else {
+            statusMessage = "Could not resolve the \(displayName(for: row.id)) folder"
+            detailText = result.outputText
+            showDetails = true
             return
         }
         reveal(url: root)
-        statusMessage = "\(installedRows.count) downloaded · \(rows.count) known"
     }
 
     @MainActor
     private func purge(_ row: StudioModelInventoryRow) async {
         removingID = row.id
-        statusMessage = "Purging \(row.id)..."
         let result = await controller.utilityCommandResult(args: ["model", "remove", row.id, "--force"])
         removingID = nil
         detailText = result.outputText
         if result.exitCode == 0 {
+            infoFactsByID[row.id] = nil
             onModelsChanged()
             await refresh()
         } else {
-            statusMessage = "Could not purge \(row.id)"
+            statusMessage = "Could not remove \(displayName(for: row.id))"
+            showDetails = true
         }
     }
 
     @MainActor
     private func optimize(_ row: StudioModelInventoryRow, replacing: Bool) async {
         optimizingID = row.id
-        statusMessage = replacing ? "Rebuilding optimization cache for \(row.id)…" : "Optimizing \(row.id)…"
-        detailText = "Preparing MiniMax-H3 inference cache…\n"
+        let commandID = UUID()
+        optimizeCommandID = commandID
+        jobLog = replacing ? "Rebuilding the MiniMax-H3 inference cache…\n" : "Preparing the MiniMax-H3 inference cache…\n"
         let result = await controller.utilityCommandResult(
             args: StudioModelOptimizationCommand.arguments(modelID: row.id, replacing: replacing),
+            commandID: commandID,
             onOutput: { chunk in
-                guard selectedID == row.id else { return }
-                detailText = StudioModelDownloadCommand.appendingOutput(chunk, to: detailText)
+                jobLog = StudioModelDownloadCommand.appendingOutput(chunk, to: jobLog)
             }
         )
         optimizingID = nil
-        detailText = result.outputText.isEmpty ? detailText : result.outputText
+        optimizeCommandID = nil
+        if selectedID == row.id {
+            detailText = result.outputText.isEmpty ? jobLog : result.outputText
+        }
         statusMessage = result.exitCode == 0
-            ? "Optimized \(row.id)"
-            : "Could not optimize \(row.id)"
+            ? "Optimized \(displayName(for: row.id))"
+            : "Could not optimize \(displayName(for: row.id))"
     }
 
     @MainActor
     private func previewStorageCleanup() async {
         isCleaningStorage = true
-        statusMessage = "Inspecting model storage..."
-        let command = await controller.utilityCommandResult(args: ["model", "gc", "--json"])
+        let commandID = UUID()
+        cleanupCommandID = commandID
+        jobLog = "Inspecting model storage…\n"
+        let command = await controller.utilityCommandResult(args: ["model", "gc", "--json"], commandID: commandID)
         isCleaningStorage = false
+        cleanupCommandID = nil
         guard command.exitCode == 0,
               let data = command.stdout.data(using: .utf8),
               let output = try? JSONDecoder().decode(StudioModelGarbageCollectOutput.self, from: data) else {
             statusMessage = "Could not inspect model storage"
             detailText = command.outputText
+            showDetails = true
             return
         }
         guard !output.plan.items.isEmpty else {
@@ -1289,21 +1507,30 @@ struct StudioModelsView: View {
             return
         }
         pendingAlert = .cleanup(output.plan)
-        statusMessage = "\(Self.bytes(output.plan.reclaimableBytes)) can be cleaned up"
     }
 
     @MainActor
     private func cleanStorage() async {
         isCleaningStorage = true
-        statusMessage = "Cleaning model storage..."
-        let command = await controller.utilityCommandResult(args: ["model", "gc", "--force", "--json"])
+        let commandID = UUID()
+        cleanupCommandID = commandID
+        jobLog = "Cleaning model storage…\n"
+        let command = await controller.utilityCommandResult(
+            args: ["model", "gc", "--force", "--json"],
+            commandID: commandID,
+            onOutput: { chunk in
+                jobLog = StudioModelDownloadCommand.appendingOutput(chunk, to: jobLog)
+            }
+        )
         isCleaningStorage = false
+        cleanupCommandID = nil
         guard command.exitCode == 0,
               let data = command.stdout.data(using: .utf8),
               let output = try? JSONDecoder().decode(StudioModelGarbageCollectOutput.self, from: data),
               let result = output.result else {
             statusMessage = "Could not clean model storage"
             detailText = command.outputText
+            showDetails = true
             return
         }
         statusMessage = "Reclaimed \(Self.bytes(result.reclaimedBytes))"
@@ -1334,15 +1561,6 @@ struct StudioModelsView: View {
                 sharedBytes: usage.sharedBytes,
                 externalBytes: usage.externalBytes
             )
-        }
-    }
-
-    private func updateStatusMessage() {
-        if let storageReport {
-            statusMessage = "\(installedRows.count) downloaded · \(Self.bytes(storageReport.applicationSupportBytes)) used"
-                + " · \(Self.bytes(storageReport.garbageCollectableBytes)) cleanable"
-        } else {
-            statusMessage = "\(installedRows.count) downloaded · \(rows.count) known"
         }
     }
 
@@ -1386,86 +1604,468 @@ struct StudioModelsView: View {
     }
 }
 
-/// One model in the catalog list: install dot, name, category/runtime facts, size in the
-/// trailing column where the eye expects it.
+// MARK: - Pull sheet
+
+/// The models that are not installed yet, each with a Pull action. Usage-terms acceptance and
+/// the progress feedback stay with the Installed page: it starts the pull and shows the job bar.
+struct StudioModelPullSheet: View {
+    let rows: [StudioModelInventoryRow]
+    let onPull: (StudioModelInventoryRow) -> Void
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var searchText = ""
+    @State private var selectedFamily: StudioModelFamily?
+
+    private var visibleRows: [StudioModelInventoryRow] {
+        StudioModelsPresenter.filter(rows, family: selectedFamily, query: searchText)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            HStack(spacing: 8) {
+                VStack(alignment: .leading, spacing: 1) {
+                    Text("Pull a model")
+                        .font(.system(size: 15, weight: .semibold))
+                        .foregroundStyle(MereRunTheme.textPrimary)
+                    Text("\(rows.count) available · downloads into managed storage")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(MereRunTheme.textMuted)
+                }
+                Spacer()
+                Button("Done") { dismiss() }
+                    .buttonStyle(ModelsSecondaryButtonStyle())
+                    .keyboardShortcut(.cancelAction)
+            }
+            .padding(EdgeInsets(top: 16, leading: 16, bottom: 10, trailing: 16))
+
+            StudioModelsSearchPill(text: $searchText, placeholder: "Search \(rows.count) models")
+                .padding(EdgeInsets(top: 0, leading: 16, bottom: 8, trailing: 16))
+
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 6) {
+                    StudioModelsChip(title: "All", isSelected: selectedFamily == nil) { selectedFamily = nil }
+                    ForEach(StudioModelsPresenter.families(in: rows)) { family in
+                        StudioModelsChip(title: family.title, isSelected: selectedFamily == family) {
+                            selectedFamily = selectedFamily == family ? nil : family
+                        }
+                    }
+                }
+            }
+            .padding(EdgeInsets(top: 0, leading: 16, bottom: 10, trailing: 16))
+
+            Rectangle().fill(MereRunTheme.border.opacity(0.4)).frame(height: 1)
+
+            if visibleRows.isEmpty {
+                Text(rows.isEmpty ? "Every known model is installed." : "No models match.")
+                    .font(MereRunTheme.bodyFont)
+                    .foregroundStyle(MereRunTheme.textMuted)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                ScrollView {
+                    LazyVStack(spacing: 1) {
+                        ForEach(visibleRows) { row in
+                            pullRow(row)
+                        }
+                    }
+                    .padding(8)
+                }
+            }
+        }
+        .frame(width: 560, height: 520)
+        .background(MereRunTheme.background)
+        .foregroundStyle(MereRunTheme.textPrimary)
+    }
+
+    private func pullRow(_ row: StudioModelInventoryRow) -> some View {
+        HStack(spacing: 10) {
+            Circle()
+                .fill(row.supported == false ? MereRunTheme.yellow : MereRunTheme.textMuted)
+                .frame(width: ModelsMetrics.dot, height: ModelsMetrics.dot)
+                .accessibilityHidden(true)
+            VStack(alignment: .leading, spacing: 1) {
+                Text(StudioModelsPresenter.displayName(row))
+                    .font(.system(size: 12.5, weight: .medium))
+                    .foregroundStyle(MereRunTheme.textPrimary)
+                    .lineLimit(1)
+                Text(pullMeta(row))
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(row.supported == false ? MereRunTheme.yellow : MereRunTheme.textMuted)
+                    .lineLimit(1)
+            }
+            Spacer(minLength: 10)
+            Button("Pull") { onPull(row) }
+                .buttonStyle(ModelsSecondaryButtonStyle())
+                .help(row.usageTerms == nil ? "Pull \(row.id)" : "Requires accepting third-party usage terms")
+        }
+        .padding(.horizontal, 10)
+        .frame(minHeight: ModelsMetrics.rowHeight)
+        .accessibilityElement(children: .combine)
+    }
+
+    private func pullMeta(_ row: StudioModelInventoryRow) -> String {
+        var parts = [StudioModelsPresenter.family(of: row).title]
+        if row.displayedSize != "—" { parts.append("\(row.displayedSize) download") }
+        if row.usageTerms != nil { parts.append("third-party terms") }
+        if row.supported == false, let reason = row.supportReasons.first { parts.append(reason) }
+        return parts.joined(separator: " · ")
+    }
+}
+
+// MARK: - Job bar
+
+/// The page-bottom job bar: dot, label, muted detail, a ≤260pt progress track, Cancel, Log.
+private struct StudioModelsJobBar: View {
+    let job: StudioModelsJob
+    let onCancel: () -> Void
+    let onLog: () -> Void
+    @Binding var showLog: Bool
+    let log: String
+
+    var body: some View {
+        HStack(spacing: 12) {
+            Circle()
+                .fill(MereRunTheme.accent)
+                .frame(width: ModelsMetrics.dot, height: ModelsMetrics.dot)
+                .accessibilityHidden(true)
+            Text(job.label)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(MereRunTheme.textPrimary)
+                .lineLimit(1)
+            if let detail = job.detail {
+                Text(detail)
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(MereRunTheme.textMuted)
+                    .lineLimit(1)
+            }
+            StudioModelsProgressTrack(fraction: job.fraction)
+                .frame(maxWidth: 260)
+            Spacer(minLength: 0)
+            Button("Cancel", action: onCancel)
+                .buttonStyle(ModelsSecondaryButtonStyle())
+                .disabled(job.isCancelling)
+            Button("Log", action: onLog)
+                .buttonStyle(ModelsSecondaryButtonStyle())
+                .popover(isPresented: $showLog, arrowEdge: .bottom) {
+                    ScrollView {
+                        Text(log)
+                            .font(.system(size: 11.5, design: .monospaced))
+                            .foregroundStyle(MereRunTheme.textSecondary)
+                            .textSelection(.enabled)
+                            .frame(maxWidth: .infinity, alignment: .topLeading)
+                            .padding(12)
+                    }
+                    .frame(width: 520, height: 280)
+                    .background(MereRunTheme.surface)
+                }
+        }
+        .padding(.horizontal, 16)
+        .frame(height: ModelsMetrics.jobBarHeight)
+        .frame(maxWidth: .infinity)
+        .background(MereRunTheme.background)
+        .overlay(alignment: .top) {
+            Rectangle().fill(MereRunTheme.border.opacity(0.53)).frame(height: 1)
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("\(job.label). \(job.detail ?? "")")
+    }
+}
+
+/// A 4pt track; indeterminate progress shows a soft animated sweep, and none under Reduce Motion.
+private struct StudioModelsProgressTrack: View {
+    let fraction: Double?
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var sweep = false
+
+    var body: some View {
+        GeometryReader { proxy in
+            ZStack(alignment: .leading) {
+                Capsule().fill(MereRunTheme.surfaceRaised)
+                if let fraction {
+                    Capsule()
+                        .fill(MereRunTheme.accent)
+                        .frame(width: max(4, proxy.size.width * min(max(fraction, 0), 1)))
+                } else if !reduceMotion {
+                    Capsule()
+                        .fill(MereRunTheme.accent.opacity(0.7))
+                        .frame(width: proxy.size.width * 0.3)
+                        .offset(x: sweep ? proxy.size.width * 0.7 : 0)
+                        .animation(.easeInOut(duration: 1.2).repeatForever(autoreverses: true), value: sweep)
+                        .onAppear { sweep = true }
+                } else {
+                    Capsule().fill(MereRunTheme.accent.opacity(0.35))
+                }
+            }
+        }
+        .frame(height: 4)
+        .accessibilityElement()
+        .accessibilityLabel("Progress")
+        .accessibilityValue(fraction.map { "\(Int(($0 * 100).rounded())) percent" } ?? "in progress")
+    }
+}
+
+// MARK: - Pieces
+
+/// One model in the list: an 8pt status dot, the display name, and "Family · size".
 private struct StudioModelListRow: View {
-    let row: StudioModelInventoryRow
+    let name: String
+    let meta: String
+    let status: StudioModelRowStatus
     let isSelected: Bool
-    let runtime: StudioRuntimeSettings?
     let action: () -> Void
 
     @State private var hovering = false
 
     var body: some View {
         Button(action: action) {
-            HStack(spacing: MereRunTheme.Spacing.sm) {
+            HStack(spacing: 10) {
                 Circle()
-                    .fill(row.isInstalled ? MereRunTheme.green : MereRunTheme.border)
-                    .frame(width: 7, height: 7)
+                    .fill(status.color)
+                    .frame(width: ModelsMetrics.dot, height: ModelsMetrics.dot)
                     .accessibilityHidden(true)
 
-                VStack(alignment: .leading, spacing: 3) {
-                    Text(row.id)
-                        .font(.system(size: 12.5, weight: .semibold))
+                VStack(alignment: .leading, spacing: 1) {
+                    Text(name)
+                        .font(.system(size: 12.5, weight: .medium))
                         .foregroundStyle(MereRunTheme.textPrimary)
                         .lineLimit(1)
                         .truncationMode(.middle)
-                    HStack(spacing: 6) {
-                        Text(row.category)
-                        if row.usageTerms != nil {
-                            Label("terms", systemImage: "doc.text")
-                                .labelStyle(.titleAndIcon)
-                        }
-                        if !row.isInstalled {
-                            Text("·")
-                            Text(row.status)
-                        }
-                        if let runtime {
-                            if runtime.pinned {
-                                Label("pinned", systemImage: "pin.fill")
-                                    .labelStyle(.titleAndIcon)
-                            }
-                            if let alias = runtime.alias {
-                                Text("→ \(alias)")
-                            }
-                        }
-                    }
-                    .font(MereRunTheme.captionFont)
-                    .foregroundStyle(MereRunTheme.textMuted)
-                    .lineLimit(1)
+                    Text(meta)
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(MereRunTheme.textMuted)
+                        .lineLimit(1)
                 }
-
-                Spacer(minLength: 8)
-
-                Text(row.displayedSize)
-                    .font(.system(size: 11, design: .monospaced))
-                    .foregroundStyle(MereRunTheme.textMuted)
+                Spacer(minLength: 0)
             }
             .padding(.horizontal, 10)
-            .padding(.vertical, 8)
+            .frame(height: ModelsMetrics.rowHeight)
             .background {
                 RoundedRectangle(cornerRadius: MereRunTheme.Radius.md)
-                    .fill(rowFill)
-                    .overlay {
-                        RoundedRectangle(cornerRadius: MereRunTheme.Radius.md)
-                            .strokeBorder(
-                                isSelected ? MereRunTheme.accent.opacity(0.5) : Color.clear,
-                                lineWidth: 1
-                            )
-                    }
+                    .fill(isSelected ? MereRunTheme.accentSoft : hovering ? MereRunTheme.hoverFill : Color.clear)
             }
             .contentShape(RoundedRectangle(cornerRadius: MereRunTheme.Radius.md))
         }
         .buttonStyle(.plain)
         .onHover { hovering = $0 }
         .animation(MereRunTheme.Motion.quick, value: hovering)
-        .accessibilityLabel("\(row.id), \(row.category), \(row.status), \(row.displayedSize)")
+        .accessibilityLabel("\(name), \(meta), \(status.accessibilityDescription)")
         .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
     }
+}
 
-    private var rowFill: Color {
-        if isSelected { return MereRunTheme.accentSoft }
-        if hovering { return MereRunTheme.hoverFill }
-        return MereRunTheme.surface.opacity(0.35)
+/// The 28pt capsule search field with a leading glass.
+private struct StudioModelsSearchPill: View {
+    @Binding var text: String
+    let placeholder: String
+
+    var body: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(MereRunTheme.textMuted)
+            TextField(placeholder, text: $text)
+                .textFieldStyle(.plain)
+                .font(.system(size: 12))
+                .foregroundStyle(MereRunTheme.textPrimary)
+            if !text.isEmpty {
+                Button {
+                    text = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.system(size: 11))
+                }
+                .buttonStyle(.mereIcon(tint: MereRunTheme.textMuted))
+                .accessibilityLabel("Clear search")
+            }
+        }
+        .padding(.horizontal, 10)
+        .frame(height: 28)
+        .frame(maxWidth: .infinity)
+        .background {
+            Capsule()
+                .fill(MereRunTheme.surface)
+                .overlay {
+                    Capsule().strokeBorder(MereRunTheme.border.opacity(0.8), lineWidth: 1)
+                }
+        }
+    }
+}
+
+/// A 24pt filter chip; selected chips take the accent wash and accent text.
+private struct StudioModelsChip: View {
+    let title: String
+    let isSelected: Bool
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Text(title)
+                .font(.system(size: 11.5, weight: .medium))
+                .foregroundStyle(isSelected ? MereRunTheme.accent : MereRunTheme.textPrimary)
+                .padding(.horizontal, 9)
+                .frame(height: 24)
+                .background {
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(isSelected ? MereRunTheme.accentSoft : MereRunTheme.surfaceRaised)
+                }
+                .contentShape(RoundedRectangle(cornerRadius: 6))
+        }
+        .buttonStyle(.plain)
+        .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
+    }
+}
+
+/// A 20pt fact tag under the detail title ("Image", "Q4 · 2.1 GB", "Default for Image").
+private struct StudioModelsTag: View {
+    let title: String
+    var accent = false
+
+    var body: some View {
+        Text(title)
+            .font(.system(size: 10.5, weight: .medium))
+            .foregroundStyle(accent ? MereRunTheme.accent : MereRunTheme.textPrimary)
+            .padding(.horizontal, 9)
+            .frame(height: 20)
+            .background {
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(accent ? MereRunTheme.accentSoft : MereRunTheme.surfaceRaised)
+            }
+    }
+}
+
+/// A key on the left, a value on the right, 24pt tall.
+private struct StudioModelsKeyValueRow: View {
+    let key: String
+    let value: String
+    let mono: Bool
+
+    var body: some View {
+        HStack(alignment: .firstTextBaseline, spacing: 12) {
+            Text(key)
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(MereRunTheme.textSecondary)
+                .lineLimit(1)
+            Spacer(minLength: 12)
+            Text(value)
+                .font(.system(size: 12, weight: .medium, design: mono ? .monospaced : .default))
+                .foregroundStyle(MereRunTheme.textPrimary)
+                .lineLimit(1)
+                .truncationMode(.middle)
+                .textSelection(.enabled)
+        }
+        .frame(minHeight: 24)
+        .accessibilityElement(children: .combine)
+    }
+}
+
+/// A status dot beside a sentence, for the Health panel.
+private struct StudioModelsStatusLine: View {
+    let text: String
+    let color: Color
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Circle()
+                .fill(color)
+                .frame(width: ModelsMetrics.dot, height: ModelsMetrics.dot)
+                .accessibilityHidden(true)
+            Text(text)
+                .font(.system(size: 12.5, weight: .medium))
+                .foregroundStyle(MereRunTheme.textPrimary)
+                .lineLimit(2)
+        }
+        .accessibilityElement(children: .combine)
+    }
+}
+
+/// A panel whose body folds away behind its title, for the secondary editors under the fold.
+private struct StudioModelsDisclosurePanel<Content: View>: View {
+    let title: String
+    @Binding var isExpanded: Bool
+    @ViewBuilder let content: () -> Content
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Button {
+                withAnimation(MereRunTheme.Motion.standard) { isExpanded.toggle() }
+            } label: {
+                HStack(spacing: 8) {
+                    Text(title)
+                        .font(.system(size: 12.5, weight: .semibold))
+                        .foregroundStyle(MereRunTheme.textPrimary)
+                    Spacer()
+                    Image(systemName: "chevron.down")
+                        .font(.system(size: 10, weight: .semibold))
+                        .foregroundStyle(MereRunTheme.textMuted)
+                        .rotationEffect(.degrees(isExpanded ? 0 : -90))
+                }
+                .padding(EdgeInsets(top: 12, leading: 16, bottom: 12, trailing: 16))
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityAddTraits(isExpanded ? [.isButton, .isSelected] : .isButton)
+            .accessibilityHint(isExpanded ? "Collapse" : "Expand")
+
+            if isExpanded {
+                content()
+                    .padding(EdgeInsets(top: 0, leading: 16, bottom: 14, trailing: 16))
+            }
+        }
+        .modelsPanel()
+    }
+}
+
+/// `btnPrimary`: 28pt, accent fill, on-accent 13pt semibold text, 6pt radius.
+private struct ModelsPrimaryButtonStyle: ButtonStyle {
+    @Environment(\.isEnabled) private var isEnabled
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.system(size: 13, weight: .semibold))
+            .foregroundStyle(onAccent)
+            .padding(.horizontal, 14)
+            .frame(height: 28)
+            .background {
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(MereRunTheme.accent.opacity(configuration.isPressed ? 0.8 : 1))
+            }
+            .opacity(isEnabled ? 1 : 0.5)
+            .contentShape(RoundedRectangle(cornerRadius: 6))
+    }
+}
+
+/// `btnSecondary`: 26pt, raised surface, hairline border, 11.5pt medium text, 6pt radius.
+private struct ModelsSecondaryButtonStyle: ButtonStyle {
+    @Environment(\.isEnabled) private var isEnabled
+
+    func makeBody(configuration: Configuration) -> some View {
+        configuration.label
+            .font(.system(size: 11.5, weight: .medium))
+            .foregroundStyle(MereRunTheme.textPrimary)
+            .padding(.horizontal, 10)
+            .frame(height: 26)
+            .background {
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(configuration.isPressed ? MereRunTheme.accentSoft : MereRunTheme.surfaceRaised)
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 6)
+                            .strokeBorder(MereRunTheme.border.opacity(0.6), lineWidth: 1)
+                    }
+            }
+            .opacity(isEnabled ? 1 : 0.5)
+            .contentShape(RoundedRectangle(cornerRadius: 6))
+    }
+}
+
+private extension View {
+    /// `panel`: surface fill, hairline border, 10pt radius.
+    func modelsPanel() -> some View {
+        background {
+            RoundedRectangle(cornerRadius: ModelsMetrics.panelRadius)
+                .fill(MereRunTheme.surface)
+                .overlay {
+                    RoundedRectangle(cornerRadius: ModelsMetrics.panelRadius)
+                        .strokeBorder(MereRunTheme.border.opacity(0.8), lineWidth: 1)
+                }
+        }
     }
 }

--- a/apps/macos/MereRunStudio/StudioRootView.swift
+++ b/apps/macos/MereRunStudio/StudioRootView.swift
@@ -34,6 +34,8 @@ struct StudioRootView: View {
     @State private var studioError: String?
     /// Locally installed models feeding the composer's quick-picker.
     @State private var installedModels: [StudioModelInventoryRow] = []
+    /// What Models ▸ Installed last reported, so the toolbar subtitle shows the real inventory.
+    @State private var modelInventorySummary: StudioModelInventorySummary?
     @State private var modelUsageTermsByID: [String: StudioModelUsageTerms] = [:]
     @State private var imageDatasetTask: StudioUtilityTask = .datasetDiscovery
     @AppStorage("mererun.app.hasCompletedWelcome") private var hasCompletedWelcome = false
@@ -287,7 +289,7 @@ struct StudioRootView: View {
                 Text(destination.domain.title)
                     .font(.system(size: 15, weight: .semibold))
                     .foregroundStyle(MereRunTheme.textPrimary)
-                Text(destination.domain.subtitle)
+                Text(domainSubtitle)
                     .font(.system(size: 11, weight: .medium))
                     .foregroundStyle(MereRunTheme.textMuted)
                     .lineLimit(1)
@@ -295,6 +297,14 @@ struct StudioRootView: View {
         }
         .accessibilityElement(children: .combine)
         .accessibilityAddTraits(.isHeader)
+    }
+
+    /// Models reports its installed count and store size; every other domain keeps its tagline.
+    private var domainSubtitle: String {
+        if destination.domain == .models, let modelInventorySummary {
+            return modelInventorySummary.subtitle
+        }
+        return destination.domain.subtitle
     }
 
     @ViewBuilder
@@ -379,10 +389,16 @@ struct StudioRootView: View {
         case .earthFlood, .earthFire, .earthTessera, .earthOlmoEarth:
             StudioGeoLabView(tool: geoToolBinding)
         case .modelsInstalled:
-            StudioModelsView(onModelsChanged: {
-                refreshReadiness()
-                refreshInstalledModels()
-            })
+            StudioModelsView(
+                onModelsChanged: {
+                    refreshReadiness()
+                    refreshInstalledModels()
+                },
+                onInventoryChanged: { modelInventorySummary = $0 },
+                adapterTargetTitle: mode.destination.domain.title,
+                onUseAdapter: applyAdapter,
+                onTrain: openTraining
+            )
         case .modelsLocations:
             StudioModelLocationsView(onLocationsChanged: {
                 refreshReadiness()
@@ -1283,6 +1299,10 @@ struct StudioRootView: View {
             guard result.exitCode == 0 else { return }
             let rows = StudioModelInventoryParser.rows(from: result.stdout)
             installedModels = rows.filter(\.isInstalled)
+            modelInventorySummary = StudioModelInventorySummary(
+                installedCount: installedModels.count,
+                storageBytes: modelInventorySummary?.storageBytes
+            )
             modelUsageTermsByID = Dictionary(
                 uniqueKeysWithValues: rows.compactMap { row in
                     row.usageTerms.map { (row.id, $0) }

--- a/apps/macos/MereRunStudioTests/StudioModelsPresenterTests.swift
+++ b/apps/macos/MereRunStudioTests/StudioModelsPresenterTests.swift
@@ -1,0 +1,330 @@
+@testable import MereRunApp
+import Foundation
+import XCTest
+
+final class StudioModelsPresenterTests: XCTestCase {
+    private func row(
+        _ id: String,
+        category: String,
+        status: String = "installed",
+        size: String = "2.1 GB",
+        title: String? = nil,
+        supported: Bool? = nil,
+        estimatedDownloadBytes: Int64? = nil
+    ) -> StudioModelInventoryRow {
+        StudioModelInventoryRow(
+            id: id,
+            category: category,
+            status: status,
+            size: size,
+            usageTerms: nil,
+            title: title,
+            estimatedDownloadBytes: estimatedDownloadBytes,
+            supported: supported
+        )
+    }
+
+    private func item(
+        mode: StudioMode = .createImage,
+        commandPreview: String,
+        status: StudioLibraryStatus = .completed,
+        createdAt: Date,
+        seconds: TimeInterval = 3.4,
+        templateID: CommandTemplateID? = nil,
+        draft: CommandDraft? = nil,
+        model: String? = nil
+    ) -> StudioLibraryItem {
+        StudioLibraryItem(
+            id: UUID(),
+            mode: mode,
+            prompt: "",
+            inputURL: nil,
+            outputURL: nil,
+            createdAt: createdAt,
+            updatedAt: createdAt.addingTimeInterval(seconds),
+            status: status,
+            exitCode: status == .failed ? 1 : 0,
+            commandPreview: commandPreview,
+            outputText: nil,
+            templateID: templateID,
+            commandDraft: draft,
+            model: model
+        )
+    }
+
+    // MARK: Families and chips
+
+    func testFamiliesGroupCategoriesTheWayTheSidebarDoes() {
+        XCTAssertEqual(StudioModelFamily.from(category: "image"), .image)
+        XCTAssertEqual(StudioModelFamily.from(category: "image-3d"), .threeD)
+        XCTAssertEqual(StudioModelFamily.from(category: "text-chat"), .chat)
+        XCTAssertEqual(StudioModelFamily.from(category: "text-code"), .chat)
+        XCTAssertEqual(StudioModelFamily.from(category: "omni-chat"), .chat)
+        XCTAssertEqual(StudioModelFamily.from(category: "text-embed"), .text)
+        XCTAssertEqual(StudioModelFamily.from(category: "vision-chat"), .vision)
+        XCTAssertEqual(StudioModelFamily.from(category: "vision-segment"), .vision)
+        XCTAssertEqual(StudioModelFamily.from(category: "speech-tts"), .voice)
+        XCTAssertEqual(StudioModelFamily.from(category: "speech-asr"), .audio)
+        XCTAssertEqual(StudioModelFamily.from(category: "audio"), .audio)
+        XCTAssertEqual(StudioModelFamily.from(category: "sfx"), .sound)
+        XCTAssertEqual(StudioModelFamily.from(category: "music"), .music)
+        XCTAssertEqual(StudioModelFamily.from(category: "video"), .video)
+        XCTAssertEqual(StudioModelFamily.from(category: "something-new"), .other)
+    }
+
+    func testChipRowListsOnlyPresentFamiliesInSidebarOrder() {
+        let rows = [
+            row("speech-tts-kokoro", category: "speech-tts"),
+            row("text-chat-qwen", category: "text-chat"),
+            row("image-zimage-nano", category: "image"),
+            row("vision-segment-sam", category: "vision-segment"),
+        ]
+        XCTAssertEqual(StudioModelsPresenter.families(in: rows), [.image, .voice, .chat, .vision])
+    }
+
+    func testFilterMatchesFamilyTitleAndDisplayName() {
+        let rows = [
+            row("image-zimage-nano", category: "image", title: "Zimage Nano"),
+            row("text-chat-qwen3.6-4b", category: "text-chat", title: "Qwen3.6 4B"),
+        ]
+        XCTAssertEqual(StudioModelsPresenter.filter(rows, family: .chat, query: "").map(\.id), ["text-chat-qwen3.6-4b"])
+        XCTAssertEqual(StudioModelsPresenter.filter(rows, family: nil, query: "nano").map(\.id), ["image-zimage-nano"])
+        XCTAssertEqual(StudioModelsPresenter.filter(rows, family: nil, query: "Chat").map(\.id), ["text-chat-qwen3.6-4b"])
+        XCTAssertTrue(StudioModelsPresenter.filter(rows, family: .image, query: "qwen").isEmpty)
+    }
+
+    func testListShowsInstalledRowsAndTheRowBeingPulled() {
+        let rows = [
+            row("image-zimage-nano", category: "image"),
+            row("vision-chat-qwen3.6-vl-4b", category: "vision-chat", status: "missing", size: "—"),
+            row("text-chat-qwen3.6-4b", category: "text-chat", status: "missing", size: "—"),
+        ]
+        let listed = StudioModelsPresenter.listRows(rows, pullingIDs: ["vision-chat-qwen3.6-vl-4b"])
+        XCTAssertEqual(listed.map(\.id), ["image-zimage-nano", "vision-chat-qwen3.6-vl-4b"])
+    }
+
+    // MARK: Row status and meta
+
+    func testRowStatusAndMetaFollowInstallPullAndSupport() {
+        let installed = row("image-zimage-nano", category: "image")
+        let flagged = row("speech-asr-parakeet-tdt", category: "speech-asr", size: "2.4 GB", supported: false)
+        let pulling = row("vision-chat-qwen3.6-vl-4b", category: "vision-chat", status: "missing", size: "—")
+        let missing = row("text-chat-qwen3.6-4b", category: "text-chat", status: "missing", size: "—", estimatedDownloadBytes: 2_600_000_000)
+        let job = StudioModelsJob(
+            kind: .pull,
+            modelID: pulling.id,
+            subject: "Qwen3.6-VL 4B",
+            progress: StudioRunProgress(label: pulling.id, fractionCompleted: 0.25, detail: "1.2 GB / 4.8 GB")
+        )
+
+        XCTAssertEqual(StudioModelsPresenter.status(of: installed, job: job), .installed)
+        XCTAssertEqual(StudioModelsPresenter.status(of: flagged, job: nil), .attention)
+        XCTAssertEqual(StudioModelsPresenter.status(of: pulling, job: job), .pulling(0.25))
+        XCTAssertEqual(StudioModelsPresenter.status(of: missing, job: job), .missing)
+
+        XCTAssertEqual(StudioModelsPresenter.meta(for: installed, status: .installed), "Image · 2.1 GB")
+        XCTAssertEqual(StudioModelsPresenter.meta(for: flagged, status: .attention), "Audio · 2.4 GB")
+        XCTAssertEqual(StudioModelsPresenter.meta(for: pulling, status: .pulling(0.25)), "Vision · pulling 25%")
+        XCTAssertEqual(StudioModelsPresenter.meta(for: pulling, status: .pulling(nil)), "Vision · pulling…")
+        XCTAssertEqual(StudioModelsPresenter.meta(for: missing, status: .missing), "Chat · 2.6 GB download")
+        XCTAssertEqual(
+            StudioModelsPresenter.meta(for: row("x", category: "image", size: "not measured"), status: .installed),
+            "Image"
+        )
+    }
+
+    func testSizeChipCombinesQuantizationAndSize() {
+        let installed = row("image-zimage-nano", category: "image")
+        let facts = StudioModelInfoFacts(root: nil, quantization: "Q4", hasManifest: true, isValid: true)
+        XCTAssertEqual(StudioModelsPresenter.sizeChip(for: installed, facts: facts), "Q4 · 2.1 GB")
+        XCTAssertEqual(StudioModelsPresenter.sizeChip(for: installed, facts: nil), "2.1 GB")
+        XCTAssertNil(StudioModelsPresenter.sizeChip(for: row("x", category: "image", size: "—"), facts: nil))
+    }
+
+    // MARK: Toolbar subtitle
+
+    func testInventorySummarySubtitleReportsCountAndStoreSize() {
+        XCTAssertEqual(StudioModelInventorySummary(installedCount: 0, storageBytes: nil).subtitle, "No models installed")
+        XCTAssertEqual(StudioModelInventorySummary(installedCount: 3, storageBytes: nil).subtitle, "3 installed")
+        let sized = StudioModelInventorySummary(installedCount: 92, storageBytes: 48_000_000_000)
+        XCTAssertEqual(sized.subtitle, "92 installed · 48 GB on this Mac")
+    }
+
+    // MARK: Defaults
+
+    func testDefaultDomainTitlesNameThePromptDomainsWhoseTemplateDefaultsToTheModel() {
+        XCTAssertEqual(StudioModelsPresenter.defaultDomainTitles(for: "image-zimage-nano"), ["Image"])
+        XCTAssertEqual(StudioModelsPresenter.defaultDomainTitles(for: StudioChatDefaults.fallbackModelID), ["Chat"])
+        XCTAssertTrue(StudioModelsPresenter.defaultDomainTitles(for: "no-such-model").isEmpty)
+    }
+
+    // MARK: Library-derived facts
+
+    func testUsageCountsRunsThatReferenceTheModelByArgumentDraftOrThread() {
+        let now = Date()
+        let items = [
+            item(commandPreview: "mere.run image generate --model image-zimage-nano --size 768x512", createdAt: now.addingTimeInterval(-300)),
+            item(commandPreview: "mere.run image generate --model=image-zimage-nano", createdAt: now.addingTimeInterval(-200)),
+            item(commandPreview: "mere.run image generate", createdAt: now.addingTimeInterval(-100), draft: {
+                var draft = CommandDraft()
+                draft.model = "image-zimage-nano"
+                return draft
+            }()),
+            item(mode: .chat, commandPreview: "mere.run text chat", createdAt: now.addingTimeInterval(-50), model: "image-zimage-nano"),
+            item(commandPreview: "mere.run image generate --model image-zimage-nano-xl", createdAt: now.addingTimeInterval(-10)),
+        ]
+        let usage = try? XCTUnwrap(StudioModelsPresenter.usage(of: "image-zimage-nano", in: items))
+        XCTAssertEqual(usage?.runs, 4)
+        XCTAssertEqual(usage?.lastUsed, items[3].updatedAt)
+        XCTAssertNil(StudioModelsPresenter.usage(of: "text-chat-qwen3.6-4b", in: items))
+    }
+
+    func testUsageLineUsesTimeTodayAndDateOtherwise() {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC")!
+        let now = calendar.date(from: DateComponents(year: 2026, month: 9, day: 3, hour: 15))!
+        let today = StudioModelsPresenter.usageLine(
+            StudioModelUsageSummary(lastUsed: now.addingTimeInterval(-3600), runs: 214),
+            now: now,
+            calendar: calendar
+        )
+        XCTAssertTrue(today.hasSuffix(" · 214 runs"), today)
+        XCTAssertFalse(today.contains("Sep"), today)
+
+        let earlier = StudioModelsPresenter.usageLine(
+            StudioModelUsageSummary(lastUsed: now.addingTimeInterval(-4 * 86_400), runs: 1),
+            now: now,
+            calendar: calendar
+        )
+        XCTAssertTrue(earlier.hasSuffix(" · 1 run"), earlier)
+        XCTAssertTrue(earlier.contains("30"), earlier)
+    }
+
+    func testLastRunDurationUsesTheLatestCompletedNonConversationRun() {
+        let now = Date()
+        let items = [
+            item(commandPreview: "mere.run image generate --model image-zimage-nano", createdAt: now.addingTimeInterval(-500), seconds: 12),
+            item(commandPreview: "mere.run image generate --model image-zimage-nano", createdAt: now.addingTimeInterval(-100), seconds: 3.4),
+            item(commandPreview: "mere.run image generate --model image-zimage-nano", status: .failed, createdAt: now.addingTimeInterval(-50), seconds: 1),
+        ]
+        XCTAssertEqual(StudioModelsPresenter.lastRunDuration(for: "image-zimage-nano", in: items), "3.4 s")
+        XCTAssertNil(StudioModelsPresenter.lastRunDuration(for: "other", in: items))
+        XCTAssertEqual(StudioModelsPresenter.duration(95), "1 min 35 s")
+    }
+
+    func testGateAndBenchmarkLinesComeFromTheLatestLibraryRuns() {
+        let now = Date()
+        let gateDate = now.addingTimeInterval(-86_400 * 4)
+        var lite = CommandDraft()
+        lite.benchmarkSuite = "lite"
+        let items = [
+            item(mode: .chat, commandPreview: "mere.run gate", status: .failed, createdAt: now.addingTimeInterval(-86_400 * 9), templateID: .qualityGate),
+            item(mode: .chat, commandPreview: "mere.run gate", createdAt: gateDate, templateID: .qualityGate),
+            item(mode: .chat, commandPreview: "mere.run model benchmark fused", createdAt: gateDate, templateID: .modelBenchmarkFused, draft: lite),
+        ]
+        let gate = StudioModelsPresenter.gateLine(in: items)
+        XCTAssertEqual(gate?.ok, true)
+        XCTAssertEqual(gate?.text, "Quality gate passed · \(StudioModelsPresenter.shortDate(gateDate.addingTimeInterval(3.4)))")
+        XCTAssertEqual(
+            StudioModelsPresenter.benchmarkLine(in: items),
+            "\(StudioModelsPresenter.shortDate(gateDate.addingTimeInterval(3.4))) · Lite suite"
+        )
+        XCTAssertNil(StudioModelsPresenter.gateLine(in: []))
+        XCTAssertNil(StudioModelsPresenter.benchmarkLine(in: []))
+    }
+
+    // MARK: Jobs
+
+    func testLibraryPullJobDescribesTheRunningComposerPull() {
+        let now = Date()
+        let rows = [row("vision-chat-qwen3.6-vl-4b", category: "vision-chat", status: "missing", size: "—", title: "Qwen3.6-VL 4B")]
+        let pull = item(
+            mode: .readImage,
+            commandPreview: "mere.run model pull vision-chat-qwen3.6-vl-4b",
+            status: .running,
+            createdAt: now,
+            templateID: .modelPull
+        )
+        let progress = StudioRunProgress(label: "vision-chat-qwen3.6-vl-4b", fractionCompleted: 0.25, detail: "1.2 GB / 4.8 GB")
+        let job = StudioModelsPresenter.libraryPullJob(in: [pull], rows: rows, progressByRequestID: [pull.id: progress])
+
+        XCTAssertEqual(job?.kind, .pull)
+        XCTAssertEqual(job?.modelID, "vision-chat-qwen3.6-vl-4b")
+        XCTAssertEqual(job?.label, "Models · Pull Qwen3.6-VL 4B")
+        XCTAssertEqual(job?.detail, "1.2 GB / 4.8 GB")
+        XCTAssertEqual(job?.fraction, 0.25)
+        XCTAssertEqual(job?.libraryItemID, pull.id)
+        XCTAssertNil(StudioModelsPresenter.libraryPullJob(in: [], rows: rows, progressByRequestID: [:]))
+    }
+
+    func testJobLabelsAndCancellingDetail() {
+        let optimize = StudioModelsJob(kind: .optimize, modelID: "video-minimax", subject: "MiniMax H3")
+        XCTAssertEqual(optimize.label, "Models · Optimize MiniMax H3")
+        XCTAssertNil(optimize.detail)
+        let cleanup = StudioModelsJob(kind: .cleanup, modelID: nil, subject: "model storage")
+        XCTAssertEqual(cleanup.label, "Models · Clean up model storage")
+        let cancelling = StudioModelsJob(kind: .pull, modelID: "x", subject: "X", isCancelling: true)
+        XCTAssertEqual(cancelling.detail, "Cancelling…")
+    }
+
+    // MARK: model info facts
+
+    func testInfoFactsParseRootQuantizationManifestAndValidation() {
+        let output = """
+        Model Root: /Users/me/Library/Application Support/MereRun/models/image-zimage-nano
+        Model ID: image-zimage-nano
+        Source: primary
+
+        Manifest (local)
+          schemaVersion: 2
+          precision: bf16
+          quantization: bits=4 groupSize=64 scheme=affine
+
+        Validation
+          isValid: true
+        """
+        let facts = StudioModelsPresenter.facts(fromInfo: output)
+        XCTAssertEqual(facts.root, "/Users/me/Library/Application Support/MereRun/models/image-zimage-nano")
+        XCTAssertEqual(facts.quantization, "Q4")
+        XCTAssertEqual(facts.hasManifest, true)
+        XCTAssertEqual(facts.isValid, true)
+        XCTAssertEqual(facts.verifiedLine, "manifest ok · validation passed")
+
+        let missing = StudioModelsPresenter.facts(fromInfo: "Model Root: /m\n\nManifest: (missing)\n\nValidation\n  isValid: false")
+        XCTAssertEqual(missing.hasManifest, false)
+        XCTAssertEqual(missing.verifiedLine, "manifest missing")
+        XCTAssertNil(StudioModelInfoFacts().verifiedLine)
+        XCTAssertTrue(StudioModelInfoFacts().isEmpty)
+    }
+
+    func testAbbreviatedPathAndSourceLine() {
+        XCTAssertEqual(
+            StudioModelsPresenter.abbreviatedPath("/Users/me/Library/Application Support/MereRun/models", home: "/Users/me"),
+            "~/Library/Application Support/MereRun/models"
+        )
+        XCTAssertEqual(StudioModelsPresenter.abbreviatedPath("/Volumes/Models", home: "/Users/me"), "/Volumes/Models")
+        let sourced = StudioModelInventoryRow(
+            id: "image-zimage-nano", category: "image", status: "installed", size: "2.1 GB",
+            usageTerms: nil, sourceRepository: "mere-run/zimage-nano-q4"
+        )
+        XCTAssertEqual(StudioModelsPresenter.sourceLine(for: sourced), "huggingface.co/mere-run/zimage-nano-q4")
+        XCTAssertNil(StudioModelsPresenter.sourceLine(for: row("x", category: "image")))
+    }
+
+    func testMemoryLineAndAdapterMeta() {
+        let both = StudioModelInventoryRow(
+            id: "x", category: "image", status: "installed", size: "1 GB", usageTerms: nil,
+            minimumUnifiedMemoryGB: 8, recommendedUnifiedMemoryGB: 16
+        )
+        XCTAssertEqual(StudioModelsPresenter.memoryLine(for: both), "8 GB min · 16 GB recommended")
+        XCTAssertNil(StudioModelsPresenter.memoryLine(for: row("x", category: "image")))
+        XCTAssertEqual(
+            StudioModelsPresenter.adapterMeta(format: "lora", byteCount: 50_331_648, version: "2", installed: true),
+            "LoRA · 50.3 MB · v2"
+        )
+        XCTAssertEqual(
+            StudioModelsPresenter.adapterMeta(format: "safetensors", byteCount: 0, version: "", installed: false),
+            "SAFETENSORS · not pulled"
+        )
+    }
+}

--- a/apps/macos/MereRunStudioTests/StudioSnapshotTests.swift
+++ b/apps/macos/MereRunStudioTests/StudioSnapshotTests.swift
@@ -26,6 +26,8 @@ final class StudioSnapshotTests: XCTestCase {
     )
     static let consoleSize = CGSize(width: 1_260, height: 780)
     static let settingsSize = CGSize(width: 560, height: 640)
+    /// The size the Studio v2 mockups are drawn at, for fidelity comparisons.
+    static let fidelitySize = CGSize(width: 1_440, height: 900)
 
     private var fixture: SnapshotFixture!
 
@@ -102,6 +104,38 @@ final class StudioSnapshotTests: XCTestCase {
         }
     }
 
+    /// Models ▸ Installed at the mockup size with a seeded inventory: `model list`,
+    /// `model capabilities`, `model storage`, `model info`, `model runtime get`, and
+    /// `adapter list` are answered by a scripted runner, and the Library carries the runs the
+    /// detail column reads (usage, a quality gate, a benchmark) plus a running composer pull so
+    /// the job bar renders. No CLI is launched.
+    func testModelsInstalledFidelitySnapshots() throws {
+        let directory = try XCTUnwrap(Self.snapshotDirectory())
+        fixture.tearDown()
+        fixture = try SnapshotFixture(
+            outputDirectory: directory,
+            processRunner: ScriptedProcessRunner(script: ModelsInventoryScript.responses)
+        )
+        try fixture.seedModelsLibrary()
+
+        for appearance in StudioSnapshotAppearance.allCases {
+            let navigation = NavigationModel()
+            let view = StudioRootView()
+                .environmentObject(fixture.controller)
+                .environmentObject(fixture.library)
+                .environmentObject(navigation)
+                .frame(width: Self.fidelitySize.width, height: Self.fidelitySize.height)
+            try fixture.write(
+                view,
+                size: Self.fidelitySize,
+                appearance: appearance,
+                name: "models-installed-\(appearance.rawValue)",
+                settle: 3.0,
+                afterAppear: { navigation.open(task: .modelsInstalled) }
+            )
+        }
+    }
+
     private static func snapshotDirectory() -> URL? {
         guard let path = ProcessInfo.processInfo.environment["MERERUN_STUDIO_SNAPSHOT_DIR"],
               !path.trimmingCharacters(in: .whitespaces).isEmpty else {
@@ -121,10 +155,11 @@ private final class SnapshotFixture {
     let controller: MereRunController
     let library: StudioLibraryStore
     let crashReporter = StudioCrashReporter()
-    private let processRunner = SnapshotProcessRunner()
+    private let processRunner: MereRunProcessRunning
 
-    init(outputDirectory: URL) throws {
+    init(outputDirectory: URL, processRunner: MereRunProcessRunning = SnapshotProcessRunner()) throws {
         self.outputDirectory = outputDirectory
+        self.processRunner = processRunner
         root = FileManager.default.temporaryDirectory
             .appendingPathComponent("StudioSnapshotTests-\(UUID().uuidString)", isDirectory: true)
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
@@ -306,6 +341,87 @@ private final class SnapshotFixture {
         }
     }
 
+    /// Runs the Models detail column reads: image generations with the seeded default model
+    /// (usage and last-run duration), a passed quality gate, a Lite benchmark, and a running
+    /// composer-initiated pull that the job bar and list report.
+    func seedModelsLibrary() throws {
+        let now = Date()
+        var rows: [StudioLibraryItem] = []
+
+        for (index, seconds) in [3.4, 3.6, 3.1].enumerated() {
+            let started = now.addingTimeInterval(-60 * Double(8 + index * 30))
+            rows.append(StudioLibraryItem(
+                id: UUID(),
+                mode: .createImage,
+                prompt: "Product shot of a linen-wrapped ceramic mug, soft window light",
+                inputURL: nil,
+                outputURL: nil,
+                createdAt: started,
+                updatedAt: started.addingTimeInterval(seconds),
+                status: .completed,
+                exitCode: 0,
+                commandPreview: "mere.run image generate --model image-zimage-nano --size 1024x1024 --steps 4",
+                outputText: nil
+            ))
+        }
+
+        let gateDate = now.addingTimeInterval(-60 * 60 * 24 * 4)
+        rows.append(StudioLibraryItem(
+            id: UUID(),
+            mode: .chat,
+            prompt: "",
+            inputURL: nil,
+            outputURL: nil,
+            createdAt: gateDate,
+            updatedAt: gateDate.addingTimeInterval(240),
+            status: .completed,
+            exitCode: 0,
+            commandPreview: "mere.run gate --suite all",
+            outputText: "gate: 5 suites passed",
+            templateID: .qualityGate
+        ))
+
+        var liteDraft = CommandDraft()
+        liteDraft.benchmarkSuite = "lite"
+        rows.append(StudioLibraryItem(
+            id: UUID(),
+            mode: .chat,
+            prompt: "",
+            inputURL: nil,
+            outputURL: nil,
+            createdAt: gateDate.addingTimeInterval(600),
+            updatedAt: gateDate.addingTimeInterval(900),
+            status: .completed,
+            exitCode: 0,
+            commandPreview: "mere.run model benchmark fused --suite lite --json",
+            outputText: nil,
+            templateID: .modelBenchmarkFused,
+            commandDraft: liteDraft
+        ))
+
+        var pullDraft = CommandDraft()
+        pullDraft.model = ModelsInventoryScript.pullingModelID
+        rows.append(StudioLibraryItem(
+            id: UUID(),
+            mode: .readImage,
+            prompt: "",
+            inputURL: nil,
+            outputURL: nil,
+            createdAt: now.addingTimeInterval(-60 * 3),
+            updatedAt: now.addingTimeInterval(-60 * 3),
+            status: .running,
+            exitCode: nil,
+            commandPreview: "mere.run model pull \(ModelsInventoryScript.pullingModelID)",
+            outputText: nil,
+            templateID: .modelPull,
+            commandDraft: pullDraft
+        ))
+
+        for row in rows.sorted(by: { $0.createdAt < $1.createdAt }) {
+            library.upsert(row)
+        }
+    }
+
     /// A soft two-tone gradient with a horizon line, so the canvas visibly shows an image.
     private static func writeFixturePNG(to url: URL, size: CGSize) throws {
         let width = Int(size.width)
@@ -410,4 +526,126 @@ private final class SnapshotProcessRunner: MereRunProcessRunning, @unchecked Sen
 
 private final class SnapshotRefusedProcess: MereRunRunningProcess {
     func terminate() {}
+}
+
+/// Answers the CLI invocations a page makes from a script keyed on their arguments, and refuses
+/// everything else the way `SnapshotProcessRunner` does. Output arrives asynchronously so the
+/// page's `.task` work observes the same ordering it would with a real process.
+private final class ScriptedProcessRunner: MereRunProcessRunning, @unchecked Sendable {
+    struct Response {
+        let matches: ([String]) -> Bool
+        let stdout: String
+        let exitCode: Int32
+    }
+
+    private let script: [Response]
+
+    init(script: [Response]) {
+        self.script = script
+    }
+
+    func start(
+        configuration: MereRunProcessConfiguration,
+        stdout: @escaping @Sendable (String) -> Void,
+        stderr: @escaping @Sendable (String) -> Void,
+        termination: @escaping @Sendable (Int32) -> Void
+    ) throws -> MereRunRunningProcess {
+        // The controller prepends `--models-root <path>` when a root is configured; match on the
+        // subcommand arguments that follow it.
+        var arguments = configuration.arguments
+        if arguments.first == "--models-root", arguments.count >= 2 {
+            arguments.removeFirst(2)
+        }
+        guard let response = script.first(where: { $0.matches(arguments) }) else {
+            DispatchQueue.global().asyncAfter(deadline: .now() + .milliseconds(30)) {
+                stderr("Snapshot harness: no scripted response for \(arguments.joined(separator: " ")).\n")
+                termination(1)
+            }
+            return SnapshotRefusedProcess()
+        }
+        DispatchQueue.global().asyncAfter(deadline: .now() + .milliseconds(30)) {
+            if !response.stdout.isEmpty { stdout(response.stdout) }
+            termination(response.exitCode)
+        }
+        return SnapshotRefusedProcess()
+    }
+}
+
+/// The model inventory the Models ▸ Installed fidelity render shows: the mockup's sample
+/// lineup, expressed the way `mere.run model list`, `model capabilities`, `model storage`,
+/// `model info`, `model runtime get`, and `adapter list` print it.
+private enum ModelsInventoryScript {
+    static let defaultModelID = "image-zimage-nano"
+    static let pullingModelID = "vision-chat-qwen3.6-vl-4b"
+
+    static let modelList = """
+    ID                         Category     Status     Referenced
+    ---------------------------------------------------------------
+    image-zimage-nano          image        installed  2.1 GB
+    text-chat-qwen3.6-4b       text-chat    installed  2.6 GB
+    vision-chat-qwen3.6-vl-4b  vision-chat  missing    —
+    video-ltx2-fast            video        installed  9.4 GB
+    music-ace-step-1.5         music        installed  3.3 GB
+    music-magenta-rt2-medium   music        installed  1.9 GB
+    speech-tts-kokoro-82m      speech-tts   installed  330 MB
+    speech-asr-parakeet-tdt    speech-asr   installed  2.4 GB
+
+    """
+
+    static let capabilities = """
+    {"models": [
+      {"id": "image-zimage-nano", "title": "Zimage Nano", "summary": "", "minimumUnifiedMemoryGB": 8, "recommendedUnifiedMemoryGB": 16, "supported": true, "reasons": [], "estimatedDownloadBytes": 2100000000, "sourceRepository": "mere-run/zimage-nano-q4", "publisher": "mere.run"},
+      {"id": "text-chat-qwen3.6-4b", "title": "Qwen3.6 4B", "summary": "", "minimumUnifiedMemoryGB": 8, "recommendedUnifiedMemoryGB": 16, "supported": true, "reasons": [], "estimatedDownloadBytes": 2600000000, "sourceRepository": "mere-run/qwen3.6-4b-q4", "publisher": "mere.run"},
+      {"id": "vision-chat-qwen3.6-vl-4b", "title": "Qwen3.6-VL 4B", "summary": "", "minimumUnifiedMemoryGB": 8, "recommendedUnifiedMemoryGB": 16, "supported": true, "reasons": [], "estimatedDownloadBytes": 4800000000, "sourceRepository": "mere-run/qwen3.6-vl-4b-q4", "publisher": "mere.run"},
+      {"id": "video-ltx2-fast", "title": "LTX-2 Fast", "summary": "", "minimumUnifiedMemoryGB": 16, "recommendedUnifiedMemoryGB": 32, "supported": true, "reasons": [], "estimatedDownloadBytes": 9400000000, "sourceRepository": "mere-run/ltx2-fast", "publisher": "mere.run"},
+      {"id": "music-ace-step-1.5", "title": "ACE-Step 1.5", "summary": "", "minimumUnifiedMemoryGB": 8, "recommendedUnifiedMemoryGB": 16, "supported": true, "reasons": [], "estimatedDownloadBytes": 3300000000, "sourceRepository": "mere-run/ace-step-1.5", "publisher": "mere.run"},
+      {"id": "music-magenta-rt2-medium", "title": "Magenta RT2 medium", "summary": "", "minimumUnifiedMemoryGB": 8, "recommendedUnifiedMemoryGB": 16, "supported": true, "reasons": [], "estimatedDownloadBytes": 1900000000, "sourceRepository": "mere-run/magenta-rt2-medium", "publisher": "mere.run"},
+      {"id": "speech-tts-kokoro-82m", "title": "Kokoro 82M", "summary": "", "minimumUnifiedMemoryGB": 4, "recommendedUnifiedMemoryGB": 8, "supported": true, "reasons": [], "estimatedDownloadBytes": 330000000, "sourceRepository": "mere-run/kokoro-82m", "publisher": "mere.run"},
+      {"id": "speech-asr-parakeet-tdt", "title": "Parakeet TDT", "summary": "", "minimumUnifiedMemoryGB": 16, "recommendedUnifiedMemoryGB": 16, "supported": false, "reasons": ["Needs 16 GB of unified memory; this Mac has 8 GB."], "estimatedDownloadBytes": 2400000000, "sourceRepository": "mere-run/parakeet-tdt", "publisher": "mere.run"}
+    ]}
+    """
+
+    static let storage = """
+    {"applicationSupportBytes": 48000000000, "garbageCollectableBytes": 0, "models": []}
+    """
+
+    static var modelInfo: String {
+        let root = NSHomeDirectory() + "/Library/Application Support/MereRun/models/image-zimage-nano"
+        return """
+        Model Root: \(root)
+        Model ID: image-zimage-nano
+        Source: primary
+        Ownership: primary-managed
+
+        Manifest (local)
+          schemaVersion: 2
+          id: image-zimage-nano
+          engine: mlx
+          precision: bf16
+          quantization: bits=4 groupSize=64 scheme=affine
+          upstreamRepoId: mere-run/zimage-nano-q4
+
+        Validation
+          isValid: true
+
+        """
+    }
+
+    static let adapters = """
+    {"schemaVersion": 1, "adapterStore": "/tmp/adapters", "adapters": [
+      {"id": "linen-still-life-v2", "title": "Linen still life", "version": "2", "summary": "", "baseModelID": "image-zimage-nano", "format": "lora", "license": "MIT", "byteCount": 48000000, "installed": true, "path": "/tmp/adapters/linen-still-life-v2"},
+      {"id": "bronze-product-shots", "title": "Bronze product shots", "version": "1", "summary": "", "baseModelID": "image-zimage-nano", "format": "lora", "license": "MIT", "byteCount": 44000000, "installed": true, "path": "/tmp/adapters/bronze-product-shots"}
+    ]}
+    """
+
+    static var responses: [ScriptedProcessRunner.Response] {
+        [
+            .init(matches: { $0 == ["model", "list"] }, stdout: modelList, exitCode: 0),
+            .init(matches: { $0 == ["model", "capabilities", "--all", "--json"] }, stdout: capabilities, exitCode: 0),
+            .init(matches: { $0 == ["model", "storage", "--json"] }, stdout: storage, exitCode: 0),
+            .init(matches: { $0.starts(with: ["model", "info", defaultModelID]) }, stdout: modelInfo, exitCode: 0),
+            .init(matches: { $0.starts(with: ["model", "runtime", "get"]) }, stdout: "{\"pinned\": false}\n", exitCode: 0),
+            .init(matches: { $0 == ["adapter", "list", "--json"] }, stdout: adapters, exitCode: 0),
+        ]
+    }
 }

--- a/apps/macos/README.md
+++ b/apps/macos/README.md
@@ -149,16 +149,32 @@ owns only the typed local `world serve` runtime endpoint, authentication, model
 selection, status, and the handoff to `https://diorama.mere.run`; it must not
 duplicate Diorama's product experience.
 
-Models ▸ Installed includes one-click managed downloads with live CLI output,
-explicit third-party terms acceptance, cancellation with resumable partials;
+Models ▸ Installed is a list-and-detail page. The toolbar subtitle reports the
+real inventory ("92 installed · 48 GB on this Mac", from `model list` and
+`model storage`). The 320pt list shows installed models plus any model being
+pulled, with a family chip row (Image, Chat, Vision, …) and a status dot: green
+installed, accent pulling, yellow when the CLI reports the model as unsupported
+on this Mac. Pull… opens a sheet of the models that are not installed yet; a
+pull keeps its explicit third-party terms acceptance, live CLI output, and
+cancellation with resumable partials. The detail column shows the model's
+facts (store, source, last used and run count from the Library, manifest
+verification from `model info`), a Health panel (latest quality gate and
+manifest audit, with Run gate and Benchmark… routing to those tasks), a
+Performance panel (last run length, unified-memory needs, latest benchmark),
+the adapters whose base model it is (Use in <domain> applies one to the
+composer, Train new… opens the trainer), and the runtime-settings editor and raw
+`model info` output under two folds. Rows whose data the CLI or Library does
+not have are omitted rather than faked. A job bar at the page bottom reports a
+pull, MiniMax-H3 optimize/rebuild, or storage clean-up in flight (composer
+pulls arrive through their Library row) with Cancel and Log. Reveal, Remove…,
+refresh, opening the store, and clean-up stay on the page.
+
 Models ▸ Health is the manifest audit and quality gate. Successful downloads
 refresh the inventory in place. Manifest audit is a structured dry run, repair
 requires confirmation and writes only missing known manifests, and
 installed-model correctness/performance gates run as durable Library jobs with
 JSON reports. Existing model browsing, storage cleanup, and runtime policy
 remain in the Models and Server domains rather than being duplicated.
-Installed MiniMax-H3 models expose a native optimize/rebuild action with streamed
-receipts instead of requiring a terminal round trip.
 
 Server is a sidebar domain. **Server ▸ Serving**
 owns API preflight/start/stop/restart, external-server reconnection, LAN/auth
@@ -241,7 +257,11 @@ recorded decision that it should not have one.
 
 `StudioSnapshotTests` renders the shell for visual review without driving the
 live app: every domain at its default task at 1280×820 in light and dark, plus
-the Settings content and the Command Console. It is skipped unless
+the Settings content and the Command Console, and Models ▸ Installed at the
+1440×900 mockup size with a scripted model inventory (`model list`,
+`capabilities`, `storage`, `info`, `runtime get`, and `adapter list` answered
+from fixtures, plus Library rows for usage, a quality gate, a benchmark, and a
+running composer pull). It is skipped unless
 `MERERUN_STUDIO_SNAPSHOT_DIR` names a directory, so CI and a plain `swift test`
 never render anything:
 
@@ -251,7 +271,8 @@ MERERUN_STUDIO_SNAPSHOT_DIR=/tmp/shell-shots swift test --filter StudioSnapshotT
 
 `StudioSnapshotRenderer` hosts each view in an `NSWindow` that is never ordered
 on screen and captures it with `cacheDisplay`, so nothing appears on the Mac
-running it. The controller uses a process runner that refuses every launch and
+running it. The controller uses a process runner that refuses every launch (or,
+for the Models render, answers only the scripted inventory commands) and
 the Library is a temporary `library.json` seeded with fixture rows, so no CLI
 process starts and the user's Library is never read or written. Two fidelity
 gaps are deliberate: macOS 26 glass and scroll-edge effects only composite on


### PR DESCRIPTION
## What changed

Studio v2 step **F9**: Models ▸ Installed rebuilt to the approved Manage mockup (`manageBoard()` / `Manage.png`), stacked on the snapshot harness branch (`studio-v2/d2-snapshots`).

- **Toolbar subtitle is real.** Models now reports "N installed · X GB on this Mac" from `model list` + `model storage --json`; other domains keep their tagline. The task control is untouched (Installed | Locations | Health | Benchmarks | Adapters).
- **Installed page** (`StudioModelsView.swift`): 320pt list column with a 28pt search pill ("Search N models"), an accent `Pull…` button, a family chip row (All / Image / Chat / Vision / Music / Voice …, selected = accentSoft + accent), and 40pt rows with an 8pt status dot (green installed, accent pulling, yellow unsupported), 12.5pt name and 11pt muted meta ("Image · 2.1 GB", "Vision · pulling 25%"), selected row accentSoft radius 9, hairline right border. Detail column: 20pt semibold name + Reveal / Optimize (when the model supports it) / Remove… plus an overflow menu (refresh, inspect, rebuild cache, open store, clean up storage…); tag row (family, "Q4 · 2.1 GB" from `model info`, "Default for Image" when a prompt task's template defaults to the model); a facts panel (Store, Source, Last used · runs from the Library, Verified from `model info`); side-by-side Health (latest quality gate, manifest audit, unsupported reason; Run gate / Benchmark… route to those tasks) and Performance (last run length, unified-memory needs, latest benchmark) panels; "Adapters using this model" (mono adapter id, "LoRA · 48 MB · v2", "Use in <domain>", "Train new…"); runtime settings and raw `model info` under two folds. Rows without data are omitted rather than faked.
- **Job bar** (40pt, top hairline, dot + label + muted detail + ≤260pt track + Cancel + Log) while a pull, MiniMax-H3 optimize/rebuild, or storage clean-up is in flight. Page-local jobs cancel through `cancelUtilityCommand`; composer-initiated pulls are read from their running `.modelPull` Library row with `progressByRequestID` and cancel through `cancel(requestID:)`. `MereRunController.swift` is not modified.
- **Nothing lost:** pull with third-party terms acceptance, cancel with resumable partials, remove with confirmation, storage clean-up preview + confirmation, optimize and cache rebuild, runtime load/unload/pin/settings, reveal in Finder, refresh. Pull… moves the not-yet-installed catalog into a sheet so the list shows what is on this Mac.
- **View-model logic** lives in `StudioModelsPresentation.swift` (families, inventory summary, row status/meta, default domains, Library-derived usage/gate/benchmark facts, `model info` facts, job descriptions) with `StudioModelsPresenterTests` (17 tests).
- **Fidelity render:** `StudioSnapshotTests.testModelsInstalledFidelitySnapshots` renders Models ▸ Installed at 1440×900, light and dark, through a scripted `MereRunProcessRunning` that answers `model list`, `capabilities`, `storage`, `info`, `runtime get`, and `adapter list` from fixtures, plus seeded Library rows (usage, a passed gate, a Lite benchmark, a running composer pull). No CLI is launched; the user's Library is never touched.
- `apps/macos/README.md` describes the page and the new render.

## Design decisions

- `onAccent` is defined `fileprivate` in `StudioModelsView.swift` with a `// F1 token:` comment; `MereRunTheme.swift`, `StudioSidebar.swift`, `StudioComposer.swift`, and `MereRunController.swift` are untouched.
- "Use in <domain>" names the last prompt mode's domain (the one `applyAdapter` targets), mirroring `StudioAdaptersView`.
- The toolbar subtitle reaches the shell through an `onInventoryChanged` callback into `StudioRootView`; the root also seeds the count from its own `model list` refresh so the subtitle is right before the page has loaded storage.
- The Optimize button appears only for models `StudioModelOptimizationCommand.supports`; the mockup shows it unconditionally.
- Runtime settings and raw `model info` are kept as two collapsed panels under Adapters (not in the mockup) so no v1 capability is lost.

## Remaining visible differences from Manage.png

- The Models task control renders as the shell's menu picker rather than the mockup's segmented control; that is `StudioTaskControlStyle` in the shell (F1 scope) and was left as is per the brief.
- The seeded render's pull is Library-backed, so its progress is indeterminate (the mockup shows 25%); a page-initiated pull shows the determinate fraction and "1.2 GB / 4.8 GB" detail.
- Sidebar wordmark/footer and toolbar chrome are the harness branch's current shell, not F1's.

## Verification

- `swiftlint --strict` clean; `swift build`; `swift test --filter MereRunAppTests` via `./scripts/check.sh` (3476 tests, 0 failures).
- `./scripts/build_mere_run_app.sh debug` builds and validates the bundle (not opened).
- `MERERUN_STUDIO_SNAPSHOT_DIR=… swift test --filter testModelsInstalledFidelitySnapshots` renders light and dark; compared side by side with `Manage.png`.
