### PR TITLE
Render streamed Markdown in interactive terminals

### DIFF
--- a/Sources/MereRunCLI/Commands/TextChatCommand.swift
+++ b/Sources/MereRunCLI/Commands/TextChatCommand.swift
@@ -199,6 +199,12 @@ struct TextChat: AsyncParsableCommand {
     @Flag(name: [.customLong("stream")], help: "Stream generated text to stdout as tokens arrive.")
     var stream: Bool = false
 
+    @Option(
+        name: [.customLong("markdown")],
+        help: "Render streamed Markdown in terminals: auto, always, or never."
+    )
+    var markdown: TerminalMarkdownMode = .auto
+
     @Flag(
         name: [.customLong("show-unmasking")],
         help: "Show revision-aware DiffusionGemma canvas drafts on stderr."
@@ -397,7 +403,16 @@ struct TextChat: AsyncParsableCommand {
             showUnmasking: showUnmasking
         )
 
-        let streamingOutput = StreamingChatOutput(enabled: stream)
+        let markdownPresentation = TerminalMarkdownPresentation.resolve(
+            mode: markdown,
+            stdoutIsTTY: CLIStdout.isInteractive(),
+            isTextResponse: responseFormat == .text,
+            environment: ProcessInfo.processInfo.environment
+        )
+        let streamingOutput = StreamingChatOutput(
+            enabled: stream,
+            markdownPresentation: markdownPresentation
+        )
         let progressHandler = TextChatProgressHandler.make(
             quiet: quiet,
             streamingOutput: streamingOutput
@@ -605,6 +620,12 @@ struct TextChat: AsyncParsableCommand {
             CLIStderr.write("[tool-loop] Hit iteration limit (\(maxIterations))\n")
         } else {
             let result = try await chatOnce(request)
+            let wroteStreamedOutput = stream && streamingOutput.hasWritten
+            if wroteStreamedOutput {
+                // Finalize terminal presentation before diagnostics so, for
+                // example, --stats cannot appear inside an open code fence.
+                streamingOutput.finishLine()
+            }
 
             let elapsed = Date().timeIntervalSince(startTime)
             if stats {
@@ -680,9 +701,7 @@ struct TextChat: AsyncParsableCommand {
                 }
             }
 
-            if stream && streamingOutput.hasWritten {
-                streamingOutput.finishLine()
-            } else {
+            if !wroteStreamedOutput {
                 print(cleanResponse(result.response, showThinking: request.showThinking))
             }
         }
@@ -1085,13 +1104,18 @@ final class StreamingChatOutput: @unchecked Sendable {
     private let lock = NSLock()
     private var wroteOutput = false
     private let writer: @Sendable (String) -> Void
+    private let markdownStream: TerminalMarkdownStream?
 
     init(
         enabled: Bool,
+        markdownPresentation: TerminalMarkdownPresentation = .raw,
         writer: @escaping @Sendable (String) -> Void = CLIStdout.write
     ) {
         self.enabled = enabled
         self.writer = writer
+        self.markdownStream = markdownPresentation.rendersMarkdown
+            ? TerminalMarkdownStream(presentation: markdownPresentation, writer: writer)
+            : nil
     }
 
     var hasWritten: Bool {
@@ -1112,7 +1136,11 @@ final class StreamingChatOutput: @unchecked Sendable {
 
         lock.lock()
         defer { lock.unlock() }
-        writer(text)
+        if let markdownStream {
+            markdownStream.append(text)
+        } else {
+            writer(text)
+        }
         wroteOutput = true
         return true
     }
@@ -1120,6 +1148,10 @@ final class StreamingChatOutput: @unchecked Sendable {
     func finishLine() {
         lock.lock()
         defer { lock.unlock() }
-        writer("\n")
+        if let markdownStream {
+            markdownStream.finish()
+        } else {
+            writer("\n")
+        }
     }
 }

--- a/Sources/MereRunCLI/Support/CLIStderr.swift
+++ b/Sources/MereRunCLI/Support/CLIStderr.swift
@@ -15,6 +15,10 @@ enum CLIStdout {
     static func write(_ text: String) {
         FileHandle.standardOutput.write(Data(text.utf8))
     }
+
+    static func isInteractive() -> Bool {
+        isatty(STDOUT_FILENO) != 0
+    }
 }
 
 enum CLIStdin {

--- a/Sources/MereRunCLI/Support/README.md
+++ b/Sources/MereRunCLI/Support/README.md
@@ -4,6 +4,9 @@ Shared helpers for the public command surface.
 
 - `CLIModelStoreBootstrap.swift`: global model-root handling.
 - `CLIOutput.swift` and `CLIStderr.swift`: output channel discipline.
+- `TerminalMarkdownPresentation.swift` and `TerminalMarkdownStream.swift`:
+  safe, append-only Markdown presentation for interactive token streams while
+  preserving raw piped output.
 - `BuiltinTools.swift`: local tool execution guardrails.
 - `MachineInferenceAdmission.swift`: crash-safe weighted admission shared by
   heavyweight CLI and API-server processes on one machine.

--- a/Sources/MereRunCLI/Support/TerminalMarkdownPresentation.swift
+++ b/Sources/MereRunCLI/Support/TerminalMarkdownPresentation.swift
@@ -1,0 +1,44 @@
+import ArgumentParser
+import Foundation
+
+enum TerminalMarkdownMode: String, CaseIterable, ExpressibleByArgument {
+    case auto
+    case always
+    case never
+}
+
+struct TerminalMarkdownPresentation: Equatable {
+    let rendersMarkdown: Bool
+    let usesANSIStyles: Bool
+    let usesColor: Bool
+
+    static let raw = TerminalMarkdownPresentation(
+        rendersMarkdown: false,
+        usesANSIStyles: false,
+        usesColor: false
+    )
+
+    static func resolve(
+        mode: TerminalMarkdownMode,
+        stdoutIsTTY: Bool,
+        isTextResponse: Bool,
+        environment: [String: String]
+    ) -> TerminalMarkdownPresentation {
+        guard isTextResponse, mode != .never else {
+            return .raw
+        }
+
+        let terminalSupportsStyles = environment["TERM"]?.lowercased() != "dumb"
+        let rendersMarkdown = mode == .always || (stdoutIsTTY && terminalSupportsStyles)
+        guard rendersMarkdown else {
+            return .raw
+        }
+
+        let usesANSIStyles = stdoutIsTTY && terminalSupportsStyles
+        return TerminalMarkdownPresentation(
+            rendersMarkdown: true,
+            usesANSIStyles: usesANSIStyles,
+            usesColor: usesANSIStyles && environment["NO_COLOR"] == nil
+        )
+    }
+}

--- a/Sources/MereRunCLI/Support/TerminalMarkdownStream.swift
+++ b/Sources/MereRunCLI/Support/TerminalMarkdownStream.swift
@@ -1,0 +1,536 @@
+import Foundation
+
+/// An append-only Markdown presenter for token streams. It deliberately avoids
+/// cursor movement so partially generated output never flickers or rewrites.
+final class TerminalMarkdownStream {
+    private enum ANSI {
+        static let reset = "\u{001B}[0m"
+        static let bold = "\u{001B}[1m"
+        static let boldOff = "\u{001B}[22m"
+        static let italic = "\u{001B}[3m"
+        static let italicOff = "\u{001B}[23m"
+        static let strike = "\u{001B}[9m"
+        static let strikeOff = "\u{001B}[29m"
+        static let accent = "\u{001B}[38;5;75m"
+        static let code = "\u{001B}[38;5;215m"
+        static let colorOff = "\u{001B}[39m"
+    }
+
+    private let presentation: TerminalMarkdownPresentation
+    private let writer: @Sendable (String) -> Void
+    private var writeBuffer = ""
+
+    private var atLineStart = true
+    private var linePrefix = ""
+    private var readingFenceHeader = false
+    private var fenceHeader = ""
+    private var inCodeFence = false
+    private var fenceLength = 3
+    private var codeLinePrefix = ""
+    private var codeLineStarted = false
+
+    private var pendingAsterisks = 0
+    private var pendingTildes = 0
+    private var previousInlineCharacter: Character?
+    private var escaped = false
+    private var bold = false
+    private var italic = false
+    private var strike = false
+    private var inlineCode = false
+    private var headingStyle = false
+    private var endedWithNewline = true
+
+    init(
+        presentation: TerminalMarkdownPresentation,
+        writer: @escaping @Sendable (String) -> Void
+    ) {
+        self.presentation = presentation
+        self.writer = writer
+    }
+
+    func append(_ text: String) {
+        for character in text {
+            consume(character)
+        }
+        flushWrites()
+    }
+
+    func finish() {
+        if readingFenceHeader {
+            openFence()
+        }
+
+        if !inCodeFence, let marker = linePrefix.first, linePrefix.count >= 3 {
+            if "-*_".contains(marker), linePrefix.allSatisfy({ $0 == marker }) {
+                linePrefix = ""
+                emitMarker(String(repeating: "─", count: 32))
+            } else if marker == "`", linePrefix.allSatisfy({ $0 == "`" }) {
+                fenceLength = linePrefix.count
+                linePrefix = ""
+                openFence()
+            }
+        }
+
+        if inCodeFence {
+            if !codeLineStarted, isClosingFence(codeLinePrefix) {
+                codeLinePrefix = ""
+            } else {
+                flushPendingCodeLine()
+            }
+            emitCodeBorder("└─")
+            emit("\n")
+            inCodeFence = false
+        } else {
+            flushLinePrefixAsInline()
+            finishInlineLine()
+        }
+
+        if presentation.usesANSIStyles {
+            queue(ANSI.reset)
+        }
+        if !endedWithNewline {
+            emit("\n")
+        }
+        flushWrites()
+    }
+
+    private func consume(_ character: Character) {
+        if readingFenceHeader {
+            if character == "\n" {
+                openFence()
+            } else {
+                fenceHeader.append(character)
+            }
+            return
+        }
+
+        if inCodeFence {
+            consumeCode(character)
+            return
+        }
+
+        if atLineStart {
+            consumeLineStart(character)
+            return
+        }
+
+        consumeInline(character)
+    }
+
+    private func consumeLineStart(_ character: Character) {
+        if linePrefix.isEmpty {
+            if character == "\n" {
+                emit("\n")
+            } else if isPotentialBlockPrefix(character) {
+                linePrefix.append(character)
+            } else {
+                atLineStart = false
+                consumeInline(character)
+            }
+            return
+        }
+
+        let first = linePrefix.first
+        switch first {
+        case "#":
+            consumeHeadingPrefix(character)
+        case ">":
+            if character == " " {
+                emitMarker("│ ")
+                linePrefix = ""
+                atLineStart = false
+            } else {
+                resolvePrefixAsInline(with: character)
+            }
+        case "+":
+            if character == " " {
+                emitMarker("• ")
+                linePrefix = ""
+                atLineStart = false
+            } else {
+                resolvePrefixAsInline(with: character)
+            }
+        case "-", "*", "_":
+            consumeListOrRulePrefix(character)
+        case "`":
+            consumeFencePrefix(character)
+        default:
+            consumeNumberedPrefix(character)
+        }
+    }
+
+    private func consumeHeadingPrefix(_ character: Character) {
+        if character == "#", linePrefix.count < 6 {
+            linePrefix.append(character)
+        } else if character == " ", (1...6).contains(linePrefix.count) {
+            linePrefix = ""
+            atLineStart = false
+            headingStyle = true
+            if presentation.usesANSIStyles { queue(ANSI.bold) }
+            if presentation.usesColor { queue(ANSI.accent) }
+        } else {
+            resolvePrefixAsInline(with: character)
+        }
+    }
+
+    private func consumeListOrRulePrefix(_ character: Character) {
+        guard let marker = linePrefix.first else { return }
+        if character == marker {
+            linePrefix.append(character)
+            return
+        }
+        if character == " ", linePrefix.count == 1, marker != "_" {
+            emitMarker("• ")
+            linePrefix = ""
+            atLineStart = false
+            return
+        }
+        if character == "\n", linePrefix.count >= 3 {
+            emitMarker(String(repeating: "─", count: 32))
+            emit("\n")
+            linePrefix = ""
+            atLineStart = true
+            return
+        }
+        resolvePrefixAsInline(with: character)
+    }
+
+    private func consumeFencePrefix(_ character: Character) {
+        if character == "`" {
+            linePrefix.append(character)
+            return
+        }
+        guard linePrefix.count >= 3 else {
+            resolvePrefixAsInline(with: character)
+            return
+        }
+
+        fenceLength = linePrefix.count
+        linePrefix = ""
+        if character == "\n" {
+            openFence()
+        } else {
+            readingFenceHeader = true
+            fenceHeader.append(character)
+        }
+    }
+
+    private func consumeNumberedPrefix(_ character: Character) {
+        if character.isNumber, !linePrefix.contains(".") {
+            linePrefix.append(character)
+        } else if character == ".", !linePrefix.contains(".") {
+            linePrefix.append(character)
+        } else if character == " ", linePrefix.last == "." {
+            emitMarker(linePrefix + " ")
+            linePrefix = ""
+            atLineStart = false
+        } else {
+            resolvePrefixAsInline(with: character)
+        }
+    }
+
+    private func resolvePrefixAsInline(with character: Character) {
+        let prefix = linePrefix
+        linePrefix = ""
+        atLineStart = false
+        for buffered in prefix {
+            consumeInline(buffered)
+        }
+        consumeInline(character)
+    }
+
+    private func flushLinePrefixAsInline() {
+        guard !linePrefix.isEmpty else { return }
+        let prefix = linePrefix
+        linePrefix = ""
+        for buffered in prefix {
+            consumeInline(buffered)
+        }
+    }
+
+    private func consumeInline(_ character: Character) {
+        if character == "\n" {
+            resolvePendingMarkers(next: nil)
+            finishInlineLine()
+            emit("\n")
+            atLineStart = true
+            previousInlineCharacter = nil
+            return
+        }
+
+        if escaped {
+            resolvePendingMarkers(next: character)
+            escaped = false
+            if "\\`*{}[]()#+-.!_>~".contains(character) {
+                emitSanitized(character)
+            } else {
+                emit("\\")
+                emitSanitized(character)
+            }
+            return
+        }
+
+        if character == "*" {
+            resolvePendingTildes(next: character)
+            pendingAsterisks += 1
+            return
+        }
+        if character == "~" {
+            resolvePendingAsterisks(next: character)
+            pendingTildes += 1
+            return
+        }
+
+        resolvePendingMarkers(next: character)
+
+        if character == "\\" {
+            escaped = true
+            return
+        }
+
+        switch character {
+        case "`":
+            inlineCode.toggle()
+            if presentation.usesColor {
+                queue(inlineCode ? ANSI.code : ANSI.colorOff)
+            }
+        default:
+            emitSanitized(character)
+        }
+    }
+
+    private func finishInlineLine() {
+        resolvePendingMarkers(next: nil)
+        if escaped {
+            escaped = false
+            emit("\\")
+        }
+
+        bold = false
+        italic = false
+        strike = false
+        inlineCode = false
+        if headingStyle || presentation.usesANSIStyles {
+            emitANSI(ANSI.reset)
+        }
+        headingStyle = false
+    }
+
+    private func resolvePendingMarkers(next: Character?) {
+        resolvePendingAsterisks(next: next)
+        resolvePendingTildes(next: next)
+    }
+
+    private func resolvePendingAsterisks(next: Character?) {
+        guard pendingAsterisks > 0 else { return }
+        var count = pendingAsterisks
+        pendingAsterisks = 0
+
+        while count >= 2 {
+            if bold, canCloseEmphasis(next: next) {
+                bold = false
+                emitANSI(ANSI.boldOff)
+            } else if !bold, canOpenEmphasis(next: next) {
+                bold = true
+                emitANSI(ANSI.bold)
+            } else {
+                emitInlineLiteral("**")
+            }
+            count -= 2
+        }
+
+        if count == 1 {
+            if italic, canCloseEmphasis(next: next) {
+                italic = false
+                emitANSI(ANSI.italicOff)
+            } else if !italic, canOpenEmphasis(next: next) {
+                italic = true
+                emitANSI(ANSI.italic)
+            } else {
+                emitInlineLiteral("*")
+            }
+        }
+    }
+
+    private func resolvePendingTildes(next: Character?) {
+        guard pendingTildes > 0 else { return }
+        var count = pendingTildes
+        pendingTildes = 0
+
+        while count >= 2 {
+            if strike, canCloseEmphasis(next: next) {
+                strike = false
+                emitANSI(ANSI.strikeOff)
+            } else if !strike, canOpenEmphasis(next: next) {
+                strike = true
+                emitANSI(ANSI.strike)
+            } else {
+                emitInlineLiteral("~~")
+            }
+            count -= 2
+        }
+
+        if count == 1 {
+            emitInlineLiteral("~")
+        }
+    }
+
+    private func canOpenEmphasis(next: Character?) -> Bool {
+        guard let next, !next.isMarkdownWhitespace else { return false }
+        guard let previousInlineCharacter else { return true }
+        return previousInlineCharacter.isMarkdownWhitespace
+            || previousInlineCharacter.isMarkdownPunctuation
+    }
+
+    private func canCloseEmphasis(next: Character?) -> Bool {
+        guard let previousInlineCharacter,
+              !previousInlineCharacter.isMarkdownWhitespace else {
+            return false
+        }
+        guard let next else { return true }
+        return next.isMarkdownWhitespace || next.isMarkdownPunctuation
+    }
+
+    private func emitInlineLiteral(_ text: String) {
+        emit(text)
+        previousInlineCharacter = text.last
+    }
+
+    private func openFence() {
+        let language = fenceHeader.trimmingCharacters(in: .whitespacesAndNewlines)
+        emitCodeBorder(language.isEmpty ? "┌─" : "┌─ \(language)")
+        emit("\n")
+        fenceHeader = ""
+        readingFenceHeader = false
+        inCodeFence = true
+        atLineStart = true
+        codeLineStarted = false
+        previousInlineCharacter = nil
+    }
+
+    private func consumeCode(_ character: Character) {
+        if !codeLineStarted {
+            if character == "`" || character == " " {
+                codeLinePrefix.append(character)
+                return
+            }
+            if character == "\n" {
+                if isClosingFence(codeLinePrefix) {
+                    codeLinePrefix = ""
+                    emitCodeBorder("└─")
+                    emit("\n")
+                    inCodeFence = false
+                    atLineStart = true
+                    previousInlineCharacter = nil
+                } else {
+                    emitCodeLinePrefix()
+                    for buffered in codeLinePrefix { emitSanitized(buffered) }
+                    codeLinePrefix = ""
+                    emit("\n")
+                    codeLineStarted = false
+                    previousInlineCharacter = nil
+                }
+                return
+            }
+
+            emitCodeLinePrefix()
+            for buffered in codeLinePrefix { emitSanitized(buffered) }
+            codeLinePrefix = ""
+            codeLineStarted = true
+        }
+
+        if character == "\n" {
+            emit("\n")
+            codeLineStarted = false
+            previousInlineCharacter = nil
+        } else {
+            emitSanitized(character)
+        }
+    }
+
+    private func flushPendingCodeLine() {
+        if !codeLinePrefix.isEmpty || codeLineStarted {
+            if !codeLineStarted { emitCodeLinePrefix() }
+            for buffered in codeLinePrefix { emitSanitized(buffered) }
+            codeLinePrefix = ""
+            if !endedWithNewline { emit("\n") }
+        }
+        codeLineStarted = false
+    }
+
+    private func isClosingFence(_ candidate: String) -> Bool {
+        let trimmed = candidate.trimmingCharacters(in: .whitespaces)
+        return trimmed.count >= fenceLength && trimmed.allSatisfy { $0 == "`" }
+    }
+
+    private func emitMarker(_ marker: String) {
+        if presentation.usesColor { queue(ANSI.accent) }
+        emit(marker)
+        if presentation.usesColor { queue(ANSI.colorOff) }
+    }
+
+    private func emitCodeBorder(_ border: String) {
+        if presentation.usesColor { queue(ANSI.code) }
+        emit(border)
+        if presentation.usesColor { queue(ANSI.colorOff) }
+    }
+
+    private func emitCodeLinePrefix() {
+        emitCodeBorder("│ ")
+    }
+
+    private func emitANSI(_ sequence: String) {
+        guard presentation.usesANSIStyles else { return }
+        queue(sequence)
+    }
+
+    private func emitSanitized(_ character: Character) {
+        for scalar in character.unicodeScalars {
+            switch scalar.value {
+            case 0x00...0x1F:
+                if scalar.value == 0x09 {
+                    emit("\t")
+                } else {
+                    emit(String(UnicodeScalar(0x2400 + scalar.value)!))
+                }
+            case 0x7F:
+                emit("␡")
+            case 0x80...0x9F:
+                emit("�")
+            default:
+                emit(String(scalar))
+            }
+        }
+        previousInlineCharacter = character
+    }
+
+    private func emit(_ text: String) {
+        guard !text.isEmpty else { return }
+        queue(text)
+        endedWithNewline = text.last == "\n"
+    }
+
+    private func queue(_ text: String) {
+        writeBuffer += text
+    }
+
+    private func flushWrites() {
+        guard !writeBuffer.isEmpty else { return }
+        writer(writeBuffer)
+        writeBuffer = ""
+    }
+
+    private func isPotentialBlockPrefix(_ character: Character) -> Bool {
+        character.isNumber || "#>*+-_`".contains(character)
+    }
+}
+
+private extension Character {
+    var isMarkdownWhitespace: Bool {
+        unicodeScalars.allSatisfy(CharacterSet.whitespacesAndNewlines.contains)
+    }
+
+    var isMarkdownPunctuation: Bool {
+        unicodeScalars.allSatisfy(CharacterSet.punctuationCharacters.contains)
+    }
+}

--- a/Sources/MereRunContract/CommandCapabilityContract.swift
+++ b/Sources/MereRunContract/CommandCapabilityContract.swift
@@ -553,6 +553,16 @@ public enum MereRunCapabilityCatalog {
             ),
             .init(flag: "--stats", label: "Stats", kind: .boolean, group: Group.run, tier: .expert),
             .init(flag: "--stream", label: "Stream", kind: .boolean, group: Group.output, tier: .standard),
+            .init(
+                flag: "--markdown",
+                label: "Terminal Markdown",
+                kind: .choice,
+                choices: ["auto", "always", "never"],
+                defaultValue: "auto",
+                group: Group.output,
+                tier: .standard,
+                dependsOn: "--stream"
+            ),
             .init(flag: "--tools", label: "Tools", kind: .string, group: Group.run, tier: .expert),
             .init(flag: "--tool-loop", label: "Tool loop", kind: .boolean, group: Group.run, tier: .expert, dependsOn: "--tools"),
             .init(

--- a/Tests/MereRunCLITests/TerminalMarkdownStreamTests.swift
+++ b/Tests/MereRunCLITests/TerminalMarkdownStreamTests.swift
@@ -1,0 +1,249 @@
+import XCTest
+@testable import MereRunCLI
+
+final class TerminalMarkdownStreamTests: XCTestCase {
+    func testAutomaticPresentationOnlyRendersInteractiveText() {
+        XCTAssertEqual(
+            TerminalMarkdownPresentation.resolve(
+                mode: .auto,
+                stdoutIsTTY: true,
+                isTextResponse: true,
+                environment: ["TERM": "xterm-256color"]
+            ),
+            TerminalMarkdownPresentation(
+                rendersMarkdown: true,
+                usesANSIStyles: true,
+                usesColor: true
+            )
+        )
+        XCTAssertEqual(
+            TerminalMarkdownPresentation.resolve(
+                mode: .auto,
+                stdoutIsTTY: false,
+                isTextResponse: true,
+                environment: ["TERM": "xterm-256color"]
+            ),
+            .raw
+        )
+        XCTAssertEqual(
+            TerminalMarkdownPresentation.resolve(
+                mode: .auto,
+                stdoutIsTTY: true,
+                isTextResponse: false,
+                environment: ["TERM": "xterm-256color"]
+            ),
+            .raw
+        )
+        XCTAssertEqual(
+            TerminalMarkdownPresentation.resolve(
+                mode: .auto,
+                stdoutIsTTY: true,
+                isTextResponse: true,
+                environment: ["TERM": "dumb"]
+            ),
+            .raw
+        )
+    }
+
+    func testAlwaysRendersStructureWithoutInjectingANSIIntoPipes() {
+        let presentation = TerminalMarkdownPresentation.resolve(
+            mode: .always,
+            stdoutIsTTY: false,
+            isTextResponse: true,
+            environment: ["TERM": "xterm-256color"]
+        )
+
+        XCTAssertTrue(presentation.rendersMarkdown)
+        XCTAssertFalse(presentation.usesANSIStyles)
+        XCTAssertFalse(presentation.usesColor)
+    }
+
+    func testNoColorKeepsTypographyButDisablesColor() {
+        let presentation = TerminalMarkdownPresentation.resolve(
+            mode: .always,
+            stdoutIsTTY: true,
+            isTextResponse: true,
+            environment: ["TERM": "xterm-256color", "NO_COLOR": "1"]
+        )
+
+        XCTAssertTrue(presentation.rendersMarkdown)
+        XCTAssertTrue(presentation.usesANSIStyles)
+        XCTAssertFalse(presentation.usesColor)
+    }
+
+    func testChunkBoundariesDoNotChangeRenderedMarkdown() {
+        let output = MarkdownOutputRecorder()
+        let renderer = TerminalMarkdownStream(
+            presentation: .init(
+                rendersMarkdown: true,
+                usesANSIStyles: false,
+                usesColor: false
+            ),
+            writer: output.write
+        )
+
+        renderer.append("# Hel")
+        renderer.append("lo\n\n- o")
+        renderer.append("ne\n**bo")
+        renderer.append("ld** and `co")
+        renderer.append("de`\n```swi")
+        renderer.append("ft\nlet x = 1\n``")
+        renderer.append("`\n")
+        renderer.finish()
+
+        XCTAssertEqual(
+            output.value,
+            """
+            Hello
+
+            • one
+            bold and code
+            ┌─ swift
+            │ let x = 1
+            └─
+
+            """
+        )
+    }
+
+    func testFinishClosesUnterminatedCodeFence() {
+        let output = MarkdownOutputRecorder()
+        let renderer = TerminalMarkdownStream(
+            presentation: .init(
+                rendersMarkdown: true,
+                usesANSIStyles: false,
+                usesColor: false
+            ),
+            writer: output.write
+        )
+
+        renderer.append("```swift\nlet value = 1")
+        renderer.finish()
+
+        XCTAssertEqual(output.value, "┌─ swift\n│ let value = 1\n└─\n")
+    }
+
+    func testFinishResolvesPendingBlockMarkers() {
+        let ruleOutput = MarkdownOutputRecorder()
+        let ruleRenderer = makePlainRenderer(writer: ruleOutput.write)
+        ruleRenderer.append("---")
+        ruleRenderer.finish()
+
+        let fenceOutput = MarkdownOutputRecorder()
+        let fenceRenderer = makePlainRenderer(writer: fenceOutput.write)
+        fenceRenderer.append("```")
+        fenceRenderer.finish()
+
+        XCTAssertEqual(ruleOutput.value, String(repeating: "─", count: 32) + "\n")
+        XCTAssertEqual(fenceOutput.value, "┌─\n└─\n")
+    }
+
+    func testClosingFenceNeedsNoTrailingNewlineAndMayBeIndented() {
+        for closingFence in ["```", "   ```"] {
+            let output = MarkdownOutputRecorder()
+            let renderer = makePlainRenderer(writer: output.write)
+
+            renderer.append("```swift\nlet ready = true\n\(closingFence)")
+            renderer.finish()
+
+            XCTAssertEqual(output.value, "┌─ swift\n│ let ready = true\n└─\n")
+        }
+    }
+
+    func testInlineContextRestartsAfterClosingFence() {
+        let output = MarkdownOutputRecorder()
+        let renderer = makePlainRenderer(writer: output.write)
+
+        renderer.append("```\nvalue\n```\n*after*")
+        renderer.finish()
+
+        XCTAssertEqual(output.value, "┌─\n│ value\n└─\nafter\n")
+    }
+
+    func testBackslashesOnlyEscapeMarkdownPunctuation() {
+        let output = MarkdownOutputRecorder()
+        let renderer = makePlainRenderer(writer: output.write)
+
+        renderer.append(#"C:\Users and \*literal star*"#)
+        renderer.finish()
+
+        XCTAssertEqual(output.value, "C:\\Users and *literal star*\n")
+    }
+
+    func testLiteralOperatorsStayVisibleWhileDelimitedEmphasisRenders() {
+        let output = MarkdownOutputRecorder()
+        let renderer = makePlainRenderer(writer: output.write)
+
+        renderer.append("2 * 3\nfile**name\n*italic* and ~~done~~")
+        renderer.finish()
+
+        XCTAssertEqual(output.value, "2 * 3\nfile**name\nitalic and done\n")
+    }
+
+    func testEachTokenChunkIsBatchedIntoOneTerminalWrite() {
+        let output = MarkdownOutputRecorder()
+        let renderer = makePlainRenderer(writer: output.write)
+
+        renderer.append("ordinary text")
+        XCTAssertEqual(output.writeCount, 1)
+
+        renderer.finish()
+        XCTAssertEqual(output.writeCount, 2)
+    }
+
+    func testRenderedModeNeutralizesTerminalControlCharacters() {
+        let output = MarkdownOutputRecorder()
+        let renderer = TerminalMarkdownStream(
+            presentation: .init(
+                rendersMarkdown: true,
+                usesANSIStyles: false,
+                usesColor: false
+            ),
+            writer: output.write
+        )
+
+        renderer.append("safe \u{001B}[31mred\u{0007}")
+        renderer.finish()
+
+        XCTAssertEqual(output.value, "safe ␛[31mred␇\n")
+        XCTAssertFalse(output.value.contains("\u{001B}"))
+    }
+
+    private func makePlainRenderer(
+        writer: @escaping @Sendable (String) -> Void
+    ) -> TerminalMarkdownStream {
+        TerminalMarkdownStream(
+            presentation: .init(
+                rendersMarkdown: true,
+                usesANSIStyles: false,
+                usesColor: false
+            ),
+            writer: writer
+        )
+    }
+}
+
+private final class MarkdownOutputRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var text = ""
+    private var writes = 0
+
+    var value: String {
+        lock.lock()
+        defer { lock.unlock() }
+        return text
+    }
+
+    var writeCount: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return writes
+    }
+
+    func write(_ value: String) {
+        lock.lock()
+        defer { lock.unlock() }
+        text += value
+        writes += 1
+    }
+}

--- a/Tests/MereRunCLITests/TextChatCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/TextChatCommandParsingTests.swift
@@ -12,6 +12,7 @@ final class TextChatCommandParsingTests: XCTestCase {
         XCTAssertEqual(cmd.prompt, "Say hello")
         XCTAssertEqual(cmd.model, TextChat.defaultChatModelId)
         XCTAssertEqual(cmd.responseFormat, .text)
+        XCTAssertEqual(cmd.markdown, .auto)
     }
 
     func testTextChatDefaultModelSelectionForMemoryBands() {
@@ -40,9 +41,11 @@ final class TextChatCommandParsingTests: XCTestCase {
         let cmd = try TextChat.parse([
             "--prompt", "Stream this",
             "--stream",
+            "--markdown", "never",
         ])
 
         XCTAssertTrue(cmd.stream)
+        XCTAssertEqual(cmd.markdown, .never)
     }
 
     func testTextChatParsesDiffusionGemmaModel() throws {

--- a/Tests/MereRunContractTests/CommandCapabilityContractTests.swift
+++ b/Tests/MereRunContractTests/CommandCapabilityContractTests.swift
@@ -365,8 +365,12 @@ private let selfLocatingOutputCapabilityIDs: [String: String] = [
 @Test func textChatChoicesComeFromTypedSharedEnums() {
     let chat = MereRunCapabilityCatalog.textChat
     let responseFormat = chat.options.first { $0.flag == "--response-format" }
+    let markdown = chat.options.first { $0.flag == "--markdown" }
 
     #expect(responseFormat?.choices == TextResponseFormat.allCases.map(\.rawValue))
+    #expect(markdown?.choices == ["auto", "always", "never"])
+    #expect(markdown?.defaultValue == "auto")
+    #expect(markdown?.dependsOn == "--stream")
 }
 
 @Test func lagunaControlsAreFirstClassAcrossSharedCommandSurfaces() {

--- a/apps/macos/StudioKit/Catalog/CommandFlags.swift
+++ b/apps/macos/StudioKit/Catalog/CommandFlags.swift
@@ -18,7 +18,8 @@ extension CommandFlags {
         package static let defaultValues = [
             "--max-tokens": "2048",
             "--response-format": "text",
-            "--lora-scale": "1.0"
+            "--lora-scale": "1.0",
+            "--markdown": "auto"
         ]
 
         package static let prompt = "--prompt"
@@ -44,6 +45,7 @@ extension CommandFlags {
         package static let reasoningEffort = "--reasoning-effort"
         package static let stats = "--stats"
         package static let stream = "--stream"
+        package static let markdown = "--markdown"
         package static let tools = "--tools"
         package static let toolLoop = "--tool-loop"
         package static let sandboxDir = "--sandbox-dir"

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -858,6 +858,9 @@ Key options:
   enabled by default even though the reasoning stays hidden. Qwen3.8 and
   Bonsai 27B also default to thinking-enabled generation.
 - `--stream`
+- `--markdown auto|always|never`: present streamed Markdown for a terminal.
+  `auto` is the default and only renders interactive text output; `always`
+  forces structural rendering, and `never` preserves the model's Markdown.
 - `--stats`: includes user-visible `ttft_s`, decode-only `first_token_s`,
   separate LFM2 prefill and decode tokens/sec, and Gemma4 MTP state and
   accept/draft counts when those runtimes are used
@@ -868,6 +871,14 @@ backend, for example native MLX/Metal for MLX models or llama.cpp/GGUF for GGUF
 models. `--quiet` does not change the requested output mode: with `--stream`,
 generated text still arrives incrementally on stdout while diagnostics remain
 suppressed.
+
+Interactive `--stream` output renders headings, lists, quotes, emphasis, and
+fenced code as they arrive. Pipes and redirections receive the exact raw
+Markdown so scripts remain stable, and `json_object` output is never decorated.
+Set `--markdown never` when a terminal should also receive raw Markdown, or
+`--markdown always` to render structure when stdout is redirected. Forced
+non-terminal rendering does not emit ANSI escapes. The `NO_COLOR` environment
+variable disables color while retaining useful typography and structure.
 
 `--lora` accepts a compatible local adapter file or cataloged adapter id.
 Native Gemma 4, Laguna XS 2.1, Inkling-Small, and LFM2.5 A1B adapters produced by
@@ -895,6 +906,7 @@ swift run mere.run text chat --model text-chat-lfm25-2.6b-4bit --prompt "Explain
 swift run mere.run text chat --model text-chat-lfm25-a1b-8bit --prompt "Summarize LFM2 in one paragraph."
 swift run mere.run text chat --model vision-chat-lfm25-3b-8bit --image ./photo.jpg --prompt "Describe this image."
 swift run mere.run text chat --stream --prompt "Write a short welcome message."
+swift run mere.run text chat --stream --markdown never --prompt "Write raw Markdown."
 swift run mere.run text chat --thinking --stats --prompt "How would you design a tokenizer?"
 ```
 

--- a/docs/runtime/text.md
+++ b/docs/runtime/text.md
@@ -93,6 +93,11 @@ swift run mere.run text chat \
   --prompt "Summarize diffusion models in one paragraph."
 ```
 
+With `--stream`, interactive terminals render common Markdown incrementally.
+Redirected stdout remains raw for scripts. Use `--markdown never` to keep raw
+Markdown in a terminal or `--markdown always` to force structural rendering;
+JSON response mode is always raw.
+
 `text-chat-gemma4-12b` runs Google's dense Gemma 4 12B-it checkpoint through
 the native Swift Gemma runtime. Managed pulls for `text-chat-gemma4-12b` and
 `vision-chat-gemma4-12b` install the `google/gemma-4-12B-it-assistant`


### PR DESCRIPTION
## Summary
- add `--markdown auto|always|never` to `text chat`, defaulting to automatic interactive-terminal rendering
- render headings, lists, quotes, emphasis, rules, and fenced code incrementally without cursor rewrites
- preserve raw Markdown for pipes and JSON, honor `NO_COLOR`, batch writes by token chunk, and neutralize model-supplied terminal controls
- publish the option through the shared command contract and generated Studio flags

## Verification
- `./scripts/check.sh`
- live Laguna XS streaming proof with forced structural rendering
- live non-TTY `auto` proof preserving raw `#` and `-` Markdown
