### PR TITLE
Reconcile declared capability outputs with what the commands write

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,20 @@ The format is based on Keep a Changelog.
 
 ### CLI
 
+- reconciled every capability's declared `output` with what the command
+  actually writes, and gave the declaration two additive fields: `flag`, the
+  option that carries the destination path, and `optional`, true when the
+  artifact is written only if that flag is passed. `kind` now consistently
+  describes a run that names no destination, so `speech transcribe`,
+  `speech diarize`, `text embed`, `text anonymize`, `vision embed`,
+  `vision ocr`, `vision face detect`/`embed`/`compare`/`batch`, `gate`,
+  `eval run`, `eval promote`, `model optimize`, and `model benchmark vlm` read
+  as the stdout runs they are, `vision pose` declares the JSON landmark file it
+  always writes, `music realtime` declares the WAV it captures on request, and
+  `image run-plan` declares the file the saved plan names rather than a run
+  directory. `model optimize` also declares its `--output` option. The fields
+  are additive, `mere.run catalog --json` omits them when unset, and contract
+  and CLI tests prove every declared destination flag is one the command parses.
 - added optional `default_value`, `group`, `tier`, `range`, and `depends_on`
   metadata to every option in the shared capability contract and populated it
   for the prompt-mode capabilities (`image.generate`, `text.chat`, `text.code`,

--- a/Sources/MereRunContract/CommandCapabilityContract.swift
+++ b/Sources/MereRunContract/CommandCapabilityContract.swift
@@ -153,6 +153,10 @@ public struct MereRunCapabilityOption: Codable, Equatable, Sendable {
     }
 }
 
+/// What a successful run leaves behind when the caller passes no destination.
+/// `text` prints its result to stdout, `service` runs until it is stopped, and
+/// `file` and `directory` always write the artifact, at a default path when the
+/// caller names none.
 public enum MereRunCapabilityOutputKind: String, Codable, Sendable {
     case text
     case file
@@ -160,18 +164,61 @@ public enum MereRunCapabilityOutputKind: String, Codable, Sendable {
     case service
 }
 
+/// The artifact one run produces, and how the caller asks for it.
+///
+/// A `text` or `service` capability that still declares a `flag` writes that
+/// artifact only when the flag is passed (`optional` is then `true`); `kind`
+/// describes what the run does without it. Look `flag` up in the capability's
+/// `options` to learn whether it names a file or a directory.
 public struct MereRunCapabilityOutput: Codable, Equatable, Sendable {
     public let kind: MereRunCapabilityOutputKind
+    /// The written artifact's extension when it is a file, and the command
+    /// always writes the same one. Absent for directories and for commands
+    /// whose extension follows another option (`speech diarize --format`).
     public let fileExtension: String?
+    /// The option whose value names the destination. Absent when the run writes
+    /// nothing, or chooses the location itself (`adapter pull`, `image run-plan`).
+    public let flag: String?
+    /// True when the artifact is written only if `flag` is passed.
+    public let optional: Bool
 
     enum CodingKeys: String, CodingKey {
         case kind
         case fileExtension = "file_extension"
+        case flag
+        case optional
     }
 
-    public init(kind: MereRunCapabilityOutputKind, fileExtension: String? = nil) {
+    public init(
+        kind: MereRunCapabilityOutputKind,
+        fileExtension: String? = nil,
+        flag: String? = nil,
+        optional: Bool = false
+    ) {
         self.kind = kind
         self.fileExtension = fileExtension
+        self.flag = flag
+        self.optional = optional
+    }
+
+    /// `flag` and `optional` are additive: a document written before they
+    /// existed decodes with no destination flag and a mandatory artifact.
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        kind = try container.decode(MereRunCapabilityOutputKind.self, forKey: .kind)
+        fileExtension = try container.decodeIfPresent(String.self, forKey: .fileExtension)
+        flag = try container.decodeIfPresent(String.self, forKey: .flag)
+        optional = try container.decodeIfPresent(Bool.self, forKey: .optional) ?? false
+    }
+
+    /// Absent fields stay absent so a decoder that predates them sees the same
+    /// JSON it always did.
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(kind, forKey: .kind)
+        try container.encodeIfPresent(fileExtension, forKey: .fileExtension)
+        try container.encodeIfPresent(flag, forKey: .flag)
+        if optional { try container.encode(true, forKey: .optional) }
     }
 }
 
@@ -559,7 +606,7 @@ public enum MereRunCapabilityCatalog {
             .init(flag: "--output", label: "Output", kind: .file),
             .init(flag: "--pretty", label: "Pretty JSON", kind: .boolean)
         ],
-        output: .init(kind: .file, fileExtension: "json")
+        output: .init(kind: .text, fileExtension: "json", flag: "--output", optional: true)
     )
 
     public static let textAnonymize = MereRunCommandCapability(
@@ -578,7 +625,7 @@ public enum MereRunCapabilityCatalog {
             .init(flag: "--pretty", label: "Pretty JSON", kind: .boolean),
             .init(flag: "--output", label: "Output", kind: .file)
         ],
-        output: .init(kind: .file)
+        output: .init(kind: .text, flag: "--output", optional: true)
     )
 
     public static let textTrainLoRA = MereRunCommandCapability(
@@ -607,7 +654,7 @@ public enum MereRunCapabilityCatalog {
             .init(flag: "--visualize-port", label: "Visualization port", kind: .integer),
             .init(flag: "--json", label: "JSON", kind: .boolean)
         ],
-        output: .init(kind: .file, fileExtension: "safetensors")
+        output: .init(kind: .file, fileExtension: "safetensors", flag: "--output")
     )
 
     public static let imageGenerate = MereRunCommandCapability(
@@ -712,7 +759,7 @@ public enum MereRunCapabilityCatalog {
             progressJSONOption,
             receiptOption
         ],
-        output: .init(kind: .file, fileExtension: "png")
+        output: .init(kind: .file, fileExtension: "png", flag: "--output")
     )
 
     public static let imageTrainLoRA = MereRunCommandCapability(
@@ -795,7 +842,7 @@ public enum MereRunCapabilityCatalog {
             .init(flag: "--synthetic-samples", label: "Synthetic samples", kind: .integer),
             .init(flag: "--quiet", label: "Quiet", kind: .boolean)
         ],
-        output: .init(kind: .file, fileExtension: "safetensors")
+        output: .init(kind: .file, fileExtension: "safetensors", flag: "--output")
     )
 
     public static let imageValidate = MereRunCommandCapability(
@@ -816,7 +863,7 @@ public enum MereRunCapabilityCatalog {
             .init(flag: "--compare", label: "Compare", kind: .boolean),
             .init(flag: "--reference-dir", label: "Reference directory", kind: .directory)
         ],
-        output: .init(kind: .directory)
+        output: .init(kind: .directory, flag: "--output")
     )
 
     public static let imageDatasetDiscover = MereRunCommandCapability(
@@ -850,7 +897,7 @@ public enum MereRunCapabilityCatalog {
             .init(flag: "--json", label: "JSON", kind: .boolean),
             .init(flag: "--materialize", label: "Materialize run", kind: .directory)
         ],
-        output: .init(kind: .directory)
+        output: .init(kind: .file)
     )
 
     public static let imageVisualizeRun = MereRunCommandCapability(
@@ -886,7 +933,7 @@ public enum MereRunCapabilityCatalog {
             .init(flag: "--dry-run", label: "Dry run", kind: .boolean),
             .init(flag: "--json", label: "JSON", kind: .boolean)
         ],
-        output: .init(kind: .directory)
+        output: .init(kind: .directory, flag: "--output")
     )
 
     public static let imageReconstruct3DTrellis2 = MereRunCommandCapability(
@@ -910,7 +957,7 @@ public enum MereRunCapabilityCatalog {
             .init(flag: "--dry-run", label: "Dry run", kind: .boolean),
             .init(flag: "--json", label: "JSON", kind: .boolean)
         ],
-        output: .init(kind: .directory)
+        output: .init(kind: .directory, flag: "--output")
     )
 
     public static let imageReconstruct3DMultiview = MereRunCommandCapability(
@@ -928,7 +975,7 @@ public enum MereRunCapabilityCatalog {
             .init(flag: "--dry-run", label: "Dry run", kind: .boolean),
             .init(flag: "--json", label: "JSON", kind: .boolean)
         ],
-        output: .init(kind: .directory)
+        output: .init(kind: .directory, flag: "--output")
     )
 
     public static let visionInspect = MereRunCommandCapability(
@@ -974,7 +1021,7 @@ public enum MereRunCapabilityCatalog {
             .init(flag: "--output", label: "Output", kind: .file),
             .init(flag: "--pretty", label: "Pretty JSON", kind: .boolean)
         ],
-        output: .init(kind: .file, fileExtension: "json")
+        output: .init(kind: .text, fileExtension: "json", flag: "--output", optional: true)
     )
 
     public static let visionCaption = MereRunCommandCapability(
@@ -1003,7 +1050,7 @@ public enum MereRunCapabilityCatalog {
                 defaultValue: "0.9", group: Group.sampling, tier: .standard, range: .init(min: 0, max: 1, step: 0.01)
             )
         ],
-        output: .init(kind: .directory)
+        output: .init(kind: .directory, flag: "--output-dir")
     )
 
     public static let visionOCR = MereRunCommandCapability(
@@ -1090,7 +1137,7 @@ public enum MereRunCapabilityCatalog {
             ),
             .init(flag: "--quiet", label: "Quiet", kind: .boolean, group: Group.run, tier: .expert)
         ],
-        output: .init(kind: .directory)
+        output: .init(kind: .text, flag: "--output-dir", optional: true)
     )
 
     public static let visionGround = MereRunCommandCapability(
@@ -1110,7 +1157,7 @@ public enum MereRunCapabilityCatalog {
             .init(flag: "--quiet", label: "Quiet", kind: .boolean, group: Group.run, tier: .expert),
             receiptOption
         ],
-        output: .init(kind: .file, fileExtension: "png")
+        output: .init(kind: .file, fileExtension: "png", flag: "--output")
     )
 
     public static let visionSegment = MereRunCommandCapability(
@@ -1142,7 +1189,7 @@ public enum MereRunCapabilityCatalog {
             .init(flag: "--quiet", label: "Quiet", kind: .boolean, group: Group.run, tier: .expert),
             receiptOption
         ],
-        output: .init(kind: .file, fileExtension: "png")
+        output: .init(kind: .file, fileExtension: "png", flag: "--output")
     )
 
     public static let visionTrack = MereRunCommandCapability(
@@ -1182,7 +1229,7 @@ public enum MereRunCapabilityCatalog {
             .init(flag: "--quiet", label: "Quiet", kind: .boolean, group: Group.run, tier: .expert),
             receiptOption
         ],
-        output: .init(kind: .file, fileExtension: "mp4")
+        output: .init(kind: .file, fileExtension: "mp4", flag: "--output")
     )
 
     public static let visionTrackLive = MereRunCommandCapability(
@@ -1204,7 +1251,7 @@ public enum MereRunCapabilityCatalog {
             .init(flag: "--show-boxes", label: "Show boxes", kind: .boolean),
             .init(flag: "--show-labels", label: "Show labels", kind: .boolean)
         ],
-        output: .init(kind: .file, fileExtension: "mp4")
+        output: .init(kind: .file, fileExtension: "mp4", flag: "--output")
     )
 
     public static let visionFaceDetect = MereRunCommandCapability(
@@ -1217,7 +1264,7 @@ public enum MereRunCapabilityCatalog {
             .init(flag: "--max-faces", label: "Max faces", kind: .integer),
             .init(flag: "--include-embeddings", label: "Embeddings", kind: .boolean)
         ],
-        output: .init(kind: .text)
+        output: .init(kind: .text, fileExtension: "json", flag: "--json-output", optional: true)
     )
 
     public static let visionFaceEmbed = MereRunCommandCapability(
@@ -1229,7 +1276,7 @@ public enum MereRunCapabilityCatalog {
         options: faceOptions + [
             .init(flag: "--face-index", label: "Face index", kind: .integer)
         ],
-        output: .init(kind: .text)
+        output: .init(kind: .text, fileExtension: "json", flag: "--json-output", optional: true)
     )
 
     public static let visionFaceCompare = MereRunCommandCapability(
@@ -1245,7 +1292,7 @@ public enum MereRunCapabilityCatalog {
             .init(flag: "--reference-face-index", label: "Reference index", kind: .integer),
             .init(flag: "--candidate-face-index", label: "Candidate index", kind: .integer)
         ],
-        output: .init(kind: .text)
+        output: .init(kind: .text, fileExtension: "json", flag: "--json-output", optional: true)
     )
 
     public static let visionFaceBatch = MereRunCommandCapability(
@@ -1264,7 +1311,7 @@ public enum MereRunCapabilityCatalog {
             .init(flag: "--jsonl-output", label: "JSONL output", kind: .file),
             .init(flag: "--fail-fast", label: "Fail fast", kind: .boolean)
         ],
-        output: .init(kind: .text)
+        output: .init(kind: .text, fileExtension: "jsonl", flag: "--jsonl-output", optional: true)
     )
 
     private static let faceOptions: [MereRunCapabilityOption] = [
@@ -1290,7 +1337,7 @@ public enum MereRunCapabilityCatalog {
             .init(flag: "--minimum-confidence", label: "Confidence", kind: .number),
             .init(flag: "--json", label: "Print JSON", kind: .boolean)
         ],
-        output: .init(kind: .text)
+        output: .init(kind: .file, fileExtension: "json", flag: "--json-output")
     )
 
     public static let visionFlow = MereRunCommandCapability(
@@ -1308,7 +1355,7 @@ public enum MereRunCapabilityCatalog {
             .init(flag: "--accuracy", label: "Accuracy", kind: .choice, choices: ["low", "medium", "high", "very-high"]),
             .init(flag: "--json", label: "Print JSON", kind: .boolean)
         ],
-        output: .init(kind: .file, fileExtension: "flo")
+        output: .init(kind: .file, fileExtension: "flo", flag: "--output")
     )
 
     public static let visionDepthVideo = MereRunCommandCapability(
@@ -1325,7 +1372,7 @@ public enum MereRunCapabilityCatalog {
             .init(flag: "--dry-run", label: "Dry run", kind: .boolean),
             .init(flag: "--json", label: "Print JSON", kind: .boolean)
         ],
-        output: .init(kind: .directory)
+        output: .init(kind: .directory, flag: "--output")
     )
 
     public static let visionGeometry = MereRunCommandCapability(
@@ -1343,7 +1390,7 @@ public enum MereRunCapabilityCatalog {
             .init(flag: "--dry-run", label: "Dry run", kind: .boolean),
             .init(flag: "--json", label: "Print JSON", kind: .boolean)
         ],
-        output: .init(kind: .directory)
+        output: .init(kind: .directory, flag: "--output")
     )
 
     public static let visionGeometryMultiview = MereRunCommandCapability(
@@ -1363,7 +1410,7 @@ public enum MereRunCapabilityCatalog {
             .init(flag: "--dry-run", label: "Dry run", kind: .boolean),
             .init(flag: "--json", label: "Print JSON", kind: .boolean)
         ],
-        output: .init(kind: .directory)
+        output: .init(kind: .directory, flag: "--output")
     )
 
     public static let audioEnhance = MereRunCommandCapability(
@@ -1398,7 +1445,7 @@ public enum MereRunCapabilityCatalog {
             ),
             .init(flag: "--quiet", label: "Quiet", kind: .boolean)
         ],
-        output: .init(kind: .file, fileExtension: "wav")
+        output: .init(kind: .file, fileExtension: "wav", flag: "--output")
     )
 
     public static let audioGenerate = MereRunCommandCapability(
@@ -1432,7 +1479,7 @@ public enum MereRunCapabilityCatalog {
             .init(flag: "--lora", label: "Audio LoRA", kind: .string, repeatable: true),
             .init(flag: "--quiet", label: "Quiet", kind: .boolean)
         ],
-        output: .init(kind: .file, fileExtension: "wav")
+        output: .init(kind: .file, fileExtension: "wav", flag: "--output")
     )
 
     public static let musicGenerate = MereRunCommandCapability(
@@ -1713,7 +1760,7 @@ public enum MereRunCapabilityCatalog {
             progressJSONOption,
             receiptOption
         ],
-        output: .init(kind: .file, fileExtension: "wav")
+        output: .init(kind: .file, fileExtension: "wav", flag: "--output")
     )
 
     public static let musicAnalyze = MereRunCommandCapability(
@@ -1770,7 +1817,7 @@ public enum MereRunCapabilityCatalog {
             .init(flag: "--context-output", label: "Context output", kind: .file),
             .init(flag: "--quiet", label: "Quiet", kind: .boolean)
         ],
-        output: .init(kind: .file)
+        output: .init(kind: .file, flag: "--output")
     )
 
     public static let musicSeparate = MereRunCommandCapability(
@@ -1794,7 +1841,7 @@ public enum MereRunCapabilityCatalog {
             ),
             .init(flag: "--quiet", label: "Quiet", kind: .boolean)
         ],
-        output: .init(kind: .directory)
+        output: .init(kind: .directory, flag: "--output-dir")
     )
 
     public static let musicRealtime = MereRunCommandCapability(
@@ -1832,7 +1879,7 @@ public enum MereRunCapabilityCatalog {
             .init(flag: "--midi-cc", label: "MIDI CC map", kind: .string, repeatable: true),
             .init(flag: "--quiet", label: "Quiet", kind: .boolean)
         ],
-        output: .init(kind: .service)
+        output: .init(kind: .service, fileExtension: "wav", flag: "--output", optional: true)
     )
 
     public static let musicTrainAdapter = MereRunCommandCapability(
@@ -1859,7 +1906,7 @@ public enum MereRunCapabilityCatalog {
             .init(flag: "--text-subdirectory", label: "Text encoder", kind: .string),
             .init(flag: "--log-every", label: "Progress interval", kind: .integer)
         ],
-        output: .init(kind: .file, fileExtension: "safetensors")
+        output: .init(kind: .file, fileExtension: "safetensors", flag: "--output")
     )
 
     public static let musicServe = MereRunCommandCapability(
@@ -2159,7 +2206,7 @@ public enum MereRunCapabilityCatalog {
             progressJSONOption,
             receiptOption
         ],
-        output: .init(kind: .file, fileExtension: "mp4")
+        output: .init(kind: .file, fileExtension: "mp4", flag: "--output")
     )
 
     public static let videoRetake = MereRunCommandCapability(
@@ -2205,7 +2252,7 @@ public enum MereRunCapabilityCatalog {
             .init(flag: "--preserve-audio", label: "Preserve audio", kind: .boolean),
             .init(flag: "--quiet", label: "Quiet", kind: .boolean)
         ],
-        output: .init(kind: .file, fileExtension: "mp4")
+        output: .init(kind: .file, fileExtension: "mp4", flag: "--output")
     )
 
     public static let videoDubIt = MereRunCommandCapability(
@@ -2236,7 +2283,7 @@ public enum MereRunCapabilityCatalog {
             .init(flag: "--video-decoder", label: "Video decoder", kind: .choice, choices: ["diffusion", "convolutional"]),
             .init(flag: "--quiet", label: "Quiet", kind: .boolean)
         ],
-        output: .init(kind: .file, fileExtension: "mp4")
+        output: .init(kind: .file, fileExtension: "mp4", flag: "--output")
     )
 
     public static let videoAnimate = MereRunCommandCapability(
@@ -2278,7 +2325,7 @@ public enum MereRunCapabilityCatalog {
             .init(flag: "--json", label: "JSON", kind: .boolean),
             .init(flag: "--quiet", label: "Quiet", kind: .boolean)
         ],
-        output: .init(kind: .file, fileExtension: "mp4")
+        output: .init(kind: .file, fileExtension: "mp4", flag: "--output")
     )
 
     public static let videoCosmos3 = MereRunCommandCapability(
@@ -2327,7 +2374,7 @@ public enum MereRunCapabilityCatalog {
             .init(flag: "--max-video-frames", label: "Reasoner video frames", kind: .integer),
             .init(flag: "--quiet", label: "Quiet", kind: .boolean)
         ],
-        output: .init(kind: .file)
+        output: .init(kind: .file, flag: "--output")
     )
 
     public static let videoPrepareMasks = MereRunCommandCapability(
@@ -2344,7 +2391,7 @@ public enum MereRunCapabilityCatalog {
             .init(flag: "--json", label: "JSON", kind: .boolean),
             .init(flag: "--quiet", label: "Quiet", kind: .boolean)
         ],
-        output: .init(kind: .directory)
+        output: .init(kind: .directory, flag: "--output-dir")
     )
 
     public static let videoExportLatents = MereRunCommandCapability(
@@ -2365,7 +2412,7 @@ public enum MereRunCapabilityCatalog {
             .init(flag: "--seed", label: "Seed", kind: .integer),
             .init(flag: "--quiet", label: "Quiet", kind: .boolean)
         ],
-        output: .init(kind: .file, fileExtension: "safetensors")
+        output: .init(kind: .file, fileExtension: "safetensors", flag: "--output")
     )
 
     public static let videoSession = MereRunCommandCapability(
@@ -2466,7 +2513,7 @@ public enum MereRunCapabilityCatalog {
             .init(flag: "--artifact", label: "Named artifact", kind: .string, repeatable: true),
             .init(flag: "--json", label: "JSON", kind: .boolean)
         ],
-        output: .init(kind: .directory)
+        output: .init(kind: .directory, flag: "--into")
     )
 
     public static let runCancel = MereRunCommandCapability(
@@ -2542,7 +2589,7 @@ public enum MereRunCapabilityCatalog {
             .init(flag: "--json-output", label: "JSON report", kind: .file),
             .init(flag: "--list", label: "List checks", kind: .boolean)
         ],
-        output: .init(kind: .file, fileExtension: "json")
+        output: .init(kind: .text, fileExtension: "json", flag: "--json-output", optional: true)
     )
 
     public static let evaluationPackValidate = MereRunCommandCapability(
@@ -2589,7 +2636,7 @@ public enum MereRunCapabilityCatalog {
             .init(flag: "--output", label: "Report", kind: .file),
             .init(flag: "--json", label: "JSON", kind: .boolean)
         ],
-        output: .init(kind: .file, fileExtension: "json")
+        output: .init(kind: .text, fileExtension: "json", flag: "--output", optional: true)
     )
 
     public static let evaluationPromote = MereRunCommandCapability(
@@ -2604,7 +2651,7 @@ public enum MereRunCapabilityCatalog {
             .init(flag: "--output", label: "Promotion receipt", kind: .file),
             .init(flag: "--json", label: "JSON", kind: .boolean)
         ],
-        output: .init(kind: .file, fileExtension: "json")
+        output: .init(kind: .text, fileExtension: "json", flag: "--output", optional: true)
     )
 
     public static let modelStorage = MereRunCommandCapability(
@@ -2866,9 +2913,10 @@ public enum MereRunCapabilityCatalog {
         ],
         options: [
             .init(flag: "--force", label: "Replace cache", kind: .boolean),
+            .init(flag: "--output", label: "Standalone checkpoint", kind: .directory),
             .init(flag: "--json", label: "JSON", kind: .boolean)
         ],
-        output: .init(kind: .text)
+        output: .init(kind: .text, flag: "--output", optional: true)
     )
 
     public static let modelBenchmarkQ36MTP = MereRunCommandCapability(
@@ -2976,7 +3024,7 @@ public enum MereRunCapabilityCatalog {
             progressJSONOption,
             receiptOption
         ],
-        output: .init(kind: .file, fileExtension: "wav")
+        output: .init(kind: .file, fileExtension: "wav", flag: "--output")
     )
 
     public static let speechTranscribe = MereRunCommandCapability(
@@ -3025,7 +3073,7 @@ public enum MereRunCapabilityCatalog {
             .init(flag: "--quiet", label: "Quiet", kind: .boolean, group: Group.run, tier: .expert),
             receiptOption
         ],
-        output: .init(kind: .file)
+        output: .init(kind: .text, fileExtension: "txt", flag: "--output", optional: true)
     )
 
     public static let speechDiarize = MereRunCommandCapability(
@@ -3045,7 +3093,7 @@ public enum MereRunCapabilityCatalog {
             .init(flag: "--merge-gap", label: "Merge gap", kind: .number),
             .init(flag: "--quiet", label: "Quiet", kind: .boolean)
         ],
-        output: .init(kind: .text)
+        output: .init(kind: .text, flag: "--output", optional: true)
     )
 
     public static let speechProfileList = MereRunCommandCapability(
@@ -3116,7 +3164,7 @@ public enum MereRunCapabilityCatalog {
             progressJSONOption,
             receiptOption
         ],
-        output: .init(kind: .file, fileExtension: "wav")
+        output: .init(kind: .file, fileExtension: "wav", flag: "--output")
     )
 
     public static let sfxVideoGenerate = MereRunCommandCapability(
@@ -3144,7 +3192,7 @@ public enum MereRunCapabilityCatalog {
             .init(flag: "--json", label: "JSON", kind: .boolean),
             .init(flag: "--quiet", label: "Quiet", kind: .boolean)
         ],
-        output: .init(kind: .file, fileExtension: "wav")
+        output: .init(kind: .file, fileExtension: "wav", flag: "--output")
     )
 
     public static let sfxAEEncode = MereRunCommandCapability(
@@ -3158,7 +3206,7 @@ public enum MereRunCapabilityCatalog {
             .init(flag: "--model", label: "Model", kind: .string),
             .init(flag: "--quiet", label: "Quiet", kind: .boolean)
         ],
-        output: .init(kind: .file, fileExtension: "npy")
+        output: .init(kind: .file, fileExtension: "npy", flag: "--output")
     )
 
     public static let sfxAEDecode = MereRunCommandCapability(
@@ -3172,7 +3220,7 @@ public enum MereRunCapabilityCatalog {
             .init(flag: "--model", label: "Model", kind: .string),
             .init(flag: "--quiet", label: "Quiet", kind: .boolean)
         ],
-        output: .init(kind: .file, fileExtension: "wav")
+        output: .init(kind: .file, fileExtension: "wav", flag: "--output")
     )
 
     public static let sfxCLAPScore = MereRunCommandCapability(
@@ -3202,7 +3250,7 @@ public enum MereRunCapabilityCatalog {
             .init(flag: "--model", label: "Model", kind: .string),
             .init(flag: "--quiet", label: "Quiet", kind: .boolean)
         ],
-        output: .init(kind: .file, fileExtension: "safetensors")
+        output: .init(kind: .file, fileExtension: "safetensors", flag: "--output")
     )
 
     public static let pluginList = MereRunCommandCapability(
@@ -3398,7 +3446,7 @@ public enum MereRunCapabilityCatalog {
             .init(flag: "--preflight", label: "Preflight", kind: .boolean),
             .init(flag: "--json", label: "JSON", kind: .boolean)
         ],
-        output: .init(kind: .file, fileExtension: "safetensors")
+        output: .init(kind: .file, fileExtension: "safetensors", flag: "--output")
     )
 
     public static let geoFire = MereRunCommandCapability(
@@ -3415,7 +3463,7 @@ public enum MereRunCapabilityCatalog {
             .init(flag: "--preflight", label: "Preflight", kind: .boolean),
             .init(flag: "--json", label: "JSON", kind: .boolean)
         ],
-        output: .init(kind: .file, fileExtension: "safetensors")
+        output: .init(kind: .file, fileExtension: "safetensors", flag: "--output")
     )
 
     public static let geoTessera = MereRunCommandCapability(
@@ -3433,7 +3481,7 @@ public enum MereRunCapabilityCatalog {
             .init(flag: "--preflight", label: "Preflight", kind: .boolean),
             .init(flag: "--json", label: "JSON", kind: .boolean)
         ],
-        output: .init(kind: .file, fileExtension: "safetensors")
+        output: .init(kind: .file, fileExtension: "safetensors", flag: "--output")
     )
 
     public static let geoOlmoEarth = MereRunCommandCapability(
@@ -3453,7 +3501,7 @@ public enum MereRunCapabilityCatalog {
             .init(flag: "--preflight", label: "Preflight", kind: .boolean),
             .init(flag: "--json", label: "JSON", kind: .boolean)
         ],
-        output: .init(kind: .file, fileExtension: "safetensors")
+        output: .init(kind: .file, fileExtension: "safetensors", flag: "--output")
     )
 
     // MARK: - Model store locations
@@ -3695,7 +3743,7 @@ public enum MereRunCapabilityCatalog {
             .init(flag: "--dry-run", label: "Dry run", kind: .boolean),
             .init(flag: "--json", label: "JSON", kind: .boolean)
         ],
-        output: .init(kind: .text)
+        output: .init(kind: .text, flag: "--output-dir", optional: true)
     )
 
     public static let modelBenchmarkToolCalls = MereRunCommandCapability(

--- a/Sources/MereRunContract/README.md
+++ b/Sources/MereRunContract/README.md
@@ -21,6 +21,16 @@ where the pipeline reports steps, `--progress-json`; the line shapes are
 documented on `MereRunCapabilityCatalog.resultReceiptExample` and
 `progressEventExample`.
 
+Each capability's `output` says what one successful run leaves behind. `kind`
+describes the run with no destination named: `text` prints to stdout, `service`
+runs until it is stopped, and `file` or `directory` always writes the artifact.
+`flag` names the option that carries the destination path, and `optional` marks
+the artifact a run writes only when that flag is passed — so a `text`
+capability with a `flag` prints its result and additionally saves it on
+request. Look `flag` up in `options` to learn whether it names a file or a
+directory. `flag` stays `nil` only where the command chooses the location
+itself; `capabilityFileOutputsDeclareADestinationFlag` lists those.
+
 When extending the contract:
 
 - Add only public CLI capabilities that a shell needs to discover or invoke.

--- a/Tests/MereRunCLITests/CapabilityCatalogTests.swift
+++ b/Tests/MereRunCLITests/CapabilityCatalogTests.swift
@@ -174,6 +174,27 @@ private let exactCapabilityOptionIDs: Set<String> = [
     "plugin.info", "plugin.run", "plugin.rollback", "speech.listen", "vision.serve"
 ]
 
+/// A capability that declares an artifact has to name a flag the CLI really
+/// parses, so the contract cannot promise shells a destination the command
+/// would reject. `adapter pull` and `image run-plan` choose their own paths and
+/// declare no flag; `capabilityFileOutputsDeclareADestinationFlag` covers them.
+@Test func capabilityOutputFlagsAreAcceptedByTheCLI() {
+    let helpByID = capabilityHelpMessages()
+
+    for capability in MereRunCapabilityCatalog.document.commands {
+        guard let flag = capability.output.flag else { continue }
+        guard let help = helpByID[capability.id] else {
+            Issue.record("Missing help fixture for \(capability.id)")
+            continue
+        }
+        let path = capability.command.joined(separator: " ")
+        #expect(
+            longOptionFlags(in: help).contains(flag),
+            "\(capability.id) writes its output to \(flag), which `mere.run \(path) --help` does not advertise"
+        )
+    }
+}
+
 /// Every `default_value` the contract advertises must be the default
 /// ArgumentParser renders in `--help`, so a CLI default change that forgets the
 /// contract fails here instead of drifting into the shells' forms.

--- a/Tests/MereRunContractTests/CommandCapabilityContractTests.swift
+++ b/Tests/MereRunContractTests/CommandCapabilityContractTests.swift
@@ -266,6 +266,84 @@ private let knownOptionGroups: Set<String> = [
     #expect(decoded.range == nil && decoded.dependsOn == nil)
 }
 
+/// Capabilities whose artifact path is not caller-chosen, with the reason. Any
+/// other file or directory output has to name the option that carries its
+/// destination so a shell can request one.
+private let selfLocatingOutputCapabilityIDs: [String: String] = [
+    "adapter.pull": "Installs into the managed adapter store and prints the verified path.",
+    "image.run-plan": "The saved plan names its own output path; --materialize adds a run directory."
+]
+
+@Test func capabilityFileOutputsDeclareADestinationFlag() {
+    for command in MereRunCapabilityCatalog.document.commands {
+        let output = command.output
+        guard output.kind == .file || output.kind == .directory else { continue }
+        if output.flag == nil {
+            #expect(
+                selfLocatingOutputCapabilityIDs[command.id] != nil,
+                "\(command.id) writes a \(output.kind.rawValue) but names no destination flag"
+            )
+        }
+        #expect(!output.optional, "\(command.id) declares a \(output.kind.rawValue) it does not always write")
+    }
+
+    for (id, reason) in selfLocatingOutputCapabilityIDs {
+        let command = MereRunCapabilityCatalog.command(id: id)
+        #expect(command != nil, "Exemption \(id) no longer matches a capability: \(reason)")
+        #expect(command?.output.flag == nil, "\(id) names a destination flag now; remove its exemption.")
+    }
+}
+
+@Test func capabilityOutputFlagsAreDeclaredOptions() {
+    for command in MereRunCapabilityCatalog.document.commands {
+        guard let flag = command.output.flag else {
+            #expect(!command.output.optional, "\(command.id) declares an optional output with no flag to request it")
+            continue
+        }
+        #expect(
+            command.options.contains { $0.flag == flag },
+            "\(command.id) writes its output to \(flag), which it does not declare as an option"
+        )
+    }
+}
+
+@Test func outputMetadataSerializesAdditivelyAndDecodesLegacyJSON() throws {
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = [.sortedKeys]
+
+    // A mandatory artifact encodes exactly the keys the previous schema had, plus `flag`.
+    let image = String(decoding: try encoder.encode(MereRunCapabilityCatalog.imageGenerate.output), as: UTF8.self)
+    #expect(image == #"{"file_extension":"png","flag":"--output","kind":"file"}"#)
+
+    // `optional` appears only where a run may write nothing.
+    let diarize = String(decoding: try encoder.encode(MereRunCapabilityCatalog.speechDiarize.output), as: UTF8.self)
+    #expect(diarize == #"{"flag":"--output","kind":"text","optional":true}"#)
+
+    let chat = String(decoding: try encoder.encode(MereRunCapabilityCatalog.textChat.output), as: UTF8.self)
+    #expect(chat == #"{"kind":"text"}"#)
+
+    let legacy = Data(#"{"kind":"file","file_extension":"png"}"#.utf8)
+    let decoded = try JSONDecoder().decode(MereRunCapabilityOutput.self, from: legacy)
+    #expect(decoded == MereRunCapabilityOutput(kind: .file, fileExtension: "png"))
+    #expect(decoded.flag == nil && !decoded.optional)
+}
+
+/// The commands that print their whole result to stdout and write nothing, even
+/// though a neighbouring command in the same family writes a file.
+@Test func stdoutOnlyCapabilitiesDeclareNoDestination() {
+    for id in [
+        "text.chat", "text.code", "vision.inspect", "music.analyze", "sfx.clap.score",
+        "image.dataset.discover", "eval.pack.validate", "speech.listen",
+        "model.benchmark.chat", "model.benchmark.code", "model.benchmark.fused",
+        "model.benchmark.tool-calls", "model.benchmark.tool-continuations",
+        "model.benchmark.api-workload"
+    ] {
+        let command = MereRunCapabilityCatalog.command(id: id)
+        #expect(command?.output.kind == .text, "\(id) no longer declares a text output")
+        #expect(command?.output.flag == nil, "\(id) names a destination flag now; declare the artifact it writes")
+    }
+}
+
 @Test func speechTranscribeSampleRatePinsTheOnlyRateTheCLIAccepts() throws {
     // `SpeechTranscribe.validate()` requires `--sample-rate 16000` on raw stdin
     // and rejects the flag entirely off it.

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -3178,6 +3178,16 @@ additive option metadata (`default_value`, `group`, `tier`, `range`,
 `depends_on`) that shells use to build forms without a second copy of the
 command surface.
 
+Each capability's `output` describes what one successful run leaves behind.
+`kind` covers the run with no destination named — `text` prints to stdout,
+`service` runs until it is stopped, and `file` or `directory` always writes the
+artifact. `flag` names the option that carries the destination path, and
+`optional` marks an artifact written only when that flag is passed, so
+`speech transcribe` reads as a `text` run that additionally saves the
+transcript to `--output` on request. `flag` is absent only where the command
+picks the path itself: `adapter pull` installs into the managed adapter store,
+and `image run-plan` writes wherever the saved plan says.
+
 ## Validation and smoke runs
 
 Standard repository validation:


### PR DESCRIPTION
## Why

Building `CommandTemplate.declaredOutputKind` in #424 surfaced eleven commands
where the contract's declared output and the app's own model disagree. Reading
each command implementation shows the contract is the wrong side more often
than the app is: it promised files that only appear on request, called one
recorded WAV a bare service, and called a delegated file a run directory. This
reconciles the declaration with what `Sources/MereRunCLI` actually writes.

## What changed

`MereRunCapabilityOutput` gains two additive fields:

- `flag` — the option whose value names the destination path.
- `optional` — true when the artifact is written only if `flag` is passed.

`kind` now consistently describes a run that names no destination: `text`
prints to stdout, `service` runs until it is stopped, and `file`/`directory`
always write the artifact (at a derived default path when the caller names
none). A stdout command therefore stays `text` while still declaring the file
it saves on request, instead of promising one it may never write.

Both fields are omitted from `mere.run catalog --json` when unset, and
`MereRunCapabilityOutput.init(from:)` decodes a document written before they
existed as "no destination flag, mandatory artifact". Every other key in
`catalog --json` is byte-identical.

### Corrected declarations

Eighteen capabilities in all: ten had the wrong `kind`, and eight kept their
kind but never mentioned the artifact they can write. The remaining forty file
and directory outputs were already right and only gained the destination flag
they always parsed.

| capability | before | after | what the command does |
| --- | --- | --- | --- |
| `speech.diarize` | `text` | `text` + `--output`, optional | renders JSON or RTTM to stdout; `-o` also saves it |
| `speech.transcribe` | `file` | `text`, `txt`, `--output`, optional | always prints; `--output` saves. The receipt already lists no outputs when the transcript only went to stdout |
| `text.embed` | `file` `json` | `text`, `json`, `--output`, optional | prints the JSON payload, then optionally writes it |
| `vision.embed` | `file` `json` | `text`, `json`, `--output`, optional | same |
| `text.anonymize` | `file` | `text`, `--output`, optional | same |
| `vision.ocr` | `directory` | `text`, `--output-dir`, optional | `--output-dir` help says "default: print to stdout" |
| `vision.face.detect` / `.embed` / `.compare` | `text` | `text`, `json`, `--json-output`, optional | `--json-output` was undeclared as the destination |
| `vision.face.batch` | `text` | `text`, `jsonl`, `--jsonl-output`, optional | "Defaults to stdout" |
| `vision.pose` | `text` | `file`, `json`, `--json-output` | always writes `<image>_pose.json`; this one really is a file |
| `gate` | `file` `json` | `text`, `json`, `--json-output`, optional | prints the report; `--json-output` is optional |
| `eval.run` | `file` `json` | `text`, `json`, `--output`, optional | "Atomically write the report JSON to this path", optional |
| `eval.promote` | `file` `json` | `text`, `json`, `--output`, optional | same |
| `model.optimize` | `text` | `text`, `--output`, optional | writes a standalone Nemotron Omni checkpoint directory; `--output` was not declared as an option at all, and now is |
| `model.benchmark.vlm` | `text` | `text`, `--output-dir`, optional | the only benchmark that writes anything, and only on external lmms-eval runs |
| `music.realtime` | `service` | `service`, `wav`, `--output`, optional | plays live and captures a WAV when asked |
| `image.run-plan` | `directory` | `file` | by default it executes the plan's `image generate` / `image train-lora`, writing wherever the plan says; `--materialize` is the only run-directory path |

Every other file or directory output keeps its kind and gains the destination
flag it always parsed (`--output`, `--output-dir`, or `run fetch --into`).

### Deliberately left alone

- The benchmark family other than `vlm` (`chat`, `code`, `fused`,
  `fused-fixture`, `tool-calls`, `tool-continuations`, `api-workload`,
  `q36-mtp`, `gemma4-kv`, `gemma4-mtp`, `laguna-dflash`) parses no destination
  option: `--json` prints a machine-readable report on stdout and nothing is
  written. `text` is correct; `CommandCatalog`'s `outputKind: .file("json")` is
  the wrong side of that drift.
- `image.dataset.discover` stays `text`. `--training-output-root` only shapes
  the `image train-lora` command lines it prints; it creates no files.
- `adapter.pull` keeps `file`/`safetensors` with no flag: it installs into the
  managed adapter store and prints the verified path.
- Store mutations that write files nobody asked for by path (`model pull`,
  `plugin install`, `speech profile create`, `model repair-manifests`) stay
  `text`.
- Sidecars (`--json-output` next to an annotated image, `--recipe-output`,
  `--mask-output-dir`, `eval run --checkpoint`) are not the primary output;
  `--receipt` already enumerates them with a `role`.

## Tests

- `capabilityOutputFlagsAreAcceptedByTheCLI` (CLI, help-derived, the pattern
  `capabilityFlagsMatchArgumentParserHelp` uses): every declared destination
  flag must appear in that command's ArgumentParser help.
- `capabilityFileOutputsDeclareADestinationFlag` (contract): a `file` or
  `directory` output must name a flag unless it is in
  `selfLocatingOutputCapabilityIDs` with the reason, and must not be optional.
- `capabilityOutputFlagsAreDeclaredOptions` (contract): the flag has to be one
  of the capability's own options, and an optional output has to have a flag.
- `outputMetadataSerializesAdditivelyAndDecodesLegacyJSON` (contract): pins the
  encoded shape and decodes a pre-`flag` document.
- `stdoutOnlyCapabilitiesDeclareNoDestination` (contract): records the commands
  that genuinely write nothing, so declaring one later is a deliberate edit.

## App-side follow-up

`ArtifactReceiptTests.testDeclaredOutputKindsDriftOnlyWhereRecorded` in #424
records an eleven-id drift set. After this lands, the contract side of all
eleven is correct, so the next app PR should fix `CommandCatalog`'s
`outputKind` for the six benchmarks that write nothing
(`.modelBenchmarkChat`, `.modelBenchmarkCode`, `.modelBenchmarkFused`,
`.modelBenchmarkToolCalls`, `.modelBenchmarkToolContinuations`,
`.modelBenchmarkAPIWorkload` — all `.file("json")` today) and then tighten that
test to assert the drift set is empty. `producesOutputFile` can also read the
new fields directly: `kind == .file || kind == .directory || output.flag != nil`
covers `music realtime` and the optional-artifact commands without the
fallback to the app's own model. I did not touch that test; it is not on `main`
yet and it still compiles against this contract.

## Verification

`swiftlint --strict`, `swift build`, `swift test --filter MereRunContractTests`,
`swift test --filter MereRunCLITests`, then `./scripts/check.sh` — all green.

## Reviewer notes

- No CLI behavior changes: this is the contract's description of behavior that
  already existed, plus one option (`model optimize --output`) the CLI already
  parsed but never advertised.
- `docs/cli.md` gains a paragraph on the `output` shape next to the existing
  `catalog --json` note; `Sources/MereRunContract/README.md` gains the same
  rules for contract authors.
