### PR TITLE
Describe the Studio the v2 work actually shipped

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,8 +6,8 @@ Guidance for AI coding agents working in this repo. For human contributor expect
 
 mere.run is a Swift package, CLI, and optional macOS GUI for local-first inference on Apple Silicon. The repo ships five things:
 
-- Swift package — `Package.swift`, `Sources/`, `Tests/`. Targets: `MereRunCLI` (the `mere.run` executable), `MereRunApp` (the optional `mere.run.app` executable), `MereRunRelayKit` (the portable relay client library), `MereRunCore`, `AudioCore`, `AudioCodecs`, `AudioSTT`, `AudioTTS`.
-- macOS client — `apps/macos/` holds the optional Studio sources, tests, and assets; its `MereRunApp` target builds the `mere.run.app` executable and runs the public CLI.
+- Swift package — `Package.swift`, `Sources/`, `Tests/`. Targets: `MereRunCLI` (the `mere.run` executable), `MereRunApp` (the optional `mere.run.app` executable) over the `StudioKit` and `StudioUI` libraries, `MereRunRelayKit` (the portable relay client library), `MereRunCore`, `AudioCore`, `AudioCodecs`, `AudioSTT`, `AudioTTS`.
+- macOS client — `apps/macos/` holds the optional Studio sources, tests, and assets, split into `StudioKit/` (no SwiftUI), `StudioUI/` (the views), and `MereRunStudio/` (the executable); its `MereRunApp` target builds `mere.run.app` and runs the public CLI.
 - iOS client — `apps/ios/` holds the XcodeGen-generated iOS Studio app, a relay client over `MereRunRelayKit`; see `docs/ios-studio.md`.
 - VitePress docs site — `package.json`, `pnpm-lock.yaml`, `docs/`. Used only to build and preview the public docs.
 - Vendored runtime artifacts — `vendor/llama.xcframework`, `vendor/mlx-swift_Cmlx.bundle`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -48,6 +48,68 @@ The format is based on Keep a Changelog.
 
 ### macOS
 
+macOS Studio has been rebuilt around one navigation. Everything the CLI can do
+now lives in a sidebar domain and a task inside it, reached the same way, and
+nothing opens in a modal window on top of your work.
+
+- replaced the sheets with **domains and tasks**. The sidebar lists fifteen
+  domains in four groups — Create, Converse, Understand, System — and each
+  domain's tasks sit in a segmented control at the top of the page. Models,
+  Server, Runs, Plugins, Geospatial (now **Earth**), and every specialist lab
+  are pages you navigate to rather than windows that cover the app, so you can
+  leave one mid-run and come back to it. Go ▸ takes you to any domain with
+  ⌘1–⌘9 and to any task of the one you are in.
+- replaced the single result stage with a **feed**. Every run of a mode is a
+  card, oldest at the top, newest above the composer: the prompt, the settings
+  it ran with, its outputs, and Vary, Rerun, Use as input, Quick Look, Reveal,
+  Copy, and Save to…. A run in flight has its own progress and Cancel on its
+  own card, a queued run has Remove, and a finished run no longer yanks the
+  selection away from whatever you were looking at — it shows a "New result"
+  pill instead. A failure leads with the reason rather than a wall of stderr,
+  and the log stays one click away.
+- gave the input-first tasks their own layout. Vision ▸ Read, Find, Segment and
+  Track and Audio ▸ Transcribe now show the answer beside the thing it is
+  about: detection boxes drawn over the picture, masks composited on it, track
+  spans under the video's scrubber, a timestamped transcript beside the
+  waveform — with contextual next steps that carry your file into the next task.
+- added the **inspector** (⌥⌘I) and removed the Options popover. Every setting
+  is grouped into sections with a Reset each and a badge counting what you
+  changed, with the rarely-used flags folded under Advanced. The two to four
+  settings that matter most stay as chips under the prompt, and the two edit the
+  same thing. Studio no longer shows CLI plumbing in either place.
+- **saved generations where you can find them.** Runs now write to
+  `~/Pictures/mere.run/<Domain>`, `~/Music/mere.run/<Domain>`, or
+  `~/Documents/mere.run/<Domain>`, named after the prompt
+  (`a-ceramic-coffee-mug-in-soft-morning-light-8812.png`) instead of into a
+  hidden Application Support folder under a template id and a timestamp.
+  Settings ▸ General takes one root that overrides all three. Existing library
+  rows keep the paths they already recorded.
+- made the **Library** browsable: a grid view beside the list, a kind filter
+  (Images, Video, Audio, Text) and Favorites, real thumbnails per kind including
+  video poster frames and audio waveforms, a hover star, rename in place, drag
+  out to Finder, and ⌘/⇧ click to build a batch for Reveal, Save to…, and
+  Delete. Delete now asks first and offers to move the run's files to the Trash.
+- added the **Activity popover** on the status pill: every job running or queued
+  anywhere in the app, with its progress and a stop control, so a model pull
+  started in one domain is visible from another. The pill also reports how many
+  jobs are running.
+- gave every task a **Command view** (⌥⌘C): the exact command your settings
+  build, option by option, with Copy, Open in Terminal, and Run. The Command
+  Console window is now generated from the capability contract rather than
+  hand-written per command, so it can run any `mere.run` command the CLI
+  declares, and "Edit command…" on a library row reopens the exact command that
+  run used.
+- rebuilt **Chat** around a thread list of its own, with the model and system
+  prompt on the thread header, Branch as well as truncate when you edit a turn,
+  and each reply recording the model and speed it ran with. Code is a preset
+  inside the same threads. Chat threads no longer clutter the media library.
+- kept your work when you move: each prompt task remembers its own prompt and
+  attachment, across task switches and across relaunches.
+- **for CLI users:** the generation commands gained `--receipt`, which prints one
+  final `{"event":"result",…}` line naming every file the run wrote and each
+  sidecar's role, and `--progress-json` now covers video, music, sound effects,
+  and speech as well as images. Studio uses both, so it stops guessing at output
+  paths by polling the filesystem — and they are just as useful in a script.
 - added `--lm-model` (music generate, analyze, and serve), `--h3-acceleration`,
   and `--audio-max-duration` (video generate) to the shared capability
   contract, so `mere.run catalog --json` and Studio agree with the CLI's

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ in its job summary, together with the lane it selected:
 
 | Lane | Selected when | What the `swift` job runs |
 | --- | --- | --- |
-| Fast | Only `apps/macos/**`, `apps/ios/**`, `docs/**`, Markdown, ordinary `scripts/**`, or `assets/`, `integrations/`, `skills/` changed | SwiftLint, the agent readiness, evaluation boundary, and documentation example checks, `swift build`, the MLX metallib verification, and `MereRunAppTests` |
+| Fast | Only `apps/macos/**`, `apps/ios/**`, `docs/**`, Markdown, ordinary `scripts/**`, or `assets/`, `integrations/`, `skills/` changed | SwiftLint, the agent readiness, evaluation boundary, and documentation example checks, `swift build`, the MLX metallib verification, and the three Studio test targets (`StudioKitTests`, `StudioUITests`, `MereRunAppTests`) |
 | Full | Anything under `Sources/**`, `Tests/**`, `vendor/**`, `Package.swift`, `Package.resolved`, `.github/**`, or the gate scripts themselves changed | `./scripts/check.sh`, which is every package test target |
 
 Both lanes build and verify the ad-hoc `MereRun.app` bundle, and both verify the

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,7 +1,19 @@
 # Design
 
 Visual system for the mere.run macOS Studio (`apps/macos/StudioUI`). The source of truth
-in code is `MereRunTheme.swift`; every color resolves dynamically for light and dark.
+in code is `StudioUI/MereRunTheme.swift`; every color resolves dynamically for light and
+dark. The measurements are `StudioKit/StudioLayout.swift`, so a layout rule can be read
+without SwiftUI.
+
+## Boards
+
+The Studio is designed as a set of **boards** — one approved 1440×900 mockup per surface, each
+named for what it draws: **Main** (Image ▸ Generate: the feed, the composer, the inspector),
+**Analyze** (Vision ▸ Find over one picture), **Converse** (Chat: thread list and transcript),
+**Command** (the raw command form and its "Will run" block), **Library** (the column in list,
+grid, and batch), **Models** (the Manage list and detail), **Realtime**, **Subjects**, and the
+**Activity** popover. `StudioSnapshotTests` renders each of them offscreen at the same size, so
+a change can be read against its board without launching the app.
 
 ## Theme
 
@@ -16,7 +28,7 @@ choice follows the system appearance — the app never forces one.
 | background | `FAF8F3` | `171614` | window base |
 | surface | `FFFFFF` | `23211D` | panels, fields |
 | surfaceRaised | `F1EDE3` | `302D27` | selected/raised fills |
-| border | `D8D2C6` | `4E493F` | hairlines (usually at 0.4–0.8 opacity) |
+| border | `D8D2C6` | `4E493F` | hairlines (0.4–0.8 opacity; 0.53 for the shell's rules) |
 | textPrimary | `211C13` | `F1EDE3` | primary text |
 | textSecondary | `5C564A` | `C9C1B3` | supporting text |
 | textMuted | `8A8273` | `918A7C` | captions, metadata |
@@ -24,41 +36,49 @@ choice follows the system appearance — the app never forces one.
 | accentSoft | `F0E7D2` | `39331F` | selection washes (Library row, active header toggle), user chat bubble |
 | onAccent | `FFFFFF` | `1B160A` | glyphs and labels on a solid `accent` fill (selected sidebar row) |
 | segmentedSelection | `FFFFFF` | `3A362E` | the raised, selected segment of a segmented control |
-| wordmarkGreen | `2D6A4F` | `2D6A4F` | the wordmark's period only — brand, not status |
+| wordmarkGreen | `2D6A4F` | `2D6A4F` | the wordmark's period only — brand, not status; the one token that does not change with appearance |
 | hoverFill | black @ 6% | white @ 7% | transient pointer hover on rows and icon buttons |
-| green / yellow / red | tuned per appearance | | success / caution / failure |
+| green | `5E7A45` | `8EAA74` | ready, installed, success |
+| yellow | `9C7520` | `D2A24E` | checking, queued, needs attention |
+| red | `C2493B` | `D98072` | unreachable, failed |
 
 Color strategy: **Restrained** — tinted neutrals plus the single bronze accent (≤10% of
-any surface). Status colors appear only as status. No gradients as decoration beyond the
-existing faint background wash; no gradient text; no glassmorphism (material is used only
-where macOS uses it: sidebar and title-bar regions).
+any surface). Status colors appear only as status. Decoration is one faint diagonal wash behind
+the prompt workspace (`surfaceRaised` 28% → `background` → `surface` 20%); no gradient text, no
+glassmorphism. Material appears only where macOS supplies it: the `NavigationSplitView` sidebar
+column. Everything else, the region under the hidden title bar included, paints `background`.
 
 ## Typography
 
-- UI: SF Pro via Dynamic-Type-relative tokens (`titleFont`, `sectionFont`, `bodyFont`,
-  `captionFont`, `monoFont` for command/code).
-- Display: New York (system serif) for empty-state headlines, welcome hero, and other
-  short display moments only — never for controls or body copy. This serif-on-paper
-  pairing is a core identity element.
+- UI: SF Pro via Dynamic-Type-relative tokens (`titleFont` `.title` semibold, `sectionFont`
+  `.subheadline` semibold, `bodyFont` `.body`, `captionFont` `.caption` medium, `monoFont`
+  `.callout` monospaced for command and code).
+- Display: New York (system serif) through `displayFont` (`.largeTitle` medium) and
+  `displaySmallFont` (`.title2` medium), for empty-state headlines and other short display
+  moments only — never for controls or body copy. This serif-on-paper pairing is a core
+  identity element.
 - Wordmark: `mere` plus a `wordmarkGreen` period in **Caveat Medium** at 27pt
-  (`MereRunTheme.Brand.font()`), the only place the face appears. The font ships in
-  `Resources/Fonts` (OFL 1.1) and is registered for the process on first use; if that
-  fails the wordmark falls back to the system serif at the same size.
-- Eyebrows (`MereEyebrow`): 10.5pt semibold, uppercase, 0.06em tracking, `textMuted` —
+  (`MereRunTheme.Brand.font()`), the only place the face appears.
+  `StudioUI/Resources/Fonts/Caveat[wght].ttf` (OFL 1.1) ships as a StudioUI resource — the
+  packaged app carries it in `MereRun_StudioUI.bundle` — and is registered with Core Text for
+  the process from `MereRunApp.init()`, before the first window draws; if that fails the
+  wordmark falls back to the system serif at the same size.
+- Eyebrows (`MereEyebrow`): 10.5pt semibold, uppercase, 0.63pt kerning, `textMuted` —
   sidebar sections, Library days, panel groups.
 - Shell sizes are literal: sidebar rows 13pt medium (semibold when selected) with 13pt
   glyphs; header title 15pt semibold over an 11.5pt medium `textMuted` subtitle on one
   line; segments 12pt (semibold when selected); Library titles 12.5pt medium with 11pt
-  medium `textMuted` meta; footer 12pt medium `textSecondary`.
-- Hierarchy through weight + size contrast; body line length capped (~65–75ch → max
-  widths ~560–680pt on text blocks).
+  medium `textMuted` meta; the footer pill 12pt medium.
+- Hierarchy through weight + size contrast; body line length capped (the feed's measure is
+  640pt, a transcript's 760pt).
 
 ## Shape & Depth
 
-- Radius scale: 6 / 8 / 9 / 10 / 18 / 20 (`MereRunTheme.Radius`). Pills and the composer
-  use the large end; fields and rows the small end.
+- Radius scale: 6 / 8 / 9 / 10 / 12 / 18 / 20 (`MereRunTheme.Radius`: `sm`, `base`, `md`, `lg`,
+  `popover`, `xl`, `xxl`). Pills and the composer use the large end; fields and rows the small end.
 - Borders are 1pt hairlines of `border` at reduced opacity; selection borders use
-  `accent`.
+  `accent`. `mereFocusRing()` is the focused-field treatment: a 1.5pt `accent` ring at 55% over
+  a soft 16% glow.
 - Shadows via `mereShadow` (warm-neutral in light, deep in dark) on floating elements
   only: composer, overlays, popovers. Flat surfaces stay flat.
 - `merePanel()` = surface fill + hairline; the standard container. Avoid nesting panels.
@@ -68,65 +88,111 @@ where macOS uses it: sidebar and title-bar regions).
 `MereRunTheme.Spacing`: 8 / 10 / 14 / 18 / 22 / 28 / 32. Rhythm varies — canvases
 breathe (24–32), rows and chips stay tight (8–12).
 
+## Layout
+
+`StudioLayoutPolicy` holds every shell measurement: window 1280×820 by default and never
+below 768×520; sidebar 212pt ideal (200 minimum, 300 maximum, user-resizable); Library column
+248pt; inspector 300pt; Command view 520pt; the feed's text measure 640pt; the content column
+never narrower than 520pt. The Command Console window keeps its own three-pane split
+(catalog 220/268/360, form 420/560/∞, log 320/440/∞).
+
 ## Motion
 
-- Ease-out only; 0.15–0.25s for state fades, `.snappy` / gentle springs for selection
-  and entrance. No bounce/elastic overshoot on layout.
-- SF Symbol effects (variableColor, bounce) mark live activity sparingly.
-- Everything decorative degrades under Reduce Motion.
+- Ease-out only: `quick` is 0.15s and `standard` 0.22s for state fades; `spring`
+  (response 0.32, damping 0.86) and `gentleSpring` (0.5, 0.9) carry selection and entrance.
+  No bounce or elastic overshoot on layout.
+- The only SF Symbol animation is the audio player's play/pause replace transition. Live
+  activity is carried by progress bars and the status dot, not by symbol effects.
+- Reduce Motion is honored where motion is structural: the shell's column and banner
+  transitions, the feed's card entrances and "New result" pill, and the Models page's
+  indeterminate progress sweep, which becomes a static capsule. Pointer-hover and
+  button-press animations are not conditioned on it.
 
 ## Components
 
-- `MereBanner` — the only inline notice component (info/warning/error).
-- `MerePrimaryButtonStyle` — accent primary action; `.bordered` for secondary.
-- `mereField()` — canonical text-field chrome.
+- `MereBanner` — the only inline notice component. Three severities (info `accent`, warning
+  `yellow`, error `red`), a tinted 12% fill inside a 35% hairline at radius 8, up to three
+  lines of `captionFont` `textSecondary`, an optional dismiss, and a VoiceOver label that
+  prefixes "Warning:" or "Error:" so severity is never color alone.
+- `MerePrimaryButtonStyle` (`.merePrimary`) — the accent primary action: `bodyFont` semibold in
+  `background` on a radius-6 `accent` fill, 28pt minimum height.
+- `MereSecondaryButtonStyle` (`.mereSecondary`) — 11.5pt medium `textPrimary` on `surfaceRaised`
+  inside a 60% hairline, radius 6, 26pt tall, lifting with `hoverFill`. The v2 surfaces use it
+  everywhere; `.bordered` survives only in the tasks that still host their v1 forms.
+- `MereIconButtonStyle` (`.mereIcon`) — a bare glyph in `textSecondary` that darkens and takes a
+  radius-6 `hoverFill` backing on hover.
+- `mereField()`, `mereHoverRow()`, `merePanel()`, `mereShadow()`, `mereFocusRing()` — the shared
+  chrome modifiers. `mereMediaFrame()` (radius 10, hairline, deep shadow) frames media on the
+  Analyze board.
+- `MereEyebrow` — the uppercase section label.
 - `MereSegmentedControl` / `MereSegment` — the segmented control: a 2pt-padded
   `surfaceRaised` pill (radius 7) of 24pt segments with 12pt side padding (radius 5.5);
   the selected segment is `segmentedSelection` with a 1pt shadow. Used for the header's
-  task control (`StudioTaskControl`, with a "More" menu segment when a domain has more
-  than six tasks) and the Library scope. Never the native `.segmented` picker.
-- `MereToolbarIconButton` — 28pt header toggles (radius 6): `accentSoft` tile and
-  accent glyph while their panel is shown, `textSecondary` glyph otherwise.
-- Status is one voice: the footer pill (32pt, radius 9, an 8pt dot, "Ready · 92 models",
-  a chevron; `hoverFill` only while hovered or open) with a popover for detail — never
-  rows of always-on pills. Dot colors: green ready/serving, yellow checking, red when the
-  status probe never answers ("Server unreachable").
-- Navigation: the grouped sidebar (Create / Converse / Understand / System), 212pt
-  ideal, on the standard macOS sidebar material; the wordmark at its top (20pt leading),
-  eyebrows for sections, 30pt rows (radius 9, 10pt side padding, 13pt glyph + label).
+  task control and the Library scope. Never the native `.segmented` picker.
+- `StudioTaskControl` — the task pill in the content header. Up to six tasks are all segments;
+  past six it shows the first five and a "More" menu segment, which takes the selected treatment
+  itself while the current task lives inside it (Vision, with ten tasks, is the only domain that
+  reaches this today).
+- `MereToolbarIconButton` — 28pt header toggles (radius 6) with a 14pt glyph: `accentSoft` tile
+  and accent glyph while their panel is shown, `textSecondary` glyph otherwise.
+- Status is one voice: the footer pill (radius 9, 32pt minimum, an 8pt dot, two lines —
+  "Ready · 92 models" over "2 running" — and a chevron; `hoverFill` only while hovered or open)
+  opening the Activity popover — never rows of always-on pills. Dot colors: green ready or
+  serving, yellow checking, red when the status probe never answers ("Server unreachable").
+  VoiceOver rejoins the two lines into one value.
+- Activity popover — a 340pt panel the shell draws over the window from the bottom-left, one row
+  per running or queued job with its progress and a stop control, over the app↔CLI version
+  handshake; with nothing running it shows the local server, models root, and resolved CLI path
+  in the same shape.
+- Navigation: the grouped sidebar (Create / Converse / Understand / System) over fifteen
+  domains, 212pt ideal, on the standard macOS sidebar material; the wordmark at its top (20pt
+  leading), eyebrows for sections, 30pt rows (radius 9, 10pt side padding, 13pt glyph + label).
   The selected row is a solid `accent` pill with `onAccent` glyph and label, drawn by the
-  row: the native `List` highlight is switched off so it looks the same whether or not
-  the window is key. No horizontal chip rails.
+  row: the native `List` highlight is switched off so it looks the same whether or not the
+  window is key. No horizontal chip rails.
 - Content header (`StudioContentHeader`): the first row of the content column, beside the
   Library, 52pt on `background` with a hairline below — never the window toolbar, which
   stays empty so the Library column runs to the top of the window. Leading (18pt in):
   14pt accent domain glyph, title, one-line subtitle. Center: the task pill. Trailing
-  (16pt in): Library, Inspector, and Command toggles. With the sidebar collapsed the first
-  header leaves room for the traffic lights.
+  (16pt in): Library, Inspector, and Command toggles. Side blocks are 220pt while the column
+  is wide enough and shrink to their content otherwise, so the pill never truncates. With the
+  sidebar collapsed the first header adds 112pt of leading inset for the traffic lights.
 - Raw command form (the Command view column and the Command Console's middle pane):
   eyebrow groups from the capability contract, each row a monospaced 12pt medium
-  `textSecondary` flag in a 168pt column beside the control the option's kind calls for,
-  over a "Will run" block — the shell-quoted command wrapped at the column width on
-  `surfaceRaised` (radius 6, 12/10 padding, 11.5pt mono), with Copy, Open in Terminal,
-  and the accent Run. The Console adds a 52pt header per pane and a template catalog
-  column that reuses the sidebar's row shape.
+  `textSecondary` flag in a fixed column (150pt in the 520pt Command view, 168pt in the
+  console) beside the control the option's kind calls for, over a "Will run" block — the
+  shell-quoted command wrapped at the column width on `surfaceRaised` (radius 8, 12/10 padding,
+  11.5pt mono), with Copy, Open in Terminal, and the accent Run. The Command view's header is
+  44pt; the console gives each of its three panes a 52pt header and draws its catalog column in
+  the sidebar's row shape.
 - Library column: 248pt on `background` with a right hairline, running from the window
-  top to the bottom. Header ("Library" 13pt
-  semibold, count 11pt muted, scope segments) at 14/14/8 padding; a 28pt capsule search
-  field (12pt); day eyebrows; rows of a 40pt thumbnail (radius 6, or a `surfaceRaised`
-  glyph tile), one-line title, and meta with an 8pt status dot while queued (yellow),
-  running (accent), or failed (red). Rows are 6/8 padded, radius 9, `accentSoft` when
-  selected, `hoverFill` on hover, in a 6pt-inset column with 2pt gaps.
+  top to the bottom. Header ("Library" 13pt semibold, count 11pt muted, scope segments) at
+  14/14/8 padding; a 28pt capsule search field (12pt) beside a filter menu (kind, favorites
+  only) and a list-or-grid toggle; day eyebrows; rows of a 40pt thumbnail (radius 6, or a
+  `surfaceRaised` glyph tile), one-line title, and meta with an 8pt status dot while queued
+  (yellow), running (accent), or failed (red). Rows are 6/8 padded, radius 9, `accentSoft` when
+  selected, `hoverFill` on hover, in a 6pt-inset column with 2pt gaps, carrying a hover star and
+  Quick Look and dragging out to Finder. Grid mode is three tiles across with 6pt gutters and
+  the title on hover; selecting more than one row raises a batch bar.
 - Chat (Converse): a 248pt thread list in place of the Library ("Threads" 13pt semibold, a
   compose icon button, a "Search threads" capsule, Today / Earlier eyebrows, 8/10-padded
   rows of a 12.5pt title over an 11pt muted "Model · time" meta, `accentSoft` when
   selected). The transcript is a 760pt centered column: a header (13.5pt semibold title,
-  model and "System: default" chips, hairline below), then turns 20pt apart, bottom-aligned,
+  model and system-prompt chips, hairline below), then turns 20pt apart, bottom-aligned,
   22/24 padded. User turns are 14pt in `accentSoft` bubbles (radius 14/14/4/14, 10/14
-  padding, max 520pt) on the right; assistant turns are unboxed 14pt Markdown at 1.55 line
-  height behind a 16pt accent chat glyph (max 640pt), with fenced code on `surfaceRaised`
+  padding, max 520pt) on the right; assistant turns are unboxed 14pt Markdown at 3pt line
+  spacing behind a 14pt accent chat glyph (max 640pt), with fenced code on `surfaceRaised`
   (radius 8, a header row of the language eyebrow and Copy over a hairline, 12pt mono) and a
   row of 28pt Copy / Retry / Branch icon buttons beside "model · tok/s · time" in 11pt muted.
   A streaming turn ends in a thin accent caret.
-- Media: audio renders as an interactive waveform (accent = played), video via AVKit in
-  a rounded, shadowed frame.
+- Media: audio renders as an interactive waveform (accent = played) over a 46pt play glyph and
+  monospaced-digit times; video plays through AVKit, framed with `mereMediaFrame()` on the
+  Analyze board and left unframed in the feed.
+
+## Accessibility
+
+Color is never the only carrier of state: a status dot always has its phrase, a banner always
+has its severity word, and a selected segment or sidebar row carries the `isSelected` trait.
+Icon-only controls carry labels and help text; eyebrows and headers carry `isHeader`; Library
+rows expose one combined label with arrow-key and Space navigation; a streaming chat turn is
+marked as updating frequently. Type is Dynamic-Type-relative throughout.

--- a/PRODUCT.md
+++ b/PRODUCT.md
@@ -7,11 +7,11 @@ product
 ## Users
 
 Developers, tinkerers, and creative professionals on Apple Silicon Macs who want to run
-AI models locally: image, video, music, sound, speech, chat, code, and vision — without a
-cloud account and without their prompts or media leaving the machine. They range from
-CLI-fluent engineers (who also use the bundled `mere.run` terminal command and the
-Advanced surface) to prompt-first creators who never open a terminal. The Studio is the
-prompt-first face; the CLI is the engine underneath.
+AI models locally: image, video, music, sound, speech, chat, code, vision, and
+Earth observation — without a cloud account and without their prompts or media leaving
+the machine. They range from CLI-fluent engineers (who also use the bundled `mere.run`
+terminal command and the Command Console) to prompt-first creators who never open a
+terminal. The Studio is the prompt-first face; the CLI is the engine underneath.
 
 Context of use: a desktop creative/utility session on macOS 15+, often long-running
 (model pulls are gigabytes, video/music renders take minutes). Light and dark
@@ -20,14 +20,15 @@ drag-and-drop, VoiceOver, Dynamic Type).
 
 ## Product Purpose
 
-mere.run Studio (`apps/macos/StudioKit`, `apps/macos/StudioUI`, `apps/macos/MereRunStudio`)
-is the macOS front end for the open-source
-mere.run local-inference CLI. Tagline: **"Create anything. Locally."** It exists so that
-local-first inference feels as effortless as a hosted tool: pick a mode, type a prompt,
+mere.run Studio (`apps/macos/StudioKit`, `apps/macos/StudioUI`, and the
+`apps/macos/MereRunStudio` executable) is the macOS front end for the
+open-source mere.run local-inference CLI. Tagline: **"Create anything. Locally."** It exists so that
+local-first inference feels as effortless as a hosted tool: pick a domain, type a prompt,
 get a previewable result — while the public CLI does the real work and stays the source
-of truth. Success is a signed, notarized v1.0 where every mode produces a usable inline
-result, state is never silent, and the app feels native rather than like a wrapped web
-page or a terminal with buttons.
+of truth. The app is signed, notarized, and shipping; success now is that every capability
+the CLI exposes has a place in the app, that the designed surfaces produce a usable inline
+result, that state is never silent, and that it feels native rather than like a wrapped
+web page or a terminal with buttons.
 
 ## Brand Personality
 
@@ -49,24 +50,35 @@ errors.
 
 ## Design Principles
 
-1. **Native first.** Structure and behavior should read as macOS: sidebar navigation,
-   thin material toolbars, real keyboard support, Quick Look, drag out as well as in.
-2. **Prompt-first, depth on demand.** The default surface is one field and one button;
-   every extra control must earn its place. Full CLI depth lives one deliberate step
-   away (Options, Advanced) and never drifts from the CLI contract.
-3. **State is never silent.** Readiness, queueing, trimming, progress, and failure are
-   always visible and always explained in words, never color alone.
-4. **Local is a feature.** Surface the on-device story: model store, server status,
+1. **Native first.** Structure and behavior should read as macOS: a `NavigationSplitView`
+   with sidebar navigation, real keyboard support and menu commands, Quick Look, drag out
+   as well as in. The window toolbar is deliberately empty so the columns run to the top
+   of the window; the domain header lives in the content column instead.
+2. **One navigation.** Every capability is a peer, reached the same way: a domain in the
+   sidebar and a task in its control. Nothing is a modal detour, and nothing lives in a
+   second navigation system.
+3. **Prompt-first, depth on demand.** The default surface is one field and one button;
+   every extra control must earn its place. Full CLI depth lives one deliberate step away
+   — the inspector, then the Command view, then the Command Console — and is rendered from
+   the capability contract, so it never drifts from the CLI.
+4. **State is never silent.** Readiness, queueing, trimming, progress, and failure are
+   always visible and always explained in words, never color alone. Work in flight is
+   listed in one place, the Activity popover, whatever page you are on.
+5. **Results are files.** A run writes a named file to a folder a person can find, and
+   the app says where. The library is a view onto those files, not a vault.
+6. **Local is a feature.** Surface the on-device story: model store, server status,
    "stays on this Mac" — as calm facts, not marketing.
-5. **Warmth over chrome.** The paper-and-bronze palette, serif display moments, and a
+7. **Warmth over chrome.** The paper-and-bronze palette, serif display moments, and a
    few earned signature details (waveforms, streaming caret) carry the identity; the
    rest stays quiet.
 
 ## Accessibility & Inclusion
 
-- VoiceOver labels/values for all stateful and icon-only controls (established in
-  WS-4.5); color is never the sole carrier of state.
+- VoiceOver labels and values for stateful and icon-only controls; selection carries the
+  `isSelected` trait, headers carry `isHeader`, and color is never the sole carrier of
+  state — a status dot always has its phrase, a banner always has its severity word.
 - Dynamic Type via relative font tokens; layouts tolerate Larger Text.
-- Respect Reduce Motion (decorative animation only, degrade gracefully) and Reduce
-  Transparency (NSVisualEffectView system fallbacks).
+- Reduce Motion is honored where motion is structural: the shell's column and banner
+  transitions, the feed's card entrances, and the Models page's indeterminate progress
+  sweep. Hover and press animations are not yet conditioned on it — a known gap.
 - Contrast target ≈ WCAG AA in both light and dark themes.

--- a/apps/macos/README.md
+++ b/apps/macos/README.md
@@ -2,32 +2,117 @@
 
 Optional SwiftUI studio wrapper around the public `mere.run` CLI.
 
+The CLI (`Sources/MereRunCLI`, `Sources/MereRunCore`) is the behavioral source
+of truth. The app translates UI state into CLI arguments, launches the public
+executable as a child process, and renders what comes back. Do not duplicate
+runtime logic here.
+
+`MereRunContract` is the compile-time and machine-readable boundary between the
+two products, and `mere.run catalog --json` emits the same document. App forms
+use its typed options; tests prove the match in both directions.
+
 ## Targets
 
 The Studio is three SwiftPM targets, so the model layer can be built and tested
 without SwiftUI and the views can be rendered without the app's scenes:
 
-- `StudioKit/` — library, no SwiftUI: the CLI resolver and environment,
-  `ProcessRunner`, `Job`/`JobStore`/lanes/`ArtifactResolver`/progress, the
-  command catalog (generated flags, `ArgumentBuilder`, `CommandDraft`), the
+- `StudioKit/` — library, no SwiftUI, 20,711 lines: the CLI resolver and
+  environment, `ProcessRunner`, `Job`/`JobStore`/lanes/`ArtifactResolver`/progress,
+  the command catalog (generated flags, `ArgumentBuilder`, `CommandDraft`), the
   Library store and its receipts, the conversation transcript, the navigation
-  vocabulary (`StudioDomain`, `StudioTask`, `StudioDestination`), readiness,
-  configuration, the serving monitor, the CLI installer, diagnostics, and crash
-  reporting.
-- `StudioUI/` — library, SwiftUI: the shell, the navigation model, the boards
-  (feed, inspector, Command view, analyze, converse, session, project, manage),
-  `ContractForm`, the theme (which owns the bundled Caveat wordmark font),
-  controls, and result renderers.
-- `MereRunStudio/` — the `mere.run.app` executable: `MereRunApp`, the app
-  delegate, the menu bar commands, the Settings scene, and the Sparkle wiring.
+  vocabulary (`StudioDomain`, `StudioTask`, `StudioDestination`), the declarative
+  schemas the views render from, readiness, configuration, the serving monitor,
+  the CLI installer, diagnostics, and crash reporting. Every one of those is
+  unit-testable without hosting a view.
+- `StudioUI/` — library, SwiftUI, 31,112 lines: the shell, `NavigationModel`, the
+  boards (feed, inspector, Command view, analyze, converse, session, project,
+  manage), `ContractForm`, the theme (which owns the bundled Caveat wordmark
+  font), the controls, and the result renderers.
+- `MereRunStudio/` — the `mere.run.app` executable, 323 lines across three files:
+  `MereRunApp`, the app delegate, the menu bar commands, the Settings scene, and
+  the Sparkle wiring. Everything else it does, it does by composing the two
+  libraries.
 
 Declarations that cross a target boundary are `package`, which is exactly the
 visibility they had while the Studio was one target; nothing became `public`.
 
 Tests follow the same split: `StudioKitTests/` (model layer, including the argv
 and default-draft fixtures), `StudioUITests/` (views, presenters, and the
-offscreen snapshot harness), and `MereRunStudioTests/` (the executable). Shared
-test doubles live in `StudioTestSupport/`, which nothing that ships depends on.
+offscreen snapshot harness), and `MereRunStudioTests/` (the executable, built as
+the `MereRunAppTests` target). Shared test doubles live in `StudioTestSupport/`,
+which nothing that ships depends on.
+
+## Shape of the app
+
+The window is one `NavigationSplitView`. The sidebar lists fifteen **domains**;
+each domain has **tasks** in a segmented control at the top of the content
+column. `StudioDestination` — one domain and one of its tasks — is the whole
+navigation state. Three sheets remain, each a true task: the image mask editor,
+Models ▸ Installed's Pull… catalog, and the Guide. Everything else that
+interrupts is an alert or a confirmation dialog — third-party model terms,
+removals, thread rename, Library delete, and a bad `mererun://` link.
+
+Fifty-four tasks fall into three shapes:
+
+- Twelve **prompt tasks** back a `StudioMode` and render the composer, a canvas,
+  and the Library column: Image ▸ Generate, Video ▸ Generate, Music ▸ Compose,
+  Sound ▸ Generate, Voice ▸ Speak, Chat ▸ Chat, Chat ▸ Code, Vision ▸ Read,
+  Find, Segment, Track, and Audio ▸ Transcribe.
+- Five of those twelve — Vision ▸ Read, Find, Segment, Track and
+  Audio ▸ Transcribe — are input-first, so their canvas is the **Analyze**
+  surface rather than the generation feed. Chat and Code get the **Converse**
+  surface and a thread list in place of the Library.
+- The other forty-two tasks host a full-height view of their own: the project
+  boards (Video ▸ Subjects, the three Train tasks), the session pages
+  (Music ▸ Realtime, Audio ▸ Live, Vision ▸ Live, Server ▸ Serving), the
+  management pages (Models, Runs, Plugins, Voice ▸ Voices), and the analysis
+  forms that have not moved to the Analyze surface yet.
+
+Every task also has a raw command surface: a **Command view** column on the
+prompt tasks, and the **Command Console** window everywhere else. Both are
+rendered from the capability contract, so a capability nobody has designed a
+surface for is still reachable the day the contract declares it.
+
+## Source map
+
+- `StudioKit/StudioNavigation.swift`: `StudioDomain`, `StudioTask`,
+  `StudioDestination`, and the `@SceneStorage` codecs. The per-window
+  `NavigationModel` that drives them is `StudioUI/StudioNavigationModel.swift`.
+- `StudioUI/StudioRootView.swift`: the `NavigationSplitView` shell, the content
+  header (`StudioUI/StudioTaskControl.swift`), and the prompt workspace; hosts
+  every task in the detail area.
+- `StudioKit/StudioTypes.swift`: user-facing mode, draft, and request types.
+- `StudioKit/CommandCatalog.swift`: `CommandTemplateID`, `CommandDraft`, and the
+  `CommandTemplate` record type.
+- `StudioKit/Catalog/`: one file per command category holding that category's
+  `CommandTemplate` records and the function that builds each template's argv.
+  `CommandFlags.swift` is generated from `MereRunCapabilityCatalog` by
+  `./scripts/update-studio-command-flags.sh`, so every flag the app emits is a
+  constant the shared contract declares and a renamed flag is a compile error;
+  `ArgumentBuilder` appends positionals, switches, `--flag value` pairs,
+  repeated options, and `--x` / `--no-x` pairs, and `optionUnlessDefault` drops
+  a value the contract already declares as the CLI's default. `CommandDefaults`
+  holds each template's starting draft, reading the contract's `default_value`
+  where it declares one. `StudioKitTests/Fixtures/command-argv.txt` and
+  `command-default-drafts.txt` pin both;
+  `./scripts/update-studio-argv-fixture.sh` re-records them.
+- `StudioKit/Jobs/`: the job model — `Job`, `JobStore`, `ArtifactResolver`,
+  `ProcessRunner`, and the read-only `StudioJobMonitor`.
+- `StudioKit/MereRunController.swift`: the facade views bind to.
+- `StudioKit/StudioLibraryStore.swift`: local library persistence.
+
+The declarative schemas live in StudioKit beside the model, and the views that
+draw them in StudioUI, one file each side:
+`StudioComposerSchema.swift` and `StudioComposer.swift`,
+`StudioContractSchema.swift` and `StudioContractForm.swift`,
+`StudioInspectorSchema.swift` and `StudioInspector.swift`,
+`StudioAnalyzeSchema.swift` / `StudioAnalyzeResults.swift` and
+`StudioAnalyzeCanvas.swift` / `StudioAnalyzeViews.swift`,
+`StudioCommandRows.swift` and `StudioCommandView.swift`,
+`StudioConsoleDraft.swift` and `StudioConsoleView.swift`,
+`StudioFeedCards.swift` and `StudioFeedCanvas.swift`,
+`StudioLibraryPresentation.swift` and `StudioLibraryPanel.swift`. That is what
+makes a surface's rules testable without rendering it.
 
 The packaged app registers two typed local-launcher routes. The strict
 `mererun://preview?path=…` route accepts one readable absolute artifact path and
@@ -37,83 +122,22 @@ path; `StudioLibraryStore` validates the versioned receipt and referenced media,
 owns persistence and deduplication, and the window's `NavigationModel` opens the
 imported row. External launchers must never edit `library.json` directly.
 
-- `StudioKit/StudioNavigation.swift`: `StudioDomain`, `StudioTask`,
-  `StudioDestination`, and the `@SceneStorage` codecs; the per-window
-  `NavigationModel` that drives them is `StudioUI/StudioNavigationModel.swift`.
-- `StudioRootView.swift`: the `NavigationSplitView` shell, the content header
-  (`StudioTaskControl.swift`), and the prompt workspace; hosts every task in
-  the detail area.
-- `StudioTypes.swift`: user-facing mode, draft, and request types.
-- `CommandCatalog.swift`: `CommandTemplateID`, `CommandDraft`, and the
-  `CommandTemplate` record type.
-- `Catalog/`: one file per command category holding that category's
-  `CommandTemplate` records and the function that builds each template's argv.
-  `CommandFlags.swift` is generated from `MereRunCapabilityCatalog` by
-  `./scripts/update-studio-command-flags.sh`, so every flag the app emits is a
-  constant the shared contract declares and a renamed flag is a compile error;
-  `ArgumentBuilder` appends positionals, switches, `--flag value` pairs,
-  repeated options, and `--x` / `--no-x` pairs, and `optionUnlessDefault` drops
-  a value the contract already declares as the CLI's default. `CommandDefaults`
-  holds each template's starting draft, reading the contract's `default_value`
-  where it declares one. `Fixtures/command-argv.txt` and
-  `Fixtures/command-default-drafts.txt` in the test target pin both;
-  `./scripts/update-studio-argv-fixture.sh` re-records them.
-- `Jobs/`: the job model. `JobStore` owns every child process the app launches
-  behind the `MereRunProcessRunning` seam (`Process()` appears only in
-  `Jobs/ProcessRunner.swift` and the synchronous `CLIBootstrapInstaller`
-  version probe), with three lanes: `inference` for Studio runs (capped at two
-  with a FIFO queue), `utility` for the hand-built CLI reads and writes behind
-  `utilityCommandResult` (capped at four, FIFO), and `probe` for readiness and
-  `status --json` probes (never queued, deduplicated by key so a repeated probe
-  joins the one in flight and a probe with stale Settings is superseded). A
-  `JobRequest` is either a catalog command (template plus draft, which drive
-  validation and output detection) or raw arguments (`JobRequest.utility` /
-  `.probe`, which skip preflight and capture complete stdout and stderr for the
-  submitter). The store publishes one observable `Job` per job (state, status,
-  progress, log, live output, artifacts, result), raw output chunks through
-  `events`, and a lossless `completions` stream.
-- Output detection: `ArtifactResolver` reads, in order, (1) the CLI's
-  `--receipt` line — the final stdout NDJSON object
-  `{"event":"result","exit":0,"outputs":[…]}`, whose first entry is the primary
-  artifact and whose sidecars carry a `role` (`detections`, `masks`, `recipe`,
-  …); (2) the output kind `MereRunCapabilityCatalog` declares for the
-  capability together with the `--output` path the request asked for, once it
-  exists; (3) the stdout path contract and `fileExists` probing, kept as the
-  fallback for the commands that print no receipt and for an older CLI. Roles
-  reach the UI on `Artifact.sidecarRole` / `roleLabel` and are persisted on
-  `StudioLibraryItem.artifactRoles`, so a result surface labels a sidecar
-  instead of guessing from its extension; sidecars found by probing are
-  labelled from the same draft fields that located them
-  (`StudioArtifactRole.inferred`). The app appends `--receipt` and
-  `--progress-json` to the launched argv for the capabilities the contract
-  lists in `receiptCapabilityIDs` / `progressJSONCapabilityIDs`, never on a
-  `--preflight` run (the CLI rejects that pair) and never in the "Will run"
-  preview or a library row's command, which stay the command a person would
-  type. A run that prints a receipt skips the 350 ms output poll; every other
-  command with an output file keeps it.
-- `MereRunController.swift`: the facade views bind to. It snapshots Settings
-  and the CLI launch into a `JobRequest` for every lane, awaits utility and
-  probe jobs on behalf of their callers (readiness results are evaluated
-  against the request current at completion), mirrors the foreground inference
-  job into its published console fields, and still owns the template selection
-  the Command Console opens on and the persisted settings.
-- `StudioLibraryStore.swift`: local library persistence.
-
 ## Shell
 
-The window is one `NavigationSplitView`. The sidebar lists fifteen **domains**
-in four sections — Create (Image, Video, Music, Sound, Voice, 3D), Converse
-(Chat), Understand (Vision, Audio, Text, Earth), System (Models, Server, Runs,
-Plugins) — with the machine status cluster as its only footer. The sidebar
-header is the wordmark (`mere` and a green period in Caveat Medium, bundled
-under `Resources/Fonts` and registered at launch by `MereRunTheme.Brand`), and
-the selected row is a solid accent pill drawn by the row itself (the native
-`List` highlight is switched off; selection, arrow keys, and VoiceOver are
-unchanged). The footer pill reads "Ready · N models" once the status probe
-answers, "Serving · N models" while the local server is up, and "Server
-unreachable" (in red) if the probe never answers, with "· N running" appended
-while jobs are in flight. It opens the **Activity popover**
-(`StudioActivity.swift`), a 340pt panel the shell draws over the window from the
+The sidebar lists the fifteen domains in four sections — Create (Image, Video,
+Music, Sound, Voice, 3D), Converse (Chat), Understand (Vision, Audio, Text,
+Earth), System (Models, Server, Runs, Plugins) — with the machine status cluster
+as its only footer. The sidebar header is the wordmark (`mere` and a green
+period in Caveat Medium, bundled under `Resources/Fonts` and registered at
+launch by `MereRunTheme.Brand`), and the selected row is a solid accent pill
+drawn by the row itself (the native `List` highlight is switched off; selection,
+arrow keys, and VoiceOver are unchanged).
+
+The footer pill reads "Ready · N models" once the status probe answers,
+"Serving · N models" while the local server is up, and "Server unreachable" (in
+red) if the probe never answers within six seconds, with "N running" on a second
+line while jobs are in flight. It opens the **Activity popover**
+(`StudioUI/StudioActivity.swift`), a 340pt panel the shell draws over the window from the
 bottom-left: one row per running or queued job in the inference and utility
 lanes (never a probe) with its progress and a stop control, over the app↔CLI
 version handshake and a link into the Server page. With nothing running the same
@@ -122,44 +146,39 @@ reads the `JobStore` directly — the lanes for which rows exist, each `Job` for
 its own progress — so nothing about the work in flight is mirrored on the
 controller.
 
-Every domain has **tasks** in a 52pt header at the top of the content column,
-beside the Library (the window toolbar stays empty so the Library column runs to
-the top of the window): one segmented pill for up to six tasks, or five segments
-plus a "More" menu segment for Vision. The header's leading item is the domain
-glyph, title, and one-line subtitle; trailing are the Library, Inspector, and
-Command toggles (the Library and Inspector toggles appear on prompt tasks only).
-Twelve tasks are the composer-driven prompt modes (`StudioMode`) and
-keep the feed, composer, and Library column; every other task hosts a former
-specialist sheet inline, full height, with its own controls and no Done button.
-Nothing that used to be a sheet is modal any more; the remaining sheets are
-true tasks (third-party terms, the image mask editor, Relay sign-in, rename,
-and the Guide). `StudioDestination` (domain + task) persists per window under
+The task control sits in a 52pt header at the top of the content column, beside
+the Library (the window toolbar stays empty so the Library column runs to the
+top of the window): one segmented pill for up to six tasks, or five segments
+plus a "More" menu segment, which today only Vision's ten tasks reach. The
+header's leading item is the domain glyph, title, and one-line subtitle;
+trailing are the Library, Inspector, and Command toggles (Library and Inspector
+appear on prompt tasks only). `StudioDestination` persists per window under
 `studio.destination`; `studio.mode` still records the last prompt mode so its
 draft and readiness survive a detour through a System task.
 
-The Library column appears on the prompt tasks (`StudioTask.isPromptTask`:
-Generate, Compose, Speak, Chat, Code, Read, Find, Segment, Track, Transcribe);
+The Library column appears on the prompt tasks (`StudioTask.isPromptTask`);
 every other task — Subjects, Realtime, Models, Train, the labs — takes the full
 content width even inside a Create domain. Chat and Code fill that column with
 their thread list instead (threads never file into the media Library). It is
-filtered to the current domain by default with an All
-segment — a row is filed under its command's domain (`CommandTemplateID.studioDomain`),
-so 3D meshes land under 3D and benchmark reports under Models — and picking a
-row from another domain switches the destination to it.
+filtered to the current domain by default with an All segment — a row is filed
+under its command's domain (`CommandTemplateID.studioDomain`), so 3D meshes land
+under 3D and benchmark reports under Models — and picking a row from another
+domain switches the destination to it.
 
 Beside the search field are a kind filter (All / Images / Video / Audio / Text,
 plus "Favorites only") and a list-or-grid toggle; grid is three thumbnails
 across with the title on hover. Thumbnails are the real thing per kind — the
 picture, an `AVAssetImageGenerator` poster frame for video, a peak silhouette
 for audio, the first line for a text result — decoded off the main actor and
-cached by path, size, and modification date (`StudioLibraryThumbnail.swift`).
-Rows carry a hover star (`StudioLibraryItem.isFavorite`, an additive optional),
-rename in place, and drag out to Finder or any app. ⌘ and ⇧ click build a batch
-(`StudioLibrarySelection`) with a bar for Reveal, Save to…, and Delete; Delete
-asks first and offers to move the run's files to the Trash. Filtering and
-day-grouping live in `StudioLibraryPresenter`, so both are testable without a
-view. The view mode, kind, and favorites filter persist per window under
-`studio.libraryView`, `studio.libraryKind`, and `studio.libraryFavorites`.
+cached by path, size, and modification date (`StudioUI/StudioLibraryThumbnail.swift`).
+Rows carry a hover star (`StudioLibraryItem.isFavorite`, an additive optional
+written as `nil` when unstarred), rename in place, and drag out to Finder or any
+app. ⌘ and ⇧ click build a batch (`StudioLibrarySelection`) with a bar for
+Reveal, Save to…, and Delete; Delete asks first and offers to move the run's
+files to the Trash. Filtering and day-grouping live in `StudioLibraryPresenter`,
+so both are testable without a view. The view mode, kind, and favorites filter
+persist per window under `studio.libraryView`, `studio.libraryKind`, and
+`studio.libraryFavorites`.
 
 Every prompt task holds its own `StudioDraft`: switching tasks or domains parks
 the one being left and restores the one being entered, so a typed prompt and an
@@ -168,12 +187,89 @@ the system text, and the attachment of each task under `studio.drafts`
 (`StudioDraftMemory`); settings come back from the task's defaults, which is
 also the baseline the inspector diffs against.
 
-**Chat** is the Converse archetype (`StudioConversationView.swift`,
-`StudioThreadList.swift`). A **thread list** replaces the Library column there —
+Menus follow macOS convention: File ▸ New Chat (⌘N) and Import Receipt…; View ▸
+Show Library (⌥⌘L), Show Inspector (⌥⌘I), Show Command View (⌥⌘C; Command
+Console on the other tasks), and the system sidebar toggle; Go ▸ every domain
+(⌘1–⌘9, then ⌥⌘1…) plus the current domain's tasks; Run ▸ Run (⌘↩), Stop (⌘.),
+Open Last Output (⇧⌘O), and Reveal Last Output in Finder (⇧⌘R), acting on the
+current composer; Help ▸ mere.run Guide (⌘?), the mere.run link, Command
+Console, and Export Diagnostics…. Settings has General, Models, Server, and
+Advanced tabs. First run shows the Image empty state with its "Get the model"
+path and a one-time dismissible banner; there is no Welcome sheet.
+
+## Composer, feed, and Analyze
+
+The **composer** under the canvas is one surface for every prompt mode
+(`StudioUI/StudioComposer.swift`, declarations in `StudioKit/StudioComposerSchema.swift`). An
+**attachment well** shows the mode's slots — Image: input and reference images;
+Video: start frame, end frame, audio; Music: source and timbre references;
+Voice: reference audio; Vision and Audio tasks: their required input; Chat: a
+per-turn image that stays behind the paperclip until attached — and every slot
+takes a drop, a paste (⌘V), or a click to pick, storing straight into the draft
+field the CLI flag reads. Code and Sound ▸ Generate declare no slots. Under the
+prompt, a **chip strip** shows up to four essentials (size, length, steps, seed,
+threshold, task, voice mode, thinking) as menus with popover editors for custom
+values; some modes show only the model chip. The **model chip** is the only
+model control: it lists `model list` rows filtered to the mode's category,
+installed first, with "Auto" for the mode's default. The chips and the inspector
+bind the same `StudioDraft`, so a value changed in one shows in the other. ⌘↩
+runs; while a conversation turn streams, the send circle becomes Stop.
+
+The **feed** above the composer (`StudioUI/StudioFeedCanvas.swift`, cards derived in
+`StudioKit/StudioFeedCards.swift`) lists the mode's runs oldest first, newest beside the
+composer. A finished run is a generation card: prompt, the chips it ran with
+(read from its own command), every output in a grid of 236pt tiles (images,
+video, 3D; audio gets the waveform player, text the Markdown renderer), and
+Vary (rerun with a fresh, recorded seed), Rerun, Use as input, Quick Look,
+Reveal, Copy, and Save to…; outputs drag out to Finder. A run in flight is a
+card that observes its `Job` directly — progress bar, "Denoising 15/24 · 0:41",
+Cancel, and the log tail behind an Activity disclosure — and a queued run is a
+row with Remove; both come from `JobStore`, not from a controller mirror. A
+failed run leads with the last meaningful stderr line, keeps the log behind
+"Show log", and offers Retry. Validation errors ("Prompt is required.") render
+as a banner under the composer; readiness (missing model, missing CLI) is a card
+at the bottom of the feed with "Get the model" and the pull's own progress, so
+it never hides earlier work. Completion never moves the Library selection; a
+result that finishes off-screen shows a "New result ↓" pill. Picking a Library
+row scrolls to its card and outlines it briefly.
+
+The input-first tasks render the **Analyze canvas**
+(`StudioUI/StudioAnalyzeCanvas.swift`, `StudioUI/StudioAnalyzeViews.swift`) instead of the feed,
+because the answer belongs beside the thing it is about rather than in a stream.
+It is one 940pt column: an input strip naming the attached file with its
+dimensions or duration, a Replace button that writes the same composer well, and
+a view switch whose segments come from the task's own result kind (Boxes /
+Masks / JSON for Find and Segment, Video / JSON for Track, Transcript /
+Timeline / JSON for Transcribe); below it the input rendered large on the left —
+the image with the result drawn over it, a video with its scrubber and
+per-object track spans, audio with the waveform player — and a 360pt result
+column on the right holding what the model found, the contextual next steps, and
+the prompt it ran with. Results are read from the documents the CLI actually
+writes (`StudioKit/StudioAnalyzeResults.swift`): `vision ground`'s normalized boxes,
+`vision segment`'s pixel boxes with their mask PNGs, `vision track`'s per-frame
+detections, `speech diarize`'s speaker turns, and the timestamped transcript
+`speech transcribe` prints. Studio always asks for that document, passing
+`--json-output` (and `--mask-output-dir` for the still tasks) beside the
+annotated output. A run in flight, a queue, a failure, and readiness use the
+feed's own cards above the result column, and earlier runs stay one click away
+in the Library column, which also puts their input back in the composer. The
+next steps open the sibling task carrying the input when the target accepts it
+(Find ▸ "Segment these" keeps the picture; "Track in video" keeps only the
+prompt, because Track needs a clip).
+
+`StudioKit/StudioAnalyzeSchema.swift` declares the surface — the result views and the next
+steps — for twenty-two tasks, seventeen of which still render their own form
+inside their task rather than this canvas (Vision ▸ Depth, Pose, Faces, Flow,
+Geometry, Live; Audio ▸ Who Spoke, Enhance, Separate; Text ▸ Embeddings,
+Anonymize; the four Earth tasks; Sound ▸ Score and Condition). Migrating one is
+a view change, not a design decision.
+
+**Chat** is the Converse surface (`StudioUI/StudioConversationView.swift`,
+`StudioUI/StudioThreadList.swift`). A **thread list** replaces the Library column there —
 every chat and code thread, searchable, grouped Today / Earlier, with a compose
 button (⌘N) — and threads never appear in the media Library. The thread header
 carries the title, the model chip (the same filtered picker as the composer,
-`StudioModelPicker.swift`), and a "System" chip that edits the system prompt in a
+`StudioUI/StudioModelPicker.swift`), and a "System" chip that edits the system prompt in a
 popover; changing either applies from the next turn, and every assistant turn
 records the model, system prompt, and decode speed it ran with
 (`StudioMessage.model` / `.systemPrompt` / `.tokensPerSecond`, additive optionals
@@ -183,371 +279,373 @@ a new thread from that point (before a user turn, after an assistant turn). The
 task control's **Code** is a preset inside the same thread list — the
 `text code` command, its default model and system prompt, monospaced code
 blocks with proportional prose — and a thread records which preset its latest
-turn used (`mode`). While a reply streams, the composer's Send circle becomes
-Stop for that thread. The transcript budget derives from the model's context
+turn used (`mode`). The transcript budget derives from the model's context
 window when the inventory reports one (or an explicit context size), else stays
 at 48k characters; a banner reports any turns trimmed from the next prompt.
 
-The **composer** under the canvas is one surface for every prompt mode
-(`StudioComposer.swift`, declarations in `StudioComposerSchema.swift`). An
-**attachment well** shows the mode's slots — Image: input and reference images;
-Video: start frame, end frame, audio; Music: source and timbre references;
-Voice: reference audio; Vision and Audio tasks: their required input; Chat: a
-per-turn image that stays behind the paperclip until attached — and every slot
-takes a drop, a paste (⌘V), or a click to pick, storing straight into the draft
-field the CLI flag reads. Under the prompt, a **chip strip** shows the mode's two
-to four essentials (size, steps, seed, length, threshold, thinking) as menus, and
-the **model chip** is the only model control: it lists `model list` rows filtered
-to the mode's category, installed first, with "Auto" for the mode's default. The
-chips and the inspector bind the same `StudioDraft`, so a value changed in one
-shows in the other.
-
-The **feed** above the composer (`StudioFeedCanvas.swift`, cards derived in
-`StudioFeedCards.swift`) lists the mode's runs oldest first, newest beside the
-composer. A finished run is a generation card: prompt, the chips it ran with
-(read from its own command), every output in a grid of 236pt tiles (images,
-video, 3D; audio gets the waveform player, text the Markdown renderer), and
-Vary (rerun with a fresh, recorded seed), Rerun, Use as input, Quick Look,
-Reveal, Copy, and Save to…; outputs drag out to Finder. Runs write to a
-user-visible folder chosen by what the file is and which domain made it
-(`StudioOutputLocation.swift`): `~/Pictures/mere.run/<Domain>` for pictures and
-clips, `~/Music/mere.run/<Domain>` for audio, `~/Documents/mere.run/<Domain>`
-for everything else, named `<slug-of-prompt>-<seed-or-short-id>.<ext>` with a
-numeric suffix on collision. Settings ▸ General takes one root that overrides
-all three (`mererun.app.outputRoot`). Nothing is migrated: Library rows keep the
-paths they recorded, Application Support holds metadata only, and a destination
-that cannot be created sends the run back to `App Outputs` with its sidecars and
-one banner saying why. A run in flight is a
-card that observes its `Job` directly — progress bar, "Denoising 15/24 · 0:41",
-Cancel, and the log tail behind an Activity disclosure — and a queued run is a
-row with Remove; both come from `JobStore`, not from the controller's foreground
-mirror. A failed run leads with the last meaningful stderr line, keeps the log
-behind "Show log", and offers Retry. Validation errors ("Prompt is required.")
-render as a banner under the composer; readiness (missing model, missing CLI)
-is a card at the bottom of the feed with "Get the model" and the pull's own
-progress, so it never hides earlier work. Completion never moves the Library
-selection; a result that finishes off-screen shows a "New result ↓" pill.
-Picking a Library row scrolls to its card and outlines it briefly.
-
-The input-first tasks — Vision ▸ Read, Find, Segment, and Track, and Audio
-▸ Transcribe — render the **Analyze canvas** (`StudioAnalyzeCanvas.swift`,
-`StudioAnalyzeViews.swift`) instead of the feed, because the answer belongs
-beside the thing it is about rather than in a stream. It is one 940pt column:
-an input strip naming the attached file with its dimensions or duration, a
-Replace button that writes the same composer well, and a view switch whose
-segments come from the task's own result kind (Boxes / Masks / JSON for Find
-and Segment, Video / JSON for Track, Transcript / Timeline / JSON for
-Transcribe); below it the input rendered large on the left — the image with
-the result drawn over it, a video with its scrubber and per-object track spans,
-audio with the waveform player — and a 360pt result column on the right
-holding what the model found, the contextual next steps, and the prompt it ran
-with. Results are read from the documents the CLI actually writes
-(`StudioAnalyzeResults.swift`): `vision ground`'s normalized boxes, `vision
-segment`'s pixel boxes with their mask PNGs, `vision track`'s per-frame
-detections, `speech diarize`'s speaker turns, and the timestamped transcript
-`speech transcribe` prints. Studio always asks for that document, passing
-`--json-output` (and `--mask-output-dir` for the still tasks) beside the
-annotated output. A run in flight, a queue, a failure, and readiness use the
-feed's own cards above the result column, and earlier runs stay one click away
-in the Library column, which also puts their input back in the composer. The
-next steps open the sibling task carrying the input when the target accepts it
-(Find ▸ "Segment these" keeps the picture; "Track in video" keeps only the
-prompt, because Track needs a clip). The archetype is declared per task in
-`StudioAnalyzeSchema.swift`, which also describes the Vision Lab, Audio, Text,
-Earth, and Sound analysis tasks that still render their lab forms.
+## Inspector, Command view, and Command Console
 
 The **inspector** (⌥⌘I, the header's Inspector toggle, remembered per task under
 `studio.inspectorTasks`) is a 300pt column rendered from the capability
-contract. `StudioContractSchema.swift` binds each option
+contract. `StudioKit/StudioContractSchema.swift` binds each option
 `MereRunCapabilityCatalog` declares to the `StudioDraft` field the app keeps it
-in, and `ContractForm` (`StudioContractForm.swift`) draws it: the option's
+in, and `ContractForm` (`StudioUI/StudioContractForm.swift`) draws it: the option's
 `kind` picks the control (a field, a checkbox, a segmented control or pop-up
 from its `choices`, a path well, a slider when its `range` has both ends and a
 stepper when it does not), its `group` picks the section (Prompt, Inputs,
 Output, Model & adapters, Sampling, Run), its `tier` decides whether it sits in
 a section or under the collapsed "Advanced · N more", its `depends_on` hides it
 until the option it needs carries a value, and a control at its `default_value`
-emits no flag. A per-flag override registry keeps the composite editors the
-contract cannot describe — the aspect presets with width × height and Swap, the
-seed with Random and Reuse last, the steps and guidance sliders over the range
-the mode's models use, seconds-or-frames, the model picker, the LoRA and
-ACE-Step adapter rows, the mask and outpaint canvas, and the ordered MiniMax
-references — and marks the attachments the composer's well owns so the
-inspector never repeats them. Each section has Reset, and the header badge
-counts the draft fields that differ from the mode's defaults.
+emits no flag. A per-flag override registry keeps the fifteen composite editors
+the contract cannot describe — the aspect presets with width × height and Swap,
+the seed with Random and Reuse last, the steps and guidance sliders over the
+range the mode's models use, seconds-or-frames, the model picker, the LoRA and
+ACE-Step adapter rows, the mask and outpaint canvas, the ordered MiniMax
+references, and the voice profile list — and marks the attachments the
+composer's well owns so the inspector never repeats them. Each section has
+Reset, and the header badge counts the draft fields that differ from the mode's
+defaults.
 
-Menus follow macOS convention: File ▸ New Chat (⌘N) and Import Receipt…, View ▸
-Show Library (⌥⌘L), Show Inspector (⌥⌘I), Show Command View (⌥⌘C; Command
-Console on other tasks), and the system sidebar toggle, Go ▸
-every domain (⌘1–⌘9, then ⌥⌘1…) plus the current domain's tasks, Run ▸ Run
-(⌘↩) and Stop (⌘.) acting on the current composer, Help ▸ Guide (⌘?). Settings
-has General, Models, Server, and Advanced tabs. First run shows the Image empty
-state with its "Get the model" path and a one-time dismissible banner.
+The inspector shows only the flags the binding table maps to a draft field, so
+no control can look live and change nothing. That makes it thin where the table
+is thin: Read, Find, Segment, Track, and Code bind between one and five flags,
+and the rest of their options are reached in the Command Console.
 
 The **Command view** (⌥⌘C on a prompt task, or the header's Command toggle)
 is a 520pt column in the inspector's place — the two are never side by side —
 showing the task's raw form from the same draft: every option the capability
-contract declares for the template, under the contract's own groups — Prompt,
-Inputs, Output, Model & adapters, Sampling, Run, and Options for a flag the
-contract has yet to describe (`StudioCommandRows.swift`) — with the value the
+contract declares for the template, under the contract's own groups — Arguments,
+Prompt, Inputs, Output, Model & adapters, Sampling, Run, and Options for a flag
+the contract has yet to describe (`StudioKit/StudioCommandRows.swift`) — with the value the
 argv carries (set rows first) or a switch for boolean flags, then "Will run"
 with the masked command line, Copy, "Open in Terminal" (copies the command and
 brings Terminal forward; the app never scripts another application), and Run.
-Values are read-only until every task renders an editable contract form; the
-chips and inspector edit them. Readiness cards' Details button opens it.
+Values are read-only: the chips and the inspector edit them. Readiness cards'
+Details button opens it.
 
 The **Command Console** window (`Window("Command Console")`,
-`StudioConsoleView.swift`) is the raw surface for every capability, in three
-resizable panes: the catalog of templates by category, the selected
+`StudioUI/StudioConsoleView.swift`) is the editable raw surface for every capability, in
+three resizable panes: the catalog of templates by category, the selected
 capability's form, and the run's log with its receipt and artifact
-(`StudioConsoleLog.swift`). The middle pane is the same `ContractForm`, drawn
-with the flag rather than the label at the head of each row, so the console has
-no per-command view of its own: `StudioConsoleDraft` keeps one value per flag,
-`StudioConsoleCommand` reads a template's own argv into those values and builds
-the argv back out of them, and the eyebrows, controls, dependencies, positional
-arguments and "Will run" block all come from `MereRunCapabilityCatalog`. A
-capability nobody has designed a surface for is therefore reachable here the day
-the contract declares it, and `StudioConsoleDraftTests` holds the identity that
-makes that safe: for every template in the catalog, seeding from its default
-command and rebuilding produces the same command. Options the contract does not
-describe go in Extra arguments; the Custom template is a plain argument editor.
+(`StudioUI/StudioConsoleLog.swift`). The middle pane is the same `ContractForm`, drawn
+with the flag rather than the label at the head of each row and with numbers
+typed rather than dragged, so the console has no per-command view of its own:
+`StudioConsoleDraft` keeps one value per flag, `StudioConsoleCommand` reads a
+template's own argv into those values and builds the argv back out of them, and
+the eyebrows, controls, dependencies, positional arguments and "Will run" block
+all come from `MereRunCapabilityCatalog`. Nothing is filtered by tier and
+nothing is compared against a default: the console emits a flag exactly when the
+draft holds a value, because what it shows is what it runs.
+`StudioConsoleDraftTests` holds the identity that makes that safe: for every
+template in the catalog, seeding from its default command and rebuilding
+produces the same command. Options the contract does not describe go in Extra
+arguments; the Custom template has no capability and keeps the catalog's raw
+argument editor, the one editor the console still writes by hand.
 
-It opens from the header's Command toggle on non-prompt tasks, ⌥⌘C there,
-Help ▸ Command Console anywhere, a Library row's "Edit command…", and the
+The console opens from the header's Command toggle on non-prompt tasks, ⌥⌘C
+there, Help ▸ Command Console anywhere, a Library row's "Edit command…", and the
 adapter fallbacks for modes whose adapters are typed only in the raw command.
 Opening it from the header carries the composer's draft into the matching
 template; a Library row reopens on the exact argv its run launched
-(`StudioLibraryItem.commandArguments`); raising an already-open console only
-brings it forward, so its edits stay. A console run is a normal inference job —
-same queue, progress, artifact resolution and Library row — and while the
+(`StudioLibraryItem.commandArguments`, an additive optional, so the console can
+set options no `CommandDraft` field carries); raising an already-open console
+only brings it forward, so its edits stay. A console run is a normal inference
+job — same queue, progress, artifact resolution and Library row — and while the
 console is key the Run menu drives it while Go and Help keep acting on the
 Studio window.
 
-Do not duplicate runtime logic here. The app should translate UI state into CLI
-arguments and let the public executable remain the behavioral source of truth.
+## Jobs, artifacts, and output
 
-`MereRunContract` is the compile-time and machine-readable boundary between the
-two products. `mere.run catalog --json` emits that same contract. App forms must
-use its typed choices, and CLI/App tests must prove that every emitted option is
-both cataloged and accepted by ArgumentParser.
+`JobStore` owns every child process the app launches behind the
+`MereRunProcessRunning` seam (`Process()` appears only in
+`StudioKit/Jobs/ProcessRunner.swift` and the synchronous `CLIBootstrapInstaller` version
+probe), with three lanes: `inference` for Studio runs (capped at two with a FIFO
+queue), `utility` for the hand-built CLI reads and writes behind
+`utilityCommandResult` (capped at four, FIFO), and `probe` for readiness and
+`status --json` probes (never queued, deduplicated by key so a repeated probe
+joins the one in flight and a probe with stale Settings is superseded). A
+`JobRequest` is either a catalog command (template plus draft, which drive
+validation and output detection) or raw arguments (`JobRequest.utility` /
+`.probe`, which skip preflight and capture complete stdout and stderr for the
+submitter). The store publishes one observable `Job` per job (state, status,
+progress, log, live output, artifacts, result), raw output chunks through
+`events`, and a lossless `completions` stream, and it retains the last fifty
+finished jobs per lane so utility churn cannot evict a run the user is reading.
+`StudioRootView` keeps the Library rows current from those two streams.
 
-The primary Video surface uses model-family-aware controls: LTX uses `--quality`
-and `--output-mode`, while native MiniMax-H3 exposes its exact `17*n+5` frame
-cadence, adaptive or explicit denoising schedule, weight-residency policy, and
-exact, balanced, or maximum denoise acceleration, plus
-ordered Ref2VA image/video/audio references without emitting incompatible LTX
-flags. Its general attachment workflow supports a start image, end keyframe,
-and source audio. The Command Console's Video templates contain
-guided SCAIL-2, Cosmos3, mask-preparation, latent-export, and resident-session
-workflows. Video ▸ Subjects hosts the SCAIL subject workflow as a three-stage
-project board (Plan → Track → Animate) with a stage rail, a mask preview that
-scrubs by frame and flips between masks and the driving clip, subject rows, and
-stats read from the CLI's manifest, tracking, and quality reports. It keeps
-multi-subject reference/selector authoring, preview and full-video SAM tracking,
-immutable keyframe corrections, the continuity/profile controls (under each
-stage's "More" row), plan.json persistence, and durable Library jobs with a job
-bar for the running stage.
+`ArtifactResolver` reads, in order, (1) the CLI's `--receipt` line — the final
+stdout NDJSON object `{"event":"result","exit":0,"outputs":[…]}`, whose first
+entry is the primary artifact and whose sidecars carry a `role` (`detections`,
+`masks`, `recipe`, …); (2) the output kind `MereRunCapabilityCatalog` declares
+for the capability together with the `--output` path the request asked for, once
+it exists; (3) the stdout path contract and `fileExists` probing, kept as the
+fallback for the commands that print no receipt and for an older CLI. Roles
+reach the UI on `Artifact.sidecarRole` / `roleLabel` and are persisted on
+`StudioLibraryItem.artifactRoles`, so a result surface labels a sidecar instead
+of guessing from its extension; sidecars found by probing are labelled from the
+same draft fields that located them (`StudioArtifactRole.inferred`).
 
-Text uses the same contract for native/MLX chat, code, embeddings,
-anonymization, and text-LoRA training. Chat exposes typed text/JSON response
-format, reasoning policy, context and KV controls, LoRA application, tool
-permissions, and preflight. Text ▸ Embeddings adds vector norms and
-cosine-similarity inspection; Text ▸ Anonymize shows original/protected PII
-spans. Chat ▸ Train hosts the text trainer rather than a generic form. Laguna XS and
-Inkling-Small are explicit model families; Inkling reasoning effort is available
-in chat and training, while omitted target modules preserve the runtime's full
-attention, MLP, expert, shared-outer, and unembedding training defaults.
+The app appends `--receipt` and `--progress-json` to the launched argv for the
+capabilities the contract lists in `receiptCapabilityIDs` (nine) and
+`progressJSONCapabilityIDs` (five), never on a `--preflight` run (the CLI
+rejects `--receipt --preflight`, and a preflight has no progress to stream) and
+never in the "Will run" preview or a Library row's command, which stay the
+command a person would type. A run that prints a receipt skips the 350 ms output
+poll; every other command with an output file keeps it.
 
-Image uses the shared contract for generation/editing, LoRA training,
-validation, dataset discovery, durable plans and dashboards, TripoSR,
-TRELLIS.2, and InstantMesh. The primary Studio surface includes multi-reference
-editing, structured prompts, LoRA catalog IDs or local adapters, Krea tuning,
-preflight, and machine-readable progress. Image ▸ Train adds dataset previews,
-preflight, launch/resume, loss metrics, samples, checkpoints, and run comparison
-for Krea 2 and FLUX.2 Klein. Image ▸ Datasets renders validation artifacts,
+Runs write to a user-visible folder chosen by what the file is and which domain
+made it (`StudioKit/StudioOutputLocation.swift`): `~/Pictures/mere.run/<Domain>` for
+pictures and clips, `~/Music/mere.run/<Domain>` for audio,
+`~/Documents/mere.run/<Domain>` for everything else, named
+`<slug-of-prompt>-<seed-or-short-id>.<ext>` with a numeric suffix on collision.
+The suffix is derived, not random, so the path the Command view previews is the
+path the run writes. Settings ▸ General takes one root that overrides all three
+(`mererun.app.outputRoot`). Nothing is migrated: Library rows keep the paths
+they recorded, Application Support holds metadata only, and a destination that
+cannot be created sends the run back to `App Outputs` with its sidecars and one
+banner saying why.
+
+`MereRunController` is the facade views bind to. It snapshots Settings and the
+CLI launch into a `JobRequest` for every lane, awaits utility and probe jobs on
+behalf of their callers (readiness results are evaluated against the request
+current at completion), mirrors the foreground inference job into the published
+console fields the Command Console and the re-hosted views still read, and owns
+the template selection the console opens on and the persisted settings.
+
+## Domains
+
+**Image** covers generation and editing, LoRA training, validation, dataset
+discovery, durable plans and dashboards. Image ▸ Generate includes
+multi-reference editing, structured prompts, LoRA catalog IDs or local adapters,
+Krea tuning, and preflight. Image ▸ Train adds dataset previews, preflight,
+launch and resume, loss metrics, samples, checkpoints, and run comparison for
+Krea 2 and FLUX.2 Klein. Image ▸ Datasets renders validation artifacts,
 candidate dataset diagnostics, and materialized plan paths.
-The 3D domain is the workspace for TripoSR, native
-TRELLIS.2 PBR reconstruction, and ordered 4/6-view InstantMesh. It includes
-engine-specific controls, immutable output directories, embedded orbitable
-Quick Look models, manifest statistics, and the shared progress/Library lifecycle.
 
-Music is a production workspace, not a prompt-only wrapper. Studio exposes
-quality planning, covers/repaint/flow edits, source and timbre-reference audio,
-candidate ranking, LM planning, adapter stacks, stems, LRC, recipes, and DAW
-delivery. Music ▸ Analyze adds standalone ACE-Step understanding with structured
-results and Music ▸ Transcribe MuScriptor transcription with an embedded MIDI
-piano roll; the resident ACE-Step server's health and lifecycle live under
-Server ▸ Music server. Music ▸ Realtime is the Magenta RT2 session: a transport
-with the live clock, the recording's waveform, Prompt A/B steering with a blend
-slider, temperature, top-k, and guidance sent over the CLI's stdin protocol as
-you release each control, the session log, and a job bar with Cancel and Log;
-it re-attaches to a running session when you navigate back to it.
-Music ▸ Train is the shared LoRA/LoKr trainer with dataset audio previews and live
-loss events. The Command Console retains the complete raw command surface.
-Audio ▸ Enhance and Audio ▸ Separate (also reachable as Music ▸ Separate) are
-the restoration workspace for native AP-BWE and
-UniverSR enhancement plus ViperX two-stem, four-stem, dereverb, and denoise
-RoFormer workflows. It exposes model-specific compute/chunk controls, previews
-source and outputs, and preserves manifests and every generated stem in Library.
-The API key is injected through `MERERUN_API_KEY`, never placed in process
-arguments.
+**Video** ▸ Generate uses model-family-aware controls: LTX uses `--quality` and
+`--output-mode`, while native MiniMax-H3 exposes its exact `17n+5` frame
+cadence, adaptive or explicit denoising schedule, weight-residency policy,
+exact/balanced/maximum denoise acceleration, and ordered Ref2VA image, video,
+and audio references, without emitting incompatible LTX flags. Its attachment
+well takes a start image, an end keyframe, and source audio. Video ▸ Subjects is
+the SCAIL subject flow as a three-stage project board (Plan → Track → Animate)
+with a stage rail, a mask preview that scrubs by frame and flips between masks
+and the driving clip, subject rows, and stats read only from the CLI's manifest,
+tracking, and quality reports. It keeps multi-subject reference and selector
+authoring, preview and full-video SAM tracking, immutable keyframe corrections,
+the continuity and profile controls under each stage's "More" row, `plan.json`
+persistence, and durable Library jobs with a job bar for the running stage. The
+guided SCAIL-2, Cosmos3, mask-preparation, latent-export, and resident-session
+commands live in the Command Console.
 
-Vision keeps the quick Read path in Studio while the Command Console exposes the
-complete VLM/VFX family: multi-image captioning, LightOn/GLM/Infinity OCR,
-grounding, text/box/point segmentation and tracking, camera capture, Buffalo-L
-face analysis, native pose and optical flow, video depth, MoGe geometry, and
-DA3 ordered multiview reconstruction. Coordinates remain typed, ordered CLI
-arguments; machine-readable results and mask directories use explicit output
-pickers. Image-to-3D lives in the 3D domain instead of being duplicated.
-Vision ▸ Depth, Pose, Faces, Flow, Geometry, and Live host the former Vision Lab
-inline. It renders face/pose overlays and dense optical-flow vectors, plays live
-tracking and depth review videos, embeds geometry point clouds, and preserves
-every JSON, EXR, mask, camera, and 3D sidecar as a durable Library artifact.
+**Music** is a production surface, not a prompt-only wrapper: quality planning,
+covers, repaint and flow edits, source and timbre-reference audio, candidate
+ranking, LM planning, adapter stacks, stems, LRC, recipes, and DAW delivery.
+Music ▸ Analyze adds standalone ACE-Step understanding with structured results;
+Music ▸ Transcribe adds MuScriptor transcription with an embedded MIDI piano
+roll; Music ▸ Separate shares the restoration surface with Audio. Music ▸
+Realtime is the Magenta RT2 session: a transport with the live clock, the
+recording's waveform, Prompt A/B steering with a blend slider, temperature,
+top-k, and guidance sent over the CLI's stdin protocol as you release each
+control, the session log, and a job bar with Cancel and Log; it re-attaches to a
+running session when you navigate back to it. Music ▸ Train is the shared
+LoRA/LoKr trainer with dataset audio previews and live loss events. The resident
+ACE-Step server's health and lifecycle live under Server ▸ Music server.
 
-Runs is a sidebar domain over the public
-`executor` and `run` contracts. It discovers local durable reports, lists Relay
-jobs, polls typed inspection state, shows artifact inventories, reveals local
-runs, and exposes verified fetch, cancellation, and immutable Relay retry.
-Client-side Relay profile setup and device sign-in also go through the CLI;
-Studio streams the approval URL but never handles the credential itself.
-Studio owns the creator's run inbox; Relay remains the control plane for node
-identity, placement, scheduling policy, model distribution, worker lifecycle,
-and fleet telemetry. The app links to the Relay console instead of copying
-those schemas or controls.
+**Sound** ▸ Generate and Video Foley produce effects; Condition, Encode, Decode,
+and Score cover conditioning, AE encode and decode, CLAP scoring, waveform
+review, NPY metadata, and durable artifacts.
 
-Diorama is the separate first-class Worlds app and owns durable world projects,
-navigation, exploration, saved routes, review, and `.diorama` bundles. Studio
-owns only the typed local `world serve` runtime endpoint, authentication, model
-selection, status, and the handoff to `https://diorama.mere.run`; it must not
-duplicate Diorama's product experience.
+**Voice** ▸ Speak, Clone, and Voices host styled or cloned synthesis, reusable
+profiles, reference recording, streaming feedback, and A/B playback.
 
-Models ▸ Installed is a list-and-detail page. The content header's subtitle
-reports the real inventory ("92 installed · 48 GB on this Mac", from `model list` and
-`model storage`). The 320pt list shows installed models plus any model being
+**3D** is the domain for TripoSR, native TRELLIS.2 PBR reconstruction, and
+ordered 4- and 6-view InstantMesh. It has engine-specific controls, immutable
+output directories, embedded orbitable Quick Look models, manifest statistics,
+and the shared progress and Library lifecycle. It runs the `image reconstruct-3d`
+family; the `vision image-to-3d` aliases stay CLI-only rather than being
+duplicated under Vision.
+
+**Chat** covers native and MLX chat and code with typed text/JSON response
+format, reasoning policy, context and KV controls, LoRA application, tool
+permissions, and preflight. Chat ▸ Train hosts the text trainer rather than a
+generic form. Laguna XS and Inkling-Small are explicit model families; Inkling
+reasoning effort is available in chat and training, and omitted target modules
+preserve the runtime's full attention, MLP, expert, shared-outer, and
+unembedding training defaults.
+
+**Vision** covers the whole VLM and VFX family: multi-image captioning,
+LightOn/GLM/Infinity OCR, grounding, text/box/point segmentation and tracking,
+camera capture, Buffalo-L face analysis, native pose and optical flow, video
+depth, MoGe geometry, and DA3 ordered multiview reconstruction. Read, Find,
+Segment, and Track are the Analyze tasks; Depth, Pose, Faces, Flow, Geometry,
+and Live host the lab form that renders face and pose overlays and dense optical
+flow vectors, plays live tracking and depth review video, embeds geometry point
+clouds, and preserves every JSON, EXR, mask, camera, and 3D sidecar as a durable
+Library artifact. Coordinates stay typed, ordered CLI arguments; machine-readable
+results and mask directories use explicit output pickers.
+
+**Audio** ▸ Transcribe is the Analyze task over `speech transcribe`. Who Spoke
+is native Sortformer diarization with JSON and RTTM timelines and
+segment-tuning controls. Enhance and Separate are the restoration surface for
+native AP-BWE and UniverSR enhancement plus ViperX two-stem, four-stem,
+dereverb, and denoise RoFormer workflows, with model-specific compute and chunk
+controls, source and output previews, and every generated stem kept in the
+Library. Audio ▸ Live is the live lane over `speech listen`: it enumerates
+capture devices through the CLI, streams partial transcripts as the recognizer
+emits them, and owns the child process directly so the operator can stop it,
+then copy or save the transcript. The packaged app and embedded CLI carry the
+microphone usage description and audio-input entitlement those capture paths
+require.
+
+**Text** ▸ Embeddings adds vector norms and cosine-similarity inspection;
+Text ▸ Anonymize shows original and protected PII spans.
+
+**Earth** is native Earth-observation inference, with Flood, Fire, TESSERA, and
+OlmoEarth tasks. It covers TerraMind flood and fire tile inference and the
+TESSERA v2 and OlmoEarth v1.2 encoders, names the tensors each input bundle must
+carry before a run rather than after it, exposes engine-specific controls
+(TESSERA output dimensions; OlmoEarth patch size, ground sample distance, and
+space-time tokens), and preserves every produced safetensors file as a durable
+Library artifact.
+
+**Models ▸ Installed** is a list-and-detail page. The content header's subtitle
+reports the real inventory ("92 installed · 48 GB on this Mac", from `model list`
+and `model storage`). The 320pt list shows installed models plus any model being
 pulled, with a family chip row (Image, Chat, Vision, …) and a status dot: green
 installed, accent pulling, yellow when the CLI reports the model as unsupported
 on this Mac. Pull… opens a sheet of the models that are not installed yet; a
 pull keeps its explicit third-party terms acceptance, live CLI output, and
-cancellation with resumable partials. The detail column shows the model's
-facts (store, source, last used and run count from the Library, manifest
-verification from `model info`), a Health panel (latest quality gate and
-manifest audit, with Run gate and Benchmark… routing to those tasks), a
-Performance panel (last run length, unified-memory needs, latest benchmark),
-the adapters whose base model it is (Use in <domain> applies one to the
-composer, Train new… opens the trainer), and the runtime-settings editor and raw
-`model info` output under two folds. Rows whose data the CLI or Library does
-not have are omitted rather than faked. A job bar at the page bottom reports a
-pull, MiniMax-H3 optimize/rebuild, or storage clean-up in flight (composer
-pulls arrive through their Library row) with Cancel and Log. Reveal, Remove…,
-refresh, opening the store, and clean-up stay on the page.
+cancellation with resumable partials. The detail column shows the model's facts
+(store, source, last used and run count from the Library, manifest verification
+from `model info`), a Health panel (latest quality gate and manifest audit, with
+Run gate and Benchmark… routing to those tasks), a Performance panel (last run
+length, unified-memory needs, latest benchmark), the adapters whose base model it
+is (Use in `<domain>` applies one to the composer, Train new… opens the
+trainer), and the runtime-settings editor and raw `model info` output under two
+folds. Rows whose data the CLI or Library does not have are omitted rather than
+faked. A job bar at the page bottom reports a pull, MiniMax-H3 optimize or
+rebuild, or storage clean-up in flight (composer pulls arrive through their
+Library row) with Cancel and Log. Reveal, Remove…, refresh, opening the store,
+and clean-up stay on the page.
 
-Models ▸ Health is the manifest audit and quality gate. Successful downloads
-refresh the inventory in place. Manifest audit is a structured dry run, repair
-requires confirmation and writes only missing known manifests, and
-installed-model correctness/performance gates run as durable Library jobs with
-JSON reports. Existing model browsing, storage cleanup, and runtime policy
-remain in the Models and Server domains rather than being duplicated.
-
-Server is a sidebar domain. **Server ▸ Serving**
-owns API preflight/start/stop/restart, external-server reconnection, LAN/auth
-safety, text and sidecar residency, load/unload and runtime policy, unified
-memory/process CPU/Metal/thermal telemetry, observed request and cache/batching
-traffic, typed Pi readiness/install/configure/session actions, copyable client
-setup, and sanitized lifecycle activity. It polls the authenticated
-`/runtime/status` contract and tolerates older payloads with missing additive
-fields. App-owned servers and agent sessions remain durable Library runs; the
-CLI/runtime remains the behavioral source of truth.
-
-Voice ▸ Clone and Voice ▸ Voices host styled or cloned synthesis, reusable
-profiles, reference recording, streaming feedback, and A/B playback; Audio ▸
-Who Spoke and Audio ▸ Live host native Sortformer speaker diarization
-with JSON/RTTM timelines and segment-tuning controls and live transcription.
-Sound ▸ Video Foley, Condition, Encode, Decode, and Score cover video
-Foley, conditioning, AE encode/decode, CLAP scoring, waveform review, NPY
-metadata, and durable artifacts. The packaged app and embedded CLI carry the
-microphone usage description and audio-input entitlement required by those
-capture paths.
-
-Plugins is a sidebar domain. It consumes the CLI's enriched
-plugin snapshot, shows installed path/version and manifest verification, offers
-channel selection and copyable pinned install commands, confirms install or
-update, and runs the plugin's fixed doctor verb. Plugin implementations remain
-out-of-process.
-
-Setup, the complete `model benchmark` family — fused Lite/Comprehensive quality
-suites, chat, code, VLM, tool-call and tool-continuation slices, Gemma4 KV and
-MTP, Qwen3.6 MTP, Laguna DFlash, and API workload replay — API serving, and Open
-WebUI also use contract-backed typed forms. Laguna is
-available as a managed chat/API engine, while Chat and Code expose min-p and
-the runtime-policy editors can persist or clear it. The run console recognizes
-adapter catalogs and structured JSON receipts, and can copy or save a receipt.
-Hugging Face tokens, API keys, and the Open WebUI admin password cross the
-process boundary through environment variables instead of appearing in argv.
-Earth is a sidebar domain for native Earth-observation inference, with Flood,
-Fire, TESSERA, and OlmoEarth tasks. It covers TerraMind flood and fire tile inference
-and the TESSERA v2 and OlmoEarth v1.2 encoders, names the tensors each input
-bundle must carry before a run rather than after it, exposes engine-specific
-controls (TESSERA output dimensions; OlmoEarth patch size, ground sample
-distance, and space-time tokens), and preserves every produced safetensors file
-as a durable Library artifact.
-
-Models ▸ Locations is the store editor over `model location`. It shows the
+**Models ▸ Locations** is the store editor over `model location`. It shows the
 writable store, read-only search roots, and explicit per-model bindings with
 live availability, adds roots and bindings through a directory picker, reveals
 any of them in Finder, and confirms before removing a root or a binding — so a
 model kept on an external volume is registered without leaving the app.
 
-Models ▸ Benchmarks runs the complete benchmark family as durable Library jobs
-beside Models ▸ Health's manifest audit and quality gate: the fused Mere Lite and Mere
-Comprehensive suites, the chat, code, and vision-language slices, tool-call and
-tool-continuation evaluations, the Gemma4 KV and MTP and Qwen3.6 MTP decode
-comparisons, Laguna DFlash, API workload replay, and fixture hashing. Each run
-prints its JSON report to the Library row rather than to a file — the benchmarks
-take no destination option — except the vision-language slice, whose
-`--output-dir` collects the external lmms-eval run.
+**Models ▸ Health** is the manifest audit and quality gate. Manifest audit is a
+structured dry run, repair requires confirmation and writes only missing known
+manifests, and installed-model correctness and performance gates run as durable
+Library jobs with JSON reports. Successful downloads refresh the inventory in
+place.
 
-Audio ▸ Live is the live lane over `speech listen`. It enumerates capture
-devices through the CLI, streams partial transcripts as the recognizer emits
-them, and owns the child process directly so the operator can stop it, then
-copy or save the transcript.
+**Models ▸ Benchmarks** runs the complete `model benchmark` family as durable
+Library jobs: the fused Mere Lite and Mere Comprehensive suites, the chat, code,
+and vision-language slices, tool-call and tool-continuation evaluations, the
+Gemma4 KV and MTP and Qwen3.6 MTP decode comparisons, Laguna DFlash, API
+workload replay, and fixture hashing. Each run prints its JSON report to the
+Library row rather than to a file — the benchmarks take no destination option —
+except the vision-language slice, whose `--output-dir` collects the external
+lmms-eval run.
 
-Server ▸ Serving has a Vision Grounding section with the same lifecycle the API server
-has: preflight, app-owned start, stop, and restart, an honest reading of who
-owns the process, a loopback-exposure warning when the endpoint would bind
-beyond localhost without a key, and the live server log.
+**Models ▸ Adapters** lists adapter catalogs and local adapters and applies one
+to a domain's composer or opens its trainer.
 
-Plugins covers the full lifecycle: catalog details, out-of-PATH runs with
-forwarded arguments, and rollback to a retained signed bundle behind a
-confirmation.
+**Server ▸ Serving** is one operational page over the local API and the resident
+model lanes: preflight, app-owned start, stop and restart, external-server
+reconnection, LAN and auth safety, text and sidecar residency, load/unload and
+runtime policy, unified-memory, process-CPU, Metal and thermal telemetry,
+observed request and cache/batching traffic, typed Pi readiness, install,
+configure and session actions, copyable client setup, and sanitized lifecycle
+activity. A Vision Grounding section gives `vision serve` the same lifecycle as
+the API server — preflight, start, stop, restart, an honest reading of who owns
+the process, a loopback-exposure warning when the endpoint would bind beyond
+localhost without a key, and the live server log. It polls the authenticated
+`/runtime/status` contract and tolerates older payloads with missing additive
+fields. App-owned servers and agent sessions stay durable Library runs. Open
+WebUI and `world serve` are catalog templates without a section on this page;
+they run from the Command Console.
 
-The executable contract test requires every Command Console template and every
-app-owned guide/config helper to resolve to a CLI help-verified capability.
-The inverse coverage test also requires every command in the shared contract to
-have an App-owned template or utility surface. A third test walks the CLI
-command tree itself and requires every public leaf command to be either
-cataloged or listed in `contractExemptCommandIDs` with the reason it stays
-CLI-only, so a new CLI command cannot silently ship without a macOS path or a
-recorded decision that it should not have one.
+**Runs** is the domain over the public `executor` and `run` contracts. It
+discovers local durable reports, lists Relay jobs, polls typed inspection state,
+shows artifact inventories, reveals local runs, and exposes verified fetch,
+cancellation, and immutable Relay retry. Client-side Relay profile setup and
+device sign-in also go through the CLI; Studio streams the approval URL but
+never handles the credential itself.
 
-`StudioSnapshotTests` renders the shell for visual review without driving the
-live app: every domain at its default task at 1280×820 in light and dark, plus
-the Settings content, and fidelity renders at the
-1440×900 mockup size for comparing against the design boards: the Command
-Console on `image generate`, the Main board
-(Image ▸ Generate with a finished generation of two in-test images, a run held
-open by the process seam mid-denoise, a queued run behind a concurrent model
-pull, and the inspector open with two changed settings; then the same feed with
-the Command view column), the composer with the boards' sample prompt
-and an in-test image attached (Image ▸ Generate and Vision ▸ Find), the
-Analyze board (Vision ▸ Find over a 1024×1024 in-test image with a seeded
-`vision ground` document, and Audio ▸ Transcribe with a synthesized recording
-and a timestamped transcript), Music ▸
-Realtime mid-session (a run the process seam holds open, fed the CLI's frame
-progress and steering echoes, with its recording synthesized on disk), and
-Models ▸ Installed with a scripted model inventory (`model list`,
-`capabilities`, `storage`, `info`, `runtime get`, and `adapter list` answered
-from fixtures, plus Library rows for usage, a quality gate, a benchmark, and a
-running composer pull). It is skipped unless
+**Plugins** consumes the CLI's enriched plugin snapshot, shows installed path,
+version, and manifest verification, offers channel selection and copyable pinned
+install commands, confirms install or update, runs the plugin's fixed doctor
+verb, and rolls back to a retained signed bundle behind a confirmation. Plugin
+implementations stay out of process.
+
+Hugging Face tokens, API keys, and the Open WebUI admin password cross the
+process boundary through environment variables (`MERERUN_API_KEY` and its
+siblings) instead of appearing in argv, in both the typed surfaces and the
+console.
+
+## Product boundaries
+
+Relay remains the control plane for node identity, placement, scheduling policy,
+model distribution, worker lifecycle, and fleet telemetry; Studio owns the
+creator's run inbox and links to the Relay console instead of copying those
+schemas or controls. Diorama is the separate first-class Worlds app and owns
+durable world projects, navigation, exploration, saved routes, review, and
+`.diorama` bundles; Studio owns only the typed local `world serve` runtime
+endpoint, authentication, model selection, status, and the handoff to
+`https://diorama.mere.run`. Graph Studio owns workflow authoring and execution.
+Each of these is recorded as a named exemption in `contractExemptCommandIDs`
+with the reason it stays CLI-only.
+
+## Coverage and tests
+
+- `StudioUITests/StudioTypesTests.testEverySharedCLICapabilityHasAnAppOwnedSurface`
+  asserts set equality between the app's capability IDs (every template plus six
+  app-owned utilities: `guide` and the five `config` commands) and the
+  contract's, so a newly cataloged CLI command cannot ship without a macOS path,
+  and an app template cannot name a capability the contract does not declare.
+- `Tests/MereRunCLITests/CapabilityCatalogTests.everyPublicCLICommandIsCatalogedOrExplicitlyExempt`
+  walks the CLI command tree itself and requires every public leaf command to be
+  either cataloged or listed in `contractExemptCommandIDs` with the reason it
+  stays CLI-only. It also rejects a stale exemption, so the list cannot rot.
+- `StudioUITests/NavigationModelTests.testEveryCommandTemplateMapsToADomain`
+  asserts that every
+  command template files into exactly one domain and that every domain owns at
+  least one command. There is no assertion that a capability maps to a single
+  *task*; the Command Console is what guarantees every capability a home.
+- `StudioKitTests/CommandContractGuardTests` builds argv from a sweep of maximal
+  and variant drafts for every local template and asserts that the subcommand
+  path matches the contract and that every emitted flag is one the contract
+  declares.
+- `StudioKitTests/CommandFlagsGenerationTests` regenerates
+  `StudioKit/Catalog/CommandFlags.swift` from the contract and diffs it against
+  the committed file.
+- `StudioKitTests/CommandArgumentGoldenTests` and `CommandDefaultDraftTests` pin
+  every template's argv and starting draft against recorded fixtures, so a
+  refactor that changes a command line has to say so.
+
+`StudioUITests/StudioSnapshotTests` renders the shell for visual review without
+driving the live app: every domain at its default task at 1280×820 in light and dark, plus
+the Settings content, and fidelity renders at the 1440×900 mockup size for
+comparing against the design boards — the Command Console on `image generate`,
+the Main board (Image ▸ Generate with a finished generation of two in-test
+images, a run held open by the process seam mid-denoise, a queued run behind a
+concurrent model pull, and the inspector open with two changed settings; then
+the same feed with the Command view column), the Library column in list, grid,
+mixed-kind, and batch states, the Activity popover over those jobs and idle, the
+composer with the boards' sample prompt and an in-test image attached
+(Image ▸ Generate and Vision ▸ Find), the Analyze board (Vision ▸ Find over a
+1024×1024 in-test image with a seeded `vision ground` document, and
+Audio ▸ Transcribe with a synthesized recording and a timestamped transcript),
+Chat with the boards' sample thread, Music ▸ Realtime mid-session (a run the
+process seam holds open, fed the CLI's frame progress and steering echoes, with
+its recording synthesized on disk), Video ▸ Subjects at each stage of a seeded
+three-subject project, and Models ▸ Installed with a scripted model inventory
+(`model list`, `capabilities`, `storage`, `info`, `runtime get`, and
+`adapter list` answered from fixtures, plus Library rows for usage, a quality
+gate, a benchmark, and a running composer pull). It is skipped unless
 `MERERUN_STUDIO_SNAPSHOT_DIR` names a directory, so CI and a plain `swift test`
 never render anything:
 
@@ -555,19 +653,28 @@ never render anything:
 MERERUN_STUDIO_SNAPSHOT_DIR=/tmp/shell-shots swift test --filter StudioSnapshotTests
 ```
 
-`StudioSnapshotRenderer` hosts each view in an `NSWindow` that is never ordered
+`StudioUITests/StudioSnapshotRenderer` hosts each view in an `NSWindow` that is
+never ordered
 on screen and captures it with `cacheDisplay`, so nothing appears on the Mac
 running it. The controller uses a process runner that refuses every launch
-(answering only the sidebar's status probe; for the Main board and Realtime
-renders it holds the generation, pull, or session launches open, and for the
-Main board and Models renders it answers the scripted `model list` and
-`capabilities` commands) and
-the Library is a temporary `library.json` seeded with fixture rows, so no CLI
-process starts and the user's Library is never read or written. Two fidelity
-gaps are deliberate: macOS 26 glass and scroll-edge effects only composite on
-screen, so the renderer lifts glass content out and hides those effects (the
-sidebar and toolbar draw as plain views), and the window keeps an opaque title
-bar because a transparent one blanks every offscreen `ScrollView`.
+(answering only the sidebar's status probe; for the fidelity renders it holds
+the generation, pull, or session launches open and answers the scripted
+inventory and readiness commands) and the Library is a temporary `library.json`
+seeded with fixture rows, so no CLI process starts and the user's Library is
+never read or written. Two fidelity gaps are deliberate: macOS 26 glass and
+scroll-edge effects only composite on screen, so the renderer lifts glass
+content out and hides those effects (the sidebar draws as a plain view), and the
+window keeps an opaque title bar because a transparent one blanks every
+offscreen `ScrollView`.
+
+The harness renders reliably but is not yet run-to-run reproducible: six boards
+— the composer, Realtime, Activity, Models, Plugins, and Subjects — draw elapsed
+time and relative dates, so re-rendering the same commit changes about twenty of
+the sixty-seven shots. Treat it as a tool for looking at a surface, not as a
+comparison gate; it cannot tell a real regression from the clock until those
+strings are frozen.
+
+## Packaging, updates, and support
 
 The public `scripts/build_mere_run_app.sh` path produces a contributor/CI app
 bundle and verifies its nested-code layout. Maintainer-only Developer ID

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -86,10 +86,12 @@ The macOS app product is intentionally outside the Linux target.
 
 ## Launch the macOS studio
 
-The Studio is a prompt-first interface for the CLI you built. It provides one
-canvas, one prompt bar, and a local library of generated artifacts. Open
-**Advanced** to see the exact command behind a generation. Launch the Studio
-from a checkout:
+The Studio is a prompt-first interface for the CLI you built. The sidebar
+lists fifteen domains, each domain has its tasks in a control at the top of the
+page, and a prompt task gives you one composer, a feed of your runs, and a local
+library of generated artifacts. Press ⌥⌘C to see the exact command behind a
+generation, or open the Command Console (Help ▸ Command Console) to run any
+`mere.run` command. Launch the Studio from a checkout:
 
 ```bash
 app_path="$(./scripts/build_mere_run_app.sh debug)"

--- a/docs/internals/source-layout.md
+++ b/docs/internals/source-layout.md
@@ -65,10 +65,12 @@ The public executable target.
 
 Exercise product Linux compatibility through this target.
 
-### `MereRunApp`
+### `StudioKit`, `StudioUI`, `MereRunApp`
 
-The optional SwiftUI Studio target. It stays macOS-only and must not become a
-Linux compatibility dependency.
+The optional Studio, in three targets under `apps/macos/`: `StudioKit` is the
+SwiftUI-free model layer, `StudioUI` holds every view, and `MereRunApp` is the
+`mere.run.app` executable that composes them. All three stay macOS-only and must
+not become Linux compatibility dependencies.
 
 ## Tests
 

--- a/docs/macos-deep-links.md
+++ b/docs/macos-deep-links.md
@@ -59,8 +59,8 @@ maintained client emits receipts under another source name, add a source case
 and contract tests.
 
 MereRun validates the receipt and referenced artifact, deduplicates repeated
-handoffs, records the completed result through its own Library store, activates
-the matching workspace, reveals Library, and selects the imported row. The
+handoffs, records the completed result through its own Library store, opens the
+domain the row belongs to, reveals Library, and selects the imported row. The
 caller must not read or write `library.json` directly.
 
 ## Local and security boundaries

--- a/docs/macos-studio-capability-review.md
+++ b/docs/macos-studio-capability-review.md
@@ -1,30 +1,84 @@
-# macOS Studio capability review
+# macOS Studio capability coverage
 
-This review compares the public CLI command tree against the surfaces macOS
-Studio owns, and identifies every capability that has not been brought to the
+## The policy
+
+Every capability the CLI declares is filed under exactly one **domain** and
+reached at a **task** inside it. Coverage is that mapping, not a count of
+bespoke views.
+
+Three things follow from it.
+
+1. **A capability's home is never in question.** `CommandTemplateID.studioDomain`
+   (`apps/macos/StudioKit/StudioNavigation.swift`) is an exhaustive mapping from
+   every command template to one of the fifteen
+   domains, so a Library row files where the work was done and a command is
+   always somewhere a person can name.
+2. **Designed surfaces are a deliberate subset.** Some capabilities have a task
+   built for what they actually produce — the Analyze canvas draws detection
+   boxes over the picture, Video ▸ Subjects is a three-stage board, Models ▸
+   Installed is a list and detail. Most do not, and that is a decision about
+   where the effort goes, not a gap in reachability.
+3. **The Command Console is the guaranteed home.** It renders any capability
+   from `MereRunCapabilityCatalog`: the option's `kind` picks the control, its
+   `choices` fill the picker, its `depends_on` gates the row, and the "Will run"
+   block is built from the same values. Nothing has to be written for a new
+   command. The day the contract declares one, the console can run it.
+
+What that retires is the earlier reading of "first class", recorded in the audit
+below: that every command must have a dedicated workspace, which in v1 was built
+as a dedicated modal sheet per command. Twenty-two sheets and a second
+navigation system in the sidebar footer were the cost.
+[macOS Studio v2](./macos-studio-v2.md) keeps the coverage goal and drops that
+reading.
+
+## What is enforced today
+
+| Guard | Where | What it proves |
+|---|---|---|
+| `everyPublicCLICommandIsCatalogedOrExplicitlyExempt` | `Tests/MereRunCLITests/CapabilityCatalogTests.swift` | Every public CLI leaf command is either in the contract or in `contractExemptCommandIDs` with the reason it stays CLI-only. It also rejects a stale exemption, so the list cannot rot. |
+| `capabilityFlagsMatchArgumentParserHelp` | same file | Every flag the contract declares is one the command's ArgumentParser help accepts. |
+| `testEverySharedCLICapabilityHasAnAppOwnedSurface` | `apps/macos/StudioUITests/StudioTypesTests.swift` | Set equality between the app's capability IDs and the contract's, in both directions. |
+| `testEveryCommandTemplateMapsToADomain` | `apps/macos/StudioUITests/NavigationModelTests.swift` | Every command template files into exactly one domain, and every domain owns at least one command. |
+| `CommandContractGuardTests` | `apps/macos/StudioKitTests` | Every flag the app can emit, from a sweep of maximal drafts, is one the contract declares, under the subcommand path the contract names. |
+
+The chain is closed in both directions: a CLI command cannot ship without a
+contract entry or a recorded exemption, a contract entry cannot ship without an
+app surface, and an app surface cannot emit a flag the contract does not
+declare.
+
+One thing is deliberately *not* asserted: that each capability maps to a single
+named task. The domain mapping is total and tested; the task mapping is a design
+decision made surface by surface, and the console is what makes the absence of a
+task assertion safe.
+
+## Exemptions
+
+Thirty-one leaf commands stay CLI-only, each named in `contractExemptCommandIDs`
+with its reason: the twelve `executor` commands and `relay serve` (the Relay
+console owns node identity, placement, scheduling, and fleet telemetry), the
+fourteen `graph` commands (Graph Studio owns workflow authoring and execution,
+and the worker verbs are a machine-to-machine protocol), the three
+`vision image-to-3d` aliases (surfaced through the 3D domain as
+`image reconstruct-3d`), and `catalog` (it emits the contract that the shells
+compile against).
+
+---
+
+# Historical audit (August 2026)
+
+Everything below is the original review, preserved as the record of how the
+coverage gaps were found and closed. It describes v1 as it shipped: the counts
+are accurate for that moment, and the "workspace" language is the superseded
+reading. Do not read it as a description of the app today — see
+[`apps/macos/README.md`](../apps/macos/README.md) for that.
+
+This review compared the public CLI command tree against the surfaces macOS
+Studio owned, and identified every capability that had not been brought to the
 app as a first-class path.
 
 Reviewed at commit `5525608` against `Sources/MereRunCLI`,
 `Sources/MereRunContract/CommandCapabilityContract.swift`, and
 `apps/macos/MereRunStudio`.
-
-> **Superseded reading (September 2026).** This review's "first-class workspace
-> per command" requirement was implemented as a dedicated sheet per command.
-> [macOS Studio v2](./macos-studio-v2.md) keeps the coverage goal and replaces
-> that reading: every capability is a peer task inside its domain, and what
-> varies is the surface archetype the task declares, not whether it has its own
-> sheet. The findings and counts below describe v1 as shipped.
-
-> **Reachability closed; workspaces outstanding.** The contract now describes
-> 127 of the CLI's 158 leaf commands, every one has a Studio surface, and the
-> remaining 31 are named exemptions in `contractExemptCommandIDs` rather than
-> silent absences. `everyPublicCLICommandIsCatalogedOrExplicitlyExempt` walks
-> the CLI command tree itself, closing the unguarded link this review
-> identified, so no future command can go missing silently.
->
-> Each capability is also first class in this repo's sense: a dedicated
-> workspace with typed controls, result rendering, and the Library lifecycle,
-> rather than a generic form. See [What shipped](#what-shipped).
 
 ## Summary
 
@@ -74,11 +128,10 @@ Because the Studio gate is keyed to the contract rather than to the CLI, an
 omission at that first link propagates silently: the command ships, Studio
 never gets a surface, and every test still passes.
 
-`apps/macos/README.md` states the intent precisely:
-
-> The inverse coverage test also requires every command in the shared contract
-> to have an App-owned template or utility surface, so a newly cataloged CLI
-> command cannot silently ship without a macOS path.
+`apps/macos/README.md` stated the intent precisely: the inverse coverage test
+requires every command in the shared contract to have an app-owned template or
+utility surface, so a newly cataloged CLI command cannot silently ship without a
+macOS path.
 
 The guarantee holds only for a *cataloged* command. Cataloging is the manual
 step, and it is where these 26 commands were lost.
@@ -202,9 +255,8 @@ instead of copying those controls.
 
 **Aliases already covered — 3 commands.** `vision image-to-3d`,
 `vision image-to-3d-trellis2`, and `vision image-to-3d-multiview` are VFX
-aliases of the `image reconstruct-3d` family, which Studio surfaces through the
-3D Creation workspace. `apps/macos/README.md` states the intent: "Image-to-3D
-workflows share the Image workspace instead of being duplicated."
+aliases of the `image reconstruct-3d` family, which Studio surfaces once rather
+than twice.
 
 **Contract introspection — 1 command.** `mere.run catalog` emits the contract
 that Studio compiles against, so the app has no need to shell out for it.
@@ -238,20 +290,20 @@ that Studio compiles against, so the app has no need to shell out for it.
    as consuming an "89-command capability contract"; it now names the current
    127 and records the external boundaries as named exemptions.
 
-## Workspaces
+## Where the closed gaps live now
 
-Reachability and promotion are both done. Each capability owns a real surface.
+The v1 destinations named in this audit were renamed and re-hosted by v2. Their
+current addresses:
 
-| Capability | Surface |
-|---|---|
-| `geo` (4) | **Geospatial Lab**, a top-level destination. Per-engine controls, the required-tensor list shown before a run, preflight, and durable Library artifacts |
-| `model benchmark` (12) | **Health & Repair**. The whole family, including the fused Lite and Comprehensive suites, runs as durable Library jobs with revealable JSON reports |
-| `model location` (5) | **Models → Locations**. Writable store, read-only roots, and explicit bindings with live availability, a directory picker, Reveal in Finder, and confirmation before removal |
-| `speech listen` (1) | **Voice Studio → Listen Live**. Device enumeration, streaming partial transcripts, operator-owned stop, copy and save |
-| `vision serve` (1) | **Serving → Vision Grounding**. Preflight, start/stop/restart, process ownership, a loopback-exposure warning, and the live server log |
-| `plugin` info/run/rollback (3) | **Plugins**. Catalog details, out-of-PATH runs with forwarded arguments, and confirmed rollback to a retained signed bundle |
-| `config list` / `path` (2) | **Settings**. Masked stored values and the resolved config path with Reveal in Finder |
+| Capability | v1 destination | Today |
+|---|---|---|
+| `geo` (4) | Geospatial Lab, a sheet | **Earth** ▸ Flood, Fire, TESSERA, OlmoEarth |
+| `model benchmark` (12) | Health & Repair, a sheet | **Models ▸ Benchmarks**, beside **Models ▸ Health** |
+| `model location` (5) | Models → Locations, a nested sheet | **Models ▸ Locations** |
+| `speech listen` (1) | Voice Studio → Listen Live | **Audio ▸ Live** |
+| `vision serve` (1) | Serving → Vision Grounding | **Server ▸ Serving**, its Vision Grounding section |
+| `plugin` info/run/rollback (3) | Plugins, a sheet | **Plugins ▸ Catalog** |
+| `config list` / `path` (2) | Settings | **Settings ▸ Advanced** |
 
-The contract and the coverage guard made this possible: each workspace is built
-against a typed capability already proven to match CLI help, rather than a
-hand-copied argument list.
+Each was built against a typed capability already proven to match CLI help,
+rather than a hand-copied argument list — which is what made the move cheap.

--- a/docs/macos-studio-roadmap.md
+++ b/docs/macos-studio-roadmap.md
@@ -5,15 +5,19 @@ This page preserves a historical source review of `apps/macos/MereRunStudio`
 `Sources/MereRunCLI` and the bundling pipeline. The implementation update
 identifies which findings no longer describe the product.
 
-> **Implementation update (July 27, 2026):** This document preserves the original
-> pre-parity audit and sequencing rationale. The capability gaps in the
-> historical findings no longer describe the product. The app consumes the shared
-> machine-readable 127-command capability contract and has executable drift tests
-> for every local Advanced template. Studio provides typed Text, Image, Video,
-> Music, Speech, SFX, Vision/VFX, geospatial, adapter, run, world, setup, model,
-> model-location, plugin, benchmark, Open WebUI, and API workflows; Graph Studio
-> and Node remain explicit external boundaries, now recorded as named exemptions
-> in the CLI coverage test rather than as silent absences. Structured receipts, file pickers, validation, retry and
+> **Implementation update (September 2026):** This document preserves the
+> original pre-parity audit and sequencing rationale. The capability gaps in the
+> historical findings no longer describe the product, and neither does its
+> vocabulary: the Advanced surface, the sheets, and the mode header's lab
+> buttons were all retired by [macOS Studio v2](./macos-studio-v2.md), which
+> replaced them with domain-and-task navigation. The app consumes the shared
+> machine-readable 127-command capability contract and has executable drift
+> tests for every template it can run. Studio provides typed text, image, video,
+> music, speech, sound, vision and VFX, Earth-observation, adapter, run, world,
+> setup, model, model-location, plugin, benchmark, Open WebUI, and API
+> workflows; Graph Studio and Node remain explicit external boundaries, now
+> recorded as named exemptions in the CLI coverage test rather than as silent
+> absences. Structured receipts, file pickers, validation, retry and
 > resume controls are implemented. See
 > [`apps/macos/README.md`](../apps/macos/README.md) for the
 > implemented surface. On July 27, 2026, the release pipeline produced a Developer

--- a/docs/macos-studio-v2.md
+++ b/docs/macos-studio-v2.md
@@ -6,6 +6,110 @@ Reviewed on September 3, 2026 against `main` at `1ef4fda3` (v0.50.0).
 prompt-to-result loop, the nineteen specialist workspaces, and the code
 architecture, each read in full.
 
+## Status
+
+Fifteen pull requests carried the plan. The Studio is now three targets —
+`StudioKit` (20,711 lines, no SwiftUI), `StudioUI` (31,112 lines), and a
+323-line `MereRunStudio` executable — with a 14,631-line test suite split the
+same way. `MereRunRootView.swift` and its 5,500 lines of Advanced forms are
+gone, and nothing is presented as a sheet except three true task sheets. What
+follows records what shipped, in which pull request, and what did not.
+
+### Shipped
+
+| # | Pull requests | Notes |
+|---|---|---|
+| A0 | [#406](https://github.com/sawfwair/mere-run/pull/406) | The argv builder is checked against the contract from maximal drafts; the three drifted flags were added to the contract |
+| A1 | [#407](https://github.com/sawfwair/mere-run/pull/407) | `Job`, `JobStore`, `JobLane`, `ArtifactResolver`, `ProcessRunner` under `Jobs/` |
+| A2 | [#410](https://github.com/sawfwair/mere-run/pull/410) | `utilityCommandResult`, readiness, and `status --json` are lane jobs; `Process()` is confined to `Jobs/ProcessRunner.swift` and `CLIBootstrapInstaller` |
+| A4 | [#408](https://github.com/sawfwair/mere-run/pull/408), [#416](https://github.com/sawfwair/mere-run/pull/416) | Landed as two pull requests, not three: the shell and navigation first, then the v2 drawing of the sidebar, content header, composer, Models, and Realtime |
+| A5 | [#425](https://github.com/sawfwair/mere-run/pull/425) | Views observe a `Job` by id; the Activity popover replaced the machine-facts popover; the global running overlay is gone |
+| A6 | [#408](https://github.com/sawfwair/mere-run/pull/408), [#429](https://github.com/sawfwair/mere-run/pull/429) | Library scope and row-to-domain switching, then per-task drafts and their `studio.drafts` scene memory. The Welcome sheet became a one-time banner in #408 |
+| B1 | [#425](https://github.com/sawfwair/mere-run/pull/425), [#428](https://github.com/sawfwair/mere-run/pull/428) | The inspector replaced the Options popover first, then was rebuilt to render from the contract's `group`, `tier`, `range`, `depends_on`, and `default_value` |
+| B2 | [#416](https://github.com/sawfwair/mere-run/pull/416) | Attachment well from `StudioComposerSchema`; the free-text Model field is gone |
+| B3 | [#425](https://github.com/sawfwair/mere-run/pull/425) | Feed canvas with generation, running, queued, failed, and readiness cards |
+| B4 | [#429](https://github.com/sawfwair/mere-run/pull/429) | Grid, kind filter, favorites, real thumbnails, batches, and visible output folders with prompt-derived names |
+| B5 | [#425](https://github.com/sawfwair/mere-run/pull/425) | Thread list, per-turn model, Code as a preset, Branch |
+| C1 | [#425](https://github.com/sawfwair/mere-run/pull/425) | `StudioAnalyzeSchema` declares the Analyze surface per task; the five input-first prompt tasks render it |
+| C2 | [#418](https://github.com/sawfwair/mere-run/pull/418), [#427](https://github.com/sawfwair/mere-run/pull/427), [#431](https://github.com/sawfwair/mere-run/pull/431) | Option metadata, `--receipt`, `--progress-json`, then the declared outputs reconciled with what the commands write |
+| C4 | [#416](https://github.com/sawfwair/mere-run/pull/416), [#425](https://github.com/sawfwair/mere-run/pull/425) | Music ▸ Realtime as the Session shape and Video ▸ Subjects as the Project shape |
+| C5 | [#432](https://github.com/sawfwair/mere-run/pull/432) | `CommandFlags` generated from the contract, `ArgumentBuilder`, `Catalog/` per category; `arguments(from:)` and `defaultDraft()` deleted |
+| C6 | [#428](https://github.com/sawfwair/mere-run/pull/428), [#430](https://github.com/sawfwair/mere-run/pull/430) | The Command view groups by the contract; the Command Console is `ContractForm` over any capability; `MereRunRootView.swift` deleted and Settings moved |
+| C7 | [#424](https://github.com/sawfwair/mere-run/pull/424) | `ArtifactResolver` prefers the receipt; the 350 ms poll runs only for commands that print none |
+| D1 | [#434](https://github.com/sawfwair/mere-run/pull/434) | `StudioKit` / `StudioUI` / `MereRunStudio`, plus `StudioKitTests`, `StudioUITests`, and a shared `StudioTestSupport`. A move-and-declare refactor: cross-boundary declarations are `package`, nothing became `public`, and all 559 tests still run |
+| D2 | [#416](https://github.com/sawfwair/mere-run/pull/416), [#425](https://github.com/sawfwair/mere-run/pull/425), [#429](https://github.com/sawfwair/mere-run/pull/429) | The offscreen snapshot harness grew with the boards it renders rather than landing at once |
+| D3 | this pull request | Documentation |
+
+### Not shipped
+
+- **The app-lifetime serving monitor.** D1 split the targets but left the
+  monitor where it was: `StudioServingMonitor` is a `@StateObject` inside
+  `StudioUI/StudioServingConsoleView.swift`, so it polls only while
+  Server ▸ Serving is on screen rather than for the life of the app.
+- **A reproducible snapshot gate.** D2's harness renders every board offscreen
+  and is what visual review runs on, but six boards draw elapsed time and
+  relative dates, so about twenty of the sixty-seven shots differ between two
+  renders of the same commit. It is a tool for looking at a surface, not a
+  comparison gate, until those strings are frozen.
+- **The `StudioTask` protocol and six archetype shells.** `StudioTask` shipped
+  as an enum of 54 tasks in `StudioKit/StudioNavigation.swift`, not a protocol
+  with a
+  `Draft` type, `requests(from:)`, and registered renderers. Three shells exist
+  in practice — the prompt workspace, the Analyze canvas, and the Converse
+  surface — and the rest of the tasks host their v1 views inline.
+- **A3, the Library write-through.** `JobStore` does not write Library rows.
+  `StudioUI/StudioRootView.swift` still keeps them current from
+  `controller.runCompletions` and `controller.jobs.events`.
+- **The controller's foreground mirror.** A5 planned to delete it. `logs`,
+  `isRunning`, `liveOutputText`, `currentProgress`, and `lastOutputURL` are
+  still published, because the Command Console window and several re-hosted
+  views read them.
+- **Contract metadata beyond the prompt modes.** 14 of the 127 capabilities
+  populate `group` and `tier` on every option, and the contract test requires it
+  of those 14 only. Every other capability's options fall to the "Options" group
+  and the `standard` tier, so the Console renders them as one flat list with
+  nothing folded under an Advanced disclosure.
+- **An editable Command view.** The Command view column lists the run's options
+  read-only over the argv preview; the chips and the inspector are what edit
+  them. The Console's form is editable, so a value no `StudioDraft` field
+  carries is set there.
+- **Purging CLI plumbing from the designed surfaces.** B1 said preflight, the
+  JSON report, timings, and their siblings would live in the Command view only.
+  They are declared `expert` in the contract instead, so they sit in the
+  inspector's collapsed "Advanced · N more" fold — out of the way, but still in
+  the inspector.
+- **A complete inspector for every prompt mode.** The inspector renders only the
+  flags `StudioKit/StudioContractSchema.swift`'s binding table maps to a
+  `StudioDraft` field, so a control can
+  never look live and change nothing. Read, Find, Segment, Track, and Code bind
+  between one and five flags, and their inspectors are correspondingly thin; the
+  rest of their options are reachable in the Command Console.
+- **A Command view on every task.** It is a column on the twelve prompt tasks
+  only. Every other task's Command toggle opens the Command Console window.
+- **C3, the Analyze migration.** `StudioKit/StudioAnalyzeSchema.swift` declares
+  an archetype for
+  22 tasks, and 5 render it: Vision ▸ Read, Find, Segment, Track and
+  Audio ▸ Transcribe. Vision ▸ Depth, Pose, Faces, Flow, Geometry, Live,
+  Audio ▸ Who Spoke, Enhance, Separate, Text ▸ Embeddings, Anonymize, the four
+  Earth tasks, and Sound ▸ Score and Condition still render their v1 lab forms
+  inside their tasks.
+- **A capability-to-task coverage test.** The guard asserts that the app's
+  capability set equals the contract's, that every public CLI leaf command is
+  cataloged or exempt, and that every command template maps to exactly one
+  domain (`testEveryCommandTemplateMapsToADomain`). Nothing asserts a mapping to
+  a single *task*; the Console is what guarantees every capability a home.
+- **`--receipt` and `--progress-json` everywhere.** `--receipt` is on 9
+  capabilities and `--progress-json` on 5. The native LTX video lanes and the
+  ACE-Step music pipeline expose no per-step callback and emit no progress
+  events; every other command keeps the `fileExists` fallback for its outputs.
+- **Release 2.0.** Not cut. This work is one Unreleased entry in `CHANGELOG.md`.
+
+The five decisions at the end of this document were resolved as written:
+Vision is one domain with ten tasks, Code is a Converse preset, the Library is a
+column, output goes to `~/Pictures`, `~/Music`, or `~/Documents` under
+`mere.run/<Domain>` by media kind, and training is a task inside Image, Chat,
+and Music.
+
 ## Verdict
 
 v1 is two products in one window. The first is the prompt-first Studio: a

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -207,7 +207,7 @@ mere.run model pull --all --accept-model-license
 Without that flag, a single-model pull and its preflight are blocked; `--all`
 skips restricted models. Restricted models never auto-download from an
 inference command. The macOS app presents the same explicit acceptance before a
-download and exposes the term links in its Models and Advanced views.
+download and exposes the term links in its Models pages.
 Batch downloads through `agent onboard --pull-recommended` skip restricted
 entries without acceptance, while `open-webui quickstart --pull`
 validates all configured models before downloading any; both accept the same

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -28,10 +28,10 @@ they do not maintain a second plugin registry.
 
 ## macOS Studio
 
-Open **Plugins** from the Studio sidebar or **View → Plugins**. The first-class
-workspace supports catalog search, installed and verified status, channel
-selection, repository access, copyable install commands, confirmed install or
-update, and the fixed plugin doctor operation. A custom catalog URL or local
+Open the **Plugins** domain in the Studio sidebar (Go ▸ Plugins). The page
+supports catalog search, installed and verified status, channel selection,
+repository access, copyable install commands, confirmed install or update,
+rollback to a retained signed bundle, and the fixed plugin doctor operation. A custom catalog URL or local
 JSON path is available for development.
 
 The UI calls the same `plugin list`, `plugin install`, and `plugin doctor`

--- a/docs/raycast.md
+++ b/docs/raycast.md
@@ -54,7 +54,8 @@ Raycast's **Uninstall Extension** action.
 Choose a command, enter its prompt in Raycast, and press Return. Raycast shows
 the CLI's most recent diagnostic while generation is active. After the command exits
 successfully and the output is readable, the extension imports the artifact,
-opens its owning MereRun workspace, reveals Library, and selects the imported row.
+opens the MereRun domain the row belongs to, reveals Library, and selects the
+imported row.
 
 Generated files are durable. By default they are written to
 `~/MereRun/Raycast` with a media-specific name and UTC timestamp, for example:

--- a/docs/repository-tour.md
+++ b/docs/repository-tour.md
@@ -62,14 +62,14 @@ To understand the CLI end to end, start with `Sources/MereRunCLI`.
 ### `apps/macos/StudioKit`, `apps/macos/StudioUI`, `apps/macos/MereRunStudio`
 
 The optional macOS studio, split into a SwiftUI-free model library
-(`StudioKit`), the views (`StudioUI`), and the executable that owns the
-scenes, menus, and Sparkle wiring (`MereRunStudio`). It does not own runtime
-behavior; it turns
-user-facing studio requests into `mere.run` arguments, launches the CLI as a
-child process, streams stdout and stderr, saves local library metadata, and keeps
-the raw command surface available in Advanced details.
+(`StudioKit`), the views (`StudioUI`), and the executable that owns the scenes,
+menus, and Sparkle wiring (`MereRunStudio`). It does not own runtime behavior;
+it turns user-facing studio requests into `mere.run` arguments, launches the CLI
+as a child process, streams stdout and stderr, saves local library metadata, and
+keeps the raw command surface available in the Command view and the Command
+Console, both rendered from the shared capability contract.
 
-Do not make this target part of Linux compatibility work. Linux contributors
+Do not make these targets part of Linux compatibility work. Linux contributors
 must validate the CLI and local API surfaces directly.
 
 ### `apps/ios`

--- a/docs/runtime/image.md
+++ b/docs/runtime/image.md
@@ -23,37 +23,32 @@ Dev, FLUX.2 Dev and Klein, HiDream O1, SenseNova U1.5, Krea 2, Qwen Image Edit
 
 ## macOS Studio
 
-The primary Create Image workspace covers text-to-image, image-to-image, and
-multi-reference editing. Its options include negative prompts, size and
-sampling, edit strength, HiDream aspect preservation, structured-prompt
-expansion, LoRA catalog IDs or local safetensors, Krea conditioning and
-quantization controls, preflight JSON, and JSON progress events.
+**Image ▸ Generate** covers text-to-image, image-to-image, and multi-reference
+editing. Its settings include negative prompts, size and sampling, edit
+strength, HiDream aspect preservation, structured-prompt expansion, LoRA catalog
+IDs or local safetensors, and Krea conditioning and quantization controls. The
+two to four settings that matter most sit as chips under the prompt; the rest
+are in the inspector (⌥⌘I), rendered from the capability contract.
 
-Create Image's **Create 3D** button opens the first-class reconstruction
-workspace. It provides single-image TripoSR and TRELLIS.2 PBR flows, ordered and
-reorderable 4/6-view InstantMesh inputs, every engine-specific runtime control,
-preflight, immutable output directories, manifest statistics, and embedded
-orbitable GLB/OBJ/PLY previews. Progress and every mesh, texture, voxel, and
-manifest artifact remain in Library.
+**Image ▸ Train** is the trainer: image-caption previews, Krea 2 and FLUX.2
+Klein recipes, memory and schedule controls, preflight, launch and resume, live
+loss charts, samples, checkpoints, history, and run comparison.
 
-Create Image's **Training** button opens the unified Training Studio with
-image-caption previews, Krea/Klein recipes, memory and schedule controls,
-preflight, launch/resume, live loss charts, samples, checkpoints, history, and
-run comparison. **Utilities** opens deterministic validation, dataset discovery
-candidate cards, and saved-plan preflight/materialization with durable paths.
+**Image ▸ Datasets** covers deterministic validation, dataset-discovery
+candidate cards, and saved-plan preflight and materialization with durable paths.
 
-**Advanced > Image** also exposes the public command family as guided forms:
+Reconstruction lives in the **3D** domain rather than under Image: single-image
+TripoSR and TRELLIS.2 PBR flows, ordered and reorderable 4- and 6-view
+InstantMesh inputs, every engine-specific runtime control, preflight, immutable
+output directories, manifest statistics, and embedded orbitable GLB, OBJ, and
+PLY previews. Progress and every mesh, texture, voxel, and manifest artifact
+stay in the Library.
 
-- Generation and editing with repeatable references, structured prompts, and LoRAs
-- Krea 2 and FLUX.2 Klein LoRA training, recipes, memory controls, checkpoints,
-  preview samples, schedules, benchmarks, and the live dashboard;
-- Dataset discovery, saved-workflow preflight, materialization, execution, and
-  durable-run visualization
-- Deterministic image-stack validation
-- TripoSR, TRELLIS.2, and four-view or six-view InstantMesh reconstruction
-
-The app launches the public CLI for all work. `mere.run catalog --json` and the
-shared contract tests keep every form flag aligned with ArgumentParser help.
+The **Command view** (⌥⌘C) shows the exact command any of these settings build,
+and the **Command Console** window runs any image command the contract declares,
+including the ones with no designed surface. The app launches the public CLI for
+all work. `mere.run catalog --json` and the shared contract tests keep every form
+flag aligned with ArgumentParser help.
 
 ## Model families
 
@@ -302,7 +297,7 @@ surface.
 
 Klein resume restores the selected adapter checkpoint before the next optimizer
 step. Krea 2 rejects `--resume-from` explicitly instead of silently starting
-another run. Training Studio discovers checkpoint artifacts beside a prior output
+another run. Image ▸ Train discovers checkpoint artifacts beside a prior output
 and sends the same public flag.
 
 ```bash

--- a/docs/runtime/model-management.md
+++ b/docs/runtime/model-management.md
@@ -90,14 +90,15 @@ remove registrations. Both operations preserve every payload byte.
 
 ## macOS Studio
 
-Open **Models**, switch the scope to **All**, and select any missing model to
-download it directly. Studio streams the underlying `model pull` output, keeps
-canceled partial downloads resumable, and refreshes the inventory after a
-successful install. Models with restricted third-party terms show their source
-links and require **Accept & Download** before transfer. Continuing confirms
-that you reviewed and accept the listed terms and agree to comply. The
-**Files** button opens the configured model store in Finder; it does not start
-a download.
+Open **Models ▸ Installed** and use **Pull…** to pick any model that is not
+installed yet and download it directly. Studio streams the underlying
+`model pull` output, keeps canceled partial downloads resumable, and refreshes
+the inventory after a successful install. Models with restricted third-party
+terms show their source links and require an explicit acceptance
+(**Accept & Pull** here, **Accept & Download** when a pull starts from a
+composer's readiness card) before transfer. Continuing confirms that you
+reviewed and accept the listed terms and agree to comply. **Open model store in
+Finder** opens the configured store; it does not start a download.
 
 ## Canonical model IDs
 
@@ -382,7 +383,7 @@ The report identifies healthy manifests, proposed or completed writes, absent
 model directories, and write errors without treating models that were never
 installed as damaged.
 
-In macOS Studio, open **Models → Health**. The workspace presents the structured
+In macOS Studio, open **Models ▸ Health**. The page presents the structured
 manifest audit, confirms repair before writing, and runs `mere.run gate` suites
 as durable Library jobs. Correctness suites can be selected independently,
 strict performance thresholds are opt-in, and baseline replacement requires a

--- a/docs/runtime/music.md
+++ b/docs/runtime/music.md
@@ -21,16 +21,19 @@ vocoder stack locally; Magenta RT2 takes CC knobs while it is still generating.
 | `mere.run music separate` | Separate stems or restore audio with native BS/MelBand RoFormer models. |
 | `mere.run music transcribe` | Transcribe a full music mix into instrument-separated MIDI with MuScriptor. |
 
-The macOS Studio app exposes its music workflows through first-class
-workspaces backed by `MereRunContract`. Its primary Music composer covers the
-production loop: create or edit, source or reference audio, quality and language-model (LM)
+The macOS Studio app exposes its music workflows through the **Music**
+domain, backed by `MereRunContract`. **Music ▸ Compose** covers the production
+loop: create or edit, source or reference audio, quality and language-model (LM)
 planning, ranked candidates, adapter stacks, stems, LRC, recipes, and DAW
-export. **Music Tools** provides structured audio analysis, MuScriptor controls
-and an embedded MIDI piano roll, plus resident-server start/stop and health.
-**Real-time** owns Magenta playback and MIDI steering. **Training Studio** owns
-LoRA/LoKr dataset inspection, launch, metrics, and run comparison. Advanced
-remains available for raw command-level control. App-to-CLI tests reject any
-emitted flag absent from `mere.run catalog --json`.
+export. **Music ▸ Analyze** provides structured audio analysis and
+**Music ▸ Transcribe** the MuScriptor controls with an embedded MIDI piano roll;
+the resident server's start, stop, and health live under **Server ▸ Music
+server**. **Music ▸ Realtime** owns Magenta playback and MIDI steering, with the
+transport, the recording's waveform, and Prompt A/B steering sent over the CLI's
+stdin protocol. **Music ▸ Train** owns LoRA/LoKr dataset inspection, launch,
+metrics, and run comparison. **Music ▸ Separate** shares the restoration surface
+with Audio. The Command Console remains available for raw command-level control.
+App-to-CLI tests reject any emitted flag absent from `mere.run catalog --json`.
 
 ## Model family
 
@@ -375,8 +378,9 @@ Kronecker evaluation instead of materializing full decoder deltas. Train either
 format with `music train-adapter`; its objective matches ACE-Step flow
 matching, and its output is directly reloadable by `music generate` or the
 resident server. Adapter training writes the same durable `run_started`,
-per-step loss/progress, `run_finished`, and `run_failed` event stream used by
-Training Studio, so a music run has live feedback and survives app relaunch.
+per-step loss/progress, `run_finished`, and `run_failed` event stream the
+Studio's Train tasks read, so a music run has live feedback and survives app
+relaunch.
 
 `music serve` holds the complete pipeline and its adapters in memory. It
 provides `GET /health`, `POST /v1/audio/music`, and serialized

--- a/docs/runtime/sfx.md
+++ b/docs/runtime/sfx.md
@@ -25,14 +25,16 @@ on-screen action.
 - `sfx-woosh-vflow-8s`
 - `sfx-mmaudio-large-44k-v2`
 
-## macOS SFX Lab
+## macOS Studio
 
-The Sound FX workspace opens **SFX Lab**, a dedicated surface for all six
-command families. It provides text generation and video-synchronized Foley,
-renoise and negative-conditioning controls, text-conditioning export, Woosh-AE
-encode/decode, and CLAP prompt/audio scoring. Generated audio and source video
-are reviewable in place. Encoded NPY results show their data type, shape, NumPy
-version, layout, and size. Progress and every output remain durable in Library.
+The **Sound** domain covers all six command families. **Sound ▸ Generate** is
+the prompt task for text-to-audio and **Sound ▸ Video Foley** synchronizes to a
+clip; **Condition**, **Encode**, **Decode**, and **Score** cover
+negative-conditioning and renoise controls, text-conditioning export, Woosh-AE
+encode and decode, and CLAP prompt and audio scoring. Generated audio and source
+video are reviewable in place. Encoded NPY results show their data type, shape,
+NumPy version, layout, and size. Progress and every output stay durable in the
+Library.
 
 ## Writing prompts
 

--- a/docs/runtime/speech.md
+++ b/docs/runtime/speech.md
@@ -34,21 +34,26 @@ the audio does not leave the machine.
 
 - `speech-diarization-sortformer` (NVIDIA Streaming Sortformer v2.1, up to four speakers)
 
-## macOS Voice Studio
+## macOS Studio
 
-The Speak and Listen workspaces expose **Voice Studio** as the purpose-built
-speech surface. It covers styled and reference/profile-cloned synthesis,
-reference recording, reusable profile create/list/delete, streaming chunk
-controls and feedback, A/B playback of recent renders, backend/task/language
-selection, transcription, and an editable transcript that can be saved as a
-durable artifact. Runs use the public CLI contract and stay in Library.
+Speech is split across two domains. **Voice ▸ Speak** is the prompt task for
+synthesis, with **Voice ▸ Clone** and **Voice ▸ Voices** covering styled and
+reference-cloned synthesis, reference recording, reusable profile create, list,
+and delete, streaming chunk controls and feedback, A/B playback of recent
+renders, and backend, task, and language selection.
+
+**Audio ▸ Transcribe** shows the timestamped transcript beside the recording's
+waveform, with a Timeline and a raw JSON view, and saves the transcript as a
+durable artifact. **Audio ▸ Who Spoke** is `speech diarize`, with an audio
+picker, the managed Sortformer default, JSON and RTTM timelines, and
+segment-tuning controls. **Audio ▸ Live** is `speech listen`: it enumerates
+capture devices through the CLI and streams partial transcripts as the
+recognizer emits them, with an operator-owned stop. Every run uses the public
+CLI contract and stays in the Library.
 
 The packaged app declares `NSMicrophoneUsageDescription` and signs both the app
 and embedded CLI with the audio-input entitlement. Recording is local; granting
 microphone access does not enable a network upload path.
-
-The app's Advanced command catalog also exposes **Diarize speakers** with an
-audio picker, managed Sortformer default, and durable JSON output in Library.
 
 ## Typical workflows
 

--- a/docs/runtime/text.md
+++ b/docs/runtime/text.md
@@ -19,16 +19,18 @@ redaction.
 ## macOS Studio
 
 The macOS app compiles against the same `MereRunContract` emitted by
-`mere.run catalog --json`. Chat's Options panel exposes text versus constrained
-`json_object` output, model-default/show/disable reasoning, context and sampling
-controls, key-value (KV) quantization, a catalog adapter ID or local LoRA file, tool
-permissions, preflight, and installed-model enforcement. **Utilities** turns
-Embeddings into a vector explorer with dimensions, norms, previews, and cosine
-similarity, and turns Anonymize into original/protected text review with labeled
-PII spans. **Training** opens a text-dataset preview, preflight, live metrics,
-artifacts, history, and comparison workspace for native LoRA. Advanced retains
-guided raw forms; every generated flag is checked against public ArgumentParser
-help in the repository gate.
+`mere.run catalog --json`. **Chat ▸ Chat**'s inspector exposes text versus
+constrained `json_object` output, model-default, show, or disable reasoning,
+context and sampling controls, key-value (KV) quantization, a catalog adapter ID
+or local LoRA file, tool permissions, preflight, and installed-model
+enforcement, rendered from the contract's own option metadata.
+**Text ▸ Embeddings** is a vector explorer with dimensions, norms, previews, and
+cosine similarity; **Text ▸ Anonymize** shows original and protected text with
+labeled PII spans. **Chat ▸ Train** opens a text-dataset preview, preflight,
+live metrics, artifacts, history, and run comparison for native LoRA. The
+Command view and the Command Console keep the raw command surface; every
+generated flag is checked against public ArgumentParser help in the repository
+gate.
 
 ## Model families
 

--- a/docs/runtime/video.md
+++ b/docs/runtime/video.md
@@ -26,24 +26,25 @@ emitted by:
 mere.run catalog video.generate --json
 ```
 
-The primary Video composer exposes independent quality and output choices,
+**Video ▸ Generate** exposes independent quality and output choices,
 text-to-video, a start image, an end keyframe, source-audio A2V with segment
 offset and modality guidance, duration or frame-count targeting, negative
 prompts, Wan controls, preflight, and timing receipts. Attaching source audio
 selects final quality plus synchronized audio-video output automatically.
 
-Video's **SCAIL** button opens a first-class Subject Studio. It authors one to
-six reference subjects with text, box, and point selectors; previews palette-safe
-SAM 3.1 masks; tracks the complete driving clip; accepts immutable keyframe
-corrections or painted binary masks; and shows reference, driving, contact-sheet,
-and result playback together. Animation/replacement semantics, trim range,
-dimensions, profile, adapter, seed, segmentation/overlap, tail, audio, output,
-and preflight controls map directly to the public CLI contract. Every mask and
-animation run remains live and restartable in Library.
+**Video ▸ Subjects** is the SCAIL subject flow, laid out as a three-stage board
+(Plan → Track → Animate). It authors one to six reference subjects with text,
+box, and point selectors; previews palette-safe SAM 3.1 masks; tracks the
+complete driving clip; accepts immutable keyframe corrections or painted binary
+masks; and shows reference, driving, contact-sheet, and result playback
+together. Animation and replacement semantics, trim range, dimensions, profile,
+adapter, seed, segmentation and overlap, tail, audio, output, and preflight
+controls map directly to the public CLI contract. Every mask and animation run
+stays live and restartable in the Library.
 
-**Advanced Video** provides typed controls for Cosmos3 generation and action modes, raw
-mask-plan execution, LTX latent export, and resident LTX sessions. Raw arguments
-are an escape hatch, not the capability contract.
+Cosmos3 generation and action modes, raw mask-plan execution, LTX latent export,
+and resident LTX sessions have no designed surface; they run from the **Command
+Console**, which builds their form from the same capability contract.
 
 ## Model family
 

--- a/docs/runtime/vision.md
+++ b/docs/runtime/vision.md
@@ -47,18 +47,20 @@ mesh. The runtime provides 19 commands that run on your machine.
 | `mere.run vision image-to-3d-multiview` | VFX alias for native 4/6-view InstantMesh reconstruction. |
 
 The macOS Studio app exposes the same surface through its shared capability
-contract. Read Image remains the fast caption/inspection entry point. Its
-**Vision Lab** button, also present in Find, Segment, and Track, opens a
-workspace for live camera tracking, Buffalo-L detection, embedding, comparison,
-batch analysis, native pose and optical flow, video depth, and single-view or
-multi-view geometry. The Lab draws native face and pose overlays and
-direction-colored flow vectors, plays annotated/depth video, embeds orbitable
-point clouds, reports request-scoped progress, and preserves structured and
-visual sidecars in Library.
+contract, as the ten tasks of the **Vision** domain. **Read**, **Find**,
+**Segment**, and **Track** show the answer beside the input: boxes drawn over
+the picture, masks composited on it, track spans under the video's scrubber, and
+the raw result document one segment away. **Depth**, **Pose**, **Faces**,
+**Flow**, **Geometry**, and **Live** cover video depth, native pose and optical
+flow, Buffalo-L detection, embedding, comparison and batch analysis, single- and
+multi-view geometry, and live camera tracking; they draw native face and pose
+overlays and direction-colored flow vectors, play annotated and depth video,
+embed orbitable point clouds, report request-scoped progress, and preserve
+structured and visual sidecars in the Library.
 
-Advanced retains typed forms for every command and raw-argument escape hatches.
-Image-to-3D commands live in the Image workspace so the app has one canonical
-reconstruction flow.
+The Command view (⌥⌘C) and the Command Console show and run the raw command for
+any of them. Image-to-3D commands live in the **3D** domain so the app has one
+canonical reconstruction flow.
 
 ## Model families
 

--- a/docs/runtime/world.md
+++ b/docs/runtime/world.md
@@ -13,9 +13,9 @@ native Swift/MLX backends:
 - `cosmos3`: the official Cosmos3-Edge checkpoint with learned action
   conditioning and the `camera_pose` action domain
 
-The macOS Studio app exposes the same resident server in **Advanced > Operations**
-with typed backend, model, state-directory, warmup, host, port, and
-authentication controls. API keys are injected with `MERERUN_API_KEY` so they
+The macOS Studio app has no designed surface for this server; it runs from
+the **Command Console**, which builds typed backend, model, state-directory,
+warmup, host, port, and authentication controls from the capability contract. API keys are injected with `MERERUN_API_KEY` so they
 do not appear in the child process argument list.
 
 ## Commands


### PR DESCRIPTION
Step D3 of [macOS Studio v2](../blob/main/docs/macos-studio-v2.md). Documentation
only; no Swift changed. Rebased onto #434, so the three-target split is part of
what this describes and every cited file path is at its post-split location.

Fourteen pull requests rebuilt the Studio, and every document that describes it
was left describing some earlier layer. `apps/macos/README.md` had accreted a
paragraph per pull request, so it introduced the domain-and-task shell and then,
three hundred lines later, the Advanced surface and the sheets that shell
replaced. `PRODUCT.md` sent CLI-fluent users to Advanced. `DESIGN.md` named
motion the theme does not define. The capability review's central requirement —
a dedicated workspace per command — is the policy v2 retired, and it read as
current.

I read the code before writing each sentence, rather than the plan.

## `apps/macos/README.md`

Rewritten as one description of one app. It opens with the three targets #434
left behind — `StudioKit` (20,711 lines, no SwiftUI, every rule in it
unit-testable), `StudioUI` (31,112 lines of views), and a 323-line
`MereRunStudio` executable that only composes them — and notes that each
declarative schema sits in StudioKit beside the view that draws it in StudioUI,
which is what makes a surface's rules testable without rendering it. Then the
fifteen domains and fifty-four tasks, the three shapes a task takes, the composer and the feed, the Analyze
canvas and what still renders a v1 form beside it, the contract-rendered
inspector, Command view, and Command Console, the job lanes and the Activity
popover, receipts-based artifact resolution, the visible output folders, the
per-domain capability material folded into one section instead of three, the
coverage guards, and the snapshot harness.

False claims found and removed:

- system pages open as sheets — they are pages; three sheets remain (mask editor,
  Pull… catalog, Guide) and the rest of the interruptions are alerts
- "first-class workspace" per command, and the Lab/Studio/Tools/Center naming
- the Advanced surface as a place, and `MereRunRootView.swift` as a file
- "a Command view on every task" — it is a column on the twelve prompt tasks;
  every other task's ⌥⌘C opens the Command Console window
- "rename behind a dialog" for Library rows — it is in place (the thread list
  still uses an alert)
- the chip strip showing "two to four" essentials — Code, Transcribe, and Find
  show one
- Models' scope switch and **Files** button — the catalog moved into **Pull…**
  and the button is **Open model store in Finder**
- Open WebUI and `world serve` as sections of Server ▸ Serving — they are
  console-only templates
- the snapshot harness as a comparison gate — it renders reliably, but six
  boards draw elapsed time and relative dates, so about twenty of the
  sixty-seven shots differ between two renders of the same commit (#434's
  finding). The README and the plan's status section now say it is a tool for
  looking at a surface, not a gate.

## `PRODUCT.md`

Verified each principle against the code. "Native first" no longer claims thin
material toolbars (the window toolbar is empty by design; the header is in the
content column). "Prompt-first, depth on demand" names the inspector, Command
view, and console instead of Options and Advanced. Added three principles the
shipped app now earns: one navigation, work in flight visible in one place, and
results as named files in a findable folder. The v1.0 success criterion is
replaced — the app is signed, notarized, and shipping. Reduce Motion is stated
honestly: honored in the shell, the feed, and the Models progress sweep, not on
hover and press. The Reduce Transparency claim is gone; nothing reads it.

## `DESIGN.md`

Adds the boards vocabulary (Main, Analyze, Converse, Command, Library, Models,
Realtime, Subjects, Activity — the 1440×900 mockups the snapshot harness renders
against), the `StudioLayoutPolicy` measurements, and an accessibility section.
Corrections against `MereRunTheme.swift` and the control files: the radius scale
has seven steps (12pt `popover` was missing); motion is `easeOut(0.15)`,
`easeOut(0.22)`, and two springs, not `.snappy`; there are no `variableColor` or
`bounce` symbol effects, only the audio player's `.replace`; `.mereSecondary`
exists and is used 72 times while `.bordered` survives in the v1 forms;
`MereIconButtonStyle`, `mereHoverRow`, `merePanel`, `mereFocusRing`, and
`mereMediaFrame` were undocumented; the footer pill is two lines; the segmented
control shows five segments plus More past six tasks, not six plus More; the
sidebar is 200/212/300 and resizable; the raw command form's flag column is 150pt
in the Command view and 168pt in the console, and its "Will run" block is radius
8; and the video frame treatment applies on the Analyze board only.

## `docs/macos-studio-capability-review.md`

New framing at the top — every capability files under exactly one domain,
designed surfaces are a deliberate subset, and the Command Console is the
guaranteed home rendered from the contract — plus a table of what the guards
actually prove and the one thing they deliberately do not (no capability-to-task
assertion). The August audit is preserved verbatim under a `# Historical audit`
heading that says not to read it as a description of the app. Its closing table
now maps each closed gap to where it lives today.

## `docs/macos-studio-v2.md`

A status section recording each sequence step, the pull requests that carried it,
and what did not ship: the `StudioKit`/`StudioUI` split; the `StudioTask`
protocol and its six archetype shells; the Library write-through into `JobStore`;
the controller's foreground mirror; contract `group`/`tier` metadata beyond the
fourteen prompt-mode capabilities; an editable Command view; a Command view on
non-prompt tasks; the Analyze migration for seventeen of the twenty-two declared
tasks; a capability-to-task coverage test; the app-lifetime serving monitor
(`StudioServingMonitor` is still a `@StateObject` inside the Server page, so it
polls only while that page is on screen); a reproducible snapshot gate; and
release 2.0. D1 moved into Shipped against #434.

## `CHANGELOG.md`

User-facing notes under Unreleased ▸ macOS: the new navigation, no more modal
sheets, the results feed, the inspector, named files in visible folders, the
Library grid and favorites, the Activity popover, the Command view and the
contract-driven console, Converse, and per-task drafts — plus a short "for CLI
users" note on `--receipt` and `--progress-json`. CI scoping is not user-facing
and is left out.

## Other docs

`grep` over `README.md`, `CONTRIBUTING.md`, `AGENTS.md`, `CODEBASE.md`, and
`docs/**` for the retired vocabulary. Fixed `docs/getting-started.md`,
`docs/plugins.md`, `docs/macos-deep-links.md`, `docs/raycast.md`,
`docs/repository-tour.md`, `docs/model-sources.md`, and the runtime pages for
image, video, music, speech, sfx, vision, text, world, and model management —
which between them named Geospatial Lab, Voice Studio, SFX Lab, Vision Lab,
Music Tools, Training Studio, Subject Studio, "Advanced > Operations",
"View → Plugins", and "the matching workspace". `docs/macos-studio-roadmap.md`
keeps its historical audit; its implementation note now points at v2 and stops
describing Advanced templates. The rebase added three more that #434 left
behind: `AGENTS.md` and `docs/internals/source-layout.md` named `MereRunApp` as
the only Studio target, and `CONTRIBUTING.md`'s fast-lane table named
`MereRunAppTests` as the only Studio test target where CI now runs all three.
The root `README.md`, `CODEBASE.md`, and `docs/workflows.md` were already
accurate.

## Verification

Re-run after the rebase, on `ae65670`:

- `./scripts/check.sh` — exit 0, including `check-docs-examples.sh`,
  `agent_readiness_check.sh`, the MLX metallib verification, and
  `DocumentationContractTests`, which validates every `mere.run` invocation in
  `docs/` against the live command tree. 242 StudioKitTests and 316
  StudioUITests, 0 failures.
- `swiftlint --strict` — exit 0, 0 violations in 1,510 files.
- `./scripts/build_mere_run_app.sh debug` — exit 0; bundle valid on disk and
  satisfies its designated requirement.

Every path the docs cite was checked against the filesystem after the rebase,
including the eighteen schema/view file pairs.

## For the reviewer

Two things I could not verify and stated conservatively. The plan's phrase
"every capability maps to exactly one (domain, task)" is true of domains and
tested (`testEveryCommandTemplateMapsToADomain`), but nothing asserts a single
task, so both the review and the README say so rather than claiming the stronger
guarantee. And `StudioFirstClassWorkspaceTests` is now a misnomer — it holds
document-decoding tests and has never held a workspace-coverage assertion; the
real guards are in `StudioTypesTests` and `CapabilityCatalogTests`. Renaming the
file is a code change and was left out of a documentation pull request.
