### PR TITLE
Rebuild Video ▸ Subjects as the Project archetype

### DIFF
--- a/apps/macos/MereRunStudio/StudioSCAILView.swift
+++ b/apps/macos/MereRunStudio/StudioSCAILView.swift
@@ -1,180 +1,28 @@
+import AppKit
+import AVFoundation
 import SwiftUI
 import UniformTypeIdentifiers
 
-private struct StudioSCAILSubject: Identifiable, Equatable {
-    let id = UUID()
-    var name: String
-    var color: String
-    var referenceImage = ""
-    var referencePrompt = ""
-    var drivingPrompt = ""
-    var referenceBox = ""
-    var drivingBox = ""
-    var referencePositivePoints = ""
-    var drivingPositivePoints = ""
-    var referenceNegativePoints = ""
-    var drivingNegativePoints = ""
-}
+// F1 token: the text/glyph color on an accent fill. Moves to MereRunTheme with the other v2 tokens.
+private let onAccent = MereRunTheme.dynamic(light: "FFFFFF", dark: "1B160A")
+// F1 token: the raised tile of a segmented control's selected segment.
+private let segmentedSelection = MereRunTheme.dynamic(light: "FFFFFF", dark: "3A362E")
 
-private struct StudioSCAILSelectorPlan: Codable {
-    let text: String?
-    let box: StudioSCAILBoxPlan?
-    let positivePoints: [StudioSCAILPointPlan]
-    let negativePoints: [StudioSCAILPointPlan]
-
-    enum CodingKeys: String, CodingKey {
-        case text
-        case box
-        case positivePoints = "positive_points"
-        case negativePoints = "negative_points"
-    }
-}
-
-private struct StudioSCAILPointPlan: Codable {
-    let x: Float
-    let y: Float
-}
-
-private struct StudioSCAILBoxPlan: Codable {
-    let x1: Float
-    let y1: Float
-    let x2: Float
-    let y2: Float
-}
-
-private struct StudioSCAILSubjectPlan: Codable {
-    let id: String
-    let color: String
-    let referenceImage: String
-    let referenceSelector: StudioSCAILSelectorPlan
-    let drivingSelector: StudioSCAILSelectorPlan
-
-    enum CodingKeys: String, CodingKey {
-        case id
-        case color
-        case referenceImage = "reference_image"
-        case referenceSelector = "reference_selector"
-        case drivingSelector = "driving_selector"
-    }
-}
-
-private struct StudioSCAILMaskPlan: Codable {
-    let schemaVersion = 1
-    let mode: String
-    let drivingVideo: String
-    let inSeconds: Double?
-    let outSeconds: Double?
-    let width: Int
-    let height: Int
-    let fps: Double
-    let subjects: [StudioSCAILSubjectPlan]
-    let corrections: [StudioSCAILCorrectionPlan]
-    let threshold: Float
-    let resolution: Int
-    let seedFrameSearchLimit: Int
-    let paletteTolerance = 192
-
-    enum CodingKeys: String, CodingKey {
-        case schemaVersion = "schema_version"
-        case mode
-        case drivingVideo = "driving_video"
-        case inSeconds = "in_seconds"
-        case outSeconds = "out_seconds"
-        case width
-        case height
-        case fps
-        case subjects
-        case corrections
-        case threshold
-        case resolution
-        case seedFrameSearchLimit = "seed_frame_search_limit"
-        case paletteTolerance = "palette_tolerance"
-    }
-}
-
-private struct StudioSCAILCorrectionPlan: Codable {
-    let subjectID: String
-    let frameIndex: Int
-    let box: StudioSCAILBoxPlan?
-    let positivePoints: [StudioSCAILPointPlan]
-    let negativePoints: [StudioSCAILPointPlan]
-    let paintedBinaryCorrectionPNG: String?
-
-    enum CodingKeys: String, CodingKey {
-        case subjectID = "subject_id"
-        case frameIndex = "frame_index"
-        case box
-        case positivePoints = "positive_points"
-        case negativePoints = "negative_points"
-        case paintedBinaryCorrectionPNG = "painted_binary_correction_png"
-    }
-}
-
-private struct StudioSCAILCorrection: Identifiable, Equatable {
-    let id = UUID()
-    var subjectID: String
-    var frameIndex = 0
-    var box = ""
-    var positivePoints = ""
-    var negativePoints = ""
-    var paintedMaskPath = ""
-}
-
-private enum StudioSCAILPlanError: LocalizedError {
-    case invalidBox(String)
-    case invalidPoints(String)
-
-    var errorDescription: String? {
-        switch self {
-        case .invalidBox(let label):
-            "\(label) box must be four comma-separated numbers with x2>x1 and y2>y1."
-        case .invalidPoints(let label):
-            "\(label) points must use x,y pairs separated by semicolons."
-        }
-    }
-}
-
-private struct StudioSCAILManifest: Decodable {
-    struct Subject: Decodable {
-        let id: String
-        let preparedReferenceImagePath: String
-        let referenceMaskPath: String
-
-        enum CodingKeys: String, CodingKey {
-            case id
-            case preparedReferenceImagePath = "prepared_reference_image_path"
-            case referenceMaskPath = "reference_mask_path"
-        }
-    }
-
-    let status: String
-    let drivingSourcePath: String
-    let drivingProxyPath: String?
-    let drivingMaskPath: String?
-    let overlayPreviewPath: String
-    let contactSheetPath: String
-    let frameCount: Int
-    let subjects: [Subject]
-
-    enum CodingKeys: String, CodingKey {
-        case status
-        case drivingSourcePath = "driving_source_path"
-        case drivingProxyPath = "driving_proxy_path"
-        case drivingMaskPath = "driving_mask_path"
-        case overlayPreviewPath = "overlay_preview_path"
-        case contactSheetPath = "contact_sheet_path"
-        case frameCount = "frame_count"
-        case subjects
-    }
-}
-
+/// Video ▸ Subjects: the Project archetype for the SCAIL flow.
+///
+/// A stage rail (Plan → Track → Animate) beside the current stage's board, over a job bar. The
+/// plan is written to `plan.json` and handed to `video prepare-masks`; the manifest, tracking, and
+/// quality reports it writes back drive the preview, the subject rows, and the stats. Animation
+/// hands the tracked masks to `video animate`. Every job is a durable Library row through
+/// `StudioSpecialistRunner`, and a fingerprint of the mask inputs invalidates prepared masks the
+/// moment any of them changes.
 struct StudioSCAILView: View {
     @EnvironmentObject private var controller: MereRunController
     @EnvironmentObject private var library: StudioLibraryStore
+    @Environment(\.studioSubjectsProjectSeed) private var seed
 
+    // Plan
     @State private var mode = "animation"
-    @State private var prompt = "a cinematic full-body performance with natural motion"
-    @State private var negativePrompt = ""
     @State private var drivingVideo = ""
     @State private var subjects = [
         StudioSCAILSubject(
@@ -186,21 +34,34 @@ struct StudioSCAILView: View {
     ]
     @State private var width = 832
     @State private var height = 480
-    @State private var fps = 16
+    @State private var fps = 24
     @State private var useTrimRange = false
     @State private var inSeconds = 0.0
     @State private var outSeconds = 10.0
     @State private var maskThreshold = 0.05
     @State private var maskResolution = 1008
     @State private var seedSearchFrames = 48
-    @State private var previewFrame = 0
     @State private var maskModel = "vision-segment-sam31"
+
+    // Track
+    @State private var previewFrame = 0
+    @State private var corrections: [StudioSCAILCorrection] = []
+    @State private var preparedManifest: StudioSCAILManifest?
+    @State private var preparedDirectory: URL?
+    @State private var preparedFingerprint = ""
+    @State private var trackingReport: StudioSCAILTrackingReport?
+    @State private var qualityReport: StudioSCAILQualityReport?
+    @State private var showsMasks = true
+
+    // Animate
+    @State private var prompt = "a cinematic full-body performance with natural motion"
+    @State private var negativePrompt = ""
     @State private var profile = "fast"
     @State private var steps = 40
     @State private var guidance = 5.0
     @State private var shift = 3.0
     @State private var sampler = "unipc"
-    @State private var seed = "42"
+    @State private var seedValue = "42"
     @State private var segmentLength = 81
     @State private var segmentOverlap = 5
     @State private var tailPolicy = "drop"
@@ -209,20 +70,45 @@ struct StudioSCAILView: View {
     @State private var modelRoot = ""
     @State private var adapterPath = ""
     @State private var adapterStrength = 1.0
-    @State private var corrections: [StudioSCAILCorrection] = []
     @State private var outputPath = StudioSpecialistFiles.timestampedDirectory(component: "SCAIL")
         .deletingLastPathComponent()
         .appendingPathComponent("scail-\(UUID().uuidString.prefix(8)).mp4")
         .path
-    @State private var preflight = false
-    @State private var preparedManifest: StudioSCAILManifest?
-    @State private var preparedDirectory: URL?
-    @State private var requestID: UUID?
-    @State private var maskRequestID: UUID?
-    @State private var errorMessage: String?
-    @State private var statusMessage = "Add a reference and driving video, then preview masks."
 
-    private let palette = ["blue", "red", "green", "magenta", "cyan", "yellow"]
+    // Jobs and chrome
+    @State private var selectedStage: StudioSubjectsStage?
+    @State private var planSavedAt: Date?
+    @State private var maskRequestID: UUID?
+    @State private var maskJob: StudioSubjectsJobBar.Job?
+    @State private var animateRequestID: UUID?
+    @State private var animateJob: StudioSubjectsJobBar.Job?
+    @State private var notice: Notice?
+    @State private var editingSubjectID: UUID?
+    @State private var showsPlanMore = false
+    @State private var showsTrackMore = false
+    @State private var showsAnimateMore = false
+    @State private var showsLog = false
+    @State private var didSeed = false
+
+    private struct Notice: Equatable {
+        let severity: MereBanner.Severity
+        let text: String
+
+        static func == (lhs: Notice, rhs: Notice) -> Bool {
+            lhs.text == rhs.text
+        }
+    }
+
+    private static let subjectsPanelWidth: CGFloat = 300
+    /// Below this column width the preview cannot sit beside the 300pt side panel without the
+    /// transport bar being squeezed, so the panel drops under it.
+    private static let sideBySideMinimumWidth: CGFloat = 640
+
+    static func isWide(columnWidth: CGFloat) -> Bool {
+        columnWidth - 48 >= sideBySideMinimumWidth
+    }
+
+    // MARK: - Derived state
 
     private var maskConfigurationFingerprint: String {
         let subjectValues = subjects.map {
@@ -246,484 +132,888 @@ struct StudioSCAILView: View {
         ].joined(separator: "§")
     }
 
+    private var maskItem: StudioLibraryItem? {
+        guard let maskRequestID else { return nil }
+        return library.items.first { $0.id == maskRequestID }
+    }
+
+    private var animateItem: StudioLibraryItem? {
+        guard let animateRequestID else { return nil }
+        return library.items.first { $0.id == animateRequestID }
+    }
+
+    private var jobPhase: StudioSubjectsJobBar.Phase {
+        let jobs: [(StudioLibraryItem, StudioSubjectsJobBar.Job)] = [
+            (maskItem, maskJob), (animateItem, animateJob),
+        ].compactMap { item, job in
+            guard let item, let job else { return nil }
+            return (item, job)
+        }
+        if let pending = jobs.first(where: { $0.0.status == .running || $0.0.status == .queued }) {
+            return pending.0.status == .queued ? .queued(pending.1) : .running(pending.1)
+        }
+        guard let latest = jobs.max(by: { $0.0.updatedAt < $1.0.updatedAt }) else { return .idle }
+        return .ended(latest.1, exitCode: latest.0.exitCode)
+    }
+
+    private var activeJobRequestID: UUID? {
+        switch jobPhase {
+        case .running(let job), .queued(let job):
+            return job.stage == .track ? maskRequestID : animateRequestID
+        case .idle, .ended:
+            return nil
+        }
+    }
+
+    private var progress: StudioSubjectsProgress {
+        var progress = StudioSubjectsProgress()
+        progress.planReady = planValidationError(includeRender: false) == nil
+        progress.previewed = preparedManifest != nil
+        progress.tracked = preparedManifest?.isTracked == true
+        progress.animated = resultVideoURL != nil
+        switch jobPhase {
+        case .running(let job), .queued(let job):
+            progress.runningStage = job.stage
+        case .idle, .ended:
+            progress.runningStage = nil
+        }
+        return progress
+    }
+
+    private var stage: StudioSubjectsStage {
+        selectedStage ?? progress.defaultStage
+    }
+
+    private var frameCount: Int? {
+        preparedManifest?.frameCount ?? trackingReport?.frameCount
+    }
+
+    private var manifestFPS: Double {
+        preparedManifest?.fps ?? trackingReport?.fps ?? Double(fps)
+    }
+
+    private var stats: StudioSubjectsStats {
+        StudioSubjectsStats.stats(
+            manifest: preparedManifest,
+            tracking: trackingReport,
+            quality: qualityReport,
+            correctionCount: corrections.count
+        )
+    }
+
+    private var overlayURL: URL? {
+        preparedManifest.map { resolve($0.overlayPreviewPath) }
+    }
+
+    private var beforeURL: URL? {
+        if let manifest = preparedManifest {
+            return resolve(manifest.drivingProxyPath ?? manifest.drivingSourcePath)
+        }
+        return pathURL(drivingVideo)
+    }
+
+    private var resultVideoURL: URL? {
+        guard let animateItem else { return nil }
+        return animateItem.allArtifactURLs.first { StudioOutputFileKind.classify($0) == .video }
+    }
+
+    // MARK: - Body
+
     var body: some View {
         VStack(spacing: 0) {
-            header
-            Divider().overlay(MereRunTheme.border.opacity(0.55))
             HStack(spacing: 0) {
-                setupColumn
-                    .frame(minWidth: 340, idealWidth: 470, maxWidth: 470)
-                Divider().overlay(MereRunTheme.border.opacity(0.55))
-                outputColumn
+                stageRail
+                stageContent
             }
+            jobBar
         }
         .background(MereRunTheme.background)
         .foregroundStyle(MereRunTheme.textPrimary)
+        .onAppear(perform: applySeed)
         .onReceive(controller.runCompletions) { result in
             guard result.templateID == .videoPrepareMasks, result.requestID == maskRequestID else {
                 return
             }
             guard result.exitCode == 0 else {
-                statusMessage = "Mask preparation failed. Open the Library row for diagnostics."
+                notice = Notice(
+                    severity: .error,
+                    text: "Mask preparation failed. Open Log, or the Library row, for diagnostics."
+                )
                 return
             }
             loadPreparedManifest()
         }
-        .onChange(of: maskConfigurationFingerprint) { _, _ in
-            guard preparedManifest != nil else { return }
+        .onChange(of: maskConfigurationFingerprint) { _, fingerprint in
+            guard preparedManifest != nil, fingerprint != preparedFingerprint else { return }
             preparedManifest = nil
             preparedDirectory = nil
-            statusMessage = "Mask inputs changed. Preview or track masks again."
+            trackingReport = nil
+            qualityReport = nil
+            notice = Notice(severity: .info, text: "Mask inputs changed. Preview or track masks again.")
         }
     }
 
-    /// The stage line: reference segmentation → driving-video tracking → review → animation.
-    private var header: some View {
-        HStack(spacing: 12) {
-            Image(systemName: "figure.run.square.stack")
-                .font(.system(size: 13, weight: .semibold))
-                .foregroundStyle(MereRunTheme.accent)
-            Text(statusMessage)
-                .font(MereRunTheme.captionFont)
-                .foregroundStyle(MereRunTheme.textSecondary)
-                .lineLimit(1)
-            Spacer()
-        }
-        .padding(.horizontal, 18)
-        .padding(.vertical, 10)
-    }
+    // MARK: - Stage rail
 
-    private var setupColumn: some View {
-        ScrollView {
-            VStack(alignment: .leading, spacing: 16) {
-                Picker("Mode", selection: $mode) {
-                    Text("Animate reference").tag("animation")
-                    Text("Replace in scene").tag("replacement")
-                }
-                .pickerStyle(.segmented)
-
-                Label(
-                    mode == "animation"
-                        ? "Keeps the reference background; driving supplies motion."
-                        : "Keeps the driving scene; references replace masked subjects.",
-                    systemImage: mode == "animation" ? "photo.on.rectangle" : "person.crop.rectangle.badge.plus"
-                )
-                .font(MereRunTheme.captionFont)
-                .foregroundStyle(MereRunTheme.textSecondary)
-
-                StudioPathField(
-                    label: "Driving video",
-                    placeholder: "/path/to/driving.mp4",
-                    path: $drivingVideo,
-                    allowedContentTypes: [.movie]
-                )
-
-                subjectEditor
-
-                DisclosureGroup("Mask preparation") {
-                    VStack(alignment: .leading, spacing: 10) {
-                        HStack {
-                            Stepper("Width \(width)", value: $width, in: 256...1536, step: 32)
-                            Stepper("Height \(height)", value: $height, in: 256...1536, step: 32)
-                        }
-                        Stepper("FPS \(fps)", value: $fps, in: 1...60)
-                        Toggle("Trim driving video", isOn: $useTrimRange)
-                        if useTrimRange {
-                            valueSlider("In point", value: $inSeconds, range: 0...3_600)
-                            valueSlider("Out point", value: $outSeconds, range: 0.1...3_600)
-                        }
-                        valueSlider("SAM threshold", value: $maskThreshold, range: 0.001...0.5)
-                        Stepper("SAM resolution \(maskResolution)", value: $maskResolution, in: 256...2016, step: 16)
-                        Stepper("Seed search frames \(seedSearchFrames)", value: $seedSearchFrames, in: 1...240)
-                        Stepper("Preview frame \(previewFrame)", value: $previewFrame, in: 0...100_000)
-                        labeledField("Mask model", text: $maskModel, placeholder: "vision-segment-sam31")
-                    }
-                    .padding(.top, 10)
-                }
-
-                HStack {
-                    Button {
-                        prepareMasks(previewOnly: true)
-                    } label: {
-                        Label("Preview masks", systemImage: "eye")
-                    }
-                    .buttonStyle(.bordered)
-                    Button {
-                        prepareMasks(previewOnly: false)
-                    } label: {
-                        Label("Track full video", systemImage: "scope")
-                    }
-                    .buttonStyle(.borderedProminent)
-                    .tint(MereRunTheme.accent)
-                }
-
-                correctionEditor
-
-                Divider().overlay(MereRunTheme.border.opacity(0.5))
-
-                VStack(alignment: .leading, spacing: 5) {
-                    Text("Direction")
-                        .font(MereRunTheme.captionFont)
+    private var stageRail: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            ProjectEyebrow("Stages")
+                .padding(EdgeInsets(top: 0, leading: 10, bottom: 6, trailing: 10))
+            ForEach(StudioSubjectsStage.allCases) { candidate in
+                stageRow(candidate, status: progress.status(of: candidate, selected: stage))
+            }
+            VStack(alignment: .leading, spacing: 0) {
+                ProjectEyebrow("Project")
+                    .padding(.bottom, 6)
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(StudioSubjectsProjectCopy.name(drivingVideo: drivingVideo))
+                        .font(.system(size: 12.5, weight: .medium))
+                        .foregroundStyle(MereRunTheme.textPrimary)
+                        .lineLimit(1)
+                    Text(StudioSubjectsProjectCopy.summary(subjectCount: subjects.count, frameCount: frameCount))
+                        .font(.system(size: 11, weight: .medium))
                         .foregroundStyle(MereRunTheme.textMuted)
-                    TextField("Describe the finished shot", text: $prompt, axis: .vertical)
-                        .lineLimit(2...5)
-                        .mereField()
-                }
-
-                labeledField("Negative prompt", text: $negativePrompt, placeholder: "Optional")
-
-                Picker("Profile", selection: $profile) {
-                    Text("Fast · 4-step").tag("fast")
-                    Text("Quality · manual").tag("quality")
-                }
-                .pickerStyle(.segmented)
-
-                if profile == "quality" {
-                    Stepper("Steps \(steps)", value: $steps, in: 1...100)
-                    valueSlider("Guidance", value: $guidance, range: 0...15)
-                    valueSlider("Schedule shift", value: $shift, range: 0...10)
-                    Picker("Sampler", selection: $sampler) {
-                        Text("UniPC").tag("unipc")
-                        Text("Euler").tag("euler")
-                    }
-                }
-
-                DisclosureGroup("Continuity, model & adapter") {
-                    VStack(alignment: .leading, spacing: 10) {
-                        labeledField("Seed", text: $seed, placeholder: "42")
-                        Stepper("Segment length \(segmentLength)", value: $segmentLength, in: 9...401, step: 8)
-                        Stepper("Overlap \(segmentOverlap)", value: $segmentOverlap, in: 1...77, step: 4)
-                        Picker("Tail", selection: $tailPolicy) {
-                            Text("Drop partial tail").tag("drop")
-                            Text("Pad and trim").tag("pad-trim")
-                        }
-                        Toggle("Carry driving audio", isOn: $carryDrivingAudio)
-                        labeledField("Model", text: $model, placeholder: "video-scail2-14b-mlx")
-                        StudioPathField(
-                            label: "Model root override",
-                            placeholder: "Managed model",
-                            path: $modelRoot,
-                            picksDirectory: true
-                        )
-                        StudioPathField(
-                            label: "Distilled adapter override",
-                            placeholder: "Fast profile uses the managed adapter automatically",
-                            path: $adapterPath
-                        )
-                        if !adapterPath.isBlank {
-                            valueSlider("Adapter strength", value: $adapterStrength, range: 0...2)
-                        }
-                    }
-                    .padding(.top, 10)
-                }
-
-                VStack(alignment: .leading, spacing: 5) {
-                    Text("Output video")
-                        .font(MereRunTheme.captionFont)
+                    Text(StudioSubjectsProjectCopy.saved(planSavedAt))
+                        .font(.system(size: 11, weight: .medium))
                         .foregroundStyle(MereRunTheme.textMuted)
-                    HStack(spacing: 8) {
-                        TextField("/path/to/output.mp4", text: $outputPath)
-                            .mereField()
-                        Button("Choose…") {
-                            if let url = StudioSpecialistFiles.saveFile(
-                                title: "Save SCAIL video",
-                                suggestedName: "scail.mp4",
-                                allowedContentTypes: [.mpeg4Movie]
-                            ) {
-                                outputPath = url.path
-                            }
-                        }
-                        .buttonStyle(.bordered)
+                }
+            }
+            .padding(EdgeInsets(top: 18, leading: 10, bottom: 0, trailing: 10))
+            Spacer(minLength: 0)
+        }
+        .padding(EdgeInsets(top: 22, leading: 12, bottom: 22, trailing: 12))
+        .frame(width: 200, alignment: .topLeading)
+        .frame(maxHeight: .infinity, alignment: .top)
+        .overlay(alignment: .trailing) {
+            Rectangle().fill(MereRunTheme.border.opacity(0.4)).frame(width: 1)
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Stages")
+    }
+
+    private func stageRow(_ candidate: StudioSubjectsStage, status: StudioSubjectsStageStatus) -> some View {
+        Button {
+            selectedStage = candidate
+        } label: {
+            HStack(spacing: 10) {
+                ZStack {
+                    Circle().fill(stageCircleFill(status))
+                    if status == .done {
+                        Image(systemName: "checkmark")
+                            .font(.system(size: 9, weight: .bold))
+                            .foregroundStyle(onAccent)
+                    } else {
+                        Text(String(candidate.rawValue))
+                            .font(.system(size: 11, weight: .semibold))
+                            .foregroundStyle(status == .todo ? MereRunTheme.textMuted : onAccent)
                     }
                 }
-                Toggle("Preflight only", isOn: $preflight)
-
-                if let errorMessage {
-                    Label(errorMessage, systemImage: "exclamationmark.triangle.fill")
-                        .font(MereRunTheme.captionFont)
-                        .foregroundStyle(MereRunTheme.red)
-                }
-
-                Button {
-                    animate()
-                } label: {
-                    Label(preflight ? "Validate SCAIL run" : "Animate subject", systemImage: "play.rectangle.fill")
-                        .frame(maxWidth: .infinity)
-                }
-                .buttonStyle(.borderedProminent)
-                .tint(MereRunTheme.accent)
-                .controlSize(.large)
-                .disabled(preparedManifest?.drivingMaskPath == nil)
+                .frame(width: 20, height: 20)
+                Text(candidate.title)
+                    .font(.system(size: 13, weight: status == .active ? .semibold : .medium))
+                    .foregroundStyle(status == .todo ? MereRunTheme.textMuted : MereRunTheme.textPrimary)
+                Spacer(minLength: 0)
             }
-            .padding(18)
+            .padding(.horizontal, 10)
+            .frame(height: 34)
+            .background {
+                RoundedRectangle(cornerRadius: 9)
+                    .fill(status == .active ? MereRunTheme.accentSoft : Color.clear)
+            }
+            .contentShape(RoundedRectangle(cornerRadius: 9))
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("\(candidate.title) stage")
+        .accessibilityValue(stageAccessibilityValue(status))
+        .accessibilityAddTraits(status == .active ? .isSelected : [])
+    }
+
+    private func stageCircleFill(_ status: StudioSubjectsStageStatus) -> Color {
+        switch status {
+        case .done: MereRunTheme.green
+        case .active: MereRunTheme.accent
+        case .todo: MereRunTheme.surfaceRaised
         }
     }
 
-    private var subjectEditor: some View {
-        VStack(alignment: .leading, spacing: 9) {
-            HStack {
-                Text("Subjects")
-                    .font(MereRunTheme.sectionFont)
-                Spacer()
-                Button {
-                    guard subjects.count < 6 else { return }
-                    let index = subjects.count
-                    subjects.append(
-                        StudioSCAILSubject(
-                            name: "subject-\(index + 1)",
-                            color: palette[index],
-                            referencePrompt: "person",
-                            drivingPrompt: "person"
-                        )
-                    )
-                } label: {
-                    Label("Add", systemImage: "plus")
-                }
-                .buttonStyle(.bordered)
-                .disabled(subjects.count >= 6)
-            }
-
-            ForEach($subjects) { $subject in
-                VStack(alignment: .leading, spacing: 8) {
-                    HStack {
-                        Circle()
-                            .fill(subjectColor(subject.color))
-                            .frame(width: 10, height: 10)
-                        TextField("Subject id", text: $subject.name)
-                            .textFieldStyle(.plain)
-                            .font(.system(size: 12, weight: .semibold))
-                        Spacer()
-                        if subjects.count > 1 {
-                            Button(role: .destructive) {
-                                subjects.removeAll { $0.id == subject.id }
-                                normalizeSubjectColors()
-                            } label: {
-                                Image(systemName: "trash")
-                            }
-                            .buttonStyle(.plain)
-                        }
-                    }
-                    HStack(spacing: 7) {
-                        TextField("Reference image", text: $subject.referenceImage)
-                            .mereField()
-                        Button("Choose…") {
-                            subject.referenceImage = StudioSpecialistFiles.chooseFile(
-                                title: "Reference for \(subject.name)",
-                                allowedContentTypes: [.image]
-                            ).first?.path ?? subject.referenceImage
-                        }
-                        .buttonStyle(.bordered)
-                    }
-                    HStack {
-                        TextField("Reference selector, e.g. woman in red", text: $subject.referencePrompt)
-                            .mereField()
-                        TextField("Driving selector, e.g. dancer", text: $subject.drivingPrompt)
-                            .mereField()
-                    }
-                    DisclosureGroup("Precise selectors") {
-                        VStack(alignment: .leading, spacing: 7) {
-                            Text("Optional box: x1,y1,x2,y2 · points: x,y; x,y")
-                                .font(MereRunTheme.captionFont)
-                                .foregroundStyle(MereRunTheme.textMuted)
-                            TextField("Reference box", text: $subject.referenceBox)
-                                .mereField()
-                            TextField("Driving box", text: $subject.drivingBox)
-                                .mereField()
-                            TextField("Reference positive points", text: $subject.referencePositivePoints)
-                                .mereField()
-                            TextField("Reference negative points", text: $subject.referenceNegativePoints)
-                                .mereField()
-                            TextField("Driving positive points", text: $subject.drivingPositivePoints)
-                                .mereField()
-                            TextField("Driving negative points", text: $subject.drivingNegativePoints)
-                                .mereField()
-                        }
-                        .padding(.top, 7)
-                    }
-                }
-                .padding(10)
-                .background(MereRunTheme.surface)
-                .clipShape(RoundedRectangle(cornerRadius: MereRunTheme.Radius.base))
-            }
+    private func stageAccessibilityValue(_ status: StudioSubjectsStageStatus) -> String {
+        switch status {
+        case .done: "done"
+        case .active: "current"
+        case .todo: "not started"
         }
     }
 
-    private var correctionEditor: some View {
-        DisclosureGroup("Keyframe corrections") {
-            VStack(alignment: .leading, spacing: 9) {
-                Text("Refine tracked masks at a frame with a box, positive/negative points, or a painted binary PNG.")
-                    .font(MereRunTheme.captionFont)
-                    .foregroundStyle(MereRunTheme.textMuted)
-                ForEach($corrections) { $correction in
-                    VStack(alignment: .leading, spacing: 7) {
-                        HStack {
-                            Picker("Subject", selection: $correction.subjectID) {
-                                ForEach(subjects) { subject in
-                                    Text(subject.name).tag(subject.name)
-                                }
-                            }
-                            Stepper(
-                                "Frame \(correction.frameIndex)",
-                                value: $correction.frameIndex,
-                                in: 0...100_000
-                            )
-                            Button(role: .destructive) {
-                                corrections.removeAll { $0.id == correction.id }
-                            } label: {
-                                Image(systemName: "trash")
-                            }
-                            .buttonStyle(.plain)
-                        }
-                        TextField("Box x1,y1,x2,y2", text: $correction.box)
-                            .mereField()
-                        TextField("Positive points x,y; x,y", text: $correction.positivePoints)
-                            .mereField()
-                        TextField("Negative points x,y; x,y", text: $correction.negativePoints)
-                            .mereField()
-                        HStack {
-                            TextField("Painted binary correction PNG", text: $correction.paintedMaskPath)
-                                .mereField()
-                            Button("Choose…") {
-                                correction.paintedMaskPath = StudioSpecialistFiles.chooseFile(
-                                    title: "Painted binary correction",
-                                    allowedContentTypes: [.png]
-                                ).first?.path ?? correction.paintedMaskPath
-                            }
-                            .buttonStyle(.bordered)
-                        }
-                    }
-                    .padding(9)
-                    .background(MereRunTheme.surface)
-                    .clipShape(RoundedRectangle(cornerRadius: MereRunTheme.Radius.base))
-                }
-                Button {
-                    if let first = subjects.first {
-                        corrections.append(StudioSCAILCorrection(subjectID: first.name))
-                    }
-                } label: {
-                    Label("Add correction", systemImage: "plus")
-                }
-                .buttonStyle(.bordered)
-            }
-            .padding(.top, 9)
-        }
-    }
+    // MARK: - Stage content
 
-    private var outputColumn: some View {
-        VStack(alignment: .leading, spacing: 13) {
-            conditioningReview
-                .frame(height: 210)
-            Divider().overlay(MereRunTheme.border.opacity(0.5))
-            Text(requestID == nil ? "Mask preparation & result" : "Animated result")
-                .font(MereRunTheme.sectionFont)
-            StudioSpecialistResultView(
-                requestID: requestID ?? maskRequestID,
-                preferredKinds: requestID == nil
-                    ? [.image, .video, .text]
-                    : [.video, .image, .text]
-            )
+    private var stageContent: some View {
+        GeometryReader { geometry in
+            ScrollView {
+                VStack(alignment: .leading, spacing: 14) {
+                    if let notice {
+                        MereBanner(severity: notice.severity, text: notice.text) {
+                            self.notice = nil
+                        }
+                    }
+                    stageHeader
+                    switch stage {
+                    case .plan: planBoard
+                    case .track: trackBoard(wide: Self.isWide(columnWidth: geometry.size.width))
+                    case .animate: animateBoard(wide: Self.isWide(columnWidth: geometry.size.width))
+                    }
+                }
+                .padding(EdgeInsets(top: 22, leading: 24, bottom: 16, trailing: 24))
+                .frame(minHeight: geometry.size.height, alignment: .top)
+            }
         }
-        .padding(18)
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
-    private var conditioningReview: some View {
-        HStack(spacing: 10) {
-            conditioningTile(
-                title: "Reference",
-                url: preparedReferenceURL ?? pathURL(subjects.first?.referenceImage)
-            )
-            conditioningTile(
-                title: preparedManifest == nil ? "Driving" : "Tracked driving",
-                url: preparedOverlayURL ?? pathURL(drivingVideo)
-            )
-            conditioningTile(
-                title: resultVideoURL == nil ? "Mask contact sheet" : "Result",
-                url: resultVideoURL ?? preparedContactSheetURL
-            )
+    private var stageHeader: some View {
+        let copy = StudioSubjectsStageCopy.copy(for: stage, progress: progress)
+        return HStack(alignment: .center, spacing: 12) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(copy.title)
+                    .font(.system(size: 17, weight: .semibold, design: .serif))
+                    .foregroundStyle(MereRunTheme.textPrimary)
+                Text(copy.description)
+                    .font(.system(size: 12.5))
+                    .foregroundStyle(MereRunTheme.textSecondary)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .accessibilityElement(children: .combine)
+            .accessibilityAddTraits(.isHeader)
+            if let secondary = copy.secondary {
+                ProjectSecondaryButton(secondary.label) { perform(secondary.action) }
+                    .disabled(!secondary.isEnabled)
+            }
+            ProjectPrimaryButton(copy.primary.label) { perform(copy.primary.action) }
+                .disabled(!copy.primary.isEnabled)
         }
     }
 
-    private func conditioningTile(title: String, url: URL?) -> some View {
-        VStack(alignment: .leading, spacing: 5) {
-            Text(title)
-                .font(MereRunTheme.captionFont)
-                .foregroundStyle(MereRunTheme.textMuted)
-            Group {
-                if let url {
-                    switch StudioOutputFileKind.classify(url) {
-                    case .image:
-                        StudioAsyncImagePreview(
-                            url: url,
-                            maxPixelSize: 900,
-                            contentMode: .fit,
-                            fallbackSystemImage: "photo"
-                        )
-                    case .video:
-                        StudioVideoPlayerView(url: url)
-                    default:
-                        Image(systemName: "doc")
-                            .frame(maxWidth: .infinity, maxHeight: .infinity)
+    private func perform(_ action: StudioSubjectsStageCopy.Action) {
+        switch action {
+        case .previewMasks: prepareMasks(previewOnly: true)
+        case .trackMasks: prepareMasks(previewOnly: false)
+        case .validateRun: animate(preflight: true)
+        case .animate: animate(preflight: false)
+        case .continueTo(let next): selectedStage = next
+        }
+    }
+
+    // MARK: Plan board
+
+    private var planBoard: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            drivingClipPanel
+            subjectsPanel
+            moreRow("More · mask preparation", isExpanded: $showsPlanMore) {
+                maskPreparationControls
+            }
+        }
+    }
+
+    private var drivingClipPanel: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Text("Driving clip")
+                    .font(.system(size: 12.5, weight: .semibold))
+                Spacer()
+                ProjectSegmented(
+                    items: [("animation", "Animate reference"), ("replacement", "Replace in scene")],
+                    selection: $mode,
+                    accessibilityLabel: "Mode"
+                )
+            }
+            Text(
+                mode == "animation"
+                    ? "Keeps the reference background; the driving clip supplies motion."
+                    : "Keeps the driving scene; references replace the masked subjects."
+            )
+            .font(.system(size: 11, weight: .medium))
+            .foregroundStyle(MereRunTheme.textMuted)
+            HStack(spacing: 8) {
+                TextField("/path/to/driving.mp4", text: $drivingVideo)
+                    .mereField()
+                    .accessibilityLabel("Driving video")
+                ProjectSecondaryButton("Choose…") {
+                    if let url = StudioSpecialistFiles.chooseFile(
+                        title: "Driving video",
+                        allowedContentTypes: [.movie]
+                    ).first {
+                        drivingVideo = url.path
                     }
-                } else {
-                    Image(systemName: "photo.badge.plus")
-                        .foregroundStyle(MereRunTheme.textMuted)
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
                 }
             }
-            .background(MereRunTheme.surface)
-            .clipShape(RoundedRectangle(cornerRadius: MereRunTheme.Radius.base))
         }
+        .padding(12)
+        .projectPanel()
+    }
+
+    private var maskPreparationControls: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                Stepper("Width \(width)", value: $width, in: 256...1_536, step: 32)
+                Stepper("Height \(height)", value: $height, in: 256...1_536, step: 32)
+                Stepper("FPS \(fps)", value: $fps, in: 1...60)
+            }
+            Toggle("Trim driving clip", isOn: $useTrimRange)
+            if useTrimRange {
+                valueSlider("In point", value: $inSeconds, range: 0...3_600)
+                valueSlider("Out point", value: $outSeconds, range: 0.1...3_600)
+            }
+            valueSlider("SAM threshold", value: $maskThreshold, range: 0.001...0.5)
+            HStack {
+                Stepper("SAM resolution \(maskResolution)", value: $maskResolution, in: 256...2_016, step: 16)
+                Stepper("Seed search frames \(seedSearchFrames)", value: $seedSearchFrames, in: 1...240)
+            }
+            labeledField("Mask model", text: $maskModel, placeholder: "vision-segment-sam31")
+        }
+    }
+
+    // MARK: Track board
+
+    private func trackBoard(wide: Bool) -> some View {
+        VStack(alignment: .leading, spacing: 14) {
+            boardRow(
+                preview: SubjectsPreview(
+                    masksURL: overlayURL,
+                    beforeURL: beforeURL,
+                    frameCount: frameCount ?? 0,
+                    fps: manifestFPS,
+                    stillFrame: preparedManifest?.previewFrame,
+                    showsMasks: $showsMasks,
+                    emptyText: progress.planReady
+                        ? "Preview a frame or track the clip to see masks here."
+                        : "Finish the plan to preview masks."
+                ),
+                side: subjectsPanel,
+                wide: wide
+            )
+            statsRow
+            moreRow("More · corrections & preview frame", isExpanded: $showsTrackMore) {
+                trackControls
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var statsRow: some View {
+        let panels = stats.panels
+        if !panels.isEmpty {
+            HStack(spacing: 10) {
+                ForEach(panels, id: \.label) { panel in
+                    VStack(alignment: .leading, spacing: 2) {
+                        Text(panel.label)
+                            .font(.system(size: 11, weight: .medium))
+                            .foregroundStyle(MereRunTheme.textMuted)
+                        Text(panel.value)
+                            .font(.system(size: 15, weight: .semibold))
+                            .foregroundStyle(MereRunTheme.textPrimary)
+                    }
+                    .padding(EdgeInsets(top: 10, leading: 12, bottom: 10, trailing: 12))
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .projectPanel(cornerRadius: 8)
+                    .accessibilityElement(children: .combine)
+                }
+            }
+        }
+    }
+
+    private var trackControls: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Stepper("Preview frame \(previewFrame)", value: $previewFrame, in: 0...100_000)
+            Text("Keyframe corrections refine tracked masks at a frame with a box, positive/negative points, or a painted binary PNG. Re-track to apply them.")
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(MereRunTheme.textMuted)
+            ForEach($corrections) { $correction in
+                correctionEditor($correction)
+            }
+            ProjectSecondaryButton("Add correction") {
+                if let first = subjects.first {
+                    corrections.append(StudioSCAILCorrection(subjectID: first.name))
+                }
+            }
+        }
+    }
+
+    private func correctionEditor(_ correction: Binding<StudioSCAILCorrection>) -> some View {
+        VStack(alignment: .leading, spacing: 7) {
+            HStack {
+                Picker("Subject", selection: correction.subjectID) {
+                    ForEach(subjects) { subject in
+                        Text(subject.name).tag(subject.name)
+                    }
+                }
+                .fixedSize()
+                Stepper("Frame \(correction.wrappedValue.frameIndex)", value: correction.frameIndex, in: 0...100_000)
+                Spacer()
+                Button(role: .destructive) {
+                    corrections.removeAll { $0.id == correction.wrappedValue.id }
+                } label: {
+                    Image(systemName: "trash")
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Remove correction")
+            }
+            TextField("Box x1,y1,x2,y2", text: correction.box)
+                .mereField()
+            HStack(spacing: 8) {
+                TextField("Positive points x,y; x,y", text: correction.positivePoints)
+                    .mereField()
+                TextField("Negative points x,y; x,y", text: correction.negativePoints)
+                    .mereField()
+            }
+            HStack(spacing: 8) {
+                TextField("Painted binary correction PNG", text: correction.paintedMaskPath)
+                    .mereField()
+                ProjectSecondaryButton("Choose…") {
+                    if let url = StudioSpecialistFiles.chooseFile(
+                        title: "Painted binary correction",
+                        allowedContentTypes: [.png]
+                    ).first {
+                        correction.wrappedValue.paintedMaskPath = url.path
+                    }
+                }
+            }
+        }
+        .padding(10)
+        .projectPanel(cornerRadius: 9)
+    }
+
+    // MARK: Animate board
+
+    private func animateBoard(wide: Bool) -> some View {
+        VStack(alignment: .leading, spacing: 14) {
+            boardRow(
+                preview: SubjectsPreview(
+                    masksURL: resultVideoURL ?? overlayURL,
+                    beforeURL: beforeURL,
+                    frameCount: frameCount ?? 0,
+                    fps: manifestFPS,
+                    stillFrame: resultVideoURL == nil ? preparedManifest?.previewFrame : nil,
+                    showsMasks: $showsMasks,
+                    emptyText: "The finished shot appears here.",
+                    masksLabel: resultVideoURL == nil ? "Masks" : "Result"
+                ),
+                side: directionPanel,
+                wide: wide
+            )
+            if let text = animateItem?.outputText, !text.isBlank, resultVideoURL == nil {
+                runOutputPanel(text)
+            }
+            moreRow("More · continuity, model & output", isExpanded: $showsAnimateMore) {
+                animateControls
+            }
+        }
+    }
+
+    private var directionPanel: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Direction")
+                .font(.system(size: 12.5, weight: .semibold))
+            TextField("Describe the finished shot", text: $prompt, axis: .vertical)
+                .lineLimit(2...5)
+                .mereField()
+                .accessibilityLabel("Prompt")
+            labeledField("Negative prompt", text: $negativePrompt, placeholder: "Optional")
+            HStack {
+                Text("Profile")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(MereRunTheme.textSecondary)
+                Spacer()
+                ProjectSegmented(
+                    items: [("fast", "Fast · 4-step"), ("quality", "Quality")],
+                    selection: $profile,
+                    accessibilityLabel: "Render profile"
+                )
+            }
+            if profile == "quality" {
+                Stepper("Steps \(steps)", value: $steps, in: 1...100)
+                valueSlider("Guidance", value: $guidance, range: 0...15)
+                valueSlider("Schedule shift", value: $shift, range: 0...10)
+                Picker("Sampler", selection: $sampler) {
+                    Text("UniPC").tag("unipc")
+                    Text("Euler").tag("euler")
+                }
+            }
+        }
+        .padding(12)
+        .projectPanel()
+    }
+
+    private func runOutputPanel(_ text: String) -> some View {
+        VStack(alignment: .leading, spacing: 0) {
+            Text("Run output")
+                .font(.system(size: 12, weight: .semibold))
+                .padding(EdgeInsets(top: 10, leading: 14, bottom: 10, trailing: 14))
+            ProjectHairline()
+            ScrollView {
+                Text(text)
+                    .font(.system(size: 11.5, design: .monospaced))
+                    .foregroundStyle(MereRunTheme.textSecondary)
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(EdgeInsets(top: 10, leading: 14, bottom: 10, trailing: 14))
+            }
+            .frame(maxHeight: 160)
+        }
+        .projectPanel()
+    }
+
+    private var animateControls: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack {
+                labeledField("Seed", text: $seedValue, placeholder: "42")
+                    .frame(maxWidth: 160)
+                Stepper("Segment length \(segmentLength)", value: $segmentLength, in: 9...401, step: 8)
+                Stepper("Overlap \(segmentOverlap)", value: $segmentOverlap, in: 1...77, step: 4)
+            }
+            HStack {
+                Picker("Tail", selection: $tailPolicy) {
+                    Text("Drop partial tail").tag("drop")
+                    Text("Pad and trim").tag("pad-trim")
+                }
+                .fixedSize()
+                Toggle("Carry driving audio", isOn: $carryDrivingAudio)
+            }
+            labeledField("Model", text: $model, placeholder: "video-scail2-14b-mlx")
+            StudioPathField(
+                label: "Model root override",
+                placeholder: "Managed model",
+                path: $modelRoot,
+                picksDirectory: true
+            )
+            StudioPathField(
+                label: "Distilled adapter override",
+                placeholder: "Fast profile uses the managed adapter automatically",
+                path: $adapterPath
+            )
+            if !adapterPath.isBlank {
+                valueSlider("Adapter strength", value: $adapterStrength, range: 0...2)
+            }
+            VStack(alignment: .leading, spacing: 5) {
+                Text("Output video")
+                    .font(MereRunTheme.captionFont)
+                    .foregroundStyle(MereRunTheme.textMuted)
+                HStack(spacing: 8) {
+                    TextField("/path/to/output.mp4", text: $outputPath)
+                        .mereField()
+                    ProjectSecondaryButton("Choose…") {
+                        if let url = StudioSpecialistFiles.saveFile(
+                            title: "Save SCAIL video",
+                            suggestedName: "scail.mp4",
+                            allowedContentTypes: [.mpeg4Movie]
+                        ) {
+                            outputPath = url.path
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // MARK: - Subjects panel
+
+    private var subjectsPanel: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("Subjects")
+                    .font(.system(size: 12.5, weight: .semibold))
+                Spacer()
+                Button(action: addSubject) {
+                    Text("+ Add")
+                        .font(.system(size: 11.5, weight: .medium))
+                        .foregroundStyle(subjects.count < 6 ? MereRunTheme.accent : MereRunTheme.textMuted)
+                }
+                .buttonStyle(.plain)
+                .disabled(subjects.count >= 6)
+                .accessibilityLabel("Add subject")
+            }
+            .padding(EdgeInsets(top: 0, leading: 2, bottom: 4, trailing: 2))
+            ForEach($subjects) { $subject in
+                subjectRow($subject)
+            }
+        }
+        .padding(12)
+        .projectPanel()
+    }
+
+    private func subjectRow(_ subject: Binding<StudioSCAILSubject>) -> some View {
+        let value = subject.wrappedValue
+        let tracked = trackingReport?.subjects.first { $0.id == value.name }
+        let trackedFrames = tracked.map { (visible: $0.visibleFrameCount, total: trackingReport?.frameCount ?? 0) }
+        let correctionFrames = corrections.filter { $0.subjectID == value.name }.map(\.frameIndex)
+        return HStack(spacing: 10) {
+            subjectSwatch(value)
+            VStack(alignment: .leading, spacing: 2) {
+                Text(value.name)
+                    .font(.system(size: 12.5, weight: .medium))
+                    .foregroundStyle(MereRunTheme.textPrimary)
+                    .lineLimit(1)
+                Text(StudioSubjectsRowCopy.meta(
+                    subject: value, trackedFrames: trackedFrames, correctionFrames: correctionFrames
+                ))
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(MereRunTheme.textMuted)
+                .lineLimit(2)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            ProjectIconButton(systemImage: "ellipsis", label: "Edit \(value.name)") {
+                editingSubjectID = value.id
+            }
+            .popover(
+                isPresented: Binding(
+                    get: { editingSubjectID == value.id },
+                    set: { if !$0 { editingSubjectID = nil } }
+                ),
+                arrowEdge: .trailing
+            ) {
+                subjectEditor(subject)
+            }
+        }
+        .padding(EdgeInsets(top: 8, leading: 10, bottom: 8, trailing: 10))
+        .background {
+            RoundedRectangle(cornerRadius: 9)
+                .fill(MereRunTheme.surface)
+                .overlay {
+                    RoundedRectangle(cornerRadius: 9)
+                        .strokeBorder(MereRunTheme.border.opacity(0.4), lineWidth: 1)
+                }
+        }
+    }
+
+    @ViewBuilder
+    private func subjectSwatch(_ subject: StudioSCAILSubject) -> some View {
+        let referenceURL = preparedManifest?.subjects
+            .first { $0.id == subject.name }
+            .map { resolve($0.preparedReferenceImagePath) }
+            ?? pathURL(subject.referenceImage)
+        ZStack {
+            RoundedRectangle(cornerRadius: 6)
+                .fill(StudioSubjectsPalette.color(named: subject.color).opacity(0.55))
+            if let referenceURL, FileManager.default.fileExists(atPath: referenceURL.path) {
+                StudioAsyncImagePreview(
+                    url: referenceURL,
+                    maxPixelSize: 144,
+                    contentMode: .fill,
+                    fallbackSystemImage: "photo"
+                )
+                .clipShape(RoundedRectangle(cornerRadius: 6))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(StudioSubjectsPalette.color(named: subject.color).opacity(0.35))
+                }
+            }
+        }
+        .frame(width: 36, height: 36)
+        .accessibilityHidden(true)
+    }
+
+    private func subjectEditor(_ subject: Binding<StudioSCAILSubject>) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 8) {
+                Circle()
+                    .fill(StudioSubjectsPalette.color(named: subject.wrappedValue.color).opacity(0.75))
+                    .frame(width: 10, height: 10)
+                TextField("Subject id", text: subject.name)
+                    .mereField()
+                    .accessibilityLabel("Subject id")
+                if subjects.count > 1 {
+                    Button(role: .destructive) {
+                        editingSubjectID = nil
+                        subjects.removeAll { $0.id == subject.wrappedValue.id }
+                        normalizeSubjectColors()
+                    } label: {
+                        Image(systemName: "trash")
+                    }
+                    .buttonStyle(.plain)
+                    .accessibilityLabel("Remove subject")
+                }
+            }
+            StudioPathField(
+                label: "Reference image",
+                placeholder: "/path/to/reference.png",
+                path: subject.referenceImage,
+                allowedContentTypes: [.image]
+            )
+            labeledField("Reference selector", text: subject.referencePrompt, placeholder: "woman in red")
+            labeledField("Driving selector", text: subject.drivingPrompt, placeholder: "dancer")
+            DisclosureGroup("Precise selectors") {
+                VStack(alignment: .leading, spacing: 7) {
+                    Text("Optional box: x1,y1,x2,y2 · points: x,y; x,y")
+                        .font(MereRunTheme.captionFont)
+                        .foregroundStyle(MereRunTheme.textMuted)
+                    TextField("Reference box", text: subject.referenceBox).mereField()
+                    TextField("Driving box", text: subject.drivingBox).mereField()
+                    TextField("Reference positive points", text: subject.referencePositivePoints).mereField()
+                    TextField("Reference negative points", text: subject.referenceNegativePoints).mereField()
+                    TextField("Driving positive points", text: subject.drivingPositivePoints).mereField()
+                    TextField("Driving negative points", text: subject.drivingNegativePoints).mereField()
+                }
+                .padding(.top, 7)
+            }
+        }
+        .padding(14)
+        .frame(width: 380)
+    }
+
+    private func addSubject() {
+        guard subjects.count < 6 else { return }
+        let index = subjects.count
+        subjects.append(
+            StudioSCAILSubject(
+                name: "subject-\(index + 1)",
+                color: StudioSubjectsPalette.names[index],
+                referencePrompt: "person",
+                drivingPrompt: "person"
+            )
+        )
+    }
+
+    // MARK: - Job bar
+
+    private var jobBar: some View {
+        let phase = jobPhase
+        let fraction = activeJobRequestID.flatMap { controller.progressByRequestID[$0]?.fractionCompleted }
+        return HStack(spacing: 12) {
+            Circle()
+                .fill(StudioSubjectsJobBar.dotColor(phase: phase))
+                .frame(width: 8, height: 8)
+            Text("Video · Subjects")
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(MereRunTheme.textPrimary)
+            Text(StudioSubjectsJobBar.detail(
+                phase: phase, subjectCount: subjects.count, frameCount: frameCount, profile: profile
+            ))
+            .font(.system(size: 12, weight: .medium))
+            .foregroundStyle(MereRunTheme.textMuted)
+            .lineLimit(1)
+            if let fraction {
+                ProjectProgressBar(fraction: fraction)
+                    .frame(maxWidth: 260)
+                    .accessibilityLabel("Job progress")
+                    .accessibilityValue("\(Int((fraction * 100).rounded())) percent")
+            }
+            Spacer(minLength: 8)
+            ProjectSecondaryButton("Cancel", action: cancelActiveJob)
+                .disabled(activeJobRequestID == nil)
+            ProjectSecondaryButton("Log") { showsLog.toggle() }
+                .disabled(maskRequestID == nil && animateRequestID == nil)
+                .popover(isPresented: $showsLog, arrowEdge: .top) { logPopover }
+        }
+        .padding(.horizontal, 16)
+        .frame(height: 40)
         .frame(maxWidth: .infinity)
-    }
-
-    private var preparedReferenceURL: URL? {
-        guard let manifest = preparedManifest, let first = manifest.subjects.first else { return nil }
-        return resolve(first.preparedReferenceImagePath)
-    }
-
-    private var preparedOverlayURL: URL? {
-        preparedManifest.map { resolve($0.overlayPreviewPath) }
-    }
-
-    private var preparedContactSheetURL: URL? {
-        preparedManifest.map { resolve($0.contactSheetPath) }
-    }
-
-    private var resultVideoURL: URL? {
-        guard let requestID,
-              let item = library.items.first(where: { $0.id == requestID }) else {
-            return nil
+        .background(MereRunTheme.background)
+        .overlay(alignment: .top) {
+            Rectangle().fill(MereRunTheme.border.opacity(0.53)).frame(height: 1)
         }
-        return item.allArtifactURLs.first {
-            StudioOutputFileKind.classify($0) == .video
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Job bar")
+    }
+
+    private var logRequestID: UUID? {
+        if let activeJobRequestID { return activeJobRequestID }
+        let candidates = [maskItem, animateItem].compactMap { $0 }
+        return candidates.max { $0.updatedAt < $1.updatedAt }?.id
+    }
+
+    private var logPopover: some View {
+        let lines = logRequestID.map { controller.logs(for: $0).map(\.text) } ?? []
+        return VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("Job log")
+                    .font(.system(size: 12, weight: .semibold))
+                Spacer()
+                Button("Copy") {
+                    NSPasteboard.general.clearContents()
+                    NSPasteboard.general.setString(lines.joined(separator: "\n"), forType: .string)
+                }
+                .controlSize(.small)
+                .disabled(lines.isEmpty)
+            }
+            ScrollView {
+                Text(lines.isEmpty ? "No output yet." : lines.joined(separator: "\n"))
+                    .font(.system(size: 11.5, design: .monospaced))
+                    .foregroundStyle(MereRunTheme.textSecondary)
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+        .padding(14)
+        .frame(width: 560, height: 340)
+    }
+
+    private func cancelActiveJob() {
+        guard let activeJobRequestID else { return }
+        controller.cancel(requestID: activeJobRequestID)
+    }
+
+    // MARK: - Shared pieces
+
+    /// The preview beside a 300pt side panel, as the board lays them out; when the column is
+    /// too narrow for both (the default window with the Library open), the panel drops below.
+    @ViewBuilder
+    private func boardRow<Side: View>(preview: SubjectsPreview, side: Side, wide: Bool) -> some View {
+        if wide {
+            HStack(alignment: .top, spacing: 16) {
+                preview
+                side.frame(width: Self.subjectsPanelWidth)
+            }
+            .frame(maxHeight: .infinity, alignment: .top)
+        } else {
+            VStack(alignment: .leading, spacing: 14) {
+                preview
+                side
+            }
+            .frame(maxHeight: .infinity, alignment: .top)
         }
     }
 
-    private func pathURL(_ path: String?) -> URL? {
-        guard let path, !path.isBlank else { return nil }
-        return URL(fileURLWithPath: NSString(string: path).expandingTildeInPath)
-    }
-
-    private func labeledField(
-        _ label: String,
-        text: Binding<String>,
-        placeholder: String
+    private func moreRow<Content: View>(
+        _ title: String,
+        isExpanded: Binding<Bool>,
+        @ViewBuilder content: () -> Content
     ) -> some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Button {
+                isExpanded.wrappedValue.toggle()
+            } label: {
+                HStack(spacing: 4) {
+                    Text(title)
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: 9, weight: .semibold))
+                        .rotationEffect(.degrees(isExpanded.wrappedValue ? 90 : 0))
+                }
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(MereRunTheme.textSecondary)
+                .frame(height: 24)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityAddTraits(isExpanded.wrappedValue ? .isSelected : [])
+            if isExpanded.wrappedValue {
+                content()
+                    .padding(12)
+                    .projectPanel()
+            }
+        }
+    }
+
+    private func labeledField(_ label: String, text: Binding<String>, placeholder: String) -> some View {
         VStack(alignment: .leading, spacing: 5) {
             Text(label)
                 .font(MereRunTheme.captionFont)
                 .foregroundStyle(MereRunTheme.textMuted)
             TextField(placeholder, text: text)
                 .mereField()
+                .accessibilityLabel(label)
         }
     }
 
-    private func valueSlider(
-        _ label: String,
-        value: Binding<Double>,
-        range: ClosedRange<Double>
-    ) -> some View {
+    private func valueSlider(_ label: String, value: Binding<Double>, range: ClosedRange<Double>) -> some View {
         VStack(alignment: .leading, spacing: 4) {
             HStack {
                 Text(label)
@@ -733,15 +1023,42 @@ struct StudioSCAILView: View {
             }
             .font(MereRunTheme.captionFont)
             Slider(value: value, in: range)
+                .accessibilityLabel(label)
         }
     }
 
+    // MARK: - Seed
+
+    private func applySeed() {
+        guard !didSeed, let seed else { return }
+        didSeed = true
+        mode = seed.mode
+        drivingVideo = seed.drivingVideo
+        width = seed.width
+        height = seed.height
+        fps = seed.fps
+        subjects = seed.subjects
+        corrections = seed.corrections
+        planSavedAt = seed.planSavedAt
+        selectedStage = seed.stage
+        if let directory = seed.preparedDirectory {
+            preparedDirectory = directory
+            loadPreparedManifest()
+        }
+        if let requestID = seed.maskRequestID {
+            maskRequestID = requestID
+            maskJob = .track
+        }
+    }
+
+    // MARK: - Jobs
+
     private func prepareMasks(previewOnly: Bool) {
-        errorMessage = nil
+        notice = nil
         guard validateInputs(includeRender: false) else { return }
         guard let planURL = writePlan() else { return }
         guard let template = CommandCatalog.template(id: .videoPrepareMasks) else {
-            errorMessage = "The mask preparation command is unavailable."
+            notice = Notice(severity: .error, text: "The mask preparation command is unavailable.")
             return
         }
         let suffix = previewOnly ? "preview-\(previewFrame)" : "tracked"
@@ -749,16 +1066,13 @@ struct StudioSCAILView: View {
             .appendingPathComponent(suffix, isDirectory: true)
         try? FileManager.default.removeItem(at: directory)
         preparedDirectory = directory
-        if !previewOnly {
-            preparedManifest = nil
-        }
 
         var draft = template.defaultDraft()
         draft.inputPath = planURL.path
         draft.outputPath = directory.path
         draft.previewFrame = previewOnly ? String(previewFrame) : ""
         draft.model = maskModel
-        requestID = nil
+        maskJob = previewOnly ? .preview(frame: previewFrame) : .track
         maskRequestID = StudioSpecialistRunner.submit(
             templateID: .videoPrepareMasks,
             mode: .video,
@@ -766,20 +1080,22 @@ struct StudioSCAILView: View {
             controller: controller,
             library: library
         )
-        statusMessage = previewOnly ? "Preparing a review frame…" : "Tracking masks through the full video…"
+        if selectedStage == .plan {
+            selectedStage = .track
+        }
     }
 
-    private func animate() {
-        errorMessage = nil
-        guard validateInputs(includeRender: true),
+    private func animate(preflight: Bool) {
+        notice = nil
+        guard validateInputs(includeRender: true, preflight: preflight),
               let manifest = preparedManifest,
               let first = manifest.subjects.first,
               let drivingMask = manifest.drivingMaskPath else {
-            errorMessage = "Run full-video mask tracking before animation."
+            notice = Notice(severity: .error, text: "Track the whole clip before animating.")
             return
         }
         guard let template = CommandCatalog.template(id: .videoAnimate) else {
-            errorMessage = "The SCAIL animation command is unavailable."
+            notice = Notice(severity: .error, text: "The SCAIL animation command is unavailable.")
             return
         }
 
@@ -806,7 +1122,7 @@ struct StudioSCAILView: View {
         draft.cfgScale = guidance
         draft.scheduleShift = shift
         draft.sampler = sampler
-        draft.seed = seed
+        draft.seed = seedValue
         draft.segmentLength = segmentLength
         draft.segmentOverlap = segmentOverlap
         draft.tailPolicy = tailPolicy
@@ -817,33 +1133,35 @@ struct StudioSCAILView: View {
         draft.loraScale = adapterStrength
         draft.preflight = preflight
         draft.json = preflight
-        requestID = StudioSpecialistRunner.submit(
+        animateJob = preflight ? .validate : .animate
+        animateRequestID = StudioSpecialistRunner.submit(
             templateID: .videoAnimate,
             mode: .video,
             draft: draft,
             controller: controller,
             library: library
         )
-        statusMessage = preflight
-            ? "Validating the complete SCAIL execution plan…"
-            : profile == "fast"
-            ? "SCAIL is animating with the managed 4-step adapter."
-            : "SCAIL quality render started."
     }
 
-    private func validateInputs(includeRender: Bool) -> Bool {
-        guard !drivingVideo.isBlank else {
-            errorMessage = "Choose a driving video."
+    private func validateInputs(includeRender: Bool, preflight: Bool = false) -> Bool {
+        if let error = planValidationError(includeRender: includeRender, preflight: preflight) {
+            notice = Notice(severity: .error, text: error)
             return false
         }
+        return true
+    }
+
+    /// The first reason the plan (and, with `includeRender`, the render settings) cannot run.
+    private func planValidationError(includeRender: Bool, preflight: Bool = false) -> String? {
+        guard !drivingVideo.isBlank else {
+            return "Choose a driving video."
+        }
         guard !subjects.isEmpty, subjects.count <= 6 else {
-            errorMessage = "SCAIL supports one to six subjects."
-            return false
+            return "SCAIL supports one to six subjects."
         }
         for subject in subjects {
             if subject.name.isBlank || subject.referenceImage.isBlank {
-                errorMessage = "Every subject needs an id and reference image."
-                return false
+                return "Every subject needs an id and reference image."
             }
             if !hasSelector(
                 text: subject.referencePrompt,
@@ -854,55 +1172,45 @@ struct StudioSCAILView: View {
                 box: subject.drivingBox,
                 points: subject.drivingPositivePoints
             ) {
-                errorMessage = "Every subject needs both a reference and driving selector."
-                return false
+                return "Every subject needs both a reference and driving selector."
             }
             let allowed = CharacterSet.alphanumerics.union(CharacterSet(charactersIn: "-_"))
             if subject.name.unicodeScalars.contains(where: { !allowed.contains($0) }) {
-                errorMessage = "Subject ids may contain only letters, numbers, hyphens, and underscores."
-                return false
+                return "Subject ids may contain only letters, numbers, hyphens, and underscores."
             }
         }
         if Set(subjects.map(\.name)).count != subjects.count {
-            errorMessage = "Subject ids must be unique."
-            return false
+            return "Subject ids must be unique."
         }
         if corrections.contains(where: { correction in
             !subjects.contains(where: { $0.name == correction.subjectID })
         }) {
-            errorMessage = "Every keyframe correction must target a current subject."
-            return false
+            return "Every keyframe correction must target a current subject."
         }
         guard width.isMultiple(of: 32), height.isMultiple(of: 32) else {
-            errorMessage = "SCAIL dimensions must be divisible by 32."
-            return false
+            return "SCAIL dimensions must be divisible by 32."
         }
         if useTrimRange && outSeconds <= inSeconds {
-            errorMessage = "The driving-video out point must be after the in point."
-            return false
+            return "The driving-video out point must be after the in point."
         }
         if includeRender {
             guard segmentOverlap < segmentLength else {
-                errorMessage = "Continuity overlap must be shorter than the segment."
-                return false
+                return "Continuity overlap must be shorter than the segment."
             }
             guard segmentLength % 4 == 1, segmentOverlap % 4 == 1 else {
-                errorMessage = "Segment length and overlap must equal 1 modulo 4."
-                return false
+                return "Segment length and overlap must equal 1 modulo 4."
             }
             if outputPath.isBlank {
-                errorMessage = "Choose an output video path."
-                return false
+                return "Choose an output video path."
             }
             if !preflight,
                FileManager.default.fileExists(
                    atPath: NSString(string: outputPath).expandingTildeInPath
                ) {
-                errorMessage = "Choose a new output filename so this result remains immutable in Library."
-                return false
+                return "Choose a new output filename so this result remains immutable in Library."
             }
         }
-        return true
+        return nil
     }
 
     private func writePlan() -> URL? {
@@ -960,9 +1268,10 @@ struct StudioSCAILView: View {
             let encoder = JSONEncoder()
             encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
             try encoder.encode(plan).write(to: url, options: .atomic)
+            planSavedAt = Date()
             return url
         } catch {
-            errorMessage = "Could not write mask plan: \(error.localizedDescription)"
+            notice = Notice(severity: .error, text: "Could not write mask plan: \(error.localizedDescription)")
             return nil
         }
     }
@@ -1015,17 +1324,29 @@ struct StudioSCAILView: View {
         guard let preparedDirectory else { return }
         let url = preparedDirectory.appendingPathComponent("manifest.json")
         do {
-            preparedManifest = try JSONDecoder().decode(
-                StudioSCAILManifest.self,
-                from: Data(contentsOf: url)
-            )
-            if preparedManifest?.drivingMaskPath == nil {
-                statusMessage = "Preview ready. Review the mask, then track the full video."
-            } else {
-                statusMessage = "Masks tracked and ready for animation."
+            let manifest = try JSONDecoder().decode(StudioSCAILManifest.self, from: Data(contentsOf: url))
+            preparedManifest = manifest
+            preparedFingerprint = maskConfigurationFingerprint
+            trackingReport = manifest.trackingPath.flatMap { path in
+                try? JSONDecoder().decode(
+                    StudioSCAILTrackingReport.self,
+                    from: Data(contentsOf: resolve(path))
+                )
+            }
+            qualityReport = manifest.qualityPath.flatMap { path in
+                try? JSONDecoder().decode(
+                    StudioSCAILQualityReport.self,
+                    from: Data(contentsOf: resolve(path))
+                )
+            }
+            if let quality = qualityReport, !quality.blockingErrors.isEmpty {
+                notice = Notice(severity: .warning, text: quality.blockingErrors.joined(separator: " "))
             }
         } catch {
-            errorMessage = "Mask run completed, but manifest could not be read: \(error.localizedDescription)"
+            notice = Notice(
+                severity: .error,
+                text: "Mask run completed, but manifest could not be read: \(error.localizedDescription)"
+            )
         }
     }
 
@@ -1038,21 +1359,516 @@ struct StudioSCAILView: View {
             .appendingPathComponent(expanded)
     }
 
+    private func pathURL(_ path: String?) -> URL? {
+        guard let path, !path.isBlank else { return nil }
+        return URL(fileURLWithPath: NSString(string: path).expandingTildeInPath)
+    }
+
     private func normalizeSubjectColors() {
         for index in subjects.indices {
-            subjects[index].color = palette[index]
+            subjects[index].color = StudioSubjectsPalette.names[index]
+        }
+    }
+}
+
+// MARK: - Preview
+
+/// The 16:9 board: the overlay preview (an image after a frame preview, a video after a full
+/// track) or the driving clip, with a transport that scrubs by frame and switches Masks ↔ Before.
+private struct SubjectsPreview: View {
+    let masksURL: URL?
+    let beforeURL: URL?
+    let frameCount: Int
+    let fps: Double
+    /// The frame a still overlay was rendered at; nil while the overlay is a video.
+    let stillFrame: Int?
+    @Binding var showsMasks: Bool
+    let emptyText: String
+    var masksLabel = "Masks"
+
+    @StateObject private var playback = SubjectsPlayback()
+
+    private var displayedURL: URL? { showsMasks ? masksURL : beforeURL }
+
+    private var displayedKind: StudioOutputFileKind? {
+        guard let displayedURL else { return nil }
+        return StudioOutputFileKind.classify(displayedURL)
+    }
+
+    private var currentFrame: Int {
+        if displayedKind == .image { return stillFrame ?? 0 }
+        return playback.frame
+    }
+
+    private var fraction: Double {
+        guard frameCount > 1 else { return 0 }
+        return min(1, max(0, Double(currentFrame) / Double(frameCount - 1)))
+    }
+
+    var body: some View {
+        ZStack {
+            Color(hex: "101010")
+            content
+            transport
+        }
+        .aspectRatio(16 / 9, contentMode: .fit)
+        .frame(maxWidth: .infinity)
+        .clipShape(RoundedRectangle(cornerRadius: 10))
+        .overlay {
+            RoundedRectangle(cornerRadius: 10)
+                .strokeBorder(MereRunTheme.border, lineWidth: 1)
+        }
+        .onAppear(perform: syncPlayback)
+        .onChange(of: displayedURL) { _, _ in syncPlayback() }
+        .onChange(of: fps) { _, _ in syncPlayback() }
+        .onDisappear { playback.pause() }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(showsMasks ? "Mask preview" : "Driving clip")
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        switch displayedKind {
+        case .image:
+            if let displayedURL {
+                StudioAsyncImagePreview(
+                    url: displayedURL,
+                    maxPixelSize: 1_600,
+                    contentMode: .fit,
+                    fallbackSystemImage: "photo"
+                )
+            }
+        case .video:
+            SubjectsPlayerLayer(player: playback.player)
+        default:
+            Text(emptyText)
+                .font(.system(size: 12.5))
+                .foregroundStyle(Color.white.opacity(0.55))
+                .multilineTextAlignment(.center)
+                .padding(24)
         }
     }
 
-    private func subjectColor(_ name: String) -> Color {
-        switch name {
-        case "blue": .blue
-        case "red": .red
-        case "green": .green
-        case "magenta": .purple
-        case "cyan": .cyan
-        case "yellow": .yellow
-        default: MereRunTheme.textMuted
+    private var transport: some View {
+        let scrubbable = displayedKind == .video && frameCount > 1
+        return VStack {
+            Spacer()
+            HStack(spacing: 10) {
+                Button(action: playback.togglePlaying) {
+                    TransportPlayGlyph(playing: playback.isPlaying)
+                        .stroke(.white, style: StrokeStyle(lineWidth: 1.7, lineCap: .round, lineJoin: .round))
+                        .frame(width: 16, height: 16)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+                .disabled(displayedKind != .video)
+                .opacity(displayedKind == .video ? 1 : 0.4)
+                .accessibilityLabel(playback.isPlaying ? "Pause" : "Play")
+                ProjectScrubber(fraction: fraction, isEnabled: scrubbable) { newFraction in
+                    guard frameCount > 1 else { return }
+                    playback.seek(frame: Int((newFraction * Double(frameCount - 1)).rounded()))
+                }
+                .accessibilityLabel("Frame")
+                .accessibilityValue("\(currentFrame) of \(frameCount)")
+                Text("\(currentFrame) / \(frameCount)")
+                    .font(.system(size: 11.5, weight: .medium, design: .monospaced))
+                    .foregroundStyle(.white)
+                    .lineLimit(1)
+                    .fixedSize()
+                ProjectSegmented(
+                    items: [("masks", masksLabel), ("before", "Before")],
+                    selection: Binding(
+                        get: { showsMasks ? "masks" : "before" },
+                        set: { showsMasks = $0 == "masks" }
+                    ),
+                    accessibilityLabel: "Preview layer"
+                )
+                .fixedSize()
+            }
+            .padding(EdgeInsets(top: 8, leading: 10, bottom: 8, trailing: 10))
+            .background {
+                RoundedRectangle(cornerRadius: 8).fill(Color.black.opacity(0.55))
+            }
+            .padding(EdgeInsets(top: 0, leading: 12, bottom: 10, trailing: 12))
+        }
+    }
+
+    private func syncPlayback() {
+        guard displayedKind == .video, let displayedURL else {
+            playback.pause()
+            return
+        }
+        playback.load(url: displayedURL, fps: fps, frame: stillFrame ?? playback.frame)
+    }
+}
+
+/// One `AVPlayer` for the preview; frames are derived from the player clock at the clip's fps.
+@MainActor
+private final class SubjectsPlayback: ObservableObject {
+    @Published private(set) var frame = 0
+    @Published private(set) var isPlaying = false
+
+    let player = AVPlayer()
+    private var fps = 24.0
+    private var url: URL?
+    private let observers: Observers
+
+    /// Holds the player's observer tokens outside the actor so they are released when the
+    /// playback object goes away, without an isolated deinit.
+    private final class Observers: @unchecked Sendable {
+        let player: AVPlayer
+        var timeObserver: AnyObject?
+        var endObserver: NSObjectProtocol?
+
+        init(player: AVPlayer) {
+            self.player = player
+        }
+
+        func reset() {
+            if let timeObserver {
+                player.removeTimeObserver(timeObserver)
+                self.timeObserver = nil
+            }
+            if let endObserver {
+                NotificationCenter.default.removeObserver(endObserver)
+                self.endObserver = nil
+            }
+        }
+
+        deinit {
+            reset()
+        }
+    }
+
+    init() {
+        player.actionAtItemEnd = .pause
+        player.isMuted = true
+        observers = Observers(player: player)
+    }
+
+    func load(url: URL, fps: Double, frame: Int) {
+        let fps = fps > 0 ? fps : 24
+        guard url != self.url || fps != self.fps else { return }
+        self.url = url
+        self.fps = fps
+        player.pause()
+        isPlaying = false
+        let item = AVPlayerItem(url: url)
+        player.replaceCurrentItem(with: item)
+        installObservers(for: item)
+        seek(frame: frame)
+    }
+
+    func togglePlaying() {
+        guard player.currentItem != nil else { return }
+        if isPlaying {
+            player.pause()
+            isPlaying = false
+        } else {
+            if let duration = player.currentItem?.duration, duration.isNumeric,
+               player.currentTime() >= duration {
+                player.seek(to: .zero)
+            }
+            player.play()
+            isPlaying = true
+        }
+    }
+
+    func pause() {
+        player.pause()
+        isPlaying = false
+    }
+
+    func seek(frame: Int) {
+        let clamped = max(0, frame)
+        self.frame = clamped
+        let time = CMTime(seconds: Double(clamped) / fps, preferredTimescale: 600)
+        player.seek(to: time, toleranceBefore: .zero, toleranceAfter: .zero)
+    }
+
+    private func installObservers(for item: AVPlayerItem) {
+        observers.reset()
+        let interval = CMTime(seconds: 1 / fps, preferredTimescale: 600)
+        observers.timeObserver = player.addPeriodicTimeObserver(forInterval: interval, queue: .main) { [weak self] time in
+            guard time.isNumeric else { return }
+            MainActor.assumeIsolated {
+                guard let self else { return }
+                let frame = Int((time.seconds * self.fps).rounded())
+                if frame != self.frame {
+                    self.frame = frame
+                }
+            }
+        } as AnyObject
+        observers.endObserver = NotificationCenter.default.addObserver(
+            forName: .AVPlayerItemDidPlayToEndTime,
+            object: item,
+            queue: .main
+        ) { [weak self] _ in
+            MainActor.assumeIsolated {
+                self?.isPlaying = false
+            }
+        }
+    }
+}
+
+private struct SubjectsPlayerLayer: NSViewRepresentable {
+    let player: AVPlayer
+
+    func makeNSView(context: Context) -> NSView {
+        let view = NSView()
+        view.wantsLayer = true
+        let layer = AVPlayerLayer(player: player)
+        layer.videoGravity = .resizeAspect
+        view.layer = layer
+        return view
+    }
+
+    func updateNSView(_ view: NSView, context: Context) {
+        (view.layer as? AVPlayerLayer)?.player = player
+    }
+}
+
+/// Stroke-only play triangle / pause bars on the 24-unit icon grid the mockup uses.
+private struct TransportPlayGlyph: Shape {
+    let playing: Bool
+
+    func path(in rect: CGRect) -> Path {
+        let unit = rect.width / 24
+        var path = Path()
+        if playing {
+            path.addRoundedRect(
+                in: CGRect(x: rect.minX + 6 * unit, y: rect.minY + 5 * unit, width: 4 * unit, height: 14 * unit),
+                cornerSize: CGSize(width: unit, height: unit)
+            )
+            path.addRoundedRect(
+                in: CGRect(x: rect.minX + 14 * unit, y: rect.minY + 5 * unit, width: 4 * unit, height: 14 * unit),
+                cornerSize: CGSize(width: unit, height: unit)
+            )
+        } else {
+            path.move(to: CGPoint(x: rect.minX + 7 * unit, y: rect.minY + 5 * unit))
+            path.addLine(to: CGPoint(x: rect.minX + 19 * unit, y: rect.minY + 12 * unit))
+            path.addLine(to: CGPoint(x: rect.minX + 7 * unit, y: rect.minY + 19 * unit))
+            path.closeSubpath()
+        }
+        return path
+    }
+}
+
+/// The transport's 3pt track with an 11pt thumb; drags seek.
+private struct ProjectScrubber: View {
+    let fraction: Double
+    let isEnabled: Bool
+    let onSeek: (Double) -> Void
+
+    var body: some View {
+        GeometryReader { geometry in
+            let width = geometry.size.width
+            ZStack(alignment: .leading) {
+                Capsule().fill(Color.white.opacity(0.3)).frame(height: 3)
+                Capsule().fill(Color.white).frame(width: width * fraction, height: 3)
+                Circle()
+                    .fill(Color.white)
+                    .frame(width: 11, height: 11)
+                    .offset(x: width * fraction - 5.5)
+            }
+            .frame(height: geometry.size.height)
+            .contentShape(Rectangle())
+            .gesture(
+                DragGesture(minimumDistance: 0)
+                    .onChanged { value in
+                        guard isEnabled, width > 0 else { return }
+                        onSeek(min(1, max(0, value.location.x / width)))
+                    }
+            )
+        }
+        .frame(height: 16)
+        .frame(maxWidth: .infinity)
+    }
+}
+
+// MARK: - Board pieces (gen.mjs primitives)
+
+private struct ProjectEyebrow: View {
+    let text: String
+
+    init(_ text: String) {
+        self.text = text
+    }
+
+    var body: some View {
+        Text(text)
+            .font(.system(size: 10.5, weight: .semibold))
+            .kerning(0.63)
+            .textCase(.uppercase)
+            .foregroundStyle(MereRunTheme.textMuted)
+            .lineLimit(1)
+            .accessibilityAddTraits(.isHeader)
+    }
+}
+
+private struct ProjectHairline: View {
+    var body: some View {
+        Rectangle()
+            .fill(MereRunTheme.border.opacity(0.4))
+            .frame(height: 1)
+    }
+}
+
+/// `btnPrimary`: 28pt, accent fill, radius 6, 13pt semibold on `onAccent`.
+private struct ProjectPrimaryButton: View {
+    let label: String
+    let action: () -> Void
+    @Environment(\.isEnabled) private var isEnabled
+
+    init(_ label: String, action: @escaping () -> Void) {
+        self.label = label
+        self.action = action
+    }
+
+    var body: some View {
+        Button(action: action) {
+            Text(label)
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(onAccent)
+                .lineLimit(1)
+                .padding(.horizontal, 14)
+                .frame(height: 28)
+                .background {
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(MereRunTheme.accent.opacity(isEnabled ? 1 : 0.45))
+                }
+                .contentShape(RoundedRectangle(cornerRadius: 6))
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+/// `btnSecondary`: 26pt, raised fill, hairline border, 11.5pt medium.
+private struct ProjectSecondaryButton: View {
+    let label: String
+    let action: () -> Void
+    @Environment(\.isEnabled) private var isEnabled
+
+    init(_ label: String, action: @escaping () -> Void) {
+        self.label = label
+        self.action = action
+    }
+
+    var body: some View {
+        Button(action: action) {
+            Text(label)
+                .font(.system(size: 11.5, weight: .medium))
+                .foregroundStyle(isEnabled ? MereRunTheme.textPrimary : MereRunTheme.textMuted)
+                .lineLimit(1)
+                .padding(.horizontal, 10)
+                .frame(height: 26)
+                .background {
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(MereRunTheme.surfaceRaised)
+                        .overlay {
+                            RoundedRectangle(cornerRadius: 6)
+                                .strokeBorder(MereRunTheme.border.opacity(0.6), lineWidth: 1)
+                        }
+                }
+                .contentShape(RoundedRectangle(cornerRadius: 6))
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+/// `iconBtn`: a 28pt quiet glyph button.
+private struct ProjectIconButton: View {
+    let systemImage: String
+    let label: String
+    let action: () -> Void
+
+    @State private var hovering = false
+
+    var body: some View {
+        Button(action: action) {
+            Image(systemName: systemImage)
+                .font(.system(size: 13, weight: .medium))
+                .foregroundStyle(MereRunTheme.textSecondary)
+                .frame(width: 28, height: 28)
+                .background {
+                    RoundedRectangle(cornerRadius: 6)
+                        .fill(hovering ? MereRunTheme.hoverFill : Color.clear)
+                }
+                .contentShape(RoundedRectangle(cornerRadius: 6))
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering = $0 }
+        .accessibilityLabel(label)
+    }
+}
+
+/// `segmented`: a 2pt-padded raised pill; the selected segment is a raised 24pt tile.
+private struct ProjectSegmented: View {
+    let items: [(tag: String, title: String)]
+    @Binding var selection: String
+    let accessibilityLabel: String
+
+    var body: some View {
+        HStack(spacing: 2) {
+            ForEach(items, id: \.tag) { item in
+                let selected = item.tag == selection
+                Button {
+                    selection = item.tag
+                } label: {
+                    Text(item.title)
+                        .font(.system(size: 12, weight: selected ? .semibold : .medium))
+                        .foregroundStyle(selected ? MereRunTheme.textPrimary : MereRunTheme.textSecondary)
+                        .lineLimit(1)
+                        .padding(.horizontal, 12)
+                        .frame(height: 24)
+                        .background {
+                            RoundedRectangle(cornerRadius: 5.5)
+                                .fill(selected ? segmentedSelection : Color.clear)
+                                .shadow(color: selected ? MereRunTheme.shadowColor : .clear, radius: 1, y: 1)
+                        }
+                        .contentShape(RoundedRectangle(cornerRadius: 5.5))
+                }
+                .buttonStyle(.plain)
+                .accessibilityAddTraits(selected ? .isSelected : [])
+            }
+        }
+        .padding(2)
+        .background {
+            RoundedRectangle(cornerRadius: 7).fill(MereRunTheme.surfaceRaised)
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(accessibilityLabel)
+    }
+}
+
+/// `progress`: a 4pt track in the raised fill with an accent bar.
+private struct ProjectProgressBar: View {
+    let fraction: Double
+
+    var body: some View {
+        GeometryReader { geometry in
+            ZStack(alignment: .leading) {
+                Capsule().fill(MereRunTheme.surfaceRaised)
+                Capsule()
+                    .fill(MereRunTheme.accent)
+                    .frame(width: geometry.size.width * min(1, max(0, fraction)))
+            }
+        }
+        .frame(height: 4)
+        .frame(maxWidth: .infinity)
+    }
+}
+
+private extension View {
+    /// `panel`: surface fill, `border` at 80%, radius 10 by default.
+    func projectPanel(cornerRadius: CGFloat = 10) -> some View {
+        background {
+            RoundedRectangle(cornerRadius: cornerRadius)
+                .fill(MereRunTheme.surface)
+                .overlay {
+                    RoundedRectangle(cornerRadius: cornerRadius)
+                        .strokeBorder(MereRunTheme.border.opacity(0.8), lineWidth: 1)
+                }
         }
     }
 }

--- a/apps/macos/MereRunStudio/StudioSubjectsProject.swift
+++ b/apps/macos/MereRunStudio/StudioSubjectsProject.swift
@@ -1,0 +1,688 @@
+import Foundation
+import SwiftUI
+
+// MARK: - Plan model (what the user authors)
+
+struct StudioSCAILSubject: Identifiable, Equatable {
+    let id = UUID()
+    var name: String
+    var color: String
+    var referenceImage = ""
+    var referencePrompt = ""
+    var drivingPrompt = ""
+    var referenceBox = ""
+    var drivingBox = ""
+    var referencePositivePoints = ""
+    var drivingPositivePoints = ""
+    var referenceNegativePoints = ""
+    var drivingNegativePoints = ""
+}
+
+struct StudioSCAILCorrection: Identifiable, Equatable {
+    let id = UUID()
+    var subjectID: String
+    var frameIndex = 0
+    var box = ""
+    var positivePoints = ""
+    var negativePoints = ""
+    var paintedMaskPath = ""
+}
+
+// MARK: - plan.json (what the CLI reads)
+
+struct StudioSCAILSelectorPlan: Codable {
+    let text: String?
+    let box: StudioSCAILBoxPlan?
+    let positivePoints: [StudioSCAILPointPlan]
+    let negativePoints: [StudioSCAILPointPlan]
+
+    enum CodingKeys: String, CodingKey {
+        case text
+        case box
+        case positivePoints = "positive_points"
+        case negativePoints = "negative_points"
+    }
+}
+
+struct StudioSCAILPointPlan: Codable {
+    let x: Float
+    let y: Float
+}
+
+struct StudioSCAILBoxPlan: Codable {
+    let x1: Float
+    let y1: Float
+    let x2: Float
+    let y2: Float
+}
+
+struct StudioSCAILSubjectPlan: Codable {
+    let id: String
+    let color: String
+    let referenceImage: String
+    let referenceSelector: StudioSCAILSelectorPlan
+    let drivingSelector: StudioSCAILSelectorPlan
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case color
+        case referenceImage = "reference_image"
+        case referenceSelector = "reference_selector"
+        case drivingSelector = "driving_selector"
+    }
+}
+
+struct StudioSCAILMaskPlan: Codable {
+    let schemaVersion = 1
+    let mode: String
+    let drivingVideo: String
+    let inSeconds: Double?
+    let outSeconds: Double?
+    let width: Int
+    let height: Int
+    let fps: Double
+    let subjects: [StudioSCAILSubjectPlan]
+    let corrections: [StudioSCAILCorrectionPlan]
+    let threshold: Float
+    let resolution: Int
+    let seedFrameSearchLimit: Int
+    let paletteTolerance = 192
+
+    enum CodingKeys: String, CodingKey {
+        case schemaVersion = "schema_version"
+        case mode
+        case drivingVideo = "driving_video"
+        case inSeconds = "in_seconds"
+        case outSeconds = "out_seconds"
+        case width
+        case height
+        case fps
+        case subjects
+        case corrections
+        case threshold
+        case resolution
+        case seedFrameSearchLimit = "seed_frame_search_limit"
+        case paletteTolerance = "palette_tolerance"
+    }
+}
+
+struct StudioSCAILCorrectionPlan: Codable {
+    let subjectID: String
+    let frameIndex: Int
+    let box: StudioSCAILBoxPlan?
+    let positivePoints: [StudioSCAILPointPlan]
+    let negativePoints: [StudioSCAILPointPlan]
+    let paintedBinaryCorrectionPNG: String?
+
+    enum CodingKeys: String, CodingKey {
+        case subjectID = "subject_id"
+        case frameIndex = "frame_index"
+        case box
+        case positivePoints = "positive_points"
+        case negativePoints = "negative_points"
+        case paintedBinaryCorrectionPNG = "painted_binary_correction_png"
+    }
+}
+
+enum StudioSCAILPlanError: LocalizedError {
+    case invalidBox(String)
+    case invalidPoints(String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidBox(let label):
+            "\(label) box must be four comma-separated numbers with x2>x1 and y2>y1."
+        case .invalidPoints(let label):
+            "\(label) points must use x,y pairs separated by semicolons."
+        }
+    }
+}
+
+// MARK: - Mask artifacts (what `video prepare-masks` writes)
+
+/// The subset of `SCAIL2MaskManifest` the app reads. Paths are relative to the output directory
+/// unless absolute. `drivingMaskPath` is nil after a preview and set after a full track.
+struct StudioSCAILManifest: Codable, Equatable {
+    struct Subject: Codable, Equatable {
+        let id: String
+        let color: String
+        let preparedReferenceImagePath: String
+        let referenceMaskPath: String
+
+        enum CodingKeys: String, CodingKey {
+            case id
+            case color
+            case preparedReferenceImagePath = "prepared_reference_image_path"
+            case referenceMaskPath = "reference_mask_path"
+        }
+    }
+
+    struct Correction: Codable, Equatable {
+        let subjectID: String
+        let frameIndex: Int
+
+        enum CodingKeys: String, CodingKey {
+            case subjectID = "subject_id"
+            case frameIndex = "frame_index"
+        }
+    }
+
+    let status: String
+    let previewFrame: Int?
+    let drivingSourcePath: String
+    let drivingProxyPath: String?
+    let drivingMaskPath: String?
+    let overlayPreviewPath: String
+    let contactSheetPath: String
+    let trackingPath: String?
+    let qualityPath: String?
+    let frameCount: Int
+    let fps: Double?
+    let subjects: [Subject]
+    let corrections: [Correction]?
+
+    enum CodingKeys: String, CodingKey {
+        case status
+        case previewFrame = "preview_frame"
+        case drivingSourcePath = "driving_source_path"
+        case drivingProxyPath = "driving_proxy_path"
+        case drivingMaskPath = "driving_mask_path"
+        case overlayPreviewPath = "overlay_preview_path"
+        case contactSheetPath = "contact_sheet_path"
+        case trackingPath = "tracking_path"
+        case qualityPath = "quality_path"
+        case frameCount = "frame_count"
+        case fps
+        case subjects
+        case corrections
+    }
+
+    var isTracked: Bool { drivingMaskPath != nil }
+}
+
+/// The subset of `SCAIL2MaskTrackingReport` (`tracking.json`) the app reads: which frames each
+/// subject was visible in.
+struct StudioSCAILTrackingReport: Codable, Equatable {
+    struct Detection: Codable, Equatable {
+        let visible: Bool
+        let score: Float
+    }
+
+    struct Frame: Codable, Equatable {
+        let frameIndex: Int
+        let detections: [Detection]
+
+        enum CodingKeys: String, CodingKey {
+            case frameIndex = "frame_index"
+            case detections
+        }
+    }
+
+    struct Subject: Codable, Equatable {
+        let id: String
+        let frames: [Frame]
+
+        /// Frames in which the subject has at least one visible detection.
+        var visibleFrameCount: Int {
+            frames.filter { frame in frame.detections.contains { $0.visible } }.count
+        }
+    }
+
+    let frameCount: Int
+    let fps: Double
+    let subjects: [Subject]
+
+    enum CodingKeys: String, CodingKey {
+        case frameCount = "frame_count"
+        case fps
+        case subjects
+    }
+}
+
+/// The subset of `SCAIL2MaskQualityReport` (`quality.json`) the app reads.
+struct StudioSCAILQualityReport: Codable, Equatable {
+    struct Warning: Codable, Equatable {
+        let code: String
+        let subjectID: String?
+        let frameIndex: Int?
+        let message: String
+
+        enum CodingKeys: String, CodingKey {
+            case code
+            case subjectID = "subject_id"
+            case frameIndex = "frame_index"
+            case message
+        }
+    }
+
+    let blockingErrors: [String]
+    let warnings: [Warning]
+
+    enum CodingKeys: String, CodingKey {
+        case blockingErrors = "blocking_errors"
+        case warnings
+    }
+
+    /// The CLI flags a frame where a subject's mask changes abruptly between neighbours.
+    static let driftCode = "abrupt_change"
+
+    var driftFrameCount: Int {
+        warnings.filter { $0.code == Self.driftCode }.count
+    }
+}
+
+// MARK: - Stages
+
+enum StudioSubjectsStage: Int, CaseIterable, Identifiable {
+    case plan = 1
+    case track
+    case animate
+
+    var id: Int { rawValue }
+
+    var title: String {
+        switch self {
+        case .plan: "Plan"
+        case .track: "Track"
+        case .animate: "Animate"
+        }
+    }
+
+    var next: StudioSubjectsStage? {
+        StudioSubjectsStage(rawValue: rawValue + 1)
+    }
+}
+
+enum StudioSubjectsStageStatus: Equatable {
+    case done
+    case active
+    case todo
+}
+
+/// What the project has achieved so far, derived from the plan, the mask manifest, and the
+/// Library. Drives the rail, the header copy, and which actions are enabled.
+struct StudioSubjectsProgress: Equatable {
+    /// The plan validates: a driving clip and every subject has a reference and selectors.
+    var planReady = false
+    /// A preview or a full track has produced a manifest.
+    var previewed = false
+    /// A full track has produced a driving mask (`drivingMaskPath`).
+    var tracked = false
+    /// An animation run has produced a video.
+    var animated = false
+    /// The stage whose job is queued or running, if any.
+    var runningStage: StudioSubjectsStage?
+
+    func isDone(_ stage: StudioSubjectsStage) -> Bool {
+        switch stage {
+        case .plan: planReady
+        case .track: tracked
+        case .animate: animated
+        }
+    }
+
+    /// The first stage that is not done; where a returning user should land.
+    var defaultStage: StudioSubjectsStage {
+        StudioSubjectsStage.allCases.first { !isDone($0) } ?? .animate
+    }
+
+    func status(of stage: StudioSubjectsStage, selected: StudioSubjectsStage) -> StudioSubjectsStageStatus {
+        if stage == selected { return .active }
+        return isDone(stage) ? .done : .todo
+    }
+}
+
+/// The header of each stage: serif title, one-line description, and the two actions.
+struct StudioSubjectsStageCopy: Equatable {
+    enum Action: Equatable {
+        case previewMasks
+        case trackMasks
+        case validateRun
+        case animate
+        case continueTo(StudioSubjectsStage)
+    }
+
+    struct Button: Equatable {
+        let label: String
+        let action: Action
+        let isEnabled: Bool
+    }
+
+    let title: String
+    let description: String
+    let secondary: Button?
+    let primary: Button
+
+    static func copy(for stage: StudioSubjectsStage, progress: StudioSubjectsProgress) -> StudioSubjectsStageCopy {
+        let busy = progress.runningStage != nil
+        switch stage {
+        case .plan:
+            return StudioSubjectsStageCopy(
+                title: "Plan the subjects",
+                description: "Choose the driving clip, then give each subject a reference image and a selector.",
+                secondary: Button(label: "Preview masks", action: .previewMasks, isEnabled: progress.planReady && !busy),
+                primary: Button(label: "Continue to Track", action: .continueTo(.track), isEnabled: progress.planReady)
+            )
+        case .track:
+            let tracking = progress.runningStage == .track
+            if progress.tracked {
+                return StudioSubjectsStageCopy(
+                    title: "Track subjects through the clip",
+                    description: "Review masks, add a correction where a mask slips, then continue to Animate.",
+                    secondary: Button(label: tracking ? "Tracking…" : "Re-track", action: .trackMasks, isEnabled: !busy),
+                    // Moving on is always allowed; the Animate stage gates its own action on the job.
+                    primary: Button(label: "Continue to Animate", action: .continueTo(.animate), isEnabled: true)
+                )
+            }
+            return StudioSubjectsStageCopy(
+                title: "Track subjects through the clip",
+                description: progress.previewed
+                    ? "Check the preview frame, then track every subject through the whole clip."
+                    : "Preview one frame to check the selectors, then track the whole clip.",
+                secondary: Button(label: "Preview frame", action: .previewMasks, isEnabled: progress.planReady && !busy),
+                primary: Button(
+                    label: tracking ? "Tracking…" : "Track subjects",
+                    action: .trackMasks,
+                    isEnabled: progress.planReady && !busy
+                )
+            )
+        case .animate:
+            let animating = progress.runningStage == .animate
+            return StudioSubjectsStageCopy(
+                title: "Animate the reference",
+                description: progress.tracked
+                    ? "Direct the finished shot, pick a profile, and render with the tracked masks."
+                    : "Track the clip first; animation renders from the tracked masks.",
+                secondary: Button(label: "Validate run", action: .validateRun, isEnabled: progress.tracked && !busy),
+                primary: Button(
+                    label: animating ? "Animating…" : "Animate",
+                    action: .animate,
+                    isEnabled: progress.tracked && !busy
+                )
+            )
+        }
+    }
+}
+
+// MARK: - Subject rows
+
+/// The 11pt meta line under a subject's name. The lead segment says how the subject is picked
+/// in the driving clip (a box, a point, or by its reference), and the trailing segment is what
+/// tracking found: corrections when there are any, otherwise the visible-frame count.
+enum StudioSubjectsRowCopy {
+    static func meta(
+        subject: StudioSCAILSubject,
+        trackedFrames: (visible: Int, total: Int)?,
+        correctionFrames: [Int]
+    ) -> String {
+        var segments = [lead(for: subject)]
+        if !correctionFrames.isEmpty {
+            let frames = correctionFrames.sorted().map(String.init).joined(separator: ", ")
+            segments.append("\(correctionFrames.count) correction\(correctionFrames.count == 1 ? "" : "s") at \(frames)")
+        } else if let trackedFrames, trackedFrames.total > 0 {
+            segments.append("\(trackedFrames.visible)/\(trackedFrames.total) frames")
+        }
+        return segments.joined(separator: " · ")
+    }
+
+    static func lead(for subject: StudioSCAILSubject) -> String {
+        if !subject.drivingBox.isBlank {
+            return "box"
+        }
+        if let point = firstPoint(in: subject.drivingPositivePoints) {
+            return "point (\(point.x), \(point.y))"
+        }
+        if !subject.referenceImage.isBlank {
+            return "ref: \(URL(fileURLWithPath: subject.referenceImage).lastPathComponent)"
+        }
+        if !subject.drivingPrompt.isBlank {
+            return "“\(subject.drivingPrompt)”"
+        }
+        return "no selector yet"
+    }
+
+    private static func firstPoint(in raw: String) -> (x: Int, y: Int)? {
+        let pair = raw.replacingOccurrences(of: "\n", with: ";").split(separator: ";").first ?? ""
+        let values = pair.split(separator: ",").compactMap {
+            Float($0.trimmingCharacters(in: .whitespacesAndNewlines))
+        }
+        guard values.count == 2 else { return nil }
+        return (Int(values[0].rounded()), Int(values[1].rounded()))
+    }
+}
+
+// MARK: - Stats
+
+/// The four stat panels under the preview. Only values the artifacts actually carry are set;
+/// the view omits a panel whose value is nil.
+struct StudioSubjectsStats: Equatable {
+    var coverage: String?
+    var drift: String?
+    var corrections: String?
+    var frames: String?
+
+    var panels: [(label: String, value: String)] {
+        [
+            ("Coverage", coverage),
+            ("Drift", drift),
+            ("Corrections", corrections),
+            ("Frames", frames),
+        ].compactMap { label, value in value.map { (label, $0) } }
+    }
+
+    static func stats(
+        manifest: StudioSCAILManifest?,
+        tracking: StudioSCAILTrackingReport?,
+        quality: StudioSCAILQualityReport?,
+        correctionCount: Int
+    ) -> StudioSubjectsStats {
+        var stats = StudioSubjectsStats(corrections: String(correctionCount))
+        if let tracking, tracking.frameCount > 0, !tracking.subjects.isEmpty {
+            let possible = tracking.frameCount * tracking.subjects.count
+            let visible = tracking.subjects.reduce(0) { $0 + $1.visibleFrameCount }
+            stats.coverage = formatPercent(Double(visible) / Double(possible))
+        }
+        if let quality, manifest?.isTracked == true {
+            stats.drift = quality.driftFrameCount == 0 ? "low" : "\(quality.driftFrameCount) flagged"
+        }
+        if let manifest, manifest.frameCount > 0 {
+            if let fps = manifest.fps ?? tracking?.fps, fps > 0 {
+                stats.frames = "\(manifest.frameCount) @ \(formatFPS(fps)) fps"
+            } else {
+                stats.frames = String(manifest.frameCount)
+            }
+        }
+        return stats
+    }
+
+    static func formatPercent(_ fraction: Double) -> String {
+        let clamped = min(1, max(0, fraction))
+        let tenths = (clamped * 1_000).rounded() / 10
+        if tenths == tenths.rounded() {
+            return "\(Int(tenths))%"
+        }
+        return String(format: "%.1f%%", tenths)
+    }
+
+    static func formatFPS(_ fps: Double) -> String {
+        if fps == fps.rounded() {
+            return String(Int(fps))
+        }
+        return String(format: "%.2f", fps)
+    }
+}
+
+// MARK: - Project rail
+
+enum StudioSubjectsProjectCopy {
+    /// The driving clip's file name without its extension names the project.
+    static func name(drivingVideo: String) -> String {
+        let trimmed = drivingVideo.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return "Untitled project" }
+        let stem = URL(fileURLWithPath: trimmed).deletingPathExtension().lastPathComponent
+        return stem.isEmpty ? "Untitled project" : stem
+    }
+
+    /// `3 subjects · 240 frames`; the frame count is only known once a preview or track ran.
+    static func summary(subjectCount: Int, frameCount: Int?) -> String {
+        var parts = ["\(subjectCount) subject\(subjectCount == 1 ? "" : "s")"]
+        if let frameCount, frameCount > 0 {
+            parts.append("\(frameCount) frames")
+        }
+        return parts.joined(separator: " · ")
+    }
+
+    /// `Saved 1:26 PM` from the last plan.json write.
+    static func saved(_ date: Date?) -> String {
+        guard let date else { return "Not saved yet" }
+        return "Saved \(timeFormatter.string(from: date))"
+    }
+
+    private static let timeFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.dateFormat = "h:mm a"
+        return formatter
+    }()
+}
+
+// MARK: - Job bar
+
+enum StudioSubjectsJobBar {
+    enum Job: Equatable {
+        case preview(frame: Int)
+        case track
+        case validate
+        case animate
+
+        var stage: StudioSubjectsStage {
+            switch self {
+            case .preview, .track: .track
+            case .validate, .animate: .animate
+            }
+        }
+    }
+
+    enum Phase: Equatable {
+        case idle
+        case queued(Job)
+        case running(Job)
+        case ended(Job, exitCode: Int32?)
+    }
+
+    static func detail(
+        phase: Phase,
+        subjectCount: Int,
+        frameCount: Int?,
+        profile: String
+    ) -> String {
+        let subjects = "\(subjectCount) subject\(subjectCount == 1 ? "" : "s")"
+        let frames = frameCount.map { " · \($0) frames" } ?? ""
+        switch phase {
+        case .idle:
+            return "No job running"
+        case .queued(let job):
+            return "\(verb(for: job)) queued behind the active job"
+        case .running(let job):
+            switch job {
+            case .preview(let frame):
+                return "Previewing frame \(frame) · \(subjects)"
+            case .track:
+                return "Tracking \(subjects)\(frames)"
+            case .validate:
+                return "Validating the SCAIL-2 run · \(profileName(profile))"
+            case .animate:
+                return "Animating with SCAIL-2 · \(profileName(profile))"
+            }
+        case .ended(let job, let exitCode):
+            if let exitCode, exitCode != 0 {
+                return "\(verb(for: job)) failed · exit \(exitCode)"
+            }
+            switch job {
+            case .preview(let frame):
+                return "Frame \(frame) previewed · \(subjects)"
+            case .track:
+                return "Masks tracked · \(subjects)\(frames)"
+            case .validate:
+                return "Run validated · \(profileName(profile))"
+            case .animate:
+                return "Animation finished · \(profileName(profile))"
+            }
+        }
+    }
+
+    static func dotColor(phase: Phase) -> Color {
+        switch phase {
+        case .idle: MereRunTheme.textMuted
+        case .queued: MereRunTheme.yellow
+        case .running: MereRunTheme.accent
+        case .ended(_, let exitCode):
+            exitCode == 0 || exitCode == nil ? MereRunTheme.green : MereRunTheme.red
+        }
+    }
+
+    private static func verb(for job: Job) -> String {
+        switch job {
+        case .preview: "Preview"
+        case .track: "Tracking"
+        case .validate: "Validation"
+        case .animate: "Animation"
+        }
+    }
+
+    private static func profileName(_ profile: String) -> String {
+        profile == "quality" ? "quality profile" : "fast profile"
+    }
+}
+
+// MARK: - Palette
+
+enum StudioSubjectsPalette {
+    static let names = ["blue", "red", "green", "magenta", "cyan", "yellow"]
+
+    /// The mask palette the CLI paints with (`SCAIL2SubjectColor.rgba8`), so swatches match the
+    /// overlay tint.
+    static func color(named name: String) -> Color {
+        switch name {
+        case "blue": Color(hex: "0000FF")
+        case "red": Color(hex: "FF0000")
+        case "green": Color(hex: "00FF00")
+        case "magenta": Color(hex: "FF00FF")
+        case "cyan": Color(hex: "00FFFF")
+        case "yellow": Color(hex: "FFFF00")
+        default: MereRunTheme.textMuted
+        }
+    }
+}
+
+// MARK: - Test seam
+
+/// When set in the environment, Video ▸ Subjects opens on this project instead of an empty
+/// plan, so the snapshot harness can render the Track stage from artifacts it wrote itself.
+/// Production never sets it.
+struct StudioSubjectsProjectSeed {
+    var mode = "animation"
+    var drivingVideo: String
+    var width = 832
+    var height = 480
+    var fps = 24
+    var subjects: [StudioSCAILSubject]
+    var corrections: [StudioSCAILCorrection] = []
+    /// A directory holding `manifest.json` (and whatever it references).
+    var preparedDirectory: URL?
+    var planSavedAt: Date?
+    var stage: StudioSubjectsStage = .track
+    /// The Library row of a mask job that is still running.
+    var maskRequestID: UUID?
+}
+
+private struct StudioSubjectsProjectSeedKey: EnvironmentKey {
+    static let defaultValue: StudioSubjectsProjectSeed? = nil
+}
+
+extension EnvironmentValues {
+    var studioSubjectsProjectSeed: StudioSubjectsProjectSeed? {
+        get { self[StudioSubjectsProjectSeedKey.self] }
+        set { self[StudioSubjectsProjectSeedKey.self] = newValue }
+    }
+}

--- a/apps/macos/MereRunStudioTests/StudioSnapshotTests.swift
+++ b/apps/macos/MereRunStudioTests/StudioSnapshotTests.swift
@@ -24,6 +24,8 @@ final class StudioSnapshotTests: XCTestCase {
         width: StudioLayoutPolicy.defaultWindowWidth,
         height: StudioLayoutPolicy.defaultWindowHeight
     )
+    /// The size the v2 mockups are drawn at.
+    static let fidelitySize = CGSize(width: 1_440, height: 900)
     static let consoleSize = CGSize(width: 1_260, height: 780)
     static let settingsSize = CGSize(width: 560, height: 640)
 
@@ -67,6 +69,42 @@ final class StudioSnapshotTests: XCTestCase {
                 )
             }
         }
+    }
+
+    /// Video ▸ Subjects in the Track stage: a three-subject plan whose masks were tracked (the
+    /// manifest, tracking, and quality reports the CLI would have written, with a synthesized
+    /// overlay frame), while a re-track job is held open by the process seam so the job bar
+    /// shows it running. No CLI starts. Rendered at the mockup size, light and dark, plus the
+    /// default window size.
+    func testVideoSubjectsProjectSnapshots() throws {
+        var seed = try fixture.seedTrackedSubjectsProject()
+        let renders: [(name: String, size: CGSize, appearance: StudioSnapshotAppearance, stage: StudioSubjectsStage)] = [
+            ("f8-subjects-light", Self.fidelitySize, .light, .track),
+            ("f8-subjects-dark", Self.fidelitySize, .dark, .track),
+            ("f8-subjects-compact-light", Self.shellSize, .light, .track),
+            ("f8-subjects-plan-light", Self.fidelitySize, .light, .plan),
+            ("f8-subjects-animate-light", Self.fidelitySize, .light, .animate)
+        ]
+        for render in renders {
+            seed.stage = render.stage
+            let navigation = NavigationModel()
+            let view = StudioRootView()
+                .environmentObject(fixture.controller)
+                .environmentObject(fixture.library)
+                .environmentObject(navigation)
+                .environment(\.studioSubjectsProjectSeed, seed)
+                .frame(width: render.size.width, height: render.size.height)
+            try fixture.write(
+                view,
+                size: render.size,
+                appearance: render.appearance,
+                name: render.name,
+                settle: 2.5,
+                afterAppear: { navigation.open(task: .videoSubjects) }
+            )
+        }
+        let maskRow = fixture.library.items.first { $0.id == seed.maskRequestID }
+        XCTAssertEqual(maskRow?.status, .running)
     }
 
     /// The Settings scene content at the width the app gives it.
@@ -306,6 +344,215 @@ private final class SnapshotFixture {
         }
     }
 
+    // MARK: Tracked subjects project
+
+    /// A `skate-clip-01` project with three subjects whose masks were tracked through 240 frames,
+    /// laid out the way `video prepare-masks` leaves an output directory: `manifest.json`,
+    /// `tracking.json`, `quality.json`, prepared reference images, and an overlay frame. The
+    /// re-track job is started through the real controller and Library paths and held open by
+    /// the process seam so the job bar shows it running.
+    func seedTrackedSubjectsProject() throws -> StudioSubjectsProjectSeed {
+        let project = root.appendingPathComponent("skate-clip-01", isDirectory: true)
+        let prepared = project.appendingPathComponent("tracked", isDirectory: true)
+        try FileManager.default.createDirectory(at: prepared, withIntermediateDirectories: true)
+        let drivingVideo = project.appendingPathComponent("skate-clip-01.mp4", isDirectory: false)
+        try Data().write(to: drivingVideo)
+
+        let frameCount = 240
+        let subjects = [
+            StudioSCAILSubject(
+                name: "Skater", color: "blue",
+                referenceImage: project.appendingPathComponent("skater-front.png").path,
+                referencePrompt: "skater", drivingPrompt: "skater"
+            ),
+            StudioSCAILSubject(
+                name: "Board", color: "red",
+                referenceImage: project.appendingPathComponent("board.png").path,
+                referencePrompt: "skateboard", drivingPositivePoints: "612,480"
+            ),
+            StudioSCAILSubject(
+                name: "Backpack", color: "green",
+                referenceImage: project.appendingPathComponent("backpack.png").path,
+                referencePrompt: "backpack", drivingBox: "500,200,600,330"
+            ),
+        ]
+        let corrections = [
+            StudioSCAILCorrection(subjectID: "Backpack", frameIndex: 88, positivePoints: "540,250"),
+            StudioSCAILCorrection(subjectID: "Backpack", frameIndex: 142, box: "505,205,605,335"),
+        ]
+        let swatches: [(name: String, color: NSColor)] = [
+            ("Skater", NSColor(calibratedRed: 0.61, green: 0.48, blue: 0.18, alpha: 1)),
+            ("Board", NSColor(calibratedRed: 0.37, green: 0.48, blue: 0.27, alpha: 1)),
+            ("Backpack", NSColor(calibratedRed: 0.61, green: 0.46, blue: 0.13, alpha: 1)),
+        ]
+        for (subject, swatch) in zip(subjects, swatches) {
+            try Self.writeSwatchPNG(to: URL(fileURLWithPath: subject.referenceImage), color: swatch.color)
+            try Self.writeSwatchPNG(
+                to: prepared.appendingPathComponent("reference-\(subject.name)-prepared.png"),
+                color: swatch.color
+            )
+        }
+        try Self.writeOverlayFramePNG(
+            to: prepared.appendingPathComponent("overlay-frame-88.png"),
+            size: CGSize(width: 832, height: 468)
+        )
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        let manifest = StudioSCAILManifest(
+            status: "ready",
+            previewFrame: 88,
+            drivingSourcePath: drivingVideo.path,
+            drivingProxyPath: "driving-proxy.mp4",
+            drivingMaskPath: "driving-mask.mov",
+            overlayPreviewPath: "overlay-frame-88.png",
+            contactSheetPath: "contact-sheet.png",
+            trackingPath: "tracking.json",
+            qualityPath: "quality.json",
+            frameCount: frameCount,
+            fps: 24,
+            subjects: subjects.map {
+                StudioSCAILManifest.Subject(
+                    id: $0.name,
+                    color: $0.color,
+                    preparedReferenceImagePath: "reference-\($0.name)-prepared.png",
+                    referenceMaskPath: "reference-\($0.name)-mask.png"
+                )
+            },
+            corrections: corrections.map {
+                StudioSCAILManifest.Correction(subjectID: $0.subjectID, frameIndex: $0.frameIndex)
+            }
+        )
+        try encoder.encode(manifest).write(to: prepared.appendingPathComponent("manifest.json"))
+        let tracking = StudioSCAILTrackingReport(
+            frameCount: frameCount,
+            fps: 24,
+            subjects: zip(subjects, [240, 231, 240]).map { subject, visible in
+                StudioSCAILTrackingReport.Subject(
+                    id: subject.name,
+                    frames: (0..<frameCount).map { index in
+                        StudioSCAILTrackingReport.Frame(
+                            frameIndex: index,
+                            detections: [
+                                StudioSCAILTrackingReport.Detection(visible: index < visible, score: 0.92)
+                            ]
+                        )
+                    }
+                )
+            }
+        )
+        try encoder.encode(tracking).write(to: prepared.appendingPathComponent("tracking.json"))
+        let quality = StudioSCAILQualityReport(
+            blockingErrors: [],
+            warnings: [
+                StudioSCAILQualityReport.Warning(
+                    code: "weak_score", subjectID: "Board", frameIndex: 233,
+                    message: "Subject Board has weak mask confidence at frame 233."
+                ),
+            ]
+        )
+        try encoder.encode(quality).write(to: prepared.appendingPathComponent("quality.json"))
+
+        // The re-track the user just asked for: a real Library row and controller session.
+        guard let template = CommandCatalog.template(id: .videoPrepareMasks) else {
+            throw StudioSnapshotError.noContentView
+        }
+        var draft = template.defaultDraft()
+        draft.inputPath = project.appendingPathComponent("plan.json").path
+        draft.outputPath = prepared.path
+        draft.model = "vision-segment-sam31"
+        let request = StudioRunRequest(
+            mode: .video,
+            templateID: .videoPrepareMasks,
+            template: template,
+            draft: draft,
+            createdAt: Date().addingTimeInterval(-95)
+        )
+        let preview = controller.commandPreview(template: template, draft: draft, masksSecrets: true)
+        library.start(request: request, commandPreview: preview, status: .running)
+        processRunner.liveSessionMarker = "prepare-masks"
+        guard controller.run(studio: request), let live = processRunner.liveStarts.last else {
+            throw StudioSnapshotError.noContentView
+        }
+        live.stderr("Preparing SCAIL-2 masks from \(draft.inputPath)\n")
+        live.stderr("Segmenting 3 reference images with vision-segment-sam31\n")
+
+        var components = Calendar.current.dateComponents([.year, .month, .day], from: Date())
+        components.hour = 13
+        components.minute = 26
+        return StudioSubjectsProjectSeed(
+            drivingVideo: drivingVideo.path,
+            fps: 24,
+            subjects: subjects,
+            corrections: corrections,
+            preparedDirectory: prepared,
+            planSavedAt: Calendar.current.date(from: components),
+            stage: .track,
+            maskRequestID: request.id
+        )
+    }
+
+    /// A flat tinted tile standing in for a subject's reference image.
+    private static func writeSwatchPNG(to url: URL, color: NSColor) throws {
+        try writePNG(to: url, size: CGSize(width: 96, height: 96)) { bounds in
+            color.setFill()
+            bounds.fill()
+        }
+    }
+
+    /// A driving frame with each subject's mask tinted over it, as the CLI's overlay preview
+    /// shows: a dark studio gradient, the skater as a tall rounded shape, the board under the
+    /// feet, the backpack at the shoulder.
+    private static func writeOverlayFramePNG(to url: URL, size: CGSize) throws {
+        try writePNG(to: url, size: size) { bounds in
+            let ground = NSGradient(colors: [
+                NSColor(calibratedRed: 0.34, green: 0.34, blue: 0.36, alpha: 1),
+                NSColor(calibratedRed: 0.23, green: 0.23, blue: 0.25, alpha: 1),
+                NSColor(calibratedRed: 0.16, green: 0.16, blue: 0.18, alpha: 1),
+            ])
+            ground?.draw(in: bounds, angle: 90)
+            let width = bounds.width
+            let height = bounds.height
+            func rect(_ x: CGFloat, _ y: CGFloat, _ w: CGFloat, _ h: CGFloat) -> CGRect {
+                // Fractions of the frame, y from the top as the mockup lays them out.
+                CGRect(x: width * x, y: height * (1 - y - h), width: width * w, height: height * h)
+            }
+            NSColor(calibratedRed: 0.61, green: 0.48, blue: 0.18, alpha: 0.45).setFill()
+            NSBezierPath(roundedRect: rect(0.38, 0.22, 0.22, 0.60), xRadius: width * 0.09, yRadius: height * 0.18).fill()
+            NSColor(calibratedRed: 0.37, green: 0.48, blue: 0.27, alpha: 0.5).setFill()
+            NSBezierPath(roundedRect: rect(0.34, 0.78, 0.32, 0.08), xRadius: 6, yRadius: 6).fill()
+            NSColor(calibratedRed: 0.61, green: 0.46, blue: 0.13, alpha: 0.5).setFill()
+            NSBezierPath(roundedRect: rect(0.52, 0.32, 0.09, 0.18), xRadius: 6, yRadius: 6).fill()
+        }
+    }
+
+    private static func writePNG(to url: URL, size: CGSize, draw: (CGRect) -> Void) throws {
+        let width = Int(size.width)
+        let height = Int(size.height)
+        guard let rep = NSBitmapImageRep(
+            bitmapDataPlanes: nil,
+            pixelsWide: width,
+            pixelsHigh: height,
+            bitsPerSample: 8,
+            samplesPerPixel: 4,
+            hasAlpha: true,
+            isPlanar: false,
+            colorSpaceName: .deviceRGB,
+            bytesPerRow: 0,
+            bitsPerPixel: 0
+        ), let context = NSGraphicsContext(bitmapImageRep: rep) else {
+            throw StudioSnapshotError.noBitmap
+        }
+        NSGraphicsContext.saveGraphicsState()
+        NSGraphicsContext.current = context
+        draw(CGRect(x: 0, y: 0, width: width, height: height))
+        NSGraphicsContext.restoreGraphicsState()
+        guard let data = rep.representation(using: .png, properties: [:]) else {
+            throw StudioSnapshotError.pngEncodingFailed
+        }
+        try data.write(to: url, options: .atomic)
+    }
+
     /// A soft two-tone gradient with a horizon line, so the canvas visibly shows an image.
     private static func writeFixturePNG(to url: URL, size: CGSize) throws {
         let width = Int(size.width)
@@ -381,14 +628,46 @@ private final class SnapshotFixture {
 
 /// Refuses every launch: reports one stderr line and a non-zero exit asynchronously so readiness
 /// and status probes settle to their "could not check" states without a CLI ever running.
+///
+/// The one exception is a launch whose arguments contain `liveSessionMarker`: that is held open
+/// as a live session (never terminated, stdin recorded) so Session-archetype views can be
+/// rendered mid-run. The test feeds it the lines the CLI would have written.
 private final class SnapshotProcessRunner: MereRunProcessRunning, @unchecked Sendable {
+    struct LiveStart {
+        let configuration: MereRunProcessConfiguration
+        let stdout: @Sendable (String) -> Void
+        let stderr: @Sendable (String) -> Void
+        let process: SnapshotLiveProcess
+    }
+
     private let lock = NSLock()
     private var refusedLaunches = 0
+    private var _liveStarts: [LiveStart] = []
+    private var _liveSessionMarker: String?
 
     var refusedLaunchCount: Int {
         lock.lock()
         defer { lock.unlock() }
         return refusedLaunches
+    }
+
+    var liveSessionMarker: String? {
+        get {
+            lock.lock()
+            defer { lock.unlock() }
+            return _liveSessionMarker
+        }
+        set {
+            lock.lock()
+            _liveSessionMarker = newValue
+            lock.unlock()
+        }
+    }
+
+    var liveStarts: [LiveStart] {
+        lock.lock()
+        defer { lock.unlock() }
+        return _liveStarts
     }
 
     func start(
@@ -398,6 +677,12 @@ private final class SnapshotProcessRunner: MereRunProcessRunning, @unchecked Sen
         termination: @escaping @Sendable (Int32) -> Void
     ) throws -> MereRunRunningProcess {
         lock.lock()
+        if let marker = _liveSessionMarker, configuration.arguments.contains(marker) {
+            let process = SnapshotLiveProcess()
+            _liveStarts.append(LiveStart(configuration: configuration, stdout: stdout, stderr: stderr, process: process))
+            lock.unlock()
+            return process
+        }
         refusedLaunches += 1
         lock.unlock()
         DispatchQueue.global().asyncAfter(deadline: .now() + .milliseconds(30)) {
@@ -410,4 +695,24 @@ private final class SnapshotProcessRunner: MereRunProcessRunning, @unchecked Sen
 
 private final class SnapshotRefusedProcess: MereRunRunningProcess {
     func terminate() {}
+}
+
+/// A session the harness holds open: nothing to terminate, stdin lines kept for assertions.
+private final class SnapshotLiveProcess: MereRunRunningProcess, @unchecked Sendable {
+    private let lock = NSLock()
+    private var _standardInputs: [String] = []
+
+    var standardInputs: [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return _standardInputs
+    }
+
+    func terminate() {}
+
+    func sendStandardInput(_ text: String) throws {
+        lock.lock()
+        _standardInputs.append(text)
+        lock.unlock()
+    }
 }

--- a/apps/macos/MereRunStudioTests/StudioSubjectsProjectTests.swift
+++ b/apps/macos/MereRunStudioTests/StudioSubjectsProjectTests.swift
@@ -1,0 +1,416 @@
+@testable import MereRunApp
+import Foundation
+import XCTest
+
+final class StudioSubjectsProjectTests: XCTestCase {
+    // MARK: - Stage state machine
+
+    func testFreshProjectStartsAtPlanWithNothingDone() {
+        let progress = StudioSubjectsProgress()
+        XCTAssertEqual(progress.defaultStage, .plan)
+        XCTAssertEqual(progress.status(of: .plan, selected: .plan), .active)
+        XCTAssertEqual(progress.status(of: .track, selected: .plan), .todo)
+        XCTAssertEqual(progress.status(of: .animate, selected: .plan), .todo)
+    }
+
+    func testPlannedProjectLandsOnTrackAndMarksPlanDone() {
+        let progress = StudioSubjectsProgress(planReady: true)
+        XCTAssertEqual(progress.defaultStage, .track)
+        XCTAssertEqual(progress.status(of: .plan, selected: .track), .done)
+        XCTAssertEqual(progress.status(of: .track, selected: .track), .active)
+        XCTAssertEqual(progress.status(of: .animate, selected: .track), .todo)
+    }
+
+    func testTrackedProjectLandsOnAnimateAndSelectionOverridesDone() {
+        let progress = StudioSubjectsProgress(planReady: true, previewed: true, tracked: true)
+        XCTAssertEqual(progress.defaultStage, .animate)
+        // Looking back at a finished stage shows it as the active row, not a check.
+        XCTAssertEqual(progress.status(of: .track, selected: .track), .active)
+        XCTAssertEqual(progress.status(of: .plan, selected: .track), .done)
+    }
+
+    func testFullyAnimatedProjectStaysOnAnimate() {
+        let progress = StudioSubjectsProgress(planReady: true, previewed: true, tracked: true, animated: true)
+        XCTAssertEqual(progress.defaultStage, .animate)
+        XCTAssertEqual(progress.status(of: .animate, selected: .plan), .done)
+    }
+
+    func testStageOrderAndNext() {
+        XCTAssertEqual(StudioSubjectsStage.allCases, [.plan, .track, .animate])
+        XCTAssertEqual(StudioSubjectsStage.plan.next, .track)
+        XCTAssertEqual(StudioSubjectsStage.track.next, .animate)
+        XCTAssertNil(StudioSubjectsStage.animate.next)
+    }
+
+    // MARK: - Stage header copy
+
+    func testPlanCopyGatesOnPlanReadiness() {
+        let notReady = StudioSubjectsStageCopy.copy(for: .plan, progress: StudioSubjectsProgress())
+        XCTAssertEqual(notReady.title, "Plan the subjects")
+        XCTAssertEqual(notReady.primary.label, "Continue to Track")
+        XCTAssertFalse(notReady.primary.isEnabled)
+        XCTAssertEqual(notReady.secondary?.label, "Preview masks")
+        XCTAssertFalse(notReady.secondary?.isEnabled ?? true)
+
+        let ready = StudioSubjectsStageCopy.copy(for: .plan, progress: StudioSubjectsProgress(planReady: true))
+        XCTAssertTrue(ready.primary.isEnabled)
+        XCTAssertEqual(ready.primary.action, .continueTo(.track))
+        XCTAssertEqual(ready.secondary?.action, .previewMasks)
+        XCTAssertTrue(ready.secondary?.isEnabled ?? false)
+    }
+
+    func testTrackCopyBeforeAndAfterTracking() {
+        let untracked = StudioSubjectsStageCopy.copy(for: .track, progress: StudioSubjectsProgress(planReady: true))
+        XCTAssertEqual(untracked.title, "Track subjects through the clip")
+        XCTAssertEqual(untracked.primary.label, "Track subjects")
+        XCTAssertEqual(untracked.primary.action, .trackMasks)
+        XCTAssertEqual(untracked.secondary?.label, "Preview frame")
+
+        let tracked = StudioSubjectsStageCopy.copy(
+            for: .track,
+            progress: StudioSubjectsProgress(planReady: true, previewed: true, tracked: true)
+        )
+        XCTAssertEqual(tracked.description, "Review masks, add a correction where a mask slips, then continue to Animate.")
+        XCTAssertEqual(tracked.secondary?.label, "Re-track")
+        XCTAssertEqual(tracked.primary.label, "Continue to Animate")
+        XCTAssertEqual(tracked.primary.action, .continueTo(.animate))
+        XCTAssertTrue(tracked.primary.isEnabled)
+    }
+
+    func testTrackCopyWhileTrackingDisablesActions() {
+        let tracking = StudioSubjectsStageCopy.copy(
+            for: .track,
+            progress: StudioSubjectsProgress(planReady: true, previewed: true, tracked: true, runningStage: .track)
+        )
+        XCTAssertEqual(tracking.secondary?.label, "Tracking…")
+        XCTAssertFalse(tracking.secondary?.isEnabled ?? true)
+        // Moving on to Animate stays possible; that stage disables its own actions while busy.
+        XCTAssertTrue(tracking.primary.isEnabled)
+
+        let firstTrack = StudioSubjectsStageCopy.copy(
+            for: .track,
+            progress: StudioSubjectsProgress(planReady: true, runningStage: .track)
+        )
+        XCTAssertEqual(firstTrack.primary.label, "Tracking…")
+        XCTAssertFalse(firstTrack.primary.isEnabled)
+    }
+
+    func testAnimateCopyRequiresTrackedMasks() {
+        let untracked = StudioSubjectsStageCopy.copy(for: .animate, progress: StudioSubjectsProgress(planReady: true))
+        XCTAssertEqual(untracked.title, "Animate the reference")
+        XCTAssertFalse(untracked.primary.isEnabled)
+        XCTAssertFalse(untracked.secondary?.isEnabled ?? true)
+
+        let tracked = StudioSubjectsStageCopy.copy(
+            for: .animate,
+            progress: StudioSubjectsProgress(planReady: true, previewed: true, tracked: true)
+        )
+        XCTAssertEqual(tracked.primary.label, "Animate")
+        XCTAssertEqual(tracked.primary.action, .animate)
+        XCTAssertTrue(tracked.primary.isEnabled)
+        XCTAssertEqual(tracked.secondary?.action, .validateRun)
+
+        let animating = StudioSubjectsStageCopy.copy(
+            for: .animate,
+            progress: StudioSubjectsProgress(planReady: true, previewed: true, tracked: true, runningStage: .animate)
+        )
+        XCTAssertEqual(animating.primary.label, "Animating…")
+        XCTAssertFalse(animating.primary.isEnabled)
+    }
+
+    func testBoardStacksBelowTheSideBySideWidth() {
+        // 1440 window with the Library open leaves ~690pt; the 1280 default leaves ~530pt.
+        XCTAssertTrue(StudioSCAILView.isWide(columnWidth: 740))
+        XCTAssertTrue(StudioSCAILView.isWide(columnWidth: 688))
+        XCTAssertFalse(StudioSCAILView.isWide(columnWidth: 580))
+    }
+
+    // MARK: - Subject rows
+
+    func testRowLeadPrefersBoxThenPointThenReference() {
+        var subject = StudioSCAILSubject(name: "skater", color: "blue", referenceImage: "/refs/skater-front.png")
+        XCTAssertEqual(StudioSubjectsRowCopy.lead(for: subject), "ref: skater-front.png")
+
+        subject.drivingPositivePoints = "612.4,479.6; 10,10"
+        XCTAssertEqual(StudioSubjectsRowCopy.lead(for: subject), "point (612, 480)")
+
+        subject.drivingBox = "500,200,600,330"
+        XCTAssertEqual(StudioSubjectsRowCopy.lead(for: subject), "box")
+    }
+
+    func testRowLeadFallsBackToDrivingPromptOrPlaceholder() {
+        var subject = StudioSCAILSubject(name: "dancer", color: "red", drivingPrompt: "dancer")
+        XCTAssertEqual(StudioSubjectsRowCopy.lead(for: subject), "“dancer”")
+        subject.drivingPrompt = ""
+        XCTAssertEqual(StudioSubjectsRowCopy.lead(for: subject), "no selector yet")
+    }
+
+    func testRowMetaShowsTrackedFramesOrCorrections() {
+        let skater = StudioSCAILSubject(name: "skater", color: "blue", referenceImage: "skater-front.png")
+        XCTAssertEqual(
+            StudioSubjectsRowCopy.meta(subject: skater, trackedFrames: (visible: 240, total: 240), correctionFrames: []),
+            "ref: skater-front.png · 240/240 frames"
+        )
+        XCTAssertEqual(
+            StudioSubjectsRowCopy.meta(subject: skater, trackedFrames: nil, correctionFrames: []),
+            "ref: skater-front.png"
+        )
+
+        var backpack = StudioSCAILSubject(name: "backpack", color: "green")
+        backpack.drivingBox = "1,1,2,2"
+        XCTAssertEqual(
+            StudioSubjectsRowCopy.meta(subject: backpack, trackedFrames: (visible: 240, total: 240), correctionFrames: [142, 88]),
+            "box · 2 corrections at 88, 142"
+        )
+        XCTAssertEqual(
+            StudioSubjectsRowCopy.meta(subject: backpack, trackedFrames: nil, correctionFrames: [12]),
+            "box · 1 correction at 12"
+        )
+    }
+
+    // MARK: - Stats
+
+    func testStatsFromTrackedArtifacts() {
+        let manifest = Self.manifest(tracked: true, frameCount: 240, fps: 24)
+        let tracking = StudioSCAILTrackingReport(
+            frameCount: 240,
+            fps: 24,
+            subjects: [
+                Self.trackedSubject("skater", visible: 240, total: 240),
+                Self.trackedSubject("board", visible: 231, total: 240),
+                Self.trackedSubject("backpack", visible: 240, total: 240),
+            ]
+        )
+        let quality = StudioSCAILQualityReport(
+            blockingErrors: [],
+            warnings: [
+                StudioSCAILQualityReport.Warning(code: "weak_score", subjectID: "board", frameIndex: 12, message: "weak"),
+            ]
+        )
+        let stats = StudioSubjectsStats.stats(manifest: manifest, tracking: tracking, quality: quality, correctionCount: 2)
+        XCTAssertEqual(stats.coverage, "98.8%")
+        XCTAssertEqual(stats.drift, "low")
+        XCTAssertEqual(stats.corrections, "2")
+        XCTAssertEqual(stats.frames, "240 @ 24 fps")
+        XCTAssertEqual(stats.panels.map(\.label), ["Coverage", "Drift", "Corrections", "Frames"])
+    }
+
+    func testDriftCountsAbruptChangesOnly() {
+        let quality = StudioSCAILQualityReport(
+            blockingErrors: [],
+            warnings: [
+                StudioSCAILQualityReport.Warning(code: "abrupt_change", subjectID: "board", frameIndex: 40, message: ""),
+                StudioSCAILQualityReport.Warning(code: "abrupt_change", subjectID: "board", frameIndex: 41, message: ""),
+                StudioSCAILQualityReport.Warning(code: "disappearance", subjectID: "board", frameIndex: 42, message: ""),
+            ]
+        )
+        let stats = StudioSubjectsStats.stats(
+            manifest: Self.manifest(tracked: true, frameCount: 100, fps: 23.976),
+            tracking: nil,
+            quality: quality,
+            correctionCount: 0
+        )
+        XCTAssertEqual(stats.drift, "2 flagged")
+        XCTAssertNil(stats.coverage)
+        XCTAssertEqual(stats.frames, "100 @ 23.98 fps")
+    }
+
+    func testStatsAfterPreviewOnlyOmitCoverageAndDrift() {
+        let quality = StudioSCAILQualityReport(blockingErrors: [], warnings: [])
+        let stats = StudioSubjectsStats.stats(
+            manifest: Self.manifest(tracked: false, frameCount: 240, fps: 24),
+            tracking: nil,
+            quality: quality,
+            correctionCount: 0
+        )
+        XCTAssertNil(stats.coverage)
+        XCTAssertNil(stats.drift)
+        XCTAssertEqual(stats.panels.map(\.label), ["Corrections", "Frames"])
+    }
+
+    func testStatsWithoutArtifactsOnlyCountCorrections() {
+        let stats = StudioSubjectsStats.stats(manifest: nil, tracking: nil, quality: nil, correctionCount: 1)
+        XCTAssertEqual(stats.panels.map(\.label), ["Corrections"])
+        XCTAssertEqual(stats.corrections, "1")
+    }
+
+    func testPercentFormatting() {
+        XCTAssertEqual(StudioSubjectsStats.formatPercent(1), "100%")
+        XCTAssertEqual(StudioSubjectsStats.formatPercent(0.5), "50%")
+        XCTAssertEqual(StudioSubjectsStats.formatPercent(0.98750), "98.8%")
+        XCTAssertEqual(StudioSubjectsStats.formatPercent(0.98611), "98.6%")
+        XCTAssertEqual(StudioSubjectsStats.formatPercent(1.4), "100%")
+    }
+
+    // MARK: - Project rail
+
+    func testProjectNameComesFromDrivingClip() {
+        XCTAssertEqual(StudioSubjectsProjectCopy.name(drivingVideo: "/clips/skate-clip-01.mp4"), "skate-clip-01")
+        XCTAssertEqual(StudioSubjectsProjectCopy.name(drivingVideo: "   "), "Untitled project")
+    }
+
+    func testProjectSummaryAndSavedCopy() {
+        XCTAssertEqual(StudioSubjectsProjectCopy.summary(subjectCount: 3, frameCount: 240), "3 subjects · 240 frames")
+        XCTAssertEqual(StudioSubjectsProjectCopy.summary(subjectCount: 1, frameCount: nil), "1 subject")
+        XCTAssertEqual(StudioSubjectsProjectCopy.saved(nil), "Not saved yet")
+
+        var components = DateComponents()
+        components.year = 2_026
+        components.month = 9
+        components.day = 3
+        components.hour = 13
+        components.minute = 26
+        let date = Calendar.current.date(from: components)!
+        XCTAssertEqual(StudioSubjectsProjectCopy.saved(date), "Saved 1:26 PM")
+    }
+
+    // MARK: - Job bar
+
+    func testJobBarDetailPerPhase() {
+        XCTAssertEqual(
+            StudioSubjectsJobBar.detail(phase: .running(.track), subjectCount: 3, frameCount: 240, profile: "fast"),
+            "Tracking 3 subjects · 240 frames"
+        )
+        XCTAssertEqual(
+            StudioSubjectsJobBar.detail(phase: .running(.track), subjectCount: 1, frameCount: nil, profile: "fast"),
+            "Tracking 1 subject"
+        )
+        XCTAssertEqual(
+            StudioSubjectsJobBar.detail(phase: .running(.preview(frame: 88)), subjectCount: 3, frameCount: 240, profile: "fast"),
+            "Previewing frame 88 · 3 subjects"
+        )
+        XCTAssertEqual(
+            StudioSubjectsJobBar.detail(phase: .running(.animate), subjectCount: 3, frameCount: 240, profile: "quality"),
+            "Animating with SCAIL-2 · quality profile"
+        )
+        XCTAssertEqual(
+            StudioSubjectsJobBar.detail(phase: .queued(.animate), subjectCount: 3, frameCount: 240, profile: "fast"),
+            "Animation queued behind the active job"
+        )
+        XCTAssertEqual(
+            StudioSubjectsJobBar.detail(phase: .ended(.track, exitCode: 0), subjectCount: 3, frameCount: 240, profile: "fast"),
+            "Masks tracked · 3 subjects · 240 frames"
+        )
+        XCTAssertEqual(
+            StudioSubjectsJobBar.detail(phase: .ended(.validate, exitCode: 2), subjectCount: 3, frameCount: 240, profile: "fast"),
+            "Validation failed · exit 2"
+        )
+        XCTAssertEqual(
+            StudioSubjectsJobBar.detail(phase: .idle, subjectCount: 3, frameCount: nil, profile: "fast"),
+            "No job running"
+        )
+    }
+
+    func testJobStageRouting() {
+        XCTAssertEqual(StudioSubjectsJobBar.Job.preview(frame: 1).stage, .track)
+        XCTAssertEqual(StudioSubjectsJobBar.Job.track.stage, .track)
+        XCTAssertEqual(StudioSubjectsJobBar.Job.validate.stage, .animate)
+        XCTAssertEqual(StudioSubjectsJobBar.Job.animate.stage, .animate)
+    }
+
+    // MARK: - Artifacts
+
+    func testManifestDecodesCLIShape() throws {
+        let json = """
+        {
+          "schema_version": 1,
+          "status": "ready",
+          "preview_frame": null,
+          "model_id": "vision-segment-sam31",
+          "model_revision": "r1",
+          "driving_source_path": "/clips/skate-clip-01.mp4",
+          "driving_proxy_path": "driving-proxy.mp4",
+          "driving_mask_path": "driving-mask.mov",
+          "overlay_preview_path": "overlay-preview.mp4",
+          "contact_sheet_path": "contact-sheet.png",
+          "tracking_path": "tracking.json",
+          "quality_path": "quality.json",
+          "frame_count": 240,
+          "fps": 24,
+          "width": 832,
+          "height": 480,
+          "subjects": [
+            {
+              "id": "skater",
+              "color": "blue",
+              "reference_image_path": "/refs/skater-front.png",
+              "prepared_reference_image_path": "reference-skater-prepared.png",
+              "reference_mask_path": "reference-skater-mask.png",
+              "seed_frame_index": 0,
+              "gap_ranges": []
+            }
+          ],
+          "corrections": [
+            {"subject_id": "skater", "frame_index": 88, "painted_mask_path": null,
+             "positive_point_count": 1, "negative_point_count": 0, "has_box": false}
+          ],
+          "artifacts": []
+        }
+        """
+        let manifest = try JSONDecoder().decode(StudioSCAILManifest.self, from: Data(json.utf8))
+        XCTAssertTrue(manifest.isTracked)
+        XCTAssertEqual(manifest.frameCount, 240)
+        XCTAssertEqual(manifest.fps, 24)
+        XCTAssertEqual(manifest.subjects.first?.id, "skater")
+        XCTAssertEqual(manifest.corrections?.first?.frameIndex, 88)
+        XCTAssertEqual(manifest.trackingPath, "tracking.json")
+    }
+
+    func testTrackingReportCountsVisibleFrames() throws {
+        let json = """
+        {
+          "schema_version": 1,
+          "model_id": "vision-segment-sam31",
+          "frame_count": 3,
+          "fps": 24,
+          "subjects": [
+            {
+              "id": "board",
+              "color": "red",
+              "seed_frame_index": 0,
+              "frames": [
+                {"frame_index": 0, "timestamp_seconds": 0, "detections": [{"object_id": "1", "label": "board", "score": 0.9, "visible": true, "box": {"x1": 0, "y1": 0, "x2": 1, "y2": 1}, "mask_area_pixels": 10}]},
+                {"frame_index": 1, "timestamp_seconds": 0.04, "detections": [{"object_id": "1", "label": "board", "score": 0.2, "visible": false, "box": {"x1": 0, "y1": 0, "x2": 1, "y2": 1}, "mask_area_pixels": 0}]},
+                {"frame_index": 2, "timestamp_seconds": 0.08, "detections": []}
+              ]
+            }
+          ]
+        }
+        """
+        let report = try JSONDecoder().decode(StudioSCAILTrackingReport.self, from: Data(json.utf8))
+        XCTAssertEqual(report.subjects.first?.visibleFrameCount, 1)
+        XCTAssertEqual(report.frameCount, 3)
+    }
+
+    // MARK: - Helpers
+
+    private static func manifest(tracked: Bool, frameCount: Int, fps: Double) -> StudioSCAILManifest {
+        StudioSCAILManifest(
+            status: tracked ? "ready" : "preview_ready",
+            previewFrame: tracked ? nil : 0,
+            drivingSourcePath: "/clips/skate-clip-01.mp4",
+            drivingProxyPath: tracked ? "driving-proxy.mp4" : nil,
+            drivingMaskPath: tracked ? "driving-mask.mov" : nil,
+            overlayPreviewPath: tracked ? "overlay-preview.mp4" : "overlay-frame-0.png",
+            contactSheetPath: "contact-sheet.png",
+            trackingPath: tracked ? "tracking.json" : nil,
+            qualityPath: "quality.json",
+            frameCount: frameCount,
+            fps: fps,
+            subjects: [],
+            corrections: nil
+        )
+    }
+
+    private static func trackedSubject(_ id: String, visible: Int, total: Int) -> StudioSCAILTrackingReport.Subject {
+        StudioSCAILTrackingReport.Subject(
+            id: id,
+            frames: (0..<total).map { index in
+                StudioSCAILTrackingReport.Frame(
+                    frameIndex: index,
+                    detections: [StudioSCAILTrackingReport.Detection(visible: index < visible, score: 0.9)]
+                )
+            }
+        )
+    }
+}

--- a/apps/macos/README.md
+++ b/apps/macos/README.md
@@ -75,10 +75,14 @@ ordered Ref2VA image/video/audio references without emitting incompatible LTX
 flags. Its general attachment workflow supports a start image, end keyframe,
 and source audio. The Command Console's Video templates contain
 guided SCAIL-2, Cosmos3, mask-preparation, latent-export, and resident-session
-workflows. Video ▸ Subjects hosts the SCAIL subject workflow with multi-subject
-reference/selector authoring, preview and full-video SAM tracking, immutable
-keyframe corrections, before/after playback, complete continuity/profile controls,
-and durable Library jobs.
+workflows. Video ▸ Subjects hosts the SCAIL subject workflow as a three-stage
+project board (Plan → Track → Animate) with a stage rail, a mask preview that
+scrubs by frame and flips between masks and the driving clip, subject rows, and
+stats read from the CLI's manifest, tracking, and quality reports. It keeps
+multi-subject reference/selector authoring, preview and full-video SAM tracking,
+immutable keyframe corrections, the continuity/profile controls (under each
+stage's "More" row), plan.json persistence, and durable Library jobs with a job
+bar for the running stage.
 
 Text uses the same contract for native/MLX chat, code, embeddings,
 anonymization, and text-LoRA training. Chat exposes typed text/JSON response


### PR DESCRIPTION
## What changed

Video ▸ Subjects (the SCAIL flow) is rebuilt as the Studio v2 **Project** archetype, to the `projectBoard()` mockup:

- **Stage rail** (200pt): eyebrow "Stages"; Plan / Track / Animate rows with a 20pt circle (green check when done, accent number when active, raised muted number when todo), the active row on `accentSoft`; below, "Project" with the clip name, `3 subjects · 240 frames`, and `Saved 1:26 PM` (all real: driving-clip stem, plan subjects, manifest frame count, last plan.json write).
- **Stage content**: serif 17pt title + 12.5pt description with `btnSecondary` / `btnPrimary` actions per stage (Plan: Preview masks / Continue to Track; Track: Preview frame · Track subjects, then Re-track / Continue to Animate; Animate: Validate run / Animate). A 16:9 preview (radius 10, dark ground, hairline) showing the CLI's overlay preview (PNG after a frame preview, video after a full track) with a transport bar: play glyph, thin scrubber with thumb, mono `88 / 240`, and a Masks | Before segmented that flips to the driving proxy/source. A 300pt Subjects panel with `+ Add` and rows (36pt tinted swatch or prepared reference thumbnail, name, meta like `ref: skater-front.png · 240/240 frames` / `point (612, 480) · 231/240 frames` / `box · 2 corrections at 88, 142`, a more-button opening the subject editor popover). A stats row of `panel`s: Coverage, Drift, Corrections, Frames @ fps.
- **Job bar** per `jobBar()`: `Video · Subjects`, a stage-specific detail (`Tracking 3 subjects · 240 frames`, `Previewing frame 88 · 3 subjects`, `Animating with SCAIL-2 · fast profile`, ended/failed variants), a progress bar when the controller reports a fraction, Cancel (`controller.cancel(requestID:)`), and Log (the run's log lines). No `MereRunController` edits.
- The board drops the side panel under the preview when the content column is narrower than 640pt (the default 1280×820 window with the Library open); at 1440×900 it sits beside it as in the mockup.

Every existing SCAIL capability is kept: multi-subject reference/selector authoring (per-row popover with precise selectors), preview and full-video SAM tracking, immutable keyframe corrections, before/after playback, continuity/profile/model/adapter/output/preflight controls (under each stage's collapsed "More" row), plan.json persistence, durable Library jobs through `StudioSpecialistRunner`, and the mask-input fingerprint that invalidates prepared masks. Two behaviour improvements: a re-track keeps the previous masks on the board until the new manifest arrives, and the two status channels (header status + form error) collapse into one `MereBanner`.

`StudioSubjectsProject.swift` holds the plan/manifest/tracking/quality models and the pure view-model logic (stage state machine, stage copy, subject row copy, stats, project-rail copy, job-bar copy) so they are unit-tested and shared with the snapshot harness. `onAccent` and the segmented selection fill are `fileprivate` with `// F1 token:` comments until the theme tokens land.

## Only real metrics

- **Coverage** = visible frames / (subjects × frames) from `tracking.json`.
- **Drift** = count of `abrupt_change` warnings in `quality.json` (`low` when zero, `N flagged` otherwise).
- **Corrections** = plan corrections; **Frames** = manifest `frame_count @ fps`.
- Coverage and Drift are omitted after a preview-only run (no tracking report yet).
- `video prepare-masks` writes no per-frame progress to stderr, so the job bar is honest and indeterminate while tracking. The mockup's `Tracking Backpack · 231/240` needs a CLI progress line first (follow-up for the CLI; the parser and job bar already accept a fraction).

## Verification

- `swiftlint --strict`, `swift build`, `swift test --filter MereRunAppTests` (294 tests), full `./scripts/check.sh` equivalent (all sub-checks + `swift test`: 3488 tests, 0 failures), and `./scripts/build_mere_run_app.sh debug` all pass.
- New `StudioSubjectsProjectTests` (24 tests): stage state machine, stage copy per progress state, subject row copy, stats/percent formatting, project rail copy, job-bar copy, manifest/tracking decoding of the CLI's JSON shape, and the side-by-side width threshold.
- Fidelity renders via the snapshot harness (`testVideoSubjectsProjectSnapshots`): a seeded tracked project (manifest/tracking/quality JSON, prepared references, synthesized overlay frame) with a re-track held open by the process seam; Track stage at 1440×900 light + dark and 1280×820, plus Plan and Animate once each. Compared side by side with `Project.png`; remaining differences below. No screenshots in the repo.

## Remaining visible differences from Project.png

- The shell still shows the Library column for Video (the mockup hides it on the Project board), so the content column is ~250pt narrower and the header description wraps; that is shell IA, not this view.
- Subject swatches and mask tints use the CLI's real palette (blue/red/green…) rather than the mockup's theme-tinted stand-ins, so they match the overlay the CLI actually paints.
- No progress bar / per-subject frame count in the job bar until the CLI emits tracking progress (above).
- Toolbar/task control chrome (segmented tasks, wordmark) belongs to F1.

## Reviewer notes

- `StudioSnapshotTests.swift` gains the same live-session process seam as `studio-v2/f7-realtime-session` (identical code), so the two branches should merge without a real conflict.
- The `StudioSCAILManifest` decoder is the subset the app reads (`SCAIL2MaskManifest` fields are all optional-safe here); `tracking_path` / `quality_path` are read when present.
