### PR TITLE
Stop offering benchmark output paths the CLI never parses

### DIFF
--- a/apps/macos/MereRunStudio/CommandCatalog.swift
+++ b/apps/macos/MereRunStudio/CommandCatalog.swift
@@ -1029,20 +1029,21 @@ struct CommandTemplate: Identifiable, Equatable {
         id.capability?.output.kind
     }
 
-    /// True when the command materializes a file or directory the app can adopt as the run's
+    /// True when the command can materialize a file or directory the app adopts as the run's
     /// primary artifact.
     ///
-    /// The contract's declared kind is read first, so a command the app models as producing
-    /// nothing still resolves its `--output` path when the contract says it writes one. The
-    /// app's own `outputKind` still counts, because a handful of commands write a file the
-    /// contract summarizes as `text` (the benchmarks' `--output` report) or as a `service`
-    /// (`music realtime`, which also records a WAV); see
-    /// `ArtifactReceiptTests.testDeclaredOutputKindsDriftOnlyWhereRecorded`.
+    /// The contract is the authority: a command writes one either because that is all it does
+    /// (`kind` is `file` or `directory`) or because the caller can name a destination
+    /// (`flag`) — a `text` or `service` command that prints to stdout until it is asked to
+    /// write. Only the rows the contract does not cover (`.custom`, the launcher entries) fall
+    /// back to the app's own `outputKind`.
+    ///
+    /// The caller still pairs this with a non-blank `outputPath`, so a run that was never asked
+    /// to write never waits for a file that will not appear; see
+    /// `ArtifactResolver.expectedOutput`.
     var producesOutputFile: Bool {
-        if declaredOutputKind == .file || declaredOutputKind == .directory {
-            return true
-        }
-        return outputKind != .none
+        guard let output = id.capability?.output else { return outputKind != .none }
+        return output.kind == .file || output.kind == .directory || output.flag != nil
     }
 
     func defaultDraft() -> CommandDraft {
@@ -4610,24 +4611,21 @@ enum CommandCatalog {
             category: .models,
             title: "Fused quality suite",
             subtitle: "Mere Lite or Mere Comprehensive versioned suite",
-            systemImage: "chart.bar.doc.horizontal",
-            outputKind: .file("json")
+            systemImage: "chart.bar.doc.horizontal"
         ),
         CommandTemplate(
             id: .modelBenchmarkChat,
             category: .models,
             title: "Chat benchmark",
             subtitle: "Grounded-chat evaluation slice",
-            systemImage: "bubble.left.and.text.bubble.right",
-            outputKind: .file("json")
+            systemImage: "bubble.left.and.text.bubble.right"
         ),
         CommandTemplate(
             id: .modelBenchmarkCode,
             category: .models,
             title: "Code benchmark",
             subtitle: "Real coding-evaluation slice with sandboxed execution",
-            systemImage: "chevron.left.forwardslash.chevron.right",
-            outputKind: .file("json")
+            systemImage: "chevron.left.forwardslash.chevron.right"
         ),
         CommandTemplate(
             id: .modelBenchmarkVLM,
@@ -4635,23 +4633,21 @@ enum CommandCatalog {
             title: "Vision-language benchmark",
             subtitle: "Synthetic or lmms-eval multimodal datasets",
             systemImage: "photo.badge.checkmark",
-            outputKind: .file("json")
+            outputKind: .directory
         ),
         CommandTemplate(
             id: .modelBenchmarkToolCalls,
             category: .models,
             title: "Tool-call benchmark",
             subtitle: "Tool selection accuracy across chat models",
-            systemImage: "wrench.and.screwdriver",
-            outputKind: .file("json")
+            systemImage: "wrench.and.screwdriver"
         ),
         CommandTemplate(
             id: .modelBenchmarkToolContinuations,
             category: .models,
             title: "Tool continuation benchmark",
             subtitle: "Gemma 4 continuation after completed tool calls",
-            systemImage: "arrow.turn.down.right",
-            outputKind: .file("json")
+            systemImage: "arrow.turn.down.right"
         ),
         CommandTemplate(
             id: .modelBenchmarkGemma4KV,
@@ -4672,8 +4668,7 @@ enum CommandCatalog {
             category: .models,
             title: "API workload benchmark",
             subtitle: "Replay a chat workload against a running API server",
-            systemImage: "server.rack",
-            outputKind: .file("json")
+            systemImage: "server.rack"
         ),
         CommandTemplate(
             id: .modelBenchmarkFusedFixture,

--- a/apps/macos/MereRunStudioTests/ArtifactReceiptTests.swift
+++ b/apps/macos/MereRunStudioTests/ArtifactReceiptTests.swift
@@ -407,31 +407,76 @@ final class ArtifactReceiptTests: XCTestCase {
         XCTAssertNil(StudioArtifactRole.label(for: nil))
     }
 
-    /// `ArtifactResolver.expectedOutput` reads the contract's declared output kind first and
-    /// falls back to the app's. These are the commands where the two disagree: each writes a
-    /// file the contract summarizes as `text` (a benchmark report) or as a `service`
-    /// (`music realtime`, which also records a WAV), or writes one the app models as producing
-    /// nothing. New drift means either the contract or `CommandCatalog` is wrong.
-    func testDeclaredOutputKindsDriftOnlyWhereRecorded() throws {
-        let recorded: Set<CommandTemplateID> = [
-            .imageRunPlan, .speechDiarize, .adapterPull, .musicRealtime,
-            .modelBenchmarkFused, .modelBenchmarkChat, .modelBenchmarkCode, .modelBenchmarkVLM,
-            .modelBenchmarkToolCalls, .modelBenchmarkToolContinuations, .modelBenchmarkAPIWorkload,
-        ]
-        var drift: Set<CommandTemplateID> = []
+    /// The commands that write a file whether or not they were asked to, and that the app still
+    /// offers no destination for, because the CLI picks the location itself. Each entry says why
+    /// the app cannot name it.
+    static let selfLocatingOutputTemplateIDs: [CommandTemplateID: String] = [
+        .adapterPull: "Installs the adapter into the managed store; there is no destination option.",
+        .imageRunPlan: "Materializes into the managed run store, named by `--materialize`.",
+        .visionPose: "Writes `<image>_pose.json` beside the image unless `--json-output` moves it.",
+    ]
+
+    /// `CommandTemplate.outputKind` is the destination the app offers for `draft.outputPath`;
+    /// the contract says whether the CLI has anywhere to put it. A command writes a file either
+    /// because that is all it does (`kind` is `file` or `directory`) or because the caller can
+    /// name a destination (`flag`) — a `text` or `service` command prints to stdout until it is
+    /// asked to write.
+    ///
+    /// So the app may only offer a destination the contract declares, and every command that
+    /// writes one unasked must either take that destination or be recorded above with its
+    /// reason. Drift means either the contract or `CommandCatalog` is wrong.
+    func testTheAppOffersExactlyTheDestinationsTheContractDeclares() throws {
+        var offered: Set<CommandTemplateID> = []
+        var unnamed: Set<CommandTemplateID> = []
         for template in CommandCatalog.templates {
             guard let declared = template.declaredOutputKind else { continue }
-            let contractProducesFile = declared == .file || declared == .directory
-            if contractProducesFile != (template.outputKind != .none) {
-                drift.insert(template.id)
+            if template.outputKind != .none, !template.producesOutputFile {
+                offered.insert(template.id)
+            }
+            let writesUnasked = declared == .file || declared == .directory
+            if writesUnasked, template.outputKind == .none {
+                unnamed.insert(template.id)
             }
         }
-        XCTAssertEqual(drift, recorded)
-        // Whichever side declares a file, the resolver adopts the requested `--output` path.
-        for id in recorded {
+        XCTAssertEqual(offered, [], "The app asks for an output path the CLI does not parse.")
+        XCTAssertEqual(unnamed, Set(Self.selfLocatingOutputTemplateIDs.keys))
+
+        // An exemption is only for a command that writes without being told where.
+        for (id, reason) in Self.selfLocatingOutputTemplateIDs {
             let template = try XCTUnwrap(CommandCatalog.template(id: id))
-            XCTAssertTrue(template.producesOutputFile, "\(id)")
+            XCTAssertTrue(template.producesOutputFile, "\(id): \(reason)")
+            XCTAssertEqual(template.outputKind, CommandOutputKind.none, "\(id): \(reason)")
+            XCTAssertNotEqual(template.declaredOutputKind, .text, "\(id): \(reason)")
         }
+    }
+
+    /// A command that only writes when asked has nothing to wait for until it is asked: the
+    /// resolver adopts the requested destination, and stays empty-handed without one.
+    func testTheResolverOnlyExpectsAFileTheRunWasAskedToWrite() throws {
+        let template = try XCTUnwrap(CommandCatalog.template(id: .speechTranscribe))
+        XCTAssertTrue(template.producesOutputFile)
+
+        var draft = template.defaultDraft()
+        draft.outputPath = ""
+        XCTAssertNil(ArtifactResolver.expectedOutput(template: template, draft: draft))
+
+        draft.outputPath = "/out/interview.txt"
+        XCTAssertEqual(
+            ArtifactResolver.expectedOutput(template: template, draft: draft),
+            URL(fileURLWithPath: "/out/interview.txt")
+        )
+
+        // `model benchmark chat` parses no destination at all, so it offers no path to expect.
+        let benchmark = try XCTUnwrap(CommandCatalog.template(id: .modelBenchmarkChat))
+        XCTAssertFalse(benchmark.producesOutputFile)
+        XCTAssertEqual(benchmark.outputKind, CommandOutputKind.none)
+        XCTAssertNil(
+            StudioOutputLocation.templateOutputPath(
+                templateID: benchmark.id,
+                title: benchmark.title,
+                outputKind: benchmark.outputKind
+            )
+        )
     }
 
     // MARK: Helpers

--- a/apps/macos/README.md
+++ b/apps/macos/README.md
@@ -445,7 +445,9 @@ beside Models ▸ Health's manifest audit and quality gate: the fused Mere Lite 
 Comprehensive suites, the chat, code, and vision-language slices, tool-call and
 tool-continuation evaluations, the Gemma4 KV and MTP and Qwen3.6 MTP decode
 comparisons, Laguna DFlash, API workload replay, and fixture hashing. Each run
-produces a reviewable, revealable JSON report.
+prints its JSON report to the Library row rather than to a file — the benchmarks
+take no destination option — except the vision-language slice, whose
+`--output-dir` collects the external lmms-eval run.
 
 Audio ▸ Live is the live lane over `speech listen`. It enumerates capture
 devices through the CLI, streams partial transcripts as the recognizer emits


### PR DESCRIPTION
`main` is red: `ArtifactReceiptTests.testDeclaredOutputKindsDriftOnlyWhereRecorded`
fails on 9f5c5465.

## Why it went red

Two green PRs that were never run together.

- #424 added the test. It recorded, as a literal set, the eleven templates where
  the contract's declared output kind and the app's `CommandTemplate.outputKind`
  disagreed at that moment.
- #427 then reconciled eighteen contract declarations with what the commands
  actually write. Its branch predated the test, so its CI never ran it, and
  #424's CI never saw the corrected contract.

Merged, nine more templates drift than the recorded set lists —
`speechTranscribe`, `visionOCR`, `visionEmbed`, `visionPose`, `textEmbed`,
`textAnonymize`, `evaluationRun`, `evaluationPromote`, `qualityGate`.

## What was actually wrong

Reading the CLI for each of them, the contract is right in every case and the
recorded set was measuring the wrong thing. `outputKind` is not "this run yields
a file" — it is "the destination the app offers for `draft.outputPath`", the
field the Command view shows and `StudioOutputLocation` names. Those nine
commands all print to stdout and write only when asked, and the app does ask:
it auto-names a destination and passes the flag. Nothing to fix there.

The genuinely wrong side is the benchmarks. `model benchmark
chat/code/fused/tool-calls/tool-continuations/api-workload` parse no destination
option at all (confirmed against each `ParsableCommand`), and the app never
passed `draft.outputPath` for them either — so `outputKind: .file("json")` was a
dead output field in the UI and a phantom path for `ArtifactResolver` to expect.
`model benchmark vlm` does take a destination, but it is `--output-dir` for the
external lmms-eval run, not a JSON file.

| template | side that was wrong | change |
| --- | --- | --- |
| `modelBenchmarkChat` | app | `.file("json")` → `.none` (no destination option) |
| `modelBenchmarkCode` | app | `.file("json")` → `.none` |
| `modelBenchmarkFused` | app | `.file("json")` → `.none` |
| `modelBenchmarkToolCalls` | app | `.file("json")` → `.none` |
| `modelBenchmarkToolContinuations` | app | `.file("json")` → `.none` |
| `modelBenchmarkAPIWorkload` | app | `.file("json")` → `.none` |
| `modelBenchmarkVLM` | app | `.file("json")` → `.directory` (`--output-dir`) |
| `speechTranscribe`, `speechDiarize`, `visionEmbed`, `visionOCR`, `textEmbed`, `textAnonymize`, `evaluationRun`, `evaluationPromote`, `qualityGate`, `musicRealtime` | neither | the test was measuring the wrong thing |
| `adapterPull`, `imageRunPlan`, `visionPose` | neither | exempted, with a reason each |

## The fix

`producesOutputFile` now comes from the contract alone, as #427 noted it should:
`kind == .file || kind == .directory || output.flag != nil`. Only the rows the
contract does not cover (`.custom`, the launcher entries) still fall back to the
app's `outputKind`. Artifact resolution is unchanged in behaviour, because
`ArtifactResolver.expectedOutput` already requires a non-blank `outputPath` — a
command that writes only when asked expects nothing until it is asked, and the
six benchmarks no longer get an auto-named path to expect at all.

The test is now an equivalence rather than a recorded list:

- the app may never offer a destination the contract has no place for
  (asserted empty, no exemptions);
- every command that writes a file *unasked* — contract `kind` of `file` or
  `directory` — must either take that destination or appear in
  `selfLocatingOutputTemplateIDs` with a one-line reason, in the same style as
  the CLI suite's `contractExemptCommandIDs`.

Three entries qualify, all genuinely self-locating: `adapterPull` (installs into
the managed adapter store), `imageRunPlan` (materializes into the managed run
store) and `visionPose` (writes `<image>_pose.json` beside the image).

## Note for the reviewer

The brief for this fix expected `musicRealtime` to stay exempt and the nine to be
flipped to `.none`. Flipping them would have removed the output-path field, and
with it the auto-named destination, from Transcribe, Diarize, OCR, both Embed
commands, Anonymize, both Evaluation commands and the quality gate — a real
product regression, since each of those flags is wired and passed today. Framing
the invariant as "the app offers exactly the destinations the contract declares"
keeps those working, reconciles `musicRealtime` outright instead of exempting it
(its `--output` flag is a real destination), and leaves the exemption map at the
three commands that truly name their own output.

## Verification

Foreground, exit codes captured:

- `swiftlint --strict` — 0 violations in 1486 files
- `swift build` — complete
- `swift test --filter MereRunAppTests` — 541 tests, 0 failures (was 1)
- `./scripts/check.sh` — exit 0
- `./scripts/build_mere_run_app.sh debug` — exit 0, bundle valid on disk

`apps/macos/README.md` said every benchmark run "produces a reviewable,
revealable JSON report"; it now says the report is printed to the Library row,
with the vision-language slice's `--output-dir` called out.
