### PR TITLE
Fix Unicode corruption in streamed chat output

### DIFF
--- a/Sources/MereRunCore/Decode/AutoregressiveDecodeEngine.swift
+++ b/Sources/MereRunCore/Decode/AutoregressiveDecodeEngine.swift
@@ -131,6 +131,7 @@ public enum AutoregressiveDecodeEngine {
         _ request: AutoregressiveDecodeRequest,
         stepForward: (MLXArray) throws -> MLXArray,
         decodeToken: ((Int) -> String)? = nil,
+        decodeTokens: (([Int]) -> String)? = nil,
         emitPiece: ((Int, String) -> Void)? = nil,
         shouldContinue: ((Int, String) -> Bool)? = nil,
         checkCancellation: (() throws -> Void)? = nil
@@ -159,6 +160,7 @@ public enum AutoregressiveDecodeEngine {
             config: samplingConfig
         )
         var pendingProgressWhitespace = ""
+        var progressDecoder = IncrementalTokenTextDecoder()
 
         func capturedDiagnostics() -> ChatLogprobDiagnostics? {
             guard request.logprobCapture.isEnabled else { return nil }
@@ -192,8 +194,8 @@ public enum AutoregressiveDecodeEngine {
             if firstTokenSeconds == nil {
                 firstTokenSeconds = Date().timeIntervalSince(start)
             }
-            let piece = decodeToken?(token) ?? ""
-            let region = regionTracker.classify(piece)
+            let tokenPiece = decodeToken?(token) ?? ""
+            let region = regionTracker.classify(tokenPiece)
             if request.logprobCapture.isEnabled {
                 let captureStart = CFAbsoluteTimeGetCurrent()
                 var measurement = tokenLogprobMeasurement(
@@ -205,7 +207,7 @@ public enum AutoregressiveDecodeEngine {
                 )
                 measurement.region = region
                 if request.logprobCapture.includesTokens, region != .reasoning {
-                    measurement.token = piece
+                    measurement.token = tokenPiece
                     if !measurement.topLogprobs.isEmpty, let decodeToken {
                         for index in measurement.topLogprobs.indices {
                             measurement.topLogprobs[index].token = decodeToken(
@@ -218,15 +220,18 @@ public enum AutoregressiveDecodeEngine {
                 logprobCaptureSeconds += CFAbsoluteTimeGetCurrent() - captureStart
             }
             diagnosticHistory.append(token)
-            if let emitPiece, !piece.isEmpty {
-                if piece.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                    pendingProgressWhitespace += piece
+            let progressPiece = decodeTokens.map {
+                progressDecoder.append(decodedText: $0(generated))
+            } ?? tokenPiece
+            if let emitPiece, !progressPiece.isEmpty {
+                if progressPiece.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                    pendingProgressWhitespace += progressPiece
                 } else {
-                    emitPiece(token, pendingProgressWhitespace + piece)
+                    emitPiece(token, pendingProgressWhitespace + progressPiece)
                     pendingProgressWhitespace = ""
                 }
             }
-            return shouldContinue?(token, piece) ?? true
+            return shouldContinue?(token, tokenPiece) ?? true
         }
 
         var buildSeconds = 0.0

--- a/Sources/MereRunCore/Decode/IncrementalTokenTextDecoder.swift
+++ b/Sources/MereRunCore/Decode/IncrementalTokenTextDecoder.swift
@@ -1,0 +1,25 @@
+/// Emits only the stable suffix of a cumulatively decoded token sequence.
+///
+/// Byte-fallback tokenizers can decode an incomplete multibyte scalar as
+/// U+FFFD when a single token or partial sequence is decoded. The replacement
+/// disappears once the remaining byte tokens arrive, so streaming must wait
+/// for a stable cumulative prefix before exposing it.
+struct IncrementalTokenTextDecoder {
+    private var emittedUTF8: [UInt8] = []
+
+    mutating func append(decodedText: String) -> String {
+        var stableText = decodedText
+        while stableText.last == "\u{FFFD}" {
+            stableText.removeLast()
+        }
+
+        let stableUTF8 = Array(stableText.utf8)
+        guard stableUTF8.starts(with: emittedUTF8) else {
+            return ""
+        }
+
+        let delta = stableUTF8.dropFirst(emittedUTF8.count)
+        emittedUTF8 = stableUTF8
+        return String(decoding: delta, as: UTF8.self)
+    }
+}

--- a/Sources/MereRunCore/Laguna/LagunaDFlashDecoder.swift
+++ b/Sources/MereRunCore/Laguna/LagunaDFlashDecoder.swift
@@ -109,6 +109,7 @@ enum LagunaDFlashDecoder {
         adaptiveAcceptanceEvaluationRounds: Int =
             LagunaDFlashRouting.defaultAcceptanceEvaluationRounds,
         decodeToken: ((Int) -> String)? = nil,
+        decodeTokens: (([Int]) -> String)? = nil,
         emitPiece: ((Int, String) -> Void)? = nil,
         checkCancellation: (() throws -> Void)? = nil
     ) throws -> LagunaDFlashDecodeResult {
@@ -136,6 +137,7 @@ enum LagunaDFlashDecoder {
         var repetitionHistory = historySeedTokens
         var firstTokenSeconds: Double?
         var pendingProgressWhitespace = ""
+        var progressDecoder = IncrementalTokenTextDecoder()
         var rounds = 0
         var draftedTokens = 0
         var acceptedDraftTokens = 0
@@ -153,8 +155,10 @@ enum LagunaDFlashDecoder {
             if firstTokenSeconds == nil {
                 firstTokenSeconds = Date().timeIntervalSince(startedAt)
             }
-            guard let decodeToken, let emitPiece else { return }
-            let piece = decodeToken(token)
+            guard let emitPiece else { return }
+            let piece = decodeTokens.map {
+                progressDecoder.append(decodedText: $0(generatedTokens))
+            } ?? decodeToken?(token) ?? ""
             if piece.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                 pendingProgressWhitespace += piece
             } else if !piece.isEmpty {

--- a/Sources/MereRunCore/Laguna/LagunaGenerator.swift
+++ b/Sources/MereRunCore/Laguna/LagunaGenerator.swift
@@ -57,6 +57,7 @@ private final class LagunaBatchedDecodeRow: @unchecked Sendable {
     var repetitionHistory: [Int]
     var firstTokenSeconds: Double?
     var pendingProgressWhitespace = ""
+    var progressDecoder = IncrementalTokenTextDecoder()
     var stopped = false
 
     init(
@@ -116,6 +117,7 @@ private final class LagunaDFlashBatchedDecodeRow: @unchecked Sendable {
     var repetitionHistory: [Int]
     var firstTokenSeconds: Double?
     var pendingProgressWhitespace = ""
+    var progressDecoder = IncrementalTokenTextDecoder()
     var stopped = false
 
     init(
@@ -792,6 +794,7 @@ public actor LagunaGenerator: ChatGenerator {
                     ? LagunaDFlashRouting.defaultMinimumAcceptanceRate
                     : nil,
                 decodeToken: { tokenizerAndTemplate.decode(token: $0) },
+                decodeTokens: { tokenizerAndTemplate.decode(tokens: $0) },
                 emitPiece: { _, piece in
                     progressHandler?(ChatProgress(stage: .generating, message: piece))
                 },
@@ -827,6 +830,7 @@ public actor LagunaGenerator: ChatGenerator {
                     model.lastPositionLogits(token, cache: caches)
                 },
                 decodeToken: { tokenizerAndTemplate.decode(token: $0) },
+                decodeTokens: { tokenizerAndTemplate.decode(tokens: $0) },
                 emitPiece: { _, piece in
                     progressHandler?(ChatProgress(stage: .generating, message: piece))
                 },
@@ -1071,7 +1075,9 @@ public actor LagunaGenerator: ChatGenerator {
                 row.firstTokenSeconds = Date().timeIntervalSince(row.decodeStart)
             }
             if let progressHandler = row.progressHandler {
-                let piece = tokenizerAndTemplate.decode(token: token)
+                let piece = row.progressDecoder.append(
+                    decodedText: tokenizerAndTemplate.decode(tokens: row.generatedTokens)
+                )
                 if piece.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                     row.pendingProgressWhitespace += piece
                 } else if !piece.isEmpty {
@@ -1604,7 +1610,9 @@ public actor LagunaGenerator: ChatGenerator {
             row.firstTokenSeconds = Date().timeIntervalSince(row.decodeStart)
         }
         guard let progressHandler = row.progressHandler else { return }
-        let piece = tokenizerAndTemplate.decode(token: token)
+        let piece = row.progressDecoder.append(
+            decodedText: tokenizerAndTemplate.decode(tokens: row.generatedTokens)
+        )
         if piece.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             row.pendingProgressWhitespace += piece
         } else if !piece.isEmpty {

--- a/Tests/MereRunCoreTests/AutoregressiveDecodeEngineTests.swift
+++ b/Tests/MereRunCoreTests/AutoregressiveDecodeEngineTests.swift
@@ -160,6 +160,26 @@ final class AutoregressiveDecodeEngineTests: XCTestCase {
         XCTAssertEqual(pieces, [" \nhello", "world"])
     }
 
+    func testCumulativeDecodeBuffersIncompleteUTF8Scalars() throws {
+        var pieces: [String] = []
+        let cumulativeText: [[Int]: String] = [
+            [3]: "can\u{FFFD}",
+            [3, 7]: "can\u{FFFD}\u{FFFD}",
+            [3, 7, 2]: "can‑",
+            [3, 7, 2, 9]: "can‑do",
+        ]
+        _ = try AutoregressiveDecodeEngine.decode(
+            request(firstToken: 3, budget: 8),
+            stepForward: scriptedModel([7, 2, 9, eos]),
+            decodeToken: { _ in "\u{FFFD}" },
+            decodeTokens: { cumulativeText[$0] ?? "" },
+            emitPiece: { _, piece in pieces.append(piece) }
+        )
+
+        XCTAssertEqual(pieces.joined(), "can‑do")
+        XCTAssertFalse(pieces.joined().contains("\u{FFFD}"))
+    }
+
     func testSummaryLogprobsMeasureEveryEmittedToken() throws {
         let result = try AutoregressiveDecodeEngine.decode(
             request(firstToken: 3, budget: 8, logprobCapture: .summary),

--- a/Tests/MereRunCoreTests/IncrementalTokenTextDecoderTests.swift
+++ b/Tests/MereRunCoreTests/IncrementalTokenTextDecoderTests.swift
@@ -1,0 +1,20 @@
+import XCTest
+@testable import MereRunCore
+
+final class IncrementalTokenTextDecoderTests: XCTestCase {
+    func testBuffersTrailingReplacementScalarsUntilSequenceResolves() {
+        var decoder = IncrementalTokenTextDecoder()
+
+        XCTAssertEqual(decoder.append(decodedText: "can\u{FFFD}"), "can")
+        XCTAssertEqual(decoder.append(decodedText: "can\u{FFFD}\u{FFFD}"), "")
+        XCTAssertEqual(decoder.append(decodedText: "can‑"), "‑")
+        XCTAssertEqual(decoder.append(decodedText: "can‑do"), "do")
+    }
+
+    func testTracksUTF8BytesAcrossExtendedGraphemeChanges() {
+        var decoder = IncrementalTokenTextDecoder()
+
+        XCTAssertEqual(decoder.append(decodedText: "e"), "e")
+        XCTAssertEqual(decoder.append(decodedText: "e\u{0301}"), "\u{0301}")
+    }
+}


### PR DESCRIPTION
## Summary

- decode generated token history cumulatively before emitting Laguna streaming deltas
- buffer unstable trailing replacement scalars until byte-fallback sequences resolve
- apply the same behavior to serial, continuous-batch, and DFlash decode paths

## Why

Some byte-fallback tokenizer sequences span multiple tokens. Decoding each token independently could expose U+FFFD replacement characters during streaming even though decoding the completed response produced correct Unicode punctuation.

## Verification

- `swift test --filter "AutoregressiveDecodeEngineTests|IncrementalTokenTextDecoderTests"`
- `swift test --filter Laguna`
- `./scripts/check.sh` (3,794 XCTest cases, 301 environment-gated skips, 0 failures; Swift Testing suites also pass)
- real installed Laguna XS chat with a local LoRA: streamed non-breaking hyphen rendered correctly and output contained no U+FFFD