### PR TITLE
Resume native text LoRA training safely

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ The format is based on Keep a Changelog.
 
 ### CLI
 
+- added `text train-lora --resume-from` for deterministic global-step
+  continuation from matching
+  optimizer-bearing checkpoints. Text checkpoints retain Adam moments in FP32,
+  record the completed global step and recipe fingerprint, and reject model,
+  dataset, configuration, layer-inventory, and tensor-shape mismatches. Legacy
+  checkpoints require an explicit verified `--resume-step`.
 - reconciled every capability's declared `output` with what the command
   actually writes, and gave the declaration two additive fields: `flag`, the
   option that carries the destination path, and `optional`, true when the

--- a/Sources/MereRunCLI/Commands/TextTrainLoRACommand.swift
+++ b/Sources/MereRunCLI/Commands/TextTrainLoRACommand.swift
@@ -12,6 +12,8 @@ struct TextTrainLoRA: AsyncParsableCommand {
         Inkling-Small, or the LFM2.5 A1B 8-bit text model. Gemma 4 12B vision
         fine-tuning accepts one dataset-relative local image on each user message.
         It writes a model-family-specific MereRun adapter manifest beside the safetensors file.
+        Use --resume-from to continue a matching optimizer-bearing checkpoint toward the
+        original total --training-steps. Legacy checkpoints also require --resume-step.
         Use --dry-run to validate data, create manifests, and prepare a reproducible run.
         """
     )
@@ -63,6 +65,18 @@ struct TextTrainLoRA: AsyncParsableCommand {
 
     @Option(name: [.long], help: "Random seed.")
     var seed: UInt64 = 42
+
+    @Option(
+        name: [.customLong("resume-from")],
+        help: "Resume from a matching text LoRA .safetensors checkpoint with Adam state."
+    )
+    var resumeFrom: String?
+
+    @Option(
+        name: [.customLong("resume-step")],
+        help: "Completed global step for a legacy checkpoint without embedded step state."
+    )
+    var resumeStep: Int?
 
     @Option(
         name: [.customLong("target-modules")],
@@ -130,7 +144,11 @@ struct TextTrainLoRA: AsyncParsableCommand {
                     trainingSteps: trainingSteps,
                     batchSize: batchSize,
                     learningRate: learningRate,
-                    seed: seed
+                    seed: seed,
+                    resumeFrom: resumeFrom.map {
+                        URL(fileURLWithPath: $0).standardizedFileURL
+                    },
+                    resumeStep: resumeStep
                 )
                 var metadata = [
                     "adapter_name": adapterName,
@@ -349,6 +367,33 @@ struct TextTrainLoRA: AsyncParsableCommand {
         guard !resolvedTargetModules().isEmpty else {
             throw ValidationError("--target-modules must include at least one target suffix")
         }
+        if let resumeStep {
+            guard resumeFrom != nil else {
+                throw ValidationError("--resume-step requires --resume-from")
+            }
+            guard resumeStep > 0, resumeStep < trainingSteps else {
+                throw ValidationError(
+                    "--resume-step must be greater than zero and below --training-steps"
+                )
+            }
+        }
+        if let resumeFrom {
+            guard !dryRun else {
+                throw ValidationError("--resume-from cannot be combined with --dry-run")
+            }
+            let resumeURL = URL(fileURLWithPath: resumeFrom).standardizedFileURL
+            guard FileManager.default.fileExists(atPath: resumeURL.path) else {
+                throw ValidationError("--resume-from checkpoint does not exist: \(resumeURL.path)")
+            }
+            guard resumeURL.pathExtension.lowercased() == "safetensors"
+                    || resumeURL.pathExtension.lowercased() == "zip" else {
+                throw ValidationError("--resume-from must be a .safetensors or .zip checkpoint")
+            }
+            let outputURL = URL(fileURLWithPath: output).standardizedFileURL
+            guard resumeURL != outputURL else {
+                throw ValidationError("--resume-from and --output must be different files")
+            }
+        }
         if visualize {
             guard !dryRun else {
                 throw ValidationError("--visualize cannot be combined with --dry-run")
@@ -443,7 +488,7 @@ struct TextTrainLoRA: AsyncParsableCommand {
             datasetSummary: datasetSummary,
             evalPromptCount: evalPromptCount,
             status: "running",
-            step: 0
+            step: resumeStep ?? 0
         )
 
         let logger = try LoRATrainingEventLogger(baseOutputURL: outputURL)
@@ -463,7 +508,7 @@ struct TextTrainLoRA: AsyncParsableCommand {
             type: "run_started",
             stage: "starting",
             message: "Text LoRA training started.",
-            step: 0,
+            step: resumeStep ?? 0,
             totalSteps: trainingSteps,
             fraction: 0,
             path: outputURL.path,

--- a/Sources/MereRunCLI/Guides/text-chat.md
+++ b/Sources/MereRunCLI/Guides/text-chat.md
@@ -120,6 +120,25 @@ mere.run text train-lora \
   --visualize
 ```
 
+The trainer writes an optimizer-bearing partial checkpoint every 100 steps.
+To continue an interrupted run, use the same model, dataset, recipe, seed, and
+total step count:
+
+```bash
+mere.run text train-lora \
+  --data ./pairs.seed.jsonl \
+  --eval ./eval.prompts.jsonl \
+  --output ./local-assistant-resumed.safetensors \
+  --model text-chat-gemma4-12b-4bit \
+  --training-steps 600 \
+  --resume-from ./local-assistant.partial.safetensors
+```
+
+The command restores the global data-order and Adam optimizer step. It rejects
+mismatched models, datasets, recipes, layer inventories, and tensor shapes.
+For a checkpoint that predates embedded step state, also specify the verified
+completed step with `--resume-step`.
+
 For an LFM2.5 A1B canary, use the same reviewed dataset format and a 10-step
 attention-only run:
 

--- a/Sources/MereRunCore/LoRA/LoRASafetensorsWriter.swift
+++ b/Sources/MereRunCore/LoRA/LoRASafetensorsWriter.swift
@@ -28,16 +28,16 @@ public enum LoRASafetensorsWriter {
             // Optionally save optimizer state (for resumable training)
             if includeOptimizerState {
                 if let m = layer.loraDownM {
-                    arrays["\(path).lora_down.m"] = m.asType(dtype)
+                    arrays["\(path).lora_down.m"] = m.asType(.float32)
                 }
                 if let v = layer.loraDownV {
-                    arrays["\(path).lora_down.v"] = v.asType(dtype)
+                    arrays["\(path).lora_down.v"] = v.asType(.float32)
                 }
                 if let m = layer.loraUpM {
-                    arrays["\(path).lora_up.m"] = m.asType(dtype)
+                    arrays["\(path).lora_up.m"] = m.asType(.float32)
                 }
                 if let v = layer.loraUpV {
-                    arrays["\(path).lora_up.v"] = v.asType(dtype)
+                    arrays["\(path).lora_up.v"] = v.asType(.float32)
                 }
             }
         }

--- a/Sources/MereRunCore/LoRA/TextLoRACheckpointLoader.swift
+++ b/Sources/MereRunCore/LoRA/TextLoRACheckpointLoader.swift
@@ -1,0 +1,422 @@
+import Foundation
+import MLX
+
+public struct TextLoRACheckpointLoadReport: Sendable, Hashable {
+    public let completedSteps: Int
+    public let layerCount: Int
+    public let usedLegacyStepOverride: Bool
+
+    public init(completedSteps: Int, layerCount: Int, usedLegacyStepOverride: Bool) {
+        self.completedSteps = completedSteps
+        self.layerCount = layerCount
+        self.usedLegacyStepOverride = usedLegacyStepOverride
+    }
+}
+
+public enum TextLoRACheckpointLoader {
+    public static let checkpointSchema = "mererun.text-lora-checkpoint.v1"
+
+    public static func load(
+        from checkpointURL: URL,
+        into loraLayers: [String: TrainableLoRALayer],
+        config: TextLoRATrainingConfig,
+        expectedMetadata: [String: String]
+    ) throws -> TextLoRACheckpointLoadReport {
+        guard FileManager.default.fileExists(atPath: checkpointURL.path) else {
+            throw TextLoRACheckpointError.fileNotFound(checkpointURL.path)
+        }
+
+        let (arrays, metadata) = try MLX.loadArraysAndMetadata(url: checkpointURL)
+        guard metadata["has_optimizer_state"] == "true" else {
+            throw TextLoRACheckpointError.optimizerStateRequired
+        }
+
+        try validateMetadata(metadata, expected: expectedMetadata)
+        try validateRankAndAlpha(metadata, loraLayers: loraLayers)
+
+        let expectedFingerprint = configFingerprint(
+            config: config,
+            loraLayers: loraLayers,
+            metadata: expectedMetadata
+        )
+        let sidecar = try LoRATrainingCheckpointState.load(nextTo: checkpointURL)
+        let completedSteps = try resolveCompletedSteps(
+            metadata: metadata,
+            sidecar: sidecar,
+            override: config.resumeStep
+        )
+        try validateResumeState(
+            sidecar,
+            metadata: metadata,
+            expectedMetadata: expectedMetadata,
+            expectedFingerprint: expectedFingerprint,
+            config: config,
+            completedSteps: completedSteps
+        )
+
+        let expectedKeys = Set(loraLayers.keys.flatMap(Self.tensorKeys(for:)))
+        let actualKeys = Set(arrays.keys)
+        let missingKeys = expectedKeys.subtracting(actualKeys).sorted()
+        let unexpectedKeys = actualKeys.subtracting(expectedKeys).sorted()
+        guard missingKeys.isEmpty, unexpectedKeys.isEmpty else {
+            throw TextLoRACheckpointError.tensorInventoryMismatch(
+                missing: missingKeys,
+                unexpected: unexpectedKeys
+            )
+        }
+
+        var loadedArrays: [MLXArray] = []
+        loadedArrays.reserveCapacity(expectedKeys.count)
+        for (path, layer) in loraLayers.sorted(by: { $0.key < $1.key }) {
+            let keys = tensorKeys(for: path)
+            let down = try requiredArray(arrays, key: keys[0], shape: layer.loraDown.shape)
+            let up = try requiredArray(arrays, key: keys[1], shape: layer.loraUp.shape)
+            let downM = try requiredOptimizerArray(
+                arrays,
+                key: keys[2],
+                shape: layer.loraDown.shape
+            )
+            let downV = try requiredOptimizerArray(
+                arrays,
+                key: keys[3],
+                shape: layer.loraDown.shape
+            )
+            let upM = try requiredOptimizerArray(
+                arrays,
+                key: keys[4],
+                shape: layer.loraUp.shape
+            )
+            let upV = try requiredOptimizerArray(
+                arrays,
+                key: keys[5],
+                shape: layer.loraUp.shape
+            )
+
+            layer.loraDown = down.asType(.float32)
+            layer.loraUp = up.asType(.float32)
+            layer.loraDownM = downM.asType(.float32)
+            layer.loraDownV = downV.asType(.float32)
+            layer.loraUpM = upM.asType(.float32)
+            layer.loraUpV = upV.asType(.float32)
+            loadedArrays.append(contentsOf: [
+                layer.loraDown,
+                layer.loraUp,
+                layer.loraDownM!,
+                layer.loraDownV!,
+                layer.loraUpM!,
+                layer.loraUpV!,
+            ])
+        }
+        eval(loadedArrays)
+
+        return TextLoRACheckpointLoadReport(
+            completedSteps: completedSteps,
+            layerCount: loraLayers.count,
+            usedLegacyStepOverride: sidecar == nil && metadata["completed_steps"] == nil
+        )
+    }
+
+    public static func configFingerprint(
+        config: TextLoRATrainingConfig,
+        loraLayers: [String: TrainableLoRALayer],
+        metadata: [String: String]
+    ) -> String {
+        let firstLayer = loraLayers.sorted(by: { $0.key < $1.key }).first?.value
+        let fields = [
+            "format=\(metadata["format"] ?? "")",
+            "base_model=\(metadata["base_model"] ?? "")",
+            "dataset_fingerprint=\(metadata["dataset_fingerprint"] ?? "")",
+            "max_sequence_length=\(metadata["max_sequence_length"] ?? "")",
+            "reasoning_effort=\(metadata["reasoning_effort"] ?? "")",
+            "training_steps=\(config.trainingSteps)",
+            "batch_size=\(config.batchSize)",
+            "learning_rate=\(config.learningRate)",
+            "weight_decay=\(config.weightDecay)",
+            "beta1=\(config.beta1)",
+            "beta2=\(config.beta2)",
+            "epsilon=\(config.epsilon)",
+            "seed=\(config.seed)",
+            "lora_rank=\(firstLayer?.loraRank ?? 0)",
+            "lora_alpha=\(firstLayer?.loraAlpha ?? 0)",
+            "layer_paths=\(loraLayers.keys.sorted().joined(separator: ","))",
+        ]
+        return LoRATrainingFingerprint.sha256Hex(fields.joined(separator: "\n"))
+    }
+
+    public static func checkpointMetadata(
+        base metadata: [String: String],
+        config: TextLoRATrainingConfig,
+        loraLayers: [String: TrainableLoRALayer],
+        completedSteps: Int
+    ) -> [String: String] {
+        var checkpointMetadata = metadata
+        checkpointMetadata["checkpoint_schema"] = checkpointSchema
+        checkpointMetadata["completed_steps"] = String(completedSteps)
+        checkpointMetadata["training_steps"] = String(config.trainingSteps)
+        checkpointMetadata["batch_size"] = String(config.batchSize)
+        checkpointMetadata["learning_rate"] = String(config.learningRate)
+        checkpointMetadata["weight_decay"] = String(config.weightDecay)
+        checkpointMetadata["beta1"] = String(config.beta1)
+        checkpointMetadata["beta2"] = String(config.beta2)
+        checkpointMetadata["epsilon"] = String(config.epsilon)
+        checkpointMetadata["seed"] = String(config.seed)
+        checkpointMetadata["training_config_fingerprint"] = configFingerprint(
+            config: config,
+            loraLayers: loraLayers,
+            metadata: metadata
+        )
+        return checkpointMetadata
+    }
+
+    private static func validateMetadata(
+        _ metadata: [String: String]?,
+        expected: [String: String]
+    ) throws {
+        let identityKeys = [
+            "format",
+            "base_model",
+            "dataset_fingerprint",
+            "max_sequence_length",
+            "reasoning_effort",
+        ]
+        for key in identityKeys {
+            guard let expectedValue = expected[key], !expectedValue.isEmpty else { continue }
+            guard let actualValue = metadata?[key] else {
+                throw TextLoRACheckpointError.missingMetadata(key)
+            }
+            guard actualValue == expectedValue else {
+                throw TextLoRACheckpointError.metadataMismatch(
+                    key: key,
+                    expected: expectedValue,
+                    actual: actualValue
+                )
+            }
+        }
+    }
+
+    private static func validateRankAndAlpha(
+        _ metadata: [String: String]?,
+        loraLayers: [String: TrainableLoRALayer]
+    ) throws {
+        guard let firstLayer = loraLayers.sorted(by: { $0.key < $1.key }).first?.value else {
+            throw TextLoRACheckpointError.noLoRALayers
+        }
+        guard let rankValue = metadata?["lora_rank"], let rank = Int(rankValue) else {
+            throw TextLoRACheckpointError.missingMetadata("lora_rank")
+        }
+        guard rank == firstLayer.loraRank else {
+            throw TextLoRACheckpointError.metadataMismatch(
+                key: "lora_rank",
+                expected: String(firstLayer.loraRank),
+                actual: rankValue
+            )
+        }
+        guard let alphaValue = metadata?["lora_alpha"], let alpha = Float(alphaValue) else {
+            throw TextLoRACheckpointError.missingMetadata("lora_alpha")
+        }
+        guard alpha == firstLayer.loraAlpha else {
+            throw TextLoRACheckpointError.metadataMismatch(
+                key: "lora_alpha",
+                expected: String(firstLayer.loraAlpha),
+                actual: alphaValue
+            )
+        }
+    }
+
+    private static func resolveCompletedSteps(
+        metadata: [String: String]?,
+        sidecar: LoRATrainingCheckpointState?,
+        override: Int?
+    ) throws -> Int {
+        let embeddedStep: Int?
+        if let sidecar {
+            embeddedStep = sidecar.step
+        } else if let raw = metadata?["completed_steps"] {
+            guard let parsed = Int(raw) else {
+                throw TextLoRACheckpointError.invalidCompletedSteps(raw)
+            }
+            embeddedStep = parsed
+        } else {
+            embeddedStep = nil
+        }
+
+        if let embeddedStep, let override, embeddedStep != override {
+            throw TextLoRACheckpointError.resumeStepMismatch(
+                checkpoint: embeddedStep,
+                requested: override
+            )
+        }
+        guard let resolved = embeddedStep ?? override else {
+            throw TextLoRACheckpointError.legacyResumeStepRequired
+        }
+        return resolved
+    }
+
+    private static func validateResumeState(
+        _ sidecar: LoRATrainingCheckpointState?,
+        metadata: [String: String]?,
+        expectedMetadata: [String: String],
+        expectedFingerprint: String,
+        config: TextLoRATrainingConfig,
+        completedSteps: Int
+    ) throws {
+        guard completedSteps > 0, completedSteps < config.trainingSteps else {
+            throw TextLoRACheckpointError.completedStepsOutOfRange(
+                completed: completedSteps,
+                total: config.trainingSteps
+            )
+        }
+
+        if let sidecar {
+            guard sidecar.totalSteps == config.trainingSteps else {
+                throw TextLoRACheckpointError.totalStepsMismatch(
+                    checkpoint: sidecar.totalSteps,
+                    requested: config.trainingSteps
+                )
+            }
+            guard sidecar.seed == config.seed else {
+                throw TextLoRACheckpointError.seedMismatch(
+                    checkpoint: sidecar.seed,
+                    requested: config.seed
+                )
+            }
+            if let expected = expectedMetadata["format"], sidecar.format != expected {
+                throw TextLoRACheckpointError.metadataMismatch(
+                    key: "format",
+                    expected: expected,
+                    actual: sidecar.format
+                )
+            }
+            if let expected = expectedMetadata["base_model"], sidecar.baseModel != expected {
+                throw TextLoRACheckpointError.metadataMismatch(
+                    key: "base_model",
+                    expected: expected,
+                    actual: sidecar.baseModel
+                )
+            }
+            if let expected = expectedMetadata["dataset_fingerprint"],
+               sidecar.datasetFingerprint != expected {
+                throw TextLoRACheckpointError.metadataMismatch(
+                    key: "dataset_fingerprint",
+                    expected: expected,
+                    actual: sidecar.datasetFingerprint ?? "<missing>"
+                )
+            }
+            guard sidecar.configFingerprint == expectedFingerprint else {
+                throw TextLoRACheckpointError.configFingerprintMismatch
+            }
+            return
+        }
+
+        if let schema = metadata?["checkpoint_schema"] {
+            guard schema == checkpointSchema else {
+                throw TextLoRACheckpointError.unsupportedSchema(schema)
+            }
+            guard metadata?["training_config_fingerprint"] == expectedFingerprint else {
+                throw TextLoRACheckpointError.configFingerprintMismatch
+            }
+        } else if config.resumeStep == nil {
+            throw TextLoRACheckpointError.legacyResumeStepRequired
+        }
+    }
+
+    private static func tensorKeys(for path: String) -> [String] {
+        [
+            "\(path).lora_down.weight",
+            "\(path).lora_up.weight",
+            "\(path).lora_down.m",
+            "\(path).lora_down.v",
+            "\(path).lora_up.m",
+            "\(path).lora_up.v",
+        ]
+    }
+
+    private static func requiredArray(
+        _ arrays: [String: MLXArray],
+        key: String,
+        shape: [Int]
+    ) throws -> MLXArray {
+        guard let array = arrays[key] else {
+            throw TextLoRACheckpointError.tensorInventoryMismatch(missing: [key], unexpected: [])
+        }
+        guard array.shape == shape else {
+            throw TextLoRACheckpointError.tensorShapeMismatch(
+                key: key,
+                expected: shape,
+                actual: array.shape
+            )
+        }
+        return array
+    }
+
+    private static func requiredOptimizerArray(
+        _ arrays: [String: MLXArray],
+        key: String,
+        shape: [Int]
+    ) throws -> MLXArray {
+        let array = try requiredArray(arrays, key: key, shape: shape)
+        guard array.dtype == .float32 else {
+            throw TextLoRACheckpointError.optimizerStateDTypeMismatch(
+                key: key,
+                actual: String(describing: array.dtype)
+            )
+        }
+        return array
+    }
+}
+
+public enum TextLoRACheckpointError: Error, LocalizedError, Sendable {
+    case fileNotFound(String)
+    case optimizerStateRequired
+    case noLoRALayers
+    case missingMetadata(String)
+    case metadataMismatch(key: String, expected: String, actual: String)
+    case invalidCompletedSteps(String)
+    case legacyResumeStepRequired
+    case resumeStepMismatch(checkpoint: Int, requested: Int)
+    case completedStepsOutOfRange(completed: Int, total: Int)
+    case totalStepsMismatch(checkpoint: Int, requested: Int)
+    case seedMismatch(checkpoint: UInt64, requested: UInt64)
+    case configFingerprintMismatch
+    case unsupportedSchema(String)
+    case tensorInventoryMismatch(missing: [String], unexpected: [String])
+    case tensorShapeMismatch(key: String, expected: [Int], actual: [Int])
+    case optimizerStateDTypeMismatch(key: String, actual: String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .fileNotFound(let path):
+            return "Text LoRA resume checkpoint does not exist: \(path)"
+        case .optimizerStateRequired:
+            return "Text LoRA resume requires a checkpoint with Adam optimizer state."
+        case .noLoRALayers:
+            return "Text LoRA resume requires at least one injected LoRA layer."
+        case .missingMetadata(let key):
+            return "Text LoRA resume checkpoint is missing required metadata '\(key)'."
+        case .metadataMismatch(let key, let expected, let actual):
+            return "Text LoRA resume metadata mismatch for '\(key)': expected '\(expected)', got '\(actual)'."
+        case .invalidCompletedSteps(let value):
+            return "Text LoRA resume checkpoint has invalid completed_steps '\(value)'."
+        case .legacyResumeStepRequired:
+            return "Legacy text LoRA checkpoints require an explicit --resume-step."
+        case .resumeStepMismatch(let checkpoint, let requested):
+            return "Text LoRA resume step mismatch: checkpoint is at \(checkpoint), requested \(requested)."
+        case .completedStepsOutOfRange(let completed, let total):
+            return "Text LoRA resume step \(completed) must be greater than zero and below total steps \(total)."
+        case .totalStepsMismatch(let checkpoint, let requested):
+            return "Text LoRA resume total-step mismatch: checkpoint planned \(checkpoint), requested \(requested)."
+        case .seedMismatch(let checkpoint, let requested):
+            return "Text LoRA resume seed mismatch: checkpoint used \(checkpoint), requested \(requested)."
+        case .configFingerprintMismatch:
+            return "Text LoRA resume training configuration does not match the checkpoint."
+        case .unsupportedSchema(let schema):
+            return "Unsupported text LoRA checkpoint schema '\(schema)'."
+        case .tensorInventoryMismatch(let missing, let unexpected):
+            return "Text LoRA resume tensor inventory mismatch; missing=\(missing), unexpected=\(unexpected)."
+        case .tensorShapeMismatch(let key, let expected, let actual):
+            return "Text LoRA resume tensor '\(key)' has shape \(actual), expected \(expected)."
+        case .optimizerStateDTypeMismatch(let key, let actual):
+            return "Text LoRA resume optimizer tensor '\(key)' has data type \(actual); expected float32."
+        }
+    }
+}

--- a/Sources/MereRunCore/TextLoRATrainer.swift
+++ b/Sources/MereRunCore/TextLoRATrainer.swift
@@ -11,6 +11,8 @@ public struct TextLoRATrainingConfig: Sendable, Hashable {
     public let beta2: Float
     public let epsilon: Float
     public let seed: UInt64
+    public let resumeFrom: URL?
+    public let resumeStep: Int?
 
     public init(
         trainingSteps: Int,
@@ -20,7 +22,9 @@ public struct TextLoRATrainingConfig: Sendable, Hashable {
         beta1: Float = 0.9,
         beta2: Float = 0.999,
         epsilon: Float = 1e-8,
-        seed: UInt64 = 42
+        seed: UInt64 = 42,
+        resumeFrom: URL? = nil,
+        resumeStep: Int? = nil
     ) {
         self.trainingSteps = trainingSteps
         self.batchSize = batchSize
@@ -30,6 +34,8 @@ public struct TextLoRATrainingConfig: Sendable, Hashable {
         self.beta2 = beta2
         self.epsilon = epsilon
         self.seed = seed
+        self.resumeFrom = resumeFrom
+        self.resumeStep = resumeStep
     }
 }
 
@@ -136,6 +142,31 @@ public enum TextLoRATrainer {
             guard let module = layer as? Module else { continue }
             try module.unfreeze(recursive: false, keys: ["loraDown", "loraUp"], strict: true)
         }
+
+        var resolvedResumeCheckpoint: LoRAResolvedCheckpoint?
+        var resumeStep = 0
+        if let resumeFrom = config.resumeFrom {
+            let resolved = try LoRACheckpointResolver.resolve(resumeFrom)
+            resolvedResumeCheckpoint = resolved
+            let report = try TextLoRACheckpointLoader.load(
+                from: resolved.checkpointURL,
+                into: loraLayers,
+                config: config,
+                expectedMetadata: metadata
+            )
+            resumeStep = report.completedSteps
+            if let outputURL {
+                LoRATrainingResumeArtifacts.restore(
+                    from: resolved.checkpointURL,
+                    sidecar: try LoRATrainingCheckpointState.load(nextTo: resolved.checkpointURL),
+                    to: outputURL
+                )
+            }
+            FileHandle.standardError.write(Data(
+                "[text-lora-train] resumed_from=\(resolved.checkpointURL.lastPathComponent) completed_steps=\(resumeStep) layers=\(report.layerCount) legacy_step_override=\(report.usedLegacyStepOverride)\n".utf8
+            ))
+        }
+        defer { resolvedResumeCheckpoint?.cleanup() }
         initializeAdamStateIfNeeded(for: loraLayers)
 
         let orderedLayers = loraLayers
@@ -210,7 +241,9 @@ public enum TextLoRATrainer {
                 withIntermediateDirectories: true
             )
         }
-        let metricsLogger = try outputURL.map { try LoRATrainingMetricsLogger(baseOutputURL: $0, resumeExisting: false) }
+        let metricsLogger = try outputURL.map {
+            try LoRATrainingMetricsLogger(baseOutputURL: $0, resumeExisting: resumeStep > 0)
+        }
         let trainingOrder = makeTrainingOrder(
             exampleCount: examples.count,
             drawCount: config.trainingSteps * config.batchSize,
@@ -223,9 +256,9 @@ public enum TextLoRATrainer {
             $0.deletingPathExtension().appendingPathExtension("partial").appendingPathExtension("safetensors")
         }
         var lastBoundaryTime = Date()
-        var lastBoundaryStep = 0
+        var lastBoundaryStep = resumeStep
 
-        for step in 0..<config.trainingSteps {
+        for step in resumeStep..<config.trainingSteps {
             let batchExamples = scheduledBatch(
                 examples,
                 order: trainingOrder,
@@ -300,11 +333,26 @@ public enum TextLoRATrainer {
                 )
             )
             if shouldSavePartial, let partialURL {
+                let checkpointMetadata = TextLoRACheckpointLoader.checkpointMetadata(
+                    base: metadata,
+                    config: config,
+                    loraLayers: loraLayers,
+                    completedSteps: stepNumber
+                )
                 try LoRASafetensorsWriter.save(
                     loraLayers: loraLayers,
                     to: partialURL,
                     includeOptimizerState: true,
-                    metadata: metadata
+                    metadata: checkpointMetadata
+                )
+                try writeCheckpointState(
+                    nextTo: partialURL,
+                    step: stepNumber,
+                    config: config,
+                    loraLayers: loraLayers,
+                    metadata: metadata,
+                    lossCSVFile: metricsLogger?.csvURL.lastPathComponent,
+                    lossHTMLFile: metricsLogger?.htmlURL.lastPathComponent
                 )
             }
         }
@@ -325,11 +373,26 @@ public enum TextLoRATrainer {
             ))
         }
         if let outputURL {
+            let checkpointMetadata = TextLoRACheckpointLoader.checkpointMetadata(
+                base: metadata,
+                config: config,
+                loraLayers: loraLayers,
+                completedSteps: config.trainingSteps
+            )
             try LoRASafetensorsWriter.save(
                 loraLayers: loraLayers,
                 to: outputURL,
                 includeOptimizerState: true,
-                metadata: metadata
+                metadata: checkpointMetadata
+            )
+            try writeCheckpointState(
+                nextTo: outputURL,
+                step: config.trainingSteps,
+                config: config,
+                loraLayers: loraLayers,
+                metadata: metadata,
+                lossCSVFile: metricsLogger?.csvURL.lastPathComponent,
+                lossHTMLFile: metricsLogger?.htmlURL.lastPathComponent
             )
             try metricsLogger?.writeArtifacts()
             if let partialURL, FileManager.default.fileExists(atPath: partialURL.path) {
@@ -481,6 +544,51 @@ public enum TextLoRATrainer {
         guard !loraLayers.isEmpty else {
             throw TextLoRATrainerError.noLoRALayers
         }
+        guard config.resumeFrom != nil || config.resumeStep == nil else {
+            throw TextLoRATrainerError.resumeStepWithoutCheckpoint
+        }
+        if let resumeStep = config.resumeStep {
+            guard resumeStep > 0, resumeStep < config.trainingSteps else {
+                throw TextLoRATrainerError.invalidResumeStep(resumeStep, config.trainingSteps)
+            }
+        }
+    }
+
+    private static func writeCheckpointState(
+        nextTo checkpointURL: URL,
+        step: Int,
+        config: TextLoRATrainingConfig,
+        loraLayers: [String: TrainableLoRALayer],
+        metadata: [String: String],
+        lossCSVFile: String?,
+        lossHTMLFile: String?
+    ) throws {
+        let state = LoRATrainingCheckpointState(
+            format: metadata["format"] ?? "mererun.text-lora",
+            baseModel: metadata["base_model"] ?? "",
+            checkpointFile: checkpointURL.lastPathComponent,
+            step: step,
+            totalSteps: config.trainingSteps,
+            seed: config.seed,
+            rngState: nil,
+            datasetFingerprint: metadata["dataset_fingerprint"],
+            configFingerprint: TextLoRACheckpointLoader.configFingerprint(
+                config: config,
+                loraLayers: loraLayers,
+                metadata: metadata
+            ),
+            configSnapshot: [
+                "batch_size": String(config.batchSize),
+                "beta1": String(config.beta1),
+                "beta2": String(config.beta2),
+                "epsilon": String(config.epsilon),
+                "learning_rate": String(config.learningRate),
+                "weight_decay": String(config.weightDecay),
+            ],
+            lossCSVFile: lossCSVFile,
+            lossHTMLFile: lossHTMLFile
+        )
+        try state.write(nextTo: checkpointURL)
     }
 
     static func makeTrainingOrder(
@@ -547,6 +655,8 @@ public enum TextLoRATrainerError: Error, LocalizedError, Sendable {
     case emptyDataset
     case noLoRALayers
     case incompleteMultimodalConfiguration
+    case resumeStepWithoutCheckpoint
+    case invalidResumeStep(Int, Int)
 
     public var errorDescription: String? {
         switch self {
@@ -562,6 +672,10 @@ public enum TextLoRATrainerError: Error, LocalizedError, Sendable {
             return "Text LoRA training requires at least one injected LoRA layer."
         case .incompleteMultimodalConfiguration:
             return "Text LoRA multimodal training requires both a batch builder and gathered forward."
+        case .resumeStepWithoutCheckpoint:
+            return "Text LoRA resume step requires a checkpoint."
+        case .invalidResumeStep(let step, let total):
+            return "Text LoRA resume step \(step) must be greater than zero and below total steps \(total)."
         }
     }
 }

--- a/Tests/MereRunCLITests/TextTrainLoRACommandParsingTests.swift
+++ b/Tests/MereRunCLITests/TextTrainLoRACommandParsingTests.swift
@@ -24,6 +24,8 @@ final class TextTrainLoRACommandParsingTests: XCTestCase {
         XCTAssertEqual(cmd.rank, 16)
         XCTAssertEqual(cmd.maxSequenceLength, 4096)
         XCTAssertEqual(cmd.reasoningEffort, 0.9)
+        XCTAssertNil(cmd.resumeFrom)
+        XCTAssertNil(cmd.resumeStep)
         XCTAssertFalse(cmd.dryRun)
         XCTAssertFalse(cmd.visualize)
         XCTAssertEqual(cmd.visualizePort, 8787)
@@ -45,6 +47,8 @@ final class TextTrainLoRACommandParsingTests: XCTestCase {
             "--max-sequence-length", "2048",
             "--reasoning-effort", "0.2",
             "--target-modules", "q_proj,v_proj",
+            "--resume-from", "/tmp/checkpoint.safetensors",
+            "--resume-step", "12",
             "--visualize",
             "--visualize-port", "8788",
             "--dry-run",
@@ -62,6 +66,8 @@ final class TextTrainLoRACommandParsingTests: XCTestCase {
         XCTAssertEqual(cmd.alpha, 16)
         XCTAssertEqual(cmd.maxSequenceLength, 2048)
         XCTAssertEqual(cmd.reasoningEffort, 0.2)
+        XCTAssertEqual(cmd.resumeFrom, "/tmp/checkpoint.safetensors")
+        XCTAssertEqual(cmd.resumeStep, 12)
         XCTAssertTrue(cmd.visualize)
         XCTAssertEqual(cmd.visualizePort, 8788)
         XCTAssertTrue(cmd.dryRun)

--- a/Tests/MereRunCoreTests/TextLoRATrainerTests.swift
+++ b/Tests/MereRunCoreTests/TextLoRATrainerTests.swift
@@ -102,6 +102,313 @@ final class TextLoRATrainerTests: MereRunCoreTestCase {
         XCTAssertTrue(recorder.savingSeen)
     }
 
+    func testNativeTrainerResumesLegacyCheckpointAtGlobalStep() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let example = TextSFTTokenizedExample(
+            inputTokenIds: [0, 1, 2],
+            labelTokenIds: [1, 2, 3],
+            lossMask: [0, 1, 1]
+        )
+        let metadata = [
+            "base_model": "tiny-causal-lm",
+            "dataset_fingerprint": "tiny-dataset",
+            "format": "mererun.text-lora.test",
+            "max_sequence_length": "128",
+        ]
+
+        MLXRandom.seed(73)
+        let continuousModel = TinyCausalLM()
+        let continuousLayers = try Gemma4TextLoRAInjector.inject(
+            into: continuousModel,
+            rank: 2,
+            targetSuffixes: ["proj"]
+        )
+        let continuousReport = try TextLoRATrainer.train(
+            model: continuousModel,
+            loraLayers: continuousLayers,
+            examples: [example],
+            config: TextLoRATrainingConfig(
+                trainingSteps: 4,
+                batchSize: 1,
+                learningRate: 0.02,
+                seed: 19
+            ),
+            metadata: metadata
+        ) { model, inputIds in
+            model(inputIds)
+        }
+
+        MLXRandom.seed(73)
+        let interruptedModel = TinyCausalLM()
+        let interruptedLayers = try Gemma4TextLoRAInjector.inject(
+            into: interruptedModel,
+            rank: 2,
+            targetSuffixes: ["proj"]
+        )
+        _ = try TextLoRATrainer.train(
+            model: interruptedModel,
+            loraLayers: interruptedLayers,
+            examples: [example],
+            config: TextLoRATrainingConfig(
+                trainingSteps: 2,
+                batchSize: 1,
+                learningRate: 0.02,
+                seed: 19
+            ),
+            metadata: metadata
+        ) { model, inputIds in
+            model(inputIds)
+        }
+        let legacyCheckpointURL = directory.appendingPathComponent("legacy.partial.safetensors")
+        try LoRASafetensorsWriter.save(
+            loraLayers: interruptedLayers,
+            to: legacyCheckpointURL,
+            includeOptimizerState: true,
+            metadata: metadata
+        )
+        let (legacyArrays, _) = try MLX.loadArraysAndMetadata(url: legacyCheckpointURL)
+        XCTAssertEqual(legacyArrays["proj.lora_down.weight"]?.dtype, .float16)
+        XCTAssertEqual(legacyArrays["proj.lora_down.m"]?.dtype, .float32)
+        XCTAssertEqual(legacyArrays["proj.lora_down.v"]?.dtype, .float32)
+
+        MLXRandom.seed(73)
+        let resumedModel = TinyCausalLM()
+        let resumedLayers = try Gemma4TextLoRAInjector.inject(
+            into: resumedModel,
+            rank: 2,
+            targetSuffixes: ["proj"]
+        )
+        let recorder = TextTrainingProgressRecorder()
+        let resumedOutputURL = directory.appendingPathComponent("resumed.safetensors")
+        let report = try TextLoRATrainer.train(
+            model: resumedModel,
+            loraLayers: resumedLayers,
+            examples: [example],
+            config: TextLoRATrainingConfig(
+                trainingSteps: 4,
+                batchSize: 1,
+                learningRate: 0.02,
+                seed: 19,
+                resumeFrom: legacyCheckpointURL,
+                resumeStep: 2
+            ),
+            outputURL: resumedOutputURL,
+            metadata: metadata,
+            progressHandler: { progress in
+                if case .training(let step, _, _) = progress.stage {
+                    recorder.record(step: step)
+                }
+            }
+        ) { model, inputIds in
+            model(inputIds)
+        }
+
+        XCTAssertEqual(report.steps, 4)
+        XCTAssertEqual(recorder.steps, [4])
+        let continuousLayer = try XCTUnwrap(continuousLayers["proj"])
+        let resumedLayer = try XCTUnwrap(resumedLayers["proj"])
+        XCTAssertLessThan(
+            MLX.abs(continuousLayer.loraDown - resumedLayer.loraDown).max().item(Float.self),
+            0.02
+        )
+        XCTAssertLessThan(
+            MLX.abs(continuousLayer.loraUp - resumedLayer.loraUp).max().item(Float.self),
+            0.02
+        )
+        XCTAssertEqual(
+            try XCTUnwrap(report.finalLoss),
+            try XCTUnwrap(continuousReport.finalLoss),
+            accuracy: 0.003
+        )
+
+        let (_, savedMetadata) = try MLX.loadArraysAndMetadata(url: resumedOutputURL)
+        XCTAssertEqual(savedMetadata["checkpoint_schema"], TextLoRACheckpointLoader.checkpointSchema)
+        XCTAssertEqual(savedMetadata["completed_steps"], "4")
+        let sidecar = try XCTUnwrap(LoRATrainingCheckpointState.load(nextTo: resumedOutputURL))
+        XCTAssertEqual(sidecar.step, 4)
+        XCTAssertEqual(sidecar.totalSteps, 4)
+    }
+
+    func testResumeCheckpointRequiresCompleteOptimizerState() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        MLXRandom.seed(79)
+        let model = TinyCausalLM()
+        let layers = try Gemma4TextLoRAInjector.inject(
+            into: model,
+            rank: 2,
+            targetSuffixes: ["proj"]
+        )
+        let checkpointURL = directory.appendingPathComponent("weights-only.safetensors")
+        let metadata = [
+            "base_model": "tiny-causal-lm",
+            "dataset_fingerprint": "tiny-dataset",
+            "format": "mererun.text-lora.test",
+            "max_sequence_length": "128",
+        ]
+        try LoRASafetensorsWriter.save(
+            loraLayers: layers,
+            to: checkpointURL,
+            metadata: metadata
+        )
+
+        XCTAssertThrowsError(
+            try TextLoRACheckpointLoader.load(
+                from: checkpointURL,
+                into: layers,
+                config: TextLoRATrainingConfig(
+                    trainingSteps: 4,
+                    batchSize: 1,
+                    learningRate: 0.02,
+                    resumeFrom: checkpointURL,
+                    resumeStep: 2
+                ),
+                expectedMetadata: metadata
+            )
+        ) { error in
+            guard case TextLoRACheckpointError.optimizerStateRequired = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+    }
+
+    func testResumeCheckpointRejectsLossyOptimizerState() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        MLXRandom.seed(81)
+        let model = TinyCausalLM()
+        let layers = try Gemma4TextLoRAInjector.inject(
+            into: model,
+            rank: 2,
+            targetSuffixes: ["proj"]
+        )
+        TextLoRATrainer.initializeAdamStateIfNeeded(for: layers)
+        let checkpointURL = directory.appendingPathComponent("lossy.safetensors")
+        let metadata = [
+            "base_model": "tiny-causal-lm",
+            "dataset_fingerprint": "tiny-dataset",
+            "format": "mererun.text-lora.test",
+            "has_optimizer_state": "true",
+            "lora_alpha": String(try XCTUnwrap(layers["proj"]).loraAlpha),
+            "lora_rank": "2",
+            "max_sequence_length": "128",
+        ]
+        var arrays: [String: MLXArray] = [:]
+        for (path, layer) in layers {
+            arrays["\(path).lora_down.weight"] = layer.loraDown.asType(.float16)
+            arrays["\(path).lora_up.weight"] = layer.loraUp.asType(.float16)
+            arrays["\(path).lora_down.m"] = try XCTUnwrap(layer.loraDownM).asType(.float16)
+            arrays["\(path).lora_down.v"] = try XCTUnwrap(layer.loraDownV).asType(.float16)
+            arrays["\(path).lora_up.m"] = try XCTUnwrap(layer.loraUpM).asType(.float16)
+            arrays["\(path).lora_up.v"] = try XCTUnwrap(layer.loraUpV).asType(.float16)
+        }
+        try MLX.save(arrays: arrays, metadata: metadata, url: checkpointURL)
+
+        XCTAssertThrowsError(
+            try TextLoRACheckpointLoader.load(
+                from: checkpointURL,
+                into: layers,
+                config: TextLoRATrainingConfig(
+                    trainingSteps: 4,
+                    batchSize: 1,
+                    learningRate: 0.02,
+                    seed: 23,
+                    resumeFrom: checkpointURL,
+                    resumeStep: 2
+                ),
+                expectedMetadata: metadata
+            )
+        ) { error in
+            guard case TextLoRACheckpointError.optimizerStateDTypeMismatch = error else {
+                return XCTFail("Unexpected error: \(error)")
+            }
+        }
+    }
+
+    func testSelfDescribingResumeCheckpointLoadsWithoutStepOverride() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        MLXRandom.seed(83)
+        let sourceModel = TinyCausalLM()
+        let sourceLayers = try Gemma4TextLoRAInjector.inject(
+            into: sourceModel,
+            rank: 2,
+            targetSuffixes: ["proj"]
+        )
+        TextLoRATrainer.initializeAdamStateIfNeeded(for: sourceLayers)
+        let checkpointURL = directory.appendingPathComponent("step-2.safetensors")
+        let metadata = [
+            "base_model": "tiny-causal-lm",
+            "dataset_fingerprint": "tiny-dataset",
+            "format": "mererun.text-lora.test",
+            "max_sequence_length": "128",
+        ]
+        let config = TextLoRATrainingConfig(
+            trainingSteps: 4,
+            batchSize: 1,
+            learningRate: 0.02,
+            seed: 23,
+            resumeFrom: checkpointURL
+        )
+        try LoRASafetensorsWriter.save(
+            loraLayers: sourceLayers,
+            to: checkpointURL,
+            includeOptimizerState: true,
+            metadata: TextLoRACheckpointLoader.checkpointMetadata(
+                base: metadata,
+                config: config,
+                loraLayers: sourceLayers,
+                completedSteps: 2
+            )
+        )
+        try LoRATrainingCheckpointState(
+            format: "mererun.text-lora.test",
+            baseModel: "tiny-causal-lm",
+            checkpointFile: checkpointURL.lastPathComponent,
+            step: 2,
+            totalSteps: 4,
+            seed: 23,
+            rngState: nil,
+            datasetFingerprint: "tiny-dataset",
+            configFingerprint: TextLoRACheckpointLoader.configFingerprint(
+                config: config,
+                loraLayers: sourceLayers,
+                metadata: metadata
+            )
+        ).write(nextTo: checkpointURL)
+
+        MLXRandom.seed(89)
+        let destinationModel = TinyCausalLM()
+        let destinationLayers = try Gemma4TextLoRAInjector.inject(
+            into: destinationModel,
+            rank: 2,
+            targetSuffixes: ["proj"]
+        )
+        let report = try TextLoRACheckpointLoader.load(
+            from: checkpointURL,
+            into: destinationLayers,
+            config: config,
+            expectedMetadata: metadata
+        )
+
+        XCTAssertEqual(report.completedSteps, 2)
+        XCTAssertEqual(report.layerCount, 1)
+        XCTAssertFalse(report.usedLegacyStepOverride)
+    }
+
     func testNativeTrainerReportsBeforeAndAfterEvaluationLoss() throws {
         MLXRandom.seed(31)
         let model = TinyCausalLM()

--- a/docs/runtime/text.md
+++ b/docs/runtime/text.md
@@ -698,6 +698,9 @@ Core hyperparameters (defaults are tuned for local Gemma4 SFT):
 - `--reasoning-effort` — Inkling renderer effort from `0` through `0.99`
   (default `0.9`; use the same value for inference)
 - `--seed` — random seed (default `42`)
+- `--resume-from` — optimizer-bearing text LoRA checkpoint to continue
+- `--resume-step` — verified completed step for a checkpoint that doesn't
+  contain embedded step state
 - `--target-modules` — comma-separated LoRA target suffixes. Gemma and Laguna
   default to q/k/v/o attention. LFM2.5 defaults to q/k/v/output attention.
   Inkling also defaults to MLPs and `lm_head`.
@@ -709,11 +712,21 @@ This list is deliberately not exhaustive; run
 The optimizer projects only loss-masked target positions through the lm_head
 (prompt and padding rows never contribute loss, so gradients are unchanged),
 reads the loss back every 10 steps rather than per step, writes a
-`<name>.partial.safetensors` checkpoint every 100 steps so a killed run can be
-salvaged, and prints `[text-lora-train] step= loss= step_s= footprint_gb=`
+`<name>.partial.safetensors` checkpoint every 100 steps so an interrupted run
+can continue, and prints `[text-lora-train] step= loss= step_s= footprint_gb=`
 diagnostics at each readback. `docs/configuration.md` documents the
 `MERERUN_TEXT_LORA_TRAIN_*` and shared `MERERUN_LORA_TRAIN_*` environment
 switches that tune or disable each behavior.
+
+To continue a self-describing checkpoint, pass `--resume-from` and use the
+same model, dataset, optimizer recipe, seed, target modules, and total
+`--training-steps`. The trainer restores the saved LoRA tensors, FP32 Adam
+moments, global optimizer step, and deterministic data-order position. It
+rejects incomplete optimizer state, changed configuration, changed tensor
+inventories, and shape mismatches. For a checkpoint that doesn't contain
+embedded step state, also pass the verified completed step with
+`--resume-step`. Write resumed output to a different file from the source
+checkpoint.
 
 ```bash
 swift run mere.run text train-lora \


### PR DESCRIPTION
## Summary

- add strict native text LoRA checkpoint loading and global-step resume
- retain Adam moments in FP32 while keeping adapter weights compact
- reject incomplete, lossy, or incompatible checkpoints before training
- document resume behavior and legacy checkpoint requirements

## Local verification

- ./scripts/check.sh
- SwiftLint: 0 violations
- XCTest: 3,784 tests, 297 skipped, 0 failures
- Swift Testing: 51 tests, 0 failures
- focused text trainer and CLI parsing suites: 23 tests, 0 failures