### PR TITLE
Rebuild Chat as the Converse archetype

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -110,7 +110,16 @@ breathe (24–32), rows and chips stay tight (8–12).
   glyph tile), one-line title, and meta with an 8pt status dot while queued (yellow),
   running (accent), or failed (red). Rows are 6/8 padded, radius 9, `accentSoft` when
   selected, `hoverFill` on hover, in a 6pt-inset column with 2pt gaps.
-- Chat: user turns in `accentSoft` bubbles right-aligned; assistant turns as unboxed
-  text blocks with a small mode glyph; fenced code in mono panels with copy.
+- Chat (Converse): a 248pt thread list in place of the Library ("Threads" 13pt semibold, a
+  compose icon button, a "Search threads" capsule, Today / Earlier eyebrows, 8/10-padded
+  rows of a 12.5pt title over an 11pt muted "Model · time" meta, `accentSoft` when
+  selected). The transcript is a 760pt centered column: a header (13.5pt semibold title,
+  model and "System: default" chips, hairline below), then turns 20pt apart, bottom-aligned,
+  22/24 padded. User turns are 14pt in `accentSoft` bubbles (radius 14/14/4/14, 10/14
+  padding, max 520pt) on the right; assistant turns are unboxed 14pt Markdown at 1.55 line
+  height behind a 16pt accent chat glyph (max 640pt), with fenced code on `surfaceRaised`
+  (radius 8, a header row of the language eyebrow and Copy over a hairline, 12pt mono) and a
+  row of 28pt Copy / Retry / Branch icon buttons beside "model · tok/s · time" in 11pt muted.
+  A streaming turn ends in a thin accent caret.
 - Media: audio renders as an interactive waveform (accent = played), video via AVKit in
   a rounded, shadowed frame.

--- a/apps/macos/MereRunStudio/ConversationTranscript.swift
+++ b/apps/macos/MereRunStudio/ConversationTranscript.swift
@@ -16,9 +16,40 @@ enum ConversationTranscript {
         let approxChars: Int
     }
 
-    /// A conservative character budget (~4 chars/token). Tunable; a per-model budget is a later
-    /// refinement. The system prompt rides in `--system` and is reserved out of the history room.
+    /// The character budget when nothing reports the model's context size (~4 chars/token, so
+    /// roughly 12k tokens of history). The system prompt rides in `--system` and is reserved
+    /// out of the history room.
     static let defaultBudgetChars = 48_000
+    /// Characters of history assumed per context token when sizing from a real context window.
+    /// Deliberately below the English average so code-heavy threads still fit.
+    static let charsPerContextToken = 3
+    /// The smallest budget a derived context can shrink to; the latest turn is always sent
+    /// regardless, so this only bounds how much history rides along.
+    static let minimumBudgetChars = 4_000
+
+    /// The history budget for a model with `contextTokens` of context, keeping `maxOutputTokens`
+    /// free for the reply. nil or a non-positive context keeps `defaultBudgetChars`, so a model
+    /// the inventory says nothing about behaves exactly as before.
+    static func budgetChars(contextTokens: Int?, maxOutputTokens: Int) -> Int {
+        guard let contextTokens, contextTokens > 0 else { return defaultBudgetChars }
+        let historyTokens = contextTokens - max(0, maxOutputTokens)
+        return max(minimumBudgetChars, historyTokens * charsPerContextToken)
+    }
+
+    /// The context size the next turn will run with: an explicit `--context-size` in the draft
+    /// wins, else what the model inventory reports for the model, else nothing (fixed budget).
+    static func contextTokens(
+        requestedContextSize: Int,
+        model: String,
+        inventory: [StudioModelInventoryRow]
+    ) -> Int? {
+        if requestedContextSize > 0 { return requestedContextSize }
+        let identity = model.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !identity.isEmpty,
+              let window = inventory.first(where: { $0.id == identity })?.contextWindow,
+              window > 0 else { return nil }
+        return window
+    }
 
     static func render(
         messages: [StudioMessage],
@@ -102,5 +133,17 @@ enum ConversationTranscript {
             )
         }
         return result.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// The decode throughput from the CLI's `--stats` line
+    /// (`time=… tokens=… decode_tps=41.20 e2e_tps=…`), scanning the run's log from the end so
+    /// the turn's own line wins over anything echoed earlier. nil when no line reports it.
+    static func decodeTokensPerSecond(in logLines: [String]) -> Double? {
+        for line in logLines.reversed() {
+            guard let range = line.range(of: "decode_tps=") else { continue }
+            let value = line[range.upperBound...].prefix { $0.isNumber || $0 == "." }
+            if let parsed = Double(value), parsed > 0 { return parsed }
+        }
+        return nil
     }
 }

--- a/apps/macos/MereRunStudio/StudioComposer.swift
+++ b/apps/macos/MereRunStudio/StudioComposer.swift
@@ -445,105 +445,13 @@ struct StudioComposer: View {
     // MARK: - Model chip
 
     private var modelChip: some View {
-        Menu {
-            Toggle(isOn: Binding(get: { draft.model.isBlank }, set: { _ in draft.model = "" })) {
-                Text(defaultModelID.isEmpty ? "Auto" : "Auto · \(Self.displayModelName(defaultModelID))")
-            }
-            let choices = mode.modelChoices(from: modelInventory)
-            let installed = choices.filter(\.isInstalled)
-            let downloadable = choices.filter { !$0.isInstalled }
-            if !installed.isEmpty {
-                Section("Installed") {
-                    ForEach(installed) { row in modelRow(row) }
-                }
-            }
-            if !downloadable.isEmpty {
-                Section("Needs download") {
-                    ForEach(downloadable) { row in modelRow(row) }
-                }
-            }
-            if choices.isEmpty {
-                Text("No \(mode.title.lowercased()) models listed yet")
-            }
-            Divider()
-            Button("Browse Models…", action: onShowModels)
-        } label: {
-            StudioComposerChipLabel(title: modelLabel, leadingSystemImage: modelStatusGlyph)
-        }
-        .menuStyle(.button)
-        .buttonStyle(.plain)
-        .menuIndicator(.hidden)
-        .fixedSize()
-        .help(modelHelp)
-        .accessibilityLabel("Model")
-        .accessibilityValue(modelAccessibilityValue)
-    }
-
-    private func modelRow(_ row: StudioModelInventoryRow) -> some View {
-        Toggle(isOn: Binding(get: { row.id == draft.model }, set: { _ in draft.model = row.id })) {
-            Label(Self.displayModelName(row.id), systemImage: row.isInstalled ? "internaldrive" : "arrow.down.circle")
-        }
-    }
-
-    /// The mode's template default, shown as "Auto".
-    private var defaultModelID: String {
-        CommandCatalog.template(id: mode.defaultTemplateID)?.defaultModel ?? ""
-    }
-
-    /// The resolved model id for this run: the explicit draft model, else the mode's default.
-    private var rawModelID: String {
-        let current = draft.model.trimmingCharacters(in: .whitespacesAndNewlines)
-        return current.isEmpty ? defaultModelID : current
-    }
-
-    private var modelLabel: String {
-        rawModelID.isEmpty ? "Auto" : Self.displayModelName(rawModelID)
-    }
-
-    /// A glyph before the model name when the model is not ready: missing locally, or unsupported.
-    private var modelStatusGlyph: String? {
-        switch readiness {
-        case .missingModel: return "arrow.down.circle"
-        case .unsupported: return "exclamationmark.triangle"
-        case .checking, .ready, .unknown: return nil
-        }
-    }
-
-    private var modelHelp: String {
-        let identity = rawModelID.isEmpty ? "Auto — the mode's default model" : "Model: \(rawModelID)"
-        switch readiness {
-        case .ready, .unknown: return identity
-        default: return "\(identity) · \(readiness.message)"
-        }
-    }
-
-    private var modelAccessibilityValue: String {
-        let identity = rawModelID.isEmpty ? "Automatic" : rawModelID
-        return "\(identity), \(readiness.title)"
-    }
-
-    /// A human-facing label for a model id: drop the modality/category prefix and
-    /// title-case the distinctive remainder ("text-agent-deepseek-v4-flash" →
-    /// "Deepseek V4 Flash"). The exact id stays in the chip's tooltip, so the
-    /// friendly name never hides what the CLI actually expects.
-    static func displayModelName(_ id: String) -> String {
-        let leaf = id.components(separatedBy: "/").last ?? id
-        let prefixes = [
-            "text-chat-", "text-agent-", "text-embed-", "text-code-",
-            "image-", "video-", "music-", "sfx-", "speech-tts-", "speech-asr-", "speech-",
-            "embed-", "vision-ground-", "vision-segment-", "vision-chat-", "vision-ocr-", "vision-", "text-"
-        ]
-        var core = leaf
-        for prefix in prefixes where core.hasPrefix(prefix) {
-            core = String(core.dropFirst(prefix.count))
-            break
-        }
-        let words = core.split(separator: "-").map { token -> String in
-            guard let first = token.first, first.isLetter else { return String(token) }
-            return first.uppercased() + token.dropFirst()
-        }
-        let label = words.joined(separator: " ")
-        return label.isEmpty ? leaf : label
+        StudioModelPicker(
+            mode: mode,
+            model: $draft.model,
+            inventory: modelInventory,
+            readiness: readiness,
+            onShowModels: onShowModels
+        )
     }
 
     // MARK: - Right cluster

--- a/apps/macos/MereRunStudio/StudioConversationView.swift
+++ b/apps/macos/MereRunStudio/StudioConversationView.swift
@@ -1,20 +1,223 @@
 import SwiftUI
 
-/// The chat/code canvas: user turns as warm bubbles on the right, assistant turns as unboxed
-/// Markdown on the left, a live streaming turn while a reply is in flight. The composer lives
-/// in the shared prompt bar below; this view renders the thread and a "New chat" affordance.
+/// The Converse surface: the thread header (title, model, system prompt) over the transcript,
+/// with the readiness state layered the way the media canvas layers it. Chat and Code share
+/// it — Code is a preset (the `text code` command and its defaults), not a second surface.
+struct StudioConverseView: View {
+    let mode: StudioMode
+    let item: StudioLibraryItem?
+    let liveText: String?
+    let isRunning: Bool
+    let readiness: ModelReadinessState
+    let error: String?
+    /// The transcript budget the next turn is trimmed to; the trim banner reports against it.
+    let budgetChars: Int
+    let modelInventory: [StudioModelInventoryRow]
+    /// The model and system prompt the NEXT turn runs with. Changing either here records on
+    /// that turn; earlier turns keep what they ran with.
+    @Binding var model: String
+    @Binding var systemPrompt: String
+    let onPullModel: () -> Void
+    let onShowDetails: () -> Void
+    let onShowModels: () -> Void
+    let onCopy: (String) -> Void
+    let onRetry: () -> Void
+    let onEdit: (UUID) -> Void
+    let onBranch: (UUID) -> Void
+    let onUseExample: (String) -> Void
+
+    private var hasTurns: Bool {
+        !(item?.messages ?? []).isEmpty || isRunning
+    }
+
+    private var needsAttention: Bool {
+        !isRunning && (readiness.blocksRun || error != nil)
+    }
+
+    var body: some View {
+        ZStack {
+            VStack(spacing: 0) {
+                StudioThreadHeader(
+                    title: item?.displayTitle ?? "New thread",
+                    mode: mode,
+                    model: $model,
+                    systemPrompt: $systemPrompt,
+                    modelInventory: modelInventory,
+                    readiness: readiness,
+                    onShowModels: onShowModels
+                )
+                if needsAttention && hasTurns {
+                    readinessNotice
+                }
+                StudioConversationView(
+                    item: item,
+                    liveText: liveText,
+                    isRunning: isRunning,
+                    mode: mode,
+                    onNewChat: {},
+                    onCopy: onCopy,
+                    onRetry: onRetry,
+                    onEdit: onEdit,
+                    onUseExample: onUseExample,
+                    onBranch: onBranch,
+                    budgetChars: budgetChars
+                )
+            }
+
+            // A thread that has not started yet gets the full readiness card; one with turns
+            // keeps its transcript visible and shows the compact notice above it instead.
+            if needsAttention && !hasTurns {
+                StudioReadinessOverlay(
+                    title: error == nil ? readiness.title : "Needs attention",
+                    message: error ?? readiness.message,
+                    canPull: error == nil && readiness.canPull,
+                    isChecking: error == nil && readiness.isChecking,
+                    onPullModel: onPullModel,
+                    onShowDetails: onShowDetails
+                )
+                .transition(.opacity)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    private var readinessNotice: some View {
+        HStack(spacing: MereRunTheme.Spacing.sm) {
+            Image(systemName: error == nil ? "arrow.down.circle" : "exclamationmark.triangle")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(error == nil ? MereRunTheme.accent : MereRunTheme.red)
+            Text(error ?? readiness.message)
+                .font(.system(size: 12))
+                .foregroundStyle(MereRunTheme.textPrimary)
+                .lineLimit(2)
+            Spacer(minLength: 8)
+            if error == nil, readiness.canPull {
+                Button("Get the model", action: onPullModel)
+                    .buttonStyle(.mereSecondary)
+            }
+        }
+        .padding(.horizontal, 12)
+        .padding(.vertical, 8)
+        .background {
+            RoundedRectangle(cornerRadius: MereRunTheme.Radius.base)
+                .fill(MereRunTheme.surfaceRaised)
+        }
+        .frame(maxWidth: 760 - 48)
+        .padding(.top, 12)
+        .accessibilityElement(children: .combine)
+    }
+}
+
+/// The thread header: title, the model chip (the same filtered picker as the composer), and the
+/// system prompt chip. Both chips edit what the next turn runs with.
+struct StudioThreadHeader: View {
+    let title: String
+    let mode: StudioMode
+    @Binding var model: String
+    @Binding var systemPrompt: String
+    let modelInventory: [StudioModelInventoryRow]
+    let readiness: ModelReadinessState
+    let onShowModels: () -> Void
+
+    @State private var editingSystemPrompt = false
+
+    static let maxWidth: CGFloat = 760
+
+    private var systemLabel: String {
+        systemPrompt.isBlank ? "System: default" : "System: custom"
+    }
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Text(title)
+                .font(.system(size: 13.5, weight: .semibold))
+                .foregroundStyle(MereRunTheme.textPrimary)
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .accessibilityAddTraits(.isHeader)
+            StudioModelPicker(
+                mode: mode,
+                model: $model,
+                inventory: modelInventory,
+                readiness: readiness,
+                onShowModels: onShowModels
+            )
+            systemChip
+        }
+        .padding(.top, 14)
+        .padding(.horizontal, 24)
+        .padding(.bottom, 10)
+        .frame(maxWidth: Self.maxWidth)
+        .overlay(alignment: .bottom) {
+            Rectangle()
+                .fill(MereRunTheme.border.opacity(0.4))
+                .frame(height: 1)
+        }
+        .frame(maxWidth: .infinity)
+    }
+
+    private var systemChip: some View {
+        Button {
+            editingSystemPrompt = true
+        } label: {
+            StudioComposerChipLabel(title: systemLabel)
+        }
+        .buttonStyle(.plain)
+        .help(systemPrompt.isBlank ? "System prompt: the command's default" : "System prompt: \(systemPrompt)")
+        .accessibilityLabel("System prompt")
+        .accessibilityValue(systemPrompt.isBlank ? "Default" : systemPrompt)
+        .popover(isPresented: $editingSystemPrompt, arrowEdge: .bottom) {
+            VStack(alignment: .leading, spacing: MereRunTheme.Spacing.sm) {
+                Text("System prompt")
+                    .font(.system(size: 12, weight: .semibold))
+                    .foregroundStyle(MereRunTheme.textPrimary)
+                TextEditor(text: $systemPrompt)
+                    .font(.system(size: 13))
+                    .scrollContentBackground(.hidden)
+                    .padding(6)
+                    .frame(width: 340, height: 140)
+                    .merePanel(cornerRadius: MereRunTheme.Radius.sm)
+                    .accessibilityLabel("System prompt")
+                HStack {
+                    Button("Use default") { systemPrompt = "" }
+                        .buttonStyle(.mereSecondary)
+                        .disabled(systemPrompt.isBlank)
+                    Spacer(minLength: 8)
+                    Text("Applies from the next turn")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(MereRunTheme.textMuted)
+                }
+            }
+            .padding(MereRunTheme.Spacing.md)
+            .background(MereRunTheme.background)
+            .foregroundStyle(MereRunTheme.textPrimary)
+        }
+    }
+}
+
+/// The transcript: user turns as warm bubbles on the right, assistant turns as unboxed Markdown
+/// behind a chat glyph on the left, a live streaming turn while a reply is in flight, all
+/// bottom-aligned in a 760pt column. The composer lives in the shared prompt bar below.
 struct StudioConversationView: View {
     let item: StudioLibraryItem?
     let liveText: String?
     let isRunning: Bool
     let mode: StudioMode
+    /// Unused by the Converse surface (the thread list owns "new thread"); kept for the
+    /// canvas call site until the Main board drops its conversation branch.
     let onNewChat: () -> Void
     let onCopy: (String) -> Void
     let onRetry: () -> Void
     let onEdit: (UUID) -> Void
     var onUseExample: ((String) -> Void)?
+    /// Branches a new thread at a turn: before a user turn (with that turn loaded for editing),
+    /// after an assistant turn.
+    var onBranch: ((UUID) -> Void)?
+    var budgetChars: Int = ConversationTranscript.defaultBudgetChars
 
     private static let streamingBubbleID = "studio.conversation.streaming"
+    static let columnWidth: CGFloat = 760
 
     private var messages: [StudioMessage] { item?.messages ?? [] }
 
@@ -22,25 +225,19 @@ struct StudioConversationView: View {
     /// trimming is never silent.
     private var droppedFromContext: Int {
         guard !messages.isEmpty else { return 0 }
-        return ConversationTranscript.render(messages: messages, systemPrompt: item?.systemPrompt).droppedCount
+        return ConversationTranscript.render(
+            messages: messages,
+            systemPrompt: item?.systemPrompt,
+            budgetChars: budgetChars
+        ).droppedCount
     }
 
     var body: some View {
         VStack(spacing: 0) {
-            // A blank new chat shows only its empty state — no header, so the
-            // thread title and the "New chat" action never read as duplicates.
-            if hasActiveConversation {
-                header
-                Divider().overlay(MereRunTheme.border.opacity(0.4))
-            }
             if droppedFromContext > 0 { contextTrimBanner }
             content
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity)
-    }
-
-    private var hasActiveConversation: Bool {
-        item != nil || !messages.isEmpty || isRunning
     }
 
     private var contextTrimBanner: some View {
@@ -49,67 +246,37 @@ struct StudioConversationView: View {
             text: "Earlier messages are trimmed from the next prompt to fit the context window (\(droppedFromContext) omitted).",
             systemImage: "scissors"
         )
-        .padding(.horizontal, 24)
+        .frame(maxWidth: Self.columnWidth - 48)
         .padding(.vertical, 8)
-    }
-
-    private var header: some View {
-        HStack(spacing: MereRunTheme.Spacing.sm) {
-            Text(item?.displayTitle ?? "Untitled chat")
-                .font(MereRunTheme.sectionFont)
-                .foregroundStyle(MereRunTheme.textSecondary)
-                .lineLimit(1)
-                .truncationMode(.tail)
-            Spacer(minLength: 12)
-            Button(action: onNewChat) {
-                Label("New chat", systemImage: "square.and.pencil")
-                    .font(MereRunTheme.captionFont)
-                    .padding(.horizontal, 8)
-                    .padding(.vertical, 5)
-            }
-            .buttonStyle(.mereIcon(tint: MereRunTheme.accent))
-            .help("Start a new conversation")
-            .accessibilityLabel("Start a new conversation")
-        }
-        .padding(.horizontal, 24)
-        .padding(.vertical, 10)
     }
 
     @ViewBuilder
     private var content: some View {
         if messages.isEmpty && !isRunning {
-            StudioConversationEmptyState(mode: mode, onUseExample: onUseExample)
+            StudioEmptyState(mode: mode, onUseExample: onUseExample, onAttach: nil)
         } else {
             ScrollViewReader { proxy in
-                ScrollView {
-                    LazyVStack(alignment: .leading, spacing: MereRunTheme.Spacing.lg) {
-                        ForEach(messages) { message in
-                            StudioTurnView(
-                                role: message.role,
-                                content: message.content,
-                                failed: message.failed,
-                                monospaced: mode == .code && message.role == .assistant,
-                                modeIcon: mode.systemImage,
-                                onCopy: message.content.isEmpty ? nil : { onCopy(message.content) },
-                                onRetry: retryAction(for: message),
-                                onEdit: editAction(for: message)
-                            )
-                            .id(message.id)
+                GeometryReader { geometry in
+                    ScrollView {
+                        VStack(alignment: .leading, spacing: 20) {
+                            ForEach(messages) { message in
+                                turn(for: message)
+                                    .id(message.id)
+                            }
+                            if isRunning {
+                                StudioTurnView(
+                                    role: .assistant,
+                                    content: liveText ?? "",
+                                    isStreaming: true
+                                )
+                                .id(Self.streamingBubbleID)
+                            }
                         }
-                        if isRunning {
-                            StudioTurnView(
-                                role: .assistant,
-                                content: liveText ?? "",
-                                failed: false,
-                                isStreaming: true,
-                                monospaced: mode == .code,
-                                modeIcon: mode.systemImage
-                            )
-                            .id(Self.streamingBubbleID)
-                        }
+                        .padding(EdgeInsets(top: 22, leading: 24, bottom: 8, trailing: 24))
+                        .frame(maxWidth: Self.columnWidth)
+                        .frame(maxWidth: .infinity)
+                        .frame(minHeight: geometry.size.height, alignment: .bottom)
                     }
-                    .padding(24)
-                    .frame(maxWidth: .infinity, alignment: .leading)
                 }
                 .onChange(of: item?.id) { _, _ in scrollToEnd(proxy) }
                 .onChange(of: messages.count) { _, _ in scrollToEnd(proxy) }
@@ -120,9 +287,47 @@ struct StudioConversationView: View {
         }
     }
 
-    /// Retry is offered only on the final assistant turn, and only when idle.
+    private func turn(for message: StudioMessage) -> some View {
+        StudioTurnView(
+            role: message.role,
+            content: message.content,
+            failed: message.failed,
+            meta: message.role == .assistant ? meta(for: message) : nil,
+            onCopy: message.content.isEmpty ? nil : { onCopy(message.content) },
+            onRetry: retryAction(for: message),
+            onEdit: editAction(for: message),
+            onBranch: branchAction(for: message),
+            actionsEnabled: !isRunning
+        )
+    }
+
+    /// "Qwen3.6 4B · 41 tok/s · 1:20 PM": the model the turn ran on (the thread's when the turn
+    /// predates per-turn recording), its decode speed when the run reported one, and its time.
+    private func meta(for message: StudioMessage) -> String {
+        var parts: [String] = []
+        let modelID = message.model ?? item?.model ?? ""
+        if !modelID.isBlank {
+            parts.append(StudioModelPicker.displayModelName(modelID))
+        }
+        if let tokensPerSecond = message.tokensPerSecond, tokensPerSecond > 0 {
+            parts.append("\(Int(tokensPerSecond.rounded())) tok/s")
+        }
+        parts.append(Self.timeFormatter.string(from: message.createdAt))
+        return parts.joined(separator: " · ")
+    }
+
+    private static let timeFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .none
+        formatter.timeStyle = .short
+        return formatter
+    }()
+
+    /// Retry is offered on the latest assistant turn (it re-runs the thread's last user turn);
+    /// the row disables it while a reply is in flight.
     private func retryAction(for message: StudioMessage) -> (() -> Void)? {
-        guard !isRunning, message.role == .assistant, message.id == messages.last?.id else { return nil }
+        guard message.role == .assistant,
+              message.id == messages.last(where: { $0.role == .assistant })?.id else { return nil }
         return onRetry
     }
 
@@ -130,6 +335,13 @@ struct StudioConversationView: View {
     private func editAction(for message: StudioMessage) -> (() -> Void)? {
         guard !isRunning, message.role == .user else { return nil }
         return { onEdit(message.id) }
+    }
+
+    /// Branch is always in the row (disabled while a reply streams) so a turn's actions never
+    /// shift as the thread runs.
+    private func branchAction(for message: StudioMessage) -> (() -> Void)? {
+        guard let onBranch else { return nil }
+        return { onBranch(message.id) }
     }
 
     private func scrollToEnd(_ proxy: ScrollViewProxy) {
@@ -144,31 +356,34 @@ struct StudioConversationView: View {
 }
 
 /// One conversation turn. User turns read as authored notes (warm bubble, right side);
-/// assistant turns read as the document itself (unboxed Markdown behind a small mode glyph).
+/// assistant turns read as the document itself (unboxed Markdown behind the chat glyph) with a
+/// row of actions and the turn's provenance underneath.
 private struct StudioTurnView: View {
     let role: StudioMessageRole
     let content: String
-    var failed: Bool = false
-    var isStreaming: Bool = false
-    var monospaced: Bool = false
-    var modeIcon: String = "bubble.left.and.bubble.right"
+    var failed = false
+    var isStreaming = false
+    /// "Model · speed · time" under an assistant turn.
+    var meta: String?
     var onCopy: (() -> Void)?
     var onRetry: (() -> Void)?
     var onEdit: (() -> Void)?
+    var onBranch: (() -> Void)?
+    /// False while a reply streams: Retry and Branch stay in the row but cannot fire.
+    var actionsEnabled = true
 
     @State private var hovering = false
 
     private var isUser: Bool { role == .user }
-    private var hasActions: Bool { onCopy != nil || onRetry != nil || onEdit != nil }
 
     var body: some View {
         HStack(alignment: .top, spacing: 0) {
             if isUser {
-                Spacer(minLength: 80)
+                Spacer(minLength: 0)
                 userBubble
             } else {
                 assistantBlock
-                Spacer(minLength: 80)
+                Spacer(minLength: 0)
             }
         }
         .onHover { hovering = $0 }
@@ -179,107 +394,66 @@ private struct StudioTurnView: View {
         .accessibilityAddTraits(isStreaming ? .updatesFrequently : [])
     }
 
+    // MARK: User
+
     private var userBubble: some View {
-        VStack(alignment: .trailing, spacing: 4) {
-            Text(content)
-                .font(MereRunTheme.bodyFont)
-                .foregroundStyle(MereRunTheme.textPrimary)
-                .textSelection(.enabled)
-                .padding(.horizontal, MereRunTheme.Spacing.md)
-                .padding(.vertical, MereRunTheme.Spacing.sm)
-                .background {
-                    UnevenRoundedRectangle(
-                        topLeadingRadius: 16,
-                        bottomLeadingRadius: 16,
-                        bottomTrailingRadius: 5,
-                        topTrailingRadius: 16
-                    )
-                    .fill(MereRunTheme.accentSoft)
-                    .overlay {
-                        UnevenRoundedRectangle(
-                            topLeadingRadius: 16,
-                            bottomLeadingRadius: 16,
-                            bottomTrailingRadius: 5,
-                            topTrailingRadius: 16
-                        )
-                        .strokeBorder(
-                            failed ? MereRunTheme.red.opacity(0.6) : MereRunTheme.accent.opacity(0.14),
-                            lineWidth: 1
-                        )
-                    }
-                }
-                .frame(maxWidth: 520, alignment: .trailing)
-
-            actionRow
-        }
-    }
-
-    private var assistantBlock: some View {
-        HStack(alignment: .top, spacing: MereRunTheme.Spacing.sm) {
-            Image(systemName: modeIcon)
-                .font(.system(size: 11, weight: .semibold))
-                .foregroundStyle(MereRunTheme.accent)
-                .frame(width: 26, height: 26)
-                .background {
-                    Circle().fill(MereRunTheme.accentSoft.opacity(0.7))
-                }
-                .padding(.top, 1)
-                .accessibilityHidden(true)
-
-            VStack(alignment: .leading, spacing: 6) {
-                assistantBody
-
+        Text(content)
+            .font(.system(size: 14))
+            .lineSpacing(3)
+            .foregroundStyle(MereRunTheme.textPrimary)
+            .textSelection(.enabled)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 10)
+            .background {
+                bubbleShape.fill(MereRunTheme.accentSoft)
+            }
+            .overlay {
                 if failed {
-                    Label("This turn failed", systemImage: "exclamationmark.triangle")
-                        .font(MereRunTheme.captionFont)
-                        .foregroundStyle(MereRunTheme.red)
-                }
-
-                actionRow
-            }
-            .frame(maxWidth: 660, alignment: .leading)
-        }
-    }
-
-    @ViewBuilder
-    private var assistantBody: some View {
-        if isStreaming && content.isEmpty {
-            StudioThinkingIndicator()
-        } else {
-            VStack(alignment: .leading, spacing: 6) {
-                StudioMarkdownText(
-                    content: content,
-                    bodyFont: monospaced ? MereRunTheme.monoFont : MereRunTheme.bodyFont
-                )
-                if isStreaming {
-                    StudioStreamingCaret()
+                    bubbleShape.strokeBorder(MereRunTheme.red.opacity(0.6), lineWidth: 1)
                 }
             }
-        }
+            .frame(maxWidth: 520, alignment: .trailing)
+            // The hover actions sit in the 20pt gap under the bubble rather than reserving
+            // their own row, so the turn rhythm stays exactly as designed.
+            .overlay(alignment: .bottomTrailing) {
+                userActions.offset(y: 20)
+            }
     }
 
-    /// Copy / edit / retry surface on hover; the row keeps its height so nothing jumps.
+    private var bubbleShape: UnevenRoundedRectangle {
+        UnevenRoundedRectangle(
+            topLeadingRadius: 14,
+            bottomLeadingRadius: 14,
+            bottomTrailingRadius: 4,
+            topTrailingRadius: 14
+        )
+    }
+
+    /// Edit and Branch surface on hover; the row keeps its height so nothing jumps.
     @ViewBuilder
-    private var actionRow: some View {
-        if !isStreaming && hasActions {
+    private var userActions: some View {
+        if onEdit != nil || onBranch != nil {
             HStack(spacing: 2) {
-                if let onCopy {
-                    turnAction("Copy", systemImage: "doc.on.doc", help: "Copy message", action: onCopy)
-                }
                 if let onEdit {
-                    turnAction("Edit", systemImage: "pencil", help: "Edit and re-run from this turn", action: onEdit)
+                    labeledAction("Edit", systemImage: "pencil", help: "Edit and re-run from this turn", action: onEdit)
                 }
-                if let onRetry {
-                    turnAction("Retry", systemImage: "arrow.clockwise", help: "Regenerate this reply", action: onRetry)
+                if let onBranch {
+                    labeledAction(
+                        "Branch",
+                        systemImage: "arrow.triangle.branch",
+                        help: "Start a new thread from this turn",
+                        action: onBranch
+                    )
+                    .disabled(!actionsEnabled)
                 }
             }
             .opacity(hovering ? 1 : 0)
             .allowsHitTesting(hovering)
-            .frame(height: 22)
+            .frame(height: 18)
         }
     }
 
-    private func turnAction(
+    private func labeledAction(
         _ title: String,
         systemImage: String,
         help: String,
@@ -289,39 +463,101 @@ private struct StudioTurnView: View {
             Label(title, systemImage: systemImage)
                 .font(MereRunTheme.captionFont)
                 .padding(.horizontal, 6)
-                .padding(.vertical, 3)
+                .padding(.vertical, 2)
         }
         .buttonStyle(.mereIcon(tint: MereRunTheme.textMuted))
         .help(help)
+    }
+
+    // MARK: Assistant
+
+    private var assistantBlock: some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: "bubble.left")
+                .font(.system(size: 14, weight: .regular))
+                .foregroundStyle(MereRunTheme.accent)
+                .frame(width: 16, height: 16)
+                .padding(.top, 3)
+                .accessibilityHidden(true)
+
+            VStack(alignment: .leading, spacing: 10) {
+                assistantBody
+
+                if failed {
+                    Label("This turn failed", systemImage: "exclamationmark.triangle")
+                        .font(MereRunTheme.captionFont)
+                        .foregroundStyle(MereRunTheme.red)
+                }
+
+                if !isStreaming { assistantActions }
+            }
+        }
+        .frame(maxWidth: 640, alignment: .leading)
+    }
+
+    @ViewBuilder
+    private var assistantBody: some View {
+        if isStreaming && content.isEmpty {
+            StudioThinkingIndicator()
+        } else {
+            StudioMarkdownText(
+                content: content,
+                bodyFont: .system(size: 14),
+                lineSpacing: 4.5,
+                streamingCaret: isStreaming
+            )
+        }
+    }
+
+    /// Copy, Retry, Branch as 28pt icon buttons, then the turn's provenance.
+    private var assistantActions: some View {
+        HStack(spacing: 2) {
+            if let onCopy {
+                iconAction("Copy message", systemImage: "doc.on.doc", action: onCopy)
+            }
+            if let onRetry {
+                iconAction("Regenerate this reply", systemImage: "arrow.clockwise", action: onRetry)
+                    .disabled(!actionsEnabled)
+            }
+            if let onBranch {
+                iconAction("Branch a new thread from here", systemImage: "arrow.triangle.branch", action: onBranch)
+                    .disabled(!actionsEnabled)
+            }
+            if let meta {
+                Text(meta)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(MereRunTheme.textMuted)
+                    .lineLimit(1)
+                    .padding(.leading, 6)
+            }
+        }
+    }
+
+    private func iconAction(_ label: String, systemImage: String, action: @escaping () -> Void) -> some View {
+        Button(action: action) {
+            Image(systemName: systemImage)
+                .font(.system(size: 13, weight: .medium))
+                .frame(width: 28, height: 28)
+        }
+        .buttonStyle(.mereIcon)
+        .help(label)
+        .accessibilityLabel(label)
     }
 
     @ViewBuilder
     private var contextMenuItems: some View {
         if let onCopy { Button("Copy") { onCopy() } }
         if let onEdit { Button("Edit…") { onEdit() } }
-        if let onRetry { Button("Retry") { onRetry() } }
+        if let onRetry, actionsEnabled { Button("Retry") { onRetry() } }
+        if let onBranch, actionsEnabled { Button("Branch from here") { onBranch() } }
     }
 
     private var accessibilityText: String {
         let speaker = isUser ? "You" : "Assistant"
         if isStreaming && content.isEmpty { return "\(speaker) is generating a reply" }
         let suffix = failed ? " (this turn failed)" : ""
-        return "\(speaker): \(content)\(suffix)"
-    }
-}
-
-/// The live-reply cursor: a small bronze bar breathing at the end of the streamed text.
-private struct StudioStreamingCaret: View {
-    var body: some View {
-        RoundedRectangle(cornerRadius: 1.5)
-            .fill(MereRunTheme.accent)
-            .frame(width: 8, height: 15)
-            .phaseAnimator([0.25, 1.0]) { view, phase in
-                view.opacity(phase)
-            } animation: { _ in
-                .easeInOut(duration: 0.55)
-            }
-            .accessibilityHidden(true)
+        let provenance = meta.map { ", \($0)" } ?? ""
+        return "\(speaker): \(content)\(suffix)\(provenance)"
     }
 }
 
@@ -347,14 +583,5 @@ private struct StudioThinkingIndicator: View {
         }
         .padding(.vertical, 4)
         .accessibilityLabel("Generating a reply")
-    }
-}
-
-private struct StudioConversationEmptyState: View {
-    let mode: StudioMode
-    var onUseExample: ((String) -> Void)?
-
-    var body: some View {
-        StudioEmptyState(mode: mode, onUseExample: onUseExample, onAttach: nil)
     }
 }

--- a/apps/macos/MereRunStudio/StudioLibraryStore.swift
+++ b/apps/macos/MereRunStudio/StudioLibraryStore.swift
@@ -128,8 +128,9 @@ final class StudioLibraryStore: ObservableObject {
     }
 
     /// Appends a user turn to a chat/code conversation, creating the thread item lazily on the
-    /// first message (so a "New chat" that is never sent leaves no empty row). System prompt and
-    /// model are captured on the item so later turns and retries replay with the same settings.
+    /// first message (so a "New chat" that is never sent leaves no empty row). The thread-level
+    /// preset, model, and system prompt follow the latest turn, so retries replay the settings
+    /// the user last chose; which turn ran with what is recorded on the assistant turns.
     @discardableResult
     func appendUser(
         conversationID: UUID,
@@ -142,6 +143,10 @@ final class StudioLibraryStore: ObservableObject {
         if let index = items.firstIndex(where: { $0.id == conversationID }) {
             var item = items[index]
             item.messages = (item.messages ?? []) + [StudioMessage(role: .user, content: content, imagePath: imagePath)]
+            item.mode = mode
+            item.model = model
+            item.systemPrompt = systemPrompt
+            item.commandPreview = mode == .code ? "mere.run text code" : "mere.run text chat"
             item.status = .running
             item.updatedAt = Date()
             items[index] = item
@@ -170,13 +175,28 @@ final class StudioLibraryStore: ObservableObject {
         return item
     }
 
-    /// Appends the assistant reply for the latest turn. A non-zero exit marks the message failed
-    /// but keeps the thread so the user can retry.
-    func appendAssistant(conversationID: UUID, content: String, exitCode: Int32) {
+    /// Appends the assistant reply for the latest turn, recording the model and system prompt
+    /// that produced it (and the decode speed when the run reported one). A non-zero exit marks
+    /// the message failed but keeps the thread so the user can retry.
+    func appendAssistant(
+        conversationID: UUID,
+        content: String,
+        exitCode: Int32,
+        model: String? = nil,
+        systemPrompt: String? = nil,
+        tokensPerSecond: Double? = nil
+    ) {
         guard let index = items.firstIndex(where: { $0.id == conversationID }) else { return }
         var item = items[index]
         var messages = item.messages ?? []
-        messages.append(StudioMessage(role: .assistant, content: content, failed: exitCode != 0))
+        messages.append(StudioMessage(
+            role: .assistant,
+            content: content,
+            failed: exitCode != 0,
+            model: model,
+            systemPrompt: systemPrompt,
+            tokensPerSecond: tokensPerSecond
+        ))
         item.messages = messages
         item.status = exitCode == 0 ? .completed : .failed
         item.exitCode = exitCode
@@ -200,6 +220,51 @@ final class StudioLibraryStore: ObservableObject {
         items[index] = item
         save()
         return removed.role == .user ? removed : nil
+    }
+
+    /// Starts a new thread from a point in an existing one: the messages before `messageID`,
+    /// plus that message itself when `inclusive`. Branching from a user turn (exclusive) leaves
+    /// the original untouched and gives the edited turn a fresh thread; branching from an
+    /// assistant turn (inclusive) forks the conversation after that reply. The branch inherits
+    /// the source's preset, model, and system prompt and gets its own message identities.
+    @discardableResult
+    func branch(conversationID: UUID, at messageID: UUID, inclusive: Bool) -> StudioLibraryItem? {
+        guard let source = items.first(where: { $0.id == conversationID }),
+              let messages = source.messages,
+              let messageIndex = messages.firstIndex(where: { $0.id == messageID }) else { return nil }
+        let end = inclusive ? messageIndex + 1 : messageIndex
+        let kept = messages[..<end].map { message in
+            StudioMessage(
+                role: message.role,
+                content: message.content,
+                createdAt: message.createdAt,
+                failed: message.failed,
+                imagePath: message.imagePath,
+                model: message.model,
+                systemPrompt: message.systemPrompt,
+                tokensPerSecond: message.tokensPerSecond
+            )
+        }
+        let now = Date()
+        let branch = StudioLibraryItem(
+            id: UUID(),
+            mode: source.mode,
+            prompt: "",
+            inputURL: nil,
+            outputURL: nil,
+            createdAt: now,
+            updatedAt: now,
+            status: kept.last?.failed == true ? .failed : .completed,
+            exitCode: kept.last?.failed == true ? 1 : 0,
+            commandPreview: source.commandPreview,
+            outputText: nil,
+            messages: kept,
+            systemPrompt: source.systemPrompt,
+            model: source.model
+        )
+        items.insert(branch, at: 0)
+        save()
+        return branch
     }
 
     /// Drops the last assistant message of a thread (used by retry before re-running the turn).

--- a/apps/macos/MereRunStudio/StudioMarkdown.swift
+++ b/apps/macos/MereRunStudio/StudioMarkdown.swift
@@ -166,25 +166,59 @@ enum StudioMarkdownParser {
 struct StudioMarkdownText: View {
     let content: String
     var bodyFont: Font = MereRunTheme.bodyFont
+    /// Extra leading between prose lines (the chat transcript reads at 1.55).
+    var lineSpacing: CGFloat = 0
+    /// Draws the live-reply caret at the end of the last block while a reply streams in, so the
+    /// cursor sits where the next character will land instead of on a line of its own.
+    var streamingCaret = false
+
+    /// The caret glyph: a thin accent bar at text height (a left one-eighth block, about 2pt
+    /// wide at body size), appended inline to the last run.
+    static let caret = Text("\u{258F}").foregroundColor(MereRunTheme.accent)
 
     var body: some View {
         let blocks = StudioMarkdownParser.parse(content)
         VStack(alignment: .leading, spacing: MereRunTheme.Spacing.sm) {
-            ForEach(Array(blocks.enumerated()), id: \.offset) { _, block in
-                blockView(block)
+            ForEach(Array(blocks.enumerated()), id: \.offset) { index, block in
+                blockView(block, caret: streamingCaret && index == blocks.count - 1)
+            }
+            if streamingCaret && blocks.isEmpty {
+                Self.caret.font(bodyFont)
             }
         }
     }
 
     @ViewBuilder
-    private func blockView(_ block: StudioMarkdownBlock) -> some View {
+    private func blockView(_ block: StudioMarkdownBlock, caret: Bool) -> some View {
         switch block {
         case .paragraph(let text):
-            Text(StudioMarkdownParser.inline(text))
-                .font(bodyFont)
-                .foregroundStyle(MereRunTheme.textPrimary)
-                .textSelection(.enabled)
-                .fixedSize(horizontal: false, vertical: true)
+            paragraph(Text(StudioMarkdownParser.inline(text)), caret: caret)
+        case .code(let language, let content):
+            StudioCodeBlock(language: language, content: content, trailingCaret: caret)
+        default:
+            if caret {
+                plainBlock(block)
+                Self.caret.font(bodyFont)
+            } else {
+                plainBlock(block)
+            }
+        }
+    }
+
+    private func paragraph(_ text: Text, caret: Bool) -> some View {
+        (caret ? text + Self.caret : text)
+            .font(bodyFont)
+            .lineSpacing(lineSpacing)
+            .foregroundStyle(MereRunTheme.textPrimary)
+            .textSelection(.enabled)
+            .fixedSize(horizontal: false, vertical: true)
+    }
+
+    @ViewBuilder
+    private func plainBlock(_ block: StudioMarkdownBlock) -> some View {
+        switch block {
+        case .paragraph(let text):
+            paragraph(Text(StudioMarkdownParser.inline(text)), caret: false)
         case .heading(let level, let text):
             Text(StudioMarkdownParser.inline(text))
                 .font(headingFont(level))
@@ -223,6 +257,7 @@ struct StudioMarkdownText: View {
                         .foregroundStyle(MereRunTheme.accent)
                     Text(StudioMarkdownParser.inline(item))
                         .font(bodyFont)
+                        .lineSpacing(lineSpacing)
                         .foregroundStyle(MereRunTheme.textPrimary)
                         .textSelection(.enabled)
                         .fixedSize(horizontal: false, vertical: true)
@@ -241,12 +276,15 @@ struct StudioMarkdownText: View {
     }
 }
 
-/// A fenced code panel: language chip, hover-revealed copy, wrapped monospaced text.
+/// A fenced code panel on `surfaceRaised`: a header row with the language eyebrow and Copy
+/// over a hairline, then wrapped 12pt monospaced text. Only the code is monospaced — prose
+/// around it stays proportional in every preset.
 private struct StudioCodeBlock: View {
     let language: String?
     let content: String
+    /// Appends the live-reply caret to the code while it is still streaming in.
+    var trailingCaret = false
 
-    @State private var hovering = false
     @State private var copied = false
 
     var body: some View {
@@ -254,44 +292,55 @@ private struct StudioCodeBlock: View {
             HStack(spacing: 8) {
                 Text(language ?? "code")
                     .font(.system(size: 10.5, weight: .semibold))
-                    .foregroundStyle(MereRunTheme.textMuted)
+                    .kerning(0.5)
                     .textCase(.uppercase)
+                    .foregroundStyle(MereRunTheme.textMuted)
                 Spacer(minLength: 0)
                 Button {
                     copy()
                 } label: {
-                    Label(copied ? "Copied" : "Copy", systemImage: copied ? "checkmark" : "doc.on.doc")
-                        .font(.system(size: 10.5, weight: .medium))
-                        .padding(.horizontal, 6)
-                        .padding(.vertical, 3)
+                    HStack(spacing: 4) {
+                        Image(systemName: copied ? "checkmark" : "doc.on.doc")
+                            .font(.system(size: 11, weight: .medium))
+                        Text(copied ? "Copied" : "Copy")
+                            .font(.system(size: 11, weight: .medium))
+                    }
+                    .padding(.horizontal, 4)
+                    .padding(.vertical, 2)
                 }
-                .buttonStyle(.mereIcon)
-                .opacity(hovering || copied ? 1 : 0)
+                .buttonStyle(.mereIcon(tint: MereRunTheme.textMuted))
                 .accessibilityLabel("Copy code")
             }
-            .padding(.horizontal, MereRunTheme.Spacing.sm)
-            .padding(.top, MereRunTheme.Spacing.xs)
-            .padding(.bottom, 4)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 6)
+            .overlay(alignment: .bottom) {
+                Rectangle()
+                    .fill(MereRunTheme.border.opacity(0.4))
+                    .frame(height: 1)
+            }
 
-            Text(content)
-                .font(.system(size: 12.5, design: .monospaced))
+            codeText
+                .font(.system(size: 12, design: .monospaced))
+                .lineSpacing(4)
                 .foregroundStyle(MereRunTheme.textPrimary)
                 .textSelection(.enabled)
                 .fixedSize(horizontal: false, vertical: true)
                 .frame(maxWidth: .infinity, alignment: .leading)
-                .padding(.horizontal, MereRunTheme.Spacing.sm)
-                .padding(.bottom, MereRunTheme.Spacing.sm)
+                .padding(.horizontal, 12)
+                .padding(.vertical, 10)
         }
         .background {
-            RoundedRectangle(cornerRadius: MereRunTheme.Radius.lg)
-                .fill(MereRunTheme.surface)
+            RoundedRectangle(cornerRadius: MereRunTheme.Radius.base)
+                .fill(MereRunTheme.surfaceRaised)
                 .overlay {
-                    RoundedRectangle(cornerRadius: MereRunTheme.Radius.lg)
-                        .strokeBorder(MereRunTheme.border.opacity(0.6), lineWidth: 1)
+                    RoundedRectangle(cornerRadius: MereRunTheme.Radius.base)
+                        .strokeBorder(MereRunTheme.border.opacity(0.4), lineWidth: 1)
                 }
         }
-        .onHover { hovering = $0 }
-        .animation(MereRunTheme.Motion.quick, value: hovering)
+    }
+
+    private var codeText: Text {
+        trailingCaret ? Text(content) + StudioMarkdownText.caret : Text(content)
     }
 
     private func copy() {

--- a/apps/macos/MereRunStudio/StudioModelPicker.swift
+++ b/apps/macos/MereRunStudio/StudioModelPicker.swift
@@ -1,0 +1,130 @@
+import SwiftUI
+
+/// The one model control: a chip that opens the `model list` rows filtered to a mode's
+/// categories, installed first, with "Auto" for the mode's default. The composer's chip strip
+/// and the Converse thread header share it, so a model is picked the same way everywhere.
+struct StudioModelPicker: View {
+    let mode: StudioMode
+    @Binding var model: String
+    /// Every row of `model list`, installed or not; the menu filters it to the mode.
+    let inventory: [StudioModelInventoryRow]
+    let readiness: ModelReadinessState
+    let onShowModels: () -> Void
+
+    var body: some View {
+        Menu {
+            Toggle(isOn: Binding(get: { model.isBlank }, set: { _ in model = "" })) {
+                Text(defaultModelID.isEmpty ? "Auto" : "Auto · \(Self.displayModelName(defaultModelID))")
+            }
+            let choices = mode.modelChoices(from: inventory)
+            let installed = choices.filter(\.isInstalled)
+            let downloadable = choices.filter { !$0.isInstalled }
+            if !installed.isEmpty {
+                Section("Installed") {
+                    ForEach(installed) { row in modelRow(row) }
+                }
+            }
+            if !downloadable.isEmpty {
+                Section("Needs download") {
+                    ForEach(downloadable) { row in modelRow(row) }
+                }
+            }
+            if choices.isEmpty {
+                Text("No \(mode.title.lowercased()) models listed yet")
+            }
+            Divider()
+            Button("Browse Models…", action: onShowModels)
+        } label: {
+            StudioComposerChipLabel(title: label, leadingSystemImage: statusGlyph)
+        }
+        .menuStyle(.button)
+        .buttonStyle(.plain)
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .help(help)
+        .accessibilityLabel("Model")
+        .accessibilityValue(accessibilityValue)
+    }
+
+    private func modelRow(_ row: StudioModelInventoryRow) -> some View {
+        Toggle(isOn: Binding(get: { row.id == model }, set: { _ in model = row.id })) {
+            Label(Self.displayModelName(row.id), systemImage: row.isInstalled ? "internaldrive" : "arrow.down.circle")
+        }
+    }
+
+    /// The mode's template default, shown as "Auto".
+    private var defaultModelID: String {
+        CommandCatalog.template(id: mode.defaultTemplateID)?.defaultModel ?? ""
+    }
+
+    /// The resolved model id for this run: the explicit model, else the mode's default.
+    private var resolvedModelID: String {
+        Self.resolvedModelID(model, mode: mode)
+    }
+
+    private var label: String {
+        resolvedModelID.isEmpty ? "Auto" : Self.displayModelName(resolvedModelID)
+    }
+
+    /// A glyph before the model name when the model is not ready: missing locally, or unsupported.
+    private var statusGlyph: String? {
+        switch readiness {
+        case .missingModel: return "arrow.down.circle"
+        case .unsupported: return "exclamationmark.triangle"
+        case .checking, .ready, .unknown: return nil
+        }
+    }
+
+    private var help: String {
+        let identity = resolvedModelID.isEmpty ? "Auto — the mode's default model" : "Model: \(resolvedModelID)"
+        switch readiness {
+        case .ready, .unknown: return identity
+        default: return "\(identity) · \(readiness.message)"
+        }
+    }
+
+    private var accessibilityValue: String {
+        let identity = resolvedModelID.isEmpty ? "Automatic" : resolvedModelID
+        return "\(identity), \(readiness.title)"
+    }
+
+    /// The model id a draft actually runs with: its explicit model, else the mode's template
+    /// default. Empty only when the mode has no default at all.
+    static func resolvedModelID(_ model: String, mode: StudioMode) -> String {
+        let current = model.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !current.isEmpty { return current }
+        return CommandCatalog.template(id: mode.defaultTemplateID)?.defaultModel ?? ""
+    }
+
+    /// A human-facing label for a model id: drop the modality/category prefix and
+    /// title-case the distinctive remainder ("text-agent-deepseek-v4-flash" →
+    /// "Deepseek V4 Flash", "text-chat-qwen3.6-4b" → "Qwen3.6 4B"). The exact id stays in
+    /// the chip's tooltip, so the friendly name never hides what the CLI actually expects.
+    static func displayModelName(_ id: String) -> String {
+        let leaf = id.components(separatedBy: "/").last ?? id
+        let prefixes = [
+            "text-chat-", "text-agent-", "text-embed-", "text-code-",
+            "image-", "video-", "music-", "sfx-", "speech-tts-", "speech-asr-", "speech-",
+            "embed-", "vision-ground-", "vision-segment-", "vision-chat-", "vision-ocr-", "vision-", "text-"
+        ]
+        var core = leaf
+        for prefix in prefixes where core.hasPrefix(prefix) {
+            core = String(core.dropFirst(prefix.count))
+            break
+        }
+        let words = core.split(separator: "-").map { token -> String in
+            if isParameterCount(token) { return token.uppercased() }
+            guard let first = token.first, first.isLetter else { return String(token) }
+            return first.uppercased() + token.dropFirst()
+        }
+        let label = words.joined(separator: " ")
+        return label.isEmpty ? leaf : label
+    }
+
+    /// "4b", "27b", "1.5b": a parameter count, which reads as "4B" the way model cards print it.
+    private static func isParameterCount(_ token: Substring) -> Bool {
+        guard token.count >= 2, token.last == "b" else { return false }
+        let digits = token.dropLast()
+        return !digits.isEmpty && digits.allSatisfy { $0.isNumber || $0 == "." } && digits.contains { $0.isNumber }
+    }
+}

--- a/apps/macos/MereRunStudio/StudioModelsView.swift
+++ b/apps/macos/MereRunStudio/StudioModelsView.swift
@@ -25,6 +25,9 @@ struct StudioModelInventoryRow: Identifiable, Equatable {
     let reclaimableBytes: Int64?
     let sharedBytes: Int64?
     let externalBytes: Int64?
+    /// The model's context window in tokens, when the inventory reports one. Conversation
+    /// threads size their transcript budget from it; nil keeps the fixed default budget.
+    let contextWindow: Int?
 
     init(
         id: String,
@@ -44,7 +47,8 @@ struct StudioModelInventoryRow: Identifiable, Equatable {
         referencedBytes: Int64? = nil,
         reclaimableBytes: Int64? = nil,
         sharedBytes: Int64? = nil,
-        externalBytes: Int64? = nil
+        externalBytes: Int64? = nil,
+        contextWindow: Int? = nil
     ) {
         self.id = id
         self.category = category
@@ -64,6 +68,7 @@ struct StudioModelInventoryRow: Identifiable, Equatable {
         self.reclaimableBytes = reclaimableBytes
         self.sharedBytes = sharedBytes
         self.externalBytes = externalBytes
+        self.contextWindow = contextWindow
     }
 
     var isInstalled: Bool {

--- a/apps/macos/MereRunStudio/StudioRootView.swift
+++ b/apps/macos/MereRunStudio/StudioRootView.swift
@@ -205,9 +205,17 @@ struct StudioRootView: View {
     private var detailArea: some View {
         HStack(spacing: 0) {
             if showsLibraryColumn {
-                libraryColumn
-                    .frame(width: StudioLayoutPolicy.libraryWidth)
-                    .transition(reduceMotion ? .identity : .move(edge: .leading).combined(with: .opacity))
+                Group {
+                    // Converse keeps its threads in their own column; they never file into
+                    // the media Library.
+                    if destination.domain == .chat {
+                        threadListColumn
+                    } else {
+                        libraryColumn
+                    }
+                }
+                .frame(width: StudioLayoutPolicy.libraryWidth)
+                .transition(reduceMotion ? .identity : .move(edge: .leading).combined(with: .opacity))
 
                 Divider()
                     .overlay(MereRunTheme.border.opacity(0.53))
@@ -255,7 +263,7 @@ struct StudioRootView: View {
 
     private var libraryColumn: some View {
         StudioLibraryPanel(
-            items: library.items,
+            items: StudioThreadListPresenter.mediaItems(in: library.items),
             domain: destination.domain,
             scope: $libraryScope,
             progressByID: controller.progressByRequestID,
@@ -266,6 +274,18 @@ struct StudioRootView: View {
             onQuickLook: { QuickLookCoordinator.shared.preview($0) },
             onRetry: retryLibraryItem,
             onEdit: editLibraryItem,
+            leadingInset: windowChromeInset
+        )
+    }
+
+    private var threadListColumn: some View {
+        StudioThreadList(
+            items: library.items,
+            selectedID: activeConversationID,
+            onSelect: openThread,
+            onNewThread: startNewConversation,
+            onDelete: deleteLibraryItem,
+            onRename: library.rename,
             leadingInset: windowChromeInset
         )
     }
@@ -514,7 +534,11 @@ struct StudioRootView: View {
 
     private var promptWorkspace: some View {
         VStack(spacing: 0) {
-            canvas
+            if mode.isConversational {
+                converseSurface
+            } else {
+                canvas
+            }
 
             composer
         }
@@ -590,20 +614,58 @@ struct StudioRootView: View {
         )
     }
 
+    /// The Converse archetype: thread header, transcript, and readiness in place of the canvas.
+    private var converseSurface: some View {
+        StudioConverseView(
+            mode: mode,
+            item: activeConversationItem,
+            liveText: activeConversationLiveText,
+            isRunning: activeConversationRunning,
+            readiness: readiness,
+            error: studioError,
+            budgetChars: conversationBudgetChars,
+            modelInventory: modelInventory,
+            model: $draft.model,
+            systemPrompt: $draft.secondaryText,
+            onPullModel: pullModel,
+            onShowDetails: { openConsole() },
+            onShowModels: { navigation.open(task: .modelsInstalled) },
+            onCopy: copyToClipboard,
+            onRetry: retryLastTurn,
+            onEdit: editMessage,
+            onBranch: branchFromMessage,
+            onUseExample: useExamplePrompt
+        )
+    }
+
+    /// The history budget for the next turn: sized from the model's context window when the
+    /// inventory (or an explicit context size) reports one, else the fixed default.
+    private var conversationBudgetChars: Int {
+        ConversationTranscript.budgetChars(
+            contextTokens: ConversationTranscript.contextTokens(
+                requestedContextSize: draft.contextSize,
+                model: StudioModelPicker.resolvedModelID(draft.model, mode: mode),
+                inventory: modelInventory
+            ),
+            maxOutputTokens: draft.maxTokens
+        )
+    }
+
     private var composer: some View {
         StudioComposer(
             mode: mode,
             draft: $draft,
             showOptions: $showOptions,
-            isRunning: controller.isRunning,
+            // A streaming thread turns Send into Stop for that thread; other domains follow
+            // the foreground run.
+            isRunning: mode.isConversational ? activeConversationRunning : controller.isRunning,
             queuedCount: controller.queuedRunCount,
             readiness: readiness,
-            sendBlocked: mode.isConversational && activeConversationRunning,
             modelInventory: modelInventory,
             lastSeed: lastSeed,
             promptFocus: $promptFocused,
             onRun: runStudioCommand,
-            onStop: controller.cancel,
+            onStop: stopCurrentRun,
             onShowModels: { navigation.open(task: .modelsInstalled) },
             onShowAdapters: {
                 showOptions = false
@@ -677,8 +739,8 @@ struct StudioRootView: View {
             runComposer: runStudioCommand,
             canRun: showsPromptWorkspace && !readiness.blocksRun
                 && !(mode.isConversational && activeConversationRunning),
-            stop: controller.cancel,
-            canStop: controller.isRunning,
+            stop: stopCurrentRun,
+            canStop: controller.isRunning || (mode.isConversational && activeConversationRunning),
             openConsole: { openConsole() },
             showGuide: { navigation.showGuide = true },
             importReceipt: importReceipt
@@ -735,12 +797,17 @@ struct StudioRootView: View {
             refreshReadiness()
         }
         .onChange(of: navigation.selectedLibraryID) { _, id in
-            // Selecting a thread of the current conversation mode opens it in the canvas.
+            // A thread selected while Converse is shown (a deep link, or the list) opens in the
+            // transcript; a thread of the other preset switches the task control to match.
             guard mode.isConversational,
                   let id,
                   let item = library.items.first(where: { $0.id == id }),
-                  item.isConversation, item.mode == mode,
+                  item.isConversation,
                   id != activeConversationID else { return }
+            guard item.mode == mode else {
+                navigation.open(task: item.mode.task)
+                return
+            }
             activeConversationID = id
             applyConversationSettings(from: item, to: &draft)
             draft.prompt = ""
@@ -789,10 +856,19 @@ struct StudioRootView: View {
             // Conversation turns append the assistant reply to the thread instead of taking the
             // single-shot completion path.
             if let conversationID = result.conversationID {
+                // The turn records what it actually ran with (the job's own command snapshot),
+                // so a thread whose model or system prompt changed mid-way says which turn used what.
+                let job = result.requestID.flatMap { controller.jobs.job(requestID: $0) }
+                let turnDraft = job?.request.draft
                 library.appendAssistant(
                     conversationID: conversationID,
                     content: conversationReplyContent(for: result),
-                    exitCode: result.exitCode
+                    exitCode: result.exitCode,
+                    model: turnDraft.map(\.model).flatMap { $0.isBlank ? nil : $0 },
+                    systemPrompt: turnDraft.map(\.secondaryText).flatMap { $0.isBlank ? nil : $0 },
+                    tokensPerSecond: job.flatMap {
+                        ConversationTranscript.decodeTokensPerSecond(in: $0.log.lines.map(\.text))
+                    }
                 )
                 // Only follow selection if this is the thread the user is currently viewing — a
                 // background turn completing must not yank selection away from the foreground.
@@ -859,14 +935,29 @@ struct StudioRootView: View {
             library.items.first { $0.id == id && $0.mode == newMode }
         }
         if newMode.isConversational {
-            // Open the picked or most recent thread for this mode (or a fresh one) and reuse its
-            // system/model so follow-ups match; the composer starts empty.
-            let thread = preferred?.isConversation == true
-                ? preferred
-                : library.items.first { $0.mode == newMode && $0.isConversation }
-            activeConversationID = thread?.id
-            navigation.selectedLibraryID = thread?.id
-            if let thread { applyConversationSettings(from: thread, to: &nextDraft) }
+            if let preferred, preferred.isConversation {
+                // A thread the user picked: open it and reuse its system/model so follow-ups match.
+                activeConversationID = preferred.id
+                applyConversationSettings(from: preferred, to: &nextDraft)
+            } else if let current = activeConversationItem {
+                // Chat ↔ Code is a preset change, not a thread change: keep the thread open and
+                // apply the preset's defaults (its command, model, and system prompt) to the
+                // next turn.
+                navigation.selectedLibraryID = current.id
+            } else if let recent = StudioThreadListPresenter.threads(in: library.items).first {
+                // Arriving fresh: open the most recent thread of either preset. One of the other
+                // preset re-enters here through the task control with it selected.
+                activeConversationID = recent.id
+                navigation.selectedLibraryID = recent.id
+                if recent.mode != newMode {
+                    navigation.open(task: recent.mode.task)
+                    return
+                }
+                applyConversationSettings(from: recent, to: &nextDraft)
+            } else {
+                activeConversationID = nil
+                navigation.selectedLibraryID = nil
+            }
             nextDraft.prompt = ""
         } else {
             activeConversationID = nil
@@ -885,9 +976,26 @@ struct StudioRootView: View {
         navigation.open(destination: item.mode.destination)
     }
 
+    /// A thread picked in the Converse list. Threads of the other preset switch the task first
+    /// (the selection observer then opens the thread); same-preset threads open directly.
+    private func openThread(_ thread: StudioLibraryItem) {
+        guard thread.id != activeConversationID else { return }
+        navigation.selectedLibraryID = thread.id
+        guard thread.mode == mode else {
+            navigation.open(task: thread.mode.task)
+            return
+        }
+        activeConversationID = thread.id
+        applyConversationSettings(from: thread, to: &draft)
+        draft.prompt = ""
+        studioError = nil
+        promptFocused = true
+    }
+
     private func deleteLibraryItem(_ id: UUID) {
         library.delete(id: id)
         if navigation.selectedLibraryID == id { navigation.selectedLibraryID = nil }
+        if activeConversationID == id { activeConversationID = nil }
     }
 
     /// Opens the Command Console window with the composer's draft carried into the Advanced
@@ -992,12 +1100,15 @@ struct StudioRootView: View {
 
         let rendered = ConversationTranscript.render(
             messages: item.messages ?? [],
-            systemPrompt: systemPrompt.isEmpty ? nil : systemPrompt
+            systemPrompt: systemPrompt.isEmpty ? nil : systemPrompt,
+            budgetChars: conversationBudgetChars
         )
 
         do {
             var runDraft = draft
             runDraft.prompt = rendered.prompt
+            // `--stats` reports the decode speed on stderr; the turn's meta line shows it.
+            runDraft.stats = true
             let request = try StudioCommandAdapter.makeRequest(
                 mode: mode, draft: runDraft, conversationID: conversationID
             )
@@ -1009,6 +1120,20 @@ struct StudioRootView: View {
             draft.inputPath = ""
         } catch {
             studioError = error.localizedDescription
+        }
+    }
+
+    /// Stops what the composer's Stop circle points at: the streaming turn of the open thread
+    /// in Converse, otherwise the foreground run.
+    private func stopCurrentRun() {
+        guard mode.isConversational, let conversationID = activeConversationID,
+              controller.runningConversationIDs.contains(conversationID) else {
+            controller.cancel()
+            return
+        }
+        for job in controller.jobs.all
+        where job.request.conversationID == conversationID && job.state.isActive {
+            controller.jobs.cancel(job.id)
         }
     }
 
@@ -1030,11 +1155,13 @@ struct StudioRootView: View {
         let systemPrompt = item.systemPrompt
         let rendered = ConversationTranscript.render(
             messages: item.messages ?? [],
-            systemPrompt: systemPrompt
+            systemPrompt: systemPrompt,
+            budgetChars: conversationBudgetChars
         )
         do {
             var runDraft = draft
             runDraft.prompt = rendered.prompt
+            runDraft.stats = true
             runDraft.secondaryText = systemPrompt ?? ""
             // Re-attach the image the last user turn carried (or none), not the cleared composer's.
             runDraft.inputPath = item.messages?.last?.imagePath ?? ""
@@ -1160,6 +1287,37 @@ struct StudioRootView: View {
             activeConversationID = nil
             navigation.selectedLibraryID = nil
         }
+    }
+
+    /// Branches a new thread at a turn. From a user turn: the thread up to (not including) that
+    /// turn, with its text loaded into the composer so the edit runs in the branch and the
+    /// original keeps its history. From an assistant turn: the thread through that reply.
+    private func branchFromMessage(_ messageID: UUID) {
+        guard let conversationID = activeConversationID,
+              !controller.runningConversationIDs.contains(conversationID),
+              let source = library.items.first(where: { $0.id == conversationID }),
+              let message = source.messages?.first(where: { $0.id == messageID }) else { return }
+        let inclusive = message.role == .assistant
+        guard let branch = library.branch(conversationID: conversationID, at: messageID, inclusive: inclusive) else {
+            return
+        }
+        if branch.messages?.isEmpty ?? true {
+            // Branching before the first turn is just a new thread carrying that prompt.
+            library.delete(id: branch.id)
+            startNewConversation()
+        } else {
+            activeConversationID = branch.id
+            navigation.selectedLibraryID = branch.id
+            applyConversationSettings(from: branch, to: &draft)
+        }
+        if message.role == .user {
+            draft.prompt = message.content
+            if mode == .chat { draft.inputPath = message.imagePath ?? "" }
+        } else {
+            draft.prompt = ""
+        }
+        studioError = nil
+        promptFocused = true
     }
 
     /// Starts a fresh, not-yet-persisted conversation (no library row until the first message).

--- a/apps/macos/MereRunStudio/StudioThreadList.swift
+++ b/apps/macos/MereRunStudio/StudioThreadList.swift
@@ -1,0 +1,310 @@
+import SwiftUI
+
+/// Pure rules for the Converse thread list: which Library rows are threads, how they group,
+/// and what their meta line says. Everything here is unit-testable without a view.
+enum StudioThreadListPresenter {
+    struct Section: Equatable {
+        let title: String
+        let threads: [StudioLibraryItem]
+    }
+
+    /// The conversation rows, most recently active first. Chat and Code threads share one list:
+    /// Code is a preset inside Converse, not a second thread pool.
+    static func threads(in items: [StudioLibraryItem]) -> [StudioLibraryItem] {
+        items.filter(\.isConversation).sorted { $0.updatedAt > $1.updatedAt }
+    }
+
+    /// The rows the media Library shows: everything that is not a thread.
+    static func mediaItems(in items: [StudioLibraryItem]) -> [StudioLibraryItem] {
+        items.filter { !$0.isConversation }
+    }
+
+    /// Threads whose title or any turn contains `query` (case-insensitive); all of them for an
+    /// empty query.
+    static func filter(_ threads: [StudioLibraryItem], query: String) -> [StudioLibraryItem] {
+        let needle = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !needle.isEmpty else { return threads }
+        return threads.filter { thread in
+            thread.displayTitle.lowercased().contains(needle)
+                || (thread.messages ?? []).contains { $0.content.lowercased().contains(needle) }
+        }
+    }
+
+    /// "Today" for threads active today, "Earlier" for the rest, in that order; a group is
+    /// omitted when empty.
+    static func sections(
+        _ threads: [StudioLibraryItem],
+        now: Date = Date(),
+        calendar: Calendar = .current
+    ) -> [Section] {
+        let today = threads.filter { calendar.isDate($0.updatedAt, inSameDayAs: now) }
+        let earlier = threads.filter { !calendar.isDate($0.updatedAt, inSameDayAs: now) }
+        var sections: [Section] = []
+        if !today.isEmpty { sections.append(Section(title: "Today", threads: today)) }
+        if !earlier.isEmpty { sections.append(Section(title: "Earlier", threads: earlier)) }
+        return sections
+    }
+
+    /// "Qwen3.6 4B · 1:20 PM" for a chat thread active today; "Code · Gemma 4 · Yesterday" for a
+    /// Code thread from yesterday; older threads show their day ("Aug 30").
+    static func meta(
+        for thread: StudioLibraryItem,
+        now: Date = Date(),
+        calendar: Calendar = .current
+    ) -> String {
+        var parts: [String] = []
+        if thread.mode == .code { parts.append("Code") }
+        parts.append(modelLabel(for: thread))
+        parts.append(activityLabel(for: thread.updatedAt, now: now, calendar: calendar))
+        return parts.joined(separator: " · ")
+    }
+
+    /// The friendly name of the model the thread last ran with, or the preset's default.
+    static func modelLabel(for thread: StudioLibraryItem) -> String {
+        let identity = StudioModelPicker.resolvedModelID(thread.model ?? "", mode: thread.mode)
+        return identity.isEmpty ? "Auto" : StudioModelPicker.displayModelName(identity)
+    }
+
+    static func activityLabel(for date: Date, now: Date, calendar: Calendar) -> String {
+        if calendar.isDate(date, inSameDayAs: now) {
+            return timeFormatter.string(from: date)
+        }
+        if let yesterday = calendar.date(byAdding: .day, value: -1, to: now),
+           calendar.isDate(date, inSameDayAs: yesterday) {
+            return "Yesterday"
+        }
+        return dayFormatter.string(from: date)
+    }
+
+    private static let timeFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .none
+        formatter.timeStyle = .short
+        return formatter
+    }()
+
+    private static let dayFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.setLocalizedDateFormatFromTemplate("MMM d")
+        return formatter
+    }()
+}
+
+/// The Converse column beside the transcript: every thread, searchable, grouped Today / Earlier,
+/// with a compose button for a new thread (also ⌘N). Replaces the Library column in the Chat
+/// domain; threads never appear in the media Library.
+struct StudioThreadList: View {
+    /// Every Library row; the list keeps the threads.
+    let items: [StudioLibraryItem]
+    let selectedID: UUID?
+    /// A row the user picked (click or arrow keys), as opposed to a programmatic selection.
+    let onSelect: (StudioLibraryItem) -> Void
+    let onNewThread: () -> Void
+    let onDelete: (UUID) -> Void
+    let onRename: (UUID, String) -> Void
+    /// Extra leading space for the header while the window's traffic lights sit over it.
+    var leadingInset: CGFloat = 0
+
+    @State private var searchText = ""
+    @State private var renamingID: UUID?
+    @State private var renameText = ""
+
+    private var threads: [StudioLibraryItem] {
+        StudioThreadListPresenter.threads(in: items)
+    }
+
+    private var visibleThreads: [StudioLibraryItem] {
+        StudioThreadListPresenter.filter(threads, query: searchText)
+    }
+
+    private var sections: [StudioThreadListPresenter.Section] {
+        StudioThreadListPresenter.sections(visibleThreads)
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            header
+            searchField
+            if visibleThreads.isEmpty {
+                emptyState
+            } else {
+                list
+            }
+        }
+        .background(MereRunTheme.background)
+        .alert("Rename thread", isPresented: renameBinding) {
+            TextField("Name", text: $renameText)
+            Button("Save") {
+                if let renamingID { onRename(renamingID, renameText) }
+                renamingID = nil
+            }
+            Button("Cancel", role: .cancel) { renamingID = nil }
+        }
+    }
+
+    private var renameBinding: Binding<Bool> {
+        Binding(get: { renamingID != nil }, set: { if !$0 { renamingID = nil } })
+    }
+
+    private var header: some View {
+        HStack(spacing: 8) {
+            Text("Threads")
+                .font(.system(size: 13, weight: .semibold))
+                .foregroundStyle(MereRunTheme.textPrimary)
+                .accessibilityAddTraits(.isHeader)
+            Spacer(minLength: 0)
+            Button(action: onNewThread) {
+                Image(systemName: "square.and.pencil")
+                    .font(.system(size: 14, weight: .medium))
+                    .frame(width: 28, height: 28)
+            }
+            .buttonStyle(.mereIcon)
+            .help("New thread (⌘N)")
+            .accessibilityLabel("New thread")
+        }
+        .padding(.top, 14)
+        .padding(.leading, 14 + leadingInset)
+        .padding(.trailing, 14)
+        .padding(.bottom, 8)
+    }
+
+    private var searchField: some View {
+        HStack(spacing: 6) {
+            Image(systemName: "magnifyingglass")
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(MereRunTheme.textMuted)
+            TextField("Search threads", text: $searchText)
+                .textFieldStyle(.plain)
+                .font(.system(size: 12))
+                .foregroundStyle(MereRunTheme.textPrimary)
+            if !searchText.isEmpty {
+                Button {
+                    searchText = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.system(size: 11))
+                }
+                .buttonStyle(.mereIcon(tint: MereRunTheme.textMuted))
+                .accessibilityLabel("Clear search")
+            }
+        }
+        .padding(.horizontal, 10)
+        .frame(height: 28)
+        .background {
+            Capsule()
+                .fill(MereRunTheme.surface)
+                .overlay {
+                    Capsule().strokeBorder(MereRunTheme.border.opacity(0.8), lineWidth: 1)
+                }
+        }
+        .padding(.horizontal, 12)
+        .padding(.bottom, 8)
+    }
+
+    private var emptyState: some View {
+        VStack(spacing: MereRunTheme.Spacing.sm) {
+            Image(systemName: "bubble.left.and.bubble.right")
+                .font(.system(size: 28, weight: .semibold))
+                .foregroundStyle(MereRunTheme.textMuted)
+            Text(threads.isEmpty ? "Threads you start will land here." : "No matching threads.")
+                .font(MereRunTheme.captionFont)
+                .foregroundStyle(MereRunTheme.textMuted)
+                .multilineTextAlignment(.center)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .padding(MereRunTheme.Spacing.xl)
+    }
+
+    private var list: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 2) {
+                ForEach(Array(sections.enumerated()), id: \.element.title) { index, section in
+                    MereEyebrow(section.title)
+                        .padding(.horizontal, 8)
+                        .padding(.top, index == 0 ? 6 : 10)
+                        .padding(.bottom, 2)
+
+                    ForEach(section.threads) { thread in
+                        StudioThreadRow(thread: thread, isSelected: selectedID == thread.id) {
+                            onSelect(thread)
+                        }
+                        .contextMenu {
+                            Button("Rename") {
+                                renameText = thread.displayTitle
+                                renamingID = thread.id
+                            }
+                            Button("Delete", role: .destructive) {
+                                onDelete(thread.id)
+                            }
+                        }
+                    }
+                }
+            }
+            .padding(.horizontal, 6)
+            .padding(.bottom, MereRunTheme.Spacing.sm)
+        }
+        .focusable()
+        .onKeyPress(.upArrow) { moveSelection(by: -1) }
+        .onKeyPress(.downArrow) { moveSelection(by: 1) }
+    }
+
+    private func moveSelection(by offset: Int) -> KeyPress.Result {
+        let visible = visibleThreads
+        guard !visible.isEmpty else { return .ignored }
+        guard let selectedID, let index = visible.firstIndex(where: { $0.id == selectedID }) else {
+            if let edge = offset > 0 ? visible.first : visible.last { onSelect(edge) }
+            return .handled
+        }
+        let next = min(max(index + offset, 0), visible.count - 1)
+        onSelect(visible[next])
+        return .handled
+    }
+}
+
+/// One thread: the title on one line and a meta line naming the preset, model, and last activity.
+private struct StudioThreadRow: View {
+    let thread: StudioLibraryItem
+    let isSelected: Bool
+    let action: () -> Void
+
+    @State private var hovering = false
+
+    private var meta: String { StudioThreadListPresenter.meta(for: thread) }
+
+    var body: some View {
+        Button(action: action) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(thread.displayTitle)
+                    .font(.system(size: 12.5, weight: .medium))
+                    .foregroundStyle(MereRunTheme.textPrimary)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+                Text(meta)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(MereRunTheme.textMuted)
+                    .lineLimit(1)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.vertical, 8)
+            .padding(.horizontal, 10)
+            .background {
+                RoundedRectangle(cornerRadius: MereRunTheme.Radius.md)
+                    .fill(rowFill)
+            }
+            .contentShape(RoundedRectangle(cornerRadius: MereRunTheme.Radius.md))
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering = $0 }
+        .animation(MereRunTheme.Motion.quick, value: hovering)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Thread, \(thread.displayTitle)")
+        .accessibilityValue(meta)
+        .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
+    }
+
+    private var rowFill: Color {
+        if isSelected { return MereRunTheme.accentSoft }
+        if hovering { return MereRunTheme.hoverFill }
+        return .clear
+    }
+}

--- a/apps/macos/MereRunStudio/StudioTypes.swift
+++ b/apps/macos/MereRunStudio/StudioTypes.swift
@@ -963,6 +963,14 @@ struct StudioMessage: Codable, Identifiable, Equatable {
     /// The image attached to this user turn (vision chat), so edit/retry resend it. Optional so
     /// older persisted threads decode unchanged.
     var imagePath: String?
+    /// The model that produced this assistant turn, recorded when the reply lands so a thread
+    /// whose model changed mid-way says which turn ran on what. nil on user turns and on threads
+    /// persisted before turns recorded it.
+    var model: String?
+    /// The system prompt in effect for this assistant turn (nil = the command's default).
+    var systemPrompt: String?
+    /// Decode throughput the CLI reported for this assistant turn (`--stats`), when it did.
+    var tokensPerSecond: Double?
 
     init(
         id: UUID = UUID(),
@@ -970,7 +978,10 @@ struct StudioMessage: Codable, Identifiable, Equatable {
         content: String,
         createdAt: Date = Date(),
         failed: Bool = false,
-        imagePath: String? = nil
+        imagePath: String? = nil,
+        model: String? = nil,
+        systemPrompt: String? = nil,
+        tokensPerSecond: Double? = nil
     ) {
         self.id = id
         self.role = role
@@ -978,6 +989,9 @@ struct StudioMessage: Codable, Identifiable, Equatable {
         self.createdAt = createdAt
         self.failed = failed
         self.imagePath = imagePath
+        self.model = model
+        self.systemPrompt = systemPrompt
+        self.tokensPerSecond = tokensPerSecond
     }
 }
 

--- a/apps/macos/MereRunStudioTests/ConversationTranscriptTests.swift
+++ b/apps/macos/MereRunStudioTests/ConversationTranscriptTests.swift
@@ -94,4 +94,62 @@ final class ConversationTranscriptTests: XCTestCase {
         XCTAssertEqual(withReserve.prompt, "latest")
         XCTAssertGreaterThanOrEqual(withReserve.approxChars, 90)
     }
+
+    func testBudgetDerivesFromContextWindowLessTheReplyRoom() {
+        XCTAssertEqual(
+            ConversationTranscript.budgetChars(contextTokens: 32_768, maxOutputTokens: 2_048),
+            (32_768 - 2_048) * ConversationTranscript.charsPerContextToken
+        )
+        // No context known: the fixed default, exactly as before.
+        XCTAssertEqual(
+            ConversationTranscript.budgetChars(contextTokens: nil, maxOutputTokens: 2_048),
+            ConversationTranscript.defaultBudgetChars
+        )
+        XCTAssertEqual(
+            ConversationTranscript.budgetChars(contextTokens: 0, maxOutputTokens: 2_048),
+            ConversationTranscript.defaultBudgetChars
+        )
+        // A tiny context still leaves room for the latest turn.
+        XCTAssertEqual(
+            ConversationTranscript.budgetChars(contextTokens: 1_024, maxOutputTokens: 4_096),
+            ConversationTranscript.minimumBudgetChars
+        )
+    }
+
+    func testContextTokensPreferExplicitSizeThenInventoryThenNothing() {
+        let inventory = [
+            StudioModelInventoryRow(
+                id: "text-chat-qwen3.6-4b", category: "text-chat", status: "installed", size: "2.4 GB",
+                usageTerms: nil, contextWindow: 40_960
+            ),
+            StudioModelInventoryRow(
+                id: "text-chat-unknown", category: "text-chat", status: "installed", size: "1 GB", usageTerms: nil
+            ),
+        ]
+        XCTAssertEqual(
+            ConversationTranscript.contextTokens(
+                requestedContextSize: 8_192, model: "text-chat-qwen3.6-4b", inventory: inventory
+            ),
+            8_192
+        )
+        XCTAssertEqual(
+            ConversationTranscript.contextTokens(requestedContextSize: 0, model: "text-chat-qwen3.6-4b", inventory: inventory),
+            40_960
+        )
+        XCTAssertNil(
+            ConversationTranscript.contextTokens(requestedContextSize: 0, model: "text-chat-unknown", inventory: inventory)
+        )
+        XCTAssertNil(ConversationTranscript.contextTokens(requestedContextSize: 0, model: "", inventory: inventory))
+    }
+
+    func testDecodeSpeedIsReadFromTheLatestStatsLine() {
+        let lines = [
+            "Loading model…",
+            "time=3.10s load=0.40s prefill=0.20s decode=2.50s tokens=98 decode_tps=39.20 e2e_tps=31.61",
+            "time=2.90s load=0.00s prefill=0.20s decode=2.40s tokens=99 decode_tps=41.25 e2e_tps=34.13 prefill_tps=812.00",
+        ]
+        XCTAssertEqual(ConversationTranscript.decodeTokensPerSecond(in: lines), 41.25)
+        XCTAssertNil(ConversationTranscript.decodeTokensPerSecond(in: ["no stats here"]))
+        XCTAssertNil(ConversationTranscript.decodeTokensPerSecond(in: ["decode_tps=0.00"]))
+    }
 }

--- a/apps/macos/MereRunStudioTests/StudioComposerSchemaTests.swift
+++ b/apps/macos/MereRunStudioTests/StudioComposerSchemaTests.swift
@@ -282,10 +282,10 @@ final class StudioComposerSchemaTests: XCTestCase {
     }
 
     func testDisplayModelNameDropsCategoryPrefixes() {
-        XCTAssertEqual(StudioComposer.displayModelName("image-zimage-nano"), "Zimage Nano")
-        XCTAssertEqual(StudioComposer.displayModelName("vision-ground-falcon-perception"), "Falcon Perception")
-        XCTAssertEqual(StudioComposer.displayModelName("speech-tts-qwen3-nano"), "Qwen3 Nano")
-        XCTAssertEqual(StudioComposer.displayModelName("text-agent-deepseek-v4-flash"), "Deepseek V4 Flash")
+        XCTAssertEqual(StudioModelPicker.displayModelName("image-zimage-nano"), "Zimage Nano")
+        XCTAssertEqual(StudioModelPicker.displayModelName("vision-ground-falcon-perception"), "Falcon Perception")
+        XCTAssertEqual(StudioModelPicker.displayModelName("speech-tts-qwen3-nano"), "Qwen3 Nano")
+        XCTAssertEqual(StudioModelPicker.displayModelName("text-agent-deepseek-v4-flash"), "Deepseek V4 Flash")
     }
 
     // MARK: - Helpers

--- a/apps/macos/MereRunStudioTests/StudioLibraryStoreTests.swift
+++ b/apps/macos/MereRunStudioTests/StudioLibraryStoreTests.swift
@@ -253,6 +253,125 @@ final class StudioLibraryStoreTests: XCTestCase {
         XCTAssertEqual(store.items.first?.messages?.isEmpty, true)
     }
 
+    func testAssistantTurnsRecordTheModelAndSystemPromptTheyRanWith() throws {
+        let url = try temporaryLibraryURL()
+        let store = StudioLibraryStore(libraryURL: url)
+        let conversationID = UUID()
+
+        store.appendUser(
+            conversationID: conversationID, mode: .chat, model: "text-chat-qwen3.6-4b",
+            systemPrompt: nil, content: "first"
+        )
+        store.appendAssistant(
+            conversationID: conversationID, content: "a1", exitCode: 0,
+            model: "text-chat-qwen3.6-4b", systemPrompt: nil, tokensPerSecond: 41.2
+        )
+        // The model and system prompt change for the NEXT turn; the earlier turn keeps its own.
+        store.appendUser(
+            conversationID: conversationID, mode: .chat, model: "text-chat-gemma4-12b-4bit",
+            systemPrompt: "Be terse.", content: "second"
+        )
+        store.appendAssistant(
+            conversationID: conversationID, content: "a2", exitCode: 0,
+            model: "text-chat-gemma4-12b-4bit", systemPrompt: "Be terse."
+        )
+
+        let reloaded = StudioLibraryStore(libraryURL: url)
+        let item = try XCTUnwrap(reloaded.items.first)
+        let assistants = try XCTUnwrap(item.messages?.filter { $0.role == .assistant })
+        XCTAssertEqual(assistants.map(\.model), ["text-chat-qwen3.6-4b", "text-chat-gemma4-12b-4bit"])
+        XCTAssertEqual(assistants.map(\.systemPrompt), [nil, "Be terse."])
+        XCTAssertEqual(assistants.map(\.tokensPerSecond), [41.2, nil])
+        // Thread-level values follow the latest turn for compatibility with retry.
+        XCTAssertEqual(item.model, "text-chat-gemma4-12b-4bit")
+        XCTAssertEqual(item.systemPrompt, "Be terse.")
+        XCTAssertNil(item.messages?.first?.model)
+    }
+
+    func testPresetChangeOnAThreadIsRecordedWhenTheNextTurnIsSent() throws {
+        let url = try temporaryLibraryURL()
+        let store = StudioLibraryStore(libraryURL: url)
+        let conversationID = UUID()
+        store.appendUser(conversationID: conversationID, mode: .chat, model: nil, systemPrompt: nil, content: "hi")
+        store.appendAssistant(conversationID: conversationID, content: "hello", exitCode: 0)
+        XCTAssertEqual(store.items.first?.mode, .chat)
+
+        store.appendUser(conversationID: conversationID, mode: .code, model: "text-code-north-mini", systemPrompt: nil, content: "now code")
+
+        let item = try XCTUnwrap(store.items.first)
+        XCTAssertEqual(item.mode, .code)
+        XCTAssertEqual(item.commandPreview, "mere.run text code")
+        XCTAssertEqual(item.messages?.count, 3)
+    }
+
+    func testBranchBeforeUserTurnKeepsEarlierTurnsAndLeavesSourceIntact() throws {
+        let url = try temporaryLibraryURL()
+        let store = StudioLibraryStore(libraryURL: url)
+        let conversationID = UUID()
+        store.appendUser(conversationID: conversationID, mode: .code, model: "m", systemPrompt: "s", content: "one")
+        store.appendAssistant(conversationID: conversationID, content: "a1", exitCode: 0, model: "m", tokensPerSecond: 12)
+        store.appendUser(conversationID: conversationID, mode: .code, model: "m", systemPrompt: "s", content: "two")
+        store.appendAssistant(conversationID: conversationID, content: "a2", exitCode: 0, model: "m")
+
+        let source = try XCTUnwrap(store.items.first)
+        let secondTurnID = try XCTUnwrap(source.messages?.first { $0.content == "two" }?.id)
+        let branch = try XCTUnwrap(store.branch(conversationID: conversationID, at: secondTurnID, inclusive: false))
+
+        XCTAssertNotEqual(branch.id, source.id)
+        XCTAssertEqual(branch.messages?.map(\.content), ["one", "a1"])
+        XCTAssertEqual(branch.mode, .code)
+        XCTAssertEqual(branch.model, "m")
+        XCTAssertEqual(branch.systemPrompt, "s")
+        XCTAssertEqual(branch.messages?.last?.tokensPerSecond, 12)
+        XCTAssertEqual(branch.status, .completed)
+        // Copies get their own identities so both threads can be edited independently.
+        XCTAssertNotEqual(branch.messages?.first?.id, source.messages?.first?.id)
+
+        let reloaded = StudioLibraryStore(libraryURL: url)
+        XCTAssertEqual(reloaded.items.count, 2)
+        XCTAssertEqual(reloaded.items.first?.id, branch.id)
+        let original = try XCTUnwrap(reloaded.items.first { $0.id == conversationID })
+        XCTAssertEqual(original.messages?.map(\.content), ["one", "a1", "two", "a2"])
+    }
+
+    func testBranchAfterAssistantTurnIncludesThatReply() throws {
+        let url = try temporaryLibraryURL()
+        let store = StudioLibraryStore(libraryURL: url)
+        let conversationID = UUID()
+        store.appendUser(conversationID: conversationID, mode: .chat, model: nil, systemPrompt: nil, content: "one")
+        store.appendAssistant(conversationID: conversationID, content: "a1", exitCode: 0)
+        store.appendUser(conversationID: conversationID, mode: .chat, model: nil, systemPrompt: nil, content: "two")
+        store.appendAssistant(conversationID: conversationID, content: "a2", exitCode: 0)
+
+        let firstReplyID = try XCTUnwrap(store.items.first?.messages?.first { $0.content == "a1" }?.id)
+        let branch = try XCTUnwrap(store.branch(conversationID: conversationID, at: firstReplyID, inclusive: true))
+        XCTAssertEqual(branch.messages?.map(\.content), ["one", "a1"])
+
+        XCTAssertNil(store.branch(conversationID: UUID(), at: firstReplyID, inclusive: true))
+        XCTAssertNil(store.branch(conversationID: conversationID, at: UUID(), inclusive: true))
+    }
+
+    func testLegacyThreadRowsDecodeWithoutPerTurnFields() throws {
+        let url = try temporaryLibraryURL()
+        let json = """
+        [{"id":"\(UUID().uuidString)","mode":"chat","prompt":"",\
+        "createdAt":"2026-01-01T00:00:00Z","updatedAt":"2026-01-01T00:00:00Z",\
+        "status":"completed","commandPreview":"mere.run text chat",\
+        "messages":[{"id":"\(UUID().uuidString)","role":"user","content":"hi",\
+        "createdAt":"2026-01-01T00:00:00Z","failed":false},\
+        {"id":"\(UUID().uuidString)","role":"assistant","content":"hello",\
+        "createdAt":"2026-01-01T00:00:01Z","failed":false}],"model":"text-chat-gemma4"}]
+        """
+        try XCTUnwrap(json.data(using: .utf8)).write(to: url)
+
+        let store = StudioLibraryStore(libraryURL: url)
+        let item = try XCTUnwrap(store.items.first)
+        XCTAssertEqual(item.messages?.count, 2)
+        XCTAssertNil(item.messages?.last?.model)
+        XCTAssertNil(item.messages?.last?.tokensPerSecond)
+        XCTAssertEqual(item.model, "text-chat-gemma4")
+    }
+
     func testLoadKeepsValidRowsWhenOneIsCorrupt() throws {
         let url = try temporaryLibraryURL()
         let good = """

--- a/apps/macos/MereRunStudioTests/StudioSnapshotTests.swift
+++ b/apps/macos/MereRunStudioTests/StudioSnapshotTests.swift
@@ -170,6 +170,55 @@ final class StudioSnapshotTests: XCTestCase {
         XCTAssertTrue(fixture.controller.canSteerRealtimeMusic(requestID: requestID))
     }
 
+    /// Chat at the mockup size with the Converse board's threads: the thread list with four
+    /// rows, the diffusion thread open (two user turns, a reply with a Python block, and a reply
+    /// streaming in), the model and system chips, and the composer's Stop circle. `model list`
+    /// and `model capabilities` are scripted so readiness is real; the turn's `text chat` is
+    /// held open by the process seam and fed its first words. Light, dark, and the default
+    /// window size.
+    func testConverseFidelitySnapshots() throws {
+        let directory = try XCTUnwrap(Self.snapshotDirectory())
+        fixture.tearDown()
+        fixture = try SnapshotFixture(
+            outputDirectory: directory,
+            seed: .converse,
+            processRunner: SnapshotProcessRunner(script: ConverseScript.responses)
+        )
+
+        var chat = StudioDraft()
+        chat.reset(for: .chat)
+        chat.model = SnapshotFixture.converseChatModelID
+        chat.thinkingMode = .hide
+
+        let renders: [(name: String, size: CGSize, appearance: StudioSnapshotAppearance)] = [
+            ("f5-converse-light", Self.fidelitySize, .light),
+            ("f5-converse-dark", Self.fidelitySize, .dark),
+            ("f5-converse-compact-light", Self.shellSize, .light)
+        ]
+        for render in renders {
+            let navigation = NavigationModel()
+            let view = StudioRootView(seededDrafts: [.chat: chat])
+                .environmentObject(fixture.controller)
+                .environmentObject(fixture.library)
+                .environmentObject(navigation)
+                .frame(width: render.size.width, height: render.size.height)
+            try fixture.write(
+                view,
+                size: render.size,
+                appearance: render.appearance,
+                name: render.name,
+                settle: 2.5,
+                afterAppear: {
+                    navigation.open(task: .chatChat)
+                    if !self.fixture.controller.runningConversationIDs.contains(SnapshotFixture.converseThreadID) {
+                        try? self.fixture.seedLiveChatTurn()
+                    }
+                }
+            )
+        }
+        XCTAssertTrue(fixture.controller.runningConversationIDs.contains(SnapshotFixture.converseThreadID))
+    }
+
     /// The Settings scene content at the width the app gives it.
     func testSettingsSnapshots() throws {
         for appearance in StudioSnapshotAppearance.allCases {
@@ -266,6 +315,8 @@ private final class SnapshotFixture {
         case fixture
         /// The four Image rows the design mockups show, newest first.
         case mockup
+        /// The four Converse threads the design mockups show, the newest with a reply in flight.
+        case converse
     }
 
     init(
@@ -295,6 +346,7 @@ private final class SnapshotFixture {
         switch seed {
         case .fixture: try seedLibrary()
         case .mockup: try seedMockupLibrary()
+        case .converse: seedConverseLibrary()
         }
     }
 
@@ -609,6 +661,143 @@ private final class SnapshotFixture {
         )
     ]
 
+    // MARK: Converse threads
+
+    /// The id of the mockup's open thread, whose last user turn is answered live.
+    static let converseThreadID = UUID()
+    static let converseChatModelID = "text-chat-qwen3.6-4b"
+
+    /// The Converse board's threads: today's diffusion thread (with a Python block and a turn
+    /// awaiting its reply), yesterday's Code thread, and two older chats.
+    private func seedConverseLibrary() {
+        let calendar = Calendar.current
+        let today = calendar.startOfDay(for: Date())
+        func at(daysAgo: Int, hour: Int, minute: Int) -> Date {
+            calendar.date(byAdding: DateComponents(day: -daysAgo, hour: hour, minute: minute), to: today) ?? today
+        }
+        let replyAt = at(daysAgo: 0, hour: 13, minute: 20)
+        let diffusion = StudioLibraryItem(
+            id: Self.converseThreadID,
+            mode: .chat,
+            prompt: "",
+            inputURL: nil,
+            outputURL: nil,
+            createdAt: at(daysAgo: 0, hour: 13, minute: 19),
+            updatedAt: replyAt,
+            status: .running,
+            exitCode: nil,
+            commandPreview: "mere.run text chat",
+            outputText: nil,
+            customTitle: "Summarize diffusion models in one paragraph",
+            messages: [
+                StudioMessage(
+                    role: .user,
+                    content: "Summarize diffusion models in one paragraph, for someone who knows what a neural net is.",
+                    createdAt: at(daysAgo: 0, hour: 13, minute: 19)
+                ),
+                StudioMessage(
+                    role: .assistant,
+                    content: """
+                    A diffusion model learns to reverse a gradual noising process. During training, \
+                    images are corrupted with increasing Gaussian noise and a network is taught to \
+                    predict that noise at each step. At sampling time it starts from pure noise and \
+                    repeatedly subtracts its predicted noise, so structure emerges over a few dozen \
+                    steps. Guidance from a text encoder steers each step toward the prompt.
+
+                    ```python
+                    x = torch.randn(1, 4, 64, 64)
+                    for t_ in scheduler.timesteps:
+                        eps = unet(x, t_, cond).sample
+                        x = scheduler.step(eps, t_, x).prev_sample
+                    ```
+                    """,
+                    createdAt: replyAt,
+                    model: Self.converseChatModelID,
+                    tokensPerSecond: 41
+                ),
+                StudioMessage(
+                    role: .user,
+                    content: "Why predict the noise instead of the image?",
+                    createdAt: replyAt
+                )
+            ],
+            systemPrompt: nil,
+            model: Self.converseChatModelID
+        )
+
+        func thread(
+            title: String,
+            reply: String,
+            mode: StudioMode,
+            model: String,
+            daysAgo: Int,
+            hour: Int
+        ) -> StudioLibraryItem {
+            let asked = at(daysAgo: daysAgo, hour: hour, minute: 5)
+            return StudioLibraryItem(
+                id: UUID(),
+                mode: mode,
+                prompt: "",
+                inputURL: nil,
+                outputURL: nil,
+                createdAt: asked,
+                updatedAt: asked.addingTimeInterval(40),
+                status: .completed,
+                exitCode: 0,
+                commandPreview: mode == .code ? "mere.run text code" : "mere.run text chat",
+                outputText: nil,
+                messages: [
+                    StudioMessage(role: .user, content: title, createdAt: asked),
+                    StudioMessage(role: .assistant, content: reply, createdAt: asked.addingTimeInterval(40), model: model)
+                ],
+                systemPrompt: nil,
+                model: model
+            )
+        }
+        let rows = [
+            diffusion,
+            thread(
+                title: "Swift function that formats byte counts",
+                reply: "```swift\nfunc formatted(bytes: Int64) -> String {\n    ByteCountFormatter.string(fromByteCount: bytes, countStyle: .file)\n}\n```",
+                mode: .code, model: "text-code-gemma-4", daysAgo: 1, hour: 16
+            ),
+            thread(
+                title: "Draft a friendly reply declining a meeting",
+                reply: "Thanks for the invitation — I can't make Thursday, but I'd be glad to catch up next week.",
+                mode: .chat, model: Self.converseChatModelID, daysAgo: 4, hour: 10
+            ),
+            thread(
+                title: "What can I cook with mushrooms, eggs, spinach?",
+                reply: "A quick frittata: sauté the mushrooms, wilt the spinach, pour over beaten eggs, and finish under the broiler.",
+                mode: .chat, model: Self.converseChatModelID, daysAgo: 6, hour: 19
+            )
+        ]
+        for row in rows.sorted(by: { $0.createdAt < $1.createdAt }) {
+            library.upsert(row)
+        }
+    }
+
+    /// Answers the open thread's last turn live: the turn runs through the real controller and
+    /// transcript paths (the process seam holds `text chat` open), and the first words of the
+    /// reply arrive on stdout so the transcript shows a streaming turn with its caret.
+    func seedLiveChatTurn() throws {
+        guard let thread = library.items.first(where: { $0.id == Self.converseThreadID }),
+              let runner = liveSessionRunner else {
+            throw StudioSnapshotError.noContentView
+        }
+        var draft = StudioDraft()
+        draft.reset(for: .chat)
+        draft.model = Self.converseChatModelID
+        draft.thinkingMode = .hide
+        draft.prompt = ConversationTranscript.render(messages: thread.messages ?? []).prompt
+        let request = try StudioCommandAdapter.makeRequest(mode: .chat, draft: draft, conversationID: thread.id)
+        runner.liveSessionMarker = "chat"
+        guard controller.run(studio: request), let live = runner.liveStarts.last else {
+            throw StudioSnapshotError.noContentView
+        }
+        live.stdout("Sure. The key idea is that noise is easier to predict than")
+    }
+
     // MARK: Live realtime session
 
     /// Starts a Magenta RT2 session through the real controller and Library paths. The process
@@ -851,6 +1040,13 @@ private final class SnapshotProcessRunner: MereRunProcessRunning, @unchecked Sen
     private var refusedLaunches = 0
     private var _liveStarts: [LiveStart] = []
     private var _liveSessionMarker: String?
+    /// Scripted answers for the short CLI reads a page makes (inventory, capabilities), consulted
+    /// before a launch is refused so a render can be both "ready" and hold a live session.
+    private let script: [ScriptedProcessRunner.Response]
+
+    init(script: [ScriptedProcessRunner.Response] = []) {
+        self.script = script
+    }
 
     var refusedLaunchCount: Int {
         lock.lock()
@@ -899,6 +1095,17 @@ private final class SnapshotProcessRunner: MereRunProcessRunning, @unchecked Sen
             DispatchQueue.global().asyncAfter(deadline: .now() + .milliseconds(30)) {
                 stdout(snapshot)
                 termination(0)
+            }
+            return SnapshotRefusedProcess()
+        }
+        var arguments = configuration.arguments
+        if arguments.first == "--models-root", arguments.count >= 2 {
+            arguments.removeFirst(2)
+        }
+        if let response = script.first(where: { $0.matches(arguments) }) {
+            DispatchQueue.global().asyncAfter(deadline: .now() + .milliseconds(30)) {
+                if !response.stdout.isEmpty { stdout(response.stdout) }
+                termination(response.exitCode)
             }
             return SnapshotRefusedProcess()
         }
@@ -983,6 +1190,26 @@ private final class ScriptedProcessRunner: MereRunProcessRunning, @unchecked Sen
             termination(response.exitCode)
         }
         return SnapshotRefusedProcess()
+    }
+}
+
+/// What the Converse render's CLI reads answer: the mockup's status footer, and the Models
+/// board's inventory and capabilities (which list the chat model installed, so Chat is ready).
+private enum ConverseScript {
+    static var responses: [ScriptedProcessRunner.Response] {
+        [
+            .init(
+                matches: { $0.first == "status" && $0.contains("--json") },
+                stdout: SnapshotProcessRunner.statusSnapshot(installedModelCount: SnapshotProcessRunner.installedModelCount),
+                exitCode: 0
+            ),
+            .init(matches: { $0 == ["model", "list"] }, stdout: ModelsInventoryScript.modelList, exitCode: 0),
+            .init(
+                matches: { $0 == ["model", "capabilities", "--all", "--json"] },
+                stdout: ModelsInventoryScript.capabilities,
+                exitCode: 0
+            ),
+        ]
     }
 }
 

--- a/apps/macos/MereRunStudioTests/StudioThreadListPresenterTests.swift
+++ b/apps/macos/MereRunStudioTests/StudioThreadListPresenterTests.swift
@@ -1,0 +1,137 @@
+@testable import MereRunApp
+import XCTest
+
+final class StudioThreadListPresenterTests: XCTestCase {
+    private let calendar = Calendar(identifier: .gregorian)
+    private let noon = Date(timeIntervalSince1970: 1_756_900_800) // 2025-09-03 12:00:00 UTC
+
+    func testThreadsAreTheConversationRowsNewestActivityFirst() {
+        let older = thread(title: "older", updatedAgo: 3_600)
+        let newer = thread(title: "newer", updatedAgo: 60)
+        let image = mediaRow()
+
+        let threads = StudioThreadListPresenter.threads(in: [older, image, newer])
+
+        XCTAssertEqual(threads.map(\.displayTitle), ["newer", "older"])
+    }
+
+    func testMediaItemsExcludeThreadsSoTheyNeverFileIntoTheLibrary() {
+        let image = mediaRow()
+        let items = [thread(title: "chat", updatedAgo: 0), image, thread(title: "code", mode: .code, updatedAgo: 0)]
+
+        XCTAssertEqual(StudioThreadListPresenter.mediaItems(in: items).map(\.id), [image.id])
+    }
+
+    func testChatAndCodeThreadsShareOneList() {
+        let chat = thread(title: "chat", mode: .chat, updatedAgo: 10)
+        let code = thread(title: "code", mode: .code, updatedAgo: 5)
+
+        XCTAssertEqual(StudioThreadListPresenter.threads(in: [chat, code]).map(\.mode), [.code, .chat])
+    }
+
+    func testFilterMatchesTitleOrAnyTurn() {
+        let diffusion = thread(title: "Summarize diffusion models", updatedAgo: 0, reply: "Noise is predicted.")
+        let bytes = thread(title: "Swift function that formats byte counts", updatedAgo: 0)
+
+        XCTAssertEqual(StudioThreadListPresenter.filter([diffusion, bytes], query: "byte").map(\.id), [bytes.id])
+        XCTAssertEqual(StudioThreadListPresenter.filter([diffusion, bytes], query: "NOISE").map(\.id), [diffusion.id])
+        XCTAssertEqual(StudioThreadListPresenter.filter([diffusion, bytes], query: "  ").count, 2)
+    }
+
+    func testSectionsSplitTodayFromEarlierAndOmitEmptyGroups() {
+        let today = thread(title: "today", updatedAgo: 3_600, now: noon)
+        let yesterday = thread(title: "yesterday", updatedAgo: 86_400, now: noon)
+        let lastWeek = thread(title: "week", updatedAgo: 86_400 * 6, now: noon)
+
+        let sections = StudioThreadListPresenter.sections([today, yesterday, lastWeek], now: noon, calendar: calendar)
+        XCTAssertEqual(sections.map(\.title), ["Today", "Earlier"])
+        XCTAssertEqual(sections[0].threads.map(\.displayTitle), ["today"])
+        XCTAssertEqual(sections[1].threads.map(\.displayTitle), ["yesterday", "week"])
+
+        let onlyEarlier = StudioThreadListPresenter.sections([lastWeek], now: noon, calendar: calendar)
+        XCTAssertEqual(onlyEarlier.map(\.title), ["Earlier"])
+    }
+
+    func testMetaNamesPresetModelAndActivity() {
+        let chat = thread(title: "chat", updatedAgo: 3_600, now: noon, model: "text-chat-qwen3.6-4b")
+        let chatMeta = StudioThreadListPresenter.meta(for: chat, now: noon, calendar: calendar)
+        XCTAssertTrue(chatMeta.hasPrefix("Qwen3.6 4B · "), chatMeta)
+        XCTAssertFalse(chatMeta.hasPrefix("Code"))
+
+        let code = thread(title: "code", mode: .code, updatedAgo: 86_400, now: noon, model: "text-code-gemma-4")
+        XCTAssertEqual(
+            StudioThreadListPresenter.meta(for: code, now: noon, calendar: calendar),
+            "Code · Gemma 4 · Yesterday"
+        )
+
+        let old = thread(title: "old", updatedAgo: 86_400 * 4, now: noon, model: "text-chat-qwen3.6-4b")
+        let oldMeta = StudioThreadListPresenter.meta(for: old, now: noon, calendar: calendar)
+        XCTAssertFalse(oldMeta.hasSuffix("Yesterday"), oldMeta)
+        XCTAssertTrue(oldMeta.hasPrefix("Qwen3.6 4B · "), oldMeta)
+    }
+
+    func testModelLabelFallsBackToThePresetDefault() {
+        let untitled = thread(title: "x", mode: .code, updatedAgo: 0, model: nil)
+        let expected = StudioModelPicker.resolvedModelID("", mode: .code)
+        XCTAssertFalse(expected.isEmpty)
+        XCTAssertEqual(
+            StudioThreadListPresenter.modelLabel(for: untitled),
+            StudioModelPicker.displayModelName(expected)
+        )
+    }
+
+    func testCodePresetMapsToItsTaskAndBack() {
+        XCTAssertEqual(StudioTask.chatCode.mode, .code)
+        XCTAssertEqual(StudioMode.code.task, .chatCode)
+        XCTAssertEqual(StudioTask.chatCode.domain, .chat)
+        XCTAssertEqual(StudioDomain.chat.tasks, [.chatChat, .chatCode, .chatTrain])
+    }
+
+    // MARK: Fixtures
+
+    private func thread(
+        title: String,
+        mode: StudioMode = .chat,
+        updatedAgo: TimeInterval,
+        now: Date = Date(),
+        model: String? = "text-chat-qwen3.6-4b",
+        reply: String = "reply"
+    ) -> StudioLibraryItem {
+        let updated = now.addingTimeInterval(-updatedAgo)
+        return StudioLibraryItem(
+            id: UUID(),
+            mode: mode,
+            prompt: "",
+            inputURL: nil,
+            outputURL: nil,
+            createdAt: updated.addingTimeInterval(-30),
+            updatedAt: updated,
+            status: .completed,
+            exitCode: 0,
+            commandPreview: "mere.run text \(mode == .code ? "code" : "chat")",
+            outputText: nil,
+            messages: [
+                StudioMessage(role: .user, content: title, createdAt: updated.addingTimeInterval(-30)),
+                StudioMessage(role: .assistant, content: reply, createdAt: updated)
+            ],
+            systemPrompt: nil,
+            model: model
+        )
+    }
+
+    private func mediaRow() -> StudioLibraryItem {
+        StudioLibraryItem(
+            id: UUID(),
+            mode: .createImage,
+            prompt: "a mug",
+            inputURL: nil,
+            outputURL: nil,
+            createdAt: Date(),
+            updatedAt: Date(),
+            status: .completed,
+            exitCode: 0,
+            commandPreview: "mere.run image generate",
+            outputText: nil
+        )
+    }
+}

--- a/apps/macos/README.md
+++ b/apps/macos/README.md
@@ -59,11 +59,31 @@ and the Guide). `StudioDestination` (domain + task) persists per window under
 draft and readiness survive a detour through a System task.
 
 The Library column appears in the domains that have a prompt mode (Image, Video,
-Music, Sound, Voice, Chat, Vision, Audio); the form- and list-shaped domains use
+Music, Sound, Voice, Vision, Audio); the form- and list-shaped domains use
 the full width. It is filtered to the current domain by default with an All
 segment — a row is filed under its command's domain (`CommandTemplateID.studioDomain`),
 so 3D meshes land under 3D and benchmark reports under Models — and picking a
 row from another domain switches the destination to it.
+
+**Chat** is the Converse archetype (`StudioConversationView.swift`,
+`StudioThreadList.swift`). A **thread list** replaces the Library column there —
+every chat and code thread, searchable, grouped Today / Earlier, with a compose
+button (⌘N) — and threads never appear in the media Library. The thread header
+carries the title, the model chip (the same filtered picker as the composer,
+`StudioModelPicker.swift`), and a "System" chip that edits the system prompt in a
+popover; changing either applies from the next turn, and every assistant turn
+records the model, system prompt, and decode speed it ran with
+(`StudioMessage.model` / `.systemPrompt` / `.tokensPerSecond`, additive optionals
+in `library.json`). Under a reply: Copy, Retry, Branch, and "model · tok/s ·
+time". Editing a user turn truncates the thread as before, or **Branch** starts
+a new thread from that point (before a user turn, after an assistant turn). The
+task control's **Code** is a preset inside the same thread list — the
+`text code` command, its default model and system prompt, monospaced code
+blocks with proportional prose — and a thread records which preset its latest
+turn used (`mode`). While a reply streams, the composer's Send circle becomes
+Stop for that thread. The transcript budget derives from the model's context
+window when the inventory reports one (or an explicit context size), else stays
+at 48k characters; a banner reports any turns trimmed from the next prompt.
 
 The **composer** under the canvas is one surface for every prompt mode
 (`StudioComposer.swift`, declarations in `StudioComposerSchema.swift`). An


### PR DESCRIPTION
## What changed

Chat becomes the **Converse archetype** from the Studio v2 plan (§4) and the Converse design board, on top of the integrated shell and composer in `studio-v2/ui-batch-1`.

**Thread list** (`StudioThreadList.swift`) — a 248pt column that replaces the Library column in the Chat domain: "Threads" header with a compose button (⌘N still works), a "Search threads" capsule, Today / Earlier eyebrows, two-line rows (title over "Qwen3.6 4B · 1:20 PM" / "Code · Gemma 4 · Yesterday"), `accentSoft` selection, arrow-key navigation, rename/delete. `StudioThreadListPresenter` holds the pure rules (threads vs. media rows, filtering, grouping, meta). Threads are filtered out of the media Library everywhere.

**Thread header + turns** (`StudioConversationView.swift`) — the 760pt column from the board: title, the model chip, and a "System: default ▾" chip that edits the system prompt in a popover; user bubbles (`accentSoft`, 14/14/4/14, 10/14, 14pt); assistant turns behind the chat glyph at 14pt/1.55 with Copy · Retry · Branch icon buttons and "model · tok/s · time"; fenced code on `surfaceRaised` r8 with a language eyebrow + Copy header row and 12pt mono; a thin inline caret while a reply streams; the trim banner stays. Code blocks are mono, prose is proportional in every preset (fixes the all-mono Code rendering). `StudioConverseView` composes the header, transcript, and readiness state (full card for an empty thread, a compact notice with "Get the model" above a thread that has turns).

**Per-turn provenance** — `StudioMessage` gains `model`, `systemPrompt`, `tokensPerSecond` (additive optionals; legacy rows decode unchanged, covered by a test). The reply records the job's own command snapshot, so changing the model or system prompt in the header applies from the NEXT turn and earlier turns keep what they ran with. Thread-level `model` / `systemPrompt` / `mode` follow the latest turn so retry keeps working. Conversation turns pass `--stats` (stderr only) so the decode speed can be shown; it is omitted when the CLI does not report it (e.g. `text code`, whose Studio mapping does not carry stats).

**Branch** — `StudioLibraryStore.branch(conversationID:at:inclusive:)`. From a user turn: the messages before it become a new thread and the turn's text loads into the composer (edit still offers the existing truncate). From an assistant turn: a new thread through that reply.

**Code as a preset** — the task control still shows Chat | Code | Train. Switching Chat ↔ Code keeps the open thread and applies the preset's defaults (the `text code` command, its default model, and its own default system prompt) to the next turn; picking a thread of the other preset switches the control to match. `StudioMode.code` persists exactly as before, and a thread's `mode` records which preset its latest turn used.

**Composer** — reuses the F2 composer; chips stay model ▾ and Thinking off ▾. While the open thread streams, the Send circle becomes the Stop circle and cancels that thread's job (not the foreground run). Run ▸ Stop follows the same rule.

**Context budget** — `ConversationTranscript.budgetChars(contextTokens:maxOutputTokens:)` sizes the history from the model's context window (3 chars/token, reply room subtracted, 4k floor) when `StudioModelInventoryRow.contextWindow` or an explicit context size provides one, else the 48k default. The row field is additive and nil from today's text parser, so behavior is unchanged until the inventory reports a window.

**Shared model picker** — the composer's model chip moved into `StudioModelPicker` so the header uses the same filtered, installed-first menu; parameter counts read as model cards print them ("4b" → "4B").

## Fidelity

`testConverseFidelitySnapshots` renders Chat at 1440×900 (light and dark) and 1280×820 with the board's sample: four threads, the diffusion thread open with two user turns, a reply with a Python block, and a reply streaming in through the real controller/transcript path (`text chat` held open by the process seam, first words fed on stdout); readiness is real via scripted `model list` / `model capabilities`. Compared side by side with `Converse.png`: layout, type, spacing, colors, radii, chips, action row, caret, and Stop circle line up. Remaining differences are platform rendering (SF vs. the board's stroke icons, the harness's title-bar strip) and the domain header glyph (two bubbles, owned by the shell).

## Verification

- `swiftlint --strict` — 0 violations
- `swift build`
- `swift test --filter MereRunAppTests` — 365 tests, 0 failures (new: thread derivation and Library filtering, per-turn model/system recording, preset recorded on send, branch before/after, legacy row decoding, budget derivation, context resolution, stats parsing, Code preset mapping)
- `./scripts/check.sh` — green
- `./scripts/build_mere_run_app.sh debug` — bundle builds and satisfies its designated requirement
- `MERERUN_STUDIO_SNAPSHOT_DIR=… swift test --filter StudioSnapshotTests/testConverseFidelitySnapshots`

## For the reviewer

- `StudioCanvas.swift` was not touched (Main board owner). Its conversation branch is now dead for the shell — `StudioRootView` renders `StudioConverseView` for conversational modes — and `StudioConversationView` keeps its old parameters (`onNewChat`, defaults for the new ones) so that call site still compiles. Follow-up for the Main board: drop `StudioCanvas`'s conversation inputs.
- `MereRunController.swift` was not touched. Stop for a thread finds the active job through `controller.jobs`; the turn's provenance comes from the job's request snapshot.
- The base branch is `studio-v2/ui-batch-1`.
