### PR TITLE
Save generations where people can find them and make the Library browsable

### DIFF
--- a/apps/macos/MereRunStudio/CommandCatalog.swift
+++ b/apps/macos/MereRunStudio/CommandCatalog.swift
@@ -1191,13 +1191,12 @@ struct CommandTemplate: Identifiable, Equatable {
             break
         }
 
-        switch outputKind {
-        case .file(let ext):
-            draft.outputPath = Self.defaultOutputURL(stem: id.rawValue, extension: ext).path
-        case .directory:
-            draft.outputPath = Self.defaultOutputDirectory(stem: id.rawValue).path
-        case .none:
-            break
+        // Destinations are user-visible folders per domain (`StudioOutputLocation`); the composer
+        // renames the file after the prompt, and specialist surfaces keep this stamped name.
+        if let path = StudioOutputLocation.templateOutputPath(
+            templateID: id, title: title, outputKind: outputKind
+        ) {
+            draft.outputPath = path
         }
 
         return draft
@@ -3367,22 +3366,6 @@ struct CommandTemplate: Identifiable, Equatable {
         return args
     }
 
-    private static func defaultOutputDirectory(stem: String) -> URL {
-        outputRoot().appendingPathComponent(stem, isDirectory: true)
-    }
-
-    private static func defaultOutputURL(stem: String, extension ext: String) -> URL {
-        let stamp = DateFormatter.mereRunTimestamp.string(from: Date())
-        return outputRoot()
-            .appendingPathComponent("\(stem)-\(stamp)")
-            .appendingPathExtension(ext)
-    }
-
-    private static func outputRoot() -> URL {
-        FileManager.default.urls(for: .applicationSupportDirectory, in: .userDomainMask)[0]
-            .appendingPathComponent("MereRun", isDirectory: true)
-            .appendingPathComponent("App Outputs", isDirectory: true)
-    }
 
     private func format(_ value: Double) -> String {
         String(format: "%.4g", value)

--- a/apps/macos/MereRunStudio/MereRunRootView.swift
+++ b/apps/macos/MereRunStudio/MereRunRootView.swift
@@ -5223,6 +5223,8 @@ struct MereRunSettingsView: View {
     @State private var hfEndpointStatus: String?
     @State private var configurationSummary = ""
     @State private var configurationPath = ""
+    /// Empty means the per-media defaults in `StudioOutputLocation`.
+    @AppStorage(StudioOutputLocation.rootDefaultsKey) private var outputRoot = ""
 
     var body: some View {
         TabView {
@@ -5271,6 +5273,16 @@ struct MereRunSettingsView: View {
         EditorSection("Models root") {
             PathField(path: $controller.modelsRoot, placeholder: "Optional model links/local-files root", mode: .openDirectory)
         }
+        EditorSection("Where generations are saved") {
+            PathField(path: $outputRoot, placeholder: outputRootPlaceholder, mode: .openDirectory)
+            Text("Leave this empty to file work by what it is: pictures and clips in `~/Pictures/mere.run`, audio in `~/Music/mere.run`, everything else in `~/Documents/mere.run`, each under a folder named for the domain. Set a folder to keep every domain together there instead. Runs already in the Library keep the paths they recorded.")
+                .font(MereRunTheme.captionFont)
+                .foregroundStyle(MereRunTheme.textMuted)
+        }
+    }
+
+    private var outputRootPlaceholder: String {
+        "~/Pictures/mere.run, ~/Music/mere.run, ~/Documents/mere.run"
     }
 
     @ViewBuilder

--- a/apps/macos/MereRunStudio/StudioAnalyzeResults.swift
+++ b/apps/macos/MereRunStudio/StudioAnalyzeResults.swift
@@ -419,10 +419,29 @@ enum StudioVisionResultPaths {
             draft.visionJSONOutputPath = stem.appendingPathExtension("json").path
         }
         if wantsMasks, draft.visionMaskOutputDirectory.isBlank {
-            draft.visionMaskOutputDirectory = stem.deletingLastPathComponent()
-                .appendingPathComponent("\(stem.lastPathComponent)-masks", isDirectory: true)
-                .path
+            draft.visionMaskOutputDirectory = maskDirectory(forStem: stem)
         }
+    }
+
+    /// Moves the sidecars of a replayed run beside its new output. Paths the user chose by hand
+    /// (anything that was not derived from the previous output) are left alone.
+    static func rederive(in draft: inout CommandDraft, previousOutputPath: String) {
+        guard !previousOutputPath.isBlank else { return }
+        let previousStem = URL(fileURLWithPath: previousOutputPath).deletingPathExtension()
+        let wantsMasks = !draft.visionMaskOutputDirectory.isBlank
+        if draft.visionJSONOutputPath == previousStem.appendingPathExtension("json").path {
+            draft.visionJSONOutputPath = ""
+        }
+        if draft.visionMaskOutputDirectory == maskDirectory(forStem: previousStem) {
+            draft.visionMaskOutputDirectory = ""
+        }
+        apply(to: &draft, wantsMasks: wantsMasks)
+    }
+
+    private static func maskDirectory(forStem stem: URL) -> String {
+        stem.deletingLastPathComponent()
+            .appendingPathComponent("\(stem.lastPathComponent)-masks", isDirectory: true)
+            .path
     }
 }
 

--- a/apps/macos/MereRunStudio/StudioLibraryPanel.swift
+++ b/apps/macos/MereRunStudio/StudioLibraryPanel.swift
@@ -38,10 +38,20 @@ struct StudioLibraryPanel: View {
     @State private var anchorID: UUID?
     @State private var pendingDelete: StudioLibraryDeleteRequest?
     @FocusState private var renameFocused: Bool
+    @Environment(\.studioLibrarySeed) private var seed
+
+    /// The layout the column draws in — the user's, unless a render is staging the other one.
+    private var effectiveViewMode: StudioLibraryViewMode {
+        seed?.viewMode ?? viewMode
+    }
+
+    private var effectiveScope: StudioLibraryScope {
+        seed?.scope ?? scope
+    }
 
     private var currentFilter: StudioLibraryFilter {
         StudioLibraryFilter(
-            scope: scope,
+            scope: effectiveScope,
             domain: domain,
             kind: kind,
             favoritesOnly: favoritesOnly,
@@ -50,7 +60,7 @@ struct StudioLibraryPanel: View {
     }
 
     private var scopedItems: [StudioLibraryItem] {
-        StudioLibraryPresenter.scoped(items, scope: scope, domain: domain)
+        StudioLibraryPresenter.scoped(items, scope: effectiveScope, domain: domain)
     }
 
     private var filteredItems: [StudioLibraryItem] {
@@ -112,14 +122,14 @@ struct StudioLibraryPanel: View {
         } message: {
             Text("Deleting removes the run from the Library. Its files stay on disk unless you move them to the Trash.")
         }
+        .onAppear(perform: applyBatchSeed)
         .onChange(of: selectedID) { _, newValue in
             // A programmatic selection (a run finishing, a deep link) replaces the batch, so the
-            // batch bar never claims rows the user can no longer see selected.
-            guard let newValue else { return }
-            if !batch.contains(newValue) {
-                batch = [newValue]
-                anchorID = newValue
-            }
+            // batch bar never claims rows the user can no longer see selected. A seeded batch is
+            // the harness staging a render, and holds.
+            guard seed?.batchCount == nil, let newValue, !batch.contains(newValue) else { return }
+            batch = [newValue]
+            anchorID = newValue
         }
     }
 
@@ -141,7 +151,7 @@ struct StudioLibraryPanel: View {
             Spacer(minLength: 0)
             MereSegmentedControl(
                 StudioLibraryScope.allCases,
-                selection: $scope,
+                selection: Binding(get: { effectiveScope }, set: { scope = $0 }),
                 accessibilityLabel: "Library scope"
             ) { scope in
                 scope == .domain ? domain.title : "All"
@@ -227,13 +237,13 @@ struct StudioLibraryPanel: View {
         Button {
             viewMode = viewMode == .list ? .grid : .list
         } label: {
-            Image(systemName: viewMode == .list ? StudioLibraryViewMode.grid.systemImage : StudioLibraryViewMode.list.systemImage)
+            Image(systemName: effectiveViewMode == .list ? StudioLibraryViewMode.grid.systemImage : StudioLibraryViewMode.list.systemImage)
                 .font(.system(size: 12, weight: .medium))
                 .frame(width: 22, height: 24)
         }
         .buttonStyle(.mereIcon(tint: MereRunTheme.textMuted))
-        .help(viewMode == .list ? "Show as a grid" : "Show as a list")
-        .accessibilityLabel(viewMode == .list ? "Show as a grid" : "Show as a list")
+        .help(effectiveViewMode == .list ? "Show as a grid" : "Show as a list")
+        .accessibilityLabel(effectiveViewMode == .list ? "Show as a grid" : "Show as a list")
     }
 
     private var emptyState: some View {
@@ -269,7 +279,7 @@ struct StudioLibraryPanel: View {
                         .padding(.top, 6)
                         .padding(.bottom, 2)
 
-                    if viewMode == .list {
+                    if effectiveViewMode == .list {
                         ForEach(section.items) { item in
                             row(for: item)
                         }
@@ -367,22 +377,18 @@ struct StudioLibraryPanel: View {
                 .font(.system(size: 11, weight: .medium))
                 .foregroundStyle(MereRunTheme.textSecondary)
             Spacer(minLength: 0)
-            Button("Reveal") { onReveal(urls(in: batch)) }
-                .buttonStyle(.mereSecondary)
-                .disabled(urls(in: batch).isEmpty)
-            Button("Save to…") { onExport(items(in: batch)) }
-                .buttonStyle(.mereSecondary)
-                .disabled(urls(in: batch).isEmpty)
-            Button {
-                pendingDelete = StudioLibraryDeleteRequest(ids: batch, count: batch.count)
-            } label: {
-                Image(systemName: "trash")
-                    .font(.system(size: 11, weight: .semibold))
-                    .frame(width: 22, height: 22)
+            // Icons, not labels: three words do not fit a 248pt column beside the count.
+            batchAction(systemImage: "folder", label: "Reveal in Finder", tint: MereRunTheme.textSecondary) {
+                onReveal(urls(in: batch))
             }
-            .buttonStyle(.mereIcon(tint: MereRunTheme.red))
-            .help("Delete the selected runs")
-            .accessibilityLabel("Delete \(batch.count) runs")
+            .disabled(urls(in: batch).isEmpty)
+            batchAction(systemImage: "square.and.arrow.down", label: "Save to…", tint: MereRunTheme.textSecondary) {
+                onExport(items(in: batch))
+            }
+            .disabled(urls(in: batch).isEmpty)
+            batchAction(systemImage: "trash", label: "Delete \(batch.count) runs", tint: MereRunTheme.red) {
+                pendingDelete = StudioLibraryDeleteRequest(ids: batch, count: batch.count)
+            }
         }
         .padding(.horizontal, 12)
         .frame(height: 36)
@@ -392,7 +398,30 @@ struct StudioLibraryPanel: View {
         }
     }
 
+    private func batchAction(
+        systemImage: String,
+        label: String,
+        tint: Color,
+        action: @escaping () -> Void
+    ) -> some View {
+        Button(action: action) {
+            Image(systemName: systemImage)
+                .font(.system(size: 12, weight: .medium))
+                .frame(width: 26, height: 24)
+        }
+        .buttonStyle(.mereIcon(tint: tint))
+        .help(label)
+        .accessibilityLabel(label)
+    }
+
     // MARK: - Selection
+
+    private func applyBatchSeed() {
+        guard let batchCount = seed?.batchCount, batchCount > 1 else { return }
+        let visible = filteredItems.prefix(batchCount).map(\.id)
+        batch = Set(visible)
+        anchorID = visible.first
+    }
 
     private func isSelected(_ id: UUID) -> Bool {
         selectedID == id || batch.contains(id)
@@ -454,6 +483,27 @@ struct StudioLibraryPanel: View {
         guard renamingID == item.id else { return }
         onRename(item.id, renameText)
         renamingID = nil
+    }
+}
+
+/// The state a render wants the column in. Only the snapshot harness sets this — the column's own
+/// view mode lives in `@SceneStorage`, which no scene backs offscreen, and a batch is built by
+/// ⌘-clicking, which a render cannot do. The app leaves it nil.
+struct StudioLibrarySeed: Equatable {
+    var viewMode: StudioLibraryViewMode?
+    var scope: StudioLibraryScope?
+    /// How many of the visible rows start out selected together.
+    var batchCount: Int?
+}
+
+private struct StudioLibrarySeedKey: EnvironmentKey {
+    static let defaultValue: StudioLibrarySeed? = nil
+}
+
+extension EnvironmentValues {
+    var studioLibrarySeed: StudioLibrarySeed? {
+        get { self[StudioLibrarySeedKey.self] }
+        set { self[StudioLibrarySeedKey.self] = newValue }
     }
 }
 
@@ -635,10 +685,13 @@ private struct StudioLibraryTile: View {
 
     var body: some View {
         Button(action: action) {
-            StudioLibraryThumbnail(item: item, side: 72)
+            // The square comes from an empty spacer, not from the thumbnail: a `scaledToFill`
+            // picture has no size of its own to fit, and would otherwise stretch the tile.
+            Color.clear
                 .frame(maxWidth: .infinity)
                 .aspectRatio(1, contentMode: .fit)
                 .background(MereRunTheme.surfaceRaised)
+                .overlay { StudioLibraryThumbnail(item: item, side: 72) }
                 .clipShape(RoundedRectangle(cornerRadius: MereRunTheme.Radius.sm))
                 .overlay(alignment: .bottom) {
                     if hovering {

--- a/apps/macos/MereRunStudio/StudioLibraryPanel.swift
+++ b/apps/macos/MereRunStudio/StudioLibraryPanel.swift
@@ -1,20 +1,30 @@
 import AppKit
 import SwiftUI
 
-/// Run history as a column beside the current task: filtered to the current domain (or All),
-/// searchable, grouped by day, keyboard-navigable (arrows move, Space previews), with Quick Look
-/// surfacing on hover. Picking a row of another domain switches the destination.
+/// Run history as a column beside the current task: filtered to the current domain (or All) and
+/// to a kind or favorites, searchable, shown as rows or as a grid of thumbnails, grouped by day,
+/// keyboard-navigable (arrows move, Space previews), with Quick Look surfacing on hover. Picking a
+/// row of another domain switches the destination; ⌘ and ⇧ build a batch to reveal, save, or
+/// delete in one go, and any row can be dragged out to Finder or another app.
 struct StudioLibraryPanel: View {
     let items: [StudioLibraryItem]
     let domain: StudioDomain
     @Binding var scope: StudioLibraryScope
+    @Binding var viewMode: StudioLibraryViewMode
+    @Binding var kind: StudioLibraryKind
+    @Binding var favoritesOnly: Bool
     let progressByID: [UUID: StudioRunProgress]
     @Binding var selectedID: UUID?
     /// A row the user picked (click or arrow keys), as opposed to a programmatic selection.
     let onSelect: (StudioLibraryItem) -> Void
-    let onDelete: (UUID) -> Void
+    /// Rows to forget, and whether their files go to the Trash with them.
+    let onDelete: (Set<UUID>, Bool) -> Void
     let onRename: (UUID, String) -> Void
+    let onToggleFavorite: (UUID) -> Void
     let onQuickLook: (URL) -> Void
+    let onReveal: ([URL]) -> Void
+    /// "Save to…": copy these rows' artifacts somewhere the user chooses.
+    let onExport: ([StudioLibraryItem]) -> Void
     let onRetry: (StudioLibraryItem) -> Void
     let onEdit: (StudioLibraryItem) -> Void
     /// Extra leading space for the header while the window's traffic lights sit over it.
@@ -23,22 +33,28 @@ struct StudioLibraryPanel: View {
     @State private var searchText = ""
     @State private var renamingID: UUID?
     @State private var renameText = ""
+    /// The batch ⌘/⇧ click builds. Always contains the open row when there is one.
+    @State private var batch: Set<UUID> = []
+    @State private var anchorID: UUID?
+    @State private var pendingDelete: StudioLibraryDeleteRequest?
+    @FocusState private var renameFocused: Bool
+
+    private var currentFilter: StudioLibraryFilter {
+        StudioLibraryFilter(
+            scope: scope,
+            domain: domain,
+            kind: kind,
+            favoritesOnly: favoritesOnly,
+            query: searchText
+        )
+    }
 
     private var scopedItems: [StudioLibraryItem] {
-        switch scope {
-        case .all: return items
-        case .domain: return items.filter { $0.domain == domain }
-        }
+        StudioLibraryPresenter.scoped(items, scope: scope, domain: domain)
     }
 
     private var filteredItems: [StudioLibraryItem] {
-        let query = searchText.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
-        guard !query.isEmpty else { return scopedItems }
-        return scopedItems.filter { item in
-            item.displayTitle.lowercased().contains(query)
-                || item.displayKindTitle.lowercased().contains(query)
-                || item.prompt.lowercased().contains(query)
-        }
+        StudioLibraryPresenter.filter(items, with: currentFilter)
     }
 
     private var daySections: [(day: Date, title: String, items: [StudioLibraryItem])] {
@@ -66,28 +82,52 @@ struct StudioLibraryPanel: View {
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
             header
-            searchField
+            searchRow
 
             if filteredItems.isEmpty {
                 emptyState
             } else {
-                list
+                content
+            }
+
+            if batch.count > 1 {
+                batchBar
             }
         }
         .background(MereRunTheme.background)
-        .alert("Rename run", isPresented: renameBinding) {
-            TextField("Name", text: $renameText)
-            Button("Save") {
-                if let renamingID { onRename(renamingID, renameText) }
-                renamingID = nil
+        .confirmationDialog(
+            pendingDelete.map(\.title) ?? "",
+            isPresented: deleteBinding,
+            titleVisibility: .visible
+        ) {
+            Button("Delete and Move Files to Trash", role: .destructive) {
+                if let pendingDelete { onDelete(pendingDelete.ids, true) }
+                clearBatch()
             }
-            Button("Cancel", role: .cancel) { renamingID = nil }
+            Button("Delete, Keep Files", role: .destructive) {
+                if let pendingDelete { onDelete(pendingDelete.ids, false) }
+                clearBatch()
+            }
+            Button("Cancel", role: .cancel) { pendingDelete = nil }
+        } message: {
+            Text("Deleting removes the run from the Library. Its files stay on disk unless you move them to the Trash.")
+        }
+        .onChange(of: selectedID) { _, newValue in
+            // A programmatic selection (a run finishing, a deep link) replaces the batch, so the
+            // batch bar never claims rows the user can no longer see selected.
+            guard let newValue else { return }
+            if !batch.contains(newValue) {
+                batch = [newValue]
+                anchorID = newValue
+            }
         }
     }
 
-    private var renameBinding: Binding<Bool> {
-        Binding(get: { renamingID != nil }, set: { if !$0 { renamingID = nil } })
+    private var deleteBinding: Binding<Bool> {
+        Binding(get: { pendingDelete != nil }, set: { if !$0 { pendingDelete = nil } })
     }
+
+    // MARK: - Header
 
     private var header: some View {
         HStack(spacing: 8) {
@@ -113,6 +153,19 @@ struct StudioLibraryPanel: View {
         .padding(.bottom, 8)
     }
 
+    /// The search field with the kind/favorites filter and the list-or-grid toggle beside it, so
+    /// the column keeps the header row the design calls for.
+    private var searchRow: some View {
+        HStack(spacing: 4) {
+            searchField
+            filterMenu
+            viewModeButton
+        }
+        .frame(height: 28)
+        .padding(.horizontal, 12)
+        .padding(.bottom, 8)
+    }
+
     private var searchField: some View {
         HStack(spacing: 6) {
             Image(systemName: "magnifyingglass")
@@ -134,6 +187,7 @@ struct StudioLibraryPanel: View {
             }
         }
         .padding(.horizontal, 10)
+        .frame(maxWidth: .infinity)
         .frame(height: 28)
         .background {
             Capsule()
@@ -142,8 +196,44 @@ struct StudioLibraryPanel: View {
                     Capsule().strokeBorder(MereRunTheme.border.opacity(0.8), lineWidth: 1)
                 }
         }
-        .padding(.horizontal, 12)
-        .padding(.bottom, 8)
+    }
+
+    private var isFiltering: Bool { kind != .all || favoritesOnly }
+
+    private var filterMenu: some View {
+        Menu {
+            Picker("Kind", selection: $kind) {
+                ForEach(StudioLibraryKind.allCases) { option in
+                    Label(option.title, systemImage: option.systemImage).tag(option)
+                }
+            }
+            .pickerStyle(.inline)
+            Divider()
+            Toggle("Favorites only", isOn: $favoritesOnly)
+        } label: {
+            Image(systemName: isFiltering ? "line.3.horizontal.decrease.circle.fill" : "line.3.horizontal.decrease.circle")
+                .font(.system(size: 12, weight: .medium))
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .frame(width: 22, height: 24)
+        .foregroundStyle(isFiltering ? MereRunTheme.accent : MereRunTheme.textMuted)
+        .help("Filter the Library by kind or favorites")
+        .accessibilityLabel("Filter")
+        .accessibilityValue(favoritesOnly ? "\(kind.title), favorites only" : kind.title)
+    }
+
+    private var viewModeButton: some View {
+        Button {
+            viewMode = viewMode == .list ? .grid : .list
+        } label: {
+            Image(systemName: viewMode == .list ? StudioLibraryViewMode.grid.systemImage : StudioLibraryViewMode.list.systemImage)
+                .font(.system(size: 12, weight: .medium))
+                .frame(width: 22, height: 24)
+        }
+        .buttonStyle(.mereIcon(tint: MereRunTheme.textMuted))
+        .help(viewMode == .list ? "Show as a grid" : "Show as a list")
+        .accessibilityLabel(viewMode == .list ? "Show as a grid" : "Show as a list")
     }
 
     private var emptyState: some View {
@@ -163,10 +253,14 @@ struct StudioLibraryPanel: View {
     private var emptyMessage: String {
         if items.isEmpty { return "Runs you create will land here." }
         if scopedItems.isEmpty { return "No \(domain.title) runs yet. Choose All to see every run." }
+        if favoritesOnly { return "No favorites here yet. Star a run to keep it close." }
+        if kind != .all { return "No \(kind.title.lowercased()) here. Choose All kinds to see every run." }
         return "No matching runs."
     }
 
-    private var list: some View {
+    // MARK: - Rows and tiles
+
+    private var content: some View {
         ScrollView {
             LazyVStack(alignment: .leading, spacing: 2, pinnedViews: []) {
                 ForEach(daySections, id: \.day) { section in
@@ -175,31 +269,12 @@ struct StudioLibraryPanel: View {
                         .padding(.top, 6)
                         .padding(.bottom, 2)
 
-                    ForEach(section.items) { item in
-                        StudioLibraryRow(
-                            item: item,
-                            progress: progressByID[item.id],
-                            isSelected: selectedID == item.id,
-                            onQuickLook: item.outputURL.map { url in { onQuickLook(url) } }
-                        ) {
-                            onSelect(item)
+                    if viewMode == .list {
+                        ForEach(section.items) { item in
+                            row(for: item)
                         }
-                        .contextMenu {
-                            if let url = item.outputURL {
-                                Button("Quick Look") { onQuickLook(url) }
-                            }
-                            if item.commandDraft != nil, item.templateID != nil {
-                                Button("Run again") { onRetry(item) }
-                                Button("Edit command…") { onEdit(item) }
-                            }
-                            Button("Rename") {
-                                renameText = item.displayTitle
-                                renamingID = item.id
-                            }
-                            Button("Delete", role: .destructive) {
-                                onDelete(item.id)
-                            }
-                        }
+                    } else {
+                        grid(for: section.items)
                     }
                 }
             }
@@ -219,26 +294,209 @@ struct StudioLibraryPanel: View {
         .onKeyPress(.downArrow) { moveSelection(by: 1) }
     }
 
+    private func row(for item: StudioLibraryItem) -> some View {
+        StudioLibraryRow(
+            item: item,
+            progress: progressByID[item.id],
+            isSelected: isSelected(item.id),
+            isRenaming: renamingID == item.id,
+            renameText: $renameText,
+            renameFocused: $renameFocused,
+            onQuickLook: item.outputURL.map { url in { onQuickLook(url) } },
+            onToggleFavorite: { onToggleFavorite(item.id) },
+            onCommitRename: { commitRename(for: item) },
+            onCancelRename: { renamingID = nil },
+            action: { click(item) }
+        )
+        .modifier(StudioLibraryDragOut(url: item.outputURL))
+        .contextMenu { menu(for: item) }
+    }
+
+    private func grid(for sectionItems: [StudioLibraryItem]) -> some View {
+        LazyVGrid(columns: Array(repeating: GridItem(.flexible(), spacing: 6), count: 3), spacing: 6) {
+            ForEach(sectionItems) { item in
+                StudioLibraryTile(
+                    item: item,
+                    progress: progressByID[item.id],
+                    isSelected: isSelected(item.id),
+                    onToggleFavorite: { onToggleFavorite(item.id) },
+                    action: { click(item) }
+                )
+                .modifier(StudioLibraryDragOut(url: item.outputURL))
+                .contextMenu { menu(for: item) }
+            }
+        }
+        .padding(.horizontal, 2)
+        .padding(.bottom, 4)
+    }
+
+    @ViewBuilder
+    private func menu(for item: StudioLibraryItem) -> some View {
+        if batch.count > 1, batch.contains(item.id) {
+            Button("Reveal \(batch.count) in Finder") { onReveal(urls(in: batch)) }
+            Button("Save \(batch.count) to…") { onExport(items(in: batch)) }
+            Divider()
+            Button("Delete \(batch.count)…", role: .destructive) {
+                pendingDelete = StudioLibraryDeleteRequest(ids: batch, count: batch.count)
+            }
+        } else {
+            if let url = item.outputURL {
+                Button("Quick Look") { onQuickLook(url) }
+                Button("Reveal in Finder") { onReveal([url]) }
+                Button("Save to…") { onExport([item]) }
+            }
+            Button(item.isStarred ? "Remove from Favorites" : "Add to Favorites") {
+                onToggleFavorite(item.id)
+            }
+            if item.commandDraft != nil, item.templateID != nil {
+                Divider()
+                Button("Run again") { onRetry(item) }
+                Button("Edit command…") { onEdit(item) }
+            }
+            Divider()
+            Button("Rename") { beginRename(item) }
+            Button("Delete…", role: .destructive) {
+                pendingDelete = StudioLibraryDeleteRequest(ids: [item.id], count: 1)
+            }
+        }
+    }
+
+    private var batchBar: some View {
+        HStack(spacing: 6) {
+            Text("\(batch.count) selected")
+                .font(.system(size: 11, weight: .medium))
+                .foregroundStyle(MereRunTheme.textSecondary)
+            Spacer(minLength: 0)
+            Button("Reveal") { onReveal(urls(in: batch)) }
+                .buttonStyle(.mereSecondary)
+                .disabled(urls(in: batch).isEmpty)
+            Button("Save to…") { onExport(items(in: batch)) }
+                .buttonStyle(.mereSecondary)
+                .disabled(urls(in: batch).isEmpty)
+            Button {
+                pendingDelete = StudioLibraryDeleteRequest(ids: batch, count: batch.count)
+            } label: {
+                Image(systemName: "trash")
+                    .font(.system(size: 11, weight: .semibold))
+                    .frame(width: 22, height: 22)
+            }
+            .buttonStyle(.mereIcon(tint: MereRunTheme.red))
+            .help("Delete the selected runs")
+            .accessibilityLabel("Delete \(batch.count) runs")
+        }
+        .padding(.horizontal, 12)
+        .frame(height: 36)
+        .background(MereRunTheme.surface)
+        .overlay(alignment: .top) {
+            Rectangle().fill(MereRunTheme.border.opacity(0.55)).frame(height: 1)
+        }
+    }
+
+    // MARK: - Selection
+
+    private func isSelected(_ id: UUID) -> Bool {
+        selectedID == id || batch.contains(id)
+    }
+
+    private func click(_ item: StudioLibraryItem) {
+        let result = StudioLibrarySelection.click(
+            on: item.id,
+            visible: filteredItems.map(\.id),
+            selection: batch,
+            anchor: anchorID,
+            modifiers: StudioLibrarySelection.Modifiers(event: NSEvent.modifierFlags)
+        )
+        batch = result.selection
+        anchorID = result.anchor
+        if result.opened != nil { onSelect(item) }
+    }
+
+    private func clearBatch() {
+        pendingDelete = nil
+        batch = selectedID.map { [$0] } ?? []
+    }
+
     private func moveSelection(by offset: Int) -> KeyPress.Result {
         let visible = filteredItems
         guard !visible.isEmpty else { return .ignored }
         guard let selectedID, let index = visible.firstIndex(where: { $0.id == selectedID }) else {
-            if let edge = offset > 0 ? visible.first : visible.last { onSelect(edge) }
+            if let edge = offset > 0 ? visible.first : visible.last { select(edge) }
             return .handled
         }
         let next = min(max(index + offset, 0), visible.count - 1)
-        onSelect(visible[next])
+        select(visible[next])
         return .handled
+    }
+
+    private func select(_ item: StudioLibraryItem) {
+        batch = [item.id]
+        anchorID = item.id
+        onSelect(item)
+    }
+
+    private func items(in ids: Set<UUID>) -> [StudioLibraryItem] {
+        filteredItems.filter { ids.contains($0.id) }
+    }
+
+    private func urls(in ids: Set<UUID>) -> [URL] {
+        items(in: ids).compactMap(\.outputURL)
+    }
+
+    // MARK: - Rename
+
+    private func beginRename(_ item: StudioLibraryItem) {
+        renameText = item.displayTitle
+        renamingID = item.id
+        renameFocused = true
+    }
+
+    private func commitRename(for item: StudioLibraryItem) {
+        guard renamingID == item.id else { return }
+        onRename(item.id, renameText)
+        renamingID = nil
+    }
+}
+
+/// One pending Delete, so the dialog knows how many rows it is about.
+private struct StudioLibraryDeleteRequest: Identifiable {
+    let ids: Set<UUID>
+    let count: Int
+
+    var id: Int { ids.hashValue }
+
+    var title: String {
+        count == 1 ? "Delete this run?" : "Delete \(count) runs?"
+    }
+}
+
+/// Drag a row or tile straight into Finder, Mail, or another app. Rows with no file are inert
+/// rather than dragging an empty promise.
+private struct StudioLibraryDragOut: ViewModifier {
+    let url: URL?
+
+    func body(content: Content) -> some View {
+        if let url {
+            content.onDrag { NSItemProvider(contentsOf: url) ?? NSItemProvider() }
+        } else {
+            content
+        }
     }
 }
 
 /// One Library row: a 40pt thumbnail (or a glyph tile), the title on one line, and a meta line
-/// that carries a status dot while the run is queued, running, or failed.
+/// that carries a status dot while the run is queued, running, or failed. Hovering reveals the
+/// favorite star and Quick Look; renaming happens in place, never in a dialog.
 private struct StudioLibraryRow: View {
     let item: StudioLibraryItem
     let progress: StudioRunProgress?
     let isSelected: Bool
+    let isRenaming: Bool
+    @Binding var renameText: String
+    var renameFocused: FocusState<Bool>.Binding
     let onQuickLook: (() -> Void)?
+    let onToggleFavorite: () -> Void
+    let onCommitRename: () -> Void
+    let onCancelRename: () -> Void
     let action: () -> Void
 
     @State private var hovering = false
@@ -253,17 +511,30 @@ private struct StudioLibraryRow: View {
     var body: some View {
         Button(action: action) {
             HStack(spacing: 10) {
-                thumbnail
+                StudioLibraryThumbnail(item: item, side: 40)
                     .frame(width: 40, height: 40)
                     .background(MereRunTheme.surfaceRaised)
                     .clipShape(RoundedRectangle(cornerRadius: MereRunTheme.Radius.sm))
 
                 VStack(alignment: .leading, spacing: 1) {
-                    Text(item.displayTitle)
-                        .font(.system(size: 12.5, weight: .medium))
-                        .foregroundStyle(MereRunTheme.textPrimary)
-                        .lineLimit(1)
-                        .truncationMode(.tail)
+                    if isRenaming {
+                        TextField("Name", text: $renameText)
+                            .textFieldStyle(.plain)
+                            .font(.system(size: 12.5, weight: .medium))
+                            .foregroundStyle(MereRunTheme.textPrimary)
+                            .focused(renameFocused)
+                            .onSubmit(onCommitRename)
+                            .onExitCommand(perform: onCancelRename)
+                            .onChange(of: renameFocused.wrappedValue) { _, focused in
+                                if !focused { onCommitRename() }
+                            }
+                    } else {
+                        Text(item.displayTitle)
+                            .font(.system(size: 12.5, weight: .medium))
+                            .foregroundStyle(MereRunTheme.textPrimary)
+                            .lineLimit(1)
+                            .truncationMode(.tail)
+                    }
                     HStack(spacing: 4) {
                         if let statusColor {
                             Circle()
@@ -278,6 +549,18 @@ private struct StudioLibraryRow: View {
                 }
 
                 Spacer(minLength: 0)
+
+                if hovering || item.isStarred {
+                    Button(action: onToggleFavorite) {
+                        Image(systemName: item.isStarred ? "star.fill" : "star")
+                            .font(.system(size: 11, weight: .semibold))
+                            .frame(width: 20, height: 24)
+                    }
+                    .buttonStyle(.mereIcon(tint: item.isStarred ? MereRunTheme.yellow : MereRunTheme.textMuted))
+                    .help(item.isStarred ? "Remove from Favorites" : "Add to Favorites")
+                    .accessibilityLabel(item.isStarred ? "Remove from Favorites" : "Add to Favorites")
+                    .transition(.opacity)
+                }
 
                 if hovering, let onQuickLook {
                     Button {
@@ -306,7 +589,7 @@ private struct StudioLibraryRow: View {
         .animation(MereRunTheme.Motion.quick, value: hovering)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel("\(item.displayKindTitle), \(item.status.rawValue), \(item.displayTitle)")
-        .accessibilityValue(meta)
+        .accessibilityValue(item.isStarred ? "\(meta), favorite" : meta)
         .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
     }
 
@@ -327,10 +610,104 @@ private struct StudioLibraryRow: View {
 
     /// "Generate · 12:43 PM" once done; "Running · 62%" / "Queued" / "Failed · 12:43 PM" otherwise.
     private var meta: String {
+        StudioLibraryRowMeta.text(
+            item: item,
+            kindTitle: kindTitle,
+            progress: progress,
+            formatter: Self.timeFormatter
+        )
+    }
+
+    private var statusColor: Color? {
+        StudioLibraryRowMeta.statusColor(for: item.status)
+    }
+}
+
+/// One grid tile: the thumbnail alone until the pointer arrives, then the title over it.
+private struct StudioLibraryTile: View {
+    let item: StudioLibraryItem
+    let progress: StudioRunProgress?
+    let isSelected: Bool
+    let onToggleFavorite: () -> Void
+    let action: () -> Void
+
+    @State private var hovering = false
+
+    var body: some View {
+        Button(action: action) {
+            StudioLibraryThumbnail(item: item, side: 72)
+                .frame(maxWidth: .infinity)
+                .aspectRatio(1, contentMode: .fit)
+                .background(MereRunTheme.surfaceRaised)
+                .clipShape(RoundedRectangle(cornerRadius: MereRunTheme.Radius.sm))
+                .overlay(alignment: .bottom) {
+                    if hovering {
+                        Text(item.displayTitle)
+                            .font(.system(size: 9.5, weight: .medium))
+                            .foregroundStyle(.white)
+                            .lineLimit(2)
+                            .multilineTextAlignment(.leading)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.horizontal, 4)
+                            .padding(.vertical, 3)
+                            .background(Color.black.opacity(0.55))
+                            .transition(.opacity)
+                    }
+                }
+                .overlay(alignment: .topLeading) {
+                    if let statusColor = StudioLibraryRowMeta.statusColor(for: item.status) {
+                        Circle()
+                            .fill(statusColor)
+                            .frame(width: 7, height: 7)
+                            .padding(4)
+                    }
+                }
+                .overlay(alignment: .topTrailing) {
+                    if hovering || item.isStarred {
+                        Button(action: onToggleFavorite) {
+                            Image(systemName: item.isStarred ? "star.fill" : "star")
+                                .font(.system(size: 9, weight: .bold))
+                                .foregroundStyle(item.isStarred ? MereRunTheme.yellow : .white)
+                                .padding(3)
+                                .background(Circle().fill(Color.black.opacity(0.4)))
+                        }
+                        .buttonStyle(.plain)
+                        .padding(3)
+                        .help(item.isStarred ? "Remove from Favorites" : "Add to Favorites")
+                        .accessibilityLabel(item.isStarred ? "Remove from Favorites" : "Add to Favorites")
+                    }
+                }
+                .clipShape(RoundedRectangle(cornerRadius: MereRunTheme.Radius.sm))
+                .overlay {
+                    RoundedRectangle(cornerRadius: MereRunTheme.Radius.sm)
+                        .strokeBorder(
+                            isSelected ? MereRunTheme.accent : MereRunTheme.border.opacity(hovering ? 0.9 : 0.5),
+                            lineWidth: isSelected ? 2 : 1
+                        )
+                }
+                .contentShape(RoundedRectangle(cornerRadius: MereRunTheme.Radius.sm))
+        }
+        .buttonStyle(.plain)
+        .onHover { hovering = $0 }
+        .animation(MereRunTheme.Motion.quick, value: hovering)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("\(item.displayKindTitle), \(item.status.rawValue), \(item.displayTitle)")
+        .accessibilityAddTraits(isSelected ? [.isButton, .isSelected] : .isButton)
+    }
+}
+
+/// The row meta line and status dot, shared by the list rows and the grid tiles.
+enum StudioLibraryRowMeta {
+    static func text(
+        item: StudioLibraryItem,
+        kindTitle: String,
+        progress: StudioRunProgress?,
+        formatter: DateFormatter
+    ) -> String {
         switch item.status {
         case .completed:
             let origin = item.source.map { "\($0.title) · " } ?? ""
-            return "\(origin)\(kindTitle) · \(Self.timeFormatter.string(from: item.createdAt))"
+            return "\(origin)\(kindTitle) · \(formatter.string(from: item.createdAt))"
         case .running:
             if let fraction = progress?.fractionCompleted {
                 return "Running · \(Int((fraction * 100).rounded()))%"
@@ -340,32 +717,16 @@ private struct StudioLibraryRow: View {
         case .queued:
             return "Queued"
         case .failed:
-            return "Failed · \(Self.timeFormatter.string(from: item.createdAt))"
+            return "Failed · \(formatter.string(from: item.createdAt))"
         }
     }
 
-    private var statusColor: Color? {
-        switch item.status {
+    static func statusColor(for status: StudioLibraryStatus) -> Color? {
+        switch status {
         case .queued: return MereRunTheme.yellow
         case .running: return MereRunTheme.accent
         case .completed: return nil
         case .failed: return MereRunTheme.red
-        }
-    }
-
-    @ViewBuilder
-    private var thumbnail: some View {
-        if let url = item.outputURL, StudioOutputFileKind.classify(url) == .image {
-            StudioAsyncImagePreview(
-                url: url,
-                maxPixelSize: 160,
-                contentMode: .fill,
-                fallbackSystemImage: item.displaySystemImage
-            )
-        } else {
-            Image(systemName: item.displaySystemImage)
-                .font(.system(size: 14, weight: .medium))
-                .foregroundStyle(MereRunTheme.textMuted)
         }
     }
 }

--- a/apps/macos/MereRunStudio/StudioLibraryPresentation.swift
+++ b/apps/macos/MereRunStudio/StudioLibraryPresentation.swift
@@ -1,0 +1,163 @@
+import AppKit
+import Foundation
+
+/// How the Library column lays its rows out.
+enum StudioLibraryViewMode: String, CaseIterable, Identifiable, Codable {
+    case list
+    case grid
+
+    var id: String { rawValue }
+
+    var systemImage: String {
+        switch self {
+        case .list: return "list.bullet"
+        case .grid: return "square.grid.2x2"
+        }
+    }
+
+    var title: String {
+        switch self {
+        case .list: return "List"
+        case .grid: return "Grid"
+        }
+    }
+}
+
+/// The media a Library row holds, as the column's filter names it. Rows are classified by their
+/// primary output file, so a Find run that wrote an annotated PNG counts as an image and its JSON
+/// sidecar does not split it out.
+enum StudioLibraryKind: String, CaseIterable, Identifiable, Codable {
+    case all
+    case images
+    case video
+    case audio
+    case text
+
+    var id: String { rawValue }
+
+    var title: String {
+        switch self {
+        case .all: return "All kinds"
+        case .images: return "Images"
+        case .video: return "Video"
+        case .audio: return "Audio"
+        case .text: return "Text"
+        }
+    }
+
+    var systemImage: String {
+        switch self {
+        case .all: return "square.stack.3d.up"
+        case .images: return "photo"
+        case .video: return "film"
+        case .audio: return "waveform"
+        case .text: return "text.alignleft"
+        }
+    }
+
+    /// Whether a row of `fileKind` (nil when the run wrote no file) belongs to this filter.
+    func matches(fileKind: StudioOutputFileKind?, hasText: Bool) -> Bool {
+        switch self {
+        case .all: return true
+        case .images: return fileKind == .image
+        case .video: return fileKind == .video
+        case .audio: return fileKind == .audio
+        case .text: return fileKind == .text || (fileKind == nil && hasText)
+        }
+    }
+}
+
+/// Everything the column filters by at once, so the presenter can be exercised without a view.
+struct StudioLibraryFilter: Equatable {
+    var scope: StudioLibraryScope = .domain
+    var domain: StudioDomain = .image
+    var kind: StudioLibraryKind = .all
+    var favoritesOnly = false
+    var query = ""
+}
+
+/// Pure filtering and day-grouping for the Library column.
+enum StudioLibraryPresenter {
+    static func fileKind(of item: StudioLibraryItem) -> StudioOutputFileKind? {
+        guard let url = item.outputURL else { return nil }
+        return StudioOutputFileKind.classify(url)
+    }
+
+    static func filter(_ items: [StudioLibraryItem], with filter: StudioLibraryFilter) -> [StudioLibraryItem] {
+        let query = filter.query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        return items.filter { item in
+            if filter.scope == .domain, item.domain != filter.domain { return false }
+            if filter.favoritesOnly, !item.isStarred { return false }
+            let hasText = item.outputText?.isBlank == false
+            if !filter.kind.matches(fileKind: fileKind(of: item), hasText: hasText) { return false }
+            guard !query.isEmpty else { return true }
+            return item.displayTitle.lowercased().contains(query)
+                || item.displayKindTitle.lowercased().contains(query)
+                || item.prompt.lowercased().contains(query)
+        }
+    }
+
+    /// The rows the column shows before the kind, favorites, and search filters narrow them — the
+    /// number the header counts.
+    static func scoped(_ items: [StudioLibraryItem], scope: StudioLibraryScope, domain: StudioDomain) -> [StudioLibraryItem] {
+        scope == .all ? items : items.filter { $0.domain == domain }
+    }
+}
+
+/// Finder-style multi-selection: plain click replaces, ⌘ toggles, ⇧ extends from the anchor.
+/// Kept out of the view so the rules are testable without synthesizing mouse events.
+enum StudioLibrarySelection {
+    struct Modifiers: Equatable {
+        var command = false
+        var shift = false
+
+        static let none = Modifiers()
+        static let command = Modifiers(command: true, shift: false)
+        static let shift = Modifiers(command: false, shift: true)
+
+        init(command: Bool = false, shift: Bool = false) {
+            self.command = command
+            self.shift = shift
+        }
+
+        init(event flags: NSEvent.ModifierFlags) {
+            command = flags.contains(.command)
+            shift = flags.contains(.shift)
+        }
+    }
+
+    struct Result: Equatable {
+        /// The whole batch after the click.
+        var selection: Set<UUID>
+        /// The row the anchor moves to (nil leaves it where it was).
+        var anchor: UUID?
+        /// The row the canvas should open, or nil when the click only changed the batch.
+        var opened: UUID?
+    }
+
+    /// `visible` is the column's current order, so ⇧ selects the run of rows the user sees.
+    static func click(
+        on id: UUID,
+        visible: [UUID],
+        selection: Set<UUID>,
+        anchor: UUID?,
+        modifiers: Modifiers
+    ) -> Result {
+        if modifiers.shift, let anchor, anchor != id,
+           let start = visible.firstIndex(of: anchor), let end = visible.firstIndex(of: id) {
+            let range = start <= end ? start...end : end...start
+            return Result(selection: Set(visible[range]), anchor: anchor, opened: id)
+        }
+        if modifiers.command {
+            var next = selection
+            if next.contains(id) {
+                next.remove(id)
+                // Deselecting the open row leaves the canvas where it is; the batch shrinks.
+                return Result(selection: next, anchor: next.isEmpty ? nil : anchor, opened: nil)
+            }
+            next.insert(id)
+            return Result(selection: next, anchor: id, opened: id)
+        }
+        return Result(selection: [id], anchor: id, opened: id)
+    }
+}

--- a/apps/macos/MereRunStudio/StudioLibraryStore.swift
+++ b/apps/macos/MereRunStudio/StudioLibraryStore.swift
@@ -9,13 +9,17 @@ final class StudioLibraryStore: ObservableObject {
 
     let libraryURL: URL
     private let fileManager: FileManager
+    /// How a deleted row's files reach the Trash. Injected so tests can delete without a Trash.
+    private let trashItem: (URL) throws -> Void
 
     init(
         libraryURL: URL = StudioLibraryStore.defaultLibraryURL(),
-        fileManager: FileManager = .default
+        fileManager: FileManager = .default,
+        trashItem: @escaping (URL) throws -> Void = { try FileManager.default.trashItem(at: $0, resultingItemURL: nil) }
     ) {
         self.libraryURL = libraryURL
         self.fileManager = fileManager
+        self.trashItem = trashItem
         load()
     }
 
@@ -280,7 +284,42 @@ final class StudioLibraryStore: ObservableObject {
     }
 
     func delete(id: UUID) {
-        items.removeAll { $0.id == id }
+        delete(ids: [id], trashingFiles: false)
+    }
+
+    /// Removes rows, and — when the user asked for it — moves every file they produced to the
+    /// Trash. Deleting the row is never blocked by a file that will not move (already deleted,
+    /// on a volume with no Trash); those come back so the caller can say which.
+    @discardableResult
+    func delete(ids: Set<UUID>, trashingFiles: Bool) -> [URL] {
+        guard !ids.isEmpty else { return [] }
+        var failures: [URL] = []
+        if trashingFiles {
+            var seen = Set<URL>()
+            for item in items where ids.contains(item.id) {
+                for url in item.allArtifactURLs where seen.insert(url.standardizedFileURL).inserted {
+                    guard fileManager.fileExists(atPath: url.path) else { continue }
+                    do {
+                        try trashItem(url)
+                    } catch {
+                        failures.append(url)
+                    }
+                }
+            }
+        }
+        items.removeAll { ids.contains($0.id) }
+        save()
+        return failures
+    }
+
+    func setFavorite(id: UUID, isFavorite: Bool) {
+        guard let index = items.firstIndex(where: { $0.id == id }) else { return }
+        var item = items[index]
+        // Written as nil rather than false when unstarred, so a row that was never starred keeps
+        // the shape older builds decode.
+        item.isFavorite = isFavorite ? true : nil
+        item.updatedAt = Date()
+        items[index] = item
         save()
     }
 

--- a/apps/macos/MereRunStudio/StudioLibraryThumbnail.swift
+++ b/apps/macos/MereRunStudio/StudioLibraryThumbnail.swift
@@ -1,0 +1,255 @@
+import AVFoundation
+import AppKit
+import SwiftUI
+
+/// Thumbnails for Library rows and tiles: the picture itself for images, a poster frame for video,
+/// a peak silhouette for audio, and the first line for a text result. Decoding is off the main
+/// actor and cached by path, size, and modification date, so scrolling a long Library re-reads
+/// nothing and a file replaced in place still refreshes.
+@MainActor
+final class StudioThumbnailCache {
+    static let shared = StudioThumbnailCache()
+
+    private let images = NSCache<NSString, NSImage>()
+    private let waveforms = NSCache<NSString, NSArray>()
+
+    init(countLimit: Int = 240) {
+        images.countLimit = countLimit
+        waveforms.countLimit = countLimit
+    }
+
+    /// The identity of one cached thumbnail. The modification date is part of it so a run that
+    /// overwrites its output in place (a retake writing the same path) invalidates its own
+    /// thumbnail; `nil` means the file is gone, which is its own distinct key.
+    nonisolated static func key(url: URL, maxPixelSize: Int, modified: Date?) -> String {
+        let stamp = modified.map { String(format: "%.0f", $0.timeIntervalSince1970) } ?? "missing"
+        return "\(url.standardizedFileURL.path)|\(maxPixelSize)|\(stamp)"
+    }
+
+    nonisolated static func modificationDate(of url: URL, fileManager: FileManager = .default) -> Date? {
+        (try? fileManager.attributesOfItem(atPath: url.path))?[.modificationDate] as? Date
+    }
+
+    func image(forKey key: String) -> NSImage? {
+        images.object(forKey: key as NSString)
+    }
+
+    func store(_ image: NSImage, forKey key: String) {
+        images.setObject(image, forKey: key as NSString)
+    }
+
+    func peaks(forKey key: String) -> [Float]? {
+        waveforms.object(forKey: key as NSString) as? [Float]
+    }
+
+    func store(_ peaks: [Float], forKey key: String) {
+        waveforms.setObject(peaks as NSArray, forKey: key as NSString)
+    }
+}
+
+/// A still from a movie, for rows whose output is a clip.
+enum StudioVideoPosterLoader {
+    /// The frame the poster is taken from: a moment in, so a clip that fades up from black does
+    /// not thumbnail as a black square.
+    static let posterTime = CMTime(seconds: 0.6, preferredTimescale: 600)
+
+    static func poster(for url: URL, maxPixelSize: CGFloat) -> StudioLoadedImage? {
+        guard StudioOutputFileKind.classify(url) == .video else { return nil }
+        let asset = AVURLAsset(url: url)
+        let generator = AVAssetImageGenerator(asset: asset)
+        generator.appliesPreferredTrackTransform = true
+        generator.maximumSize = CGSize(width: maxPixelSize, height: maxPixelSize)
+        generator.requestedTimeToleranceBefore = CMTime(seconds: 0.5, preferredTimescale: 600)
+        generator.requestedTimeToleranceAfter = CMTime(seconds: 2, preferredTimescale: 600)
+        guard let cgImage = try? generator.copyCGImage(at: posterTime, actualTime: nil) else {
+            return nil
+        }
+        return StudioLoadedImage(image: NSImage(
+            cgImage: cgImage,
+            size: NSSize(width: cgImage.width, height: cgImage.height)
+        ))
+    }
+}
+
+/// The thumbnail for one Library row or grid tile.
+struct StudioLibraryThumbnail: View {
+    let item: StudioLibraryItem
+    /// The tile's side in points; the decode asks for twice that in pixels.
+    let side: CGFloat
+
+    private var url: URL? { item.outputURL }
+
+    private var kind: StudioOutputFileKind? {
+        StudioLibraryPresenter.fileKind(of: item)
+    }
+
+    var body: some View {
+        Group {
+            switch kind {
+            case .image:
+                if let url {
+                    StudioAsyncImagePreview(
+                        url: url,
+                        maxPixelSize: side * 2,
+                        contentMode: .fill,
+                        fallbackSystemImage: item.displaySystemImage
+                    )
+                } else {
+                    glyph
+                }
+            case .video:
+                if let url {
+                    StudioPosterThumbnail(url: url, side: side, fallbackSystemImage: item.displaySystemImage)
+                } else {
+                    glyph
+                }
+            case .audio:
+                if let url {
+                    StudioWaveformThumbnail(url: url, side: side)
+                } else {
+                    glyph
+                }
+            default:
+                if let line = firstLine {
+                    Text(line)
+                        .font(.system(size: max(7, side * 0.16), weight: .medium, design: .monospaced))
+                        .foregroundStyle(MereRunTheme.textSecondary)
+                        .lineLimit(side > 56 ? 3 : 2)
+                        .multilineTextAlignment(.leading)
+                        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                        .padding(4)
+                } else {
+                    glyph
+                }
+            }
+        }
+        .accessibilityHidden(true)
+    }
+
+    private var glyph: some View {
+        Image(systemName: item.displaySystemImage)
+            .font(.system(size: max(11, side * 0.34), weight: .medium))
+            .foregroundStyle(MereRunTheme.textMuted)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+    }
+
+    /// The opening of a text result — the transcript's first sentence, the caption, the JSON's
+    /// first key — so a text row is legible without opening it.
+    private var firstLine: String? {
+        guard let text = item.outputText?.trimmingCharacters(in: .whitespacesAndNewlines), !text.isEmpty else {
+            return nil
+        }
+        let line = text.split(separator: "\n", omittingEmptySubsequences: true).first.map(String.init) ?? text
+        return String(line.prefix(120))
+    }
+}
+
+/// A movie's poster frame, decoded once and cached.
+private struct StudioPosterThumbnail: View {
+    let url: URL
+    let side: CGFloat
+    let fallbackSystemImage: String
+
+    @State private var image: NSImage?
+    @State private var failed = false
+
+    var body: some View {
+        Group {
+            if let image {
+                Image(nsImage: image)
+                    .resizable()
+                    .scaledToFill()
+            } else if failed {
+                Image(systemName: fallbackSystemImage)
+                    .font(.system(size: max(11, side * 0.34), weight: .medium))
+                    .foregroundStyle(MereRunTheme.textMuted)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                Color.clear
+            }
+        }
+        .overlay(alignment: .bottomTrailing) {
+            if image != nil {
+                Image(systemName: "play.fill")
+                    .font(.system(size: max(6, side * 0.16), weight: .bold))
+                    .foregroundStyle(.white)
+                    .padding(2)
+                    .background(Circle().fill(Color.black.opacity(0.45)))
+                    .padding(3)
+            }
+        }
+        .task(id: url) {
+            let maxPixelSize = side * 2
+            let key = StudioThumbnailCache.key(
+                url: url,
+                maxPixelSize: Int(maxPixelSize.rounded()),
+                modified: StudioThumbnailCache.modificationDate(of: url)
+            )
+            if let cached = StudioThumbnailCache.shared.image(forKey: key) {
+                image = cached
+                return
+            }
+            let loaded = await Task.detached(priority: .utility) {
+                StudioVideoPosterLoader.poster(for: url, maxPixelSize: maxPixelSize)
+            }.value
+            guard !Task.isCancelled else { return }
+            if let poster = loaded?.image {
+                StudioThumbnailCache.shared.store(poster, forKey: key)
+                image = poster
+            } else {
+                failed = true
+            }
+        }
+    }
+}
+
+/// A miniature of the same peaks the player draws, so an audio row reads as audio.
+private struct StudioWaveformThumbnail: View {
+    let url: URL
+    let side: CGFloat
+
+    @State private var peaks: [Float] = []
+
+    private var barCount: Int { max(10, Int(side / 3)) }
+
+    var body: some View {
+        Canvas { context, size in
+            let bars = peaks.isEmpty ? [Float](repeating: 0.22, count: barCount) : peaks
+            let slot = size.width / CGFloat(bars.count)
+            let barWidth = max(1, slot * 0.55)
+            let middle = size.height / 2
+            for (index, peak) in bars.enumerated() {
+                let height = max(1.5, CGFloat(peak) * size.height * 0.78)
+                let rect = CGRect(
+                    x: CGFloat(index) * slot + (slot - barWidth) / 2,
+                    y: middle - height / 2,
+                    width: barWidth,
+                    height: height
+                )
+                context.fill(
+                    Path(roundedRect: rect, cornerRadius: barWidth / 2),
+                    with: .color(peaks.isEmpty ? MereRunTheme.textMuted.opacity(0.4) : MereRunTheme.accent.opacity(0.75))
+                )
+            }
+        }
+        .padding(.horizontal, 4)
+        .task(id: url) {
+            let count = barCount
+            let key = StudioThumbnailCache.key(
+                url: url,
+                maxPixelSize: count,
+                modified: StudioThumbnailCache.modificationDate(of: url)
+            )
+            if let cached = StudioThumbnailCache.shared.peaks(forKey: key) {
+                peaks = cached
+                return
+            }
+            let loaded = await Task.detached(priority: .utility) {
+                StudioWaveformLoader.peaks(url: url, barCount: count)
+            }.value
+            guard !Task.isCancelled, let loaded else { return }
+            StudioThumbnailCache.shared.store(loaded, forKey: key)
+            peaks = loaded
+        }
+    }
+}

--- a/apps/macos/MereRunStudio/StudioLibraryThumbnail.swift
+++ b/apps/macos/MereRunStudio/StudioLibraryThumbnail.swift
@@ -159,6 +159,7 @@ private struct StudioPosterThumbnail: View {
                 Image(nsImage: image)
                     .resizable()
                     .scaledToFill()
+                    .clipped()
             } else if failed {
                 Image(systemName: fallbackSystemImage)
                     .font(.system(size: max(11, side * 0.34), weight: .medium))

--- a/apps/macos/MereRunStudio/StudioNavigation.swift
+++ b/apps/macos/MereRunStudio/StudioNavigation.swift
@@ -620,3 +620,68 @@ enum StudioInspectorTaskMemory {
         Set(raw.split(separator: ",").compactMap { StudioTask(rawValue: String($0)) })
     }
 }
+
+/// What a per-task draft is worth keeping across a relaunch: the words the user typed and the
+/// file they attached. Sampling settings are not persisted — they come back from the task's own
+/// defaults, which is also the baseline the inspector diffs against — so `@SceneStorage` stays
+/// small enough to be a scene value rather than a database.
+struct StudioDraftMemoryEntry: Codable, Equatable {
+    var prompt = ""
+    var secondaryText = ""
+    var inputPath = ""
+
+    var isEmpty: Bool {
+        prompt.isBlank && secondaryText.isBlank && inputPath.isBlank
+    }
+}
+
+/// Encodes the unsent work of every prompt task as one `@SceneStorage` string, keyed by task, so
+/// switching domains or tasks — and quitting — never throws away a half-written prompt.
+enum StudioDraftMemory {
+    static func entry(for draft: StudioDraft) -> StudioDraftMemoryEntry {
+        StudioDraftMemoryEntry(
+            prompt: draft.prompt,
+            secondaryText: draft.secondaryText,
+            inputPath: draft.inputPath
+        )
+    }
+
+    static func encode(_ entries: [StudioTask: StudioDraftMemoryEntry]) -> String {
+        let kept = entries.filter { !$0.value.isEmpty }
+        guard !kept.isEmpty else { return "" }
+        let keyed = Dictionary(uniqueKeysWithValues: kept.map { ($0.key.rawValue, $0.value) })
+        guard let data = try? JSONEncoder.mereRunApp.encode(keyed),
+              let text = String(data: data, encoding: .utf8) else {
+            return ""
+        }
+        return text
+    }
+
+    static func decode(_ raw: String) -> [StudioTask: StudioDraftMemoryEntry] {
+        guard !raw.isBlank, let data = raw.data(using: .utf8),
+              let keyed = try? JSONDecoder.mereRunApp.decode([String: StudioDraftMemoryEntry].self, from: data) else {
+            return [:]
+        }
+        var entries: [StudioTask: StudioDraftMemoryEntry] = [:]
+        for (key, value) in keyed {
+            guard let task = StudioTask(rawValue: key), task.isPromptTask, !value.isEmpty else { continue }
+            entries[task] = value
+        }
+        return entries
+    }
+
+    /// Puts a remembered entry back into a fresh draft. An attachment whose file has since moved
+    /// or been emptied out of a temporary directory is dropped rather than restored as a dangling
+    /// path the composer would show as a chip and the run would fail on.
+    static func apply(
+        _ entry: StudioDraftMemoryEntry,
+        to draft: inout StudioDraft,
+        fileManager: FileManager = .default
+    ) {
+        if !entry.prompt.isBlank { draft.prompt = entry.prompt }
+        if !entry.secondaryText.isBlank { draft.secondaryText = entry.secondaryText }
+        if !entry.inputPath.isBlank, fileManager.fileExists(atPath: entry.inputPath) {
+            draft.inputPath = entry.inputPath
+        }
+    }
+}

--- a/apps/macos/MereRunStudio/StudioOutputLocation.swift
+++ b/apps/macos/MereRunStudio/StudioOutputLocation.swift
@@ -1,0 +1,345 @@
+import Foundation
+
+/// Where a run's file lands, and what it is called.
+///
+/// Studio used to write every artifact to
+/// `~/Library/Application Support/MereRun/App Outputs/<templateID>-<timestamp>.<ext>` — a folder
+/// Finder hides and a name nobody can read. Outputs now go to a user-visible folder chosen by
+/// what the file *is*, filed under the domain that made it, and named after the prompt:
+///
+/// ```
+/// ~/Pictures/mere.run/Image/a-ceramic-coffee-mug-in-soft-morning-light-8812.png
+/// ~/Music/mere.run/Voice/welcome-aboard-3f9c21.wav
+/// ~/Documents/mere.run/Vision/every-coffee-cup-and-what-it-sits-on-a41b02.json
+/// ```
+///
+/// Application Support keeps metadata only (`library.json`, receipts). Existing Library rows keep
+/// the paths they recorded; nothing is migrated.
+///
+/// A user-visible root can be overridden in Settings ▸ General (`mererun.app.outputRoot`); when it
+/// is set, every domain is filed under `<root>/<Domain>/` regardless of media. When the
+/// destination cannot be created — a sandbox denial, a missing external volume, a read-only
+/// home — `preparingDestination` moves the run back to App Outputs and reports why, so a run never
+/// fails just because of where it was going to write.
+enum StudioOutputLocation {
+    /// The `UserDefaults` key holding the user's chosen root ("" = the per-media defaults).
+    static let rootDefaultsKey = "mererun.app.outputRoot"
+
+    /// Longest slug we keep before the identifier suffix.
+    static let maximumSlugLength = 60
+
+    // MARK: - Roots
+
+    /// The folder a file of `kind` for `domain` belongs in, given a configured root (may be blank)
+    /// and a home directory. Pure: touches no filesystem.
+    static func directory(
+        domain: StudioDomain,
+        kind: StudioOutputFileKind,
+        configuredRoot: String,
+        home: URL
+    ) -> URL {
+        let root = configuredRoot.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !root.isEmpty {
+            return URL(fileURLWithPath: NSString(string: root).expandingTildeInPath, isDirectory: true)
+                .appendingPathComponent(domain.title, isDirectory: true)
+        }
+        return home
+            .appendingPathComponent(mediaFolder(for: kind), isDirectory: true)
+            .appendingPathComponent("mere.run", isDirectory: true)
+            .appendingPathComponent(domain.title, isDirectory: true)
+    }
+
+    /// Pictures for stills and clips, Music for anything that plays, Documents for the rest.
+    static func mediaFolder(for kind: StudioOutputFileKind) -> String {
+        switch kind {
+        case .image, .video: return "Pictures"
+        case .audio: return "Music"
+        case .text, .model3D, .other: return "Documents"
+        }
+    }
+
+    /// `~/Library/Application Support/MereRun/App Outputs` — the pre-v2 destination, kept as the
+    /// fallback when a user-visible folder cannot be written.
+    static func appOutputsRoot(fileManager: FileManager = .default) -> URL {
+        let support = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true)
+                .appendingPathComponent("Library/Application Support", isDirectory: true)
+        return support
+            .appendingPathComponent("MereRun", isDirectory: true)
+            .appendingPathComponent("App Outputs", isDirectory: true)
+    }
+
+    private static func configuredRoot() -> String {
+        UserDefaults.standard.string(forKey: rootDefaultsKey) ?? ""
+    }
+
+    // MARK: - Names
+
+    /// A file-name stem from free text: lowercased, diacritics folded, everything that is not a
+    /// letter or a digit treated as a word break, words joined by hyphens, and cut at a word
+    /// boundary no longer than `limit`. Empty when the text carries no letters or digits.
+    static func slug(_ text: String, limit: Int = maximumSlugLength) -> String {
+        let folded = text.folding(options: [.diacriticInsensitive, .widthInsensitive], locale: Locale(identifier: "en_US"))
+            .lowercased()
+        var words: [String] = []
+        var current = ""
+        for character in folded.unicodeScalars {
+            if CharacterSet.alphanumerics.contains(character), character.isASCII {
+                current.unicodeScalars.append(character)
+            } else if !current.isEmpty {
+                words.append(current)
+                current = ""
+            }
+        }
+        if !current.isEmpty { words.append(current) }
+        guard !words.isEmpty, limit > 0 else { return "" }
+
+        var slug = ""
+        for word in words {
+            if slug.isEmpty {
+                slug = String(word.prefix(limit))
+                continue
+            }
+            guard slug.count + 1 + word.count <= limit else { break }
+            slug += "-" + word
+        }
+        return slug
+    }
+
+    /// The stable part of a name: the prompt's slug, or `fallbackStem` when the prompt has no
+    /// usable characters (Transcribe and the other input-first tasks have no prompt at all).
+    static func stem(prompt: String, fallbackStem: String) -> String {
+        let promptSlug = slug(prompt)
+        if !promptSlug.isEmpty { return promptSlug }
+        let fallback = slug(fallbackStem)
+        return fallback.isEmpty ? "output" : fallback
+    }
+
+    /// The identifier that follows the slug: the seed when the run has one (so a reproducible
+    /// picture is named after the number that reproduces it), otherwise a short id derived from
+    /// the run's own settings. It is derived rather than random so the path the Command view shows
+    /// is the path the run writes — a random id would change on every keystroke.
+    static func identifier(seed: String, fingerprint: String) -> String {
+        let seedSlug = slug(seed, limit: 20)
+        return seedSlug.isEmpty ? shortIdentifier(for: fingerprint) : seedSlug
+    }
+
+    /// Six hex characters of an FNV-1a hash — stable across launches, unlike `Hasher`.
+    static func shortIdentifier(for text: String) -> String {
+        var hash: UInt64 = 0xcbf2_9ce4_8422_2325
+        for byte in Array(text.utf8) {
+            hash ^= UInt64(byte)
+            hash = hash &* 0x0000_0100_0000_01b3
+        }
+        return String(String(format: "%016lx", hash).suffix(6))
+    }
+
+    /// `<stem>-<identifier>.<ext>`, with `-2`, `-3`… inserted before the extension until `exists`
+    /// says the name is free. `exists` is a predicate rather than a `FileManager` call so the
+    /// naming rule is testable without touching a disk.
+    static func uniqueFileName(
+        stem: String,
+        identifier: String,
+        fileExtension: String,
+        exists: (String) -> Bool
+    ) -> String {
+        let base = identifier.isEmpty ? stem : "\(stem)-\(identifier)"
+        let suffix = fileExtension.isEmpty ? "" : ".\(fileExtension)"
+        var candidate = base + suffix
+        var counter = 2
+        while exists(candidate) {
+            candidate = "\(base)-\(counter)\(suffix)"
+            counter += 1
+            // A pathological directory must not hang a run; fall back to a one-off random id.
+            if counter > 999 {
+                candidate = "\(base)-\(shortIdentifier(for: UUID().uuidString))\(suffix)"
+                break
+            }
+        }
+        return candidate
+    }
+
+    // MARK: - Whole destinations
+
+    /// The full path a run should write to. Pure apart from the existence checks that make the
+    /// name collision-safe; the directory is created later, by `preparingDestination`.
+    static func outputURL(
+        domain: StudioDomain,
+        prompt: String,
+        seed: String = "",
+        fingerprint: String = "",
+        fallbackStem: String,
+        fileExtension: String,
+        identifierOverride: String? = nil,
+        configuredRoot: String? = nil,
+        home: URL = URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true),
+        fileManager: FileManager = .default
+    ) -> URL {
+        let directory = directory(
+            domain: domain,
+            kind: StudioOutputFileKind.classify(URL(fileURLWithPath: "output.\(fileExtension)")),
+            configuredRoot: configuredRoot ?? Self.configuredRoot(),
+            home: home
+        )
+        let name = uniqueFileName(
+            stem: stem(prompt: prompt, fallbackStem: fallbackStem),
+            identifier: identifierOverride ?? identifier(seed: seed, fingerprint: fingerprint),
+            fileExtension: fileExtension,
+            exists: { fileManager.fileExists(atPath: directory.appendingPathComponent($0).path) }
+        )
+        return directory.appendingPathComponent(name, isDirectory: false)
+    }
+
+    /// A directory destination (`--output-dir` commands): `<root>/<Domain>/<stem>-<identifier>`.
+    static func outputDirectoryURL(
+        domain: StudioDomain,
+        prompt: String,
+        fingerprint: String = "",
+        fallbackStem: String,
+        identifierOverride: String? = nil,
+        configuredRoot: String? = nil,
+        home: URL = URL(fileURLWithPath: NSHomeDirectory(), isDirectory: true),
+        fileManager: FileManager = .default
+    ) -> URL {
+        let directory = directory(
+            domain: domain,
+            kind: .other,
+            configuredRoot: configuredRoot ?? Self.configuredRoot(),
+            home: home
+        )
+        let name = uniqueFileName(
+            stem: stem(prompt: prompt, fallbackStem: fallbackStem),
+            identifier: identifierOverride ?? shortIdentifier(for: fingerprint),
+            fileExtension: "",
+            exists: { fileManager.fileExists(atPath: directory.appendingPathComponent($0).path) }
+        )
+        return directory.appendingPathComponent(name, isDirectory: true)
+    }
+
+    /// The destination a template starts a draft with, before anyone types a prompt: the domain's
+    /// user-visible folder and the command's own name plus a timestamp. Drafts are made once per
+    /// surface, so the timestamp is stable for as long as the draft is — the Command Console shows
+    /// the path the run will actually write.
+    static func templateOutputPath(
+        templateID: CommandTemplateID,
+        title: String,
+        outputKind: CommandOutputKind,
+        now: Date = Date()
+    ) -> String? {
+        let stamp = DateFormatter.mereRunTimestamp.string(from: now)
+        switch outputKind {
+        case .file(let ext):
+            return outputURL(
+                domain: templateID.studioDomain,
+                prompt: "",
+                fallbackStem: title,
+                fileExtension: ext,
+                identifierOverride: stamp
+            ).path
+        case .directory:
+            return outputDirectoryURL(
+                domain: templateID.studioDomain,
+                prompt: "",
+                fallbackStem: title,
+                identifierOverride: stamp
+            ).path
+        case .none:
+            return nil
+        }
+    }
+
+    /// The destination for one Studio run: the same folder the template already chose, but named
+    /// after the prompt. `.none` output kinds (chat, the utility probes) keep `existing`.
+    static func namedOutputPath(
+        templateID: CommandTemplateID,
+        outputKind: CommandOutputKind,
+        prompt: String,
+        seed: String,
+        fingerprint: String,
+        fallbackStem: String,
+        existing: String
+    ) -> String {
+        switch outputKind {
+        case .file(let ext):
+            return outputURL(
+                domain: templateID.studioDomain,
+                prompt: prompt,
+                seed: seed,
+                fingerprint: fingerprint,
+                fallbackStem: fallbackStem,
+                fileExtension: ext
+            ).path
+        case .directory:
+            return outputDirectoryURL(
+                domain: templateID.studioDomain,
+                prompt: prompt,
+                fingerprint: fingerprint,
+                fallbackStem: fallbackStem
+            ).path
+        case .none:
+            return existing
+        }
+    }
+
+    // MARK: - Preparing a run
+
+    /// The result of making a destination real: the draft to run, and why it had to move.
+    struct Preparation: Equatable {
+        var draft: CommandDraft
+        /// nil when the intended destination was created (or already existed).
+        var fallbackReason: String?
+    }
+
+    /// Creates the destination directory of `draft`, redirecting the run to App Outputs when that
+    /// is impossible. Every path the draft writes that lived beside the output — the vision result
+    /// document, the per-detection mask directory, the timings report — moves with it, so a
+    /// redirected run still keeps its sidecars together.
+    static func preparingDestination(
+        of draft: CommandDraft,
+        fileManager: FileManager = .default
+    ) -> Preparation {
+        guard !draft.outputPath.isBlank else { return Preparation(draft: draft) }
+        let output = URL(fileURLWithPath: draft.outputPath)
+        // A directory destination is itself the folder to create; a file destination needs its parent.
+        let intended = draft.outputPath.hasSuffix("/") ? output : output.deletingLastPathComponent()
+
+        do {
+            try fileManager.createDirectory(at: intended, withIntermediateDirectories: true)
+            return Preparation(draft: draft)
+        } catch {
+            let fallbackDirectory = appOutputsRoot(fileManager: fileManager)
+            guard (try? fileManager.createDirectory(at: fallbackDirectory, withIntermediateDirectories: true)) != nil else {
+                // Nowhere to write at all: run as asked and let the CLI report the real failure.
+                return Preparation(draft: draft)
+            }
+            var moved = draft
+            let originalDirectory = intended.standardizedFileURL.path
+            moved.outputPath = redirect(draft.outputPath, from: originalDirectory, to: fallbackDirectory)
+            moved.visionJSONOutputPath = redirect(draft.visionJSONOutputPath, from: originalDirectory, to: fallbackDirectory)
+            moved.visionMaskOutputDirectory = redirect(
+                draft.visionMaskOutputDirectory, from: originalDirectory, to: fallbackDirectory
+            )
+            moved.timingsOutputPath = redirect(draft.timingsOutputPath, from: originalDirectory, to: fallbackDirectory)
+            return Preparation(
+                draft: moved,
+                fallbackReason: "Could not write to \(abbreviate(intended)): \(error.localizedDescription)"
+            )
+        }
+    }
+
+    /// Rewrites a path that lived in `directory` so it lives in `replacement` instead. Paths
+    /// elsewhere (a user-chosen report location) are left exactly as they are.
+    private static func redirect(_ path: String, from directory: String, to replacement: URL) -> String {
+        guard !path.isBlank else { return path }
+        let url = URL(fileURLWithPath: path)
+        guard url.deletingLastPathComponent().standardizedFileURL.path == directory else { return path }
+        return replacement.appendingPathComponent(url.lastPathComponent).path
+    }
+
+    /// `~/Pictures/mere.run/Image` rather than the full home path, for the banner text.
+    static func abbreviate(_ url: URL, home: String = NSHomeDirectory()) -> String {
+        let path = url.standardizedFileURL.path
+        guard !home.isEmpty, path == home || path.hasPrefix(home + "/") else { return path }
+        return "~" + path.dropFirst(home.count)
+    }
+}

--- a/apps/macos/MereRunStudio/StudioRootView.swift
+++ b/apps/macos/MereRunStudio/StudioRootView.swift
@@ -19,6 +19,9 @@ struct StudioRootView: View {
     @SceneStorage("studio.mode") private var lastPromptMode: StudioMode = .createImage
     @SceneStorage("studio.showLibrary") private var storedShowLibrary = true
     @SceneStorage("studio.libraryScope") private var libraryScope: StudioLibraryScope = .domain
+    @SceneStorage("studio.libraryView") private var libraryViewMode: StudioLibraryViewMode = .list
+    @SceneStorage("studio.libraryKind") private var libraryKind: StudioLibraryKind = .all
+    @SceneStorage("studio.libraryFavorites") private var libraryFavoritesOnly = false
     /// The prompt tasks whose inspector stays open, as `StudioInspectorTaskMemory` encodes them.
     @SceneStorage("studio.inspectorTasks") private var storedInspectorTasks = ""
     @State private var columnVisibility: NavigationSplitViewVisibility = .all
@@ -410,12 +413,18 @@ struct StudioRootView: View {
             items: StudioThreadListPresenter.mediaItems(in: library.items),
             domain: destination.domain,
             scope: $libraryScope,
+            viewMode: $libraryViewMode,
+            kind: $libraryKind,
+            favoritesOnly: $libraryFavoritesOnly,
             progressByID: controller.progressByRequestID,
             selectedID: $navigation.selectedLibraryID,
             onSelect: selectLibraryItem,
-            onDelete: deleteLibraryItem,
+            onDelete: deleteLibraryItems,
             onRename: library.rename,
+            onToggleFavorite: toggleLibraryFavorite,
             onQuickLook: { QuickLookCoordinator.shared.preview($0) },
+            onReveal: revealInFinder,
+            onExport: exportLibraryItems,
             onRetry: retryLibraryItem,
             onEdit: editLibraryItem,
             leadingInset: windowChromeInset
@@ -1284,9 +1293,91 @@ struct StudioRootView: View {
     }
 
     private func deleteLibraryItem(_ id: UUID) {
-        library.delete(id: id)
-        if navigation.selectedLibraryID == id { navigation.selectedLibraryID = nil }
-        if activeConversationID == id { activeConversationID = nil }
+        deleteLibraryItems([id], trashingFiles: false)
+    }
+
+    /// Library ▸ Delete, for one row or a whole batch. The files follow the rows into the Trash
+    /// only when the user chose that in the confirmation.
+    private func deleteLibraryItems(_ ids: Set<UUID>, trashingFiles: Bool) {
+        let failures = library.delete(ids: ids, trashingFiles: trashingFiles)
+        if let first = failures.first {
+            studioError = failures.count == 1
+                ? "Could not move \(first.lastPathComponent) to the Trash."
+                : "Could not move \(failures.count) files to the Trash."
+        }
+        if let selected = navigation.selectedLibraryID, ids.contains(selected) {
+            navigation.selectedLibraryID = nil
+        }
+        if let conversation = activeConversationID, ids.contains(conversation) {
+            activeConversationID = nil
+        }
+    }
+
+    private func toggleLibraryFavorite(_ id: UUID) {
+        guard let item = library.items.first(where: { $0.id == id }) else { return }
+        library.setFavorite(id: id, isFavorite: !item.isStarred)
+    }
+
+    private func revealInFinder(_ urls: [URL]) {
+        let existing = urls.filter { FileManager.default.fileExists(atPath: $0.path) }
+        guard !existing.isEmpty else {
+            studioError = "Those files are no longer on disk."
+            return
+        }
+        NSWorkspace.shared.activateFileViewerSelecting(existing)
+    }
+
+    /// "Save to…": copies a row's artifacts (or a whole batch's) somewhere the user picks, leaving
+    /// the originals — and the Library rows that point at them — untouched.
+    private func exportLibraryItems(_ selected: [StudioLibraryItem]) {
+        let urls = selected.flatMap(\.allArtifactURLs)
+            .filter { FileManager.default.fileExists(atPath: $0.path) }
+        guard !urls.isEmpty else {
+            studioError = "Those runs have no files to save."
+            return
+        }
+
+        if urls.count == 1, let source = urls.first {
+            let panel = NSSavePanel()
+            panel.nameFieldStringValue = source.lastPathComponent
+            panel.canCreateDirectories = true
+            guard panel.runModal() == .OK, let destination = panel.url else { return }
+            copyExport(from: [source], into: destination.deletingLastPathComponent(), names: [destination.lastPathComponent])
+            return
+        }
+
+        let panel = NSOpenPanel()
+        panel.canChooseFiles = false
+        panel.canChooseDirectories = true
+        panel.canCreateDirectories = true
+        panel.prompt = "Save"
+        panel.message = "Choose a folder for \(urls.count) files."
+        guard panel.runModal() == .OK, let directory = panel.url else { return }
+        copyExport(from: urls, into: directory, names: urls.map(\.lastPathComponent))
+    }
+
+    private func copyExport(from sources: [URL], into directory: URL, names: [String]) {
+        let fileManager = FileManager.default
+        var failures = 0
+        for (source, name) in zip(sources, names) {
+            var destination = directory.appendingPathComponent(name)
+            var counter = 2
+            let stem = destination.deletingPathExtension().lastPathComponent
+            let ext = destination.pathExtension
+            while fileManager.fileExists(atPath: destination.path), counter < 1_000 {
+                let candidate = ext.isEmpty ? "\(stem)-\(counter)" : "\(stem)-\(counter).\(ext)"
+                destination = directory.appendingPathComponent(candidate)
+                counter += 1
+            }
+            do {
+                try fileManager.copyItem(at: source, to: destination)
+            } catch {
+                failures += 1
+            }
+        }
+        if failures > 0 {
+            studioError = failures == 1 ? "One file could not be saved." : "\(failures) files could not be saved."
+        }
     }
 
     /// Opens the Command Console window with the composer's draft carried into the Advanced

--- a/apps/macos/MereRunStudio/StudioRootView.swift
+++ b/apps/macos/MereRunStudio/StudioRootView.swift
@@ -44,6 +44,9 @@ struct StudioRootView: View {
     @State private var pendingPullRefresh: StudioReadinessRefresh?
     @State private var pendingRestrictedPull: StudioRunRequest?
     @State private var studioError: String?
+    /// A run whose user-visible destination could not be created, explained once per launch.
+    @State private var outputFallbackNotice: String?
+    @State private var outputFallbackAnnounced = false
     /// Every `model list` row, installed or not, feeding the composer's model chip.
     @State private var modelInventory: [StudioModelInventoryRow] = []
     /// What Models ▸ Installed last reported, so the content header's subtitle shows the real inventory.
@@ -374,6 +377,17 @@ struct StudioRootView: View {
             MereBanner(
                 severity: .warning,
                 text: "Run history not saved: \(persistenceError)"
+            )
+            .padding(.horizontal, MereRunTheme.Spacing.lg)
+            .padding(.top, MereRunTheme.Spacing.sm)
+        }
+
+        if let outputFallbackNotice {
+            MereBanner(
+                severity: .warning,
+                text: outputFallbackNotice,
+                systemImage: "folder.badge.questionmark",
+                onDismiss: { self.outputFallbackNotice = nil }
             )
             .padding(.horizontal, MereRunTheme.Spacing.lg)
             .padding(.top, MereRunTheme.Spacing.sm)
@@ -1338,7 +1352,7 @@ struct StudioRootView: View {
         }
 
         do {
-            let request = try StudioCommandAdapter.makeRequest(mode: mode, draft: draft)
+            let request = try prepareDestination(of: StudioCommandAdapter.makeRequest(mode: mode, draft: draft))
             let preview = controller
                 .commandPreview(template: request.template, draft: request.draft, masksSecrets: true)
             let status: StudioLibraryStatus = jobMonitor.hasInferenceCapacity ? .running : .queued
@@ -1348,6 +1362,27 @@ struct StudioRootView: View {
         } catch {
             studioError = error.localizedDescription
         }
+    }
+
+    /// Makes the run's destination folder exist. A sandbox denial, a read-only home, or a root
+    /// pointing at a volume that is not mounted sends the run back to App Outputs rather than
+    /// failing it; the banner says so once per launch so the surprise is explained, not silent.
+    private func prepareDestination(of request: StudioRunRequest) -> StudioRunRequest {
+        let prepared = StudioOutputLocation.preparingDestination(of: request.draft)
+        if let reason = prepared.fallbackReason, !outputFallbackAnnounced {
+            outputFallbackAnnounced = true
+            outputFallbackNotice = "\(reason) Saving to \(StudioOutputLocation.abbreviate(StudioOutputLocation.appOutputsRoot())) instead."
+        }
+        guard prepared.draft != request.draft else { return request }
+        return StudioRunRequest(
+            id: request.id,
+            mode: request.mode,
+            templateID: request.templateID,
+            template: request.template,
+            draft: prepared.draft,
+            createdAt: request.createdAt,
+            conversationID: request.conversationID
+        )
     }
 
     /// The composer's Stop: the run of this mode in flight, or the thread's turn.
@@ -1581,13 +1616,28 @@ struct StudioRootView: View {
             studioError = "This older Library item does not include a replayable command."
             return
         }
-        let request = StudioRunRequest(
+        // A replay writes its own file: the recorded draft still points at the run that made it,
+        // so Rerun and Vary would otherwise overwrite the picture they came from.
+        var replayDraft = commandDraft
+        if !commandDraft.outputPath.isBlank {
+            replayDraft.outputPath = StudioOutputLocation.namedOutputPath(
+                templateID: templateID,
+                outputKind: template.outputKind,
+                prompt: commandDraft.prompt,
+                seed: commandDraft.seed,
+                fingerprint: "\(templateID.rawValue)\u{1}\(commandDraft.prompt)\u{1}\(commandDraft.model)\u{1}\(item.id)",
+                fallbackStem: template.title,
+                existing: commandDraft.outputPath
+            )
+            StudioVisionResultPaths.rederive(in: &replayDraft, previousOutputPath: commandDraft.outputPath)
+        }
+        let request = prepareDestination(of: StudioRunRequest(
             mode: item.mode,
             templateID: templateID,
             template: template,
-            draft: commandDraft
-        )
-        let preview = controller.commandPreview(template: template, draft: commandDraft, masksSecrets: true)
+            draft: replayDraft
+        ))
+        let preview = controller.commandPreview(template: template, draft: request.draft, masksSecrets: true)
         let status: StudioLibraryStatus = jobMonitor.hasInferenceCapacity ? .running : .queued
         library.start(request: request, commandPreview: preview, status: status)
         navigation.selectedLibraryID = request.id

--- a/apps/macos/MereRunStudio/StudioRootView.swift
+++ b/apps/macos/MereRunStudio/StudioRootView.swift
@@ -24,6 +24,9 @@ struct StudioRootView: View {
     @SceneStorage("studio.libraryFavorites") private var libraryFavoritesOnly = false
     /// The prompt tasks whose inspector stays open, as `StudioInspectorTaskMemory` encodes them.
     @SceneStorage("studio.inspectorTasks") private var storedInspectorTasks = ""
+    /// The unsent prompt, system text, and attachment of every prompt task, as
+    /// `StudioDraftMemory` encodes them, so a relaunch resumes mid-sentence.
+    @SceneStorage("studio.drafts") private var storedDrafts = ""
     @State private var columnVisibility: NavigationSplitViewVisibility = .all
     /// The status probe never answered within its grace period, so the footer says so.
     @State private var probeTimedOut = false
@@ -31,6 +34,11 @@ struct StudioRootView: View {
     /// destination observer activates a mode exactly once however the destination arrived.
     @State private var activatedMode: StudioMode?
     @State private var draft = StudioDraft()
+    /// The draft each prompt task is holding, so leaving Image ▸ Generate for Video ▸ Generate and
+    /// coming back finds the prompt, the attachment, and the settings exactly as they were. The
+    /// composer, the inspector, and the Command view all read `draft`, which is this dictionary's
+    /// entry for the current task.
+    @State private var draftsByTask: [StudioTask: StudioDraft] = [:]
     @State private var isDropTargeted = false
     /// Which jobs exist; the feed re-derives its cards when one starts or finishes.
     @StateObject private var jobMonitor = StudioJobMonitor()
@@ -1057,12 +1065,15 @@ struct StudioRootView: View {
         }
         .onChange(of: draft.inputPath) { _, _ in
             studioError = nil
+            park(draft, for: mode)
         }
         .onChange(of: draft.prompt) { _, _ in
             studioError = nil
+            park(draft, for: mode)
         }
         .onChange(of: draft.secondaryText) { _, _ in
             studioError = nil
+            park(draft, for: mode)
         }
         .onChange(of: controller.cliPath) { _, _ in
             studioError = nil
@@ -1168,8 +1179,15 @@ struct StudioRootView: View {
     /// Library row the user just picked (so selecting a row of another domain lands on that row),
     /// otherwise opens the most recent item or thread of the mode.
     private func activateMode(_ newMode: StudioMode) {
+        // Park the task being left before anything else touches `draft`, so nothing typed here is
+        // lost by the switch; the task being entered gets its own draft back.
+        if let leaving = activatedMode, leaving != newMode {
+            park(draft, for: leaving)
+        }
         activatedMode = newMode
-        var nextDraft = seededDrafts[newMode] ?? freshDraft(for: newMode)
+        let parked = seededDrafts[newMode] == nil ? parkedDraft(for: newMode) : nil
+        var nextDraft = seededDrafts[newMode] ?? parked ?? freshDraft(for: newMode)
+        let hadParkedDraft = parked != nil
         studioError = nil
         let preferred = navigation.selectedLibraryID.flatMap { id in
             library.items.first { $0.id == id && $0.mode == newMode }
@@ -1198,7 +1216,9 @@ struct StudioRootView: View {
                 activeConversationID = nil
                 navigation.selectedLibraryID = nil
             }
-            nextDraft.prompt = ""
+            // Opening a thread clears the composer, but a half-written message this task was
+            // already holding survives the detour.
+            if !hadParkedDraft { nextDraft.prompt = "" }
         } else {
             activeConversationID = nil
             let selected = preferred ?? library.items.first { $0.mode == newMode }
@@ -1215,8 +1235,26 @@ struct StudioRootView: View {
         }
         pendingAnalyzeHandoff = nil
         draft = nextDraft
+        park(nextDraft, for: newMode)
         controller.checkReadiness(for: newMode, draft: draft)
         if newMode != .listen { promptFocused = true }
+    }
+
+    /// Remembers a task's draft: in full for this launch, and — for the prompt, the system text,
+    /// and the attachment — across relaunches through `@SceneStorage`.
+    private func park(_ draft: StudioDraft, for mode: StudioMode) {
+        draftsByTask[mode.task] = draft
+        storedDrafts = StudioDraftMemory.encode(draftsByTask.mapValues(StudioDraftMemory.entry(for:)))
+    }
+
+    /// The draft this task was last holding: the live one when it has been visited this launch,
+    /// otherwise the task's defaults with whatever the last session left unsent laid back on top.
+    private func parkedDraft(for mode: StudioMode) -> StudioDraft? {
+        if let parked = draftsByTask[mode.task] { return parked }
+        guard let entry = StudioDraftMemory.decode(storedDrafts)[mode.task] else { return nil }
+        var restored = freshDraft(for: mode)
+        StudioDraftMemory.apply(entry, to: &restored)
+        return restored
     }
 
     /// A Library row the user clicked. Rows of another mode switch the destination first;

--- a/apps/macos/MereRunStudio/StudioTypes.swift
+++ b/apps/macos/MereRunStudio/StudioTypes.swift
@@ -1047,6 +1047,11 @@ struct StudioLibraryItem: Codable, Identifiable, Equatable {
     var model: String? = nil
     /// Origin for entries imported by an external local launcher. nil means a Studio-owned run.
     var source: StudioLibrarySource? = nil
+    /// Starred in the Library column. Optional + additive so rows written before favorites
+    /// existed decode unchanged (nil reads as not favorite).
+    var isFavorite: Bool? = nil
+
+    var isStarred: Bool { isFavorite == true }
 
     var displayTitle: String {
         if let customTitle, !customTitle.isBlank { return customTitle }

--- a/apps/macos/MereRunStudio/StudioTypes.swift
+++ b/apps/macos/MereRunStudio/StudioTypes.swift
@@ -649,6 +649,21 @@ enum StudioCommandAdapter {
         let prompt = studioDraft.prompt.trimmingCharacters(in: .whitespacesAndNewlines)
         let secondary = studioDraft.secondaryText.trimmingCharacters(in: .whitespacesAndNewlines)
 
+        // Name the file after what the user asked for, before the per-mode branches derive their
+        // sidecars (the vision result document, the mask directory) from it. Input-first tasks have
+        // no prompt to name themselves after, so they take the attachment's name instead.
+        draft.outputPath = StudioOutputLocation.namedOutputPath(
+            templateID: templateID,
+            outputKind: template.outputKind,
+            prompt: prompt,
+            seed: studioDraft.seed,
+            fingerprint: "\(templateID.rawValue)\u{1}\(prompt)\u{1}\(studioDraft.model)\u{1}\(studioDraft.inputPath)",
+            fallbackStem: studioDraft.inputPath.isBlank
+                ? template.title
+                : URL(fileURLWithPath: studioDraft.inputPath).deletingPathExtension().lastPathComponent,
+            existing: draft.outputPath
+        )
+
         switch mode {
         case .createImage:
             draft.prompt = prompt

--- a/apps/macos/MereRunStudioTests/StudioLibraryPresentationTests.swift
+++ b/apps/macos/MereRunStudioTests/StudioLibraryPresentationTests.swift
@@ -1,0 +1,269 @@
+@testable import MereRunApp
+import XCTest
+
+final class StudioLibraryPresentationTests: XCTestCase {
+    // MARK: - Filtering
+
+    func testScopeNarrowsToTheCurrentDomainAndAllShowsEverything() {
+        let items = [
+            item(mode: .createImage, templateID: .imageGenerate, output: "mug.png"),
+            item(mode: .speak, templateID: .speechSynthesize, output: "line.wav"),
+        ]
+
+        XCTAssertEqual(StudioLibraryPresenter.scoped(items, scope: .all, domain: .image).count, 2)
+        let scoped = StudioLibraryPresenter.scoped(items, scope: .domain, domain: .image)
+        XCTAssertEqual(scoped.map(\.mode), [.createImage])
+    }
+
+    func testKindFilterSplitsImagesVideoAudioAndText() {
+        let image = item(mode: .createImage, templateID: .imageGenerate, output: "mug.png")
+        let clip = item(mode: .video, templateID: .videoGenerate, output: "clip.mp4")
+        let song = item(mode: .music, templateID: .musicGenerate, output: "song.wav")
+        let document = item(mode: .findObjects, templateID: .visionGround, output: "boxes.json")
+        let transcript = item(mode: .listen, templateID: .speechTranscribe, output: nil, outputText: "Welcome aboard.")
+        let items = [image, clip, song, document, transcript]
+
+        func matching(_ kind: StudioLibraryKind) -> [UUID] {
+            StudioLibraryPresenter.filter(
+                items, with: StudioLibraryFilter(scope: .all, kind: kind)
+            ).map(\.id)
+        }
+
+        XCTAssertEqual(matching(.all).count, 5)
+        XCTAssertEqual(matching(.images), [image.id])
+        XCTAssertEqual(matching(.video), [clip.id])
+        XCTAssertEqual(matching(.audio), [song.id])
+        XCTAssertEqual(matching(.text), [document.id, transcript.id])
+    }
+
+    func testFavoritesFilterKeepsOnlyStarredRows() {
+        var starred = item(mode: .createImage, templateID: .imageGenerate, output: "mug.png")
+        starred.isFavorite = true
+        let plain = item(mode: .createImage, templateID: .imageGenerate, output: "plate.png")
+
+        let filtered = StudioLibraryPresenter.filter(
+            [starred, plain], with: StudioLibraryFilter(scope: .all, favoritesOnly: true)
+        )
+        XCTAssertEqual(filtered.map(\.id), [starred.id])
+        XCTAssertTrue(starred.isStarred)
+        XCTAssertFalse(plain.isStarred, "a row with no isFavorite key is not a favorite")
+    }
+
+    func testSearchMatchesTitleKindAndPromptAndComposesWithTheOtherFilters() {
+        var starred = item(
+            mode: .createImage, templateID: .imageGenerate, output: "mug.png",
+            prompt: "a ceramic coffee mug"
+        )
+        starred.isFavorite = true
+        let other = item(
+            mode: .createImage, templateID: .imageGenerate, output: "diner.png",
+            prompt: "a rainy diner window"
+        )
+
+        let filter = StudioLibraryFilter(
+            scope: .domain, domain: .image, kind: .images, favoritesOnly: true, query: "COFFEE"
+        )
+        XCTAssertEqual(StudioLibraryPresenter.filter([starred, other], with: filter).map(\.id), [starred.id])
+        XCTAssertTrue(
+            StudioLibraryPresenter.filter(
+                [starred, other],
+                with: StudioLibraryFilter(scope: .all, query: "nothing here")
+            ).isEmpty
+        )
+    }
+
+    // MARK: - Multi-selection
+
+    func testPlainClickReplacesTheBatchAndOpensTheRow() {
+        let ids = [UUID(), UUID(), UUID()]
+        let result = StudioLibrarySelection.click(
+            on: ids[2], visible: ids, selection: [ids[0]], anchor: ids[0], modifiers: .none
+        )
+        XCTAssertEqual(result.selection, [ids[2]])
+        XCTAssertEqual(result.anchor, ids[2])
+        XCTAssertEqual(result.opened, ids[2])
+    }
+
+    func testCommandClickAddsAndRemovesWithoutChangingWhatIsOpen() {
+        let ids = [UUID(), UUID(), UUID()]
+        let added = StudioLibrarySelection.click(
+            on: ids[2], visible: ids, selection: [ids[0]], anchor: ids[0], modifiers: .command
+        )
+        XCTAssertEqual(added.selection, [ids[0], ids[2]])
+        XCTAssertEqual(added.opened, ids[2])
+
+        let removed = StudioLibrarySelection.click(
+            on: ids[2], visible: ids, selection: added.selection, anchor: ids[2], modifiers: .command
+        )
+        XCTAssertEqual(removed.selection, [ids[0]])
+        XCTAssertNil(removed.opened, "deselecting a row must not yank the canvas to it")
+    }
+
+    func testShiftClickSelectsTheRunOfVisibleRowsInEitherDirection() {
+        let ids = (0..<5).map { _ in UUID() }
+        let down = StudioLibrarySelection.click(
+            on: ids[3], visible: ids, selection: [ids[1]], anchor: ids[1], modifiers: .shift
+        )
+        XCTAssertEqual(down.selection, Set(ids[1...3]))
+        XCTAssertEqual(down.anchor, ids[1], "the anchor stays put so the range can be re-dragged")
+
+        let up = StudioLibrarySelection.click(
+            on: ids[0], visible: ids, selection: down.selection, anchor: ids[3], modifiers: .shift
+        )
+        XCTAssertEqual(up.selection, Set(ids[0...3]))
+    }
+
+    func testShiftClickWithNoAnchorBehavesLikeAPlainClick() {
+        let ids = [UUID(), UUID()]
+        let result = StudioLibrarySelection.click(
+            on: ids[1], visible: ids, selection: [], anchor: nil, modifiers: .shift
+        )
+        XCTAssertEqual(result.selection, [ids[1]])
+        XCTAssertEqual(result.opened, ids[1])
+    }
+
+    func testModifiersReadTheEventFlags() {
+        XCTAssertEqual(StudioLibrarySelection.Modifiers(event: [.command]), .command)
+        XCTAssertEqual(StudioLibrarySelection.Modifiers(event: [.shift]), .shift)
+        XCTAssertEqual(StudioLibrarySelection.Modifiers(event: [.option]), .none)
+    }
+
+    // MARK: - Thumbnail cache
+
+    func testThumbnailCacheKeysSeparatePathSizeAndModificationDate() {
+        let url = URL(fileURLWithPath: "/tmp/mere/clip.mp4")
+        let stamp = Date(timeIntervalSince1970: 1_700_000_000)
+        let key = StudioThumbnailCache.key(url: url, maxPixelSize: 80, modified: stamp)
+
+        XCTAssertEqual(key, "/tmp/mere/clip.mp4|80|1700000000")
+        XCTAssertEqual(key, StudioThumbnailCache.key(url: url, maxPixelSize: 80, modified: stamp))
+        XCTAssertNotEqual(key, StudioThumbnailCache.key(url: url, maxPixelSize: 160, modified: stamp))
+        XCTAssertNotEqual(
+            key,
+            StudioThumbnailCache.key(url: url, maxPixelSize: 80, modified: stamp.addingTimeInterval(1)),
+            "a file rewritten in place must not keep its old thumbnail"
+        )
+        XCTAssertEqual(
+            StudioThumbnailCache.key(url: url, maxPixelSize: 80, modified: nil),
+            "/tmp/mere/clip.mp4|80|missing"
+        )
+    }
+
+    func testThumbnailCacheKeysStandardizeThePath() {
+        XCTAssertEqual(
+            StudioThumbnailCache.key(url: URL(fileURLWithPath: "/tmp/mere/../mere/clip.mp4"), maxPixelSize: 40, modified: nil),
+            StudioThumbnailCache.key(url: URL(fileURLWithPath: "/tmp/mere/clip.mp4"), maxPixelSize: 40, modified: nil)
+        )
+    }
+
+    @MainActor
+    func testThumbnailCacheStoresAndReturnsByKey() {
+        let cache = StudioThumbnailCache()
+        let image = NSImage(size: NSSize(width: 4, height: 4))
+        cache.store(image, forKey: "a")
+        cache.store([0.1, 0.9], forKey: "b")
+
+        XCTAssertIdentical(cache.image(forKey: "a"), image)
+        XCTAssertNil(cache.image(forKey: "b"))
+        XCTAssertEqual(cache.peaks(forKey: "b"), [0.1, 0.9])
+    }
+
+    // MARK: - Per-task drafts
+
+    func testDraftMemoryKeepsEachTaskSeparate() {
+        var image = StudioDraft()
+        image.reset(for: .createImage)
+        image.prompt = "a ceramic coffee mug"
+        var video = StudioDraft()
+        video.reset(for: .video)
+        video.prompt = "a slow pan over rooftops"
+        video.inputPath = "/tmp/frame.png"
+
+        let encoded = StudioDraftMemory.encode([
+            .imageGenerate: StudioDraftMemory.entry(for: image),
+            .videoGenerate: StudioDraftMemory.entry(for: video),
+        ])
+        let decoded = StudioDraftMemory.decode(encoded)
+
+        XCTAssertEqual(decoded[.imageGenerate]?.prompt, "a ceramic coffee mug")
+        XCTAssertEqual(decoded[.videoGenerate]?.prompt, "a slow pan over rooftops")
+        XCTAssertEqual(decoded[.videoGenerate]?.inputPath, "/tmp/frame.png")
+        XCTAssertEqual(decoded[.imageGenerate]?.inputPath, "")
+        XCTAssertNil(decoded[.chatChat])
+    }
+
+    func testDraftMemoryDropsEmptyEntriesAndUnknownTasks() {
+        var empty = StudioDraft()
+        empty.reset(for: .findObjects)
+        empty.prompt = ""
+        XCTAssertEqual(StudioDraftMemory.encode([.visionFind: StudioDraftMemory.entry(for: empty)]), "")
+        XCTAssertTrue(StudioDraftMemory.decode("").isEmpty)
+        XCTAssertTrue(StudioDraftMemory.decode("not json").isEmpty)
+        XCTAssertTrue(
+            StudioDraftMemory.decode(#"{"nope.task":{"prompt":"x","secondaryText":"","inputPath":""}}"#).isEmpty
+        )
+        XCTAssertTrue(
+            StudioDraftMemory.decode(#"{"models.installed":{"prompt":"x","secondaryText":"","inputPath":""}}"#).isEmpty,
+            "only prompt tasks have a draft to restore"
+        )
+    }
+
+    func testRestoringADraftPutsBackTheWordsButNotAMissingAttachment() throws {
+        let file = FileManager.default.temporaryDirectory
+            .appendingPathComponent("StudioDraftMemoryTests-\(UUID().uuidString).png")
+        try Data([0]).write(to: file)
+        addTeardownBlock { try? FileManager.default.removeItem(at: file) }
+
+        var restored = StudioDraft()
+        restored.reset(for: .createImage)
+        StudioDraftMemory.apply(
+            StudioDraftMemoryEntry(prompt: "a rainy diner", secondaryText: "no text", inputPath: file.path),
+            to: &restored
+        )
+        XCTAssertEqual(restored.prompt, "a rainy diner")
+        XCTAssertEqual(restored.secondaryText, "no text")
+        XCTAssertEqual(restored.inputPath, file.path)
+
+        var dangling = StudioDraft()
+        dangling.reset(for: .createImage)
+        StudioDraftMemory.apply(
+            StudioDraftMemoryEntry(prompt: "a rainy diner", inputPath: "/tmp/gone-\(UUID().uuidString).png"),
+            to: &dangling
+        )
+        XCTAssertEqual(dangling.inputPath, "", "a file that has since gone is not restored as a chip")
+    }
+
+    func testRestoringDoesNotClobberSettingsTheTaskDefaults() {
+        var draft = StudioDraft()
+        draft.reset(for: .video)
+        let defaultWidth = draft.width
+        StudioDraftMemory.apply(StudioDraftMemoryEntry(prompt: "rooftops"), to: &draft)
+        XCTAssertEqual(draft.width, defaultWidth)
+        XCTAssertEqual(draft.prompt, "rooftops")
+    }
+
+    // MARK: - Helpers
+
+    private func item(
+        mode: StudioMode,
+        templateID: CommandTemplateID,
+        output: String?,
+        outputText: String? = nil,
+        prompt: String = "prompt"
+    ) -> StudioLibraryItem {
+        StudioLibraryItem(
+            id: UUID(),
+            mode: mode,
+            prompt: prompt,
+            inputURL: nil,
+            outputURL: output.map { URL(fileURLWithPath: "/tmp/\($0)") },
+            createdAt: Date(),
+            updatedAt: Date(),
+            status: .completed,
+            exitCode: 0,
+            commandPreview: "mere.run",
+            outputText: outputText,
+            templateID: templateID
+        )
+    }
+}

--- a/apps/macos/MereRunStudioTests/StudioLibraryStoreTests.swift
+++ b/apps/macos/MereRunStudioTests/StudioLibraryStoreTests.swift
@@ -572,6 +572,233 @@ final class StudioLibraryStoreTests: XCTestCase {
         }
     }
 
+    // MARK: - Favorites
+
+    func testFavoritesSurviveAReloadAndUnstarringLeavesTheKeyOut() throws {
+        let url = try temporaryLibraryURL()
+        let store = StudioLibraryStore(libraryURL: url)
+        let item = makeItem(prompt: "a ceramic coffee mug")
+        store.upsert(item)
+
+        store.setFavorite(id: item.id, isFavorite: true)
+        XCTAssertTrue(StudioLibraryStore(libraryURL: url).items.first?.isStarred == true)
+
+        store.setFavorite(id: item.id, isFavorite: false)
+        let reloaded = StudioLibraryStore(libraryURL: url)
+        XCTAssertFalse(reloaded.items.first?.isStarred == true)
+        // Unstarred rows keep the shape a build without favorites writes and reads.
+        let text = try String(contentsOf: url, encoding: .utf8)
+        XCTAssertFalse(text.contains("isFavorite"))
+    }
+
+    func testFavoritingAnUnknownRowIsANoOp() throws {
+        let store = StudioLibraryStore(libraryURL: try temporaryLibraryURL())
+        store.setFavorite(id: UUID(), isFavorite: true)
+        XCTAssertTrue(store.items.isEmpty)
+    }
+
+    // MARK: - Delete
+
+    func testDeleteMovesEveryArtifactToTheTrashOnlyWhenAsked() throws {
+        let url = try temporaryLibraryURL()
+        let directory = url.deletingLastPathComponent()
+        let primary = directory.appendingPathComponent("mug.png")
+        let sidecar = directory.appendingPathComponent("mug.json")
+        try Data([0]).write(to: primary)
+        try Data([0]).write(to: sidecar)
+
+        var trashed: [URL] = []
+        let store = StudioLibraryStore(libraryURL: url, trashItem: { trashed.append($0) })
+        var kept = makeItem(prompt: "kept")
+        kept.outputURL = primary
+        var item = makeItem(prompt: "a ceramic coffee mug")
+        item.outputURL = primary
+        item.artifactURLs = [primary, sidecar]
+        store.upsert(kept)
+        store.upsert(item)
+
+        store.delete(ids: [kept.id], trashingFiles: false)
+        XCTAssertTrue(trashed.isEmpty, "forgetting a row must not touch its files")
+
+        let failures = store.delete(ids: [item.id], trashingFiles: true)
+        XCTAssertTrue(failures.isEmpty)
+        XCTAssertEqual(Set(trashed), [primary, sidecar], "the primary output and its sidecars go together")
+        XCTAssertTrue(store.items.isEmpty)
+    }
+
+    func testDeleteReportsFilesItCouldNotTrashButStillForgetsTheRow() throws {
+        let url = try temporaryLibraryURL()
+        let file = url.deletingLastPathComponent().appendingPathComponent("locked.png")
+        try Data([0]).write(to: file)
+
+        struct TrashFailure: Error {}
+        let store = StudioLibraryStore(libraryURL: url, trashItem: { _ in throw TrashFailure() })
+        var item = makeItem(prompt: "locked")
+        item.outputURL = file
+        store.upsert(item)
+
+        let failures = store.delete(ids: [item.id], trashingFiles: true)
+        XCTAssertEqual(failures, [file])
+        XCTAssertTrue(store.items.isEmpty)
+    }
+
+    func testDeleteSkipsFilesThatAreAlreadyGone() throws {
+        let url = try temporaryLibraryURL()
+        var trashed: [URL] = []
+        let store = StudioLibraryStore(libraryURL: url, trashItem: { trashed.append($0) })
+        var item = makeItem(prompt: "already gone")
+        item.outputURL = url.deletingLastPathComponent().appendingPathComponent("missing.png")
+        store.upsert(item)
+
+        XCTAssertTrue(store.delete(ids: [item.id], trashingFiles: true).isEmpty)
+        XCTAssertTrue(trashed.isEmpty)
+    }
+
+    func testBatchDeleteRemovesEveryNamedRowAndLeavesTheRest() throws {
+        let store = StudioLibraryStore(libraryURL: try temporaryLibraryURL())
+        let first = makeItem(prompt: "one")
+        let second = makeItem(prompt: "two")
+        let survivor = makeItem(prompt: "three")
+        for row in [first, second, survivor] { store.upsert(row) }
+
+        store.delete(ids: [first.id, second.id], trashingFiles: false)
+        XCTAssertEqual(store.items.map(\.prompt), ["three"])
+    }
+
+    // MARK: - library.json compatibility
+
+    /// A library.json in exactly the shape shipped before favorites existed. It must keep
+    /// decoding, row for row, with `isFavorite` reading as nil.
+    func testRowsWrittenBeforeFavoritesStillDecode() throws {
+        let url = try temporaryLibraryURL()
+        try Self.legacyLibraryFixture.write(to: url, atomically: true, encoding: .utf8)
+
+        let store = StudioLibraryStore(libraryURL: url)
+
+        XCTAssertEqual(store.items.count, 3)
+        let image = try XCTUnwrap(store.items.first { $0.prompt == "A lighthouse on a basalt shore at dusk" })
+        XCTAssertEqual(image.mode, .createImage)
+        XCTAssertEqual(image.templateID, .imageGenerate)
+        XCTAssertEqual(image.outputURL?.path, "/Users/example/Library/Application Support/MereRun/App Outputs/imageGenerate-20260101-120000.png")
+        XCTAssertEqual(image.artifactURLs?.count, 1)
+        XCTAssertEqual(image.status, .completed)
+        XCTAssertNil(image.isFavorite)
+        XCTAssertFalse(image.isStarred)
+
+        let thread = try XCTUnwrap(store.items.first { $0.isConversation })
+        XCTAssertEqual(thread.messages?.count, 2)
+        XCTAssertEqual(thread.model, "gemma4-e4b")
+
+        let imported = try XCTUnwrap(store.items.first { $0.source == .raycast })
+        XCTAssertEqual(imported.customTitle, "Raycast mug")
+
+        // Rewriting must not disturb the rows that were already there.
+        store.setFavorite(id: image.id, isFavorite: true)
+        let reloaded = StudioLibraryStore(libraryURL: url)
+        XCTAssertEqual(reloaded.items.count, 3)
+        XCTAssertTrue(reloaded.items.first { $0.id == image.id }?.isStarred == true)
+        XCTAssertEqual(reloaded.items.first { $0.isConversation }?.messages?.count, 2)
+    }
+
+    /// The reverse direction: a row this build wrote, read by a decoder that does not know the
+    /// key, still decodes every field it does know.
+    func testFavoriteRowsDecodeWithoutTheNewKey() throws {
+        var item = makeItem(prompt: "starred")
+        item.isFavorite = true
+        let data = try JSONEncoder.mereRunApp.encode([item])
+
+        struct LegacyRow: Decodable {
+            let id: UUID
+            let mode: String
+            let prompt: String
+            let status: String
+        }
+        let rows = try JSONDecoder.mereRunApp.decode([LegacyRow].self, from: data)
+        XCTAssertEqual(rows.count, 1)
+        XCTAssertEqual(rows.first?.prompt, "starred")
+        XCTAssertEqual(rows.first?.mode, "createImage")
+        XCTAssertEqual(rows.first?.status, "completed")
+    }
+
+    private static let legacyLibraryFixture = """
+    [
+      {
+        "artifactURLs" : [
+          "file:///Users/example/Library/Application%20Support/MereRun/App%20Outputs/imageGenerate-20260101-120000.png"
+        ],
+        "commandPreview" : "mere.run image generate --model image-zimage-nano",
+        "createdAt" : "2026-01-01T12:00:00Z",
+        "exitCode" : 0,
+        "id" : "6C4F2B22-2C1B-4B3E-9A61-9C2E1F5B7A01",
+        "mode" : "createImage",
+        "outputURL" : "file:///Users/example/Library/Application%20Support/MereRun/App%20Outputs/imageGenerate-20260101-120000.png",
+        "prompt" : "A lighthouse on a basalt shore at dusk",
+        "status" : "completed",
+        "templateID" : "imageGenerate",
+        "updatedAt" : "2026-01-01T12:00:04Z"
+      },
+      {
+        "commandPreview" : "mere.run text chat --model gemma4-e4b",
+        "createdAt" : "2026-01-01T11:00:00Z",
+        "exitCode" : 0,
+        "id" : "6C4F2B22-2C1B-4B3E-9A61-9C2E1F5B7A02",
+        "messages" : [
+          {
+            "content" : "Explain a Fresnel lens.",
+            "createdAt" : "2026-01-01T11:00:00Z",
+            "failed" : false,
+            "id" : "6C4F2B22-2C1B-4B3E-9A61-9C2E1F5B7A03",
+            "role" : "user"
+          },
+          {
+            "content" : "It folds a thick lens into rings.",
+            "createdAt" : "2026-01-01T11:00:09Z",
+            "failed" : false,
+            "id" : "6C4F2B22-2C1B-4B3E-9A61-9C2E1F5B7A04",
+            "model" : "gemma4-e4b",
+            "role" : "assistant"
+          }
+        ],
+        "mode" : "chat",
+        "model" : "gemma4-e4b",
+        "prompt" : "",
+        "status" : "completed",
+        "updatedAt" : "2026-01-01T11:00:09Z"
+      },
+      {
+        "commandPreview" : "mere.run image generate",
+        "createdAt" : "2026-01-01T10:00:00Z",
+        "customTitle" : "Raycast mug",
+        "exitCode" : 0,
+        "id" : "6C4F2B22-2C1B-4B3E-9A61-9C2E1F5B7A05",
+        "mode" : "createImage",
+        "outputURL" : "file:///Users/example/Pictures/mug.png",
+        "prompt" : "a ceramic coffee mug",
+        "source" : "raycast",
+        "status" : "completed",
+        "templateID" : "imageGenerate",
+        "updatedAt" : "2026-01-01T10:00:03Z"
+      }
+    ]
+    """
+
+    private func makeItem(prompt: String) -> StudioLibraryItem {
+        StudioLibraryItem(
+            id: UUID(),
+            mode: .createImage,
+            prompt: prompt,
+            inputURL: nil,
+            outputURL: nil,
+            createdAt: Date(),
+            updatedAt: Date(),
+            status: .completed,
+            exitCode: 0,
+            commandPreview: "mere.run image generate",
+            outputText: nil,
+            templateID: .imageGenerate
+        )
+    }
+
     private func writeReceipt(_ receipt: StudioLibraryImportReceipt, beside libraryURL: URL) throws -> URL {
         let receiptURL = libraryURL.deletingLastPathComponent()
             .appendingPathComponent("receipt-\(UUID().uuidString).json")

--- a/apps/macos/MereRunStudioTests/StudioOutputLocationTests.swift
+++ b/apps/macos/MereRunStudioTests/StudioOutputLocationTests.swift
@@ -1,0 +1,305 @@
+@testable import MereRunApp
+import XCTest
+
+final class StudioOutputLocationTests: XCTestCase {
+    private let home = URL(fileURLWithPath: "/Users/example", isDirectory: true)
+
+    override func setUp() {
+        super.setUp()
+        // The per-media defaults are what these assertions describe; a root someone configured in
+        // this process's defaults would move every path.
+        UserDefaults.standard.removeObject(forKey: StudioOutputLocation.rootDefaultsKey)
+    }
+
+    // MARK: - Slugs
+
+    func testSlugLowercasesStripsPunctuationAndJoinsWithHyphens() {
+        XCTAssertEqual(
+            StudioOutputLocation.slug("A ceramic coffee mug, in soft morning light!"),
+            "a-ceramic-coffee-mug-in-soft-morning-light"
+        )
+        XCTAssertEqual(StudioOutputLocation.slug("  spaced   out  "), "spaced-out")
+        XCTAssertEqual(StudioOutputLocation.slug("Seed #8812 (v2)"), "seed-8812-v2")
+    }
+
+    func testSlugFoldsDiacriticsAndDropsNonASCII() {
+        XCTAssertEqual(StudioOutputLocation.slug("café au lait"), "cafe-au-lait")
+        // Nothing usable survives, so the caller's fallback stem takes over.
+        XCTAssertEqual(StudioOutputLocation.slug("日本語"), "")
+        XCTAssertEqual(StudioOutputLocation.slug("!!! ??? ---"), "")
+    }
+
+    func testSlugStopsAtAWordBoundaryWithinTheLimit() {
+        let prompt = "a tiny brass astronaut watering a bonsai tree in cinematic macro detail"
+        let slug = StudioOutputLocation.slug(prompt)
+        XCTAssertLessThanOrEqual(slug.count, StudioOutputLocation.maximumSlugLength)
+        XCTAssertEqual(slug, "a-tiny-brass-astronaut-watering-a-bonsai-tree-in-cinematic")
+        XCTAssertFalse(slug.hasSuffix("-"))
+    }
+
+    func testSlugTruncatesASingleOverlongWord() {
+        let slug = StudioOutputLocation.slug(String(repeating: "x", count: 200))
+        XCTAssertEqual(slug.count, StudioOutputLocation.maximumSlugLength)
+    }
+
+    func testStemFallsBackWhenThePromptHasNothingToSlug() {
+        XCTAssertEqual(StudioOutputLocation.stem(prompt: "", fallbackStem: "narration"), "narration")
+        XCTAssertEqual(StudioOutputLocation.stem(prompt: "???", fallbackStem: "Transcribe audio"), "transcribe-audio")
+        XCTAssertEqual(StudioOutputLocation.stem(prompt: "", fallbackStem: "???"), "output")
+    }
+
+    // MARK: - Identifiers
+
+    func testIdentifierPrefersTheSeedAndIsOtherwiseStable() {
+        XCTAssertEqual(StudioOutputLocation.identifier(seed: "8812", fingerprint: "anything"), "8812")
+        let first = StudioOutputLocation.identifier(seed: "", fingerprint: "imageGenerate|a mug")
+        let second = StudioOutputLocation.identifier(seed: "  ", fingerprint: "imageGenerate|a mug")
+        XCTAssertEqual(first, second, "the same run must preview the path it will write")
+        XCTAssertEqual(first.count, 6)
+        XCTAssertNotEqual(first, StudioOutputLocation.identifier(seed: "", fingerprint: "imageGenerate|a plate"))
+    }
+
+    // MARK: - Collisions
+
+    func testUniqueFileNameTakesANumericSuffixUntilItIsFree() {
+        var taken: Set<String> = ["mug-8812.png", "mug-8812-2.png"]
+        let name = StudioOutputLocation.uniqueFileName(
+            stem: "mug", identifier: "8812", fileExtension: "png", exists: { taken.contains($0) }
+        )
+        XCTAssertEqual(name, "mug-8812-3.png")
+
+        taken = []
+        XCTAssertEqual(
+            StudioOutputLocation.uniqueFileName(
+                stem: "mug", identifier: "8812", fileExtension: "png", exists: { taken.contains($0) }
+            ),
+            "mug-8812.png"
+        )
+    }
+
+    func testUniqueFileNameHandlesADirectoryDestinationWithNoExtension() {
+        let taken: Set<String> = ["run-a1b2c3"]
+        XCTAssertEqual(
+            StudioOutputLocation.uniqueFileName(
+                stem: "run", identifier: "a1b2c3", fileExtension: "", exists: { taken.contains($0) }
+            ),
+            "run-a1b2c3-2"
+        )
+    }
+
+    func testUniqueFileNameGivesUpOnTheNumericSuffixRatherThanLooping() {
+        let name = StudioOutputLocation.uniqueFileName(
+            stem: "mug", identifier: "8812", fileExtension: "png", exists: { _ in true }
+        )
+        XCTAssertTrue(name.hasPrefix("mug-8812-"))
+        XCTAssertTrue(name.hasSuffix(".png"))
+    }
+
+    // MARK: - Roots
+
+    func testDefaultRootsFilePicturesMusicAndDocumentsByMedia() {
+        XCTAssertEqual(
+            StudioOutputLocation.directory(domain: .image, kind: .image, configuredRoot: "", home: home).path,
+            "/Users/example/Pictures/mere.run/Image"
+        )
+        XCTAssertEqual(
+            StudioOutputLocation.directory(domain: .video, kind: .video, configuredRoot: "", home: home).path,
+            "/Users/example/Pictures/mere.run/Video"
+        )
+        XCTAssertEqual(
+            StudioOutputLocation.directory(domain: .voice, kind: .audio, configuredRoot: "", home: home).path,
+            "/Users/example/Music/mere.run/Voice"
+        )
+        XCTAssertEqual(
+            StudioOutputLocation.directory(domain: .music, kind: .audio, configuredRoot: "", home: home).path,
+            "/Users/example/Music/mere.run/Music"
+        )
+        XCTAssertEqual(
+            StudioOutputLocation.directory(domain: .vision, kind: .text, configuredRoot: "", home: home).path,
+            "/Users/example/Documents/mere.run/Vision"
+        )
+        XCTAssertEqual(
+            StudioOutputLocation.directory(domain: .threeD, kind: .model3D, configuredRoot: "", home: home).path,
+            "/Users/example/Documents/mere.run/3D"
+        )
+    }
+
+    func testAConfiguredRootOverridesEveryMediaFolder() {
+        for kind in [StudioOutputFileKind.image, .audio, .text] {
+            XCTAssertEqual(
+                StudioOutputLocation.directory(
+                    domain: .image, kind: kind, configuredRoot: "~/Creative", home: home
+                ).path,
+                NSString(string: "~/Creative").expandingTildeInPath + "/Image"
+            )
+        }
+    }
+
+    func testOutputURLNamesTheFileAfterThePromptInTheDomainFolder() {
+        let url = StudioOutputLocation.outputURL(
+            domain: .image,
+            prompt: "A ceramic coffee mug in soft morning light",
+            seed: "8812",
+            fallbackStem: "Generate image",
+            fileExtension: "png",
+            configuredRoot: "",
+            home: home
+        )
+        XCTAssertEqual(
+            url.path,
+            "/Users/example/Pictures/mere.run/Image/a-ceramic-coffee-mug-in-soft-morning-light-8812.png"
+        )
+    }
+
+    // MARK: - Fallback
+
+    func testPreparingDestinationCreatesTheFolderAndLeavesTheDraftAlone() throws {
+        let root = try temporaryDirectory()
+        var draft = CommandDraft()
+        draft.outputPath = root.appendingPathComponent("Pictures/mere.run/Image/mug-8812.png").path
+
+        let prepared = StudioOutputLocation.preparingDestination(of: draft)
+
+        XCTAssertNil(prepared.fallbackReason)
+        XCTAssertEqual(prepared.draft, draft)
+        var isDirectory: ObjCBool = false
+        XCTAssertTrue(FileManager.default.fileExists(
+            atPath: root.appendingPathComponent("Pictures/mere.run/Image").path, isDirectory: &isDirectory
+        ))
+        XCTAssertTrue(isDirectory.boolValue)
+    }
+
+    func testAnUncreatableDestinationFallsBackToAppOutputsWithItsSidecars() throws {
+        let root = try temporaryDirectory()
+        // A regular file where the destination's parent folder needs to be: creation must fail.
+        let blocker = root.appendingPathComponent("blocked")
+        try Data("not a folder".utf8).write(to: blocker)
+        let intended = blocker.appendingPathComponent("Image")
+
+        var draft = CommandDraft()
+        draft.outputPath = intended.appendingPathComponent("mug-8812.png").path
+        draft.visionJSONOutputPath = intended.appendingPathComponent("mug-8812.json").path
+        draft.visionMaskOutputDirectory = intended.appendingPathComponent("mug-8812-masks").path
+        draft.timingsOutputPath = "/Users/example/elsewhere/timings.json"
+
+        let prepared = StudioOutputLocation.preparingDestination(of: draft)
+
+        let fallback = StudioOutputLocation.appOutputsRoot()
+        XCTAssertNotNil(prepared.fallbackReason)
+        XCTAssertEqual(prepared.draft.outputPath, fallback.appendingPathComponent("mug-8812.png").path)
+        XCTAssertEqual(prepared.draft.visionJSONOutputPath, fallback.appendingPathComponent("mug-8812.json").path)
+        XCTAssertEqual(
+            prepared.draft.visionMaskOutputDirectory,
+            fallback.appendingPathComponent("mug-8812-masks").path
+        )
+        XCTAssertEqual(
+            prepared.draft.timingsOutputPath, "/Users/example/elsewhere/timings.json",
+            "a path the user chose elsewhere is not dragged into the fallback"
+        )
+    }
+
+    func testPreparingADraftWithNoOutputIsANoOp() {
+        let draft = CommandDraft()
+        let prepared = StudioOutputLocation.preparingDestination(of: draft)
+        XCTAssertNil(prepared.fallbackReason)
+        XCTAssertEqual(prepared.draft, draft)
+    }
+
+    func testAbbreviateShortensTheHomeDirectory() {
+        XCTAssertEqual(
+            StudioOutputLocation.abbreviate(
+                URL(fileURLWithPath: "/Users/example/Pictures/mere.run/Image"), home: "/Users/example"
+            ),
+            "~/Pictures/mere.run/Image"
+        )
+        XCTAssertEqual(
+            StudioOutputLocation.abbreviate(URL(fileURLWithPath: "/Volumes/Work/out"), home: "/Users/example"),
+            "/Volumes/Work/out"
+        )
+    }
+
+    // MARK: - Through the command adapter
+
+    func testStudioRunsAreNamedAfterThePromptUnderTheDomainFolder() throws {
+        var studio = StudioDraft()
+        studio.reset(for: .createImage)
+        studio.prompt = "A ceramic coffee mug in soft morning light"
+        studio.seed = "8812"
+
+        let request = try StudioCommandAdapter.makeRequest(mode: .createImage, draft: studio)
+        let url = URL(fileURLWithPath: request.draft.outputPath)
+
+        XCTAssertEqual(url.lastPathComponent, "a-ceramic-coffee-mug-in-soft-morning-light-8812.png")
+        XCTAssertEqual(url.deletingLastPathComponent().lastPathComponent, "Image")
+        XCTAssertEqual(url.deletingLastPathComponent().deletingLastPathComponent().lastPathComponent, "mere.run")
+        XCTAssertFalse(request.draft.outputPath.contains("App Outputs"))
+    }
+
+    func testVisionSidecarsSitBesideTheNamedOutput() throws {
+        var studio = StudioDraft()
+        studio.reset(for: .findObjects)
+        studio.prompt = "every coffee cup"
+        studio.inputPath = "/tmp/mug.png"
+
+        let request = try StudioCommandAdapter.makeRequest(mode: .findObjects, draft: studio)
+        let output = URL(fileURLWithPath: request.draft.outputPath)
+        let stem = output.deletingPathExtension()
+
+        XCTAssertEqual(request.draft.visionJSONOutputPath, stem.appendingPathExtension("json").path)
+        XCTAssertTrue(request.draft.visionMaskOutputDirectory.hasPrefix(stem.path))
+        XCTAssertEqual(output.deletingLastPathComponent().lastPathComponent, "Vision")
+    }
+
+    func testAPreviewAndItsRunAgreeOnThePath() throws {
+        var studio = StudioDraft()
+        studio.reset(for: .createImage)
+        studio.prompt = "a rainy diner window at dusk"
+
+        let preview = try StudioCommandAdapter.makeRequest(mode: .createImage, draft: studio, validating: false)
+        let run = try StudioCommandAdapter.makeRequest(mode: .createImage, draft: studio)
+        XCTAssertEqual(preview.draft.outputPath, run.draft.outputPath)
+    }
+
+    func testAnInputFirstTaskIsNamedAfterItsAttachment() throws {
+        var studio = StudioDraft()
+        studio.reset(for: .listen)
+        studio.inputPath = "/tmp/Morning Standup.wav"
+
+        let request = try StudioCommandAdapter.makeRequest(mode: .listen, draft: studio)
+        XCTAssertTrue(
+            URL(fileURLWithPath: request.draft.outputPath).lastPathComponent.hasPrefix("morning-standup-"),
+            request.draft.outputPath
+        )
+    }
+
+    func testReplayedSidecarsMoveWithTheNewOutput() {
+        var draft = CommandDraft()
+        draft.outputPath = "/out/Vision/cup-1.png"
+        draft.visionJSONOutputPath = "/out/Vision/cup-1.json"
+        draft.visionMaskOutputDirectory = "/out/Vision/cup-1-masks"
+        draft.outputPath = "/out/Vision/cup-2.png"
+
+        StudioVisionResultPaths.rederive(in: &draft, previousOutputPath: "/out/Vision/cup-1.png")
+
+        XCTAssertEqual(draft.visionJSONOutputPath, "/out/Vision/cup-2.json")
+        XCTAssertEqual(draft.visionMaskOutputDirectory, "/out/Vision/cup-2-masks")
+    }
+
+    func testAHandChosenSidecarSurvivesAReplay() {
+        var draft = CommandDraft()
+        draft.visionJSONOutputPath = "/Users/example/reports/detections.json"
+        draft.outputPath = "/out/Vision/cup-2.png"
+
+        StudioVisionResultPaths.rederive(in: &draft, previousOutputPath: "/out/Vision/cup-1.png")
+
+        XCTAssertEqual(draft.visionJSONOutputPath, "/Users/example/reports/detections.json")
+    }
+
+    private func temporaryDirectory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("StudioOutputLocationTests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: url) }
+        return url
+    }
+}

--- a/apps/macos/MereRunStudioTests/StudioSnapshotTests.swift
+++ b/apps/macos/MereRunStudioTests/StudioSnapshotTests.swift
@@ -1,4 +1,5 @@
 @testable import MereRunApp
+import AVFoundation
 import AppKit
 import Foundation
 import SwiftUI
@@ -88,6 +89,55 @@ final class StudioSnapshotTests: XCTestCase {
                         navigation.toggleInspector(for: .imageGenerate)
                     }
                 }
+            )
+        }
+    }
+
+    /// The Library column at the mockup's 1440×900 on Image ▸ Generate: list mode light and dark
+    /// (which must still read as `Main.png`'s column), grid mode light and dark with the same rows
+    /// as three-across thumbnails, and one render with three rows selected so the batch bar shows.
+    /// The rows come from the mockup fixture, so the thumbnails are real decoded pictures.
+    func testLibraryColumnFidelitySnapshots() throws {
+        let fidelity = try SnapshotFixture(
+            outputDirectory: fixture.outputDirectory,
+            seed: .mockup,
+            processRunner: SnapshotProcessRunner(script: ModelsInventoryScript.readinessResponses)
+        )
+        defer { fidelity.tearDown() }
+        // The same board the Main render shows, so the list column can be laid over `Main.png`:
+        // two finished generations, one running, one queued.
+        try fidelity.startMainBoardJobs()
+        try fidelity.seedLibraryColumnVariety()
+
+        var draft = StudioDraft()
+        draft.reset(for: .createImage)
+        draft.prompt = "a ceramic coffee mug in soft morning light"
+
+        // List mode keeps the mockup's own scope (this domain) so the column reads as `Main.png`;
+        // grid and the batch render widen it to All, where every kind of thumbnail is on show.
+        let renders: [(name: String, appearance: StudioSnapshotAppearance, seed: StudioLibrarySeed)] = [
+            ("b4-library-list-light", .light, StudioLibrarySeed(viewMode: .list)),
+            ("b4-library-list-dark", .dark, StudioLibrarySeed(viewMode: .list)),
+            ("b4-library-grid-light", .light, StudioLibrarySeed(viewMode: .grid, scope: .all)),
+            ("b4-library-grid-dark", .dark, StudioLibrarySeed(viewMode: .grid, scope: .all)),
+            ("b4-library-kinds-light", .light, StudioLibrarySeed(viewMode: .list, scope: .all)),
+            ("b4-library-multiselect-light", .light, StudioLibrarySeed(viewMode: .list, scope: .all, batchCount: 3)),
+        ]
+        for render in renders {
+            let navigation = NavigationModel()
+            let view = StudioRootView(seededDrafts: [.createImage: draft])
+                .environmentObject(fidelity.controller)
+                .environmentObject(fidelity.library)
+                .environmentObject(navigation)
+                .environment(\.studioLibrarySeed, render.seed)
+                .frame(width: Self.fidelitySize.width, height: Self.fidelitySize.height)
+            try fidelity.write(
+                view,
+                size: Self.fidelitySize,
+                appearance: render.appearance,
+                name: render.name,
+                settle: 3.0,
+                afterAppear: { navigation.toggleInspector(for: .imageGenerate) }
             )
         }
     }
@@ -942,6 +992,68 @@ private final class SnapshotFixture {
         )
     }
 
+    /// One finished run per kind of thumbnail the column draws — a clip (poster frame), a spoken
+    /// line (peak silhouette), and a transcript (first line) — plus a star on the mockup's mug, so
+    /// the Library renders exercise every branch with real files rather than glyphs.
+    func seedLibraryColumnVariety() throws {
+        let clip = root.appendingPathComponent("rooftops.mp4", isDirectory: false)
+        try Self.writeFixtureMP4(to: clip, size: CGSize(width: 256, height: 144), frames: 12)
+        let line = root.appendingPathComponent("welcome.wav", isDirectory: false)
+        try Self.writeSilentWAV(to: line, seconds: 3)
+
+        let rows: [StudioLibraryItem] = [
+            StudioLibraryItem(
+                id: UUID(),
+                mode: .video,
+                prompt: "A slow pan over wet rooftops at first light",
+                inputURL: nil,
+                outputURL: clip,
+                createdAt: Self.mockupTime(hour: 12, minute: 12),
+                updatedAt: Self.mockupTime(hour: 12, minute: 13),
+                status: .completed,
+                exitCode: 0,
+                commandPreview: "mere.run video generate --model video-ltx2 --frames 121",
+                outputText: nil,
+                templateID: .videoGenerate,
+                artifactURLs: [clip]
+            ),
+            StudioLibraryItem(
+                id: UUID(),
+                mode: .speak,
+                prompt: "Welcome aboard. Everything you make here stays on this Mac.",
+                inputURL: nil,
+                outputURL: line,
+                createdAt: Self.mockupTime(hour: 11, minute: 40),
+                updatedAt: Self.mockupTime(hour: 11, minute: 40),
+                status: .completed,
+                exitCode: 0,
+                commandPreview: "mere.run speech synthesize --voice nova",
+                outputText: nil,
+                templateID: .speechSynthesize,
+                artifactURLs: [line]
+            ),
+            StudioLibraryItem(
+                id: UUID(),
+                mode: .listen,
+                prompt: "",
+                inputURL: line,
+                outputURL: nil,
+                createdAt: Self.mockupTime(hour: 11, minute: 8),
+                updatedAt: Self.mockupTime(hour: 11, minute: 8),
+                status: .completed,
+                exitCode: 0,
+                commandPreview: "mere.run speech transcribe welcome.wav --timestamps",
+                outputText: Self.transcriptText,
+                templateID: .speechTranscribe
+            )
+        ]
+        for row in rows.sorted(by: { $0.createdAt < $1.createdAt }) { library.upsert(row) }
+
+        if let mug = library.items.last(where: { $0.mode == .createImage }) {
+            library.setFavorite(id: mug.id, isFavorite: true)
+        }
+    }
+
     /// Runs the Models detail column reads: image generations with the seeded default model
     /// (usage and last-run duration), a passed quality gate, a Lite benchmark, and a running
     /// composer-initiated pull that the job bar and list report.
@@ -1483,6 +1595,60 @@ private final class SnapshotFixture {
             throw StudioSnapshotError.pngEncodingFailed
         }
         try data.write(to: url, options: .atomic)
+    }
+
+    /// A real, playable H.264 file: a handful of frames whose hue drifts, so the Library's poster
+    /// frame comes from `AVAssetImageGenerator` decoding an actual movie rather than a stub.
+    private static func writeFixtureMP4(to url: URL, size: CGSize, frames: Int) throws {
+        let writer = try AVAssetWriter(outputURL: url, fileType: .mp4)
+        let input = AVAssetWriterInput(mediaType: .video, outputSettings: [
+            AVVideoCodecKey: AVVideoCodecType.h264,
+            AVVideoWidthKey: Int(size.width),
+            AVVideoHeightKey: Int(size.height)
+        ])
+        input.expectsMediaDataInRealTime = false
+        let adaptor = AVAssetWriterInputPixelBufferAdaptor(
+            assetWriterInput: input,
+            sourcePixelBufferAttributes: [kCVPixelBufferPixelFormatTypeKey as String: kCVPixelFormatType_32ARGB]
+        )
+        writer.add(input)
+        guard writer.startWriting() else { throw StudioSnapshotError.noBitmap }
+        writer.startSession(atSourceTime: .zero)
+
+        for frame in 0..<frames {
+            var buffer: CVPixelBuffer?
+            guard let pool = adaptor.pixelBufferPool,
+                  CVPixelBufferPoolCreatePixelBuffer(nil, pool, &buffer) == kCVReturnSuccess,
+                  let pixelBuffer = buffer else {
+                throw StudioSnapshotError.noBitmap
+            }
+            CVPixelBufferLockBaseAddress(pixelBuffer, [])
+            if let base = CVPixelBufferGetBaseAddress(pixelBuffer),
+               let context = CGContext(
+                   data: base,
+                   width: Int(size.width),
+                   height: Int(size.height),
+                   bitsPerComponent: 8,
+                   bytesPerRow: CVPixelBufferGetBytesPerRow(pixelBuffer),
+                   space: CGColorSpaceCreateDeviceRGB(),
+                   bitmapInfo: CGImageAlphaInfo.noneSkipFirst.rawValue
+               ) {
+                let hue = CGFloat(frame) / CGFloat(max(1, frames)) * 0.2 + 0.55
+                context.setFillColor(NSColor(calibratedHue: hue, saturation: 0.5, brightness: 0.7, alpha: 1).cgColor)
+                context.fill(CGRect(origin: .zero, size: size))
+                context.setFillColor(NSColor(calibratedWhite: 0.12, alpha: 1).cgColor)
+                context.fill(CGRect(x: 0, y: 0, width: size.width, height: size.height * 0.32))
+            }
+            CVPixelBufferUnlockBaseAddress(pixelBuffer, [])
+            while !input.isReadyForMoreMediaData { usleep(2_000) }
+            adaptor.append(pixelBuffer, withPresentationTime: CMTime(value: CMTimeValue(frame), timescale: 12))
+        }
+
+        input.markAsFinished()
+        let finished = DispatchSemaphore(value: 0)
+        writer.finishWriting { finished.signal() }
+        finished.wait()
+        guard writer.status == .completed else { throw StudioSnapshotError.noBitmap }
     }
 
     /// A soft two-tone gradient with a horizon line, so the canvas visibly shows an image.

--- a/apps/macos/README.md
+++ b/apps/macos/README.md
@@ -88,6 +88,27 @@ segment — a row is filed under its command's domain (`CommandTemplateID.studio
 so 3D meshes land under 3D and benchmark reports under Models — and picking a
 row from another domain switches the destination to it.
 
+Beside the search field are a kind filter (All / Images / Video / Audio / Text,
+plus "Favorites only") and a list-or-grid toggle; grid is three thumbnails
+across with the title on hover. Thumbnails are the real thing per kind — the
+picture, an `AVAssetImageGenerator` poster frame for video, a peak silhouette
+for audio, the first line for a text result — decoded off the main actor and
+cached by path, size, and modification date (`StudioLibraryThumbnail.swift`).
+Rows carry a hover star (`StudioLibraryItem.isFavorite`, an additive optional),
+rename in place, and drag out to Finder or any app. ⌘ and ⇧ click build a batch
+(`StudioLibrarySelection`) with a bar for Reveal, Save to…, and Delete; Delete
+asks first and offers to move the run's files to the Trash. Filtering and
+day-grouping live in `StudioLibraryPresenter`, so both are testable without a
+view. The view mode, kind, and favorites filter persist per window under
+`studio.libraryView`, `studio.libraryKind`, and `studio.libraryFavorites`.
+
+Every prompt task holds its own `StudioDraft`: switching tasks or domains parks
+the one being left and restores the one being entered, so a typed prompt and an
+attachment survive the detour. Across relaunches the scene remembers the prompt,
+the system text, and the attachment of each task under `studio.drafts`
+(`StudioDraftMemory`); settings come back from the task's defaults, which is
+also the baseline the inspector diffs against.
+
 **Chat** is the Converse archetype (`StudioConversationView.swift`,
 `StudioThreadList.swift`). A **thread list** replaces the Library column there —
 every chat and code thread, searchable, grouped Today / Earlier, with a compose
@@ -128,7 +149,16 @@ composer. A finished run is a generation card: prompt, the chips it ran with
 (read from its own command), every output in a grid of 236pt tiles (images,
 video, 3D; audio gets the waveform player, text the Markdown renderer), and
 Vary (rerun with a fresh, recorded seed), Rerun, Use as input, Quick Look,
-Reveal, Copy, and Save to…; outputs drag out to Finder. A run in flight is a
+Reveal, Copy, and Save to…; outputs drag out to Finder. Runs write to a
+user-visible folder chosen by what the file is and which domain made it
+(`StudioOutputLocation.swift`): `~/Pictures/mere.run/<Domain>` for pictures and
+clips, `~/Music/mere.run/<Domain>` for audio, `~/Documents/mere.run/<Domain>`
+for everything else, named `<slug-of-prompt>-<seed-or-short-id>.<ext>` with a
+numeric suffix on collision. Settings ▸ General takes one root that overrides
+all three (`mererun.app.outputRoot`). Nothing is migrated: Library rows keep the
+paths they recorded, Application Support holds metadata only, and a destination
+that cannot be created sends the run back to `App Outputs` with its sidecars and
+one banner saying why. A run in flight is a
 card that observes its `Job` directly — progress bar, "Denoising 15/24 · 0:41",
 Cancel, and the log tail behind an Activity disclosure — and a queued run is a
 row with Remove; both come from `JobStore`, not from the controller's foreground


### PR DESCRIPTION
Studio v2 step B4 + A6: outputs people can find, a Library they can actually use, and a draft per task.

## Visible, named outputs

Generations used to land in `~/Library/Application Support/MereRun/App Outputs/<templateID>-<timestamp>.<ext>` — a folder Finder hides and a name nobody can read. `StudioOutputLocation.swift` now files a run by what it is and which domain made it:

| media | destination |
|---|---|
| images, video | `~/Pictures/mere.run/<Domain>/` |
| audio, music | `~/Music/mere.run/<Domain>/` |
| everything else | `~/Documents/mere.run/<Domain>/` |

Names are `<slug-of-prompt>-<seed-or-short-id>.<ext>`, e.g.
`~/Pictures/mere.run/Image/a-ceramic-coffee-mug-in-soft-morning-light-8812.png`.
Slugs are lowercased, diacritic-folded, punctuation-stripped, hyphen-joined and cut at a word boundary at 60 characters; the identifier is the seed when the run has one, otherwise six hex characters derived from the command, prompt, model and input — derived rather than random so the path the Command view previews is the path the run writes. Collisions take `-2`, `-3`, …

Input-first tasks (Transcribe, Read) have no prompt to name themselves after, so they take the attachment's name. Vision sidecars (`--json-output`, the mask directory) still sit beside the output because the name is chosen before the per-mode branches derive them.

Settings ▸ General takes one root (`mererun.app.outputRoot`) that overrides all three defaults and files every domain under it. **Nothing is migrated**: existing Library rows keep the paths they recorded, and Application Support keeps metadata only.

A destination that cannot be created — a sandbox denial, a root on a volume that is not mounted — sends the run back to App Outputs *with its sidecars* and explains itself once per launch in a `MereBanner`, rather than failing the run. Rerun and Vary now write their own file instead of overwriting the run they replay.

## Library column

- **Grid | List** toggle beside the search field; grid is three thumbnails across with the title on hover.
- **Kind filter** (All / Images / Video / Audio / Text) plus **Favorites only**, alongside the existing domain scope.
- **Favorites**: a hover star, persisted as `StudioLibraryItem.isFavorite`, an additive optional written as `nil` when unstarred so `library.json` keeps the shape older builds read.
- **Multi-select** with ⌘/⇧ click (`StudioLibrarySelection`, pure so the Finder rules are testable) and a batch bar for Reveal, Save to…, and Delete.
- **Drag out from rows and tiles**, not just the big preview.
- **Inline rename** in the row; the modal alert is gone.
- **Delete asks first** and offers "Delete and Move Files to Trash", which actually trashes every artifact of the run.
- **Real thumbnails**: an `AVAssetImageGenerator` poster frame for video (taken 0.6 s in so a fade-up does not thumbnail as black), a peak silhouette for audio, and the first line for a text result — all decoded off the main actor and cached by path, size, and modification date.

Filtering and day-grouping moved into `StudioLibraryPresenter`; the store gained `delete(ids:trashingFiles:)` and `setFavorite`, with the trash operation injected so tests never need a real Trash.

## Per-task drafts (A6)

Switching tasks replaced the one shared draft with a fresh one, so Image → Video → Image lost the typed prompt and the attachment. Each prompt task now holds its own `StudioDraft`: leaving parks it, entering restores it. The composer, the inspector, and the Command view keep reading the same `draft`, so all three stay in step with the task's own memory.

Across relaunches the scene remembers the part that is the user's own work — the prompt, the system text, the attachment — as one `studio.drafts` string beside the existing `studio.inspectorTasks` memory. Settings come back from the task's defaults, which is also the baseline the inspector diffs against, so the scene value stays small. An attachment whose file has since gone is dropped rather than restored as a dangling chip.

## Compatibility

- `library.json` gains one additive optional; a fixture in the pre-favorites format is asserted to decode row for row, and a row written by this build is asserted to decode under a decoder that does not know the key.
- The Raycast receipt-import contract is unchanged.
- New `@SceneStorage` keys are all under `studio.*`; the new `UserDefaults` key is under `mererun.app.*`.

## Verification

- `swiftlint --strict`, `swift build`, `swift test --filter MereRunAppTests` (503 tests), `./scripts/check.sh` (exit 0), `./scripts/build_mere_run_app.sh debug`.
- 47 new tests: slug rules and collision suffixes, per-media roots and the configured-root override, the stable identifier, the App Outputs fallback carrying sidecars, the same paths arriving through `StudioCommandAdapter`; scope/kind/favorites/search filtering, the ⌘/⇧ selection rules, thumbnail cache keys, per-task draft isolation and restore; favorites persistence, trash-on-delete, batch delete, and the `library.json` fixture.
- Fidelity: `testLibraryColumnFidelitySnapshots` renders the column at 1440×900 with the Main board's rows — list light/dark (which lay over `Main.png`'s column), grid light/dark, all kinds at the All scope, and a three-row batch. The renders caught two bugs, both fixed here: a grid tile stretched by a `scaledToFill` thumbnail that had no size to fit, and a batch bar whose three text labels did not fit a 248pt column.

## Notes for review

- The column's header row is byte-for-byte the mockup's (title, count, domain/All segment). The only additions to the chrome are two 22pt icon controls beside the search field — the filter menu and the view toggle — which narrow the search capsule and leave every vertical metric unchanged. There was nowhere else in the mockup's column to put them.
- `StudioLibrarySeed` is a test-only environment value: the column's view mode lives in `@SceneStorage`, which no scene backs offscreen, and a batch is built by ⌘-clicking, which a render cannot do.
- `CommandTemplate.defaultDraft()` now uses the same roots (with a timestamp instead of a prompt slug), so specialist surfaces and the Command Console write somewhere visible too.
- Untouched, per the step's boundaries: `MereRunController.swift`, `Jobs/**`, `StudioInspectorSchema.swift`, `StudioCommandRows.swift`.
