### PR TITLE
Add contract option metadata and structured CLI receipts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,30 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+### CLI
+
+- added optional `default_value`, `group`, `tier`, `range`, and `depends_on`
+  metadata to every option in the shared capability contract and populated it
+  for the prompt-mode capabilities (`image.generate`, `text.chat`, `text.code`,
+  `speech.synthesize`, `speech.transcribe`, `vision.inspect`, `vision.ocr`,
+  `vision.caption`, `vision.ground`, `vision.segment`, `vision.track`,
+  `music.generate`, `video.generate`, `sfx.generate`). The fields are additive,
+  `mere.run catalog --json` omits them when unset, and a CLI test proves every
+  declared default matches the ArgumentParser help.
+- added `--receipt` to `image generate`, `video generate`, `music generate`,
+  `sfx generate`, `speech synthesize`, `speech transcribe`, `vision ground`,
+  `vision segment`, and `vision track`. It appends one final
+  `{"event":"result","exit":0,"outputs":[{"path":…,"kind":…}]}` line to stdout
+  after the unchanged human output, listing the primary artifact first and any
+  sidecars (detections, masks, recipes, candidates, stems, timings) with a
+  `role`.
+- extended `--progress-json` from `image generate` to `video generate`
+  (MiniMax-H3 and Wan lanes), `music generate` (MiniMax Music 3 and Magenta
+  RT2 lanes), `sfx generate`, and `speech synthesize`, using the same
+  `{"event":"progress","stage":…,"step":…,"total_steps":…}` line. The native
+  LTX video lanes and the ACE-Step pipeline expose no per-step callback and
+  emit no events.
+
 ### macOS
 
 - added `--lm-model` (music generate, analyze, and serve), `--h3-acceleration`,

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,13 +22,15 @@ The format is based on Keep a Changelog.
   `{"event":"result","exit":0,"outputs":[{"path":…,"kind":…}]}` line to stdout
   after the unchanged human output, listing the primary artifact first and any
   sidecars (detections, masks, recipes, candidates, stems, timings) with a
-  `role`.
+  `role`. `--receipt` is rejected together with `--preflight`.
 - extended `--progress-json` from `image generate` to `video generate`
   (MiniMax-H3 and Wan lanes), `music generate` (MiniMax Music 3 and Magenta
   RT2 lanes), `sfx generate`, and `speech synthesize`, using the same
-  `{"event":"progress","stage":…,"step":…,"total_steps":…}` line. The native
-  LTX video lanes and the ACE-Step pipeline expose no per-step callback and
-  emit no events.
+  `{"event":"progress","stage":…,"step":…,"total_steps":…}` line under one
+  convention: `step` is 0-based while a stage runs, every determinate stage
+  ends with exactly one `step == total_steps` event, and `total_steps: 0`
+  marks an indeterminate stage. The native LTX video lanes and the ACE-Step
+  music pipeline expose no per-step callback and emit no events.
 
 ### macOS
 

--- a/Sources/MereRunCLI/Commands/ImageGenerateCommand.swift
+++ b/Sources/MereRunCLI/Commands/ImageGenerateCommand.swift
@@ -150,11 +150,11 @@ struct ImageGenerate: AsyncParsableCommand {
     @Flag(name: [.short, .long], help: "Print only the output path.")
     var quiet: Bool = false
 
-    @Flag(
-        name: [.customLong("progress-json")],
-        help: "Stream progress to stderr as JSON lines (one object per event) instead of human-readable text. Takes precedence over --quiet for progress output."
-    )
+    @Flag(name: [.customLong(CLIGenerationProgressPrinter.flagName)], help: CLIGenerationProgressPrinter.flagHelp)
     var progressJson: Bool = false
+
+    @Flag(name: [.customLong(RunReceipt.flagName)], help: RunReceipt.flagHelp)
+    var receipt: Bool = false
 
     func run() async throws {
         try validateStaticOptions()
@@ -451,6 +451,13 @@ struct ImageGenerate: AsyncParsableCommand {
             )
             // stdout: machine-readable path (easy for scripts)
             print(result.outputURL.path)
+            try RunReceipt.emit(
+                RunReceipt.generatedImageOutputs(
+                    image: result.outputURL,
+                    structuredPrompt: structuredPrompt ? structuredPromptOutput.map { URL(fileURLWithPath: $0) } : nil
+                ),
+                enabled: receipt
+            )
         } catch {
             try? runEventLogger?.record(
                 type: "run_failed",

--- a/Sources/MereRunCLI/Commands/ImageGenerateCommand.swift
+++ b/Sources/MereRunCLI/Commands/ImageGenerateCommand.swift
@@ -156,6 +156,10 @@ struct ImageGenerate: AsyncParsableCommand {
     @Flag(name: [.customLong(RunReceipt.flagName)], help: RunReceipt.flagHelp)
     var receipt: Bool = false
 
+    func validate() throws {
+        try RunReceipt.validate(receipt: receipt, preflight: preflight)
+    }
+
     func run() async throws {
         try validateStaticOptions()
         let kreaConditioningRebalance = try Self.resolveKreaConditioningRebalance(

--- a/Sources/MereRunCLI/Commands/MusicGenerateCommand.swift
+++ b/Sources/MereRunCLI/Commands/MusicGenerateCommand.swift
@@ -1393,6 +1393,7 @@ struct MusicGenerate: AsyncParsableCommand {
             loadingStrategy: loadingStrategy,
             performanceMode: performanceMode
         )
+        let progressStream = progressJson ? JSONProgressStream() : nil
         let result = try pipeline.generate(
             options: MiniMaxMusic3GenerationOptions(
                 caption: effectiveCaption,
@@ -1411,8 +1412,9 @@ struct MusicGenerate: AsyncParsableCommand {
                 seedStrategy: seedStrategy
             ),
             progress: { event in
-                if progressJson {
-                    CLIStderr.write(Self.miniMaxProgressJSONLine(event) + "\n")
+                if let progressStream {
+                    let progress = Self.miniMaxProgressEvent(event)
+                    progressStream.report(stage: progress.stage, step: progress.step, totalSteps: progress.totalSteps)
                     return
                 }
                 guard !quiet else { return }
@@ -1432,6 +1434,7 @@ struct MusicGenerate: AsyncParsableCommand {
                 }
             }
         )
+        progressStream?.finish()
         if let miniMaxProfileOutput {
             guard let profile = result.profile else {
                 throw ValidationError("MiniMax Music 3 profiling did not produce a receipt.")
@@ -1524,21 +1527,18 @@ struct MusicGenerate: AsyncParsableCommand {
         try RunReceipt.emit(RunReceipt.generatedAudioOutputs(audio: outputURL, sidecars: receiptSidecars), enabled: receipt)
     }
 
-    /// MiniMax Music 3 reports three sequential stages with 1-based counters;
-    /// flow denoising is flattened across chunks so `step` reaches `total_steps`
-    /// exactly once at the end of the last chunk.
-    static func miniMaxProgressJSONLine(_ event: MiniMaxMusic3Progress) -> String {
+    /// MiniMax Music 3 reports three sequential stages with 1-based completion
+    /// counters. Flow denoising is flattened across chunks, and every counter is
+    /// shifted to the 0-based in-progress index `JSONProgressStream` expects; the
+    /// stream adds the terminal `step == total_steps` event when a stage ends.
+    static func miniMaxProgressEvent(_ event: MiniMaxMusic3Progress) -> (stage: String, step: Int, totalSteps: Int) {
         switch event {
         case .semantic(let frame, let maximum):
-            return CLIGenerationProgressPrinter.progressJSONLine(stage: "semantic", step: frame, totalSteps: maximum)
+            return ("semantic", frame - 1, maximum)
         case .denoise(let chunk, let chunkCount, let step, let stepCount):
-            return CLIGenerationProgressPrinter.progressJSONLine(
-                stage: "denoising",
-                step: (chunk - 1) * stepCount + step,
-                totalSteps: chunkCount * stepCount
-            )
+            return ("denoising", (chunk - 1) * stepCount + step - 1, chunkCount * stepCount)
         case .decode(let chunk, let chunkCount):
-            return CLIGenerationProgressPrinter.progressJSONLine(stage: "decoding", step: chunk, totalSteps: chunkCount)
+            return ("decoding", chunk - 1, chunkCount)
         }
     }
 
@@ -1801,6 +1801,7 @@ struct MusicGenerate: AsyncParsableCommand {
         if !quiet {
             CLIStderr.write("Loading Magenta RT2 model from \(resources.modelURL.path)\n")
         }
+        let progressStream = progressJson ? JSONProgressStream() : nil
         let audio = try await MagentaRT2Renderer.render(
             MagentaRT2RenderRequest(
                 prompt: caption,
@@ -1810,18 +1811,15 @@ struct MusicGenerate: AsyncParsableCommand {
             ),
             progress: { frame, total in
                 guard frame % 10 == 0 || frame + 1 == total else { return }
-                if progressJson {
-                    CLIGenerationProgressPrinter.writeJSONProgress(
-                        stage: "generating",
-                        step: frame + 1 == total ? total : frame,
-                        totalSteps: total
-                    )
+                if let progressStream {
+                    progressStream.report(stage: "generating", step: frame, totalSteps: total)
                     return
                 }
                 guard !quiet else { return }
                 CLIStderr.write("Generated Magenta RT2 frame \(frame + 1)/\(total)\n")
             }
         )
+        progressStream?.finish()
         let writer = try StreamingWAVWriter(
             outputURL: outputURL,
             sampleRate: MagentaRT2Resources.sampleRate,

--- a/Sources/MereRunCLI/Commands/MusicGenerateCommand.swift
+++ b/Sources/MereRunCLI/Commands/MusicGenerateCommand.swift
@@ -1413,7 +1413,7 @@ struct MusicGenerate: AsyncParsableCommand {
             ),
             progress: { event in
                 if let progressStream {
-                    let progress = Self.miniMaxProgressEvent(event)
+                    let progress = Self.miniMaxProgressEvent(event, strategy: flowStrategy)
                     progressStream.report(stage: progress.stage, step: progress.step, totalSteps: progress.totalSteps)
                     return
                 }
@@ -1531,12 +1531,25 @@ struct MusicGenerate: AsyncParsableCommand {
     /// counters. Flow denoising is flattened across chunks, and every counter is
     /// shifted to the 0-based in-progress index `JSONProgressStream` expects; the
     /// stream adds the terminal `step == total_steps` event when a stage ends.
-    static func miniMaxProgressEvent(_ event: MiniMaxMusic3Progress) -> (stage: String, step: Int, totalSteps: Int) {
+    ///
+    /// The two flow strategies visit the (chunk, step) grid in opposite orders —
+    /// `sequential` denoises one chunk at a time, `overlap-average` runs one step
+    /// across every window — so the flattening has to follow the strategy for
+    /// `step` to stay monotonic. A counter that went backwards would read as a
+    /// restarted stage and close `denoising` early.
+    static func miniMaxProgressEvent(
+        _ event: MiniMaxMusic3Progress,
+        strategy: MiniMaxMusic3FlowStrategy
+    ) -> (stage: String, step: Int, totalSteps: Int) {
         switch event {
         case .semantic(let frame, let maximum):
             return ("semantic", frame - 1, maximum)
         case .denoise(let chunk, let chunkCount, let step, let stepCount):
-            return ("denoising", (chunk - 1) * stepCount + step - 1, chunkCount * stepCount)
+            let completed = switch strategy {
+            case .sequential: (chunk - 1) * stepCount + step
+            case .overlapAverage: (step - 1) * chunkCount + chunk
+            }
+            return ("denoising", completed - 1, chunkCount * stepCount)
         case .decode(let chunk, let chunkCount):
             return ("decoding", chunk - 1, chunkCount)
         }

--- a/Sources/MereRunCLI/Commands/MusicGenerateCommand.swift
+++ b/Sources/MereRunCLI/Commands/MusicGenerateCommand.swift
@@ -447,6 +447,12 @@ struct MusicGenerate: AsyncParsableCommand {
     @Flag(name: [.short, .long], help: "Quiet mode (suppress stderr diagnostics).")
     var quiet: Bool = false
 
+    @Flag(name: [.customLong(CLIGenerationProgressPrinter.flagName)], help: CLIGenerationProgressPrinter.flagHelp)
+    var progressJson: Bool = false
+
+    @Flag(name: [.customLong(RunReceipt.flagName)], help: RunReceipt.flagHelp)
+    var receipt: Bool = false
+
     @Option(name: [.customLong("temperature")], help: "Magenta RT2 sampling temperature.")
     var magentaTemperature: Float = 1.0
 
@@ -951,6 +957,7 @@ struct MusicGenerate: AsyncParsableCommand {
             sampleRate: 48_000,
             options: exportOptions
         )
+        var receiptSidecars: [RunReceipt.Output] = []
         if keepCandidates {
             for candidate in ranked.candidates {
                 let candidateURL = candidateOutputURL(
@@ -964,6 +971,7 @@ struct MusicGenerate: AsyncParsableCommand {
                     sampleRate: 48_000,
                     options: exportOptions
                 )
+                receiptSidecars.append(.init(url: candidateURL, kind: .audio, role: "candidate"))
             }
         }
 
@@ -1006,6 +1014,7 @@ struct MusicGenerate: AsyncParsableCommand {
                     audio: extracted.audio
                 )
             )
+            receiptSidecars.append(.init(url: stemURL, kind: .audio, role: "stem"))
         }
 
         let synchronizedLyrics: ACEStepLRCDocument? = {
@@ -1163,6 +1172,16 @@ struct MusicGenerate: AsyncParsableCommand {
             CLIStderr.write("Saved audio: \(outputURL.path)\n")
         }
         print(outputURL.path)
+        if let synchronizedLyricsURL {
+            receiptSidecars.append(.init(url: synchronizedLyricsURL, kind: .text, role: "lyrics"))
+        }
+        if let recipeURL {
+            receiptSidecars.append(.init(url: recipeURL, kind: .json, role: "recipe"))
+        }
+        if let dawBundle {
+            receiptSidecars.append(.init(url: resolveUserPath(dawBundle), kind: .directory, role: "daw-bundle"))
+        }
+        try RunReceipt.emit(RunReceipt.generatedAudioOutputs(audio: outputURL, sidecars: receiptSidecars), enabled: receipt)
     }
 
     private func loadAdapters(
@@ -1221,6 +1240,7 @@ struct MusicGenerate: AsyncParsableCommand {
     }
 
     private func runMiniMaxMusic3(explicitDurationSeconds: Float?) async throws {
+        var receiptSidecars: [RunReceipt.Output] = []
         try validateMiniMaxMusic3Options(explicitDurationSeconds: explicitDurationSeconds)
         let inputLRC = try loadLRC()
         let inputLyrics = instrumental
@@ -1303,6 +1323,7 @@ struct MusicGenerate: AsyncParsableCommand {
             if !quiet {
                 CLIStderr.write("Saved composition: \(compositionURL.path)\n")
             }
+            receiptSidecars.append(.init(url: compositionURL, kind: .json, role: "composition"))
         } else {
             composition = nil
         }
@@ -1390,6 +1411,10 @@ struct MusicGenerate: AsyncParsableCommand {
                 seedStrategy: seedStrategy
             ),
             progress: { event in
+                if progressJson {
+                    CLIStderr.write(Self.miniMaxProgressJSONLine(event) + "\n")
+                    return
+                }
                 guard !quiet else { return }
                 switch event {
                 case .semantic(let frame, let maximum):
@@ -1422,6 +1447,7 @@ struct MusicGenerate: AsyncParsableCommand {
             if !quiet {
                 CLIStderr.write("Saved MiniMax profile: \(profileURL.path)\n")
             }
+            receiptSidecars.append(.init(url: profileURL, kind: .json, role: "profile"))
         }
         let exportOptions = ACEStepAudioExportOptions(
             format: exportFormat,
@@ -1486,6 +1512,7 @@ struct MusicGenerate: AsyncParsableCommand {
             if !quiet {
                 CLIStderr.write("Saved recipe: \(recipeURL.path)\n")
             }
+            receiptSidecars.append(.init(url: recipeURL, kind: .json, role: "recipe"))
         }
         if !quiet {
             CLIStderr.write(
@@ -1494,6 +1521,25 @@ struct MusicGenerate: AsyncParsableCommand {
             CLIStderr.write("Saved audio: \(outputURL.path)\n")
         }
         print(outputURL.path)
+        try RunReceipt.emit(RunReceipt.generatedAudioOutputs(audio: outputURL, sidecars: receiptSidecars), enabled: receipt)
+    }
+
+    /// MiniMax Music 3 reports three sequential stages with 1-based counters;
+    /// flow denoising is flattened across chunks so `step` reaches `total_steps`
+    /// exactly once at the end of the last chunk.
+    static func miniMaxProgressJSONLine(_ event: MiniMaxMusic3Progress) -> String {
+        switch event {
+        case .semantic(let frame, let maximum):
+            return CLIGenerationProgressPrinter.progressJSONLine(stage: "semantic", step: frame, totalSteps: maximum)
+        case .denoise(let chunk, let chunkCount, let step, let stepCount):
+            return CLIGenerationProgressPrinter.progressJSONLine(
+                stage: "denoising",
+                step: (chunk - 1) * stepCount + step,
+                totalSteps: chunkCount * stepCount
+            )
+        case .decode(let chunk, let chunkCount):
+            return CLIGenerationProgressPrinter.progressJSONLine(stage: "decoding", step: chunk, totalSteps: chunkCount)
+        }
     }
 
     var resolvedMiniMaxInferenceSteps: Int {
@@ -1763,7 +1809,16 @@ struct MusicGenerate: AsyncParsableCommand {
                 controls: controls
             ),
             progress: { frame, total in
-                guard !quiet, frame % 10 == 0 || frame + 1 == total else { return }
+                guard frame % 10 == 0 || frame + 1 == total else { return }
+                if progressJson {
+                    CLIGenerationProgressPrinter.writeJSONProgress(
+                        stage: "generating",
+                        step: frame + 1 == total ? total : frame,
+                        totalSteps: total
+                    )
+                    return
+                }
+                guard !quiet else { return }
                 CLIStderr.write("Generated Magenta RT2 frame \(frame + 1)/\(total)\n")
             }
         )
@@ -1778,6 +1833,7 @@ struct MusicGenerate: AsyncParsableCommand {
             CLIStderr.write("Saved audio: \(outputURL.path)\n")
         }
         print(outputURL.path)
+        try RunReceipt.emit(RunReceipt.generatedAudioOutputs(audio: outputURL), enabled: receipt)
     }
 
     private func validateMagentaRT2Options() throws {

--- a/Sources/MereRunCLI/Commands/SFXGenerateCommand.swift
+++ b/Sources/MereRunCLI/Commands/SFXGenerateCommand.swift
@@ -45,6 +45,12 @@ struct SFXGenerate: AsyncParsableCommand {
     @Flag(name: [.short, .long], help: "Quiet mode (suppress stderr diagnostics).")
     var quiet: Bool = false
 
+    @Flag(name: [.customLong(CLIGenerationProgressPrinter.flagName)], help: CLIGenerationProgressPrinter.flagHelp)
+    var progressJson: Bool = false
+
+    @Flag(name: [.customLong(RunReceipt.flagName)], help: RunReceipt.flagHelp)
+    var receipt: Bool = false
+
     var durationSeconds: Float {
         durationOverride ?? (SFXMMAudioRuntime.isMMAudio(model: model)
             ? MMAudioResources.defaultDurationSeconds
@@ -95,6 +101,10 @@ struct SFXGenerate: AsyncParsableCommand {
                 renoiseSchedule: renoiseSchedule
             ),
             progress: { completed, total in
+                if progressJson {
+                    CLIGenerationProgressPrinter.writeJSONProgress(stage: "denoising", step: completed, totalSteps: total)
+                    return
+                }
                 guard !quiet else { return }
                 CLIStderr.write("Generated Woosh step \(completed)/\(total)\n")
             }
@@ -105,6 +115,7 @@ struct SFXGenerate: AsyncParsableCommand {
             CLIStderr.write("Saved audio: \(outputURL.path)\n")
         }
         print(outputURL.path)
+        try RunReceipt.emit(RunReceipt.generatedAudioOutputs(audio: outputURL), enabled: receipt)
     }
 
     private func runMMAudio() async throws {
@@ -135,6 +146,10 @@ struct SFXGenerate: AsyncParsableCommand {
                 seed: seed
             ),
             progress: { completed, total in
+                if progressJson {
+                    CLIGenerationProgressPrinter.writeJSONProgress(stage: "denoising", step: completed, totalSteps: total)
+                    return
+                }
                 guard !quiet else { return }
                 CLIStderr.write("Generated MMAudio step \(completed)/\(total)\n")
             }
@@ -148,6 +163,7 @@ struct SFXGenerate: AsyncParsableCommand {
             CLIStderr.write("Saved audio: \(outputURL.path)\n")
         }
         print(outputURL.path)
+        try RunReceipt.emit(RunReceipt.generatedAudioOutputs(audio: outputURL), enabled: receipt)
     }
 
     func parseRenoiseSchedule() throws -> [Float] {

--- a/Sources/MereRunCLI/Commands/SFXGenerateCommand.swift
+++ b/Sources/MereRunCLI/Commands/SFXGenerateCommand.swift
@@ -103,7 +103,8 @@ struct SFXGenerate: AsyncParsableCommand {
             ),
             progress: { completed, total in
                 if let progressStream {
-                    progressStream.report(stage: "denoising", step: completed - 1, totalSteps: total)
+                    let progress = Self.denoiseProgressEvent(completed: completed, total: total)
+                    progressStream.report(stage: progress.stage, step: progress.step, totalSteps: progress.totalSteps)
                     return
                 }
                 guard !quiet else { return }
@@ -150,7 +151,8 @@ struct SFXGenerate: AsyncParsableCommand {
             ),
             progress: { completed, total in
                 if let progressStream {
-                    progressStream.report(stage: "denoising", step: completed - 1, totalSteps: total)
+                    let progress = Self.denoiseProgressEvent(completed: completed, total: total)
+                    progressStream.report(stage: progress.stage, step: progress.step, totalSteps: progress.totalSteps)
                     return
                 }
                 guard !quiet else { return }
@@ -168,6 +170,13 @@ struct SFXGenerate: AsyncParsableCommand {
         }
         print(outputURL.path)
         try RunReceipt.emit(RunReceipt.generatedAudioOutputs(audio: outputURL), enabled: receipt)
+    }
+
+    /// Woosh and MMAudio both count denoise *completions* from 1, so the counter
+    /// is shifted onto the 0-based in-progress index `JSONProgressStream`
+    /// expects; the stream adds the terminal `step == total_steps` event.
+    static func denoiseProgressEvent(completed: Int, total: Int) -> (stage: String, step: Int, totalSteps: Int) {
+        ("denoising", completed - 1, total)
     }
 
     func parseRenoiseSchedule() throws -> [Float] {

--- a/Sources/MereRunCLI/Commands/SFXGenerateCommand.swift
+++ b/Sources/MereRunCLI/Commands/SFXGenerateCommand.swift
@@ -91,6 +91,7 @@ struct SFXGenerate: AsyncParsableCommand {
             CLIStderr.write("Loading Woosh checkpoints from \(resolved.checkpointsRootURL.path)\n")
         }
         let generator = try WooshGenerator(resources: resolved)
+        let progressStream = progressJson ? JSONProgressStream() : nil
         let result = try generator.generate(
             prompt: prompt,
             config: WooshDenoiseConfig(
@@ -101,8 +102,8 @@ struct SFXGenerate: AsyncParsableCommand {
                 renoiseSchedule: renoiseSchedule
             ),
             progress: { completed, total in
-                if progressJson {
-                    CLIGenerationProgressPrinter.writeJSONProgress(stage: "denoising", step: completed, totalSteps: total)
+                if let progressStream {
+                    progressStream.report(stage: "denoising", step: completed - 1, totalSteps: total)
                     return
                 }
                 guard !quiet else { return }
@@ -110,6 +111,7 @@ struct SFXGenerate: AsyncParsableCommand {
             }
         )
 
+        progressStream?.finish()
         try SFXWAVWriter.writeMonoPCM16(samples: result.samples, to: outputURL, sampleRate: result.sampleRate)
         if !quiet {
             CLIStderr.write("Saved audio: \(outputURL.path)\n")
@@ -136,6 +138,7 @@ struct SFXGenerate: AsyncParsableCommand {
             CLIStderr.write("Loading native MMAudio assets from \(resources.rootURL.path)\n")
         }
         let generator = try MMAudioGenerator(resources: resources)
+        let progressStream = progressJson ? JSONProgressStream() : nil
         let result = try await generator.generateText(
             prompt: prompt,
             negativePrompt: negativePrompt,
@@ -146,14 +149,15 @@ struct SFXGenerate: AsyncParsableCommand {
                 seed: seed
             ),
             progress: { completed, total in
-                if progressJson {
-                    CLIGenerationProgressPrinter.writeJSONProgress(stage: "denoising", step: completed, totalSteps: total)
+                if let progressStream {
+                    progressStream.report(stage: "denoising", step: completed - 1, totalSteps: total)
                     return
                 }
                 guard !quiet else { return }
                 CLIStderr.write("Generated MMAudio step \(completed)/\(total)\n")
             }
         )
+        progressStream?.finish()
         try SFXWAVWriter.writeMonoPCM16(
             samples: result.samples,
             to: outputURL,

--- a/Sources/MereRunCLI/Commands/SpeechSynthesizeCommand.swift
+++ b/Sources/MereRunCLI/Commands/SpeechSynthesizeCommand.swift
@@ -8,6 +8,18 @@ import MereRunCore
 
 // MARK: - Speech Synthesize Command
 
+/// The one non-streaming synthesis call `speech synthesize` makes, so a test
+/// can substitute a fixture generator for Qwen3-TTS.
+protocol CLISpeechSynthesizing {
+    func generate(
+        _ request: TTSRequest,
+        modelPath: String?,
+        progressHandler: (@Sendable (TTSProgress) -> Void)?
+    ) async throws -> TTSResult
+}
+
+extension Qwen3TTSGenerator: CLISpeechSynthesizing {}
+
 enum TalkModeOption: String, ExpressibleByArgument {
     case style
     case clone
@@ -75,6 +87,14 @@ struct SpeechSynthesize: AsyncParsableCommand {
     @Flag(name: [.customLong(RunReceipt.flagName)], help: RunReceipt.flagHelp)
     var receipt: Bool = false
 
+    /// Test seam: replaces the Qwen3-TTS generator on the non-streaming path so
+    /// the command's output contract can be exercised without a model. Setting
+    /// it also skips the Metal bundle check, which the fixture does not need.
+    /// Tests set and clear it around one `run()`; the CLI never touches it.
+    nonisolated(unsafe) static var synthesizerOverride: (any CLISpeechSynthesizing)?
+
+    private var synthesizer: (any CLISpeechSynthesizing)? { Self.synthesizerOverride }
+
     func run() async throws {
         if stream {
             guard streamChunkTokens > 0 else {
@@ -82,7 +102,9 @@ struct SpeechSynthesize: AsyncParsableCommand {
             }
         }
 
-        try MLXBundleSupport.ensureAvailable(quiet: quiet)
+        if synthesizer == nil {
+            try MLXBundleSupport.ensureAvailable(quiet: quiet)
+        }
         let outputURL = URL(fileURLWithPath: output).standardizedFileURL
 
         // Ensure output directory exists
@@ -90,15 +112,16 @@ struct SpeechSynthesize: AsyncParsableCommand {
         try FileManager.default.createDirectory(at: outputDir, withIntermediateDirectories: true)
 
         let modelSelection = try resolveModelSelection()
-        let generator = Qwen3TTSGenerator(modelId: modelSelection.modelId)
+        let qwenGenerator = Qwen3TTSGenerator(modelId: modelSelection.modelId)
         let profileStore = VoiceProfileStore()
 
         let request = try await buildRequest(outputURL: outputURL, profileStore: profileStore)
 
         if stream {
-            try await runStreaming(request: request, generator: generator, modelPath: modelSelection.modelPath)
+            try await runStreaming(request: request, generator: qwenGenerator, modelPath: modelSelection.modelPath)
             return
         }
+        let generator: any CLISpeechSynthesizing = synthesizer ?? qwenGenerator
 
         if !quiet {
             FileHandle.standardError.write(Data("Generating speech with native Qwen3-TTS...\n".utf8))
@@ -108,12 +131,9 @@ struct SpeechSynthesize: AsyncParsableCommand {
         if progressJson {
             // Qwen3-TTS reports stage changes and a running token count with no
             // known total, so every event is indeterminate (`total_steps: 0`).
+            let progressStream = JSONProgressStream()
             progressHandler = { progress in
-                CLIGenerationProgressPrinter.writeJSONProgress(
-                    stage: progress.stage.rawValue,
-                    step: progress.tokensGenerated,
-                    totalSteps: 0
-                )
+                progressStream.report(stage: progress.stage.rawValue, step: progress.tokensGenerated, totalSteps: 0)
             }
         } else if quiet {
             progressHandler = nil
@@ -167,18 +187,15 @@ struct SpeechSynthesize: AsyncParsableCommand {
         var writer: StreamingWAVWriter?
         var tokenCount = 0
         var result: TTSResult?
+        let progressStream = progressJson ? JSONProgressStream() : nil
 
         for try await event in stream {
             switch event {
             case .token:
                 tokenCount += 1
                 if tokenCount % 25 == 0 {
-                    if progressJson {
-                        CLIGenerationProgressPrinter.writeJSONProgress(
-                            stage: TTSStage.generating.rawValue,
-                            step: tokenCount,
-                            totalSteps: 0
-                        )
+                    if let progressStream {
+                        progressStream.report(stage: TTSStage.generating.rawValue, step: tokenCount, totalSteps: 0)
                     } else if !quiet {
                         FileHandle.standardError.write(
                             Data("[generating] \(tokenCount) tokens\n".utf8)

--- a/Sources/MereRunCLI/Commands/SpeechSynthesizeCommand.swift
+++ b/Sources/MereRunCLI/Commands/SpeechSynthesizeCommand.swift
@@ -69,6 +69,12 @@ struct SpeechSynthesize: AsyncParsableCommand {
     @Flag(name: [.short, .long], help: "Quiet mode (suppress progress output).")
     var quiet: Bool = false
 
+    @Flag(name: [.customLong(CLIGenerationProgressPrinter.flagName)], help: CLIGenerationProgressPrinter.flagHelp)
+    var progressJson: Bool = false
+
+    @Flag(name: [.customLong(RunReceipt.flagName)], help: RunReceipt.flagHelp)
+    var receipt: Bool = false
+
     func run() async throws {
         if stream {
             guard streamChunkTokens > 0 else {
@@ -99,7 +105,17 @@ struct SpeechSynthesize: AsyncParsableCommand {
         }
 
         let progressHandler: (@Sendable (TTSProgress) -> Void)?
-        if quiet {
+        if progressJson {
+            // Qwen3-TTS reports stage changes and a running token count with no
+            // known total, so every event is indeterminate (`total_steps: 0`).
+            progressHandler = { progress in
+                CLIGenerationProgressPrinter.writeJSONProgress(
+                    stage: progress.stage.rawValue,
+                    step: progress.tokensGenerated,
+                    totalSteps: 0
+                )
+            }
+        } else if quiet {
             progressHandler = nil
         } else {
             progressHandler = { progress in
@@ -127,6 +143,7 @@ struct SpeechSynthesize: AsyncParsableCommand {
         }
 
         print(result.audioURL.path)
+        try RunReceipt.emit(RunReceipt.generatedAudioOutputs(audio: result.audioURL), enabled: receipt)
     }
 
     private func runStreaming(
@@ -155,10 +172,18 @@ struct SpeechSynthesize: AsyncParsableCommand {
             switch event {
             case .token:
                 tokenCount += 1
-                if !quiet && tokenCount % 25 == 0 {
-                    FileHandle.standardError.write(
-                        Data("[generating] \(tokenCount) tokens\n".utf8)
-                    )
+                if tokenCount % 25 == 0 {
+                    if progressJson {
+                        CLIGenerationProgressPrinter.writeJSONProgress(
+                            stage: TTSStage.generating.rawValue,
+                            step: tokenCount,
+                            totalSteps: 0
+                        )
+                    } else if !quiet {
+                        FileHandle.standardError.write(
+                            Data("[generating] \(tokenCount) tokens\n".utf8)
+                        )
+                    }
                 }
 
             case .audioChunk(let samples, let sampleRate):
@@ -183,6 +208,7 @@ struct SpeechSynthesize: AsyncParsableCommand {
         }
 
         print(result.audioURL.path)
+        try RunReceipt.emit(RunReceipt.generatedAudioOutputs(audio: result.audioURL), enabled: receipt)
     }
 
     private func buildRequest(

--- a/Sources/MereRunCLI/Commands/SpeechTranscribeCommand.swift
+++ b/Sources/MereRunCLI/Commands/SpeechTranscribeCommand.swift
@@ -99,8 +99,14 @@ struct SpeechTranscribe: AsyncParsableCommand {
     @Flag(name: [.short, .long], help: "Quiet mode (suppress progress output).")
     var quiet: Bool = false
 
+    @Flag(name: [.customLong(RunReceipt.flagName)], help: RunReceipt.flagHelp)
+    var receipt: Bool = false
+
     func validate() throws {
         let readsStandardInput = audio == "-"
+        if receipt && readsStandardInput {
+            throw ValidationError("--receipt is not available for raw streaming stdin ('-'); use --jsonl.")
+        }
         if stream {
             guard streamChunkMs > 0 else {
                 throw ValidationError("--stream-chunk-ms must be > 0.")
@@ -207,17 +213,27 @@ struct SpeechTranscribe: AsyncParsableCommand {
             }
         }
 
-        if let outputPath = output {
-            let outputURL = URL(fileURLWithPath: outputPath).standardizedFileURL
-            let outputDir = outputURL.deletingLastPathComponent()
-            try FileManager.default.createDirectory(at: outputDir, withIntermediateDirectories: true)
-            try outputText.write(to: outputURL, atomically: true, encoding: .utf8)
-            if !quiet {
-                CLIStderr.write("Transcript saved to: \(outputURL.path)\n")
-            }
-        }
-
+        let transcriptURL = try writeTranscriptIfRequested(outputText)
         print(outputText)
+        try emitReceipt(transcriptURL: transcriptURL)
+    }
+
+    /// Writes the transcript to `--output` when set and returns its URL. The
+    /// receipt lists no outputs when the transcript only went to stdout.
+    private func writeTranscriptIfRequested(_ outputText: String) throws -> URL? {
+        guard let outputPath = output else { return nil }
+        let outputURL = URL(fileURLWithPath: outputPath).standardizedFileURL
+        let outputDir = outputURL.deletingLastPathComponent()
+        try FileManager.default.createDirectory(at: outputDir, withIntermediateDirectories: true)
+        try outputText.write(to: outputURL, atomically: true, encoding: .utf8)
+        if !quiet {
+            CLIStderr.write("Transcript saved to: \(outputURL.path)\n")
+        }
+        return outputURL
+    }
+
+    private func emitReceipt(transcriptURL: URL?) throws {
+        try RunReceipt.emit(RunReceipt.transcriptOutputs(transcriptURL), enabled: receipt)
     }
 
     private func runStandardInput() async throws {
@@ -320,17 +336,9 @@ struct SpeechTranscribe: AsyncParsableCommand {
                 }
             }
 
-            if let outputPath = output {
-                let outputURL = URL(fileURLWithPath: outputPath).standardizedFileURL
-                let outputDir = outputURL.deletingLastPathComponent()
-                try FileManager.default.createDirectory(at: outputDir, withIntermediateDirectories: true)
-                try outputText.write(to: outputURL, atomically: true, encoding: .utf8)
-                if !quiet {
-                    CLIStderr.write("Transcript saved to: \(outputURL.path)\n")
-                }
-            }
-
+            let transcriptURL = try writeTranscriptIfRequested(outputText)
             print(outputText)
+            try emitReceipt(transcriptURL: transcriptURL)
         } catch {
             eventTask.cancel()
             await live.cancel()

--- a/Sources/MereRunCLI/Commands/SpeechTranscribeCommand.swift
+++ b/Sources/MereRunCLI/Commands/SpeechTranscribeCommand.swift
@@ -102,6 +102,14 @@ struct SpeechTranscribe: AsyncParsableCommand {
     @Flag(name: [.customLong(RunReceipt.flagName)], help: RunReceipt.flagHelp)
     var receipt: Bool = false
 
+    /// Test seam: forwarded to `CLIASRRouting.transcribe` so the file path can
+    /// run against a fixture backend. Setting it also skips the Metal bundle
+    /// check, which the fixture does not need. Tests set and clear it around
+    /// one `run()`; the CLI never touches it.
+    nonisolated(unsafe) static var transcriptionExecutorOverride: (any CLIASRTranscriptionExecutor)?
+
+    private var transcriptionExecutor: (any CLIASRTranscriptionExecutor)? { Self.transcriptionExecutorOverride }
+
     func validate() throws {
         let readsStandardInput = audio == "-"
         if receipt && readsStandardInput {
@@ -146,7 +154,9 @@ struct SpeechTranscribe: AsyncParsableCommand {
     func run() async throws {
         let readsStandardInput = audio == "-"
 
-        try MLXBundleSupport.ensureAvailable(quiet: quiet)
+        if transcriptionExecutor == nil {
+            try MLXBundleSupport.ensureAvailable(quiet: quiet)
+        }
         if readsStandardInput {
             try await runStandardInput()
             return
@@ -197,7 +207,8 @@ struct SpeechTranscribe: AsyncParsableCommand {
             request: request,
             preferredBackend: backend.backend,
             modelOverride: model,
-            progressHandler: progressHandler
+            progressHandler: progressHandler,
+            executor: transcriptionExecutor
         )
         let result = execution.result
         let outputText = renderOutput(result: result, includeTimestamps: timestamps)

--- a/Sources/MereRunCLI/Commands/VideoCommand.swift
+++ b/Sources/MereRunCLI/Commands/VideoCommand.swift
@@ -688,6 +688,12 @@ struct VideoGenerate: AsyncParsableCommand {
     @Flag(name: [.short, .long], help: "Quiet mode (suppress stderr diagnostics).")
     var quiet: Bool = false
 
+    @Flag(name: [.customLong(CLIGenerationProgressPrinter.flagName)], help: CLIGenerationProgressPrinter.flagHelp)
+    var progressJson: Bool = false
+
+    @Flag(name: [.customLong(RunReceipt.flagName)], help: RunReceipt.flagHelp)
+    var receipt: Bool = false
+
     var variant: LTXVideoVariant {
         effectiveOutputMode.compatibilityVariant
     }
@@ -1314,7 +1320,16 @@ struct VideoGenerate: AsyncParsableCommand {
             )
             let generator = MiniMaxH3Generator(retainsRuntime: slidingWindowOptions != nil)
             let reportsProgress = !quiet
+            let progressJson = progressJson
             let progressHandler: @Sendable (MiniMaxH3GenerationProgress) -> Void = { progress in
+                if progressJson {
+                    CLIGenerationProgressPrinter.writeJSONProgress(
+                        stage: progress.stage.rawValue,
+                        step: progress.stepIndex,
+                        totalSteps: progress.totalSteps
+                    )
+                    return
+                }
                 guard reportsProgress else { return }
                 if progress.stage == .denoising {
                     CLIStderr.write("Denoising \(progress.stepIndex + 1)/\(progress.totalSteps)\n")
@@ -1333,6 +1348,14 @@ struct VideoGenerate: AsyncParsableCommand {
                             slidingWindowOptions: slidingWindowOptions,
                             resources: h3Resources,
                             windowHandler: { index, count in
+                                if progressJson {
+                                    CLIGenerationProgressPrinter.writeJSONProgress(
+                                        stage: "window",
+                                        step: index,
+                                        totalSteps: count
+                                    )
+                                    return
+                                }
                                 guard reportsProgress else { return }
                                 CLIStderr.write("H3 window \(index + 1)/\(count)\n")
                             },
@@ -1355,6 +1378,7 @@ struct VideoGenerate: AsyncParsableCommand {
             )
             if !quiet { CLIStderr.write("Saved: \(outputURL.path)\n") }
             print(outputURL.path)
+            try emitReceipt(primary: outputURL, kind: .video, includesTimings: false)
             return
         }
         if h3Adapter != nil {
@@ -1880,11 +1904,20 @@ struct VideoGenerate: AsyncParsableCommand {
             CLIStderr.write("Mode: image-to-video\n")
         }
         let reportsProgress = !quiet
+        let progressJson = progressJson
         let generator = Wan2TI2VGenerator()
         let result = try await generator.generate(
             options: options,
             resources: Wan2Resources(rootURL: modelRoot),
             progressHandler: { progress in
+                if progressJson {
+                    CLIGenerationProgressPrinter.writeJSONProgress(
+                        stage: progress.stage.rawValue,
+                        step: progress.stepIndex,
+                        totalSteps: progress.totalSteps
+                    )
+                    return
+                }
                 guard reportsProgress else { return }
                 if progress.stage == .denoising {
                     CLIStderr.write("Denoising \(progress.stepIndex + 1)/\(progress.totalSteps)\n")
@@ -1902,6 +1935,7 @@ struct VideoGenerate: AsyncParsableCommand {
             CLIStderr.write("Saved: \(outputURL.path)\n")
         }
         print(outputURL.path)
+        try emitReceipt(primary: outputURL, kind: .video, includesTimings: false)
     }
 
     private func runNativeAudioToVideoGenerate(
@@ -2045,6 +2079,7 @@ struct VideoGenerate: AsyncParsableCommand {
             CLIStderr.write("Saved: \(outputURL.path)\n")
         }
         print(outputURL.path)
+        try emitReceipt(primary: outputURL, kind: .video, includesTimings: true)
     }
 
     private func runNativeGenerate(
@@ -2524,6 +2559,24 @@ struct VideoGenerate: AsyncParsableCommand {
             CLIStderr.write("Saved: \(savedArtifactURL.path)\n")
         }
         print(savedArtifactURL.path)
+        try emitReceipt(
+            primary: savedArtifactURL,
+            kind: skipHDRMP4 ? .directory : .video,
+            includesTimings: true
+        )
+    }
+
+    /// The `--receipt` line for every video lane. Only the LTX lanes write the
+    /// optional `--timings-output` JSON, so the other lanes leave it out.
+    private func emitReceipt(primary: URL, kind: RunReceipt.OutputKind, includesTimings: Bool) throws {
+        try RunReceipt.emit(
+            RunReceipt.generatedVideoOutputs(
+                primary: primary,
+                kind: kind,
+                timings: includesTimings ? timingsOutput.map { URL(fileURLWithPath: $0) } : nil
+            ),
+            enabled: receipt
+        )
     }
 
     private func resolveAutoDuration(

--- a/Sources/MereRunCLI/Commands/VideoCommand.swift
+++ b/Sources/MereRunCLI/Commands/VideoCommand.swift
@@ -694,6 +694,10 @@ struct VideoGenerate: AsyncParsableCommand {
     @Flag(name: [.customLong(RunReceipt.flagName)], help: RunReceipt.flagHelp)
     var receipt: Bool = false
 
+    func validate() throws {
+        try RunReceipt.validate(receipt: receipt, preflight: preflight)
+    }
+
     var variant: LTXVideoVariant {
         effectiveOutputMode.compatibilityVariant
     }
@@ -1320,10 +1324,10 @@ struct VideoGenerate: AsyncParsableCommand {
             )
             let generator = MiniMaxH3Generator(retainsRuntime: slidingWindowOptions != nil)
             let reportsProgress = !quiet
-            let progressJson = progressJson
+            let progressStream = progressJson ? JSONProgressStream() : nil
             let progressHandler: @Sendable (MiniMaxH3GenerationProgress) -> Void = { progress in
-                if progressJson {
-                    CLIGenerationProgressPrinter.writeJSONProgress(
+                if let progressStream {
+                    progressStream.report(
                         stage: progress.stage.rawValue,
                         step: progress.stepIndex,
                         totalSteps: progress.totalSteps
@@ -1348,12 +1352,8 @@ struct VideoGenerate: AsyncParsableCommand {
                             slidingWindowOptions: slidingWindowOptions,
                             resources: h3Resources,
                             windowHandler: { index, count in
-                                if progressJson {
-                                    CLIGenerationProgressPrinter.writeJSONProgress(
-                                        stage: "window",
-                                        step: index,
-                                        totalSteps: count
-                                    )
+                                if let progressStream {
+                                    progressStream.mark(stage: "window", step: index, totalSteps: count)
                                     return
                                 }
                                 guard reportsProgress else { return }
@@ -1369,6 +1369,7 @@ struct VideoGenerate: AsyncParsableCommand {
                     )
                 }
             }
+            progressStream?.finish()
             try LTXVideoMP4Writer.writeMP4(
                 frames: result.frames,
                 fps: MiniMaxH3Geometry.framesPerSecond,
@@ -1904,14 +1905,14 @@ struct VideoGenerate: AsyncParsableCommand {
             CLIStderr.write("Mode: image-to-video\n")
         }
         let reportsProgress = !quiet
-        let progressJson = progressJson
+        let progressStream = progressJson ? JSONProgressStream() : nil
         let generator = Wan2TI2VGenerator()
         let result = try await generator.generate(
             options: options,
             resources: Wan2Resources(rootURL: modelRoot),
             progressHandler: { progress in
-                if progressJson {
-                    CLIGenerationProgressPrinter.writeJSONProgress(
+                if let progressStream {
+                    progressStream.report(
                         stage: progress.stage.rawValue,
                         step: progress.stepIndex,
                         totalSteps: progress.totalSteps
@@ -1930,6 +1931,7 @@ struct VideoGenerate: AsyncParsableCommand {
             CLIStderr.write("Decoded frames shape: \(shapeString(result.frames.shape))\n")
             CLIStderr.write("Writing MP4...\n")
         }
+        progressStream?.finish()
         try LTXVideoMP4Writer.writeMP4(frames: result.frames, fps: fps, to: outputURL)
         if !quiet {
             CLIStderr.write("Saved: \(outputURL.path)\n")

--- a/Sources/MereRunCLI/Commands/VisionGroundCommand.swift
+++ b/Sources/MereRunCLI/Commands/VisionGroundCommand.swift
@@ -74,6 +74,9 @@ struct VisionGround: AsyncParsableCommand {
     @Flag(name: [.short, .long], help: "Print only the annotated output image path.")
     var quiet: Bool = false
 
+    @Flag(name: [.customLong(RunReceipt.flagName)], help: RunReceipt.flagHelp)
+    var receipt: Bool = false
+
     func validate() throws {
         guard !query.isEmpty else {
             throw ValidationError("Provide at least one --query or --prompt value.")
@@ -149,6 +152,14 @@ struct VisionGround: AsyncParsableCommand {
                 print("Masks: \(maskOutputDirectoryURL.path)")
             }
         }
+        try RunReceipt.emit(
+            RunReceipt.annotatedImageOutputs(
+                image: result.annotatedImageURL,
+                detections: result.jsonOutputURL,
+                masks: maskOutputDirectoryURL
+            ),
+            enabled: receipt
+        )
     }
 
     static func resolveModelRoot(

--- a/Sources/MereRunCLI/Commands/VisionGroundCommand.swift
+++ b/Sources/MereRunCLI/Commands/VisionGroundCommand.swift
@@ -84,6 +84,7 @@ struct VisionGround: AsyncParsableCommand {
         if json && !preflight {
             throw ValidationError("--json is only supported with --preflight for vision ground.")
         }
+        try RunReceipt.validate(receipt: receipt, preflight: preflight)
     }
 
     func run() async throws {

--- a/Sources/MereRunCLI/Commands/VisionSegmentCommand.swift
+++ b/Sources/MereRunCLI/Commands/VisionSegmentCommand.swift
@@ -76,6 +76,9 @@ struct VisionSegment: AsyncParsableCommand {
     @Flag(name: [.customShort("q"), .long], help: "Suppress normal progress output.")
     var quiet: Bool = false
 
+    @Flag(name: [.customLong(RunReceipt.flagName)], help: RunReceipt.flagHelp)
+    var receipt: Bool = false
+
     func validate() throws {
         if json && !preflight {
             throw ValidationError("--json is only supported with --preflight for vision segment.")
@@ -146,6 +149,14 @@ struct VisionSegment: AsyncParsableCommand {
                 print("Masks: \(maskOutputDirectoryURL.path)")
             }
         }
+        try RunReceipt.emit(
+            RunReceipt.annotatedImageOutputs(
+                image: result.annotatedImageURL,
+                detections: result.jsonOutputURL,
+                masks: maskOutputDirectoryURL
+            ),
+            enabled: receipt
+        )
     }
 
     func makePreflightEnvelope(

--- a/Sources/MereRunCLI/Commands/VisionSegmentCommand.swift
+++ b/Sources/MereRunCLI/Commands/VisionSegmentCommand.swift
@@ -83,6 +83,7 @@ struct VisionSegment: AsyncParsableCommand {
         if json && !preflight {
             throw ValidationError("--json is only supported with --preflight for vision segment.")
         }
+        try RunReceipt.validate(receipt: receipt, preflight: preflight)
         if preflight {
             return
         }

--- a/Sources/MereRunCLI/Commands/VisionTrackCommand.swift
+++ b/Sources/MereRunCLI/Commands/VisionTrackCommand.swift
@@ -63,6 +63,9 @@ struct VisionTrack: AsyncParsableCommand {
     @Flag(name: [.customShort("q"), .long], help: "Suppress normal progress output.")
     var quiet: Bool = false
 
+    @Flag(name: [.customLong(RunReceipt.flagName)], help: RunReceipt.flagHelp)
+    var receipt: Bool = false
+
     func validate() throws {
         if json && !preflight {
             throw ValidationError("--json is only supported with --preflight for vision track.")
@@ -145,6 +148,14 @@ struct VisionTrack: AsyncParsableCommand {
                 print("Masks: \(maskOutputDirectoryURL.path)")
             }
         }
+        try RunReceipt.emit(
+            RunReceipt.annotatedVideoOutputs(
+                videoPath: result.annotatedVideoPath,
+                trackingPath: result.jsonOutputPath,
+                masks: maskOutputDirectoryURL
+            ),
+            enabled: receipt
+        )
     }
 
     func parsedPromptSet() throws -> SAM31PromptSet {

--- a/Sources/MereRunCLI/Commands/VisionTrackCommand.swift
+++ b/Sources/MereRunCLI/Commands/VisionTrackCommand.swift
@@ -70,6 +70,7 @@ struct VisionTrack: AsyncParsableCommand {
         if json && !preflight {
             throw ValidationError("--json is only supported with --preflight for vision track.")
         }
+        try RunReceipt.validate(receipt: receipt, preflight: preflight)
         if preflight {
             return
         }

--- a/Sources/MereRunCLI/Support/CLIGenerationProgressPrinter.swift
+++ b/Sources/MereRunCLI/Support/CLIGenerationProgressPrinter.swift
@@ -21,13 +21,94 @@ enum CLIGenerationProgressPrinter {
     static func progressJSONLine(stage: String, step: Int, totalSteps: Int) -> String {
         "{\"event\":\"progress\",\"stage\":\"\(stage)\",\"step\":\(step),\"total_steps\":\(totalSteps)}"
     }
+}
 
-    /// Writes one progress line to stderr. Stage names are `rawValue`-style
-    /// identifiers without quotes or newlines, so no escaping is needed.
-    static func writeJSONProgress(stage: String, step: Int, totalSteps: Int) {
-        CLIStderr.write(progressJSONLine(stage: stage, step: step, totalSteps: totalSteps) + "\n")
+/// Normalizes a pipeline's ad-hoc progress callbacks onto the documented
+/// `--progress-json` convention before they reach stderr:
+///
+/// - `step` is 0-based while a stage is in progress;
+/// - every determinate stage (`total_steps > 0`) ends with exactly one event
+///   whose `step == total_steps`, written when the next stage begins, when the
+///   same stage restarts (sliding windows), or by `finish()` at the end of the
+///   run at the latest;
+/// - indeterminate stages (`total_steps == 0`) carry no terminal event.
+///
+/// Milestone stages recorded with `mark` (for example MiniMax-H3 sliding
+/// windows) interleave with the ordinary stage sequence, so they only close
+/// in `finish()`.
+final class JSONProgressStream: @unchecked Sendable {
+    private let write: @Sendable (String) -> Void
+    private let lock = NSLock()
+    private var currentStage: String?
+    private var currentTotal = 0
+    private var lastStep: Int?
+    private var milestoneOrder: [String] = []
+    private var milestones: [String: (step: Int, total: Int)] = [:]
+
+    init(write: @escaping @Sendable (String) -> Void = { CLIStderr.write($0) }) {
+        self.write = write
     }
 
+    /// Reports progress for a sequential stage. `step` is the 0-based index of
+    /// the step that is in progress (or just finished when the pipeline only
+    /// counts completions; pass `completed - 1` in that case).
+    func report(stage: String, step: Int, totalSteps: Int) {
+        lock.lock()
+        defer { lock.unlock() }
+        if stage != currentStage || totalSteps != currentTotal {
+            closeCurrentStage()
+            currentStage = stage
+            currentTotal = totalSteps
+            lastStep = nil
+        } else if let lastStep, step < lastStep {
+            // The stage restarted (for example the next sliding window), so
+            // the previous cycle is complete.
+            closeCurrentStage()
+            self.lastStep = nil
+        }
+        guard step != lastStep else { return }
+        lastStep = step
+        emit(stage: stage, step: step, totalSteps: totalSteps)
+    }
+
+    /// Records a milestone stage that runs alongside the ordinary stages.
+    func mark(stage: String, step: Int, totalSteps: Int) {
+        lock.lock()
+        defer { lock.unlock() }
+        if let existing = milestones[stage], existing.step == step, existing.total == totalSteps { return }
+        if milestones[stage] == nil { milestoneOrder.append(stage) }
+        milestones[stage] = (step, totalSteps)
+        emit(stage: stage, step: step, totalSteps: totalSteps)
+    }
+
+    /// Closes every stage that has not reached its total. Call once after the
+    /// pipeline returns.
+    func finish() {
+        lock.lock()
+        defer { lock.unlock() }
+        closeCurrentStage()
+        currentStage = nil
+        lastStep = nil
+        for stage in milestoneOrder {
+            guard let milestone = milestones[stage], milestone.total > 0, milestone.step != milestone.total else { continue }
+            emit(stage: stage, step: milestone.total, totalSteps: milestone.total)
+        }
+        milestoneOrder = []
+        milestones = [:]
+    }
+
+    private func closeCurrentStage() {
+        guard let stage = currentStage, currentTotal > 0, lastStep != currentTotal else { return }
+        lastStep = currentTotal
+        emit(stage: stage, step: currentTotal, totalSteps: currentTotal)
+    }
+
+    private func emit(stage: String, step: Int, totalSteps: Int) {
+        write(CLIGenerationProgressPrinter.progressJSONLine(stage: stage, step: step, totalSteps: totalSteps) + "\n")
+    }
+}
+
+extension CLIGenerationProgressPrinter {
     /// Machine-readable progress for wrappers (`--progress-json`): one JSON
     /// line per event on stderr, so stdout stays reserved for the output path.
     static func makeJSONProgressHandler(

--- a/Sources/MereRunCLI/Support/CLIGenerationProgressPrinter.swift
+++ b/Sources/MereRunCLI/Support/CLIGenerationProgressPrinter.swift
@@ -1,14 +1,31 @@
+import ArgumentParser
 import Foundation
 import MereRunCore
 
 enum CLIGenerationProgressPrinter {
+    static let flagName = "progress-json"
+    static let flagHelpText = "Stream progress to stderr as JSON lines (one object per event) instead of human-readable text. Takes precedence over --quiet for progress output."
+    static let flagHelp = ArgumentHelp(flagHelpText)
+
     /// One NDJSON object per distinct progress event, e.g.
     /// `{"event":"progress","stage":"denoising","step":2,"total_steps":4}`.
     /// `step` is the generator's raw 0-based step index; stages emit a final
     /// event with `step == total_steps` when they finish.
     static func progressJSONLine(_ progress: GenerationProgress) -> String {
-        "{\"event\":\"progress\",\"stage\":\"\(progress.stage.rawValue)\"," +
-            "\"step\":\(progress.stepIndex),\"total_steps\":\(progress.totalSteps)}"
+        progressJSONLine(stage: progress.stage.rawValue, step: progress.stepIndex, totalSteps: progress.totalSteps)
+    }
+
+    /// The same event shape for pipelines that report progress with their own
+    /// types. `totalSteps == 0` marks an indeterminate stage (for example token
+    /// streaming with no known length); readers should show a spinner for it.
+    static func progressJSONLine(stage: String, step: Int, totalSteps: Int) -> String {
+        "{\"event\":\"progress\",\"stage\":\"\(stage)\",\"step\":\(step),\"total_steps\":\(totalSteps)}"
+    }
+
+    /// Writes one progress line to stderr. Stage names are `rawValue`-style
+    /// identifiers without quotes or newlines, so no escaping is needed.
+    static func writeJSONProgress(stage: String, step: Int, totalSteps: Int) {
+        CLIStderr.write(progressJSONLine(stage: stage, step: step, totalSteps: totalSteps) + "\n")
     }
 
     /// Machine-readable progress for wrappers (`--progress-json`): one JSON

--- a/Sources/MereRunCLI/Support/RunReceipt.swift
+++ b/Sources/MereRunCLI/Support/RunReceipt.swift
@@ -41,6 +41,16 @@ struct RunReceipt: Codable, Equatable {
     static let flagName = "receipt"
     static let flagHelpText = "Print a final JSON result line to stdout listing every output path and kind."
     static let flagHelp = ArgumentHelp(flagHelpText)
+    static let preflightConflictMessage =
+        "--receipt cannot be combined with --preflight; preflight prints a report without producing a result."
+
+    /// Rejects `--receipt --preflight`, which would otherwise exit 0 without
+    /// ever printing a receipt.
+    static func validate(receipt: Bool, preflight: Bool) throws {
+        if receipt && preflight {
+            throw ValidationError(preflightConflictMessage)
+        }
+    }
 
     let event: String
     let outputs: [Output]

--- a/Sources/MereRunCLI/Support/RunReceipt.swift
+++ b/Sources/MereRunCLI/Support/RunReceipt.swift
@@ -1,0 +1,144 @@
+import ArgumentParser
+import Foundation
+
+/// The structured result line long-running generation commands print as the
+/// final stdout line when `--receipt` is set:
+///
+///     {"event":"result","exit":0,"outputs":[{"kind":"image","path":"/abs/out.png"}]}
+///
+/// The first output is always the primary artifact. Sidecars follow it and
+/// carry a `role` (`detections`, `masks`, `recipe`, `lyrics`, ...). A receipt
+/// is only printed after the command succeeded, so `exit` is always `0`; a
+/// failed run exits nonzero without a receipt. Human output above the receipt
+/// is unchanged, so wrappers parse the last line and ignore the rest.
+struct RunReceipt: Codable, Equatable {
+    enum OutputKind: String, Codable {
+        case image
+        case video
+        case audio
+        case text
+        case json
+        case directory
+    }
+
+    struct Output: Codable, Equatable {
+        let path: String
+        let kind: OutputKind
+        let role: String?
+
+        init(path: String, kind: OutputKind, role: String? = nil) {
+            self.path = path
+            self.kind = kind
+            self.role = role
+        }
+
+        init(url: URL, kind: OutputKind, role: String? = nil) {
+            self.init(path: url.standardizedFileURL.path, kind: kind, role: role)
+        }
+    }
+
+    static let eventName = "result"
+    static let flagName = "receipt"
+    static let flagHelpText = "Print a final JSON result line to stdout listing every output path and kind."
+    static let flagHelp = ArgumentHelp(flagHelpText)
+
+    let event: String
+    let outputs: [Output]
+    let exit: Int32
+
+    init(outputs: [Output], exit: Int32 = 0) {
+        self.event = Self.eventName
+        self.outputs = outputs
+        self.exit = exit
+    }
+
+    /// One JSON object with no embedded newlines, suitable for NDJSON streams.
+    func line() throws -> String {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes]
+        let data = try encoder.encode(self)
+        guard let line = String(data: data, encoding: .utf8) else {
+            throw RunReceiptError.encoding
+        }
+        return line
+    }
+
+    /// Prints the receipt when `enabled`; a no-op otherwise so call sites can
+    /// pass the flag through without branching.
+    static func emit(
+        _ outputs: [Output],
+        enabled: Bool,
+        write: (String) -> Void = { Swift.print($0) }
+    ) throws {
+        guard enabled else { return }
+        write(try RunReceipt(outputs: outputs).line())
+    }
+}
+
+/// Output lists for each command family, kept together so the primary-first
+/// ordering and the sidecar roles stay consistent across commands.
+extension RunReceipt {
+    /// `image generate`: the PNG plus the optional structured-prompt JSON.
+    static func generatedImageOutputs(image: URL, structuredPrompt: URL?) -> [Output] {
+        var outputs = [Output(url: image, kind: .image)]
+        if let structuredPrompt {
+            outputs.append(Output(url: structuredPrompt, kind: .json, role: "structured-prompt"))
+        }
+        return outputs
+    }
+
+    /// `video generate`: the MP4 (or EXR directory) plus the optional timings JSON.
+    static func generatedVideoOutputs(primary: URL, kind: OutputKind, timings: URL?) -> [Output] {
+        var outputs = [Output(url: primary, kind: kind)]
+        if let timings {
+            outputs.append(Output(url: timings, kind: .json, role: "timings"))
+        }
+        return outputs
+    }
+
+    /// `music generate`, `sfx generate`, `speech synthesize`: one WAV plus any
+    /// sidecars the lane wrote (candidates, stems, lyrics, recipe, bundle).
+    static func generatedAudioOutputs(audio: URL, sidecars: [Output] = []) -> [Output] {
+        [Output(url: audio, kind: .audio)] + sidecars
+    }
+
+    /// `speech transcribe`: the transcript file, or nothing when it only went to stdout.
+    static func transcriptOutputs(_ transcript: URL?) -> [Output] {
+        transcript.map { [Output(url: $0, kind: .text)] } ?? []
+    }
+
+    /// `vision ground` and `vision segment`: annotated image, detections JSON, optional mask directory.
+    static func annotatedImageOutputs(image: URL, detections: URL, masks: URL?) -> [Output] {
+        var outputs = [
+            Output(url: image, kind: .image),
+            Output(url: detections, kind: .json, role: "detections"),
+        ]
+        if let masks {
+            outputs.append(Output(url: masks, kind: .directory, role: "masks"))
+        }
+        return outputs
+    }
+
+    /// `vision track`: annotated video, optional tracking JSON, optional mask directory.
+    static func annotatedVideoOutputs(videoPath: String, trackingPath: String?, masks: URL?) -> [Output] {
+        var outputs = [Output(path: videoPath, kind: .video)]
+        if let trackingPath {
+            outputs.append(Output(path: trackingPath, kind: .json, role: "tracking"))
+        }
+        if let masks {
+            outputs.append(Output(url: masks, kind: .directory, role: "masks"))
+        }
+        return outputs
+    }
+}
+
+enum RunReceiptError: Error, CustomStringConvertible {
+    case encoding
+
+    var description: String {
+        switch self {
+        case .encoding:
+            return "Could not encode the run receipt as UTF-8."
+        }
+    }
+}

--- a/Sources/MereRunContract/CommandCapabilityContract.swift
+++ b/Sources/MereRunContract/CommandCapabilityContract.swift
@@ -243,16 +243,18 @@ public enum MereRunCapabilityCatalog {
     public static let schemaVersion = 1
 
     /// The `--progress-json` stderr event shape, one JSON object per line.
-    /// `step` is the pipeline's 0-based step index (or a 1-based counter for
-    /// pipelines that count that way); every stage emits a final event with
-    /// `step == total_steps`, and `total_steps == 0` marks an indeterminate
-    /// stage such as token streaming with no known length.
+    /// `step` is 0-based while a stage is in progress; every determinate stage
+    /// ends with exactly one event whose `step == total_steps`, written when
+    /// the stage completes or at the end of the run at the latest.
+    /// `total_steps == 0` marks an indeterminate stage (token streaming with no
+    /// known length) that carries no terminal event.
     public static let progressEventExample =
         #"{"event":"progress","stage":"denoising","step":2,"total_steps":4}"#
 
     /// The `--receipt` final stdout line. The first output is the primary
     /// artifact; sidecars follow with a `role`. It is printed only after a
-    /// successful run, so `exit` is always `0`.
+    /// successful run, so `exit` is always `0`; `--receipt` is rejected
+    /// together with `--preflight`, which produces no result.
     public static let resultReceiptExample =
         #"{"event":"result","exit":0,"outputs":[{"kind":"image","path":"/abs/out.png"}]}"#
 
@@ -3013,7 +3015,7 @@ public enum MereRunCapabilityCatalog {
             .init(flag: "--input-format", label: "Input format", kind: .string, group: Group.inputs, tier: .expert, dependsOn: "--stream"),
             .init(
                 flag: "--sample-rate", label: "Sample rate", kind: .integer,
-                group: Group.inputs, tier: .expert, range: .init(min: 8_000, max: 48_000, step: 1), dependsOn: "--stream"
+                group: Group.inputs, tier: .expert, dependsOn: "--stream"
             ),
             .init(flag: "--jsonl", label: "JSON Lines", kind: .boolean, group: Group.output, tier: .expert, dependsOn: "--stream"),
             .init(flag: "--no-timestamps", label: "No timestamps", kind: .boolean, group: Group.output, tier: .standard),

--- a/Sources/MereRunContract/CommandCapabilityContract.swift
+++ b/Sources/MereRunContract/CommandCapabilityContract.swift
@@ -3013,9 +3013,12 @@ public enum MereRunCapabilityCatalog {
                 defaultValue: "2000", group: Group.run, tier: .expert, range: .init(min: 100, max: 10_000, step: 100), dependsOn: "--stream"
             ),
             .init(flag: "--input-format", label: "Input format", kind: .string, group: Group.inputs, tier: .expert, dependsOn: "--stream"),
+            // Raw stdin protocol v1 accepts exactly 16 kHz, so the range pins
+            // the single value a shell may send rather than a span.
             .init(
                 flag: "--sample-rate", label: "Sample rate", kind: .integer,
-                group: Group.inputs, tier: .expert, dependsOn: "--stream"
+                group: Group.inputs, tier: .expert, range: .init(min: 16_000, max: 16_000, step: 1),
+                dependsOn: "--stream"
             ),
             .init(flag: "--jsonl", label: "JSON Lines", kind: .boolean, group: Group.output, tier: .expert, dependsOn: "--stream"),
             .init(flag: "--no-timestamps", label: "No timestamps", kind: .boolean, group: Group.output, tier: .standard),

--- a/Sources/MereRunContract/CommandCapabilityContract.swift
+++ b/Sources/MereRunContract/CommandCapabilityContract.swift
@@ -58,6 +58,41 @@ public struct MereRunCapabilityArgument: Codable, Equatable, Sendable {
     }
 }
 
+/// How prominently a shell should surface an option. `essential` options are the
+/// two to four controls a shell keeps visible next to the prompt, `standard`
+/// options fill the regular inspector sections, and `expert` options collapse
+/// under an advanced disclosure.
+public enum MereRunCapabilityOptionTier: String, Codable, Sendable {
+    case essential
+    case standard
+    case expert
+}
+
+/// A numeric range hint for integer and number options. Every field is optional
+/// so a contract entry can declare only a lower bound or only a step.
+public struct MereRunCapabilityRange: Codable, Equatable, Sendable {
+    public let min: Double?
+    public let max: Double?
+    public let step: Double?
+
+    public init(min: Double? = nil, max: Double? = nil, step: Double? = nil) {
+        self.min = min
+        self.max = max
+        self.step = step
+    }
+}
+
+/// Shared group names shells use to section options. Capabilities may use other
+/// strings; these are the ones the built-in shells recognize.
+public enum MereRunCapabilityOptionGroup {
+    public static let prompt = "Prompt"
+    public static let inputs = "Inputs"
+    public static let output = "Output"
+    public static let modelAndAdapters = "Model & adapters"
+    public static let sampling = "Sampling"
+    public static let run = "Run"
+}
+
 public struct MereRunCapabilityOption: Codable, Equatable, Sendable {
     public let flag: String
     public let label: String
@@ -65,6 +100,31 @@ public struct MereRunCapabilityOption: Codable, Equatable, Sendable {
     public let required: Bool
     public let repeatable: Bool
     public let choices: [String]
+    /// The CLI's static ArgumentParser default rendered as the CLI would parse it
+    /// (`"1024"`, `"0.7"`, `"peak"`). Absent when the default is machine- or
+    /// model-specific.
+    public let defaultValue: String?
+    /// Section name for shells; see `MereRunCapabilityOptionGroup`.
+    public let group: String?
+    public let tier: MereRunCapabilityOptionTier?
+    public let range: MereRunCapabilityRange?
+    /// Flag of another option on the same capability that must be set for this
+    /// option to have any effect.
+    public let dependsOn: String?
+
+    enum CodingKeys: String, CodingKey {
+        case flag
+        case label
+        case kind
+        case required
+        case repeatable
+        case choices
+        case defaultValue = "default_value"
+        case group
+        case tier
+        case range
+        case dependsOn = "depends_on"
+    }
 
     public init(
         flag: String,
@@ -72,7 +132,12 @@ public struct MereRunCapabilityOption: Codable, Equatable, Sendable {
         kind: MereRunCapabilityValueKind,
         required: Bool = false,
         repeatable: Bool = false,
-        choices: [String] = []
+        choices: [String] = [],
+        defaultValue: String? = nil,
+        group: String? = nil,
+        tier: MereRunCapabilityOptionTier? = nil,
+        range: MereRunCapabilityRange? = nil,
+        dependsOn: String? = nil
     ) {
         self.flag = flag
         self.label = label
@@ -80,6 +145,11 @@ public struct MereRunCapabilityOption: Codable, Equatable, Sendable {
         self.required = required
         self.repeatable = repeatable
         self.choices = choices
+        self.defaultValue = defaultValue
+        self.group = group
+        self.tier = tier
+        self.range = range
+        self.dependsOn = dependsOn
     }
 }
 
@@ -148,8 +218,55 @@ public struct MereRunCapabilityDocument: Codable, Equatable, Sendable {
     }
 }
 
+private typealias Group = MereRunCapabilityOptionGroup
+
+/// The machine-readable flags shared by every long-running generation command.
+/// `--receipt` prints the final `{"event":"result",...}` line; `--progress-json`
+/// streams `{"event":"progress",...}` lines on stderr.
+private let receiptOption = MereRunCapabilityOption(
+    flag: "--receipt",
+    label: "Result receipt",
+    kind: .boolean,
+    group: Group.run,
+    tier: .expert
+)
+
+private let progressJSONOption = MereRunCapabilityOption(
+    flag: "--progress-json",
+    label: "Progress JSON",
+    kind: .boolean,
+    group: Group.run,
+    tier: .expert
+)
+
 public enum MereRunCapabilityCatalog {
     public static let schemaVersion = 1
+
+    /// The `--progress-json` stderr event shape, one JSON object per line.
+    /// `step` is the pipeline's 0-based step index (or a 1-based counter for
+    /// pipelines that count that way); every stage emits a final event with
+    /// `step == total_steps`, and `total_steps == 0` marks an indeterminate
+    /// stage such as token streaming with no known length.
+    public static let progressEventExample =
+        #"{"event":"progress","stage":"denoising","step":2,"total_steps":4}"#
+
+    /// The `--receipt` final stdout line. The first output is the primary
+    /// artifact; sidecars follow with a `role`. It is printed only after a
+    /// successful run, so `exit` is always `0`.
+    public static let resultReceiptExample =
+        #"{"event":"result","exit":0,"outputs":[{"kind":"image","path":"/abs/out.png"}]}"#
+
+    /// Capability ids whose commands print the `--receipt` line.
+    public static let receiptCapabilityIDs: [String] = [
+        "image.generate", "video.generate", "music.generate", "sfx.generate",
+        "speech.synthesize", "speech.transcribe",
+        "vision.ground", "vision.segment", "vision.track"
+    ]
+
+    /// Capability ids whose commands stream `--progress-json` events.
+    public static let progressJSONCapabilityIDs: [String] = [
+        "image.generate", "video.generate", "music.generate", "sfx.generate", "speech.synthesize"
+    ]
 
     public static let document = MereRunCapabilityDocument(
         schemaVersion: schemaVersion,
@@ -294,49 +411,98 @@ public enum MereRunCapabilityCatalog {
         title: "Chat",
         summary: "Run local chat, vision, JSON, LoRA, reasoning, and tool workflows.",
         options: [
-            .init(flag: "--prompt", label: "Prompt", kind: .string, required: true),
-            .init(flag: "--image", label: "Image", kind: .file),
-            .init(flag: "--system", label: "System prompt", kind: .string),
-            .init(flag: "--max-tokens", label: "Max tokens", kind: .integer),
-            .init(flag: "--context-size", label: "Context size", kind: .integer),
-            .init(flag: "--temperature", label: "Temperature", kind: .number),
-            .init(flag: "--top-p", label: "Top-p", kind: .number),
-            .init(flag: "--top-k", label: "Top-k", kind: .integer),
-            .init(flag: "--min-p", label: "Min-p", kind: .number),
-            .init(flag: "--kv-bits", label: "KV bits", kind: .integer),
+            .init(flag: "--prompt", label: "Prompt", kind: .string, required: true, group: Group.prompt, tier: .essential),
+            .init(flag: "--image", label: "Image", kind: .file, group: Group.inputs, tier: .standard),
+            .init(flag: "--system", label: "System prompt", kind: .string, group: Group.prompt, tier: .standard),
+            .init(
+                flag: "--max-tokens", label: "Max tokens", kind: .integer,
+                defaultValue: "2048", group: Group.sampling, tier: .standard,
+                range: .init(min: 1, max: 131_072, step: 1)
+            ),
+            .init(
+                flag: "--context-size", label: "Context size", kind: .integer,
+                group: Group.sampling, tier: .expert, range: .init(min: 512, max: 1_048_576, step: 1)
+            ),
+            .init(
+                flag: "--temperature", label: "Temperature", kind: .number,
+                group: Group.sampling, tier: .standard, range: .init(min: 0, max: 2, step: 0.05)
+            ),
+            .init(
+                flag: "--top-p", label: "Top-p", kind: .number,
+                group: Group.sampling, tier: .standard, range: .init(min: 0, max: 1, step: 0.01)
+            ),
+            .init(
+                flag: "--top-k", label: "Top-k", kind: .integer,
+                group: Group.sampling, tier: .expert, range: .init(min: 0, max: 1_000, step: 1)
+            ),
+            .init(
+                flag: "--min-p", label: "Min-p", kind: .number,
+                group: Group.sampling, tier: .expert, range: .init(min: 0, max: 1, step: 0.01)
+            ),
+            .init(
+                flag: "--kv-bits", label: "KV bits", kind: .integer,
+                group: Group.run, tier: .expert, range: .init(min: 2, max: 8, step: 1)
+            ),
             .init(
                 flag: "--kv-quant-scheme",
                 label: "KV quantization",
                 kind: .choice,
-                choices: ["uniform", "polar", "turboquant"]
+                choices: ["uniform", "polar", "turboquant"],
+                group: Group.run, tier: .expert, dependsOn: "--kv-bits"
             ),
-            .init(flag: "--kv-group-size", label: "KV group size", kind: .integer),
-            .init(flag: "--quantized-kv-start", label: "Quantized KV start", kind: .integer),
-            .init(flag: "--model-root", label: "Model root", kind: .directory),
-            .init(flag: "--model", label: "Model", kind: .string),
+            .init(
+                flag: "--kv-group-size", label: "KV group size", kind: .integer,
+                group: Group.run, tier: .expert, dependsOn: "--kv-bits"
+            ),
+            .init(
+                flag: "--quantized-kv-start", label: "Quantized KV start", kind: .integer,
+                group: Group.run, tier: .expert, range: .init(min: 0, step: 1), dependsOn: "--kv-bits"
+            ),
+            .init(flag: "--model-root", label: "Model root", kind: .directory, group: Group.modelAndAdapters, tier: .expert),
+            .init(flag: "--model", label: "Model", kind: .string, group: Group.modelAndAdapters, tier: .essential),
             .init(
                 flag: "--response-format",
                 label: "Response format",
                 kind: .choice,
-                choices: TextResponseFormat.allCases.map(\.rawValue)
+                choices: TextResponseFormat.allCases.map(\.rawValue),
+                defaultValue: TextResponseFormat.text.rawValue, group: Group.output, tier: .standard
             ),
-            .init(flag: "--lora", label: "LoRA", kind: .file),
-            .init(flag: "--lora-scale", label: "LoRA scale", kind: .number),
-            .init(flag: "--thinking", label: "Show thinking", kind: .boolean),
-            .init(flag: "--no-thinking", label: "Disable thinking", kind: .boolean),
-            .init(flag: "--reasoning-effort", label: "Inkling reasoning effort", kind: .number),
-            .init(flag: "--stats", label: "Stats", kind: .boolean),
-            .init(flag: "--stream", label: "Stream", kind: .boolean),
-            .init(flag: "--tools", label: "Tools", kind: .string),
-            .init(flag: "--tool-loop", label: "Tool loop", kind: .boolean),
-            .init(flag: "--sandbox-dir", label: "Sandbox directory", kind: .directory),
-            .init(flag: "--allow-shell-exec", label: "Allow shell", kind: .boolean),
-            .init(flag: "--allow-absolute-tool-paths", label: "Allow absolute paths", kind: .boolean),
-            .init(flag: "--auto-approve-tools", label: "Auto-approve tools", kind: .boolean),
-            .init(flag: "--quiet", label: "Quiet", kind: .boolean),
-            .init(flag: "--preflight", label: "Preflight", kind: .boolean),
-            .init(flag: "--json", label: "JSON preflight", kind: .boolean),
-            .init(flag: "--require-installed", label: "Require installed", kind: .boolean)
+            .init(flag: "--lora", label: "LoRA", kind: .file, group: Group.modelAndAdapters, tier: .standard),
+            .init(
+                flag: "--lora-scale", label: "LoRA scale", kind: .number,
+                defaultValue: "1.0", group: Group.modelAndAdapters, tier: .standard,
+                range: .init(min: 0, max: 2, step: 0.05), dependsOn: "--lora"
+            ),
+            .init(flag: "--thinking", label: "Show thinking", kind: .boolean, group: Group.sampling, tier: .standard),
+            .init(flag: "--no-thinking", label: "Disable thinking", kind: .boolean, group: Group.sampling, tier: .standard),
+            .init(
+                flag: "--reasoning-effort", label: "Inkling reasoning effort", kind: .number,
+                group: Group.sampling, tier: .expert, range: .init(min: 0, max: 1, step: 0.01)
+            ),
+            .init(flag: "--stats", label: "Stats", kind: .boolean, group: Group.run, tier: .expert),
+            .init(flag: "--stream", label: "Stream", kind: .boolean, group: Group.output, tier: .standard),
+            .init(flag: "--tools", label: "Tools", kind: .string, group: Group.run, tier: .expert),
+            .init(flag: "--tool-loop", label: "Tool loop", kind: .boolean, group: Group.run, tier: .expert, dependsOn: "--tools"),
+            .init(
+                flag: "--sandbox-dir", label: "Sandbox directory", kind: .directory,
+                group: Group.run, tier: .expert, dependsOn: "--tools"
+            ),
+            .init(
+                flag: "--allow-shell-exec", label: "Allow shell", kind: .boolean,
+                group: Group.run, tier: .expert, dependsOn: "--tools"
+            ),
+            .init(
+                flag: "--allow-absolute-tool-paths", label: "Allow absolute paths", kind: .boolean,
+                group: Group.run, tier: .expert, dependsOn: "--tools"
+            ),
+            .init(
+                flag: "--auto-approve-tools", label: "Auto-approve tools", kind: .boolean,
+                group: Group.run, tier: .expert, dependsOn: "--tools"
+            ),
+            .init(flag: "--quiet", label: "Quiet", kind: .boolean, group: Group.run, tier: .expert),
+            .init(flag: "--preflight", label: "Preflight", kind: .boolean, group: Group.run, tier: .expert),
+            .init(flag: "--json", label: "JSON preflight", kind: .boolean, group: Group.run, tier: .expert, dependsOn: "--preflight"),
+            .init(flag: "--require-installed", label: "Require installed", kind: .boolean, group: Group.run, tier: .expert)
         ],
         output: .init(kind: .text)
     )
@@ -347,16 +513,32 @@ public enum MereRunCapabilityCatalog {
         title: "Code",
         summary: "Run local code generation with GGUF models through llama.cpp.",
         options: [
-            .init(flag: "--prompt", label: "Prompt", kind: .string, required: true),
-            .init(flag: "--system", label: "System prompt", kind: .string),
-            .init(flag: "--max-tokens", label: "Max tokens", kind: .integer),
-            .init(flag: "--temperature", label: "Temperature", kind: .number),
-            .init(flag: "--top-p", label: "Top-p", kind: .number),
-            .init(flag: "--min-p", label: "Min-p", kind: .number),
-            .init(flag: "--model", label: "Model", kind: .file),
-            .init(flag: "--stats", label: "Stats", kind: .boolean),
-            .init(flag: "--quiet", label: "Quiet", kind: .boolean),
-            .init(flag: "--stream", label: "Stream", kind: .boolean)
+            .init(flag: "--prompt", label: "Prompt", kind: .string, required: true, group: Group.prompt, tier: .essential),
+            .init(
+                flag: "--system", label: "System prompt", kind: .string,
+                defaultValue: "You are a helpful coding assistant.", group: Group.prompt, tier: .standard
+            ),
+            .init(
+                flag: "--max-tokens", label: "Max tokens", kind: .integer,
+                defaultValue: "2048", group: Group.sampling, tier: .standard,
+                range: .init(min: 1, max: 131_072, step: 1)
+            ),
+            .init(
+                flag: "--temperature", label: "Temperature", kind: .number,
+                defaultValue: "1.0", group: Group.sampling, tier: .standard, range: .init(min: 0, max: 2, step: 0.05)
+            ),
+            .init(
+                flag: "--top-p", label: "Top-p", kind: .number,
+                defaultValue: "0.95", group: Group.sampling, tier: .standard, range: .init(min: 0, max: 1, step: 0.01)
+            ),
+            .init(
+                flag: "--min-p", label: "Min-p", kind: .number,
+                defaultValue: "0.0", group: Group.sampling, tier: .expert, range: .init(min: 0, max: 1, step: 0.01)
+            ),
+            .init(flag: "--model", label: "Model", kind: .file, group: Group.modelAndAdapters, tier: .essential),
+            .init(flag: "--stats", label: "Stats", kind: .boolean, group: Group.run, tier: .expert),
+            .init(flag: "--quiet", label: "Quiet", kind: .boolean, group: Group.run, tier: .expert),
+            .init(flag: "--stream", label: "Stream", kind: .boolean, group: Group.output, tier: .standard)
         ],
         output: .init(kind: .text)
     )
@@ -432,43 +614,101 @@ public enum MereRunCapabilityCatalog {
         title: "Generate and edit images",
         summary: "Generate, transform, or personalize images with references, structured prompts, and LoRAs.",
         options: [
-            .init(flag: "--prompt", label: "Prompt", kind: .string, required: true),
-            .init(flag: "--negative-prompt", label: "Negative prompt", kind: .string),
-            .init(flag: "--cfg", label: "CFG scale", kind: .number),
-            .init(flag: "--sigma-shift", label: "Sigma shift", kind: .number),
-            .init(flag: "--output", label: "Output", kind: .file),
-            .init(flag: "--width", label: "Width", kind: .integer),
-            .init(flag: "--height", label: "Height", kind: .integer),
-            .init(flag: "--steps", label: "Steps", kind: .integer),
-            .init(flag: "--seed", label: "Seed", kind: .integer),
-            .init(flag: "--model", label: "Model", kind: .string),
-            .init(flag: "--input", label: "Input image", kind: .file),
-            .init(flag: "--mask", label: "Edit mask", kind: .file),
-            .init(flag: "--outpaint", label: "Outpaint padding", kind: .string),
-            .init(flag: "--mask-feather", label: "Mask feather", kind: .integer),
-            .init(flag: "--ref-image", label: "Reference image", kind: .file, repeatable: true),
-            .init(flag: "--keep-original-aspect", label: "Keep original aspect", kind: .boolean),
-            .init(flag: "--strength", label: "Edit strength", kind: .number),
-            .init(flag: "--max-sequence-length", label: "Max sequence length", kind: .integer),
-            .init(flag: "--structured-prompt", label: "Structured prompt", kind: .boolean),
-            .init(flag: "--structured-prompt-model", label: "Prompt model", kind: .string),
-            .init(flag: "--structured-prompt-model-root", label: "Prompt model root", kind: .directory),
-            .init(flag: "--structured-prompt-max-tokens", label: "Prompt max tokens", kind: .integer),
-            .init(flag: "--structured-prompt-output", label: "Structured prompt output", kind: .file),
-            .init(flag: "--lora", label: "LoRA", kind: .file),
-            .init(flag: "--lora-scale", label: "LoRA scale", kind: .number),
-            .init(flag: "--krea-conditioning-multiplier", label: "Krea conditioning", kind: .number),
-            .init(flag: "--krea-conditioning-layer-weights", label: "Krea layer weights", kind: .string),
+            .init(flag: "--prompt", label: "Prompt", kind: .string, required: true, group: Group.prompt, tier: .essential),
+            .init(flag: "--negative-prompt", label: "Negative prompt", kind: .string, group: Group.prompt, tier: .standard),
+            .init(
+                flag: "--cfg", label: "CFG scale", kind: .number,
+                group: Group.sampling, tier: .standard, range: .init(min: 0, max: 20, step: 0.5)
+            ),
+            .init(
+                flag: "--sigma-shift", label: "Sigma shift", kind: .number,
+                group: Group.sampling, tier: .expert, range: .init(min: 0, max: 16, step: 0.1)
+            ),
+            .init(flag: "--output", label: "Output", kind: .file, group: Group.output, tier: .standard),
+            .init(
+                flag: "--width", label: "Width", kind: .integer,
+                defaultValue: "1024", group: Group.output, tier: .essential, range: .init(min: 256, max: 2_048, step: 16)
+            ),
+            .init(
+                flag: "--height", label: "Height", kind: .integer,
+                defaultValue: "1024", group: Group.output, tier: .essential, range: .init(min: 256, max: 2_048, step: 16)
+            ),
+            .init(
+                flag: "--steps", label: "Steps", kind: .integer,
+                group: Group.sampling, tier: .essential, range: .init(min: 1, max: 100, step: 1)
+            ),
+            .init(flag: "--seed", label: "Seed", kind: .integer, group: Group.sampling, tier: .essential, range: .init(min: 0, step: 1)),
+            .init(flag: "--model", label: "Model", kind: .string, group: Group.modelAndAdapters, tier: .essential),
+            .init(flag: "--input", label: "Input image", kind: .file, group: Group.inputs, tier: .standard),
+            .init(flag: "--mask", label: "Edit mask", kind: .file, group: Group.inputs, tier: .standard, dependsOn: "--input"),
+            .init(
+                flag: "--outpaint", label: "Outpaint padding", kind: .string,
+                group: Group.inputs, tier: .expert, dependsOn: "--input"
+            ),
+            .init(
+                flag: "--mask-feather", label: "Mask feather", kind: .integer,
+                defaultValue: "8", group: Group.inputs, tier: .expert, range: .init(min: 0, max: 128, step: 1), dependsOn: "--input"
+            ),
+            .init(
+                flag: "--ref-image", label: "Reference image", kind: .file, repeatable: true,
+                group: Group.inputs, tier: .standard
+            ),
+            .init(
+                flag: "--keep-original-aspect", label: "Keep original aspect", kind: .boolean,
+                group: Group.inputs, tier: .expert, dependsOn: "--ref-image"
+            ),
+            .init(
+                flag: "--strength", label: "Edit strength", kind: .number,
+                group: Group.inputs, tier: .standard, range: .init(min: 0, max: 1, step: 0.05)
+            ),
+            .init(
+                flag: "--max-sequence-length", label: "Max sequence length", kind: .integer,
+                defaultValue: "512", group: Group.sampling, tier: .expert, range: .init(min: 64, max: 4_096, step: 64)
+            ),
+            .init(flag: "--structured-prompt", label: "Structured prompt", kind: .boolean, group: Group.prompt, tier: .standard),
+            .init(
+                flag: "--structured-prompt-model", label: "Prompt model", kind: .string,
+                defaultValue: "text-chat-gemma4-12b-4bit", group: Group.prompt, tier: .expert, dependsOn: "--structured-prompt"
+            ),
+            .init(
+                flag: "--structured-prompt-model-root", label: "Prompt model root", kind: .directory,
+                group: Group.prompt, tier: .expert, dependsOn: "--structured-prompt"
+            ),
+            .init(
+                flag: "--structured-prompt-max-tokens", label: "Prompt max tokens", kind: .integer,
+                defaultValue: "2048", group: Group.prompt, tier: .expert,
+                range: .init(min: 1, max: 8_192, step: 1), dependsOn: "--structured-prompt"
+            ),
+            .init(
+                flag: "--structured-prompt-output", label: "Structured prompt output", kind: .file,
+                group: Group.prompt, tier: .expert, dependsOn: "--structured-prompt"
+            ),
+            .init(flag: "--lora", label: "LoRA", kind: .file, group: Group.modelAndAdapters, tier: .standard),
+            .init(
+                flag: "--lora-scale", label: "LoRA scale", kind: .number,
+                defaultValue: "1.0", group: Group.modelAndAdapters, tier: .standard,
+                range: .init(min: 0, max: 2, step: 0.05), dependsOn: "--lora"
+            ),
+            .init(
+                flag: "--krea-conditioning-multiplier", label: "Krea conditioning", kind: .number,
+                group: Group.sampling, tier: .expert
+            ),
+            .init(
+                flag: "--krea-conditioning-layer-weights", label: "Krea layer weights", kind: .string,
+                group: Group.sampling, tier: .expert
+            ),
             .init(
                 flag: "--krea-base-quantization-bits",
                 label: "Krea base quantization",
                 kind: .choice,
-                choices: ["4", "8"]
+                choices: ["4", "8"],
+                group: Group.modelAndAdapters, tier: .expert
             ),
-            .init(flag: "--preflight", label: "Preflight", kind: .boolean),
-            .init(flag: "--json", label: "JSON", kind: .boolean),
-            .init(flag: "--quiet", label: "Quiet", kind: .boolean),
-            .init(flag: "--progress-json", label: "Progress JSON", kind: .boolean)
+            .init(flag: "--preflight", label: "Preflight", kind: .boolean, group: Group.run, tier: .expert),
+            .init(flag: "--json", label: "JSON", kind: .boolean, group: Group.run, tier: .expert, dependsOn: "--preflight"),
+            .init(flag: "--quiet", label: "Quiet", kind: .boolean, group: Group.run, tier: .expert),
+            progressJSONOption,
+            receiptOption
         ],
         output: .init(kind: .file, fileExtension: "png")
     )
@@ -696,11 +936,20 @@ public enum MereRunCapabilityCatalog {
         summary: "Describe or answer questions about an image with a local VLM.",
         arguments: [.init(name: "image", label: "Image", kind: .file, required: true)],
         options: [
-            .init(flag: "--prompt", label: "Prompt", kind: .string),
-            .init(flag: "--model", label: "Model", kind: .string),
-            .init(flag: "--max-tokens", label: "Max tokens", kind: .integer),
-            .init(flag: "--temperature", label: "Temperature", kind: .number),
-            .init(flag: "--top-p", label: "Top-p", kind: .number)
+            .init(flag: "--prompt", label: "Prompt", kind: .string, group: Group.prompt, tier: .essential),
+            .init(flag: "--model", label: "Model", kind: .string, group: Group.modelAndAdapters, tier: .essential),
+            .init(
+                flag: "--max-tokens", label: "Max tokens", kind: .integer,
+                defaultValue: "2048", group: Group.sampling, tier: .standard, range: .init(min: 1, max: 8_192, step: 1)
+            ),
+            .init(
+                flag: "--temperature", label: "Temperature", kind: .number,
+                defaultValue: "0.7", group: Group.sampling, tier: .standard, range: .init(min: 0, max: 2, step: 0.05)
+            ),
+            .init(
+                flag: "--top-p", label: "Top-p", kind: .number,
+                defaultValue: "0.9", group: Group.sampling, tier: .standard, range: .init(min: 0, max: 1, step: 0.01)
+            )
         ],
         output: .init(kind: .text)
     )
@@ -733,15 +982,24 @@ public enum MereRunCapabilityCatalog {
         summary: "Generate training-friendly captions for one or more images.",
         arguments: [.init(name: "images", label: "Images", kind: .file, required: true)],
         options: [
-            .init(flag: "--model", label: "Model", kind: .string),
-            .init(flag: "--output-dir", label: "Output directory", kind: .directory),
-            .init(flag: "--prompt", label: "Prompt", kind: .string),
-            .init(flag: "--prompt-file", label: "Prompt file", kind: .file),
-            .init(flag: "--focus", label: "Focus", kind: .string, repeatable: true),
-            .init(flag: "--trigger-token", label: "Trigger token", kind: .string),
-            .init(flag: "--max-tokens", label: "Max tokens", kind: .integer),
-            .init(flag: "--temperature", label: "Temperature", kind: .number),
-            .init(flag: "--top-p", label: "Top-p", kind: .number)
+            .init(flag: "--model", label: "Model", kind: .string, group: Group.modelAndAdapters, tier: .essential),
+            .init(flag: "--output-dir", label: "Output directory", kind: .directory, group: Group.output, tier: .standard),
+            .init(flag: "--prompt", label: "Prompt", kind: .string, group: Group.prompt, tier: .essential),
+            .init(flag: "--prompt-file", label: "Prompt file", kind: .file, group: Group.prompt, tier: .expert),
+            .init(flag: "--focus", label: "Focus", kind: .string, repeatable: true, group: Group.prompt, tier: .standard),
+            .init(flag: "--trigger-token", label: "Trigger token", kind: .string, group: Group.prompt, tier: .standard),
+            .init(
+                flag: "--max-tokens", label: "Max tokens", kind: .integer,
+                defaultValue: "96", group: Group.sampling, tier: .standard, range: .init(min: 1, max: 2_048, step: 1)
+            ),
+            .init(
+                flag: "--temperature", label: "Temperature", kind: .number,
+                defaultValue: "0.2", group: Group.sampling, tier: .standard, range: .init(min: 0, max: 2, step: 0.05)
+            ),
+            .init(
+                flag: "--top-p", label: "Top-p", kind: .number,
+                defaultValue: "0.9", group: Group.sampling, tier: .standard, range: .init(min: 0, max: 1, step: 0.01)
+            )
         ],
         output: .init(kind: .directory)
     )
@@ -753,33 +1011,82 @@ public enum MereRunCapabilityCatalog {
         summary: "Extract text with native LightOn/Infinity or external GLM/Infinity runtimes.",
         arguments: [.init(name: "images", label: "Images", kind: .file, required: true)],
         options: [
-            .init(flag: "--backend", label: "Backend", kind: .choice, choices: ["lighton", "glm", "infinity"]),
-            .init(flag: "--compare", label: "Compare", kind: .boolean),
-            .init(flag: "--model", label: "LightOn model", kind: .string),
-            .init(flag: "--glmocr-cli", label: "GLM executable", kind: .file),
-            .init(flag: "--glm-config", label: "GLM config", kind: .file),
-            .init(flag: "--infinity-runtime", label: "Infinity runtime", kind: .choice, choices: ["native", "external"]),
-            .init(flag: "--infinity-parser-cli", label: "Parser executable", kind: .file),
-            .init(flag: "--infinity-model", label: "Infinity model", kind: .string),
+            .init(
+                flag: "--backend", label: "Backend", kind: .choice, choices: ["lighton", "glm", "infinity"],
+                defaultValue: "lighton", group: Group.modelAndAdapters, tier: .essential
+            ),
+            .init(flag: "--compare", label: "Compare", kind: .boolean, group: Group.run, tier: .expert),
+            .init(
+                flag: "--model", label: "LightOn model", kind: .string,
+                defaultValue: "vision-ocr-lighton", group: Group.modelAndAdapters, tier: .standard
+            ),
+            .init(
+                flag: "--glmocr-cli", label: "GLM executable", kind: .file,
+                defaultValue: "glmocr", group: Group.modelAndAdapters, tier: .expert
+            ),
+            .init(flag: "--glm-config", label: "GLM config", kind: .file, group: Group.modelAndAdapters, tier: .expert),
+            .init(
+                flag: "--infinity-runtime", label: "Infinity runtime", kind: .choice, choices: ["native", "external"],
+                defaultValue: "native", group: Group.modelAndAdapters, tier: .expert
+            ),
+            .init(
+                flag: "--infinity-parser-cli", label: "Parser executable", kind: .file,
+                defaultValue: "parser", group: Group.modelAndAdapters, tier: .expert
+            ),
+            .init(
+                flag: "--infinity-model", label: "Infinity model", kind: .string,
+                defaultValue: "vision-ocr-infinity-pro-int8", group: Group.modelAndAdapters, tier: .expert
+            ),
             .init(
                 flag: "--infinity-backend",
                 label: "Infinity backend",
                 kind: .choice,
-                choices: ["transformers", "vllm-engine", "vllm-server"]
+                choices: ["transformers", "vllm-engine", "vllm-server"],
+                defaultValue: "vllm-server", group: Group.modelAndAdapters, tier: .expert
             ),
-            .init(flag: "--infinity-api-url", label: "Infinity API URL", kind: .string),
-            .init(flag: "--infinity-api-key", label: "Infinity API key", kind: .string),
-            .init(flag: "--infinity-task", label: "Infinity task", kind: .choice, choices: ["doc2json", "doc2md", "custom"]),
-            .init(flag: "--infinity-prompt", label: "Infinity prompt", kind: .string),
-            .init(flag: "--infinity-output-format", label: "Infinity format", kind: .choice, choices: ["md", "json"]),
-            .init(flag: "--infinity-batch-size", label: "Batch size", kind: .integer),
-            .init(flag: "--infinity-model-cache-dir", label: "Model cache", kind: .directory),
-            .init(flag: "--infinity-min-pixels", label: "Minimum pixels", kind: .integer),
-            .init(flag: "--infinity-max-pixels", label: "Maximum pixels", kind: .integer),
-            .init(flag: "--output-dir", label: "Output directory", kind: .directory),
-            .init(flag: "--max-tokens", label: "Max tokens", kind: .integer),
-            .init(flag: "--temperature", label: "Temperature", kind: .number),
-            .init(flag: "--quiet", label: "Quiet", kind: .boolean)
+            .init(
+                flag: "--infinity-api-url", label: "Infinity API URL", kind: .string,
+                defaultValue: "http://localhost:8000/v1/chat/completions", group: Group.modelAndAdapters, tier: .expert
+            ),
+            .init(
+                flag: "--infinity-api-key", label: "Infinity API key", kind: .string,
+                defaultValue: "EMPTY", group: Group.modelAndAdapters, tier: .expert
+            ),
+            .init(
+                flag: "--infinity-task", label: "Infinity task", kind: .choice, choices: ["doc2json", "doc2md", "custom"],
+                defaultValue: "doc2json", group: Group.prompt, tier: .expert
+            ),
+            .init(flag: "--infinity-prompt", label: "Infinity prompt", kind: .string, group: Group.prompt, tier: .expert),
+            .init(
+                flag: "--infinity-output-format", label: "Infinity format", kind: .choice, choices: ["md", "json"],
+                defaultValue: "md", group: Group.output, tier: .expert
+            ),
+            .init(
+                flag: "--infinity-batch-size", label: "Batch size", kind: .integer,
+                defaultValue: "1", group: Group.run, tier: .expert, range: .init(min: 1, max: 64, step: 1)
+            ),
+            .init(
+                flag: "--infinity-model-cache-dir", label: "Model cache", kind: .directory,
+                group: Group.modelAndAdapters, tier: .expert
+            ),
+            .init(
+                flag: "--infinity-min-pixels", label: "Minimum pixels", kind: .integer,
+                defaultValue: "2048", group: Group.inputs, tier: .expert, range: .init(min: 1, step: 1)
+            ),
+            .init(
+                flag: "--infinity-max-pixels", label: "Maximum pixels", kind: .integer,
+                defaultValue: "16777216", group: Group.inputs, tier: .expert, range: .init(min: 1, step: 1)
+            ),
+            .init(flag: "--output-dir", label: "Output directory", kind: .directory, group: Group.output, tier: .standard),
+            .init(
+                flag: "--max-tokens", label: "Max tokens", kind: .integer,
+                defaultValue: "4096", group: Group.sampling, tier: .standard, range: .init(min: 1, max: 16_384, step: 1)
+            ),
+            .init(
+                flag: "--temperature", label: "Temperature", kind: .number,
+                defaultValue: "0.2", group: Group.sampling, tier: .standard, range: .init(min: 0, max: 2, step: 0.05)
+            ),
+            .init(flag: "--quiet", label: "Quiet", kind: .boolean, group: Group.run, tier: .expert)
         ],
         output: .init(kind: .directory)
     )
@@ -791,11 +1098,15 @@ public enum MereRunCapabilityCatalog {
         summary: "Ground one or more text expressions with native Falcon Perception.",
         arguments: [.init(name: "image", label: "Image", kind: .file, required: true)],
         options: [
-            .init(flag: "--query", label: "Query", kind: .string, repeatable: true),
-            .init(flag: "--model", label: "Model", kind: .string),
-            .init(flag: "--output", label: "Annotated image", kind: .file),
-            .init(flag: "--json-output", label: "JSON output", kind: .file),
-            .init(flag: "--mask-output-dir", label: "Mask directory", kind: .directory)
+            .init(flag: "--query", label: "Query", kind: .string, repeatable: true, group: Group.prompt, tier: .essential),
+            .init(flag: "--model", label: "Model", kind: .string, group: Group.modelAndAdapters, tier: .essential),
+            .init(flag: "--output", label: "Annotated image", kind: .file, group: Group.output, tier: .standard),
+            .init(flag: "--json-output", label: "JSON output", kind: .file, group: Group.output, tier: .standard),
+            .init(flag: "--mask-output-dir", label: "Mask directory", kind: .directory, group: Group.output, tier: .standard),
+            .init(flag: "--preflight", label: "Preflight", kind: .boolean, group: Group.run, tier: .expert),
+            .init(flag: "--json", label: "JSON preflight", kind: .boolean, group: Group.run, tier: .expert, dependsOn: "--preflight"),
+            .init(flag: "--quiet", label: "Quiet", kind: .boolean, group: Group.run, tier: .expert),
+            receiptOption
         ],
         output: .init(kind: .file, fileExtension: "png")
     )
@@ -807,17 +1118,27 @@ public enum MereRunCapabilityCatalog {
         summary: "Segment text, box, or point prompts with native SAM 3.1.",
         arguments: [.init(name: "image", label: "Image", kind: .file, required: true)],
         options: [
-            .init(flag: "--prompt", label: "Text prompt", kind: .string, repeatable: true),
-            .init(flag: "--box", label: "Box prompt", kind: .string, repeatable: true),
-            .init(flag: "--point", label: "Point prompt", kind: .string, repeatable: true),
-            .init(flag: "--model", label: "Model", kind: .string),
-            .init(flag: "--output", label: "Annotated image", kind: .file),
-            .init(flag: "--json-output", label: "JSON output", kind: .file),
-            .init(flag: "--mask-output-dir", label: "Mask directory", kind: .directory),
-            .init(flag: "--threshold", label: "Threshold", kind: .number),
-            .init(flag: "--resolution", label: "Resolution", kind: .integer),
-            .init(flag: "--show-boxes", label: "Show boxes", kind: .boolean),
-            .init(flag: "--multimask", label: "Multiple masks", kind: .boolean)
+            .init(flag: "--prompt", label: "Text prompt", kind: .string, repeatable: true, group: Group.prompt, tier: .essential),
+            .init(flag: "--box", label: "Box prompt", kind: .string, repeatable: true, group: Group.inputs, tier: .standard),
+            .init(flag: "--point", label: "Point prompt", kind: .string, repeatable: true, group: Group.inputs, tier: .standard),
+            .init(flag: "--model", label: "Model", kind: .string, group: Group.modelAndAdapters, tier: .essential),
+            .init(flag: "--output", label: "Annotated image", kind: .file, group: Group.output, tier: .standard),
+            .init(flag: "--json-output", label: "JSON output", kind: .file, group: Group.output, tier: .standard),
+            .init(flag: "--mask-output-dir", label: "Mask directory", kind: .directory, group: Group.output, tier: .standard),
+            .init(
+                flag: "--threshold", label: "Threshold", kind: .number,
+                defaultValue: "0.05", group: Group.sampling, tier: .standard, range: .init(min: 0, max: 1, step: 0.01)
+            ),
+            .init(
+                flag: "--resolution", label: "Resolution", kind: .integer,
+                defaultValue: "1008", group: Group.sampling, tier: .expert, range: .init(min: 256, max: 2_048, step: 16)
+            ),
+            .init(flag: "--show-boxes", label: "Show boxes", kind: .boolean, group: Group.output, tier: .standard),
+            .init(flag: "--multimask", label: "Multiple masks", kind: .boolean, group: Group.sampling, tier: .expert),
+            .init(flag: "--preflight", label: "Preflight", kind: .boolean, group: Group.run, tier: .expert),
+            .init(flag: "--json", label: "JSON preflight", kind: .boolean, group: Group.run, tier: .expert, dependsOn: "--preflight"),
+            .init(flag: "--quiet", label: "Quiet", kind: .boolean, group: Group.run, tier: .expert),
+            receiptOption
         ],
         output: .init(kind: .file, fileExtension: "png")
     )
@@ -829,21 +1150,35 @@ public enum MereRunCapabilityCatalog {
         summary: "Track text, box, or point prompted objects through video.",
         arguments: [.init(name: "video", label: "Video", kind: .file, required: true)],
         options: [
-            .init(flag: "--prompt", label: "Text prompt", kind: .string, repeatable: true),
-            .init(flag: "--box", label: "Box prompt", kind: .string, repeatable: true),
-            .init(flag: "--point", label: "Point prompt", kind: .string, repeatable: true),
-            .init(flag: "--model", label: "Model", kind: .string),
-            .init(flag: "--output", label: "Annotated video", kind: .file),
-            .init(flag: "--json-output", label: "JSON output", kind: .file),
-            .init(flag: "--mask-output-dir", label: "Mask directory", kind: .directory),
-            .init(flag: "--init-frame", label: "Initial frame", kind: .integer),
-            .init(flag: "--end-frame", label: "End frame", kind: .integer),
-            .init(flag: "--threshold", label: "Threshold", kind: .number),
-            .init(flag: "--resolution", label: "Resolution", kind: .integer),
-            .init(flag: "--show-boxes", label: "Show boxes", kind: .boolean),
-            .init(flag: "--show-labels", label: "Show labels", kind: .boolean),
-            .init(flag: "--preflight", label: "Preflight", kind: .boolean),
-            .init(flag: "--json", label: "JSON preflight", kind: .boolean)
+            .init(flag: "--prompt", label: "Text prompt", kind: .string, repeatable: true, group: Group.prompt, tier: .essential),
+            .init(flag: "--box", label: "Box prompt", kind: .string, repeatable: true, group: Group.inputs, tier: .standard),
+            .init(flag: "--point", label: "Point prompt", kind: .string, repeatable: true, group: Group.inputs, tier: .standard),
+            .init(flag: "--model", label: "Model", kind: .string, group: Group.modelAndAdapters, tier: .essential),
+            .init(flag: "--output", label: "Annotated video", kind: .file, group: Group.output, tier: .standard),
+            .init(flag: "--json-output", label: "JSON output", kind: .file, group: Group.output, tier: .standard),
+            .init(flag: "--mask-output-dir", label: "Mask directory", kind: .directory, group: Group.output, tier: .standard),
+            .init(
+                flag: "--init-frame", label: "Initial frame", kind: .integer,
+                defaultValue: "0", group: Group.inputs, tier: .standard, range: .init(min: 0, step: 1)
+            ),
+            .init(
+                flag: "--end-frame", label: "End frame", kind: .integer,
+                group: Group.inputs, tier: .standard, range: .init(min: 0, step: 1)
+            ),
+            .init(
+                flag: "--threshold", label: "Threshold", kind: .number,
+                defaultValue: "0.05", group: Group.sampling, tier: .standard, range: .init(min: 0, max: 1, step: 0.01)
+            ),
+            .init(
+                flag: "--resolution", label: "Resolution", kind: .integer,
+                defaultValue: "1008", group: Group.sampling, tier: .expert, range: .init(min: 256, max: 2_048, step: 16)
+            ),
+            .init(flag: "--show-boxes", label: "Show boxes", kind: .boolean, group: Group.output, tier: .standard),
+            .init(flag: "--show-labels", label: "Show labels", kind: .boolean, group: Group.output, tier: .expert),
+            .init(flag: "--preflight", label: "Preflight", kind: .boolean, group: Group.run, tier: .expert),
+            .init(flag: "--json", label: "JSON preflight", kind: .boolean, group: Group.run, tier: .expert, dependsOn: "--preflight"),
+            .init(flag: "--quiet", label: "Quiet", kind: .boolean, group: Group.run, tier: .expert),
+            receiptOption
         ],
         output: .init(kind: .file, fileExtension: "mp4")
     )
@@ -1107,104 +1442,274 @@ public enum MereRunCapabilityCatalog {
             .init(name: "caption", label: "Music prompt", kind: .string, required: true)
         ],
         options: [
-            .init(flag: "--lyrics", label: "Lyrics", kind: .string),
-            .init(flag: "--lyrics-file", label: "Lyrics file", kind: .file),
-            .init(flag: "--instrumental", label: "Instrumental", kind: .boolean),
-            .init(flag: "--lrc-file", label: "LRC file", kind: .file),
-            .init(flag: "--lrc-output", label: "LRC output", kind: .file),
-            .init(flag: "--output", label: "Audio output", kind: .file),
-            .init(flag: "--export-format", label: "Audio format", kind: .choice, choices: ["pcm16", "pcm24", "float32"]),
-            .init(flag: "--normalize", label: "Normalization", kind: .choice, choices: ["none", "peak"]),
-            .init(flag: "--target-peak-db", label: "Peak target", kind: .number),
-            .init(flag: "--fade-in-ms", label: "Fade in", kind: .number),
-            .init(flag: "--fade-out-ms", label: "Fade out", kind: .number),
-            .init(flag: "--no-dither", label: "Disable dither", kind: .boolean),
-            .init(flag: "--recipe-output", label: "Recipe output", kind: .file),
-            .init(flag: "--no-recipe", label: "Disable recipe", kind: .boolean),
-            .init(flag: "--daw-bundle", label: "DAW bundle", kind: .directory),
-            .init(flag: "--stems", label: "Stems", kind: .string),
-            .init(flag: "--adapter", label: "Adapter", kind: .file, repeatable: true),
-            .init(flag: "--adapter-kind", label: "Adapter kind", kind: .choice, choices: ["auto", "lora", "lokr"]),
-            .init(flag: "--adapter-scale", label: "Adapter scale", kind: .number, repeatable: true),
-            .init(flag: "--model", label: "Model", kind: .string),
-            .init(flag: "--checkpoints-root", label: "Checkpoints root", kind: .directory),
-            .init(flag: "--decoder-subdirectory", label: "Decoder", kind: .string),
-            .init(flag: "--vae-subdirectory", label: "VAE", kind: .string),
-            .init(flag: "--lm-subdirectory", label: "Language model", kind: .string),
-            .init(flag: "--lm-model", label: "LM model", kind: .string),
-            .init(flag: "--text-subdirectory", label: "Text encoder", kind: .string),
-            .init(flag: "--use-lm", label: "Use LM planning", kind: .boolean),
-            .init(flag: "--no-lm", label: "Disable LM planning", kind: .boolean),
-            .init(flag: "--analyze-source-audio", label: "Analyze source", kind: .boolean),
-            .init(flag: "--duration", label: "Duration", kind: .number),
-            .init(flag: "--quality", label: "Quality", kind: .choice, choices: ["draft", "song", "final", "edit"]),
-            .init(flag: "--steps", label: "Steps", kind: .integer),
-            .init(flag: "--shift", label: "Scheduler shift", kind: .number),
-            .init(flag: "--infer-method", label: "Inference method", kind: .choice, choices: ["ode", "sde"]),
-            .init(flag: "--sampler", label: "Sampler", kind: .choice, choices: ["euler", "heun"]),
-            .init(flag: "--guidance-scale", label: "Guidance scale", kind: .number),
-            .init(flag: "--guidance-mode", label: "Guidance mode", kind: .choice, choices: ["apg", "adg", "cfg"]),
-            .init(flag: "--cfg-interval-start", label: "CFG start", kind: .number),
-            .init(flag: "--cfg-interval-end", label: "CFG end", kind: .number),
-            .init(flag: "--velocity-norm-threshold", label: "Velocity clamp", kind: .number),
-            .init(flag: "--velocity-ema-factor", label: "Velocity EMA", kind: .number),
-            .init(flag: "--seed", label: "Seed", kind: .integer),
-            .init(flag: "--candidates", label: "Candidate count", kind: .integer),
-            .init(flag: "--keep-candidates", label: "Keep candidates", kind: .boolean),
-            .init(flag: "--audio-cover-strength", label: "Cover strength", kind: .number),
-            .init(flag: "--cover-noise-strength", label: "Cover noise", kind: .number),
-            .init(flag: "--retake-seed", label: "Retake seed", kind: .integer),
-            .init(flag: "--retake-variance", label: "Retake variance", kind: .number),
-            .init(flag: "--vocal-language", label: "Vocal language", kind: .string),
-            .init(flag: "--instruction", label: "Instruction", kind: .string),
+            .init(flag: "--lyrics", label: "Lyrics", kind: .string, group: Group.prompt, tier: .standard),
+            .init(flag: "--lyrics-file", label: "Lyrics file", kind: .file, group: Group.prompt, tier: .expert),
+            .init(flag: "--instrumental", label: "Instrumental", kind: .boolean, group: Group.prompt, tier: .standard),
+            .init(flag: "--lrc-file", label: "LRC file", kind: .file, group: Group.prompt, tier: .expert),
+            .init(flag: "--lrc-output", label: "LRC output", kind: .file, group: Group.output, tier: .expert),
+            .init(flag: "--output", label: "Audio output", kind: .file, group: Group.output, tier: .standard),
+            .init(
+                flag: "--export-format", label: "Audio format", kind: .choice, choices: ["pcm16", "pcm24", "float32"],
+                defaultValue: "pcm24", group: Group.output, tier: .expert
+            ),
+            .init(
+                flag: "--normalize", label: "Normalization", kind: .choice, choices: ["none", "peak"],
+                defaultValue: "peak", group: Group.output, tier: .expert
+            ),
+            .init(
+                flag: "--target-peak-db", label: "Peak target", kind: .number,
+                defaultValue: "-1.0", group: Group.output, tier: .expert, range: .init(min: -24, max: 0, step: 0.5)
+            ),
+            .init(
+                flag: "--fade-in-ms", label: "Fade in", kind: .number,
+                defaultValue: "5.0", group: Group.output, tier: .expert, range: .init(min: 0, max: 5_000, step: 1)
+            ),
+            .init(
+                flag: "--fade-out-ms", label: "Fade out", kind: .number,
+                defaultValue: "20.0", group: Group.output, tier: .expert, range: .init(min: 0, max: 5_000, step: 1)
+            ),
+            .init(flag: "--no-dither", label: "Disable dither", kind: .boolean, group: Group.output, tier: .expert),
+            .init(flag: "--recipe-output", label: "Recipe output", kind: .file, group: Group.output, tier: .expert),
+            .init(flag: "--no-recipe", label: "Disable recipe", kind: .boolean, group: Group.output, tier: .expert),
+            .init(flag: "--daw-bundle", label: "DAW bundle", kind: .directory, group: Group.output, tier: .expert),
+            .init(flag: "--stems", label: "Stems", kind: .string, group: Group.output, tier: .expert),
+            .init(flag: "--adapter", label: "Adapter", kind: .file, repeatable: true, group: Group.modelAndAdapters, tier: .standard),
+            .init(
+                flag: "--adapter-kind", label: "Adapter kind", kind: .choice, choices: ["auto", "lora", "lokr"],
+                defaultValue: "auto", group: Group.modelAndAdapters, tier: .expert, dependsOn: "--adapter"
+            ),
+            .init(
+                flag: "--adapter-scale", label: "Adapter scale", kind: .number, repeatable: true,
+                group: Group.modelAndAdapters, tier: .standard, range: .init(min: 0, max: 2, step: 0.05), dependsOn: "--adapter"
+            ),
+            .init(
+                flag: "--model", label: "Model", kind: .string,
+                defaultValue: "music-acestep", group: Group.modelAndAdapters, tier: .essential
+            ),
+            .init(flag: "--checkpoints-root", label: "Checkpoints root", kind: .directory, group: Group.modelAndAdapters, tier: .expert),
+            .init(
+                flag: "--decoder-subdirectory", label: "Decoder", kind: .string,
+                defaultValue: "acestep-v15-turbo", group: Group.modelAndAdapters, tier: .expert
+            ),
+            .init(
+                flag: "--vae-subdirectory", label: "VAE", kind: .string,
+                defaultValue: "vae", group: Group.modelAndAdapters, tier: .expert
+            ),
+            .init(flag: "--lm-subdirectory", label: "Language model", kind: .string, group: Group.modelAndAdapters, tier: .expert),
+            .init(flag: "--lm-model", label: "LM model", kind: .string, group: Group.modelAndAdapters, tier: .expert),
+            .init(flag: "--text-subdirectory", label: "Text encoder", kind: .string, group: Group.modelAndAdapters, tier: .expert),
+            .init(flag: "--use-lm", label: "Use LM planning", kind: .boolean, group: Group.sampling, tier: .expert),
+            .init(flag: "--no-lm", label: "Disable LM planning", kind: .boolean, group: Group.sampling, tier: .expert),
+            .init(
+                flag: "--analyze-source-audio", label: "Analyze source", kind: .boolean,
+                group: Group.inputs, tier: .expert, dependsOn: "--source-audio"
+            ),
+            .init(
+                flag: "--duration", label: "Duration", kind: .number,
+                group: Group.sampling, tier: .essential, range: .init(min: 1, max: 600, step: 1)
+            ),
+            .init(
+                flag: "--quality", label: "Quality", kind: .choice, choices: ["draft", "song", "final", "edit"],
+                group: Group.sampling, tier: .essential
+            ),
+            .init(
+                flag: "--steps", label: "Steps", kind: .integer,
+                group: Group.sampling, tier: .standard, range: .init(min: 1, max: 200, step: 1)
+            ),
+            .init(
+                flag: "--shift", label: "Scheduler shift", kind: .number,
+                group: Group.sampling, tier: .expert, range: .init(min: 0, max: 10, step: 0.1)
+            ),
+            .init(
+                flag: "--infer-method", label: "Inference method", kind: .choice, choices: ["ode", "sde"],
+                group: Group.sampling, tier: .expert
+            ),
+            .init(flag: "--sampler", label: "Sampler", kind: .choice, choices: ["euler", "heun"], group: Group.sampling, tier: .expert),
+            .init(
+                flag: "--guidance-scale", label: "Guidance scale", kind: .number,
+                group: Group.sampling, tier: .standard, range: .init(min: 1, max: 20, step: 0.1)
+            ),
+            .init(
+                flag: "--guidance-mode", label: "Guidance mode", kind: .choice, choices: ["apg", "adg", "cfg"],
+                group: Group.sampling, tier: .expert
+            ),
+            .init(
+                flag: "--cfg-interval-start", label: "CFG start", kind: .number,
+                group: Group.sampling, tier: .expert, range: .init(min: 0, max: 1, step: 0.01)
+            ),
+            .init(
+                flag: "--cfg-interval-end", label: "CFG end", kind: .number,
+                group: Group.sampling, tier: .expert, range: .init(min: 0, max: 1, step: 0.01)
+            ),
+            .init(
+                flag: "--velocity-norm-threshold", label: "Velocity clamp", kind: .number,
+                group: Group.sampling, tier: .expert, range: .init(min: 0, step: 0.1)
+            ),
+            .init(
+                flag: "--velocity-ema-factor", label: "Velocity EMA", kind: .number,
+                group: Group.sampling, tier: .expert, range: .init(min: 0, max: 1, step: 0.01)
+            ),
+            .init(flag: "--seed", label: "Seed", kind: .integer, group: Group.sampling, tier: .essential, range: .init(min: 0, step: 1)),
+            .init(
+                flag: "--candidates", label: "Candidate count", kind: .integer,
+                group: Group.sampling, tier: .standard, range: .init(min: 1, max: 16, step: 1)
+            ),
+            .init(
+                flag: "--keep-candidates", label: "Keep candidates", kind: .boolean,
+                group: Group.output, tier: .expert, dependsOn: "--candidates"
+            ),
+            .init(
+                flag: "--audio-cover-strength", label: "Cover strength", kind: .number,
+                defaultValue: "1.0", group: Group.inputs, tier: .standard, range: .init(min: 0, max: 1, step: 0.05),
+                dependsOn: "--source-audio"
+            ),
+            .init(
+                flag: "--cover-noise-strength", label: "Cover noise", kind: .number,
+                defaultValue: "0.0", group: Group.inputs, tier: .expert, range: .init(min: 0, max: 1, step: 0.05),
+                dependsOn: "--source-audio"
+            ),
+            .init(flag: "--retake-seed", label: "Retake seed", kind: .integer, group: Group.sampling, tier: .expert, range: .init(min: 0, step: 1)),
+            .init(
+                flag: "--retake-variance", label: "Retake variance", kind: .number,
+                defaultValue: "0.0", group: Group.sampling, tier: .expert, range: .init(min: 0, max: 1, step: 0.05),
+                dependsOn: "--retake-seed"
+            ),
+            .init(flag: "--vocal-language", label: "Vocal language", kind: .string, defaultValue: "en", group: Group.prompt, tier: .standard),
+            .init(
+                flag: "--instruction", label: "Instruction", kind: .string,
+                defaultValue: "Fill the audio semantic mask based on the given conditions:", group: Group.prompt, tier: .expert
+            ),
             .init(
                 flag: "--task-type",
                 label: "Task",
                 kind: .choice,
-                choices: ["text2music", "repaint", "cover", "cover-nofsq", "extract", "lego", "complete"]
+                choices: ["text2music", "repaint", "cover", "cover-nofsq", "extract", "lego", "complete"],
+                defaultValue: "text2music", group: Group.inputs, tier: .standard
             ),
-            .init(flag: "--source-audio", label: "Source audio", kind: .file),
-            .init(flag: "--reference-audio", label: "Reference audio", kind: .file, repeatable: true),
-            .init(flag: "--track-name", label: "Track name", kind: .string),
-            .init(flag: "--complete-track-classes", label: "Track classes", kind: .string),
-            .init(flag: "--non-cover", label: "No FSQ cover", kind: .boolean),
-            .init(flag: "--repaint-start", label: "Repaint start", kind: .number),
-            .init(flag: "--repaint-end", label: "Repaint end", kind: .number),
-            .init(flag: "--chunk-mask-mode", label: "Chunk mask", kind: .choice, choices: ["auto", "explicit"]),
-            .init(flag: "--repaint-mode", label: "Repaint mode", kind: .choice, choices: ["conservative", "balanced", "aggressive"]),
-            .init(flag: "--repaint-strength", label: "Repaint strength", kind: .number),
-            .init(flag: "--flow-edit", label: "Flow edit", kind: .boolean),
-            .init(flag: "--source-caption", label: "Source caption", kind: .string),
-            .init(flag: "--source-lyrics", label: "Source lyrics", kind: .string),
-            .init(flag: "--flow-edit-n-min", label: "Flow start", kind: .number),
-            .init(flag: "--flow-edit-n-max", label: "Flow end", kind: .number),
-            .init(flag: "--flow-edit-n-average", label: "Flow samples", kind: .integer),
-            .init(flag: "--bpm", label: "BPM", kind: .integer),
-            .init(flag: "--keyscale", label: "Key", kind: .string),
-            .init(flag: "--timesignature", label: "Time signature", kind: .string),
-            .init(flag: "--lm-temperature", label: "LM temperature", kind: .number),
-            .init(flag: "--lm-top-k", label: "LM top-k", kind: .integer),
-            .init(flag: "--lm-top-p", label: "LM top-p", kind: .number),
-            .init(flag: "--lm-repetition-penalty", label: "LM repetition penalty", kind: .number),
-            .init(flag: "--lm-cfg-scale", label: "LM CFG scale", kind: .number),
-            .init(flag: "--lm-negative-prompt", label: "LM negative prompt", kind: .string),
-            .init(flag: "--metadata-duration", label: "Metadata duration", kind: .string),
-            .init(flag: "--metadata-language", label: "Metadata language", kind: .string),
-            .init(flag: "--no-tiled-vae", label: "Disable tiled VAE", kind: .boolean),
-            .init(flag: "--vae-chunk-size", label: "VAE chunk", kind: .integer),
-            .init(flag: "--vae-overlap", label: "VAE overlap", kind: .integer),
-            .init(flag: "--quiet", label: "Quiet", kind: .boolean),
-            .init(flag: "--temperature", label: "RT2 temperature", kind: .number),
-            .init(flag: "--style-conditioning", label: "RT2 style", kind: .choice, choices: ["streaming", "full"]),
-            .init(flag: "--top-k", label: "RT2 top-k", kind: .integer),
-            .init(flag: "--cfg-musiccoca", label: "MusicCoCa CFG", kind: .number),
-            .init(flag: "--cfg-notes", label: "Notes CFG", kind: .number),
-            .init(flag: "--cfg-drums", label: "Drums CFG", kind: .number),
-            .init(flag: "--drumless", label: "Drumless", kind: .boolean),
-            .init(flag: "--unmask-width", label: "Unmask width", kind: .integer),
-            .init(flag: "--seed-rotation", label: "Seed rotation", kind: .integer),
-            .init(flag: "--prefill-silence", label: "Prefill silence", kind: .boolean),
-            .init(flag: "--prefill-duration", label: "Prefill duration", kind: .number)
+            .init(flag: "--source-audio", label: "Source audio", kind: .file, group: Group.inputs, tier: .standard),
+            .init(
+                flag: "--reference-audio", label: "Reference audio", kind: .file, repeatable: true,
+                group: Group.inputs, tier: .standard
+            ),
+            .init(flag: "--track-name", label: "Track name", kind: .string, group: Group.inputs, tier: .expert),
+            .init(flag: "--complete-track-classes", label: "Track classes", kind: .string, group: Group.inputs, tier: .expert),
+            .init(flag: "--non-cover", label: "No FSQ cover", kind: .boolean, group: Group.inputs, tier: .expert, dependsOn: "--source-audio"),
+            .init(
+                flag: "--repaint-start", label: "Repaint start", kind: .number,
+                defaultValue: "0.0", group: Group.inputs, tier: .standard, range: .init(min: 0, step: 0.1), dependsOn: "--source-audio"
+            ),
+            .init(
+                flag: "--repaint-end", label: "Repaint end", kind: .number,
+                defaultValue: "-1.0", group: Group.inputs, tier: .standard, range: .init(min: -1, step: 0.1), dependsOn: "--source-audio"
+            ),
+            .init(
+                flag: "--chunk-mask-mode", label: "Chunk mask", kind: .choice, choices: ["auto", "explicit"],
+                defaultValue: "auto", group: Group.inputs, tier: .expert, dependsOn: "--source-audio"
+            ),
+            .init(
+                flag: "--repaint-mode", label: "Repaint mode", kind: .choice, choices: ["conservative", "balanced", "aggressive"],
+                defaultValue: "balanced", group: Group.inputs, tier: .expert, dependsOn: "--source-audio"
+            ),
+            .init(
+                flag: "--repaint-strength", label: "Repaint strength", kind: .number,
+                defaultValue: "0.5", group: Group.inputs, tier: .expert, range: .init(min: 0, max: 1, step: 0.05),
+                dependsOn: "--source-audio"
+            ),
+            .init(flag: "--flow-edit", label: "Flow edit", kind: .boolean, group: Group.inputs, tier: .standard, dependsOn: "--source-audio"),
+            .init(flag: "--source-caption", label: "Source caption", kind: .string, group: Group.inputs, tier: .standard, dependsOn: "--flow-edit"),
+            .init(flag: "--source-lyrics", label: "Source lyrics", kind: .string, group: Group.inputs, tier: .expert, dependsOn: "--flow-edit"),
+            .init(
+                flag: "--flow-edit-n-min", label: "Flow start", kind: .number,
+                defaultValue: "0.0", group: Group.inputs, tier: .expert, range: .init(min: 0, max: 1, step: 0.05), dependsOn: "--flow-edit"
+            ),
+            .init(
+                flag: "--flow-edit-n-max", label: "Flow end", kind: .number,
+                defaultValue: "1.0", group: Group.inputs, tier: .expert, range: .init(min: 0, max: 1, step: 0.05), dependsOn: "--flow-edit"
+            ),
+            .init(
+                flag: "--flow-edit-n-average", label: "Flow samples", kind: .integer,
+                defaultValue: "1", group: Group.inputs, tier: .expert, range: .init(min: 1, max: 16, step: 1), dependsOn: "--flow-edit"
+            ),
+            .init(flag: "--bpm", label: "BPM", kind: .integer, group: Group.prompt, tier: .standard, range: .init(min: 20, max: 300, step: 1)),
+            .init(flag: "--keyscale", label: "Key", kind: .string, group: Group.prompt, tier: .standard),
+            .init(flag: "--timesignature", label: "Time signature", kind: .string, group: Group.prompt, tier: .standard),
+            .init(
+                flag: "--lm-temperature", label: "LM temperature", kind: .number,
+                defaultValue: "0.85", group: Group.sampling, tier: .expert, range: .init(min: 0, max: 2, step: 0.05)
+            ),
+            .init(
+                flag: "--lm-top-k", label: "LM top-k", kind: .integer,
+                defaultValue: "0", group: Group.sampling, tier: .expert, range: .init(min: 0, max: 1_000, step: 1)
+            ),
+            .init(
+                flag: "--lm-top-p", label: "LM top-p", kind: .number,
+                defaultValue: "0.9", group: Group.sampling, tier: .expert, range: .init(min: 0, max: 1, step: 0.01)
+            ),
+            .init(
+                flag: "--lm-repetition-penalty", label: "LM repetition penalty", kind: .number,
+                defaultValue: "1.0", group: Group.sampling, tier: .expert, range: .init(min: 0.5, max: 2, step: 0.05)
+            ),
+            .init(
+                flag: "--lm-cfg-scale", label: "LM CFG scale", kind: .number,
+                defaultValue: "2.0", group: Group.sampling, tier: .expert, range: .init(min: 0, max: 10, step: 0.1)
+            ),
+            .init(
+                flag: "--lm-negative-prompt", label: "LM negative prompt", kind: .string,
+                defaultValue: "NO USER INPUT", group: Group.sampling, tier: .expert
+            ),
+            .init(flag: "--metadata-duration", label: "Metadata duration", kind: .string, group: Group.prompt, tier: .expert),
+            .init(flag: "--metadata-language", label: "Metadata language", kind: .string, group: Group.prompt, tier: .expert),
+            .init(flag: "--no-tiled-vae", label: "Disable tiled VAE", kind: .boolean, group: Group.run, tier: .expert),
+            .init(
+                flag: "--vae-chunk-size", label: "VAE chunk", kind: .integer,
+                defaultValue: "512", group: Group.run, tier: .expert, range: .init(min: 64, max: 4_096, step: 64)
+            ),
+            .init(
+                flag: "--vae-overlap", label: "VAE overlap", kind: .integer,
+                defaultValue: "64", group: Group.run, tier: .expert, range: .init(min: 0, max: 1_024, step: 8)
+            ),
+            .init(flag: "--quiet", label: "Quiet", kind: .boolean, group: Group.run, tier: .expert),
+            .init(
+                flag: "--temperature", label: "RT2 temperature", kind: .number,
+                defaultValue: "1.0", group: Group.sampling, tier: .expert, range: .init(min: 0, max: 2, step: 0.05)
+            ),
+            .init(
+                flag: "--style-conditioning", label: "RT2 style", kind: .choice, choices: ["streaming", "full"],
+                defaultValue: "streaming", group: Group.sampling, tier: .expert
+            ),
+            .init(
+                flag: "--top-k", label: "RT2 top-k", kind: .integer,
+                defaultValue: "100", group: Group.sampling, tier: .expert, range: .init(min: 0, max: 1_000, step: 1)
+            ),
+            .init(
+                flag: "--cfg-musiccoca", label: "MusicCoCa CFG", kind: .number,
+                defaultValue: "3.0", group: Group.sampling, tier: .expert, range: .init(min: 0, max: 20, step: 0.1)
+            ),
+            .init(
+                flag: "--cfg-notes", label: "Notes CFG", kind: .number,
+                defaultValue: "5.0", group: Group.sampling, tier: .expert, range: .init(min: 0, max: 20, step: 0.1)
+            ),
+            .init(
+                flag: "--cfg-drums", label: "Drums CFG", kind: .number,
+                defaultValue: "1.0", group: Group.sampling, tier: .expert, range: .init(min: 0, max: 20, step: 0.1)
+            ),
+            .init(flag: "--drumless", label: "Drumless", kind: .boolean, group: Group.sampling, tier: .expert),
+            .init(
+                flag: "--unmask-width", label: "Unmask width", kind: .integer,
+                defaultValue: "0", group: Group.sampling, tier: .expert, range: .init(min: 0, step: 1)
+            ),
+            .init(
+                flag: "--seed-rotation", label: "Seed rotation", kind: .integer,
+                defaultValue: "0", group: Group.sampling, tier: .expert, range: .init(min: 0, step: 1)
+            ),
+            .init(flag: "--prefill-silence", label: "Prefill silence", kind: .boolean, group: Group.sampling, tier: .expert),
+            .init(
+                flag: "--prefill-duration", label: "Prefill duration", kind: .number,
+                defaultValue: "1.64", group: Group.sampling, tier: .expert, range: .init(min: 0, max: 30, step: 0.01),
+                dependsOn: "--prefill-silence"
+            ),
+            progressJSONOption,
+            receiptOption
         ],
         output: .init(kind: .file, fileExtension: "wav")
     )
@@ -1387,42 +1892,78 @@ public enum MereRunCapabilityCatalog {
             .init(name: "prompt", label: "Prompt", kind: .string, required: true)
         ],
         options: [
-            .init(flag: "--output", label: "Output", kind: .file),
-            .init(flag: "--model", label: "Model", kind: .string),
+            .init(flag: "--output", label: "Output", kind: .file, group: Group.output, tier: .standard),
+            .init(flag: "--model", label: "Model", kind: .string, group: Group.modelAndAdapters, tier: .essential),
             .init(
                 flag: "--quality",
                 label: "Quality",
                 kind: .choice,
-                choices: LTXVideoQuality.allCases.map(\.rawValue)
+                choices: LTXVideoQuality.allCases.map(\.rawValue),
+                group: Group.sampling, tier: .essential
             ),
             .init(
                 flag: "--output-mode",
                 label: "Output mode",
                 kind: .choice,
-                choices: LTXVideoOutputMode.allCases.map(\.rawValue)
+                choices: LTXVideoOutputMode.allCases.map(\.rawValue),
+                group: Group.output, tier: .essential
             ),
-            .init(flag: "--model-root", label: "Model root", kind: .directory),
-            .init(flag: "--auto-duration", label: "Auto duration range", kind: .string),
-            .init(flag: "--video-decoder", label: "Video decoder", kind: .choice, choices: ["diffusion", "convolutional"]),
-            .init(flag: "--hdr", label: "HDR color space", kind: .choice, choices: ["srgb-linear", "acescg", "acescct"]),
-            .init(flag: "--hdr-transfer", label: "HDR transfer", kind: .choice, choices: ["acescct", "logc3"]),
-            .init(flag: "--high-quality-hdr", label: "High quality HDR", kind: .boolean),
-            .init(flag: "--text-embeddings", label: "Precomputed text contexts", kind: .file),
-            .init(flag: "--spatial-tile", label: "VAE spatial tile", kind: .integer),
-            .init(flag: "--spatial-overlap", label: "VAE spatial overlap", kind: .integer),
-            .init(flag: "--skip-mp4", label: "EXR only", kind: .boolean),
-            .init(flag: "--width", label: "Width", kind: .integer),
-            .init(flag: "--height", label: "Height", kind: .integer),
-            .init(flag: "--num-frames", label: "Frames", kind: .integer),
-            .init(flag: "--duration", label: "Duration", kind: .number),
-            .init(flag: "--fps", label: "Frames per second", kind: .integer),
-            .init(flag: "--seed", label: "Seed", kind: .integer),
-            .init(flag: "--steps", label: "Denoising steps", kind: .integer),
+            .init(flag: "--model-root", label: "Model root", kind: .directory, group: Group.modelAndAdapters, tier: .expert),
+            .init(flag: "--auto-duration", label: "Auto duration range", kind: .string, group: Group.sampling, tier: .expert),
+            .init(
+                flag: "--video-decoder", label: "Video decoder", kind: .choice, choices: ["diffusion", "convolutional"],
+                group: Group.run, tier: .expert
+            ),
+            .init(
+                flag: "--hdr", label: "HDR color space", kind: .choice, choices: ["srgb-linear", "acescg", "acescct"],
+                group: Group.output, tier: .expert
+            ),
+            .init(
+                flag: "--hdr-transfer", label: "HDR transfer", kind: .choice, choices: ["acescct", "logc3"],
+                group: Group.output, tier: .expert, dependsOn: "--hdr"
+            ),
+            .init(flag: "--high-quality-hdr", label: "High quality HDR", kind: .boolean, group: Group.output, tier: .expert, dependsOn: "--hdr"),
+            .init(flag: "--text-embeddings", label: "Precomputed text contexts", kind: .file, group: Group.inputs, tier: .expert),
+            .init(
+                flag: "--spatial-tile", label: "VAE spatial tile", kind: .integer,
+                group: Group.run, tier: .expert, range: .init(min: 256, max: 4_096, step: 32)
+            ),
+            .init(
+                flag: "--spatial-overlap", label: "VAE spatial overlap", kind: .integer,
+                defaultValue: "256", group: Group.run, tier: .expert, range: .init(min: 0, max: 1_024, step: 32)
+            ),
+            .init(flag: "--skip-mp4", label: "EXR only", kind: .boolean, group: Group.output, tier: .expert, dependsOn: "--hdr"),
+            .init(
+                flag: "--width", label: "Width", kind: .integer,
+                group: Group.output, tier: .essential, range: .init(min: 256, max: 2_048, step: 16)
+            ),
+            .init(
+                flag: "--height", label: "Height", kind: .integer,
+                group: Group.output, tier: .essential, range: .init(min: 256, max: 2_048, step: 16)
+            ),
+            .init(
+                flag: "--num-frames", label: "Frames", kind: .integer,
+                group: Group.sampling, tier: .standard, range: .init(min: 1, max: 1_000, step: 1)
+            ),
+            .init(
+                flag: "--duration", label: "Duration", kind: .number,
+                group: Group.sampling, tier: .essential, range: .init(min: 1, max: 60, step: 0.5)
+            ),
+            .init(
+                flag: "--fps", label: "Frames per second", kind: .integer,
+                group: Group.sampling, tier: .standard, range: .init(min: 1, max: 60, step: 1)
+            ),
+            .init(flag: "--seed", label: "Seed", kind: .integer, group: Group.sampling, tier: .essential, range: .init(min: 0, step: 1)),
+            .init(
+                flag: "--steps", label: "Denoising steps", kind: .integer,
+                group: Group.sampling, tier: .standard, range: .init(min: 1, max: 100, step: 1)
+            ),
             .init(
                 flag: "--h3-weight-mode",
                 label: "MiniMax-H3 weight mode",
                 kind: .choice,
-                choices: ["auto", "quantized", "resident-bf16"]
+                choices: ["auto", "quantized", "resident-bf16"],
+                defaultValue: "auto", group: Group.modelAndAdapters, tier: .expert
             ),
             .init(
                 flag: "--h3-acceleration",
@@ -1431,65 +1972,190 @@ public enum MereRunCapabilityCatalog {
                 choices: [
                     "quality", "balanced", "maximum",
                     "layers-45", "layers-40", "velocity-reuse-2", "token-reduction"
-                ]
+                ],
+                defaultValue: "quality", group: Group.sampling, tier: .expert
             ),
-            .init(flag: "--guidance-scale", label: "Wan guidance", kind: .number),
-            .init(flag: "--shift", label: "Wan schedule shift", kind: .number),
-            .init(flag: "--negative-prompt", label: "Negative prompt", kind: .string),
-            .init(flag: "--enhance-prompt", label: "Enhance prompt", kind: .boolean),
-            .init(flag: "--prompt-enhancer-model", label: "Prompt enhancer", kind: .string),
-            .init(flag: "--prompt-enhancer-model-root", label: "Prompt enhancer root", kind: .directory),
-            .init(flag: "--audio", label: "Source audio", kind: .file),
-            .init(flag: "--audio-start-time", label: "Audio start", kind: .number),
-            .init(flag: "--audio-max-duration", label: "Audio max duration", kind: .number),
-            .init(flag: "--a2v-guidance-scale", label: "Audio-to-video guidance", kind: .number),
-            .init(flag: "--video-cfg-guidance-scale", label: "Video CFG guidance", kind: .number),
-            .init(flag: "--audio-cfg-guidance-scale", label: "Audio CFG guidance", kind: .number),
-            .init(flag: "--v2a-guidance-scale", label: "Video-to-audio guidance", kind: .number),
-            .init(flag: "--a2v-steps", label: "Audio-to-video steps", kind: .integer),
-            .init(flag: "--ltx-preset", label: "LTX preset", kind: .choice, choices: ["standard", "hq"]),
-            .init(flag: "--ltx-pipeline", label: "LTX pipeline", kind: .choice, choices: ["two-stage", "dev-one-stage"]),
-            .init(flag: "--ltx-sampler", label: "LTX sampler", kind: .choice, choices: ["euler", "res2s", "euler-ancestral", "cfg-plus-plus", "gradient-estimating-euler"]),
-            .init(flag: "--ltx-sigmas", label: "Stage one sigmas", kind: .string),
-            .init(flag: "--ltx-stage-2-sigmas", label: "Stage two sigmas", kind: .string),
-            .init(flag: "--distilled-lora-strength-stage-1", label: "Stage one distilled strength", kind: .number),
-            .init(flag: "--distilled-lora-strength-stage-2", label: "Stage two distilled strength", kind: .number),
-            .init(flag: "--ltx-sampler-eta", label: "Sampler eta", kind: .number),
-            .init(flag: "--video-stg-scale", label: "Video STG", kind: .number),
-            .init(flag: "--video-guidance-rescale", label: "Video rescale", kind: .number),
-            .init(flag: "--video-stg-block", label: "Video STG block", kind: .integer, repeatable: true),
-            .init(flag: "--video-guidance-skip-step", label: "Video guidance skip", kind: .integer),
-            .init(flag: "--audio-stg-scale", label: "Audio STG", kind: .number),
-            .init(flag: "--audio-guidance-rescale", label: "Audio rescale", kind: .number),
-            .init(flag: "--audio-stg-block", label: "Audio STG block", kind: .integer, repeatable: true),
-            .init(flag: "--audio-guidance-skip-step", label: "Audio guidance skip", kind: .integer),
-            .init(flag: "--no-res2s-bong-math", label: "Disable Res2s anchor refinement", kind: .boolean),
-            .init(flag: "--res2s-bong-max-iterations", label: "Res2s iterations", kind: .integer),
-            .init(flag: "--gradient-estimation-gamma", label: "Gradient estimate gamma", kind: .number),
-            .init(flag: "--image", label: "Start image", kind: .file),
-            .init(flag: "--image-strength", label: "Start image strength", kind: .number),
-            .init(flag: "--end-image", label: "End image", kind: .file),
-            .init(flag: "--end-image-strength", label: "End image strength", kind: .number),
-            .init(flag: "--image-conditioning", label: "Timed image guide", kind: .string, repeatable: true),
-            .init(flag: "--num-generated-keyframes", label: "Generated keyframe count", kind: .integer),
-            .init(flag: "--generated-keyframe", label: "Generated keyframe", kind: .integer, repeatable: true),
-            .init(flag: "--lora", label: "LTX LoRA", kind: .string, repeatable: true),
-            .init(flag: "--video-conditioning", label: "IC-LoRA reference video", kind: .string, repeatable: true),
-            .init(flag: "--conditioning-attention-strength", label: "Reference attention", kind: .number),
-            .init(flag: "--conditioning-attention-mask", label: "Reference attention mask", kind: .file),
-            .init(flag: "--skip-stage-2", label: "Stage one preview", kind: .boolean),
-            .init(flag: "--reference-downscale-factor", label: "Reference spatial scale", kind: .integer),
-            .init(flag: "--reference-temporal-scale-factor", label: "Reference temporal scale", kind: .integer),
-            .init(flag: "--dfr", label: "Diffusion fidelity rendering", kind: .boolean),
-            .init(flag: "--temporal-upsample-rounds", label: "Temporal refinement rounds", kind: .integer),
-            .init(flag: "--detailing-lora", label: "Detailing IC-LoRA", kind: .string, repeatable: true),
-            .init(flag: "--detailing-reference-downscale-factor", label: "Detail reference scale", kind: .integer),
-            .init(flag: "--reference", label: "Ordered H3 reference", kind: .string, repeatable: true),
-            .init(flag: "--preflight", label: "Preflight", kind: .boolean),
-            .init(flag: "--json", label: "JSON", kind: .boolean),
-            .init(flag: "--timings", label: "Timings", kind: .boolean),
-            .init(flag: "--timings-output", label: "Timings output", kind: .file),
-            .init(flag: "--quiet", label: "Quiet", kind: .boolean)
+            .init(
+                flag: "--guidance-scale", label: "Wan guidance", kind: .number,
+                defaultValue: "5.0", group: Group.sampling, tier: .standard, range: .init(min: 0, max: 20, step: 0.1)
+            ),
+            .init(
+                flag: "--shift", label: "Wan schedule shift", kind: .number,
+                defaultValue: "5.0", group: Group.sampling, tier: .expert, range: .init(min: 0, max: 10, step: 0.1)
+            ),
+            .init(flag: "--negative-prompt", label: "Negative prompt", kind: .string, group: Group.prompt, tier: .standard),
+            .init(flag: "--enhance-prompt", label: "Enhance prompt", kind: .boolean, group: Group.prompt, tier: .standard),
+            .init(
+                flag: "--prompt-enhancer-model", label: "Prompt enhancer", kind: .string,
+                group: Group.prompt, tier: .expert, dependsOn: "--enhance-prompt"
+            ),
+            .init(
+                flag: "--prompt-enhancer-model-root", label: "Prompt enhancer root", kind: .directory,
+                group: Group.prompt, tier: .expert, dependsOn: "--enhance-prompt"
+            ),
+            .init(flag: "--audio", label: "Source audio", kind: .file, group: Group.inputs, tier: .standard),
+            .init(
+                flag: "--audio-start-time", label: "Audio start", kind: .number,
+                defaultValue: "0.0", group: Group.inputs, tier: .standard, range: .init(min: 0, step: 0.1), dependsOn: "--audio"
+            ),
+            .init(
+                flag: "--audio-max-duration", label: "Audio max duration", kind: .number,
+                group: Group.inputs, tier: .expert, range: .init(min: 0, step: 0.1), dependsOn: "--audio"
+            ),
+            .init(
+                flag: "--a2v-guidance-scale", label: "Audio-to-video guidance", kind: .number,
+                defaultValue: "3.0", group: Group.sampling, tier: .expert, range: .init(min: 0, max: 20, step: 0.1)
+            ),
+            .init(
+                flag: "--video-cfg-guidance-scale", label: "Video CFG guidance", kind: .number,
+                defaultValue: "3.0", group: Group.sampling, tier: .expert, range: .init(min: 0, max: 20, step: 0.1)
+            ),
+            .init(
+                flag: "--audio-cfg-guidance-scale", label: "Audio CFG guidance", kind: .number,
+                defaultValue: "7.0", group: Group.sampling, tier: .expert, range: .init(min: 0, max: 20, step: 0.1)
+            ),
+            .init(
+                flag: "--v2a-guidance-scale", label: "Video-to-audio guidance", kind: .number,
+                defaultValue: "3.0", group: Group.sampling, tier: .expert, range: .init(min: 0, max: 20, step: 0.1)
+            ),
+            .init(
+                flag: "--a2v-steps", label: "Audio-to-video steps", kind: .integer,
+                defaultValue: "30", group: Group.sampling, tier: .expert, range: .init(min: 1, max: 100, step: 1)
+            ),
+            .init(
+                flag: "--ltx-preset", label: "LTX preset", kind: .choice, choices: ["standard", "hq"],
+                defaultValue: "standard", group: Group.sampling, tier: .expert
+            ),
+            .init(
+                flag: "--ltx-pipeline", label: "LTX pipeline", kind: .choice, choices: ["two-stage", "dev-one-stage"],
+                defaultValue: "two-stage", group: Group.sampling, tier: .expert
+            ),
+            .init(
+                flag: "--ltx-sampler", label: "LTX sampler", kind: .choice,
+                choices: ["euler", "res2s", "euler-ancestral", "cfg-plus-plus", "gradient-estimating-euler"],
+                group: Group.sampling, tier: .expert
+            ),
+            .init(flag: "--ltx-sigmas", label: "Stage one sigmas", kind: .string, group: Group.sampling, tier: .expert),
+            .init(flag: "--ltx-stage-2-sigmas", label: "Stage two sigmas", kind: .string, group: Group.sampling, tier: .expert),
+            .init(
+                flag: "--distilled-lora-strength-stage-1", label: "Stage one distilled strength", kind: .number,
+                group: Group.sampling, tier: .expert, range: .init(min: 0, max: 1, step: 0.05)
+            ),
+            .init(
+                flag: "--distilled-lora-strength-stage-2", label: "Stage two distilled strength", kind: .number,
+                group: Group.sampling, tier: .expert, range: .init(min: 0, max: 1, step: 0.05)
+            ),
+            .init(
+                flag: "--ltx-sampler-eta", label: "Sampler eta", kind: .number,
+                defaultValue: "0.5", group: Group.sampling, tier: .expert, range: .init(min: 0, max: 1, step: 0.05)
+            ),
+            .init(
+                flag: "--video-stg-scale", label: "Video STG", kind: .number,
+                defaultValue: "1.0", group: Group.sampling, tier: .expert, range: .init(min: 0, max: 10, step: 0.1)
+            ),
+            .init(
+                flag: "--video-guidance-rescale", label: "Video rescale", kind: .number,
+                defaultValue: "0.7", group: Group.sampling, tier: .expert, range: .init(min: 0, max: 1, step: 0.05)
+            ),
+            .init(
+                flag: "--video-stg-block", label: "Video STG block", kind: .integer, repeatable: true,
+                group: Group.sampling, tier: .expert, range: .init(min: 0, step: 1)
+            ),
+            .init(
+                flag: "--video-guidance-skip-step", label: "Video guidance skip", kind: .integer,
+                defaultValue: "0", group: Group.sampling, tier: .expert, range: .init(min: 0, max: 10, step: 1)
+            ),
+            .init(
+                flag: "--audio-stg-scale", label: "Audio STG", kind: .number,
+                defaultValue: "1.0", group: Group.sampling, tier: .expert, range: .init(min: 0, max: 10, step: 0.1)
+            ),
+            .init(
+                flag: "--audio-guidance-rescale", label: "Audio rescale", kind: .number,
+                defaultValue: "0.7", group: Group.sampling, tier: .expert, range: .init(min: 0, max: 1, step: 0.05)
+            ),
+            .init(
+                flag: "--audio-stg-block", label: "Audio STG block", kind: .integer, repeatable: true,
+                group: Group.sampling, tier: .expert, range: .init(min: 0, step: 1)
+            ),
+            .init(
+                flag: "--audio-guidance-skip-step", label: "Audio guidance skip", kind: .integer,
+                defaultValue: "0", group: Group.sampling, tier: .expert, range: .init(min: 0, max: 10, step: 1)
+            ),
+            .init(flag: "--no-res2s-bong-math", label: "Disable Res2s anchor refinement", kind: .boolean, group: Group.sampling, tier: .expert),
+            .init(
+                flag: "--res2s-bong-max-iterations", label: "Res2s iterations", kind: .integer,
+                defaultValue: "100", group: Group.sampling, tier: .expert, range: .init(min: 1, max: 1_000, step: 1)
+            ),
+            .init(
+                flag: "--gradient-estimation-gamma", label: "Gradient estimate gamma", kind: .number,
+                defaultValue: "2.0", group: Group.sampling, tier: .expert, range: .init(min: 0, max: 10, step: 0.1)
+            ),
+            .init(flag: "--image", label: "Start image", kind: .file, group: Group.inputs, tier: .essential),
+            .init(
+                flag: "--image-strength", label: "Start image strength", kind: .number,
+                defaultValue: "1.0", group: Group.inputs, tier: .standard, range: .init(min: 0, max: 1, step: 0.05), dependsOn: "--image"
+            ),
+            .init(flag: "--end-image", label: "End image", kind: .file, group: Group.inputs, tier: .standard, dependsOn: "--image"),
+            .init(
+                flag: "--end-image-strength", label: "End image strength", kind: .number,
+                defaultValue: "1.0", group: Group.inputs, tier: .standard, range: .init(min: 0, max: 1, step: 0.05), dependsOn: "--end-image"
+            ),
+            .init(
+                flag: "--image-conditioning", label: "Timed image guide", kind: .string, repeatable: true,
+                group: Group.inputs, tier: .expert
+            ),
+            .init(
+                flag: "--num-generated-keyframes", label: "Generated keyframe count", kind: .integer,
+                defaultValue: "0", group: Group.sampling, tier: .expert, range: .init(min: 0, max: 16, step: 1)
+            ),
+            .init(
+                flag: "--generated-keyframe", label: "Generated keyframe", kind: .integer, repeatable: true,
+                group: Group.sampling, tier: .expert, range: .init(min: 0, step: 1)
+            ),
+            .init(flag: "--lora", label: "LTX LoRA", kind: .string, repeatable: true, group: Group.modelAndAdapters, tier: .standard),
+            .init(
+                flag: "--video-conditioning", label: "IC-LoRA reference video", kind: .string, repeatable: true,
+                group: Group.inputs, tier: .expert
+            ),
+            .init(
+                flag: "--conditioning-attention-strength", label: "Reference attention", kind: .number,
+                defaultValue: "1.0", group: Group.inputs, tier: .expert, range: .init(min: 0, max: 1, step: 0.05),
+                dependsOn: "--video-conditioning"
+            ),
+            .init(
+                flag: "--conditioning-attention-mask", label: "Reference attention mask", kind: .file,
+                group: Group.inputs, tier: .expert, dependsOn: "--video-conditioning"
+            ),
+            .init(flag: "--skip-stage-2", label: "Stage one preview", kind: .boolean, group: Group.sampling, tier: .expert),
+            .init(
+                flag: "--reference-downscale-factor", label: "Reference spatial scale", kind: .integer,
+                group: Group.inputs, tier: .expert, range: .init(min: 1, max: 8, step: 1), dependsOn: "--video-conditioning"
+            ),
+            .init(
+                flag: "--reference-temporal-scale-factor", label: "Reference temporal scale", kind: .integer,
+                group: Group.inputs, tier: .expert, range: .init(min: 1, max: 8, step: 1), dependsOn: "--video-conditioning"
+            ),
+            .init(flag: "--dfr", label: "Diffusion fidelity rendering", kind: .boolean, group: Group.sampling, tier: .expert),
+            .init(
+                flag: "--temporal-upsample-rounds", label: "Temporal refinement rounds", kind: .integer,
+                defaultValue: "0", group: Group.sampling, tier: .expert, range: .init(min: 0, max: 2, step: 1), dependsOn: "--dfr"
+            ),
+            .init(
+                flag: "--detailing-lora", label: "Detailing IC-LoRA", kind: .string, repeatable: true,
+                group: Group.modelAndAdapters, tier: .expert, dependsOn: "--dfr"
+            ),
+            .init(
+                flag: "--detailing-reference-downscale-factor", label: "Detail reference scale", kind: .integer,
+                group: Group.modelAndAdapters, tier: .expert, range: .init(min: 1, max: 8, step: 1), dependsOn: "--dfr"
+            ),
+            .init(flag: "--reference", label: "Ordered H3 reference", kind: .string, repeatable: true, group: Group.inputs, tier: .standard),
+            .init(flag: "--preflight", label: "Preflight", kind: .boolean, group: Group.run, tier: .expert),
+            .init(flag: "--json", label: "JSON", kind: .boolean, group: Group.run, tier: .expert, dependsOn: "--preflight"),
+            .init(flag: "--timings", label: "Timings", kind: .boolean, group: Group.run, tier: .expert),
+            .init(flag: "--timings-output", label: "Timings output", kind: .file, group: Group.run, tier: .expert),
+            .init(flag: "--quiet", label: "Quiet", kind: .boolean, group: Group.run, tier: .expert),
+            progressJSONOption,
+            receiptOption
         ],
         output: .init(kind: .file, fileExtension: "mp4")
     )
@@ -2271,19 +2937,42 @@ public enum MereRunCapabilityCatalog {
             .init(name: "text", label: "Text", kind: .string, required: true)
         ],
         options: [
-            .init(flag: "--output", label: "Output", kind: .file, required: true),
-            .init(flag: "--model", label: "Model", kind: .string),
-            .init(flag: "--voice", label: "Voice", kind: .string),
-            .init(flag: "--mode", label: "Mode", kind: .choice, choices: ["style", "clone"]),
-            .init(flag: "--profile", label: "Profile", kind: .string),
-            .init(flag: "--ref-audio", label: "Reference audio", kind: .file),
-            .init(flag: "--ref-text", label: "Reference text", kind: .string),
-            .init(flag: "--language", label: "Language", kind: .string),
-            .init(flag: "--save-profile", label: "Save profile", kind: .string),
-            .init(flag: "--temperature", label: "Temperature", kind: .number),
-            .init(flag: "--stream", label: "Stream", kind: .boolean),
-            .init(flag: "--stream-chunk-tokens", label: "Chunk tokens", kind: .integer),
-            .init(flag: "--quiet", label: "Quiet", kind: .boolean)
+            .init(flag: "--output", label: "Output", kind: .file, required: true, group: Group.output, tier: .essential),
+            .init(
+                flag: "--model", label: "Model", kind: .string,
+                defaultValue: "speech-tts-qwen3-nano", group: Group.modelAndAdapters, tier: .essential
+            ),
+            .init(
+                flag: "--voice", label: "Voice", kind: .string,
+                defaultValue: "A calm female voice with clear pronunciation", group: Group.prompt, tier: .essential
+            ),
+            .init(
+                flag: "--mode", label: "Mode", kind: .choice, choices: ["style", "clone"],
+                defaultValue: "style", group: Group.inputs, tier: .standard
+            ),
+            .init(flag: "--profile", label: "Profile", kind: .string, group: Group.inputs, tier: .standard),
+            .init(flag: "--ref-audio", label: "Reference audio", kind: .file, group: Group.inputs, tier: .standard),
+            .init(
+                flag: "--ref-text", label: "Reference text", kind: .string,
+                group: Group.inputs, tier: .standard, dependsOn: "--ref-audio"
+            ),
+            .init(flag: "--language", label: "Language", kind: .string, defaultValue: "auto", group: Group.prompt, tier: .standard),
+            .init(
+                flag: "--save-profile", label: "Save profile", kind: .string,
+                group: Group.inputs, tier: .expert, dependsOn: "--ref-audio"
+            ),
+            .init(
+                flag: "--temperature", label: "Temperature", kind: .number,
+                defaultValue: "0.6", group: Group.sampling, tier: .standard, range: .init(min: 0, max: 2, step: 0.05)
+            ),
+            .init(flag: "--stream", label: "Stream", kind: .boolean, group: Group.output, tier: .expert),
+            .init(
+                flag: "--stream-chunk-tokens", label: "Chunk tokens", kind: .integer,
+                defaultValue: "25", group: Group.output, tier: .expert, range: .init(min: 1, max: 500, step: 1), dependsOn: "--stream"
+            ),
+            .init(flag: "--quiet", label: "Quiet", kind: .boolean, group: Group.run, tier: .expert),
+            progressJSONOption,
+            receiptOption
         ],
         output: .init(kind: .file, fileExtension: "wav")
     )
@@ -2297,20 +2986,39 @@ public enum MereRunCapabilityCatalog {
             .init(name: "audio", label: "Audio", kind: .file, required: true)
         ],
         options: [
-            .init(flag: "--output", label: "Output", kind: .file),
-            .init(flag: "--model", label: "Model", kind: .string),
-            .init(flag: "--backend", label: "Backend", kind: .choice, choices: ["auto", "parakeet", "qwen"]),
-            .init(flag: "--task", label: "Task", kind: .choice, choices: ["transcribe", "translate"]),
-            .init(flag: "--language", label: "Language", kind: .string),
-            .init(flag: "--max-tokens", label: "Max tokens", kind: .integer),
-            .init(flag: "--stream", label: "Stream", kind: .boolean),
-            .init(flag: "--stream-chunk-ms", label: "Feed interval", kind: .integer),
-            .init(flag: "--stream-decode-ms", label: "Decode interval", kind: .integer),
-            .init(flag: "--input-format", label: "Input format", kind: .string),
-            .init(flag: "--sample-rate", label: "Sample rate", kind: .integer),
-            .init(flag: "--jsonl", label: "JSON Lines", kind: .boolean),
-            .init(flag: "--no-timestamps", label: "No timestamps", kind: .boolean),
-            .init(flag: "--quiet", label: "Quiet", kind: .boolean)
+            .init(flag: "--output", label: "Output", kind: .file, group: Group.output, tier: .standard),
+            .init(flag: "--model", label: "Model", kind: .string, group: Group.modelAndAdapters, tier: .standard),
+            .init(
+                flag: "--backend", label: "Backend", kind: .choice, choices: ["auto", "parakeet", "qwen"],
+                defaultValue: "auto", group: Group.modelAndAdapters, tier: .essential
+            ),
+            .init(
+                flag: "--task", label: "Task", kind: .choice, choices: ["transcribe", "translate"],
+                defaultValue: "transcribe", group: Group.prompt, tier: .essential
+            ),
+            .init(flag: "--language", label: "Language", kind: .string, group: Group.prompt, tier: .standard),
+            .init(
+                flag: "--max-tokens", label: "Max tokens", kind: .integer,
+                defaultValue: "448", group: Group.sampling, tier: .standard, range: .init(min: 1, max: 8_192, step: 1)
+            ),
+            .init(flag: "--stream", label: "Stream", kind: .boolean, group: Group.run, tier: .expert),
+            .init(
+                flag: "--stream-chunk-ms", label: "Feed interval", kind: .integer,
+                defaultValue: "200", group: Group.run, tier: .expert, range: .init(min: 10, max: 5_000, step: 10), dependsOn: "--stream"
+            ),
+            .init(
+                flag: "--stream-decode-ms", label: "Decode interval", kind: .integer,
+                defaultValue: "2000", group: Group.run, tier: .expert, range: .init(min: 100, max: 10_000, step: 100), dependsOn: "--stream"
+            ),
+            .init(flag: "--input-format", label: "Input format", kind: .string, group: Group.inputs, tier: .expert, dependsOn: "--stream"),
+            .init(
+                flag: "--sample-rate", label: "Sample rate", kind: .integer,
+                group: Group.inputs, tier: .expert, range: .init(min: 8_000, max: 48_000, step: 1), dependsOn: "--stream"
+            ),
+            .init(flag: "--jsonl", label: "JSON Lines", kind: .boolean, group: Group.output, tier: .expert, dependsOn: "--stream"),
+            .init(flag: "--no-timestamps", label: "No timestamps", kind: .boolean, group: Group.output, tier: .standard),
+            .init(flag: "--quiet", label: "Quiet", kind: .boolean, group: Group.run, tier: .expert),
+            receiptOption
         ],
         output: .init(kind: .file)
     )
@@ -2379,15 +3087,29 @@ public enum MereRunCapabilityCatalog {
             .init(name: "prompt", label: "Prompt", kind: .string, required: true)
         ],
         options: [
-            .init(flag: "--negative-prompt", label: "Negative prompt", kind: .string),
-            .init(flag: "--output", label: "Output", kind: .file),
-            .init(flag: "--model", label: "Model", kind: .string),
-            .init(flag: "--duration", label: "Duration", kind: .number),
-            .init(flag: "--steps", label: "Steps", kind: .integer),
-            .init(flag: "--cfg", label: "CFG", kind: .number),
-            .init(flag: "--seed", label: "Seed", kind: .integer),
-            .init(flag: "--renoise", label: "Renoise", kind: .string),
-            .init(flag: "--quiet", label: "Quiet", kind: .boolean)
+            .init(flag: "--negative-prompt", label: "Negative prompt", kind: .string, group: Group.prompt, tier: .standard),
+            .init(flag: "--output", label: "Output", kind: .file, group: Group.output, tier: .standard),
+            .init(
+                flag: "--model", label: "Model", kind: .string,
+                defaultValue: "sfx-woosh-dflow", group: Group.modelAndAdapters, tier: .essential
+            ),
+            .init(
+                flag: "--duration", label: "Duration", kind: .number,
+                group: Group.sampling, tier: .essential, range: .init(min: 0.5, max: 30, step: 0.5)
+            ),
+            .init(
+                flag: "--steps", label: "Steps", kind: .integer,
+                group: Group.sampling, tier: .standard, range: .init(min: 1, max: 100, step: 1)
+            ),
+            .init(
+                flag: "--cfg", label: "CFG", kind: .number,
+                defaultValue: "4.5", group: Group.sampling, tier: .standard, range: .init(min: 0, max: 20, step: 0.1)
+            ),
+            .init(flag: "--seed", label: "Seed", kind: .integer, group: Group.sampling, tier: .essential, range: .init(min: 0, step: 1)),
+            .init(flag: "--renoise", label: "Renoise", kind: .string, group: Group.sampling, tier: .expert),
+            .init(flag: "--quiet", label: "Quiet", kind: .boolean, group: Group.run, tier: .expert),
+            progressJSONOption,
+            receiptOption
         ],
         output: .init(kind: .file, fileExtension: "wav")
     )

--- a/Sources/MereRunContract/README.md
+++ b/Sources/MereRunContract/README.md
@@ -10,9 +10,23 @@ runtime into the app.
 use this module to build and validate commands instead of maintaining a second
 copy of the command surface.
 
+Each option may carry additive shell metadata: `default_value` (the CLI's
+static ArgumentParser default, rendered as the CLI parses it), `group` (one of
+`MereRunCapabilityOptionGroup`), `tier` (`essential`, `standard`, `expert`),
+`range` (`min`, `max`, `step` for numeric options), and `depends_on` (another
+flag on the same capability that must be set for this one to matter). The
+prompt-mode capabilities populate all of them; other capabilities may leave
+them `nil`. Long-running generation capabilities also declare `--receipt` and,
+where the pipeline reports steps, `--progress-json`; the line shapes are
+documented on `MereRunCapabilityCatalog.resultReceiptExample` and
+`progressEventExample`.
+
 When extending the contract:
 
 - Add only public CLI capabilities that a shell needs to discover or invoke.
+- Only record a `default_value` when the CLI default is static; machine- or
+  model-specific defaults stay `nil`. `capabilityDefaultValuesMatchArgumentParserHelp`
+  checks every recorded default against the CLI help.
 - Prefer typed enums for bounded choices shared by more than one target.
 - Preserve existing identifiers and serialized values. Bump the schema version
   when making a breaking catalog change.

--- a/Tests/MereRunCLITests/CLIGenerationProgressPrinterTests.swift
+++ b/Tests/MereRunCLITests/CLIGenerationProgressPrinterTests.swift
@@ -31,6 +31,52 @@ final class CLIGenerationProgressPrinterTests: XCTestCase {
         )
     }
 
+    func testGenericProgressLineMatchesTheImageEventShape() {
+        XCTAssertEqual(
+            CLIGenerationProgressPrinter.progressJSONLine(stage: "denoising", step: 2, totalSteps: 4),
+            CLIGenerationProgressPrinter.progressJSONLine(
+                GenerationProgress(stage: .denoising, stepIndex: 2, totalSteps: 4)
+            )
+        )
+        XCTAssertEqual(
+            CLIGenerationProgressPrinter.progressJSONLine(stage: "generating", step: 50, totalSteps: 0),
+            #"{"event":"progress","stage":"generating","step":50,"total_steps":0}"#
+        )
+    }
+
+    func testMiniMaxMusicProgressFlattensChunksSoTheLastStepReachesTheTotal() throws {
+        func decode(_ line: String) throws -> (stage: String, step: Int, total: Int) {
+            let object = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any])
+            XCTAssertEqual(object["event"] as? String, "progress")
+            return (
+                try XCTUnwrap(object["stage"] as? String),
+                try XCTUnwrap(object["step"] as? Int),
+                try XCTUnwrap(object["total_steps"] as? Int)
+            )
+        }
+
+        let semantic = try decode(MusicGenerate.miniMaxProgressJSONLine(.semantic(frame: 25, maximum: 1_500)))
+        XCTAssertEqual(semantic.stage, "semantic")
+        XCTAssertEqual(semantic.step, 25)
+        XCTAssertEqual(semantic.total, 1_500)
+
+        let firstChunk = try decode(MusicGenerate.miniMaxProgressJSONLine(
+            .denoise(chunk: 1, chunkCount: 3, step: 1, stepCount: 30)
+        ))
+        XCTAssertEqual(firstChunk.stage, "denoising")
+        XCTAssertEqual(firstChunk.step, 1)
+        XCTAssertEqual(firstChunk.total, 90)
+
+        let lastChunk = try decode(MusicGenerate.miniMaxProgressJSONLine(
+            .denoise(chunk: 3, chunkCount: 3, step: 30, stepCount: 30)
+        ))
+        XCTAssertEqual(lastChunk.step, lastChunk.total)
+
+        let decodeStage = try decode(MusicGenerate.miniMaxProgressJSONLine(.decode(chunk: 2, chunkCount: 2)))
+        XCTAssertEqual(decodeStage.stage, "decoding")
+        XCTAssertEqual(decodeStage.step, decodeStage.total)
+    }
+
     func testJSONProgressHandlerEmitsOneLinePerDistinctEvent() {
         final class Sink: @unchecked Sendable {
             var lines: [String] = []

--- a/Tests/MereRunCLITests/CLIGenerationProgressPrinterTests.swift
+++ b/Tests/MereRunCLITests/CLIGenerationProgressPrinterTests.swift
@@ -44,37 +44,156 @@ final class CLIGenerationProgressPrinterTests: XCTestCase {
         )
     }
 
-    func testMiniMaxMusicProgressFlattensChunksSoTheLastStepReachesTheTotal() throws {
-        func decode(_ line: String) throws -> (stage: String, step: Int, total: Int) {
+    // MARK: - The documented convention: 0-based in progress, one terminal step == total_steps
+
+    private struct Event: Equatable {
+        let stage: String
+        let step: Int
+        let total: Int
+    }
+
+    private func events(_ lines: [String]) throws -> [Event] {
+        try lines.map { line in
+            XCTAssertTrue(line.hasSuffix("\n") && !line.dropLast().contains("\n"), "not one NDJSON line: \(line)")
             let object = try XCTUnwrap(JSONSerialization.jsonObject(with: Data(line.utf8)) as? [String: Any])
             XCTAssertEqual(object["event"] as? String, "progress")
-            return (
-                try XCTUnwrap(object["stage"] as? String),
-                try XCTUnwrap(object["step"] as? Int),
-                try XCTUnwrap(object["total_steps"] as? Int)
+            return Event(
+                stage: try XCTUnwrap(object["stage"] as? String),
+                step: try XCTUnwrap(object["step"] as? Int),
+                total: try XCTUnwrap(object["total_steps"] as? Int)
             )
         }
+    }
 
-        let semantic = try decode(MusicGenerate.miniMaxProgressJSONLine(.semantic(frame: 25, maximum: 1_500)))
+    private func makeStream() -> (JSONProgressStream, () -> [String]) {
+        final class Sink: @unchecked Sendable {
+            var lines: [String] = []
+        }
+        let sink = Sink()
+        return (JSONProgressStream { sink.lines.append($0) }, { sink.lines })
+    }
+
+    func testSFXCompletionCountsBecomeZeroBasedStepsPlusOneTerminalEvent() throws {
+        let (stream, lines) = makeStream()
+        // Woosh and MMAudio report `completed` 1...N; the command passes `completed - 1`.
+        for completed in 1...4 {
+            stream.report(stage: "denoising", step: completed - 1, totalSteps: 4)
+        }
+        stream.finish()
+
+        XCTAssertEqual(try events(lines()), [
+            Event(stage: "denoising", step: 0, total: 4),
+            Event(stage: "denoising", step: 1, total: 4),
+            Event(stage: "denoising", step: 2, total: 4),
+            Event(stage: "denoising", step: 3, total: 4),
+            Event(stage: "denoising", step: 4, total: 4),
+        ])
+    }
+
+    func testMiniMaxMusicCountersFlattenToZeroBasedStepsAndCloseEachStage() throws {
+        let semantic = MusicGenerate.miniMaxProgressEvent(.semantic(frame: 1, maximum: 1_500))
         XCTAssertEqual(semantic.stage, "semantic")
-        XCTAssertEqual(semantic.step, 25)
-        XCTAssertEqual(semantic.total, 1_500)
+        XCTAssertEqual(semantic.step, 0)
+        XCTAssertEqual(semantic.totalSteps, 1_500)
 
-        let firstChunk = try decode(MusicGenerate.miniMaxProgressJSONLine(
-            .denoise(chunk: 1, chunkCount: 3, step: 1, stepCount: 30)
-        ))
+        let firstChunk = MusicGenerate.miniMaxProgressEvent(.denoise(chunk: 1, chunkCount: 3, step: 1, stepCount: 30))
         XCTAssertEqual(firstChunk.stage, "denoising")
-        XCTAssertEqual(firstChunk.step, 1)
-        XCTAssertEqual(firstChunk.total, 90)
+        XCTAssertEqual(firstChunk.step, 0)
+        XCTAssertEqual(firstChunk.totalSteps, 90)
 
-        let lastChunk = try decode(MusicGenerate.miniMaxProgressJSONLine(
-            .denoise(chunk: 3, chunkCount: 3, step: 30, stepCount: 30)
-        ))
-        XCTAssertEqual(lastChunk.step, lastChunk.total)
+        let lastChunk = MusicGenerate.miniMaxProgressEvent(.denoise(chunk: 3, chunkCount: 3, step: 30, stepCount: 30))
+        XCTAssertEqual(lastChunk.step, 89)
+        XCTAssertEqual(lastChunk.totalSteps, 90)
 
-        let decodeStage = try decode(MusicGenerate.miniMaxProgressJSONLine(.decode(chunk: 2, chunkCount: 2)))
-        XCTAssertEqual(decodeStage.stage, "decoding")
-        XCTAssertEqual(decodeStage.step, decodeStage.total)
+        let (stream, lines) = makeStream()
+        for event: MiniMaxMusic3Progress in [
+            .semantic(frame: 1, maximum: 2), .semantic(frame: 2, maximum: 2),
+            .denoise(chunk: 1, chunkCount: 2, step: 1, stepCount: 2), .denoise(chunk: 1, chunkCount: 2, step: 2, stepCount: 2),
+            .denoise(chunk: 2, chunkCount: 2, step: 1, stepCount: 2), .denoise(chunk: 2, chunkCount: 2, step: 2, stepCount: 2),
+            .decode(chunk: 1, chunkCount: 2), .decode(chunk: 2, chunkCount: 2),
+        ] {
+            let progress = MusicGenerate.miniMaxProgressEvent(event)
+            stream.report(stage: progress.stage, step: progress.step, totalSteps: progress.totalSteps)
+        }
+        stream.finish()
+
+        XCTAssertEqual(try events(lines()), [
+            Event(stage: "semantic", step: 0, total: 2),
+            Event(stage: "semantic", step: 1, total: 2),
+            Event(stage: "semantic", step: 2, total: 2),
+            Event(stage: "denoising", step: 0, total: 4),
+            Event(stage: "denoising", step: 1, total: 4),
+            Event(stage: "denoising", step: 2, total: 4),
+            Event(stage: "denoising", step: 3, total: 4),
+            Event(stage: "denoising", step: 4, total: 4),
+            Event(stage: "decoding", step: 0, total: 2),
+            Event(stage: "decoding", step: 1, total: 2),
+            Event(stage: "decoding", step: 2, total: 2),
+        ])
+    }
+
+    func testLoadingStagesThatOnlyReportStepZeroCloseWhenTheNextStageBegins() throws {
+        // Wan2 reports `encodingText`/`loadingTransformer` as step 0 of `steps`
+        // and never again; `decoding` arrives already terminal.
+        let (stream, lines) = makeStream()
+        stream.report(stage: "encodingText", step: 0, totalSteps: 3)
+        stream.report(stage: "loadingTransformer", step: 0, totalSteps: 3)
+        for step in 0..<3 {
+            stream.report(stage: "denoising", step: step, totalSteps: 3)
+        }
+        stream.report(stage: "decoding", step: 3, totalSteps: 3)
+        stream.finish()
+
+        XCTAssertEqual(try events(lines()), [
+            Event(stage: "encodingText", step: 0, total: 3),
+            Event(stage: "encodingText", step: 3, total: 3),
+            Event(stage: "loadingTransformer", step: 0, total: 3),
+            Event(stage: "loadingTransformer", step: 3, total: 3),
+            Event(stage: "denoising", step: 0, total: 3),
+            Event(stage: "denoising", step: 1, total: 3),
+            Event(stage: "denoising", step: 2, total: 3),
+            Event(stage: "denoising", step: 3, total: 3),
+            Event(stage: "decoding", step: 3, total: 3),
+        ])
+    }
+
+    func testSlidingWindowsRestartDenoisingAndCloseTheWindowMilestoneAtTheEnd() throws {
+        // MiniMax-H3 emits the window index before each window's 0..<N denoising steps.
+        let (stream, lines) = makeStream()
+        for window in 0..<2 {
+            stream.mark(stage: "window", step: window, totalSteps: 2)
+            for step in 0..<2 {
+                stream.report(stage: "denoising", step: step, totalSteps: 2)
+            }
+        }
+        stream.finish()
+
+        XCTAssertEqual(try events(lines()), [
+            Event(stage: "window", step: 0, total: 2),
+            Event(stage: "denoising", step: 0, total: 2),
+            Event(stage: "denoising", step: 1, total: 2),
+            Event(stage: "window", step: 1, total: 2),
+            Event(stage: "denoising", step: 2, total: 2),
+            Event(stage: "denoising", step: 0, total: 2),
+            Event(stage: "denoising", step: 1, total: 2),
+            Event(stage: "denoising", step: 2, total: 2),
+            Event(stage: "window", step: 2, total: 2),
+        ])
+    }
+
+    func testIndeterminateStagesCarryNoTerminalEventAndRepeatsAreDeduplicated() throws {
+        let (stream, lines) = makeStream()
+        stream.report(stage: "loadingModel", step: 0, totalSteps: 0)
+        stream.report(stage: "generating", step: 25, totalSteps: 0)
+        stream.report(stage: "generating", step: 25, totalSteps: 0)
+        stream.report(stage: "generating", step: 50, totalSteps: 0)
+        stream.finish()
+
+        XCTAssertEqual(try events(lines()), [
+            Event(stage: "loadingModel", step: 0, total: 0),
+            Event(stage: "generating", step: 25, total: 0),
+            Event(stage: "generating", step: 50, total: 0),
+        ])
     }
 
     func testJSONProgressHandlerEmitsOneLinePerDistinctEvent() {

--- a/Tests/MereRunCLITests/CLIGenerationProgressPrinterTests.swift
+++ b/Tests/MereRunCLITests/CLIGenerationProgressPrinterTests.swift
@@ -75,9 +75,11 @@ final class CLIGenerationProgressPrinterTests: XCTestCase {
 
     func testSFXCompletionCountsBecomeZeroBasedStepsPlusOneTerminalEvent() throws {
         let (stream, lines) = makeStream()
-        // Woosh and MMAudio report `completed` 1...N; the command passes `completed - 1`.
+        // Woosh and MMAudio both report `completed` 1...N (WooshGenerator and
+        // MMAudioNetwork call `progress?(step + 1, config.steps)`).
         for completed in 1...4 {
-            stream.report(stage: "denoising", step: completed - 1, totalSteps: 4)
+            let progress = SFXGenerate.denoiseProgressEvent(completed: completed, total: 4)
+            stream.report(stage: progress.stage, step: progress.step, totalSteps: progress.totalSteps)
         }
         stream.finish()
 
@@ -91,20 +93,25 @@ final class CLIGenerationProgressPrinterTests: XCTestCase {
     }
 
     func testMiniMaxMusicCountersFlattenToZeroBasedStepsAndCloseEachStage() throws {
-        let semantic = MusicGenerate.miniMaxProgressEvent(.semantic(frame: 1, maximum: 1_500))
+        let semantic = MusicGenerate.miniMaxProgressEvent(.semantic(frame: 1, maximum: 1_500), strategy: .sequential)
         XCTAssertEqual(semantic.stage, "semantic")
         XCTAssertEqual(semantic.step, 0)
         XCTAssertEqual(semantic.totalSteps, 1_500)
 
-        let firstChunk = MusicGenerate.miniMaxProgressEvent(.denoise(chunk: 1, chunkCount: 3, step: 1, stepCount: 30))
+        let firstChunk = MusicGenerate.miniMaxProgressEvent(
+            .denoise(chunk: 1, chunkCount: 3, step: 1, stepCount: 30), strategy: .sequential
+        )
         XCTAssertEqual(firstChunk.stage, "denoising")
         XCTAssertEqual(firstChunk.step, 0)
         XCTAssertEqual(firstChunk.totalSteps, 90)
 
-        let lastChunk = MusicGenerate.miniMaxProgressEvent(.denoise(chunk: 3, chunkCount: 3, step: 30, stepCount: 30))
+        let lastChunk = MusicGenerate.miniMaxProgressEvent(
+            .denoise(chunk: 3, chunkCount: 3, step: 30, stepCount: 30), strategy: .sequential
+        )
         XCTAssertEqual(lastChunk.step, 89)
         XCTAssertEqual(lastChunk.totalSteps, 90)
 
+        // `sequential` denoises chunk by chunk (MiniMaxMusic3Pipeline.denoise).
         let (stream, lines) = makeStream()
         for event: MiniMaxMusic3Progress in [
             .semantic(frame: 1, maximum: 2), .semantic(frame: 2, maximum: 2),
@@ -112,7 +119,7 @@ final class CLIGenerationProgressPrinterTests: XCTestCase {
             .denoise(chunk: 2, chunkCount: 2, step: 1, stepCount: 2), .denoise(chunk: 2, chunkCount: 2, step: 2, stepCount: 2),
             .decode(chunk: 1, chunkCount: 2), .decode(chunk: 2, chunkCount: 2),
         ] {
-            let progress = MusicGenerate.miniMaxProgressEvent(event)
+            let progress = MusicGenerate.miniMaxProgressEvent(event, strategy: .sequential)
             stream.report(stage: progress.stage, step: progress.step, totalSteps: progress.totalSteps)
         }
         stream.finish()
@@ -129,6 +136,29 @@ final class CLIGenerationProgressPrinterTests: XCTestCase {
             Event(stage: "decoding", step: 0, total: 2),
             Event(stage: "decoding", step: 1, total: 2),
             Event(stage: "decoding", step: 2, total: 2),
+        ])
+    }
+
+    func testMiniMaxMusicOverlapAverageStaysMonotonicAcrossWindows() throws {
+        // `denoiseOverlapAverage` runs one flow step across every window before
+        // advancing, the opposite order from `sequential`. Flattening chunk-major
+        // there would make `step` fall back and close `denoising` on every step.
+        let (stream, lines) = makeStream()
+        for event: MiniMaxMusic3Progress in [
+            .denoise(chunk: 1, chunkCount: 2, step: 1, stepCount: 2), .denoise(chunk: 2, chunkCount: 2, step: 1, stepCount: 2),
+            .denoise(chunk: 1, chunkCount: 2, step: 2, stepCount: 2), .denoise(chunk: 2, chunkCount: 2, step: 2, stepCount: 2),
+        ] {
+            let progress = MusicGenerate.miniMaxProgressEvent(event, strategy: .overlapAverage)
+            stream.report(stage: progress.stage, step: progress.step, totalSteps: progress.totalSteps)
+        }
+        stream.finish()
+
+        XCTAssertEqual(try events(lines()), [
+            Event(stage: "denoising", step: 0, total: 4),
+            Event(stage: "denoising", step: 1, total: 4),
+            Event(stage: "denoising", step: 2, total: 4),
+            Event(stage: "denoising", step: 3, total: 4),
+            Event(stage: "denoising", step: 4, total: 4),
         ])
     }
 

--- a/Tests/MereRunCLITests/CapabilityCatalogTests.swift
+++ b/Tests/MereRunCLITests/CapabilityCatalogTests.swift
@@ -5,8 +5,8 @@ import Testing
 
 @testable import MereRunCLI
 
-@Test func capabilityFlagsMatchArgumentParserHelp() {
-    let helpByID: [String: String] = [
+private func capabilityHelpMessages() -> [String: String] {
+    [
         "text.chat": TextChat.helpMessage(),
         "text.code": TextCode.helpMessage(),
         "text.embed": TextEmbed.helpMessage(),
@@ -135,6 +135,10 @@ import Testing
         "speech.listen": SpeechListen.helpMessage(),
         "vision.serve": VisionServe.helpMessage()
     ]
+}
+
+@Test func capabilityFlagsMatchArgumentParserHelp() {
+    let helpByID = capabilityHelpMessages()
 
     for capability in MereRunCapabilityCatalog.document.commands {
         let help = helpByID[capability.id]
@@ -169,6 +173,56 @@ private let exactCapabilityOptionIDs: Set<String> = [
     "model.benchmark.gemma4-mtp", "model.benchmark.api-workload",
     "plugin.info", "plugin.run", "plugin.rollback", "speech.listen", "vision.serve"
 ]
+
+/// Every `default_value` the contract advertises must be the default
+/// ArgumentParser renders in `--help`, so a CLI default change that forgets the
+/// contract fails here instead of drifting into the shells' forms.
+@Test func capabilityDefaultValuesMatchArgumentParserHelp() {
+    let helpByID = capabilityHelpMessages()
+
+    for capability in MereRunCapabilityCatalog.document.commands {
+        guard let help = helpByID[capability.id] else { continue }
+        for option in capability.options {
+            guard let defaultValue = option.defaultValue else { continue }
+            let block = helpBlock(for: option.flag, in: help)
+            #expect(block != nil, "\(capability.id) \(option.flag) is missing from the CLI help")
+            // ArgumentParser renders `(default: x)` for plain options and
+            // `(values: a, b; default: x)` for enum-backed ones.
+            #expect(
+                block?.contains("default: \(defaultValue))") == true,
+                "\(capability.id) \(option.flag) declares default \(defaultValue) but the CLI help says: \(block ?? "")"
+            )
+        }
+    }
+}
+
+/// The help text for one option: its `  --flag ...` line plus the wrapped
+/// continuation lines up to the next option or section, re-flowed onto one
+/// line so wrapped `(default: …)` clauses can be matched.
+private func helpBlock(for flag: String, in help: String) -> String? {
+    let lines = help.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
+    guard let start = lines.firstIndex(where: { line in
+        guard line.hasPrefix("  -") else { return false }
+        for token in line.trimmingCharacters(in: .whitespaces).split(whereSeparator: \.isWhitespace) {
+            guard token.hasPrefix("-") else { break }
+            for alias in token.split(whereSeparator: { $0 == "," || $0 == "/" }) {
+                let name = alias.prefix { $0 == "-" || $0.isLetter || $0.isNumber }
+                if name == flag { return true }
+            }
+        }
+        return false
+    }) else { return nil }
+
+    var block = [lines[start]]
+    for line in lines[(start + 1)...] {
+        guard line.hasPrefix(" "), !line.hasPrefix("  -") else { break }
+        block.append(line)
+    }
+    return block
+        .joined(separator: " ")
+        .split(whereSeparator: \.isWhitespace)
+        .joined(separator: " ")
+}
 
 private func longOptionFlags(in help: String) -> Set<String> {
     Set(help.split(separator: "\n").flatMap { line -> [String] in

--- a/Tests/MereRunCLITests/ReceiptCommandRunTests.swift
+++ b/Tests/MereRunCLITests/ReceiptCommandRunTests.swift
@@ -1,0 +1,152 @@
+import AudioCore
+import Foundation
+import XCTest
+@testable import MereRunCLI
+
+/// Runs real command paths against fixture backends and checks the stdout
+/// contract: without `--receipt` the output is exactly what the command has
+/// always printed, and with it the receipt is the final line.
+final class ReceiptCommandRunTests: XCTestCase {
+    private struct FixtureASR: CLIASRTranscriptionExecutor {
+        let text: String
+
+        func transcribeQwen(
+            request: ASRRequest, modelID: String, modelPath: String?,
+            progressHandler: (@Sendable (ASRProgress) -> Void)?
+        ) async throws -> ASRResult {
+            ASRResult(text: text, language: "en", duration: 1.5)
+        }
+
+        func transcribeParakeet(
+            request: ASRRequest, modelID: String, modelPath: String?,
+            progressHandler: (@Sendable (ASRProgress) -> Void)?
+        ) async throws -> ASRResult {
+            ASRResult(text: text, language: "en", duration: 1.5)
+        }
+    }
+
+    private struct FixtureTTS: CLISpeechSynthesizing {
+        func generate(
+            _ request: TTSRequest,
+            modelPath: String?,
+            progressHandler: (@Sendable (TTSProgress) -> Void)?
+        ) async throws -> TTSResult {
+            progressHandler?(TTSProgress(stage: .generating, tokensGenerated: 25))
+            try Data("RIFF".utf8).write(to: request.outputURL)
+            return TTSResult(audioURL: request.outputURL, duration: 1.0)
+        }
+    }
+
+    private var temporaryDirectory: URL!
+
+    override func setUpWithError() throws {
+        temporaryDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mererun-receipt-tests", isDirectory: true)
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)
+    }
+
+    override func tearDownWithError() throws {
+        SpeechTranscribe.transcriptionExecutorOverride = nil
+        SpeechSynthesize.synthesizerOverride = nil
+        try? FileManager.default.removeItem(at: temporaryDirectory)
+    }
+
+    /// Captures everything the body prints to file descriptor 1.
+    private func capturingStandardOutput(_ body: () async throws -> Void) async throws -> String {
+        fflush(stdout)
+        let pipe = Pipe()
+        let saved = dup(STDOUT_FILENO)
+        XCTAssertNotEqual(dup2(pipe.fileHandleForWriting.fileDescriptor, STDOUT_FILENO), -1)
+        var failure: Error?
+        do {
+            try await body()
+        } catch {
+            failure = error
+        }
+        fflush(stdout)
+        dup2(saved, STDOUT_FILENO)
+        close(saved)
+        try pipe.fileHandleForWriting.close()
+        let data = pipe.fileHandleForReading.readDataToEndOfFile()
+        if let failure { throw failure }
+        return String(decoding: data, as: UTF8.self)
+    }
+
+    private func receipt(fromLastLineOf stdout: String) throws -> [String: Any] {
+        XCTAssertTrue(stdout.hasSuffix("\n"))
+        let lastLine = try XCTUnwrap(stdout.dropLast().split(separator: "\n", omittingEmptySubsequences: false).last)
+        let object = try JSONSerialization.jsonObject(with: Data(lastLine.utf8))
+        let receipt = try XCTUnwrap(object as? [String: Any])
+        XCTAssertEqual(receipt["event"] as? String, "result")
+        XCTAssertEqual(receipt["exit"] as? Int, 0)
+        return receipt
+    }
+
+    // MARK: - speech transcribe
+
+    private func transcribeCommand(_ extra: [String]) throws -> SpeechTranscribe {
+        let audioURL = temporaryDirectory.appendingPathComponent("talk.wav")
+        try Data("RIFF".utf8).write(to: audioURL)
+        SpeechTranscribe.transcriptionExecutorOverride = FixtureASR(text: "hello from the fixture")
+        return try SpeechTranscribe.parse([audioURL.path, "--backend", "parakeet", "--quiet"] + extra)
+    }
+
+    func testTranscribeStdoutWithoutReceiptIsJustTheTranscript() async throws {
+        let command = try transcribeCommand([])
+        let stdout = try await capturingStandardOutput { try await command.run() }
+        XCTAssertEqual(stdout, "hello from the fixture\n")
+    }
+
+    func testTranscribeReceiptIsTheLastLineAndListsTheOutputFile() async throws {
+        let transcriptURL = temporaryDirectory.appendingPathComponent("talk.txt")
+        let command = try transcribeCommand(["--receipt", "--output", transcriptURL.path])
+        let stdout = try await capturingStandardOutput { try await command.run() }
+
+        XCTAssertTrue(stdout.hasPrefix("hello from the fixture\n"))
+        XCTAssertEqual(stdout.split(separator: "\n").count, 2)
+        let receipt = try receipt(fromLastLineOf: stdout)
+        let outputs = try XCTUnwrap(receipt["outputs"] as? [[String: Any]])
+        XCTAssertEqual(outputs.count, 1)
+        XCTAssertEqual(outputs[0]["kind"] as? String, "text")
+        XCTAssertEqual(outputs[0]["path"] as? String, transcriptURL.standardizedFileURL.path)
+        XCTAssertEqual(try String(contentsOf: transcriptURL, encoding: .utf8), "hello from the fixture")
+    }
+
+    func testTranscribeReceiptHasNoOutputsWhenTheTranscriptOnlyWentToStdout() async throws {
+        let command = try transcribeCommand(["--receipt"])
+        let stdout = try await capturingStandardOutput { try await command.run() }
+
+        XCTAssertEqual(stdout, "hello from the fixture\n{\"event\":\"result\",\"exit\":0,\"outputs\":[]}\n")
+    }
+
+    // MARK: - speech synthesize
+
+    private func synthesizeCommand(_ extra: [String]) throws -> (SpeechSynthesize, URL) {
+        let outputURL = temporaryDirectory.appendingPathComponent("hello.wav")
+        SpeechSynthesize.synthesizerOverride = FixtureTTS()
+        let command = try SpeechSynthesize.parse(["Hello there", "--output", outputURL.path, "--quiet"] + extra)
+        return (command, outputURL)
+    }
+
+    func testSynthesizeStdoutWithoutReceiptIsJustTheOutputPath() async throws {
+        let (command, outputURL) = try synthesizeCommand([])
+        let stdout = try await capturingStandardOutput { try await command.run() }
+        XCTAssertEqual(stdout, outputURL.standardizedFileURL.path + "\n")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: outputURL.path))
+    }
+
+    func testSynthesizeReceiptFollowsThePathLineAndListsTheWAV() async throws {
+        let (command, outputURL) = try synthesizeCommand(["--receipt", "--progress-json"])
+        let stdout = try await capturingStandardOutput { try await command.run() }
+
+        let lines = stdout.split(separator: "\n")
+        XCTAssertEqual(lines.count, 2)
+        XCTAssertEqual(String(lines[0]), outputURL.standardizedFileURL.path)
+        let receipt = try receipt(fromLastLineOf: stdout)
+        let outputs = try XCTUnwrap(receipt["outputs"] as? [[String: Any]])
+        XCTAssertEqual(outputs.map { $0["kind"] as? String }, ["audio"])
+        XCTAssertEqual(outputs[0]["path"] as? String, outputURL.standardizedFileURL.path)
+        XCTAssertNil(outputs[0]["role"])
+    }
+}

--- a/Tests/MereRunCLITests/RunReceiptTests.swift
+++ b/Tests/MereRunCLITests/RunReceiptTests.swift
@@ -178,6 +178,20 @@ final class RunReceiptTests: XCTestCase {
         XCTAssertThrowsError(try VisionGround.parse(["/tmp/a.png", "--query", "cat", "--json"]))
     }
 
+    func testReceiptIsRejectedTogetherWithPreflight() {
+        XCTAssertThrowsError(try ImageGenerate.parse(["--prompt", "a cat", "--preflight", "--receipt"])) { error in
+            XCTAssertTrue(String(describing: error).contains("--receipt cannot be combined with --preflight"))
+        }
+        XCTAssertThrowsError(try VideoGenerate.parse(["a cat", "--preflight", "--receipt"]))
+        XCTAssertThrowsError(try VisionGround.parse(["/tmp/a.png", "--query", "cat", "--preflight", "--receipt"]))
+        XCTAssertThrowsError(try VisionSegment.parse(["/tmp/a.png", "--preflight", "--receipt"]))
+        XCTAssertThrowsError(try VisionTrack.parse(["/tmp/a.mp4", "--preflight", "--receipt"]))
+
+        XCTAssertNoThrow(try ImageGenerate.parse(["--prompt", "a cat", "--preflight", "--json"]))
+        XCTAssertNoThrow(try VideoGenerate.parse(["a cat", "--preflight"]))
+        XCTAssertNoThrow(try VisionSegment.parse(["/tmp/a.png", "--preflight"]))
+    }
+
     func testSpeechTranscribeRejectsReceiptForRawStreamingStdin() {
         XCTAssertThrowsError(try SpeechTranscribe.parse([
             "-", "--stream", "--input-format", "pcm-s16le", "--sample-rate", "16000", "--receipt",

--- a/Tests/MereRunCLITests/RunReceiptTests.swift
+++ b/Tests/MereRunCLITests/RunReceiptTests.swift
@@ -1,0 +1,206 @@
+import Foundation
+import XCTest
+@testable import MereRunCLI
+
+final class RunReceiptTests: XCTestCase {
+    private func decode(_ line: String) throws -> [String: Any] {
+        let object = try JSONSerialization.jsonObject(with: Data(line.utf8))
+        return try XCTUnwrap(object as? [String: Any])
+    }
+
+    private func outputs(in line: String) throws -> [[String: Any]] {
+        try XCTUnwrap(try decode(line)["outputs"] as? [[String: Any]])
+    }
+
+    func testReceiptLineIsOneSortedJSONObject() throws {
+        let receipt = RunReceipt(outputs: [
+            .init(path: "/tmp/out.png", kind: .image),
+            .init(path: "/tmp/prompt.json", kind: .json, role: "structured-prompt"),
+        ])
+
+        let line = try receipt.line()
+        XCTAssertEqual(
+            line,
+            #"{"event":"result","exit":0,"outputs":[{"kind":"image","path":"/tmp/out.png"},"# +
+                #"{"kind":"json","path":"/tmp/prompt.json","role":"structured-prompt"}]}"#
+        )
+        XCTAssertFalse(line.contains("\n"))
+
+        let decoded = try decode(line)
+        XCTAssertEqual(decoded["event"] as? String, "result")
+        XCTAssertEqual(decoded["exit"] as? Int, 0)
+        XCTAssertEqual(try outputs(in: line).count, 2)
+    }
+
+    func testEmitIsANoOpUnlessEnabled() throws {
+        var written: [String] = []
+        let audioOutputs = [RunReceipt.Output(path: "/tmp/out.wav", kind: .audio)]
+
+        try RunReceipt.emit(audioOutputs, enabled: false, write: { written.append($0) })
+        XCTAssertTrue(written.isEmpty)
+
+        try RunReceipt.emit(audioOutputs, enabled: true, write: { written.append($0) })
+        XCTAssertEqual(written.count, 1)
+        XCTAssertEqual(try outputs(in: written[0]).first?["kind"] as? String, "audio")
+    }
+
+    func testOutputURLsAreStandardizedAbsolutePaths() {
+        let output = RunReceipt.Output(url: URL(fileURLWithPath: "/tmp/../tmp/./clip.mp4"), kind: .video)
+        XCTAssertEqual(output.path, "/tmp/clip.mp4")
+        XCTAssertNil(output.role)
+    }
+
+    func testGeneratedImageOutputsListStructuredPromptAsSidecar() throws {
+        let plain = RunReceipt.generatedImageOutputs(image: URL(fileURLWithPath: "/tmp/a.png"), structuredPrompt: nil)
+        XCTAssertEqual(plain.map(\.kind), [.image])
+
+        let line = try RunReceipt(outputs: RunReceipt.generatedImageOutputs(
+            image: URL(fileURLWithPath: "/tmp/a.png"),
+            structuredPrompt: URL(fileURLWithPath: "/tmp/a-prompt.json")
+        )).line()
+        let entries = try outputs(in: line)
+        XCTAssertEqual(entries.map { $0["kind"] as? String }, ["image", "json"])
+        XCTAssertEqual(entries.map { $0["path"] as? String }, ["/tmp/a.png", "/tmp/a-prompt.json"])
+        XCTAssertEqual(entries[1]["role"] as? String, "structured-prompt")
+    }
+
+    func testGeneratedVideoOutputsCoverMP4EXRDirectoryAndTimings() throws {
+        let mp4 = RunReceipt.generatedVideoOutputs(primary: URL(fileURLWithPath: "/tmp/v.mp4"), kind: .video, timings: nil)
+        XCTAssertEqual(mp4.map(\.kind), [.video])
+
+        let exr = RunReceipt.generatedVideoOutputs(
+            primary: URL(fileURLWithPath: "/tmp/v_exr"),
+            kind: .directory,
+            timings: URL(fileURLWithPath: "/tmp/v-timings.json")
+        )
+        let entries = try outputs(in: try RunReceipt(outputs: exr).line())
+        XCTAssertEqual(entries.map { $0["kind"] as? String }, ["directory", "json"])
+        XCTAssertEqual(entries[1]["role"] as? String, "timings")
+    }
+
+    func testGeneratedAudioOutputsKeepThePrimaryWAVFirst() throws {
+        let entries = try outputs(in: try RunReceipt(outputs: RunReceipt.generatedAudioOutputs(
+            audio: URL(fileURLWithPath: "/tmp/song.wav"),
+            sidecars: [
+                .init(url: URL(fileURLWithPath: "/tmp/song.candidate-2.seed-7.wav"), kind: .audio, role: "candidate"),
+                .init(url: URL(fileURLWithPath: "/tmp/song.lrc"), kind: .text, role: "lyrics"),
+                .init(url: URL(fileURLWithPath: "/tmp/song.recipe.json"), kind: .json, role: "recipe"),
+                .init(url: URL(fileURLWithPath: "/tmp/song-bundle"), kind: .directory, role: "daw-bundle"),
+            ]
+        )).line())
+
+        XCTAssertEqual(entries.first?["path"] as? String, "/tmp/song.wav")
+        XCTAssertNil(entries.first?["role"])
+        XCTAssertEqual(
+            entries.dropFirst().map { $0["role"] as? String },
+            ["candidate", "lyrics", "recipe", "daw-bundle"]
+        )
+        XCTAssertEqual(entries.map { $0["kind"] as? String }, ["audio", "audio", "text", "json", "directory"])
+    }
+
+    func testTranscriptOutputsAreEmptyWhenTranscriptOnlyWentToStdout() throws {
+        XCTAssertTrue(RunReceipt.transcriptOutputs(nil).isEmpty)
+        let line = try RunReceipt(outputs: RunReceipt.transcriptOutputs(nil)).line()
+        XCTAssertEqual(line, #"{"event":"result","exit":0,"outputs":[]}"#)
+
+        let file = RunReceipt.transcriptOutputs(URL(fileURLWithPath: "/tmp/talk.txt"))
+        XCTAssertEqual(file.map(\.kind), [.text])
+        XCTAssertEqual(file.first?.path, "/tmp/talk.txt")
+    }
+
+    func testAnnotatedImageOutputsListDetectionsAndOptionalMasks() throws {
+        let withoutMasks = RunReceipt.annotatedImageOutputs(
+            image: URL(fileURLWithPath: "/tmp/photo_grounded.jpg"),
+            detections: URL(fileURLWithPath: "/tmp/photo_grounded.json"),
+            masks: nil
+        )
+        XCTAssertEqual(withoutMasks.map(\.kind), [.image, .json])
+        XCTAssertEqual(withoutMasks.map(\.role), [nil, "detections"])
+
+        let entries = try outputs(in: try RunReceipt(outputs: RunReceipt.annotatedImageOutputs(
+            image: URL(fileURLWithPath: "/tmp/photo_segmented.png"),
+            detections: URL(fileURLWithPath: "/tmp/photo_segmented.json"),
+            masks: URL(fileURLWithPath: "/tmp/masks")
+        )).line())
+        XCTAssertEqual(entries.map { $0["kind"] as? String }, ["image", "json", "directory"])
+        XCTAssertEqual(entries[2]["role"] as? String, "masks")
+        XCTAssertEqual(entries[2]["path"] as? String, "/tmp/masks")
+    }
+
+    func testAnnotatedVideoOutputsListTrackingJSONAndMasks() throws {
+        let entries = try outputs(in: try RunReceipt(outputs: RunReceipt.annotatedVideoOutputs(
+            videoPath: "/tmp/clip_tracked.mp4",
+            trackingPath: "/tmp/clip_tracked.json",
+            masks: URL(fileURLWithPath: "/tmp/clip-masks")
+        )).line())
+        XCTAssertEqual(entries.map { $0["kind"] as? String }, ["video", "json", "directory"])
+        XCTAssertEqual(entries.map { $0["role"] as? String }, [nil, "tracking", "masks"])
+
+        let minimal = RunReceipt.annotatedVideoOutputs(videoPath: "/tmp/clip_tracked.mp4", trackingPath: nil, masks: nil)
+        XCTAssertEqual(minimal.map(\.kind), [.video])
+    }
+
+    // MARK: - Command flag parsing
+
+    func testEveryReceiptCommandParsesTheFlag() throws {
+        XCTAssertTrue(try ImageGenerate.parse(["--prompt", "a cat", "--receipt", "--progress-json"]).receipt)
+        XCTAssertTrue(try VideoGenerate.parse(["a cat", "--receipt", "--progress-json"]).receipt)
+        XCTAssertTrue(try VideoGenerate.parse(["a cat", "--progress-json"]).progressJson)
+        XCTAssertTrue(try MusicGenerate.parse(["lofi beat", "--receipt", "--progress-json"]).receipt)
+        XCTAssertTrue(try MusicGenerate.parse(["lofi beat", "--progress-json"]).progressJson)
+        XCTAssertTrue(try SFXGenerate.parse(["door slam", "--receipt", "--progress-json"]).receipt)
+        XCTAssertTrue(try SFXGenerate.parse(["door slam", "--progress-json"]).progressJson)
+        XCTAssertTrue(try SpeechSynthesize.parse(["hello", "--output", "/tmp/h.wav", "--receipt", "--progress-json"]).receipt)
+        XCTAssertTrue(try SpeechSynthesize.parse(["hello", "--output", "/tmp/h.wav", "--progress-json"]).progressJson)
+        XCTAssertTrue(try SpeechTranscribe.parse(["/tmp/talk.wav", "--receipt"]).receipt)
+        XCTAssertTrue(try VisionGround.parse(["/tmp/a.png", "--query", "cat", "--receipt"]).receipt)
+        XCTAssertTrue(try VisionSegment.parse(["/tmp/a.png", "--prompt", "cat", "--receipt"]).receipt)
+        XCTAssertTrue(try VisionTrack.parse(["/tmp/a.mp4", "--prompt", "cat", "--receipt"]).receipt)
+    }
+
+    func testReceiptDefaultsOffSoHumanOutputIsUnchanged() throws {
+        XCTAssertFalse(try ImageGenerate.parse(["--prompt", "a cat"]).receipt)
+        XCTAssertFalse(try VideoGenerate.parse(["a cat"]).receipt)
+        XCTAssertFalse(try VideoGenerate.parse(["a cat"]).progressJson)
+        XCTAssertFalse(try MusicGenerate.parse(["lofi beat"]).receipt)
+        XCTAssertFalse(try SFXGenerate.parse(["door slam"]).receipt)
+        XCTAssertFalse(try SpeechSynthesize.parse(["hello", "--output", "/tmp/h.wav"]).receipt)
+        XCTAssertFalse(try SpeechTranscribe.parse(["/tmp/talk.wav"]).receipt)
+        XCTAssertFalse(try VisionGround.parse(["/tmp/a.png", "--query", "cat"]).receipt)
+        XCTAssertFalse(try VisionSegment.parse(["/tmp/a.png", "--prompt", "cat"]).receipt)
+        XCTAssertFalse(try VisionTrack.parse(["/tmp/a.mp4", "--prompt", "cat"]).receipt)
+    }
+
+    func testReceiptDoesNotRequirePreflightUnlikeJSON() throws {
+        XCTAssertNoThrow(try VisionGround.parse(["/tmp/a.png", "--query", "cat", "--receipt"]).validate())
+        XCTAssertNoThrow(try VisionSegment.parse(["/tmp/a.png", "--prompt", "cat", "--receipt"]).validate())
+        XCTAssertNoThrow(try VisionTrack.parse(["/tmp/a.mp4", "--prompt", "cat", "--receipt"]).validate())
+        XCTAssertThrowsError(try VisionGround.parse(["/tmp/a.png", "--query", "cat", "--json"]))
+    }
+
+    func testSpeechTranscribeRejectsReceiptForRawStreamingStdin() {
+        XCTAssertThrowsError(try SpeechTranscribe.parse([
+            "-", "--stream", "--input-format", "pcm-s16le", "--sample-rate", "16000", "--receipt",
+        ]))
+        XCTAssertNoThrow(try SpeechTranscribe.parse([
+            "-", "--stream", "--input-format", "pcm-s16le", "--sample-rate", "16000", "--jsonl",
+        ]))
+    }
+
+    func testReceiptAndProgressFlagsShareOneHelpString() {
+        for help in [
+            ImageGenerate.helpMessage(), VideoGenerate.helpMessage(), MusicGenerate.helpMessage(),
+            SFXGenerate.helpMessage(), SpeechSynthesize.helpMessage(), SpeechTranscribe.helpMessage(),
+            VisionGround.helpMessage(), VisionSegment.helpMessage(), VisionTrack.helpMessage(),
+        ] {
+            XCTAssertTrue(help.contains("--receipt"))
+            XCTAssertTrue(help.contains("JSON result line"))
+        }
+        for help in [
+            ImageGenerate.helpMessage(), VideoGenerate.helpMessage(), MusicGenerate.helpMessage(),
+            SFXGenerate.helpMessage(), SpeechSynthesize.helpMessage(),
+        ] {
+            XCTAssertTrue(help.contains("--progress-json"))
+        }
+    }
+}

--- a/Tests/MereRunContractTests/CommandCapabilityContractTests.swift
+++ b/Tests/MereRunContractTests/CommandCapabilityContractTests.swift
@@ -141,6 +141,131 @@ import Testing
     #expect(decoded == document)
 }
 
+/// The capabilities behind Studio's prompt modes. Every option on these carries
+/// the group and tier metadata the contract-driven inspector renders from.
+private let promptModeCapabilityIDs: [String] = [
+    "image.generate", "text.chat", "text.code",
+    "speech.synthesize", "speech.transcribe",
+    "vision.inspect", "vision.ocr", "vision.caption", "vision.ground", "vision.segment", "vision.track",
+    "music.generate", "video.generate", "sfx.generate"
+]
+
+private let knownOptionGroups: Set<String> = [
+    MereRunCapabilityOptionGroup.prompt,
+    MereRunCapabilityOptionGroup.inputs,
+    MereRunCapabilityOptionGroup.output,
+    MereRunCapabilityOptionGroup.modelAndAdapters,
+    MereRunCapabilityOptionGroup.sampling,
+    MereRunCapabilityOptionGroup.run
+]
+
+@Test func promptModeCapabilitiesDeclareOptionMetadata() {
+    for id in promptModeCapabilityIDs {
+        let capability = MereRunCapabilityCatalog.command(id: id)
+        #expect(capability != nil, "Missing prompt-mode capability \(id)")
+        for option in capability?.options ?? [] {
+            #expect(option.group != nil, "\(id) \(option.flag) has no group")
+            #expect(option.tier != nil, "\(id) \(option.flag) has no tier")
+        }
+        #expect(
+            capability?.options.contains { $0.tier == .essential } == true,
+            "\(id) declares no essential option for the chip strip"
+        )
+    }
+}
+
+@Test func capabilityOptionMetadataIsWellFormed() {
+    for command in MereRunCapabilityCatalog.document.commands {
+        let flags = Set(command.options.map(\.flag))
+        for option in command.options {
+            let context = "\(command.id) \(option.flag)"
+
+            if let group = option.group {
+                #expect(knownOptionGroups.contains(group), "\(context) uses unknown group \(group)")
+            }
+
+            if let value = option.defaultValue {
+                switch option.kind {
+                case .integer:
+                    #expect(Int(value) != nil, "\(context) default \(value) is not an integer")
+                case .number:
+                    #expect(Double(value) != nil, "\(context) default \(value) is not a number")
+                case .boolean:
+                    #expect(["true", "false"].contains(value), "\(context) default \(value) is not a boolean")
+                case .choice:
+                    #expect(option.choices.contains(value), "\(context) default \(value) is not one of \(option.choices)")
+                case .string, .file, .directory:
+                    #expect(!value.isEmpty, "\(context) declares an empty default")
+                }
+            }
+
+            if let dependsOn = option.dependsOn {
+                #expect(dependsOn != option.flag, "\(context) depends on itself")
+                #expect(flags.contains(dependsOn), "\(context) depends on undeclared flag \(dependsOn)")
+            }
+
+            guard let range = option.range else { continue }
+            #expect(option.kind == .integer || option.kind == .number, "\(context) declares a range on a non-numeric option")
+            #expect(range.min != nil || range.max != nil || range.step != nil, "\(context) declares an empty range")
+            if let min = range.min, let max = range.max {
+                #expect(min <= max, "\(context) range min \(min) exceeds max \(max)")
+            }
+            if let step = range.step {
+                #expect(step > 0, "\(context) range step must be positive")
+            }
+            if option.kind == .integer {
+                for bound in [range.min, range.max, range.step].compactMap({ $0 }) {
+                    #expect(bound == bound.rounded(), "\(context) integer range uses fractional bound \(bound)")
+                }
+            }
+            if let value = option.defaultValue, let number = Double(value) {
+                if let min = range.min {
+                    #expect(number >= min, "\(context) default \(value) is below range min \(min)")
+                }
+                if let max = range.max {
+                    #expect(number <= max, "\(context) default \(value) is above range max \(max)")
+                }
+            }
+        }
+    }
+}
+
+@Test func receiptAndProgressFlagsAreDeclaredExactlyWhereEmitted() {
+    let commands = MereRunCapabilityCatalog.document.commands
+    let withReceipt = commands.filter { $0.options.contains { $0.flag == "--receipt" } }.map(\.id)
+    let withProgress = commands.filter { $0.options.contains { $0.flag == "--progress-json" } }.map(\.id)
+
+    #expect(Set(withReceipt) == Set(MereRunCapabilityCatalog.receiptCapabilityIDs))
+    #expect(Set(withProgress) == Set(MereRunCapabilityCatalog.progressJSONCapabilityIDs))
+    #expect(Set(MereRunCapabilityCatalog.progressJSONCapabilityIDs).isSubset(of: Set(withReceipt)))
+}
+
+@Test func optionMetadataSerializesAdditivelyAndDecodesLegacyJSON() throws {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys]
+
+    let width = try #require(MereRunCapabilityCatalog.imageGenerate.options.first { $0.flag == "--width" })
+    let widthJSON = String(decoding: try encoder.encode(width), as: UTF8.self)
+    #expect(widthJSON.contains(#""default_value":"1024""#))
+    #expect(widthJSON.contains(#""group":"Output""#))
+    #expect(widthJSON.contains(#""tier":"essential""#))
+    #expect(widthJSON.contains(#""range":{"max":2048,"min":256,"step":16}"#))
+    #expect(!widthJSON.contains("depends_on"))
+
+    let mask = try #require(MereRunCapabilityCatalog.imageGenerate.options.first { $0.flag == "--mask" })
+    #expect(String(decoding: try encoder.encode(mask), as: UTF8.self).contains(#""depends_on":"--input""#))
+
+    let bare = MereRunCapabilityOption(flag: "--x", label: "X", kind: .string)
+    let bareJSON = String(decoding: try encoder.encode(bare), as: UTF8.self)
+    #expect(bareJSON == #"{"choices":[],"flag":"--x","kind":"string","label":"X","repeatable":false,"required":false}"#)
+
+    let legacy = Data(#"{"flag":"--y","label":"Y","kind":"integer","required":false,"repeatable":false,"choices":[]}"#.utf8)
+    let decoded = try JSONDecoder().decode(MereRunCapabilityOption.self, from: legacy)
+    #expect(decoded == MereRunCapabilityOption(flag: "--y", label: "Y", kind: .integer))
+    #expect(decoded.defaultValue == nil && decoded.group == nil && decoded.tier == nil)
+    #expect(decoded.range == nil && decoded.dependsOn == nil)
+}
+
 @Test func capabilityFlagsAreUniqueWithinCommands() {
     for command in MereRunCapabilityCatalog.document.commands {
         let flags = command.options.map(\.flag)

--- a/Tests/MereRunContractTests/CommandCapabilityContractTests.swift
+++ b/Tests/MereRunContractTests/CommandCapabilityContractTests.swift
@@ -266,6 +266,17 @@ private let knownOptionGroups: Set<String> = [
     #expect(decoded.range == nil && decoded.dependsOn == nil)
 }
 
+@Test func speechTranscribeSampleRatePinsTheOnlyRateTheCLIAccepts() throws {
+    // `SpeechTranscribe.validate()` requires `--sample-rate 16000` on raw stdin
+    // and rejects the flag entirely off it.
+    let sampleRate = try #require(
+        MereRunCapabilityCatalog.speechTranscribe.options.first { $0.flag == "--sample-rate" }
+    )
+    #expect(sampleRate.range?.min == 16_000)
+    #expect(sampleRate.range?.max == 16_000)
+    #expect(sampleRate.dependsOn == "--stream")
+}
+
 @Test func capabilityFlagsAreUniqueWithinCommands() {
     for command in MereRunCapabilityCatalog.document.commands {
         let flags = command.options.map(\.flag)

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -3141,7 +3141,8 @@ the rest:
   `daw-bundle`).
 - `kind` is one of `image`, `video`, `audio`, `text`, `json`, `directory`.
 - The receipt is printed only after a successful run, so `exit` is always `0`;
-  a failed run exits nonzero without a receipt.
+  a failed run exits nonzero without a receipt. `--receipt` is rejected
+  together with `--preflight`, which prints a report and produces no result.
 - Supported by `image generate`, `video generate`, `music generate`,
   `sfx generate`, `speech synthesize`, `speech transcribe`, `vision ground`,
   `vision segment`, and `vision track`.
@@ -3154,16 +3155,23 @@ replacing the human-readable progress text and taking precedence over
 {"event":"progress","stage":"denoising","step":2,"total_steps":4}
 ```
 
-- `step` is the pipeline's step counter (0-based for the image generators,
-  1-based where the pipeline counts that way); every stage emits a final event
-  with `step == total_steps`.
+One convention holds for every lane:
+
+- `step` is 0-based while a stage is in progress: `step: 2` of
+  `total_steps: 4` means the third step is running.
+- Every determinate stage (`total_steps > 0`) ends with exactly one event
+  whose `step == total_steps`. It is written when the stage completes (the
+  next stage begins, or the same stage restarts for the next sliding window)
+  and, for the last stage, when the pipeline returns, so a wrapper can wait
+  for it without hanging at `total_steps - 1`.
 - `total_steps: 0` marks an indeterminate stage, for example
-  `speech synthesize` token counts.
+  `speech synthesize` token counts; it carries no terminal event, so treat the
+  receipt or the exit status as completion.
 - Supported by `image generate` (all models), `video generate` (MiniMax-H3
-  and Wan lanes), `music generate` (MiniMax Music 3 and Magenta RT2 lanes),
-  `sfx generate` (Woosh and MMAudio), and `speech synthesize`. The native LTX
-  video lanes and the ACE-Step music pipeline expose no cheap per-step callback
-  and emit no progress events.
+  and Wan lanes; `window` counts H3 sliding windows), `music generate`
+  (MiniMax Music 3 and Magenta RT2 lanes), `sfx generate` (Woosh and MMAudio),
+  and `speech synthesize`. The native LTX video lanes and the ACE-Step music
+  pipeline expose no cheap per-step callback and emit no progress events.
 
 `mere.run catalog --json` declares both flags per capability and carries the
 additive option metadata (`default_value`, `group`, `tier`, `range`,

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -504,6 +504,9 @@ Key options:
   with `step == total_steps`. Takes precedence over `--quiet` for progress
   output, so wrappers can keep stdout limited to the output path while still
   observing per-step progress.
+- `--receipt`: append a final `{"event":"result",...}` JSON line to stdout
+  listing the PNG and, with `--structured-prompt-output`, the prompt JSON; see
+  [Machine-readable receipts and progress](#machine-readable-receipts-and-progress)
 
 Unless `--quiet` is set, progress diagnostics on stderr include the native image
 backend, for example `native MLX/Metal (default device: gpu)` on Apple Silicon.
@@ -1063,6 +1066,10 @@ Key options:
 - `--stream`
 - `--stream-chunk-tokens`
 - `--quiet`
+- `--progress-json`: stage and token-count events on stderr as JSON lines;
+  Qwen3-TTS has no known total, so events carry `total_steps: 0`
+- `--receipt`: final JSON result line listing the WAV; see
+  [Machine-readable receipts and progress](#machine-readable-receipts-and-progress)
 
 Examples:
 
@@ -1097,6 +1104,9 @@ Key options:
 - `--no-timestamps`
 - `--output`
 - `--quiet`
+- `--receipt`: final JSON result line listing the `--output` transcript file
+  (empty `outputs` when the transcript only went to stdout); not available
+  with raw stdin, which already speaks `--jsonl`
 
 Examples:
 
@@ -1196,6 +1206,12 @@ Key options:
 - `--resolution`
 - `--show-boxes`
 - `--multimask`: emit up to three candidates per geometry-prompted object
+- `--preflight`
+- `--json`: only with `--preflight`
+- `--quiet`
+- `--receipt`: final JSON result line listing the annotated image, the
+  detections JSON, and the mask directory; see
+  [Machine-readable receipts and progress](#machine-readable-receipts-and-progress)
 
 Defaults:
 
@@ -1242,6 +1258,10 @@ Key options:
 - `--json`: only with `--preflight`
 - `--show-boxes`
 - `--show-labels`
+- `--quiet`
+- `--receipt`: final JSON result line listing the annotated video, the
+  tracking JSON, and the mask directory; see
+  [Machine-readable receipts and progress](#machine-readable-receipts-and-progress)
 
 Defaults:
 
@@ -1468,6 +1488,12 @@ Key options:
 - `--text-subdirectory`
 - `--seed`
 - `--quiet`
+- `--progress-json`: JSON progress lines on stderr for the MiniMax Music 3
+  (`semantic`, `denoising`, `decoding`) and Magenta RT2 (`generating`) lanes;
+  the ACE-Step pipeline exposes no per-step callback and emits none
+- `--receipt`: final JSON result line listing the WAV first, then any
+  candidates, stems, LRC, recipe, composition, profile, or DAW bundle it wrote;
+  see [Machine-readable receipts and progress](#machine-readable-receipts-and-progress)
 
 Magenta RT2 options:
 
@@ -1686,6 +1712,9 @@ Key options:
 - `--renoise`
 - `--seed`
 - `--quiet`
+- `--progress-json`: one `denoising` JSON progress line per step on stderr
+- `--receipt`: final JSON result line listing the WAV; see
+  [Machine-readable receipts and progress](#machine-readable-receipts-and-progress)
 
 Examples:
 
@@ -1926,6 +1955,12 @@ Key options:
   timings on stderr; unavailable for legacy merged distilled roots
 - `--timings-output`: write those timings as JSON
 - `--quiet`
+- `--progress-json`: JSON progress lines on stderr for the MiniMax-H3 and Wan
+  lanes (stage plus `denoising` steps, and `window` for H3 sliding windows);
+  the native LTX lanes expose no per-step callback and emit none
+- `--receipt`: final JSON result line listing the MP4 (or the EXR directory
+  with `--skip-mp4`) and, on LTX lanes, the `--timings-output` JSON; see
+  [Machine-readable receipts and progress](#machine-readable-receipts-and-progress)
 
 Environment:
 
@@ -3086,6 +3121,54 @@ swift run mere.run model pull text-agent-deepseek-v4-flash
 swift run mere.run agent install-pi
 swift run mere.run agent start --model text-agent-deepseek-v4-flash
 ```
+
+### Machine-readable receipts and progress
+
+Long-running generation commands share two machine-readable surfaces so
+wrappers and the Studio app never have to probe the file system or parse prose.
+
+`--receipt` appends one final JSON line to stdout after the command's normal
+output. Human output above it is unchanged, so parse the last line and ignore
+the rest:
+
+```json
+{"event":"result","exit":0,"outputs":[{"kind":"image","path":"/abs/out.png"},{"kind":"json","path":"/abs/out-prompt.json","role":"structured-prompt"}]}
+```
+
+- `outputs[0]` is the primary artifact; sidecars follow it with a `role`
+  (`structured-prompt`, `timings`, `detections`, `tracking`, `masks`,
+  `candidate`, `stem`, `lyrics`, `recipe`, `composition`, `profile`,
+  `daw-bundle`).
+- `kind` is one of `image`, `video`, `audio`, `text`, `json`, `directory`.
+- The receipt is printed only after a successful run, so `exit` is always `0`;
+  a failed run exits nonzero without a receipt.
+- Supported by `image generate`, `video generate`, `music generate`,
+  `sfx generate`, `speech synthesize`, `speech transcribe`, `vision ground`,
+  `vision segment`, and `vision track`.
+
+`--progress-json` streams one JSON object per progress event on stderr,
+replacing the human-readable progress text and taking precedence over
+`--quiet`:
+
+```json
+{"event":"progress","stage":"denoising","step":2,"total_steps":4}
+```
+
+- `step` is the pipeline's step counter (0-based for the image generators,
+  1-based where the pipeline counts that way); every stage emits a final event
+  with `step == total_steps`.
+- `total_steps: 0` marks an indeterminate stage, for example
+  `speech synthesize` token counts.
+- Supported by `image generate` (all models), `video generate` (MiniMax-H3
+  and Wan lanes), `music generate` (MiniMax Music 3 and Magenta RT2 lanes),
+  `sfx generate` (Woosh and MMAudio), and `speech synthesize`. The native LTX
+  video lanes and the ACE-Step music pipeline expose no cheap per-step callback
+  and emit no progress events.
+
+`mere.run catalog --json` declares both flags per capability and carries the
+additive option metadata (`default_value`, `group`, `tier`, `range`,
+`depends_on`) that shells use to build forms without a second copy of the
+command surface.
 
 ## Validation and smoke runs
 


### PR DESCRIPTION
Studio v2 step C2 (docs/macos-studio-v2.md §6, §7). CLI and contract only; the macOS app is untouched.

## What changed

### Contract option metadata (additive)

`MereRunCapabilityOption` gains five optional fields, serialized in snake_case and omitted when `nil`, so existing `catalog --json` consumers keep decoding:

| field | type | meaning |
|---|---|---|
| `default_value` | `String?` | the CLI's static ArgumentParser default, rendered as the CLI parses it (`"1024"`, `"0.7"`, `"peak"`); `nil` when the default is machine- or model-specific |
| `group` | `String?` | section name; `MereRunCapabilityOptionGroup` defines `Prompt`, `Inputs`, `Output`, `Model & adapters`, `Sampling`, `Run` |
| `tier` | `MereRunCapabilityOptionTier?` | `essential` (chip strip), `standard` (inspector sections), `expert` (collapsed under Advanced) |
| `range` | `MereRunCapabilityRange?` | optional `min`, `max`, `step` for integer and number options |
| `depends_on` | `String?` | another flag on the same capability that must be set for this one to matter |

Populated for every option of the 14 capabilities behind the 12 prompt modes: `image.generate`, `text.chat`, `text.code`, `speech.synthesize`, `speech.transcribe`, `vision.inspect`, `vision.ocr`, `vision.caption`, `vision.ground`, `vision.segment`, `vision.track`, `music.generate`, `video.generate`, `sfx.generate`. Other capabilities leave the fields `nil`. `vision.ground` also gains `--preflight`, `--json`, `--quiet`, and `vision.segment`/`vision.track` gain `--quiet`, which the CLI already accepted.

### Result receipts

New `--receipt` flag on `image generate`, `video generate`, `music generate`, `sfx generate`, `speech synthesize`, `speech transcribe`, `vision ground`, `vision segment`, and `vision track`. `--json` on these commands already means "structured preflight report" (and video/vision reject it outside `--preflight`), so a separate flag keeps that meaning intact. When set, the command appends one final line to stdout after its unchanged human output:

```json
{"event":"result","exit":0,"outputs":[{"kind":"image","path":"/abs/out.png"},{"kind":"json","path":"/abs/out-prompt.json","role":"structured-prompt"}]}
```

- `outputs[0]` is the primary artifact; sidecars follow with a `role` (`structured-prompt`, `timings`, `detections`, `tracking`, `masks`, `candidate`, `stem`, `lyrics`, `recipe`, `composition`, `profile`, `daw-bundle`).
- `kind` is `image | video | audio | text | json | directory`.
- Printed only after success, so `exit` is always `0`; failures exit nonzero with no receipt. `--receipt --preflight` is rejected with a clear message rather than exiting 0 without a receipt.
- `speech transcribe` lists the `--output` file, or an empty `outputs` when the transcript only went to stdout; `--receipt` is rejected for raw stdin (`-`), which already speaks `--jsonl`.
- Encoded in one place, `Sources/MereRunCLI/Support/RunReceipt.swift`, with per-family output builders that the tests exercise directly.

### Progress JSON

`--progress-json` keeps the existing `{"event":"progress","stage":…,"step":…,"total_steps":…}` shape (already parsed by Studio) under one convention, enforced in the CLI layer by `JSONProgressStream` so core pipelines are untouched:

- `step` is 0-based while a stage is in progress.
- Every determinate stage (`total_steps > 0`) ends with exactly one event whose `step == total_steps`, written when the next stage begins, when the same stage restarts (H3 sliding windows), or when the pipeline returns. A wrapper can wait for it without hanging at `total_steps - 1`.
- `total_steps: 0` marks an indeterminate stage with no terminal event (`speech synthesize` token counts); the receipt or exit status is the completion signal.

Lanes: `video generate` MiniMax-H3 (stages, `denoising`, `window` milestones) and Wan; `music generate` MiniMax Music 3 (`semantic`, `denoising` flattened across chunks, `decoding`) and Magenta RT2 (`generating`); `sfx generate` Woosh and MMAudio; `speech synthesize`. The native LTX video generators and the ACE-Step music pipeline expose no per-step callback and emit nothing rather than a fake.

The contract records both flags per capability (`receiptCapabilityIDs`, `progressJSONCapabilityIDs`) and documents the two line shapes (`resultReceiptExample`, `progressEventExample`).

### Docs and changelog

`docs/cli.md` gains the flags in each command section plus a shared "Machine-readable receipts and progress" section; the generated command inventory is unchanged (no new subcommands). CHANGELOG has a CLI entry under Unreleased. `docs/macos-studio-capability-review.md` is untouched.

## Tests

- Contract: 127 ids unchanged; new tests prove every populated `default_value` parses for its kind, every `depends_on` names a declared flag, every `range` is sane (min ≤ max, positive step, whole numbers for integers, default inside the range), the prompt-mode capabilities carry group and tier on every option, receipt/progress flags are declared exactly where emitted, and the JSON stays additive (new keys omitted when `nil`, legacy JSON decodes).
- CLI: `capabilityDefaultValuesMatchArgumentParserHelp` checks every recorded default against the ArgumentParser `--help` text, so a CLI default change that forgets the contract fails locally. `capabilityFlagsMatchArgumentParserHelp` still passes. `RunReceiptTests` cover the line shape, the no-op when disabled, each family's outputs, flag parsing on all nine commands, and the `--receipt --preflight` rejection.
- `ReceiptCommandRunTests` runs the real `speech transcribe` (file path) and `speech synthesize` (non-streaming) commands against fixture backends through the `CLIASRTranscriptionExecutor` seam and a new `CLISpeechSynthesizing` seam, capturing fd 1: without `--receipt` stdout is byte-for-byte the pre-existing output (`<transcript>\n`, `<path>\n`), and with it the receipt is the final line with the right kind and path (and empty `outputs` for a stdout-only transcript).
- `CLIGenerationProgressPrinterTests` pins the progress convention: SFX completion counts become 0-based steps plus one terminal event; MiniMax Music 3 counters flatten to 0-based and each stage closes; Wan2-style stages that only report step 0 close when the next stage begins and an already-terminal `decoding` event is not duplicated; H3 sliding windows restart `denoising` with a terminal per window and close the `window` milestone at the end; indeterminate stages carry no terminal event.

## Verification

- `swiftlint --strict`: 0 violations
- `swift build`
- `swift test --filter MereRunContractTests`
- `swift test --filter MereRunCLITests`
- `./scripts/check.sh`

## For the app-side steps

- C3 `ContractForm`: render from `kind` plus `tier`/`group`; `depends_on` hides or disables a control until its parent flag is set; `range` drives steppers and sliders; `default_value` is the CLI's own default, so leaving a control at it means omitting the flag.
- C7 `ArtifactResolver`: pass `--receipt`, read the last stdout line when it starts with `{"event":"result"`, take `outputs[0]` as the primary artifact and the rest as sidecars keyed by `role`. Pass `--progress-json` for the five capabilities in `progressJSONCapabilityIDs`; treat `total_steps == 0` as indeterminate.
