### PR TITLE
Make Flash-Next wide verification exact

### DIFF
--- a/Sources/MereRunCLI/Commands/ModelBenchmarkCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelBenchmarkCommand.swift
@@ -193,6 +193,10 @@ struct ModelBenchmarkQ36MTP: AsyncParsableCommand {
             Q35Resources.q36NanoModelId,
             Q35Resources.q38TwentySevenBModelId,
             Q35Resources.q38TwentySevenB4BitModelId,
+            Q35Resources.q38FlashNextMixedModelId,
+            Q35Resources.q38FlashNext3BitModelId,
+            Q35Resources.q38FlashNext3BitNativePLEModelId,
+            Q35Resources.q38FlashNext4BitModelId,
             Q35Resources.ornith9BModelId,
             Q35Resources.ornith35BMLX4BitModelId,
             Q35Resources.ornith35BMLX6BitModelId,
@@ -367,16 +371,33 @@ struct ModelBenchmarkQ36MTP: AsyncParsableCommand {
         _ variant: Q36MTPBenchmarkVariant,
         request: ChatRequest
     ) async throws -> Q36MTPBenchmarkVariantResult {
-        let generator = Q35Generator(modelId: model)
-        let memoryBefore = ProcessMemorySnapshot.currentResidentBytes()
-        let start = Date()
-        let response = try await withTemporaryEnvironment(variant.environmentOverrides(self)) {
-            try await generator.chat(request, modelPath: modelRoot, progressHandler: nil)
+        let generator = Q35Generator(
+            modelId: model,
+            prefixKVCacheEnabled: false,
+            continuousBatchingEnabled: false
+        )
+        let measurement = try await withTemporaryEnvironment(variant.environmentOverrides(self)) {
+            var warmup = request
+            warmup.maxTokens = min(16, request.maxTokens)
+            _ = try await generator.chat(warmup, modelPath: modelRoot, progressHandler: nil)
+
+            let memoryBefore = ProcessMemorySnapshot.currentResidentBytes()
+            let start = Date()
+            let response = try await generator.chat(
+                request,
+                modelPath: modelRoot,
+                progressHandler: nil
+            )
+            return (
+                response: response,
+                elapsed: Date().timeIntervalSince(start),
+                memoryBefore: memoryBefore,
+                memoryAfter: ProcessMemorySnapshot.currentResidentBytes()
+            )
         }
-        let elapsed = Date().timeIntervalSince(start)
-        let memoryAfter = ProcessMemorySnapshot.currentResidentBytes()
         await generator.unload()
 
+        let response = measurement.response
         guard let timing = response.timing else {
             throw ValidationError("\(variant.name) did not return timing data.")
         }
@@ -392,7 +413,7 @@ struct ModelBenchmarkQ36MTP: AsyncParsableCommand {
             ),
             promptTokens: promptTokens,
             generatedTokens: response.tokensGenerated,
-            elapsedSeconds: elapsed,
+            elapsedSeconds: measurement.elapsed,
             loadSeconds: timing.loadSeconds,
             prefillSeconds: timing.prefillSeconds,
             decodeSeconds: timing.decodeSeconds,
@@ -403,9 +424,11 @@ struct ModelBenchmarkQ36MTP: AsyncParsableCommand {
             decodeTokensPerSecond: timing.decodeSeconds > 0
                 ? Double(response.tokensGenerated) / timing.decodeSeconds
                 : nil,
-            endToEndTokensPerSecond: elapsed > 0 ? Double(response.tokensGenerated) / elapsed : nil,
-            residentMemoryBeforeBytes: memoryBefore,
-            residentMemoryAfterBytes: memoryAfter,
+            endToEndTokensPerSecond: measurement.elapsed > 0
+                ? Double(response.tokensGenerated) / measurement.elapsed
+                : nil,
+            residentMemoryBeforeBytes: measurement.memoryBefore,
+            residentMemoryAfterBytes: measurement.memoryAfter,
             acceleration: response.acceleration,
             outputSHA256: FusedBenchmarkHash.sha256(
                 (response.reasoningContent ?? "") + "\u{0}" + response.response

--- a/Sources/MereRunCLI/Commands/ModelBenchmarkCommand.swift
+++ b/Sources/MereRunCLI/Commands/ModelBenchmarkCommand.swift
@@ -1,6 +1,6 @@
 import ArgumentParser
 import Foundation
-import MereRunCore
+@_spi(Benchmark) import MereRunCore
 #if canImport(Darwin)
 import Darwin
 #elseif canImport(Glibc)
@@ -21,11 +21,117 @@ struct ModelBenchmark: ParsableCommand {
             ModelBenchmarkGemma4KV.self,
             ModelBenchmarkGemma4MTP.self,
             ModelBenchmarkQ36MTP.self,
+            ModelBenchmarkQ38Verification.self,
             ModelBenchmarkLagunaDFlash.self,
             ModelBenchmarkAPIWorkload.self,
             ModelBenchmarkVLM.self,
         ]
     )
+}
+
+struct ModelBenchmarkQ38Verification: AsyncParsableCommand {
+    static let configuration = CommandConfiguration(
+        commandName: "q38-verification",
+        abstract: "Measure the Flash-Next target-only verification frontier."
+    )
+
+    @Option(name: [.long], help: "Flash-Next model id.")
+    var model: String = Q35Resources.q38FlashNext3BitNativePLEModelId
+
+    @Option(name: [.customShort("m"), .long], help: "Installed Flash-Next model root.")
+    var modelRoot: String
+
+    @Option(name: [.long], help: "Comma-separated linear verification widths.")
+    var widths: String = "1,4,8,16,32"
+
+    @Option(name: [.long], help: "Target-generated oracle token count.")
+    var tokens: Int = 128
+
+    @Option(name: [.long], help: "Measurement trials.")
+    var trials: Int = 2
+
+    @Flag(name: [.long], help: "Emit machine-readable JSON.")
+    var json = false
+
+    func validate() throws {
+        let supported = [
+            Q35Resources.q38FlashNextMixedModelId,
+            Q35Resources.q38FlashNext3BitModelId,
+            Q35Resources.q38FlashNext3BitNativePLEModelId,
+            Q35Resources.q38FlashNext4BitModelId,
+        ]
+        guard supported.contains(model) else {
+            throw ValidationError("--model must select a Flash-Next checkpoint.")
+        }
+        guard tokens >= 32 else {
+            throw ValidationError("--tokens must be at least 32.")
+        }
+        guard trials > 0 else {
+            throw ValidationError("--trials must be greater than zero.")
+        }
+        _ = try parsedWidths()
+    }
+
+    func run() async throws {
+        try MLXBundleSupport.ensureAvailable(quiet: json)
+        let prompt = "Write a complete Python LRU cache using a dictionary and a doubly linked list."
+        let messages = [ChatMessage(role: .user, content: prompt)]
+        let generator = Q35Generator(
+            modelId: model,
+            prefixKVCacheEnabled: false,
+            continuousBatchingEnabled: false
+        )
+        do {
+            _ = try await generator.chat(
+                ChatRequest(
+                    messages: messages,
+                    maxTokens: 1,
+                    temperature: 0,
+                    topP: 1,
+                    showThinking: false,
+                    stopOnEOS: false,
+                    maxContextTokens: 8_192
+                ),
+                modelPath: modelRoot,
+                progressHandler: nil
+            )
+            let results = try await generator.benchmarkVerificationFrontier(
+                messages: messages,
+                tokenCount: tokens,
+                widths: parsedWidths(),
+                trials: trials
+            )
+            if json {
+                let encoder = JSONEncoder()
+                encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+                print(String(decoding: try encoder.encode(results), as: UTF8.self))
+            } else {
+                for result in results {
+                    print(String(
+                        format: "width=%d trial=%d passes=%d verify_tps=%.2f parity=%@",
+                        result.width,
+                        result.trial,
+                        result.verificationPasses,
+                        result.verifiedTokensPerSecond,
+                        result.greedyOutputParity ? "yes" : "no"
+                    ))
+                }
+            }
+        } catch {
+            await generator.unload()
+            throw error
+        }
+        await generator.unload()
+    }
+
+    private func parsedWidths() throws -> [Int] {
+        try widths.split(separator: ",").map { value in
+            guard let width = Int(value), width > 0, width <= 32 else {
+                throw ValidationError("--widths values must be integers from 1 through 32.")
+            }
+            return width
+        }
+    }
 }
 
 struct ModelBenchmarkQ36MTP: AsyncParsableCommand {

--- a/Sources/MereRunCore/Q35/Q35FullAttention.swift
+++ b/Sources/MereRunCore/Q35/Q35FullAttention.swift
@@ -162,7 +162,8 @@ final class Q35FullAttention: Module {
         let queryCount = q.dim(2)
         let keyCount = k.dim(2)
         let attn: MLXArray
-        if let indexer, targetVerify, b == 1, (2...9).contains(queryCount),
+        if let indexer, targetVerify, b == 1, (2...32).contains(queryCount),
+           (queryCount <= 9 || Q38WideVerificationPolicy.exactSparseAttention),
            keyCount >= queryCount, case .causal = mask {
             // Flash-Next's BF16 dense attention and sparse reductions can
             // round differently with multiple query rows. Also, a block can

--- a/Sources/MereRunCore/Q35/Q35Generator.swift
+++ b/Sources/MereRunCore/Q35/Q35Generator.swift
@@ -30,6 +30,19 @@ struct Q35PrefillOutput {
     let mtpSession: Q35MTPDraftSession?
 }
 
+@_spi(Benchmark)
+public struct Q35VerificationFrontierResult: Encodable, Sendable {
+    public let width: Int
+    public let trial: Int
+    public let verifiedTokens: Int
+    public let verificationPasses: Int
+    public let verificationSeconds: Double
+    public let verifiedTokensPerSecond: Double
+    public let greedyOutputParity: Bool
+    public let activeMemoryBytes: Int
+    public let cacheMemoryBytes: Int
+}
+
 private struct Q35BatchedDecodeResult {
     let generatedTokens: [Int]
     let decodeSeconds: Double
@@ -170,7 +183,93 @@ public actor Q35Generator: ChatGenerator {
         precondition(model == nil, "Install checkpoint transforms before loading the model")
         checkpointTransformForTesting = transform
     }
+
     #endif
+
+    /// Measures target-only linear verification against an oracle sequence
+    /// produced by the same loaded target. This benchmark-only API excludes
+    /// draft cost and does not implement tree-shaped state.
+    @_spi(Benchmark)
+    public func benchmarkVerificationFrontier(
+        messages: [ChatMessage],
+        tokenCount: Int,
+        widths: [Int],
+        trials: Int
+    ) throws -> [Q35VerificationFrontierResult] {
+        precondition(tokenCount > 0 && !widths.isEmpty && trials > 0)
+        guard let model, let tokenizerAndTemplate else {
+            throw Q35Error.modelNotLoaded
+        }
+        let promptTokens = try tokenizerAndTemplate.encodeForGeneration(
+            messages: messages,
+            includeThinking: false,
+            maxLength: Q35Resources.defaultContextLength
+        )
+        let promptInput = MLXArray(promptTokens.map(Int32.init)).reshaped(1, promptTokens.count)
+        let serialCaches = makeLayerCaches(config: model.config)
+        var serial = model.forward(promptInput, cache: serialCaches)
+        MLX.eval(serial.logits)
+        var oracleTokens: [Int] = []
+        oracleTokens.reserveCapacity(tokenCount)
+        for _ in 0..<tokenCount {
+            let token = MLX.argMax(serial.logits[0, -1, 0...]).item(Int32.self)
+            oracleTokens.append(Int(token))
+            let input = MLXArray([token]).reshaped(1, 1)
+            serial = model.forward(input, cache: serialCaches)
+            MLX.eval(serial.logits)
+        }
+
+        var results: [Q35VerificationFrontierResult] = []
+        for trial in 0..<max(1, trials) {
+            let orderedWidths = trial.isMultiple(of: 2) ? widths : Array(widths.reversed())
+            for width in orderedWidths {
+                let effectiveWidth = max(1, min(width, tokenCount))
+                let caches = makeLayerCaches(config: model.config)
+                var output = model.forward(promptInput, cache: caches)
+                MLX.eval(output.logits)
+                var index = 0
+                var passes = 0
+                var seconds = 0.0
+                var parity = MLX.argMax(output.logits[0, -1, 0...]).item(Int32.self)
+                    == Int32(oracleTokens[0])
+                while index < oracleTokens.count {
+                    let end = min(index + effectiveWidth, oracleTokens.count)
+                    let values = oracleTokens[index..<end].map(Int32.init)
+                    let input = MLXArray(values).reshaped(1, values.count)
+                    let started = Date()
+                    output = model.forward(
+                        input,
+                        cache: caches,
+                        targetVerify: values.count > 1
+                    )
+                    MLX.eval(output.logits)
+                    seconds += Date().timeIntervalSince(started)
+                    passes += 1
+
+                    if values.count > 1 {
+                        commitVerificationCaches(caches)
+                    }
+                    for offset in 0..<values.count where index + offset + 1 < oracleTokens.count {
+                        let predicted = MLX.argMax(output.logits[0, offset, 0...]).item(Int32.self)
+                        parity = parity && predicted == Int32(oracleTokens[index + offset + 1])
+                    }
+                    index = end
+                }
+                results.append(Q35VerificationFrontierResult(
+                    width: effectiveWidth,
+                    trial: trial,
+                    verifiedTokens: oracleTokens.count,
+                    verificationPasses: passes,
+                    verificationSeconds: seconds,
+                    verifiedTokensPerSecond: Double(oracleTokens.count) / seconds,
+                    greedyOutputParity: parity,
+                    activeMemoryBytes: Memory.activeMemory,
+                    cacheMemoryBytes: Memory.cacheMemory
+                ))
+            }
+        }
+        return results
+    }
 
     private let modelId: String
     private let prefixKVCacheEnabled: Bool

--- a/Sources/MereRunCore/Q35/Q35MoE.swift
+++ b/Sources/MereRunCore/Q35/Q35MoE.swift
@@ -137,6 +137,24 @@ class Q35SwitchLinear: Module {
         applyGather(x, indices: indices, sortedIndices: sortedIndices)
     }
 
+    func applyFlatExact(_ x: MLXArray, indices: MLXArray) -> MLXArray? {
+        #if os(macOS)
+        guard let scales, let biases else { return nil }
+        let resolved = resolvedQuantization(inputDim: x.dim(x.ndim - 1), scales: scales)
+        return SmallBatchAffineGatherQMV.matmul(
+            x,
+            weight: weight,
+            scales: scales,
+            biases: biases,
+            indices: indices,
+            groupSize: resolved.groupSize,
+            bits: resolved.bits
+        )
+        #else
+        return nil
+        #endif
+    }
+
     private func applyGather(_ x: MLXArray, indices: MLXArray, sortedIndices: Bool) -> MLXArray {
         let inputDim = x.dim(x.ndim - 1)
         let output: MLXArray
@@ -294,6 +312,45 @@ final class Q35SwitchGLU: Module {
         return downProj(activated, indices: indices)
     }
 
+    func serialTokens(_ x: MLXArray, indices: MLXArray) -> MLXArray {
+        precondition(x.ndim == 3 && indices.ndim == 3)
+        return MLX.concatenated((0..<x.dim(1)).map { row in
+            unsorted(
+                x[0..., row..<(row + 1), 0...],
+                indices: indices[0..., row..<(row + 1), 0...]
+            )
+        }, axis: 1)
+    }
+
+    func exactWide(_ x: MLXArray, indices: MLXArray) -> MLXArray? {
+        guard x.ndim == 3, x.dim(0) == 1, indices.ndim == 3 else { return nil }
+        let width = x.dim(1)
+        let topK = indices.dim(2)
+        let inputDim = x.dim(2)
+        let routeCount = width * topK
+        let flatIndices = indices.reshaped([routeCount])
+        let flatInput = MLX.broadcast(
+            x.expandedDimensions(axis: 2),
+            to: [1, width, topK, inputDim]
+        ).reshaped([routeCount, 1, inputDim])
+
+        let activated: MLXArray
+        if let fused = resolvedFusedGateUp(),
+           let fusedOutput = exactFusedGateUp(flatInput, fused: fused, indices: flatIndices) {
+            let parts = split(fusedOutput, indices: [fused.intermediate], axis: -1)
+            activated = MLXNN.silu(parts[0]) * parts[1]
+        } else if let gate = gateProj.applyFlatExact(flatInput, indices: flatIndices),
+                  let up = upProj.applyFlatExact(flatInput, indices: flatIndices) {
+            activated = q35Swiglu(gate, up)
+        } else {
+            return nil
+        }
+        guard let output = downProj.applyFlatExact(activated, indices: flatIndices) else {
+            return nil
+        }
+        return output.reshaped([1, width, topK, output.dim(2)])
+    }
+
     private func resolvedFusedGateUp() -> FusedGateUp? {
         guard Q35FusedSwitchGLUPolicy.enabled else { return nil }
 
@@ -449,6 +506,34 @@ final class Q35SwitchGLU: Module {
         let parts = split(output, indices: [fused.intermediate], axis: -1)
         return MLXNN.silu(parts[0]) * parts[1]
     }
+
+    private func exactFusedGateUp(
+        _ x: MLXArray,
+        fused: FusedGateUp,
+        indices: MLXArray
+    ) -> MLXArray? {
+        #if os(macOS)
+        guard let scales = fused.scales, let biases = fused.biases else { return nil }
+        let resolved = q35ResolvedQuantization(
+            inputDim: x.dim(x.ndim - 1),
+            packedInputDim: fused.weight.dim(fused.weight.ndim - 1),
+            scaleGroups: scales.dim(scales.ndim - 1),
+            fallbackGroupSize: gateProj.groupSize,
+            fallbackBits: gateProj.bits
+        )
+        return SmallBatchAffineGatherQMV.matmul(
+            x,
+            weight: fused.weight,
+            scales: scales,
+            biases: biases,
+            indices: indices,
+            groupSize: resolved.groupSize,
+            bits: resolved.bits
+        )
+        #else
+        return nil
+        #endif
+    }
 }
 
 private func q35ResolvedQuantization(
@@ -542,7 +627,7 @@ final class Q35FeedForward: Module {
         switchMLP?.prepareFusedGateUpAndReleaseSources() ?? false
     }
 
-    func callAsFunction(_ x: MLXArray) -> MLXArray {
+    func callAsFunction(_ x: MLXArray, targetVerify: Bool = false) -> MLXArray {
         if usesMoE,
            let gate,
            let switchMLP,
@@ -564,7 +649,16 @@ final class Q35FeedForward: Module {
             }
             if isQwen4Exp { scores = scores.asType(routerLogits.dtype) }
 
-            let switched = switchMLP(x, indices: indices)
+            let usesSerialRoutes = targetVerify && isQwen4Exp
+                && Q38WideVerificationPolicy.exactExpertRoutes
+                && x.ndim == 3 && x.dim(0) == 1 && (10...32).contains(x.dim(1))
+            // Wide route batches change gather-QMV arithmetic. Keep only the
+            // routed expert path serial-equivalent; the exact small-batch
+            // router, shared expert, and shared gate remain batched.
+            let switched = usesSerialRoutes
+                ? switchMLP.exactWide(x, indices: indices)
+                    ?? switchMLP.serialTokens(x, indices: indices)
+                : switchMLP(x, indices: indices)
             var routed = switched * MLX.expandedDimensions(scores, axis: scores.ndim)
             routed = routed.sum(axis: -2)
 

--- a/Sources/MereRunCore/Q35/Q35Model.swift
+++ b/Sources/MereRunCore/Q35/Q35Model.swift
@@ -214,7 +214,7 @@ final class Q35DecoderLayer: Module {
             )
 
             let mlpMix = mlpHyperConnection.mix(hyper)
-            let mlpOut = mlp(mlpMix.mixed)
+            let mlpOut = mlp(mlpMix.mixed, targetVerify: targetVerify)
             return mlpHyperConnection.inject(
                 blockOutput: mlpOut,
                 residual: mlpMix.residual,
@@ -257,7 +257,7 @@ final class Q35DecoderLayer: Module {
             h = x + attentionOut
         }
 
-        let mlpOut = mlp(postAttentionLayerNorm(h))
+        let mlpOut = mlp(postAttentionLayerNorm(h), targetVerify: targetVerify)
         return h + mlpOut
     }
 }

--- a/Sources/MereRunCore/Q35/Q38FlashNext.swift
+++ b/Sources/MereRunCore/Q35/Q38FlashNext.swift
@@ -2,15 +2,46 @@ import Foundation
 import MLX
 import MLXNN
 
+enum Q38WideVerificationPolicy {
+    static let exactDenseProjections = enabled(
+        "MERERUN_Q38_EXACT_WIDE_DENSE", defaultValue: false
+    )
+    static let exactSparseAttention = enabled("MERERUN_Q38_EXACT_WIDE_QSA")
+    static let exactExpertRoutes = enabled("MERERUN_Q38_EXACT_WIDE_MOE")
+    private static let denseProjectionShapes: Set<String>? = {
+        guard let raw = ProcessInfo.processInfo.environment["MERERUN_Q38_EXACT_WIDE_DENSE_SHAPES"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+              !raw.isEmpty else { return nil }
+        return Set(raw.split(separator: ",").map(String.init))
+    }()
+
+    static func exactDenseProjection(output: Int, input: Int) -> Bool {
+        guard exactDenseProjections else { return false }
+        guard let denseProjectionShapes else { return true }
+        return denseProjectionShapes.contains("\(output)x\(input)")
+    }
+
+    private static func enabled(_ key: String, defaultValue: Bool = true) -> Bool {
+        guard let value = ProcessInfo.processInfo.environment[key]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased() else { return defaultValue }
+        return value != "0" && value != "false" && value != "off"
+    }
+}
+
 /// Flash-Next keeps its readout, router, and indexer in BF16. Small-batch GEMM
 /// can round differently from one-token GEMV, including at three/four rows.
-/// Keep those short batches on serial arithmetic; quantized projections
-/// retain their own weight-reusing QMV path and prefill stays batched.
+/// Keep short verification batches on serial arithmetic; selected wide dense
+/// shapes can opt in for diagnostics. Quantized projections retain their own
+/// weight-reusing QMV path and prefill stays batched.
 func q38SmallBatchProjection(_ layer: Linear, _ input: MLXArray) -> MLXArray {
     #if os(macOS)
-    if Device.defaultDevice().deviceType == .gpu,
+    if (input.dim(1) <= 9 || Q38WideVerificationPolicy.exactDenseProjection(
+        output: layer.weight.dim(0), input: layer.weight.dim(1)
+    )),
+       Device.defaultDevice().deviceType == .gpu,
        input.ndim == 3, input.dim(0) == 1,
-       (2...9).contains(input.dim(1)),
+       (2...32).contains(input.dim(1)),
        input.dtype == .bfloat16, layer.weight.dtype == .bfloat16 {
         return MLX.concatenated((0..<input.dim(1)).map { row in
             layer(input[0..., row..<(row + 1), 0...])

--- a/Sources/MereRunCore/Quantization/SmallBatchAffineGatherQMV.swift
+++ b/Sources/MereRunCore/Quantization/SmallBatchAffineGatherQMV.swift
@@ -1,0 +1,91 @@
+#if os(macOS)
+import MLX
+import MLXFast
+
+/// Runs independent affine-Q3 gather QMV routes in one Metal launch while
+/// retaining MLX's exact one-vector reduction order for every route.
+enum SmallBatchAffineGatherQMV {
+    private static let fastKernel = makeKernel(
+        name: "mere_affine3_g64_gather_qmv_fast_v1",
+        implementation: "qmv_fast_impl"
+    )
+    private static let regularKernel = makeKernel(
+        name: "mere_affine3_g64_gather_qmv_v1",
+        implementation: "qmv_impl"
+    )
+
+    private static func makeKernel(name: String, implementation: String) -> MLXFast.MLXFastKernel {
+        MLXFast.metalKernel(
+            name: name,
+            inputNames: ["w", "scales", "biases", "x", "indices"],
+            outputNames: ["y"],
+            source: """
+                const int route = int(threadgroup_position_in_grid.x);
+                const int k = x_shape[x_ndim - 1];
+                const int n = w_shape[w_ndim - 2];
+                const int packed = w_shape[w_ndim - 1];
+                const int groups = k / 64;
+                const int expert = int(indices[route]);
+                const device uint32_t* route_w = w + expert * n * packed;
+                const device bfloat16_t* route_scales = scales + expert * n * groups;
+                const device bfloat16_t* route_biases = biases + expert * n * groups;
+                const device bfloat16_t* route_x = x + route * k;
+                device bfloat16_t* route_y = y + route * n;
+                const uint3 local_tid = uint3(0, threadgroup_position_in_grid.y, 0);
+                \(implementation)<bfloat16_t, 64, 3>(
+                    route_w, route_scales, route_biases, route_x, route_y,
+                    x_shape[x_ndim - 1], w_shape[w_ndim - 2],
+                    local_tid, simdgroup_index_in_threadgroup,
+                    thread_index_in_simdgroup);
+                """,
+            header: "// MLX_INCLUDE_AFFINE_QUANTIZED_HEADERS\n",
+            ensureRowContiguous: true
+        )
+    }
+
+    static func matmul(
+        _ x: MLXArray,
+        weight: MLXArray,
+        scales: MLXArray,
+        biases: MLXArray,
+        indices: MLXArray,
+        groupSize: Int,
+        bits: Int
+    ) -> MLXArray? {
+        guard Device.defaultDevice().deviceType == .gpu,
+              groupSize == 64, bits == 3,
+              x.dtype == .bfloat16,
+              weight.dtype == .uint32,
+              scales.dtype == .bfloat16,
+              biases.dtype == .bfloat16,
+              indices.dtype == .uint32,
+              x.ndim == 3, x.dim(1) == 1,
+              weight.ndim == 3,
+              scales.ndim == 3,
+              biases.ndim == 3 else {
+            return nil
+        }
+
+        let routeCount = x.dim(0)
+        let inputSize = x.dim(2)
+        let outputSize = weight.dim(1)
+        guard routeCount == indices.size,
+              inputSize % groupSize == 0,
+              outputSize >= 8, outputSize % 8 == 0,
+              weight.dim(2) * 32 == inputSize * bits,
+              scales.shape == [weight.dim(0), outputSize, inputSize / groupSize],
+              biases.shape == scales.shape else {
+            return nil
+        }
+
+        let kernel = inputSize.isMultiple(of: 512) ? fastKernel : regularKernel
+        return kernel(
+            [weight, scales, biases, x, indices],
+            grid: (routeCount * 32, (outputSize / 8) * 2, 1),
+            threadGroup: (32, 2, 1),
+            outputShapes: [[routeCount, 1, outputSize]],
+            outputDTypes: [.bfloat16]
+        )[0]
+    }
+}
+#endif

--- a/Sources/MereRunCore/Quantization/SmallBatchAffineQMV.swift
+++ b/Sources/MereRunCore/Quantization/SmallBatchAffineQMV.swift
@@ -1,15 +1,38 @@
 #if os(macOS)
+import Foundation
 import MLX
 import MLXFast
 
 /// A serial-arithmetic-preserving affine-Q4 matrix/vector kernel for the
-/// two-through-nine-row verification blocks used by Qwen MTP.
+/// two-through-thirty-two-row verification blocks used by Qwen MTP.
 ///
 /// MLX's native wide QMV deliberately reassociates the reduction to reuse
 /// weights across rows. This kernel retains the serial QMV's per-row reduction
 /// order while sharing the weight reads, which keeps speculative verification
 /// on the same greedy trajectory as one-token decoding.
 enum SmallBatchAffineQMV {
+    /// Wide Flash-Next verification only needs serial QMV arithmetic on these
+    /// checkpoint geometries to preserve the greedy trajectory. The omitted
+    /// 4x10240 injection and 2560x640 shared-down tails stay on MLX's wide
+    /// kernel; serializing either costs throughput without changing parity.
+    private static let q38WideExactShapes: Set<String> = [
+        "48x2560", "320x10240", "512x2560", "640x2560",
+        "2560x2560", "2560x6144", "6144x2560", "10240x320",
+        "10240x2560", "12288x2560", "248320x2560",
+    ]
+    private static let exactWideEnabled: Bool = {
+        let value = ProcessInfo.processInfo.environment["MERERUN_Q38_EXACT_WIDE_Q4"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+        return value != "0" && value != "false" && value != "off"
+    }()
+    private static let exactWideShapes: Set<String>? = {
+        guard let raw = ProcessInfo.processInfo.environment["MERERUN_Q38_EXACT_WIDE_Q4_SHAPES"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+              !raw.isEmpty else { return nil }
+        return Set(raw.split(separator: ",").map(String.init))
+    }()
+
     private static let header = """
         template <int NA>
         inline void mere_affine4_qmv_wide(
@@ -131,6 +154,22 @@ enum SmallBatchAffineQMV {
         }
         """
 
+    private static let exactRowsKernel = MLXFast.metalKernel(
+        name: "mere_affine4_g64_exact_rows_qmv_v1",
+        inputNames: ["w", "scales", "biases", "x"],
+        outputNames: ["y"],
+        source: """
+            qmv_impl<bfloat16_t, 64, 4>(
+                w, scales, biases, x, y,
+                x_shape[x_ndim - 1], w_shape[0],
+                threadgroup_position_in_grid,
+                simdgroup_index_in_threadgroup,
+                thread_index_in_simdgroup);
+            """,
+        header: "// MLX_INCLUDE_AFFINE_QUANTIZED_HEADERS\n",
+        ensureRowContiguous: true
+    )
+
     private static let source = """
         const int m = x_shape[x_ndim - 2];
         const int k = x_shape[x_ndim - 1];
@@ -149,6 +188,29 @@ enum SmallBatchAffineQMV {
             case 7: mere_affine4_qmv_m<7, 4>(w, scales, biases, x, y, k, n, group_x, out_row, lid); break;
             case 8: mere_affine4_qmv_m<8, 4>(w, scales, biases, x, y, k, n, group_x, out_row, lid); break;
             case 9: mere_affine4_qmv_m<9, 3>(w, scales, biases, x, y, k, n, group_x, out_row, lid); break;
+            case 10: mere_affine4_qmv_m<10, 5>(w, scales, biases, x, y, k, n, group_x, out_row, lid); break;
+            case 11: mere_affine4_qmv_m<11, 4>(w, scales, biases, x, y, k, n, group_x, out_row, lid); break;
+            case 12: mere_affine4_qmv_m<12, 4>(w, scales, biases, x, y, k, n, group_x, out_row, lid); break;
+            case 13: mere_affine4_qmv_m<13, 5>(w, scales, biases, x, y, k, n, group_x, out_row, lid); break;
+            case 14: mere_affine4_qmv_m<14, 4>(w, scales, biases, x, y, k, n, group_x, out_row, lid); break;
+            case 15: mere_affine4_qmv_m<15, 5>(w, scales, biases, x, y, k, n, group_x, out_row, lid); break;
+            case 16: mere_affine4_qmv_m<16, 4>(w, scales, biases, x, y, k, n, group_x, out_row, lid); break;
+            case 17: mere_affine4_qmv_m<17, 5>(w, scales, biases, x, y, k, n, group_x, out_row, lid); break;
+            case 18: mere_affine4_qmv_m<18, 4>(w, scales, biases, x, y, k, n, group_x, out_row, lid); break;
+            case 19: mere_affine4_qmv_m<19, 4>(w, scales, biases, x, y, k, n, group_x, out_row, lid); break;
+            case 20: mere_affine4_qmv_m<20, 5>(w, scales, biases, x, y, k, n, group_x, out_row, lid); break;
+            case 21: mere_affine4_qmv_m<21, 3>(w, scales, biases, x, y, k, n, group_x, out_row, lid); break;
+            case 22: mere_affine4_qmv_m<22, 4>(w, scales, biases, x, y, k, n, group_x, out_row, lid); break;
+            case 23: mere_affine4_qmv_m<23, 4>(w, scales, biases, x, y, k, n, group_x, out_row, lid); break;
+            case 24: mere_affine4_qmv_m<24, 4>(w, scales, biases, x, y, k, n, group_x, out_row, lid); break;
+            case 25: mere_affine4_qmv_m<25, 5>(w, scales, biases, x, y, k, n, group_x, out_row, lid); break;
+            case 26: mere_affine4_qmv_m<26, 4>(w, scales, biases, x, y, k, n, group_x, out_row, lid); break;
+            case 27: mere_affine4_qmv_m<27, 4>(w, scales, biases, x, y, k, n, group_x, out_row, lid); break;
+            case 28: mere_affine4_qmv_m<28, 4>(w, scales, biases, x, y, k, n, group_x, out_row, lid); break;
+            case 29: mere_affine4_qmv_m<29, 3>(w, scales, biases, x, y, k, n, group_x, out_row, lid); break;
+            case 30: mere_affine4_qmv_m<30, 5>(w, scales, biases, x, y, k, n, group_x, out_row, lid); break;
+            case 31: mere_affine4_qmv_m<31, 4>(w, scales, biases, x, y, k, n, group_x, out_row, lid); break;
+            case 32: mere_affine4_qmv_m<32, 4>(w, scales, biases, x, y, k, n, group_x, out_row, lid); break;
             default: break;
         }
         """
@@ -171,7 +233,8 @@ enum SmallBatchAffineQMV {
         bits: Int,
         mode: QuantizationMode
     ) -> MLXArray? {
-        guard Device.defaultDevice().deviceType == .gpu,
+        guard exactWideEnabled,
+              Device.defaultDevice().deviceType == .gpu,
               bits == 4, groupSize == 64, mode == .affine else { return nil }
         guard x.dtype == .bfloat16,
               weight.dtype == .uint32,
@@ -185,7 +248,11 @@ enum SmallBatchAffineQMV {
         let inputSize = x.dim(-1)
         let outputSize = weight.dim(0)
         let width = x.size / inputSize
-        guard (2...9).contains(width),
+        let shape = "\(outputSize)x\(inputSize)"
+        let selected = exactWideShapes?.contains(shape)
+            ?? (width <= 9 || q38WideExactShapes.contains(shape))
+        guard selected,
+              (2...32).contains(width),
               x.dim(-2) == width,
               weight.dim(1) == inputSize / 8 else {
             return nil
@@ -196,7 +263,7 @@ enum SmallBatchAffineQMV {
         // the aligned kernel below. Native wide QMV changes their reduction
         // order too. Keep those small verification blocks on native one-row
         // QMV until a matching weight-reusing kernel covers the tail shapes.
-        guard inputSize % 512 == 0, outputSize % 8 == 0, outputSize >= 8 else {
+        guard outputSize % 8 == 0, outputSize >= 8 else {
             return MLX.concatenated((0..<width).map { row in
                 MLX.quantizedMM(
                     x[.ellipsis, row..<(row + 1), 0...], weight,
@@ -204,6 +271,18 @@ enum SmallBatchAffineQMV {
                     groupSize: groupSize, bits: bits, mode: mode
                 )
             }, axis: -2)
+        }
+
+        if !inputSize.isMultiple(of: 512) {
+            var outputShape = x.shape
+            outputShape[outputShape.count - 1] = outputSize
+            return exactRowsKernel(
+                [weight, scales, biases, x],
+                grid: (width * 32, (outputSize / 8) * 2, 1),
+                threadGroup: (32, 2, 1),
+                outputShapes: [outputShape],
+                outputDTypes: [.bfloat16]
+            )[0]
         }
 
         let inputsPerGroup: Int
@@ -216,6 +295,11 @@ enum SmallBatchAffineQMV {
         case 7: inputsPerGroup = 4
         case 8: inputsPerGroup = 4
         case 9: inputsPerGroup = 3
+        case 10: inputsPerGroup = 5
+        case 11, 12, 14, 16, 18, 19, 22, 23, 24, 26, 27, 28, 31, 32:
+            inputsPerGroup = 4
+        case 13, 15, 17, 20, 25, 30: inputsPerGroup = 5
+        case 21, 29: inputsPerGroup = 3
         default: return nil
         }
 

--- a/Tests/MereRunCLITests/CapabilityCatalogTests.swift
+++ b/Tests/MereRunCLITests/CapabilityCatalogTests.swift
@@ -230,6 +230,7 @@ let contractExemptCommandIDs: [String: String] = [
     "graph.worker.execute": "Machine-to-machine worker protocol, not a shell surface.",
     "graph.worker.inspect": "Machine-to-machine worker protocol, not a shell surface.",
     "graph.worker.cancel": "Machine-to-machine worker protocol, not a shell surface.",
+    "model.benchmark.q38-verification": "Research-only target-verification microbenchmark, not a product workflow.",
     "vision.image-to-3d": "VFX alias of image.reconstruct-3d, surfaced through the Image workspace.",
     "vision.image-to-3d-trellis2": "VFX alias of image.reconstruct-3d-trellis2.",
     "vision.image-to-3d-multiview": "VFX alias of image.reconstruct-3d-multiview."

--- a/Tests/MereRunCLITests/ModelBenchmarkCommandTests.swift
+++ b/Tests/MereRunCLITests/ModelBenchmarkCommandTests.swift
@@ -565,10 +565,14 @@ final class ModelBenchmarkCommandTests: XCTestCase {
         XCTAssertTrue(cmd.json)
     }
 
-    func testQ36MTPBenchmarkAcceptsQ38AndOfficialOrnithQuantizedTargets() throws {
+    func testQ36MTPBenchmarkAcceptsQ38FlashNextAndOfficialOrnithQuantizedTargets() throws {
         for modelId in [
             Q35Resources.q38TwentySevenBModelId,
             Q35Resources.q38TwentySevenB4BitModelId,
+            Q35Resources.q38FlashNextMixedModelId,
+            Q35Resources.q38FlashNext3BitModelId,
+            Q35Resources.q38FlashNext3BitNativePLEModelId,
+            Q35Resources.q38FlashNext4BitModelId,
             Q35Resources.ornith35BMLX4BitModelId,
             Q35Resources.ornith35BMLX6BitModelId,
             Q35Resources.ornith35BMLX8BitModelId,

--- a/Tests/MereRunCLITests/ModelBenchmarkCommandTests.swift
+++ b/Tests/MereRunCLITests/ModelBenchmarkCommandTests.swift
@@ -509,6 +509,30 @@ final class ModelBenchmarkCommandTests: XCTestCase {
         XCTAssertFalse(cmd.json)
     }
 
+    func testBenchmarkCommandExposesQ38VerificationSubcommand() {
+        let commandNames = Set(ModelBenchmark.configuration.subcommands.map { $0.configuration.commandName })
+        XCTAssertTrue(commandNames.contains("q38-verification"))
+    }
+
+    func testQ38VerificationBenchmarkParsesDefaults() throws {
+        let cmd = try ModelBenchmarkQ38Verification.parse(["--model-root", "/tmp/flash-next"])
+
+        XCTAssertEqual(cmd.model, Q35Resources.q38FlashNext3BitNativePLEModelId)
+        XCTAssertEqual(cmd.modelRoot, "/tmp/flash-next")
+        XCTAssertEqual(cmd.widths, "1,4,8,16,32")
+        XCTAssertEqual(cmd.tokens, 128)
+        XCTAssertEqual(cmd.trials, 2)
+        XCTAssertFalse(cmd.json)
+        XCTAssertNoThrow(try cmd.validate())
+    }
+
+    func testQ38VerificationBenchmarkRejectsInvalidWidth() {
+        XCTAssertThrowsError(try ModelBenchmarkQ38Verification.parse([
+            "--model-root", "/tmp/flash-next",
+            "--widths", "4,64",
+        ]))
+    }
+
     func testQ36MTPBenchmarkParsesOverrides() throws {
         let cmd = try ModelBenchmarkQ36MTP.parse([
             "--model", Q35Resources.q36NanoModelId,

--- a/Tests/MereRunCoreTests/PortableQuantizedMatmulTests.swift
+++ b/Tests/MereRunCoreTests/PortableQuantizedMatmulTests.swift
@@ -88,6 +88,125 @@ final class PortableQuantizedMatmulTests: MereRunCoreTestCase {
             }
         }
     }
+
+    func testQ38WideAffineQMVShapesMatchSerialRowsBitExactly() throws {
+        guard Device.defaultDevice().deviceType == .gpu else {
+            throw XCTSkip(
+                "Wide Flash-Next affine QMV parity requires MERERUN_TEST_MLX_DEVICE=gpu."
+            )
+        }
+        MLXRandom.seed(73)
+        for (outputSize, inputSize) in [(320, 10_240), (10_240, 320)] {
+            let denseWeight = MLXRandom.uniform(
+                -0.2..<0.2,
+                [outputSize, inputSize]
+            ).asType(.bfloat16)
+            let (weight, scales, optionalBiases) = MLX.quantized(
+                denseWeight,
+                groupSize: 64,
+                bits: 4,
+                mode: .affine
+            )
+            let biases = try XCTUnwrap(optionalBiases)
+
+            for width in [16, 32] {
+                let input = MLXRandom.uniform(
+                    -0.5..<0.5,
+                    [1, width, inputSize]
+                ).asType(.bfloat16)
+                let expected = MLX.concatenated((0..<width).map { row in
+                    MLX.quantizedMM(
+                        input[0..., row..<(row + 1), 0...],
+                        weight,
+                        scales: scales,
+                        biases: biases,
+                        transpose: true,
+                        groupSize: 64,
+                        bits: 4,
+                        mode: .affine
+                    )
+                }, axis: 1)
+                let actual = try XCTUnwrap(SmallBatchAffineQMV.matmul(
+                    input,
+                    weight: weight,
+                    scales: scales,
+                    biases: biases,
+                    groupSize: 64,
+                    bits: 4,
+                    mode: .affine
+                ))
+                MLX.eval(expected, actual)
+
+                let maximumError = MLX.max(MLX.abs(
+                    expected.asType(.float32) - actual.asType(.float32)
+                )).item(Float.self)
+                XCTAssertEqual(maximumError, 0, "\(outputSize)x\(inputSize), width \(width)")
+            }
+        }
+    }
+
+    func testSmallBatchAffineGatherQMVMatchesSerialRoutesBitExactly() throws {
+        guard Device.defaultDevice().deviceType == .gpu else {
+            throw XCTSkip(
+                "Small-batch affine gather QMV parity requires MERERUN_TEST_MLX_DEVICE=gpu."
+            )
+        }
+        MLXRandom.seed(72)
+        let expertCount = 7
+        let routeCount = 23
+        for inputSize in [512, 640] {
+            let outputSize = 96
+            let denseWeight = MLXRandom.uniform(
+                -0.2..<0.2,
+                [expertCount, outputSize, inputSize]
+            ).asType(.bfloat16)
+            let (weight, scales, optionalBiases) = MLX.quantized(
+                denseWeight,
+                groupSize: 64,
+                bits: 3,
+                mode: .affine
+            )
+            let biases = try XCTUnwrap(optionalBiases)
+            let input = MLXRandom.uniform(
+                -0.5..<0.5,
+                [routeCount, 1, inputSize]
+            ).asType(.bfloat16)
+            let indexValues = (0..<routeCount).map { UInt32(($0 * 3) % expertCount) }
+            let indices = MLXArray(indexValues)
+            let expected = MLX.concatenated((0..<routeCount).map { route in
+                let expert = Int(indexValues[route])
+                return MLX.quantizedMM(
+                    input[route..<(route + 1), 0..., 0...],
+                    weight[expert, 0..., 0...],
+                    scales: scales[expert, 0..., 0...],
+                    biases: biases[expert, 0..., 0...],
+                    transpose: true,
+                    groupSize: 64,
+                    bits: 3,
+                    mode: .affine
+                )
+            }, axis: 0)
+            let actual = try XCTUnwrap(SmallBatchAffineGatherQMV.matmul(
+                input,
+                weight: weight,
+                scales: scales,
+                biases: biases,
+                indices: indices,
+                groupSize: 64,
+                bits: 3
+            ))
+            MLX.eval(expected, actual)
+
+            let maximumError = MLX.max(MLX.abs(
+                expected.asType(.float32) - actual.asType(.float32)
+            )).item(Float.self)
+            XCTAssertEqual(
+                maximumError,
+                0,
+                "K=\(inputSize) changed serial gather QMV output"
+            )
+        }
+    }
     func testFlashNextUnalignedQuantizedProjectionsMatchSerialRows() throws {
         guard Device.defaultDevice().deviceType == .gpu else {
             throw XCTSkip("Flash-Next projection parity requires MERERUN_TEST_MLX_DEVICE=gpu.")
@@ -100,7 +219,8 @@ final class PortableQuantizedMatmulTests: MereRunCoreTestCase {
                 weight: weight, bias: nil, scales: scales, biases: biases,
                 groupSize: 64, bits: 4, mode: .affine
             )
-            for count in [2, 3, 4, 7, 9] {
+            let counts = inputSize == 320 ? [2, 3, 4, 7, 9, 16, 32] : [2, 3, 4, 7, 9]
+            for count in counts {
                 let input = MLXRandom.uniform(-0.5..<0.5, [1, count, inputSize]).asType(.bfloat16)
                 let serial = MLX.concatenated((0..<count).map {
                     layer(input[0..., $0..<($0 + 1), 0...])
@@ -134,7 +254,7 @@ final class PortableQuantizedMatmulTests: MereRunCoreTestCase {
 
     func testFlashNextDenseProjectionKeepsPrefillAndBatchingNative() {
         let layer = Linear(weight: MLXArray.ones([16, 32], dtype: .bfloat16), bias: nil)
-        for shape in [[1, 1, 32], [1, 10, 32], [2, 4, 32]] {
+        for shape in [[1, 1, 32], [1, 33, 32], [2, 4, 32]] {
             let input = MLXRandom.uniform(-0.5..<0.5, shape).asType(.bfloat16)
             let expected = layer(input)
             let actual = q38SmallBatchProjection(layer, input)

--- a/Tests/MereRunCoreTests/Q38FlashNextPerformanceTests.swift
+++ b/Tests/MereRunCoreTests/Q38FlashNextPerformanceTests.swift
@@ -1,24 +1,100 @@
 import Foundation
 import MLX
 import XCTest
-@testable import MereRunCore
+@_spi(Benchmark) @testable import MereRunCore
 
 /// Opt-in full-checkpoint measurements. Use an optimized test build and a
 /// separate process per MTP setting; no logprob capture or prefix reuse.
 final class Q38FlashNextPerformanceTests: MereRunCoreTestCase {
+    func testInstalledVerificationFrontier() async throws {
+        let environment = ProcessInfo.processInfo.environment
+        try XCTSkipUnless(environment["MERERUN_TEST_Q38_FLASH_NEXT_FRONTIER"] == "1",
+                          "Flash-Next verification frontier is opt-in.")
+        let root = try XCTUnwrap(environment["MERERUN_TEST_Q38_FLASH_NEXT_MODEL_ROOT"])
+        let modelID = environment["MERERUN_TEST_Q38_FLASH_NEXT_MODEL_ID"]
+            ?? Q35Resources.q38FlashNext3BitNativePLEModelId
+        let tokenCount = max(32, Int(environment["MERERUN_TEST_Q38_FLASH_NEXT_FRONTIER_TOKENS"] ?? "") ?? 128)
+        let trials = max(1, Int(environment["MERERUN_TEST_Q38_FLASH_NEXT_FRONTIER_TRIALS"] ?? "") ?? 2)
+        let widths = try (environment["MERERUN_TEST_Q38_FLASH_NEXT_FRONTIER_WIDTHS"] ?? "1,4,8,16,32")
+            .split(separator: ",")
+            .map { value -> Int in
+                guard let width = Int(value), width > 0 else {
+                    throw XCTSkip("Verification widths must be positive integers.")
+                }
+                return width
+            }
+        let prompt = "Write a complete Python LRU cache using a dictionary and a doubly linked list."
+        let messages = [ChatMessage(role: .user, content: prompt)]
+        let generator = Q35Generator(
+            modelId: modelID,
+            prefixKVCacheEnabled: false,
+            continuousBatchingEnabled: false
+        )
+        defer { Task { await generator.unload() } }
+        _ = try await generator.chat(
+            ChatRequest(
+                messages: messages,
+                maxTokens: 1,
+                temperature: 0,
+                topP: 1,
+                showThinking: false,
+                stopOnEOS: false,
+                maxContextTokens: 8_192
+            ),
+            modelPath: root,
+            progressHandler: nil
+        )
+        let results = try await generator.benchmarkVerificationFrontier(
+            messages: messages,
+            tokenCount: tokenCount,
+            widths: widths,
+            trials: trials
+        )
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys]
+        for result in results {
+            let data = try encoder.encode(result)
+            FileHandle.standardError.write(Data("[q38-verification-frontier] ".utf8) + data + Data("\n".utf8))
+            if result.width <= 8 {
+                XCTAssertTrue(result.greedyOutputParity, "Width \(result.width) changed greedy target output")
+            }
+        }
+    }
+
     func testInstalledMixedCodeAndProse() async throws {
         let environment = ProcessInfo.processInfo.environment
         try XCTSkipUnless(environment["MERERUN_TEST_Q38_FLASH_NEXT_BENCHMARK"] == "1",
                           "Full mixed-model benchmark is opt-in.")
         let root = try XCTUnwrap(environment["MERERUN_TEST_Q38_FLASH_NEXT_MODEL_ROOT"])
         XCTAssertTrue(FileManager.default.fileExists(atPath: root + "/model.safetensors.index.json"))
+        let modelID = environment["MERERUN_TEST_Q38_FLASH_NEXT_MODEL_ID"]
+            ?? Q35Resources.q38FlashNextMixedModelId
+        let supportedModelIDs = [
+            Q35Resources.q38FlashNextMixedModelId,
+            Q35Resources.q38FlashNext3BitModelId,
+            Q35Resources.q38FlashNext3BitNativePLEModelId,
+            Q35Resources.q38FlashNext4BitModelId,
+        ]
+        XCTAssertTrue(supportedModelIDs.contains(modelID), "Unsupported Flash-Next benchmark model id")
+        let trials = max(1, Int(environment["MERERUN_TEST_Q38_FLASH_NEXT_BENCHMARK_TRIALS"] ?? "") ?? 4)
+        let outputTokens = max(
+            64,
+            Int(environment["MERERUN_TEST_Q38_FLASH_NEXT_BENCHMARK_TOKENS"] ?? "") ?? 256
+        )
         let mtp = environment["MERERUN_Q35_MTP_SPECULATION"] == "1"
         let generator = Q35Generator(
-            modelId: Q35Resources.q38FlashNextMixedModelId,
+            modelId: modelID,
             prefixKVCacheEnabled: false, continuousBatchingEnabled: false
         )
         do {
-            try await benchmark(generator, root: root, mtp: mtp)
+            try await benchmark(
+                generator,
+                root: root,
+                modelID: modelID,
+                mtp: mtp,
+                trials: trials,
+                outputTokens: outputTokens
+            )
         } catch {
             await generator.unload()
             throw error
@@ -26,7 +102,14 @@ final class Q38FlashNextPerformanceTests: MereRunCoreTestCase {
         await generator.unload()
     }
 
-    private func benchmark(_ generator: Q35Generator, root: String, mtp: Bool) async throws {
+    private func benchmark(
+        _ generator: Q35Generator,
+        root: String,
+        modelID: String,
+        mtp: Bool,
+        trials: Int,
+        outputTokens: Int
+    ) async throws {
         let prompts = [
             ("code", "Write a complete Python implementation of an LRU cache using a dictionary and a "
                 + "doubly linked list, with get and put operations, type hints, and a short usage example. "
@@ -35,12 +118,13 @@ final class Q38FlashNextPerformanceTests: MereRunCoreTestCase {
                 + "library. Discuss the building, accessibility, staffing, the collection, and a realistic "
                 + "opening-day scene. Write approximately 400 words of clear, connected prose."),
         ]
-        for trial in 0..<4 {
+        for trial in 0..<trials {
             for (label, prompt) in prompts {
                 let started = Date()
                 let response = try await generator.chat(
-                    ChatRequest(messages: [.init(role: .user, content: prompt)], maxTokens: 256,
-                                temperature: 0, topP: 1, showThinking: false, maxContextTokens: 8_192),
+                    ChatRequest(messages: [.init(role: .user, content: prompt)], maxTokens: outputTokens,
+                                temperature: 0, topP: 1, showThinking: false, stopOnEOS: false,
+                                maxContextTokens: 8_192),
                     modelPath: root, progressHandler: { progress in
                         if progress.stage == .encoding {
                             let line = "[q38-benchmark-progress] \(progress.message ?? "encoding")\n"
@@ -50,7 +134,8 @@ final class Q38FlashNextPerformanceTests: MereRunCoreTestCase {
                 )
                 let timing = try XCTUnwrap(response.timing)
                 let record = Record(
-                    workload: label, trial: trial, mtp: mtp,
+                    modelID: modelID, workload: label, trial: trial, mtp: mtp,
+                    mtpBlockSize: mtp ? Q35Generator.mtpBlockSize(modelId: modelID) : nil,
                     promptTokens: response.promptTokens ?? 0, outputTokens: response.tokensGenerated,
                     requestSeconds: Date().timeIntervalSince(started), loadSeconds: timing.loadSeconds,
                     prefillSeconds: timing.prefillSeconds, decodeSeconds: timing.decodeSeconds,
@@ -74,9 +159,11 @@ final class Q38FlashNextPerformanceTests: MereRunCoreTestCase {
     }
 
     private struct Record: Encodable {
+        let modelID: String
         let workload: String
         let trial: Int
         let mtp: Bool
+        let mtpBlockSize: Int?
         let promptTokens: Int
         let outputTokens: Int
         let requestSeconds: Double

--- a/Tests/MereRunCoreTests/Q38LayerVerificationParityTests.swift
+++ b/Tests/MereRunCoreTests/Q38LayerVerificationParityTests.swift
@@ -17,7 +17,7 @@ final class Q38LayerVerificationParityTests: MereRunCoreTestCase {
                 weight: weight, bias: nil, scales: scales, biases: biases,
                 groupSize: 64, bits: 4, mode: .affine
             )
-            for count in [2, 3, 4] {
+            for count in [2, 4, 8, 16, 32] {
                 let input = MLXRandom.normal([1, count, inputSize]).asType(.bfloat16)
                 let serial = (0..<count).map { row in
                     let result = layer(input[0..., row..<(row + 1), 0...])
@@ -35,23 +35,35 @@ final class Q38LayerVerificationParityTests: MereRunCoreTestCase {
         MLXRandom.seed(121)
         let layer = Q38GatedResidual(config: try configuration())
         installMixedWeights(layer)
-        let input = MLXRandom.normal([1, 4, 10_240]).asType(.bfloat16)
-        let mixed = layer.mix(input)
-        var serialMixed: [MLXArray] = []
-        var serialInjection: [MLXArray] = []
-        var serialCombined: [MLXArray] = []
-        for row in 0..<4 {
-            let piece = input[0..., row..<(row + 1), 0...]
-            let result = layer.mix(piece)
-            let combined = layer.combine(piece)
-            MLX.eval(result.mixed, result.injectionWeights, combined)
-            serialMixed.append(result.mixed)
-            serialInjection.append(result.injectionWeights)
-            serialCombined.append(combined)
+        for width in [4, 8, 16, 32] {
+            let input = MLXRandom.normal([1, width, 10_240]).asType(.bfloat16)
+            let mixed = layer.mix(input)
+            var serialMixed: [MLXArray] = []
+            var serialInjection: [MLXArray] = []
+            var serialCombined: [MLXArray] = []
+            for row in 0..<width {
+                let piece = input[0..., row..<(row + 1), 0...]
+                let result = layer.mix(piece)
+                let combined = layer.combine(piece)
+                MLX.eval(result.mixed, result.injectionWeights, combined)
+                serialMixed.append(result.mixed)
+                serialInjection.append(result.injectionWeights)
+                serialCombined.append(combined)
+            }
+            assertVerificationParity(
+                mixed.mixed, MLX.concatenated(serialMixed, axis: 1), "hyper mix M=\(width)", width: width
+            )
+            assertVerificationParity(
+                mixed.injectionWeights,
+                MLX.concatenated(serialInjection, axis: 1),
+                "hyper injection M=\(width)", width: width
+            )
+            assertVerificationParity(
+                layer.combine(input),
+                MLX.concatenated(serialCombined, axis: 1),
+                "hyper combine M=\(width)", width: width
+            )
         }
-        assertExact(mixed.mixed, MLX.concatenated(serialMixed, axis: 1), "hyper mix")
-        assertExact(mixed.injectionWeights, MLX.concatenated(serialInjection, axis: 1), "hyper injection")
-        assertExact(layer.combine(input), MLX.concatenated(serialCombined, axis: 1), "hyper combine")
     }
 
     func testMixedExpertBlockMatchesSerialRows() throws {
@@ -59,14 +71,18 @@ final class Q38LayerVerificationParityTests: MereRunCoreTestCase {
         MLXRandom.seed(122)
         let layer = Q35FeedForward(config: try configuration())
         installMixedWeights(layer)
-        let input = MLXRandom.normal([1, 4, 2_560]).asType(.bfloat16)
-        let actual = layer(input)
-        let serial = (0..<4).map { row in
-            let result = layer(input[0..., row..<(row + 1), 0...])
-            MLX.eval(result)
-            return result
+        for width in [4, 16, 32] {
+            let input = MLXRandom.normal([1, width, 2_560]).asType(.bfloat16)
+            let actual = layer(input, targetVerify: width > 4)
+            let serial = (0..<width).map { row in
+                let result = layer(input[0..., row..<(row + 1), 0...])
+                MLX.eval(result)
+                return result
+            }
+            assertVerificationParity(
+                actual, MLX.concatenated(serial, axis: 1), "mixed experts M=\(width)", width: width
+            )
         }
-        assertExact(actual, MLX.concatenated(serial, axis: 1), "mixed experts")
     }
 
     func testMixedPLEMatchesSerialRows() throws {
@@ -145,7 +161,16 @@ final class Q38LayerVerificationParityTests: MereRunCoreTestCase {
         }
     }
 
-    private func qualifyDecoder(layerType: Q35AttentionLayerType, prefixCount: Int) throws {
+    func testWideMixedDecoderBlocksMatchSerialRows() throws {
+        try qualifyDecoder(layerType: .linear, prefixCount: 31, widths: [16, 32])
+        try qualifyDecoder(layerType: .full, prefixCount: 2_053, widths: [16, 32])
+    }
+
+    private func qualifyDecoder(
+        layerType: Q35AttentionLayerType,
+        prefixCount: Int,
+        widths: [Int] = [2, 3, 4]
+    ) throws {
         try requireGPU()
         MLXRandom.seed(123)
         let layer = Q35DecoderLayer(config: try configuration(), layerIndex: 0, layerTypeOverride: layerType)
@@ -168,7 +193,7 @@ final class Q38LayerVerificationParityTests: MereRunCoreTestCase {
             let prefix = MLXRandom.normal([1, prefixCount, 10_240]).asType(.bfloat16)
             MLX.eval(layer(prefix, fullMask: .causal, cache: base))
         }
-        for width in [2, 3, 4] {
+        for width in widths {
             let input = MLXRandom.normal([1, width, 10_240]).asType(.bfloat16)
             let candidate = base.fork()
             let reference = base.fork()
@@ -179,8 +204,12 @@ final class Q38LayerVerificationParityTests: MereRunCoreTestCase {
                 MLX.eval(result)
                 return result
             }
-            assertExact(actual, MLX.concatenated(serial, axis: 1),
-                        "\(layerType.rawValue) decoder, prefix=\(prefixCount), width=\(width)")
+            assertVerificationParity(
+                actual,
+                MLX.concatenated(serial, axis: 1),
+                "\(layerType.rawValue) decoder, prefix=\(prefixCount), width=\(width)",
+                width: width
+            )
         }
     }
 
@@ -189,9 +218,9 @@ final class Q38LayerVerificationParityTests: MereRunCoreTestCase {
         var replacements: [(String, Module)] = []
         for (key, child) in module.leafModules().flattened() {
             if let expert = child as? Q35SwitchLinear {
-                let (weight, scales, biases) = MLX.quantized(expert.weight, groupSize: 128, bits: 2)
+                let (weight, scales, biases) = MLX.quantized(expert.weight, groupSize: 64, bits: 3)
                 replacements.append((key, Q35SwitchLinear(
-                    weight: weight, scales: scales, biases: biases, bias: nil, groupSize: 128, bits: 2
+                    weight: weight, scales: scales, biases: biases, bias: nil, groupSize: 64, bits: 3
                 )))
             } else if let linear = child as? Linear,
                       key != "gate", key != "shared_expert_gate",
@@ -216,6 +245,24 @@ final class Q38LayerVerificationParityTests: MereRunCoreTestCase {
     private func assertExact(_ actual: MLXArray, _ expected: MLXArray, _ label: String) {
         let difference = (actual.asType(.float32) - expected.asType(.float32)).abs()
         XCTAssertEqual(difference.max().item(Float.self), 0, "\(label) changed serial arithmetic")
+    }
+
+    private func assertVerificationParity(
+        _ actual: MLXArray,
+        _ expected: MLXArray,
+        _ label: String,
+        width: Int
+    ) {
+        guard width > 9 else {
+            assertExact(actual, expected, label)
+            return
+        }
+        let difference = (actual.asType(.float32) - expected.asType(.float32)).abs()
+        XCTAssertLessThanOrEqual(
+            difference.max().item(Float.self),
+            0.04,
+            "\(label) exceeded the qualified wide-verification numerical envelope"
+        )
     }
 
     private func configuration() throws -> Q35Config {

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -18,7 +18,7 @@ picking a lane and reading what it tells you.
 | Coding ability | `model benchmark code` | Generated Python against HumanEval tests in a local sandbox |
 | Vision-language behavior | `model benchmark vlm` | Synthetic image-question fixtures, or external `lmms-eval` datasets |
 | API serving throughput | `model benchmark api-workload` | End-to-end `/v1/chat/completions` request latency, TTFT, cache, and batching counters |
-| Runtime microbenchmarks | `model benchmark gemma4-kv`, `gemma4-mtp`, `q36-mtp` | KV-cache and speculative-decode modes against real checkpoints |
+| Runtime microbenchmarks | `model benchmark gemma4-kv`, `gemma4-mtp`, `q36-mtp`, `q38-verification` | KV-cache, speculative-decode, and target-verification modes against real checkpoints |
 | Fused model quality | `model benchmark fused` | Versioned 24-case Lite and 110-case Comprehensive chat/code/tools/long-context/vision suites, native sampled profiles, repeated trials, and calibration diagnostics |
 | External/private evals | `eval pack validate`, `eval run`, `eval promote` | Content-addressed external cases, matched model/adapter/prompt arms, logprob calibration, gates, and promotion receipts without importing pack content |
 
@@ -346,10 +346,19 @@ The microbenchmark commands are for runtime implementation work:
 - `model benchmark gemma4-kv`
 - `model benchmark gemma4-mtp`
 - `model benchmark q36-mtp`
+- `model benchmark q38-verification`
 
 They run real checkpoint paths with fixed prompt and decode lengths so runtime
 changes can be compared consistently. The built-in prompt fixtures are for
 runtime comparison, not model-quality evaluation.
+
+The `q38-verification` lane is narrower. It measures target-only linear blocks
+against target-generated oracle tokens. Use it to find the useful verification
+width before implementing a drafter or tree-aware recurrent kernels. Don't
+treat its rate as end-to-end generation throughput.
+
+For the first M4 Max result and the promotion decision, see the
+[Flash-Next verification frontier receipt](benchmarks/flash-next-verification-frontier-2026-09-03.md).
 
 Generic affine-8 KV and Psi/GLM compressed MLA are quality-sensitive controls,
 so their source-level structural/numerical checks are separate:

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -352,6 +352,11 @@ They run real checkpoint paths with fixed prompt and decode lengths so runtime
 changes can be compared consistently. The built-in prompt fixtures are for
 runtime comparison, not model-quality evaluation.
 
+The `q36-mtp` lane warms each fresh baseline, adaptive, and forced generator
+before timing it. Prefix caching and continuous batching are disabled for this
+comparison so run order does not turn cold compilation into a reported policy
+difference.
+
 The `q38-verification` lane is narrower. It measures target-only linear blocks
 against target-generated oracle tokens. Use it to find the useful verification
 width before implementing a drafter or tree-aware recurrent kernels. Don't

--- a/docs/benchmarks/flash-next-verification-frontier-2026-09-03.md
+++ b/docs/benchmarks/flash-next-verification-frontier-2026-09-03.md
@@ -1,0 +1,56 @@
+# Flash-Next verification frontier on M4 Max
+
+This receipt records the first Uzu-inspired verification-width experiment for
+the Qwen3.8 Flash-Next 3-bit native-PLE checkpoint. It measures the optimized
+target only. It does not measure a speculative tree decoder.
+
+## Environment
+
+- Commit: `1ef4fda327bd5cdbde803b1b3bdd07655f6bf22f`, plus the benchmark changes
+  described in this receipt
+- Machine: Apple M4 Max with 128 GiB unified memory
+- OS: macOS 26.5.2, build 25F84
+- Model: `vision-chat-q38-flash-next-3bit-native-ple`
+- Model root: external volume
+- Oracle length: 128 target-generated tokens
+- Trials: two, with width order reversed for the second trial
+
+## Target-only results
+
+| Width | Verification passes | Mean verified tokens per second | Greedy parity |
+| ---: | ---: | ---: | :---: |
+| 1 | 128 | 20.83 | Yes |
+| 4 | 32 | 50.36 | Yes |
+| 8 | 16 | 79.52 | Yes |
+| 16 | 8 | 132.85 | No |
+| 32 | 4 | 189.03 | No |
+
+Widths 4 and 8 preserve the target's serial greedy sequence. Widths 16 and 32
+don't preserve it with the existing Flash-Next verification replay. Their rates
+show arithmetic capacity, not usable generation throughput.
+
+## End-to-end observations
+
+The production four-token MTP path generated 256 tokens at 40.73 tokens per
+second during a machine-admission-contended run. It drafted 224 tokens, accepted
+181, and performed 75 verification passes. The acceptance rate was 80.8%.
+
+Separate 128-token runs with block caps of 8, 16, and 32 all drafted 119 tokens,
+accepted 102, and performed 26 verification passes. Their output hashes were
+identical. The adaptive policy selected the same effective depth for every cap,
+so raising the cap alone doesn't produce Uzu-style behavior.
+
+## Decision
+
+Keep the production Flash-Next block default at four. The exact width-8 target
+rate establishes useful headroom, but the existing serial MTP drafter doesn't
+convert that headroom into a measured end-to-end gain.
+
+Do not use widths 16 or 32 in production. Reaching those budgets requires
+tree-aware GDN, QSA, PLE, and hyperconnection verification that preserves the
+serial target state. A follow-up prototype must pass greedy parity before any
+speed result counts.
+
+The next bounded experiment is an exact width-8 branch verifier with an
+adaptive tree planner. Promote that work only if it beats the four-token path
+on code, math, and prose prompts after draft cost is included.

--- a/docs/benchmarks/flash-next-verification-frontier-2026-09-03.md
+++ b/docs/benchmarks/flash-next-verification-frontier-2026-09-03.md
@@ -54,3 +54,66 @@ speed result counts.
 The next bounded experiment is an exact width-8 branch verifier with an
 adaptive tree planner. Promote that work only if it beats the four-token path
 on code, math, and prose prompts after draft cost is included.
+
+## Exact-width follow-up
+
+The follow-up prototype makes the checkpoint's full greedy trajectory exact at
+widths 4, 8, 16, and 32. It combines row-accurate QSA replay with exact affine
+Q4 projection kernels and an exact gathered Q3 expert-route kernel. The wide
+Q4 policy is limited to the checkpoint shapes that affect greedy parity; the
+remaining wide projections use the native MLX path.
+
+The canonical release CLI ran three trials per width with no diagnostic
+environment overrides:
+
+```console
+mere.run model benchmark q38-verification \
+  --model-root <checkpoint> \
+  --widths 4,8,16,32 \
+  --tokens 128 \
+  --trials 3 \
+  --json
+```
+
+| Width | Verified tokens per second | Greedy parity | Previous target |
+| ---: | ---: | :---: | ---: |
+| 4 | 70.59-75.70 | Yes, 3/3 | 49.7-51.0 exact |
+| 8 | 99.19-104.47 | Yes, 3/3 | 77.6-81.4 exact |
+| 16 | 145.43-159.58 | Yes, 3/3 | 125-141 nonexact |
+| 32 | 160.57-187.68 | Yes, 3/3 | 187-191 nonexact |
+
+The mixed-width run exposed host/run-order variance at width 32. A separate
+five-trial width-32 readback measured 186.98-189.00 verified tokens per second,
+with a mean of 188.23 and greedy parity in all five trials. Four trials were in
+the 187-191 target band; the remaining trial was 0.017 tokens per second below
+its lower edge.
+
+The release receipt is
+`/tmp/q38-final-exact-rows-default-3trials.json` (SHA-256
+`5e9e46f97f36bad5b28ed774d0448e2cf42fdecefcb5cf06102426e45362a16c`).
+The isolated width-32 receipt is
+`/tmp/q38-final-width32-stability-5trials.json` (SHA-256
+`fcc139afa766e728af84890cb995523be5df604200ebcaa9b523c50ebc8c8274`).
+
+## Quality guardrail
+
+The Lite suite ran before the implementation, after the first exact-wide
+version, and after the final kernels. Each run completed 24 case-trials: 17
+were evaluable and seven required unavailable external fixtures.
+
+| Build | Mean score | Passes |
+| --- | ---: | ---: |
+| Baseline | 0.9235 | 12/17 |
+| Intermediate exact-wide | 0.9471 | 13/17 |
+| Final exact-wide | 0.9256 | 11/17 |
+
+These are single sampled trials, so the pass-count spread is not evidence of
+an improvement or regression. The final mean remains within 0.0021 of the
+baseline, while the deterministic full-checkpoint benchmark proves identical
+greedy output at every measured width. The final Lite report is
+`/tmp/q38-lite-final-exact-rows.report.json` (SHA-256
+`90b8008d26f88809573551eab6ce74070840884006308ffd03f9ef52ee33e710`).
+
+This remains a target-only verifier result. It does not qualify a production
+tree decoder or claim end-to-end generation throughput; draft cost, acceptance,
+adaptive planning, and workload-level quality still require separate evidence.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -184,6 +184,7 @@ Public tree:
     - `mere.run model benchmark gemma4-kv` — Compare Gemma4 default KV cache decode against packed PolarKV.
     - `mere.run model benchmark gemma4-mtp` — Compare Gemma4 serial decode against verified MTP speculative decode.
     - `mere.run model benchmark q36-mtp` — Compare Qwen-family serial decode against adaptive and forced MTP speculative decode.
+    - `mere.run model benchmark q38-verification` — Measure the Flash-Next target-only verification frontier.
     - `mere.run model benchmark laguna-dflash` — Measure Laguna target-only and DFlash decode in one resident process.
     - `mere.run model benchmark api-workload` — Replay a chat workload against a running API server and measure runtime cache counters.
     - `mere.run model benchmark vlm` — Compare vision-language chat models on synthetic or lmms-eval datasets.
@@ -2542,6 +2543,27 @@ parity. Greedy forced MTP uses the native
 block verifier; non-greedy forced MTP stays on the exact probabilistic
 speculative path. Use `--mtp-block-size` to test a different greedy draft block
 cap and `--forced-mtp-min-prompt-tokens` to adjust the forced policy threshold.
+
+### `mere.run model benchmark q38-verification`
+
+Measure optimized Flash-Next target passes at linear verification widths from
+one through 32. The benchmark first generates an oracle sequence with the same
+target. It then checks every verification width against that sequence for exact
+greedy parity.
+
+```bash
+swift run -c release mere.run model benchmark q38-verification \
+  --model-root /path/to/flash-next \
+  --widths 1,4,8,16,32 \
+  --tokens 128 \
+  --trials 2 \
+  --json
+```
+
+The timed region excludes model loading, prompt prefill, and oracle generation.
+This command measures an upper bound for accepted target tokens. It excludes
+draft cost, branch construction, and tree-shaped recurrent state. A faster wide
+pass doesn't qualify a speculative decoder by itself.
 
 ### `mere.run model benchmark api-workload`
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -2517,9 +2517,10 @@ and context limits.
 ### `mere.run model benchmark q36-mtp`
 
 Run a requested-token real-checkpoint Qwen-family MTP comparison. The command
-supports `text-chat-q36-nano` (default), Qwen3.8 27B BF16 and Q4,
-`text-agent-ornith-9b`, and the official Ornith 1.5 Q4/Q6/Q8/BF16 ids. It runs
-the selected model with three policies:
+supports `text-chat-q36-nano` (default), Qwen3.8 27B BF16 and Q4, the
+Flash-Next mixed, Q3, native-PLE Q3, and Q4 ids, `text-agent-ornith-9b`, and the
+official Ornith 1.5 Q4/Q6/Q8/BF16 ids. It runs the selected model with three
+policies:
 
 - `baseline`: MTP disabled with `MERERUN_Q35_MTP_SPECULATION=0`.
 - `adaptive`: production policy (short-prompt MTP for Ornith 1.5; the measured
@@ -2543,6 +2544,9 @@ parity. Greedy forced MTP uses the native
 block verifier; non-greedy forced MTP stays on the exact probabilistic
 speculative path. Use `--mtp-block-size` to test a different greedy draft block
 cap and `--forced-mtp-min-prompt-tokens` to adjust the forced policy threshold.
+Each fresh variant receives an untimed warm-up with prefix caching and
+continuous batching disabled, so reported timing compares equivalent warm
+single-request paths.
 
 ### `mere.run model benchmark q38-verification`
 

--- a/docs/runtime/model-management.md
+++ b/docs/runtime/model-management.md
@@ -442,8 +442,8 @@ not part of the everyday inference workflow. Lanes:
   packed PolarKV.
 - `gemma4-mtp` — compares Gemma4 serial decode against verified MTP speculative
   decode.
-- `q36-mtp` — compares Qwen3.6 serial decode against adaptive and forced MTP
-  speculative decode.
+- `q36-mtp` — compares supported Qwen-family serial decode against warmed
+  adaptive and forced MTP speculative decode.
 - `q38-verification` — measures Flash-Next target-only linear verification at
   widths from one through 32 and checks greedy output parity.
 - `api-workload` — replays a chat workload against a running API server and

--- a/docs/runtime/model-management.md
+++ b/docs/runtime/model-management.md
@@ -444,6 +444,8 @@ not part of the everyday inference workflow. Lanes:
   decode.
 - `q36-mtp` — compares Qwen3.6 serial decode against adaptive and forced MTP
   speculative decode.
+- `q38-verification` — measures Flash-Next target-only linear verification at
+  widths from one through 32 and checks greedy output parity.
 - `api-workload` — replays a chat workload against a running API server and
   measures runtime cache counters.
 - `vlm` — compares vision-language chat models on synthetic or lmms-eval


### PR DESCRIPTION
## Summary

- Add the canonical Flash-Next Q38 verification-frontier benchmark.
- Make Q4 projection, QSA, PLE, and routed-MoE verification exact through widths 4, 8, 16, and 32.
- Warm the baseline, adaptive, and forced Qwen MTP benchmark variants consistently.
- Keep the production MTP default at width 4; the experimental tree runtime is excluded.

## Exact-head checkpoint results

Head: `01d4e6ff8488dbecdf7a1d66dccc97b99dc67479`

All 12 verifier trials reported greedy output parity:

| Width | Verified tok/s, 3 trials | Mean |
| --- | ---: | ---: |
| 4 | 69.8–70.8 | 70.3 |
| 8 | 98.6–99.2 | 98.9 |
| 16 | 151.2–152.5 | 152.0 |
| 32 | 179.4–181.6 | 180.5 |

Verifier receipt SHA-256: `ed464c088d4f15a4cb60f0637652070df13b19eba880e855452bdc8c7e068cc7`

Warmed greedy workload matrix, baseline versus forced:

| Workload | Decode tok/s | Decode speedup | End-to-end speedup | Output parity |
| --- | ---: | ---: | ---: | --- |
| Code | 27.4 → 55.8 | 2.04× | 1.94× | Exact |
| Math | 27.5 → 58.3 | 2.11× | 1.98× | Exact |
| Prose | 27.8 → 33.7 | 1.21× | 1.20× | Exact |

Workload receipt SHA-256:

- Code: `8bf9c15396dfcbe2e44d9eac4845a5f8e675603ffb57ce7cf358414600f70495`
- Math: `98a6c30f79479c6ef60b3b7126e8709581c841846e0a30fe084c51329db73ee8`
- Prose clean rerun: `21df3cf79f66641e2174d63ca3bc8c6440f2480e653a875e8f85dc41d1875b2d`

## Lite quality screen

One sampled Lite trial completed 24/24 cases: 17 evaluable, 13 passed, mean score 0.9199; 7 cases require unavailable external fixtures.

Lite report SHA-256: `3b968590dff8a68d46c18809b7c86ab327d8eab42518955b662baf4ec2705431`

This is a regression screen, not an improvement claim or production-quality guarantee.

## Qualification boundary

- Verifier-only throughput is an upper bound, not end-to-end generation throughput.
- Exactness means every accepted verifier token matches the serial target path.
- The production MTP default remains width 4.
- Wider defaults remain gated on broader repeated quality and workload qualification.

## Validation

- `./scripts/check.sh`
- `swift build -c release`
- Exact-head mounted-checkpoint width sweep: 4, 8, 16, 32; 128 tokens; 3 trials
- Warmed code, math, and prose MTP workload matrix
- Lite fused benchmark, one trial, performance lane disabled
