### PR TITLE
Open the Activity popover from the sidebar footer

### DIFF
--- a/apps/macos/MereRunStudio/MereRunTheme.swift
+++ b/apps/macos/MereRunStudio/MereRunTheme.swift
@@ -138,6 +138,8 @@ enum MereRunTheme {
         static let base: CGFloat = 8
         static let md: CGFloat = 9
         static let lg: CGFloat = 10
+        /// Floating panels that overlay the shell (the Activity popover).
+        static let popover: CGFloat = 12
         static let xl: CGFloat = 18
         static let xxl: CGFloat = 20
     }

--- a/apps/macos/MereRunStudio/StudioActivity.swift
+++ b/apps/macos/MereRunStudio/StudioActivity.swift
@@ -1,0 +1,338 @@
+import SwiftUI
+
+/// One line of the Activity popover: a job that is running or waiting in one of the two work
+/// lanes. Probe jobs never appear — a readiness check is not work the user started.
+struct StudioActivityRow: Identifiable, Equatable {
+    let id: JobID
+    /// "Image · Generate", "Models · Pull image-zimage-nano": the job's domain and its task.
+    let title: String
+    let isRunning: Bool
+    /// The first job waiting for a lane slot, which reads "Queued · next".
+    let isNextInQueue: Bool
+}
+
+/// How the Activity popover reads a `JobStore`: which jobs it lists, in what order, and the copy
+/// each row and the header carry. Pure functions over the store and one job, so every string the
+/// popover shows is testable without a view.
+enum StudioActivity {
+    /// The lanes whose jobs are the user's work. `.probe` is deliberately absent.
+    static let lanes: [JobLane] = [.inference, .utility]
+
+    /// Running jobs first (lane order, then start order), then the queue in FIFO order — the order
+    /// the work will actually finish in.
+    @MainActor
+    static func rows(in store: JobStore) -> [StudioActivityRow] {
+        let running = lanes.flatMap { store.running(in: $0) }
+        let queued = lanes.flatMap { store.queued(in: $0) }
+        return running.map {
+            StudioActivityRow(id: $0.id, title: title(for: $0), isRunning: true, isNextInQueue: false)
+        } + queued.enumerated().map { index, job in
+            StudioActivityRow(id: job.id, title: title(for: job), isRunning: false, isNextInQueue: index == 0)
+        }
+    }
+
+    /// "3 jobs · 1 queued" beside the popover's title.
+    static func summary(_ rows: [StudioActivityRow]) -> String {
+        let jobs = rows.count == 1 ? "1 job" : "\(rows.count) jobs"
+        let queued = rows.filter { !$0.isRunning }.count
+        return queued == 0 ? jobs : "\(jobs) · \(queued) queued"
+    }
+
+    /// The domain and task a job belongs to, so a row names the work rather than the command.
+    @MainActor
+    static func title(for job: Job) -> String {
+        "\(StudioDomain(templateID: job.request.template.id).title) · \(task(for: job))"
+    }
+
+    /// The line under the title: step progress and elapsed time for a run, transferred bytes and
+    /// time left for a pull, queue position for a job that has not started.
+    @MainActor
+    static func detail(for job: Job, elapsed: TimeInterval?, isNextInQueue: Bool) -> String {
+        guard !job.state.isQueued else {
+            return isNextInQueue ? "Queued · next" : "Queued"
+        }
+        if job.request.template.id == .modelPull, let download = downloadDetail(job.progress) {
+            return download
+        }
+        let status = StudioRunningStatus.text(progress: job.progress, fallback: job.status)
+        guard let elapsed else { return status }
+        return "\(status) · \(StudioTimeFormat.string(elapsed))"
+    }
+
+    /// "mere.run 0.50.0 · CLI matched" in the popover's footer: the app's version and whether the
+    /// CLI beside it reports the same one (a mismatch means the CLI came from PATH, not the bundle).
+    static func versionLine(appVersion: String, cliVersion: String?) -> String {
+        guard let cliVersion, !cliVersion.isBlank else {
+            return "mere.run \(appVersion) · CLI not resolved"
+        }
+        return cliVersion == appVersion
+            ? "mere.run \(appVersion) · CLI matched"
+            : "mere.run \(appVersion) · CLI \(cliVersion)"
+    }
+
+    /// Rewrites the CLI's download progress detail ("1.2 GB / 4.8 GB 9.7 MB/s ETA 3m 20s") as the
+    /// popover's shorter "1.2 of 4.8 GB · 3 min left". Returns nil when the line carries neither a
+    /// byte count nor an ETA, so the caller falls back to the job's own status.
+    static func downloadDetail(_ progress: StudioRunProgress?) -> String? {
+        guard let detail = progress?.detail else { return nil }
+        var parts: [String] = []
+        if let bytes = transferredBytes(in: detail) { parts.append(bytes) }
+        if let eta = timeLeft(in: detail) { parts.append(eta) }
+        if parts.isEmpty, detail.localizedCaseInsensitiveContains("extracting") {
+            parts.append("Extracting…")
+        }
+        return parts.isEmpty ? nil : parts.joined(separator: " · ")
+    }
+
+    // MARK: - Private
+
+    @MainActor
+    private static func task(for job: Job) -> String {
+        let template = job.request.template
+        if template.id == .modelPull {
+            let model = job.request.draft.model.trimmingCharacters(in: .whitespacesAndNewlines)
+            // The same friendly name the composer's model chip shows, so one model reads the same
+            // way wherever it appears.
+            return model.isEmpty ? "Pull model" : "Pull \(StudioComposer.displayModelName(model))"
+        }
+        // A prompt task names itself the way the task control does ("Generate", "Transcribe");
+        // everything else falls back to the template's own title.
+        if let task = StudioTask.allCases.first(where: { $0.mode?.defaultTemplateID == template.id }) {
+            return task.title
+        }
+        return template.title
+    }
+
+    /// "1.2 GB / 4.8 GB" → "1.2 of 4.8 GB" (one unit when both sides agree, both when they differ).
+    private static func transferredBytes(in detail: String) -> String? {
+        let pattern = #"(\d+(?:[.,]\d+)?)\s*(B|KB|MB|GB|TB)\s*/\s*(\d+(?:[.,]\d+)?)\s*(B|KB|MB|GB|TB)"#
+        guard let match = detail.range(of: pattern, options: .regularExpression) else { return nil }
+        let fields = detail[match].split(separator: "/").map { $0.trimmingCharacters(in: .whitespaces) }
+        guard fields.count == 2 else { return nil }
+        let completed = fields[0].split(separator: " ").map(String.init)
+        let total = fields[1]
+        guard completed.count == 2 else { return nil }
+        return completed[1] == total.split(separator: " ").last.map(String.init)
+            ? "\(completed[0]) of \(total)"
+            : "\(fields[0]) of \(total)"
+    }
+
+    /// "ETA 3m 20s" → "3 min left"; the largest unit is enough at a glance.
+    private static func timeLeft(in detail: String) -> String? {
+        guard let eta = detail.range(of: #"ETA\s+\d+[hms]"#, options: .regularExpression) else { return nil }
+        let value = detail[eta].dropFirst(3).trimmingCharacters(in: .whitespaces)
+        let amount = value.prefix { $0.isNumber }
+        guard !amount.isEmpty, let unit = value.dropFirst(amount.count).first else { return nil }
+        switch unit {
+        case "h": return "\(amount) hr left"
+        case "m": return "\(amount) min left"
+        default: return "\(amount) sec left"
+        }
+    }
+}
+
+/// The Activity popover: what this Mac is working on right now, one row per running or queued job
+/// with the control to stop it, over the app↔CLI version handshake and a way into the Server page.
+/// With nothing running it shows the machine's own state instead, in the same shape.
+///
+/// It observes the `JobStore` directly — the lane contents for which rows exist, each `Job` for its
+/// own progress — rather than any mirrored copy of that state.
+struct StudioActivityPopover: View {
+    @ObservedObject var jobs: JobStore
+    let status: StudioMachineStatus
+    let appVersion: String
+    let cliVersion: String?
+    let modelsRoot: String
+    let resolvedCLI: String
+    let onOpenServer: () -> Void
+    let onOpenModels: () -> Void
+
+    /// Bumped whenever a job starts or finishes: lane membership is not itself published, so the
+    /// row list is re-derived from the store's own event stream.
+    @State private var generation = 0
+
+    static let width: CGFloat = 340
+    static let cornerRadius: CGFloat = MereRunTheme.Radius.popover
+
+    var body: some View {
+        // Reading `generation` here is what ties the row list to the store's start/finish events.
+        _ = generation
+        let rows = StudioActivity.rows(in: jobs)
+        return VStack(alignment: .leading, spacing: 0) {
+            header(rows)
+            if rows.isEmpty {
+                machineDetails
+            } else {
+                ForEach(rows) { row in
+                    if let job = jobs.job(row.id) {
+                        StudioActivityJobRow(job: job, row: row) { jobs.cancel(row.id) }
+                    }
+                }
+            }
+            Divider()
+                .overlay(MereRunTheme.border.opacity(0.4))
+                .padding(.top, 4)
+            footer
+        }
+        .padding(.vertical, 6)
+        .frame(width: Self.width)
+        // The shadow belongs to the panel, not to the panel's contents: `shadow` applied to a
+        // stack is inherited by every leaf inside it, which would darken a halo around each row.
+        .background {
+            RoundedRectangle(cornerRadius: Self.cornerRadius)
+                .fill(MereRunTheme.surface)
+                .overlay {
+                    RoundedRectangle(cornerRadius: Self.cornerRadius)
+                        .strokeBorder(MereRunTheme.border, lineWidth: 1)
+                }
+                .mereShadow(radius: 12, y: 8)
+        }
+        .onReceive(jobs.events) { _ in generation &+= 1 }
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Activity")
+    }
+
+    private func header(_ rows: [StudioActivityRow]) -> some View {
+        HStack(spacing: 8) {
+            Text("Activity")
+                .font(.system(size: 12.5, weight: .semibold))
+                .foregroundStyle(MereRunTheme.textPrimary)
+            Spacer(minLength: 12)
+            Text(rows.isEmpty ? "Nothing running" : StudioActivity.summary(rows))
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(MereRunTheme.textMuted)
+        }
+        .padding(.horizontal, 14)
+        .padding(.top, 8)
+        .padding(.bottom, 6)
+        .accessibilityElement(children: .combine)
+        .accessibilityAddTraits(.isHeader)
+    }
+
+    /// What the popover says when no job is in flight: the same three facts the machine-status
+    /// details carried, drawn as Activity rows.
+    private var machineDetails: some View {
+        VStack(alignment: .leading, spacing: 0) {
+            detailRow(dot: status.dotColor, title: "Local server", detail: status.serverDetail)
+            Button(action: onOpenModels) {
+                detailRow(dot: nil, title: "Models", detail: modelsDetail)
+            }
+            .buttonStyle(.plain)
+            .help("Open Models ▸ Installed")
+            detailRow(dot: nil, title: "CLI", detail: resolvedCLI.isBlank ? "Not resolved" : resolvedCLI)
+        }
+    }
+
+    private var modelsDetail: String {
+        let root = modelsRoot.trimmingCharacters(in: .whitespacesAndNewlines)
+        let location = root.isEmpty
+            ? "default location"
+            : (root as NSString).abbreviatingWithTildeInPath
+        return "\(status.modelsDetail) · \(location)"
+    }
+
+    private func detailRow(dot: Color?, title: String, detail: String) -> some View {
+        HStack(spacing: 10) {
+            Circle()
+                .fill(dot ?? .clear)
+                .frame(width: 8, height: 8)
+            VStack(alignment: .leading, spacing: 3) {
+                Text(title)
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(MereRunTheme.textPrimary)
+                Text(detail)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundStyle(MereRunTheme.textMuted)
+                    .lineLimit(2)
+                    .truncationMode(.middle)
+            }
+            Spacer(minLength: 0)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 14)
+        .padding(.vertical, 8)
+        .contentShape(Rectangle())
+        .accessibilityElement(children: .combine)
+    }
+
+    private var footer: some View {
+        HStack(spacing: 8) {
+            Text(StudioActivity.versionLine(appVersion: appVersion, cliVersion: cliVersion))
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(MereRunTheme.textMuted)
+                .lineLimit(1)
+            Spacer(minLength: 12)
+            Button("Open Server", action: onOpenServer)
+                .buttonStyle(.plain)
+                .font(.system(size: 11.5, weight: .medium))
+                .foregroundStyle(MereRunTheme.accent)
+                .help("Open the Server page")
+        }
+        .padding(.horizontal, 14)
+        .padding(.top, 8)
+        .padding(.bottom, 4)
+    }
+}
+
+/// One job in the Activity popover. It observes its own `Job`, so a chatty run redraws this row
+/// and nothing else in the shell.
+private struct StudioActivityJobRow: View {
+    @ObservedObject var job: Job
+    let row: StudioActivityRow
+    let onCancel: () -> Void
+
+    var body: some View {
+        HStack(spacing: 10) {
+            Circle()
+                .fill(row.isRunning ? MereRunTheme.accent : MereRunTheme.yellow)
+                .frame(width: 8, height: 8)
+            VStack(alignment: .leading, spacing: 3) {
+                Text(row.title)
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundStyle(MereRunTheme.textPrimary)
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                if let progress = job.progress {
+                    StudioProgressBar(fraction: progress.fractionCompleted)
+                        .frame(height: 4)
+                }
+                detail
+                    .font(.system(size: 11, weight: .medium))
+                    .monospacedDigit()
+                    .foregroundStyle(MereRunTheme.textMuted)
+                    .lineLimit(1)
+            }
+            // A queued row has no progress bar to fill the width, so the stop control still needs
+            // pushing to the trailing edge where every other row's sits.
+            .frame(maxWidth: .infinity, alignment: .leading)
+            Button(action: onCancel) {
+                Image(systemName: row.isRunning ? "stop" : "xmark")
+                    .font(.system(size: 12, weight: .medium))
+                    .frame(width: 28, height: 28)
+            }
+            .buttonStyle(.mereIcon)
+            .help(row.isRunning ? "Stop this job" : "Remove this job from the queue")
+            .accessibilityLabel(row.isRunning ? "Stop \(row.title)" : "Remove \(row.title) from the queue")
+        }
+        .padding(.horizontal, 14)
+        .padding(.vertical, 8)
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel(row.title)
+    }
+
+    /// A running job's elapsed time ticks; a queued one has nothing to count.
+    @ViewBuilder
+    private var detail: some View {
+        if row.isRunning, let startedAt = job.startedAt {
+            TimelineView(.periodic(from: startedAt, by: 1)) { context in
+                Text(StudioActivity.detail(
+                    for: job,
+                    elapsed: context.date.timeIntervalSince(startedAt),
+                    isNextInQueue: row.isNextInQueue
+                ))
+            }
+        } else {
+            Text(StudioActivity.detail(for: job, elapsed: nil, isNextInQueue: row.isNextInQueue))
+        }
+    }
+}

--- a/apps/macos/MereRunStudio/StudioNavigation.swift
+++ b/apps/macos/MereRunStudio/StudioNavigation.swift
@@ -499,6 +499,9 @@ final class NavigationModel: ObservableObject {
     @Published var showCommandColumn = false
     /// Help ▸ mere.run Guide presents the Guide sheet on the Studio window from any key window.
     @Published var showGuide = false
+    /// Whether the sidebar footer's Activity popover is open. The shell draws it over the window,
+    /// so the state lives here rather than inside the sidebar column.
+    @Published var showActivity = false
 
     init(destination: StudioDestination = .default) {
         self.destination = destination

--- a/apps/macos/MereRunStudio/StudioRootView.swift
+++ b/apps/macos/MereRunStudio/StudioRootView.swift
@@ -22,6 +22,8 @@ struct StudioRootView: View {
     /// The prompt tasks whose inspector stays open, as `StudioInspectorTaskMemory` encodes them.
     @SceneStorage("studio.inspectorTasks") private var storedInspectorTasks = ""
     @State private var columnVisibility: NavigationSplitViewVisibility = .all
+    /// The status probe never answered within its grace period, so the footer says so.
+    @State private var probeTimedOut = false
     /// The prompt mode the composer, canvas, and readiness were last set up for, so the
     /// destination observer activates a mode exactly once however the destination arrived.
     @State private var activatedMode: StudioMode?
@@ -244,15 +246,74 @@ struct StudioRootView: View {
             StudioSidebar(
                 selectedDomain: domainBinding,
                 unavailableMessages: domainUnavailableMessages,
-                serverStatus: controller.serverStatus,
-                resolvedCLI: controller.resolvedCLI,
-                onShowServer: { navigation.open(domain: .server) },
-                onShowModels: { navigation.open(task: .modelsInstalled) }
+                status: machineStatus,
+                runningJobs: runningJobCount,
+                isActivityOpen: $navigation.showActivity
             )
         } detail: {
             detailArea
         }
         .background(MereRunTheme.background.ignoresSafeArea())
+        // The controller publishes nil until the status probe answers; a probe that never answers
+        // must still resolve, so the footer stops saying "Checking…" after the grace period.
+        .task(id: controller.serverStatus == nil) {
+            guard controller.serverStatus == nil else {
+                probeTimedOut = false
+                return
+            }
+            try? await Task.sleep(for: .seconds(StudioMachineStatus.checkingGracePeriod))
+            guard !Task.isCancelled, controller.serverStatus == nil else { return }
+            probeTimedOut = true
+        }
+        .overlay(alignment: .bottomLeading) { activityOverlay }
+    }
+
+    private var machineStatus: StudioMachineStatus {
+        StudioMachineStatus(serverStatus: controller.serverStatus, probeTimedOut: probeTimedOut)
+    }
+
+    /// How many jobs the footer pill counts: the user's work, never a readiness probe.
+    private var runningJobCount: Int {
+        _ = jobMonitor.generation
+        return StudioActivity.lanes.reduce(0) { $0 + controller.jobs.running(in: $1).count }
+    }
+
+    /// The Activity popover, drawn over the whole window rather than inside the sidebar column: it
+    /// is 340pt wide and would be clipped by the column, and it must float over the Library.
+    @ViewBuilder
+    private var activityOverlay: some View {
+        if navigation.showActivity {
+            ZStack(alignment: .bottomLeading) {
+                // Anywhere else in the window dismisses it, the way a popover does.
+                Color.clear
+                    .contentShape(Rectangle())
+                    .onTapGesture { navigation.showActivity = false }
+                StudioActivityPopover(
+                    jobs: controller.jobs,
+                    status: machineStatus,
+                    appVersion: controller.appVersion,
+                    cliVersion: controller.cliVersion,
+                    modelsRoot: controller.modelsRoot,
+                    resolvedCLI: controller.resolvedCLI,
+                    onOpenServer: {
+                        navigation.showActivity = false
+                        navigation.open(domain: .server)
+                    },
+                    onOpenModels: {
+                        navigation.showActivity = false
+                        navigation.open(task: .modelsInstalled)
+                    }
+                )
+                .padding(.leading, 10)
+                .padding(.bottom, 56)
+                Button("Close Activity") { navigation.showActivity = false }
+                    .keyboardShortcut(.cancelAction)
+                    .frame(width: 0, height: 0)
+                    .opacity(0)
+                    .accessibilityHidden(true)
+            }
+            .transition(reduceMotion ? .identity : .opacity)
+        }
     }
 
     // The detail area runs to the top of the window (the title bar is hidden and nothing sits in

--- a/apps/macos/MereRunStudio/StudioSidebar.swift
+++ b/apps/macos/MereRunStudio/StudioSidebar.swift
@@ -12,10 +12,12 @@ import SwiftUI
 struct StudioSidebar: View {
     @Binding var selectedDomain: StudioDomain
     let unavailableMessages: [StudioDomain: String]
-    let serverStatus: StudioServerStatus?
-    let resolvedCLI: String
-    let onShowServer: () -> Void
-    let onShowModels: () -> Void
+    let status: StudioMachineStatus
+    /// How many jobs are running right now; the footer pill counts them beside the machine state.
+    let runningJobs: Int
+    /// Whether the Activity popover is open. The popover itself is drawn by the shell, over the
+    /// whole window: it is wider than this column and would otherwise be clipped by it.
+    @Binding var isActivityOpen: Bool
 
     var body: some View {
         List(selection: selectionBinding) {
@@ -104,15 +106,10 @@ struct StudioSidebar: View {
     }
 
     private var footer: some View {
-        StudioStatusCluster(
-            serverStatus: serverStatus,
-            resolvedCLI: resolvedCLI,
-            onShowServer: onShowServer,
-            onShowModels: onShowModels
-        )
-        .padding(.horizontal, 10)
-        .padding(.top, 10)
-        .padding(.bottom, 14)
+        StudioStatusCluster(status: status, runningJobs: runningJobs, isActivityOpen: $isActivityOpen)
+            .padding(.horizontal, 10)
+            .padding(.top, 10)
+            .padding(.bottom, 14)
     }
 }
 
@@ -174,6 +171,20 @@ enum StudioMachineStatus: Equatable {
         }
     }
 
+    /// The footer pill with the work count appended: "Ready · 92 models · 2 running". The count is
+    /// dropped when nothing is in flight, so a quiet machine keeps the quiet line.
+    func summary(runningJobs: Int) -> String {
+        guard let work = Self.workCount(runningJobs) else { return summary }
+        return "\(summary) · \(work)"
+    }
+
+    /// "2 running", or nothing at all when the machine is idle. The pill puts this on its own
+    /// line — the 212pt sidebar has no room for it beside the state — and reads the two together
+    /// as one value for VoiceOver and the tooltip.
+    static func workCount(_ runningJobs: Int) -> String? {
+        runningJobs > 0 ? "\(runningJobs) running" : nil
+    }
+
     /// The server line in the details popover.
     var serverDetail: String {
         switch self {
@@ -206,6 +217,12 @@ enum StudioMachineStatus: Equatable {
         }
     }
 
+    /// The pill's label color. Only a machine we cannot reach is worth colouring: it is the one
+    /// state the user has to act on.
+    var summaryColor: Color {
+        self == .unreachable ? MereRunTheme.red : MereRunTheme.textSecondary
+    }
+
     var isServing: Bool {
         if case .serving = self { return true }
         return false
@@ -216,186 +233,62 @@ enum StudioMachineStatus: Equatable {
     }
 }
 
-/// One quiet line for machine state — dot, word, count — with the full story in a popover.
+/// One quiet line for machine state — dot, word, count — and the button that opens the Activity
+/// popover with the work in flight.
 private struct StudioStatusCluster: View {
-    let serverStatus: StudioServerStatus?
-    let resolvedCLI: String
-    let onShowServer: () -> Void
-    let onShowModels: () -> Void
+    let status: StudioMachineStatus
+    let runningJobs: Int
+    @Binding var isActivityOpen: Bool
 
-    @State private var showDetails = false
     @State private var hovering = false
-    @State private var probeTimedOut = false
 
-    private var status: StudioMachineStatus {
-        StudioMachineStatus(serverStatus: serverStatus, probeTimedOut: probeTimedOut)
+    private var summary: String {
+        status.summary(runningJobs: runningJobs)
     }
 
     var body: some View {
         Button {
-            showDetails.toggle()
+            isActivityOpen.toggle()
         } label: {
             HStack(spacing: 8) {
                 Circle()
                     .fill(status.dotColor)
                     .frame(width: 8, height: 8)
-                Text(status.summary)
-                    .font(.system(size: 12, weight: .medium))
-                    .foregroundStyle(MereRunTheme.textSecondary)
-                    .lineLimit(1)
+                // The 212pt sidebar cannot hold the state and the work count on one line, so the
+                // count takes a second line rather than truncating the state the user came for.
+                VStack(alignment: .leading, spacing: 0) {
+                    Text(status.summary)
+                        .foregroundStyle(status.summaryColor)
+                    if let work = StudioMachineStatus.workCount(runningJobs) {
+                        Text(work)
+                            .foregroundStyle(MereRunTheme.textMuted)
+                    }
+                }
+                .font(.system(size: 12, weight: .medium))
+                .lineLimit(1)
                 Spacer(minLength: 0)
                 Image(systemName: "chevron.down")
                     .font(.system(size: 9, weight: .semibold))
                     .foregroundStyle(MereRunTheme.textMuted)
             }
             .padding(.horizontal, 10)
-            .frame(height: 32)
+            // Tight enough that the two-line pill still clears the Activity popover above it.
+            .padding(.vertical, 4)
+            .frame(minHeight: 32)
             .background {
                 RoundedRectangle(cornerRadius: MereRunTheme.Radius.md)
-                    .fill(hovering || showDetails ? MereRunTheme.hoverFill : Color.clear)
+                    .fill(hovering || isActivityOpen ? MereRunTheme.hoverFill : Color.clear)
             }
             .contentShape(RoundedRectangle(cornerRadius: MereRunTheme.Radius.md))
         }
         .buttonStyle(.plain)
         .onHover { hovering = $0 }
         .animation(MereRunTheme.Motion.quick, value: hovering)
-        // The controller publishes nil until the probe answers; a probe that never answers must
-        // still resolve, so the footer stops saying "Checking…" after the grace period.
-        .task(id: serverStatus == nil) {
-            guard serverStatus == nil else {
-                probeTimedOut = false
-                return
-            }
-            try? await Task.sleep(for: .seconds(StudioMachineStatus.checkingGracePeriod))
-            guard !Task.isCancelled, serverStatus == nil else { return }
-            probeTimedOut = true
-        }
-        .popover(isPresented: $showDetails, arrowEdge: .top) {
-            StudioStatusDetails(
-                status: status,
-                resolvedCLI: resolvedCLI,
-                onShowServer: {
-                    showDetails = false
-                    onShowServer()
-                },
-                onShowModels: {
-                    showDetails = false
-                    onShowModels()
-                }
-            )
-        }
-        .accessibilityLabel("Machine status")
-        .accessibilityValue(status.summary)
-        .accessibilityHint("Shows local server details and opens the Server domain")
-    }
-}
-
-private struct StudioStatusDetails: View {
-    let status: StudioMachineStatus
-    let resolvedCLI: String
-    let onShowServer: () -> Void
-    let onShowModels: () -> Void
-
-    @State private var copiedCLI = false
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: MereRunTheme.Spacing.md) {
-            detailRow(
-                icon: "bolt.horizontal.circle",
-                title: "Local server",
-                value: status.serverDetail,
-                valueColor: serverValueColor
-            )
-
-            Button {
-                onShowServer()
-            } label: {
-                Label("Open Server", systemImage: "network")
-                    .frame(maxWidth: .infinity)
-            }
-            .buttonStyle(.merePrimary)
-
-            HStack(alignment: .firstTextBaseline) {
-                detailRow(
-                    icon: "shippingbox",
-                    title: "Models",
-                    value: status.modelsDetail,
-                    valueColor: MereRunTheme.textSecondary
-                )
-                Spacer(minLength: 12)
-                Button("Browse…", action: onShowModels)
-                    .buttonStyle(.bordered)
-                    .controlSize(.small)
-            }
-
-            VStack(alignment: .leading, spacing: 4) {
-                HStack(spacing: 7) {
-                    Image(systemName: "terminal")
-                        .font(.system(size: 11, weight: .semibold))
-                        .foregroundStyle(MereRunTheme.accent)
-                        .frame(width: 16)
-                    Text("CLI")
-                        .font(MereRunTheme.captionFont)
-                        .foregroundStyle(MereRunTheme.textMuted)
-                    Spacer(minLength: 12)
-                    Button {
-                        copyCLI()
-                    } label: {
-                        Image(systemName: copiedCLI ? "checkmark" : "doc.on.doc")
-                            .font(.system(size: 10, weight: .semibold))
-                            .padding(3)
-                    }
-                    .buttonStyle(.mereIcon)
-                    .help("Copy CLI path")
-                    .accessibilityLabel("Copy CLI path")
-                }
-                Text(resolvedCLI)
-                    .font(.system(size: 11, design: .monospaced))
-                    .foregroundStyle(MereRunTheme.textSecondary)
-                    .textSelection(.enabled)
-                    .lineLimit(2)
-                    .truncationMode(.middle)
-            }
-        }
-        .padding(MereRunTheme.Spacing.lg)
-        .frame(width: 320)
-    }
-
-    private var serverValueColor: Color {
-        switch status {
-        case .serving: return MereRunTheme.green
-        case .unreachable: return MereRunTheme.red
-        case .checking, .ready: return MereRunTheme.textSecondary
-        }
-    }
-
-    private func detailRow(icon: String, title: String, value: String, valueColor: Color) -> some View {
-        VStack(alignment: .leading, spacing: 3) {
-            HStack(spacing: 7) {
-                Image(systemName: icon)
-                    .font(.system(size: 11, weight: .semibold))
-                    .foregroundStyle(MereRunTheme.accent)
-                    .frame(width: 16)
-                Text(title)
-                    .font(MereRunTheme.captionFont)
-                    .foregroundStyle(MereRunTheme.textMuted)
-            }
-            Text(value)
-                .font(.system(size: 12, weight: .medium))
-                .foregroundStyle(valueColor)
-                .lineLimit(2)
-        }
-    }
-
-    private func copyCLI() {
-        let pasteboard = NSPasteboard.general
-        pasteboard.clearContents()
-        pasteboard.setString(resolvedCLI, forType: .string)
-        copiedCLI = true
-        Task {
-            try? await Task.sleep(nanoseconds: 1_400_000_000)
-            copiedCLI = false
-        }
+        // The pill splits the line in two; the tooltip and VoiceOver read it back as one.
+        .help(summary)
+        .accessibilityLabel("Activity and machine status")
+        .accessibilityValue(summary)
+        .accessibilityHint("Shows the jobs in flight, the local server, and a way into the Server page")
     }
 }
 

--- a/apps/macos/MereRunStudioTests/StudioActivityTests.swift
+++ b/apps/macos/MereRunStudioTests/StudioActivityTests.swift
@@ -1,0 +1,241 @@
+@testable import MereRunApp
+import Foundation
+import XCTest
+
+/// What the Activity popover reads out of a `JobStore`: which rows exist and in what order, the
+/// copy on each row, the header count, and the footer's version handshake.
+@MainActor
+final class StudioActivityTests: XCTestCase {
+    func testRowsListRunningJobsBeforeQueuedAndNeverListProbes() throws {
+        let runner = RecordingProcessRunner()
+        let store = JobStore(processRunner: runner)
+
+        let first = store.submit(try makeRequest(templateID: .imageGenerate))
+        let second = store.submit(try makeRequest(templateID: .imageGenerate))
+        let queued = store.submit(try makeRequest(templateID: .imageGenerate))
+        let alsoQueued = store.submit(try makeRequest(templateID: .imageGenerate))
+        let utility = store.submit(try makeRequest(lane: .utility, templateID: .modelList))
+        _ = store.submit(try makeRequest(lane: .probe, templateID: .modelCapabilities, dedupeKey: "readiness"))
+
+        let rows = StudioActivity.rows(in: store)
+
+        XCTAssertEqual(rows.map(\.id), [first, second, utility, queued, alsoQueued])
+        XCTAssertEqual(rows.map(\.isRunning), [true, true, true, false, false])
+        XCTAssertEqual(rows.filter(\.isNextInQueue).map(\.id), [queued], "only the head of the queue is next")
+        XCTAssertEqual(StudioActivity.summary(rows), "5 jobs · 2 queued")
+    }
+
+    func testRowTitlesNameTheDomainAndTheTask() throws {
+        let runner = RecordingProcessRunner()
+        let store = JobStore(processRunner: runner)
+
+        let generate = store.submit(try makeRequest(templateID: .imageGenerate))
+        let transcribe = store.submit(try makeRequest(lane: .utility, templateID: .speechTranscribe))
+        let pull = store.submit(try makeRequest(lane: .utility, templateID: .modelPull) { draft in
+            draft.model = "vision-chat-qwen3.6-vl-4b"
+        })
+        let gate = store.submit(try makeRequest(lane: .utility, templateID: .qualityGate))
+
+        XCTAssertEqual(StudioActivity.title(for: try XCTUnwrap(store.job(generate))), "Image · Generate")
+        XCTAssertEqual(StudioActivity.title(for: try XCTUnwrap(store.job(transcribe))), "Audio · Transcribe")
+        XCTAssertEqual(
+            StudioActivity.title(for: try XCTUnwrap(store.job(pull))),
+            "Models · Pull Qwen3.6 Vl 4b",
+            "a pull names its model the way the composer's model chip does"
+        )
+        // A job with no task of its own falls back to the template's title.
+        XCTAssertEqual(StudioActivity.title(for: try XCTUnwrap(store.job(gate))), "Models · Quality gate")
+    }
+
+    func testQueuedRowsSayWhereTheyAreInTheQueue() throws {
+        let runner = RecordingProcessRunner()
+        let store = JobStore(processRunner: runner)
+        _ = store.submit(try makeRequest(templateID: .imageGenerate))
+        _ = store.submit(try makeRequest(templateID: .imageGenerate))
+        let next = store.submit(try makeRequest(templateID: .imageGenerate))
+        let behind = store.submit(try makeRequest(templateID: .imageGenerate))
+
+        XCTAssertEqual(
+            StudioActivity.detail(for: try XCTUnwrap(store.job(next)), elapsed: nil, isNextInQueue: true),
+            "Queued · next"
+        )
+        XCTAssertEqual(
+            StudioActivity.detail(for: try XCTUnwrap(store.job(behind)), elapsed: nil, isNextInQueue: false),
+            "Queued"
+        )
+    }
+
+    func testRunningRowReportsStepProgressAndElapsedTime() async throws {
+        let runner = RecordingProcessRunner()
+        let store = JobStore(processRunner: runner)
+        let id = store.submit(try makeRequest(templateID: .imageGenerate))
+
+        runner.starts[0].stderr("{\"event\":\"progress\",\"stage\":\"denoising\",\"step\":14,\"total_steps\":24}\n")
+        await settle()
+
+        let job = try XCTUnwrap(store.job(id))
+        XCTAssertEqual(job.progress?.fractionCompleted, 15.0 / 24.0)
+        XCTAssertEqual(
+            StudioActivity.detail(for: job, elapsed: 41, isNextInQueue: false),
+            "Denoising 15/24 · 0:41"
+        )
+        // Before the first progress line there is still the job's own status.
+        let fresh = try XCTUnwrap(store.job(store.submit(try makeRequest(templateID: .imageGenerate))))
+        XCTAssertEqual(StudioActivity.detail(for: fresh, elapsed: 3, isNextInQueue: false), "Running · 0:03")
+    }
+
+    func testRunningPullReportsTransferredBytesAndTimeLeft() async throws {
+        let runner = RecordingProcessRunner()
+        let store = JobStore(processRunner: runner)
+        let id = store.submit(try makeRequest(lane: .utility, templateID: .modelPull) { draft in
+            draft.model = "vision-chat-qwen3.6-vl-4b"
+        })
+
+        runner.starts[0].stderr("[vision-chat-qwen3.6-vl-4b] 25%  1.2 GB / 4.8 GB  9.7 MB/s  ETA 3m 20s\n")
+        await settle()
+
+        let job = try XCTUnwrap(store.job(id))
+        XCTAssertEqual(job.progress?.fractionCompleted, 0.25)
+        XCTAssertEqual(
+            StudioActivity.detail(for: job, elapsed: 96, isNextInQueue: false),
+            "1.2 of 4.8 GB · 3 min left"
+        )
+    }
+
+    func testDownloadDetailShortensTheCLIProgressLine() {
+        XCTAssertEqual(
+            StudioActivity.downloadDetail(progress(detail: "900 MB / 4.8 GB 9.7 MB/s ETA 45s")),
+            "900 MB of 4.8 GB · 45 sec left"
+        )
+        XCTAssertEqual(
+            StudioActivity.downloadDetail(progress(detail: "2.1 GB / 12.4 GB 4 MB/s ETA 1h 12m")),
+            "2.1 of 12.4 GB · 1 hr left"
+        )
+        XCTAssertEqual(StudioActivity.downloadDetail(progress(detail: "1.2 GB / 4.8 GB")), "1.2 of 4.8 GB")
+        XCTAssertEqual(StudioActivity.downloadDetail(progress(detail: "extracting…")), "Extracting…")
+        // Nothing recognisable leaves the caller to fall back to the job's status line.
+        XCTAssertNil(StudioActivity.downloadDetail(progress(detail: "resolving manifest")))
+        XCTAssertNil(StudioActivity.downloadDetail(nil))
+    }
+
+    func testHeaderSummaryCountsJobsAndTheQueue() {
+        XCTAssertEqual(StudioActivity.summary([]), "0 jobs")
+        XCTAssertEqual(StudioActivity.summary([row(running: true)]), "1 job")
+        XCTAssertEqual(StudioActivity.summary([row(running: true), row(running: true)]), "2 jobs")
+        XCTAssertEqual(
+            StudioActivity.summary([row(running: true), row(running: true), row(running: false)]),
+            "3 jobs · 1 queued"
+        )
+    }
+
+    func testCancellingARowStopsThatJobAndDropsItFromTheList() async throws {
+        let runner = RecordingProcessRunner()
+        let store = JobStore(processRunner: runner)
+        _ = store.submit(try makeRequest(templateID: .imageGenerate))
+        let running = store.submit(try makeRequest(templateID: .imageGenerate))
+        let queued = store.submit(try makeRequest(templateID: .imageGenerate))
+
+        // The row id is the job id, so the popover's stop button cancels exactly its own job.
+        let queuedRow = try XCTUnwrap(StudioActivity.rows(in: store).first { !$0.isRunning })
+        XCTAssertEqual(queuedRow.id, queued)
+        XCTAssertTrue(store.cancel(queuedRow.id))
+        XCTAssertFalse(StudioActivity.rows(in: store).contains { $0.id == queued })
+
+        let runningRow = try XCTUnwrap(StudioActivity.rows(in: store).first { $0.id == running })
+        XCTAssertTrue(runningRow.isRunning)
+        XCTAssertTrue(store.cancel(runningRow.id))
+        XCTAssertEqual(runner.processes[1].terminateCallCount, 1)
+
+        runner.starts[1].termination(15)
+        await settle()
+        XCTAssertFalse(StudioActivity.rows(in: store).contains { $0.id == running })
+    }
+
+    func testFooterReportsTheVersionHandshake() {
+        XCTAssertEqual(
+            StudioActivity.versionLine(appVersion: "0.50.0", cliVersion: "0.50.0"),
+            "mere.run 0.50.0 · CLI matched"
+        )
+        XCTAssertEqual(
+            StudioActivity.versionLine(appVersion: "0.50.0", cliVersion: "0.49.1"),
+            "mere.run 0.50.0 · CLI 0.49.1"
+        )
+        XCTAssertEqual(
+            StudioActivity.versionLine(appVersion: "0.50.0", cliVersion: nil),
+            "mere.run 0.50.0 · CLI not resolved"
+        )
+        XCTAssertEqual(
+            StudioActivity.versionLine(appVersion: "0.50.0", cliVersion: "  "),
+            "mere.run 0.50.0 · CLI not resolved"
+        )
+    }
+
+    // MARK: - Footer pill
+
+    func testFooterPillCountsRunningJobs() {
+        let ready = StudioMachineStatus.ready(installedModels: 92)
+        XCTAssertEqual(ready.summary(runningJobs: 0), "Ready · 92 models")
+        XCTAssertEqual(ready.summary(runningJobs: 2), "Ready · 92 models · 2 running")
+        XCTAssertEqual(ready.summary(runningJobs: 1), "Ready · 92 models · 1 running")
+        XCTAssertEqual(
+            StudioMachineStatus.serving(installedModels: 3, loadedModel: "gemma4-e4b").summary(runningJobs: 1),
+            "Serving · 3 models · 1 running"
+        )
+        XCTAssertEqual(StudioMachineStatus.unreachable.summary(runningJobs: 1), "Server unreachable · 1 running")
+    }
+
+    func testTheWorkCountIsItsOwnLineOnlyWhileJobsRun() {
+        XCTAssertNil(StudioMachineStatus.workCount(0), "an idle machine keeps the one-line pill")
+        XCTAssertEqual(StudioMachineStatus.workCount(1), "1 running")
+        XCTAssertEqual(StudioMachineStatus.workCount(2), "2 running")
+    }
+
+    func testOnlyAnUnreachableServerColoursTheFooterPill() {
+        XCTAssertEqual(StudioMachineStatus.unreachable.summaryColor, MereRunTheme.red)
+        XCTAssertEqual(StudioMachineStatus.checking.summaryColor, MereRunTheme.textSecondary)
+        XCTAssertEqual(StudioMachineStatus.ready(installedModels: 1).summaryColor, MereRunTheme.textSecondary)
+    }
+
+    // MARK: - Helpers
+
+    private func row(running: Bool) -> StudioActivityRow {
+        StudioActivityRow(id: JobID(), title: "Image · Generate", isRunning: running, isNextInQueue: false)
+    }
+
+    private func progress(detail: String?) -> StudioRunProgress? {
+        detail.map { StudioRunProgress(label: "model", fractionCompleted: 0.25, detail: $0) }
+    }
+
+    private func makeRequest(
+        lane: JobLane = .inference,
+        templateID: CommandTemplateID,
+        dedupeKey: String? = nil,
+        configure: (inout CommandDraft) -> Void = { _ in }
+    ) throws -> JobRequest {
+        let template = try XCTUnwrap(CommandCatalog.template(id: templateID))
+        var draft = template.defaultDraft()
+        draft.prompt = draft.prompt.isEmpty ? "a ceramic coffee mug in soft morning light" : draft.prompt
+        draft.inputPath = "/tmp/input.wav"
+        configure(&draft)
+        let args = template.arguments(from: draft)
+        return JobRequest(
+            lane: lane,
+            template: template,
+            draft: draft,
+            requestID: UUID(),
+            configuration: MereRunProcessConfiguration(
+                executableURL: URL(fileURLWithPath: "/usr/bin/true"),
+                arguments: args,
+                currentDirectoryURL: FileManager.default.temporaryDirectory,
+                environment: [:],
+                keepsStandardInputOpen: false
+            ),
+            displayCommand: (["mere.run"] + args).shellQuoted(),
+            dedupeKey: dedupeKey
+        )
+    }
+
+    private func settle() async {
+        for _ in 0..<6 { await Task.yield() }
+    }
+}

--- a/apps/macos/MereRunStudioTests/StudioSnapshotTests.swift
+++ b/apps/macos/MereRunStudioTests/StudioSnapshotTests.swift
@@ -92,6 +92,64 @@ final class StudioSnapshotTests: XCTestCase {
         }
     }
 
+    /// The Activity popover over the Main board, as `ActivityDark.png` shows it: the sidebar
+    /// footer's popover open on the same three jobs the board runs — the fox generation denoising,
+    /// the model pull a quarter of the way through, and the diner generation queued behind them.
+    /// Light and dark; the jobs come from the harness's scripted process runner, so no CLI runs.
+    func testActivityPopoverFidelitySnapshots() throws {
+        let fidelity = try SnapshotFixture(
+            outputDirectory: fixture.outputDirectory,
+            seed: .mockup,
+            processRunner: SnapshotProcessRunner(script: ModelsInventoryScript.readinessResponses)
+        )
+        defer { fidelity.tearDown() }
+        try fidelity.startMainBoardJobs()
+        // The popover's footer reports the version handshake, which the shell never probes itself.
+        fidelity.controller.refreshCLIVersion()
+
+        var draft = StudioDraft()
+        draft.reset(for: .createImage)
+        draft.prompt = "a ceramic coffee mug in soft morning light"
+        draft.cfgScale = 3.5
+        draft.sigmaShift = 3.0
+
+        for appearance in StudioSnapshotAppearance.allCases {
+            let navigation = NavigationModel()
+            let view = StudioRootView(seededDrafts: [.createImage: draft])
+                .environmentObject(fidelity.controller)
+                .environmentObject(fidelity.library)
+                .environmentObject(navigation)
+                .frame(width: Self.fidelitySize.width, height: Self.fidelitySize.height)
+            try fidelity.write(
+                view,
+                size: Self.fidelitySize,
+                appearance: appearance,
+                name: "f11-activity-\(appearance.rawValue)",
+                settle: 3.0,
+                afterAppear: {
+                    navigation.toggleInspector(for: .imageGenerate)
+                    navigation.showActivity = true
+                }
+            )
+        }
+
+        // With nothing in flight the same popover carries the machine's own state instead.
+        let idleNavigation = NavigationModel()
+        let idle = StudioRootView()
+            .environmentObject(fixture.controller)
+            .environmentObject(fixture.library)
+            .environmentObject(idleNavigation)
+            .frame(width: Self.fidelitySize.width, height: Self.fidelitySize.height)
+        try fixture.write(
+            idle,
+            size: Self.fidelitySize,
+            appearance: .dark,
+            name: "f11-activity-idle-dark",
+            settle: 3.0,
+            afterAppear: { idleNavigation.showActivity = true }
+        )
+    }
+
     override func tearDownWithError() throws {
         fixture?.tearDown()
         fixture = nil
@@ -569,7 +627,10 @@ private final class SnapshotFixture {
         var pullDraft = pullTemplate.defaultDraft()
         pullDraft.model = ModelsInventoryScript.pullingModelID
         let pull = StudioRunRequest(mode: .readImage, templateID: .modelPull, template: pullTemplate, draft: pullDraft)
-        guard controller.run(studio: pull) else { throw StudioSnapshotError.noContentView }
+        guard controller.run(studio: pull), let pullLive = runner.liveStarts.last else {
+            throw StudioSnapshotError.noContentView
+        }
+        pullLive.stderr("[\(ModelsInventoryScript.pullingModelID)] 25%  1.2 GB / 4.8 GB  9.7 MB/s  ETA 3m 20s\n")
 
         var queuedDraft = StudioDraft()
         queuedDraft.reset(for: .createImage)
@@ -1130,7 +1191,15 @@ private enum ModelsInventoryScript {
         [
             .init(matches: { $0 == ["model", "list"] }, stdout: modelList, exitCode: 0),
             .init(matches: { $0 == ["model", "capabilities", "--all", "--json"] }, stdout: capabilities, exitCode: 0),
+            version,
         ]
+    }
+
+    /// The CLI's own version, answered with the app's, so the Activity popover's footer shows the
+    /// matched handshake a bundled CLI produces.
+    static var version: SnapshotProcessRunner.Response {
+        let bundled = Bundle.main.object(forInfoDictionaryKey: "CFBundleShortVersionString") as? String
+        return .init(matches: { $0 == ["--version"] }, stdout: (bundled ?? "dev") + "\n", exitCode: 0)
     }
 
     static var responses: [SnapshotProcessRunner.Response] {

--- a/apps/macos/README.md
+++ b/apps/macos/README.md
@@ -42,10 +42,20 @@ the selected row is a solid accent pill drawn by the row itself (the native
 `List` highlight is switched off; selection, arrow keys, and VoiceOver are
 unchanged). The footer pill reads "Ready · N models" once the status probe
 answers, "Serving · N models" while the local server is up, and "Server
-unreachable" if the probe never answers; its popover holds the details. Every
-domain has **tasks** in a 52pt header at the top of the content column, beside
-the Library (the window toolbar stays empty so the Library column runs to the
-top of the window): one segmented pill for up to six tasks, or five segments
+unreachable" (in red) if the probe never answers, with "· N running" appended
+while jobs are in flight. It opens the **Activity popover**
+(`StudioActivity.swift`), a 340pt panel the shell draws over the window from the
+bottom-left: one row per running or queued job in the inference and utility
+lanes (never a probe) with its progress and a stop control, over the app↔CLI
+version handshake and a link into the Server page. With nothing running the same
+panel shows the local server, the models root, and the resolved CLI path. It
+reads the `JobStore` directly — the lanes for which rows exist, each `Job` for
+its own progress — so nothing about the work in flight is mirrored on the
+controller.
+
+Every domain has **tasks** in a 52pt header at the top of the content column,
+beside the Library (the window toolbar stays empty so the Library column runs to
+the top of the window): one segmented pill for up to six tasks, or five segments
 plus a "More" menu segment for Vision. The header's leading item is the domain
 glyph, title, and one-line subtitle; trailing are the Library, Inspector, and
 Command toggles (the Library and Inspector toggles appear on prompt tasks only).


### PR DESCRIPTION
## What changed

The sidebar footer pill's popover held three static facts about this Mac and
nothing about the work in flight: a run's progress lived only on its feed card,
and a queued job was invisible outside the domain that queued it. This replaces
it with the **Activity popover** (`StudioActivity.swift`), built to the
`activityPopover` block of the approved mockup and the bottom-left of
`ActivityDark.png`.

- A 340pt `surface` panel, r12, hairline border, `mereShadow`, drawn by the
  shell over the window from the bottom-left (the sidebar column is 212pt and
  would clip it, and it has to float over the Library).
- Header: "Activity" 12.5 semibold beside the count, "3 jobs · 1 queued".
- One row per running or queued job across the **inference and utility** lanes.
  Probes never appear — a readiness check is not work the user started. Rows are
  running first (lane order), then the queue in FIFO order: the order the work
  will finish in. Each row is an 8pt dot (accent running, yellow queued), the
  title in 12 medium ("Image · Generate", "Models · Pull …" from the existing
  `StudioDomain(templateID:)` mapping plus the task control's own task name), a
  4pt `StudioProgressBar` when progress is reported, an 11pt muted detail line,
  and a 28pt stop (running) or ✕ (queued) button calling `jobs.cancel(id)`.
- The detail line reads step progress and elapsed time for a run
  ("Denoising 15/24 · 0:41"), transferred bytes and time left for a pull
  ("1.2 of 4.8 GB · 3 min left", rewritten from the CLI's own progress line),
  and queue position for a job that has not started ("Queued · next").
- Under a hairline, the footer reports the real app↔CLI version handshake
  ("mere.run 0.50.0 · CLI matched" / "· CLI 0.49.1" / "· CLI not resolved") and
  an accent "Open Server" link into the Server domain.
- With nothing in flight the panel keeps the local server, models root, and
  resolved CLI path the old popover showed, drawn as Activity rows.

The panel observes the `JobStore` with `@ObservedObject` — the lanes for which
rows exist, each `Job` for its own progress — so nothing about the work in
flight is mirrored on the controller. `MereRunController.swift` is untouched.

The footer pill keeps `StudioMachineStatus` (including "Server unreachable" in
red) and adds the count of jobs running. The 212pt sidebar cannot hold
"Ready · 92 models · 2 running" on one line, so the count takes a second line;
the tooltip and the VoiceOver value still read the whole string, which is what
`StudioMachineStatus.summary(runningJobs:)` returns.

The `probeTimedOut` grace period moved from the status cluster up to
`StudioRootView`, because both the pill and the popover need the resolved
machine status.

## Design decisions

- **Utility lane included, probe lane excluded.** The plan's Activity surface is
  "what this Mac is working on"; a readiness probe is not that, and probes are
  deduplicated and uncapped so they would churn the list.
- **The popover lives in the shell, not the sidebar.** It is wider than the
  column and must float over the Library, so `NavigationModel.showActivity`
  holds the state and `StudioRootView` draws the overlay. Escape and a click
  anywhere else dismiss it.
- **A model pull names its model with `StudioComposer.displayModelName`**, the
  same helper the composer's model chip uses, so one model reads the same way
  wherever it appears. That renders `vision-chat-qwen3.6-vl-4b` as
  "Qwen3.6 Vl 4b" where the mockup drew "Qwen3.6-VL 4B"; fixing the casing
  belongs in that shared helper rather than in a second, diverging copy here.

## Verification

- `swiftlint --strict`, `swift build`, `swift test --filter MereRunAppTests`
  (379 tests, 0 failures), `./scripts/build_mere_run_app.sh debug`, and the full
  `./scripts/check.sh` all pass.
- New `StudioActivityTests` cover row derivation (titles, details, running
  before queued, probes excluded), the download-line rewrite, the header count,
  cancel wiring through `JobStore.cancel`, the version handshake, and the pill's
  count copy and colour.
- Fidelity: `StudioSnapshotTests.testActivityPopoverFidelitySnapshots` renders
  the Main board at 1440×900 in light and dark with the popover open on the
  three jobs the board already runs, plus the idle panel in dark. The jobs are
  seeded through the JobStore with the harness's scripted process runner, so no
  CLI is launched while rendering. The renders were compared side by side with
  `ActivityDark.png`; two rendering-only fixes came out of that pass — the
  panel's shadow now belongs to its background shape (a `shadow` on a stack is
  inherited by every leaf, which drew a dark halo around each row), and the
  footer pill no longer truncates.

## Remaining differences from the mockup

All three are environmental rather than layout, and are listed so the reviewer
does not chase them:

- "Models · Pull Qwen3.6 Vl 4b" vs the mockup's "Qwen3.6-VL 4B" — see above.
- The footer version reads "mere.run 16.0" in a render because the test host's
  bundle supplies the version; the app reports its own.
- The elapsed time drifts a few seconds past the mockup's "0:41" because the
  clock runs while the harness settles the view.
