### PR TITLE
Fix Gemma 4 cache growth for uneven prefill chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+### Runtime
+
+- fixed Gemma 4 full-attention cache growth for uneven prompt chunks. Growth
+  now allocates space for the entire incoming chunk after trimming unused
+  capacity, preventing MLX broadcast-shape crashes during prefill.
+
 ### CLI
 
 - added `text train-lora --resume-from` for deterministic global-step

--- a/Sources/MereRunCore/Gemma4/Gemma4Model.swift
+++ b/Sources/MereRunCore/Gemma4/Gemma4Model.swift
@@ -217,8 +217,9 @@ final class Gemma4FullKVCache: Gemma4AttentionCache {
             let heads = keys.dim(1)
             let keyDim = keys.dim(3)
             let valueDim = values.dim(3)
-            let missing = max(0, newOffset - (self.keys?.dim(2) ?? 0))
-            let steps = max(1, (missing + Self.allocationStep - 1) / Self.allocationStep)
+            // Growth retains only the valid prefix below, discarding spare
+            // capacity. Allocate enough new rows for the entire incoming chunk.
+            let steps = max(1, (keys.dim(2) + Self.allocationStep - 1) / Self.allocationStep)
             let growth = steps * Self.allocationStep
             let newKeys = MLXArray.zeros([batch, heads, growth, keyDim], dtype: keys.dtype)
             let newValues = MLXArray.zeros([batch, heads, growth, valueDim], dtype: values.dtype)

--- a/Tests/MereRunCoreTests/Gemma4FullKVCacheTests.swift
+++ b/Tests/MereRunCoreTests/Gemma4FullKVCacheTests.swift
@@ -1,0 +1,33 @@
+import MLX
+import XCTest
+@testable import MereRunCore
+
+final class Gemma4FullKVCacheTests: MereRunCoreTestCase {
+    func testPrefillGrowthPreservesEveryKeyAndValue() throws {
+        // Semantic prompt boundaries need not align with the 256-token capacity
+        // step. Growing after 175 tokens must retain room for all 337 new tokens.
+        for chunks in [[175, 337, 1, 511], [255, 258], [256, 256, 1], [257, 512]] {
+            let cache = Gemma4FullKVCache()
+            let count = chunks.reduce(0, +)
+            let keys = MLXArray((0..<(count * 8)).map(Float.init)).reshaped(1, 1, count, 8)
+            let values = MLXArray((0..<(count * 4)).map { -Float($0) }).reshaped(1, 1, count, 4)
+            var offset = 0
+
+            for chunk in chunks {
+                let end = offset + chunk
+                cache.append(
+                    keys: keys[0..., 0..., offset..<end, 0...],
+                    values: values[0..., 0..., offset..<end, 0...]
+                )
+                cache.evaluateStorage()
+                let state = try XCTUnwrap(cache.currentState())
+                XCTAssertEqual(cache.offset, end)
+                XCTAssertEqual(state.0.shape, [1, 1, end, 8])
+                XCTAssertEqual(state.1.shape, [1, 1, end, 4])
+                XCTAssertEqual(MLX.abs(state.0 - keys[0..., 0..., 0..<end, 0...]).max().item(Float.self), 0)
+                XCTAssertEqual(MLX.abs(state.1 - values[0..., 0..., 0..<end, 0...]).max().item(Float.self), 0)
+                offset = end
+            }
+        }
+    }
+}


### PR DESCRIPTION
Gemma 4 could crash during prefill when an incoming prompt chunk outgrew a partially filled full-attention KV buffer. Growth counted unused capacity and then discarded it, leaving a 256-token destination for a 337-token update. Allocate the entire incoming chunk after retaining the valid prefix.

Adds a regression covering uneven and aligned chunks, subsequent decoding, and exact preservation of every key and value. The regression reproduces the old MLX broadcast-shape crash; a debugger backtrace from the ATE-derived evaluation confirms the same `Gemma4FullKVCache.append` path.

Validation: `./scripts/check.sh` passed (3,822 XCTest cases, 303 expected skips; 51 Swift Testing tests), targeted cache/model tests passed, and Gemma 4 12B Q4 completed the original eight-case ATE smoke with 8/8 passing using default settings. This is bounded runtime validation, not a complete model benchmark. The related 240-case benchmark and reports are in https://github.com/sawfwair/mere-run-plugins/pull/50.
