### PR TITLE
Render input-first tasks on the Analyze canvas

### DIFF
--- a/apps/macos/MereRunStudio/StudioAnalyzeCanvas.swift
+++ b/apps/macos/MereRunStudio/StudioAnalyzeCanvas.swift
@@ -1,0 +1,497 @@
+import AVFoundation
+import AppKit
+import ImageIO
+import SwiftUI
+
+/// What the Analyze canvas asks the workspace to do beyond the shared feed actions.
+struct StudioAnalyzeActions {
+    /// Pick a different input; writes the composer's well so the two never disagree.
+    let replaceInput: () -> Void
+    /// Continue in a sibling task, carrying this input and prompt.
+    let openTask: (StudioTask) -> Void
+    /// Write part of the result somewhere the user picks.
+    let save: (StudioAnalyzeSaveKind) -> Void
+}
+
+/// The Analyze archetype: one input on the left, what the model found on the right.
+///
+/// Input-first tasks are not a feed — you point them at a file, and the answer belongs beside the
+/// thing it is about. So the canvas shows the current input large with the result drawn over it,
+/// a result column that names what was found and what to do next, and the run in flight (or the
+/// failure) as the same cards the Generate feed uses. Earlier runs stay in the Library column.
+struct StudioAnalyzeCanvas: View {
+    let archetype: StudioAnalyzeArchetype
+    let mode: StudioMode
+    /// Every row of this mode, oldest first, as the feed builds them.
+    let cards: [StudioFeedCard]
+    /// The Library row the user picked, when they picked one.
+    let selectedID: UUID?
+    /// The composer's well: the file the next run would read.
+    let inputPath: String
+    let readiness: ModelReadinessState
+    let pullJob: Job?
+    let actions: StudioFeedActions
+    let analyze: StudioAnalyzeActions
+
+    @State private var chosenView: StudioAnalyzeResultView?
+    @State private var loaded: StudioAnalyzeLoadedResult?
+    @State private var inputSize: CGSize?
+    @State private var inputDuration: TimeInterval?
+
+    private enum Metrics {
+        static let contentWidth: CGFloat = 940
+        static let resultColumnWidth: CGFloat = 360
+        static let columnSpacing: CGFloat = 20
+        static let mediaMaxHeight: CGFloat = 520
+        static let insets = EdgeInsets(top: 22, leading: 24, bottom: 6, trailing: 24)
+    }
+
+    // MARK: Derived state
+
+    private var inputURL: URL? {
+        let trimmed = inputPath.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : URL(fileURLWithPath: trimmed)
+    }
+
+    /// The run whose result is on screen: the picked Library row when it finished, else the most
+    /// recent finished run of this task.
+    private var resultCard: StudioFeedCard? {
+        if let selectedID, let picked = cards.first(where: { $0.id == selectedID }), picked.kind == .generation {
+            return picked
+        }
+        return cards.last { $0.kind == .generation }
+    }
+
+    /// The cards that sit above the result: everything still in flight, plus the newest failure.
+    private var pendingCards: [StudioFeedCard] {
+        var pending = cards.filter { $0.kind == .running || $0.kind == .queued }
+        if let last = cards.last, last.kind == .failed { pending.append(last) }
+        return pending
+    }
+
+    private var showsReadinessCard: Bool {
+        readiness.blocksRun || pullJob != nil
+    }
+
+    private var hasBody: Bool {
+        resultCard != nil || !pendingCards.isEmpty || showsReadinessCard
+    }
+
+    private var view: StudioAnalyzeResultView {
+        guard let chosenView, archetype.views.contains(chosenView) else { return archetype.defaultView }
+        return chosenView
+    }
+
+    private var document: StudioAnalyzeDocument? {
+        guard let loaded, loaded.itemID == resultCard?.id else { return nil }
+        return loaded.document
+    }
+
+    private var detections: [StudioAnalyzeDetection] {
+        guard let document else { return [] }
+        let size = inputSize ?? document.reportedInputSize ?? CGSize(width: 1, height: 1)
+        return document.detections(imageSize: size)
+    }
+
+    /// Whether the result on screen is about the input on screen. Replacing the input must not
+    /// leave the previous run's boxes drawn over a different picture, so the overlays wait for
+    /// the next run while the panel keeps listing what the last one found.
+    private var resultDescribesInput: Bool {
+        guard let itemInput = resultCard?.item.inputURL else { return true }
+        guard let inputURL else { return false }
+        return itemInput.standardizedFileURL == inputURL.standardizedFileURL
+    }
+
+    private var overlayDetections: [StudioAnalyzeDetection] {
+        resultDescribesInput ? detections : []
+    }
+
+    var body: some View {
+        Group {
+            if hasBody {
+                content
+            } else {
+                StudioEmptyState(mode: mode, onUseExample: actions.useExample, onAttach: actions.attach)
+                    .padding(MereRunTheme.Spacing.xxxl)
+            }
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        .task(id: resultCard?.id) { await loadDocument() }
+        .task(id: inputPath) { await measureInput() }
+    }
+
+    private var content: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 0) {
+                inputStrip
+                    .padding(.bottom, 10)
+                HStack(alignment: .top, spacing: Metrics.columnSpacing) {
+                    inputColumn
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    resultColumn
+                        .frame(width: Metrics.resultColumnWidth)
+                }
+            }
+            .padding(Metrics.insets)
+            .frame(maxWidth: Metrics.contentWidth)
+            .frame(maxWidth: .infinity)
+        }
+    }
+
+    // MARK: - Input strip
+
+    private var inputStrip: some View {
+        HStack(spacing: 10) {
+            Text("Input")
+                .font(.system(size: 12, weight: .medium))
+                .foregroundStyle(MereRunTheme.textSecondary)
+            StudioAnalyzeChip(text: inputDescription)
+                .help(inputURL?.path ?? "No input attached")
+            Button(inputURL == nil ? "Choose…" : "Replace", action: analyze.replaceInput)
+                .buttonStyle(.mereSecondary)
+                .help("Pick a different \(archetype.inputKind.noun)")
+            Spacer(minLength: 8)
+            if archetype.views.count > 1 {
+                MereSegmentedControl(
+                    archetype.views,
+                    selection: Binding(get: { view }, set: { chosenView = $0 }),
+                    accessibilityLabel: "Result view"
+                ) { $0.title }
+            }
+        }
+        .accessibilityElement(children: .contain)
+    }
+
+    private var inputDescription: String {
+        guard let inputURL else { return "No input" }
+        var parts = [inputURL.lastPathComponent]
+        if let inputSize {
+            parts.append("\(Int(inputSize.width))×\(Int(inputSize.height))")
+        } else if let inputDuration {
+            parts.append(StudioTimeFormat.string(inputDuration))
+        }
+        return parts.joined(separator: " · ")
+    }
+
+    // MARK: - Input column
+
+    @ViewBuilder
+    private var inputColumn: some View {
+        switch view {
+        case .json:
+            StudioAnalyzeDocumentView(url: loaded?.url, text: loaded?.raw)
+                .frame(height: Metrics.mediaMaxHeight)
+                .mereMediaFrame()
+        case .transcript, .timeline, .text, .score, .stems, .vectors:
+            mediaView
+        default:
+            mediaView
+        }
+    }
+
+    @ViewBuilder
+    private var mediaView: some View {
+        switch archetype.inputKind {
+        case .image:
+            imageView
+        case .video:
+            videoView
+        case .audio:
+            audioView
+        case .file:
+            fileView
+        }
+    }
+
+    @ViewBuilder
+    private var imageView: some View {
+        if let inputURL {
+            StudioAnalyzeImageView(
+                url: inputURL,
+                maxHeight: Metrics.mediaMaxHeight,
+                detections: view == .masks ? [] : overlayDetections,
+                masks: view == .masks ? overlayDetections : [],
+                imageSize: inputSize
+            )
+            .mereMediaFrame()
+        } else {
+            missingInput
+        }
+    }
+
+    @ViewBuilder
+    private var videoView: some View {
+        if let inputURL {
+            VStack(spacing: 8) {
+                StudioVideoPlayerView(url: playableVideoURL ?? inputURL)
+                    .aspectRatio(videoAspect, contentMode: .fit)
+                    .frame(maxHeight: Metrics.mediaMaxHeight - 26)
+                    .mereMediaFrame()
+                if case .tracking(let tracking) = document {
+                    StudioAnalyzeTrackScrubber(document: tracking)
+                }
+            }
+        } else {
+            missingInput
+        }
+    }
+
+    /// Track writes an annotated clip; that is the one worth playing when it exists.
+    private var playableVideoURL: URL? {
+        guard let outputURL = resultCard?.item.outputURL,
+              StudioOutputFileKind.classify(outputURL) == .video else { return nil }
+        return outputURL
+    }
+
+    private var videoAspect: CGFloat {
+        guard let size = inputSize ?? document?.reportedInputSize, size.height > 0 else { return 16.0 / 9 }
+        return size.width / size.height
+    }
+
+    @ViewBuilder
+    private var audioView: some View {
+        if let inputURL {
+            StudioAudioPlayerView(url: playableAudioURL ?? inputURL)
+                .frame(height: 220)
+                .mereMediaFrame()
+        } else {
+            missingInput
+        }
+    }
+
+    /// Enhance and Separate write new audio; the player should offer the result, not the source.
+    private var playableAudioURL: URL? {
+        guard archetype.views.contains(.audio) || archetype.views.contains(.stems),
+              let outputURL = resultCard?.item.outputURL,
+              StudioOutputFileKind.classify(outputURL) == .audio else { return nil }
+        return outputURL
+    }
+
+    @ViewBuilder
+    private var fileView: some View {
+        if let inputURL {
+            VStack(spacing: MereRunTheme.Spacing.sm) {
+                Image(systemName: "doc.text")
+                    .font(.system(size: 34, weight: .medium))
+                    .foregroundStyle(MereRunTheme.accent)
+                Text(inputURL.lastPathComponent)
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundStyle(MereRunTheme.textPrimary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+            }
+            .frame(maxWidth: .infinity)
+            .frame(height: 220)
+            .mereMediaFrame()
+        } else {
+            missingInput
+        }
+    }
+
+    private var missingInput: some View {
+        VStack(spacing: MereRunTheme.Spacing.sm) {
+            Image(systemName: "paperclip")
+                .font(.system(size: 26, weight: .medium))
+                .foregroundStyle(MereRunTheme.textMuted)
+            Text("No \(archetype.inputKind.noun) attached.")
+                .font(.system(size: 13))
+                .foregroundStyle(MereRunTheme.textSecondary)
+        }
+        .frame(maxWidth: .infinity)
+        .frame(height: 220)
+        .mereMediaFrame()
+    }
+
+    // MARK: - Result column
+
+    private var resultColumn: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            ForEach(pendingCards) { card in
+                pendingCard(card)
+            }
+            if showsReadinessCard {
+                StudioReadinessCard(
+                    readiness: readiness,
+                    pullJob: pullJob,
+                    onPullModel: actions.pullModel,
+                    onShowDetails: actions.showDetails,
+                    onCancelPull: { actions.cancel($0) }
+                )
+            }
+            if let resultCard {
+                resultPanel(resultCard)
+                StudioAnalyzePromptPanel(item: resultCard.item)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func pendingCard(_ card: StudioFeedCard) -> some View {
+        switch card.kind {
+        case .running:
+            if let job = card.job {
+                StudioRunningCard(item: card.item, job: job, isHighlighted: false) { actions.cancel(job) }
+            } else {
+                StudioFailureCard(item: card.item, job: nil, isHighlighted: false, actions: actions)
+            }
+        case .queued:
+            StudioQueuedRow(
+                item: card.item,
+                position: StudioFeedCardBuilder.queuePosition(of: card, in: cards) ?? 0,
+                isHighlighted: false
+            ) {
+                actions.remove(card)
+            }
+        case .failed:
+            StudioFailureCard(item: card.item, job: card.job, isHighlighted: false, actions: actions)
+        case .generation:
+            EmptyView()
+        }
+    }
+
+    @ViewBuilder
+    private func resultPanel(_ card: StudioFeedCard) -> some View {
+        StudioAnalyzeResultPanel(
+            item: card.item,
+            document: document,
+            detections: detections,
+            speechSegments: document?.speechSegments ?? [],
+            outputText: card.item.outputText,
+            view: view,
+            nextActions: archetype.nextActions,
+            onOpenTask: analyze.openTask,
+            onSave: analyze.save
+        )
+    }
+
+    // MARK: - Loading
+
+    private func loadDocument() async {
+        guard let item = resultCard?.item else {
+            loaded = nil
+            return
+        }
+        let itemID = item.id
+        let url = StudioAnalyzeDocumentSource.url(for: item)
+        let fallbackText = item.outputText
+        let result = await Task.detached(priority: .userInitiated) {
+            StudioAnalyzeLoadedResult.load(itemID: itemID, url: url, fallbackText: fallbackText)
+        }.value
+        guard !Task.isCancelled else { return }
+        loaded = result
+    }
+
+    private func measureInput() async {
+        guard let inputURL else {
+            inputSize = nil
+            inputDuration = nil
+            return
+        }
+        let kind = archetype.inputKind
+        let measured = await Task.detached(priority: .userInitiated) {
+            StudioAnalyzeMediaInfo.measure(inputURL, kind: kind)
+        }.value
+        guard !Task.isCancelled else { return }
+        inputSize = measured.size
+        inputDuration = measured.duration
+    }
+}
+
+extension StudioAnalyzeInputKind {
+    /// "image", "video", "audio file", "file" — the word the strip and empty state use.
+    var noun: String {
+        switch self {
+        case .image: return "image"
+        case .video: return "video"
+        case .audio: return "audio file"
+        case .file: return "file"
+        }
+    }
+}
+
+// MARK: - Loading the result document
+
+/// Where a run's result document lives.
+enum StudioAnalyzeDocumentSource {
+    private static let documentExtensions = ["json", "txt", "vtt", "srt", "jsonl"]
+
+    /// The artifact holding the run's structured result: the `--json-output` sidecar for the
+    /// vision tasks, the transcript the speech tasks write.
+    static func url(for item: StudioLibraryItem) -> URL? {
+        let artifacts = item.allArtifactURLs
+        for pathExtension in documentExtensions {
+            if let match = artifacts.first(where: { $0.pathExtension.lowercased() == pathExtension }) {
+                return match
+            }
+        }
+        return nil
+    }
+}
+
+/// A decoded result document, tied to the run it came from so a stale one is never drawn.
+struct StudioAnalyzeLoadedResult: Equatable {
+    let itemID: UUID
+    let url: URL?
+    /// The document as written, for the JSON view.
+    let raw: String?
+    let document: StudioAnalyzeDocument?
+
+    static func load(itemID: UUID, url: URL?, fallbackText: String?) -> StudioAnalyzeLoadedResult {
+        if let url, let data = try? Data(contentsOf: url), !data.isEmpty {
+            return StudioAnalyzeLoadedResult(
+                itemID: itemID,
+                url: url,
+                raw: String(data: data, encoding: .utf8),
+                document: StudioAnalyzeDocument.decode(data)
+            )
+        }
+        guard let fallbackText, !fallbackText.isBlank, let data = fallbackText.data(using: .utf8) else {
+            return StudioAnalyzeLoadedResult(itemID: itemID, url: url, raw: nil, document: nil)
+        }
+        return StudioAnalyzeLoadedResult(
+            itemID: itemID,
+            url: nil,
+            raw: fallbackText,
+            document: StudioAnalyzeDocument.decode(data)
+        )
+    }
+}
+
+/// What the input strip can say about a file without decoding all of it.
+enum StudioAnalyzeMediaInfo {
+    struct Measurement: Equatable {
+        var size: CGSize?
+        var duration: TimeInterval?
+    }
+
+    static func measure(_ url: URL, kind: StudioAnalyzeInputKind) -> Measurement {
+        switch kind {
+        case .image:
+            return Measurement(size: pixelSize(of: url), duration: nil)
+        case .video:
+            let asset = AVURLAsset(url: url)
+            let track = asset.tracks(withMediaType: .video).first
+            let size = track.map { $0.naturalSize.applying($0.preferredTransform) }
+                .map { CGSize(width: abs($0.width), height: abs($0.height)) }
+            return Measurement(size: size, duration: CMTimeGetSeconds(asset.duration))
+        case .audio:
+            let asset = AVURLAsset(url: url)
+            let duration = CMTimeGetSeconds(asset.duration)
+            return Measurement(size: nil, duration: duration.isFinite ? duration : nil)
+        case .file:
+            return Measurement()
+        }
+    }
+
+    /// The image's own pixel dimensions, read from its metadata without decoding the pixels.
+    static func pixelSize(of url: URL) -> CGSize? {
+        guard let source = CGImageSourceCreateWithURL(url as CFURL, nil),
+              let properties = CGImageSourceCopyPropertiesAtIndex(source, 0, nil) as? [CFString: Any],
+              let width = properties[kCGImagePropertyPixelWidth] as? Int,
+              let height = properties[kCGImagePropertyPixelHeight] as? Int,
+              width > 0, height > 0 else {
+            return nil
+        }
+        return CGSize(width: width, height: height)
+    }
+}

--- a/apps/macos/MereRunStudio/StudioAnalyzeCanvas.swift
+++ b/apps/macos/MereRunStudio/StudioAnalyzeCanvas.swift
@@ -73,8 +73,11 @@ struct StudioAnalyzeCanvas: View {
         readiness.blocksRun || pullJob != nil
     }
 
+    /// An input-first task shows its input the moment there is one: attaching a picture and then
+    /// still being told to "Choose image…" would be absurd, so the serif empty state is only for
+    /// an empty well with nothing to report.
     private var hasBody: Bool {
-        resultCard != nil || !pendingCards.isEmpty || showsReadinessCard
+        inputURL != nil || resultCard != nil || !pendingCards.isEmpty || showsReadinessCard
     }
 
     private var view: StudioAnalyzeResultView {
@@ -151,7 +154,8 @@ struct StudioAnalyzeCanvas: View {
                 .buttonStyle(.mereSecondary)
                 .help("Pick a different \(archetype.inputKind.noun)")
             Spacer(minLength: 8)
-            if archetype.views.count > 1 {
+            // Nothing has been found yet, so there is nothing to switch between.
+            if archetype.views.count > 1, resultCard != nil {
                 MereSegmentedControl(
                     archetype.views,
                     selection: Binding(get: { view }, set: { chosenView = $0 }),

--- a/apps/macos/MereRunStudio/StudioAnalyzeResults.swift
+++ b/apps/macos/MereRunStudio/StudioAnalyzeResults.swift
@@ -1,0 +1,463 @@
+import CoreGraphics
+import Foundation
+
+// The result documents the CLI writes for the input-first tasks, decoded into one shape the
+// Analyze canvas can draw. These mirror what `MereRunCore` encodes today — camelCase Swift
+// property names for the vision writers, snake_case for `speech diarize` — so a decode failure
+// here means the CLI changed, not that the app guessed.
+
+// MARK: - vision ground
+
+/// `mere.run vision ground --json-output` (`FalconPerceptionGroundingMetadata`).
+///
+/// Its boxes are **normalized** 0…1 in the input image's frame; `xy` is the box centre and `hw`
+/// is height-then-width. `score` is optional and today's grounder leaves it unset.
+struct StudioVisionGroundDocument: Decodable, Equatable {
+    struct Box: Decodable, Equatable {
+        let x1: Double
+        let y1: Double
+        let x2: Double
+        let y2: Double
+    }
+
+    struct Detection: Decodable, Equatable {
+        let label: String
+        let box: Box
+        let score: Double?
+        let maskPath: String?
+    }
+
+    let schemaVersion: Int
+    let modelID: String
+    let inputImagePath: String
+    let annotatedImagePath: String?
+    let queries: [String]
+    let detections: [Detection]
+}
+
+// MARK: - vision segment
+
+/// `mere.run vision segment --json-output` (`SAM31SegmentationMetadata`).
+///
+/// Its boxes are **absolute pixels**, xyxy, in the input image's frame.
+struct StudioVisionSegmentDocument: Decodable, Equatable {
+    struct Box: Decodable, Equatable {
+        let x1: Double
+        let y1: Double
+        let x2: Double
+        let y2: Double
+    }
+
+    struct Detection: Decodable, Equatable {
+        let objectID: String?
+        let label: String
+        let promptKind: String?
+        let score: Double
+        let box: Box
+        let maskAreaPixels: Int
+        let maskPath: String?
+    }
+
+    let schemaVersion: Int
+    let modelID: String
+    let inputImagePath: String
+    let annotatedImagePath: String?
+    let prompts: [String]
+    let threshold: Double
+    let detections: [Detection]
+}
+
+// MARK: - vision track
+
+/// `mere.run vision track --json-output` (`SAM31TrackingRun`).
+///
+/// Boxes are **absolute pixels** in `frameWidth` × `frameHeight`. Every frame carries an entry for
+/// every tracked object, including the ones it lost (`visible: false`, `score: 0`).
+struct StudioVisionTrackDocument: Decodable, Equatable {
+    struct Box: Decodable, Equatable {
+        let x1: Double
+        let y1: Double
+        let x2: Double
+        let y2: Double
+    }
+
+    struct TrackedObject: Decodable, Equatable {
+        let objectID: String
+        let label: String
+        let seedFrameIndex: Int
+    }
+
+    struct FrameDetection: Decodable, Equatable {
+        let objectID: String
+        let label: String
+        let score: Double
+        let visible: Bool
+        let box: Box
+        let maskPath: String?
+    }
+
+    struct Frame: Decodable, Equatable {
+        let frameIndex: Int
+        let timestampSeconds: Double
+        let detections: [FrameDetection]
+    }
+
+    let schemaVersion: Int
+    let modelID: String
+    let inputVideoPath: String
+    let annotatedVideoPath: String?
+    let fps: Double
+    let frameWidth: Int
+    let frameHeight: Int
+    let objects: [TrackedObject]
+    let frames: [Frame]
+
+    var duration: TimeInterval {
+        guard fps > 0 else { return 0 }
+        return Double(frames.count) / fps
+    }
+}
+
+// MARK: - speech diarize
+
+/// `mere.run speech diarize --format json` (`SpeechDiarizationPayload`), the only one of these
+/// documents the CLI writes in snake_case.
+struct StudioDiarizationDocument: Decodable, Equatable {
+    struct Segment: Decodable, Equatable {
+        let speaker: String
+        let speakerIndex: Int
+        let startSeconds: Double
+        let endSeconds: Double
+
+        enum CodingKeys: String, CodingKey {
+            case speaker
+            case speakerIndex = "speaker_index"
+            case startSeconds = "start_seconds"
+            case endSeconds = "end_seconds"
+        }
+    }
+
+    let schemaVersion: Int
+    let model: String
+    let durationSeconds: Double
+    let speakerCount: Int
+    let segments: [Segment]
+
+    enum CodingKeys: String, CodingKey {
+        case schemaVersion = "schema_version"
+        case model
+        case durationSeconds = "duration_seconds"
+        case speakerCount = "speaker_count"
+        case segments
+    }
+}
+
+// MARK: - speech transcribe
+
+/// What `mere.run speech transcribe` writes: the whole transcript, a blank line, then one
+/// `[MM:SS.mmm --> MM:SS.mmm] text` line per alignment (an hours field appears past an hour).
+/// It is text, not JSON, so it is parsed rather than decoded.
+struct StudioTranscriptDocument: Equatable {
+    struct Segment: Equatable, Identifiable {
+        let index: Int
+        let start: TimeInterval
+        let end: TimeInterval
+        let text: String
+
+        var id: Int { index }
+    }
+
+    let text: String
+    let segments: [Segment]
+
+    var duration: TimeInterval {
+        segments.last?.end ?? 0
+    }
+
+    /// Parses the transcript the CLI wrote. A file with no timestamp lines still yields its text.
+    static func parse(_ raw: String) -> StudioTranscriptDocument {
+        var segments: [Segment] = []
+        var prose: [String] = []
+        for line in raw.components(separatedBy: .newlines) {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if let segment = parseSegment(trimmed, index: segments.count) {
+                segments.append(segment)
+            } else if !trimmed.isEmpty, segments.isEmpty {
+                prose.append(trimmed)
+            }
+        }
+        let text = prose.isEmpty
+            ? segments.map(\.text).joined(separator: " ")
+            : prose.joined(separator: "\n")
+        return StudioTranscriptDocument(text: text, segments: segments)
+    }
+
+    /// "[00:04.120 --> 00:07.400] and that is the whole idea."
+    private static func parseSegment(_ line: String, index: Int) -> Segment? {
+        guard line.hasPrefix("["), let close = line.firstIndex(of: "]") else { return nil }
+        let stamps = String(line[line.index(after: line.startIndex)..<close])
+        let parts = stamps.components(separatedBy: "-->").map { $0.trimmingCharacters(in: .whitespaces) }
+        guard parts.count == 2,
+              let start = seconds(parts[0]),
+              let end = seconds(parts[1]) else { return nil }
+        let text = String(line[line.index(after: close)...]).trimmingCharacters(in: .whitespaces)
+        return Segment(index: index, start: start, end: end, text: text)
+    }
+
+    /// "MM:SS.mmm" or "HH:MM:SS.mmm" to seconds.
+    static func seconds(_ stamp: String) -> TimeInterval? {
+        let fields = stamp.components(separatedBy: ":")
+        guard (2...3).contains(fields.count) else { return nil }
+        var total: TimeInterval = 0
+        for field in fields.dropLast() {
+            guard let value = Double(field) else { return nil }
+            total = total * 60 + value
+        }
+        guard let last = Double(fields[fields.count - 1]) else { return nil }
+        return total * 60 + last
+    }
+}
+
+// MARK: - One shape the canvas draws
+
+/// One thing a run found: what it is, how sure the model was, and where it is in the input's own
+/// pixels (origin top-left), with the mask PNG the run wrote for it when there is one.
+struct StudioAnalyzeDetection: Identifiable, Equatable {
+    let id: Int
+    let label: String
+    let confidence: Double?
+    /// The input's pixel space, origin top-left.
+    let box: CGRect
+    let maskURL: URL?
+
+    /// "[246, 307, 717, 758]" — the same xyxy the result document carries, rounded to pixels.
+    var boxDescription: String {
+        let values = [box.minX, box.minY, box.maxX, box.maxY].map { Int($0.rounded()) }
+        return "[\(values.map(String.init).joined(separator: ", "))]"
+    }
+
+    var confidenceDescription: String? {
+        guard let confidence else { return nil }
+        return String(format: "%.2f", confidence)
+    }
+}
+
+/// The result document of the run the Analyze canvas is showing.
+enum StudioAnalyzeDocument: Equatable {
+    case ground(StudioVisionGroundDocument)
+    case segmentation(StudioVisionSegmentDocument)
+    case tracking(StudioVisionTrackDocument)
+    case diarization(StudioDiarizationDocument)
+    case transcript(StudioTranscriptDocument)
+
+    /// Decodes whichever document `data` holds. The vision writers all emit a JSON object with a
+    /// distinguishing key (`queries`, `prompts`, `frames`), so the shape identifies itself; a
+    /// payload that is not JSON at all is read as a transcript.
+    static func decode(_ data: Data) -> StudioAnalyzeDocument? {
+        let decoder = JSONDecoder()
+        if let document = try? decoder.decode(StudioVisionTrackDocument.self, from: data) {
+            return .tracking(document)
+        }
+        if let document = try? decoder.decode(StudioVisionSegmentDocument.self, from: data) {
+            return .segmentation(document)
+        }
+        if let document = try? decoder.decode(StudioVisionGroundDocument.self, from: data) {
+            return .ground(document)
+        }
+        if let document = try? decoder.decode(StudioDiarizationDocument.self, from: data) {
+            return .diarization(document)
+        }
+        guard let text = String(data: data, encoding: .utf8), !text.isBlank else { return nil }
+        let transcript = StudioTranscriptDocument.parse(text)
+        return transcript.segments.isEmpty && transcript.text.isEmpty ? nil : .transcript(transcript)
+    }
+
+    /// The model the run used, as the document records it.
+    var modelID: String? {
+        switch self {
+        case .ground(let document): return document.modelID
+        case .segmentation(let document): return document.modelID
+        case .tracking(let document): return document.modelID
+        case .diarization(let document): return document.model
+        case .transcript: return nil
+        }
+    }
+
+    /// The pixel size the document itself knows, when it records one (only `track` does).
+    var reportedInputSize: CGSize? {
+        guard case .tracking(let document) = self else { return nil }
+        return CGSize(width: document.frameWidth, height: document.frameHeight)
+    }
+
+    /// The detections to draw, in the input's pixel space.
+    ///
+    /// - Parameters:
+    ///   - imageSize: the input's pixel size. `ground` stores normalized boxes, so its detections
+    ///     cannot be placed without it; the pixel-space documents ignore it.
+    ///   - frame: which tracked frame to read, for `track`.
+    func detections(imageSize: CGSize, frame: Int = 0) -> [StudioAnalyzeDetection] {
+        switch self {
+        case .ground(let document):
+            return document.detections.enumerated().map { index, detection in
+                StudioAnalyzeDetection(
+                    id: index,
+                    label: detection.label,
+                    confidence: detection.score,
+                    box: CGRect(
+                        x: detection.box.x1 * imageSize.width,
+                        y: detection.box.y1 * imageSize.height,
+                        width: (detection.box.x2 - detection.box.x1) * imageSize.width,
+                        height: (detection.box.y2 - detection.box.y1) * imageSize.height
+                    ),
+                    maskURL: detection.maskPath.map { URL(fileURLWithPath: $0) }
+                )
+            }
+        case .segmentation(let document):
+            return document.detections.enumerated().map { index, detection in
+                StudioAnalyzeDetection(
+                    id: index,
+                    label: detection.label,
+                    confidence: detection.score,
+                    box: CGRect(
+                        x: detection.box.x1,
+                        y: detection.box.y1,
+                        width: detection.box.x2 - detection.box.x1,
+                        height: detection.box.y2 - detection.box.y1
+                    ),
+                    maskURL: detection.maskPath.map { URL(fileURLWithPath: $0) }
+                )
+            }
+        case .tracking(let document):
+            guard let match = document.frames.first(where: { $0.frameIndex == frame })
+                ?? document.frames.first else { return [] }
+            return match.detections.enumerated().compactMap { index, detection in
+                guard detection.visible else { return nil }
+                return StudioAnalyzeDetection(
+                    id: index,
+                    label: detection.label,
+                    confidence: detection.score,
+                    box: CGRect(
+                        x: detection.box.x1,
+                        y: detection.box.y1,
+                        width: detection.box.x2 - detection.box.x1,
+                        height: detection.box.y2 - detection.box.y1
+                    ),
+                    maskURL: detection.maskPath.map { URL(fileURLWithPath: $0) }
+                )
+            }
+        case .diarization, .transcript:
+            return []
+        }
+    }
+
+    /// The result panel's header: what the run found, in the task's own words.
+    func summary(detectionCount: Int) -> String {
+        switch self {
+        case .ground, .segmentation:
+            return detectionCount == 1 ? "1 object found" : "\(detectionCount) objects found"
+        case .tracking(let document):
+            let objects = document.objects.count == 1 ? "1 object" : "\(document.objects.count) objects"
+            return "\(objects) across \(document.frames.count) frames"
+        case .diarization(let document):
+            let speakers = document.speakerCount == 1 ? "1 speaker" : "\(document.speakerCount) speakers"
+            return "\(speakers) · \(document.segments.count) turns"
+        case .transcript(let document):
+            let count = document.segments.count
+            return count == 1 ? "1 segment" : "\(count) segments"
+        }
+    }
+
+    /// Spoken turns for the transcript and timeline views, whichever document carries them.
+    var speechSegments: [StudioAnalyzeSpeechSegment] {
+        switch self {
+        case .transcript(let document):
+            return document.segments.map {
+                StudioAnalyzeSpeechSegment(
+                    id: $0.index, speaker: nil, start: $0.start, end: $0.end, text: $0.text
+                )
+            }
+        case .diarization(let document):
+            return document.segments.enumerated().map { index, segment in
+                StudioAnalyzeSpeechSegment(
+                    id: index,
+                    speaker: "Speaker \(segment.speakerIndex + 1)",
+                    start: segment.startSeconds,
+                    end: segment.endSeconds,
+                    text: ""
+                )
+            }
+        default:
+            return []
+        }
+    }
+}
+
+/// One spoken turn: a transcript line, or a diarized speaker turn.
+struct StudioAnalyzeSpeechSegment: Identifiable, Equatable {
+    let id: Int
+    let speaker: String?
+    let start: TimeInterval
+    let end: TimeInterval
+    let text: String
+
+    /// "0:04" — the same clock the players use.
+    var startDescription: String {
+        StudioTimeFormat.string(start)
+    }
+}
+
+// MARK: - Where a run writes its result document
+
+/// Where a Studio vision run puts the documents the Analyze canvas reads: a `.json` sidecar
+/// beside the annotated output, and a `-masks` directory next to it. Both are the CLI's own
+/// `--json-output` and `--mask-output-dir`; Studio only chooses the paths.
+enum StudioVisionResultPaths {
+    static func apply(to draft: inout CommandDraft, wantsMasks: Bool) {
+        guard !draft.outputPath.isBlank else { return }
+        let stem = URL(fileURLWithPath: draft.outputPath).deletingPathExtension()
+        if draft.visionJSONOutputPath.isBlank {
+            draft.visionJSONOutputPath = stem.appendingPathExtension("json").path
+        }
+        if wantsMasks, draft.visionMaskOutputDirectory.isBlank {
+            draft.visionMaskOutputDirectory = stem.deletingLastPathComponent()
+                .appendingPathComponent("\(stem.lastPathComponent)-masks", isDirectory: true)
+                .path
+        }
+    }
+}
+
+// MARK: - Pixels to points
+
+/// Placing pixel-space result geometry on the view that shows the input.
+enum StudioAnalyzeGeometry {
+    /// Where a pixel-space rect lands inside a view of `displaySize` that shows the whole image
+    /// with no letterboxing — the Analyze canvas sizes its media container to the input's own
+    /// aspect ratio, so one uniform scale maps both axes.
+    static func viewRect(for pixelBox: CGRect, imageSize: CGSize, displaySize: CGSize) -> CGRect {
+        guard imageSize.width > 0, imageSize.height > 0 else { return .zero }
+        let scaleX = displaySize.width / imageSize.width
+        let scaleY = displaySize.height / imageSize.height
+        return CGRect(
+            x: pixelBox.minX * scaleX,
+            y: pixelBox.minY * scaleY,
+            width: pixelBox.width * scaleX,
+            height: pixelBox.height * scaleY
+        )
+    }
+
+    /// The rect an image of `imageSize` occupies when aspect-fitted into `bounds`, for containers
+    /// that do letterbox (a video player, a preview whose height is capped).
+    static func fittedRect(imageSize: CGSize, in bounds: CGSize) -> CGRect {
+        guard imageSize.width > 0, imageSize.height > 0, bounds.width > 0, bounds.height > 0 else {
+            return .zero
+        }
+        let scale = min(bounds.width / imageSize.width, bounds.height / imageSize.height)
+        let fitted = CGSize(width: imageSize.width * scale, height: imageSize.height * scale)
+        return CGRect(
+            x: (bounds.width - fitted.width) / 2,
+            y: (bounds.height - fitted.height) / 2,
+            width: fitted.width,
+            height: fitted.height
+        )
+    }
+}

--- a/apps/macos/MereRunStudio/StudioAnalyzeSchema.swift
+++ b/apps/macos/MereRunStudio/StudioAnalyzeSchema.swift
@@ -1,0 +1,286 @@
+import Foundation
+import UniformTypeIdentifiers
+
+// The Analyze archetype's declarative surface: which result views an input-first task can switch
+// between, and which contextual next steps its result offers. The views in
+// `StudioAnalyzeCanvas.swift` render from these declarations, so a task's shape lives in one
+// place and is testable without SwiftUI.
+
+/// One of the views the Analyze input strip switches between. The set a task offers depends on
+/// what its result actually is, not on the domain it lives in.
+enum StudioAnalyzeResultView: String, CaseIterable, Identifiable, Hashable {
+    /// Detection rectangles drawn over the input.
+    case boxes
+    /// Segmentation masks composited over the input.
+    case masks
+    /// The result overlaid on the video with a scrubber.
+    case video
+    /// Depth or another single-channel map rendered as an image.
+    case depth
+    /// Landmarks and keypoints over the input.
+    case points
+    /// A dense vector field (optical flow, embeddings).
+    case vectors
+    /// A reconstructed scene or point cloud.
+    case scene
+    /// A georeferenced raster over the input.
+    case map
+    /// Spoken text with timestamps.
+    case transcript
+    /// Segments laid out along the input's duration.
+    case timeline
+    /// The audio result with the waveform player.
+    case audio
+    /// Separated stems.
+    case stems
+    /// Plain text (a caption, OCR, a rewritten document).
+    case text
+    /// One number and how it was reached.
+    case score
+    /// The raw result document, monospaced.
+    case json
+
+    var id: String { rawValue }
+
+    /// The segment's label, exactly as the design draws it.
+    var title: String {
+        switch self {
+        case .boxes: return "Boxes"
+        case .masks: return "Masks"
+        case .video: return "Video"
+        case .depth: return "Depth"
+        case .points: return "Points"
+        case .vectors: return "Vectors"
+        case .scene: return "Scene"
+        case .map: return "Map"
+        case .transcript: return "Transcript"
+        case .timeline: return "Timeline"
+        case .audio: return "Audio"
+        case .stems: return "Stems"
+        case .text: return "Text"
+        case .score: return "Score"
+        case .json: return "JSON"
+        }
+    }
+}
+
+/// What the Analyze canvas renders on the left: the input the task was pointed at.
+enum StudioAnalyzeInputKind: Equatable {
+    case image
+    case video
+    case audio
+    /// A file the canvas can only name (a text corpus, a GeoTIFF the app does not decode).
+    case file
+}
+
+/// What one contextual next step does.
+enum StudioAnalyzeNextActionKind: Equatable {
+    /// Continue in a sibling task, carrying this task's input when the target accepts it.
+    case openTask(StudioTask)
+    /// Write part of the result somewhere the user picks.
+    case save(StudioAnalyzeSaveKind)
+}
+
+/// Which artifact a "Save…" next step writes.
+enum StudioAnalyzeSaveKind: Equatable {
+    /// The result document the run wrote (`--json-output`).
+    case json
+    /// The text the run produced (a transcript, a caption).
+    case text
+    /// The primary media output (an annotated image, a tracked clip, enhanced audio).
+    case media
+}
+
+/// One button in the result panel's action row.
+struct StudioAnalyzeNextAction: Identifiable, Equatable {
+    let title: String
+    let kind: StudioAnalyzeNextActionKind
+
+    var id: String { title }
+
+    static func open(_ title: String, _ task: StudioTask) -> StudioAnalyzeNextAction {
+        StudioAnalyzeNextAction(title: title, kind: .openTask(task))
+    }
+
+    static func save(_ title: String, _ kind: StudioAnalyzeSaveKind) -> StudioAnalyzeNextAction {
+        StudioAnalyzeNextAction(title: title, kind: .save(kind))
+    }
+}
+
+/// The Analyze archetype for one task: an input on the left, one result on the right, and the
+/// steps that continue from it. Every input-first task — the ones that take a file, run a single
+/// pass over it, and show what the model found — declares one.
+struct StudioAnalyzeArchetype: Equatable {
+    let task: StudioTask
+    let inputKind: StudioAnalyzeInputKind
+    /// The strip's view switch, in order; the first is the default.
+    let views: [StudioAnalyzeResultView]
+    let nextActions: [StudioAnalyzeNextAction]
+
+    var defaultView: StudioAnalyzeResultView {
+        views.first ?? .json
+    }
+
+    /// The tasks this archetype's next steps can hand off to.
+    var siblingTasks: [StudioTask] {
+        nextActions.compactMap { action in
+            if case .openTask(let task) = action.kind { return task }
+            return nil
+        }
+    }
+}
+
+extension StudioTask {
+    /// The Analyze archetype this task renders with, or nil for tasks that are not input-first
+    /// (Generate, Compose, Chat, and the Project, Session, and Manage tasks).
+    var analyzeArchetype: StudioAnalyzeArchetype? {
+        StudioAnalyzeArchetype.archetypes[self]
+    }
+
+    /// Whether this task renders the Analyze archetype rather than the generation feed.
+    var isAnalyzeTask: Bool {
+        analyzeArchetype != nil
+    }
+}
+
+extension StudioAnalyzeArchetype {
+    // swiftlint:disable:next function_body_length
+    static let archetypes: [StudioTask: StudioAnalyzeArchetype] = {
+        var table: [StudioTask: StudioAnalyzeArchetype] = [:]
+
+        func add(
+            _ task: StudioTask,
+            _ inputKind: StudioAnalyzeInputKind,
+            _ views: [StudioAnalyzeResultView],
+            _ nextActions: [StudioAnalyzeNextAction]
+        ) {
+            table[task] = StudioAnalyzeArchetype(
+                task: task, inputKind: inputKind, views: views, nextActions: nextActions
+            )
+        }
+
+        // Vision
+        add(.visionRead, .image, [.text], [
+            .open("Find objects", .visionFind),
+            .save("Save text", .text)
+        ])
+        add(.visionFind, .image, [.boxes, .masks, .json], [
+            .open("Segment these", .visionSegment),
+            .open("Track in video", .visionTrack),
+            .save("Save JSON", .json)
+        ])
+        add(.visionSegment, .image, [.boxes, .masks, .json], [
+            .open("Track in video", .visionTrack),
+            .open("Read this image", .visionRead),
+            .save("Save JSON", .json)
+        ])
+        add(.visionTrack, .video, [.video, .json], [
+            .open("Segment a frame", .visionSegment),
+            .save("Save JSON", .json)
+        ])
+        add(.visionDepth, .image, [.depth, .json], [
+            .open("Find objects", .visionFind),
+            .save("Save JSON", .json)
+        ])
+        add(.visionPose, .image, [.points, .json], [
+            .open("Detect faces", .visionFaces),
+            .save("Save JSON", .json)
+        ])
+        add(.visionFaces, .image, [.boxes, .points, .json], [
+            .open("Pose landmarks", .visionPose),
+            .save("Save JSON", .json)
+        ])
+        add(.visionFlow, .image, [.vectors, .json], [
+            .save("Save flow", .media)
+        ])
+        add(.visionGeometry, .image, [.scene, .json], [
+            .save("Save scene", .media)
+        ])
+        add(.visionLive, .video, [.video, .json], [
+            .open("Track a clip", .visionTrack),
+            .save("Save JSON", .json)
+        ])
+
+        // Audio
+        add(.audioTranscribe, .audio, [.transcript, .timeline, .json], [
+            .open("Who spoke", .audioWhoSpoke),
+            .open("Enhance audio", .audioEnhance),
+            .save("Save transcript", .text)
+        ])
+        add(.audioWhoSpoke, .audio, [.transcript, .timeline, .json], [
+            .open("Transcribe", .audioTranscribe),
+            .save("Save JSON", .json)
+        ])
+        add(.audioEnhance, .audio, [.audio, .json], [
+            .open("Transcribe", .audioTranscribe),
+            .open("Separate stems", .audioSeparate),
+            .save("Save audio", .media)
+        ])
+        add(.audioSeparate, .audio, [.stems, .json], [
+            .open("Transcribe", .audioTranscribe),
+            .save("Save stems", .media)
+        ])
+
+        // Text
+        add(.textEmbeddings, .file, [.vectors, .json], [
+            .save("Save JSON", .json)
+        ])
+        add(.textAnonymize, .file, [.text], [
+            .save("Save text", .text)
+        ])
+
+        // Earth
+        for task in [StudioTask.earthFlood, .earthFire, .earthTessera, .earthOlmoEarth] {
+            add(task, .file, [.map, .json], [.save("Save JSON", .json)])
+        }
+
+        // Sound analysis
+        add(.soundScore, .audio, [.score], [
+            .open("Transcribe", .audioTranscribe),
+            .save("Save JSON", .json)
+        ])
+        add(.soundCondition, .audio, [.audio, .json], [
+            .save("Save audio", .media)
+        ])
+
+        return table
+    }()
+}
+
+/// Carrying one task's input into the sibling task a next step opens.
+///
+/// A handoff only carries the file when the target genuinely takes it: "Track in video" from a
+/// still image opens Track with the prompt but an empty well, because Track needs a clip. The
+/// prompt always carries, so the user never retypes what they were looking for.
+struct StudioAnalyzeHandoff: Equatable {
+    let task: StudioTask
+    let inputPath: String
+    let prompt: String
+
+    /// Whether `target` accepts `url` as its input, which decides if the well is carried over.
+    static func carriesInput(_ url: URL, to target: StudioTask) -> Bool {
+        guard let mode = target.mode else {
+            // A task without a composer keeps whatever the shared draft holds, and its own form
+            // validates the file; carrying is only refused when the extension is unreadable.
+            return UTType(filenameExtension: url.pathExtension) != nil
+        }
+        return mode.attachmentSlots.contains { $0.accepts(url) }
+    }
+
+    /// The handoff a next step produces, or nil when there is nothing to carry.
+    static func make(to target: StudioTask, inputPath: String, prompt: String) -> StudioAnalyzeHandoff {
+        let trimmed = inputPath.trimmingCharacters(in: .whitespacesAndNewlines)
+        let carried = trimmed.isEmpty || carriesInput(URL(fileURLWithPath: trimmed), to: target)
+            ? trimmed
+            : ""
+        return StudioAnalyzeHandoff(task: target, inputPath: carried, prompt: prompt)
+    }
+
+    /// Applies the handoff to the draft the target task is about to show.
+    func apply(to draft: inout StudioDraft) {
+        guard let mode = task.mode else { return }
+        draft.prompt = prompt
+        guard !inputPath.isEmpty else { return }
+        _ = draft.attach(dropped: [URL(fileURLWithPath: inputPath)], for: mode)
+    }
+}

--- a/apps/macos/MereRunStudio/StudioAnalyzeViews.swift
+++ b/apps/macos/MereRunStudio/StudioAnalyzeViews.swift
@@ -1,0 +1,582 @@
+import AppKit
+import SwiftUI
+
+// The pieces the Analyze canvas is built from: the input chip, the media frame, the native result
+// renderings (boxes, masks, track spans, transcripts, raw documents), and the two panels of the
+// result column.
+
+// MARK: - Shared chrome
+
+extension View {
+    /// The board's media frame: radius 10 on a hairline border, with the panel shadow.
+    func mereMediaFrame() -> some View {
+        clipShape(RoundedRectangle(cornerRadius: MereRunTheme.Radius.lg))
+            .overlay {
+                RoundedRectangle(cornerRadius: MereRunTheme.Radius.lg)
+                    .strokeBorder(MereRunTheme.border, lineWidth: 1)
+            }
+            .mereShadow(radius: 24, y: 8)
+    }
+
+    /// The board's `panel`: `surface` on a 1pt border at 80%, radius 10.
+    func mereAnalyzePanel() -> some View {
+        background {
+            RoundedRectangle(cornerRadius: MereRunTheme.Radius.lg)
+                .fill(MereRunTheme.surface)
+                .overlay {
+                    RoundedRectangle(cornerRadius: MereRunTheme.Radius.lg)
+                        .strokeBorder(MereRunTheme.border.opacity(0.8), lineWidth: 1)
+                }
+        }
+    }
+}
+
+/// The board's `chip`: 24pt tall on `surfaceRaised`, radius 6, 11.5pt medium. The compact variant
+/// (20pt, 10.5pt) is what the parameter strips use.
+struct StudioAnalyzeChip: View {
+    let text: String
+    var isCompact = false
+
+    var body: some View {
+        Text(text)
+            .font(.system(size: isCompact ? 10.5 : 11.5, weight: .medium))
+            .foregroundStyle(MereRunTheme.textPrimary)
+            .lineLimit(1)
+            .truncationMode(.middle)
+            .padding(.horizontal, 9)
+            .frame(height: isCompact ? 20 : 24)
+            .background {
+                RoundedRectangle(cornerRadius: MereRunTheme.Radius.sm)
+                    .fill(MereRunTheme.surfaceRaised)
+            }
+    }
+}
+
+// MARK: - Image with overlays
+
+/// The input image at its own aspect ratio, with the run's result drawn over it.
+///
+/// The frame hugs the picture (`aspectRatio(.fit)` reports the fitted size), so the overlay's
+/// coordinate space *is* the displayed image and one uniform scale maps result pixels onto it.
+struct StudioAnalyzeImageView: View {
+    let url: URL
+    let maxHeight: CGFloat
+    /// Drawn as 2pt accent rectangles with a label tab.
+    let detections: [StudioAnalyzeDetection]
+    /// Composited as a soft accent tint.
+    let masks: [StudioAnalyzeDetection]
+    /// The image's true pixel size, which the result's coordinates are in.
+    let imageSize: CGSize?
+
+    @State private var image: NSImage?
+    @State private var didLoad = false
+
+    private var pixelSize: CGSize {
+        if let imageSize, imageSize.width > 0, imageSize.height > 0 { return imageSize }
+        if let image, image.size.width > 0, image.size.height > 0 { return image.size }
+        return CGSize(width: 1, height: 1)
+    }
+
+    var body: some View {
+        Group {
+            if let image {
+                Image(nsImage: image)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .frame(maxHeight: maxHeight)
+                    .overlay { overlay }
+            } else {
+                Rectangle()
+                    .fill(MereRunTheme.surfaceRaised)
+                    .aspectRatio(1, contentMode: .fit)
+                    .frame(maxHeight: maxHeight)
+                    .overlay {
+                        if didLoad {
+                            Image(systemName: "photo")
+                                .font(.system(size: 32, weight: .semibold))
+                                .foregroundStyle(MereRunTheme.textMuted)
+                        } else {
+                            ProgressView().controlSize(.small)
+                        }
+                    }
+            }
+        }
+        .task(id: url) {
+            didLoad = false
+            image = nil
+            let loaded = await Task.detached(priority: .userInitiated) {
+                StudioImagePreviewLoader.downsampledImage(from: url, maxPixelSize: 1_600)
+            }.value
+            guard !Task.isCancelled else { return }
+            image = loaded?.image
+            didLoad = true
+        }
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel(accessibilityDescription)
+    }
+
+    private var accessibilityDescription: String {
+        guard !detections.isEmpty else { return "Input image \(url.lastPathComponent)" }
+        return "Input image with \(detections.count) results: "
+            + detections.map(\.label).joined(separator: ", ")
+    }
+
+    private var overlay: some View {
+        GeometryReader { geometry in
+            ZStack(alignment: .topLeading) {
+                ForEach(masks) { detection in
+                    maskLayer(detection, in: geometry.size)
+                }
+                ForEach(detections) { detection in
+                    box(detection, in: geometry.size)
+                }
+            }
+        }
+        .allowsHitTesting(false)
+    }
+
+    private func box(_ detection: StudioAnalyzeDetection, in size: CGSize) -> some View {
+        let rect = StudioAnalyzeGeometry.viewRect(
+            for: detection.box, imageSize: pixelSize, displaySize: size
+        )
+        return RoundedRectangle(cornerRadius: 4)
+            .strokeBorder(MereRunTheme.accent, lineWidth: 2)
+            .frame(width: max(rect.width, 2), height: max(rect.height, 2))
+            .overlay(alignment: .topLeading) {
+                StudioAnalyzeBoxLabel(text: detection.tabLabel)
+                    .fixedSize()
+                    .offset(x: -2, y: -22)
+            }
+            .offset(x: rect.minX, y: rect.minY)
+    }
+
+    /// The mask PNG the run wrote, tinted; a detection with no mask file falls back to a tinted
+    /// box so the Masks view never comes up empty.
+    @ViewBuilder
+    private func maskLayer(_ detection: StudioAnalyzeDetection, in size: CGSize) -> some View {
+        if let maskURL = detection.maskURL {
+            StudioAnalyzeMaskLayer(url: maskURL)
+        } else {
+            let rect = StudioAnalyzeGeometry.viewRect(
+                for: detection.box, imageSize: pixelSize, displaySize: size
+            )
+            RoundedRectangle(cornerRadius: 4)
+                .fill(MereRunTheme.accent.opacity(0.45))
+                .frame(width: max(rect.width, 2), height: max(rect.height, 2))
+                .offset(x: rect.minX, y: rect.minY)
+        }
+    }
+}
+
+/// "coffee cup 0.94" on an accent tab that sits on top of its box.
+private struct StudioAnalyzeBoxLabel: View {
+    let text: String
+
+    var body: some View {
+        Text(text)
+            .font(.system(size: 11, weight: .semibold))
+            .foregroundStyle(MereRunTheme.onAccent)
+            .lineLimit(1)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background {
+                UnevenRoundedRectangle(
+                    cornerRadii: .init(topLeading: 4, bottomLeading: 0, bottomTrailing: 0, topTrailing: 4)
+                )
+                .fill(MereRunTheme.accent)
+            }
+    }
+}
+
+extension StudioAnalyzeDetection {
+    /// What the box tab reads: "coffee cup 0.94", or just the label when there is no score.
+    var tabLabel: String {
+        [label, confidenceDescription].compactMap { $0 }.joined(separator: " ")
+    }
+}
+
+/// One mask PNG composited over the image. The file is white-on-black (or white on transparent),
+/// so its luminance becomes the alpha of an accent wash.
+private struct StudioAnalyzeMaskLayer: View {
+    let url: URL
+
+    @State private var mask: NSImage?
+
+    var body: some View {
+        Group {
+            if let mask {
+                Rectangle()
+                    .fill(MereRunTheme.accent)
+                    .mask {
+                        Image(nsImage: mask)
+                            .resizable()
+                            .aspectRatio(contentMode: .fill)
+                            .luminanceToAlpha()
+                    }
+                    .opacity(0.45)
+            } else {
+                Color.clear
+            }
+        }
+        .task(id: url) {
+            let loaded = await Task.detached(priority: .userInitiated) {
+                StudioImagePreviewLoader.downsampledImage(from: url, maxPixelSize: 1_600)
+            }.value
+            guard !Task.isCancelled else { return }
+            mask = loaded?.image
+        }
+    }
+}
+
+// MARK: - Track spans
+
+/// Where each tracked object is visible across the clip, under the video's own scrubber.
+struct StudioAnalyzeTrackScrubber: View {
+    let document: StudioVisionTrackDocument
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 5) {
+            ForEach(document.objects, id: \.objectID) { object in
+                HStack(spacing: 8) {
+                    Text(object.label)
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundStyle(MereRunTheme.textSecondary)
+                        .lineLimit(1)
+                        .frame(width: 92, alignment: .leading)
+                    GeometryReader { geometry in
+                        ZStack(alignment: .leading) {
+                            Capsule().fill(MereRunTheme.surfaceRaised)
+                            ForEach(Array(spans(of: object.objectID).enumerated()), id: \.offset) { _, span in
+                                Capsule()
+                                    .fill(MereRunTheme.accent)
+                                    .frame(width: max(2, geometry.size.width * span.width))
+                                    .offset(x: geometry.size.width * span.start)
+                            }
+                        }
+                    }
+                    .frame(height: 6)
+                    Text(StudioTimeFormat.string(document.duration))
+                        .font(.system(size: 11, weight: .medium, design: .monospaced))
+                        .foregroundStyle(MereRunTheme.textMuted)
+                }
+                .accessibilityElement(children: .combine)
+                .accessibilityLabel("\(object.label) visible in \(visibleFrameCount(of: object.objectID)) frames")
+            }
+        }
+    }
+
+    private struct Span {
+        let start: Double
+        let width: Double
+    }
+
+    private func visibleFrameCount(of objectID: String) -> Int {
+        document.frames.filter { frame in
+            frame.detections.contains { $0.objectID == objectID && $0.visible }
+        }.count
+    }
+
+    /// The runs of consecutive frames where the object is visible, as fractions of the clip.
+    private func spans(of objectID: String) -> [Span] {
+        let total = Double(document.frames.count)
+        guard total > 0 else { return [] }
+        var spans: [Span] = []
+        var runStart: Int?
+        for (index, frame) in document.frames.enumerated() {
+            let visible = frame.detections.contains { $0.objectID == objectID && $0.visible }
+            if visible, runStart == nil {
+                runStart = index
+            } else if !visible, let start = runStart {
+                spans.append(Span(start: Double(start) / total, width: Double(index - start) / total))
+                runStart = nil
+            }
+        }
+        if let start = runStart {
+            spans.append(Span(start: Double(start) / total, width: (total - Double(start)) / total))
+        }
+        return spans
+    }
+}
+
+// MARK: - Raw document
+
+/// The result document as the run wrote it, monospaced.
+struct StudioAnalyzeDocumentView: View {
+    let url: URL?
+    let text: String?
+
+    var body: some View {
+        ScrollView([.vertical, .horizontal]) {
+            Text(text ?? "This run left no result document.")
+                .font(.system(size: 11.5, design: .monospaced))
+                .foregroundStyle(text == nil ? MereRunTheme.textMuted : MereRunTheme.textPrimary)
+                .textSelection(.enabled)
+                .padding(MereRunTheme.Spacing.md)
+                .frame(maxWidth: .infinity, alignment: .leading)
+        }
+        .background(MereRunTheme.surface)
+        .accessibilityLabel(url.map { "Result document \($0.lastPathComponent)" } ?? "Result document")
+    }
+}
+
+// MARK: - Result panel
+
+/// What the model found: a header that names it, one row per result, and the steps that continue
+/// from it.
+struct StudioAnalyzeResultPanel: View {
+    let item: StudioLibraryItem
+    let document: StudioAnalyzeDocument?
+    let detections: [StudioAnalyzeDetection]
+    let speechSegments: [StudioAnalyzeSpeechSegment]
+    let outputText: String?
+    let view: StudioAnalyzeResultView
+    let nextActions: [StudioAnalyzeNextAction]
+    let onOpenTask: (StudioTask) -> Void
+    let onSave: (StudioAnalyzeSaveKind) -> Void
+
+    private static let rowsMaxHeight: CGFloat = 320
+    /// More rows than this and the list scrolls at `rowsMaxHeight` rather than growing.
+    private static let scrollingRowThreshold = 7
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            hairline(0.4)
+            rows
+            actionRow
+        }
+        .mereAnalyzePanel()
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(summary)
+    }
+
+    private var summary: String {
+        if let document { return document.summary(detectionCount: detections.count) }
+        if outputText?.isBlank == false { return "Result" }
+        return "No result"
+    }
+
+    private var meta: String {
+        var parts: [String] = []
+        if let model = document?.modelID ?? item.commandDraft?.model, !model.isBlank {
+            parts.append(StudioComposer.displayModelName(model))
+        }
+        let elapsed = item.updatedAt.timeIntervalSince(item.createdAt)
+        if elapsed >= 0.05 { parts.append(String(format: "%.1f s", elapsed)) }
+        return parts.joined(separator: " · ")
+    }
+
+    private var header: some View {
+        HStack(spacing: 8) {
+            Text(summary)
+                .font(.system(size: 12.5, weight: .semibold))
+                .foregroundStyle(MereRunTheme.textPrimary)
+            Spacer(minLength: 8)
+            Text(meta)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(MereRunTheme.textMuted)
+                .lineLimit(1)
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 12)
+    }
+
+    private func hairline(_ opacity: Double) -> some View {
+        Rectangle()
+            .fill(MereRunTheme.border.opacity(opacity))
+            .frame(height: 1)
+    }
+
+    @ViewBuilder
+    private var rows: some View {
+        switch view {
+        case .transcript, .timeline:
+            speechRows
+        case .text, .score:
+            textRow
+        default:
+            if detections.isEmpty {
+                textRow
+            } else {
+                detectionRows
+            }
+        }
+    }
+
+    private var detectionRows: some View {
+        boundedRows(count: detections.count) {
+            ForEach(detections) { detection in
+                HStack(spacing: 10) {
+                    RoundedRectangle(cornerRadius: 2)
+                        .fill(MereRunTheme.accent)
+                        .frame(width: 10, height: 10)
+                    Text(detection.label)
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundStyle(MereRunTheme.textPrimary)
+                        .lineLimit(1)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                    if let confidence = detection.confidenceDescription {
+                        Text(confidence)
+                            .font(.system(size: 12, weight: .medium, design: .monospaced))
+                            .foregroundStyle(MereRunTheme.textSecondary)
+                            .fixedSize()
+                    }
+                    Text(detection.boxDescription)
+                        .font(.system(size: 11.5, weight: .medium, design: .monospaced))
+                        .foregroundStyle(MereRunTheme.textMuted)
+                        .lineLimit(1)
+                        .fixedSize()
+                }
+                .padding(.horizontal, 14)
+                .padding(.vertical, 10)
+                .accessibilityElement(children: .combine)
+                hairline(0.27)
+            }
+        }
+    }
+
+    private var speechRows: some View {
+        boundedRows(count: speechSegments.count) {
+            ForEach(speechSegments) { segment in
+                HStack(alignment: .top, spacing: 10) {
+                    Text(segment.startDescription)
+                        .font(.system(size: 11.5, weight: .medium, design: .monospaced))
+                        .foregroundStyle(MereRunTheme.textMuted)
+                        .frame(width: 44, alignment: .leading)
+                    VStack(alignment: .leading, spacing: 2) {
+                        if let speaker = segment.speaker {
+                            Text(speaker)
+                                .font(.system(size: 11, weight: .semibold))
+                                .foregroundStyle(MereRunTheme.accent)
+                        }
+                        if !segment.text.isEmpty {
+                            Text(segment.text)
+                                .font(.system(size: 13))
+                                .foregroundStyle(MereRunTheme.textPrimary)
+                                .fixedSize(horizontal: false, vertical: true)
+                                .textSelection(.enabled)
+                        }
+                    }
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                .padding(.horizontal, 14)
+                .padding(.vertical, 10)
+                .accessibilityElement(children: .combine)
+                hairline(0.27)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var textRow: some View {
+        if let text = outputText?.trimmingCharacters(in: .whitespacesAndNewlines), !text.isEmpty {
+            ScrollView {
+                Text(text)
+                    .font(.system(size: 13))
+                    .foregroundStyle(MereRunTheme.textPrimary)
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.horizontal, 14)
+                    .padding(.vertical, 12)
+            }
+            .frame(maxHeight: Self.rowsMaxHeight)
+            hairline(0.27)
+        } else {
+            Text("This run left no readable result.")
+                .font(.system(size: 12.5))
+                .foregroundStyle(MereRunTheme.textMuted)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.horizontal, 14)
+                .padding(.vertical, 12)
+            hairline(0.27)
+        }
+    }
+
+    /// Rows size to their content; a long list scrolls inside the panel instead of pushing the
+    /// action row off the column.
+    @ViewBuilder
+    private func boundedRows<Content: View>(
+        count: Int,
+        @ViewBuilder content: () -> Content
+    ) -> some View {
+        if count > Self.scrollingRowThreshold {
+            ScrollView {
+                VStack(spacing: 0) { content() }
+            }
+            .frame(height: Self.rowsMaxHeight)
+        } else {
+            VStack(spacing: 0) { content() }
+        }
+    }
+
+    private var actionRow: some View {
+        HStack(spacing: 6) {
+            ForEach(nextActions) { action in
+                if case .openTask(let task) = action.kind {
+                    Button(action.title) { onOpenTask(task) }
+                        .buttonStyle(.mereSecondary)
+                        .help("Open \(task.domain.title) ▸ \(task.title) with this input")
+                }
+            }
+            Spacer(minLength: 8)
+            ForEach(nextActions) { action in
+                if case .save(let kind) = action.kind {
+                    Button(action.title) { onSave(kind) }
+                        .buttonStyle(.mereSecondary)
+                }
+            }
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 10)
+    }
+}
+
+// MARK: - Prompt panel
+
+/// What was asked, and the settings it ran with.
+struct StudioAnalyzePromptPanel: View {
+    let item: StudioLibraryItem
+
+    private var prompt: String {
+        item.prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+
+    /// The run's own chips, capitalized the way the board draws them.
+    private var chips: [String] {
+        StudioFeedChips.chips(for: item).map { chip in
+            guard let first = chip.first else { return chip }
+            return first.uppercased() + chip.dropFirst()
+        }
+    }
+
+    var body: some View {
+        if !prompt.isEmpty || !chips.isEmpty {
+            VStack(alignment: .leading, spacing: 8) {
+                Text(prompt.isEmpty ? "Run" : "Prompt")
+                    .font(.system(size: 11, weight: .semibold))
+                    .kerning(0.55)
+                    .textCase(.uppercase)
+                    .foregroundStyle(MereRunTheme.textMuted)
+                    .accessibilityAddTraits(.isHeader)
+                if !prompt.isEmpty {
+                    Text(prompt)
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundStyle(MereRunTheme.textPrimary)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .textSelection(.enabled)
+                }
+                if !chips.isEmpty {
+                    HStack(spacing: 4) {
+                        ForEach(chips, id: \.self) { chip in
+                            StudioAnalyzeChip(text: chip, isCompact: true)
+                        }
+                    }
+                }
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 12)
+            .mereAnalyzePanel()
+        }
+    }
+}

--- a/apps/macos/MereRunStudio/StudioAnalyzeViews.swift
+++ b/apps/macos/MereRunStudio/StudioAnalyzeViews.swift
@@ -141,6 +141,12 @@ struct StudioAnalyzeImageView: View {
         )
         return RoundedRectangle(cornerRadius: 4)
             .strokeBorder(MereRunTheme.accent, lineWidth: 2)
+            // The design's inset hairline: it keeps the accent edge readable over a pale subject.
+            .overlay {
+                RoundedRectangle(cornerRadius: 3)
+                    .strokeBorder(Color.black.opacity(0.25), lineWidth: 1)
+                    .padding(2)
+            }
             .frame(width: max(rect.width, 2), height: max(rect.height, 2))
             .overlay(alignment: .topLeading) {
                 StudioAnalyzeBoxLabel(text: detection.tabLabel)

--- a/apps/macos/MereRunStudio/StudioFeedCanvas.swift
+++ b/apps/macos/MereRunStudio/StudioFeedCanvas.swift
@@ -313,8 +313,11 @@ enum StudioFeedChips {
             chips.append("\(StudioComposerPresets.secondsText(draft.durationSeconds)) s")
             chips.append(stepsChip(draft.steps))
             chips.append(seedChip(draft.seed))
-        case .findObjects, .segment, .track:
+        case .segment, .track:
+            // `vision ground` has no threshold flag, so Find never claims one.
             chips.append("threshold \(StudioComposerPresets.decimalText(draft.visionThreshold))")
+        case .findObjects:
+            break
         case .speak:
             chips.append(draft.voiceMode == "clone" ? "cloned voice" : "preset voice")
         case .listen:

--- a/apps/macos/MereRunStudio/StudioRootView.swift
+++ b/apps/macos/MereRunStudio/StudioRootView.swift
@@ -37,6 +37,8 @@ struct StudioRootView: View {
     /// The conversation the canvas/composer targets in chat/code modes. nil means a fresh,
     /// not-yet-sent conversation (so the library has no empty row until the first message).
     @State private var activeConversationID: UUID?
+    /// An Analyze next step in flight: the input and prompt to hand the task being opened.
+    @State private var pendingAnalyzeHandoff: StudioAnalyzeHandoff?
     @State private var pendingPullRefresh: StudioReadinessRefresh?
     @State private var pendingRestrictedPull: StudioRunRequest?
     @State private var studioError: String?
@@ -685,6 +687,18 @@ struct StudioRootView: View {
                 onUseExample: useExamplePrompt
             )
             .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if let archetype = destination.task.analyzeArchetype {
+            StudioAnalyzeCanvas(
+                archetype: archetype,
+                mode: mode,
+                cards: feedCards,
+                selectedID: navigation.selectedLibraryID,
+                inputPath: draft.inputPath,
+                readiness: readiness,
+                pullJob: activePullJob,
+                actions: feedActions,
+                analyze: analyzeActions
+            )
         } else {
             StudioFeedCanvas(
                 mode: mode,
@@ -696,6 +710,14 @@ struct StudioRootView: View {
                 actions: feedActions
             )
         }
+    }
+
+    private var analyzeActions: StudioAnalyzeActions {
+        StudioAnalyzeActions(
+            replaceInput: chooseAttachment,
+            openTask: openSiblingTask,
+            save: saveAnalyzeResult
+        )
     }
 
     private var feedActions: StudioFeedActions {
@@ -1006,8 +1028,19 @@ struct StudioRootView: View {
             nextDraft.prompt = ""
         } else {
             activeConversationID = nil
-            navigation.selectedLibraryID = preferred?.id ?? library.items.first { $0.mode == newMode }?.id
+            let selected = preferred ?? library.items.first { $0.mode == newMode }
+            navigation.selectedLibraryID = selected?.id
+            // An input-first task is about a file: opening it on a past run should show that run's
+            // input, so the canvas and the composer's well never disagree.
+            if newMode.destination.task.isAnalyzeTask, nextDraft.inputPath.isBlank {
+                applyAnalyzeInput(from: selected, to: &nextDraft)
+            }
         }
+        if let handoff = pendingAnalyzeHandoff, handoff.task.mode == newMode {
+            handoff.apply(to: &nextDraft)
+            navigation.selectedLibraryID = nil
+        }
+        pendingAnalyzeHandoff = nil
         draft = nextDraft
         controller.checkReadiness(for: newMode, draft: draft)
         if newMode != .listen { promptFocused = true }
@@ -1019,8 +1052,19 @@ struct StudioRootView: View {
     private func selectLibraryItem(_ item: StudioLibraryItem) {
         navigation.selectedLibraryID = item.id
         highlightCard(item.id)
-        guard item.mode != mode || !showsPromptWorkspace else { return }
+        guard item.mode != mode || !showsPromptWorkspace else {
+            if destination.task.isAnalyzeTask { applyAnalyzeInput(from: item, to: &draft) }
+            return
+        }
         navigation.open(destination: item.mode.destination)
+    }
+
+    /// Puts a past Analyze run's input and prompt back in the composer, so the canvas shows the
+    /// picture that run was about and re-running it is one click away.
+    private func applyAnalyzeInput(from item: StudioLibraryItem?, to draft: inout StudioDraft) {
+        guard let item, let inputURL = item.inputURL else { return }
+        draft.inputPath = inputURL.path
+        if !item.prompt.isBlank { draft.prompt = item.prompt }
     }
 
     private func highlightCard(_ id: UUID) {
@@ -1163,6 +1207,70 @@ struct StudioRootView: View {
         }
         commandDraft.seed = String(Int.random(in: 1...Int(Int32.max)))
         runLibraryItem(item, draft: commandDraft)
+    }
+
+    /// A contextual next step on an Analyze result: opens the sibling task with this run's input
+    /// and prompt carried over, so "Segment these" continues from the same picture.
+    private func openSiblingTask(_ task: StudioTask) {
+        if task.mode != nil {
+            pendingAnalyzeHandoff = StudioAnalyzeHandoff.make(
+                to: task, inputPath: draft.inputPath, prompt: draft.prompt
+            )
+            navigation.selectedLibraryID = nil
+        }
+        // A task without a composer reads this same draft, so its input is already carried.
+        navigation.open(destination: task.destination)
+    }
+
+    /// The Analyze result column's "Save…" steps.
+    private func saveAnalyzeResult(_ kind: StudioAnalyzeSaveKind) {
+        guard let item = analyzeResultItem else { return }
+        switch kind {
+        case .json:
+            guard let url = StudioAnalyzeDocumentSource.url(for: item) else {
+                studioError = "This run did not write a result document."
+                return
+            }
+            saveOutput(url)
+        case .media:
+            guard let url = item.outputURL else {
+                studioError = "This run did not write an output file."
+                return
+            }
+            saveOutput(url)
+        case .text:
+            if let url = StudioAnalyzeDocumentSource.url(for: item), url.pathExtension != "json" {
+                saveOutput(url)
+                return
+            }
+            saveText(item.outputText, suggestedName: "transcript.txt")
+        }
+    }
+
+    /// The run the Analyze canvas is showing: the picked Library row, else this mode's newest.
+    private var analyzeResultItem: StudioLibraryItem? {
+        let finished = feedCards.filter { $0.kind == .generation }
+        if let selectedLibraryID = navigation.selectedLibraryID,
+           let picked = finished.first(where: { $0.id == selectedLibraryID }) {
+            return picked.item
+        }
+        return finished.last?.item
+    }
+
+    private func saveText(_ text: String?, suggestedName: String) {
+        guard let text, !text.isBlank else {
+            studioError = "This run left no text to save."
+            return
+        }
+        guard let destination = StudioSpecialistFiles.saveFile(
+            title: "Save result",
+            suggestedName: suggestedName
+        ) else { return }
+        do {
+            try text.write(to: destination, atomically: true, encoding: .utf8)
+        } catch {
+            studioError = "Could not save \(destination.lastPathComponent): \(error.localizedDescription)"
+        }
     }
 
     /// Loads an output into the composer's well as the next run's input.

--- a/apps/macos/MereRunStudio/StudioTypes.swift
+++ b/apps/macos/MereRunStudio/StudioTypes.swift
@@ -757,6 +757,10 @@ enum StudioCommandAdapter {
             draft.inputPath = studioDraft.inputPath
             draft.model = studioDraft.model.isBlank ? draft.model : studioDraft.model
             draft.visionThreshold = studioDraft.visionThreshold
+            // Studio renders these results natively, so it always asks for the structured
+            // document beside the annotated output. Masks are per-detection PNG sidecars; a
+            // tracked clip writes one set per frame, so only the still tasks request them.
+            StudioVisionResultPaths.apply(to: &draft, wantsMasks: mode != .track)
 
         case .music:
             draft.prompt = prompt

--- a/apps/macos/MereRunStudioTests/StudioAnalyzeTests.swift
+++ b/apps/macos/MereRunStudioTests/StudioAnalyzeTests.swift
@@ -1,0 +1,488 @@
+@testable import MereRunApp
+import CoreGraphics
+import Foundation
+import XCTest
+
+/// The Analyze archetype: decoding the documents the CLI really writes, putting their coordinates
+/// on screen, and the per-task view switch and next steps the canvas renders from.
+final class StudioAnalyzeTests: XCTestCase {
+    // MARK: - vision ground
+
+    /// `FalconPerceptionGroundingMetadata` as the grounder encodes it: camelCase keys, escaped
+    /// slashes, `queries` rather than `prompts`, and boxes normalized to 0…1.
+    private let groundJSON = """
+    {
+      "annotatedImagePath" : "\\/tmp\\/mug_grounded.png",
+      "detections" : [
+        {
+          "box" : { "x1" : 0.240234375, "x2" : 0.700195312, "y1" : 0.299804687, "y2" : 0.740234375 },
+          "hw" : { "h" : 0.440429687, "w" : 0.459960937 },
+          "label" : "coffee cup",
+          "maskPath" : "\\/tmp\\/masks\\/coffee-cup_mask_0.png",
+          "score" : 0.94,
+          "xy" : { "x" : 0.470214843, "y" : 0.520019531 }
+        },
+        {
+          "box" : { "x1" : 0.080078125, "x2" : 0.259765625, "y1" : 0.739257812, "y2" : 0.899414062 },
+          "hw" : { "h" : 0.16015625, "w" : 0.1796875 },
+          "label" : "saucer",
+          "score" : 0.81,
+          "xy" : { "x" : 0.169921875, "y" : 0.819335937 }
+        }
+      ],
+      "inputImagePath" : "\\/tmp\\/mug.png",
+      "jsonOutputPath" : "\\/tmp\\/mug_grounded.json",
+      "modelID" : "vision-ground-falcon-perception",
+      "queries" : [ "every coffee cup and what it sits on" ],
+      "schemaVersion" : 1
+    }
+    """
+
+    func testGroundDocumentDecodesAndScalesNormalizedBoxesToPixels() throws {
+        let document = try XCTUnwrap(StudioAnalyzeDocument.decode(Data(groundJSON.utf8)))
+        guard case .ground(let ground) = document else {
+            return XCTFail("Expected a ground document, got \(document)")
+        }
+        XCTAssertEqual(ground.schemaVersion, 1)
+        XCTAssertEqual(ground.modelID, "vision-ground-falcon-perception")
+        XCTAssertEqual(ground.queries, ["every coffee cup and what it sits on"])
+        XCTAssertEqual(document.modelID, "vision-ground-falcon-perception")
+
+        let detections = document.detections(imageSize: CGSize(width: 1_024, height: 1_024))
+        XCTAssertEqual(detections.map(\.label), ["coffee cup", "saucer"])
+        XCTAssertEqual(detections[0].boxDescription, "[246, 307, 717, 758]")
+        XCTAssertEqual(detections[1].boxDescription, "[82, 757, 266, 921]")
+        XCTAssertEqual(detections[0].confidenceDescription, "0.94")
+        XCTAssertEqual(detections[0].tabLabel, "coffee cup 0.94")
+        XCTAssertEqual(detections[0].maskURL?.lastPathComponent, "coffee-cup_mask_0.png")
+        XCTAssertNil(detections[1].maskURL)
+        XCTAssertEqual(document.summary(detectionCount: detections.count), "2 objects found")
+    }
+
+    /// Today's grounder never sets `score`, so the confidence column has to be optional.
+    func testGroundDetectionWithoutScoreHasNoConfidence() throws {
+        let json = """
+        {
+          "detections" : [
+            { "box" : { "x1" : 0, "x2" : 0.5, "y1" : 0, "y2" : 0.5 }, "label" : "person" }
+          ],
+          "inputImagePath" : "/tmp/a.png",
+          "annotatedImagePath" : "/tmp/a_grounded.png",
+          "modelID" : "vision-ground-falcon-perception",
+          "queries" : [ "person" ],
+          "schemaVersion" : 1
+        }
+        """
+        let document = try XCTUnwrap(StudioAnalyzeDocument.decode(Data(json.utf8)))
+        let detections = document.detections(imageSize: CGSize(width: 800, height: 600))
+        XCTAssertNil(detections[0].confidenceDescription)
+        XCTAssertEqual(detections[0].tabLabel, "person")
+        XCTAssertEqual(detections[0].boxDescription, "[0, 0, 400, 300]")
+        XCTAssertEqual(document.summary(detectionCount: 1), "1 object found")
+    }
+
+    // MARK: - vision segment
+
+    /// `SAM31SegmentationMetadata`: schema 2, `prompts`, absolute pixel xyxy, optional `objectID`,
+    /// `promptKind`, `maskPath`.
+    func testSegmentDocumentDecodesPixelBoxesAndMasks() throws {
+        let json = """
+        {
+          "annotatedImagePath" : "\\/tmp\\/crowd_segmented.png",
+          "detections" : [
+            {
+              "box" : { "x1" : 412, "x2" : 638, "y1" : 96, "y2" : 701 },
+              "label" : "person",
+              "maskAreaPixels" : 84213,
+              "maskPath" : "\\/tmp\\/masks\\/person_mask_0.png",
+              "objectID" : "person",
+              "promptKind" : "text",
+              "score" : 0.7431640625
+            },
+            {
+              "box" : { "x1" : 21, "x2" : 179, "y1" : 41, "y2" : 298 },
+              "label" : "phone",
+              "maskAreaPixels" : 30112,
+              "score" : 0.9091796875
+            }
+          ],
+          "inputImagePath" : "\\/tmp\\/crowd.png",
+          "jsonOutputPath" : "\\/tmp\\/crowd_segmented.json",
+          "modelID" : "vision-segment-sam31",
+          "prompts" : [ "person", "phone" ],
+          "resolution" : 1008,
+          "schemaVersion" : 2,
+          "threshold" : 0.05000000074505806
+        }
+        """
+        let document = try XCTUnwrap(StudioAnalyzeDocument.decode(Data(json.utf8)))
+        guard case .segmentation(let segmentation) = document else {
+            return XCTFail("Expected a segmentation document, got \(document)")
+        }
+        XCTAssertEqual(segmentation.schemaVersion, 2)
+        XCTAssertEqual(segmentation.prompts, ["person", "phone"])
+        XCTAssertEqual(segmentation.detections[1].objectID, nil)
+
+        // Pixel documents ignore the image size they are handed.
+        let detections = document.detections(imageSize: CGSize(width: 1_280, height: 960))
+        XCTAssertEqual(detections[0].boxDescription, "[412, 96, 638, 701]")
+        XCTAssertEqual(detections[1].boxDescription, "[21, 41, 179, 298]")
+        XCTAssertEqual(detections[0].confidenceDescription, "0.74")
+        XCTAssertEqual(detections[0].maskURL?.path, "/tmp/masks/person_mask_0.png")
+        XCTAssertNil(detections[1].maskURL)
+    }
+
+    // MARK: - vision track
+
+    /// `SAM31TrackingRun`: every frame carries an entry for every object, including the ones the
+    /// tracker lost (`visible: false`), which must not be drawn.
+    func testTrackDocumentReadsFramesAndDropsInvisibleDetections() throws {
+        let json = """
+        {
+          "annotatedVideoPath" : "\\/tmp\\/street_tracked.mp4",
+          "droppedFrameCount" : 0,
+          "fps" : 30,
+          "frameHeight" : 720,
+          "frameWidth" : 1280,
+          "frames" : [
+            {
+              "detections" : [
+                {
+                  "box" : { "x1" : 402, "x2" : 611, "y1" : 288, "y2" : 431 },
+                  "label" : "red car", "maskAreaPixels" : 21874, "objectID" : "red-car",
+                  "score" : 0.86328125, "visible" : true
+                }
+              ],
+              "frameIndex" : 0, "timestampSeconds" : 0
+            },
+            {
+              "detections" : [
+                {
+                  "box" : { "x1" : 409, "x2" : 618, "y1" : 289, "y2" : 433 },
+                  "label" : "red car", "maskAreaPixels" : 0, "objectID" : "red-car",
+                  "score" : 0, "visible" : false
+                }
+              ],
+              "frameIndex" : 1, "timestampSeconds" : 0.03333333333333333
+            }
+          ],
+          "initFrameIndex" : 0,
+          "inputVideoPath" : "\\/tmp\\/street.mp4",
+          "modelID" : "vision-segment-sam31",
+          "objects" : [
+            { "label" : "red car", "objectID" : "red-car", "promptKind" : "text", "seedFrameIndex" : 0,
+              "seedPoints" : [] }
+          ],
+          "schemaVersion" : 1
+        }
+        """
+        let document = try XCTUnwrap(StudioAnalyzeDocument.decode(Data(json.utf8)))
+        guard case .tracking(let tracking) = document else {
+            return XCTFail("Expected a tracking document, got \(document)")
+        }
+        XCTAssertEqual(tracking.frameWidth, 1_280)
+        XCTAssertEqual(document.reportedInputSize, CGSize(width: 1_280, height: 720))
+        XCTAssertEqual(tracking.duration, 2.0 / 30, accuracy: 0.0001)
+        XCTAssertEqual(document.summary(detectionCount: 1), "1 object across 2 frames")
+
+        let first = document.detections(imageSize: CGSize(width: 1_280, height: 720), frame: 0)
+        XCTAssertEqual(first.map(\.boxDescription), ["[402, 288, 611, 431]"])
+        XCTAssertTrue(document.detections(imageSize: CGSize(width: 1_280, height: 720), frame: 1).isEmpty)
+    }
+
+    // MARK: - speech
+
+    func testDiarizationDocumentDecodesSnakeCase() throws {
+        let json = """
+        {
+          "duration_seconds" : 12.5,
+          "model" : "speech-diarize-pyannote",
+          "schema_version" : 1,
+          "segments" : [
+            { "duration_seconds" : 4.0, "end_seconds" : 4.0, "speaker" : "speaker_0",
+              "speaker_index" : 0, "start_seconds" : 0.0 },
+            { "duration_seconds" : 3.5, "end_seconds" : 8.0, "speaker" : "speaker_1",
+              "speaker_index" : 1, "start_seconds" : 4.5 }
+          ],
+          "speaker_count" : 2
+        }
+        """
+        let document = try XCTUnwrap(StudioAnalyzeDocument.decode(Data(json.utf8)))
+        guard case .diarization = document else {
+            return XCTFail("Expected a diarization document, got \(document)")
+        }
+        XCTAssertEqual(document.modelID, "speech-diarize-pyannote")
+        XCTAssertEqual(document.summary(detectionCount: 0), "2 speakers · 2 turns")
+        let segments = document.speechSegments
+        XCTAssertEqual(segments.map(\.speaker), ["Speaker 1", "Speaker 2"])
+        XCTAssertEqual(segments[1].start, 4.5)
+    }
+
+    /// `speech transcribe` writes text, not JSON: the transcript, a blank line, then one
+    /// `[MM:SS.mmm --> MM:SS.mmm]` line per alignment.
+    func testTranscriptTextParsesTimestampedSegments() throws {
+        let text = """
+        Welcome aboard. Everything you make here stays on this Mac.
+
+        [00:00.000 --> 00:02.480] Welcome aboard.
+        [00:02.480 --> 01:05.900] Everything you make here stays on this Mac.
+        """
+        let document = try XCTUnwrap(StudioAnalyzeDocument.decode(Data(text.utf8)))
+        guard case .transcript(let transcript) = document else {
+            return XCTFail("Expected a transcript, got \(document)")
+        }
+        XCTAssertEqual(transcript.text, "Welcome aboard. Everything you make here stays on this Mac.")
+        XCTAssertEqual(transcript.segments.count, 2)
+        XCTAssertEqual(transcript.segments[0].text, "Welcome aboard.")
+        XCTAssertEqual(transcript.segments[1].start, 2.48, accuracy: 0.001)
+        XCTAssertEqual(transcript.duration, 65.9, accuracy: 0.001)
+        XCTAssertEqual(document.summary(detectionCount: 0), "2 segments")
+        XCTAssertEqual(document.speechSegments.map(\.startDescription), ["0:00", "0:02"])
+    }
+
+    func testTranscriptTimestampsAcceptAnHoursField() {
+        XCTAssertEqual(StudioTranscriptDocument.seconds("00:02.480"), 2.48)
+        XCTAssertEqual(StudioTranscriptDocument.seconds("01:02:03.500"), 3_723.5)
+        XCTAssertNil(StudioTranscriptDocument.seconds("nonsense"))
+    }
+
+    func testUnreadableDataDecodesToNothing() {
+        XCTAssertNil(StudioAnalyzeDocument.decode(Data()))
+        XCTAssertNil(StudioAnalyzeDocument.decode(Data("   \n  ".utf8)))
+    }
+
+    // MARK: - Pixels to points
+
+    func testViewRectScalesPixelBoxesOntoTheDisplayedImage() {
+        let box = CGRect(x: 246, y: 307, width: 471, height: 451)
+        let mapped = StudioAnalyzeGeometry.viewRect(
+            for: box,
+            imageSize: CGSize(width: 1_024, height: 1_024),
+            displaySize: CGSize(width: 512, height: 512)
+        )
+        XCTAssertEqual(mapped.minX, 123, accuracy: 0.001)
+        XCTAssertEqual(mapped.minY, 153.5, accuracy: 0.001)
+        XCTAssertEqual(mapped.width, 235.5, accuracy: 0.001)
+        XCTAssertEqual(mapped.height, 225.5, accuracy: 0.001)
+    }
+
+    /// A non-square image scales each axis by its own ratio, because the container is sized to the
+    /// image's aspect ratio before the overlay is drawn.
+    func testViewRectScalesEachAxisIndependently() {
+        let mapped = StudioAnalyzeGeometry.viewRect(
+            for: CGRect(x: 640, y: 180, width: 320, height: 90),
+            imageSize: CGSize(width: 1_280, height: 720),
+            displaySize: CGSize(width: 512, height: 288)
+        )
+        XCTAssertEqual(mapped, CGRect(x: 256, y: 72, width: 128, height: 36))
+    }
+
+    func testViewRectOfAnUnmeasuredImageIsEmpty() {
+        XCTAssertEqual(
+            StudioAnalyzeGeometry.viewRect(
+                for: CGRect(x: 1, y: 1, width: 1, height: 1),
+                imageSize: .zero,
+                displaySize: CGSize(width: 100, height: 100)
+            ),
+            .zero
+        )
+    }
+
+    func testFittedRectCentersALetterboxedImage() {
+        let fitted = StudioAnalyzeGeometry.fittedRect(
+            imageSize: CGSize(width: 1_600, height: 800),
+            in: CGSize(width: 400, height: 400)
+        )
+        XCTAssertEqual(fitted, CGRect(x: 0, y: 100, width: 400, height: 200))
+    }
+
+    // MARK: - Per-task views
+
+    func testViewSegmentsMatchWhatEachTaskProduces() {
+        XCTAssertEqual(StudioTask.visionFind.analyzeArchetype?.views, [.boxes, .masks, .json])
+        XCTAssertEqual(StudioTask.visionSegment.analyzeArchetype?.views, [.boxes, .masks, .json])
+        XCTAssertEqual(StudioTask.visionTrack.analyzeArchetype?.views, [.video, .json])
+        XCTAssertEqual(StudioTask.audioTranscribe.analyzeArchetype?.views, [.transcript, .timeline, .json])
+        XCTAssertEqual(StudioTask.audioWhoSpoke.analyzeArchetype?.views, [.transcript, .timeline, .json])
+        XCTAssertEqual(StudioTask.visionRead.analyzeArchetype?.views, [.text])
+        XCTAssertEqual(
+            StudioTask.visionFind.analyzeArchetype?.views.map(\.title),
+            ["Boxes", "Masks", "JSON"]
+        )
+    }
+
+    func testEveryInputFirstTaskDeclaresAnArchetypeAndTheOthersDoNot() {
+        let expected: Set<StudioTask> = [
+            .visionRead, .visionFind, .visionSegment, .visionTrack, .visionDepth, .visionPose,
+            .visionFaces, .visionFlow, .visionGeometry, .visionLive,
+            .audioTranscribe, .audioWhoSpoke, .audioEnhance, .audioSeparate,
+            .textEmbeddings, .textAnonymize,
+            .earthFlood, .earthFire, .earthTessera, .earthOlmoEarth,
+            .soundScore, .soundCondition
+        ]
+        XCTAssertEqual(Set(StudioTask.allCases.filter(\.isAnalyzeTask)), expected)
+        for task in expected {
+            let archetype = StudioAnalyzeArchetype.archetypes[task]
+            XCTAssertEqual(archetype?.task, task, "\(task) archetype records the wrong task")
+            XCTAssertFalse(archetype?.views.isEmpty ?? true, "\(task) declares no result view")
+            XCTAssertEqual(archetype?.defaultView, archetype?.views.first)
+        }
+        XCTAssertFalse(StudioTask.imageGenerate.isAnalyzeTask)
+        XCTAssertFalse(StudioTask.chatChat.isAnalyzeTask)
+        XCTAssertFalse(StudioTask.musicRealtime.isAnalyzeTask)
+    }
+
+    func testInputKindsMatchWhatEachTaskTakes() {
+        XCTAssertEqual(StudioTask.visionFind.analyzeArchetype?.inputKind, .image)
+        XCTAssertEqual(StudioTask.visionTrack.analyzeArchetype?.inputKind, .video)
+        XCTAssertEqual(StudioTask.audioTranscribe.analyzeArchetype?.inputKind, .audio)
+        XCTAssertEqual(StudioTask.textEmbeddings.analyzeArchetype?.inputKind, .file)
+        XCTAssertEqual(StudioAnalyzeInputKind.audio.noun, "audio file")
+    }
+
+    // MARK: - Next actions
+
+    func testFindOffersTheBoardsNextSteps() throws {
+        let archetype = try XCTUnwrap(StudioTask.visionFind.analyzeArchetype)
+        XCTAssertEqual(
+            archetype.nextActions.map(\.title),
+            ["Segment these", "Track in video", "Save JSON"]
+        )
+        XCTAssertEqual(archetype.siblingTasks, [.visionSegment, .visionTrack])
+        XCTAssertEqual(archetype.nextActions.last?.kind, .save(.json))
+    }
+
+    func testEveryNextStepTargetsARealSiblingTask() {
+        for task in StudioTask.allCases.filter(\.isAnalyzeTask) {
+            guard let archetype = task.analyzeArchetype else { continue }
+            for sibling in archetype.siblingTasks {
+                XCTAssertNotEqual(sibling, task, "\(task) offers itself as a next step")
+                XCTAssertTrue(sibling.isAnalyzeTask, "\(task) hands off to \(sibling), which is not input-first")
+            }
+        }
+    }
+
+    /// The image carries into Segment, which takes images; Track needs a clip, so it opens with
+    /// the prompt and an empty well rather than an input it cannot use.
+    func testHandoffCarriesTheInputOnlyWhereTheTargetAcceptsIt() {
+        let image = URL(fileURLWithPath: "/tmp/mug.png")
+        XCTAssertTrue(StudioAnalyzeHandoff.carriesInput(image, to: .visionSegment))
+        XCTAssertTrue(StudioAnalyzeHandoff.carriesInput(image, to: .visionRead))
+        XCTAssertFalse(StudioAnalyzeHandoff.carriesInput(image, to: .visionTrack))
+        XCTAssertTrue(
+            StudioAnalyzeHandoff.carriesInput(URL(fileURLWithPath: "/tmp/clip.mp4"), to: .visionTrack)
+        )
+
+        let carried = StudioAnalyzeHandoff.make(
+            to: .visionSegment, inputPath: image.path, prompt: "every coffee cup"
+        )
+        XCTAssertEqual(carried.inputPath, image.path)
+        XCTAssertEqual(carried.prompt, "every coffee cup")
+
+        let dropped = StudioAnalyzeHandoff.make(
+            to: .visionTrack, inputPath: image.path, prompt: "every coffee cup"
+        )
+        XCTAssertEqual(dropped.inputPath, "")
+        XCTAssertEqual(dropped.prompt, "every coffee cup")
+    }
+
+    func testHandoffAppliesToTheTargetTasksDraft() {
+        var draft = StudioDraft()
+        draft.reset(for: .segment)
+        StudioAnalyzeHandoff
+            .make(to: .visionSegment, inputPath: "/tmp/mug.png", prompt: "the saucer")
+            .apply(to: &draft)
+        XCTAssertEqual(draft.inputPath, "/tmp/mug.png")
+        XCTAssertEqual(draft.prompt, "the saucer")
+
+        var trackDraft = StudioDraft()
+        trackDraft.reset(for: .track)
+        StudioAnalyzeHandoff
+            .make(to: .visionTrack, inputPath: "/tmp/mug.png", prompt: "the saucer")
+            .apply(to: &trackDraft)
+        XCTAssertEqual(trackDraft.inputPath, "")
+        XCTAssertEqual(trackDraft.prompt, "the saucer")
+    }
+
+    // MARK: - Where the result document lives
+
+    func testDocumentSourcePrefersTheJSONSidecar() {
+        let item = StudioLibraryItem(
+            id: UUID(),
+            mode: .findObjects,
+            prompt: "every coffee cup",
+            inputURL: URL(fileURLWithPath: "/tmp/mug.png"),
+            outputURL: URL(fileURLWithPath: "/tmp/out/vision.ground-1.png"),
+            createdAt: Date(),
+            updatedAt: Date(),
+            status: .completed,
+            exitCode: 0,
+            commandPreview: "mere.run vision ground",
+            outputText: nil,
+            artifactURLs: [
+                URL(fileURLWithPath: "/tmp/out/vision.ground-1.png"),
+                URL(fileURLWithPath: "/tmp/out/vision.ground-1.json")
+            ]
+        )
+        XCTAssertEqual(
+            StudioAnalyzeDocumentSource.url(for: item)?.lastPathComponent,
+            "vision.ground-1.json"
+        )
+    }
+
+    func testDocumentSourceFallsBackToATranscriptFile() {
+        let item = StudioLibraryItem(
+            id: UUID(),
+            mode: .listen,
+            prompt: "",
+            inputURL: URL(fileURLWithPath: "/tmp/talk.wav"),
+            outputURL: URL(fileURLWithPath: "/tmp/out/talk.txt"),
+            createdAt: Date(),
+            updatedAt: Date(),
+            status: .completed,
+            exitCode: 0,
+            commandPreview: "mere.run speech transcribe",
+            outputText: "Welcome aboard."
+        )
+        XCTAssertEqual(StudioAnalyzeDocumentSource.url(for: item)?.lastPathComponent, "talk.txt")
+    }
+
+    /// The canvas can only render what the run was asked to write, so Studio's vision runs always
+    /// request the structured document beside the annotated output.
+    func testStudioVisionRunsRequestTheirResultDocument() throws {
+        var draft = StudioDraft()
+        draft.reset(for: .findObjects)
+        draft.inputPath = "/tmp/mug.png"
+        draft.prompt = "every coffee cup"
+        let request = try StudioCommandAdapter.makeRequest(mode: .findObjects, draft: draft)
+        XCTAssertTrue(request.draft.visionJSONOutputPath.hasSuffix(".json"))
+        XCTAssertEqual(
+            URL(fileURLWithPath: request.draft.visionJSONOutputPath).deletingPathExtension(),
+            URL(fileURLWithPath: request.draft.outputPath).deletingPathExtension()
+        )
+        XCTAssertTrue(request.draft.visionMaskOutputDirectory.hasSuffix("-masks"))
+
+        var trackDraft = StudioDraft()
+        trackDraft.reset(for: .track)
+        trackDraft.inputPath = "/tmp/clip.mp4"
+        trackDraft.prompt = "the red car"
+        let trackRequest = try StudioCommandAdapter.makeRequest(mode: .track, draft: trackDraft)
+        XCTAssertTrue(trackRequest.draft.visionJSONOutputPath.hasSuffix(".json"))
+        // A tracked clip writes one mask set per frame; Studio does not ask for thousands of PNGs.
+        XCTAssertTrue(trackRequest.draft.visionMaskOutputDirectory.isEmpty)
+    }
+
+    func testResultPathsLeaveExplicitChoicesAlone() {
+        var draft = CommandDraft()
+        draft.outputPath = "/tmp/out/vision.ground-1.png"
+        draft.visionJSONOutputPath = "/elsewhere/mine.json"
+        StudioVisionResultPaths.apply(to: &draft, wantsMasks: true)
+        XCTAssertEqual(draft.visionJSONOutputPath, "/elsewhere/mine.json")
+        XCTAssertEqual(draft.visionMaskOutputDirectory, "/tmp/out/vision.ground-1-masks")
+
+        var blank = CommandDraft()
+        StudioVisionResultPaths.apply(to: &blank, wantsMasks: true)
+        XCTAssertTrue(blank.visionJSONOutputPath.isEmpty)
+        XCTAssertTrue(blank.visionMaskOutputDirectory.isEmpty)
+    }
+}

--- a/apps/macos/MereRunStudioTests/StudioSnapshotTests.swift
+++ b/apps/macos/MereRunStudioTests/StudioSnapshotTests.swift
@@ -200,6 +200,52 @@ final class StudioSnapshotTests: XCTestCase {
         XCTAssertTrue(fixture.controller.canSteerRealtimeMusic(requestID: requestID))
     }
 
+    /// The Analyze board: Vision ▸ Find at the mockup's 1440×900, with a 1024×1024 image in the
+    /// composer's well and a finished `vision ground` run whose `--json-output` document carries
+    /// the board's two detections, so the boxes, the label tabs, the detection rows, and the
+    /// contextual next steps are all rendered from a real result document. Then Audio ▸ Transcribe
+    /// once, to show the same archetype carrying a waveform and a transcript.
+    func testAnalyzeBoardFidelitySnapshots() throws {
+        let analyze = try SnapshotFixture(
+            outputDirectory: fixture.outputDirectory,
+            seed: .analyze,
+            processRunner: SnapshotProcessRunner(script: ModelsInventoryScript.analyzeReadinessResponses)
+        )
+        defer { analyze.tearDown() }
+
+        var find = StudioDraft()
+        find.reset(for: .findObjects)
+        find.prompt = SnapshotFixture.analyzePrompt
+        find.inputPath = analyze.largeMugURL.path
+        find.visionThreshold = 0.3
+
+        var listen = StudioDraft()
+        listen.reset(for: .listen)
+        listen.inputPath = analyze.narrationURL.path
+
+        let renders: [(name: String, task: StudioTask, appearance: StudioSnapshotAppearance)] = [
+            ("f6-analyze-find-light", .visionFind, .light),
+            ("f6-analyze-find-dark", .visionFind, .dark),
+            ("f6-analyze-transcribe-light", .audioTranscribe, .light)
+        ]
+        for render in renders {
+            let navigation = NavigationModel()
+            let view = StudioRootView(seededDrafts: [.findObjects: find, .listen: listen])
+                .environmentObject(analyze.controller)
+                .environmentObject(analyze.library)
+                .environmentObject(navigation)
+                .frame(width: Self.fidelitySize.width, height: Self.fidelitySize.height)
+            try analyze.write(
+                view,
+                size: Self.fidelitySize,
+                appearance: render.appearance,
+                name: render.name,
+                settle: 3.0,
+                afterAppear: { navigation.open(task: render.task) }
+            )
+        }
+    }
+
     /// The Settings scene content at the width the app gives it.
     func testSettingsSnapshots() throws {
         for appearance in StudioSnapshotAppearance.allCases {
@@ -286,6 +332,10 @@ private final class SnapshotFixture {
     let crashReporter = StudioCrashReporter()
     /// A placeholder "mug.png" for the attachment well, drawn in-test.
     let mugURL: URL
+    /// The same picture at 1024×1024, the size the Analyze board's result document is in.
+    private(set) var largeMugURL: URL!
+    /// A short recording for the Transcribe board's waveform.
+    private(set) var narrationURL: URL!
     private let processRunner: MereRunProcessRunning
     /// The default runner's live-session seam; nil when the fixture was given a scripted runner.
     private var liveSessionRunner: SnapshotProcessRunner? { processRunner as? SnapshotProcessRunner }
@@ -296,6 +346,9 @@ private final class SnapshotFixture {
         case fixture
         /// The finished Image rows the design boards show; `startMainBoardJobs` adds the live ones.
         case mockup
+        /// The Analyze board's rows: a finished `vision ground` with its result document, an
+        /// earlier Read and Segment, and a transcript.
+        case analyze
     }
 
     init(
@@ -325,6 +378,7 @@ private final class SnapshotFixture {
         switch seed {
         case .fixture: try seedLibrary()
         case .mockup: try seedMockupLibrary()
+        case .analyze: try seedAnalyzeLibrary()
         }
     }
 
@@ -532,6 +586,150 @@ private final class SnapshotFixture {
             library.upsert(row)
         }
     }
+
+    /// The prompt the Analyze board asks Vision ▸ Find.
+    static let analyzePrompt = "every coffee cup and what it sits on"
+
+    /// The Analyze board's rows: a finished `vision ground` whose `--json-output` document holds
+    /// the board's two detections in the shape `FalconPerceptionGrounder` writes (normalized
+    /// boxes, camelCase keys), the earlier Read and Segment the Library column lists, and a
+    /// transcript so Audio ▸ Transcribe renders the same archetype.
+    private func seedAnalyzeLibrary() throws {
+        guard let groundTemplate = CommandCatalog.template(id: .visionGround) else {
+            throw StudioSnapshotError.noContentView
+        }
+        let directory = root.appendingPathComponent("analyze", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+        let mug = directory.appendingPathComponent("mug.png", isDirectory: false)
+        try Self.writeMugPNG(to: mug, side: 1_024)
+        largeMugURL = mug
+        let annotated = directory.appendingPathComponent("mug_grounded.png", isDirectory: false)
+        try Self.writeMugPNG(to: annotated, side: 1_024)
+        let document = directory.appendingPathComponent("mug_grounded.json", isDirectory: false)
+        try Self.groundDocument(input: mug, annotated: annotated, document: document)
+            .write(to: document, atomically: true, encoding: .utf8)
+        let narration = directory.appendingPathComponent("narration.wav", isDirectory: false)
+        try Self.writeSilentWAV(to: narration, seconds: 6)
+        narrationURL = narration
+
+        var findDraft = groundTemplate.defaultDraft()
+        findDraft.prompt = Self.analyzePrompt
+        findDraft.inputPath = mug.path
+        findDraft.outputPath = annotated.path
+        findDraft.visionJSONOutputPath = document.path
+        findDraft.visionThreshold = 0.3
+
+        let findAt = Self.mockupTime(hour: 13, minute: 31)
+        var rows: [StudioLibraryItem] = [
+            StudioLibraryItem(
+                id: UUID(),
+                mode: .findObjects,
+                prompt: Self.analyzePrompt,
+                inputURL: mug,
+                outputURL: annotated,
+                createdAt: findAt,
+                updatedAt: findAt.addingTimeInterval(1.8),
+                status: .completed,
+                exitCode: 0,
+                commandPreview: "mere.run vision ground mug.png --query \"\(Self.analyzePrompt)\"",
+                outputText: nil,
+                templateID: .visionGround,
+                commandDraft: findDraft,
+                artifactURLs: [annotated, document]
+            ),
+            StudioLibraryItem(
+                id: UUID(),
+                mode: .readImage,
+                prompt: "Describe this scene in one paragraph",
+                inputURL: mug,
+                outputURL: nil,
+                createdAt: Self.mockupTime(hour: 13, minute: 31).addingTimeInterval(-60 * 60 * 24),
+                updatedAt: Self.mockupTime(hour: 13, minute: 32).addingTimeInterval(-60 * 60 * 24),
+                status: .completed,
+                exitCode: 0,
+                commandPreview: "mere.run vision inspect mug.png",
+                outputText: """
+                A white ceramic mug sits just left of centre on a warm grey table, lit from the \
+                upper right so a soft shadow falls across the saucer beneath it.
+                """
+            ),
+            StudioLibraryItem(
+                id: UUID(),
+                mode: .segment,
+                prompt: "the neon sign",
+                inputURL: mug,
+                outputURL: nil,
+                createdAt: findAt.addingTimeInterval(-60 * 60 * 24 * 5),
+                updatedAt: findAt.addingTimeInterval(-60 * 60 * 24 * 5 + 3),
+                status: .completed,
+                exitCode: 0,
+                commandPreview: "mere.run vision segment diner.png --prompt \"the neon sign\""
+            ),
+            StudioLibraryItem(
+                id: UUID(),
+                mode: .listen,
+                prompt: "",
+                inputURL: narration,
+                outputURL: nil,
+                createdAt: Self.mockupTime(hour: 11, minute: 8),
+                updatedAt: Self.mockupTime(hour: 11, minute: 8).addingTimeInterval(2.4),
+                status: .completed,
+                exitCode: 0,
+                commandPreview: "mere.run speech transcribe narration.wav --timestamps",
+                outputText: Self.transcriptText,
+                templateID: .speechTranscribe
+            )
+        ]
+        rows.sort { $0.createdAt < $1.createdAt }
+        for row in rows { library.upsert(row) }
+    }
+
+    /// The board's two detections as `vision ground --json-output` writes them: normalized 0…1
+    /// boxes, camelCase keys, sorted. `[246, 307, 717, 758]` and `[82, 757, 266, 921]` of a
+    /// 1024×1024 image are what the app must show once it scales them back to pixels.
+    private static func groundDocument(input: URL, annotated: URL, document: URL) -> String {
+        func normalized(_ box: [Int]) -> String {
+            let values = box.map { Double($0) / 1_024 }
+            return """
+            { "x1" : \(values[0]), "y1" : \(values[1]), "x2" : \(values[2]), "y2" : \(values[3]) }
+            """
+        }
+        return """
+        {
+          "annotatedImagePath" : "\(annotated.path)",
+          "detections" : [
+            {
+              "box" : \(normalized([246, 307, 717, 758])),
+              "hw" : { "h" : 0.4404296875, "w" : 0.4599609375 },
+              "label" : "coffee cup",
+              "score" : 0.94,
+              "xy" : { "x" : 0.4702148437, "y" : 0.5200195312 }
+            },
+            {
+              "box" : \(normalized([82, 757, 266, 921])),
+              "hw" : { "h" : 0.16015625, "w" : 0.1796875 },
+              "label" : "saucer",
+              "score" : 0.81,
+              "xy" : { "x" : 0.169921875, "y" : 0.8193359375 }
+            }
+          ],
+          "inputImagePath" : "\(input.path)",
+          "jsonOutputPath" : "\(document.path)",
+          "modelID" : "vision-ground-falcon-perception",
+          "queries" : [ "\(analyzePrompt)" ],
+          "schemaVersion" : 1
+        }
+        """
+    }
+
+    private static let transcriptText = """
+    Welcome aboard. Everything you make here stays on this Mac, and nothing is uploaded.
+
+    [00:00.000 --> 00:02.480] Welcome aboard.
+    [00:02.480 --> 00:04.960] Everything you make here stays on this Mac,
+    [00:04.960 --> 00:06.000] and nothing is uploaded.
+    """
 
     private static func mockupTime(hour: Int, minute: Int) -> Date {
         let calendar = Calendar.current
@@ -1130,6 +1328,36 @@ private enum ModelsInventoryScript {
         [
             .init(matches: { $0 == ["model", "list"] }, stdout: modelList, exitCode: 0),
             .init(matches: { $0 == ["model", "capabilities", "--all", "--json"] }, stdout: capabilities, exitCode: 0),
+        ]
+    }
+
+    /// `model list` and `model capabilities` with Vision ▸ Find's model installed, so the Analyze
+    /// board renders its result rather than a readiness card.
+    static var analyzeReadinessResponses: [SnapshotProcessRunner.Response] {
+        let extraModels = [
+            (id: "vision-ground-falcon-perception", category: "vision-ground", title: "Falcon Perception"),
+            (id: "speech-asr-parakeet", category: "speech-asr", title: "Parakeet")
+        ]
+        let list = modelList.replacingOccurrences(
+            of: "image-zimage-nano          image        installed  2.1 GB",
+            with: (["image-zimage-nano          image        installed  2.1 GB"]
+                + extraModels.map { "\($0.id)  \($0.category)  installed  1.8 GB" })
+                .joined(separator: "\n")
+        )
+        let extraCapabilities = extraModels.map { model in
+            """
+            ,{"id": "\(model.id)", "title": "\(model.title)", "summary": "", \
+            "minimumUnifiedMemoryGB": 8, "recommendedUnifiedMemoryGB": 16, "supported": true, \
+            "reasons": [], "estimatedDownloadBytes": 1800000000, \
+            "sourceRepository": "mere-run/\(model.id)", "publisher": "mere.run"}
+            """
+        }.joined(separator: "\n")
+        let capabilityJSON = capabilities.replacingOccurrences(
+            of: "\n]}", with: "\n\(extraCapabilities)\n]}"
+        )
+        return [
+            .init(matches: { $0 == ["model", "list"] }, stdout: list, exitCode: 0),
+            .init(matches: { $0 == ["model", "capabilities", "--all", "--json"] }, stdout: capabilityJSON, exitCode: 0),
         ]
     }
 

--- a/apps/macos/README.md
+++ b/apps/macos/README.md
@@ -98,6 +98,33 @@ progress, so it never hides earlier work. Completion never moves the Library
 selection; a result that finishes off-screen shows a "New result ↓" pill.
 Picking a Library row scrolls to its card and outlines it briefly.
 
+The input-first tasks — Vision ▸ Read, Find, Segment, and Track, and Audio
+▸ Transcribe — render the **Analyze canvas** (`StudioAnalyzeCanvas.swift`,
+`StudioAnalyzeViews.swift`) instead of the feed, because the answer belongs
+beside the thing it is about rather than in a stream. It is one 940pt column:
+an input strip naming the attached file with its dimensions or duration, a
+Replace button that writes the same composer well, and a view switch whose
+segments come from the task's own result kind (Boxes / Masks / JSON for Find
+and Segment, Video / JSON for Track, Transcript / Timeline / JSON for
+Transcribe); below it the input rendered large on the left — the image with
+the result drawn over it, a video with its scrubber and per-object track spans,
+audio with the waveform player — and a 360pt result column on the right
+holding what the model found, the contextual next steps, and the prompt it ran
+with. Results are read from the documents the CLI actually writes
+(`StudioAnalyzeResults.swift`): `vision ground`'s normalized boxes, `vision
+segment`'s pixel boxes with their mask PNGs, `vision track`'s per-frame
+detections, `speech diarize`'s speaker turns, and the timestamped transcript
+`speech transcribe` prints. Studio always asks for that document, passing
+`--json-output` (and `--mask-output-dir` for the still tasks) beside the
+annotated output. A run in flight, a queue, a failure, and readiness use the
+feed's own cards above the result column, and earlier runs stay one click away
+in the Library column, which also puts their input back in the composer. The
+next steps open the sibling task carrying the input when the target accepts it
+(Find ▸ "Segment these" keeps the picture; "Track in video" keeps only the
+prompt, because Track needs a clip). The archetype is declared per task in
+`StudioAnalyzeSchema.swift`, which also describes the Vision Lab, Audio, Text,
+Earth, and Sound analysis tasks that still render their lab forms.
+
 The **inspector** (⌥⌘I, the header's Inspector toggle, remembered per task under
 `studio.inspectorTasks`) is a 300pt column rendered from
 `StudioInspectorSchema.swift`: Prompt (negative or system prompt, lyrics, voice
@@ -350,7 +377,10 @@ the Settings content and the Command Console, and fidelity renders at the
 open by the process seam mid-denoise, a queued run behind a concurrent model
 pull, and the inspector open with two changed settings; then the same feed with
 the Command view column), the composer with the boards' sample prompt
-and an in-test image attached (Image ▸ Generate and Vision ▸ Find), Music ▸
+and an in-test image attached (Image ▸ Generate and Vision ▸ Find), the
+Analyze board (Vision ▸ Find over a 1024×1024 in-test image with a seeded
+`vision ground` document, and Audio ▸ Transcribe with a synthesized recording
+and a timestamped transcript), Music ▸
 Realtime mid-session (a run the process seam holds open, fed the CLI's frame
 progress and steering echoes, with its recording synthesized on disk), and
 Models ▸ Installed with a scripted model inventory (`model list`,


### PR DESCRIPTION
Vision ▸ Read, Find, Segment and Track, and Audio ▸ Transcribe are not a feed.
You point them at a file, and the answer belongs beside the thing it is about.
They now render the **Analyze archetype** instead of the generation feed.

## What the board is

One 940pt column, 22/24 padding, on top of the feed's own composer:

- an **input strip** — "Input", a chip naming the attached file with its pixel
  size or duration, a `Replace` button that writes the same composer well the
  paperclip does, and a right-aligned view switch whose segments come from the
  task's own result kind (Boxes / Masks / JSON for Find and Segment, Video /
  JSON for Track, Transcript / Timeline / JSON for Transcribe and Who Spoke);
- the **input drawn large** on the left (up to 520pt, radius 10, hairline,
  panel shadow) — the image with the result over it, a video with its scrubber
  and per-object track spans, audio with the waveform player;
- a **360pt result column** — a panel header that names what was found
  ("2 objects found") with the model and elapsed time, one row per result
  (colour swatch, label, monospaced confidence, monospaced xyxy box), the
  contextual next steps, and the prompt the run used below it.

Runs in flight, queues, failures and readiness reuse the feed's own cards above
the result column, so nothing about how a run reports itself changed. Earlier
runs stay one click away in the Library column, which also puts their input
back in the composer, so the canvas always shows the picture the selected run
is about.

## The results are real

Nothing is faked or re-derived: every rendering reads the document the CLI
already writes (`StudioAnalyzeResults.swift`).

- `vision ground` — `FalconPerceptionGroundingMetadata`, whose boxes are
  normalized 0…1 and whose `score` is optional (today's grounder leaves it
  unset), scaled to the image's own pixels before they are placed.
- `vision segment` — `SAM31SegmentationMetadata`: absolute pixel xyxy plus the
  per-detection mask PNGs, composited at 45% over the picture.
- `vision track` — `SAM31TrackingRun`: per-frame detections, with the frames an
  object was lost (`visible: false`) dropped rather than drawn.
- `speech diarize` — `SpeechDiarizationPayload`, the one snake_case document.
- `speech transcribe` — the `[MM:SS.mmm --> MM:SS.mmm] text` transcript it
  prints, parsed rather than decoded.

To have those documents to read, Studio now passes `--json-output` (and
`--mask-output-dir` for the still tasks; a tracked clip would write one set per
frame) beside the annotated output it already asked for. Both are the CLI's own
flags — Studio only chooses the paths.

While checking that, one thing the mockup claimed turned out not to exist:
`vision ground` has no threshold flag, so Find no longer shows a "Threshold"
chip for an argument it never sent. Segment and Track, which do take one, keep
theirs.

## Handing off

The result's next steps open the sibling task carrying this run's input and
prompt. The input is only carried where the target actually accepts it: Find ▸
"Segment these" keeps the picture, "Track in video" keeps only the prompt,
because Track needs a clip.

## Where the shape lives

`StudioAnalyzeSchema.swift` declares the archetype per task — its input kind,
its view segments and its next steps — so a task's shape is one table, testable
without SwiftUI. It also covers the Vision Lab, Audio, Text, Earth and Sound
analysis tasks that still render their lab forms today: those have no composer
mode, so migrating them is a later view change rather than a design decision,
and the declaration is already there for it.

## Verified

- `swiftlint --strict`, `swift build`, `swift test --filter MereRunAppTests`
  (390 tests), `./scripts/check.sh`, and `./scripts/build_mere_run_app.sh debug`
  all green.
- New tests cover decoding each document against CLI-shaped fixtures (including
  a ground detection with no score and a tracker that lost an object),
  pixel→view mapping for fitted and letterboxed containers, the per-task view
  segments and input kinds, that every next step targets a real sibling task,
  the handoff's carry rule, which artifact counts as the result document, and
  that a Studio vision run really does request one.
- Fidelity renders at 1440×900, light and dark, of Vision ▸ Find over a
  1024×1024 in-test image with a seeded `vision ground` document holding the
  design's two detections (coffee cup 0.94 `[246, 307, 717, 758]`, saucer 0.81
  `[82, 757, 266, 921]`), plus Audio ▸ Transcribe, via
  `MERERUN_STUDIO_SNAPSHOT_DIR=… swift test --filter StudioSnapshotTests`.

## For the reviewer

Two deliberate departures from the mockup, both because the mockup's content is
sample data: the model reads "Falcon Perception" (what the document says) rather
than "Qwen3.6-VL 4B", and Find has no threshold chip, as above.

One difference I did not fix here: `MereSecondaryButtonStyle` fills with
`surface` at 50% where the design's `btnSecondary` fills with `surfaceRaised`
and uses `textPrimary`, so every secondary button ("Replace", "Segment these",
"Save JSON") reads white instead of the design's soft fill. It is the shell's
shared control and every board uses it, so it belongs in one change rather than
in this one.
