### PR TITLE
Scope CI jobs to the paths a pull request changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,13 +4,16 @@ on:
   push:
     branches: [main]
   pull_request:
+  merge_group:
 
 permissions:
   contents: read
 
 concurrency:
-  group: ci-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  # Merge-queue runs each get their own gh-readonly-queue ref, and cancelling
+  # one would leave the queue waiting on a check that never reports.
+  group: ci-${{ github.event_name }}-${{ github.event.merge_group.head_ref || github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
 
 jobs:
   changes:
@@ -28,7 +31,9 @@ jobs:
       - name: Classify the changed paths
         id: filter
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
+          # A merge-queue run has no pull request; it diffs the queued branch
+          # against the main tip the group was formed on.
+          BASE_SHA: ${{ github.event.merge_group.base_sha || github.event.pull_request.base.sha || github.event.before }}
           HEAD_SHA: ${{ github.sha }}
         run: |
           set -euo pipefail
@@ -47,6 +52,9 @@ jobs:
           # All three are default-deny: a path this classifier does not
           # recognise lands in `other`, which selects the full gate everywhere,
           # so a new top-level directory can never silently take a short route.
+          # The same applies when the base commit cannot be resolved, which is
+          # what keeps a merge-queue run on the full gate whenever its diff is
+          # not computable: that run is the last gate before main.
           # Required checks keep reporting under their own names in both lanes;
           # a job with nothing to prove reports success from a no-op step rather
           # than being skipped.
@@ -169,24 +177,34 @@ jobs:
             printf -- '- iOS build required: %s\n' "$ios_required"
           } >>"$GITHUB_STEP_SUMMARY"
 
+  # A required check, so this job always runs and always reports under its own
+  # name. A documentation-only change has no native build to prove and reports
+  # success from the step below instead of being skipped, which matters for the
+  # merge queue: a required check that never reports leaves a merge group
+  # waiting until it times out.
   swift:
     needs: changes
-    if: needs.changes.outputs.code == 'true'
+    if: always()
     runs-on: macos-26
     env:
       MERERUN_SWIFT_DISABLE_INDEX_STORE: '1'
       LANE: ${{ needs.changes.outputs.lane }}
+      RUN_GATE: ${{ needs.changes.result == 'success' && needs.changes.outputs.code == 'true' }}
     steps:
-      - uses: actions/checkout@v7
-        with:
-          persist-credentials: false
-      - uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: '26.4'
       - name: Report selected lane
+        shell: bash
+        env:
+          CHANGE_DETECTION_RESULT: ${{ needs.changes.result }}
         run: |
           set -euo pipefail
-          if [[ "$LANE" == "fast" ]]; then
+          if [[ "$CHANGE_DETECTION_RESULT" != "success" ]]; then
+            echo "Change detection did not succeed: $CHANGE_DETECTION_RESULT" >&2
+            exit 1
+          fi
+          if [[ "$RUN_GATE" != "true" ]]; then
+            note='no native change'
+            detail='Nothing outside documentation changed, so there is no package gate to run.'
+          elif [[ "$LANE" == "fast" ]]; then
             note='fast lane: app-only change'
             detail='SwiftLint, agent readiness, evaluation boundary, docs examples, swift build, metallib verification, MereRunAppTests, and the app bundle build.'
           else
@@ -198,8 +216,18 @@ jobs:
             printf -- '- **%s**\n' "$note"
             printf -- '- %s\n' "$detail"
           } >>"$GITHUB_STEP_SUMMARY"
+          printf 'Native gate required: %s\n' "$RUN_GATE"
           printf 'Lane: %s\n' "$LANE"
+      - uses: actions/checkout@v7
+        if: env.RUN_GATE == 'true'
+        with:
+          persist-credentials: false
+      - uses: maxim-lobanov/setup-xcode@v1
+        if: env.RUN_GATE == 'true'
+        with:
+          xcode-version: '26.4'
       - name: Restore SwiftPM dependencies
+        if: env.RUN_GATE == 'true'
         uses: actions/cache@v6
         with:
           path: |
@@ -218,6 +246,7 @@ jobs:
       # either lane seed the other: both compile the same package graph with the
       # same flags.
       - name: Restore SwiftPM build directory
+        if: env.RUN_GATE == 'true'
         id: build-cache
         uses: actions/cache/restore@v6
         with:
@@ -233,6 +262,7 @@ jobs:
             swiftbuild-${{ runner.os }}-${{ runner.arch }}-xcode-26.4-${{ hashFiles('Package.swift', 'Package.resolved') }}-${{ env.LANE }}-
             swiftbuild-${{ runner.os }}-${{ runner.arch }}-xcode-26.4-${{ hashFiles('Package.swift', 'Package.resolved') }}-
       - name: Discard cached MLX Metal libraries
+        if: env.RUN_GATE == 'true'
         run: |
           set -euo pipefail
           # A stale metallib silently corrupts inference, so it is the one build
@@ -249,16 +279,17 @@ jobs:
             \) -print -delete
           fi
       - name: Install check dependencies
+        if: env.RUN_GATE == 'true'
         run: |
           # macos-26 currently carries an untrusted aws/tap that causes every
           # Homebrew command to fail before resolving Homebrew/core formulae.
           brew untap --force aws/tap
           brew install swiftlint ripgrep
       - name: Run package checks
-        if: env.LANE != 'fast'
+        if: env.RUN_GATE == 'true' && env.LANE != 'fast'
         run: ./scripts/check.sh
       - name: Run app-scoped package checks
-        if: env.LANE == 'fast'
+        if: env.RUN_GATE == 'true' && env.LANE == 'fast'
         run: |
           set -euo pipefail
           # Same non-test checks as ./scripts/check.sh, then only the macOS app
@@ -272,8 +303,10 @@ jobs:
           ./scripts/build_mlx_metallib.sh --verify-only vendor/mlx-swift_Cmlx.bundle
           swift test --disable-index-store --filter MereRunAppTests
       - name: Build app bundle (ad-hoc)
+        if: env.RUN_GATE == 'true'
         run: ./scripts/build_mere_run_app.sh debug
       - name: Verify bundle structure
+        if: env.RUN_GATE == 'true'
         run: |
           set -euo pipefail
           bundle="$(swift build --disable-index-store --show-bin-path)/MereRun.app"
@@ -302,7 +335,7 @@ jobs:
       # from scratch by build_mere_run_app.sh, and the metallib is deliberately
       # never carried between runs.
       - name: Prune reproducible products before caching
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: env.RUN_GATE == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
         run: |
           set -euo pipefail
           rm -rf .build/arm64-apple-macosx/debug/ModuleCache
@@ -315,7 +348,7 @@ jobs:
           \) -delete
           du -sh .build/arm64-apple-macosx
       - name: Save SwiftPM build directory
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: env.RUN_GATE == 'true' && github.event_name == 'push' && github.ref == 'refs/heads/main'
         uses: actions/cache/save@v6
         with:
           path: |
@@ -436,7 +469,9 @@ jobs:
             echo "Change detection did not succeed: $CHANGE_DETECTION_RESULT" >&2
             exit 1
           fi
-          if [[ "$CODE_REQUIRED" == "true" && "$SWIFT_RESULT" != "success" ]]; then
+          # The swift job now always runs and always concludes, so any result
+          # other than success is a failure here regardless of the lane.
+          if [[ "$SWIFT_RESULT" != "success" ]]; then
             echo "macOS package and bundle checks did not succeed: $SWIFT_RESULT" >&2
             exit 1
           fi
@@ -486,6 +521,7 @@ jobs:
       RUN_GATE: ${{ needs.changes.result == 'success' && needs.changes.outputs.code == 'true' && needs.changes.outputs.linux == 'true' }}
     steps:
       - name: Verify change detection
+        shell: bash
         env:
           CHANGE_DETECTION_RESULT: ${{ needs.changes.result }}
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,12 +17,15 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       code: ${{ steps.filter.outputs.code }}
+      lane: ${{ steps.filter.outputs.lane }}
+      linux: ${{ steps.filter.outputs.linux }}
+      ios: ${{ steps.filter.outputs.ios }}
     steps:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           persist-credentials: false
-      - name: Detect changes that require native builds
+      - name: Classify the changed paths
         id: filter
         env:
           BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.before }}
@@ -30,27 +33,141 @@ jobs:
         run: |
           set -euo pipefail
 
+          # Every changed path is sorted into one category, and the categories
+          # decide four things:
+          #
+          #   code   native builds are needed at all (unchanged behaviour)
+          #   lane   which package gate the macOS `swift` job runs:
+          #          `full` is ./scripts/check.sh (every test target), `fast` is
+          #          the same non-test checks plus the macOS app target and its
+          #          tests. Both lanes build and verify the app bundle.
+          #   linux  the Linux CLI compatibility gate has something to prove
+          #   ios    the iOS app build and tests have something to prove
+          #
+          # All three are default-deny: a path this classifier does not
+          # recognise lands in `other`, which selects the full gate everywhere,
+          # so a new top-level directory can never silently take a short route.
+          # Required checks keep reporting under their own names in both lanes;
+          # a job with nothing to prove reports success from a no-op step rather
+          # than being skipped.
+
           code_required=true
+          lane=full
+          linux_required=true
+          ios_required=true
+          categories=''
+
+          record_category() {
+            case " $categories " in
+              *" $1 "*) ;;
+              *) categories="${categories:+$categories }$1" ;;
+            esac
+          }
+
           if [[ -n "$BASE_SHA" && ! "$BASE_SHA" =~ ^0+$ ]] \
               && git cat-file -e "${BASE_SHA}^{commit}"; then
             mapfile -t changed_files < <(git diff --name-only "$BASE_SHA" "$HEAD_SHA")
             if (( ${#changed_files[@]} > 0 )); then
               code_required=false
+              lane=fast
+              linux_required=false
+              ios_required=false
               for path in "${changed_files[@]}"; do
                 case "$path" in
                   docs/*|README.md|CHANGELOG.md|CODEBASE.md|CONTRIBUTING.md|SECURITY.md|LICENSE|package.json|pnpm-lock.yaml|pnpm-workspace.yaml|.github/workflows/docs.yml)
                     ;;
                   *)
                     code_required=true
-                    break
+                    ;;
+                esac
+
+                case "$path" in
+                  # Workflow edits always take every gate: the lanes are defined
+                  # here, so they cannot be trusted to validate themselves.
+                  .github/*)
+                    record_category workflows
+                    lane=full
+                    linux_required=true
+                    ios_required=true
+                    ;;
+                  # The gate scripts are only exercised end to end by the full
+                  # macOS gate and the Linux gate that invoke them.
+                  scripts/check.sh|scripts/check-linux.sh|scripts/build_mlx_metallib.sh|scripts/build_mere_run_app.sh)
+                    record_category gate-scripts
+                    lane=full
+                    linux_required=true
+                    ;;
+                  Sources/*|Tests/*|Package.swift|Package.resolved|vendor/*)
+                    record_category cli-core
+                    lane=full
+                    linux_required=true
+                    ios_required=true
+                    ;;
+                  # scripts/check-linux.sh sources and exercises the rest of
+                  # scripts/, so the Linux gate stays in for any of them.
+                  scripts/*)
+                    record_category scripts
+                    linux_required=true
+                    ;;
+                  # The macOS app target is excluded from the Linux package view
+                  # and is not part of the iOS Xcode project.
+                  apps/macos/*)
+                    record_category app
+                    ;;
+                  apps/ios/*)
+                    record_category ios
+                    ios_required=true
+                    ;;
+                  # The documentation checks are platform independent and run in
+                  # the macOS job in both lanes.
+                  docs/*|*.md|LICENSE|package.json|pnpm-lock.yaml|pnpm-workspace.yaml)
+                    record_category docs
+                    ;;
+                  # Not compiled by Package.swift; the app bundle build in both
+                  # lanes covers the parts that ship inside MereRun.app.
+                  assets/*|integrations/*|skills/*)
+                    record_category resources
+                    ;;
+                  *)
+                    record_category other
+                    lane=full
+                    linux_required=true
+                    ios_required=true
                     ;;
                 esac
               done
             fi
           fi
 
-          echo "code=$code_required" >>"$GITHUB_OUTPUT"
+          [[ -n "$categories" ]] || categories='(none detected)'
+
+          if [[ "$lane" == "fast" ]]; then
+            lane_note='**fast lane: app-only change** (SwiftLint, repository checks, swift build, MereRunAppTests, app bundle)'
+          else
+            lane_note='**full gate** (scripts/check.sh, every package test target, plus the app bundle)'
+          fi
+
+          {
+            echo "code=$code_required"
+            echo "lane=$lane"
+            echo "linux=$linux_required"
+            echo "ios=$ios_required"
+          } >>"$GITHUB_OUTPUT"
+
+          printf 'Change categories: %s\n' "$categories"
           printf 'Native builds required: %s\n' "$code_required"
+          printf 'Package gate lane: %s\n' "$lane"
+          printf 'Linux CLI gate required: %s\n' "$linux_required"
+          printf 'iOS build required: %s\n' "$ios_required"
+
+          {
+            printf '### CI scope\n\n'
+            printf -- '- Change categories: %s\n' "$categories"
+            printf -- '- Native builds required: %s\n' "$code_required"
+            printf -- '- macOS package gate: %s\n' "$lane_note"
+            printf -- '- Linux CLI gate required: %s\n' "$linux_required"
+            printf -- '- iOS build required: %s\n' "$ios_required"
+          } >>"$GITHUB_STEP_SUMMARY"
 
   swift:
     needs: changes
@@ -58,6 +175,7 @@ jobs:
     runs-on: macos-26
     env:
       MERERUN_SWIFT_DISABLE_INDEX_STORE: '1'
+      LANE: ${{ needs.changes.outputs.lane }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -65,6 +183,22 @@ jobs:
       - uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: '26.4'
+      - name: Report selected lane
+        run: |
+          set -euo pipefail
+          if [[ "$LANE" == "fast" ]]; then
+            note='fast lane: app-only change'
+            detail='SwiftLint, agent readiness, evaluation boundary, docs examples, swift build, metallib verification, MereRunAppTests, and the app bundle build.'
+          else
+            note='full gate'
+            detail='./scripts/check.sh (every package test target) plus the app bundle build.'
+          fi
+          {
+            printf '### macOS package gate\n\n'
+            printf -- '- **%s**\n' "$note"
+            printf -- '- %s\n' "$detail"
+          } >>"$GITHUB_STEP_SUMMARY"
+          printf 'Lane: %s\n' "$LANE"
       - name: Restore SwiftPM dependencies
         uses: actions/cache@v6
         with:
@@ -74,6 +208,46 @@ jobs:
             .build/checkouts
             .build/repositories
           key: swiftpm-${{ runner.os }}-${{ runner.arch }}-xcode-26.4-${{ hashFiles('Package.swift', 'Package.resolved') }}
+      # Compiled objects are restored on every run and re-saved only from main,
+      # so pull requests start from the warm build directory of the commit they
+      # branched from without every PR writing a multi-gigabyte cache entry.
+      # llbuild revalidates restored outputs by path, size, and modification
+      # time, so the dependency checkouts restored above keep their C++ objects
+      # valid while every freshly checked-out first-party source recompiles.
+      # The lane is part of the key, and the lane-agnostic restore key lets
+      # either lane seed the other: both compile the same package graph with the
+      # same flags.
+      - name: Restore SwiftPM build directory
+        id: build-cache
+        uses: actions/cache/restore@v6
+        with:
+          path: |
+            .build/arm64-apple-macosx
+            .build/build.db
+            .build/debug.yaml
+            .build/plugin-tools.yaml
+            .build/plugins
+            .build/swiftlint.cache
+          key: swiftbuild-${{ runner.os }}-${{ runner.arch }}-xcode-26.4-${{ hashFiles('Package.swift', 'Package.resolved') }}-${{ env.LANE }}-${{ github.sha }}
+          restore-keys: |
+            swiftbuild-${{ runner.os }}-${{ runner.arch }}-xcode-26.4-${{ hashFiles('Package.swift', 'Package.resolved') }}-${{ env.LANE }}-
+            swiftbuild-${{ runner.os }}-${{ runner.arch }}-xcode-26.4-${{ hashFiles('Package.swift', 'Package.resolved') }}-
+      - name: Discard cached MLX Metal libraries
+        run: |
+          set -euo pipefail
+          # A stale metallib silently corrupts inference, so it is the one build
+          # product that is never reused across runs. Deleting the restored
+          # copies puts the build directory back in the state a cold checkout
+          # would have: scripts/build_mlx_metallib.sh regenerates and re-stamps
+          # them from this checkout, and its --verify-only pass still audits the
+          # tracked vendor/mlx-swift_Cmlx.bundle against the pinned sources.
+          if [[ -d .build/arm64-apple-macosx ]]; then
+            find .build/arm64-apple-macosx \( \
+              -name 'default.metallib' \
+              -o -name 'default.metallib.version' \
+              -o -name 'mlx.metallib' \
+            \) -print -delete
+          fi
       - name: Install check dependencies
         run: |
           # macos-26 currently carries an untrusted aws/tap that causes every
@@ -81,7 +255,22 @@ jobs:
           brew untap --force aws/tap
           brew install swiftlint ripgrep
       - name: Run package checks
+        if: env.LANE != 'fast'
         run: ./scripts/check.sh
+      - name: Run app-scoped package checks
+        if: env.LANE == 'fast'
+        run: |
+          set -euo pipefail
+          # Same non-test checks as ./scripts/check.sh, then only the macOS app
+          # target's tests. Anything that can change CLI or Core behaviour
+          # selects the full lane in the `changes` job.
+          swiftlint --strict --cache-path .build/swiftlint.cache
+          bash ./scripts/agent_readiness_check.sh
+          bash ./scripts/check-evaluation-boundary.sh
+          bash ./scripts/check-docs-examples.sh
+          swift build --disable-index-store
+          ./scripts/build_mlx_metallib.sh --verify-only vendor/mlx-swift_Cmlx.bundle
+          swift test --disable-index-store --filter MereRunAppTests
       - name: Build app bundle (ad-hoc)
         run: ./scripts/build_mere_run_app.sh debug
       - name: Verify bundle structure
@@ -106,10 +295,43 @@ jobs:
           codesign -d --entitlements :- "${bundle}/Contents/Helpers/mere.run" 2>&1 \
             | grep -q 'com.apple.security.device.audio-input'
           codesign --verify --strict --verbose=2 "$bundle"
+      # Only main writes the rolling build cache, and only after every check has
+      # passed. Products that are cheap to reproduce, or that must never be
+      # reused, are removed first: the clang module cache and the debug symbol
+      # bundles are regenerated on demand, the assembled app bundle is rebuilt
+      # from scratch by build_mere_run_app.sh, and the metallib is deliberately
+      # never carried between runs.
+      - name: Prune reproducible products before caching
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        run: |
+          set -euo pipefail
+          rm -rf .build/arm64-apple-macosx/debug/ModuleCache
+          rm -rf .build/arm64-apple-macosx/debug/MereRun.app
+          find .build/arm64-apple-macosx -maxdepth 2 -name '*.dSYM' -exec rm -rf {} +
+          find .build/arm64-apple-macosx \( \
+            -name 'default.metallib' \
+            -o -name 'default.metallib.version' \
+            -o -name 'mlx.metallib' \
+          \) -delete
+          du -sh .build/arm64-apple-macosx
+      - name: Save SwiftPM build directory
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        uses: actions/cache/save@v6
+        with:
+          path: |
+            .build/arm64-apple-macosx
+            .build/build.db
+            .build/debug.yaml
+            .build/plugin-tools.yaml
+            .build/plugins
+            .build/swiftlint.cache
+          key: swiftbuild-${{ runner.os }}-${{ runner.arch }}-xcode-26.4-${{ hashFiles('Package.swift', 'Package.resolved') }}-${{ env.LANE }}-${{ github.sha }}
 
+  # Not a required check, so this one is simply skipped when nothing the iOS
+  # project compiles has changed (apps/macos/** is not part of it).
   ios:
     needs: changes
-    if: needs.changes.outputs.code == 'true'
+    if: needs.changes.outputs.code == 'true' && needs.changes.outputs.ios == 'true'
     runs-on: macos-26
     steps:
       - uses: actions/checkout@v7
@@ -252,16 +474,37 @@ jobs:
           grep -R "CUDA" README.md docs/development-workflow.md docs/testing.md docs/repository-tour.md docs/internals/source-layout.md >/dev/null
           grep -R "macOS-only" README.md docs/getting-started.md docs/repository-tour.md docs/internals/source-layout.md >/dev/null
 
+  # A required check, so this job always runs and always reports under its own
+  # name. When nothing the Linux CLI compiles or exercises has changed it
+  # reports success from the no-op step below instead of being skipped.
   linux-cli:
     needs: changes
-    if: needs.changes.outputs.code == 'true'
+    if: always()
     runs-on: ubuntu-22.04
     container: swift:6.0-jammy
+    env:
+      RUN_GATE: ${{ needs.changes.result == 'success' && needs.changes.outputs.code == 'true' && needs.changes.outputs.linux == 'true' }}
     steps:
+      - name: Verify change detection
+        env:
+          CHANGE_DETECTION_RESULT: ${{ needs.changes.result }}
+        run: |
+          set -euo pipefail
+          if [[ "$CHANGE_DETECTION_RESULT" != "success" ]]; then
+            echo "Change detection did not succeed: $CHANGE_DETECTION_RESULT" >&2
+            exit 1
+          fi
+          if [[ "$RUN_GATE" == "true" ]]; then
+            echo "Running the Linux CLI compatibility gate."
+          else
+            echo "No Linux-visible change; the Linux CLI gate has nothing to prove."
+          fi
       - uses: actions/checkout@v7
+        if: env.RUN_GATE == 'true'
         with:
           persist-credentials: false
       - name: Install Linux check dependencies
+        if: env.RUN_GATE == 'true'
         run: |
           apt-get update
           apt-get install -y --no-install-recommends \
@@ -285,6 +528,7 @@ jobs:
             zlib1g-dev \
             zstd
       - name: Restore SwiftPM and Linux native dependencies
+        if: env.RUN_GATE == 'true'
         uses: actions/cache@v6
         with:
           path: |
@@ -294,4 +538,5 @@ jobs:
             .build/repositories
           key: swiftpm-${{ runner.os }}-${{ runner.arch }}-swift-6.0-${{ hashFiles('Package.swift', 'Package.resolved', 'scripts/prepare-linux-native.sh', 'scripts/linux-arm64-bf16-toolchain.sh') }}
       - name: Run Linux CLI compatibility gate
+        if: env.RUN_GATE == 'true'
         run: ./scripts/check-linux.sh

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -4,22 +4,42 @@ on:
   pull_request:
   push:
     branches: [main]
+  merge_group:
 
 permissions:
   contents: read
 
+concurrency:
+  # Merge-queue runs each get their own gh-readonly-queue ref, and cancelling
+  # one would leave the queue waiting on a check that never reports.
+  group: security-${{ github.event_name }}-${{ github.event.merge_group.head_ref || github.event.pull_request.number || github.ref }}
+  cancel-in-progress: ${{ github.event_name != 'merge_group' }}
+
 jobs:
+  # A required check, so the job always runs and always reports under its own
+  # name. actions/dependency-review-action only supports pull requests, so on a
+  # merge-queue or push run the job reports success from a no-op step instead of
+  # being skipped: a required check that never reports leaves a merge group
+  # waiting until it times out. The review itself already ran on the pull
+  # request that entered the queue.
   dependency-review:
-    if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: read
     steps:
+      - name: Report that dependency review is pull-request only
+        if: github.event_name != 'pull_request'
+        run: |
+          echo "Dependency review runs on pull requests only."
+          echo "Event: ${{ github.event_name }}; the pull request's own review already reported."
+
       - name: Checkout
+        if: github.event_name == 'pull_request'
         uses: actions/checkout@v7
 
       - name: Dependency review
+        if: github.event_name == 'pull_request'
         uses: actions/dependency-review-action@v5
 
   secret-scan:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,37 @@
 - If you touch vendored artifacts or third-party package pins, update [`THIRD_PARTY_NOTICES.md`](./THIRD_PARTY_NOTICES.md).
 - Do not add hosted-service, billing, or app-store-only surfaces back into this repo.
 
+## Continuous integration lanes
+
+`./scripts/check.sh` is the local gate for every change. It stays the one command
+you run before opening a pull request, whatever you touched.
+
+Continuous integration scopes itself to the paths a pull request changes so a
+change confined to the macOS app does not pay for the whole package test suite.
+The `changes` job sorts every changed path into a category and prints the result
+in its job summary, together with the lane it selected:
+
+| Lane | Selected when | What the `swift` job runs |
+| --- | --- | --- |
+| Fast | Only `apps/macos/**`, `apps/ios/**`, `docs/**`, Markdown, ordinary `scripts/**`, or `assets/`, `integrations/`, `skills/` changed | SwiftLint, the agent readiness, evaluation boundary, and documentation example checks, `swift build`, the MLX metallib verification, and `MereRunAppTests` |
+| Full | Anything under `Sources/**`, `Tests/**`, `vendor/**`, `Package.swift`, `Package.resolved`, `.github/**`, or the gate scripts themselves changed | `./scripts/check.sh`, which is every package test target |
+
+Both lanes build and verify the ad-hoc `MereRun.app` bundle, and both verify the
+vendored MLX Metal library against the pinned kernel sources. Path classification
+is default-deny: a path no rule recognises selects the full lane everywhere, so
+a new top-level directory can never take the short route by accident.
+
+Two more scopes come from the same classification. The Linux CLI gate runs when
+a change can reach the Linux CLI or the scripts it invokes, and reports success
+from a no-op step otherwise, so its required check always reports. The iOS job
+runs only when a change can reach the iOS project.
+
+The macOS job restores the SwiftPM build directory from a cache that only pushes
+to `main` write. Its key covers the Xcode version, `Package.swift`,
+`Package.resolved`, and the lane. The MLX Metal library is never restored or
+saved: a stale one silently corrupts inference, so every run regenerates and
+re-stamps it from the checkout.
+
 ## Writing documentation
 
 Follow the [documentation style guide](./docs/documentation-style.md) for public

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,6 +33,30 @@ a change can reach the Linux CLI or the scripts it invokes, and reports success
 from a no-op step otherwise, so its required check always reports. The iOS job
 runs only when a change can reach the iOS project.
 
+## Merge queue
+
+`main` merges through a merge queue. GitHub builds a `merge_group` ref for each
+queued pull request and waits for the six required checks — `swift`,
+`macos-app-bundle`, `linux-cli`, `linux-cli-compatibility-docs`,
+`dependency-review`, and `secret-scan` — to report on it, so both `ci.yml` and
+`security.yml` also trigger on `merge_group`.
+
+Two rules keep the queue moving:
+
+- Every required check runs and reports under its own name on a merge group.
+  A job with nothing to prove reports success from a no-op step rather than
+  being skipped, because a required check that never reports leaves a merge
+  group waiting until it times out. `dependency-review` is the clearest case:
+  the action it wraps only supports pull requests, so on a merge group the job
+  reports that the pull request's own review already ran.
+- Lane selection still applies. A merge group diffs against
+  `github.event.merge_group.base_sha`. If that diff cannot be computed the run
+  falls back to the full gate, because a merge group is the last check before
+  `main`.
+
+Merge-queue runs are never cancelled by concurrency, since a cancelled run
+reports nothing and stalls the queue.
+
 The macOS job restores the SwiftPM build directory from a cache that only pushes
 to `main` write. Its key covers the Xcode version, `Package.swift`,
 `Package.resolved`, and the lane. The MLX Metal library is never restored or

--- a/docs/development-workflow.md
+++ b/docs/development-workflow.md
@@ -43,6 +43,11 @@ For most changes:
 That keeps the package healthy without forcing a full manual validation cycle
 for every tiny edit.
 
+Continuous integration narrows itself to the paths a pull request changes, so a
+change confined to the macOS app runs a shorter package gate than a change to
+the CLI or Core. `./scripts/check.sh` remains the local gate for everything. See
+the root `CONTRIBUTING.md` file for the lane rules.
+
 ## Which command to run
 
 ### Docs-only change


### PR DESCRIPTION
## Why

`.github/workflows/ci.yml` ran `./scripts/check.sh` in the `swift` job for every
pull request, so a change confined to `apps/macos/MereRunStudio` paid for the
whole package build, all ~3,500 tests across CLI, Core, Contract, Relay and the
macOS app, plus the full Linux CLI gate and the iOS Release build and tests.
Recent runs took 20 to 30 minutes, and because `main` moves, that cost is paid
again on every rebase.

## Lanes

The `changes` job already had a base SHA. It now sorts every changed path into a
category and derives three scopes from it, alongside the existing `code`
decision:

| Category | Paths | Full macOS gate | Linux gate | iOS |
| --- | --- | --- | --- | --- |
| `workflows` | `.github/**` | yes | yes | yes |
| `gate-scripts` | `scripts/check.sh`, `scripts/check-linux.sh`, `scripts/build_mlx_metallib.sh`, `scripts/build_mere_run_app.sh` | yes | yes | no |
| `cli-core` | `Sources/**`, `Tests/**`, `Package.swift`, `Package.resolved`, `vendor/**` | yes | yes | yes |
| `scripts` | rest of `scripts/**` | no | yes | no |
| `app` | `apps/macos/**` | no | no | no |
| `ios` | `apps/ios/**` | no | no | yes |
| `docs` | `docs/**`, Markdown, `LICENSE`, `package.json`, `pnpm-*.yaml` | no | no | no |
| `resources` | `assets/**`, `integrations/**`, `skills/**` | no | no | no |
| `other` | anything else | yes | yes | yes |

- **Full lane** runs `./scripts/check.sh` exactly as today.
- **Fast lane** runs the same non-test checks — `swiftlint --strict`,
  `agent_readiness_check.sh`, `check-evaluation-boundary.sh`,
  `check-docs-examples.sh` — then `swift build`,
  `build_mlx_metallib.sh --verify-only`, and `swift test --filter MereRunAppTests`.

Both lanes then build the ad-hoc `MereRun.app` bundle and run the existing bundle
verification unchanged.

Classification is **default-deny**: a path no rule recognises lands in `other`
and selects the full gate everywhere, so a new top-level directory can never
take a short route by accident. Any change under `.github/**` forces the full
gate, because the lanes are defined there and cannot be trusted to validate
themselves. The gate scripts are treated the same way. The lane and the derived
scopes are printed to the `changes` job summary and to the `swift` job summary
("fast lane: app-only change" / "full gate").

## Required checks

All six required names still report in both lanes:

- `swift` runs in both lanes under the same job name; only the step inside it
  differs.
- `swift` is `if: always()` and runs in both lanes under the same job name; only
  the step inside it differs. A documentation-only change, which has no native
  build to prove, reports **success from its lane-reporting step** rather than
  being skipped.
- `linux-cli` is `if: always()` with its heavy steps guarded. When nothing
  Linux-visible changed it reports **success from a no-op step**.
- `macos-app-bundle` and `linux-cli-compatibility-docs` still run with
  `if: always()`. `macos-app-bundle` now treats any non-success `swift` result
  as a failure, since `swift` always concludes.
- `dependency-review` is `if: always()` at the job level; see the merge-queue
  section below. `secret-scan` already ran on every event.

`ios` is not a required check, so it is simply skipped when nothing the iOS
project compiles has changed.

## Merge queue

A merge queue is enabled on `main` (squash, ALLGREEN). GitHub builds a
`merge_group` ref per queued pull request and waits for the six required checks
to report on it. Nothing triggered on `merge_group`, so queued pull requests sat
in `AWAITING_CHECKS` until they timed out.

- `ci.yml` and `security.yml` both add `merge_group:` to their `on:`.
- Both `concurrency` groups now key on `github.event_name` plus
  `github.event.merge_group.head_ref || github.event.pull_request.number ||
  github.ref`, and `cancel-in-progress` is off for `merge_group`: a cancelled
  queue run reports nothing and stalls the queue.
- The `changes` job resolves its base from `github.event.merge_group.base_sha`
  before the pull request base and the push before-SHA, so lane selection still
  works on a merge group. An unresolvable base falls back to the full gate,
  which is what a merge group deserves as the last check before `main`.
- `actions/dependency-review-action` supports pull requests only, so the
  `dependency-review` job no longer carries a job-level `if`. On a merge-group
  or push run it reports success from a step that explains the pull request's
  own review already ran; on a pull request it checks out and runs the action
  exactly as before.

## Caching

Two caches, both keyed on the Xcode version and `hashFiles('Package.swift', 'Package.resolved')`:

- The existing dependency cache (`~/Library/Caches/org.swift.swiftpm`,
  `.build/artifacts`, `.build/checkouts`, `.build/repositories`) is unchanged.
- A new rolling build cache over `.build/arm64-apple-macosx`, `.build/build.db`,
  `.build/debug.yaml`, `.build/plugin-tools.yaml`, `.build/plugins` and
  `.build/swiftlint.cache`, with the lane appended to the key and a
  lane-agnostic restore key so either lane can seed the other. It is **restored
  on every run and saved only from pushes to `main`**, after every check has
  passed, so pull requests start warm without each one writing a multi-gigabyte
  entry.

Before saving, the reproducible products are pruned: the clang module cache, the
`.dSYM` bundles and the assembled `MereRun.app`. That takes the entry from 3.7 GB
to 2.1 GB on disk, about 0.5 GB compressed.

**The MLX metallib is never cached.** Restored copies are deleted immediately
after restore, and again before save, so every run is in the same state a cold
checkout would be: `build_mere_run_app.sh` regenerates and re-stamps the library
from this checkout, and `build_mlx_metallib.sh --verify-only vendor/mlx-swift_Cmlx.bundle`
still audits the tracked vendored bundle against the pinned mlx-swift revision,
the MLX core revision, and a hash of the kernel sources. That verification runs
in **both** lanes.

## Verification

- `actionlint .github/workflows/ci.yml` is clean, as `main` is.
- The classifier's `run:` body was extracted and exercised against 22 synthetic
  change sets covering every category, mixed sets, unknown top-level paths, and
  a missing base SHA. Every case produced the intended `code`/`lane`/`linux`/`ios`
  combination, and both the unknown-path and missing-base-SHA cases fall back to
  the full gate.
- Both lanes' command sequences were run locally on this checkout, on a warm
  build directory:

  | Lane | Steps | Wall time |
  | --- | --- | --- |
  | Fast | swiftlint 1s, repository checks 0s, `swift build` 22s, metallib verify 1s, `MereRunAppTests` 38s (358 tests), app bundle 20s | **82s** |
  | Full | `./scripts/check.sh` 211s (3,579 tests, 130s of execution), app bundle 32s | **243s** |

  A cold `swift build` on the same machine is 114s, so the build cache is worth
  roughly 3x on the compile alone; a tar round trip of the pruned build directory
  (new inodes, preserved mtimes) reproduced a complete no-op build, confirming
  llbuild revalidates by path, size and modification time rather than inode.
- The metallib guard was checked by corrupting `kernel-sources-sha256` in a copy
  of the vendored sidecar: `--verify-only` reports `STALE: kernel source hash
  mismatch` and exits 1.
- The bundle verification block was run against the fast lane's output:
  `codesign --verify --strict` reports valid on disk and satisfying its
  designated requirement.

## Expected saving

A UI-only pull request drops from the full `check.sh` plus the Linux gate plus
the iOS build to the fast lane alone. On the measured local ratios that is about
a third of the macOS package gate's work, and the Linux and iOS jobs — which set
the wall-clock ceiling for that kind of change — no longer run at all.

## Still forces more than it should

- `swift test --filter MereRunAppTests` still **compiles** every test target;
  SwiftPM has no way to build one test target's bundle in isolation. The fast
  lane saves the ~130s of execution and the CLI/Core test link, not their
  compile.
- The `linux-cli` container image is still pulled on the no-op path. Keeping the
  required check name reporting was worth more than that minute.
- A change to any root-level shell script (`demo.sh`, `test-all.sh`) or dotfile
  lands in `other` and takes the full gate. That is deliberate for now; add an
  explicit rule if it becomes common.
- This pull request changes `.github/**`, so it exercises the **full** lane only.
  The fast lane's first real exercise will be the next `apps/macos`-only change.

## Fix carried in this branch

The first push exposed a real bug in the new `linux-cli` guard: container jobs
default to `sh -e {0}`, and dash rejects `set -o pipefail`, so the
change-detection step failed before doing anything. The step now asks for
`shell: bash` explicitly.

## Documentation

`CONTRIBUTING.md` gains a "Continuous integration lanes" section describing both
lanes, the derived Linux and iOS scopes, and the cache, and states plainly that
`./scripts/check.sh` remains the local gate for everything.
`docs/development-workflow.md` points at it. A "Merge queue" section documents
the `merge_group` trigger, why every required check reports there, and why queue
runs are never cancelled.
