### PR TITLE
Resolve Studio artifacts from the CLI's result receipts

### DIFF
--- a/apps/macos/MereRunStudio/CommandCatalog.swift
+++ b/apps/macos/MereRunStudio/CommandCatalog.swift
@@ -275,6 +275,56 @@ enum CommandTemplateID: String, CaseIterable, Codable {
         case .visionServe: return "vision.serve"
         }
     }
+
+    /// The capability's contract entry, when the command is one the shared contract declares.
+    var capability: MereRunCommandCapability? {
+        capabilityID.flatMap { MereRunCapabilityCatalog.command(id: $0) }
+    }
+
+    /// True when the CLI prints the `{"event":"result"}` receipt line for this command under
+    /// `--receipt`. The contract owns the list, so a capability that gains the flag needs no
+    /// change here.
+    var emitsRunReceipt: Bool {
+        guard let capabilityID else { return false }
+        return MereRunCapabilityCatalog.receiptCapabilityIDs.contains(capabilityID)
+    }
+
+    /// True when the CLI streams `--progress-json` events for this command.
+    var emitsProgressJSON: Bool {
+        guard let capabilityID else { return false }
+        return MereRunCapabilityCatalog.progressJSONCapabilityIDs.contains(capabilityID)
+    }
+}
+
+/// The flags the app adds to a run's argv so it can read the CLI's structured output: the
+/// result receipt it resolves artifacts from, and the progress event stream it renders.
+///
+/// They are transport rather than user intent, so they are appended to the launched argv only —
+/// never to the "Will run" preview, a library row's command, or the console's echo of the
+/// command, all of which stay the command a person would type. `--preflight` runs get neither:
+/// the CLI rejects `--receipt --preflight`, and a preflight report has no progress to stream.
+enum StudioMachineOutputFlags {
+    static let receipt = "--receipt"
+    static let progressJSON = "--progress-json"
+
+    /// The flags to append to `arguments` for one run, in a stable order. Empty when the
+    /// capability declares neither, when the run is a preflight, or when the app already passes
+    /// the flag from the draft.
+    static func arguments(
+        template: CommandTemplate,
+        draft: CommandDraft,
+        appendingTo arguments: [String]
+    ) -> [String] {
+        guard !draft.preflight, !arguments.contains("--preflight") else { return [] }
+        var flags: [String] = []
+        if template.id.emitsRunReceipt, !arguments.contains(receipt) {
+            flags.append(receipt)
+        }
+        if template.id.emitsProgressJSON, !arguments.contains(progressJSON) {
+            flags.append(progressJSON)
+        }
+        return flags
+    }
 }
 
 enum CommandInputKind: Equatable {
@@ -971,6 +1021,28 @@ struct CommandTemplate: Identifiable, Equatable {
         self.defaultModel = defaultModel
         self.defaultExtraArguments = defaultExtraArguments
         self.externalURL = externalURL
+    }
+
+    /// The output kind the shared contract declares for this command, or nil for the rows the
+    /// contract does not cover (`.custom`, and launcher-only entries).
+    var declaredOutputKind: MereRunCapabilityOutputKind? {
+        id.capability?.output.kind
+    }
+
+    /// True when the command materializes a file or directory the app can adopt as the run's
+    /// primary artifact.
+    ///
+    /// The contract's declared kind is read first, so a command the app models as producing
+    /// nothing still resolves its `--output` path when the contract says it writes one. The
+    /// app's own `outputKind` still counts, because a handful of commands write a file the
+    /// contract summarizes as `text` (the benchmarks' `--output` report) or as a `service`
+    /// (`music realtime`, which also records a WAV); see
+    /// `ArtifactReceiptTests.testDeclaredOutputKindsDriftOnlyWhereRecorded`.
+    var producesOutputFile: Bool {
+        if declaredOutputKind == .file || declaredOutputKind == .directory {
+            return true
+        }
+        return outputKind != .none
     }
 
     func defaultDraft() -> CommandDraft {

--- a/apps/macos/MereRunStudio/Jobs/ArtifactResolver.swift
+++ b/apps/macos/MereRunStudio/Jobs/ArtifactResolver.swift
@@ -1,6 +1,42 @@
 import Foundation
 
-/// Finds the files a run produced from what the request asked for and what the CLI printed.
+/// Everything one run produced, and how the app learned about it.
+struct ArtifactResolution: Equatable {
+    /// Which rung of the precedence ladder produced this resolution.
+    enum Source: Equatable {
+        /// The CLI's `--receipt` line named every output and its role.
+        case receipt
+        /// The contract declares a file or directory output and the requested `--output` landed.
+        case declaredOutput
+        /// Nothing structured was available: stdout heuristics and filesystem probing.
+        case probe
+        /// The run produced no file (a text command, a failed run, a conversation turn).
+        case none
+    }
+
+    static let empty = ArtifactResolution(source: .none, artifacts: [])
+
+    let source: Source
+    /// Primary artifact first, then sidecars in the order they were reported or discovered.
+    let artifacts: [Artifact]
+
+    var primary: URL? {
+        artifacts.first { $0.role == .primary }?.url
+    }
+
+    var sidecars: [Artifact] {
+        artifacts.filter { $0.role == .sidecar }
+    }
+}
+
+/// Finds the files a run produced, in this order:
+///
+/// 1. the CLI's `--receipt` line, which names every output, its kind and its sidecar role;
+/// 2. the contract's declared output kind together with the `--output` path the request asked
+///    for, once that path exists;
+/// 3. the stdout path contract and filesystem probing, the fallback for commands that emit no
+///    receipt and for a CLI older than `--receipt`.
+///
 /// Filesystem existence checks go through `MereRunFileProbing` so detection is unit-testable
 /// without touching the real disk.
 struct ArtifactResolver {
@@ -9,22 +45,29 @@ struct ArtifactResolver {
     /// How many trailing stdout lines the last-resort probe considers.
     static let stdoutCandidateLineLimit = 40
 
-    /// The explicit `--output` path a request asked for, when its template produces one.
+    /// The explicit `--output` path a request asked for, when the command declares a file or
+    /// directory output.
     static func expectedOutput(template: CommandTemplate, draft: CommandDraft) -> URL? {
-        guard template.outputKind != .none, !draft.outputPath.isBlank else {
+        guard template.producesOutputFile, !draft.outputPath.isBlank else {
             return nil
         }
         return URL(fileURLWithPath: NSString(string: draft.outputPath).expandingTildeInPath)
     }
 
-    /// The run's main output, if it exists yet.
+    /// The run's main output, if it is known yet. Cheap enough to run on every stdout chunk: it
+    /// reads the receipt and probes single paths, and never enumerates a directory.
     func primaryOutput(expected: URL?, stdout: String) -> URL? {
-        // 1. The explicit `--output` path the request asked for, once it has landed.
+        // 1. The receipt is authoritative: the CLI listed what it wrote.
+        if let receipt = StudioRunReceipt.parse(stdout: stdout), let first = receipt.outputs.first {
+            return first.url
+        }
+
+        // 2. The explicit `--output` path the request asked for, once it has landed.
         if let expected, fileSystem.fileExists(atPath: expected.path) {
             return expected
         }
 
-        // 2. Honor the CLI's stdout contract: media commands print the artifact path as a bare
+        // 3. Honor the CLI's stdout contract: media commands print the artifact path as a bare
         //    line and directory/OCR commands as `input -> output` pairs, most-recent first.
         //    This is the only path that detects `input -> output` outputs at all (a whole pair
         //    line never resolves as a file), and it targets the result line rather than guessing.
@@ -35,7 +78,7 @@ struct ArtifactResolver {
             }
         }
 
-        // 3. Fallback for commands without a clean path contract: the last trailing stdout
+        // 4. Fallback for commands without a clean path contract: the last trailing stdout
         //    line that happens to resolve to an existing file (e.g. a relative path).
         let candidates = stdout
             .components(separatedBy: .newlines)
@@ -63,5 +106,46 @@ struct ArtifactResolver {
             guard fileSystem.fileExists(atPath: expanded) else { return nil }
             return URL(fileURLWithPath: expanded)
         }
+    }
+
+    /// The complete artifact list for a finished run, with each sidecar's role attached.
+    /// A receipt short-circuits every probe: the CLI already listed what it wrote.
+    func resolve(
+        template: CommandTemplate,
+        draft: CommandDraft,
+        expected: URL?,
+        stdout: String
+    ) -> ArtifactResolution {
+        if let receipt = StudioRunReceipt.parse(stdout: stdout), !receipt.outputs.isEmpty {
+            var artifacts = [Artifact(url: receipt.outputs[0].url, role: .primary)]
+            artifacts += receipt.outputs.dropFirst().map {
+                Artifact(url: $0.url, role: .sidecar, sidecarRole: $0.role)
+            }
+            return ArtifactResolution(source: .receipt, artifacts: artifacts)
+        }
+
+        let declared = expected.flatMap { fileSystem.fileExists(atPath: $0.path) ? $0 : nil }
+        let primary = declared ?? primaryOutput(expected: expected, stdout: stdout)
+        let discovered = StudioArtifactDiscovery.urls(
+            templateID: template.id,
+            draft: draft,
+            primaryOutput: primary,
+            reportedOutputs: reportedOutputs(stdout: stdout)
+        )
+        guard primary != nil || !discovered.isEmpty else {
+            return .empty
+        }
+
+        var artifacts = primary.map { [Artifact(url: $0, role: .primary)] } ?? []
+        artifacts += discovered
+            .filter { $0 != primary }
+            .map {
+                Artifact(
+                    url: $0,
+                    role: .sidecar,
+                    sidecarRole: StudioArtifactRole.inferred(for: $0, templateID: template.id, draft: draft)
+                )
+            }
+        return ArtifactResolution(source: declared != nil ? .declaredOutput : .probe, artifacts: artifacts)
     }
 }

--- a/apps/macos/MereRunStudio/Jobs/Job.swift
+++ b/apps/macos/MereRunStudio/Jobs/Job.swift
@@ -298,8 +298,24 @@ struct Artifact: Hashable, Identifiable {
 
     let url: URL
     let role: Role
+    /// What this sidecar is, in the CLI receipt's vocabulary (`detections`, `masks`,
+    /// `daw-bundle`, …). Nil for the primary artifact, and for a sidecar found by probing whose
+    /// purpose could not be inferred. See `StudioArtifactRole`.
+    let sidecarRole: String?
 
     var id: URL { url }
+
+    /// A display label for the sidecar's role ("Structured prompt", "DAW bundle"), or nil when
+    /// the run reported none and the result surface should fall back to the file name.
+    var roleLabel: String? {
+        StudioArtifactRole.label(for: sidecarRole)
+    }
+
+    init(url: URL, role: Role, sidecarRole: String? = nil) {
+        self.url = url
+        self.role = role
+        self.sidecarRole = role == .primary ? nil : sidecarRole
+    }
 }
 
 /// The durable outcome of one job, delivered exactly once through `JobStore.completions`.
@@ -317,6 +333,10 @@ struct JobResult: Identifiable, Equatable {
     let exitCode: Int32
     let outputURL: URL?
     let artifactURLs: [URL]
+    /// What each sidecar in `artifactURLs` is, keyed by its standardized path. Empty for runs
+    /// that produced no sidecars and for CLIs older than `--receipt` whose sidecar roles could
+    /// not be inferred.
+    let artifactRoles: [String: String]
     let outputText: String?
     let completedAt: Date
     /// When this run was a chat/code turn, the conversation it belongs to (so completion routes
@@ -336,6 +356,7 @@ struct JobResult: Identifiable, Equatable {
         exitCode: Int32,
         outputURL: URL?,
         artifactURLs: [URL] = [],
+        artifactRoles: [String: String] = [:],
         outputText: String?,
         completedAt: Date = Date(),
         conversationID: UUID? = nil,
@@ -349,6 +370,7 @@ struct JobResult: Identifiable, Equatable {
         self.exitCode = exitCode
         self.outputURL = outputURL
         self.artifactURLs = artifactURLs
+        self.artifactRoles = artifactRoles
         self.outputText = outputText
         self.completedAt = completedAt
         self.conversationID = conversationID
@@ -455,6 +477,13 @@ final class Job: ObservableObject, Identifiable {
     /// Whether output-file detection applies: catalog commands other than conversation turns.
     /// Conversation replies are prose, and raw commands have no output contract to read.
     var detectsArtifacts: Bool { !request.command.isRaw && !isConversationTurn }
+    /// Whether this run will print the `--receipt` result line naming everything it wrote. Such
+    /// a run needs no filesystem poll: the receipt arrives on stdout and settles the artifacts.
+    var expectsRunReceipt: Bool {
+        detectsArtifacts
+            && request.templateID?.emitsRunReceipt == true
+            && request.configuration.arguments.contains(StudioMachineOutputFlags.receipt)
+    }
     private var isConversationTurn: Bool { request.conversationID != nil }
     private var isRawCommand: Bool { request.command.isRaw }
     /// The template a result is attributed to; raw commands report the catalog's raw-argument one.
@@ -534,6 +563,9 @@ final class Job: ObservableObject, Identifiable {
                 self.progress = progress
                 continue
             }
+            // The receipt is the app's transport for reading the run's outputs, not something a
+            // person asked the CLI to print, so it stays out of the console.
+            if StudioRunReceipt.isReceiptLine(line) { continue }
             log.append(LogLine(stream: stream, text: line))
         }
     }
@@ -560,21 +592,18 @@ final class Job: ObservableObject, Identifiable {
         // Conversation replies are prose, not artifacts — never run output-file detection on them
         // (a path-like substring in a reply must not become a bogus artifact or status). Raw
         // commands have no output contract to read either.
-        let detectedOutput = detectsArtifacts
-            ? resolver.primaryOutput(expected: expectedOutput, stdout: stdoutBuffer)
-            : nil
-        let reportedOutputs = detectsArtifacts ? resolver.reportedOutputs(stdout: stdoutBuffer) : []
-        let artifactURLs: [URL]
-        if case .templated(let template, let draft) = request.command {
-            artifactURLs = StudioArtifactDiscovery.urls(
-                templateID: template.id,
+        let resolution: ArtifactResolution
+        if detectsArtifacts, case .templated(let template, let draft) = request.command {
+            resolution = resolver.resolve(
+                template: template,
                 draft: draft,
-                primaryOutput: detectedOutput,
-                reportedOutputs: reportedOutputs
+                expected: expectedOutput,
+                stdout: stdoutBuffer
             )
         } else {
-            artifactURLs = []
+            resolution = .empty
         }
+        let detectedOutput = resolution.primary
         // Conversation turns finalize from the unbounded, think-stripped accumulator so long
         // replies are not clipped by the 32 KB console buffer; raw commands from their complete
         // stdout/stderr for the same reason; other modes use the console buffers.
@@ -586,12 +615,27 @@ final class Job: ObservableObject, Identifiable {
         } else if isRawCommand {
             outputText = Self.capturedResultText(stdout: fullOutput, stderr: fullErrorOutput, exitCode: exitCode)
         } else {
-            outputText = Self.capturedResultText(stdout: stdoutBuffer, stderr: stderrBuffer, exitCode: exitCode)
+            // The receipt is the app's own transport, not part of the run's output: it must not
+            // land in a library row or in a transcript the CLI printed to stdout.
+            outputText = Self.capturedResultText(
+                stdout: StudioRunReceipt.strippingReceiptLines(from: stdoutBuffer),
+                stderr: stderrBuffer,
+                exitCode: exitCode
+            )
         }
 
+        // A resident session (`video session`) reports its render over its own stdin protocol,
+        // so keep the live primary when nothing was resolved from the run's output.
         let primary = detectedOutput ?? primaryArtifactURL
-        artifacts = (primary.map { [Artifact(url: $0, role: .primary)] } ?? [])
-            + artifactURLs.filter { $0 != primary }.map { Artifact(url: $0, role: .sidecar) }
+        let sidecars = resolution.sidecars.filter { $0.url != primary }
+        artifacts = (primary.map { [Artifact(url: $0, role: .primary)] } ?? []) + sidecars
+        let artifactURLs = artifacts.map(\.url)
+        let artifactRoles = Dictionary(
+            sidecars.compactMap { artifact in
+                artifact.sidecarRole.map { (artifact.url.standardizedFileURL.path, $0) }
+            },
+            uniquingKeysWith: { first, _ in first }
+        )
 
         if exitCode == 0 {
             status = detectedOutput.map { "Completed: \($0.lastPathComponent)" } ?? "Completed"
@@ -611,6 +655,7 @@ final class Job: ObservableObject, Identifiable {
             exitCode: exitCode,
             outputURL: detectedOutput,
             artifactURLs: artifactURLs,
+            artifactRoles: artifactRoles,
             outputText: outputText,
             completedAt: date,
             conversationID: request.conversationID,

--- a/apps/macos/MereRunStudio/Jobs/JobStore.swift
+++ b/apps/macos/MereRunStudio/Jobs/JobStore.swift
@@ -50,6 +50,7 @@ final class JobStore: ObservableObject {
     /// Eviction never crosses lanes, so probe and utility churn cannot drop a finished run.
     static let finishedJobRetentionLimit = 50
     /// How often a running job is re-probed for its `--output` file while the CLI is silent.
+    /// Only commands that print no `--receipt` line are watched this way; see `start`.
     static let defaultOutputWatchInterval: Duration = .milliseconds(350)
 
     private let processRunner: MereRunProcessRunning
@@ -243,7 +244,9 @@ final class JobStore: ObservableObject {
         events.send(.started(job))
         job.note(job.displayCommand, stream: .system)
         events.send(.changed(job))
-        if job.detectsArtifacts {
+        // A run that prints a receipt names its outputs on stdout, so `consume` settles them the
+        // moment the line arrives; only the commands without one need the filesystem poll.
+        if job.detectsArtifacts, !job.expectsRunReceipt {
             startOutputWatch(for: job)
         }
 

--- a/apps/macos/MereRunStudio/MereRunController.swift
+++ b/apps/macos/MereRunStudio/MereRunController.swift
@@ -1090,13 +1090,25 @@ final class MereRunController: ObservableObject {
         refreshResolvedCLI()
         let launch = cliResolve(cliPath)
         let args = commandArguments(template: template, draft: draft)
+        // The structured-output flags are the app's own transport: the launched process gets
+        // them, the preview and the library row keep the command a person would type.
+        let launchArgs = args + StudioMachineOutputFlags.arguments(
+            template: template,
+            draft: draft,
+            appendingTo: args
+        )
         let request = JobRequest(
             lane: .inference,
             template: template,
             draft: draft,
             requestID: requestID,
             conversationID: conversationID,
-            configuration: processConfiguration(launch: launch, args: args, template: template, draft: draft),
+            configuration: processConfiguration(
+                launch: launch,
+                args: launchArgs,
+                template: template,
+                draft: draft
+            ),
             displayCommand: launch.displayCommand(for: args)
         )
         let id = jobs.submit(request)

--- a/apps/macos/MereRunStudio/StudioAnalyzeCanvas.swift
+++ b/apps/macos/MereRunStudio/StudioAnalyzeCanvas.swift
@@ -418,11 +418,19 @@ extension StudioAnalyzeInputKind {
 /// Where a run's result document lives.
 enum StudioAnalyzeDocumentSource {
     private static let documentExtensions = ["json", "txt", "vtt", "srt", "jsonl"]
+    /// The receipt roles that name a structured result, most specific first.
+    private static let documentRoles = [StudioArtifactRole.detections, StudioArtifactRole.tracking]
 
     /// The artifact holding the run's structured result: the `--json-output` sidecar for the
-    /// vision tasks, the transcript the speech tasks write.
+    /// vision tasks, the transcript the speech tasks write. A run whose receipt named its
+    /// sidecars says which file that is; extension order is the fallback for the rest.
     static func url(for item: StudioLibraryItem) -> URL? {
         let artifacts = item.allArtifactURLs
+        for role in documentRoles {
+            if let match = artifacts.first(where: { item.artifactRole(for: $0) == role }) {
+                return match
+            }
+        }
         for pathExtension in documentExtensions {
             if let match = artifacts.first(where: { $0.pathExtension.lowercased() == pathExtension }) {
                 return match

--- a/apps/macos/MereRunStudio/StudioFeedCanvas.swift
+++ b/apps/macos/MereRunStudio/StudioFeedCanvas.swift
@@ -364,12 +364,20 @@ struct StudioGenerationCard: View {
         files.filter { [.image, .video, .audio, .model3D].contains(StudioOutputFileKind.classify($0)) }
     }
 
+    /// Prose the card previews inline. A file the run reported a role for is never prose: its
+    /// structured-prompt or timings JSON belongs in the sidecar row under its own name.
     private var textFiles: [URL] {
-        files.filter { StudioOutputFileKind.classify($0) == .text }
+        files.filter { StudioOutputFileKind.classify($0) == .text && item.artifactRole(for: $0) == nil }
     }
 
+    /// The run's non-media companions: everything the CLI's receipt named with a role, plus
+    /// whatever the extension leaves unclassified for a run that reported none.
     private var sidecars: [URL] {
-        files.filter { StudioOutputFileKind.classify($0) == .other }
+        files.filter { url in
+            let kind = StudioOutputFileKind.classify(url)
+            guard ![.image, .video, .audio, .model3D].contains(kind) else { return false }
+            return item.artifactRole(for: url) != nil || kind == .other
+        }
     }
 
     private var primaryURL: URL? {
@@ -429,7 +437,9 @@ struct StudioGenerationCard: View {
                         HStack(spacing: 4) {
                             Image(systemName: "doc")
                                 .font(.system(size: 9, weight: .semibold))
-                            Text(url.lastPathComponent)
+                            // The receipt says what the file is ("Structured prompt"); only a
+                            // run that reported no role falls back to its name.
+                            Text(item.artifactRoleLabel(for: url) ?? url.lastPathComponent)
                                 .font(.system(size: 10.5, weight: .medium))
                                 .lineLimit(1)
                         }

--- a/apps/macos/MereRunStudio/StudioLibraryStore.swift
+++ b/apps/macos/MereRunStudio/StudioLibraryStore.swift
@@ -103,7 +103,8 @@ final class StudioLibraryStore: ObservableObject {
         outputURL: URL?,
         outputText: String?,
         commandPreview: String,
-        artifactURLs: [URL] = []
+        artifactURLs: [URL] = [],
+        artifactRoles: [String: String] = [:]
     ) {
         guard let index = items.firstIndex(where: { $0.id == id }) else { return }
         var item = items[index]
@@ -117,6 +118,7 @@ final class StudioLibraryStore: ObservableObject {
         if !artifactURLs.isEmpty {
             item.artifactURLs = artifactURLs
         }
+        item.artifactRoles = artifactRoles.isEmpty ? nil : artifactRoles
         item.outputText = outputText
 
         if shouldKeep(item) {

--- a/apps/macos/MereRunStudio/StudioRootView.swift
+++ b/apps/macos/MereRunStudio/StudioRootView.swift
@@ -1097,7 +1097,8 @@ struct StudioRootView: View {
                     outputURL: result.outputURL,
                     outputText: result.outputText,
                     commandPreview: result.commandPreview.maskingAPIKeyValue(),
-                    artifactURLs: result.artifactURLs
+                    artifactURLs: result.artifactURLs,
+                    artifactRoles: result.artifactRoles
                 )
                 if result.exitCode == 0, library.items.first(where: { $0.id == requestID })?.mode == mode {
                     newResultID = requestID

--- a/apps/macos/MereRunStudio/StudioTypes.swift
+++ b/apps/macos/MereRunStudio/StudioTypes.swift
@@ -1025,6 +1025,11 @@ struct StudioLibraryItem: Codable, Identifiable, Equatable {
     /// Every materialized artifact associated with the run. `outputURL` remains the primary item
     /// for backward compatibility and Quick Look.
     var artifactURLs: [URL]? = nil
+    /// What each sidecar in `artifactURLs` is, keyed by its standardized path: the CLI receipt's
+    /// role (`detections`, `masks`, `recipe`, …) so a result surface labels it rather than
+    /// guessing from the file extension. Absent for rows written before receipts and for files
+    /// whose role could not be determined. See `StudioArtifactRole`.
+    var artifactRoles: [String: String]? = nil
     // Conversation channel — non-nil only for .chat / .code threads. Optional + additive so
     // legacy library.json rows (which lack these keys) decode unchanged with nil.
     var messages: [StudioMessage]? = nil
@@ -1065,6 +1070,18 @@ struct StudioLibraryItem: Codable, Identifiable, Equatable {
 
     var isConversation: Bool {
         messages != nil
+    }
+
+    /// The receipt role recorded for one artifact, or nil for the primary output and for rows
+    /// whose run predates receipts.
+    func artifactRole(for url: URL) -> String? {
+        artifactRoles?[url.standardizedFileURL.path]
+    }
+
+    /// A display label for one artifact's role ("Detections", "DAW bundle"), or nil when the run
+    /// reported none.
+    func artifactRoleLabel(for url: URL) -> String? {
+        StudioArtifactRole.label(for: artifactRole(for: url))
     }
 }
 
@@ -1383,20 +1400,68 @@ enum StudioProgressParser {
         )
     }
 
-    /// One NDJSON progress event; only the denoising stage carries the step bar (load
-    /// stages stay indeterminate and are left to the running overlay's status line).
+    /// Human labels for the stage names the `--progress-json` lanes emit: the image and video
+    /// generation stages (`GenerationStage`), the speech stages (`TTSStage`), and the music
+    /// milestones. The label names the stage the CLI reported, so the feed card and the Activity
+    /// popover read "Denoising 15/24". A stage this build does not know is humanized from its own
+    /// name, so a newer CLI still renders a labelled bar.
+    private static let jsonStageLabels: [String: String] = [
+        "loadingModel": "Loading model",
+        "loadingEncoder": "Loading encoder",
+        "encodingText": "Encoding prompt",
+        "encodingReferenceImages": "Encoding references",
+        "loadingVAE": "Loading VAE",
+        "loadingTransformer": "Loading transformer",
+        "loadingLoRA": "Loading adapter",
+        "denoising": "Denoising",
+        "decoding": "Decoding",
+        "saving": "Saving output",
+        "preprocessingReference": "Preparing reference",
+        "encodingReference": "Encoding reference",
+        "buildingPrompt": "Building prompt",
+        "tokenizing": "Tokenizing",
+        "generating": "Generating",
+        "semantic": "Semantic frames",
+        "window": "Window",
+    ]
+
+    /// One NDJSON progress event, in the convention every `--progress-json` lane follows:
+    /// `step` is 0-based while a stage runs, each determinate stage ends with exactly one event
+    /// whose `step == total_steps`, and `total_steps == 0` marks an indeterminate stage (token
+    /// streaming with no known length). Indeterminate stages resolve to a labelled value with no
+    /// fraction, which every progress surface renders as a spinner rather than a 0% bar.
     private static func parseGenerationJSON(_ line: String) -> StudioRunProgress? {
         guard let data = line.data(using: .utf8),
               let progress = try? JSONDecoder().decode(GenerationProgressEvent.self, from: data),
               progress.event == "progress",
-              progress.stage == "denoising",
-              progress.totalSteps > 0 else { return nil }
+              !progress.stage.isBlank else { return nil }
+        let label = jsonStageLabels[progress.stage] ?? humanizedStage(progress.stage)
+        guard progress.totalSteps > 0 else {
+            // Indeterminate: report how far it has come without claiming a percentage.
+            let detail = progress.step > 0 ? "Step \(progress.step)" : nil
+            return StudioRunProgress(label: label, fractionCompleted: nil, detail: detail)
+        }
         let current = min(progress.step + 1, progress.totalSteps) // the CLI emits a 0-based step index
         return StudioRunProgress(
-            label: progress.stage.capitalized,
+            label: label,
             fractionCompleted: Double(current) / Double(progress.totalSteps),
             detail: "Step \(current) of \(progress.totalSteps)"
         )
+    }
+
+    /// "encodingSomething" / "encoding-something" → "Encoding something".
+    private static func humanizedStage(_ stage: String) -> String {
+        var words = ""
+        for character in stage.replacingOccurrences(of: "-", with: " ")
+            .replacingOccurrences(of: "_", with: " ") {
+            if character.isUppercase, !words.isEmpty, words.last != " " {
+                words.append(" ")
+                words.append(contentsOf: character.lowercased())
+            } else {
+                words.append(character)
+            }
+        }
+        return words.prefix(1).uppercased() + words.dropFirst()
     }
 
     /// Specialist workflows use concise human progress lines rather than the image-generation
@@ -1541,6 +1606,160 @@ enum StudioResultParser {
     /// True when a line is an absolute or tilde-rooted filesystem path rather than prose.
     static func isPathLike(_ candidate: String) -> Bool {
         candidate.hasPrefix("/") || candidate.hasPrefix("~/")
+    }
+}
+
+/// The CLI's structured result line, printed as the final stdout line when a run was launched
+/// with `--receipt`:
+///
+///     {"event":"result","exit":0,"outputs":[{"kind":"image","path":"/abs/out.png"}]}
+///
+/// The first output is the run's primary artifact; the rest are sidecars carrying a `role`
+/// (`detections`, `masks`, `recipe`, …). Only a successful run prints one, so `exit` is always
+/// `0`. Human output above the line is unchanged, which is why parsing scans the trailing lines
+/// rather than assuming the receipt is last: a resident process or a shell wrapper may print
+/// after it.
+struct StudioRunReceipt: Decodable, Equatable {
+    struct Output: Decodable, Equatable {
+        let path: String
+        /// The CLI's output kind (`image`, `video`, `audio`, `text`, `json`, `directory`). Kept
+        /// as a string so a kind the app does not know yet still decodes.
+        let kind: String
+        /// The sidecar's purpose; nil for the primary artifact.
+        let role: String?
+
+        var url: URL {
+            URL(fileURLWithPath: NSString(string: path).expandingTildeInPath)
+        }
+    }
+
+    static let eventName = "result"
+    /// How many trailing stdout lines are searched for the receipt.
+    static let trailingLineLimit = 40
+
+    let event: String
+    let exit: Int32
+    let outputs: [Output]
+
+    /// The last receipt in `stdout`, or nil when the run predates `--receipt` or did not emit one.
+    /// Lines that merely look like JSON are skipped, so a trailing progress or protocol line
+    /// after the receipt does not hide it.
+    static func parse(stdout: String) -> StudioRunReceipt? {
+        let candidates = stdout
+            .components(separatedBy: .newlines)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { $0.hasPrefix("{") && $0.contains("\"\(eventName)\"") }
+            .suffix(trailingLineLimit)
+        for line in candidates.reversed() {
+            guard let data = line.data(using: .utf8),
+                  let receipt = try? JSONDecoder().decode(StudioRunReceipt.self, from: data),
+                  receipt.event == eventName else {
+                continue
+            }
+            return receipt
+        }
+        return nil
+    }
+
+    /// `stdout` without its receipt lines, so a receipt never reaches the console log, a library
+    /// row's captured text, or a transcript the CLI printed to stdout.
+    static func strippingReceiptLines(from stdout: String) -> String {
+        guard stdout.contains("\"\(eventName)\"") else { return stdout }
+        return stdout
+            .components(separatedBy: "\n")
+            .filter { !isReceiptLine($0) }
+            .joined(separator: "\n")
+    }
+
+    static func isReceiptLine(_ line: String) -> Bool {
+        let trimmed = line.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard trimmed.hasPrefix("{"), trimmed.contains("\"\(eventName)\""),
+              let data = trimmed.data(using: .utf8),
+              let receipt = try? JSONDecoder().decode(StudioRunReceipt.self, from: data) else {
+            return false
+        }
+        return receipt.event == eventName
+    }
+}
+
+/// The receipt vocabulary for what a sidecar file is, so the output grid and the Analyze result
+/// column label sidecars instead of guessing from a file extension. Unknown roles (a newer CLI
+/// than this build) keep their raw string and are humanized for display.
+enum StudioArtifactRole {
+    static let structuredPrompt = "structured-prompt"
+    static let timings = "timings"
+    static let detections = "detections"
+    static let tracking = "tracking"
+    static let masks = "masks"
+    static let candidate = "candidate"
+    static let stem = "stem"
+    static let lyrics = "lyrics"
+    static let recipe = "recipe"
+    static let composition = "composition"
+    static let profile = "profile"
+    static let dawBundle = "daw-bundle"
+
+    /// Every role the CLI emits today, in the order the receipt lists them per family.
+    static let known = [
+        structuredPrompt, timings, detections, tracking, masks,
+        candidate, stem, lyrics, recipe, composition, profile, dawBundle,
+    ]
+
+    private static let labels: [String: String] = [
+        structuredPrompt: "Structured prompt",
+        timings: "Timings",
+        detections: "Detections",
+        tracking: "Tracking",
+        masks: "Masks",
+        candidate: "Candidate",
+        stem: "Stem",
+        lyrics: "Lyrics",
+        recipe: "Recipe",
+        composition: "Composition",
+        profile: "Profile",
+        dawBundle: "DAW bundle",
+    ]
+
+    /// A display label for a role: the known title, or the raw role humanized ("foo-bar" → "Foo bar").
+    static func label(for role: String?) -> String? {
+        guard let role, !role.isBlank else { return nil }
+        if let label = labels[role] { return label }
+        let words = role.replacingOccurrences(of: "-", with: " ")
+            .replacingOccurrences(of: "_", with: " ")
+        return words.prefix(1).uppercased() + words.dropFirst()
+    }
+
+    /// The role of a file discovered by probing rather than reported by a receipt. It reads the
+    /// same draft fields `StudioArtifactDiscovery` used to find the file, so older CLIs label
+    /// their sidecars the same way a receipt would.
+    static func inferred(for url: URL, templateID: CommandTemplateID, draft: CommandDraft) -> String? {
+        let path = url.standardizedFileURL.path
+        func matches(_ candidate: String) -> Bool {
+            guard !candidate.isBlank else { return false }
+            let expanded = URL(fileURLWithPath: NSString(string: candidate).expandingTildeInPath)
+            return expanded.standardizedFileURL.path == path
+        }
+        func isInside(_ candidate: String) -> Bool {
+            guard !candidate.isBlank else { return false }
+            let expanded = URL(fileURLWithPath: NSString(string: candidate).expandingTildeInPath)
+                .standardizedFileURL.path
+            return path == expanded || path.hasPrefix(expanded + "/")
+        }
+
+        if matches(draft.visionJSONOutputPath) || matches(draft.visionJSONLOutput) {
+            return templateID == .visionTrack || templateID == .visionTrackLive ? tracking : detections
+        }
+        if isInside(draft.visionMaskOutputDirectory) { return masks }
+        if matches(draft.musicRecipeOutput) { return recipe }
+        if matches(draft.musicLRCOutput) { return lyrics }
+        if isInside(draft.musicDAWBundle) { return dawBundle }
+
+        let name = url.lastPathComponent
+        if name.contains(".candidate-") { return candidate }
+        if name.contains(".stem-") { return stem }
+        if name.hasSuffix(".recipe.json") { return recipe }
+        if name.hasSuffix(".lrc") { return lyrics }
+        return nil
     }
 }
 

--- a/apps/macos/MereRunStudioTests/ArtifactReceiptTests.swift
+++ b/apps/macos/MereRunStudioTests/ArtifactReceiptTests.swift
@@ -1,0 +1,583 @@
+@testable import MereRunApp
+import Foundation
+import MereRunContract
+import XCTest
+
+/// The receipt path: the flags the app adds, the parser that reads the CLI's result line, the
+/// precedence `ArtifactResolver` applies, and the roles that reach `Job.artifacts`.
+@MainActor
+final class ArtifactReceiptTests: XCTestCase {
+    // MARK: Parsing
+
+    func testValidReceiptDecodesPrimaryAndSidecarRoles() throws {
+        let stdout = """
+        Loading model…
+        /out/render.png
+        {"event":"result","exit":0,"outputs":[\
+        {"kind":"image","path":"/out/render.png"},\
+        {"kind":"json","path":"/out/render.prompt.json","role":"structured-prompt"}]}
+        """
+
+        let receipt = try XCTUnwrap(StudioRunReceipt.parse(stdout: stdout))
+        XCTAssertEqual(receipt.event, "result")
+        XCTAssertEqual(receipt.exit, 0)
+        XCTAssertEqual(receipt.outputs.map(\.path), ["/out/render.png", "/out/render.prompt.json"])
+        XCTAssertEqual(receipt.outputs.map(\.kind), ["image", "json"])
+        XCTAssertEqual(receipt.outputs.map(\.role), [nil, "structured-prompt"])
+    }
+
+    func testMalformedAndAbsentReceiptsAreIgnored() {
+        XCTAssertNil(StudioRunReceipt.parse(stdout: ""))
+        XCTAssertNil(StudioRunReceipt.parse(stdout: "/out/render.png\nDone.\n"))
+        // Truncated JSON, a wrong event, and a shape that is not a receipt at all.
+        XCTAssertNil(StudioRunReceipt.parse(stdout: #"{"event":"result","exit":0,"outputs":[{"kind""#))
+        XCTAssertNil(StudioRunReceipt.parse(stdout: #"{"event":"progress","stage":"denoising","step":1,"total_steps":4}"#))
+        XCTAssertNil(StudioRunReceipt.parse(stdout: #"{"status":"result","output":"/out/render.mp4"}"#))
+    }
+
+    func testReceiptIsFoundAmongOtherJSONLinesAndAfterTrailingOutput() throws {
+        let stdout = """
+        {"event":"progress","stage":"denoising","step":3,"total_steps":4}
+        {"status":"result","output":"/out/other.mp4"}
+        {"event":"result","exit":0,"outputs":[{"kind":"audio","path":"/out/song.wav"}]}
+        Wrote /out/song.wav
+        {"note":"trailing"}
+        """
+
+        let receipt = try XCTUnwrap(StudioRunReceipt.parse(stdout: stdout))
+        XCTAssertEqual(receipt.outputs.map(\.path), ["/out/song.wav"])
+    }
+
+    func testTheLastReceiptWinsWhenARunPrintsMoreThanOne() throws {
+        let stdout = """
+        {"event":"result","exit":0,"outputs":[{"kind":"image","path":"/out/first.png"}]}
+        {"event":"result","exit":0,"outputs":[{"kind":"image","path":"/out/second.png"}]}
+        """
+        XCTAssertEqual(try XCTUnwrap(StudioRunReceipt.parse(stdout: stdout)).outputs.first?.path, "/out/second.png")
+    }
+
+    func testStrippingReceiptLinesLeavesTheRunsOwnOutput() {
+        let stdout = """
+        the quick brown fox
+        {"event":"result","exit":0,"outputs":[{"kind":"text","path":"/out/transcript.txt"}]}
+        """
+        XCTAssertEqual(StudioRunReceipt.strippingReceiptLines(from: stdout), "the quick brown fox")
+        XCTAssertEqual(StudioRunReceipt.strippingReceiptLines(from: "no receipt here"), "no receipt here")
+    }
+
+    // MARK: Precedence
+
+    func testReceiptOutranksTheDeclaredOutputPathAndStdoutHeuristics() throws {
+        let probe = StubFileProbe()
+        probe.existingPaths = ["/out/expected.png", "/out/printed.png"]
+        let resolver = ArtifactResolver(fileSystem: probe)
+        let template = try XCTUnwrap(CommandCatalog.template(id: .imageGenerate))
+        var draft = template.defaultDraft()
+        draft.prompt = "a cat"
+        draft.outputPath = "/out/expected.png"
+        let stdout = """
+        /out/printed.png
+        {"event":"result","exit":0,"outputs":[\
+        {"kind":"image","path":"/out/receipt.png"},\
+        {"kind":"json","path":"/out/receipt.prompt.json","role":"structured-prompt"}]}
+        """
+
+        let resolution = resolver.resolve(
+            template: template,
+            draft: draft,
+            expected: ArtifactResolver.expectedOutput(template: template, draft: draft),
+            stdout: stdout
+        )
+
+        XCTAssertEqual(resolution.source, .receipt)
+        XCTAssertEqual(resolution.primary?.path, "/out/receipt.png")
+        XCTAssertEqual(resolution.sidecars.map(\.url.path), ["/out/receipt.prompt.json"])
+        XCTAssertEqual(resolution.sidecars.map(\.sidecarRole), ["structured-prompt"])
+        XCTAssertEqual(resolution.sidecars.first?.roleLabel, "Structured prompt")
+    }
+
+    func testTheDeclaredOutputPathOutranksStdoutHeuristics() throws {
+        let probe = StubFileProbe()
+        probe.existingPaths = ["/out/expected.png", "/out/printed.png"]
+        let resolver = ArtifactResolver(fileSystem: probe)
+        let template = try XCTUnwrap(CommandCatalog.template(id: .imageGenerate))
+        var draft = template.defaultDraft()
+        draft.prompt = "a cat"
+        draft.outputPath = "/out/expected.png"
+
+        let resolution = resolver.resolve(
+            template: template,
+            draft: draft,
+            expected: ArtifactResolver.expectedOutput(template: template, draft: draft),
+            stdout: "/out/printed.png\n"
+        )
+
+        XCTAssertEqual(resolution.source, .declaredOutput)
+        XCTAssertEqual(resolution.primary?.path, "/out/expected.png")
+    }
+
+    func testProbingIsTheFallbackWhenNoReceiptAndNoDeclaredOutputLanded() throws {
+        let probe = StubFileProbe()
+        probe.existingPaths = ["/out/printed.png"]
+        let resolver = ArtifactResolver(fileSystem: probe)
+        let template = try XCTUnwrap(CommandCatalog.template(id: .imageGenerate))
+        var draft = template.defaultDraft()
+        draft.prompt = "a cat"
+        draft.outputPath = "/out/never-written.png"
+
+        let resolution = resolver.resolve(
+            template: template,
+            draft: draft,
+            expected: ArtifactResolver.expectedOutput(template: template, draft: draft),
+            stdout: "/out/printed.png\n"
+        )
+
+        XCTAssertEqual(resolution.source, .probe)
+        XCTAssertEqual(resolution.primary?.path, "/out/printed.png")
+    }
+
+    func testAFailedRunWithNothingOnDiskResolvesToNoArtifacts() throws {
+        let resolver = ArtifactResolver(fileSystem: StubFileProbe())
+        let template = try XCTUnwrap(CommandCatalog.template(id: .imageGenerate))
+        var draft = template.defaultDraft()
+        draft.outputPath = "/out/never-written.png"
+
+        let resolution = resolver.resolve(
+            template: template,
+            draft: draft,
+            expected: ArtifactResolver.expectedOutput(template: template, draft: draft),
+            stdout: "error: model not installed\n"
+        )
+        XCTAssertEqual(resolution, .empty)
+    }
+
+    func testLivePrimaryDetectionPrefersTheReceiptOverTheExpectedPath() {
+        let probe = StubFileProbe()
+        probe.existingPaths = ["/out/expected.png"]
+        let resolver = ArtifactResolver(fileSystem: probe)
+        let expected = URL(fileURLWithPath: "/out/expected.png")
+
+        XCTAssertEqual(resolver.primaryOutput(expected: expected, stdout: "")?.path, "/out/expected.png")
+        XCTAssertEqual(
+            resolver.primaryOutput(
+                expected: expected,
+                stdout: #"{"event":"result","exit":0,"outputs":[{"kind":"image","path":"/out/receipt.png"}]}"#
+            )?.path,
+            "/out/receipt.png"
+        )
+    }
+
+    func testProbeDiscoveredSidecarsStillCarryTheirRole() throws {
+        let temp = try makeTemporaryDirectory()
+        let overlay = temp.appendingPathComponent("frame.png", isDirectory: false)
+        let detections = temp.appendingPathComponent("frame.json", isDirectory: false)
+        try Data("png".utf8).write(to: overlay)
+        try Data("{}".utf8).write(to: detections)
+
+        let probe = StubFileProbe()
+        probe.existingPaths = [overlay.path]
+        let resolver = ArtifactResolver(fileSystem: probe)
+        let template = try XCTUnwrap(CommandCatalog.template(id: .visionGround))
+        var draft = template.defaultDraft()
+        draft.inputPath = "/in/frame.png"
+        draft.prompt = "a cat"
+        draft.outputPath = overlay.path
+        draft.visionJSONOutputPath = detections.path
+
+        let resolution = resolver.resolve(
+            template: template,
+            draft: draft,
+            expected: ArtifactResolver.expectedOutput(template: template, draft: draft),
+            stdout: ""
+        )
+
+        XCTAssertEqual(resolution.source, .declaredOutput)
+        XCTAssertEqual(resolution.primary?.path, overlay.path)
+        XCTAssertEqual(resolution.sidecars.map(\.sidecarRole), ["detections"])
+    }
+
+    // MARK: Flags
+
+    func testFlagsAreAddedOnlyForCapabilitiesThatDeclareThem() throws {
+        for template in CommandCatalog.templates {
+            var draft = template.defaultDraft()
+            draft.preflight = false
+            let arguments = template.arguments(from: draft)
+            let flags = StudioMachineOutputFlags.arguments(
+                template: template,
+                draft: draft,
+                appendingTo: arguments
+            )
+            let capabilityID = template.id.capabilityID
+            XCTAssertEqual(
+                flags.contains(StudioMachineOutputFlags.receipt),
+                capabilityID.map(MereRunCapabilityCatalog.receiptCapabilityIDs.contains) ?? false,
+                "\(template.id) receipt flag"
+            )
+            XCTAssertEqual(
+                flags.contains(StudioMachineOutputFlags.progressJSON),
+                capabilityID.map(MereRunCapabilityCatalog.progressJSONCapabilityIDs.contains) ?? false,
+                "\(template.id) progress flag"
+            )
+            // Whatever the app adds, the contract must already declare it for that capability.
+            if let capability = template.id.capability {
+                let declared = Set(capability.options.map(\.flag))
+                for flag in flags {
+                    XCTAssertTrue(declared.contains(flag), "\(template.id) emits undeclared \(flag)")
+                }
+            }
+        }
+    }
+
+    func testNoMachineOutputFlagIsEverAddedToAPreflightRun() throws {
+        for template in CommandCatalog.templates where template.id.emitsRunReceipt {
+            var draft = template.defaultDraft()
+            draft.preflight = true
+            let arguments = template.arguments(from: draft)
+            XCTAssertEqual(
+                StudioMachineOutputFlags.arguments(template: template, draft: draft, appendingTo: arguments),
+                [],
+                "\(template.id) must not combine --receipt with --preflight"
+            )
+            // Also guarded when a surface spells preflight with a different draft field.
+            var other = template.defaultDraft()
+            other.preflight = false
+            XCTAssertEqual(
+                StudioMachineOutputFlags.arguments(
+                    template: template,
+                    draft: other,
+                    appendingTo: template.arguments(from: other) + ["--preflight"]
+                ),
+                []
+            )
+        }
+    }
+
+    func testFlagsAreNotDuplicatedWhenTheDraftAlreadyPassesThem() throws {
+        let template = try XCTUnwrap(CommandCatalog.template(id: .imageGenerate))
+        var draft = template.defaultDraft()
+        draft.prompt = "a cat"
+        draft.outputPath = "/out/render.png"
+        draft.progressJSON = true
+        let arguments = template.arguments(from: draft)
+
+        XCTAssertTrue(arguments.contains(StudioMachineOutputFlags.progressJSON))
+        XCTAssertEqual(
+            StudioMachineOutputFlags.arguments(template: template, draft: draft, appendingTo: arguments),
+            [StudioMachineOutputFlags.receipt]
+        )
+    }
+
+    func testSubmittedRunCarriesTheFlagsWhileThePreviewStaysTheTypedCommand() throws {
+        let runner = RecordingProcessRunner()
+        let controller = MereRunController(processRunner: runner, resolvesCLIOnInit: false)
+        controller.cliPath = "/usr/bin/true"
+        let template = try XCTUnwrap(CommandCatalog.template(id: .imageGenerate))
+        var draft = template.defaultDraft()
+        draft.prompt = "a cat"
+        draft.outputPath = try makeTemporaryDirectory().appendingPathComponent("render.png").path
+
+        XCTAssertTrue(
+            controller.run(
+                studio: StudioRunRequest(
+                    mode: .createImage,
+                    templateID: .imageGenerate,
+                    template: template,
+                    draft: draft
+                )
+            )
+        )
+
+        let launched = runner.starts[0].configuration.arguments
+        XCTAssertEqual(Array(launched.suffix(2)), ["--receipt", "--progress-json"])
+        let preview = controller.commandPreview(template: template, draft: draft, masksSecrets: true)
+        XCTAssertFalse(preview.contains("--receipt"))
+        XCTAssertFalse(preview.contains("--progress-json"))
+        XCTAssertFalse(controller.commandArguments(template: template, draft: draft).contains("--receipt"))
+    }
+
+    // MARK: Job lifecycle
+
+    func testReceiptSettlesArtifactsWithRolesAndSkipsTheOutputWatch() async throws {
+        let runner = RecordingProcessRunner()
+        let store = JobStore(processRunner: runner, fileSystem: StubFileProbe())
+        let temp = try makeTemporaryDirectory()
+        let render = temp.appendingPathComponent("render.png", isDirectory: false)
+        let structuredPrompt = temp.appendingPathComponent("render.prompt.json", isDirectory: false)
+        let id = store.submit(try makeImageRequest(output: render))
+        let job = try XCTUnwrap(store.job(id))
+
+        XCTAssertTrue(job.expectsRunReceipt)
+        XCTAssertNil(job.outputWatchTask, "a receipt run needs no filesystem poll")
+
+        runner.starts[0].stdout("\(render.path)\n")
+        runner.starts[0].stdout(
+            #"{"event":"result","exit":0,"outputs":[{"kind":"image","path":"\#(render.path)"},"#
+                + #"{"kind":"json","path":"\#(structuredPrompt.path)","role":"structured-prompt"}]}"# + "\n"
+        )
+        await settle()
+
+        XCTAssertEqual(job.primaryArtifactURL?.path, render.path)
+        XCTAssertFalse(
+            job.log.lines.contains { $0.text.contains("\"event\":\"result\"") },
+            "the receipt is transport, not console output"
+        )
+
+        runner.starts[0].termination(0)
+        await settle()
+
+        XCTAssertEqual(job.artifacts.map(\.url.path), [render.path, structuredPrompt.path])
+        XCTAssertEqual(job.artifacts.map(\.role), [.primary, .sidecar])
+        XCTAssertEqual(job.artifacts.map(\.sidecarRole), [nil, "structured-prompt"])
+        let result = try XCTUnwrap(job.result)
+        XCTAssertEqual(result.outputURL?.path, render.path)
+        XCTAssertEqual(result.artifactRoles, [structuredPrompt.path: "structured-prompt"])
+        XCTAssertEqual(result.outputText, render.path, "the receipt never reaches the library row")
+    }
+
+    func testCommandsWithoutAReceiptKeepTheOutputWatch() async throws {
+        let runner = RecordingProcessRunner()
+        let store = JobStore(processRunner: runner, fileSystem: StubFileProbe())
+        let template = try XCTUnwrap(CommandCatalog.template(id: .visionCaption))
+        var draft = template.defaultDraft()
+        draft.inputPath = "/in/frame.png"
+        let id = store.submit(makeRequest(template: template, draft: draft))
+        let job = try XCTUnwrap(store.job(id))
+
+        XCTAssertFalse(job.expectsRunReceipt)
+        XCTAssertNotNil(job.outputWatchTask)
+
+        runner.starts[0].termination(0)
+        await settle()
+    }
+
+    func testLibraryRowKeepsSidecarRolesAndStaysDecodableWithoutThem() throws {
+        let roles = ["/out/render.prompt.json": "structured-prompt"]
+        var item = makeLibraryItem(
+            mode: .createImage,
+            outputURL: URL(fileURLWithPath: "/out/render.png"),
+            artifactURLs: [URL(fileURLWithPath: "/out/render.prompt.json")],
+            roles: roles
+        )
+        XCTAssertEqual(item.artifactRoleLabel(for: URL(fileURLWithPath: "/out/render.prompt.json")), "Structured prompt")
+        XCTAssertNil(item.artifactRoleLabel(for: URL(fileURLWithPath: "/out/render.png")))
+
+        let encoded = try JSONEncoder().encode(item)
+        let decoded = try JSONDecoder().decode(StudioLibraryItem.self, from: encoded)
+        XCTAssertEqual(decoded.artifactRoles, roles)
+
+        // A row written before receipts has no `artifactRoles` key at all.
+        item.artifactRoles = nil
+        var object = try XCTUnwrap(
+            try JSONSerialization.jsonObject(with: JSONEncoder().encode(item)) as? [String: Any]
+        )
+        object.removeValue(forKey: "artifactRoles")
+        let legacy = try JSONDecoder().decode(
+            StudioLibraryItem.self,
+            from: JSONSerialization.data(withJSONObject: object)
+        )
+        XCTAssertNil(legacy.artifactRoles)
+    }
+
+    /// The Analyze result column reads the sidecar the receipt named rather than the first
+    /// artifact whose extension happens to match.
+    func testAnalyzeReadsTheRoleNamedResultDocumentBeforeGuessingByExtension() {
+        let overlay = URL(fileURLWithPath: "/out/frame.png")
+        let timings = URL(fileURLWithPath: "/out/frame.timings.json")
+        let detections = URL(fileURLWithPath: "/out/frame.detections.json")
+        var item = makeLibraryItem(
+            mode: .findObjects,
+            outputURL: overlay,
+            artifactURLs: [timings, detections],
+            roles: [timings.path: "timings", detections.path: "detections"]
+        )
+        XCTAssertEqual(StudioAnalyzeDocumentSource.url(for: item), detections)
+
+        // A row from before receipts still resolves by extension order.
+        item.artifactRoles = nil
+        XCTAssertEqual(StudioAnalyzeDocumentSource.url(for: item), timings)
+    }
+
+    func testEveryReceiptRoleTheCLIEmitsHasALabel() {
+        for role in StudioArtifactRole.known {
+            XCTAssertNotNil(StudioArtifactRole.label(for: role), role)
+        }
+        // A role from a newer CLI is humanized rather than dropped.
+        XCTAssertEqual(StudioArtifactRole.label(for: "depth-map"), "Depth map")
+        XCTAssertNil(StudioArtifactRole.label(for: nil))
+    }
+
+    /// `ArtifactResolver.expectedOutput` reads the contract's declared output kind first and
+    /// falls back to the app's. These are the commands where the two disagree: each writes a
+    /// file the contract summarizes as `text` (a benchmark report) or as a `service`
+    /// (`music realtime`, which also records a WAV), or writes one the app models as producing
+    /// nothing. New drift means either the contract or `CommandCatalog` is wrong.
+    func testDeclaredOutputKindsDriftOnlyWhereRecorded() throws {
+        let recorded: Set<CommandTemplateID> = [
+            .imageRunPlan, .speechDiarize, .adapterPull, .musicRealtime,
+            .modelBenchmarkFused, .modelBenchmarkChat, .modelBenchmarkCode, .modelBenchmarkVLM,
+            .modelBenchmarkToolCalls, .modelBenchmarkToolContinuations, .modelBenchmarkAPIWorkload,
+        ]
+        var drift: Set<CommandTemplateID> = []
+        for template in CommandCatalog.templates {
+            guard let declared = template.declaredOutputKind else { continue }
+            let contractProducesFile = declared == .file || declared == .directory
+            if contractProducesFile != (template.outputKind != .none) {
+                drift.insert(template.id)
+            }
+        }
+        XCTAssertEqual(drift, recorded)
+        // Whichever side declares a file, the resolver adopts the requested `--output` path.
+        for id in recorded {
+            let template = try XCTUnwrap(CommandCatalog.template(id: id))
+            XCTAssertTrue(template.producesOutputFile, "\(id)")
+        }
+    }
+
+    // MARK: Helpers
+
+    private func makeImageRequest(output: URL) throws -> JobRequest {
+        let template = try XCTUnwrap(CommandCatalog.template(id: .imageGenerate))
+        var draft = template.defaultDraft()
+        draft.prompt = "a cat"
+        draft.outputPath = output.path
+        return makeRequest(template: template, draft: draft)
+    }
+
+    private func makeRequest(template: CommandTemplate, draft: CommandDraft) -> JobRequest {
+        let arguments = template.arguments(from: draft)
+        let launched = arguments + StudioMachineOutputFlags.arguments(
+            template: template,
+            draft: draft,
+            appendingTo: arguments
+        )
+        return JobRequest(
+            lane: .inference,
+            template: template,
+            draft: draft,
+            requestID: UUID(),
+            conversationID: nil,
+            configuration: MereRunProcessConfiguration(
+                executableURL: URL(fileURLWithPath: "/usr/bin/true"),
+                arguments: launched,
+                currentDirectoryURL: FileManager.default.temporaryDirectory,
+                environment: [:],
+                keepsStandardInputOpen: false
+            ),
+            displayCommand: (["mere.run"] + arguments).shellQuoted()
+        )
+    }
+
+    private func makeLibraryItem(
+        mode: StudioMode,
+        outputURL: URL,
+        artifactURLs: [URL],
+        roles: [String: String]
+    ) -> StudioLibraryItem {
+        StudioLibraryItem(
+            id: UUID(),
+            mode: mode,
+            prompt: "a cat",
+            inputURL: nil,
+            outputURL: outputURL,
+            createdAt: Date(),
+            updatedAt: Date(),
+            status: .completed,
+            exitCode: 0,
+            commandPreview: "mere.run \(mode.rawValue)",
+            outputText: nil,
+            customTitle: nil,
+            artifactURLs: artifactURLs,
+            artifactRoles: roles
+        )
+    }
+
+    private func makeTemporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("ArtifactReceiptTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: url) }
+        return url
+    }
+
+    private func settle() async {
+        for _ in 0..<6 { await Task.yield() }
+    }
+}
+
+/// The `--progress-json` convention, which every lane that streams progress now follows.
+final class ProgressConventionTests: XCTestCase {
+    func testZeroBasedStepsAndTheTerminalEventSpanTheWholeBar() throws {
+        let first = try XCTUnwrap(StudioProgressParser.parse(event(stage: "denoising", step: 0, total: 4)))
+        XCTAssertEqual(first.label, "Denoising")
+        XCTAssertEqual(try XCTUnwrap(first.fractionCompleted), 0.25, accuracy: 0.001)
+        XCTAssertEqual(first.detail, "Step 1 of 4")
+
+        let terminal = try XCTUnwrap(StudioProgressParser.parse(event(stage: "denoising", step: 4, total: 4)))
+        XCTAssertEqual(try XCTUnwrap(terminal.fractionCompleted), 1.0, accuracy: 0.001)
+        XCTAssertEqual(terminal.detail, "Step 4 of 4")
+    }
+
+    func testIndeterminateStagesReportNoFractionSoSurfacesShowASpinner() throws {
+        // `speech synthesize` streams tokens with no known length.
+        let streaming = try XCTUnwrap(StudioProgressParser.parse(event(stage: "generating", step: 128, total: 0)))
+        XCTAssertEqual(streaming.label, "Generating")
+        XCTAssertNil(streaming.fractionCompleted)
+        XCTAssertEqual(streaming.detail, "Step 128")
+
+        let opening = try XCTUnwrap(StudioProgressParser.parse(event(stage: "loadingModel", step: 0, total: 0)))
+        XCTAssertEqual(opening.label, "Loading model")
+        XCTAssertNil(opening.fractionCompleted)
+        XCTAssertNil(opening.detail)
+    }
+
+    func testEveryLanesStagesResolveToALabelledUpdate() throws {
+        let stages: [(stage: String, label: String)] = [
+            // image and video generation (`GenerationStage`)
+            ("loadingModel", "Loading model"),
+            ("loadingEncoder", "Loading encoder"),
+            ("encodingText", "Encoding prompt"),
+            ("encodingReferenceImages", "Encoding references"),
+            ("loadingTransformer", "Loading transformer"),
+            ("loadingLoRA", "Loading adapter"),
+            ("loadingVAE", "Loading VAE"),
+            ("denoising", "Denoising"),
+            ("decoding", "Decoding"),
+            ("saving", "Saving output"),
+            // speech synthesis (`TTSStage`)
+            ("preprocessingReference", "Preparing reference"),
+            ("encodingReference", "Encoding reference"),
+            ("buildingPrompt", "Building prompt"),
+            ("tokenizing", "Tokenizing"),
+            ("generating", "Generating"),
+            // music generation milestones
+            ("semantic", "Semantic frames"),
+            // video sliding windows
+            ("window", "Window"),
+        ]
+        for (stage, label) in stages {
+            let progress = try XCTUnwrap(
+                StudioProgressParser.parse(event(stage: stage, step: 1, total: 8)),
+                stage
+            )
+            XCTAssertEqual(progress.label, label, stage)
+            XCTAssertEqual(try XCTUnwrap(progress.fractionCompleted), 0.25, accuracy: 0.001, stage)
+        }
+    }
+
+    func testAStageThisBuildDoesNotKnowIsStillRendered() throws {
+        let progress = try XCTUnwrap(StudioProgressParser.parse(event(stage: "superResolving", step: 1, total: 2)))
+        XCTAssertEqual(progress.label, "Super resolving")
+        XCTAssertEqual(try XCTUnwrap(progress.fractionCompleted), 1.0, accuracy: 0.001)
+    }
+
+    func testNonProgressJSONLinesAreNotMistakenForProgress() {
+        XCTAssertNil(StudioProgressParser.parse(#"{"event":"result","exit":0,"outputs":[]}"#))
+        XCTAssertNil(StudioProgressParser.parse(#"{"status":"result","output":"/out/x.mp4"}"#))
+        XCTAssertNil(StudioProgressParser.parse(#"{"event":"progress","stage":"","step":1,"total_steps":4}"#))
+    }
+
+    private func event(stage: String, step: Int, total: Int) -> String {
+        #"{"event":"progress","stage":"\#(stage)","step":\#(step),"total_steps":\#(total)}"#
+    }
+}

--- a/apps/macos/README.md
+++ b/apps/macos/README.md
@@ -30,8 +30,26 @@ imported row. External launchers must never edit `library.json` directly.
   `.probe`, which skip preflight and capture complete stdout and stderr for the
   submitter). The store publishes one observable `Job` per job (state, status,
   progress, log, live output, artifacts, result), raw output chunks through
-  `events`, and a lossless `completions` stream. `ArtifactResolver` finds a
-  run's outputs from the request and the CLI's stdout.
+  `events`, and a lossless `completions` stream.
+- Output detection: `ArtifactResolver` reads, in order, (1) the CLI's
+  `--receipt` line — the final stdout NDJSON object
+  `{"event":"result","exit":0,"outputs":[…]}`, whose first entry is the primary
+  artifact and whose sidecars carry a `role` (`detections`, `masks`, `recipe`,
+  …); (2) the output kind `MereRunCapabilityCatalog` declares for the
+  capability together with the `--output` path the request asked for, once it
+  exists; (3) the stdout path contract and `fileExists` probing, kept as the
+  fallback for the commands that print no receipt and for an older CLI. Roles
+  reach the UI on `Artifact.sidecarRole` / `roleLabel` and are persisted on
+  `StudioLibraryItem.artifactRoles`, so a result surface labels a sidecar
+  instead of guessing from its extension; sidecars found by probing are
+  labelled from the same draft fields that located them
+  (`StudioArtifactRole.inferred`). The app appends `--receipt` and
+  `--progress-json` to the launched argv for the capabilities the contract
+  lists in `receiptCapabilityIDs` / `progressJSONCapabilityIDs`, never on a
+  `--preflight` run (the CLI rejects that pair) and never in the "Will run"
+  preview or a library row's command, which stay the command a person would
+  type. A run that prints a receipt skips the 350 ms output poll; every other
+  command with an output file keeps it.
 - `MereRunController.swift`: the facade views bind to. It snapshots Settings
   and the CLI launch into a `JobRequest` for every lane, awaits utility and
   probe jobs on behalf of their callers (readiness results are evaluated


### PR DESCRIPTION
Studio v2 step **C7**. The app stops guessing what a run produced and reads the
structured output PR #418 added to the CLI.

## What changed

**Emitting the flags.** `StudioMachineOutputFlags` (in `CommandCatalog.swift`)
appends `--receipt` when the run's capability is in
`MereRunCapabilityCatalog.receiptCapabilityIDs` and `--progress-json` when it is
in `progressJSONCapabilityIDs`, deduplicated against whatever the draft already
emits. The single site that builds a templated `JobRequest`
(`MereRunController.submitInferenceJob`) appends them.

*Decision: the flags never appear in the "Will run" preview, in the console's
echo of the command, or in a library row's `commandPreview`.* They are the app's
own transport, not something the user asked for; the preview stays the command a
person would type and would get the same result from. Because the flag is
hidden, the receipt line is also kept out of the console log and out of the
captured text a library row shows — otherwise a `speech transcribe` row would
end with an unexplained JSON object. The launched argv is the only place they
appear, and `StudioMachineOutputFlags.arguments` returns nothing when the run is
a preflight (checked both on `draft.preflight` and on `--preflight` already
being in the argv, since some surfaces spell it with a different draft field),
so `--receipt --preflight` can never be built.

**Precedence in `ArtifactResolver`.** `resolve(template:draft:expected:stdout:)`
returns an `ArtifactResolution` carrying the source it used:

1. **`.receipt`** — the last `{"event":"result",…}` line in stdout.
   `outputs[0]` is the primary, the rest are sidecars carrying their `role`. A
   receipt with a non-empty `outputs` array short-circuits every probe. (An
   *empty* receipt — `speech transcribe` with no `--output` — deliberately falls
   through, since there is no file to adopt.)
2. **`.declaredOutput`** — the `--output` path the request asked for, gated on
   the output kind the contract declares for the capability
   (`CommandTemplate.declaredOutputKind`), once that path exists.
3. **`.probe`** — today's stdout path contract (`bare path` and `input -> output`
   lines) plus `fileExists` probing and `StudioArtifactDiscovery`, kept for the
   commands that emit no receipt and for an older CLI.

`primaryOutput(expected:stdout:)`, which runs on every stdout chunk while the
job is live, gained the same receipt step at the front, so the artifact settles
the moment the line arrives rather than at exit.

**The poll.** `JobStore.start` now starts the 350 ms output watch only when
`job.detectsArtifacts && !job.expectsRunReceipt`. That removes it for the nine
receipt capabilities: `image.generate`, `video.generate`, `music.generate`,
`sfx.generate`, `speech.synthesize`, `speech.transcribe`, `vision.ground`,
`vision.segment`, `vision.track`.

*Still on the poll* (every other templated command with an output file), most
notably: the three training lanes (`image.train-lora`, `text.train-lora`,
`music.train-adapter`), the rest of Vision (`caption`, `ocr`, `inspect`,
`pose`, `flow`, `depth-video`, `geometry*`, `face.*`, `track-live`), the 3D
reconstructions, the other video commands (`retake`, `dub-it`, `animate`,
`prepare-masks`, `export-latents`), `audio.enhance` / `audio.generate`,
`music.separate` / `analyze` / `transcribe`, the Earth commands and
`model.optimize`. A preflight run of a receipt capability also keeps the poll,
since it is launched without the flag.

**Progress.** `StudioProgressParser` handled only `stage == "denoising"` with
`total_steps > 0`; every other stage and every indeterminate stage produced
nothing, so an indeterminate lane left the previous bar frozen on screen. It now
accepts any `progress` event, maps each lane's stage names to a label
(`GenerationStage` for image and video, `TTSStage` for speech, the music and
video milestones), humanizes a stage a future CLI adds, and returns a labelled
value with `fractionCompleted == nil` for `total_steps: 0`. Every progress
surface in the app already renders a nil fraction as a spinner
(`StudioCanvas`, `StudioSpecialistComponents`, `StudioLibraryPanel`,
`StudioModelsPresentation`), so indeterminate stages now show a spinner with a
stage label instead of a 0% bar. The 0-based-step and terminal-event convention
is unchanged in how it maps to the bar and is now covered per lane.

**Roles in the UI.** `Artifact` gained `sidecarRole` plus a `roleLabel`
("Structured prompt", "Detections", "Masks", "DAW bundle", …), `JobResult`
gained `artifactRoles`, and `StudioLibraryItem` gained the additive optional
`artifactRoles: [String: String]?` (path → role) with
`artifactRole(for:)` / `artifactRoleLabel(for:)`. Sidecars found by probing get
the same vocabulary from `StudioArtifactRole.inferred`, which reads the draft
fields `StudioArtifactDiscovery` used to find them, so a command without a
receipt labels its sidecars the same way.

## Wired into the batch-2 surfaces (added after rebasing on #425)

- **Generation card** (`StudioFeedCanvas`): it sorted a run's outputs by file
  extension, so a structured prompt or timings JSON was dumped as a raw text
  preview and the remaining sidecars were chips named by file name. Every file
  the run reported a role for now stays in the sidecar row under the role's own
  name ("Structured prompt", "Timings"); the extension split and the file name
  remain the fallback for a run that reported none.
- **Analyze result column** (`StudioAnalyzeDocumentSource`): it picked the
  result document by extension order, which chose whichever JSON came first. It
  now takes the sidecar the receipt named as the `detections` or `tracking`
  document, keeping extension order for older rows.
- Anywhere else that wants a label: `Artifact.roleLabel` for a live job,
  `StudioLibraryItem.artifactRoleLabel(for:)` for a library row; both are nil
  when the run reported no role, which is the signal to fall back to the name.
- The Command view's argv preview shows `commandArguments(template:draft:)`,
  which by design excludes `--receipt` / `--progress-json`. If it ever wants to
  show exactly what was launched, read `job.request.configuration.arguments`.
- `CommandTemplate.declaredOutputKind` / `producesOutputFile` and
  `CommandTemplateID.capability` are the contract accessors added here; C5's
  `ArgumentBuilder` and C6's `ContractForm` can use the same lookup.

Merge note: batch 2 also touched `parseGenerationJSON`, changing the JSON lane's
label from the fixed "Generating" to the stage name. That intent is kept — the
stage-label table maps `denoising` to "Denoising", so the feed card and the
Activity popover still read "Denoising 15/24" — and it now extends to every
other stage rather than only that one.

## Files touched outside `Jobs/`, `StudioTypes.swift` and `CommandCatalog.swift`

`StudioLibraryStore.complete` gained an `artifactRoles:` parameter with a
default and its single call site in `StudioRootView.swift` passes
`result.artifactRoles` (one line each). `StudioFeedCanvas.swift` and
`StudioAnalyzeCanvas.swift` carry the labelling described above: three small
computed properties and one `Text`, no layout changes.

## Verification

`swiftlint --strict` clean, `swift build`, `swift test --filter MereRunAppTests`
(482 tests, 0 failures — 26 new), `./scripts/check.sh` green, and
`./scripts/build_mere_run_app.sh debug` produces a valid signed-on-disk bundle.
New tests cover receipt parsing (valid, malformed, absent, among other JSON
lines, followed by trailing output, more than one), the precedence order, roles
reaching `Job.artifacts` and a library row, the poll being skipped only for
receipt runs, the flags being added only where the contract declares them and
never with `--preflight`, and the progress convention per lane. All of it runs
on the recording process runner; nothing launches the CLI.

## Reviewer note

`testDeclaredOutputKindsDriftOnlyWhereRecorded` records eleven commands where
the contract's declared output kind and the app's disagree (the benchmarks and
`speech diarize` write an `--output` report the contract calls `text`;
`music realtime` records a WAV the contract calls a `service`; `image.run-plan`
and `adapter.pull` write files the app models as producing nothing). So
`producesOutputFile` reads the contract first and still honours the app's kind,
rather than letting the contract alone drop those artifacts. Reconciling the two
is a contract change and belongs in its own PR.

