### PR TITLE
Publish generation results and Ornith upstream head comparison

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -1,5 +1,7 @@
 import { defineConfig } from 'vitepress'
 import { existsSync } from 'node:fs'
+import { cp } from 'node:fs/promises'
+import { join } from 'node:path'
 import { mereMarkdown } from './theme/mere/markdown'
 
 function resolveBase(): string {
@@ -26,6 +28,13 @@ export default defineConfig({
   base: resolveBase(),
   cleanUrls: true,
   lastUpdated: true,
+  async buildEnd(config) {
+    await cp(
+      join(config.srcDir, 'benchmarks/receipts'),
+      join(config.outDir, 'benchmarks/receipts'),
+      { recursive: true }
+    )
+  },
   srcExclude: [
     'README.md',
     'macos-studio-roadmap.md',

--- a/docs/benchmarking.md
+++ b/docs/benchmarking.md
@@ -365,13 +365,17 @@ with `uncontended: false`. Keep the repetition range visible and treat the
 result as a workstation observation. The collector still checks memory pressure
 and refuses to start alongside another inference process.
 
+Record the binary's build commit with `--build-source-revision`. The receipt
+distinguishes that revision from the checkout's current head, captures CPU load
+averages, and rejects a binary replaced during measurement.
+
 Set `MERERUN_Q35_MTP_PROFILE=1` only for diagnosis. The optional
 `acceleration.speculationProfile` contains per-round draft, target-forward,
 acceptance, and repair timings, plus serial fallback time. Submission time
 can include waits inside a model forward. Profiling adds synchronization and
 must be disabled for throughput conclusions.
 
-For the experiment controls and qualification status, see the
+For the scheduling defaults, controls, and measured workload results, see the
 [Qwen and Ornith generation tuning report](benchmarks/ornith-qwen-generation-tuning-2026-09-05.md).
 
 The microbenchmark commands are for runtime implementation work:

--- a/docs/benchmarks/ornith-mtp-upstream-check-2026-09-05.md
+++ b/docs/benchmarks/ornith-mtp-upstream-check-2026-09-05.md
@@ -1,0 +1,112 @@
+# Ornith MTP upstream comparison
+
+Replacing only Ornith 1.5's MTP draft head improved draft acceptance in the
+existing mere.run runtime. With three drafts per verification round, code
+acceptance increased from 34.8% to 70.7%, and prose acceptance increased from
+13.4% to 31.0%. All 40 measured requests preserved the serial target's exact
+output hash and 256-token count. These results identify head quality as a
+limiting factor on these prompts; they do not establish that the runtime has
+no remaining performance issues.
+
+This is a follow-up to the [complete generation workload report](ornith-qwen-generation-tuning-2026-09-05.md).
+The replacement head remains an experiment. The scheduling defaults in
+[PR #443](https://github.com/sawfwair/mere-run/pull/443) retain the installed
+model weights and head selection.
+
+## References and implementation checks
+
+The main architecture reference is vLLM's
+[Qwen3.5 MTP implementation](https://github.com/vllm-project/vllm/blob/f4eccdadefc6501fafeb1a0bf7f171ff24f984b0/vllm/model_executor/models/qwen3_5_mtp.py).
+It normalizes the next-token embedding and target hidden state separately,
+concatenates embedding then hidden, applies the fusion projection and a
+full-attention decoder layer, and returns the head's normalized output.
+mere.run follows these operations and reuses the target output projection.
+
+The Ornith target supplies its post-normalization hidden state to MTP. This
+matches the [merged llama.cpp correction](https://github.com/ggml-org/llama.cpp/pull/24025).
+The installed raw HF head uses zero-centered RMSNorm weights, which mere.run
+loads without subtracting one and evaluates with a `1 + weight` scale.
+The inspected vLLM path uses the corresponding Gemma-style RMSNorm.
+
+An Apple Silicon reference is
+[oMLX's Qwen3.5 MoE MTP adapter](https://github.com/jundot/omlx/blob/e467261edc786efd33b1e9023d5c4a827f8aa1c1/omlx/patches/mlx_vlm_mtp/qwen35_moe_vlm_runtime.py).
+That revision captures a pre-normalization target state, so it is not an
+interchangeable reference for the hidden-state input checked here. It also
+handles mixed raw-HF and converted-MLX head normalization conventions. The
+installed head inspected in this experiment uses the raw-HF convention.
+
+[Shisa's replacement head](https://huggingface.co/shisa-ai/Ornith-1.5-35B-A3B-MTP-ONLY)
+provides a concrete head-quality comparison. Its publisher reports weak stock
+head acceptance and documents a Qwen3.6-initialized, KL-distilled replacement.
+The publisher marks it experimental and reports unresolved runtime correctness
+issues in some vLLM tests. Their throughput figures are not Mac measurements.
+
+Our native head contains 785 tensors. Local samples include a projection
+standard deviation near 0.02 and `mtp.norm.weight` mean 0.022813. These are
+consistent with the reported stock-head statistics; they do not prove whether
+or how the head was trained.
+
+## Head comparison
+
+Both model roots use the same installed Ornith Q4 target files. The experiment
+uses a separate root with symbolic links to the target and a replacement MTP
+component. No installed model files were changed.
+
+The replacement is pinned to revision
+`2b19b31bfe1659c6b0d9459ec3cbd87e34a322ef`. Its original 1,689,283,688-byte
+safetensors file matches the publisher's SHA-256:
+`73c6e839971fff3c6d78dbcb6a15895bbab340a2898e98aa6943070751de712e`.
+The 19 fused tensors were expanded into 785 per-expert tensors for the existing
+loader by copying BF16 bytes unchanged. Every output tensor was read back and
+hash-checked. No normalization values or quantization were changed.
+
+### Three-draft diagnostic
+
+Each row contains one measured 256-token request after a 256-token warm-up.
+The diagnostic uses block size 4 and a draft-cost estimate of `1e-100`.
+Counters verify three proposed drafts in every round except the final token
+budget tail. This cost override is a measurement control, not a selected default.
+
+| Workload | Stock accepted / drafted | Stock acceptance | Replacement accepted / drafted | Replacement acceptance | Stock / replacement rounds |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Code | 130 / 374 | 34.8% | 174 / 246 | 70.7% | 125 / 82 |
+| Prose | 73 / 544 | 13.4% | 123 / 397 | 31.0% | 182 / 133 |
+
+### Adaptive policy
+
+These rows use the default draft-cost estimate of 0.18 and block size 4, with
+three measured requests after a 256-token warm-up. Acceptance counts were
+identical across repetitions. Decode TPS is the median with minimum and maximum
+in parentheses.
+
+| Workload | Stock acceptance | Replacement acceptance | Stock adaptive TPS (range) | Replacement adaptive TPS (range) |
+| --- | ---: | ---: | ---: | ---: |
+| Code | 51.9% | 71.7% | 94.4 (77.2–96.9) | 99.6 (93.3–110.9) |
+| Prose | 25.9% | 38.3% | 73.8 (66.6–74.7) | 76.8 (75.1–84.9) |
+
+The adaptive policy can stop drafting, so its acceptance rates are conditional
+on the drafts it chooses to attempt. They are not directly comparable to the
+three-draft diagnostic. The CLI's `forced` variant also adapts draft depth; it
+forces MTP admission and is retained as an additional repetition control.
+
+Other inference was detected during some runs. The same-target serial medians
+varied between 80.7 and 85.4 TPS for code and between 78.2 and 83.0 TPS for prose.
+These shared-workstation timings do not isolate the speedup caused by changing
+the head. Higher draft acceptance reduces verification work, but total latency
+also depends on draft computation, verification cost, and system load.
+
+## Evidence and limits
+
+The eight [machine-readable receipts](receipts/ornith-mtp-head-comparison-2026-09-05.json)
+retain all 40 measured requests, output hashes, acceptance counts, timing, GPU
+and CPU samples, model provenance, conversion hashes, and script hashes. The
+artifact SHA-256 is
+`7505b6706c2da8effd233aafc82a698bb659ae146b441086bf459fd1317f42ba`.
+The runtime is the unchanged `c3ef55db5f09b2bcc6526bec4dd2a78eaa27aee6` release
+build used in the generation report.
+
+This check covers two short text prompts with greedy, fixed-length generation.
+It does not qualify replacement-head behavior for long contexts, tools,
+multimodal input, sampling, or concurrent serving. Exact output checks establish
+the tested verifier behavior; they do not measure downstream answer quality.
+The replacement needs broader model qualification before becoming a default.

--- a/docs/benchmarks/ornith-qwen-generation-tuning-2026-09-05.md
+++ b/docs/benchmarks/ornith-qwen-generation-tuning-2026-09-05.md
@@ -12,6 +12,11 @@ generation. Target-verification rates from that assessment are not generation
 throughput. [PR #443](https://github.com/sawfwair/mere-run/pull/443) contains the
 scheduling changes and the repeated-request benchmark harness.
 
+The subsequent [Ornith upstream head comparison](ornith-mtp-upstream-check-2026-09-05.md)
+identifies weak stock-head acceptance on the code and prose prompts. A separate
+replacement-head experiment improves acceptance while preserving the tested
+outputs. The tables below retain the original installed-head measurements.
+
 ## Final workload results
 
 The tables show median decode tokens per second, with all three repetitions'

--- a/docs/benchmarks/ornith-qwen-generation-tuning-2026-09-05.md
+++ b/docs/benchmarks/ornith-qwen-generation-tuning-2026-09-05.md
@@ -1,34 +1,120 @@
 # Qwen and Ornith generation tuning
 
-This qualification follows the [Flash-Next transfer assessment](ornith-qwen-flash-transfer-2026-09-05.md)
-and merged [PR #442](https://github.com/sawfwair/mere-run/pull/442). It tests
-complete generation with the installed Qwen3.8-27B Q4 and Ornith 1.5 Q4
-checkpoints on an Apple M4 Max with 128 GB unified memory.
+Managed Qwen3.8 27B Q4 and Ornith 1.5 Q4 now keep compiled activation graphs
+inside each request's MLX stream, submit short decoder blocks asynchronously,
+and use pipelined target decoding after permanent greedy MTP fallback. These
+changes address repeated-request stalls. Other model IDs retain their scheduling
+defaults. Draft-cost and generation block-size defaults are unchanged.
 
-The scheduling defaults apply to the two managed Q4 models. The workload
-measurements retain every repetition and record the existing desktop load. Target-verification rates
-from the transfer assessment are not generation throughput.
+This follow-up to the [Flash-Next transfer assessment](ornith-qwen-flash-transfer-2026-09-05.md)
+and [PR #442](https://github.com/sawfwair/mere-run/pull/442) measures complete
+generation. Target-verification rates from that assessment are not generation
+throughput. [PR #443](https://github.com/sawfwair/mere-run/pull/443) contains the
+scheduling changes and the repeated-request benchmark harness.
 
-## Scheduling changes
+## Final workload results
 
-Each managed Q4 request owns its compiled activation graphs. Swift inference uses
-task-local MLX streams, while the C++ compilation cache uses the thread's
-default stream in its cache key. Reusing compiled functions across requests
-can retain graphs traced on an earlier request's stream. The request scope
-covers SiLU, SwiGLU, precise gated normalization, and decay preparation.
+The tables show median decode tokens per second, with all three repetitions'
+minimum and maximum in parentheses. Serial disables MTP; adaptive MTP is the
+managed model's default policy. Both use the new scheduling defaults. Request
+TPS includes prefill and request overhead, with model loading warmed separately.
+The MTP/serial column divides the two decode medians.
 
-The Q4 Qwen 27B and Ornith geometries submit short decoder blocks
+These are observations from an active desktop on an Apple M4 Max with 128 GB
+unified memory. No exclusive-machine throughput ceiling is claimed. Fixed-token
+runs ignore EOS; the prompts measure runtime behavior, not completion quality.
+
+### Ornith 1.5 35B-A3B Q4
+
+| Workload | Serial decode TPS (range) | Adaptive MTP decode TPS (range) | MTP request TPS | MTP TTFT (ms) | MTP/serial |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Code | 130.8 (129.5–132.4) | 65.9 (65.8–68.1) | 64.1 | 166 | 0.50× |
+| Chat | 64.3 (61.8–69.7) | 56.0 (55.9–62.2) | 54.0 | 199 | 0.87× |
+| Prose | 67.0 (58.2–69.1) | 64.4 (62.2–68.0) | 62.7 | 115 | 0.96× |
+| Math | 70.3 (66.1–73.8) | 80.7 (52.5–81.9) | 78.3 | 106 | 1.15× |
+| Summarization | 73.1 (62.5–83.9) | 81.6 (78.0–89.4) | 64.5 | 1101 | 1.12× |
+
+### Qwen3.8 27B Q4
+
+| Workload | Serial decode TPS (range) | Adaptive MTP decode TPS (range) | MTP request TPS | MTP TTFT (ms) | MTP/serial |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| Code | 12.1 (11.9–12.5) | 28.8 (28.4–30.1) | 26.8 | 703 | 2.38× |
+| Chat | 11.8 (10.9–12.7) | 20.9 (20.7–21.3) | 18.7 | 1441 | 1.78× |
+| Prose | 13.3 (13.2–13.5) | 14.6 (14.4–16.0) | 13.8 | 935 | 1.09× |
+| Math | 11.2 (10.1–11.7) | 23.8 (23.7–23.9) | 22.0 | 855 | 2.13× |
+| Summarization | 11.8 (11.1–11.9) | 23.5 (22.5–23.6) | 17.8 | 3483 | 1.99× |
+
+MTP does not beat serial decoding on every prompt. Absolute rates also differ
+substantially between the selection sweep, the final table, and the reversed
+order controls. These runs do not isolate the cause of that variation or establish
+a release-to-release speedup. Keep both repetition ranges and order controls
+visible when comparing settings on a shared workstation.
+
+### Reversed order
+
+These additional code and prose runs execute adaptive MTP before serial. The
+main code and prose table runs serial first. Each order has its own warm-up and
+three measured requests; the results are not pooled.
+
+| Model | Workload | Reversed serial TPS (range) | Reversed MTP TPS (range) |
+| --- | --- | ---: | ---: |
+| Ornith 1.5 35B-A3B Q4 | Code | 50.2 (45.5–54.7) | 47.8 (43.9–53.1) |
+| Ornith 1.5 35B-A3B Q4 | Prose | 78.4 (71.5–83.9) | 44.4 (25.6–61.2) |
+| Qwen3.8 27B Q4 | Code | 12.5 (9.2–14.2) | 24.1 (22.9–24.8) |
+| Qwen3.8 27B Q4 | Prose | 8.8 (8.3–9.5) | 16.0 (9.9–17.5) |
+
+### Sampled generation
+
+Separate runs use temperature 0.7 and top-p 0.9. Output hashes and every
+repetition are retained, but sampled outputs do not claim greedy parity or
+identical continuations across variants.
+
+| Model | Workload | Serial decode TPS (range) | Adaptive MTP decode TPS (range) | MTP request TPS |
+| --- | --- | ---: | ---: | ---: |
+| Ornith 1.5 35B-A3B Q4 | Chat | 44.2 (26.7–52.4) | 51.4 (44.5–51.8) | 49.0 |
+| Ornith 1.5 35B-A3B Q4 | Prose | 89.7 (76.2–106.0) | 63.3 (62.3–68.0) | 61.7 |
+| Qwen3.8 27B Q4 | Chat | 14.3 (9.1–15.4) | 20.3 (20.0–21.0) | 18.4 |
+| Qwen3.8 27B Q4 | Prose | 15.7 (14.7–16.0) | 17.0 (16.7–17.6) | 16.1 |
+
+## Setting selection
+
+The selection sweep used the same earlier optimized binary with explicit
+scheduling switches off or on. It compared the existing draft-cost estimate
+0.18 against 0.35 for Ornith and 0.30 for Qwen. Each setting retained every
+repetition, including the large stalls in the switches-off control. These
+controls describe the tested switches, not a separate release-to-release
+benchmark.
+
+| Model | Settings | Code MTP TPS (range) | Prose MTP TPS (range) |
+| --- | --- | ---: | ---: |
+| Ornith 1.5 35B-A3B Q4 | Scheduling off, cost 0.18 | 94.3 (33.8–97.2) | 23.0 (19.1–74.9) |
+| Ornith 1.5 35B-A3B Q4 | Scheduling on, cost 0.18 | 133.6 (133.1–137.5) | 119.5 (119.0–121.1) |
+| Ornith 1.5 35B-A3B Q4 | Scheduling on, cost 0.35 | 135.2 (122.8–141.0) | 116.1 (109.8–127.7) |
+| Qwen3.8 27B Q4 | Scheduling off, cost 0.18 | 30.0 (29.5–31.5) | 22.5 (19.0–22.9) |
+| Qwen3.8 27B Q4 | Scheduling on, cost 0.18 | 34.8 (33.7–35.6) | 21.8 (21.4–21.9) |
+| Qwen3.8 27B Q4 | Scheduling on, cost 0.30 | 36.5 (30.1–37.0) | 22.2 (21.8–22.5) |
+
+Higher draft costs did not establish a consistent benefit across these prompts,
+so the cost remains 0.18. Generation blocks remain eight tokens for Qwen and
+four for Ornith. The scheduling changes passed exactness checks and address the
+repeated-request stalls; these desktop measurements do not establish a universal
+percentage speedup.
+
+## Runtime behavior and controls
+
+Swift inference uses task-local MLX streams, while the C++ compilation cache
+uses the thread's default stream in its cache key. Sharing compiled functions
+across requests can reuse graphs traced on an earlier request's stream. Each
+managed Q4 request now owns its SiLU, SwiGLU, precise gated-normalization, and
+decay-preparation graphs.
+
+Supported Q4 Qwen 27B and Ornith geometries submit short decoder blocks
 asynchronously. Final logits are evaluated before target acceptance or cache
-commit. Prefill and unsupported geometries retain blocking boundaries.
+commit. Prefill and unsupported geometries retain blocking boundaries. Once the
+greedy adaptive policy permanently selects zero draft tokens, the remaining
+request uses the existing pipelined target decoder.
 
-When the greedy drafting policy permanently selects zero draft tokens, the
-remaining generation uses the existing pipelined target decoder. The
-draft-cost estimate is configurable for matched comparisons.
-
-The controls are as follows. Scheduling defaults are on only for the two
-managed Q4 model IDs. Other model IDs require an explicit `1` override.
-
-| Environment variable | Explicit value | Managed Q4 default |
+| Environment variable | Explicit control | Managed Q4 default |
 | --- | --- | --- |
 | `MERERUN_Q35_SCOPED_COMPILE` | `0` restores shared compiled graphs | On |
 | `MERERUN_Q35_ASYNC_DECODE_BLOCKS` | `0` restores blocking submission | On |
@@ -36,57 +122,91 @@ managed Q4 model IDs. Other model IDs require an explicit `1` override.
 | `MERERUN_Q35_MTP_HEAD_COST_RATIO` | Positive finite value up to `5` | `0.18` |
 | `MERERUN_Q35_MTP_PROFILE` | `1` records synchronized phase timings | Off |
 
-Generation block defaults remain eight tokens for Qwen and four for Ornith.
-The explored higher draft costs did not establish a consistent gain, so these
-defaults remain unchanged.
+Other model IDs require an explicit `1` to opt into the experimental scheduling
+controls; geometry and runtime-path eligibility checks still apply. Synchronized
+profiling changes scheduling and is excluded from all throughput tables.
 
-## Measurement contract
+## Measurement and provenance
 
-Use an optimized binary. Keep a model loaded across warm-up and measured
-requests, disable prefix caching and continuous batching, and retain every
-measured repetition. Report decode throughput and complete-request throughput
-separately. Complete-request timing includes prefill and request overhead but
-excludes the initial model load warmed in a separate request.
+Each final variant keeps its model loaded for one 256-token warm-up followed
+by three 256-token measured requests. Prefix caching and continuous batching are
+disabled. Greedy runs use temperature 0, top-p 1, and an 8,192-token context
+limit. Main code, prose, and summarization cases run serial first; chat and
+math run MTP first. The five fixed prompts are retained in the receipts. The 18 final receipts
+contain 108 measured requests: 84 greedy and 24 sampled. All 84 greedy requests
+preserved exact output hashes and token counts, including reversed-order runs.
+Code and prose also match the selection sweep's frozen output hashes.
 
-The receipt collector covers code, chat, prose, math, and summarization.
-Greedy comparisons require identical output hashes and generated-token
-counts. Single-variant receipts require an explicit matching target-only
-reference. Sampled chat and prose use a separate measurement and do not claim
-greedy-output parity. The fixed-token benchmark ignores EOS, so these prompts
-measure runtime behavior rather than completion quality.
+The collector's default admission requires at most 10% initial GPU utilization,
+normal memory pressure, and no detected inference or active HyperFrames GPU
+worker. This run explicitly uses `--allow-desktop-load`, which records
+`measurementMode: desktop-load` and `uncontended: false` on every receipt. It
+retains GPU samples, CPU load averages, memory pressure, swap state, and detected
+worker counts. GPU samples during inference include this benchmark's own work.
+Polling cannot establish the absence of every source of contention.
 
-Before a run, the collector requires normal memory pressure, no detected
-competing inference or active HyperFrames GPU worker, and device utilization
-of at most 10%. It records competing processes throughout the run. Retain
-affected receipts as diagnostics and repeat them in a separate directory.
-Process polling cannot prove the absence of every possible source of GPU
-contention.
+This task's runtime builds and correctness tests finished before the final throughput
+run. Earlier selection runs overlapped local CPU validation in some cases and
+remain separate from the final workload tables. Longer requests, exclusive-machine
+measurements, vision workloads, and model-quality evaluation are outside these
+results.
 
-For this workstation observation, `--allow-desktop-load` accepts the existing
-graphics activity and explicitly records `measurementMode: desktop-load` and
-`uncontended: false`. GPU samples and detected competing workers remain in the
-receipt. These measurements describe this desktop session and cannot establish
-an isolated hardware ceiling or justify production promotion on their own.
+Across final receipts, initial GPU utilization ranged from 0% to 72%,
+and the initial one-minute CPU load average ranged from 3.96 to 45.20.
+The maximum recorded memory-pressure level was 1; the largest per-receipt
+swap increase was 0.00 MiB.
 
-The workstation measurements use one 256-token warm-up and three 256-token
-measured requests per variant. Reversed variant order checks order effects.
-Synchronized profiling is excluded from TPS conclusions. Longer requests and
-exclusive-machine measurements remain separate performance qualification.
+| Model | Max post-request serial RSS (GiB) | Max post-request MTP RSS (GiB) |
+| --- | ---: | ---: |
+| Ornith 1.5 35B-A3B Q4 | 8.71 | 8.82 |
+| Qwen3.8 27B Q4 | 14.38 | 14.74 |
 
-## Validation receipts
+Resident memory is sampled after each request; the receipts separately record system pressure and swap.
 
-The runtime at `f847be2ef7ca2f8896829c3cc0b6a1a55ea72ea9` passed the local
-gate: 3,907 XCTest checks with 309 opt-in skips and no failures, plus 51 Swift
-Testing checks. The gate also completed lint, build, CLI help, and hygiene
-checks. The documentation build passed.
+The final release binary was built from `c3ef55db5f09b2bcc6526bec4dd2a78eaa27aee6` using
+`swift build -c release --product mere.run --disable-index-store`. Its SHA-256 is
+`37ae108285410acec9ee3863de69475fb74ce9b472bf23c05e0e0df8ce26414c`.
+Report-only changes after that revision do not change
+its runtime sources. The environment used macOS 26.5.2 (25F84), Apple Swift 6.3,
+and mlx-swift revision `7558b9cff75746e3ce25802aecbdc498b240af7f`.
 
-Installed-checkpoint checks passed on both models with the proposed scheduling
-and fallback controls enabled. These checks cover a prompt over 4,096 tokens,
-exact cache replay, follow-up reuse, preserved original checkpoints, and exact
-code and prose agreement with target-only decoding. Separate Metal checks
-cover request-owned graphs, activation arithmetic in FP32, FP16, and BF16,
-draft-history snapshots, attention boundaries, and verifier parity.
+The [machine-readable receipts](receipts/ornith-qwen-generation-tuning-2026-09-05.json)
+include every measured repetition from both selection and final runs, binary and
+collector hashes, the build revision, synthetic prompts, model source revisions,
+and numeric load samples. Machine-local paths and process identifiers are
+omitted. The receipt file's SHA-256 is
+`cb73aa4dfe4f007301277af9ab28354a0ed51faf196e8138bcdda73edb65fd76`.
 
-Earlier timing receipts predate the GPU-utilization start check. They remain
-separate diagnostic evidence and do not establish the workload table.
-No final performance promotion is claimed by these correctness checks.
+To reproduce the greedy workload sweep with installed models:
+
+```bash
+swift build -c release --product mere.run --disable-index-store
+python3 scripts/benchmark-q35-generation.py \
+  --binary .build/release/mere.run \
+  --build-source-revision "$(git rev-parse HEAD)" \
+  --model ornith --output .build/q35-generation-ornith \
+  --workloads code chat prose math summary \
+  --tokens 256 --warmups 1 --warmup-tokens 256 --repetitions 3 \
+  --variants baseline,adaptive --allow-desktop-load
+```
+
+Repeat with `--model qwen` and a new output directory. Reverse the variants for
+an order control; use MTP first for chat and math to match the main table.
+Add `--temperature 0.7 --top-p 0.9` for separate sampled runs.
+Omit `--allow-desktop-load` when collecting a quiet-window qualification.
+
+## Validation
+
+The runtime revision passed `./scripts/check.sh`: 3,909 XCTest cases with 309
+opt-in skips and no failures, plus 51 Swift Testing checks. This gate includes
+strict lint, build, CLI help, documentation examples, and hygiene checks. Five
+receipt-collector tests passed, including contention labeling, critical-pressure
+termination, and rejecting a binary replaced during measurement.
+
+Eight targeted Metal checks passed for request-owned graphs, FP32/FP16/BF16
+activation arithmetic, Q4 verification, accepted-prefix restoration, and draft
+history. Both installed managed Q4 checkpoints passed a prompt over 4,096 tokens,
+exact cache replay, follow-up reuse, preservation of the original cached prompt,
+and exact 256-token code/prose agreement with target-only decoding using the
+new defaults. The final greedy receipts add exactness checks across all five
+workloads, with order controls for code and prose. The documentation build passed.

--- a/docs/benchmarks/receipts/ornith-mtp-head-comparison-2026-09-05.json
+++ b/docs/benchmarks/receipts/ornith-mtp-head-comparison-2026-09-05.json
@@ -1,0 +1,4316 @@
+{
+  "hardware": {
+    "build": "25F84",
+    "chip": "Apple M4 Max",
+    "cpuCores": "proc 16:12:4:0",
+    "gpus": [
+      {
+        "spdisplays_vendor": "sppci_vendor_Apple",
+        "sppci_model": "Apple M4 Max"
+      }
+    ],
+    "macOS": "26.5.2",
+    "memory": "128 GB"
+  },
+  "measuredRequestCount": 40,
+  "measurementMode": "desktop-load",
+  "nativeManifest": {
+    "components": {
+      "text_encoder": {
+        "path": ".",
+        "type": "local"
+      },
+      "tokenizer": {
+        "path": ".",
+        "type": "local"
+      }
+    },
+    "createdAt": "2026-09-01T00:00:00Z",
+    "engine": "qwen3.5-hybrid-moe",
+    "family": "code",
+    "id": "text-agent-ornith-35b-mlx-4bit",
+    "precision": "int4",
+    "quantization": {
+      "bits": 4,
+      "groupSize": 64,
+      "scheme": "mlx-affine"
+    },
+    "schemaVersion": 3,
+    "sources": [
+      {
+        "repository": "ornith-ai/Ornith-1.5-35B-A3B-MLX-4bit",
+        "revision": "19504d912fa8fc7622bf6b1de3db5d5d890b1f02",
+        "role": "primary"
+      },
+      {
+        "destination_path": "vision",
+        "repository": "ornith-ai/Ornith-1.5-35B-A3B",
+        "revision": "10fbf86fed7ecee4a061f8b499a618f46001cac1",
+        "role": "component"
+      },
+      {
+        "destination_path": "mtp",
+        "repository": "ornith-ai/Ornith-1.5-35B-A3B",
+        "revision": "e4dfb35a93d4b6822a811a7676f3488514abe7e2",
+        "role": "component"
+      }
+    ],
+    "supports": [
+      "chat",
+      "code_generation",
+      "vision_chat"
+    ],
+    "tier": "large",
+    "upstreamRepoId": "Sawfwair/Ornith-1.5-35B-A3B-MLX-4bit-Vision-MTP@main",
+    "variant": "standard"
+  },
+  "nativeWeightSamples": {
+    "mtp.fc.weight": {
+      "kurtosis": 3.0214835225202146,
+      "mean": -4.9299292960824914e-05,
+      "sampleOffset": 0,
+      "sampleSHA256": "484180dc8f4b77ae51995c7385c075df860855db063874ac5ecba6f0f9c6cb97",
+      "sampledElements": 131072,
+      "shape": [
+        2048,
+        4096
+      ],
+      "std": 0.01955987411031103
+    },
+    "mtp.layers.0.input_layernorm.weight": {
+      "kurtosis": 3.6118599945227525,
+      "mean": 6.404218765965197e-05,
+      "sampleOffset": 0,
+      "sampleSHA256": "7c92e12fccdb1881952f19355a1cb5917232ee8f645b537ecc6d69406aa4c90b",
+      "sampledElements": 2048,
+      "shape": [
+        2048
+      ],
+      "std": 0.0030159244756922674
+    },
+    "mtp.layers.0.mlp.experts.0.gate_proj.weight": {
+      "kurtosis": 2.991531189047493,
+      "mean": 9.004271419144061e-06,
+      "sampleOffset": 0,
+      "sampleSHA256": "49c5db85ed787a28cf7c36224afe380d0b1fa626845257c7e66c8fd6ca4cfb37",
+      "sampledElements": 131072,
+      "shape": [
+        512,
+        2048
+      ],
+      "std": 0.020003666514507124
+    },
+    "mtp.layers.0.post_attention_layernorm.weight": {
+      "kurtosis": 2.2387142423957247,
+      "mean": 0.014827951788902283,
+      "sampleOffset": 0,
+      "sampleSHA256": "8fa7efce152478f908c345b190e69855e67144ece805c8b4e6472848259b7264",
+      "sampledElements": 2048,
+      "shape": [
+        2048
+      ],
+      "std": 0.003557646256180927
+    },
+    "mtp.layers.0.self_attn.k_norm.weight": {
+      "kurtosis": 5.06695032806935,
+      "mean": 0.003916800022125244,
+      "sampleOffset": 0,
+      "sampleSHA256": "2e214650d043e35fbe3265e4643850213826cd6ab3281f7ba4f2f163fa2c18c2",
+      "sampledElements": 256,
+      "shape": [
+        256
+      ],
+      "std": 0.006808641192886044
+    },
+    "mtp.layers.0.self_attn.q_norm.weight": {
+      "kurtosis": 5.096090662783112,
+      "mean": 0.003900587558746338,
+      "sampleOffset": 0,
+      "sampleSHA256": "ed69036ab530cca5821540d652a582a6bb4dd09488fcb218b6305c997f03d991",
+      "sampledElements": 256,
+      "shape": [
+        256
+      ],
+      "std": 0.006802023062471432
+    },
+    "mtp.layers.0.self_attn.q_proj.weight": {
+      "kurtosis": 3.0036876036026885,
+      "mean": 4.9245207762282917e-05,
+      "sampleOffset": 0,
+      "sampleSHA256": "ff4ecae5b5ed69d7263a275d986617f1aa076db8f6c09320241f64b938445b98",
+      "sampledElements": 131072,
+      "shape": [
+        8192,
+        2048
+      ],
+      "std": 0.01981054411044665
+    },
+    "mtp.norm.weight": {
+      "kurtosis": 5.712824124474569,
+      "mean": 0.022813022136688232,
+      "sampleOffset": 0,
+      "sampleSHA256": "143bf88c151448b4ffd3b4f6904a3f0aba160226a0c0a793b09e8a43ef261e8e",
+      "sampledElements": 2048,
+      "shape": [
+        2048
+      ],
+      "std": 0.00016635696933195242
+    },
+    "mtp.pre_fc_norm_embedding.weight": {
+      "kurtosis": 46.68578845009673,
+      "mean": -0.0213392972946167,
+      "sampleOffset": 0,
+      "sampleSHA256": "193b5bb2587669b688683aaac841861952efc545030ee156c6fc0eb110e0ac1e",
+      "sampledElements": 2048,
+      "shape": [
+        2048
+      ],
+      "std": 0.0009901922788203565
+    },
+    "mtp.pre_fc_norm_hidden.weight": {
+      "kurtosis": 11.910876484698072,
+      "mean": 0.015706644859164953,
+      "sampleOffset": 0,
+      "sampleSHA256": "f7b563b7f438ddee84d11cab83595e33181c2e3d5197f1cee79651806175635b",
+      "sampledElements": 2048,
+      "shape": [
+        2048
+      ],
+      "std": 0.005580469827694355
+    }
+  },
+  "notes": [
+    "Target files are symbolic links to the same native Q4 checkpoint; this experiment does not modify them. The replacement head is tested in a separate model root.",
+    "The fused replacement head is split into per-expert tensors by copying BF16 bytes unchanged. Every output tensor is hash-checked after conversion.",
+    "The forced CLI variant enables MTP but still adapts depth. It is an additional repetition control, not a fixed-depth policy.",
+    "The fixed-depth diagnostic sets the draft cost estimate to 1e-100. Counters verify three drafts in every round except the final token-budget tail. This is a diagnostic override, not a selected default.",
+    "All 40 measured requests match the prior serial output hashes at 256 generated tokens. This bounded text-only check does not qualify a replacement model default.",
+    "Other inference was detected during some runs. Timing is an observation under shared load, not an isolated head speedup claim."
+  ],
+  "records": [
+    {
+      "id": "head-native/ornith-code",
+      "rawReceiptSHA256": "a3ad6ca8fa4a49def3d10008372ffe441f3039623cee81659fc599af303571d4",
+      "receipt": {
+        "after": {
+          "gpuDeviceUtilizationPercent": 70,
+          "loadAverage": [
+            13.28955078125,
+            12.99951171875,
+            11.83056640625
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7260.25M  free = 931.75M  (encrypted)",
+          "swapUsedMiB": 7260.25
+        },
+        "before": {
+          "gpuDeviceUtilizationPercent": 70,
+          "loadAverage": [
+            11.85302734375,
+            12.509765625,
+            11.56884765625
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7260.25M  free = 931.75M  (encrypted)",
+          "swapUsedMiB": 7260.25
+        },
+        "binarySHA256": "37ae108285410acec9ee3863de69475fb74ce9b472bf23c05e0e0df8ce26414c",
+        "buildSourceRevision": "c3ef55db5f09b2bcc6526bec4dd2a78eaa27aee6",
+        "collectorSHA256": "77bfd1f99c1bc4008ccc83bb52b5e1861f625b636c6fa335e406264be05bb8bd",
+        "command": [
+          "mere.run",
+          "model",
+          "benchmark",
+          "q36-mtp",
+          "--model",
+          "text-agent-ornith-35b-mlx-4bit",
+          "--prompt",
+          "Write a complete Python implementation of an LRU cache using a dictionary and a doubly linked list, with get and put operations, type hints, and a short usage example. Return the code directly without introductory prose.",
+          "--decode-tokens",
+          "256",
+          "--context-size",
+          "8192",
+          "--temperature",
+          "0.0",
+          "--top-p",
+          "1.0",
+          "--json",
+          "--variants",
+          "baseline,adaptive,forced",
+          "--warmups",
+          "1",
+          "--warmup-tokens",
+          "256",
+          "--repetitions",
+          "3",
+          "--model-root",
+          "<ornith-native-root>",
+          "--mtp-block-size",
+          "4"
+        ],
+        "competingInferenceProcessCount": 1,
+        "gpuSamples": [
+          {
+            "deviceUtilizationPercent": 29,
+            "elapsedSeconds": 0.09890103340148926,
+            "loadAverage": [
+              11.85302734375,
+              12.509765625,
+              11.56884765625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 32,
+            "elapsedSeconds": 2.2065160274505615,
+            "loadAverage": [
+              11.85302734375,
+              12.509765625,
+              11.56884765625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 35,
+            "elapsedSeconds": 4.318637132644653,
+            "loadAverage": [
+              11.22412109375,
+              12.3681640625,
+              11.5244140625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 34,
+            "elapsedSeconds": 6.44563102722168,
+            "loadAverage": [
+              11.22412109375,
+              12.3681640625,
+              11.5244140625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 33,
+            "elapsedSeconds": 8.558012962341309,
+            "loadAverage": [
+              10.5654296875,
+              12.21240234375,
+              11.47412109375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 35,
+            "elapsedSeconds": 10.665738105773926,
+            "loadAverage": [
+              10.5654296875,
+              12.21240234375,
+              11.47412109375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 31,
+            "elapsedSeconds": 12.777828216552734,
+            "loadAverage": [
+              9.95947265625,
+              12.05908203125,
+              11.42431640625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 37,
+            "elapsedSeconds": 14.884357929229736,
+            "loadAverage": [
+              9.95947265625,
+              12.05908203125,
+              11.42431640625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 34,
+            "elapsedSeconds": 17.185256958007812,
+            "loadAverage": [
+              9.95947265625,
+              12.05908203125,
+              11.42431640625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 35,
+            "elapsedSeconds": 19.29167604446411,
+            "loadAverage": [
+              9.88232421875,
+              12.0078125,
+              11.40966796875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 38,
+            "elapsedSeconds": 21.48834800720215,
+            "loadAverage": [
+              9.88232421875,
+              12.0078125,
+              11.40966796875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 58,
+            "elapsedSeconds": 23.710412979125977,
+            "loadAverage": [
+              18.0595703125,
+              13.66748046875,
+              11.9990234375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 73,
+            "elapsedSeconds": 25.86149501800537,
+            "loadAverage": [
+              18.0595703125,
+              13.66748046875,
+              11.9990234375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 76,
+            "elapsedSeconds": 28.077956914901733,
+            "loadAverage": [
+              17.57421875,
+              13.6396484375,
+              11.9990234375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 78,
+            "elapsedSeconds": 30.234001874923706,
+            "loadAverage": [
+              17.57421875,
+              13.6396484375,
+              11.9990234375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 85,
+            "elapsedSeconds": 32.38717007637024,
+            "loadAverage": [
+              16.96728515625,
+              13.5791015625,
+              11.9873046875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 85,
+            "elapsedSeconds": 34.54029703140259,
+            "loadAverage": [
+              16.96728515625,
+              13.5791015625,
+              11.9873046875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 68,
+            "elapsedSeconds": 36.6781210899353,
+            "loadAverage": [
+              16.96728515625,
+              13.5791015625,
+              11.9873046875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 35,
+            "elapsedSeconds": 38.784889221191406,
+            "loadAverage": [
+              15.9287109375,
+              13.419921875,
+              11.9404296875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 71,
+            "elapsedSeconds": 40.90580987930298,
+            "loadAverage": [
+              15.9287109375,
+              13.419921875,
+              11.9404296875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 88,
+            "elapsedSeconds": 43.11917591094971,
+            "loadAverage": [
+              15.37353515625,
+              13.34619140625,
+              11.9228515625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 82,
+            "elapsedSeconds": 45.273066997528076,
+            "loadAverage": [
+              15.37353515625,
+              13.34619140625,
+              11.9228515625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 87,
+            "elapsedSeconds": 47.40899205207825,
+            "loadAverage": [
+              14.62255859375,
+              13.22412109375,
+              11.8876953125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 90,
+            "elapsedSeconds": 49.56229090690613,
+            "loadAverage": [
+              14.62255859375,
+              13.22412109375,
+              11.8876953125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 89,
+            "elapsedSeconds": 51.68311905860901,
+            "loadAverage": [
+              14.62255859375,
+              13.22412109375,
+              11.8876953125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 46,
+            "elapsedSeconds": 53.80327916145325,
+            "loadAverage": [
+              14.171875,
+              13.15380859375,
+              11.87060546875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 90,
+            "elapsedSeconds": 55.92646884918213,
+            "loadAverage": [
+              14.171875,
+              13.15380859375,
+              11.87060546875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 92,
+            "elapsedSeconds": 58.10748505592346,
+            "loadAverage": [
+              13.83740234375,
+              13.10107421875,
+              11.859375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 87,
+            "elapsedSeconds": 60.25806212425232,
+            "loadAverage": [
+              13.83740234375,
+              13.10107421875,
+              11.859375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 88,
+            "elapsedSeconds": 62.41029095649719,
+            "loadAverage": [
+              13.28955078125,
+              12.99951171875,
+              11.83056640625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 87,
+            "elapsedSeconds": 64.55060005187988,
+            "loadAverage": [
+              13.28955078125,
+              12.99951171875,
+              11.83056640625
+            ]
+          }
+        ],
+        "knownRenderingWorkerCount": 0,
+        "maxPressureLevel": 1,
+        "measurementMode": "desktop-load",
+        "peakResidentBytes": 9735749632,
+        "processSeconds": 66.66186714172363,
+        "profiled": false,
+        "prompt": "Write a complete Python implementation of an LRU cache using a dictionary and a doubly linked list, with get and put operations, type hints, and a short usage example. Return the code directly without introductory prose.",
+        "runtimeOverrides": {},
+        "sourceHead": "a036360014af49fc5cffd0c113af89ab12d5b8c3",
+        "startedUnixSeconds": 1788628196.24911,
+        "uncontended": false,
+        "workload": "code"
+      },
+      "scenarios": [
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 1.0848764964197781,
+            "forced": 1.1707623723723515
+          },
+          "endToEndSpeedups": {
+            "adaptive": 1.0920840374623484,
+            "forced": 1.1554816671876453
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 220,
+          "repetition": 1,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 3.5957460403442383,
+              "decodeTokensPerSecond": 71.19523935441555,
+              "elapsedSeconds": 3.717833995819092,
+              "endToEndTokensPerSecond": 68.85729709499833,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.014678001403808594,
+              "generatedTokens": 256,
+              "loadSeconds": 1.5974044799804688e-05,
+              "name": "baseline",
+              "outputSHA256": "cd134369dacefc1cc1bc8bceceb5cfb2dc106e35c077361b20e79108d05fabb4",
+              "policy": "disabled",
+              "prefillSeconds": 0.12098395824432373,
+              "prefillTokensPerSecond": 446.34016594950964,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 7701544960,
+              "residentMemoryBeforeBytes": 7701479424,
+              "ttftSeconds": 0.13567793369293213
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.5186721991701245,
+                "acceptedDraftTokens": 125,
+                "draftHistoryTokens": 53,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 241,
+                "rounds": 131,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 3.314428925514221,
+              "decodeTokensPerSecond": 77.23804183258585,
+              "elapsedSeconds": 3.4043478965759277,
+              "endToEndTokensPerSecond": 75.1979550202502,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.00030791759490966797,
+              "generatedTokens": 256,
+              "loadSeconds": 8.106231689453125e-06,
+              "name": "adaptive",
+              "outputSHA256": "cd134369dacefc1cc1bc8bceceb5cfb2dc106e35c077361b20e79108d05fabb4",
+              "policy": "adaptive",
+              "prefillSeconds": 0.08888208866119385,
+              "prefillTokensPerSecond": 607.5464788619053,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 9468788736,
+              "residentMemoryBeforeBytes": 9468248064,
+              "ttftSeconds": 0.08919811248779297
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.5186721991701245,
+                "acceptedDraftTokens": 125,
+                "draftHistoryTokens": 53,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 241,
+                "rounds": 131,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 3.0712859630584717,
+              "decodeTokensPerSecond": 83.35270732819295,
+              "elapsedSeconds": 3.2175620794296265,
+              "endToEndTokensPerSecond": 79.56334444536368,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0002499818801879883,
+              "generatedTokens": 256,
+              "loadSeconds": 9.059906005859375e-06,
+              "name": "forced",
+              "outputSHA256": "cd134369dacefc1cc1bc8bceceb5cfb2dc106e35c077361b20e79108d05fabb4",
+              "policy": "forced",
+              "prefillSeconds": 0.14524400234222412,
+              "prefillTokensPerSecond": 371.78815737096755,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 9735716864,
+              "residentMemoryBeforeBytes": 9735602176,
+              "ttftSeconds": 0.14550304412841797
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 1.0278167464769092,
+            "forced": 1.0520218600639588
+          },
+          "endToEndSpeedups": {
+            "adaptive": 1.0232376395410712,
+            "forced": 1.0504327596273844
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 220,
+          "repetition": 2,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 2.715014934539795,
+              "decodeTokensPerSecond": 94.29045739057526,
+              "elapsedSeconds": 2.833701014518738,
+              "endToEndTokensPerSecond": 90.34121761200619,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.011608004570007324,
+              "generatedTokens": 256,
+              "loadSeconds": 1.0967254638671875e-05,
+              "name": "baseline",
+              "outputSHA256": "cd134369dacefc1cc1bc8bceceb5cfb2dc106e35c077361b20e79108d05fabb4",
+              "policy": "disabled",
+              "prefillSeconds": 0.11755704879760742,
+              "prefillTokensPerSecond": 459.3514429999797,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 7701708800,
+              "residentMemoryBeforeBytes": 7701643264,
+              "ttftSeconds": 0.12917602062225342
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.5186721991701245,
+                "acceptedDraftTokens": 125,
+                "draftHistoryTokens": 53,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 241,
+                "rounds": 131,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 2.641535997390747,
+              "decodeTokensPerSecond": 96.9133111390007,
+              "elapsedSeconds": 2.769347906112671,
+              "endToEndTokensPerSecond": 92.44053426257547,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.00039196014404296875,
+              "generatedTokens": 256,
+              "loadSeconds": 1.0013580322265625e-05,
+              "name": "adaptive",
+              "outputSHA256": "cd134369dacefc1cc1bc8bceceb5cfb2dc106e35c077361b20e79108d05fabb4",
+              "policy": "adaptive",
+              "prefillSeconds": 0.12667405605316162,
+              "prefillTokensPerSecond": 426.2909208286319,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 9468805120,
+              "residentMemoryBeforeBytes": 9468788736,
+              "ttftSeconds": 0.12707602977752686
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.5186721991701245,
+                "acceptedDraftTokens": 125,
+                "draftHistoryTokens": 53,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 241,
+                "rounds": 131,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 2.580759048461914,
+              "decodeTokensPerSecond": 99.19562237031442,
+              "elapsedSeconds": 2.6976510286331177,
+              "endToEndTokensPerSecond": 94.89737452427772,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.00024306774139404297,
+              "generatedTokens": 256,
+              "loadSeconds": 1.0013580322265625e-05,
+              "name": "forced",
+              "outputSHA256": "cd134369dacefc1cc1bc8bceceb5cfb2dc106e35c077361b20e79108d05fabb4",
+              "policy": "forced",
+              "prefillSeconds": 0.11579394340515137,
+              "prefillTokensPerSecond": 466.3456344263139,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 9735733248,
+              "residentMemoryBeforeBytes": 9735716864,
+              "ttftSeconds": 0.11604702472686768
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 1.1046774447484344,
+            "forced": 1.1860965479669476
+          },
+          "endToEndSpeedups": {
+            "adaptive": 1.0979870464553185,
+            "forced": 1.1810170528411412
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 220,
+          "repetition": 3,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 2.996092915534973,
+              "decodeTokensPerSecond": 85.44461310682998,
+              "elapsedSeconds": 3.1261579990386963,
+              "endToEndTokensPerSecond": 81.88965499463585,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.012669920921325684,
+              "generatedTokens": 256,
+              "loadSeconds": 1.1920928955078125e-05,
+              "name": "baseline",
+              "outputSHA256": "cd134369dacefc1cc1bc8bceceb5cfb2dc106e35c077361b20e79108d05fabb4",
+              "policy": "disabled",
+              "prefillSeconds": 0.12894201278686523,
+              "prefillTokensPerSecond": 418.792904134817,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 7701757952,
+              "residentMemoryBeforeBytes": 7701708800,
+              "ttftSeconds": 0.141623854637146
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.5186721991701245,
+                "acceptedDraftTokens": 125,
+                "draftHistoryTokens": 53,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 241,
+                "rounds": 131,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 2.7121880054473877,
+              "decodeTokensPerSecond": 94.38873687437153,
+              "elapsedSeconds": 2.8471720218658447,
+              "endToEndTokensPerSecond": 89.91378042280525,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.00024509429931640625,
+              "generatedTokens": 256,
+              "loadSeconds": 1.0967254638671875e-05,
+              "name": "adaptive",
+              "outputSHA256": "cd134369dacefc1cc1bc8bceceb5cfb2dc106e35c077361b20e79108d05fabb4",
+              "policy": "adaptive",
+              "prefillSeconds": 0.13391101360321045,
+              "prefillTokensPerSecond": 403.25286581734434,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 9468821504,
+              "residentMemoryBeforeBytes": 9468805120,
+              "ttftSeconds": 0.13416707515716553
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.5186721991701245,
+                "acceptedDraftTokens": 125,
+                "draftHistoryTokens": 53,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 241,
+                "rounds": 131,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 2.5260109901428223,
+              "decodeTokensPerSecond": 101.34556064838245,
+              "elapsedSeconds": 2.6470049619674683,
+              "endToEndTokensPerSecond": 96.71307899994267,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.00028192996978759766,
+              "generatedTokens": 256,
+              "loadSeconds": 1.0013580322265625e-05,
+              "name": "forced",
+              "outputSHA256": "cd134369dacefc1cc1bc8bceceb5cfb2dc106e35c077361b20e79108d05fabb4",
+              "policy": "forced",
+              "prefillSeconds": 0.11988508701324463,
+              "prefillTokensPerSecond": 450.43133675195315,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 9735749632,
+              "residentMemoryBeforeBytes": 9735733248,
+              "ttftSeconds": 0.12017703056335449
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        }
+      ]
+    },
+    {
+      "id": "head-native/ornith-prose",
+      "rawReceiptSHA256": "91df068b1b1c127e623e970af764c9fb1ca5e066e74a28288b38a6c21406626b",
+      "receipt": {
+        "after": {
+          "gpuDeviceUtilizationPercent": 53,
+          "loadAverage": [
+            9.71337890625,
+            10.90380859375,
+            11.25537109375
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7228.25M  free = 963.75M  (encrypted)",
+          "swapUsedMiB": 7228.25
+        },
+        "before": {
+          "gpuDeviceUtilizationPercent": 28,
+          "loadAverage": [
+            9.1103515625,
+            11.16796875,
+            11.373046875
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7228.25M  free = 963.75M  (encrypted)",
+          "swapUsedMiB": 7228.25
+        },
+        "binarySHA256": "37ae108285410acec9ee3863de69475fb74ce9b472bf23c05e0e0df8ce26414c",
+        "buildSourceRevision": "c3ef55db5f09b2bcc6526bec4dd2a78eaa27aee6",
+        "collectorSHA256": "846c9089342036559de416f10a5f572f3e4afd5005e4eb87be4924ba5cf38446",
+        "command": [
+          "mere.run",
+          "model",
+          "benchmark",
+          "q36-mtp",
+          "--model",
+          "text-agent-ornith-35b-mlx-4bit",
+          "--prompt",
+          "Explain how a small community could turn an abandoned railway station into a public library. Discuss the building, accessibility, staffing, the collection, and a realistic opening-day scene. Write approximately 400 words of clear, connected prose.",
+          "--decode-tokens",
+          "256",
+          "--context-size",
+          "8192",
+          "--temperature",
+          "0.0",
+          "--top-p",
+          "1.0",
+          "--json",
+          "--variants",
+          "baseline,adaptive,forced",
+          "--warmups",
+          "1",
+          "--warmup-tokens",
+          "256",
+          "--repetitions",
+          "3",
+          "--model-root",
+          "<ornith-native-root>",
+          "--mtp-block-size",
+          "4"
+        ],
+        "competingInferenceProcessCount": 0,
+        "gpuSamples": [
+          {
+            "deviceUtilizationPercent": 35,
+            "elapsedSeconds": 0.09956789016723633,
+            "loadAverage": [
+              9.1103515625,
+              11.16796875,
+              11.373046875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 49,
+            "elapsedSeconds": 2.209686756134033,
+            "loadAverage": [
+              9.1103515625,
+              11.16796875,
+              11.373046875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 71,
+            "elapsedSeconds": 4.345058917999268,
+            "loadAverage": [
+              8.78076171875,
+              11.0654296875,
+              11.33544921875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 73,
+            "elapsedSeconds": 6.549370765686035,
+            "loadAverage": [
+              8.78076171875,
+              11.0654296875,
+              11.33544921875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 72,
+            "elapsedSeconds": 8.717552900314331,
+            "loadAverage": [
+              8.6376953125,
+              10.99755859375,
+              11.3095703125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 67,
+            "elapsedSeconds": 10.885081768035889,
+            "loadAverage": [
+              8.6376953125,
+              10.99755859375,
+              11.3095703125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 81,
+            "elapsedSeconds": 13.045910835266113,
+            "loadAverage": [
+              8.34619140625,
+              10.89794921875,
+              11.2724609375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 65,
+            "elapsedSeconds": 15.198587894439697,
+            "loadAverage": [
+              8.34619140625,
+              10.89794921875,
+              11.2724609375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 33,
+            "elapsedSeconds": 17.32518196105957,
+            "loadAverage": [
+              8.34619140625,
+              10.89794921875,
+              11.2724609375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 79,
+            "elapsedSeconds": 19.565580129623413,
+            "loadAverage": [
+              8.158203125,
+              10.81640625,
+              11.2412109375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 63,
+            "elapsedSeconds": 21.742613077163696,
+            "loadAverage": [
+              8.158203125,
+              10.81640625,
+              11.2412109375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 72,
+            "elapsedSeconds": 23.908179998397827,
+            "loadAverage": [
+              8.6259765625,
+              10.869140625,
+              11.25732421875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 79,
+            "elapsedSeconds": 26.0570707321167,
+            "loadAverage": [
+              8.6259765625,
+              10.869140625,
+              11.25732421875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 82,
+            "elapsedSeconds": 28.24056100845337,
+            "loadAverage": [
+              8.33544921875,
+              10.771484375,
+              11.22021484375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 63,
+            "elapsedSeconds": 30.4471378326416,
+            "loadAverage": [
+              8.33544921875,
+              10.771484375,
+              11.22021484375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 65,
+            "elapsedSeconds": 32.6312198638916,
+            "loadAverage": [
+              8.54833984375,
+              10.77490234375,
+              11.21875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 49,
+            "elapsedSeconds": 34.75780200958252,
+            "loadAverage": [
+              8.54833984375,
+              10.77490234375,
+              11.21875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 72,
+            "elapsedSeconds": 36.87370777130127,
+            "loadAverage": [
+              8.54833984375,
+              10.77490234375,
+              11.21875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 89,
+            "elapsedSeconds": 39.07434391975403,
+            "loadAverage": [
+              8.42431640625,
+              10.7119140625,
+              11.19384765625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 83,
+            "elapsedSeconds": 41.22540903091431,
+            "loadAverage": [
+              8.42431640625,
+              10.7119140625,
+              11.19384765625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 89,
+            "elapsedSeconds": 43.368520975112915,
+            "loadAverage": [
+              8.47021484375,
+              10.68310546875,
+              11.1806640625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 72,
+            "elapsedSeconds": 45.57179880142212,
+            "loadAverage": [
+              8.47021484375,
+              10.68310546875,
+              11.1806640625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 63,
+            "elapsedSeconds": 47.791865825653076,
+            "loadAverage": [
+              9.71337890625,
+              10.90380859375,
+              11.25537109375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 62,
+            "elapsedSeconds": 50.00240993499756,
+            "loadAverage": [
+              9.71337890625,
+              10.90380859375,
+              11.25537109375
+            ]
+          }
+        ],
+        "knownRenderingWorkerCount": 0,
+        "maxPressureLevel": 1,
+        "measurementMode": "desktop-load",
+        "peakResidentBytes": 10577412096,
+        "processSeconds": 52.11630702018738,
+        "profiled": false,
+        "prompt": "Explain how a small community could turn an abandoned railway station into a public library. Discuss the building, accessibility, staffing, the collection, and a realistic opening-day scene. Write approximately 400 words of clear, connected prose.",
+        "runtimeOverrides": {},
+        "sourceHead": "a036360014af49fc5cffd0c113af89ab12d5b8c3",
+        "startedUnixSeconds": 1788628541.218084,
+        "uncontended": false,
+        "workload": "prose"
+      },
+      "scenarios": [
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 1.0328521653589708,
+            "forced": 1.0412936646192108
+          },
+          "endToEndSpeedups": {
+            "adaptive": 1.0355083113717127,
+            "forced": 1.0160502132125473
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 247,
+          "repetition": 1,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 3.583178997039795,
+              "decodeTokensPerSecond": 71.44493764098631,
+              "elapsedSeconds": 3.693624973297119,
+              "endToEndTokensPerSecond": 69.30860654526094,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.012874960899353027,
+              "generatedTokens": 256,
+              "loadSeconds": 1.2993812561035156e-05,
+              "name": "baseline",
+              "outputSHA256": "ca3ac87c453ea9cb8fdd5fe572ce7e0e9930e17487f37393e45606052e4db11e",
+              "policy": "disabled",
+              "prefillSeconds": 0.10907602310180664,
+              "prefillTokensPerSecond": 550.0750604374226,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 7682703360,
+              "residentMemoryBeforeBytes": 7682572288,
+              "ttftSeconds": 0.1219639778137207
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.25892857142857145,
+                "acceptedDraftTokens": 29,
+                "draftHistoryTokens": 59,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 112,
+                "rounds": 69,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 3.469208002090454,
+              "decodeTokensPerSecond": 73.79205854642936,
+              "elapsedSeconds": 3.5669679641723633,
+              "endToEndTokensPerSecond": 71.76963812720959,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.00025403499603271484,
+              "generatedTokens": 256,
+              "loadSeconds": 1.2040138244628906e-05,
+              "name": "adaptive",
+              "outputSHA256": "ca3ac87c453ea9cb8fdd5fe572ce7e0e9930e17487f37393e45606052e4db11e",
+              "policy": "adaptive",
+              "prefillSeconds": 0.09630405902862549,
+              "prefillTokensPerSecond": 623.0266990321306,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 9462956032,
+              "residentMemoryBeforeBytes": 9462923264,
+              "ttftSeconds": 0.09657013416290283
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.25892857142857145,
+                "acceptedDraftTokens": 29,
+                "draftHistoryTokens": 59,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 112,
+                "rounds": 69,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 3.4410840272903442,
+              "decodeTokensPerSecond": 74.39516093467363,
+              "elapsedSeconds": 3.6352779865264893,
+              "endToEndTokensPerSecond": 70.42102445777694,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.00039005279541015625,
+              "generatedTokens": 256,
+              "loadSeconds": 1.5974044799804688e-05,
+              "name": "forced",
+              "outputSHA256": "ca3ac87c453ea9cb8fdd5fe572ce7e0e9930e17487f37393e45606052e4db11e",
+              "policy": "forced",
+              "prefillSeconds": 0.1927579641342163,
+              "prefillTokensPerSecond": 311.2711854448843,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 10576412672,
+              "residentMemoryBeforeBytes": 10576265216,
+              "ttftSeconds": 0.19316399097442627
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 0.9000243484900335,
+            "forced": 0.7652165903884272
+          },
+          "endToEndSpeedups": {
+            "adaptive": 0.8983221030593455,
+            "forced": 0.7711971462976194
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 247,
+          "repetition": 2,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 3.084099054336548,
+              "decodeTokensPerSecond": 83.00641305279696,
+              "elapsedSeconds": 3.195328116416931,
+              "endToEndTokensPerSecond": 80.11696785839466,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.013645052909851074,
+              "generatedTokens": 256,
+              "loadSeconds": 1.2040138244628906e-05,
+              "name": "baseline",
+              "outputSHA256": "ca3ac87c453ea9cb8fdd5fe572ce7e0e9930e17487f37393e45606052e4db11e",
+              "policy": "disabled",
+              "prefillSeconds": 0.10991299152374268,
+              "prefillTokensPerSecond": 545.886333982996,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 7682834432,
+              "residentMemoryBeforeBytes": 7682801664,
+              "ttftSeconds": 0.12357008457183838
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.25892857142857145,
+                "acceptedDraftTokens": 29,
+                "draftHistoryTokens": 59,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 112,
+                "rounds": 69,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 3.426684021949768,
+              "decodeTokensPerSecond": 74.7077928283382,
+              "elapsedSeconds": 3.556995987892151,
+              "endToEndTokensPerSecond": 71.97084305729108,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0002880096435546875,
+              "generatedTokens": 256,
+              "loadSeconds": 1.2993812561035156e-05,
+              "name": "adaptive",
+              "outputSHA256": "ca3ac87c453ea9cb8fdd5fe572ce7e0e9930e17487f37393e45606052e4db11e",
+              "policy": "adaptive",
+              "prefillSeconds": 0.1285640001296997,
+              "prefillTokensPerSecond": 466.69363071676344,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 9462972416,
+              "residentMemoryBeforeBytes": 9462956032,
+              "ttftSeconds": 0.12886500358581543
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.25892857142857145,
+                "acceptedDraftTokens": 29,
+                "draftHistoryTokens": 59,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 112,
+                "rounds": 69,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 4.03036093711853,
+              "decodeTokensPerSecond": 63.517884376634726,
+              "elapsedSeconds": 4.143334984779358,
+              "endToEndTokensPerSecond": 61.78597698241205,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0001819133758544922,
+              "generatedTokens": 256,
+              "loadSeconds": 9.059906005859375e-06,
+              "name": "forced",
+              "outputSHA256": "ca3ac87c453ea9cb8fdd5fe572ce7e0e9930e17487f37393e45606052e4db11e",
+              "policy": "forced",
+              "prefillSeconds": 0.11139607429504395,
+              "prefillTokensPerSecond": 538.6186217037042,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 10576429056,
+              "residentMemoryBeforeBytes": 10576412672,
+              "ttftSeconds": 0.1115870475769043
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 0.7768550370517061,
+            "forced": 0.6913859976388208
+          },
+          "endToEndSpeedups": {
+            "adaptive": 0.7806879319047791,
+            "forced": 0.6954202319179869
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 247,
+          "repetition": 3,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 2.9849629402160645,
+              "decodeTokensPerSecond": 85.76320883282712,
+              "elapsedSeconds": 3.0896880626678467,
+              "endToEndTokensPerSecond": 82.85626082878807,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.01008296012878418,
+              "generatedTokens": 256,
+              "loadSeconds": 9.894371032714844e-06,
+              "name": "baseline",
+              "outputSHA256": "ca3ac87c453ea9cb8fdd5fe572ce7e0e9930e17487f37393e45606052e4db11e",
+              "policy": "disabled",
+              "prefillSeconds": 0.10303997993469238,
+              "prefillTokensPerSecond": 582.2982500387569,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 7682883584,
+              "residentMemoryBeforeBytes": 7682850816,
+              "ttftSeconds": 0.11313283443450928
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.25892857142857145,
+                "acceptedDraftTokens": 29,
+                "draftHistoryTokens": 59,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 112,
+                "rounds": 69,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 3.842368006706238,
+              "decodeTokensPerSecond": 66.62558077549912,
+              "elapsedSeconds": 3.9576480388641357,
+              "endToEndTokensPerSecond": 64.68488291178951,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.000308990478515625,
+              "generatedTokens": 256,
+              "loadSeconds": 1.5974044799804688e-05,
+              "name": "adaptive",
+              "outputSHA256": "ca3ac87c453ea9cb8fdd5fe572ce7e0e9930e17487f37393e45606052e4db11e",
+              "policy": "adaptive",
+              "prefillSeconds": 0.11349809169769287,
+              "prefillTokensPerSecond": 528.6432494372912,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 9462988800,
+              "residentMemoryBeforeBytes": 9462972416,
+              "ttftSeconds": 0.1138230562210083
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.25892857142857145,
+                "acceptedDraftTokens": 29,
+                "draftHistoryTokens": 59,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 112,
+                "rounds": 69,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 4.317360997200012,
+              "decodeTokensPerSecond": 59.2954816995907,
+              "elapsedSeconds": 4.442907929420471,
+              "endToEndTokensPerSecond": 57.619920121413,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0008810758590698242,
+              "generatedTokens": 256,
+              "loadSeconds": 1.609325408935547e-05,
+              "name": "forced",
+              "outputSHA256": "ca3ac87c453ea9cb8fdd5fe572ce7e0e9930e17487f37393e45606052e4db11e",
+              "policy": "forced",
+              "prefillSeconds": 0.12390100955963135,
+              "prefillTokensPerSecond": 484.2575553924205,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 10577412096,
+              "residentMemoryBeforeBytes": 10576429056,
+              "ttftSeconds": 0.12479817867279053
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        }
+      ]
+    },
+    {
+      "id": "head-shisa/ornith-code",
+      "rawReceiptSHA256": "d07c3264a44e5cfa72dad9b3ea2cf1a55c1a9ad6b54c99f08e3003a8d2ab8055",
+      "receipt": {
+        "after": {
+          "gpuDeviceUtilizationPercent": 77,
+          "loadAverage": [
+            11.03759765625,
+            11.876953125,
+            11.62548828125
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7228.25M  free = 963.75M  (encrypted)",
+          "swapUsedMiB": 7228.25
+        },
+        "before": {
+          "gpuDeviceUtilizationPercent": 94,
+          "loadAverage": [
+            10.828125,
+            12.46337890625,
+            11.79736328125
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7228.25M  free = 963.75M  (encrypted)",
+          "swapUsedMiB": 7228.25
+        },
+        "binarySHA256": "37ae108285410acec9ee3863de69475fb74ce9b472bf23c05e0e0df8ce26414c",
+        "buildSourceRevision": "c3ef55db5f09b2bcc6526bec4dd2a78eaa27aee6",
+        "collectorSHA256": "846c9089342036559de416f10a5f572f3e4afd5005e4eb87be4924ba5cf38446",
+        "command": [
+          "mere.run",
+          "model",
+          "benchmark",
+          "q36-mtp",
+          "--model",
+          "text-agent-ornith-35b-mlx-4bit",
+          "--prompt",
+          "Write a complete Python implementation of an LRU cache using a dictionary and a doubly linked list, with get and put operations, type hints, and a short usage example. Return the code directly without introductory prose.",
+          "--decode-tokens",
+          "256",
+          "--context-size",
+          "8192",
+          "--temperature",
+          "0.0",
+          "--top-p",
+          "1.0",
+          "--json",
+          "--variants",
+          "baseline,adaptive,forced",
+          "--warmups",
+          "1",
+          "--warmup-tokens",
+          "256",
+          "--repetitions",
+          "3",
+          "--model-root",
+          "<ornith-shisa-comparison-root>",
+          "--mtp-block-size",
+          "4"
+        ],
+        "competingInferenceProcessCount": 3,
+        "gpuSamples": [
+          {
+            "deviceUtilizationPercent": 52,
+            "elapsedSeconds": 0.11832499504089355,
+            "loadAverage": [
+              10.828125,
+              12.46337890625,
+              11.79736328125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 53,
+            "elapsedSeconds": 2.2368199825286865,
+            "loadAverage": [
+              10.828125,
+              12.46337890625,
+              11.79736328125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 56,
+            "elapsedSeconds": 4.3541481494903564,
+            "loadAverage": [
+              10.361328125,
+              12.33935546875,
+              11.75732421875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 54,
+            "elapsedSeconds": 6.473680019378662,
+            "loadAverage": [
+              10.361328125,
+              12.33935546875,
+              11.75732421875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 54,
+            "elapsedSeconds": 8.591490030288696,
+            "loadAverage": [
+              10.091796875,
+              12.25048828125,
+              11.72900390625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 60,
+            "elapsedSeconds": 10.708516120910645,
+            "loadAverage": [
+              10.091796875,
+              12.25048828125,
+              11.72900390625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 53,
+            "elapsedSeconds": 12.82706618309021,
+            "loadAverage": [
+              10.091796875,
+              12.25048828125,
+              11.72900390625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 56,
+            "elapsedSeconds": 14.935826063156128,
+            "loadAverage": [
+              10.484375,
+              12.2958984375,
+              11.748046875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 50,
+            "elapsedSeconds": 17.051244974136353,
+            "loadAverage": [
+              10.484375,
+              12.2958984375,
+              11.748046875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 54,
+            "elapsedSeconds": 19.158644914627075,
+            "loadAverage": [
+              10.125,
+              12.19091796875,
+              11.71435546875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 53,
+            "elapsedSeconds": 21.264770984649658,
+            "loadAverage": [
+              10.125,
+              12.19091796875,
+              11.71435546875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 49,
+            "elapsedSeconds": 23.375953197479248,
+            "loadAverage": [
+              10.19482421875,
+              12.1708984375,
+              11.7099609375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 52,
+            "elapsedSeconds": 25.49115300178528,
+            "loadAverage": [
+              10.19482421875,
+              12.1708984375,
+              11.7099609375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 51,
+            "elapsedSeconds": 27.61297106742859,
+            "loadAverage": [
+              10.19482421875,
+              12.1708984375,
+              11.7099609375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 56,
+            "elapsedSeconds": 29.725414037704468,
+            "loadAverage": [
+              10.25927734375,
+              12.1513671875,
+              11.70556640625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 55,
+            "elapsedSeconds": 31.841758966445923,
+            "loadAverage": [
+              10.25927734375,
+              12.1513671875,
+              11.70556640625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 61,
+            "elapsedSeconds": 33.94855713844299,
+            "loadAverage": [
+              10.158203125,
+              12.0986328125,
+              11.689453125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 55,
+            "elapsedSeconds": 36.06132698059082,
+            "loadAverage": [
+              10.158203125,
+              12.0986328125,
+              11.689453125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 61,
+            "elapsedSeconds": 38.16933298110962,
+            "loadAverage": [
+              10.158203125,
+              12.0986328125,
+              11.689453125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 59,
+            "elapsedSeconds": 40.28424596786499,
+            "loadAverage": [
+              10.9462890625,
+              12.2294921875,
+              11.73779296875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 62,
+            "elapsedSeconds": 42.397154092788696,
+            "loadAverage": [
+              10.9462890625,
+              12.2294921875,
+              11.73779296875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 63,
+            "elapsedSeconds": 44.51339316368103,
+            "loadAverage": [
+              10.5498046875,
+              12.1259765625,
+              11.7041015625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 62,
+            "elapsedSeconds": 46.62525200843811,
+            "loadAverage": [
+              10.5498046875,
+              12.1259765625,
+              11.7041015625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 56,
+            "elapsedSeconds": 48.742576122283936,
+            "loadAverage": [
+              10.02490234375,
+              11.99072265625,
+              11.65869140625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 56,
+            "elapsedSeconds": 50.853517055511475,
+            "loadAverage": [
+              10.02490234375,
+              11.99072265625,
+              11.65869140625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 57,
+            "elapsedSeconds": 52.97040295600891,
+            "loadAverage": [
+              10.02490234375,
+              11.99072265625,
+              11.65869140625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 56,
+            "elapsedSeconds": 55.08648705482483,
+            "loadAverage": [
+              9.7822265625,
+              11.90771484375,
+              11.63134765625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 53,
+            "elapsedSeconds": 57.20277810096741,
+            "loadAverage": [
+              9.7822265625,
+              11.90771484375,
+              11.63134765625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 90,
+            "elapsedSeconds": 59.31470608711243,
+            "loadAverage": [
+              9.79931640625,
+              11.8759765625,
+              11.62158203125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 80,
+            "elapsedSeconds": 61.45782017707825,
+            "loadAverage": [
+              9.79931640625,
+              11.8759765625,
+              11.62158203125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 64,
+            "elapsedSeconds": 63.60557579994202,
+            "loadAverage": [
+              9.49462890625,
+              11.7783203125,
+              11.58837890625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 80,
+            "elapsedSeconds": 65.75560903549194,
+            "loadAverage": [
+              9.49462890625,
+              11.7783203125,
+              11.58837890625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 92,
+            "elapsedSeconds": 67.93596196174622,
+            "loadAverage": [
+              9.49462890625,
+              11.7783203125,
+              11.58837890625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 84,
+            "elapsedSeconds": 70.0869550704956,
+            "loadAverage": [
+              8.89404296875,
+              11.61572265625,
+              11.53173828125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 76,
+            "elapsedSeconds": 72.2046959400177,
+            "loadAverage": [
+              8.89404296875,
+              11.61572265625,
+              11.53173828125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 72,
+            "elapsedSeconds": 74.32415103912354,
+            "loadAverage": [
+              8.822265625,
+              11.5556640625,
+              11.5107421875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 93,
+            "elapsedSeconds": 76.46840381622314,
+            "loadAverage": [
+              8.822265625,
+              11.5556640625,
+              11.5107421875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 91,
+            "elapsedSeconds": 78.59751796722412,
+            "loadAverage": [
+              8.51611328125,
+              11.44677734375,
+              11.47216796875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 92,
+            "elapsedSeconds": 80.76137399673462,
+            "loadAverage": [
+              8.51611328125,
+              11.44677734375,
+              11.47216796875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 91,
+            "elapsedSeconds": 82.91092801094055,
+            "loadAverage": [
+              8.51611328125,
+              11.44677734375,
+              11.47216796875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 58,
+            "elapsedSeconds": 85.0312750339508,
+            "loadAverage": [
+              10.556640625,
+              11.82080078125,
+              11.60400390625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 68,
+            "elapsedSeconds": 87.16380786895752,
+            "loadAverage": [
+              10.556640625,
+              11.82080078125,
+              11.60400390625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 87,
+            "elapsedSeconds": 89.36801815032959,
+            "loadAverage": [
+              10.431640625,
+              11.77392578125,
+              11.58837890625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 89,
+            "elapsedSeconds": 91.54511404037476,
+            "loadAverage": [
+              10.431640625,
+              11.77392578125,
+              11.58837890625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 72,
+            "elapsedSeconds": 93.76098608970642,
+            "loadAverage": [
+              11.03759765625,
+              11.876953125,
+              11.62548828125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 84,
+            "elapsedSeconds": 95.92904281616211,
+            "loadAverage": [
+              11.03759765625,
+              11.876953125,
+              11.62548828125
+            ]
+          }
+        ],
+        "knownRenderingWorkerCount": 0,
+        "maxPressureLevel": 1,
+        "measurementMode": "desktop-load",
+        "peakResidentBytes": 9856024576,
+        "processSeconds": 98.0307559967041,
+        "profiled": false,
+        "prompt": "Write a complete Python implementation of an LRU cache using a dictionary and a doubly linked list, with get and put operations, type hints, and a short usage example. Return the code directly without introductory prose.",
+        "runtimeOverrides": {},
+        "sourceHead": "a036360014af49fc5cffd0c113af89ab12d5b8c3",
+        "startedUnixSeconds": 1788628395.241246,
+        "uncontended": false,
+        "workload": "code"
+      },
+      "scenarios": [
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 1.5457090394708357,
+            "forced": 1.6053270409189653
+          },
+          "endToEndSpeedups": {
+            "adaptive": 1.560915470012023,
+            "forced": 1.6129221595537933
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 220,
+          "repetition": 1,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 4.241733074188232,
+              "decodeTokensPerSecond": 60.3526896960607,
+              "elapsedSeconds": 4.522978901863098,
+              "endToEndTokensPerSecond": 56.59986605167424,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.017681002616882324,
+              "generatedTokens": 256,
+              "loadSeconds": 1.6927719116210938e-05,
+              "name": "baseline",
+              "outputSHA256": "cd134369dacefc1cc1bc8bceceb5cfb2dc106e35c077361b20e79108d05fabb4",
+              "policy": "disabled",
+              "prefillSeconds": 0.27916502952575684,
+              "prefillTokensPerSecond": 193.43397019223625,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 7702183936,
+              "residentMemoryBeforeBytes": 7701790720,
+              "ttftSeconds": 0.29686295986175537
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.7166666666666667,
+                "acceptedDraftTokens": 172,
+                "draftHistoryTokens": 53,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 240,
+                "rounds": 84,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 2.7441989183425903,
+              "decodeTokensPerSecond": 93.2876980195794,
+              "elapsedSeconds": 2.8976449966430664,
+              "endToEndTokensPerSecond": 88.34760652066663,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.00021696090698242188,
+              "generatedTokens": 256,
+              "loadSeconds": 1.800060272216797e-05,
+              "name": "adaptive",
+              "outputSHA256": "cd134369dacefc1cc1bc8bceceb5cfb2dc106e35c077361b20e79108d05fabb4",
+              "policy": "adaptive",
+              "prefillSeconds": 0.1523810625076294,
+              "prefillTokensPerSecond": 354.3747438911337,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 9462726656,
+              "residentMemoryBeforeBytes": 9462546432,
+              "ttftSeconds": 0.15261602401733398
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.7166666666666667,
+                "acceptedDraftTokens": 172,
+                "draftHistoryTokens": 53,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 240,
+                "rounds": 84,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 2.642285943031311,
+              "decodeTokensPerSecond": 96.88580476127765,
+              "elapsedSeconds": 2.8042140007019043,
+              "endToEndTokensPerSecond": 91.29117818252185,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0003769397735595703,
+              "generatedTokens": 256,
+              "loadSeconds": 2.6941299438476562e-05,
+              "name": "forced",
+              "outputSHA256": "cd134369dacefc1cc1bc8bceceb5cfb2dc106e35c077361b20e79108d05fabb4",
+              "policy": "forced",
+              "prefillSeconds": 0.16035401821136475,
+              "prefillTokensPerSecond": 336.75489147282786,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 9855959040,
+              "residentMemoryBeforeBytes": 9855877120,
+              "ttftSeconds": 0.1607578992843628
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 1.375151707900838,
+            "forced": 1.2041249776187184
+          },
+          "endToEndSpeedups": {
+            "adaptive": 1.3483844634786688,
+            "forced": 1.1991384229630937
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 220,
+          "repetition": 2,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 3.173090934753418,
+              "decodeTokensPerSecond": 80.67843161888263,
+              "elapsedSeconds": 3.308441996574402,
+              "endToEndTokensPerSecond": 77.37781114647477,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.02306199073791504,
+              "generatedTokens": 256,
+              "loadSeconds": 2.300739288330078e-05,
+              "name": "baseline",
+              "outputSHA256": "cd134369dacefc1cc1bc8bceceb5cfb2dc106e35c077361b20e79108d05fabb4",
+              "policy": "disabled",
+              "prefillSeconds": 0.13394999504089355,
+              "prefillTokensPerSecond": 403.13551324518045,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 7702364160,
+              "residentMemoryBeforeBytes": 7702282240,
+              "ttftSeconds": 0.1570349931716919
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.7166666666666667,
+                "acceptedDraftTokens": 172,
+                "draftHistoryTokens": 53,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 240,
+                "rounds": 84,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 2.307447910308838,
+              "decodeTokensPerSecond": 110.94508303146742,
+              "elapsedSeconds": 2.453634023666382,
+              "endToEndTokensPerSecond": 104.33503836789315,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0002269744873046875,
+              "generatedTokens": 256,
+              "loadSeconds": 1.4066696166992188e-05,
+              "name": "adaptive",
+              "outputSHA256": "cd134369dacefc1cc1bc8bceceb5cfb2dc106e35c077361b20e79108d05fabb4",
+              "policy": "adaptive",
+              "prefillSeconds": 0.14468610286712646,
+              "prefillTokensPerSecond": 373.22174645612847,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 9462775808,
+              "residentMemoryBeforeBytes": 9462726656,
+              "ttftSeconds": 0.14492714405059814
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.7166666666666667,
+                "acceptedDraftTokens": 172,
+                "draftHistoryTokens": 53,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 240,
+                "rounds": 84,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 2.6351840496063232,
+              "decodeTokensPerSecond": 97.14691466740035,
+              "elapsedSeconds": 2.759015917778015,
+              "endToEndTokensPerSecond": 92.78670643051986,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.00024700164794921875,
+              "generatedTokens": 256,
+              "loadSeconds": 2.002716064453125e-05,
+              "name": "forced",
+              "outputSHA256": "cd134369dacefc1cc1bc8bceceb5cfb2dc106e35c077361b20e79108d05fabb4",
+              "policy": "forced",
+              "prefillSeconds": 0.12221503257751465,
+              "prefillTokensPerSecond": 441.8441730214375,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 9855991808,
+              "residentMemoryBeforeBytes": 9855959040,
+              "ttftSeconds": 0.1224820613861084
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 1.08450430615813,
+            "forced": 1.3524445507005722
+          },
+          "endToEndSpeedups": {
+            "adaptive": 1.071940314349145,
+            "forced": 1.3425097246177768
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 220,
+          "repetition": 3,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 2.787137985229492,
+              "decodeTokensPerSecond": 91.85049371673682,
+              "elapsedSeconds": 2.9183489084243774,
+              "endToEndTokensPerSecond": 87.7208339486093,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.013678908348083496,
+              "generatedTokens": 256,
+              "loadSeconds": 2.002716064453125e-05,
+              "name": "baseline",
+              "outputSHA256": "cd134369dacefc1cc1bc8bceceb5cfb2dc106e35c077361b20e79108d05fabb4",
+              "policy": "disabled",
+              "prefillSeconds": 0.12973403930664062,
+              "prefillTokensPerSecond": 416.23617277779414,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 7702413312,
+              "residentMemoryBeforeBytes": 7702364160,
+              "ttftSeconds": 0.14343297481536865
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.7166666666666667,
+                "acceptedDraftTokens": 172,
+                "draftHistoryTokens": 53,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 240,
+                "rounds": 84,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 2.56996488571167,
+              "decodeTokensPerSecond": 99.61225595855134,
+              "elapsedSeconds": 2.722491979598999,
+              "endToEndTokensPerSecond": 94.03149831784141,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0002919435501098633,
+              "generatedTokens": 256,
+              "loadSeconds": 1.800060272216797e-05,
+              "name": "adaptive",
+              "outputSHA256": "cd134369dacefc1cc1bc8bceceb5cfb2dc106e35c077361b20e79108d05fabb4",
+              "policy": "adaptive",
+              "prefillSeconds": 0.15029501914978027,
+              "prefillTokensPerSecond": 359.29334388776346,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 9463021568,
+              "residentMemoryBeforeBytes": 9462775808,
+              "ttftSeconds": 0.1506049633026123
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.7166666666666667,
+                "acceptedDraftTokens": 172,
+                "draftHistoryTokens": 53,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 240,
+                "rounds": 84,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 2.0608149766921997,
+              "decodeTokensPerSecond": 124.22269970635786,
+              "elapsedSeconds": 2.1738009452819824,
+              "endToEndTokensPerSecond": 117.7660726275892,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.00036203861236572266,
+              "generatedTokens": 256,
+              "loadSeconds": 2.5987625122070312e-05,
+              "name": "forced",
+              "outputSHA256": "cd134369dacefc1cc1bc8bceceb5cfb2dc106e35c077361b20e79108d05fabb4",
+              "policy": "forced",
+              "prefillSeconds": 0.11141002178192139,
+              "prefillTokensPerSecond": 484.69607254634457,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 9856024576,
+              "residentMemoryBeforeBytes": 9855991808,
+              "ttftSeconds": 0.11179804801940918
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        }
+      ]
+    },
+    {
+      "id": "head-shisa/ornith-prose",
+      "rawReceiptSHA256": "895d64fe4de303350fc35b7cec734dd462972e63cf03cf69f8bd23196d231aca",
+      "receipt": {
+        "after": {
+          "gpuDeviceUtilizationPercent": 71,
+          "loadAverage": [
+            9.1103515625,
+            11.16796875,
+            11.373046875
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7228.25M  free = 963.75M  (encrypted)",
+          "swapUsedMiB": 7228.25
+        },
+        "before": {
+          "gpuDeviceUtilizationPercent": 47,
+          "loadAverage": [
+            11.03759765625,
+            11.876953125,
+            11.62548828125
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7228.25M  free = 963.75M  (encrypted)",
+          "swapUsedMiB": 7228.25
+        },
+        "binarySHA256": "37ae108285410acec9ee3863de69475fb74ce9b472bf23c05e0e0df8ce26414c",
+        "buildSourceRevision": "c3ef55db5f09b2bcc6526bec4dd2a78eaa27aee6",
+        "collectorSHA256": "846c9089342036559de416f10a5f572f3e4afd5005e4eb87be4924ba5cf38446",
+        "command": [
+          "mere.run",
+          "model",
+          "benchmark",
+          "q36-mtp",
+          "--model",
+          "text-agent-ornith-35b-mlx-4bit",
+          "--prompt",
+          "Explain how a small community could turn an abandoned railway station into a public library. Discuss the building, accessibility, staffing, the collection, and a realistic opening-day scene. Write approximately 400 words of clear, connected prose.",
+          "--decode-tokens",
+          "256",
+          "--context-size",
+          "8192",
+          "--temperature",
+          "0.0",
+          "--top-p",
+          "1.0",
+          "--json",
+          "--variants",
+          "baseline,adaptive,forced",
+          "--warmups",
+          "1",
+          "--warmup-tokens",
+          "256",
+          "--repetitions",
+          "3",
+          "--model-root",
+          "<ornith-shisa-comparison-root>",
+          "--mtp-block-size",
+          "4"
+        ],
+        "competingInferenceProcessCount": 0,
+        "gpuSamples": [
+          {
+            "deviceUtilizationPercent": 49,
+            "elapsedSeconds": 0.10965871810913086,
+            "loadAverage": [
+              10.4736328125,
+              11.74609375,
+              11.58056640625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 46,
+            "elapsedSeconds": 2.23213267326355,
+            "loadAverage": [
+              10.4736328125,
+              11.74609375,
+              11.58056640625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 90,
+            "elapsedSeconds": 4.376412868499756,
+            "loadAverage": [
+              10.4736328125,
+              11.74609375,
+              11.58056640625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 86,
+            "elapsedSeconds": 6.534968852996826,
+            "loadAverage": [
+              9.955078125,
+              11.6171875,
+              11.5361328125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 57,
+            "elapsedSeconds": 8.726781845092773,
+            "loadAverage": [
+              9.955078125,
+              11.6171875,
+              11.5361328125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 70,
+            "elapsedSeconds": 10.871057748794556,
+            "loadAverage": [
+              9.55810546875,
+              11.50732421875,
+              11.49755859375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 83,
+            "elapsedSeconds": 13.048832654953003,
+            "loadAverage": [
+              9.55810546875,
+              11.50732421875,
+              11.49755859375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 73,
+            "elapsedSeconds": 15.167414665222168,
+            "loadAverage": [
+              9.51318359375,
+              11.46533203125,
+              11.48291015625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 59,
+            "elapsedSeconds": 17.289249658584595,
+            "loadAverage": [
+              9.51318359375,
+              11.46533203125,
+              11.48291015625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 91,
+            "elapsedSeconds": 19.414830684661865,
+            "loadAverage": [
+              9.51318359375,
+              11.46533203125,
+              11.48291015625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 89,
+            "elapsedSeconds": 21.552681922912598,
+            "loadAverage": [
+              9.1513671875,
+              11.35791015625,
+              11.44482421875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 87,
+            "elapsedSeconds": 23.685011863708496,
+            "loadAverage": [
+              9.1513671875,
+              11.35791015625,
+              11.44482421875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 73,
+            "elapsedSeconds": 25.84903383255005,
+            "loadAverage": [
+              8.89892578125,
+              11.2685546875,
+              11.41259765625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 84,
+            "elapsedSeconds": 28.012802839279175,
+            "loadAverage": [
+              8.89892578125,
+              11.2685546875,
+              11.41259765625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 85,
+            "elapsedSeconds": 30.144019842147827,
+            "loadAverage": [
+              8.74658203125,
+              11.197265625,
+              11.38671875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 44,
+            "elapsedSeconds": 32.259968757629395,
+            "loadAverage": [
+              8.74658203125,
+              11.197265625,
+              11.38671875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 79,
+            "elapsedSeconds": 34.59884071350098,
+            "loadAverage": [
+              8.74658203125,
+              11.197265625,
+              11.38671875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 69,
+            "elapsedSeconds": 36.78156876564026,
+            "loadAverage": [
+              9.4072265625,
+              11.29345703125,
+              11.41943359375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 84,
+            "elapsedSeconds": 38.92733383178711,
+            "loadAverage": [
+              9.4072265625,
+              11.29345703125,
+              11.41943359375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 86,
+            "elapsedSeconds": 41.10124969482422,
+            "loadAverage": [
+              9.29443359375,
+              11.23876953125,
+              11.39892578125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 80,
+            "elapsedSeconds": 43.255640745162964,
+            "loadAverage": [
+              9.29443359375,
+              11.23876953125,
+              11.39892578125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 79,
+            "elapsedSeconds": 45.435494899749756,
+            "loadAverage": [
+              9.1103515625,
+              11.16796875,
+              11.373046875
+            ]
+          }
+        ],
+        "knownRenderingWorkerCount": 0,
+        "maxPressureLevel": 1,
+        "measurementMode": "desktop-load",
+        "peakResidentBytes": 9755033600,
+        "processSeconds": 47.53456377983093,
+        "profiled": false,
+        "prompt": "Explain how a small community could turn an abandoned railway station into a public library. Discuss the building, accessibility, staffing, the collection, and a realistic opening-day scene. Write approximately 400 words of clear, connected prose.",
+        "runtimeOverrides": {},
+        "sourceHead": "a036360014af49fc5cffd0c113af89ab12d5b8c3",
+        "startedUnixSeconds": 1788628493.4797702,
+        "uncontended": false,
+        "workload": "prose"
+      },
+      "scenarios": [
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 0.9824945435528925,
+            "forced": 1.0827973635047208
+          },
+          "endToEndSpeedups": {
+            "adaptive": 0.9770922208951219,
+            "forced": 1.0953359541917016
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 247,
+          "repetition": 1,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 3.273890972137451,
+              "decodeTokensPerSecond": 78.19441825604328,
+              "elapsedSeconds": 3.4237769842147827,
+              "endToEndTokensPerSecond": 74.7712252229862,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.010705947875976562,
+              "generatedTokens": 256,
+              "loadSeconds": 1.990795135498047e-05,
+              "name": "baseline",
+              "outputSHA256": "ca3ac87c453ea9cb8fdd5fe572ce7e0e9930e17487f37393e45606052e4db11e",
+              "policy": "disabled",
+              "prefillSeconds": 0.14859390258789062,
+              "prefillTokensPerSecond": 403.7850743203348,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 7700463616,
+              "residentMemoryBeforeBytes": 7699824640,
+              "ttftSeconds": 0.15931975841522217
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.3832752613240418,
+                "acceptedDraftTokens": 110,
+                "draftHistoryTokens": 59,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 287,
+                "rounds": 146,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 3.332223057746887,
+              "decodeTokensPerSecond": 76.8255892728552,
+              "elapsedSeconds": 3.50404691696167,
+              "endToEndTokensPerSecond": 73.05838251217695,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.00022304058074951172,
+              "generatedTokens": 256,
+              "loadSeconds": 1.609325408935547e-05,
+              "name": "adaptive",
+              "outputSHA256": "ca3ac87c453ea9cb8fdd5fe572ce7e0e9930e17487f37393e45606052e4db11e",
+              "policy": "adaptive",
+              "prefillSeconds": 0.1705690622329712,
+              "prefillTokensPerSecond": 351.76367398942017,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 9467379712,
+              "residentMemoryBeforeBytes": 9467117568,
+              "ttftSeconds": 0.17080819606781006
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.3832752613240418,
+                "acceptedDraftTokens": 110,
+                "draftHistoryTokens": 59,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 287,
+                "rounds": 146,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 3.0235490798950195,
+              "decodeTokensPerSecond": 84.66870992842907,
+              "elapsedSeconds": 3.1257779598236084,
+              "endToEndTokensPerSecond": 81.89961132570222,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0002560615539550781,
+              "generatedTokens": 256,
+              "loadSeconds": 2.300739288330078e-05,
+              "name": "forced",
+              "outputSHA256": "ca3ac87c453ea9cb8fdd5fe572ce7e0e9930e17487f37393e45606052e4db11e",
+              "policy": "forced",
+              "prefillSeconds": 0.10066699981689453,
+              "prefillTokensPerSecond": 596.0245175592333,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 9754853376,
+              "residentMemoryBeforeBytes": 9754755072,
+              "ttftSeconds": 0.10094606876373291
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 0.963908886769912,
+            "forced": 0.9650665965425653
+          },
+          "endToEndSpeedups": {
+            "adaptive": 0.9728165540143687,
+            "forced": 0.9702400420890998
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 247,
+          "repetition": 2,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 3.28643000125885,
+              "decodeTokensPerSecond": 77.89607565106834,
+              "elapsedSeconds": 3.4365620613098145,
+              "endToEndTokensPerSecond": 74.49305306665346,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.011965036392211914,
+              "generatedTokens": 256,
+              "loadSeconds": 1.609325408935547e-05,
+              "name": "baseline",
+              "outputSHA256": "ca3ac87c453ea9cb8fdd5fe572ce7e0e9930e17487f37393e45606052e4db11e",
+              "policy": "disabled",
+              "prefillSeconds": 0.14888405799865723,
+              "prefillTokensPerSecond": 402.99815041675674,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 7700611072,
+              "residentMemoryBeforeBytes": 7700561920,
+              "ttftSeconds": 0.1608651876449585
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.3832752613240418,
+                "acceptedDraftTokens": 110,
+                "draftHistoryTokens": 59,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 287,
+                "rounds": 146,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 3.409482002258301,
+              "decodeTokensPerSecond": 75.08471956456614,
+              "elapsedSeconds": 3.5325900316238403,
+              "endToEndTokensPerSecond": 72.46807518231132,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.00026798248291015625,
+              "generatedTokens": 256,
+              "loadSeconds": 1.4901161193847656e-05,
+              "name": "adaptive",
+              "outputSHA256": "ca3ac87c453ea9cb8fdd5fe572ce7e0e9930e17487f37393e45606052e4db11e",
+              "policy": "adaptive",
+              "prefillSeconds": 0.12176096439361572,
+              "prefillTokensPerSecond": 492.76876459386824,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 9467412480,
+              "residentMemoryBeforeBytes": 9467379712,
+              "ttftSeconds": 0.12204384803771973
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.3832752613240418,
+                "acceptedDraftTokens": 110,
+                "draftHistoryTokens": 59,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 287,
+                "rounds": 146,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 3.4053919315338135,
+              "decodeTokensPerSecond": 75.17490061259872,
+              "elapsedSeconds": 3.54197096824646,
+              "endToEndTokensPerSecond": 72.27614294273539,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0002599954605102539,
+              "generatedTokens": 256,
+              "loadSeconds": 1.6927719116210938e-05,
+              "name": "forced",
+              "outputSHA256": "ca3ac87c453ea9cb8fdd5fe572ce7e0e9930e17487f37393e45606052e4db11e",
+              "policy": "forced",
+              "prefillSeconds": 0.13514196872711182,
+              "prefillTokensPerSecond": 443.9775486855325,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 9754935296,
+              "residentMemoryBeforeBytes": 9754853376,
+              "ttftSeconds": 0.13541889190673828
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 0.943025868117279,
+            "forced": 0.850958039664927
+          },
+          "endToEndSpeedups": {
+            "adaptive": 0.9432507257589713,
+            "forced": 0.8536093604352072
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 247,
+          "repetition": 3,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 2.8435860872268677,
+              "decodeTokensPerSecond": 90.02716715696737,
+              "elapsedSeconds": 2.9476839303970337,
+              "endToEndTokensPerSecond": 86.84784598514213,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.008930087089538574,
+              "generatedTokens": 256,
+              "loadSeconds": 1.5020370483398438e-05,
+              "name": "baseline",
+              "outputSHA256": "ca3ac87c453ea9cb8fdd5fe572ce7e0e9930e17487f37393e45606052e4db11e",
+              "policy": "disabled",
+              "prefillSeconds": 0.10278904438018799,
+              "prefillTokensPerSecond": 583.7197958381317,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 7700692992,
+              "residentMemoryBeforeBytes": 7700627456,
+              "ttftSeconds": 0.11173415184020996
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.3832752613240418,
+                "acceptedDraftTokens": 110,
+                "draftHistoryTokens": 59,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 287,
+                "rounds": 146,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 3.0153850317001343,
+              "decodeTokensPerSecond": 84.89794746233854,
+              "elapsedSeconds": 3.1250269412994385,
+              "endToEndTokensPerSecond": 81.91929375608868,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.00021696090698242188,
+              "generatedTokens": 256,
+              "loadSeconds": 1.5974044799804688e-05,
+              "name": "adaptive",
+              "outputSHA256": "ca3ac87c453ea9cb8fdd5fe572ce7e0e9930e17487f37393e45606052e4db11e",
+              "policy": "adaptive",
+              "prefillSeconds": 0.10828399658203125,
+              "prefillTokensPerSecond": 554.0984992601987,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 9467445248,
+              "residentMemoryBeforeBytes": 9467412480,
+              "ttftSeconds": 0.10851693153381348
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.3832752613240418,
+                "acceptedDraftTokens": 110,
+                "draftHistoryTokens": 59,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 287,
+                "rounds": 146,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 3.3416290283203125,
+              "decodeTokensPerSecond": 76.60934168047964,
+              "elapsedSeconds": 3.453200101852417,
+              "endToEndTokensPerSecond": 74.13413426655255,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.00022792816162109375,
+              "generatedTokens": 256,
+              "loadSeconds": 1.800060272216797e-05,
+              "name": "forced",
+              "outputSHA256": "ca3ac87c453ea9cb8fdd5fe572ce7e0e9930e17487f37393e45606052e4db11e",
+              "policy": "forced",
+              "prefillSeconds": 0.11011898517608643,
+              "prefillTokensPerSecond": 544.8651738304402,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 9755033600,
+              "residentMemoryBeforeBytes": 9754935296,
+              "ttftSeconds": 0.11036491394042969
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        }
+      ]
+    },
+    {
+      "id": "fixed-native/ornith-code",
+      "rawReceiptSHA256": "62659c573298d269536a40863c577e8d1aef2139fb5d22d7e0857bd9e0700ea8",
+      "receipt": {
+        "after": {
+          "gpuDeviceUtilizationPercent": 89,
+          "loadAverage": [
+            7.90380859375,
+            10.16162109375,
+            10.951171875
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7228.25M  free = 963.75M  (encrypted)",
+          "swapUsedMiB": 7228.25
+        },
+        "before": {
+          "gpuDeviceUtilizationPercent": 45,
+          "loadAverage": [
+            8.51904296875,
+            10.35498046875,
+            11.02783203125
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7228.25M  free = 963.75M  (encrypted)",
+          "swapUsedMiB": 7228.25
+        },
+        "binarySHA256": "37ae108285410acec9ee3863de69475fb74ce9b472bf23c05e0e0df8ce26414c",
+        "buildSourceRevision": "c3ef55db5f09b2bcc6526bec4dd2a78eaa27aee6",
+        "collectorSHA256": "846c9089342036559de416f10a5f572f3e4afd5005e4eb87be4924ba5cf38446",
+        "command": [
+          "mere.run",
+          "model",
+          "benchmark",
+          "q36-mtp",
+          "--model",
+          "text-agent-ornith-35b-mlx-4bit",
+          "--prompt",
+          "Write a complete Python implementation of an LRU cache using a dictionary and a doubly linked list, with get and put operations, type hints, and a short usage example. Return the code directly without introductory prose.",
+          "--decode-tokens",
+          "256",
+          "--context-size",
+          "8192",
+          "--temperature",
+          "0.0",
+          "--top-p",
+          "1.0",
+          "--json",
+          "--variants",
+          "adaptive",
+          "--warmups",
+          "1",
+          "--warmup-tokens",
+          "256",
+          "--repetitions",
+          "1",
+          "--model-root",
+          "<ornith-native-root>",
+          "--mtp-block-size",
+          "4"
+        ],
+        "competingInferenceProcessCount": 0,
+        "gpuSamples": [
+          {
+            "deviceUtilizationPercent": 45,
+            "elapsedSeconds": 0.14454293251037598,
+            "loadAverage": [
+              8.51904296875,
+              10.35498046875,
+              11.02783203125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 40,
+            "elapsedSeconds": 2.3325541019439697,
+            "loadAverage": [
+              8.51904296875,
+              10.35498046875,
+              11.02783203125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 78,
+            "elapsedSeconds": 4.455059051513672,
+            "loadAverage": [
+              8.51904296875,
+              10.35498046875,
+              11.02783203125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 94,
+            "elapsedSeconds": 6.599163293838501,
+            "loadAverage": [
+              8.15673828125,
+              10.2490234375,
+              10.986328125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 88,
+            "elapsedSeconds": 8.719600200653076,
+            "loadAverage": [
+              8.15673828125,
+              10.2490234375,
+              10.986328125
+            ]
+          }
+        ],
+        "knownRenderingWorkerCount": 1,
+        "maxPressureLevel": 1,
+        "measurementMode": "desktop-load",
+        "peakResidentBytes": 9464086528,
+        "processSeconds": 10.829271078109741,
+        "profiled": false,
+        "prompt": "Write a complete Python implementation of an LRU cache using a dictionary and a doubly linked list, with get and put operations, type hints, and a short usage example. Return the code directly without introductory prose.",
+        "runtimeOverrides": {
+          "MERERUN_Q35_MTP_HEAD_COST_RATIO": "1e-100"
+        },
+        "sourceHead": "a036360014af49fc5cffd0c113af89ab12d5b8c3",
+        "startedUnixSeconds": 1788628638.968309,
+        "uncontended": false,
+        "workload": "code"
+      },
+      "scenarios": [
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {},
+          "endToEndSpeedups": {},
+          "promptCharacters": 220,
+          "repetition": 1,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "acceptanceRate": 0.34759358288770054,
+                "acceptedDraftTokens": 130,
+                "draftHistoryTokens": 53,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 374,
+                "rounds": 125,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 3.7711130380630493,
+              "decodeTokensPerSecond": 67.88446737504556,
+              "elapsedSeconds": 3.958549976348877,
+              "endToEndTokensPerSecond": 64.67014475742924,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.00044095516204833984,
+              "generatedTokens": 256,
+              "loadSeconds": 1.5974044799804688e-05,
+              "name": "adaptive",
+              "outputSHA256": "cd134369dacefc1cc1bc8bceceb5cfb2dc106e35c077361b20e79108d05fabb4",
+              "policy": "adaptive",
+              "prefillSeconds": 0.18637597560882568,
+              "prefillTokensPerSecond": 289.7369139107158,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 9464119296,
+              "residentMemoryBeforeBytes": 9463726080,
+              "ttftSeconds": 0.18683290481567383
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        }
+      ]
+    },
+    {
+      "id": "fixed-native/ornith-prose",
+      "rawReceiptSHA256": "025eb7ebf936ed873d7ae97d459179b539e811305f618034345f956b435b9823",
+      "receipt": {
+        "after": {
+          "gpuDeviceUtilizationPercent": 87,
+          "loadAverage": [
+            8.3056640625,
+            10.17236328125,
+            10.9453125
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7220.25M  free = 971.75M  (encrypted)",
+          "swapUsedMiB": 7220.25
+        },
+        "before": {
+          "gpuDeviceUtilizationPercent": 0,
+          "loadAverage": [
+            7.90380859375,
+            10.16162109375,
+            10.951171875
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7228.25M  free = 963.75M  (encrypted)",
+          "swapUsedMiB": 7228.25
+        },
+        "binarySHA256": "37ae108285410acec9ee3863de69475fb74ce9b472bf23c05e0e0df8ce26414c",
+        "buildSourceRevision": "c3ef55db5f09b2bcc6526bec4dd2a78eaa27aee6",
+        "collectorSHA256": "846c9089342036559de416f10a5f572f3e4afd5005e4eb87be4924ba5cf38446",
+        "command": [
+          "mere.run",
+          "model",
+          "benchmark",
+          "q36-mtp",
+          "--model",
+          "text-agent-ornith-35b-mlx-4bit",
+          "--prompt",
+          "Explain how a small community could turn an abandoned railway station into a public library. Discuss the building, accessibility, staffing, the collection, and a realistic opening-day scene. Write approximately 400 words of clear, connected prose.",
+          "--decode-tokens",
+          "256",
+          "--context-size",
+          "8192",
+          "--temperature",
+          "0.0",
+          "--top-p",
+          "1.0",
+          "--json",
+          "--variants",
+          "adaptive",
+          "--warmups",
+          "1",
+          "--warmup-tokens",
+          "256",
+          "--repetitions",
+          "1",
+          "--model-root",
+          "<ornith-native-root>",
+          "--mtp-block-size",
+          "4"
+        ],
+        "competingInferenceProcessCount": 0,
+        "gpuSamples": [
+          {
+            "deviceUtilizationPercent": 29,
+            "elapsedSeconds": 0.1181330680847168,
+            "loadAverage": [
+              7.90380859375,
+              10.16162109375,
+              10.951171875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 40,
+            "elapsedSeconds": 2.2327349185943604,
+            "loadAverage": [
+              7.90380859375,
+              10.16162109375,
+              10.951171875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 87,
+            "elapsedSeconds": 4.362911939620972,
+            "loadAverage": [
+              8.0712890625,
+              10.15869140625,
+              10.9453125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 93,
+            "elapsedSeconds": 6.518233776092529,
+            "loadAverage": [
+              8.0712890625,
+              10.15869140625,
+              10.9453125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 90,
+            "elapsedSeconds": 8.776556730270386,
+            "loadAverage": [
+              8.3056640625,
+              10.17236328125,
+              10.9453125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 90,
+            "elapsedSeconds": 10.95705509185791,
+            "loadAverage": [
+              8.3056640625,
+              10.17236328125,
+              10.9453125
+            ]
+          }
+        ],
+        "knownRenderingWorkerCount": 0,
+        "maxPressureLevel": 1,
+        "measurementMode": "desktop-load",
+        "peakResidentBytes": 9461891072,
+        "processSeconds": 13.073042869567871,
+        "profiled": false,
+        "prompt": "Explain how a small community could turn an abandoned railway station into a public library. Discuss the building, accessibility, staffing, the collection, and a realistic opening-day scene. Write approximately 400 words of clear, connected prose.",
+        "runtimeOverrides": {
+          "MERERUN_Q35_MTP_HEAD_COST_RATIO": "1e-100"
+        },
+        "sourceHead": "a036360014af49fc5cffd0c113af89ab12d5b8c3",
+        "startedUnixSeconds": 1788628650.059385,
+        "uncontended": false,
+        "workload": "prose"
+      },
+      "scenarios": [
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {},
+          "endToEndSpeedups": {},
+          "promptCharacters": 247,
+          "repetition": 1,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "acceptanceRate": 0.13419117647058823,
+                "acceptedDraftTokens": 73,
+                "draftHistoryTokens": 59,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 544,
+                "rounds": 182,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 4.637614965438843,
+              "decodeTokensPerSecond": 55.20078788510972,
+              "elapsedSeconds": 4.827111005783081,
+              "endToEndTokensPerSecond": 53.03379178421654,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.00048100948333740234,
+              "generatedTokens": 256,
+              "loadSeconds": 1.5974044799804688e-05,
+              "name": "adaptive",
+              "outputSHA256": "ca3ac87c453ea9cb8fdd5fe572ce7e0e9930e17487f37393e45606052e4db11e",
+              "policy": "adaptive",
+              "prefillSeconds": 0.18763399124145508,
+              "prefillTokensPerSecond": 319.77148491602225,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 7414300672,
+              "residentMemoryBeforeBytes": 9462251520,
+              "ttftSeconds": 0.18813097476959229
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        }
+      ]
+    },
+    {
+      "id": "fixed-shisa/ornith-code",
+      "rawReceiptSHA256": "e5135cf25500ea67da9bffe3c379b6d21f776b5a349a29a9472028281ea72374",
+      "receipt": {
+        "after": {
+          "gpuDeviceUtilizationPercent": 82,
+          "loadAverage": [
+            8.51904296875,
+            10.35498046875,
+            11.02783203125
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7228.25M  free = 963.75M  (encrypted)",
+          "swapUsedMiB": 7228.25
+        },
+        "before": {
+          "gpuDeviceUtilizationPercent": 39,
+          "loadAverage": [
+            7.958984375,
+            10.3154296875,
+            11.02294921875
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7228.25M  free = 963.75M  (encrypted)",
+          "swapUsedMiB": 7228.25
+        },
+        "binarySHA256": "37ae108285410acec9ee3863de69475fb74ce9b472bf23c05e0e0df8ce26414c",
+        "buildSourceRevision": "c3ef55db5f09b2bcc6526bec4dd2a78eaa27aee6",
+        "collectorSHA256": "846c9089342036559de416f10a5f572f3e4afd5005e4eb87be4924ba5cf38446",
+        "command": [
+          "mere.run",
+          "model",
+          "benchmark",
+          "q36-mtp",
+          "--model",
+          "text-agent-ornith-35b-mlx-4bit",
+          "--prompt",
+          "Write a complete Python implementation of an LRU cache using a dictionary and a doubly linked list, with get and put operations, type hints, and a short usage example. Return the code directly without introductory prose.",
+          "--decode-tokens",
+          "256",
+          "--context-size",
+          "8192",
+          "--temperature",
+          "0.0",
+          "--top-p",
+          "1.0",
+          "--json",
+          "--variants",
+          "adaptive",
+          "--warmups",
+          "1",
+          "--warmup-tokens",
+          "256",
+          "--repetitions",
+          "1",
+          "--model-root",
+          "<ornith-shisa-comparison-root>",
+          "--mtp-block-size",
+          "4"
+        ],
+        "competingInferenceProcessCount": 0,
+        "gpuSamples": [
+          {
+            "deviceUtilizationPercent": 31,
+            "elapsedSeconds": 0.09989619255065918,
+            "loadAverage": [
+              7.958984375,
+              10.3154296875,
+              11.02294921875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 40,
+            "elapsedSeconds": 2.213371992111206,
+            "loadAverage": [
+              7.958984375,
+              10.3154296875,
+              11.02294921875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 88,
+            "elapsedSeconds": 4.577566146850586,
+            "loadAverage": [
+              8.0419921875,
+              10.29345703125,
+              11.0107421875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 90,
+            "elapsedSeconds": 6.707096099853516,
+            "loadAverage": [
+              8.0419921875,
+              10.29345703125,
+              11.0107421875
+            ]
+          }
+        ],
+        "knownRenderingWorkerCount": 0,
+        "maxPressureLevel": 1,
+        "measurementMode": "desktop-load",
+        "peakResidentBytes": 9463103488,
+        "processSeconds": 8.842375993728638,
+        "profiled": false,
+        "prompt": "Write a complete Python implementation of an LRU cache using a dictionary and a doubly linked list, with get and put operations, type hints, and a short usage example. Return the code directly without introductory prose.",
+        "runtimeOverrides": {
+          "MERERUN_Q35_MTP_HEAD_COST_RATIO": "1e-100"
+        },
+        "sourceHead": "a036360014af49fc5cffd0c113af89ab12d5b8c3",
+        "startedUnixSeconds": 1788628629.833557,
+        "uncontended": false,
+        "workload": "code"
+      },
+      "scenarios": [
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {},
+          "endToEndSpeedups": {},
+          "promptCharacters": 220,
+          "repetition": 1,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "acceptanceRate": 0.7073170731707317,
+                "acceptedDraftTokens": 174,
+                "draftHistoryTokens": 53,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 246,
+                "rounds": 82,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 2.225687026977539,
+              "decodeTokensPerSecond": 115.02066413517514,
+              "elapsedSeconds": 2.451653003692627,
+              "endToEndTokensPerSecond": 104.41934466844138,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0005600452423095703,
+              "generatedTokens": 256,
+              "loadSeconds": 2.7894973754882812e-05,
+              "name": "adaptive",
+              "outputSHA256": "cd134369dacefc1cc1bc8bceceb5cfb2dc106e35c077361b20e79108d05fabb4",
+              "policy": "adaptive",
+              "prefillSeconds": 0.22465908527374268,
+              "prefillTokensPerSecond": 240.36419419317969,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 9463119872,
+              "residentMemoryBeforeBytes": 9462890496,
+              "ttftSeconds": 0.22524702548980713
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        }
+      ]
+    },
+    {
+      "id": "fixed-shisa/ornith-prose",
+      "rawReceiptSHA256": "52480fd3a9a90548183191b56bf76db51360f59980df4e037768bc3e0a256689",
+      "receipt": {
+        "after": {
+          "gpuDeviceUtilizationPercent": 61,
+          "loadAverage": [
+            11.40185546875,
+            10.77197265625,
+            11.142578125
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7220.25M  free = 971.75M  (encrypted)",
+          "swapUsedMiB": 7220.25
+        },
+        "before": {
+          "gpuDeviceUtilizationPercent": 38,
+          "loadAverage": [
+            8.3056640625,
+            10.17236328125,
+            10.9453125
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7220.25M  free = 971.75M  (encrypted)",
+          "swapUsedMiB": 7220.25
+        },
+        "binarySHA256": "37ae108285410acec9ee3863de69475fb74ce9b472bf23c05e0e0df8ce26414c",
+        "buildSourceRevision": "c3ef55db5f09b2bcc6526bec4dd2a78eaa27aee6",
+        "collectorSHA256": "846c9089342036559de416f10a5f572f3e4afd5005e4eb87be4924ba5cf38446",
+        "command": [
+          "mere.run",
+          "model",
+          "benchmark",
+          "q36-mtp",
+          "--model",
+          "text-agent-ornith-35b-mlx-4bit",
+          "--prompt",
+          "Explain how a small community could turn an abandoned railway station into a public library. Discuss the building, accessibility, staffing, the collection, and a realistic opening-day scene. Write approximately 400 words of clear, connected prose.",
+          "--decode-tokens",
+          "256",
+          "--context-size",
+          "8192",
+          "--temperature",
+          "0.0",
+          "--top-p",
+          "1.0",
+          "--json",
+          "--variants",
+          "adaptive",
+          "--warmups",
+          "1",
+          "--warmup-tokens",
+          "256",
+          "--repetitions",
+          "1",
+          "--model-root",
+          "<ornith-shisa-comparison-root>",
+          "--mtp-block-size",
+          "4"
+        ],
+        "competingInferenceProcessCount": 0,
+        "gpuSamples": [
+          {
+            "deviceUtilizationPercent": 30,
+            "elapsedSeconds": 0.11353707313537598,
+            "loadAverage": [
+              8.3056640625,
+              10.17236328125,
+              10.9453125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 36,
+            "elapsedSeconds": 2.2294111251831055,
+            "loadAverage": [
+              8.92138671875,
+              10.26904296875,
+              10.974609375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 38,
+            "elapsedSeconds": 4.344074964523315,
+            "loadAverage": [
+              8.92138671875,
+              10.26904296875,
+              10.974609375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 47,
+            "elapsedSeconds": 6.481417894363403,
+            "loadAverage": [
+              11.08935546875,
+              10.69580078125,
+              11.12109375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 48,
+            "elapsedSeconds": 8.593395948410034,
+            "loadAverage": [
+              11.08935546875,
+              10.69580078125,
+              11.12109375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 63,
+            "elapsedSeconds": 10.709580898284912,
+            "loadAverage": [
+              11.001953125,
+              10.68408203125,
+              11.1142578125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 89,
+            "elapsedSeconds": 12.834691047668457,
+            "loadAverage": [
+              11.001953125,
+              10.68408203125,
+              11.1142578125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 90,
+            "elapsedSeconds": 14.993717908859253,
+            "loadAverage": [
+              11.001953125,
+              10.68408203125,
+              11.1142578125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 86,
+            "elapsedSeconds": 17.124790906906128,
+            "loadAverage": [
+              11.40185546875,
+              10.77197265625,
+              11.142578125
+            ]
+          }
+        ],
+        "knownRenderingWorkerCount": 2,
+        "maxPressureLevel": 1,
+        "measurementMode": "desktop-load",
+        "peakResidentBytes": 9463070720,
+        "processSeconds": 19.21707797050476,
+        "profiled": false,
+        "prompt": "Explain how a small community could turn an abandoned railway station into a public library. Discuss the building, accessibility, staffing, the collection, and a realistic opening-day scene. Write approximately 400 words of clear, connected prose.",
+        "runtimeOverrides": {
+          "MERERUN_Q35_MTP_HEAD_COST_RATIO": "1e-100"
+        },
+        "sourceHead": "a036360014af49fc5cffd0c113af89ab12d5b8c3",
+        "startedUnixSeconds": 1788628663.394814,
+        "uncontended": false,
+        "workload": "prose"
+      },
+      "scenarios": [
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {},
+          "endToEndSpeedups": {},
+          "promptCharacters": 247,
+          "repetition": 1,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "acceptanceRate": 0.30982367758186397,
+                "acceptedDraftTokens": 123,
+                "draftHistoryTokens": 59,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 397,
+                "rounds": 133,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 4.401049971580505,
+              "decodeTokensPerSecond": 58.16793757242099,
+              "elapsedSeconds": 4.512463092803955,
+              "endToEndTokensPerSecond": 56.73176594136456,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0001989603042602539,
+              "generatedTokens": 256,
+              "loadSeconds": 2.300739288330078e-05,
+              "name": "adaptive",
+              "outputSHA256": "ca3ac87c453ea9cb8fdd5fe572ce7e0e9930e17487f37393e45606052e4db11e",
+              "policy": "adaptive",
+              "prefillSeconds": 0.110260009765625,
+              "prefillTokensPerSecond": 544.1682812067534,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 9463480320,
+              "residentMemoryBeforeBytes": 9462661120,
+              "ttftSeconds": 0.11048197746276855
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        }
+      ]
+    }
+  ],
+  "releaseBuild": {
+    "binarySHA256": "37ae108285410acec9ee3863de69475fb74ce9b472bf23c05e0e0df8ce26414c",
+    "command": "swift build -c release --product mere.run --disable-index-store",
+    "completedUnixSeconds": 1788623568.49564,
+    "sourceRevision": "c3ef55db5f09b2bcc6526bec4dd2a78eaa27aee6",
+    "swiftVersion": "Apple Swift version 6.3 (swiftlang-6.3.0.123.5 clang-2100.0.123.102)\nTarget: arm64-apple-macosx26.0"
+  },
+  "replacement": {
+    "method": "Split fused expert axes into per-expert views; copy all BF16 bytes unchanged; no normalization or quantization conversion.",
+    "outputSHA256": "d1b500efb9ed14e3c855ef87a118c1d4a7de27029ed5f27e7e4fae48a1d34028",
+    "source": {
+      "filename": "model-mtp.safetensors",
+      "repository": "shisa-ai/Ornith-1.5-35B-A3B-MTP-ONLY",
+      "revision": "2b19b31bfe1659c6b0d9459ec3cbd87e34a322ef",
+      "sha256": "73c6e839971fff3c6d78dbcb6a15895bbab340a2898e98aa6943070751de712e",
+      "size": 1689283688
+    },
+    "tensorCount": 785,
+    "tensorSHA256": {
+      "mtp.fc.weight": "6c78add4323c817e7b67ef75704716ac2fcdea5521e6ed80a77ec92282595b15",
+      "mtp.layers.0.input_layernorm.weight": "b43759c8f0817c5cde7c4df3d6cd2a9565b37ece2cee0613eacc92e01795b235",
+      "mtp.layers.0.mlp.experts.0.down_proj.weight": "5dd2d1488fe98a743a5b1fd04c86da0f144c1b57692e9243626d450a89f153c8",
+      "mtp.layers.0.mlp.experts.0.gate_proj.weight": "fb3a743efb391719aa04989dabedda78ab0d24119fa69d96c59f6487fb414706",
+      "mtp.layers.0.mlp.experts.0.up_proj.weight": "4492d10fec24409e137a41c7165bdc50839bb2ab245016d665f8bae261496410",
+      "mtp.layers.0.mlp.experts.1.down_proj.weight": "a30b4bdfa2e82273b3f02064aad6c59920f3077877b9b64258467c35ac353e2e",
+      "mtp.layers.0.mlp.experts.1.gate_proj.weight": "d000096311ba4c74bbd1b1f27a686c8a0a02fe5437a47d0a29f63479378e2632",
+      "mtp.layers.0.mlp.experts.1.up_proj.weight": "9aa1b22ba2fbf0de8d7c920a6b11575a7dca7396a0de24c43db3d392dbd02d38",
+      "mtp.layers.0.mlp.experts.10.down_proj.weight": "dafd4fbb45234ad1de3eda0b91ac3a801f74688c9808c53ad5732ab958ae3c90",
+      "mtp.layers.0.mlp.experts.10.gate_proj.weight": "face458a14f57540c5db21cdc6befafeaf52a02ccad296b57dd86182519f329c",
+      "mtp.layers.0.mlp.experts.10.up_proj.weight": "549d22b5cf03fbc5e53aa67558c7a21a7259432277075b9668b9ec62b6fba911",
+      "mtp.layers.0.mlp.experts.100.down_proj.weight": "92495f810f7fe66629d4736af57fe5603a17bdc800d6439d5095f08896e98d1e",
+      "mtp.layers.0.mlp.experts.100.gate_proj.weight": "62c0b352f6ceb0758d12efe595bd5ee2e9ceaae0b18e2ba0fa59b3110a82716b",
+      "mtp.layers.0.mlp.experts.100.up_proj.weight": "5d28cd7c415cbd968da7d73d4fbca6704b046a719c54986cb304752a7e266664",
+      "mtp.layers.0.mlp.experts.101.down_proj.weight": "5c6d0b0aaf566c50d7a6c2189161add67396988b2e554ee511ccd83ca73717d2",
+      "mtp.layers.0.mlp.experts.101.gate_proj.weight": "fa145b75162c3c5f0790cd66b61e21aac2b72242e4499f8bdb2c329507137a48",
+      "mtp.layers.0.mlp.experts.101.up_proj.weight": "2a9650c1c5625d460a0957a6d5f0a68cb35bff5c653343ff93ff35ad33b9e1f0",
+      "mtp.layers.0.mlp.experts.102.down_proj.weight": "f1609099be871c1e61c33dcd779782cddc2792b4ae22b0b85246e15e185313f1",
+      "mtp.layers.0.mlp.experts.102.gate_proj.weight": "4ee37f4396aaf4d18c36a8ae965d73aabfafdb77e8b56edca8f04558d12e2d32",
+      "mtp.layers.0.mlp.experts.102.up_proj.weight": "dfcc330c0f7995d48ab5b97ba5a50e63f8fe798a3ed22cf2e80ef44da642363f",
+      "mtp.layers.0.mlp.experts.103.down_proj.weight": "2715a8cc608747570801b13df51c43536365ad0bcd5348e39cb56fbd8a0d8338",
+      "mtp.layers.0.mlp.experts.103.gate_proj.weight": "2ebf4c5f6c62cb3ca8029e76334177e7e30415fb40e01d9f85cbd14a577c04a9",
+      "mtp.layers.0.mlp.experts.103.up_proj.weight": "9cd2e326d8a3006c26cf786c9a649655e0b9db2ef6e17608ae4b24fcd7966070",
+      "mtp.layers.0.mlp.experts.104.down_proj.weight": "baf833bc07a081aef6289bb7caa552ce78157bddbfc9124bc3bd312453a9b531",
+      "mtp.layers.0.mlp.experts.104.gate_proj.weight": "351ac9b1b68c1b33623e4a2bac31f406bd59a63edb3df7e9a9bbf52a25fb5601",
+      "mtp.layers.0.mlp.experts.104.up_proj.weight": "c2ec0c7893b385ac674fac2ba3ccfc4a499086a52d94d4994abec2fc9961f58d",
+      "mtp.layers.0.mlp.experts.105.down_proj.weight": "ecbf29a4d7a999650fce1768b5cd26a5c7fee8168bfdff2e0656af9d88307448",
+      "mtp.layers.0.mlp.experts.105.gate_proj.weight": "520d34efc501eaa0a44d508957b3ceba1ec673c9521e8832fd8ff09dc2018ea7",
+      "mtp.layers.0.mlp.experts.105.up_proj.weight": "3b8541230f29db785bc2b8b568e58916b44961f74833bdb625f68a0e44c4e478",
+      "mtp.layers.0.mlp.experts.106.down_proj.weight": "d2c4c0f96c60aec2eb4c9650ded76f57f9c12ae16199bd64ad07f0648b8014c9",
+      "mtp.layers.0.mlp.experts.106.gate_proj.weight": "3a47f188a193ed3d7a4dd7ad761bbd63f67168e4749f1566c794ac44d6c59f4e",
+      "mtp.layers.0.mlp.experts.106.up_proj.weight": "5af027d83316154e50f9636477c977169c448a925d5fd0a10a69fa5de6942c24",
+      "mtp.layers.0.mlp.experts.107.down_proj.weight": "8e09e7a9defb77f4d2c31d331152f635abc121d5bc9562c40133910a26bfc33f",
+      "mtp.layers.0.mlp.experts.107.gate_proj.weight": "98e9aa78bf95386a72c32242a15bf955c7a94f0e0b967c5ec5714f26913fed5a",
+      "mtp.layers.0.mlp.experts.107.up_proj.weight": "dbdddcffe2fefe7489af8730a355f2d8b67d5cd8693e6839e05500db93aeb1cc",
+      "mtp.layers.0.mlp.experts.108.down_proj.weight": "75d396b42d32b31a675feb226a396dad8b66742b58ff6e9fea34b174156c4d0a",
+      "mtp.layers.0.mlp.experts.108.gate_proj.weight": "3102ea8d708febfea9eb82d84b5bddbbe7759dc3ff33252aba868ed481cfabaa",
+      "mtp.layers.0.mlp.experts.108.up_proj.weight": "31444ca75de1e18ed56a3790e085de8e7212266a05c9f5c6d4a0674c32538587",
+      "mtp.layers.0.mlp.experts.109.down_proj.weight": "f138e5010c9b905f332ae83e27bc85ab9d27ac24fc4d616494f50f9fccd63263",
+      "mtp.layers.0.mlp.experts.109.gate_proj.weight": "ef2fb21a53b44980d40611862ba6cdc068f33779389e7c4601bce3867869cb43",
+      "mtp.layers.0.mlp.experts.109.up_proj.weight": "5dde6bc8f39adbe3ae883c65af863895aaef38b49caabcd1227f0215e4e07803",
+      "mtp.layers.0.mlp.experts.11.down_proj.weight": "f165db2c0ac50f34f47125309765115fafba94502b8f9c30f97a3c3d69a4bc5d",
+      "mtp.layers.0.mlp.experts.11.gate_proj.weight": "b8d4878162a79dbfed3efdd5dbd5d1cae3fac2860a74a3d5768f260aa5ba712f",
+      "mtp.layers.0.mlp.experts.11.up_proj.weight": "0be6cae66ae89f792247e10a22d5749df43072e6b276c1d0bc2287e0ec0424a0",
+      "mtp.layers.0.mlp.experts.110.down_proj.weight": "9b1c51f1199c954c41e916435c5e3aee3c4ef4b76909060d6ff0ba05bb20b4fe",
+      "mtp.layers.0.mlp.experts.110.gate_proj.weight": "bc83b13669a3a956e23f56992218cd16aeb6159e19b075934b10bdd9c064f8bb",
+      "mtp.layers.0.mlp.experts.110.up_proj.weight": "531aa2c8ac1854a3ac2a0a0ebbb8263c8cc339bf4cadf32c6d64b51bb2bbbf2e",
+      "mtp.layers.0.mlp.experts.111.down_proj.weight": "aec36bfb8204994f91fcb35362d8cad53f9d28fc26251915d5c09cec17e0f535",
+      "mtp.layers.0.mlp.experts.111.gate_proj.weight": "d2fee92a61ec85cba3a3a75f4dbfd9ab52802372d2925a6e59075186a5b3a98f",
+      "mtp.layers.0.mlp.experts.111.up_proj.weight": "cb25887ab2d0226c854dd746935faec05fce90527fd76153017e876ef202f295",
+      "mtp.layers.0.mlp.experts.112.down_proj.weight": "5bbaf4f55b30b1d5d8254e75c9ff82ac7536cd6d27ecd4a7dec0e8339aaf481f",
+      "mtp.layers.0.mlp.experts.112.gate_proj.weight": "38e8c586a819cde4f1ed8f47911c5a8065bafab03c41aaa6ea3b05a957a03bc1",
+      "mtp.layers.0.mlp.experts.112.up_proj.weight": "a1c3fb51e3638dc29f34bd3aff74a0d6f01471f920ad9d4ec07eca17bff559ca",
+      "mtp.layers.0.mlp.experts.113.down_proj.weight": "e43bcad74201c5fcae1714e137c8daa12d51f1d7a4f7e43e0f7b5ba33989e815",
+      "mtp.layers.0.mlp.experts.113.gate_proj.weight": "21e2175647865f4363736414340aaa117ab95e05007b7d03bdafb987a5c37285",
+      "mtp.layers.0.mlp.experts.113.up_proj.weight": "8e22c7dda17b087b8af628d70294ecc3ed743ea358f85df5fb99d57ca080eff8",
+      "mtp.layers.0.mlp.experts.114.down_proj.weight": "366e4f0f51b927327afcf640a5959d38f54fec1be96b4e3b4b4536620cdd7de8",
+      "mtp.layers.0.mlp.experts.114.gate_proj.weight": "d1bb158515af347a4526706277152672759ec2d26def6de057b3ed069545b648",
+      "mtp.layers.0.mlp.experts.114.up_proj.weight": "11b43ef56c8bba3bff80f4f7103fd99cf485439b206badb4a3453eae53e9c895",
+      "mtp.layers.0.mlp.experts.115.down_proj.weight": "ed5a5313025a194133de3334adf32711ee73f7c200833a6652cc851132306d27",
+      "mtp.layers.0.mlp.experts.115.gate_proj.weight": "e014ef1f5fffd1e90e119e8068d19957c20731c2ceed3663c8630d8e7d789408",
+      "mtp.layers.0.mlp.experts.115.up_proj.weight": "59b15ff4c70494ea89202fbb420a71e68de02675c9f227b9d2634ec51b46d640",
+      "mtp.layers.0.mlp.experts.116.down_proj.weight": "042071eeaa98e47512e6ab64f756353e743e2e1ce84cbe4c06ef98dab4975df0",
+      "mtp.layers.0.mlp.experts.116.gate_proj.weight": "53464ffb10c70f3856a9e810c64f59aace74965c0003df85a5f5a0034718fd4b",
+      "mtp.layers.0.mlp.experts.116.up_proj.weight": "157d63eb6aa250871ee8d50b98ce548613574b7611dd84661b0336be1cf600c1",
+      "mtp.layers.0.mlp.experts.117.down_proj.weight": "48c887a1cca3c6b784d5c08c8c9dee63475e6f28c49e523860993c2ee48810d0",
+      "mtp.layers.0.mlp.experts.117.gate_proj.weight": "1d16169bdef5065aee17aaaa60a5bedcde20aab25615d7167e37b5b23bc15065",
+      "mtp.layers.0.mlp.experts.117.up_proj.weight": "2c1cbd08966136eb421f94f8387f2569dd38cbfc942164e4c97b1d1078ed7ef3",
+      "mtp.layers.0.mlp.experts.118.down_proj.weight": "0de9f573dc14700c9da3eda8c558e704bc8794dfbb9f3d9a496ceaa7444351ab",
+      "mtp.layers.0.mlp.experts.118.gate_proj.weight": "e219b9b8fb599c5e9de282558fc2a5235bdd169f34c1028c34aa1826e9ffd509",
+      "mtp.layers.0.mlp.experts.118.up_proj.weight": "d1d8782fae4827fbc25e312bb0f49aa6ec39f03c4d7e08b52381a10e2ed32702",
+      "mtp.layers.0.mlp.experts.119.down_proj.weight": "d9ab78a9ae79d7f7b1907dc450428939ae6adc46838efe213a9457d6cb519252",
+      "mtp.layers.0.mlp.experts.119.gate_proj.weight": "e367e04ac5e619f9d5baae0ff1e551cd85ca210aa02aeaa51812233ed564b912",
+      "mtp.layers.0.mlp.experts.119.up_proj.weight": "d731403d22aa45d7dded194bc483d9d61208f06aa932b7c1d3a17b4f2e0e68f1",
+      "mtp.layers.0.mlp.experts.12.down_proj.weight": "a8ccad9b807ae1db51454e0c92c7db64b3a3eb407acced215aafe72d10c9ae60",
+      "mtp.layers.0.mlp.experts.12.gate_proj.weight": "075f1b36ed86660d5e42807c2dd210144fa17d6bc4ddfc9a61297aa918768a04",
+      "mtp.layers.0.mlp.experts.12.up_proj.weight": "8a01cda352955434833a2712538027edfe06e34f77cc9bfc76a48fe559f1b5b7",
+      "mtp.layers.0.mlp.experts.120.down_proj.weight": "afdb8b2991d7f2ae6b2d7afac3358b3692c8b3d6d888a6fb4403d1484bf276fa",
+      "mtp.layers.0.mlp.experts.120.gate_proj.weight": "28560c62065b05612b90059d00c1c4dd16f48afc1509219fe07b52aadcef2305",
+      "mtp.layers.0.mlp.experts.120.up_proj.weight": "5367e2580c35c1ef7c2396fa35fe932a2316fd1adfc4ff9399e815fee1aee806",
+      "mtp.layers.0.mlp.experts.121.down_proj.weight": "ac1d489cbd0e744366c837b2bfd0f157b7176e2a2ed57adaf232c9b819534af6",
+      "mtp.layers.0.mlp.experts.121.gate_proj.weight": "424a5b7d782b878f02fe377d8630f513c2038fe235f9d5383e2110c9c64716e8",
+      "mtp.layers.0.mlp.experts.121.up_proj.weight": "9b2148019fd2f3d5a574e546f43f7432f74ec341119391ffe8e9b21b37dc43e2",
+      "mtp.layers.0.mlp.experts.122.down_proj.weight": "e38e12f23a9a045ef6a15ef570ea8e0454f74e380f7a6b473e1b51981e3d9d01",
+      "mtp.layers.0.mlp.experts.122.gate_proj.weight": "dc6e1948e769eb2b74b1555bec3624696cbaf21883039ab00eaa8368f59b909d",
+      "mtp.layers.0.mlp.experts.122.up_proj.weight": "b0cad197121801ae839b3a670fa33c662dd483e682db9ceb39f37f89802f5fdd",
+      "mtp.layers.0.mlp.experts.123.down_proj.weight": "6910426a36b51dff382c31026d2e95aa0d529c3e97641a5a51f70b7ab0f10a82",
+      "mtp.layers.0.mlp.experts.123.gate_proj.weight": "bf310dff32c9657efcf4eed90226d519a5e1c72a1576278596d92fe9347d5915",
+      "mtp.layers.0.mlp.experts.123.up_proj.weight": "fb5973f8f878f05c4d50bf19a793235e3016c3141246b7d26b9fc727b010bbb4",
+      "mtp.layers.0.mlp.experts.124.down_proj.weight": "624563063a001ca97e017befeeb210f3327684dc57d0e09c35526dfe09e44900",
+      "mtp.layers.0.mlp.experts.124.gate_proj.weight": "97dc7b6be7ae527dbaa87004ee771bcf6f04c152018d2ea5d3845bea541ee9c3",
+      "mtp.layers.0.mlp.experts.124.up_proj.weight": "870f308613dca3b3c614bcd68376ff425a78f2f50b976c19957250bc189a5f27",
+      "mtp.layers.0.mlp.experts.125.down_proj.weight": "c515de3a8889f42a2515d6a2f96b8c9e32ff1073e26774ab7956e6d71f77dbc5",
+      "mtp.layers.0.mlp.experts.125.gate_proj.weight": "5a0103824b78f340013bab5b4f34b1cba34d4fff6b2105e29faba443345d966e",
+      "mtp.layers.0.mlp.experts.125.up_proj.weight": "4e1310b2c3f5590494cf7de4f2aab88647c6aa49c1981a5626c46f4a117201fe",
+      "mtp.layers.0.mlp.experts.126.down_proj.weight": "1157dbee2affa049ca1e24e4e591b12cf9492df9a2bb8f62db1209973634be3a",
+      "mtp.layers.0.mlp.experts.126.gate_proj.weight": "776ef61c97c8a48446a7783a584323ebff1c57e3a024b94aa7f4f4ba384ddba7",
+      "mtp.layers.0.mlp.experts.126.up_proj.weight": "99b3b3d69b6b59c863b3515307951712044ff8064a0368db2e1a3e438abb7192",
+      "mtp.layers.0.mlp.experts.127.down_proj.weight": "e1809b313a349c2f9675ac9c9cf3a2c41879f2a78ebbe820afd4ed6b43441886",
+      "mtp.layers.0.mlp.experts.127.gate_proj.weight": "19fb7928232da1b0f507073884343fe3394447d2c7f3a49e2963d1cd36b105e7",
+      "mtp.layers.0.mlp.experts.127.up_proj.weight": "25f4d5aa9660bafc3626f05c4d30f78c6591630c8474d35db3b06b52819eb775",
+      "mtp.layers.0.mlp.experts.128.down_proj.weight": "3e27951eefdb9a7c272b67f9d3bb996da74ae3256550470606a8ef747c99c514",
+      "mtp.layers.0.mlp.experts.128.gate_proj.weight": "75f98183489dd5d100695b24855171163c3b2887b3c8050a5ef7f52a7a7363e2",
+      "mtp.layers.0.mlp.experts.128.up_proj.weight": "72481b2dee696bcf3828f4fb39fc50cb40108c0956a0f3bc41af487da6114ba5",
+      "mtp.layers.0.mlp.experts.129.down_proj.weight": "823c7badd67c0c04769abbaba256c7da0be4a08e588b42608cc85d78c3b0dcf0",
+      "mtp.layers.0.mlp.experts.129.gate_proj.weight": "021f34112287592d3ca367aad42156dc232fab4ba30cba553bd4e7cda19fb7af",
+      "mtp.layers.0.mlp.experts.129.up_proj.weight": "85e4e7b203f9a655abd3a73ea086e2785bd8c6fa94eefe4ff1a50812d34fbe94",
+      "mtp.layers.0.mlp.experts.13.down_proj.weight": "a2ee8dcbc64d98bb10c7dd4c11b11124160dff86224acdac3fb2d2b033aa3117",
+      "mtp.layers.0.mlp.experts.13.gate_proj.weight": "41651cd1540d62acf47dbd14bd6e157af223029e37df753304fc8631f1bf26f3",
+      "mtp.layers.0.mlp.experts.13.up_proj.weight": "c420407cc08eca4fbc1546dfe48e52a730e18a813c9c0c902fc29aa352396169",
+      "mtp.layers.0.mlp.experts.130.down_proj.weight": "0fe6984b744277bb8ab6f517de0bf85801e3a62d7cecd0ed4b387f485d5225d1",
+      "mtp.layers.0.mlp.experts.130.gate_proj.weight": "c654acd474db81052462bdeb304070fbc4bd110357839d8e10559e858f006b48",
+      "mtp.layers.0.mlp.experts.130.up_proj.weight": "6a7478698893e3378ce4e5a912293e311f41604e702585a99413fcd150854628",
+      "mtp.layers.0.mlp.experts.131.down_proj.weight": "106b954ecdaf97c9d3981cbdd4d1b3dfae1ccfa0946d3cf6ba1dae6eb484562f",
+      "mtp.layers.0.mlp.experts.131.gate_proj.weight": "78344adca0f66f696e52561c27166f75388699cb95cb147fd2d9e53eeed35d6a",
+      "mtp.layers.0.mlp.experts.131.up_proj.weight": "0d2955077976bbabbdb460084bf69416b9606950f0af46ed35a259dcbe3cc878",
+      "mtp.layers.0.mlp.experts.132.down_proj.weight": "b3bad1c36bf5d6c405bb82fbbe7480f472df47e9c473d7a50484848b6f0891c0",
+      "mtp.layers.0.mlp.experts.132.gate_proj.weight": "23ae189c238123117db6aabe11b3db026d82fbd22338305dde866f037c8e8a4d",
+      "mtp.layers.0.mlp.experts.132.up_proj.weight": "a8997a3481165c8ceaa6e9e99fb2b766f70e8114ab0b84f2b52bb6daa9941cb2",
+      "mtp.layers.0.mlp.experts.133.down_proj.weight": "b12926a5600710e5480ef9986252579b9dbaa5fa7ba0696a407ced120e8f4c11",
+      "mtp.layers.0.mlp.experts.133.gate_proj.weight": "f57085449666e4214d291b191ccc00479d6cda983f7d53ca39679344236b6a56",
+      "mtp.layers.0.mlp.experts.133.up_proj.weight": "6eb8258b156d7693cfe788dcebc18cbdb3c4721e91198cca18e7625b9e1c68af",
+      "mtp.layers.0.mlp.experts.134.down_proj.weight": "dcab8fede8115abfc348e4739781d54e21b1a89f1c67ca7b92d417b174b89028",
+      "mtp.layers.0.mlp.experts.134.gate_proj.weight": "f34031b233f9d4c30e841a00cc5ff5d8580f8eec3d218a6d2d44b1d3b96243c4",
+      "mtp.layers.0.mlp.experts.134.up_proj.weight": "c30d97815031ea9675bcd7951bd8e94b824b311cb03b974fc8e215466b89e2bc",
+      "mtp.layers.0.mlp.experts.135.down_proj.weight": "49757c4a620aca351ea1ef5cc7603c3288649a7cd57e8158ee1327b948422ca6",
+      "mtp.layers.0.mlp.experts.135.gate_proj.weight": "f9d89b4e3ca4fdf5d03d2a396bda5c26806818ff713ce181c56178ab197d9b51",
+      "mtp.layers.0.mlp.experts.135.up_proj.weight": "64a97400a9a5b375f5fb8de63d685cfddbb6eca82b68a10b77f8425a0db016e9",
+      "mtp.layers.0.mlp.experts.136.down_proj.weight": "9fc53c8d3ad3a0a2ada8f231f45cdd108b1de8134ca143fb180c15f3b9b50c58",
+      "mtp.layers.0.mlp.experts.136.gate_proj.weight": "6525feef14cf6e6f286e2da3bb26b9c348ac07fd1d07e61d26a0e1d7b1bec135",
+      "mtp.layers.0.mlp.experts.136.up_proj.weight": "3587d6dd76fc051ea40d18b86c2cde7994da9cc36bb8c5874a0c2aef71e2ce2a",
+      "mtp.layers.0.mlp.experts.137.down_proj.weight": "860f79d633e9c2b3af3533b6857cbb1392d1a13ed34bda8db5fc1b4a161ba6b9",
+      "mtp.layers.0.mlp.experts.137.gate_proj.weight": "6037d142065cf36186320678c10833a8cffc0fd5b028b3e5b0d7dc106f3c49c8",
+      "mtp.layers.0.mlp.experts.137.up_proj.weight": "b3083bb4e1846877a0edff9beba0593618ae3a38e85071b07725a753e9e2cbe4",
+      "mtp.layers.0.mlp.experts.138.down_proj.weight": "bb0ff99df67cf2ffec40f6d53e7030b6292fb947f8dd0b4821e7c36648ec2eb4",
+      "mtp.layers.0.mlp.experts.138.gate_proj.weight": "300e97d60a864dd6f997e86266893d918bf64df5dcf9c4fe39beb430629124d9",
+      "mtp.layers.0.mlp.experts.138.up_proj.weight": "520f1050ec8efef60179c402a007478f03d340628554050e476d7bbe6c043808",
+      "mtp.layers.0.mlp.experts.139.down_proj.weight": "2046d22d46fb8f91f2c5d269ca7ec42733257a2e7fc3f5d0cb65d146e4f6ab72",
+      "mtp.layers.0.mlp.experts.139.gate_proj.weight": "c5af3b115ff2098de70faa63e1a4d1693cc662f88aec248e593dccdbff1ccbb2",
+      "mtp.layers.0.mlp.experts.139.up_proj.weight": "eb4a186442fcd58587b34cb994addca071c99529b1f3b1fe4008df18c6223d11",
+      "mtp.layers.0.mlp.experts.14.down_proj.weight": "25a4bd0eb23f2d197fb89a64b9ec4df4c1f5c25e5e85df3cbec3f0ad60517d4c",
+      "mtp.layers.0.mlp.experts.14.gate_proj.weight": "22c7b7c79079eadeef85cc059a6b380c37838d763f4780707c8bc7437cb14ac9",
+      "mtp.layers.0.mlp.experts.14.up_proj.weight": "98498a0d4adc391e4ee2ea33ea5ff186f7bb9b89baecf8c542e84df60cadbd60",
+      "mtp.layers.0.mlp.experts.140.down_proj.weight": "10ae976cc7f8c89600bf10984a59b16189e680cabe15e196b7434b50c93623ed",
+      "mtp.layers.0.mlp.experts.140.gate_proj.weight": "29d56df8800863bb532ee984fa2a34b28a7ea938f3be007864cce4efb2672eb9",
+      "mtp.layers.0.mlp.experts.140.up_proj.weight": "5c3acd5ce2b888ef4bce27e022ebb793f61782c6ec713f4d67df5f81e0062871",
+      "mtp.layers.0.mlp.experts.141.down_proj.weight": "baa97682a0689f0d2b6768a823f9efdedb21463197c344d979dd21798f37b485",
+      "mtp.layers.0.mlp.experts.141.gate_proj.weight": "e59f8d0e2918211314555fcec8aa2d40c927ef14e9637cb25881092e0f3db87a",
+      "mtp.layers.0.mlp.experts.141.up_proj.weight": "433d086bd96af11ab978fb7c1eb4088bde158a095c7f57f78c22a0b87754658a",
+      "mtp.layers.0.mlp.experts.142.down_proj.weight": "6724131919aad66846c82a477bc21e63b0e23d0bad9f41200b281abf2a00d1b2",
+      "mtp.layers.0.mlp.experts.142.gate_proj.weight": "a1579e64882e83933aba653c3ada38b37125f70f1130d9742782737f1943328b",
+      "mtp.layers.0.mlp.experts.142.up_proj.weight": "9e1169b900db027e4898c71b42765f12f9cf682a7606ac0b59f55d227ca02d2f",
+      "mtp.layers.0.mlp.experts.143.down_proj.weight": "50bf54f2a2c29168792e8fa8e63f09ed02ce62ffadac073c5df466e5f9195682",
+      "mtp.layers.0.mlp.experts.143.gate_proj.weight": "175c2bf11a3d6ffa8a355bcdf37198d4959c16bf79485e0e86a8ce8a9e8fb24e",
+      "mtp.layers.0.mlp.experts.143.up_proj.weight": "17962d070083a57ee4004bfbbacc7ad0282ee69a4709d08aaa92c570eb1e3ddd",
+      "mtp.layers.0.mlp.experts.144.down_proj.weight": "74e37b6e47a5803057c1b4ac4f486d8944b9b33c997ab2a81c7e1374588ad616",
+      "mtp.layers.0.mlp.experts.144.gate_proj.weight": "51a276b9f4c2ed77638660afa8a03cd730c2eb0e3d2bb8e21328fa35837e15b5",
+      "mtp.layers.0.mlp.experts.144.up_proj.weight": "339c2f2bd06db25e3686946102d06cf50dbec0ef661da14402c30bd002f360c5",
+      "mtp.layers.0.mlp.experts.145.down_proj.weight": "cd2e5bc8a05ac96c2fd94041c04447590455d551081c53b304941c38be1b8e6f",
+      "mtp.layers.0.mlp.experts.145.gate_proj.weight": "8d40fa7df8aaff1754d9bfd145401182aebc694f9d5e95a8994c30f72d7b04a9",
+      "mtp.layers.0.mlp.experts.145.up_proj.weight": "a0cde5e64c8827b42dbbc639a9644edb9270c686a48a8e4c154c01fe7716a558",
+      "mtp.layers.0.mlp.experts.146.down_proj.weight": "5cf5db83300dac8767e2784d4fbc121aa46b1b81379071c7c73dbbb1492ba500",
+      "mtp.layers.0.mlp.experts.146.gate_proj.weight": "9c0af6dcd47193ed75f8675da735bde958c3b7dbcc0efa220aad722ed970546b",
+      "mtp.layers.0.mlp.experts.146.up_proj.weight": "343d465be086065665e90028cfddb2e0740bd982a8665b3fbd24897dbd9eb69d",
+      "mtp.layers.0.mlp.experts.147.down_proj.weight": "f1d9b4bd1b762c498515da5e9b992cd1315a140072f825c6b368ca4c173927ec",
+      "mtp.layers.0.mlp.experts.147.gate_proj.weight": "403359e6cde7766811d8fd56742c019524d23c232c5d0463db6f09216ff966d5",
+      "mtp.layers.0.mlp.experts.147.up_proj.weight": "aa2661c62f3cf235098589f8e5d1fc285eb9fe69ada33d4084f472fb60c195bf",
+      "mtp.layers.0.mlp.experts.148.down_proj.weight": "6366a8f5d1d9d3572067b892410380b45bcc852bc2b1c3a212fe7fb99d0499a5",
+      "mtp.layers.0.mlp.experts.148.gate_proj.weight": "45e3985d1f23b8b83316fa2587c6f2765b54e7145c61deaba28479351dc37c4d",
+      "mtp.layers.0.mlp.experts.148.up_proj.weight": "e9fd091f9375cb547c5c330048a27f1f30514771c40eaf25196524718e4a4c5a",
+      "mtp.layers.0.mlp.experts.149.down_proj.weight": "c7c95df692624038d53d866e29d5da9f1830aa636e31124c7073883f9f88faf2",
+      "mtp.layers.0.mlp.experts.149.gate_proj.weight": "78481dd07f264d0b854b8444f5ce1d7a83b7a96de3bc9c46c1d9dcde71f40eb2",
+      "mtp.layers.0.mlp.experts.149.up_proj.weight": "cfffe2c4188ea639f9c1424298adbba5e89922e6fe3b01acf8ab12d905b629ba",
+      "mtp.layers.0.mlp.experts.15.down_proj.weight": "023e52a2fe37a500ab13c4f9bf9e0f64e90c9a52d5fcc1e8c37cd7b4b4d5de03",
+      "mtp.layers.0.mlp.experts.15.gate_proj.weight": "feb175364c22a807df6fe540cb33048903631f143ca89e8d854a95a0896cca7e",
+      "mtp.layers.0.mlp.experts.15.up_proj.weight": "e0411901f2bda771cebd33dcf74baec98d2587c455e2cb031aef285329e636fe",
+      "mtp.layers.0.mlp.experts.150.down_proj.weight": "b957b0aa36e843c27243bb8f438cf335bbbd2a0d7fc9bb214d9762bc98ffb09c",
+      "mtp.layers.0.mlp.experts.150.gate_proj.weight": "f1e2919feaa70a57368f382d81d98ffe9ead9a75c88627492b696fcfa5a6bd3a",
+      "mtp.layers.0.mlp.experts.150.up_proj.weight": "7911cb877c18c9ff040fbf4ed6b7a4ab2e70c6ad672ecd51d493634887e0d60a",
+      "mtp.layers.0.mlp.experts.151.down_proj.weight": "00f06ccb5f9db2f54e040ece30f1e496640bb28f60450e715783da419ccad756",
+      "mtp.layers.0.mlp.experts.151.gate_proj.weight": "b4764815cff2bbe64d7d1b68466c9a81bacb5a32327dcb544d1cda547b02d755",
+      "mtp.layers.0.mlp.experts.151.up_proj.weight": "0d57e9084ab3258eec11d90d642cc0415acc072db1a12154d0843b5bad57b4cf",
+      "mtp.layers.0.mlp.experts.152.down_proj.weight": "c113954f4d1162c06d2b2311c9cc101076b3972fd600b36c6e54be3f2319c8d4",
+      "mtp.layers.0.mlp.experts.152.gate_proj.weight": "9609ba9e532fbc9eb9374af593dd1d45b0eaaa04091cb1571157ed427923d765",
+      "mtp.layers.0.mlp.experts.152.up_proj.weight": "18e6112751545cf42f5dbf07405c2353496069658352b2f3f969fcaeb49a1bcb",
+      "mtp.layers.0.mlp.experts.153.down_proj.weight": "8e1883db51d37f7fa9f9b10b2f3ebdd261667a51e118e1d5d64ccba9cd62150b",
+      "mtp.layers.0.mlp.experts.153.gate_proj.weight": "930e6d95b7231881bddd95d19d2f8b5e0cb475750cca0781dfd1f219505951c4",
+      "mtp.layers.0.mlp.experts.153.up_proj.weight": "172a6110d451390a1465c4514885276595775d2a2567f13d94e2f261088642aa",
+      "mtp.layers.0.mlp.experts.154.down_proj.weight": "a691d7f921ac7d9049fa02047b3c02ab7ab0ebf70d45fb3240d6e579bf0e41f0",
+      "mtp.layers.0.mlp.experts.154.gate_proj.weight": "5e3e4c95410ca8ca06b276790b0a6d0121bd779f2a1aac759aa1ea83d01a55ef",
+      "mtp.layers.0.mlp.experts.154.up_proj.weight": "dbad306a390544069f81dc4cd9a3c5bf98d4483c9563d1a4249b3e918a21ddb1",
+      "mtp.layers.0.mlp.experts.155.down_proj.weight": "694b25303db8d6d8b380aadc3a6c326d11b220fafb865fc5e68570f51bd934dc",
+      "mtp.layers.0.mlp.experts.155.gate_proj.weight": "0db69a79540763dc99d3e3e617ade4ef33e65c0d4e42ca3b8b1d8a494dc0bee4",
+      "mtp.layers.0.mlp.experts.155.up_proj.weight": "f89f8a951e381bdc3364fb57b4190fabab0ce3659e1500b499330d889f888b6b",
+      "mtp.layers.0.mlp.experts.156.down_proj.weight": "e1a300b17fc753446774cba9dc5c78322bce97f11b9e734a7d6c5e46940edfaa",
+      "mtp.layers.0.mlp.experts.156.gate_proj.weight": "332d1d1255b32f6b9b672705ec62f93ffbb3ab732c0497308092798e4431a4fc",
+      "mtp.layers.0.mlp.experts.156.up_proj.weight": "e2010445f749d3ad04ef4eaa5c2811358c43c59b761bcb07607ddb1df7683fa7",
+      "mtp.layers.0.mlp.experts.157.down_proj.weight": "a2701e9e5279e8ab67f2c249776f60d301d38ce3fbf86e7b8612e77b8167056f",
+      "mtp.layers.0.mlp.experts.157.gate_proj.weight": "18e1b29a6e659613532b63cb4a901736f8bfa2b5d96fb6392ceb8b749eee7c39",
+      "mtp.layers.0.mlp.experts.157.up_proj.weight": "03ab8e46cc159760d084122e3b1aeb725c5733e24ee06060a4f5746a34fcce62",
+      "mtp.layers.0.mlp.experts.158.down_proj.weight": "3babedcb2457620caaf3a86d5c74df61c4c1fcfd545e0836350fa283b5d91710",
+      "mtp.layers.0.mlp.experts.158.gate_proj.weight": "333cb3eca4bfdb4ac00badff1067929eb67c389fef077c8e759eee92e1a167a3",
+      "mtp.layers.0.mlp.experts.158.up_proj.weight": "0169512d61681bdd2dafa2f1a2662bef12c4d2c66dd2e8c853597cddb4a3adea",
+      "mtp.layers.0.mlp.experts.159.down_proj.weight": "25dbcf4bdcc0fff22e660025dc6b199f430d03ff0558f2f8e60136e32fcc8954",
+      "mtp.layers.0.mlp.experts.159.gate_proj.weight": "05ecbaed06cb3e3d767c7734b51b3b7aa62ae6b2f1b555aa068b4b5bd373c696",
+      "mtp.layers.0.mlp.experts.159.up_proj.weight": "c27132fc4deb650d0d1ae0185bf115fa6d7108d2cdfb50640a307267faa37e08",
+      "mtp.layers.0.mlp.experts.16.down_proj.weight": "a022187635ccd0bc10d49a6e012c0cbaf7644d1af7552ddd174dea2e7f9b886e",
+      "mtp.layers.0.mlp.experts.16.gate_proj.weight": "8e6d47d882886c075f306e171897de40eba74a94c3aa368686a9e40860ee9ef1",
+      "mtp.layers.0.mlp.experts.16.up_proj.weight": "08b16511b4dbe9906429fe624c84819be3e717c29289d4d1bfe85f3fafa2bf6e",
+      "mtp.layers.0.mlp.experts.160.down_proj.weight": "1d3bbe266840b7a141cd29a9653aae2621caa1478040db2f3550c7cd62c6a6ba",
+      "mtp.layers.0.mlp.experts.160.gate_proj.weight": "d33e295fc70e68a2e514b598664d116326024836239b2c3d8c5cc7e66aed0ed1",
+      "mtp.layers.0.mlp.experts.160.up_proj.weight": "c4d638f5b2a2c8809f54854c0e17e4622db0a2324f819183414a8ddb1d46a98f",
+      "mtp.layers.0.mlp.experts.161.down_proj.weight": "7018e855119a16666b44fcdbfda00e178f3d43e93ca4391610e5aa341d7fc761",
+      "mtp.layers.0.mlp.experts.161.gate_proj.weight": "4f5d1c40eef410c44a2574fe853b1da9302038e68c3660a70d4719afe2e5a255",
+      "mtp.layers.0.mlp.experts.161.up_proj.weight": "e84a4e01071d61ee6d28bd9eb2e4913749c4097822558ef6c5426eefaadea0bb",
+      "mtp.layers.0.mlp.experts.162.down_proj.weight": "4f21a92db348ac4e15f820abe1b20fc940434c29e22583f5c8b8408530dacb30",
+      "mtp.layers.0.mlp.experts.162.gate_proj.weight": "4157f0349b66aebbbd17c31f676aaf9714f216e07ae4a710c34afed943a0417e",
+      "mtp.layers.0.mlp.experts.162.up_proj.weight": "0d711a96883b8257a267456a51491482574e7846b810011abed253d8f25fe60c",
+      "mtp.layers.0.mlp.experts.163.down_proj.weight": "e841d86faf6927caabcb60747de2fe5d2bf4d9ae1493df59af87ce91ced38923",
+      "mtp.layers.0.mlp.experts.163.gate_proj.weight": "6bc6650169fb6ef04a56e307ba389b0206a7020bf8b6743202005f601824bc77",
+      "mtp.layers.0.mlp.experts.163.up_proj.weight": "f83d8d87b1196773c61e9f179f4938de8318533bfd54eba56a1985c15539c080",
+      "mtp.layers.0.mlp.experts.164.down_proj.weight": "31d2254a4ed84ebd152045e611123bb1bd78b5ce7951a95de4642bd438304e09",
+      "mtp.layers.0.mlp.experts.164.gate_proj.weight": "94f302d045ddeb16ec8fd1237bbee8da7972ab2e1ce6c0863b772f2b827564b9",
+      "mtp.layers.0.mlp.experts.164.up_proj.weight": "ba7ede1d9cf039a6f0cea2f58a1a7d94a9b02552233587cdccf61affcfafbda7",
+      "mtp.layers.0.mlp.experts.165.down_proj.weight": "07850652035400b480f57948a139cd9422d312d6960041a6f4b24314fcec5346",
+      "mtp.layers.0.mlp.experts.165.gate_proj.weight": "b28328728f3575cde1fa824afadee6f384854b3656888aa3917a51dcdd6aef26",
+      "mtp.layers.0.mlp.experts.165.up_proj.weight": "9aa3eb1d0b657de3d871d87dfbaf9f65f0319f66c367f0a59afd5709d53d3268",
+      "mtp.layers.0.mlp.experts.166.down_proj.weight": "c8ee8c771c38cb56ebf8dec15969e3ad04dd9902e4085fd2354ca68abce35b94",
+      "mtp.layers.0.mlp.experts.166.gate_proj.weight": "0a77fdeb5652fe3d2b8671cf1efbc3a6d92feeeafee02b13c8a18d1cb5eea807",
+      "mtp.layers.0.mlp.experts.166.up_proj.weight": "245019903bf19b789d86068f7ca81ffd8a663b7c58e4c625a375f1abcc966299",
+      "mtp.layers.0.mlp.experts.167.down_proj.weight": "1f70acfb06728c15ea1d3595ab20ad6ce661a480473fb32ca303997ac8251cca",
+      "mtp.layers.0.mlp.experts.167.gate_proj.weight": "6082c6139c5709fd88fe783923f69bde5f403e7f5634f5f149b013bc152b7f1a",
+      "mtp.layers.0.mlp.experts.167.up_proj.weight": "1987c993d6c55dfd1825a8086dcce9e9fa76275d9d7a7d6efe96039564b66ca1",
+      "mtp.layers.0.mlp.experts.168.down_proj.weight": "14eb66f7ba38838a5bce196b9995e351117371fdb0497d99a32954a691fad5ad",
+      "mtp.layers.0.mlp.experts.168.gate_proj.weight": "ba5e80ee1c7c8e207f57ee2601b12fad8d3b786b5e7c9325d86f9591483346db",
+      "mtp.layers.0.mlp.experts.168.up_proj.weight": "7ea68916deb2357c14bee6a9a50b59019a19af9b83bead9d0b4efc4e9c7c410b",
+      "mtp.layers.0.mlp.experts.169.down_proj.weight": "6ef9e037227711e1dc2c964ed9d66ad195bcefc2d365b6abf5ea5bf2c02aa5cb",
+      "mtp.layers.0.mlp.experts.169.gate_proj.weight": "cedb961938f36f5993953411f5e1024e9362b700f2604607499cd23f581c8990",
+      "mtp.layers.0.mlp.experts.169.up_proj.weight": "f3f962408d73cab30fa7e069c50f5f48571e2505b0f2e8272c1ee29441e011af",
+      "mtp.layers.0.mlp.experts.17.down_proj.weight": "374a463525b1d2c6efc671fcc1cadb93fbd8f6c9e3f8e9b756614a3ef9d83f2a",
+      "mtp.layers.0.mlp.experts.17.gate_proj.weight": "b2d28d479c971f7e5a7ce6be28b93028136b6ef007edf83d1ef2b78d23b07b3f",
+      "mtp.layers.0.mlp.experts.17.up_proj.weight": "32c2fb539b64ed068caaa846c95933691cdddfcfc4278e84007261867d9bdbc2",
+      "mtp.layers.0.mlp.experts.170.down_proj.weight": "e35c80b45df50c8ad3486fa1328b08750c572215669097681d9db9a56dc7cec9",
+      "mtp.layers.0.mlp.experts.170.gate_proj.weight": "ee36bb329bc19f5736ba8ceedeefe513d10a20742ecf6f7d49432abe876c7e06",
+      "mtp.layers.0.mlp.experts.170.up_proj.weight": "095118cb6e3ede28821f8b3325c1b015b38a745e700e8d32d8c2686e231c32e2",
+      "mtp.layers.0.mlp.experts.171.down_proj.weight": "fec550976f3627a8dc42cad7fe654f644df31cb9a76f9e77637b9e339b3e053a",
+      "mtp.layers.0.mlp.experts.171.gate_proj.weight": "03e48557e6540c7d3b3e6970819b0e2e8f55dc7a2298c35630cda38f848aa76b",
+      "mtp.layers.0.mlp.experts.171.up_proj.weight": "1bb8ef4cd095fb4685a05c4bcdb682986b9982a0125acdc29775e80ee0b7f082",
+      "mtp.layers.0.mlp.experts.172.down_proj.weight": "ec13b3322c55d711a87eeddec8949a4cf16778dabf6d69e963e6da1a8819c908",
+      "mtp.layers.0.mlp.experts.172.gate_proj.weight": "4cb1157f070616b4a5e45a011b46861cc64efd0e8632023483fa9a079db81f61",
+      "mtp.layers.0.mlp.experts.172.up_proj.weight": "847588e684987ce85add1f3e4605b3233440f62b0adca7d75520e06b752a3661",
+      "mtp.layers.0.mlp.experts.173.down_proj.weight": "260138ef7775673c85782fee4809b078aaa6fdc11be4a542757729f365cfa633",
+      "mtp.layers.0.mlp.experts.173.gate_proj.weight": "013ff5e85cf3bfd27f913997ec73b120298810e72633ef6f0f9fbdf832fa350b",
+      "mtp.layers.0.mlp.experts.173.up_proj.weight": "e39cf208f547753b157eaa30f6b0e5caf85c52e14425b26b11e064fbbebd8375",
+      "mtp.layers.0.mlp.experts.174.down_proj.weight": "4fbd8ae6a88c57a13bf1479db8543b9d301078d7a6cbb619f6a71e59c4e099c8",
+      "mtp.layers.0.mlp.experts.174.gate_proj.weight": "611e488af53cb9cdeed9399d38a518fc7d09eb4d6be1d16982403f3e3a2d1000",
+      "mtp.layers.0.mlp.experts.174.up_proj.weight": "f2a27c6572d18ef55ae4925c618b8027017dec9602ffbfb3f7f4ad381598e1a1",
+      "mtp.layers.0.mlp.experts.175.down_proj.weight": "4731c9cc905952be611257e7c729a7ab912b9bd5529963ca980676bd04f4889f",
+      "mtp.layers.0.mlp.experts.175.gate_proj.weight": "9a89a0dfb7a3fabd696c78b4f624e8bc454c1f22c787f41bd5b5e6c7da51f8ac",
+      "mtp.layers.0.mlp.experts.175.up_proj.weight": "d8dc60452b233f89b9578587d5fbbcc24924f9a3bebbe9c4bfa383cd5def9f63",
+      "mtp.layers.0.mlp.experts.176.down_proj.weight": "650b918cb1e963cf1069b721d7fc9cbcf576c0ef7f554a871941da4aec3f8437",
+      "mtp.layers.0.mlp.experts.176.gate_proj.weight": "e9944558b5ec92f07e75effde62a9f1ce358b49ce207e3654f4010d3c15b3d68",
+      "mtp.layers.0.mlp.experts.176.up_proj.weight": "991af89a60ceca60c9dedfb75a4069edea89a04339943e60fdd19316e3536396",
+      "mtp.layers.0.mlp.experts.177.down_proj.weight": "984f44fa1fb63911f5a8b1b4a54f3a96b347c32534762d27ba555f9591c0ddc3",
+      "mtp.layers.0.mlp.experts.177.gate_proj.weight": "6ec67baf9e2f04d5a63d896444ae48db1e7da39fb97fcd3e8ea7be1a5a1cccfc",
+      "mtp.layers.0.mlp.experts.177.up_proj.weight": "7816ef13756793cb9fda5a4fde8f79feadb5b5983403e89f71315c86f601f196",
+      "mtp.layers.0.mlp.experts.178.down_proj.weight": "dab5801e16a1735b28bc550e5a22618ee3083d4b34e2867a2c071004a1d0be03",
+      "mtp.layers.0.mlp.experts.178.gate_proj.weight": "fc31e94341982c3882c31010b48f0876190a1c3b83c45e93c3bc8ff1df796547",
+      "mtp.layers.0.mlp.experts.178.up_proj.weight": "dd7faba71dc35804c2031f1de9c6303f999528819feca03c788756ba76a76f24",
+      "mtp.layers.0.mlp.experts.179.down_proj.weight": "c64f913736a8d8eaaf7a3a8f2800e0440f31028d56b87289ad5c5ecd59fa60ca",
+      "mtp.layers.0.mlp.experts.179.gate_proj.weight": "a90a5639399814d2d9a7dcb7f26a7f59af0731231edb74060d474a5f1b511873",
+      "mtp.layers.0.mlp.experts.179.up_proj.weight": "cd9b23a76f27f69ae025bfbc63ffb98626ee33e9b915b764983d1853452e19b3",
+      "mtp.layers.0.mlp.experts.18.down_proj.weight": "fa6e5c28b0fbca7a0d19807b54b1e1d6989fe4af30dab2538a8abb692e6b0244",
+      "mtp.layers.0.mlp.experts.18.gate_proj.weight": "2c2001d0f8accaee53ee450cb14f468c59567cfca00eaf700ec52220d9fa09a6",
+      "mtp.layers.0.mlp.experts.18.up_proj.weight": "945391927318b6db6b87f581d1d8346f67c05dae0c0c1c07a7bf7bcb78b08649",
+      "mtp.layers.0.mlp.experts.180.down_proj.weight": "627d4ea804515f39de5b4c87b8a8a2326f8c10e72d0aefe86a3c22d0e887135b",
+      "mtp.layers.0.mlp.experts.180.gate_proj.weight": "6ea921caa6f2be426b652fc59e269965dbbdc53cc242fe45910c4bc3409cc2db",
+      "mtp.layers.0.mlp.experts.180.up_proj.weight": "f36d0b2ae0cb504adc29175a0943fa56113689c9327739e80d4b70f24721c0b0",
+      "mtp.layers.0.mlp.experts.181.down_proj.weight": "d0f6f0a6c7e1a4ae947a45e3b8ca62da86b543ac50b41e6a771107077d124e9d",
+      "mtp.layers.0.mlp.experts.181.gate_proj.weight": "bc52d502d05e51e779ae42b1a8b1f668dcd06625855026e6fb133fcde6727716",
+      "mtp.layers.0.mlp.experts.181.up_proj.weight": "8a74ff391e19ce6128dfc6821d405d7bbba4e1dae0fb770cf780520d59e465eb",
+      "mtp.layers.0.mlp.experts.182.down_proj.weight": "877a43ba9fb36d400b82eaf3f910da58703ab6ec4a1dd22c014103ac58f8705e",
+      "mtp.layers.0.mlp.experts.182.gate_proj.weight": "1e8f0e054b0e9330fed27528afc6ad608dbe1c173a20874b3c20788b67018b2a",
+      "mtp.layers.0.mlp.experts.182.up_proj.weight": "b6f2c57d2d53d4ccdda992f91dc23540420e95395d3e932a840bfdc1778487c9",
+      "mtp.layers.0.mlp.experts.183.down_proj.weight": "9d4b63326cb346464458ce84022775d2617dcdcec52cdc6f1d179e1365612250",
+      "mtp.layers.0.mlp.experts.183.gate_proj.weight": "d8024cb9e87d70b5b2402758313b8961c70920af5b49291bab73bd652e6ac646",
+      "mtp.layers.0.mlp.experts.183.up_proj.weight": "f9ddb9297cd81cb815ea037e6dc855bf7a0e954ec198c3e5965f29d59430aa3f",
+      "mtp.layers.0.mlp.experts.184.down_proj.weight": "e042f96003000f7be7c729556197c179a260f591e6f9ca91e2c8b102f805e0e7",
+      "mtp.layers.0.mlp.experts.184.gate_proj.weight": "d9fffb88502ab42dbd81a225f26445cd4826a1ed8b9860e58c8d78d9b2955b97",
+      "mtp.layers.0.mlp.experts.184.up_proj.weight": "7b32a487375f2af7429cefc910b2dd76c83123eb87071c2a8ab794c2d78dd350",
+      "mtp.layers.0.mlp.experts.185.down_proj.weight": "b6450c80ea43f288d7eab46d2e740e21a73065996641ea44601ef7c37763d8eb",
+      "mtp.layers.0.mlp.experts.185.gate_proj.weight": "be3835ae5c20ae25937c0627bf2fa2287b3948d594f4fbc9eacd95b8257c96b8",
+      "mtp.layers.0.mlp.experts.185.up_proj.weight": "b4ff21ffb55875a1b49543d6ea4fbddc5b024a7a16eeab519904a5d80d918c87",
+      "mtp.layers.0.mlp.experts.186.down_proj.weight": "b7488bee7676bdc15021fe9cab9c8f5e46177afdc9a5d60a54fcc9442fca357e",
+      "mtp.layers.0.mlp.experts.186.gate_proj.weight": "1d17c4cd966be3a53fe3cce02be7805cfb7d1226b69efe9cc422b2c8fea44e08",
+      "mtp.layers.0.mlp.experts.186.up_proj.weight": "004907b70be2f95b88a0d5abe9e7d4afde2d149206244d64a605717159142b9b",
+      "mtp.layers.0.mlp.experts.187.down_proj.weight": "ca0aff9469196b153e4c8482f3815616904d4fd105b34268b8eb88e53f0eeccd",
+      "mtp.layers.0.mlp.experts.187.gate_proj.weight": "4de0fee80b611d067f4b92a34cbe2304d8160270cea2b694b53776c0d8d592b6",
+      "mtp.layers.0.mlp.experts.187.up_proj.weight": "2075876464b07896cfcd53ff1c711cf53ab1251735b19a24bdfa2571f3eb3cd9",
+      "mtp.layers.0.mlp.experts.188.down_proj.weight": "ac1d46284cfc8befb5569339b272b322bcce62ed76ea89ffbce54099aeb35e95",
+      "mtp.layers.0.mlp.experts.188.gate_proj.weight": "b7090130e2981d72e404977846fbf6f6c6c24b8a5ec8c158ac14546b7c3e3b36",
+      "mtp.layers.0.mlp.experts.188.up_proj.weight": "cfb3e27df696d8c7b80df342fdc4dcb13814b4aefadc79bd915be7c52ab1d166",
+      "mtp.layers.0.mlp.experts.189.down_proj.weight": "9e2e82abd1c69f316d958e090710c06c8e6665b103036be9e9a120f6b27ec8b5",
+      "mtp.layers.0.mlp.experts.189.gate_proj.weight": "298a42fba1d361e062f5a7a26706f5ae0139d056025b987d7cbc0d045a4c09e7",
+      "mtp.layers.0.mlp.experts.189.up_proj.weight": "f12f50598acc1dd5248791a81ef263ffab867edc0fab56db053481f8e87dbb88",
+      "mtp.layers.0.mlp.experts.19.down_proj.weight": "bb4b37e03659f52c5c9eb66d52d81fb03dba2a344384eb012406759bfc902b82",
+      "mtp.layers.0.mlp.experts.19.gate_proj.weight": "6cf16f0742e21dcf4756e61d64b47e42134b66972f4759e6c32bb01eb4d6606b",
+      "mtp.layers.0.mlp.experts.19.up_proj.weight": "9666c98e4644b35a484073674f9cb1a3e1275b7e8cca08e0d80778856493e28e",
+      "mtp.layers.0.mlp.experts.190.down_proj.weight": "3f9a58a510c7c1625b693cbc3c26e6e66499fd86da4aa65880e27b020c729b98",
+      "mtp.layers.0.mlp.experts.190.gate_proj.weight": "ecb920722a55727e4e1476de663fa5145cd2dd733968e47ef5c22c9556ba91e6",
+      "mtp.layers.0.mlp.experts.190.up_proj.weight": "37f3c9646de2005bbe77a641558cd5a70d59fe415e06599dbca96d78dc6acf3a",
+      "mtp.layers.0.mlp.experts.191.down_proj.weight": "08d99ce34c5bd98c96ac3e35bcd3228e10f4c86b2ad796e51e1e882b37543dee",
+      "mtp.layers.0.mlp.experts.191.gate_proj.weight": "72462ed4c57f7a3d3be3c07a4aa130d40560fa25083324b208a15997a189ee08",
+      "mtp.layers.0.mlp.experts.191.up_proj.weight": "eaef0f93a695a2558eda077734e5de776208ef293b45dc0ca0837ff2ac562cee",
+      "mtp.layers.0.mlp.experts.192.down_proj.weight": "d8abd5bec0faa4fa300d3fdd178ca06bafdd73b97186e433092b2750f4aea3b6",
+      "mtp.layers.0.mlp.experts.192.gate_proj.weight": "966957f11d99d76e1b69ed29a77c968c4fbed86a2a8b73f5a9b41559dc91ad6f",
+      "mtp.layers.0.mlp.experts.192.up_proj.weight": "4edebcf675aaba018a829085b90cad700b465c2f85095783663622d012d2e50e",
+      "mtp.layers.0.mlp.experts.193.down_proj.weight": "f30b1c9326da0446e7724bf4c969665a4b2a5276a125d5a82694d1d121428a44",
+      "mtp.layers.0.mlp.experts.193.gate_proj.weight": "78f06806d4eb7f924c731b77c88e8cfec5f5df1074546f77e847a2ad1758773d",
+      "mtp.layers.0.mlp.experts.193.up_proj.weight": "f12ce06d692c731b054429b856e76f86f6f02e16957aa8ddc014dc2d62831f03",
+      "mtp.layers.0.mlp.experts.194.down_proj.weight": "8c04a8eb63f67b0bffdd7e5374bef568ff5996115aa7be943c23d1a58550c915",
+      "mtp.layers.0.mlp.experts.194.gate_proj.weight": "ad98ec9d06bb62decc8666db1c4ceeba6b570750d1e31dea5466ad57c05633e2",
+      "mtp.layers.0.mlp.experts.194.up_proj.weight": "cb2afc9b297d6d65bd7a00f7b284129aee8db93d7ee088a35251a7d80aa29a7f",
+      "mtp.layers.0.mlp.experts.195.down_proj.weight": "9e9c511504e871726dd9eb8e43a79f7e4767ef1fc9a6c4b1e6f296405bf4f380",
+      "mtp.layers.0.mlp.experts.195.gate_proj.weight": "d40e1908615230766c7b9ade464a9a2c14869e33f3bfa285f86b3fe17a9eab55",
+      "mtp.layers.0.mlp.experts.195.up_proj.weight": "f8260221feeea838cdc0f2c3c446c39a547a099e15fd45bb408fa684141acc6f",
+      "mtp.layers.0.mlp.experts.196.down_proj.weight": "3f46445a3a75ece45978703b0c4b524c0cd1b687ac96080ca8b1794103225a9d",
+      "mtp.layers.0.mlp.experts.196.gate_proj.weight": "d544afd3ca4058314992e37ffe94f4ad852c5d8113dc54eadb648d83efcdc1c5",
+      "mtp.layers.0.mlp.experts.196.up_proj.weight": "b1ace11a115f5de0d4b832761facc62b812767a9c6b1defe8f5c1717d1b7cd7f",
+      "mtp.layers.0.mlp.experts.197.down_proj.weight": "389fd206fc3e1a2bfbf3b464ec86b1ceb29212051c6e6cf149ae0d3cb37c0ca2",
+      "mtp.layers.0.mlp.experts.197.gate_proj.weight": "92b1bc70d946fa91a4f436f40a6104a44ebc12ae14089d5bdbcace36c6c9882c",
+      "mtp.layers.0.mlp.experts.197.up_proj.weight": "b0a4ab850449cd42e4f2a6d79ace58967de72ba5f23da89cfbfb2a8f51b4fc58",
+      "mtp.layers.0.mlp.experts.198.down_proj.weight": "f73c7db4f96709c1d92f47b65e72876115f7b29f7a7769c10823d0d2a6019176",
+      "mtp.layers.0.mlp.experts.198.gate_proj.weight": "1d1f449a41c4fb8da9c81cf4d93292084b329725b6c3f32091ea1b510d9144e6",
+      "mtp.layers.0.mlp.experts.198.up_proj.weight": "672045852fb129d9e1fbf2fd3407077c41c92482add1257129e2163a1b6de8dc",
+      "mtp.layers.0.mlp.experts.199.down_proj.weight": "4b845944eece1e204ac8d130828b6aadc2edf5825f903e45c9506d24f5f40b09",
+      "mtp.layers.0.mlp.experts.199.gate_proj.weight": "5774a1ea636008148c0dd62f2076030e5009fe9924756f07f7c144cd221e3949",
+      "mtp.layers.0.mlp.experts.199.up_proj.weight": "8befd740e23e777a77ceab15d27ba6f3b151fe7bf6ec0da429a78748aae8f03f",
+      "mtp.layers.0.mlp.experts.2.down_proj.weight": "0b664a651a8629f90f592596e64fa051c933d6fbe20f0d6a65b12e7b5a67d7dd",
+      "mtp.layers.0.mlp.experts.2.gate_proj.weight": "10391d8566ed94b905ac1d3146bbd9c07ae971af4b23b2f07f536874fe70da01",
+      "mtp.layers.0.mlp.experts.2.up_proj.weight": "0fe10accac8ee750054fd50b42d0516e6303bfd5387c80c5d34dbc1d5337b365",
+      "mtp.layers.0.mlp.experts.20.down_proj.weight": "d990a44f2c4b387d468f95bfae79e52d7f058b7a2a81fb8498addb46e0330e5c",
+      "mtp.layers.0.mlp.experts.20.gate_proj.weight": "b130c0a5cf4b5b1976d15c84e6c60e38c2151866cbf461331f11b31715e26cbc",
+      "mtp.layers.0.mlp.experts.20.up_proj.weight": "5f0659c9b5ca88b6d1a7d3176559718fb7c8bbda75b54a7475d2ea20aa125260",
+      "mtp.layers.0.mlp.experts.200.down_proj.weight": "34e96f4ce4c7979fd4854d7242ed68c4b7f7553ae6f634c25e3b105a9f810e14",
+      "mtp.layers.0.mlp.experts.200.gate_proj.weight": "90e0c74a0939a952d2e56a7c939bbd20d9ced9b5b943b5f5de5395eda96cf08f",
+      "mtp.layers.0.mlp.experts.200.up_proj.weight": "0b04367a67c109f37b61a319c6d67480a92565f8fbe0c5771d57a7437dbd3b32",
+      "mtp.layers.0.mlp.experts.201.down_proj.weight": "a95b16d6e663d055ca2596254283d6c0c8d06283b4c9313da86e57fb3e80de74",
+      "mtp.layers.0.mlp.experts.201.gate_proj.weight": "0218856c043a29a5cb6fd50bcedb34551a4494f7268fefe4815ac0f6a1639f90",
+      "mtp.layers.0.mlp.experts.201.up_proj.weight": "11b7be6734773ff8d1296e2d76f93deb227de42b4c2b7d5114187d8bc1b9c82a",
+      "mtp.layers.0.mlp.experts.202.down_proj.weight": "a7b8444a4f619ceb8bc0c3ec607c318d3c0b0534d8d2260204c341f694c239e2",
+      "mtp.layers.0.mlp.experts.202.gate_proj.weight": "2674e47a0eaf7a5f06243304454f829f028001d17028eceee03878faf80016b0",
+      "mtp.layers.0.mlp.experts.202.up_proj.weight": "68759d069a66ca58f403ba848c2c91b258eb533546fc167c6d11fe4c1de62126",
+      "mtp.layers.0.mlp.experts.203.down_proj.weight": "c99ca642b59093de676711eb0db4da0aea383fe6e504789966d59f549304a96c",
+      "mtp.layers.0.mlp.experts.203.gate_proj.weight": "c365756405614190dee01ee694ebe04503f4b77f38a209594bddf9713bf1b6cb",
+      "mtp.layers.0.mlp.experts.203.up_proj.weight": "0641a7759ffa93dfbfa4af2e6b15c24f060eedf9b8945e442eac1a696b952e57",
+      "mtp.layers.0.mlp.experts.204.down_proj.weight": "51eb57567ea51385f3c5c9506efdd0ab28fe640722cbd65f51f392ee259673b6",
+      "mtp.layers.0.mlp.experts.204.gate_proj.weight": "d475629d0e66554c4063ed70427c973fba9dfda061783d104b9c777e64b7e6e6",
+      "mtp.layers.0.mlp.experts.204.up_proj.weight": "dd7cb40fd1a5887581e87ad97d6e1c55e31aaf727cd88edb8941425f654873d3",
+      "mtp.layers.0.mlp.experts.205.down_proj.weight": "39e951b4db675a5c325968be9e01a9708531f625dcf944b149460ec708792285",
+      "mtp.layers.0.mlp.experts.205.gate_proj.weight": "75937225d219de966d74cb9fa8f853d7cc4701fc0302de3ab4bbdd1ee9994717",
+      "mtp.layers.0.mlp.experts.205.up_proj.weight": "bd4af60e1e7b29b237c9571bf28843ec639e5c04bd643ba54ea198a3b5cb7b58",
+      "mtp.layers.0.mlp.experts.206.down_proj.weight": "130f142cd68ae41aa0503153d22bf2aca98b9e54fcfab3afed97b9695eba62cd",
+      "mtp.layers.0.mlp.experts.206.gate_proj.weight": "918c27b80b9300783f98f8540edc0e7cbb5c5a363008aebb32f12f8fa0eb434b",
+      "mtp.layers.0.mlp.experts.206.up_proj.weight": "d9ffcfa7951152228625e7387b14519865a181f026893c0907d40d980c76037d",
+      "mtp.layers.0.mlp.experts.207.down_proj.weight": "fdb685704bdfd4c2d0cd5db81c053aba9c6bb0bd1a9b767002c5f3faedd7b1b8",
+      "mtp.layers.0.mlp.experts.207.gate_proj.weight": "eb21a2f9264065a5fb4ec3b7ea53e4710667d9b45069aac3971dd3f4db5fdd52",
+      "mtp.layers.0.mlp.experts.207.up_proj.weight": "e35b101498cb61b694671c712cc79943494fceb414cf6975202fbec08c7a1fb3",
+      "mtp.layers.0.mlp.experts.208.down_proj.weight": "072e7f42d6db307030982f439ecba00e85a431f9f08773c88830f0bfaeeddd3d",
+      "mtp.layers.0.mlp.experts.208.gate_proj.weight": "b8cf6f575743e9f9c0f632005baa4b8dd3e827f912f6a4c5736ca257f9808059",
+      "mtp.layers.0.mlp.experts.208.up_proj.weight": "930ad8304c24623f0cfbd8e4026b24ed93a31155724c13e87cca15cd8a52648d",
+      "mtp.layers.0.mlp.experts.209.down_proj.weight": "68aa7842d5d0a0eb94a21138c059ec40aa5e1130fba85eb45a0722c5e41ed626",
+      "mtp.layers.0.mlp.experts.209.gate_proj.weight": "bc703c2966de55b2417dd736b9f14127eec52548676c413bf2504ffdcb0fe30b",
+      "mtp.layers.0.mlp.experts.209.up_proj.weight": "525579bcc35652ca40dfbac136b7675f16271741044c3aa633b8d73440287c7a",
+      "mtp.layers.0.mlp.experts.21.down_proj.weight": "0fd9b377b75c2683226d37a05ba32ec8dec263ae1cd771aefa28d102837c013e",
+      "mtp.layers.0.mlp.experts.21.gate_proj.weight": "b23b5c692e23b12d4728905962995deb7fae912f86d1aaecc46a36d36815f9df",
+      "mtp.layers.0.mlp.experts.21.up_proj.weight": "ad7e41381d837e383ef8d28c7d92996cab32501114fe01774316ae1b19ac5eec",
+      "mtp.layers.0.mlp.experts.210.down_proj.weight": "c03cccf94a69d1631852cea347bac06e9b1939b21d5034f032e66f2aec88c248",
+      "mtp.layers.0.mlp.experts.210.gate_proj.weight": "0751f75f4222579a1eff2ecf25861d03d6a3bd686908235c117ac29e48bbd5f7",
+      "mtp.layers.0.mlp.experts.210.up_proj.weight": "124f6c834d13a335e839fa3030b98fdf2298794e5635a280a2c1889b5be03ce0",
+      "mtp.layers.0.mlp.experts.211.down_proj.weight": "21fa21cf4ec34fd19ef54a6028ac38426e4bee16704b317f49a554ca61f117df",
+      "mtp.layers.0.mlp.experts.211.gate_proj.weight": "a362e33d0ef25c6a6c0934fd87e7a9b6964a59f78d45885e57abb1cf45c4b5d9",
+      "mtp.layers.0.mlp.experts.211.up_proj.weight": "8cc7d87542b72a34fd84c7b7d917c7bd80df551bf9b7b1d88d714490f100d696",
+      "mtp.layers.0.mlp.experts.212.down_proj.weight": "415db8a9126e32fef3dfc85f7404ca520d582cf3165e95d590cd8b77d28018e8",
+      "mtp.layers.0.mlp.experts.212.gate_proj.weight": "026a6c30974c28e864255225f9248c9f8b5389ffebf0caea417afaefadcb8f82",
+      "mtp.layers.0.mlp.experts.212.up_proj.weight": "ac16cd96ab741e1b234209efbbeed3d55b618a0b3b080d8fa105b94e47eb0b85",
+      "mtp.layers.0.mlp.experts.213.down_proj.weight": "2c7e6d3909edde319fc55af25dfac70086f6f97cb15ec802ce5aac9320f944eb",
+      "mtp.layers.0.mlp.experts.213.gate_proj.weight": "01ece1326662da4dbd6671c29b3f24475feca348745452e11650f7355781aa8a",
+      "mtp.layers.0.mlp.experts.213.up_proj.weight": "4713b1f32186a788ae6f197b0b2e7200f158c1a6264a2a21c80a28077c1f6652",
+      "mtp.layers.0.mlp.experts.214.down_proj.weight": "279937e6c2e14801af6e8842421dcf019ded218ed0853c545959d910ca8a9265",
+      "mtp.layers.0.mlp.experts.214.gate_proj.weight": "72b4ef9da7a11b6468f57099a2a14230cd0547ee4ad0978fe3e00fa164aec698",
+      "mtp.layers.0.mlp.experts.214.up_proj.weight": "59ea51b27e1a8418b858d96c1598ca543371e17f91f5986684110935d50d04eb",
+      "mtp.layers.0.mlp.experts.215.down_proj.weight": "4f6bb20d4bd439c63561bd1322c70c19ecda6863e013b812fd0af7c02d9b4454",
+      "mtp.layers.0.mlp.experts.215.gate_proj.weight": "c3d86a2ef6e8085dea60e8f382de06f6bd2bb7018e3a76f00483f2cffaf94e6a",
+      "mtp.layers.0.mlp.experts.215.up_proj.weight": "58dee34807a31171e9cdcfeda38120e6f400fb8e62dfe3718b66d3a89ddccdeb",
+      "mtp.layers.0.mlp.experts.216.down_proj.weight": "5c988d7e4222386c0936245cc89a9cd3df5194ad9a49363f3339109539b60e89",
+      "mtp.layers.0.mlp.experts.216.gate_proj.weight": "ecd863168fe8c9bd9a07968623bb36cf910d59f9b177f565712e409e5d13deb7",
+      "mtp.layers.0.mlp.experts.216.up_proj.weight": "7354ea03c6dcf6876be82d28331a0c242424fffd35bcd446bdbd02b6fd587a4f",
+      "mtp.layers.0.mlp.experts.217.down_proj.weight": "5c0e21de7776fe5da3d6a4358923c99638d2b62cd40cc4a053c3d7d80c1c1d48",
+      "mtp.layers.0.mlp.experts.217.gate_proj.weight": "798e030c4ff10141e036ed9f28b7fc31ca1daeee360ccef49514e0bbf55ec69b",
+      "mtp.layers.0.mlp.experts.217.up_proj.weight": "8d28aa953c0334c673ec3745501fd6569ee20ea7e1166dcd5164033de1a79610",
+      "mtp.layers.0.mlp.experts.218.down_proj.weight": "5bc0fcc1e5c70ca099a090e8c90ef826dd7dc69691529734223758077f3f6d27",
+      "mtp.layers.0.mlp.experts.218.gate_proj.weight": "e8023eeaa49ff4caa91363097c86c181e43d7f89ade41d525656fccd86951182",
+      "mtp.layers.0.mlp.experts.218.up_proj.weight": "653c551acdbc7263624102986f5d0fa38b7f502263248de53d62f2972f251f76",
+      "mtp.layers.0.mlp.experts.219.down_proj.weight": "4f95785108937a783eeb9ea181f1b7c783f5e977de330c5941f26545fdb542a1",
+      "mtp.layers.0.mlp.experts.219.gate_proj.weight": "9657ca72152060ef24b8dbe82b3888477e2cf797f314606deb593fb0c60b8af0",
+      "mtp.layers.0.mlp.experts.219.up_proj.weight": "cef38b3671dc149be8ae41578ec6bd07fba01a557882082ac6c6363e1b0f61f7",
+      "mtp.layers.0.mlp.experts.22.down_proj.weight": "90b10bc483e9c3a6771b3969ebc755d94936c45c4be3c49e08d0e589a08f65c6",
+      "mtp.layers.0.mlp.experts.22.gate_proj.weight": "9e8a54b0057456a0d7e4b74a8df779d2b8d8312750b453ab2dd437e8e3be20d4",
+      "mtp.layers.0.mlp.experts.22.up_proj.weight": "1494e54b56ea3cc29b877410be4653876309c22ca9a6adf7c8719ade579d2a1f",
+      "mtp.layers.0.mlp.experts.220.down_proj.weight": "a2c6708abcae81ef05c36281a57556ade0b5320e50150b5f678d2a5cd18ff1d7",
+      "mtp.layers.0.mlp.experts.220.gate_proj.weight": "4ed9e95cd8825682b313d48819dd1fb5ca914c1de401b5bd7c55ab5d2dfdfec8",
+      "mtp.layers.0.mlp.experts.220.up_proj.weight": "e0df781dec3d3f890e94fd3b29044c2ff66f5629c9a5f4b54ace17da0deb196b",
+      "mtp.layers.0.mlp.experts.221.down_proj.weight": "ba41653f2f9e2817c6f8f84c6847ad6993e526f0fcb9005aca97898a8f34c9ed",
+      "mtp.layers.0.mlp.experts.221.gate_proj.weight": "19ffc00b4b538a7f617b5842e9ab2e64eff717543114329403bb0c84cf6646ef",
+      "mtp.layers.0.mlp.experts.221.up_proj.weight": "a3ea1c1edbc719bfdb9ca14f2bbc76e6dab77112ddf6c18d497afa598531425a",
+      "mtp.layers.0.mlp.experts.222.down_proj.weight": "78c93ca24a3c9d3694e4183602ebabd3bc4610510c541702642147df692fa7cc",
+      "mtp.layers.0.mlp.experts.222.gate_proj.weight": "6ae28cd1a98d8ffcba20556a28cc6e1a5eb204d399b464ccec44b6fa67a14a06",
+      "mtp.layers.0.mlp.experts.222.up_proj.weight": "f78dbc83dfd1ba82cfa998837d8535790091936b3cb6de6626d797d66e967487",
+      "mtp.layers.0.mlp.experts.223.down_proj.weight": "a53ca1fac61bf07bb5a65e787a88f5015f9259f5ff90c25cde716eef34e4cb12",
+      "mtp.layers.0.mlp.experts.223.gate_proj.weight": "6dcb448f3dc2f488637ac388c7bc6fa5d5aaae1699e3a40657d06b07aedea297",
+      "mtp.layers.0.mlp.experts.223.up_proj.weight": "9fc809e787d1c185cf8f412938d9ce1be67a7f5478163b0e0113e6c571c3d537",
+      "mtp.layers.0.mlp.experts.224.down_proj.weight": "e6e0826dfd27ad5e38952dea70a9b59ad4a147e09a7bbaae5a425b5cdc7d28b2",
+      "mtp.layers.0.mlp.experts.224.gate_proj.weight": "a5d54cb7e51d509bc855ac90a9e265be0331e142dd94409b4aab7d804565fb1d",
+      "mtp.layers.0.mlp.experts.224.up_proj.weight": "6a3bf9bb0e10c8b07433ec4607bfb09beac4645012ee94b313f3e8cd8c425dfd",
+      "mtp.layers.0.mlp.experts.225.down_proj.weight": "0bcfe6a01cea53ebfa7f4096142c0c4aa5c8134e494346164af89bdcb2ad60e4",
+      "mtp.layers.0.mlp.experts.225.gate_proj.weight": "3392d8d8cc9fbdfdbe15d14cc30d395c00b56f3b5a8a0fa1396ef72b8622f564",
+      "mtp.layers.0.mlp.experts.225.up_proj.weight": "b5c3c3c475f3c2d65e775c6bd6fde6a912e54d16f0b607f9b8e934a20c50b50e",
+      "mtp.layers.0.mlp.experts.226.down_proj.weight": "30acce71209c0df39eda2f2fee8962c4a803f118e3804f378a2a4fd6b93db993",
+      "mtp.layers.0.mlp.experts.226.gate_proj.weight": "e1f58d006f775ed7e0f0728001afd4ed2fe45e7480a0d310178fb03fd07cb6ba",
+      "mtp.layers.0.mlp.experts.226.up_proj.weight": "4e7a4c726f242f624edbb77fa629fbb663c0dd2f77b3520e62291d2d1298ea26",
+      "mtp.layers.0.mlp.experts.227.down_proj.weight": "08f398cac001fc8fa538e8528e852a1f05b221d4f2d1758b4ef5e2751313cda9",
+      "mtp.layers.0.mlp.experts.227.gate_proj.weight": "d72816d3a5e4f9257a37d920fe1dcd92e85c0042c25460a615a8ff7548ca957c",
+      "mtp.layers.0.mlp.experts.227.up_proj.weight": "2995bf8b73ac42bdc58f660bb24b187452e41db307da3167360d5f3c04310d39",
+      "mtp.layers.0.mlp.experts.228.down_proj.weight": "b9bddf7bc4a02861df19ac9eb43515f290b3a42cc5ae6d10974dcb7da10afbaf",
+      "mtp.layers.0.mlp.experts.228.gate_proj.weight": "92d9f198bdd439f0dda3c7d561be81dde7203ed7da00cd635c3ef59a3e5bfad6",
+      "mtp.layers.0.mlp.experts.228.up_proj.weight": "974a3a2b159876564d594584882d49e1934c2a51f7d4b9625793024b16e1d8ab",
+      "mtp.layers.0.mlp.experts.229.down_proj.weight": "0824ef6b6e5e892366ba6615c32e479e38d2f79605683eaa92572d372a876273",
+      "mtp.layers.0.mlp.experts.229.gate_proj.weight": "6ebacf231335c6569040fe072f831041013e29d8884153a5ca7365dd23cb9b9a",
+      "mtp.layers.0.mlp.experts.229.up_proj.weight": "a9b6c578f41817ce5c0bdfbc3ce2b51674887a53e02b458d598eaf3eb890728f",
+      "mtp.layers.0.mlp.experts.23.down_proj.weight": "4988c1ce4ea895598fa233bd127f8393753cefcc074aea186e05ce810641629c",
+      "mtp.layers.0.mlp.experts.23.gate_proj.weight": "fbc03b279fd164ae08c97342f2368e06fd8f2918de542931f88cb3ba36a8ece0",
+      "mtp.layers.0.mlp.experts.23.up_proj.weight": "5676b1967942512588fd7ddb03915df9cf35d135b7c324ea56a0c19794e6b434",
+      "mtp.layers.0.mlp.experts.230.down_proj.weight": "cdd7a0b076487d26812572f5f4b28f4c2eaf7270d3800d8515d5222f035081fa",
+      "mtp.layers.0.mlp.experts.230.gate_proj.weight": "cc1c7f8ca3af58f5818a650c8e721f358b4e352b81b4929339e4976de55556ca",
+      "mtp.layers.0.mlp.experts.230.up_proj.weight": "e72cff78e0cd521c34c48f916e291b59b69d5a740f876142aa33df96a74d2910",
+      "mtp.layers.0.mlp.experts.231.down_proj.weight": "9d5d47ff51a2b723df8daaeac356f81d8d10d71ed697053916fde6b676f21f10",
+      "mtp.layers.0.mlp.experts.231.gate_proj.weight": "1ffbb4236c6f4eb1c47e215cbc01eb7ec238fb59bcca4efed8bfd28a869ba695",
+      "mtp.layers.0.mlp.experts.231.up_proj.weight": "e5490ef9a2c6b89faead783e9da5064bc3d86cd9771fb9054585e520970f0f39",
+      "mtp.layers.0.mlp.experts.232.down_proj.weight": "17506ec6f6ec5c55d16a3076ffb4d8c2c1ab8168783c0f986be64266ebe058a0",
+      "mtp.layers.0.mlp.experts.232.gate_proj.weight": "2443916ef275bc5af3479cdcf5d8fd94ed18cf07e6a68020943a5898a6abdde3",
+      "mtp.layers.0.mlp.experts.232.up_proj.weight": "8179acfc493f82c2bc9d1c5682168df3393f8f22d1d9c1464b765ce48b310a36",
+      "mtp.layers.0.mlp.experts.233.down_proj.weight": "9273b0ef1c939e65bd73bc415f06ccb00c953a9b26c8d3d7cc8340d8fcb67c71",
+      "mtp.layers.0.mlp.experts.233.gate_proj.weight": "cd0119678b80232b3a5e6737cfeeca2cb1c6697e999f406f27fcf0b518a86c25",
+      "mtp.layers.0.mlp.experts.233.up_proj.weight": "7eea3589ecce7e2ca253bc1c4b994204a616a702e4b95de58cc0b68c50d4847b",
+      "mtp.layers.0.mlp.experts.234.down_proj.weight": "7e315c037c0a31cfd124e09f4a4d04c48771e5137b908e312727a5c68accda5a",
+      "mtp.layers.0.mlp.experts.234.gate_proj.weight": "89f3c310901c103d224c8ea059b93e99b15bd099c582ad9aca760d82b8f921c4",
+      "mtp.layers.0.mlp.experts.234.up_proj.weight": "794e8e956d2a1c3e623be2c1ba1b53c0241ba12564ee61113fb810a6f1d7afde",
+      "mtp.layers.0.mlp.experts.235.down_proj.weight": "9ceacb0834b68e1900f7b8a5fd1bec678c8f923b8f04d0181b86b4e8ad946350",
+      "mtp.layers.0.mlp.experts.235.gate_proj.weight": "4038b7af522fda2d640f7f8f791e5be3e369d5a56dc75f420dcf0b048f810618",
+      "mtp.layers.0.mlp.experts.235.up_proj.weight": "ca323593e3d3d6a26a571d171a4eb7b59792847337a2966bc0d793316626c07c",
+      "mtp.layers.0.mlp.experts.236.down_proj.weight": "033186eb9ac4b3afd41a526899d5dd4b5f9b65e9a720dce273c551466b274571",
+      "mtp.layers.0.mlp.experts.236.gate_proj.weight": "a3147d6a8a23c398eac42123ca4191b323a648cc7fd387fb962eb3b256eb291b",
+      "mtp.layers.0.mlp.experts.236.up_proj.weight": "59bc002c1718238fbc882908eddab01c5e3de6a087b44b9c0ebc827efb2d420f",
+      "mtp.layers.0.mlp.experts.237.down_proj.weight": "a65952d1642632b9b8c4505451f80d43303cecc89d0073ac85fab670375b8fdc",
+      "mtp.layers.0.mlp.experts.237.gate_proj.weight": "e668063720a9922d0f360a69292c4769c87910e27e11d9dae61a56fbee1ba199",
+      "mtp.layers.0.mlp.experts.237.up_proj.weight": "52ac23b707260119318077b343e7cc8a3ee2b50d33bbd8b8babe2460f1522916",
+      "mtp.layers.0.mlp.experts.238.down_proj.weight": "792208f9a93ff14cb5f99fbc330505828fd8bb19c72a5ba2c9b8cbc46c3f6b89",
+      "mtp.layers.0.mlp.experts.238.gate_proj.weight": "905fb39d3b187a2533e51101302ac1b707f2ec010507ceb7a05b16810d686897",
+      "mtp.layers.0.mlp.experts.238.up_proj.weight": "03c1b50b6a6468689ea3bfcb8d7f1a599587eb82e2017b94e02e8bc2015457b7",
+      "mtp.layers.0.mlp.experts.239.down_proj.weight": "ebf7fd5a2c0e72b81d979cff0daf866c2834f4ac6bf13015f6ae8c25caf0a40d",
+      "mtp.layers.0.mlp.experts.239.gate_proj.weight": "97940cc5ad3bd03df0410d9eca45a7a78240e29a372c9653a8f50e34b5d2b965",
+      "mtp.layers.0.mlp.experts.239.up_proj.weight": "13c282f5937084a45971b90c3d99ca4d2fd08f95e414773112cf9e59e8393b2b",
+      "mtp.layers.0.mlp.experts.24.down_proj.weight": "83bebdf525572155872da66d091f04d890b8d3376761c845805e123838a53b84",
+      "mtp.layers.0.mlp.experts.24.gate_proj.weight": "64c07cee2e7b0fa816d2b7b44df2fc989dd6b0c685def794c859498d2694f53b",
+      "mtp.layers.0.mlp.experts.24.up_proj.weight": "0e917f78a83d895a502b21b7ab62a5a160908a04a4a3c1c3dc0536d1286cce78",
+      "mtp.layers.0.mlp.experts.240.down_proj.weight": "9c7bd92776f0e43dcce17e540dfb043f6926a29bd87b558a31cbcebb25d598f6",
+      "mtp.layers.0.mlp.experts.240.gate_proj.weight": "e2ed58f7b971d0544614b26bbe96ca037da336267b97b6c6e4a15aa7f7861202",
+      "mtp.layers.0.mlp.experts.240.up_proj.weight": "8d1e0ab12196e82d478eeeb214cac1de02463cffee82c38ec5ca6332b87ea6bf",
+      "mtp.layers.0.mlp.experts.241.down_proj.weight": "dababdae3fafec40bf17b03bd2134cd8d990e7f11fa8bb61a981e42088f8b5f4",
+      "mtp.layers.0.mlp.experts.241.gate_proj.weight": "7a64d127af7013fd6b574b81315975539a85e80d461edbbbcc6162a8d6bf421b",
+      "mtp.layers.0.mlp.experts.241.up_proj.weight": "85107b56f79950cce4d4b80e43634ffe2bfba2fa19f5272f3bdbc63aa093075d",
+      "mtp.layers.0.mlp.experts.242.down_proj.weight": "3ce440809527af21762edf6bce5c9c8dafabc64f98f1e2b3b86e74064b2901d5",
+      "mtp.layers.0.mlp.experts.242.gate_proj.weight": "31e7991e341c9955414995a9030bd680a150517c00be8b36205e21a57e03a04b",
+      "mtp.layers.0.mlp.experts.242.up_proj.weight": "4d9e9ede22652162c5c5f0fa6e30edfa9b88cb97e70c105ca1982ce4dfc24f79",
+      "mtp.layers.0.mlp.experts.243.down_proj.weight": "89f123d4ce63a5315fb7ed9651bf7f6e1d062c524d0cf7452d8746ac0b731b43",
+      "mtp.layers.0.mlp.experts.243.gate_proj.weight": "8ae4fa786fba1b856542711f1a5b2cdc582a5b4b4997670cfc3365103bfbde6b",
+      "mtp.layers.0.mlp.experts.243.up_proj.weight": "e43c27f1b92819912d5b5316858d75d55939c022fa5e2e364f3c0321cc10c085",
+      "mtp.layers.0.mlp.experts.244.down_proj.weight": "450aaec5bb3206de153f827acc12dede6edae4d471fde46421d904b52625e4a9",
+      "mtp.layers.0.mlp.experts.244.gate_proj.weight": "a2252b04b0e5bf942b15e8ed91a34ae81d12244322e8ce770e9017d27c6ac34a",
+      "mtp.layers.0.mlp.experts.244.up_proj.weight": "8b741b576a3b57522171b0cfce05e7d5fc1c00c6c3a05801a5bb807c7bdee450",
+      "mtp.layers.0.mlp.experts.245.down_proj.weight": "43d533784c3b7bfc73253099a05efb5bab36f4318e0d0026bccbd975626ce880",
+      "mtp.layers.0.mlp.experts.245.gate_proj.weight": "7376fa3359764f8b1c5cf11d31b816154b70632fee7c68e3447f0309dc768c3e",
+      "mtp.layers.0.mlp.experts.245.up_proj.weight": "6c9630b8a36e09336fc95c95924a46bc86c2919e110ee3db9d310431a864efc7",
+      "mtp.layers.0.mlp.experts.246.down_proj.weight": "b874d3c4fde280ffb27882f03f91d24b4f66d1ab5865846e4a65bf6ce502e8f1",
+      "mtp.layers.0.mlp.experts.246.gate_proj.weight": "dc1bc0befc469043bcd8aef7de1c16c628427f54a08ed25685121a5483eb0493",
+      "mtp.layers.0.mlp.experts.246.up_proj.weight": "fd9db686e616a027bd028fac14295178e7c1e293354d368eb72444988694c6ce",
+      "mtp.layers.0.mlp.experts.247.down_proj.weight": "ae6e5edb2ac39eaa2948e54adb92ed275e64f156c1980973a5e9dd3c7bf72c7e",
+      "mtp.layers.0.mlp.experts.247.gate_proj.weight": "690dc243364585385672c23d6aaafb65e2c2882a1f07d6df9d80239c6f990da1",
+      "mtp.layers.0.mlp.experts.247.up_proj.weight": "b0459e253c7b8981a130a89fb9188c26cb1027ed91a67aac9ca76468c436c001",
+      "mtp.layers.0.mlp.experts.248.down_proj.weight": "c7d45076e53c9aca18f62970631660fce6e6668b420c1d73a57a20b8c1c7e0e8",
+      "mtp.layers.0.mlp.experts.248.gate_proj.weight": "f7192b0d990309bc860eb82d5a989eac224ff6a0be6b15fec0c94e06b0833ae9",
+      "mtp.layers.0.mlp.experts.248.up_proj.weight": "f7de1cc3460953e03471f10b0c15b683d36aa67a06b618bc52ce18e104cf6e1d",
+      "mtp.layers.0.mlp.experts.249.down_proj.weight": "f6099a2d8ad3cf4ffacb1aae02d2349af29e0f2aff5f13d621ac185b20c29ee8",
+      "mtp.layers.0.mlp.experts.249.gate_proj.weight": "84f74285774dfb62266f30cabf094522b76e95aa6502089dadc7d17c9015076e",
+      "mtp.layers.0.mlp.experts.249.up_proj.weight": "7a64480e4ff384543f2ffb2433ec896ee79a41e4cb1f364610a4ee23fcc12922",
+      "mtp.layers.0.mlp.experts.25.down_proj.weight": "39c12d08a5365130ca5b88cb06f6debb3b7897829a07cf1a48dc016c839c303a",
+      "mtp.layers.0.mlp.experts.25.gate_proj.weight": "8d96eba11e4299731dcdc1bfcaa1038cb452673a212375b858d18a5ea1964efa",
+      "mtp.layers.0.mlp.experts.25.up_proj.weight": "68db334a6a5cbb33395b29a1d79c6ea6a9750c82eac71fd2c9131d7e19da9d3b",
+      "mtp.layers.0.mlp.experts.250.down_proj.weight": "7640280e6a79753ac22da23a468191bb5f26b48d3d4e54043b2de556a7604f48",
+      "mtp.layers.0.mlp.experts.250.gate_proj.weight": "c815daafae7232dddfdf691d429be272c35e8daf8f9f18d810032c92a6bfed8b",
+      "mtp.layers.0.mlp.experts.250.up_proj.weight": "3cf16d3b8c550bcfe9c1c6d8239bd8e8ace3f056702e90f23ff6ac1dc3be8524",
+      "mtp.layers.0.mlp.experts.251.down_proj.weight": "4db81a3cb1f78530ba800478fd26cc84f3be977f5914bd0c16fb668af565cfee",
+      "mtp.layers.0.mlp.experts.251.gate_proj.weight": "c14b82ab3ae2bfe227c7e9d5307ef0f238e670fe28d5de90d52fe84dd6a80767",
+      "mtp.layers.0.mlp.experts.251.up_proj.weight": "a9eacd6737960ddb0a92b9f3c5dc453c53f5bd179c79ebb0137f972f346b28bf",
+      "mtp.layers.0.mlp.experts.252.down_proj.weight": "3875aad88c1b2b6fd52786d3d88b03613dc3c7abb4319597cf9e8a9de2f8203f",
+      "mtp.layers.0.mlp.experts.252.gate_proj.weight": "8e6de4a479d092f71f930b8d262136183471581b757575c6abd5a767e5682286",
+      "mtp.layers.0.mlp.experts.252.up_proj.weight": "0b0b940aeb0eb9b26f31dfe88ac14fb0eed48028ad759e2eb2b6380cd0f21150",
+      "mtp.layers.0.mlp.experts.253.down_proj.weight": "5f6975f9f130455c86b2c73447e33b6e670e745a41ec08f7dc0ee04261e80cbc",
+      "mtp.layers.0.mlp.experts.253.gate_proj.weight": "7e005e8b7340deccb96dcd208323d0afd4b4a34db2f1d2d6f54f3570f12e6305",
+      "mtp.layers.0.mlp.experts.253.up_proj.weight": "8ea94803f131990d58e25e89f03a8acd48a7401bb9acd440ed62462a27f7dd22",
+      "mtp.layers.0.mlp.experts.254.down_proj.weight": "a0b61bb33beb9dbc64da63b7a3c8d5738853e3ac80d9e069bfb306ade6dd4240",
+      "mtp.layers.0.mlp.experts.254.gate_proj.weight": "239e7e007884d7b320c930215f27a56f875c252762cd1c5a56fe0c8892d7d1f4",
+      "mtp.layers.0.mlp.experts.254.up_proj.weight": "d008ceec192f73b01e50996368d401333e0a5f9e47502e708ffb0f5045fa7ba1",
+      "mtp.layers.0.mlp.experts.255.down_proj.weight": "18de4a2190e62616be33035abb9190d54479a61173fc0eed5eb453aa58091670",
+      "mtp.layers.0.mlp.experts.255.gate_proj.weight": "fa3999aaa9d985f5d09bbcfada29e5495651b10b4f84dfce96514edb3bf7fba7",
+      "mtp.layers.0.mlp.experts.255.up_proj.weight": "e66110da68289375ef07edcb2aaf4a08d4ce6cfd41dfaa3180daac24fc1600d7",
+      "mtp.layers.0.mlp.experts.26.down_proj.weight": "b6aeb0439241c4e802d16b3dbb0accaf4da3a5c1178f09db4e8d33f393d02672",
+      "mtp.layers.0.mlp.experts.26.gate_proj.weight": "78260e018d17e5bbd48010059d9d15374a7644e8dd5b6c2b9ce8c14e09fd38df",
+      "mtp.layers.0.mlp.experts.26.up_proj.weight": "152652d0c341f0038ee955e7de3b16c1d01146f58b6bab07ee839806af8aead3",
+      "mtp.layers.0.mlp.experts.27.down_proj.weight": "c476f172517060e8a071a7b44d2523a66d44f6402b1acd72bf8d460830152353",
+      "mtp.layers.0.mlp.experts.27.gate_proj.weight": "22a9328288c8e9fc8a9976bb9a85ae17d4269bb11d9cbd8f22ca71fb326c6d3c",
+      "mtp.layers.0.mlp.experts.27.up_proj.weight": "494f65a633c85aef7b06174ae9c9b736119d8de383b5ad226a53a9311dc548c0",
+      "mtp.layers.0.mlp.experts.28.down_proj.weight": "edb2e5755bcc3ca408b75a6df972f71fb24694257936652f440f2f6712992157",
+      "mtp.layers.0.mlp.experts.28.gate_proj.weight": "8d0947910deb5bd29604691b217a812bd110c2e2ece209832ce1425a5b8346a0",
+      "mtp.layers.0.mlp.experts.28.up_proj.weight": "202d87fcbb250f0ae2103dc7200a251503a2bebaa606925046d672c7365eee18",
+      "mtp.layers.0.mlp.experts.29.down_proj.weight": "880e7d5e38a51359c0e4a6cd134dcb6645fc59da23fc7c6b81ccfdfd7dc12a5f",
+      "mtp.layers.0.mlp.experts.29.gate_proj.weight": "80c912cab7816db253237b2b83f7af8c5e2fb17c038f2b4c3902390d50d65414",
+      "mtp.layers.0.mlp.experts.29.up_proj.weight": "a77ea116b2ad42975c04ebec262660ecfe465d9c02c61aeb6ddae252f250099c",
+      "mtp.layers.0.mlp.experts.3.down_proj.weight": "95d1b2858f030663f3bd8940c129417152dbd7e2ae32c592b9b78fd4054c213f",
+      "mtp.layers.0.mlp.experts.3.gate_proj.weight": "a4820c5513f4c9462e245dcdfc9edc864bcb019282c3944870bf0ce4133e8aae",
+      "mtp.layers.0.mlp.experts.3.up_proj.weight": "cb473712a84d298318340a3103a05f23d000ab9d6f1ea2e96e3ebbcbc4f40432",
+      "mtp.layers.0.mlp.experts.30.down_proj.weight": "92838ce3c99c138ce39fba405fe6401c42dda4885d3fa37b5a2b765c58a3039d",
+      "mtp.layers.0.mlp.experts.30.gate_proj.weight": "cb2aedf42bea9fb9f33b5c8542484841859843b19ac07a5cbbf8c8a5b0d00546",
+      "mtp.layers.0.mlp.experts.30.up_proj.weight": "6974c6a586a0aa796f5ed0d34dd2e5a1c65f7d1c6e009294737a1864e30c2df9",
+      "mtp.layers.0.mlp.experts.31.down_proj.weight": "d793a55d43cd0ef8e82d5146810529e4de5cd2aaa42c17a64d00cf1176498f05",
+      "mtp.layers.0.mlp.experts.31.gate_proj.weight": "47683d0e9a426218aa7d1c2552480329e87a82c6696aea9c863d67599109ae78",
+      "mtp.layers.0.mlp.experts.31.up_proj.weight": "1bb5b30d0a9a661c17c9a2c34890de2f3e75760ce5cdd21a9f56a65656c67842",
+      "mtp.layers.0.mlp.experts.32.down_proj.weight": "73bdd6474cf90f4d1454b166e9cf6618f676dee114b7d16db0ee0b70fae47d36",
+      "mtp.layers.0.mlp.experts.32.gate_proj.weight": "b96f5962530a015ca7ff0951cd150f8a6e3357f17c204a8c0068dc43e7ca0804",
+      "mtp.layers.0.mlp.experts.32.up_proj.weight": "c971d314b5ad55e9376deb984a6abdd17fa43a5955cc650f8ea6bc1caeef5872",
+      "mtp.layers.0.mlp.experts.33.down_proj.weight": "75ead5684e99d6931356782c6e9181f94d588d21f38eadcb1f77d6653ac99ba2",
+      "mtp.layers.0.mlp.experts.33.gate_proj.weight": "9ecf473bb6ddbcf1c05b82bd2c31291b3768bb9006553abbe23311ce60cc81e9",
+      "mtp.layers.0.mlp.experts.33.up_proj.weight": "006b3972c07fb5f9d52557deb59c4be3b9c7afb586345c58c91cf76a4dff58da",
+      "mtp.layers.0.mlp.experts.34.down_proj.weight": "188b21f0c48dc9101ac96817d308630df4e51fc0b32911a4011f2cbff7ec2124",
+      "mtp.layers.0.mlp.experts.34.gate_proj.weight": "733259ac100f3270e598c6647f4c282d704d16194f9cd16b25ec570931e799c9",
+      "mtp.layers.0.mlp.experts.34.up_proj.weight": "47c480b68315d826440b11cd4d92d470d4f3b98b6eeae949a42e2d1021ff2d2e",
+      "mtp.layers.0.mlp.experts.35.down_proj.weight": "8da3e09a29c9b739faef7bd96fa84f907cae7bdee89eeda8a2caa0b0a9b472e1",
+      "mtp.layers.0.mlp.experts.35.gate_proj.weight": "1799ab564681542b23054eac44917c8ba8b5cfe29994a58aec360e7fdc0b26ad",
+      "mtp.layers.0.mlp.experts.35.up_proj.weight": "769bfe28f267d957fe213835b4dc8c4a851d2ee92a6c0923f13432af442756ab",
+      "mtp.layers.0.mlp.experts.36.down_proj.weight": "54f48c4c54e11d3b5b0d2c0f2a00bc377fbb480afe9dcaddabd16a3d5995d020",
+      "mtp.layers.0.mlp.experts.36.gate_proj.weight": "fedd5e0a2354275d30da00b0686e1f62923bd70e040ed591b71d4a29989a2baa",
+      "mtp.layers.0.mlp.experts.36.up_proj.weight": "819fbd7bb13a304a146fef6036423094221307e716fb0bd7b7d03f551d6563d9",
+      "mtp.layers.0.mlp.experts.37.down_proj.weight": "35aaac3dd1999099779da7b7138b756787ce6766e495b83a0bd40eaa7f9cc01d",
+      "mtp.layers.0.mlp.experts.37.gate_proj.weight": "2d5e047fb3c8d1e3021f838318f3d7fd287764fde87ba741d2cb94aae5618013",
+      "mtp.layers.0.mlp.experts.37.up_proj.weight": "88d775e65c9b23e0342f6e8b2e2cbca35f84c219a076a3193880199cbd0f2ecd",
+      "mtp.layers.0.mlp.experts.38.down_proj.weight": "c70aa59d9e30fba8b013702fd3502933b79f1394944749398e681d24af35cccd",
+      "mtp.layers.0.mlp.experts.38.gate_proj.weight": "484fe200f20452513c7ee1ada80f75d5e307ed30a3a0b4c2bdf3806387eafffa",
+      "mtp.layers.0.mlp.experts.38.up_proj.weight": "de2032d9ecc9b0b29c2116d438a7c0faf12f35a08124599c0bf7740670a98f68",
+      "mtp.layers.0.mlp.experts.39.down_proj.weight": "eed077dbbbb1487134a863bb9e37787a58ae050dba55ba00075b30bea35791ce",
+      "mtp.layers.0.mlp.experts.39.gate_proj.weight": "b91b2cdfe489a1cf99ae7256085697ce30318c4b7057356a969d3fe3aef82652",
+      "mtp.layers.0.mlp.experts.39.up_proj.weight": "f629cd45b7c4e84b33e6a3a8a336e587255203ddf6e020b9a6db240db63b256b",
+      "mtp.layers.0.mlp.experts.4.down_proj.weight": "71ec25cce2f20105f7bed5a62007b87d2430fb992ea6df0723319939b2c4e282",
+      "mtp.layers.0.mlp.experts.4.gate_proj.weight": "de6ba36f5a358e0e209718872de8f8e1caf83f53d06203dae7fce69efb9cc509",
+      "mtp.layers.0.mlp.experts.4.up_proj.weight": "d49664d84cdaec820a8da8f8574b97506c544dbebe7126008bacfab2a5897aac",
+      "mtp.layers.0.mlp.experts.40.down_proj.weight": "0879d8be7f4919691978ed05a4732de4f42bc33cc526e22ca04edd3150cde9c1",
+      "mtp.layers.0.mlp.experts.40.gate_proj.weight": "a1c8e9f0abdf3bd7fca61c36ebfc401eb66cca46daa70087dc0da9e5ea737319",
+      "mtp.layers.0.mlp.experts.40.up_proj.weight": "a094dd646e369ed71918b74dee6ca5d5295d57c04ae5fe4c6de19df41e0f0586",
+      "mtp.layers.0.mlp.experts.41.down_proj.weight": "4f338d5eed8d0c2581f1fbf16fb32745a2c550bb5932dbd8834eaaeb3e9c676a",
+      "mtp.layers.0.mlp.experts.41.gate_proj.weight": "58243ed82f57f2ddfce6725c58c88eff69dd45ed78095ec8aadf004b3d83ae2a",
+      "mtp.layers.0.mlp.experts.41.up_proj.weight": "3ef4a6722ec9697c6f7b824d9c0e88011f9d689908dfa901917230e331b95c4d",
+      "mtp.layers.0.mlp.experts.42.down_proj.weight": "917df29ae8829b3181b0d248e50624e2694482276f9eab917e5bd1d18cef29f1",
+      "mtp.layers.0.mlp.experts.42.gate_proj.weight": "bd65b367f4ec8bff6cc09d47867265409986d8ac7307cb645d1e1eef8d6d0bde",
+      "mtp.layers.0.mlp.experts.42.up_proj.weight": "8c801ab737e42cce8c34b4249b24791bfb2e67360e4d139e612a3f07d4d7e218",
+      "mtp.layers.0.mlp.experts.43.down_proj.weight": "1ea28680476ddac4e629088851d457323ab79dfe2cfda22812550bef2ee7ab88",
+      "mtp.layers.0.mlp.experts.43.gate_proj.weight": "aff1dc072594cd29b2ec987e9ec942b558b26edfa4db0cbf985da88cbc742ae3",
+      "mtp.layers.0.mlp.experts.43.up_proj.weight": "df276fb463f97c47d49b33aba92340f41c78cabdbcb63892e0222b6e54a9e681",
+      "mtp.layers.0.mlp.experts.44.down_proj.weight": "b2b6be8e21ec3fcd977b24045ca73ea888ebc18f8051a335c6b8b0aa0097b9b2",
+      "mtp.layers.0.mlp.experts.44.gate_proj.weight": "42b375ec9a2c695d1279afc1a7805db26dfa4ff47495fd66dfb710ccf0593c4d",
+      "mtp.layers.0.mlp.experts.44.up_proj.weight": "c3e53dddae9a27abd980f16be43033f7cc40b550a76f24258f534b4e689d27b4",
+      "mtp.layers.0.mlp.experts.45.down_proj.weight": "ee2f3c77c6950e1d28f027eb306120146d509786ca88680b492c2fc413ef51c5",
+      "mtp.layers.0.mlp.experts.45.gate_proj.weight": "cdcc187e8e32da7df74bbb96d477cbec8f188f05222458bb0847d4261865d4ad",
+      "mtp.layers.0.mlp.experts.45.up_proj.weight": "61c82263bb635e01a398125a0d827bd1d37a676165f100350ebb75026a3d0028",
+      "mtp.layers.0.mlp.experts.46.down_proj.weight": "50a6f3426c6a12b900d9c5858e37c5f05fc9561ed641795563fab1e0c1473c90",
+      "mtp.layers.0.mlp.experts.46.gate_proj.weight": "868eef4c4142dfa5ed665f0a47ed19f7f3065758c68567ddc2d5743466708998",
+      "mtp.layers.0.mlp.experts.46.up_proj.weight": "cd7f5456a746157d0816e0c76fbb351eabf0047d1b9f70d108cf5f0c54d8a9e3",
+      "mtp.layers.0.mlp.experts.47.down_proj.weight": "50f434ccb04932f5bbef13f80b35cca46e18ea9533431363d4bf3b028ca1cd07",
+      "mtp.layers.0.mlp.experts.47.gate_proj.weight": "2b8995b59e6c22094e92cc530587008897eee26b1a0c6b00aa85734e9b10e302",
+      "mtp.layers.0.mlp.experts.47.up_proj.weight": "ff17468c8c717d0f0935a7eea34b65fec68e43329503c52eed9127dbbdf32186",
+      "mtp.layers.0.mlp.experts.48.down_proj.weight": "a4d72c91b1e457eb6a34119c8612e07b2d278412ba465b44e170ccfd4b0f7c0e",
+      "mtp.layers.0.mlp.experts.48.gate_proj.weight": "db4faa1fc2ab57e96f83dfa1ae767990e5c1df20a024a75905cc265c4acc91a0",
+      "mtp.layers.0.mlp.experts.48.up_proj.weight": "37f76de8c6056a33928f8215777ce9790d921122273eee0687014bcf6c49da20",
+      "mtp.layers.0.mlp.experts.49.down_proj.weight": "97b10adf03fa2c6187cd5c5e477e5025f94c7df1790d840a1e26f36d160c189d",
+      "mtp.layers.0.mlp.experts.49.gate_proj.weight": "30c18d1fb0a94e7d0e2cb88b4a675d565bc9c58635ebc090ad98c79a726776e3",
+      "mtp.layers.0.mlp.experts.49.up_proj.weight": "bd3b671450b230f328b0c5adc182448970499de66efb152cf1bd884b70d4b719",
+      "mtp.layers.0.mlp.experts.5.down_proj.weight": "231214f47ba0f68959a78fe9d0816f85182f5507171de8f7c3483e87c5555f42",
+      "mtp.layers.0.mlp.experts.5.gate_proj.weight": "e88bd926c57fec01ea97f1a91a39edcc3f72877ab3e10216afb2e4cf8089db83",
+      "mtp.layers.0.mlp.experts.5.up_proj.weight": "7ddad17b3f628237bb323bfaa4332ec9ddaeffe93758e3315ec55527c20db49e",
+      "mtp.layers.0.mlp.experts.50.down_proj.weight": "93fc72ce984927819e8579e8bf6ceaaed09dfa21aa06245f384392186795f647",
+      "mtp.layers.0.mlp.experts.50.gate_proj.weight": "c6e5a844af5f9f25b45c227b5c22edd116c860adc992dcc2abf1770629fd94f0",
+      "mtp.layers.0.mlp.experts.50.up_proj.weight": "9e0be2c8b10c9871926fe87cd2003fd5767a605b5f49fa059b168e79edbe6e25",
+      "mtp.layers.0.mlp.experts.51.down_proj.weight": "3a633df4ff92ad6919ef31410add7ccccc516b247b442357307be49cf1043dfd",
+      "mtp.layers.0.mlp.experts.51.gate_proj.weight": "6ca930e2bbba851bd24f6e36ba4a54aa28c58d1798d05fd56f26726a4ee65e0d",
+      "mtp.layers.0.mlp.experts.51.up_proj.weight": "b908ba3defbb743aa01632ad1e9ace16a6dde77493a12f86e777847335f1bd8c",
+      "mtp.layers.0.mlp.experts.52.down_proj.weight": "c37824918092ebce1c31720369998edc60bff13d4f53caccda90bd49931ee25f",
+      "mtp.layers.0.mlp.experts.52.gate_proj.weight": "b08fd99947c4c7f2dc22824c10dfd9d172d5fe56a7fe7a940d5205a5b6b5a67b",
+      "mtp.layers.0.mlp.experts.52.up_proj.weight": "c90b3ed9da42cc67008765f4e1eb4123b64ea5b1fa7363e8c8ef94fa82b4528b",
+      "mtp.layers.0.mlp.experts.53.down_proj.weight": "e0e6c900609829d9022a10294422e2f9db9ec7de704f893b45354842244d3cf8",
+      "mtp.layers.0.mlp.experts.53.gate_proj.weight": "a42a82212927f113b357f16843f51dc714d70d0b6dd7184a92f534d1c7fbd405",
+      "mtp.layers.0.mlp.experts.53.up_proj.weight": "486cb05a1a937189286ff835c3aedf879206d1dbb4b5d4676c9eec025bb85171",
+      "mtp.layers.0.mlp.experts.54.down_proj.weight": "3d9a234ae937b3767687b45d25afc4b45f87870c3d8a388fe268f95fe1c8a4c0",
+      "mtp.layers.0.mlp.experts.54.gate_proj.weight": "b180e70bd5bccf1524f7b39e9eb7360bb6c1b6ca4a4406ecafeddcff51679686",
+      "mtp.layers.0.mlp.experts.54.up_proj.weight": "9d47308d966b1a060fd1d5f0974743685e8a74bea8b4e501854ca83d51b4e585",
+      "mtp.layers.0.mlp.experts.55.down_proj.weight": "9d4d2ff1d251d1a2be8b3340307445d2fa25bd30225413772cfdfc88b46a88c5",
+      "mtp.layers.0.mlp.experts.55.gate_proj.weight": "efc2e5a17fd2cd4a0aa1f10aa76f443795d35f1ea974636ac4890af0aa37a754",
+      "mtp.layers.0.mlp.experts.55.up_proj.weight": "f983247b537fb8d1bfaafbb0a20bd803c8bfededfd978644d55f597989e38bb5",
+      "mtp.layers.0.mlp.experts.56.down_proj.weight": "a78b17ee3e371332a6482439f310f2fd73fe789c5c721250640d2d4a4b9752c5",
+      "mtp.layers.0.mlp.experts.56.gate_proj.weight": "f15e3aeb170ee783c8b9a6d2c6820e2d713e27be1bd6b9dd776e65826ea42a4a",
+      "mtp.layers.0.mlp.experts.56.up_proj.weight": "661b1e6b14bbd027b8eeb947e75bddfb5e15c0116b5af6fec61033f6b6940f3f",
+      "mtp.layers.0.mlp.experts.57.down_proj.weight": "f1604c092212e94717ed999adc4ff3a1c6023134c109522816f49ff5977d430c",
+      "mtp.layers.0.mlp.experts.57.gate_proj.weight": "2e8c68b01431271e59a196f6931834538d63fc6e17e114e90b27febca6628220",
+      "mtp.layers.0.mlp.experts.57.up_proj.weight": "66792da5c3585bccdb0356e789fdf1ae8e3469bd1b8d6755f6290ab7b070e570",
+      "mtp.layers.0.mlp.experts.58.down_proj.weight": "07a0e8c2615a3d7f93bcdad27df127d3d6aac39152ec91d24d634f27547c4a77",
+      "mtp.layers.0.mlp.experts.58.gate_proj.weight": "bc29055e4acaafbe950feb2c5d8974e9feb79cfcaa314f2ef4179d59caf0dc51",
+      "mtp.layers.0.mlp.experts.58.up_proj.weight": "308f0f61b72aa8b5df9febb22436dfd1650355ccec5870b65c9626f672b63b9a",
+      "mtp.layers.0.mlp.experts.59.down_proj.weight": "b8960eb7d115fc06adfe0ea68b5bca81f6627ad49ba6fdd41e3d2221e56f0f65",
+      "mtp.layers.0.mlp.experts.59.gate_proj.weight": "b64e0975c8a889c7936221f02c6fe284bfbc9eaa753ef057dbd2792e895e3d8f",
+      "mtp.layers.0.mlp.experts.59.up_proj.weight": "455a59d0641157ecb894996836f3ff53cf9527c9b902ba0fca8be30de49f392f",
+      "mtp.layers.0.mlp.experts.6.down_proj.weight": "2d0dd0b00fb3221916c2e9d933c071c2d6811437ec07fdcc3d4897d3341e87f7",
+      "mtp.layers.0.mlp.experts.6.gate_proj.weight": "669f419ab4baf3b676d9e31a1ca9f0f3e1a49b3799ad245461ecc2df6194439d",
+      "mtp.layers.0.mlp.experts.6.up_proj.weight": "25f5790216c5408dbb60a2c6b9e9180087d4163561072963746586e51591ba25",
+      "mtp.layers.0.mlp.experts.60.down_proj.weight": "481490ac04cbe7315ce36fb662fd845cafbfdbbbe7e16228a671ee08dbdac0e0",
+      "mtp.layers.0.mlp.experts.60.gate_proj.weight": "1640e4c696645ec39557529649bfbb3a3f5917481f8d55b884a6ef6bbe0a6118",
+      "mtp.layers.0.mlp.experts.60.up_proj.weight": "14b9c96d3d132f3b50b3d45758b6cb1417152830f97e6ada03d02d2d160e85ce",
+      "mtp.layers.0.mlp.experts.61.down_proj.weight": "86d7befe08eb8d6c626e50ab234a75db77887cd723a516535c28a5f517045fd2",
+      "mtp.layers.0.mlp.experts.61.gate_proj.weight": "c8d6c5bc6ada05d2ce789574056cf5c0000fc36bc5181fd5baa7b907a286f557",
+      "mtp.layers.0.mlp.experts.61.up_proj.weight": "b8c707c150ec2aa815d8bae69228c0a90445992301e8cb8d1390ccc2a0f71a0d",
+      "mtp.layers.0.mlp.experts.62.down_proj.weight": "2c0f6f88f481996cd0fdb9ce4911406300a25059d4da9b0792e500131a8f61f4",
+      "mtp.layers.0.mlp.experts.62.gate_proj.weight": "e3d5d491c54a98a4d438a2068e2dd6b96e7aba851d3f2ab4cc524038a8bfc0fb",
+      "mtp.layers.0.mlp.experts.62.up_proj.weight": "f0bd97a804d5abbd23014df50cba31dccaead35b8f2e9fdb00af9fe8eecf1d31",
+      "mtp.layers.0.mlp.experts.63.down_proj.weight": "ad668f819e9d5c201c0bac6a5f7a68b363e2e6dc2621ce63b0c074da4191d82f",
+      "mtp.layers.0.mlp.experts.63.gate_proj.weight": "02763344ffd002983f717fbf736e9205cdfae73414f5ef149d66bc8240fb98e6",
+      "mtp.layers.0.mlp.experts.63.up_proj.weight": "013b901f98373addb53252ecc9cdecdeb66a01899f5a0be6354cb7ae80a76299",
+      "mtp.layers.0.mlp.experts.64.down_proj.weight": "4603e3d5e5a9429c90cfed45164668d6ba49605f8303faaed28a38216ba5c1f3",
+      "mtp.layers.0.mlp.experts.64.gate_proj.weight": "2f68434cdd36a8404c9b5097cd2b465b52ed1f03c7b65638ea12017fbce5ee6d",
+      "mtp.layers.0.mlp.experts.64.up_proj.weight": "61ee53c8b285e7a57ed8c833c8527f67b81b376b0506727a64b3bad1fac4a784",
+      "mtp.layers.0.mlp.experts.65.down_proj.weight": "9e61891c5f8269cf655a4d9bfc68a7aa297750cd3986f51c4a866e2b32a62696",
+      "mtp.layers.0.mlp.experts.65.gate_proj.weight": "93a8c48d823b32ed9e17124df8764a2eb44909f01e076803d306a98603d6fb7a",
+      "mtp.layers.0.mlp.experts.65.up_proj.weight": "ea03cfe213852c59adfcc3095ec4bd8b3d19adfc98357a5a22d7b0f1e4d62ee6",
+      "mtp.layers.0.mlp.experts.66.down_proj.weight": "8c843dfb136e425b4dc909bcdc26c53d7a67889a99dc54edf63c9a9a0764a68c",
+      "mtp.layers.0.mlp.experts.66.gate_proj.weight": "30f98ddb8813a82737c0313dc569f56fa23687b7604a15f0c99ef25e2c86fe21",
+      "mtp.layers.0.mlp.experts.66.up_proj.weight": "4450d14b0f37a39b98543d3634152ca3593fa066ce8cb9e578a4aafce76e0850",
+      "mtp.layers.0.mlp.experts.67.down_proj.weight": "40bf776d6d53f5b83aa8e8f7e7605184b8c0106d05e8261ea4a5223ab48d5fd3",
+      "mtp.layers.0.mlp.experts.67.gate_proj.weight": "8fcdd687064fc726d1858605a4e5c4aec8720ab1dda62b3cf79204bb8826052b",
+      "mtp.layers.0.mlp.experts.67.up_proj.weight": "98303983301abe2f09260b4474e4b941607e8eb90f5a13941ddc5c19665afbf7",
+      "mtp.layers.0.mlp.experts.68.down_proj.weight": "1a273995ec1aa50aef1fb81e906520de7f82b180d8389cf317276371711d297d",
+      "mtp.layers.0.mlp.experts.68.gate_proj.weight": "70c121a388ef82d926e519ae3e2a07cd453bbd1bd5872fafcab8ee8fa897db14",
+      "mtp.layers.0.mlp.experts.68.up_proj.weight": "1fd02461a0afb08bb2a3f4823965aedf7e8151c80d77911b24a829f2315b2778",
+      "mtp.layers.0.mlp.experts.69.down_proj.weight": "20058bb02ac5517a0ff3829763e1ea49353804766e2d24d0fdec7767a25d7b34",
+      "mtp.layers.0.mlp.experts.69.gate_proj.weight": "bed3cf955a211669de3742e98df4ac2ba3e7e7171281d61211a6980250e28c62",
+      "mtp.layers.0.mlp.experts.69.up_proj.weight": "8433247ce3bf296433193a4e86a35d454086df175cebcbc473abe706d4f2727c",
+      "mtp.layers.0.mlp.experts.7.down_proj.weight": "5d14105e74cdb9d2c0042cc757c264ed847ebc402e836ab851841be42de15582",
+      "mtp.layers.0.mlp.experts.7.gate_proj.weight": "090b12f9ac1472dbe439a7404a538cbda90789c45157ef588108aa45c383d1b3",
+      "mtp.layers.0.mlp.experts.7.up_proj.weight": "ac1652e59ee21d8c2e2827306afc9956c0e23b47b0ebb1e34bf8394940dd20d3",
+      "mtp.layers.0.mlp.experts.70.down_proj.weight": "75d7159af885b76aa6bbc5573c059e9a1accaa73dde4b6c5aaa88251d008dda5",
+      "mtp.layers.0.mlp.experts.70.gate_proj.weight": "e45ee17e3d47906b02456e73d9fc2d75d182f405d0dc86bc407cd15b50298ce7",
+      "mtp.layers.0.mlp.experts.70.up_proj.weight": "bd252a3eeb323997c0c190f6b21fd052d977d99f13c0c5ab766d2751e31f4fe5",
+      "mtp.layers.0.mlp.experts.71.down_proj.weight": "183c331a57464c649d9a6b55ba332c105c3e9d9b62d766b63a0aecef69f5bcfe",
+      "mtp.layers.0.mlp.experts.71.gate_proj.weight": "9a53e47d314ac8546a36039f7df007cf3a83852f68848e9fa4675e04491d49b0",
+      "mtp.layers.0.mlp.experts.71.up_proj.weight": "e47aa42656fae1958ef84f5589afe84c8d3ad6157f1794841c8968f364216cf0",
+      "mtp.layers.0.mlp.experts.72.down_proj.weight": "24f2a7e69ece84782bde0f22f1b36c90c7ac49cf9d4e5a4fbfff559e7b4e6068",
+      "mtp.layers.0.mlp.experts.72.gate_proj.weight": "4259e6aff59d033e6d33dbb38a335c8d246a4ef3cd2eade987235bda8703f589",
+      "mtp.layers.0.mlp.experts.72.up_proj.weight": "2ff48fa82b2c74093f9d581787f2ff1bbf0a751624e423912961707bdedf7a2f",
+      "mtp.layers.0.mlp.experts.73.down_proj.weight": "80e4d8a6ae8935c55e29bb60eed9e16e154d104e274a61434a75415ac3616406",
+      "mtp.layers.0.mlp.experts.73.gate_proj.weight": "21aa5124aed4a93bea49f5f32137c1cea307885ac12d66dc9f454f1358f85c31",
+      "mtp.layers.0.mlp.experts.73.up_proj.weight": "118265b01d4a8f9e6e75dfacfd3a078cf324e268c62be06e3423d036503eb18c",
+      "mtp.layers.0.mlp.experts.74.down_proj.weight": "ed191407a8e416d9c958230759460f8385676bbeaee1a8e32b930050734ff567",
+      "mtp.layers.0.mlp.experts.74.gate_proj.weight": "a80f79a4b49bc5fd3086c3c9a22cb738a0917da355e019655814370f7d696623",
+      "mtp.layers.0.mlp.experts.74.up_proj.weight": "32ff466da619007c9bf3ba6184392268e0e38e6a457450c8b0294b9006ffb8d2",
+      "mtp.layers.0.mlp.experts.75.down_proj.weight": "0a263ff797424a42be0c2d56d824733375099783a086a8a993e11aee8f7a8f0b",
+      "mtp.layers.0.mlp.experts.75.gate_proj.weight": "a1a3b2efaf50e4ce9abb7729dbd4e7e92ce70742ccc642799933ec54ed42d299",
+      "mtp.layers.0.mlp.experts.75.up_proj.weight": "57135a81523051560dbfb0fc4936bbbc17c56be64c8e7f87f03a881967333312",
+      "mtp.layers.0.mlp.experts.76.down_proj.weight": "27aee72040a0a863fa6df2b6c35ce8e0b691ec83f573fb0a6c91162b9453865a",
+      "mtp.layers.0.mlp.experts.76.gate_proj.weight": "a7758d21b653101df68aa1e1c3acb92b428df7ce45fa65e37e5b670e05057382",
+      "mtp.layers.0.mlp.experts.76.up_proj.weight": "a33cf561be28b81c733956deed3497e7d9f4feca7af47f804586f45a8747e82c",
+      "mtp.layers.0.mlp.experts.77.down_proj.weight": "a25a6378f389df1d29503dcc003362b67b9d19000c5185a59a5f60bc3a5daf67",
+      "mtp.layers.0.mlp.experts.77.gate_proj.weight": "859f064f7a0143b7b8c2d3cc0204929552632b86e268ae17a635e0cd9bff3843",
+      "mtp.layers.0.mlp.experts.77.up_proj.weight": "cb0fb2c05faba0fd2979ef94626268a37eb1c8c0d190f1b9118e37df3a704e47",
+      "mtp.layers.0.mlp.experts.78.down_proj.weight": "8859b8271af72adc73b74287e6b64ae1c5b9dcd1e8451b97e012250350014c93",
+      "mtp.layers.0.mlp.experts.78.gate_proj.weight": "00806ecaf56fb305a3f93063e80c8fa8b95d9b5a9022439b017c3025673ec728",
+      "mtp.layers.0.mlp.experts.78.up_proj.weight": "140e219df8c820eaf1ae0fd3735bb8ae507511e2c3c3d4a214233efce358557e",
+      "mtp.layers.0.mlp.experts.79.down_proj.weight": "7f0108e99456039d89c29934afe666173c9cf97fef0c989901faa28b785b1341",
+      "mtp.layers.0.mlp.experts.79.gate_proj.weight": "54620a869d226097b8d9c891bc5f2b9df0dcaf41fcb43fab110be73a0fff6999",
+      "mtp.layers.0.mlp.experts.79.up_proj.weight": "7aefc967e455ac3be6afe9862a97efd00805b721b8d3cacb0ae1806f0ec5d892",
+      "mtp.layers.0.mlp.experts.8.down_proj.weight": "f4c772947b6e853e806534a130e72011e37fcb7055c681ee1edfa3dd456d1442",
+      "mtp.layers.0.mlp.experts.8.gate_proj.weight": "fbee1c65802299e6afbfc03b389c7f15913077f7d0ba0a1c1205b65c45ef274c",
+      "mtp.layers.0.mlp.experts.8.up_proj.weight": "c4158be257940570fc496b309246dfb15e3e5c1d4a1b98ca75958f2a90562523",
+      "mtp.layers.0.mlp.experts.80.down_proj.weight": "9464efba51035be18bd572ee989c1dac87bec63cf2bd714d09755ceb9574f910",
+      "mtp.layers.0.mlp.experts.80.gate_proj.weight": "f248b3a355c2ae410a4857b6c66a6c64706aa57a7f8660712800a3414bd5e133",
+      "mtp.layers.0.mlp.experts.80.up_proj.weight": "7f6a05197bfd77a8d0c44114a032277b5615652f1eb9f8dc4027fb944875b8e0",
+      "mtp.layers.0.mlp.experts.81.down_proj.weight": "ec9aaa666b64ec927450dbcbc7006f87973f0a80280ee27a270e4669e9b93afe",
+      "mtp.layers.0.mlp.experts.81.gate_proj.weight": "98511996998b478533a38af09941ced9511ca0fbefaca96a9463211d4bdde7bc",
+      "mtp.layers.0.mlp.experts.81.up_proj.weight": "2918650858ad2b55e9fc0035dca8e85a3f39e2f8a61bc48ada540aa5a125de62",
+      "mtp.layers.0.mlp.experts.82.down_proj.weight": "918332fdccafdef75092dd997a451271660099d22f877961a053fccf884a0fa4",
+      "mtp.layers.0.mlp.experts.82.gate_proj.weight": "64a34c4f617a8d9bfdf9f022a547fdbc3107206cfc08d1ddcb3fab55ac87535c",
+      "mtp.layers.0.mlp.experts.82.up_proj.weight": "e199b2d083025eda8a549dde8069c2a7e95359ce021ba3efce871619f724c349",
+      "mtp.layers.0.mlp.experts.83.down_proj.weight": "73401f31c70ecea064f53e1c87ebf976002959d01d4f8670a4b6dca2bec67812",
+      "mtp.layers.0.mlp.experts.83.gate_proj.weight": "2afcac31cfec9d50b5cbff5a8267d1af50873f6e83c9433a00bb864f217727e3",
+      "mtp.layers.0.mlp.experts.83.up_proj.weight": "ee63814b48a895da3a4eaf980d151ccf1c3f56a67620e42a0411ab77e1d4a29b",
+      "mtp.layers.0.mlp.experts.84.down_proj.weight": "c64eb6764f1f6ba3c22dd117ec94139fa6a004bcbf468d08f1c53ddbf23f02e1",
+      "mtp.layers.0.mlp.experts.84.gate_proj.weight": "99bf64f254a7ace855215216ac95fed22f09a505f92b7685cda0e49601e4b18d",
+      "mtp.layers.0.mlp.experts.84.up_proj.weight": "f79e5476dd5466668debaf400c61969cfe757e8968bde85d9534b6c2eb22fb24",
+      "mtp.layers.0.mlp.experts.85.down_proj.weight": "f1a20d77d9f1a6c50ee0eb149140d6ab180c91175223eaddad0c5bb644c7d843",
+      "mtp.layers.0.mlp.experts.85.gate_proj.weight": "00568bf3f53ed656a2f3485596720e3ed0890b45053d21d9c46afe348b902f71",
+      "mtp.layers.0.mlp.experts.85.up_proj.weight": "3910016d49c3eeebbb786692a2f5e44116cf7baa361d90043db96b06e4ba30a3",
+      "mtp.layers.0.mlp.experts.86.down_proj.weight": "374d388ae9a2bc800b78a31679aed5393dbaf953c0d0bbf7e23cd33780a7487d",
+      "mtp.layers.0.mlp.experts.86.gate_proj.weight": "cca549fbaffe1567f2fe390841e3dbadc7ed6d1294bf76cba77f21310bf6caeb",
+      "mtp.layers.0.mlp.experts.86.up_proj.weight": "131ca757d74dc98256579536be95a4b70e5e76ca01a6077bad863c5150bb770e",
+      "mtp.layers.0.mlp.experts.87.down_proj.weight": "ff2f52b8b86347b492c8c9a58989d44d5f41be0cd6eb57190019abba7bc58308",
+      "mtp.layers.0.mlp.experts.87.gate_proj.weight": "eb4f5f4671d36dc71d1eff2d7ff933e63e9417b716b0bae3a47c20dbf368f9e0",
+      "mtp.layers.0.mlp.experts.87.up_proj.weight": "114c6fc0c5585036d69e6ec818c2285cf1a6619e3c598e71d038a9083373a698",
+      "mtp.layers.0.mlp.experts.88.down_proj.weight": "846c184a8a9e800497398284dbb4f0414ec691a5a6c3747cdbb85dbd886b8bf2",
+      "mtp.layers.0.mlp.experts.88.gate_proj.weight": "f91d946fd2617168a2550aa2753a3ddc862f7a1f50da7bc0fdf171682481409d",
+      "mtp.layers.0.mlp.experts.88.up_proj.weight": "967aa2af8800155433c94be3c01b0664fd43c027d04f27785ad98364520b8b78",
+      "mtp.layers.0.mlp.experts.89.down_proj.weight": "6396d40eeb7d20badb05aeaaba126fa7cf3195f59d0dbb1d0d64834e5b851f50",
+      "mtp.layers.0.mlp.experts.89.gate_proj.weight": "a6054f877b08012aaa64c163dec3dc5c45a505a15b7f97de76fe50c9ee7b1399",
+      "mtp.layers.0.mlp.experts.89.up_proj.weight": "c79be2e715c8b89c86d2e5074a842a9164bd7d6821593c94f6f13611e0ee5598",
+      "mtp.layers.0.mlp.experts.9.down_proj.weight": "b89a3fa04af7988d4861ea6cbb97e3a7968868cabca413d9a3f3a62d783bae5a",
+      "mtp.layers.0.mlp.experts.9.gate_proj.weight": "6de0eec30e5bb6d74ed4ebcfeb1163c414979ecc6413a5d2e249bc30f4b2929f",
+      "mtp.layers.0.mlp.experts.9.up_proj.weight": "9a5985ecd5a87e724bd5b077fbfccf5a327b44423558253c388f12abaa5a55fa",
+      "mtp.layers.0.mlp.experts.90.down_proj.weight": "624418567b29a84cc2aca51e7d44b8897bb974c81a2b19f1baf99c913e72532d",
+      "mtp.layers.0.mlp.experts.90.gate_proj.weight": "802b910259e3a88d5063ba93a5efd65e56516438067264033fca9674a651a350",
+      "mtp.layers.0.mlp.experts.90.up_proj.weight": "19e53083b6944e92695a352ac0a504e0c9611bef2540b1e36127cfba8ffdcd17",
+      "mtp.layers.0.mlp.experts.91.down_proj.weight": "f853eccef12ea94ba83ce9665c8a47b7c5f290da18ec9abbb353a68e1bc1528b",
+      "mtp.layers.0.mlp.experts.91.gate_proj.weight": "f48bd94e721fdcd28e9a375cc5bc6124fea9666aee6ffbf2bc53377f4ef57841",
+      "mtp.layers.0.mlp.experts.91.up_proj.weight": "b1111f4c2f52b8633d5b28090d151781d60f2c6abd0ea4c3deee8b666a293ac9",
+      "mtp.layers.0.mlp.experts.92.down_proj.weight": "c229c741aa20aec86a489f3f3f1f6ee4592bf2d8db891d35d3024b25355abf1f",
+      "mtp.layers.0.mlp.experts.92.gate_proj.weight": "2740df26d9d9be3b6846e15b7dfc81435ad4f6d1243e7db3b756d63117ecd635",
+      "mtp.layers.0.mlp.experts.92.up_proj.weight": "158381cf6afe8d88da7507cd5ef11e31bd7e8b2a2f6008dd3f093ac26b1baa19",
+      "mtp.layers.0.mlp.experts.93.down_proj.weight": "df36895a00fc174124c05e1a1e2bd6447b872179a484947fe9724539e970c2c0",
+      "mtp.layers.0.mlp.experts.93.gate_proj.weight": "5795e537215d753434145947b7f06c4aaac6d0f4aa12bf53e4d9c7890c910cd6",
+      "mtp.layers.0.mlp.experts.93.up_proj.weight": "f56cff1177d689ebb9365a7d5a089629a68e65470e0682fe49a3c29ff5225a5a",
+      "mtp.layers.0.mlp.experts.94.down_proj.weight": "15aae6e00eb59a280acc87e0fcb0c892308a11f0ab8e7cdc3f7affba254fd383",
+      "mtp.layers.0.mlp.experts.94.gate_proj.weight": "abeff47122c1a9ee5cf8d04b715f9351ba132b6331bab7e306ce6050af242018",
+      "mtp.layers.0.mlp.experts.94.up_proj.weight": "3269168a2d5491c7e1ec580b1c4e911fa681a6d2c414bb9ab3d81ae9a138822f",
+      "mtp.layers.0.mlp.experts.95.down_proj.weight": "27acc8f75f90ea4bd197dfc3f7e52ea8a9a6a617413c8e658072fc97c6cfdf81",
+      "mtp.layers.0.mlp.experts.95.gate_proj.weight": "ba0760e2727b86aa7809c6cda6a0ef37d9a760cb66bab288b0581c42d5cf5f0c",
+      "mtp.layers.0.mlp.experts.95.up_proj.weight": "5246425a2f3e8245b854b8408444d4c74677aa3417d3fb9009b90f40e449b2ca",
+      "mtp.layers.0.mlp.experts.96.down_proj.weight": "f4f83390f9498aa64d47195c703d1d200f26294bbdf3b09c1aafb29e30b7d506",
+      "mtp.layers.0.mlp.experts.96.gate_proj.weight": "dabfaca3bf0bde565a2dd6a60ede4483e62ea163c3946daa4cd2c77362370c71",
+      "mtp.layers.0.mlp.experts.96.up_proj.weight": "3cbbe92657766d694ebe3cf877a73d9408d320766d97489de4b31c24201b2866",
+      "mtp.layers.0.mlp.experts.97.down_proj.weight": "d3e93dc54081dbb55b2a4fdaf54150fadc3ed19edcf1e63bb35652574ef1fc46",
+      "mtp.layers.0.mlp.experts.97.gate_proj.weight": "2046420a0cbb4b0881098a70005bf6818ad14574aa7d5900baf306d83d0280f7",
+      "mtp.layers.0.mlp.experts.97.up_proj.weight": "4ee052f8f168c475af93c29ae933731e15f800d7e62bdae8fb3805184527c6a6",
+      "mtp.layers.0.mlp.experts.98.down_proj.weight": "b431bb1682f77b9a592e91cccffa1049786637b5262cf893949855e6e02a3c17",
+      "mtp.layers.0.mlp.experts.98.gate_proj.weight": "4a75fe796f2fd65260734b964dc297ed8ec1e8d3defec7a6a0c61644348a166d",
+      "mtp.layers.0.mlp.experts.98.up_proj.weight": "8abf15d1191d51133b44846d76be86d71f1c87a61a279705985a5c0923d67b8e",
+      "mtp.layers.0.mlp.experts.99.down_proj.weight": "ce887727c3401c533171b0856479ef45e33525258b575fe7428c1e7b89329f16",
+      "mtp.layers.0.mlp.experts.99.gate_proj.weight": "eea5068c186e8249a5eeb34138d589e5b52b5eb1219f9193ec0fcb8c6c62eade",
+      "mtp.layers.0.mlp.experts.99.up_proj.weight": "6a8fb97c0b83ea2e0f7c1f85d700c06aac3bdbcce453e636501e7dfea49d6e33",
+      "mtp.layers.0.mlp.gate.weight": "e34e3b8a785986d5b478d0b04ef849ea12f9142d31f3ab07e2502b58d0ab822e",
+      "mtp.layers.0.mlp.shared_expert.down_proj.weight": "9a82c9c6a93bc53fbfd5a79b93a4d3485412d0895fa000e6e9b7ad758192c11b",
+      "mtp.layers.0.mlp.shared_expert.gate_proj.weight": "93425f95c5ec8e3237ae4ce151b40f95b54ee68fa720d41ab18412b309c81779",
+      "mtp.layers.0.mlp.shared_expert.up_proj.weight": "0d1d65e0ed8d8bba8aac2bce930a4f2365edfb63615a80c1294386304759ef28",
+      "mtp.layers.0.mlp.shared_expert_gate.weight": "f9ac81158b4c356605fcd8264cfa5be4b2612e7de23ce9b88aa37072055855db",
+      "mtp.layers.0.post_attention_layernorm.weight": "f92c1d7302889dd31c1d5d086b1cfac0805f204fd9f709a14661378e820083ad",
+      "mtp.layers.0.self_attn.k_norm.weight": "1ee87c4657834a89f1cb0f8483347d551069f04e6e07e4543a2951ae6a56e0b6",
+      "mtp.layers.0.self_attn.k_proj.weight": "fa90afa9f9bb79878c3b4d5f479590bca11a44e17bdfb24aa8f14fabb92df6b6",
+      "mtp.layers.0.self_attn.o_proj.weight": "7cd4a221f1e0e9c32a8c03c60bd07ddb9bc9fef835d63f2261a16983536e7104",
+      "mtp.layers.0.self_attn.q_norm.weight": "163ca258eb7111696fe00e913a3b04d63d2d644caf26bfedaf4e02e861cccba3",
+      "mtp.layers.0.self_attn.q_proj.weight": "7169b9729c2cfe8d590b320767be99ec8a25568135db3b5954cc64d002c7fb1e",
+      "mtp.layers.0.self_attn.v_proj.weight": "7a5a0d43e5bba5034fa9551b5d5429662cd1c1abd0397cf13d5c4467b4bef3e1",
+      "mtp.norm.weight": "3d8daa26ffdfb2f4a75881888c4dee0f79db1d760961ff131db557d75f2605b5",
+      "mtp.pre_fc_norm_embedding.weight": "4e4d59355c416509a6cf575c00cef764bed66e5dba0a8ab0bea5cebfea82bd76",
+      "mtp.pre_fc_norm_hidden.weight": "d55d4bb32a22854c8fe7c219b9a9084e3fc8677ec226ef73e4025dc546bc1313"
+    }
+  },
+  "schemaVersion": 1,
+  "scripts": {
+    "benchmark-head-comparison.py": "846c9089342036559de416f10a5f572f3e4afd5005e4eb87be4924ba5cf38446",
+    "omlx-qwen35_moe_vlm_runtime.py": "358ef6edadb9b841de9020d0c3c0f8e487f9154bb74a14a37a24db0add1b5a33",
+    "prepare-head-comparison.py": "fabb5b2e3a0bb61cb7bba131459c5ceb72be7cb1881759a305af60fec86fc7b3",
+    "run-fixed-depth-comparison.py": "d40b216207ca3b13b74cc9fc0ca15225303862ebf1f3d9f207e37d850456aa96",
+    "run-head-comparison.py": "73d4c5bc25d439170a67a5a67c835bdacb105c9db97e47d06d89f560d53fc6c3",
+    "vllm-qwen3_5.py": "3abeac36180df7bd1bd96b1a7c698a8f212d92c063026420cbdd16d1980e90e6",
+    "vllm-qwen3_5_mtp.py": "89b0bde1d11fe5768a634e4365c78274e20694b26f4c6bb68e934328d8d0b190"
+  },
+  "upstreamSources": {
+    "omlx-qwen35_moe_vlm_runtime.py": "https://raw.githubusercontent.com/jundot/omlx/e467261edc786efd33b1e9023d5c4a827f8aa1c1/omlx/patches/mlx_vlm_mtp/qwen35_moe_vlm_runtime.py",
+    "vllm-qwen3_5.py": "https://raw.githubusercontent.com/vllm-project/vllm/f4eccdadefc6501fafeb1a0bf7f171ff24f984b0/vllm/model_executor/models/qwen3_5.py",
+    "vllm-qwen3_5_mtp.py": "https://raw.githubusercontent.com/vllm-project/vllm/f4eccdadefc6501fafeb1a0bf7f171ff24f984b0/vllm/model_executor/models/qwen3_5_mtp.py"
+  }
+}

--- a/docs/benchmarks/receipts/ornith-qwen-generation-tuning-2026-09-05.json
+++ b/docs/benchmarks/receipts/ornith-qwen-generation-tuning-2026-09-05.json
@@ -1,0 +1,19515 @@
+{
+  "hardware": {
+    "build": "25F84",
+    "chip": "Apple M4 Max",
+    "cpuCores": "proc 16:12:4:0",
+    "gpus": [
+      {
+        "spdisplays_vendor": "sppci_vendor_Apple",
+        "sppci_model": "Apple M4 Max"
+      }
+    ],
+    "macOS": "26.5.2",
+    "memory": "128 GB"
+  },
+  "measurementMode": "desktop-load",
+  "modelManifests": [
+    {
+      "components": {
+        "text_encoder": {
+          "path": ".",
+          "type": "local"
+        },
+        "tokenizer": {
+          "path": ".",
+          "type": "local"
+        }
+      },
+      "createdAt": "2026-09-01T00:00:00Z",
+      "engine": "qwen3.5-hybrid-moe",
+      "family": "code",
+      "id": "text-agent-ornith-35b-mlx-4bit",
+      "precision": "int4",
+      "quantization": {
+        "bits": 4,
+        "groupSize": 64,
+        "scheme": "mlx-affine"
+      },
+      "schemaVersion": 3,
+      "sources": [
+        {
+          "repository": "ornith-ai/Ornith-1.5-35B-A3B-MLX-4bit",
+          "revision": "19504d912fa8fc7622bf6b1de3db5d5d890b1f02",
+          "role": "primary"
+        },
+        {
+          "destination_path": "vision",
+          "repository": "ornith-ai/Ornith-1.5-35B-A3B",
+          "revision": "10fbf86fed7ecee4a061f8b499a618f46001cac1",
+          "role": "component"
+        },
+        {
+          "destination_path": "mtp",
+          "repository": "ornith-ai/Ornith-1.5-35B-A3B",
+          "revision": "e4dfb35a93d4b6822a811a7676f3488514abe7e2",
+          "role": "component"
+        }
+      ],
+      "supports": [
+        "chat",
+        "code_generation",
+        "vision_chat"
+      ],
+      "tier": "large",
+      "upstreamRepoId": "Sawfwair/Ornith-1.5-35B-A3B-MLX-4bit-Vision-MTP@main",
+      "variant": "standard"
+    },
+    {
+      "components": {
+        "text_encoder": {
+          "path": ".",
+          "type": "local"
+        },
+        "tokenizer": {
+          "path": ".",
+          "type": "local"
+        }
+      },
+      "createdAt": "2026-08-29T13:08:53Z",
+      "engine": "qwen3.5-hybrid-moe",
+      "family": "qwen",
+      "id": "vision-chat-q38-27b-4bit",
+      "precision": "int4",
+      "quantization": {
+        "bits": 4,
+        "groupSize": 64,
+        "scheme": "mlx-affine"
+      },
+      "schemaVersion": 3,
+      "sources": [
+        {
+          "repository": "EigenLabs/Qwen3.8-27B-4bit",
+          "revision": "eda45ab47f465d08d6558f0353a2346e2eb9d5b3",
+          "role": "primary"
+        },
+        {
+          "destination_path": "mtp",
+          "repository": "morgan/qwen38-27b-mtp-r20k-lr3-q4-g64-q2-rerank",
+          "revision": "fd4a99c590dd6e468c0e2a28168c235e32151a4b",
+          "role": "component"
+        },
+        {
+          "destination_path": "vision",
+          "repository": "Qwen/Qwen3.8-27B",
+          "revision": "1d4bf0f2ff6012fd82039f2fa52739d0dd7c60c0",
+          "role": "component"
+        },
+        {
+          "destination_path": "licenses/qwen3.8",
+          "repository": "Qwen/Qwen3.8-27B",
+          "revision": "1d4bf0f2ff6012fd82039f2fa52739d0dd7c60c0",
+          "role": "component"
+        }
+      ],
+      "supports": [
+        "chat",
+        "code_generation",
+        "vision_chat"
+      ],
+      "tier": "latest",
+      "upstreamRepoId": "EigenLabs/Qwen3.8-27B-4bit@eda45ab47f465d08d6558f0353a2346e2eb9d5b3",
+      "variant": "standard"
+    }
+  ],
+  "notes": [
+    "All measured repetitions are retained. Model load is warmed separately; complete-request timing includes prefill and request overhead.",
+    "Scheduling selection used the earlier f847be2e binary with explicit environment overrides. Final workloads use the recorded release build with no scheduling overrides.",
+    "Machine-local command paths and process identifiers are omitted. Counts and utilization samples are preserved.",
+    "Fixed-token measurements ignore EOS and do not evaluate completion quality. Sampled runs do not claim greedy parity."
+  ],
+  "records": [
+    {
+      "id": "finish-selection/ornith-c18/ornith-code",
+      "model": "text-agent-ornith-35b-mlx-4bit",
+      "rawReceiptSHA256": "ab7286d68ba567842ed1b603798bcbcc41a8956195613f90c48e22ce15d6635a",
+      "receipt": {
+        "after": {
+          "gpuDeviceUtilizationPercent": 90,
+          "loadAverage": [
+            5.40087890625,
+            6.3662109375,
+            7.38916015625
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7276.25M  free = 915.75M  (encrypted)",
+          "swapUsedMiB": 7276.25
+        },
+        "before": {
+          "gpuDeviceUtilizationPercent": 0,
+          "loadAverage": [
+            5.447265625,
+            6.4443359375,
+            7.44091796875
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7276.25M  free = 915.75M  (encrypted)",
+          "swapUsedMiB": 7276.25
+        },
+        "binarySHA256": "cdec91928873110a516e18abcf0db7904cde7398977a7e5b9317c0776a3c1737",
+        "buildSourceRevision": "f847be2ef7ca2f8896829c3cc0b6a1a55ea72ea9",
+        "collectorSHA256": "c5d800333764ac360dd08c27bd99ccf3bc3be6afb203f82ac9fddef41d7ce682",
+        "command": [
+          "mere.run",
+          "model",
+          "benchmark",
+          "q36-mtp",
+          "--model",
+          "text-agent-ornith-35b-mlx-4bit",
+          "--prompt",
+          "Write a complete Python implementation of an LRU cache using a dictionary and a doubly linked list, with get and put operations, type hints, and a short usage example. Return the code directly without introductory prose.",
+          "--decode-tokens",
+          "256",
+          "--context-size",
+          "8192",
+          "--temperature",
+          "0",
+          "--top-p",
+          "1",
+          "--json",
+          "--variants",
+          "baseline,adaptive",
+          "--warmups",
+          "1",
+          "--warmup-tokens",
+          "256",
+          "--repetitions",
+          "3",
+          "--mtp-block-size",
+          "4"
+        ],
+        "competingInferenceProcessCount": 0,
+        "gpuSamples": [
+          {
+            "deviceUtilizationPercent": 0,
+            "elapsedSeconds": 0.0815439224243164,
+            "loadAverage": [
+              5.447265625,
+              6.4443359375,
+              7.44091796875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 71,
+            "elapsedSeconds": 2.192143201828003,
+            "loadAverage": [
+              5.447265625,
+              6.4443359375,
+              7.44091796875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 70,
+            "elapsedSeconds": 4.293489217758179,
+            "loadAverage": [
+              5.4912109375,
+              6.4365234375,
+              7.43212890625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 75,
+            "elapsedSeconds": 6.397712230682373,
+            "loadAverage": [
+              5.4912109375,
+              6.4365234375,
+              7.43212890625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 72,
+            "elapsedSeconds": 8.50563931465149,
+            "loadAverage": [
+              5.37158203125,
+              6.39599609375,
+              7.41162109375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 99,
+            "elapsedSeconds": 10.607057332992554,
+            "loadAverage": [
+              5.37158203125,
+              6.39599609375,
+              7.41162109375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 81,
+            "elapsedSeconds": 12.70720911026001,
+            "loadAverage": [
+              5.37158203125,
+              6.39599609375,
+              7.41162109375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 89,
+            "elapsedSeconds": 14.817098140716553,
+            "loadAverage": [
+              5.26171875,
+              6.35595703125,
+              7.3916015625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 86,
+            "elapsedSeconds": 16.92239809036255,
+            "loadAverage": [
+              5.26171875,
+              6.35595703125,
+              7.3916015625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 86,
+            "elapsedSeconds": 19.030346155166626,
+            "loadAverage": [
+              5.40087890625,
+              6.3662109375,
+              7.38916015625
+            ]
+          }
+        ],
+        "knownRenderingWorkerCount": 0,
+        "maxPressureLevel": 1,
+        "measurementMode": "desktop-load",
+        "peakResidentBytes": 9462693888,
+        "processSeconds": 21.13405704498291,
+        "profiled": false,
+        "prompt": "Write a complete Python implementation of an LRU cache using a dictionary and a doubly linked list, with get and put operations, type hints, and a short usage example. Return the code directly without introductory prose.",
+        "runtimeOverrides": {
+          "MERERUN_Q35_ASYNC_DECODE_BLOCKS": "1",
+          "MERERUN_Q35_MTP_HEAD_COST_RATIO": "0.18",
+          "MERERUN_Q35_MTP_PIPELINED_FALLBACK": "1",
+          "MERERUN_Q35_SCOPED_COMPILE": "1"
+        },
+        "sourceHead": "9319a217579cff3e3bbea002fb93451fe719a868",
+        "startedUnixSeconds": 1788621813.2354639,
+        "uncontended": false,
+        "workload": "code"
+      },
+      "scenarios": [
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 0.9908294243221866
+          },
+          "endToEndSpeedups": {
+            "adaptive": 0.9913776188590493
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 220,
+          "repetition": 1,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 1.8451869487762451,
+              "decodeTokensPerSecond": 138.73932945915476,
+              "elapsedSeconds": 1.9189720153808594,
+              "endToEndTokensPerSecond": 133.4047593962393,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.0074269771575927734,
+              "generatedTokens": 256,
+              "loadSeconds": 5.9604644775390625e-06,
+              "name": "baseline",
+              "outputSHA256": "cd134369dacefc1cc1bc8bceceb5cfb2dc106e35c077361b20e79108d05fabb4",
+              "policy": "disabled",
+              "prefillSeconds": 0.07226800918579102,
+              "prefillTokensPerSecond": 747.2185910251588,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 7693549568,
+              "residentMemoryBeforeBytes": 7693418496,
+              "ttftSeconds": 0.07970094680786133
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.5186721991701245,
+                "acceptedDraftTokens": 125,
+                "draftHistoryTokens": 53,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 241,
+                "rounds": 131,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 1.8622649908065796,
+              "decodeTokensPerSecond": 137.46700993886049,
+              "elapsedSeconds": 1.935662031173706,
+              "endToEndTokensPerSecond": 132.2544927147081,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.00017404556274414062,
+              "generatedTokens": 256,
+              "loadSeconds": 5.9604644775390625e-06,
+              "name": "adaptive",
+              "outputSHA256": "cd134369dacefc1cc1bc8bceceb5cfb2dc106e35c077361b20e79108d05fabb4",
+              "policy": "adaptive",
+              "prefillSeconds": 0.07181298732757568,
+              "prefillTokensPerSecond": 751.9531217059449,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 9462546432,
+              "residentMemoryBeforeBytes": 9462497280,
+              "ttftSeconds": 0.07199299335479736
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 0.955751554872881
+          },
+          "endToEndSpeedups": {
+            "adaptive": 0.9573893593369335
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 220,
+          "repetition": 2,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 1.8309409618377686,
+              "decodeTokensPerSecond": 139.81881739269483,
+              "elapsedSeconds": 1.9049999713897705,
+              "endToEndTokensPerSecond": 134.38320411797076,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.00734400749206543,
+              "generatedTokens": 256,
+              "loadSeconds": 5.9604644775390625e-06,
+              "name": "baseline",
+              "outputSHA256": "cd134369dacefc1cc1bc8bceceb5cfb2dc106e35c077361b20e79108d05fabb4",
+              "policy": "disabled",
+              "prefillSeconds": 0.07248198986053467,
+              "prefillTokensPerSecond": 745.0126590605947,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 7693844480,
+              "residentMemoryBeforeBytes": 7693647872,
+              "ttftSeconds": 0.07983195781707764
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.5186721991701245,
+                "acceptedDraftTokens": 125,
+                "draftHistoryTokens": 53,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 241,
+                "rounds": 131,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 1.915708065032959,
+              "decodeTokensPerSecond": 133.6320521235555,
+              "elapsedSeconds": 1.9897860288619995,
+              "endToEndTokensPerSecond": 128.6570496961484,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0001710653305053711,
+              "generatedTokens": 256,
+              "loadSeconds": 6.9141387939453125e-06,
+              "name": "adaptive",
+              "outputSHA256": "cd134369dacefc1cc1bc8bceceb5cfb2dc106e35c077361b20e79108d05fabb4",
+              "policy": "adaptive",
+              "prefillSeconds": 0.07250797748565674,
+              "prefillTokensPerSecond": 744.7456386530997,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 9462595584,
+              "residentMemoryBeforeBytes": 9462546432,
+              "ttftSeconds": 0.07268595695495605
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 0.9224825188672527
+          },
+          "endToEndSpeedups": {
+            "adaptive": 0.9247339504748578
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 220,
+          "repetition": 3,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 1.774337887763977,
+              "decodeTokensPerSecond": 144.27917127025424,
+              "elapsedSeconds": 1.8480299711227417,
+              "endToEndTokensPerSecond": 138.52589189582852,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.007406949996948242,
+              "generatedTokens": 256,
+              "loadSeconds": 7.033348083496094e-06,
+              "name": "baseline",
+              "outputSHA256": "cd134369dacefc1cc1bc8bceceb5cfb2dc106e35c077361b20e79108d05fabb4",
+              "policy": "disabled",
+              "prefillSeconds": 0.07218503952026367,
+              "prefillTokensPerSecond": 748.0774459483562,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 7694090240,
+              "residentMemoryBeforeBytes": 7693844480,
+              "ttftSeconds": 0.07959902286529541
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.5186721991701245,
+                "acceptedDraftTokens": 125,
+                "draftHistoryTokens": 53,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 241,
+                "rounds": 131,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 1.9234379529953003,
+              "decodeTokensPerSecond": 133.0950133334639,
+              "elapsedSeconds": 1.9984450340270996,
+              "endToEndTokensPerSecond": 128.0995952558826,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0001589059829711914,
+              "generatedTokens": 256,
+              "loadSeconds": 5.9604644775390625e-06,
+              "name": "adaptive",
+              "outputSHA256": "cd134369dacefc1cc1bc8bceceb5cfb2dc106e35c077361b20e79108d05fabb4",
+              "policy": "adaptive",
+              "prefillSeconds": 0.07333493232727051,
+              "prefillTokensPerSecond": 736.3475807002201,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 9462693888,
+              "residentMemoryBeforeBytes": 9462595584,
+              "ttftSeconds": 0.07349979877471924
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        }
+      ]
+    },
+    {
+      "id": "finish-selection/ornith-c18/ornith-prose",
+      "model": "text-agent-ornith-35b-mlx-4bit",
+      "rawReceiptSHA256": "66e0883b3a0752924f6946858ab5a8f95b9ff41f5245f9136017150a4c865351",
+      "receipt": {
+        "after": {
+          "gpuDeviceUtilizationPercent": 88,
+          "loadAverage": [
+            5.6318359375,
+            6.34912109375,
+            7.353515625
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7276.25M  free = 915.75M  (encrypted)",
+          "swapUsedMiB": 7276.25
+        },
+        "before": {
+          "gpuDeviceUtilizationPercent": 0,
+          "loadAverage": [
+            5.40087890625,
+            6.3662109375,
+            7.38916015625
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7276.25M  free = 915.75M  (encrypted)",
+          "swapUsedMiB": 7276.25
+        },
+        "binarySHA256": "cdec91928873110a516e18abcf0db7904cde7398977a7e5b9317c0776a3c1737",
+        "buildSourceRevision": "f847be2ef7ca2f8896829c3cc0b6a1a55ea72ea9",
+        "collectorSHA256": "c5d800333764ac360dd08c27bd99ccf3bc3be6afb203f82ac9fddef41d7ce682",
+        "command": [
+          "mere.run",
+          "model",
+          "benchmark",
+          "q36-mtp",
+          "--model",
+          "text-agent-ornith-35b-mlx-4bit",
+          "--prompt",
+          "Explain how a small community could turn an abandoned railway station into a public library. Discuss the building, accessibility, staffing, the collection, and a realistic opening-day scene. Write approximately 400 words of clear, connected prose.",
+          "--decode-tokens",
+          "256",
+          "--context-size",
+          "8192",
+          "--temperature",
+          "0",
+          "--top-p",
+          "1",
+          "--json",
+          "--variants",
+          "adaptive,baseline",
+          "--warmups",
+          "1",
+          "--warmup-tokens",
+          "256",
+          "--repetitions",
+          "3",
+          "--mtp-block-size",
+          "4"
+        ],
+        "competingInferenceProcessCount": 0,
+        "gpuSamples": [
+          {
+            "deviceUtilizationPercent": 0,
+            "elapsedSeconds": 0.08645415306091309,
+            "loadAverage": [
+              5.40087890625,
+              6.3662109375,
+              7.38916015625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 31,
+            "elapsedSeconds": 2.190883159637451,
+            "loadAverage": [
+              5.60888671875,
+              6.39306640625,
+              7.392578125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 88,
+            "elapsedSeconds": 4.295640230178833,
+            "loadAverage": [
+              5.60888671875,
+              6.39306640625,
+              7.392578125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 91,
+            "elapsedSeconds": 6.402127265930176,
+            "loadAverage": [
+              5.60888671875,
+              6.39306640625,
+              7.392578125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 88,
+            "elapsedSeconds": 8.50639009475708,
+            "loadAverage": [
+              5.47998046875,
+              6.35302734375,
+              7.37255859375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 76,
+            "elapsedSeconds": 10.613569021224976,
+            "loadAverage": [
+              5.47998046875,
+              6.35302734375,
+              7.37255859375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 65,
+            "elapsedSeconds": 12.712785005569458,
+            "loadAverage": [
+              5.841796875,
+              6.4130859375,
+              7.3876953125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 76,
+            "elapsedSeconds": 14.813679218292236,
+            "loadAverage": [
+              5.841796875,
+              6.4130859375,
+              7.3876953125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 83,
+            "elapsedSeconds": 16.918843984603882,
+            "loadAverage": [
+              5.77392578125,
+              6.38916015625,
+              7.37353515625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 82,
+            "elapsedSeconds": 19.038222074508667,
+            "loadAverage": [
+              5.77392578125,
+              6.38916015625,
+              7.37353515625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 83,
+            "elapsedSeconds": 21.148324966430664,
+            "loadAverage": [
+              5.77392578125,
+              6.38916015625,
+              7.37353515625
+            ]
+          }
+        ],
+        "knownRenderingWorkerCount": 0,
+        "maxPressureLevel": 1,
+        "measurementMode": "desktop-load",
+        "peakResidentBytes": 9463054336,
+        "processSeconds": 23.25626015663147,
+        "profiled": false,
+        "prompt": "Explain how a small community could turn an abandoned railway station into a public library. Discuss the building, accessibility, staffing, the collection, and a realistic opening-day scene. Write approximately 400 words of clear, connected prose.",
+        "runtimeOverrides": {
+          "MERERUN_Q35_ASYNC_DECODE_BLOCKS": "1",
+          "MERERUN_Q35_MTP_HEAD_COST_RATIO": "0.18",
+          "MERERUN_Q35_MTP_PIPELINED_FALLBACK": "1",
+          "MERERUN_Q35_SCOPED_COMPILE": "1"
+        },
+        "sourceHead": "9319a217579cff3e3bbea002fb93451fe719a868",
+        "startedUnixSeconds": 1788621834.491798,
+        "uncontended": false,
+        "workload": "prose"
+      },
+      "scenarios": [
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 0.8719640672950005
+          },
+          "endToEndSpeedups": {
+            "adaptive": 0.8759395567474784
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 247,
+          "repetition": 1,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "acceptanceRate": 0.25892857142857145,
+                "acceptedDraftTokens": 29,
+                "draftHistoryTokens": 59,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 112,
+                "rounds": 69,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 2.1430710554122925,
+              "decodeTokensPerSecond": 119.45474199442711,
+              "elapsedSeconds": 2.221827983856201,
+              "endToEndTokensPerSecond": 115.22044094326637,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0003650188446044922,
+              "generatedTokens": 256,
+              "loadSeconds": 6.079673767089844e-06,
+              "name": "adaptive",
+              "outputSHA256": "ca3ac87c453ea9cb8fdd5fe572ce7e0e9930e17487f37393e45606052e4db11e",
+              "policy": "adaptive",
+              "prefillSeconds": 0.07698297500610352,
+              "prefillTokensPerSecond": 779.3931060113351,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 9462743040,
+              "residentMemoryBeforeBytes": 9462415360,
+              "ttftSeconds": 0.0773540735244751
+            },
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 1.8686809539794922,
+              "decodeTokensPerSecond": 136.99502820683722,
+              "elapsedSeconds": 1.9461870193481445,
+              "endToEndTokensPerSecond": 131.53925982187704,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.007520914077758789,
+              "generatedTokens": 256,
+              "loadSeconds": 5.9604644775390625e-06,
+              "name": "baseline",
+              "outputSHA256": "ca3ac87c453ea9cb8fdd5fe572ce7e0e9930e17487f37393e45606052e4db11e",
+              "policy": "disabled",
+              "prefillSeconds": 0.07584500312805176,
+              "prefillTokensPerSecond": 791.0870528767717,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 9332129792,
+              "residentMemoryBeforeBytes": 9332064256,
+              "ttftSeconds": 0.08337187767028809
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 0.9493325516802852
+          },
+          "endToEndSpeedups": {
+            "adaptive": 0.9499885322222813
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 247,
+          "repetition": 2,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "acceptanceRate": 0.25892857142857145,
+                "acceptedDraftTokens": 29,
+                "draftHistoryTokens": 59,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 112,
+                "rounds": 69,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 2.113981008529663,
+              "decodeTokensPerSecond": 121.09853350955865,
+              "elapsedSeconds": 2.1933770179748535,
+              "endToEndTokensPerSecond": 116.71500061415112,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.00016307830810546875,
+              "generatedTokens": 256,
+              "loadSeconds": 5.9604644775390625e-06,
+              "name": "adaptive",
+              "outputSHA256": "ca3ac87c453ea9cb8fdd5fe572ce7e0e9930e17487f37393e45606052e4db11e",
+              "policy": "adaptive",
+              "prefillSeconds": 0.0777510404586792,
+              "prefillTokensPerSecond": 771.6938531759843,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 9462956032,
+              "residentMemoryBeforeBytes": 9462841344,
+              "ttftSeconds": 0.07792007923126221
+            },
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 2.006870985031128,
+              "decodeTokensPerSecond": 127.5617625195918,
+              "elapsedSeconds": 2.0836830139160156,
+              "endToEndTokensPerSecond": 122.85937846125681,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.008145928382873535,
+              "generatedTokens": 256,
+              "loadSeconds": 5.9604644775390625e-06,
+              "name": "baseline",
+              "outputSHA256": "ca3ac87c453ea9cb8fdd5fe572ce7e0e9930e17487f37393e45606052e4db11e",
+              "policy": "disabled",
+              "prefillSeconds": 0.07517600059509277,
+              "prefillTokensPerSecond": 798.127055510274,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 9332162560,
+              "residentMemoryBeforeBytes": 9332129792,
+              "ttftSeconds": 0.08332788944244385
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 0.9290656070891764
+          },
+          "endToEndSpeedups": {
+            "adaptive": 0.9322534747827848
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 247,
+          "repetition": 3,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "acceptanceRate": 0.25892857142857145,
+                "acceptedDraftTokens": 29,
+                "draftHistoryTokens": 59,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 112,
+                "rounds": 69,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 2.150523066520691,
+              "decodeTokensPerSecond": 119.04080639050282,
+              "elapsedSeconds": 2.2277320623397827,
+              "endToEndTokensPerSecond": 114.91507633603105,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.00031304359436035156,
+              "generatedTokens": 256,
+              "loadSeconds": 5.9604644775390625e-06,
+              "name": "adaptive",
+              "outputSHA256": "ca3ac87c453ea9cb8fdd5fe572ce7e0e9930e17487f37393e45606052e4db11e",
+              "policy": "adaptive",
+              "prefillSeconds": 0.07560300827026367,
+              "prefillTokensPerSecond": 793.6192140068496,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 9463054336,
+              "residentMemoryBeforeBytes": 9462956032,
+              "ttftSeconds": 0.07592201232910156
+            },
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 1.9979770183563232,
+              "decodeTokensPerSecond": 128.1296019163442,
+              "elapsedSeconds": 2.0768109560012817,
+              "endToEndTokensPerSecond": 123.26591366452807,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.00781095027923584,
+              "generatedTokens": 256,
+              "loadSeconds": 6.079673767089844e-06,
+              "name": "baseline",
+              "outputSHA256": "ca3ac87c453ea9cb8fdd5fe572ce7e0e9930e17487f37393e45606052e4db11e",
+              "policy": "disabled",
+              "prefillSeconds": 0.07689595222473145,
+              "prefillTokensPerSecond": 780.2751414619022,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 9332178944,
+              "residentMemoryBeforeBytes": 9332162560,
+              "ttftSeconds": 0.08471298217773438
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        }
+      ]
+    },
+    {
+      "id": "finish-selection/ornith-c35/ornith-code",
+      "model": "text-agent-ornith-35b-mlx-4bit",
+      "rawReceiptSHA256": "49aea00f60c4eb706de442673fe11ea4e08ecf5761a21128f14ef66c5f10e656",
+      "receipt": {
+        "after": {
+          "gpuDeviceUtilizationPercent": 85,
+          "loadAverage": [
+            6.79931640625,
+            6.568359375,
+            7.408203125
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7276.25M  free = 915.75M  (encrypted)",
+          "swapUsedMiB": 7276.25
+        },
+        "before": {
+          "gpuDeviceUtilizationPercent": 0,
+          "loadAverage": [
+            5.6318359375,
+            6.34912109375,
+            7.353515625
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7276.25M  free = 915.75M  (encrypted)",
+          "swapUsedMiB": 7276.25
+        },
+        "binarySHA256": "cdec91928873110a516e18abcf0db7904cde7398977a7e5b9317c0776a3c1737",
+        "buildSourceRevision": "f847be2ef7ca2f8896829c3cc0b6a1a55ea72ea9",
+        "collectorSHA256": "c5d800333764ac360dd08c27bd99ccf3bc3be6afb203f82ac9fddef41d7ce682",
+        "command": [
+          "mere.run",
+          "model",
+          "benchmark",
+          "q36-mtp",
+          "--model",
+          "text-agent-ornith-35b-mlx-4bit",
+          "--prompt",
+          "Write a complete Python implementation of an LRU cache using a dictionary and a doubly linked list, with get and put operations, type hints, and a short usage example. Return the code directly without introductory prose.",
+          "--decode-tokens",
+          "256",
+          "--context-size",
+          "8192",
+          "--temperature",
+          "0",
+          "--top-p",
+          "1",
+          "--json",
+          "--variants",
+          "baseline,adaptive",
+          "--warmups",
+          "1",
+          "--warmup-tokens",
+          "256",
+          "--repetitions",
+          "3",
+          "--mtp-block-size",
+          "4"
+        ],
+        "competingInferenceProcessCount": 0,
+        "gpuSamples": [
+          {
+            "deviceUtilizationPercent": 0,
+            "elapsedSeconds": 0.08911299705505371,
+            "loadAverage": [
+              5.6318359375,
+              6.34912109375,
+              7.353515625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 52,
+            "elapsedSeconds": 2.194761037826538,
+            "loadAverage": [
+              5.6318359375,
+              6.34912109375,
+              7.353515625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 77,
+            "elapsedSeconds": 4.3024938106536865,
+            "loadAverage": [
+              6.1416015625,
+              6.44287109375,
+              7.38037109375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 66,
+            "elapsedSeconds": 6.414725065231323,
+            "loadAverage": [
+              6.1416015625,
+              6.44287109375,
+              7.38037109375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 86,
+            "elapsedSeconds": 8.519077062606812,
+            "loadAverage": [
+              6.2900390625,
+              6.46826171875,
+              7.3837890625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 98,
+            "elapsedSeconds": 10.614816904067993,
+            "loadAverage": [
+              6.2900390625,
+              6.46826171875,
+              7.3837890625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 67,
+            "elapsedSeconds": 12.72452712059021,
+            "loadAverage": [
+              6.2900390625,
+              6.46826171875,
+              7.3837890625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 88,
+            "elapsedSeconds": 14.835228204727173,
+            "loadAverage": [
+              6.3466796875,
+              6.47705078125,
+              7.38134765625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 86,
+            "elapsedSeconds": 16.95377516746521,
+            "loadAverage": [
+              6.3466796875,
+              6.47705078125,
+              7.38134765625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 79,
+            "elapsedSeconds": 19.067198038101196,
+            "loadAverage": [
+              6.79931640625,
+              6.568359375,
+              7.408203125
+            ]
+          }
+        ],
+        "knownRenderingWorkerCount": 0,
+        "maxPressureLevel": 1,
+        "measurementMode": "desktop-load",
+        "peakResidentBytes": 9467527168,
+        "processSeconds": 21.17357587814331,
+        "profiled": false,
+        "prompt": "Write a complete Python implementation of an LRU cache using a dictionary and a doubly linked list, with get and put operations, type hints, and a short usage example. Return the code directly without introductory prose.",
+        "runtimeOverrides": {
+          "MERERUN_Q35_ASYNC_DECODE_BLOCKS": "1",
+          "MERERUN_Q35_MTP_HEAD_COST_RATIO": "0.35",
+          "MERERUN_Q35_MTP_PIPELINED_FALLBACK": "1",
+          "MERERUN_Q35_SCOPED_COMPILE": "1"
+        },
+        "sourceHead": "9319a217579cff3e3bbea002fb93451fe719a868",
+        "startedUnixSeconds": 1788621857.881758,
+        "uncontended": false,
+        "workload": "code"
+      },
+      "scenarios": [
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 1.0940898949345736
+          },
+          "endToEndSpeedups": {
+            "adaptive": 1.090033853747573
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 220,
+          "repetition": 1,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 1.9861888885498047,
+              "decodeTokensPerSecond": 128.89005747429982,
+              "elapsedSeconds": 2.060573935508728,
+              "endToEndTokensPerSecond": 124.23723099108163,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.00848388671875,
+              "generatedTokens": 256,
+              "loadSeconds": 5.9604644775390625e-06,
+              "name": "baseline",
+              "outputSHA256": "cd134369dacefc1cc1bc8bceceb5cfb2dc106e35c077361b20e79108d05fabb4",
+              "policy": "disabled",
+              "prefillSeconds": 0.07282507419586182,
+              "prefillTokensPerSecond": 741.5028490704714,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 7684620288,
+              "residentMemoryBeforeBytes": 7684341760,
+              "ttftSeconds": 0.08131492137908936
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.6097560975609756,
+                "acceptedDraftTokens": 125,
+                "draftHistoryTokens": 53,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 205,
+                "rounds": 130,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 1.8153799772262573,
+              "decodeTokensPerSecond": 141.01730944016785,
+              "elapsedSeconds": 1.890376091003418,
+              "endToEndTokensPerSecond": 135.4227876761361,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.00020396709442138672,
+              "generatedTokens": 256,
+              "loadSeconds": 5.9604644775390625e-06,
+              "name": "adaptive",
+              "outputSHA256": "cd134369dacefc1cc1bc8bceceb5cfb2dc106e35c077361b20e79108d05fabb4",
+              "policy": "adaptive",
+              "prefillSeconds": 0.07333004474639893,
+              "prefillTokensPerSecond": 736.3966596059089,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 9467412480,
+              "residentMemoryBeforeBytes": 9467346944,
+              "ttftSeconds": 0.07353997230529785
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 0.9023155041251927
+          },
+          "endToEndSpeedups": {
+            "adaptive": 0.9033363554453183
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 220,
+          "repetition": 2,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 1.8812980651855469,
+              "decodeTokensPerSecond": 136.07625752528028,
+              "elapsedSeconds": 1.954930067062378,
+              "endToEndTokensPerSecond": 130.9509758498341,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.007853031158447266,
+              "generatedTokens": 256,
+              "loadSeconds": 7.033348083496094e-06,
+              "name": "baseline",
+              "outputSHA256": "cd134369dacefc1cc1bc8bceceb5cfb2dc106e35c077361b20e79108d05fabb4",
+              "policy": "disabled",
+              "prefillSeconds": 0.0721750259399414,
+              "prefillTokensPerSecond": 748.1812343917231,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 7685128192,
+              "residentMemoryBeforeBytes": 7684718592,
+              "ttftSeconds": 0.08003509044647217
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.6097560975609756,
+                "acceptedDraftTokens": 125,
+                "draftHistoryTokens": 53,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 205,
+                "rounds": 130,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 2.084967017173767,
+              "decodeTokensPerSecond": 122.78371690839282,
+              "elapsedSeconds": 2.164121985435486,
+              "endToEndTokensPerSecond": 118.29277726619702,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.00020003318786621094,
+              "generatedTokens": 256,
+              "loadSeconds": 9.059906005859375e-06,
+              "name": "adaptive",
+              "outputSHA256": "cd134369dacefc1cc1bc8bceceb5cfb2dc106e35c077361b20e79108d05fabb4",
+              "policy": "adaptive",
+              "prefillSeconds": 0.07732093334197998,
+              "prefillTokensPerSecond": 698.3878448694526,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 9467461632,
+              "residentMemoryBeforeBytes": 9467412480,
+              "ttftSeconds": 0.07753002643585205
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 0.9583593961964133
+          },
+          "endToEndSpeedups": {
+            "adaptive": 0.9573203954950966
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 220,
+          "repetition": 3,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 1.8140190839767456,
+              "decodeTokensPerSecond": 141.1231018798266,
+              "elapsedSeconds": 1.8873590230941772,
+              "endToEndTokensPerSecond": 135.63926993620328,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.007634997367858887,
+              "generatedTokens": 256,
+              "loadSeconds": 5.9604644775390625e-06,
+              "name": "baseline",
+              "outputSHA256": "cd134369dacefc1cc1bc8bceceb5cfb2dc106e35c077361b20e79108d05fabb4",
+              "policy": "disabled",
+              "prefillSeconds": 0.07190501689910889,
+              "prefillTokensPerSecond": 750.9907142608462,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 7685308416,
+              "residentMemoryBeforeBytes": 7685128192,
+              "ttftSeconds": 0.07954597473144531
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.6097560975609756,
+                "acceptedDraftTokens": 125,
+                "draftHistoryTokens": 53,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 205,
+                "rounds": 130,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 1.8928380012512207,
+              "decodeTokensPerSecond": 135.24665070691555,
+              "elapsedSeconds": 1.9715019464492798,
+              "endToEndTokensPerSecond": 129.8502395399923,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0002410411834716797,
+              "generatedTokens": 256,
+              "loadSeconds": 9.059906005859375e-06,
+              "name": "adaptive",
+              "outputSHA256": "cd134369dacefc1cc1bc8bceceb5cfb2dc106e35c077361b20e79108d05fabb4",
+              "policy": "adaptive",
+              "prefillSeconds": 0.07664299011230469,
+              "prefillTokensPerSecond": 704.5654132344524,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 9467527168,
+              "residentMemoryBeforeBytes": 9467461632,
+              "ttftSeconds": 0.07689309120178223
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        }
+      ]
+    },
+    {
+      "id": "finish-selection/ornith-c35/ornith-prose",
+      "model": "text-agent-ornith-35b-mlx-4bit",
+      "rawReceiptSHA256": "8f2cd3cdbaad81517a5df24812258b42ba0d4933f3fecfa7080111270102c728",
+      "receipt": {
+        "after": {
+          "gpuDeviceUtilizationPercent": 72,
+          "loadAverage": [
+            6.60400390625,
+            6.55078125,
+            7.37744140625
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7276.25M  free = 915.75M  (encrypted)",
+          "swapUsedMiB": 7276.25
+        },
+        "before": {
+          "gpuDeviceUtilizationPercent": 0,
+          "loadAverage": [
+            6.79931640625,
+            6.568359375,
+            7.408203125
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7276.25M  free = 915.75M  (encrypted)",
+          "swapUsedMiB": 7276.25
+        },
+        "binarySHA256": "cdec91928873110a516e18abcf0db7904cde7398977a7e5b9317c0776a3c1737",
+        "buildSourceRevision": "f847be2ef7ca2f8896829c3cc0b6a1a55ea72ea9",
+        "collectorSHA256": "c5d800333764ac360dd08c27bd99ccf3bc3be6afb203f82ac9fddef41d7ce682",
+        "command": [
+          "mere.run",
+          "model",
+          "benchmark",
+          "q36-mtp",
+          "--model",
+          "text-agent-ornith-35b-mlx-4bit",
+          "--prompt",
+          "Explain how a small community could turn an abandoned railway station into a public library. Discuss the building, accessibility, staffing, the collection, and a realistic opening-day scene. Write approximately 400 words of clear, connected prose.",
+          "--decode-tokens",
+          "256",
+          "--context-size",
+          "8192",
+          "--temperature",
+          "0",
+          "--top-p",
+          "1",
+          "--json",
+          "--variants",
+          "adaptive,baseline",
+          "--warmups",
+          "1",
+          "--warmup-tokens",
+          "256",
+          "--repetitions",
+          "3",
+          "--mtp-block-size",
+          "4"
+        ],
+        "competingInferenceProcessCount": 0,
+        "gpuSamples": [
+          {
+            "deviceUtilizationPercent": 0,
+            "elapsedSeconds": 0.09021329879760742,
+            "loadAverage": [
+              6.79931640625,
+              6.568359375,
+              7.408203125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 29,
+            "elapsedSeconds": 2.1937642097473145,
+            "loadAverage": [
+              7.21533203125,
+              6.658203125,
+              7.43505859375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 73,
+            "elapsedSeconds": 4.302427291870117,
+            "loadAverage": [
+              7.21533203125,
+              6.658203125,
+              7.43505859375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 85,
+            "elapsedSeconds": 6.408513069152832,
+            "loadAverage": [
+              7.21533203125,
+              6.658203125,
+              7.43505859375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 80,
+            "elapsedSeconds": 8.53226923942566,
+            "loadAverage": [
+              7.03759765625,
+              6.63037109375,
+              7.42041015625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 83,
+            "elapsedSeconds": 10.644622087478638,
+            "loadAverage": [
+              7.03759765625,
+              6.63037109375,
+              7.42041015625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 77,
+            "elapsedSeconds": 12.743419170379639,
+            "loadAverage": [
+              6.7939453125,
+              6.58642578125,
+              7.39990234375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 81,
+            "elapsedSeconds": 14.848475217819214,
+            "loadAverage": [
+              6.7939453125,
+              6.58642578125,
+              7.39990234375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 83,
+            "elapsedSeconds": 16.991605043411255,
+            "loadAverage": [
+              6.7939453125,
+              6.58642578125,
+              7.39990234375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 80,
+            "elapsedSeconds": 19.12017822265625,
+            "loadAverage": [
+              6.56982421875,
+              6.54345703125,
+              7.3798828125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 80,
+            "elapsedSeconds": 21.241218090057373,
+            "loadAverage": [
+              6.56982421875,
+              6.54345703125,
+              7.3798828125
+            ]
+          }
+        ],
+        "knownRenderingWorkerCount": 0,
+        "maxPressureLevel": 1,
+        "measurementMode": "desktop-load",
+        "peakResidentBytes": 9462972416,
+        "processSeconds": 23.360762119293213,
+        "profiled": false,
+        "prompt": "Explain how a small community could turn an abandoned railway station into a public library. Discuss the building, accessibility, staffing, the collection, and a realistic opening-day scene. Write approximately 400 words of clear, connected prose.",
+        "runtimeOverrides": {
+          "MERERUN_Q35_ASYNC_DECODE_BLOCKS": "1",
+          "MERERUN_Q35_MTP_HEAD_COST_RATIO": "0.35",
+          "MERERUN_Q35_MTP_PIPELINED_FALLBACK": "1",
+          "MERERUN_Q35_SCOPED_COMPILE": "1"
+        },
+        "sourceHead": "9319a217579cff3e3bbea002fb93451fe719a868",
+        "startedUnixSeconds": 1788621879.1798248,
+        "uncontended": false,
+        "workload": "prose"
+      },
+      "scenarios": [
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 1.1410732342359655
+          },
+          "endToEndSpeedups": {
+            "adaptive": 1.1369387338834978
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 247,
+          "repetition": 1,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "acceptanceRate": 0.35135135135135137,
+                "acceptedDraftTokens": 13,
+                "draftHistoryTokens": 59,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 37,
+                "rounds": 27,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 2.004284977912903,
+              "decodeTokensPerSecond": 127.7263477105822,
+              "elapsedSeconds": 2.082953929901123,
+              "endToEndTokensPerSecond": 122.90238220110429,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.00035393238067626953,
+              "generatedTokens": 256,
+              "loadSeconds": 6.079673767089844e-06,
+              "name": "adaptive",
+              "outputSHA256": "ca3ac87c453ea9cb8fdd5fe572ce7e0e9930e17487f37393e45606052e4db11e",
+              "policy": "adaptive",
+              "prefillSeconds": 0.07696199417114258,
+              "prefillTokensPerSecond": 779.605578651929,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 9462595584,
+              "residentMemoryBeforeBytes": 9462431744,
+              "ttftSeconds": 0.07732200622558594
+            },
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 2.2870359420776367,
+              "decodeTokensPerSecond": 111.93527626305652,
+              "elapsedSeconds": 2.3681910037994385,
+              "endToEndTokensPerSecond": 108.09938876943752,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.007764935493469238,
+              "generatedTokens": 256,
+              "loadSeconds": 5.9604644775390625e-06,
+              "name": "baseline",
+              "outputSHA256": "ca3ac87c453ea9cb8fdd5fe572ce7e0e9930e17487f37393e45606052e4db11e",
+              "policy": "disabled",
+              "prefillSeconds": 0.07937800884246826,
+              "prefillTokensPerSecond": 755.8768590312538,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 9333374976,
+              "residentMemoryBeforeBytes": 9333358592,
+              "ttftSeconds": 0.08714890480041504
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 1.0226831934141067
+          },
+          "endToEndSpeedups": {
+            "adaptive": 1.0269078496183501
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 247,
+          "repetition": 2,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "acceptanceRate": 0.35135135135135137,
+                "acceptedDraftTokens": 13,
+                "draftHistoryTokens": 59,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 37,
+                "rounds": 27,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 2.204231023788452,
+              "decodeTokensPerSecond": 116.1402762401956,
+              "elapsedSeconds": 2.2830159664154053,
+              "endToEndTokensPerSecond": 112.1323739149968,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.00017702579498291016,
+              "generatedTokens": 256,
+              "loadSeconds": 5.9604644775390625e-06,
+              "name": "adaptive",
+              "outputSHA256": "ca3ac87c453ea9cb8fdd5fe572ce7e0e9930e17487f37393e45606052e4db11e",
+              "policy": "adaptive",
+              "prefillSeconds": 0.07688391208648682,
+              "prefillTokensPerSecond": 780.397333742668,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 9462857728,
+              "residentMemoryBeforeBytes": 9462693888,
+              "ttftSeconds": 0.07706689834594727
+            },
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 2.25423002243042,
+              "decodeTokensPerSecond": 113.56427580712953,
+              "elapsedSeconds": 2.3444470167160034,
+              "endToEndTokensPerSecond": 109.19419299080316,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.00899207592010498,
+              "generatedTokens": 256,
+              "loadSeconds": 7.987022399902344e-06,
+              "name": "baseline",
+              "outputSHA256": "ca3ac87c453ea9cb8fdd5fe572ce7e0e9930e17487f37393e45606052e4db11e",
+              "policy": "disabled",
+              "prefillSeconds": 0.08819401264190674,
+              "prefillTokensPerSecond": 680.3182914878519,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 9333391360,
+              "residentMemoryBeforeBytes": 9333374976,
+              "ttftSeconds": 0.09719407558441162
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 0.9746427989289399
+          },
+          "endToEndSpeedups": {
+            "adaptive": 0.9765837767275062
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 247,
+          "repetition": 3,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "acceptanceRate": 0.35135135135135137,
+                "acceptedDraftTokens": 13,
+                "draftHistoryTokens": 59,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 37,
+                "rounds": 27,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 2.3322750329971313,
+              "decodeTokensPerSecond": 109.76407000808248,
+              "elapsedSeconds": 2.41703999042511,
+              "endToEndTokensPerSecond": 105.91467291154527,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.00039398670196533203,
+              "generatedTokens": 256,
+              "loadSeconds": 7.987022399902344e-06,
+              "name": "adaptive",
+              "outputSHA256": "ca3ac87c453ea9cb8fdd5fe572ce7e0e9930e17487f37393e45606052e4db11e",
+              "policy": "adaptive",
+              "prefillSeconds": 0.08265900611877441,
+              "prefillTokensPerSecond": 725.8737168190091,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 9462972416,
+              "residentMemoryBeforeBytes": 9462857728,
+              "ttftSeconds": 0.08306097984313965
+            },
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 2.2731350660324097,
+              "decodeTokensPerSecond": 112.6197927370982,
+              "elapsedSeconds": 2.360442042350769,
+              "endToEndTokensPerSecond": 108.45426212839739,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.00869607925415039,
+              "generatedTokens": 256,
+              "loadSeconds": 8.940696716308594e-06,
+              "name": "baseline",
+              "outputSHA256": "ca3ac87c453ea9cb8fdd5fe572ce7e0e9930e17487f37393e45606052e4db11e",
+              "policy": "disabled",
+              "prefillSeconds": 0.08537507057189941,
+              "prefillTokensPerSecond": 702.7812638757404,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 9333473280,
+              "residentMemoryBeforeBytes": 9333391360,
+              "ttftSeconds": 0.09408009052276611
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        }
+      ]
+    },
+    {
+      "id": "finish-selection/ornith-current/ornith-code",
+      "model": "text-agent-ornith-35b-mlx-4bit",
+      "rawReceiptSHA256": "cb6c69a11fa006a86c4298673d89b7f1737867ac2c5feeee2030c6607fbde952",
+      "receipt": {
+        "after": {
+          "gpuDeviceUtilizationPercent": 67,
+          "loadAverage": [
+            6.4990234375,
+            6.76904296875,
+            7.63037109375
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7284.25M  free = 907.75M  (encrypted)",
+          "swapUsedMiB": 7284.25
+        },
+        "before": {
+          "gpuDeviceUtilizationPercent": 33,
+          "loadAverage": [
+            5.826171875,
+            6.958984375,
+            7.78515625
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7284.25M  free = 907.75M  (encrypted)",
+          "swapUsedMiB": 7284.25
+        },
+        "binarySHA256": "cdec91928873110a516e18abcf0db7904cde7398977a7e5b9317c0776a3c1737",
+        "buildSourceRevision": "f847be2ef7ca2f8896829c3cc0b6a1a55ea72ea9",
+        "collectorSHA256": "c5d800333764ac360dd08c27bd99ccf3bc3be6afb203f82ac9fddef41d7ce682",
+        "command": [
+          "mere.run",
+          "model",
+          "benchmark",
+          "q36-mtp",
+          "--model",
+          "text-agent-ornith-35b-mlx-4bit",
+          "--prompt",
+          "Write a complete Python implementation of an LRU cache using a dictionary and a doubly linked list, with get and put operations, type hints, and a short usage example. Return the code directly without introductory prose.",
+          "--decode-tokens",
+          "256",
+          "--context-size",
+          "8192",
+          "--temperature",
+          "0",
+          "--top-p",
+          "1",
+          "--json",
+          "--variants",
+          "baseline,adaptive",
+          "--warmups",
+          "1",
+          "--warmup-tokens",
+          "256",
+          "--repetitions",
+          "3",
+          "--mtp-block-size",
+          "4"
+        ],
+        "competingInferenceProcessCount": 0,
+        "gpuSamples": [
+          {
+            "deviceUtilizationPercent": 0,
+            "elapsedSeconds": 0.08044600486755371,
+            "loadAverage": [
+              5.826171875,
+              6.958984375,
+              7.78515625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 0,
+            "elapsedSeconds": 2.1741960048675537,
+            "loadAverage": [
+              5.826171875,
+              6.958984375,
+              7.78515625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 6,
+            "elapsedSeconds": 4.268815040588379,
+            "loadAverage": [
+              5.439453125,
+              6.85986328125,
+              7.7451171875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 8,
+            "elapsedSeconds": 6.354426860809326,
+            "loadAverage": [
+              5.439453125,
+              6.85986328125,
+              7.7451171875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 2,
+            "elapsedSeconds": 8.446568965911865,
+            "loadAverage": [
+              5.16357421875,
+              6.77880859375,
+              7.71142578125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 2,
+            "elapsedSeconds": 10.538522005081177,
+            "loadAverage": [
+              5.16357421875,
+              6.77880859375,
+              7.71142578125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 1,
+            "elapsedSeconds": 12.627027034759521,
+            "loadAverage": [
+              5.16357421875,
+              6.77880859375,
+              7.71142578125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 21,
+            "elapsedSeconds": 14.722172975540161,
+            "loadAverage": [
+              4.91015625,
+              6.69921875,
+              7.677734375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 7,
+            "elapsedSeconds": 16.810291051864624,
+            "loadAverage": [
+              4.91015625,
+              6.69921875,
+              7.677734375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 66,
+            "elapsedSeconds": 18.90547800064087,
+            "loadAverage": [
+              4.5966796875,
+              6.6044921875,
+              7.63818359375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 74,
+            "elapsedSeconds": 21.000041961669922,
+            "loadAverage": [
+              4.5966796875,
+              6.6044921875,
+              7.63818359375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 73,
+            "elapsedSeconds": 23.091065883636475,
+            "loadAverage": [
+              4.62890625,
+              6.57763671875,
+              7.62255859375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 61,
+            "elapsedSeconds": 25.18607997894287,
+            "loadAverage": [
+              4.62890625,
+              6.57763671875,
+              7.62255859375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 51,
+            "elapsedSeconds": 27.282843828201294,
+            "loadAverage": [
+              4.62890625,
+              6.57763671875,
+              7.62255859375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 58,
+            "elapsedSeconds": 29.378443956375122,
+            "loadAverage": [
+              4.8984375,
+              6.60107421875,
+              7.62451171875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 54,
+            "elapsedSeconds": 31.473056077957153,
+            "loadAverage": [
+              4.8984375,
+              6.60107421875,
+              7.62451171875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 51,
+            "elapsedSeconds": 33.571044921875,
+            "loadAverage": [
+              4.666015625,
+              6.5244140625,
+              7.59130859375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 61,
+            "elapsedSeconds": 35.665650844573975,
+            "loadAverage": [
+              4.666015625,
+              6.5244140625,
+              7.59130859375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 46,
+            "elapsedSeconds": 37.76602506637573,
+            "loadAverage": [
+              4.666015625,
+              6.5244140625,
+              7.59130859375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 46,
+            "elapsedSeconds": 39.859127044677734,
+            "loadAverage": [
+              5.0126953125,
+              6.5654296875,
+              7.59912109375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 48,
+            "elapsedSeconds": 41.95647692680359,
+            "loadAverage": [
+              5.0126953125,
+              6.5654296875,
+              7.59912109375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 49,
+            "elapsedSeconds": 44.05706000328064,
+            "loadAverage": [
+              5.41162109375,
+              6.6220703125,
+              7.61279296875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 50,
+            "elapsedSeconds": 46.1512770652771,
+            "loadAverage": [
+              5.41162109375,
+              6.6220703125,
+              7.61279296875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 47,
+            "elapsedSeconds": 48.24592590332031,
+            "loadAverage": [
+              5.61865234375,
+              6.64453125,
+              7.61474609375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 34,
+            "elapsedSeconds": 50.34685492515564,
+            "loadAverage": [
+              5.61865234375,
+              6.64453125,
+              7.61474609375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 14,
+            "elapsedSeconds": 52.44521713256836,
+            "loadAverage": [
+              5.61865234375,
+              6.64453125,
+              7.61474609375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 54,
+            "elapsedSeconds": 54.54545211791992,
+            "loadAverage": [
+              5.80908203125,
+              6.6669921875,
+              7.61669921875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 60,
+            "elapsedSeconds": 56.64780902862549,
+            "loadAverage": [
+              5.80908203125,
+              6.6669921875,
+              7.61669921875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 50,
+            "elapsedSeconds": 58.74777913093567,
+            "loadAverage": [
+              6.064453125,
+              6.70556640625,
+              7.62451171875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 49,
+            "elapsedSeconds": 60.8488450050354,
+            "loadAverage": [
+              6.064453125,
+              6.70556640625,
+              7.62451171875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 67,
+            "elapsedSeconds": 62.951130867004395,
+            "loadAverage": [
+              6.064453125,
+              6.70556640625,
+              7.62451171875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 68,
+            "elapsedSeconds": 65.04809808731079,
+            "loadAverage": [
+              6.21923828125,
+              6.72705078125,
+              7.62646484375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 43,
+            "elapsedSeconds": 67.14617896080017,
+            "loadAverage": [
+              6.21923828125,
+              6.72705078125,
+              7.62646484375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 45,
+            "elapsedSeconds": 69.24268174171448,
+            "loadAverage": [
+              6.28173828125,
+              6.7314453125,
+              7.62255859375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 46,
+            "elapsedSeconds": 71.34277892112732,
+            "loadAverage": [
+              6.28173828125,
+              6.7314453125,
+              7.62255859375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 69,
+            "elapsedSeconds": 73.4442949295044,
+            "loadAverage": [
+              6.4990234375,
+              6.76904296875,
+              7.63037109375
+            ]
+          }
+        ],
+        "knownRenderingWorkerCount": 0,
+        "maxPressureLevel": 1,
+        "measurementMode": "desktop-load",
+        "peakResidentBytes": 9465626624,
+        "processSeconds": 75.56408905982971,
+        "profiled": false,
+        "prompt": "Write a complete Python implementation of an LRU cache using a dictionary and a doubly linked list, with get and put operations, type hints, and a short usage example. Return the code directly without introductory prose.",
+        "runtimeOverrides": {
+          "MERERUN_Q35_ASYNC_DECODE_BLOCKS": "0",
+          "MERERUN_Q35_MTP_HEAD_COST_RATIO": "0.18",
+          "MERERUN_Q35_MTP_PIPELINED_FALLBACK": "0",
+          "MERERUN_Q35_SCOPED_COMPILE": "0"
+        },
+        "sourceHead": "9319a217579cff3e3bbea002fb93451fe719a868",
+        "startedUnixSeconds": 1788621668.162966,
+        "uncontended": false,
+        "workload": "code"
+      },
+      "scenarios": [
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 1.0145822943673193
+          },
+          "endToEndSpeedups": {
+            "adaptive": 0.9962947392324731
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 220,
+          "repetition": 1,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 2.753132939338684,
+              "decodeTokensPerSecond": 92.98497589494986,
+              "elapsedSeconds": 2.8493560552597046,
+              "endToEndTokensPerSecond": 89.8448614477094,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.010051965713500977,
+              "generatedTokens": 256,
+              "loadSeconds": 5.0067901611328125e-06,
+              "name": "baseline",
+              "outputSHA256": "cd134369dacefc1cc1bc8bceceb5cfb2dc106e35c077361b20e79108d05fabb4",
+              "policy": "disabled",
+              "prefillSeconds": 0.09485197067260742,
+              "prefillTokensPerSecond": 569.308150553743,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 7681687552,
+              "residentMemoryBeforeBytes": 7681294336,
+              "ttftSeconds": 0.10490894317626953
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.5186721991701245,
+                "acceptedDraftTokens": 125,
+                "draftHistoryTokens": 53,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 241,
+                "rounds": 131,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 2.7135629653930664,
+              "decodeTokensPerSecond": 94.34091018518811,
+              "elapsedSeconds": 2.859952926635742,
+              "endToEndTokensPerSecond": 89.51196280742332,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0004099607467651367,
+              "generatedTokens": 256,
+              "loadSeconds": 6.079673767089844e-06,
+              "name": "adaptive",
+              "outputSHA256": "cd134369dacefc1cc1bc8bceceb5cfb2dc106e35c077361b20e79108d05fabb4",
+              "policy": "adaptive",
+              "prefillSeconds": 0.14471793174743652,
+              "prefillTokensPerSecond": 373.1396610493401,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 9465331712,
+              "residentMemoryBeforeBytes": 9465167872,
+              "ttftSeconds": 0.14513397216796875
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 1.4587341633593276
+          },
+          "endToEndSpeedups": {
+            "adaptive": 1.4522251372150823
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 220,
+          "repetition": 2,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 11.044227957725525,
+              "decodeTokensPerSecond": 23.179528798201414,
+              "elapsedSeconds": 11.159536957740784,
+              "endToEndTokensPerSecond": 22.940019910272913,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.035768985748291016,
+              "generatedTokens": 256,
+              "loadSeconds": 6.079673767089844e-06,
+              "name": "baseline",
+              "outputSHA256": "cd134369dacefc1cc1bc8bceceb5cfb2dc106e35c077361b20e79108d05fabb4",
+              "policy": "disabled",
+              "prefillSeconds": 0.11391401290893555,
+              "prefillTokensPerSecond": 474.0417673036271,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 7681900544,
+              "residentMemoryBeforeBytes": 7681785856,
+              "ttftSeconds": 0.14968907833099365
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.5186721991701245,
+                "acceptedDraftTokens": 125,
+                "draftHistoryTokens": 53,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 241,
+                "rounds": 131,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 7.571103930473328,
+              "decodeTokensPerSecond": 33.81277054850778,
+              "elapsedSeconds": 7.684440016746521,
+              "endToEndTokensPerSecond": 33.3140735619128,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0001779794692993164,
+              "generatedTokens": 256,
+              "loadSeconds": 6.9141387939453125e-06,
+              "name": "adaptive",
+              "outputSHA256": "cd134369dacefc1cc1bc8bceceb5cfb2dc106e35c077361b20e79108d05fabb4",
+              "policy": "adaptive",
+              "prefillSeconds": 0.11170697212219238,
+              "prefillTokensPerSecond": 483.40760629454064,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 9465495552,
+              "residentMemoryBeforeBytes": 9465331712,
+              "ttftSeconds": 0.11189186573028564
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 5.684248955463109
+          },
+          "endToEndSpeedups": {
+            "adaptive": 5.457757220444022
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 220,
+          "repetition": 3,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 14.967503070831299,
+              "decodeTokensPerSecond": 17.103721227817438,
+              "elapsedSeconds": 15.104926943778992,
+              "endToEndTokensPerSecond": 16.948112424034885,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.0425419807434082,
+              "generatedTokens": 256,
+              "loadSeconds": 6.079673767089844e-06,
+              "name": "baseline",
+              "outputSHA256": "cd134369dacefc1cc1bc8bceceb5cfb2dc106e35c077361b20e79108d05fabb4",
+              "policy": "disabled",
+              "prefillSeconds": 0.1359950304031372,
+              "prefillTokensPerSecond": 397.0733330469868,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 7682375680,
+              "residentMemoryBeforeBytes": 7681900544,
+              "ttftSeconds": 0.1785430908203125
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.5186721991701245,
+                "acceptedDraftTokens": 125,
+                "draftHistoryTokens": 53,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 241,
+                "rounds": 131,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 2.633154034614563,
+              "decodeTokensPerSecond": 97.22180952375348,
+              "elapsedSeconds": 2.7676069736480713,
+              "endToEndTokensPerSecond": 92.49868295517344,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.00036895275115966797,
+              "generatedTokens": 256,
+              "loadSeconds": 6.079673767089844e-06,
+              "name": "adaptive",
+              "outputSHA256": "cd134369dacefc1cc1bc8bceceb5cfb2dc106e35c077361b20e79108d05fabb4",
+              "policy": "adaptive",
+              "prefillSeconds": 0.13273298740386963,
+              "prefillTokensPerSecond": 406.8317986070259,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 9465626624,
+              "residentMemoryBeforeBytes": 9465495552,
+              "ttftSeconds": 0.1331080198287964
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        }
+      ]
+    },
+    {
+      "id": "finish-selection/ornith-current/ornith-prose",
+      "model": "text-agent-ornith-35b-mlx-4bit",
+      "rawReceiptSHA256": "bc1063a3b1a006b78ee077b691e43bc3601831c815fad800e21da1135a03db88",
+      "receipt": {
+        "after": {
+          "gpuDeviceUtilizationPercent": 75,
+          "loadAverage": [
+            5.447265625,
+            6.4443359375,
+            7.44091796875
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7276.25M  free = 915.75M  (encrypted)",
+          "swapUsedMiB": 7276.25
+        },
+        "before": {
+          "gpuDeviceUtilizationPercent": 0,
+          "loadAverage": [
+            6.4990234375,
+            6.76904296875,
+            7.63037109375
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7284.25M  free = 907.75M  (encrypted)",
+          "swapUsedMiB": 7284.25
+        },
+        "binarySHA256": "cdec91928873110a516e18abcf0db7904cde7398977a7e5b9317c0776a3c1737",
+        "buildSourceRevision": "f847be2ef7ca2f8896829c3cc0b6a1a55ea72ea9",
+        "collectorSHA256": "c5d800333764ac360dd08c27bd99ccf3bc3be6afb203f82ac9fddef41d7ce682",
+        "command": [
+          "mere.run",
+          "model",
+          "benchmark",
+          "q36-mtp",
+          "--model",
+          "text-agent-ornith-35b-mlx-4bit",
+          "--prompt",
+          "Explain how a small community could turn an abandoned railway station into a public library. Discuss the building, accessibility, staffing, the collection, and a realistic opening-day scene. Write approximately 400 words of clear, connected prose.",
+          "--decode-tokens",
+          "256",
+          "--context-size",
+          "8192",
+          "--temperature",
+          "0",
+          "--top-p",
+          "1",
+          "--json",
+          "--variants",
+          "adaptive,baseline",
+          "--warmups",
+          "1",
+          "--warmup-tokens",
+          "256",
+          "--repetitions",
+          "3",
+          "--mtp-block-size",
+          "4"
+        ],
+        "competingInferenceProcessCount": 0,
+        "gpuSamples": [
+          {
+            "deviceUtilizationPercent": 0,
+            "elapsedSeconds": 0.08449792861938477,
+            "loadAverage": [
+              6.4990234375,
+              6.76904296875,
+              7.63037109375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 36,
+            "elapsedSeconds": 2.1868579387664795,
+            "loadAverage": [
+              6.4990234375,
+              6.76904296875,
+              7.63037109375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 66,
+            "elapsedSeconds": 4.288841962814331,
+            "loadAverage": [
+              6.21875,
+              6.7060546875,
+              7.60302734375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 66,
+            "elapsedSeconds": 6.388010025024414,
+            "loadAverage": [
+              6.21875,
+              6.7060546875,
+              7.60302734375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 51,
+            "elapsedSeconds": 8.487811088562012,
+            "loadAverage": [
+              6.201171875,
+              6.69384765625,
+              7.59326171875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 53,
+            "elapsedSeconds": 10.580504179000854,
+            "loadAverage": [
+              6.201171875,
+              6.69384765625,
+              7.59326171875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 50,
+            "elapsedSeconds": 12.67274808883667,
+            "loadAverage": [
+              6.02490234375,
+              6.64892578125,
+              7.57177734375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 51,
+            "elapsedSeconds": 14.773230075836182,
+            "loadAverage": [
+              6.02490234375,
+              6.64892578125,
+              7.57177734375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 54,
+            "elapsedSeconds": 16.867496967315674,
+            "loadAverage": [
+              6.02490234375,
+              6.64892578125,
+              7.57177734375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 68,
+            "elapsedSeconds": 18.964004278182983,
+            "loadAverage": [
+              6.1826171875,
+              6.6708984375,
+              7.57421875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 70,
+            "elapsedSeconds": 21.058720111846924,
+            "loadAverage": [
+              6.1826171875,
+              6.6708984375,
+              7.57421875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 54,
+            "elapsedSeconds": 23.157839059829712,
+            "loadAverage": [
+              6.328125,
+              6.69287109375,
+              7.57666015625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 52,
+            "elapsedSeconds": 25.25394606590271,
+            "loadAverage": [
+              6.328125,
+              6.69287109375,
+              7.57666015625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 47,
+            "elapsedSeconds": 27.357171058654785,
+            "loadAverage": [
+              6.328125,
+              6.69287109375,
+              7.57666015625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 53,
+            "elapsedSeconds": 29.45439910888672,
+            "loadAverage": [
+              6.5419921875,
+              6.73095703125,
+              7.5849609375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 51,
+            "elapsedSeconds": 31.550530195236206,
+            "loadAverage": [
+              6.5419921875,
+              6.73095703125,
+              7.5849609375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 49,
+            "elapsedSeconds": 33.64287304878235,
+            "loadAverage": [
+              6.49853515625,
+              6.71875,
+              7.5751953125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 31,
+            "elapsedSeconds": 35.74376130104065,
+            "loadAverage": [
+              6.49853515625,
+              6.71875,
+              7.5751953125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 66,
+            "elapsedSeconds": 37.84064221382141,
+            "loadAverage": [
+              6.45849609375,
+              6.70654296875,
+              7.56591796875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 45,
+            "elapsedSeconds": 39.935879945755005,
+            "loadAverage": [
+              6.45849609375,
+              6.70654296875,
+              7.56591796875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 60,
+            "elapsedSeconds": 42.03589415550232,
+            "loadAverage": [
+              6.45849609375,
+              6.70654296875,
+              7.56591796875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 59,
+            "elapsedSeconds": 44.12905025482178,
+            "loadAverage": [
+              6.26123046875,
+              6.6611328125,
+              7.544921875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 0,
+            "elapsedSeconds": 46.220110177993774,
+            "loadAverage": [
+              6.26123046875,
+              6.6611328125,
+              7.544921875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 45,
+            "elapsedSeconds": 48.31564116477966,
+            "loadAverage": [
+              6.0,
+              6.60009765625,
+              7.51806640625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 72,
+            "elapsedSeconds": 50.41105103492737,
+            "loadAverage": [
+              6.0,
+              6.60009765625,
+              7.51806640625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 72,
+            "elapsedSeconds": 52.505523920059204,
+            "loadAverage": [
+              6.16015625,
+              6.623046875,
+              7.5205078125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 47,
+            "elapsedSeconds": 54.60018825531006,
+            "loadAverage": [
+              6.16015625,
+              6.623046875,
+              7.5205078125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 47,
+            "elapsedSeconds": 56.69531607627869,
+            "loadAverage": [
+              6.16015625,
+              6.623046875,
+              7.5205078125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 49,
+            "elapsedSeconds": 58.78992509841919,
+            "loadAverage": [
+              5.98681640625,
+              6.5791015625,
+              7.49951171875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 48,
+            "elapsedSeconds": 60.889541149139404,
+            "loadAverage": [
+              5.98681640625,
+              6.5791015625,
+              7.49951171875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 48,
+            "elapsedSeconds": 62.98503518104553,
+            "loadAverage": [
+              5.74755859375,
+              6.51953125,
+              7.47314453125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 50,
+            "elapsedSeconds": 65.0788049697876,
+            "loadAverage": [
+              5.74755859375,
+              6.51953125,
+              7.47314453125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 73,
+            "elapsedSeconds": 67.17199516296387,
+            "loadAverage": [
+              5.74755859375,
+              6.51953125,
+              7.47314453125
+            ]
+          }
+        ],
+        "knownRenderingWorkerCount": 0,
+        "maxPressureLevel": 1,
+        "measurementMode": "desktop-load",
+        "peakResidentBytes": 9462726656,
+        "processSeconds": 69.27412724494934,
+        "profiled": false,
+        "prompt": "Explain how a small community could turn an abandoned railway station into a public library. Discuss the building, accessibility, staffing, the collection, and a realistic opening-day scene. Write approximately 400 words of clear, connected prose.",
+        "runtimeOverrides": {
+          "MERERUN_Q35_ASYNC_DECODE_BLOCKS": "0",
+          "MERERUN_Q35_MTP_HEAD_COST_RATIO": "0.18",
+          "MERERUN_Q35_MTP_PIPELINED_FALLBACK": "0",
+          "MERERUN_Q35_SCOPED_COMPILE": "0"
+        },
+        "sourceHead": "9319a217579cff3e3bbea002fb93451fe719a868",
+        "startedUnixSeconds": 1788621743.847849,
+        "uncontended": false,
+        "workload": "prose"
+      },
+      "scenarios": [
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 0.24795829896450483
+          },
+          "endToEndSpeedups": {
+            "adaptive": 0.2581012202123395
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 247,
+          "repetition": 1,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "acceptanceRate": 0.25892857142857145,
+                "acceptedDraftTokens": 29,
+                "draftHistoryTokens": 59,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 112,
+                "rounds": 69,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 11.13976001739502,
+              "decodeTokensPerSecond": 22.98074640748539,
+              "elapsedSeconds": 11.256517887115479,
+              "endToEndTokensPerSecond": 22.742379354544862,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0001989603042602539,
+              "generatedTokens": 256,
+              "loadSeconds": 6.079673767089844e-06,
+              "name": "adaptive",
+              "outputSHA256": "ca3ac87c453ea9cb8fdd5fe572ce7e0e9930e17487f37393e45606052e4db11e",
+              "policy": "adaptive",
+              "prefillSeconds": 0.11489701271057129,
+              "prefillTokensPerSecond": 522.2067883622148,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 9462022144,
+              "residentMemoryBeforeBytes": 9455878144,
+              "ttftSeconds": 0.11510205268859863
+            },
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 2.7621959447860718,
+              "decodeTokensPerSecond": 92.679884091216,
+              "elapsedSeconds": 2.9053210020065308,
+              "endToEndTokensPerSecond": 88.11418766573338,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.011691927909851074,
+              "generatedTokens": 256,
+              "loadSeconds": 6.9141387939453125e-06,
+              "name": "baseline",
+              "outputSHA256": "ca3ac87c453ea9cb8fdd5fe572ce7e0e9930e17487f37393e45606052e4db11e",
+              "policy": "disabled",
+              "prefillSeconds": 0.1413710117340088,
+              "prefillTokensPerSecond": 424.4151560073058,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 9340862464,
+              "residentMemoryBeforeBytes": 9340780544,
+              "ttftSeconds": 0.1530698537826538
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 3.9744117402503765
+          },
+          "endToEndSpeedups": {
+            "adaptive": 3.819465327026811
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 247,
+          "repetition": 2,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "acceptanceRate": 0.25892857142857145,
+                "acceptedDraftTokens": 29,
+                "draftHistoryTokens": 59,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 112,
+                "rounds": 69,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 3.4193450212478638,
+              "decodeTokensPerSecond": 74.86813948554824,
+              "elapsedSeconds": 3.584097981452942,
+              "endToEndTokensPerSecond": 71.42661872659555,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0004349946975708008,
+              "generatedTokens": 256,
+              "loadSeconds": 5.0067901611328125e-06,
+              "name": "adaptive",
+              "outputSHA256": "ca3ac87c453ea9cb8fdd5fe572ce7e0e9930e17487f37393e45606052e4db11e",
+              "policy": "adaptive",
+              "prefillSeconds": 0.16295599937438965,
+              "prefillTokensPerSecond": 368.19755167252634,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 9462349824,
+              "residentMemoryBeforeBytes": 9462120448,
+              "ttftSeconds": 0.16339600086212158
+            },
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 13.589884996414185,
+              "decodeTokensPerSecond": 18.837539836985226,
+              "elapsedSeconds": 13.689337968826294,
+              "endToEndTokensPerSecond": 18.70068520354817,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.04110395908355713,
+              "generatedTokens": 256,
+              "loadSeconds": 5.9604644775390625e-06,
+              "name": "baseline",
+              "outputSHA256": "ca3ac87c453ea9cb8fdd5fe572ce7e0e9930e17487f37393e45606052e4db11e",
+              "policy": "disabled",
+              "prefillSeconds": 0.09785699844360352,
+              "prefillTokensPerSecond": 613.1395909775315,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 9340911616,
+              "residentMemoryBeforeBytes": 9340862464,
+              "ttftSeconds": 0.13896691799163818
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 0.20702898008284243
+          },
+          "endToEndSpeedups": {
+            "adaptive": 0.2138995125701697
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 247,
+          "repetition": 3,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "acceptanceRate": 0.25892857142857145,
+                "acceptedDraftTokens": 29,
+                "draftHistoryTokens": 59,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 112,
+                "rounds": 69,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 13.427946090698242,
+              "decodeTokensPerSecond": 19.0647175875494,
+              "elapsedSeconds": 13.545103073120117,
+              "endToEndTokensPerSecond": 18.899819264426636,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.00017702579498291016,
+              "generatedTokens": 256,
+              "loadSeconds": 5.9604644775390625e-06,
+              "name": "adaptive",
+              "outputSHA256": "ca3ac87c453ea9cb8fdd5fe572ce7e0e9930e17487f37393e45606052e4db11e",
+              "policy": "adaptive",
+              "prefillSeconds": 0.1153249740600586,
+              "prefillTokensPerSecond": 520.2689225731226,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 9462743040,
+              "residentMemoryBeforeBytes": 9462349824,
+              "ttftSeconds": 0.11550796031951904
+            },
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 2.7799739837646484,
+              "decodeTokensPerSecond": 92.08719272017218,
+              "elapsedSeconds": 2.8972909450531006,
+              "endToEndTokensPerSecond": 88.35840267857812,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.010432004928588867,
+              "generatedTokens": 256,
+              "loadSeconds": 5.9604644775390625e-06,
+              "name": "baseline",
+              "outputSHA256": "ca3ac87c453ea9cb8fdd5fe572ce7e0e9930e17487f37393e45606052e4db11e",
+              "policy": "disabled",
+              "prefillSeconds": 0.11570405960083008,
+              "prefillTokensPerSecond": 518.5643460306864,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 9340977152,
+              "residentMemoryBeforeBytes": 9340911616,
+              "ttftSeconds": 0.12614202499389648
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        }
+      ]
+    },
+    {
+      "id": "finish-selection/qwen-c18/qwen-code",
+      "model": "vision-chat-q38-27b-4bit",
+      "rawReceiptSHA256": "ae3ad0408b23796a01790a8d88620cf41f2e8141a7ce0b7ac5f815b420502564",
+      "receipt": {
+        "after": {
+          "gpuDeviceUtilizationPercent": 64,
+          "loadAverage": [
+            16.2158203125,
+            13.74462890625,
+            10.48193359375
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7276.25M  free = 915.75M  (encrypted)",
+          "swapUsedMiB": 7276.25
+        },
+        "before": {
+          "gpuDeviceUtilizationPercent": 21,
+          "loadAverage": [
+            12.73046875,
+            10.03955078125,
+            8.75439453125
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7276.25M  free = 915.75M  (encrypted)",
+          "swapUsedMiB": 7276.25
+        },
+        "binarySHA256": "cdec91928873110a516e18abcf0db7904cde7398977a7e5b9317c0776a3c1737",
+        "buildSourceRevision": "f847be2ef7ca2f8896829c3cc0b6a1a55ea72ea9",
+        "collectorSHA256": "c5d800333764ac360dd08c27bd99ccf3bc3be6afb203f82ac9fddef41d7ce682",
+        "command": [
+          "mere.run",
+          "model",
+          "benchmark",
+          "q36-mtp",
+          "--model",
+          "vision-chat-q38-27b-4bit",
+          "--prompt",
+          "Write a complete Python implementation of an LRU cache using a dictionary and a doubly linked list, with get and put operations, type hints, and a short usage example. Return the code directly without introductory prose.",
+          "--decode-tokens",
+          "256",
+          "--context-size",
+          "8192",
+          "--temperature",
+          "0",
+          "--top-p",
+          "1",
+          "--json",
+          "--variants",
+          "baseline,adaptive",
+          "--warmups",
+          "1",
+          "--warmup-tokens",
+          "256",
+          "--repetitions",
+          "3",
+          "--mtp-block-size",
+          "8"
+        ],
+        "competingInferenceProcessCount": 0,
+        "gpuSamples": [
+          {
+            "deviceUtilizationPercent": 25,
+            "elapsedSeconds": 0.08994936943054199,
+            "loadAverage": [
+              12.73046875,
+              10.03955078125,
+              8.75439453125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 16,
+            "elapsedSeconds": 2.2729241847991943,
+            "loadAverage": [
+              12.73046875,
+              10.03955078125,
+              8.75439453125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 83,
+            "elapsedSeconds": 4.51036524772644,
+            "loadAverage": [
+              15.955078125,
+              10.75244140625,
+              9.01318359375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 71,
+            "elapsedSeconds": 6.744260311126709,
+            "loadAverage": [
+              15.955078125,
+              10.75244140625,
+              9.01318359375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 74,
+            "elapsedSeconds": 8.985917329788208,
+            "loadAverage": [
+              15.955078125,
+              10.75244140625,
+              9.01318359375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 76,
+            "elapsedSeconds": 11.202836275100708,
+            "loadAverage": [
+              18.04052734375,
+              11.27099609375,
+              9.2060546875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 70,
+            "elapsedSeconds": 13.442066192626953,
+            "loadAverage": [
+              18.04052734375,
+              11.27099609375,
+              9.2060546875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 73,
+            "elapsedSeconds": 15.679009199142456,
+            "loadAverage": [
+              20.439453125,
+              11.88037109375,
+              9.43310546875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 76,
+            "elapsedSeconds": 17.893596172332764,
+            "loadAverage": [
+              20.439453125,
+              11.88037109375,
+              9.43310546875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 71,
+            "elapsedSeconds": 20.13033437728882,
+            "loadAverage": [
+              22.32568359375,
+              12.41357421875,
+              9.63525390625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 79,
+            "elapsedSeconds": 22.384579181671143,
+            "loadAverage": [
+              22.32568359375,
+              12.41357421875,
+              9.63525390625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 89,
+            "elapsedSeconds": 24.846886157989502,
+            "loadAverage": [
+              22.53955078125,
+              12.6220703125,
+              9.72509765625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 57,
+            "elapsedSeconds": 27.331428289413452,
+            "loadAverage": [
+              22.53955078125,
+              12.6220703125,
+              9.72509765625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 62,
+            "elapsedSeconds": 29.856426000595093,
+            "loadAverage": [
+              21.935546875,
+              12.6611328125,
+              9.755859375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 82,
+            "elapsedSeconds": 32.254027128219604,
+            "loadAverage": [
+              21.935546875,
+              12.6611328125,
+              9.755859375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 75,
+            "elapsedSeconds": 34.57110118865967,
+            "loadAverage": [
+              22.1005859375,
+              12.84912109375,
+              9.8388671875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 81,
+            "elapsedSeconds": 37.10563516616821,
+            "loadAverage": [
+              22.1005859375,
+              12.84912109375,
+              9.8388671875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 73,
+            "elapsedSeconds": 39.58717226982117,
+            "loadAverage": [
+              20.89111328125,
+              12.751953125,
+              9.82177734375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 81,
+            "elapsedSeconds": 41.97731423377991,
+            "loadAverage": [
+              20.89111328125,
+              12.751953125,
+              9.82177734375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 79,
+            "elapsedSeconds": 44.56009340286255,
+            "loadAverage": [
+              19.8583984375,
+              12.6728515625,
+              9.81103515625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 84,
+            "elapsedSeconds": 47.05228519439697,
+            "loadAverage": [
+              19.8583984375,
+              12.6728515625,
+              9.81103515625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 92,
+            "elapsedSeconds": 49.3834912776947,
+            "loadAverage": [
+              19.8583984375,
+              12.6728515625,
+              9.81103515625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 98,
+            "elapsedSeconds": 51.65529704093933,
+            "loadAverage": [
+              18.50830078125,
+              12.51220703125,
+              9.77099609375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 65,
+            "elapsedSeconds": 53.99842619895935,
+            "loadAverage": [
+              18.50830078125,
+              12.51220703125,
+              9.77099609375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 73,
+            "elapsedSeconds": 56.274572134017944,
+            "loadAverage": [
+              19.50830078125,
+              12.81884765625,
+              9.89501953125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 75,
+            "elapsedSeconds": 58.69168734550476,
+            "loadAverage": [
+              19.50830078125,
+              12.81884765625,
+              9.89501953125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 70,
+            "elapsedSeconds": 61.02362012863159,
+            "loadAverage": [
+              22.75048828125,
+              13.60205078125,
+              10.1884765625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 62,
+            "elapsedSeconds": 63.79757118225098,
+            "loadAverage": [
+              22.75048828125,
+              13.60205078125,
+              10.1884765625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 76,
+            "elapsedSeconds": 66.57898807525635,
+            "loadAverage": [
+              25.41259765625,
+              14.3056640625,
+              10.45654296875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 74,
+            "elapsedSeconds": 69.18661832809448,
+            "loadAverage": [
+              25.41259765625,
+              14.3056640625,
+              10.45654296875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 67,
+            "elapsedSeconds": 72.06473422050476,
+            "loadAverage": [
+              25.05908203125,
+              14.41650390625,
+              10.51806640625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 61,
+            "elapsedSeconds": 74.69224500656128,
+            "loadAverage": [
+              27.05615234375,
+              15.0068359375,
+              10.7490234375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 71,
+            "elapsedSeconds": 77.41719031333923,
+            "loadAverage": [
+              27.05615234375,
+              15.0068359375,
+              10.7490234375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 72,
+            "elapsedSeconds": 79.86537218093872,
+            "loadAverage": [
+              25.85009765625,
+              14.95654296875,
+              10.75634765625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 37,
+            "elapsedSeconds": 82.01041007041931,
+            "loadAverage": [
+              25.85009765625,
+              14.95654296875,
+              10.75634765625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 95,
+            "elapsedSeconds": 84.12613916397095,
+            "loadAverage": [
+              25.85009765625,
+              14.95654296875,
+              10.75634765625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 95,
+            "elapsedSeconds": 86.2422924041748,
+            "loadAverage": [
+              24.26025390625,
+              14.8076171875,
+              10.72802734375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 95,
+            "elapsedSeconds": 88.3397102355957,
+            "loadAverage": [
+              24.26025390625,
+              14.8076171875,
+              10.72802734375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 94,
+            "elapsedSeconds": 90.43194031715393,
+            "loadAverage": [
+              22.6376953125,
+              14.6279296875,
+              10.6884765625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 90,
+            "elapsedSeconds": 92.53108620643616,
+            "loadAverage": [
+              22.6376953125,
+              14.6279296875,
+              10.6884765625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 87,
+            "elapsedSeconds": 94.62742829322815,
+            "loadAverage": [
+              20.90478515625,
+              14.4013671875,
+              10.63134765625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 89,
+            "elapsedSeconds": 96.72533130645752,
+            "loadAverage": [
+              20.90478515625,
+              14.4013671875,
+              10.63134765625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 99,
+            "elapsedSeconds": 98.83446025848389,
+            "loadAverage": [
+              20.90478515625,
+              14.4013671875,
+              10.63134765625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 92,
+            "elapsedSeconds": 100.93036532402039,
+            "loadAverage": [
+              19.470703125,
+              14.2119140625,
+              10.58642578125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 93,
+            "elapsedSeconds": 103.02559733390808,
+            "loadAverage": [
+              19.470703125,
+              14.2119140625,
+              10.58642578125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 83,
+            "elapsedSeconds": 105.11733317375183,
+            "loadAverage": [
+              18.1513671875,
+              14.025390625,
+              10.54150390625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 87,
+            "elapsedSeconds": 107.21281027793884,
+            "loadAverage": [
+              18.1513671875,
+              14.025390625,
+              10.54150390625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 94,
+            "elapsedSeconds": 109.31486535072327,
+            "loadAverage": [
+              18.1513671875,
+              14.025390625,
+              10.54150390625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 89,
+            "elapsedSeconds": 111.4118402004242,
+            "loadAverage": [
+              17.01806640625,
+              13.85888671875,
+              10.5029296875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 95,
+            "elapsedSeconds": 113.5851502418518,
+            "loadAverage": [
+              17.01806640625,
+              13.85888671875,
+              10.5029296875
+            ]
+          }
+        ],
+        "knownRenderingWorkerCount": 0,
+        "maxPressureLevel": 1,
+        "measurementMode": "desktop-load",
+        "peakResidentBytes": 15825534976,
+        "processSeconds": 115.73394727706909,
+        "profiled": false,
+        "prompt": "Write a complete Python implementation of an LRU cache using a dictionary and a doubly linked list, with get and put operations, type hints, and a short usage example. Return the code directly without introductory prose.",
+        "runtimeOverrides": {
+          "MERERUN_Q35_ASYNC_DECODE_BLOCKS": "1",
+          "MERERUN_Q35_MTP_HEAD_COST_RATIO": "0.18",
+          "MERERUN_Q35_MTP_PIPELINED_FALLBACK": "1",
+          "MERERUN_Q35_SCOPED_COMPILE": "1"
+        },
+        "sourceHead": "9319a217579cff3e3bbea002fb93451fe719a868",
+        "startedUnixSeconds": 1788622152.0609658,
+        "uncontended": false,
+        "workload": "code"
+      },
+      "scenarios": [
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 2.268967813829826
+          },
+          "endToEndSpeedups": {
+            "adaptive": 2.1998864014325235
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 220,
+          "repetition": 1,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 16.311511993408203,
+              "decodeTokensPerSecond": 15.69443716213767,
+              "elapsedSeconds": 17.112749099731445,
+              "endToEndTokensPerSecond": 14.95960692861543,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.18932998180389404,
+              "generatedTokens": 256,
+              "loadSeconds": 4.506111145019531e-05,
+              "name": "baseline",
+              "outputSHA256": "ca2c0ddf75b621ec62d587ff04b6f89f528aafe8d744b0730c298166deb5f461",
+              "policy": "disabled",
+              "prefillSeconds": 0.7973200082778931,
+              "prefillTokensPerSecond": 67.7268843618172,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 15408726016,
+              "residentMemoryBeforeBytes": 15408168960,
+              "ttftSeconds": 0.9866950511932373
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.7236363636363636,
+                "acceptedDraftTokens": 199,
+                "draftHistoryTokens": 53,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 275,
+                "rounds": 57,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 7.18895697593689,
+              "decodeTokensPerSecond": 35.61017277706509,
+              "elapsedSeconds": 7.778923988342285,
+              "endToEndTokensPerSecond": 32.90943585303685,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0004049539566040039,
+              "generatedTokens": 256,
+              "loadSeconds": 2.002716064453125e-05,
+              "name": "adaptive",
+              "outputSHA256": "ca2c0ddf75b621ec62d587ff04b6f89f528aafe8d744b0730c298166deb5f461",
+              "policy": "adaptive",
+              "prefillSeconds": 0.5884289741516113,
+              "prefillTokensPerSecond": 91.76978424262069,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 15825453056,
+              "residentMemoryBeforeBytes": 15825289216,
+              "ttftSeconds": 0.5888539552688599
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 2.1500023550409892
+          },
+          "endToEndSpeedups": {
+            "adaptive": 2.0355788658270653
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 220,
+          "repetition": 2,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 15.818511009216309,
+              "decodeTokensPerSecond": 16.18357125084954,
+              "elapsedSeconds": 16.30987799167633,
+              "endToEndTokensPerSecond": 15.696009506058132,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.05109703540802002,
+              "generatedTokens": 256,
+              "loadSeconds": 6.103515625e-05,
+              "name": "baseline",
+              "outputSHA256": "ca2c0ddf75b621ec62d587ff04b6f89f528aafe8d744b0730c298166deb5f461",
+              "policy": "disabled",
+              "prefillSeconds": 0.4870070219039917,
+              "prefillTokensPerSecond": 110.88135811447403,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 15408939008,
+              "residentMemoryBeforeBytes": 15408840704,
+              "ttftSeconds": 0.5381650924682617
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.7236363636363636,
+                "acceptedDraftTokens": 199,
+                "draftHistoryTokens": 53,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 275,
+                "rounds": 57,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 7.357438921928406,
+              "decodeTokensPerSecond": 34.79471630230016,
+              "elapsedSeconds": 8.012402892112732,
+              "endToEndTokensPerSecond": 31.950465228352645,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0003019571304321289,
+              "generatedTokens": 256,
+              "loadSeconds": 1.800060272216797e-05,
+              "name": "adaptive",
+              "outputSHA256": "ca2c0ddf75b621ec62d587ff04b6f89f528aafe8d744b0730c298166deb5f461",
+              "policy": "adaptive",
+              "prefillSeconds": 0.6535149812698364,
+              "prefillTokensPerSecond": 82.63008737010635,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 15825485824,
+              "residentMemoryBeforeBytes": 15825453056,
+              "ttftSeconds": 0.6538349390029907
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 2.8682243538654957
+          },
+          "endToEndSpeedups": {
+            "adaptive": 2.7103948283552017
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 220,
+          "repetition": 3,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 21.767886996269226,
+              "decodeTokensPerSecond": 11.760443264147575,
+              "elapsedSeconds": 22.133236050605774,
+              "endToEndTokensPerSecond": 11.566315897714986,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.0465700626373291,
+              "generatedTokens": 256,
+              "loadSeconds": 4.601478576660156e-05,
+              "name": "baseline",
+              "outputSHA256": "ca2c0ddf75b621ec62d587ff04b6f89f528aafe8d744b0730c298166deb5f461",
+              "policy": "disabled",
+              "prefillSeconds": 0.3599209785461426,
+              "prefillTokensPerSecond": 150.03293283466414,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 15409004544,
+              "residentMemoryBeforeBytes": 15408939008,
+              "ttftSeconds": 0.4065370559692383
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.7236363636363636,
+                "acceptedDraftTokens": 199,
+                "draftHistoryTokens": 53,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 275,
+                "rounds": 57,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 7.5893250703811646,
+              "decodeTokensPerSecond": 33.7315897824815,
+              "elapsedSeconds": 8.166056036949158,
+              "endToEndTokensPerSecond": 31.34928279228925,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0004380941390991211,
+              "generatedTokens": 256,
+              "loadSeconds": 1.800060272216797e-05,
+              "name": "adaptive",
+              "outputSHA256": "ca2c0ddf75b621ec62d587ff04b6f89f528aafe8d744b0730c298166deb5f461",
+              "policy": "adaptive",
+              "prefillSeconds": 0.574834942817688,
+              "prefillTokensPerSecond": 93.94000951874352,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 15825534976,
+              "residentMemoryBeforeBytes": 15825485824,
+              "ttftSeconds": 0.5752910375595093
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        }
+      ]
+    },
+    {
+      "id": "finish-selection/qwen-c18/qwen-prose",
+      "model": "vision-chat-q38-27b-4bit",
+      "rawReceiptSHA256": "aa62f4ccd6741fb5e2a88d1cbb62f48ca829c6a975e937d2dca27643db253596",
+      "receipt": {
+        "after": {
+          "gpuDeviceUtilizationPercent": 92,
+          "loadAverage": [
+            8.36279296875,
+            11.66259765625,
+            10.0908203125
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7276.25M  free = 915.75M  (encrypted)",
+          "swapUsedMiB": 7276.25
+        },
+        "before": {
+          "gpuDeviceUtilizationPercent": 41,
+          "loadAverage": [
+            16.2158203125,
+            13.74462890625,
+            10.48193359375
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7276.25M  free = 915.75M  (encrypted)",
+          "swapUsedMiB": 7276.25
+        },
+        "binarySHA256": "cdec91928873110a516e18abcf0db7904cde7398977a7e5b9317c0776a3c1737",
+        "buildSourceRevision": "f847be2ef7ca2f8896829c3cc0b6a1a55ea72ea9",
+        "collectorSHA256": "c5d800333764ac360dd08c27bd99ccf3bc3be6afb203f82ac9fddef41d7ce682",
+        "command": [
+          "mere.run",
+          "model",
+          "benchmark",
+          "q36-mtp",
+          "--model",
+          "vision-chat-q38-27b-4bit",
+          "--prompt",
+          "Explain how a small community could turn an abandoned railway station into a public library. Discuss the building, accessibility, staffing, the collection, and a realistic opening-day scene. Write approximately 400 words of clear, connected prose.",
+          "--decode-tokens",
+          "256",
+          "--context-size",
+          "8192",
+          "--temperature",
+          "0",
+          "--top-p",
+          "1",
+          "--json",
+          "--variants",
+          "adaptive,baseline",
+          "--warmups",
+          "1",
+          "--warmup-tokens",
+          "256",
+          "--repetitions",
+          "3",
+          "--mtp-block-size",
+          "8"
+        ],
+        "competingInferenceProcessCount": 0,
+        "gpuSamples": [
+          {
+            "deviceUtilizationPercent": 39,
+            "elapsedSeconds": 0.11649203300476074,
+            "loadAverage": [
+              16.2158203125,
+              13.74462890625,
+              10.48193359375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 71,
+            "elapsedSeconds": 2.2170190811157227,
+            "loadAverage": [
+              16.2158203125,
+              13.74462890625,
+              10.48193359375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 73,
+            "elapsedSeconds": 4.311152935028076,
+            "loadAverage": [
+              14.9970703125,
+              13.53271484375,
+              10.42626953125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 88,
+            "elapsedSeconds": 6.403930902481079,
+            "loadAverage": [
+              14.9970703125,
+              13.53271484375,
+              10.42626953125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 97,
+            "elapsedSeconds": 8.500807046890259,
+            "loadAverage": [
+              14.9970703125,
+              13.53271484375,
+              10.42626953125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 82,
+            "elapsedSeconds": 10.597621202468872,
+            "loadAverage": [
+              14.0361328125,
+              13.357421875,
+              10.38232421875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 66,
+            "elapsedSeconds": 12.692683219909668,
+            "loadAverage": [
+              14.0361328125,
+              13.357421875,
+              10.38232421875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 91,
+            "elapsedSeconds": 14.789412021636963,
+            "loadAverage": [
+              13.072265625,
+              13.16845703125,
+              10.3330078125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 87,
+            "elapsedSeconds": 16.88393211364746,
+            "loadAverage": [
+              13.072265625,
+              13.16845703125,
+              10.3330078125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 87,
+            "elapsedSeconds": 18.976946115493774,
+            "loadAverage": [
+              12.42578125,
+              13.03271484375,
+              10.3017578125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 83,
+            "elapsedSeconds": 21.066922187805176,
+            "loadAverage": [
+              12.42578125,
+              13.03271484375,
+              10.3017578125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 83,
+            "elapsedSeconds": 23.160953044891357,
+            "loadAverage": [
+              12.42578125,
+              13.03271484375,
+              10.3017578125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 77,
+            "elapsedSeconds": 25.25238013267517,
+            "loadAverage": [
+              11.7509765625,
+              12.88232421875,
+              10.2646484375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 89,
+            "elapsedSeconds": 27.349311113357544,
+            "loadAverage": [
+              11.7509765625,
+              12.88232421875,
+              10.2646484375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 86,
+            "elapsedSeconds": 29.44742703437805,
+            "loadAverage": [
+              11.2099609375,
+              12.75146484375,
+              10.2333984375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 91,
+            "elapsedSeconds": 31.551965951919556,
+            "loadAverage": [
+              11.2099609375,
+              12.75146484375,
+              10.2333984375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 83,
+            "elapsedSeconds": 33.645081996917725,
+            "loadAverage": [
+              10.63232421875,
+              12.60595703125,
+              10.19677734375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 84,
+            "elapsedSeconds": 35.73726201057434,
+            "loadAverage": [
+              10.63232421875,
+              12.60595703125,
+              10.19677734375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 68,
+            "elapsedSeconds": 37.8272819519043,
+            "loadAverage": [
+              10.63232421875,
+              12.60595703125,
+              10.19677734375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 80,
+            "elapsedSeconds": 39.920876264572144,
+            "loadAverage": [
+              10.02099609375,
+              12.4462890625,
+              10.154296875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 82,
+            "elapsedSeconds": 42.01561617851257,
+            "loadAverage": [
+              10.02099609375,
+              12.4462890625,
+              10.154296875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 91,
+            "elapsedSeconds": 44.11212396621704,
+            "loadAverage": [
+              9.61865234375,
+              12.322265625,
+              10.1240234375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 84,
+            "elapsedSeconds": 46.20360612869263,
+            "loadAverage": [
+              9.61865234375,
+              12.322265625,
+              10.1240234375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 82,
+            "elapsedSeconds": 48.296584129333496,
+            "loadAverage": [
+              9.61865234375,
+              12.322265625,
+              10.1240234375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 89,
+            "elapsedSeconds": 50.390113830566406,
+            "loadAverage": [
+              9.00830078125,
+              12.15087890625,
+              10.076171875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 75,
+            "elapsedSeconds": 52.4989550113678,
+            "loadAverage": [
+              9.00830078125,
+              12.15087890625,
+              10.076171875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 71,
+            "elapsedSeconds": 54.628763914108276,
+            "loadAverage": [
+              8.60693359375,
+              12.01513671875,
+              10.04052734375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 59,
+            "elapsedSeconds": 57.129313230514526,
+            "loadAverage": [
+              8.60693359375,
+              12.01513671875,
+              10.04052734375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 77,
+            "elapsedSeconds": 59.608875036239624,
+            "loadAverage": [
+              11.36083984375,
+              12.529296875,
+              10.2333984375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 94,
+            "elapsedSeconds": 61.98652982711792,
+            "loadAverage": [
+              11.36083984375,
+              12.529296875,
+              10.2333984375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 92,
+            "elapsedSeconds": 64.49066996574402,
+            "loadAverage": [
+              11.89208984375,
+              12.6201171875,
+              10.27880859375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 93,
+            "elapsedSeconds": 67.03268599510193,
+            "loadAverage": [
+              11.89208984375,
+              12.6201171875,
+              10.27880859375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 76,
+            "elapsedSeconds": 69.91038012504578,
+            "loadAverage": [
+              12.30078125,
+              12.6923828125,
+              10.31787109375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 76,
+            "elapsedSeconds": 72.6122350692749,
+            "loadAverage": [
+              12.30078125,
+              12.6923828125,
+              10.31787109375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 74,
+            "elapsedSeconds": 75.35951590538025,
+            "loadAverage": [
+              13.8779296875,
+              13.0126953125,
+              10.44482421875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 93,
+            "elapsedSeconds": 77.61324191093445,
+            "loadAverage": [
+              13.8779296875,
+              13.0126953125,
+              10.44482421875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 79.76711988449097,
+            "loadAverage": [
+              13.4072265625,
+              12.92919921875,
+              10.43017578125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 81.90829086303711,
+            "loadAverage": [
+              13.4072265625,
+              12.92919921875,
+              10.43017578125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 84.0415608882904,
+            "loadAverage": [
+              12.57373046875,
+              12.76416015625,
+              10.38623046875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 86.16651821136475,
+            "loadAverage": [
+              12.57373046875,
+              12.76416015625,
+              10.38623046875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 99,
+            "elapsedSeconds": 88.28314900398254,
+            "loadAverage": [
+              12.57373046875,
+              12.76416015625,
+              10.38623046875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 99,
+            "elapsedSeconds": 90.38642501831055,
+            "loadAverage": [
+              11.88671875,
+              12.61865234375,
+              10.3486328125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 92.50648093223572,
+            "loadAverage": [
+              11.88671875,
+              12.61865234375,
+              10.3486328125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 94.62218403816223,
+            "loadAverage": [
+              11.2548828125,
+              12.47509765625,
+              10.31103515625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 96.72173500061035,
+            "loadAverage": [
+              11.2548828125,
+              12.47509765625,
+              10.31103515625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 98.85145497322083,
+            "loadAverage": [
+              10.75390625,
+              12.3505859375,
+              10.27978515625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 100.98022103309631,
+            "loadAverage": [
+              10.75390625,
+              12.3505859375,
+              10.27978515625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 103.10233807563782,
+            "loadAverage": [
+              10.75390625,
+              12.3505859375,
+              10.27978515625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 105.2264609336853,
+            "loadAverage": [
+              10.29296875,
+              12.228515625,
+              10.24853515625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 99,
+            "elapsedSeconds": 107.33183598518372,
+            "loadAverage": [
+              10.29296875,
+              12.228515625,
+              10.24853515625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 109.4474241733551,
+            "loadAverage": [
+              9.70849609375,
+              12.0751953125,
+              10.2060546875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 111.55328702926636,
+            "loadAverage": [
+              9.70849609375,
+              12.0751953125,
+              10.2060546875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 113.67311596870422,
+            "loadAverage": [
+              9.2509765625,
+              11.94091796875,
+              10.16943359375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 115.77610206604004,
+            "loadAverage": [
+              9.2509765625,
+              11.94091796875,
+              10.16943359375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 117.8837080001831,
+            "loadAverage": [
+              9.2509765625,
+              11.94091796875,
+              10.16943359375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 119.99038290977478,
+            "loadAverage": [
+              8.830078125,
+              11.80908203125,
+              10.1328125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 122.10567688941956,
+            "loadAverage": [
+              8.830078125,
+              11.80908203125,
+              10.1328125
+            ]
+          }
+        ],
+        "knownRenderingWorkerCount": 1,
+        "maxPressureLevel": 1,
+        "measurementMode": "desktop-load",
+        "peakResidentBytes": 15805136896,
+        "processSeconds": 124.23306202888489,
+        "profiled": false,
+        "prompt": "Explain how a small community could turn an abandoned railway station into a public library. Discuss the building, accessibility, staffing, the collection, and a realistic opening-day scene. Write approximately 400 words of clear, connected prose.",
+        "runtimeOverrides": {
+          "MERERUN_Q35_ASYNC_DECODE_BLOCKS": "1",
+          "MERERUN_Q35_MTP_HEAD_COST_RATIO": "0.18",
+          "MERERUN_Q35_MTP_PIPELINED_FALLBACK": "1",
+          "MERERUN_Q35_SCOPED_COMPILE": "1"
+        },
+        "sourceHead": "9319a217579cff3e3bbea002fb93451fe719a868",
+        "startedUnixSeconds": 1788622267.974062,
+        "uncontended": false,
+        "workload": "prose"
+      },
+      "scenarios": [
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 1.5080370540050727
+          },
+          "endToEndSpeedups": {
+            "adaptive": 1.4616616499015473
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 247,
+          "repetition": 1,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "acceptanceRate": 0.4074074074074074,
+                "acceptedDraftTokens": 132,
+                "draftHistoryTokens": 59,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 324,
+                "rounds": 124,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 11.698272943496704,
+              "decodeTokensPerSecond": 21.88357215090586,
+              "elapsedSeconds": 12.399502992630005,
+              "endToEndTokensPerSecond": 20.645988807145,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0004019737243652344,
+              "generatedTokens": 256,
+              "loadSeconds": 1.800060272216797e-05,
+              "name": "adaptive",
+              "outputSHA256": "f0eee860afeee246903ecb69993c7b7fee39cc16b60c5bf6535276f31f58bcda",
+              "policy": "adaptive",
+              "prefillSeconds": 0.6994040012359619,
+              "prefillTokensPerSecond": 85.78732734438198,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 15804776448,
+              "residentMemoryBeforeBytes": 15804334080,
+              "ttftSeconds": 0.6998239755630493
+            },
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 17.64142906665802,
+              "decodeTokensPerSecond": 14.511296053891424,
+              "elapsedSeconds": 18.123878002166748,
+              "endToEndTokensPerSecond": 14.125012316315232,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.15963101387023926,
+              "generatedTokens": 256,
+              "loadSeconds": 9.202957153320312e-05,
+              "name": "baseline",
+              "outputSHA256": "f0eee860afeee246903ecb69993c7b7fee39cc16b60c5bf6535276f31f58bcda",
+              "policy": "disabled",
+              "prefillSeconds": 0.47853004932403564,
+              "prefillTokensPerSecond": 125.38397554083615,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 15418966016,
+              "residentMemoryBeforeBytes": 15418867712,
+              "ttftSeconds": 0.6382530927658081
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 1.4328934240681084
+          },
+          "endToEndSpeedups": {
+            "adaptive": 1.4252402925136542
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 247,
+          "repetition": 2,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "acceptanceRate": 0.4074074074074074,
+                "acceptedDraftTokens": 132,
+                "draftHistoryTokens": 59,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 324,
+                "rounds": 124,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 11.7376629114151,
+              "decodeTokensPerSecond": 21.810133919507532,
+              "elapsedSeconds": 12.467804908752441,
+              "endToEndTokensPerSecond": 20.532884647584368,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.00029098987579345703,
+              "generatedTokens": 256,
+              "loadSeconds": 4.208087921142578e-05,
+              "name": "adaptive",
+              "outputSHA256": "f0eee860afeee246903ecb69993c7b7fee39cc16b60c5bf6535276f31f58bcda",
+              "policy": "adaptive",
+              "prefillSeconds": 0.7281429767608643,
+              "prefillTokensPerSecond": 82.40139905888994,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 15805054976,
+              "residentMemoryBeforeBytes": 15804891136,
+              "ttftSeconds": 0.7284760475158691
+            },
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 16.818819999694824,
+              "decodeTokensPerSecond": 15.221044044983245,
+              "elapsedSeconds": 17.769617915153503,
+              "endToEndTokensPerSecond": 14.406612523823,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.051451921463012695,
+              "generatedTokens": 256,
+              "loadSeconds": 2.5987625122070312e-05,
+              "name": "baseline",
+              "outputSHA256": "f0eee860afeee246903ecb69993c7b7fee39cc16b60c5bf6535276f31f58bcda",
+              "policy": "disabled",
+              "prefillSeconds": 0.9476369619369507,
+              "prefillTokensPerSecond": 63.31538596527643,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 15418949632,
+              "residentMemoryBeforeBytes": 15418982400,
+              "ttftSeconds": 0.9991148710250854
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 1.3600837881207897
+          },
+          "endToEndSpeedups": {
+            "adaptive": 1.352929165886891
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 247,
+          "repetition": 3,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "acceptanceRate": 0.4074074074074074,
+                "acceptedDraftTokens": 132,
+                "draftHistoryTokens": 59,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 324,
+                "rounds": 124,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 11.951074004173279,
+              "decodeTokensPerSecond": 21.420668963358906,
+              "elapsedSeconds": 12.69511103630066,
+              "endToEndTokensPerSecond": 20.165243082001282,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0002930164337158203,
+              "generatedTokens": 256,
+              "loadSeconds": 2.193450927734375e-05,
+              "name": "adaptive",
+              "outputSHA256": "f0eee860afeee246903ecb69993c7b7fee39cc16b60c5bf6535276f31f58bcda",
+              "policy": "adaptive",
+              "prefillSeconds": 0.7422250509262085,
+              "prefillTokensPerSecond": 80.83801526925983,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 15805153280,
+              "residentMemoryBeforeBytes": 15805054976,
+              "ttftSeconds": 0.7425400018692017
+            },
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 16.254462003707886,
+              "decodeTokensPerSecond": 15.749521573928597,
+              "elapsedSeconds": 17.175585985183716,
+              "endToEndTokensPerSecond": 14.90487720307388,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.05259203910827637,
+              "generatedTokens": 256,
+              "loadSeconds": 4.303455352783203e-05,
+              "name": "baseline",
+              "outputSHA256": "f0eee860afeee246903ecb69993c7b7fee39cc16b60c5bf6535276f31f58bcda",
+              "policy": "disabled",
+              "prefillSeconds": 0.9180610179901123,
+              "prefillTokensPerSecond": 65.35513307313329,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 15419015168,
+              "residentMemoryBeforeBytes": 15418949632,
+              "ttftSeconds": 0.9706960916519165
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        }
+      ]
+    },
+    {
+      "id": "finish-selection/qwen-c30/qwen-code",
+      "model": "vision-chat-q38-27b-4bit",
+      "rawReceiptSHA256": "981120fcd69a9d240c110a081e66d94d62a5f3f579f6470eab225cae7c98b5fa",
+      "receipt": {
+        "after": {
+          "gpuDeviceUtilizationPercent": 69,
+          "loadAverage": [
+            9.93896484375,
+            10.96044921875,
+            9.97705078125
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7276.25M  free = 915.75M  (encrypted)",
+          "swapUsedMiB": 7276.25
+        },
+        "before": {
+          "gpuDeviceUtilizationPercent": 41,
+          "loadAverage": [
+            8.36279296875,
+            11.66259765625,
+            10.0908203125
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7276.25M  free = 915.75M  (encrypted)",
+          "swapUsedMiB": 7276.25
+        },
+        "binarySHA256": "cdec91928873110a516e18abcf0db7904cde7398977a7e5b9317c0776a3c1737",
+        "buildSourceRevision": "f847be2ef7ca2f8896829c3cc0b6a1a55ea72ea9",
+        "collectorSHA256": "c5d800333764ac360dd08c27bd99ccf3bc3be6afb203f82ac9fddef41d7ce682",
+        "command": [
+          "mere.run",
+          "model",
+          "benchmark",
+          "q36-mtp",
+          "--model",
+          "vision-chat-q38-27b-4bit",
+          "--prompt",
+          "Write a complete Python implementation of an LRU cache using a dictionary and a doubly linked list, with get and put operations, type hints, and a short usage example. Return the code directly without introductory prose.",
+          "--decode-tokens",
+          "256",
+          "--context-size",
+          "8192",
+          "--temperature",
+          "0",
+          "--top-p",
+          "1",
+          "--json",
+          "--variants",
+          "baseline,adaptive",
+          "--warmups",
+          "1",
+          "--warmup-tokens",
+          "256",
+          "--repetitions",
+          "3",
+          "--mtp-block-size",
+          "8"
+        ],
+        "competingInferenceProcessCount": 0,
+        "gpuSamples": [
+          {
+            "deviceUtilizationPercent": 49,
+            "elapsedSeconds": 0.08810806274414062,
+            "loadAverage": [
+              8.36279296875,
+              11.66259765625,
+              10.0908203125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 81,
+            "elapsedSeconds": 2.19541597366333,
+            "loadAverage": [
+              8.36279296875,
+              11.66259765625,
+              10.0908203125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 79,
+            "elapsedSeconds": 4.3029890060424805,
+            "loadAverage": [
+              7.93310546875,
+              11.5185546875,
+              10.048828125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 37,
+            "elapsedSeconds": 6.413963079452515,
+            "loadAverage": [
+              7.93310546875,
+              11.5185546875,
+              10.048828125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 39,
+            "elapsedSeconds": 8.514007806777954,
+            "loadAverage": [
+              7.93310546875,
+              11.5185546875,
+              10.048828125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 41,
+            "elapsedSeconds": 10.628266096115112,
+            "loadAverage": [
+              7.69775390625,
+              11.41015625,
+              10.01904296875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 36,
+            "elapsedSeconds": 12.73709511756897,
+            "loadAverage": [
+              7.69775390625,
+              11.41015625,
+              10.01904296875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 40,
+            "elapsedSeconds": 14.840160131454468,
+            "loadAverage": [
+              7.6416015625,
+              11.3369140625,
+              10.0009765625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 37,
+            "elapsedSeconds": 16.94929814338684,
+            "loadAverage": [
+              7.6416015625,
+              11.3369140625,
+              10.0009765625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 51,
+            "elapsedSeconds": 19.053713083267212,
+            "loadAverage": [
+              7.6416015625,
+              11.3369140625,
+              10.0009765625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 21.17399311065674,
+            "loadAverage": [
+              7.509765625,
+              11.248046875,
+              9.97705078125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 23.278244972229004,
+            "loadAverage": [
+              7.509765625,
+              11.248046875,
+              9.97705078125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 25.37913703918457,
+            "loadAverage": [
+              7.1484375,
+              11.11083984375,
+              9.93603515625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 27.487257957458496,
+            "loadAverage": [
+              7.1484375,
+              11.11083984375,
+              9.93603515625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 29.602432012557983,
+            "loadAverage": [
+              6.57568359375,
+              10.92626953125,
+              9.87744140625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 31.70416498184204,
+            "loadAverage": [
+              6.57568359375,
+              10.92626953125,
+              9.87744140625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 33.81872200965881,
+            "loadAverage": [
+              6.57568359375,
+              10.92626953125,
+              9.87744140625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 99,
+            "elapsedSeconds": 35.92046403884888,
+            "loadAverage": [
+              6.369140625,
+              10.81103515625,
+              9.8427734375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 38.025678873062134,
+            "loadAverage": [
+              6.369140625,
+              10.81103515625,
+              9.8427734375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 40.13490319252014,
+            "loadAverage": [
+              6.57958984375,
+              10.78076171875,
+              9.83740234375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 42.23935604095459,
+            "loadAverage": [
+              6.57958984375,
+              10.78076171875,
+              9.83740234375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 44.34653401374817,
+            "loadAverage": [
+              6.37255859375,
+              10.66796875,
+              9.802734375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 46.4538471698761,
+            "loadAverage": [
+              6.37255859375,
+              10.66796875,
+              9.802734375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 48.56352114677429,
+            "loadAverage": [
+              6.37255859375,
+              10.66796875,
+              9.802734375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 50.67429995536804,
+            "loadAverage": [
+              6.10205078125,
+              10.54052734375,
+              9.7626953125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 99,
+            "elapsedSeconds": 52.79206204414368,
+            "loadAverage": [
+              6.10205078125,
+              10.54052734375,
+              9.7626953125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 54.97821402549744,
+            "loadAverage": [
+              5.93359375,
+              10.431640625,
+              9.728515625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 90,
+            "elapsedSeconds": 57.57572889328003,
+            "loadAverage": [
+              5.93359375,
+              10.431640625,
+              9.728515625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 69,
+            "elapsedSeconds": 60.34495496749878,
+            "loadAverage": [
+              6.6591796875,
+              10.50732421875,
+              9.75927734375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 73,
+            "elapsedSeconds": 63.06168603897095,
+            "loadAverage": [
+              6.6591796875,
+              10.50732421875,
+              9.75927734375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 81,
+            "elapsedSeconds": 65.80584716796875,
+            "loadAverage": [
+              7.56689453125,
+              10.63134765625,
+              9.80712890625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 63,
+            "elapsedSeconds": 68.58082103729248,
+            "loadAverage": [
+              7.56689453125,
+              10.63134765625,
+              9.80712890625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 62,
+            "elapsedSeconds": 71.54237818717957,
+            "loadAverage": [
+              7.921875,
+              10.65380859375,
+              9.81982421875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 53,
+            "elapsedSeconds": 73.9482901096344,
+            "loadAverage": [
+              7.921875,
+              10.65380859375,
+              9.81982421875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 54,
+            "elapsedSeconds": 76.19201707839966,
+            "loadAverage": [
+              8.48828125,
+              10.7255859375,
+              9.85009765625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 85,
+            "elapsedSeconds": 78.90555715560913,
+            "loadAverage": [
+              8.48828125,
+              10.7255859375,
+              9.85009765625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 81,
+            "elapsedSeconds": 81.59321999549866,
+            "loadAverage": [
+              9.48974609375,
+              10.89599609375,
+              9.9150390625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 75,
+            "elapsedSeconds": 84.24869298934937,
+            "loadAverage": [
+              9.48974609375,
+              10.89599609375,
+              9.9150390625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 80,
+            "elapsedSeconds": 86.85451984405518,
+            "loadAverage": [
+              10.4912109375,
+              11.080078125,
+              9.98583984375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 76,
+            "elapsedSeconds": 89.53718113899231,
+            "loadAverage": [
+              12.29345703125,
+              11.44384765625,
+              10.12060546875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 89,
+            "elapsedSeconds": 91.72378301620483,
+            "loadAverage": [
+              12.29345703125,
+              11.44384765625,
+              10.12060546875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 93,
+            "elapsedSeconds": 93.82181215286255,
+            "loadAverage": [
+              12.29345703125,
+              11.44384765625,
+              10.12060546875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 93,
+            "elapsedSeconds": 95.9191062450409,
+            "loadAverage": [
+              11.708984375,
+              11.33642578125,
+              10.09033203125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 98,
+            "elapsedSeconds": 98.01730394363403,
+            "loadAverage": [
+              11.708984375,
+              11.33642578125,
+              10.09033203125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 86,
+            "elapsedSeconds": 100.11240792274475,
+            "loadAverage": [
+              10.93115234375,
+              11.18115234375,
+              10.04248046875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 99,
+            "elapsedSeconds": 102.21092104911804,
+            "loadAverage": [
+              10.93115234375,
+              11.18115234375,
+              10.04248046875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 93,
+            "elapsedSeconds": 104.30623602867126,
+            "loadAverage": [
+              10.4560546875,
+              11.078125,
+              10.0126953125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 89,
+            "elapsedSeconds": 106.39893889427185,
+            "loadAverage": [
+              10.4560546875,
+              11.078125,
+              10.0126953125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 90,
+            "elapsedSeconds": 108.49073600769043,
+            "loadAverage": [
+              10.4560546875,
+              11.078125,
+              10.0126953125
+            ]
+          }
+        ],
+        "knownRenderingWorkerCount": 1,
+        "maxPressureLevel": 1,
+        "measurementMode": "desktop-load",
+        "peakResidentBytes": 15817195520,
+        "processSeconds": 110.60778713226318,
+        "profiled": false,
+        "prompt": "Write a complete Python implementation of an LRU cache using a dictionary and a doubly linked list, with get and put operations, type hints, and a short usage example. Return the code directly without introductory prose.",
+        "runtimeOverrides": {
+          "MERERUN_Q35_ASYNC_DECODE_BLOCKS": "1",
+          "MERERUN_Q35_MTP_HEAD_COST_RATIO": "0.3",
+          "MERERUN_Q35_MTP_PIPELINED_FALLBACK": "1",
+          "MERERUN_Q35_SCOPED_COMPILE": "1"
+        },
+        "sourceHead": "9319a217579cff3e3bbea002fb93451fe719a868",
+        "startedUnixSeconds": 1788622392.333998,
+        "uncontended": false,
+        "workload": "code"
+      },
+      "scenarios": [
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 1.9044892694489648
+          },
+          "endToEndSpeedups": {
+            "adaptive": 1.9206018874168254
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 220,
+          "repetition": 1,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 16.171544075012207,
+              "decodeTokensPerSecond": 15.83027562566296,
+              "elapsedSeconds": 17.096933007240295,
+              "endToEndTokensPerSecond": 14.973445815783908,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.05190408229827881,
+              "generatedTokens": 256,
+              "loadSeconds": 2.09808349609375e-05,
+              "name": "baseline",
+              "outputSHA256": "ca2c0ddf75b621ec62d587ff04b6f89f528aafe8d744b0730c298166deb5f461",
+              "policy": "disabled",
+              "prefillSeconds": 0.922996997833252,
+              "prefillTokensPerSecond": 58.50506570093482,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 15396716544,
+              "residentMemoryBeforeBytes": 15396569088,
+              "ttftSeconds": 0.9749220609664917
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.7710843373493976,
+                "acceptedDraftTokens": 192,
+                "draftHistoryTokens": 53,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 249,
+                "rounds": 64,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 8.491276025772095,
+              "decodeTokensPerSecond": 30.148590061494605,
+              "elapsedSeconds": 8.901862025260925,
+              "endToEndTokensPerSecond": 28.75802829492814,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.01044309139251709,
+              "generatedTokens": 256,
+              "loadSeconds": 4.601478576660156e-05,
+              "name": "adaptive",
+              "outputSHA256": "ca2c0ddf75b621ec62d587ff04b6f89f528aafe8d744b0730c298166deb5f461",
+              "policy": "adaptive",
+              "prefillSeconds": 0.4070429801940918,
+              "prefillTokensPerSecond": 132.6641230227112,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 15817129984,
+              "residentMemoryBeforeBytes": 15815376896,
+              "ttftSeconds": 0.4175320863723755
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 2.286526283353526
+          },
+          "endToEndSpeedups": {
+            "adaptive": 2.22807127253675
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 220,
+          "repetition": 2,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 15.81271493434906,
+              "decodeTokensPerSecond": 16.18950326132205,
+              "elapsedSeconds": 16.6581369638443,
+              "endToEndTokensPerSecond": 15.367864999287491,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.04707193374633789,
+              "generatedTokens": 256,
+              "loadSeconds": 5.1975250244140625e-05,
+              "name": "baseline",
+              "outputSHA256": "ca2c0ddf75b621ec62d587ff04b6f89f528aafe8d744b0730c298166deb5f461",
+              "policy": "disabled",
+              "prefillSeconds": 0.8409600257873535,
+              "prefillTokensPerSecond": 64.21232679810458,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 15396847616,
+              "residentMemoryBeforeBytes": 15396831232,
+              "ttftSeconds": 0.8880839347839355
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.7710843373493976,
+                "acceptedDraftTokens": 192,
+                "draftHistoryTokens": 53,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 249,
+                "rounds": 64,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 6.9156060218811035,
+              "decodeTokensPerSecond": 37.01772472145049,
+              "elapsedSeconds": 7.47648298740387,
+              "endToEndTokensPerSecond": 34.24069852513546,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0003770589828491211,
+              "generatedTokens": 256,
+              "loadSeconds": 2.09808349609375e-05,
+              "name": "adaptive",
+              "outputSHA256": "ca2c0ddf75b621ec62d587ff04b6f89f528aafe8d744b0730c298166deb5f461",
+              "policy": "adaptive",
+              "prefillSeconds": 0.559149980545044,
+              "prefillTokensPerSecond": 96.57516208327914,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 15817162752,
+              "residentMemoryBeforeBytes": 15817129984,
+              "ttftSeconds": 0.559548020362854
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 2.8668528774133106
+          },
+          "endToEndSpeedups": {
+            "adaptive": 2.7216101728632554
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 220,
+          "repetition": 3,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 20.13426899909973,
+              "decodeTokensPerSecond": 12.714640894658087,
+              "elapsedSeconds": 20.875707983970642,
+              "endToEndTokensPerSecond": 12.263057147406398,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.05099892616271973,
+              "generatedTokens": 256,
+              "loadSeconds": 2.193450927734375e-05,
+              "name": "baseline",
+              "outputSHA256": "ca2c0ddf75b621ec62d587ff04b6f89f528aafe8d744b0730c298166deb5f461",
+              "policy": "disabled",
+              "prefillSeconds": 0.7390890121459961,
+              "prefillTokensPerSecond": 73.06291815001723,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 15397109760,
+              "residentMemoryBeforeBytes": 15396847616,
+              "ttftSeconds": 0.7901098728179932
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.7710843373493976,
+                "acceptedDraftTokens": 192,
+                "draftHistoryTokens": 53,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 249,
+                "rounds": 64,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 7.023126006126404,
+              "decodeTokensPerSecond": 36.45100483412749,
+              "elapsedSeconds": 7.670351982116699,
+              "endToEndTokensPerSecond": 33.375261082784704,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.00035691261291503906,
+              "generatedTokens": 256,
+              "loadSeconds": 1.895427703857422e-05,
+              "name": "adaptive",
+              "outputSHA256": "ca2c0ddf75b621ec62d587ff04b6f89f528aafe8d744b0730c298166deb5f461",
+              "policy": "adaptive",
+              "prefillSeconds": 0.6456530094146729,
+              "prefillTokensPerSecond": 83.63625540745883,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 15817195520,
+              "residentMemoryBeforeBytes": 15817162752,
+              "ttftSeconds": 0.6460288763046265
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        }
+      ]
+    },
+    {
+      "id": "finish-selection/qwen-c30/qwen-prose",
+      "model": "vision-chat-q38-27b-4bit",
+      "rawReceiptSHA256": "16e51686bc2dd0d8ba236e991e720836494ac98f3dd354458999011a964d608f",
+      "receipt": {
+        "after": {
+          "gpuDeviceUtilizationPercent": 77,
+          "loadAverage": [
+            4.4814453125,
+            8.5244140625,
+            9.13525390625
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7276.25M  free = 915.75M  (encrypted)",
+          "swapUsedMiB": 7276.25
+        },
+        "before": {
+          "gpuDeviceUtilizationPercent": 50,
+          "loadAverage": [
+            9.93896484375,
+            10.96044921875,
+            9.97705078125
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7276.25M  free = 915.75M  (encrypted)",
+          "swapUsedMiB": 7276.25
+        },
+        "binarySHA256": "cdec91928873110a516e18abcf0db7904cde7398977a7e5b9317c0776a3c1737",
+        "buildSourceRevision": "f847be2ef7ca2f8896829c3cc0b6a1a55ea72ea9",
+        "collectorSHA256": "c5d800333764ac360dd08c27bd99ccf3bc3be6afb203f82ac9fddef41d7ce682",
+        "command": [
+          "mere.run",
+          "model",
+          "benchmark",
+          "q36-mtp",
+          "--model",
+          "vision-chat-q38-27b-4bit",
+          "--prompt",
+          "Explain how a small community could turn an abandoned railway station into a public library. Discuss the building, accessibility, staffing, the collection, and a realistic opening-day scene. Write approximately 400 words of clear, connected prose.",
+          "--decode-tokens",
+          "256",
+          "--context-size",
+          "8192",
+          "--temperature",
+          "0",
+          "--top-p",
+          "1",
+          "--json",
+          "--variants",
+          "adaptive,baseline",
+          "--warmups",
+          "1",
+          "--warmup-tokens",
+          "256",
+          "--repetitions",
+          "3",
+          "--mtp-block-size",
+          "8"
+        ],
+        "competingInferenceProcessCount": 0,
+        "gpuSamples": [
+          {
+            "deviceUtilizationPercent": 40,
+            "elapsedSeconds": 0.08319902420043945,
+            "loadAverage": [
+              9.93896484375,
+              10.96044921875,
+              9.97705078125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 53,
+            "elapsedSeconds": 2.1835098266601562,
+            "loadAverage": [
+              9.93896484375,
+              10.96044921875,
+              9.97705078125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 81,
+            "elapsedSeconds": 4.286635160446167,
+            "loadAverage": [
+              9.46337890625,
+              10.8447265625,
+              9.94189453125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 92,
+            "elapsedSeconds": 6.381968021392822,
+            "loadAverage": [
+              9.46337890625,
+              10.8447265625,
+              9.94189453125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 80,
+            "elapsedSeconds": 8.473695993423462,
+            "loadAverage": [
+              9.46337890625,
+              10.8447265625,
+              9.94189453125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 77,
+            "elapsedSeconds": 10.568106174468994,
+            "loadAverage": [
+              9.18603515625,
+              10.76416015625,
+              9.91845703125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 78,
+            "elapsedSeconds": 12.660989999771118,
+            "loadAverage": [
+              9.18603515625,
+              10.76416015625,
+              9.91845703125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 83,
+            "elapsedSeconds": 14.756610870361328,
+            "loadAverage": [
+              8.6103515625,
+              10.61865234375,
+              9.87158203125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 84,
+            "elapsedSeconds": 16.854438066482544,
+            "loadAverage": [
+              8.6103515625,
+              10.61865234375,
+              9.87158203125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 87,
+            "elapsedSeconds": 18.95078682899475,
+            "loadAverage": [
+              8.24072265625,
+              10.50830078125,
+              9.8369140625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 83,
+            "elapsedSeconds": 21.046904802322388,
+            "loadAverage": [
+              8.24072265625,
+              10.50830078125,
+              9.8369140625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 78,
+            "elapsedSeconds": 23.140676021575928,
+            "loadAverage": [
+              8.24072265625,
+              10.50830078125,
+              9.8369140625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 90,
+            "elapsedSeconds": 25.230878114700317,
+            "loadAverage": [
+              7.90087890625,
+              10.39990234375,
+              9.80224609375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 71,
+            "elapsedSeconds": 27.32303810119629,
+            "loadAverage": [
+              7.90087890625,
+              10.39990234375,
+              9.80224609375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 85,
+            "elapsedSeconds": 29.41638684272766,
+            "loadAverage": [
+              7.90869140625,
+              10.35986328125,
+              9.79150390625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 83,
+            "elapsedSeconds": 31.509045124053955,
+            "loadAverage": [
+              7.90869140625,
+              10.35986328125,
+              9.79150390625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 74,
+            "elapsedSeconds": 33.604341983795166,
+            "loadAverage": [
+              7.35498046875,
+              10.2041015625,
+              9.73974609375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 79,
+            "elapsedSeconds": 35.70349907875061,
+            "loadAverage": [
+              7.35498046875,
+              10.2041015625,
+              9.73974609375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 87,
+            "elapsedSeconds": 37.79845094680786,
+            "loadAverage": [
+              7.35498046875,
+              10.2041015625,
+              9.73974609375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 75,
+            "elapsedSeconds": 39.90022897720337,
+            "loadAverage": [
+              7.24609375,
+              10.13427734375,
+              9.7177734375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 89,
+            "elapsedSeconds": 41.99768090248108,
+            "loadAverage": [
+              7.24609375,
+              10.13427734375,
+              9.7177734375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 71,
+            "elapsedSeconds": 44.10057878494263,
+            "loadAverage": [
+              6.90576171875,
+              10.015625,
+              9.67822265625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 79,
+            "elapsedSeconds": 46.201536893844604,
+            "loadAverage": [
+              6.90576171875,
+              10.015625,
+              9.67822265625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 74,
+            "elapsedSeconds": 48.302613735198975,
+            "loadAverage": [
+              6.90576171875,
+              10.015625,
+              9.67822265625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 69,
+            "elapsedSeconds": 50.40633296966553,
+            "loadAverage": [
+              6.3525390625,
+              9.84912109375,
+              9.62109375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 82,
+            "elapsedSeconds": 52.520609855651855,
+            "loadAverage": [
+              6.3525390625,
+              9.84912109375,
+              9.62109375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 35,
+            "elapsedSeconds": 54.633506774902344,
+            "loadAverage": [
+              6.1640625,
+              9.751953125,
+              9.587890625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 39,
+            "elapsedSeconds": 56.75975203514099,
+            "loadAverage": [
+              6.1640625,
+              9.751953125,
+              9.587890625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 37,
+            "elapsedSeconds": 58.87088584899902,
+            "loadAverage": [
+              5.99072265625,
+              9.65625,
+              9.5546875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 37,
+            "elapsedSeconds": 60.99455499649048,
+            "loadAverage": [
+              5.99072265625,
+              9.65625,
+              9.5546875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 33,
+            "elapsedSeconds": 63.10622191429138,
+            "loadAverage": [
+              5.99072265625,
+              9.65625,
+              9.5546875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 43,
+            "elapsedSeconds": 65.21710705757141,
+            "loadAverage": [
+              5.9111328125,
+              9.57861328125,
+              9.52783203125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 33,
+            "elapsedSeconds": 67.33113598823547,
+            "loadAverage": [
+              5.9111328125,
+              9.57861328125,
+              9.52783203125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 85,
+            "elapsedSeconds": 69.4352080821991,
+            "loadAverage": [
+              5.677734375,
+              9.46923828125,
+              9.4892578125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 71.54713201522827,
+            "loadAverage": [
+              5.677734375,
+              9.46923828125,
+              9.4892578125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 73.66341996192932,
+            "loadAverage": [
+              5.3828125,
+              9.34521484375,
+              9.4453125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 75.7834677696228,
+            "loadAverage": [
+              5.3828125,
+              9.34521484375,
+              9.4453125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 77.88332891464233,
+            "loadAverage": [
+              5.3828125,
+              9.34521484375,
+              9.4453125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 80.00029301643372,
+            "loadAverage": [
+              5.27197265625,
+              9.25634765625,
+              9.4130859375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 82.10288381576538,
+            "loadAverage": [
+              5.27197265625,
+              9.25634765625,
+              9.4130859375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 84.21901392936707,
+            "loadAverage": [
+              5.009765625,
+              9.1357421875,
+              9.36962890625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 99,
+            "elapsedSeconds": 86.32019281387329,
+            "loadAverage": [
+              5.009765625,
+              9.1357421875,
+              9.36962890625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 88.42929196357727,
+            "loadAverage": [
+              5.009765625,
+              9.1357421875,
+              9.36962890625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 90.53942108154297,
+            "loadAverage": [
+              4.8486328125,
+              9.03369140625,
+              9.33203125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 92.66448593139648,
+            "loadAverage": [
+              4.8486328125,
+              9.03369140625,
+              9.33203125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 94.76693987846375,
+            "loadAverage": [
+              4.6201171875,
+              8.91650390625,
+              9.2890625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 96.86728096008301,
+            "loadAverage": [
+              4.6201171875,
+              8.91650390625,
+              9.2890625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 98.98701500892639,
+            "loadAverage": [
+              4.330078125,
+              8.78466796875,
+              9.240234375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 101.10234713554382,
+            "loadAverage": [
+              4.330078125,
+              8.78466796875,
+              9.240234375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 87,
+            "elapsedSeconds": 103.19229507446289,
+            "loadAverage": [
+              4.330078125,
+              8.78466796875,
+              9.240234375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 95,
+            "elapsedSeconds": 105.2909369468689,
+            "loadAverage": [
+              4.30322265625,
+              8.705078125,
+              9.20947265625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 107.40547204017639,
+            "loadAverage": [
+              4.30322265625,
+              8.705078125,
+              9.20947265625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 109.52663397789001,
+            "loadAverage": [
+              4.19873046875,
+              8.6103515625,
+              9.1728515625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 111.6428530216217,
+            "loadAverage": [
+              4.19873046875,
+              8.6103515625,
+              9.1728515625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 83,
+            "elapsedSeconds": 113.82783699035645,
+            "loadAverage": [
+              4.2626953125,
+              8.55029296875,
+              9.14794921875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 71,
+            "elapsedSeconds": 116.36687278747559,
+            "loadAverage": [
+              4.2626953125,
+              8.55029296875,
+              9.14794921875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 83,
+            "elapsedSeconds": 118.87349891662598,
+            "loadAverage": [
+              4.4814453125,
+              8.5244140625,
+              9.13525390625
+            ]
+          }
+        ],
+        "knownRenderingWorkerCount": 0,
+        "maxPressureLevel": 1,
+        "measurementMode": "desktop-load",
+        "peakResidentBytes": 15815147520,
+        "processSeconds": 121.09185099601746,
+        "profiled": false,
+        "prompt": "Explain how a small community could turn an abandoned railway station into a public library. Discuss the building, accessibility, staffing, the collection, and a realistic opening-day scene. Write approximately 400 words of clear, connected prose.",
+        "runtimeOverrides": {
+          "MERERUN_Q35_ASYNC_DECODE_BLOCKS": "1",
+          "MERERUN_Q35_MTP_HEAD_COST_RATIO": "0.3",
+          "MERERUN_Q35_MTP_PIPELINED_FALLBACK": "1",
+          "MERERUN_Q35_SCOPED_COMPILE": "1"
+        },
+        "sourceHead": "9319a217579cff3e3bbea002fb93451fe719a868",
+        "startedUnixSeconds": 1788622503.062458,
+        "uncontended": false,
+        "workload": "prose"
+      },
+      "scenarios": [
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 1.4522703439435756
+          },
+          "endToEndSpeedups": {
+            "adaptive": 1.4490255085590151
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 247,
+          "repetition": 1,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "acceptanceRate": 0.49407114624505927,
+                "acceptedDraftTokens": 125,
+                "draftHistoryTokens": 59,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 253,
+                "rounds": 131,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 11.374314069747925,
+              "decodeTokensPerSecond": 22.50685170377693,
+              "elapsedSeconds": 12.068704009056091,
+              "endToEndTokensPerSecond": 21.21188818682629,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0003960132598876953,
+              "generatedTokens": 256,
+              "loadSeconds": 1.990795135498047e-05,
+              "name": "adaptive",
+              "outputSHA256": "f0eee860afeee246903ecb69993c7b7fee39cc16b60c5bf6535276f31f58bcda",
+              "policy": "adaptive",
+              "prefillSeconds": 0.6927779912948608,
+              "prefillTokensPerSecond": 86.60783216836163,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 15814787072,
+              "residentMemoryBeforeBytes": 15814557696,
+              "ttftSeconds": 0.6931939125061035
+            },
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 16.51857900619507,
+              "decodeTokensPerSecond": 15.497701097896536,
+              "elapsedSeconds": 17.487859964370728,
+              "endToEndTokensPerSecond": 14.63872655210913,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.05291104316711426,
+              "generatedTokens": 256,
+              "loadSeconds": 2.8967857360839844e-05,
+              "name": "baseline",
+              "outputSHA256": "f0eee860afeee246903ecb69993c7b7fee39cc16b60c5bf6535276f31f58bcda",
+              "policy": "disabled",
+              "prefillSeconds": 0.9662530422210693,
+              "prefillTokensPerSecond": 62.09553541180218,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 15426945024,
+              "residentMemoryBeforeBytes": 15426895872,
+              "ttftSeconds": 1.0191930532455444
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 1.3804458779822655
+          },
+          "endToEndSpeedups": {
+            "adaptive": 1.3551175307244239
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 247,
+          "repetition": 2,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "acceptanceRate": 0.49407114624505927,
+                "acceptedDraftTokens": 125,
+                "draftHistoryTokens": 59,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 253,
+                "rounds": 131,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 11.735543012619019,
+              "decodeTokensPerSecond": 21.814073684083283,
+              "elapsedSeconds": 12.62632405757904,
+              "endToEndTokensPerSecond": 20.275101354327603,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.00040400028228759766,
+              "generatedTokens": 256,
+              "loadSeconds": 1.800060272216797e-05,
+              "name": "adaptive",
+              "outputSHA256": "f0eee860afeee246903ecb69993c7b7fee39cc16b60c5bf6535276f31f58bcda",
+              "policy": "adaptive",
+              "prefillSeconds": 0.8891839981079102,
+              "prefillTokensPerSecond": 67.47759758123591,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 15814950912,
+              "residentMemoryBeforeBytes": 15814885376,
+              "ttftSeconds": 0.8896059989929199
+            },
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 16.200281977653503,
+              "decodeTokensPerSecond": 15.802194082369905,
+              "elapsedSeconds": 17.110153079032898,
+              "endToEndTokensPerSecond": 14.96187665987087,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.049934983253479004,
+              "generatedTokens": 256,
+              "loadSeconds": 5.0067901611328125e-05,
+              "name": "baseline",
+              "outputSHA256": "f0eee860afeee246903ecb69993c7b7fee39cc16b60c5bf6535276f31f58bcda",
+              "policy": "disabled",
+              "prefillSeconds": 0.9059699773788452,
+              "prefillTokensPerSecond": 66.22736017543558,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 15426945024,
+              "residentMemoryBeforeBytes": 15426977792,
+              "ttftSeconds": 0.9559550285339355
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 1.4536891035427015
+          },
+          "endToEndSpeedups": {
+            "adaptive": 1.4526044060963965
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 247,
+          "repetition": 3,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "acceptanceRate": 0.49407114624505927,
+                "acceptedDraftTokens": 125,
+                "draftHistoryTokens": 59,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 253,
+                "rounds": 131,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 11.530770897865295,
+              "decodeTokensPerSecond": 22.201464435252422,
+              "elapsedSeconds": 12.270874977111816,
+              "endToEndTokensPerSecond": 20.862407976407763,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.00038993358612060547,
+              "generatedTokens": 256,
+              "loadSeconds": 2.002716064453125e-05,
+              "name": "adaptive",
+              "outputSHA256": "f0eee860afeee246903ecb69993c7b7fee39cc16b60c5bf6535276f31f58bcda",
+              "policy": "adaptive",
+              "prefillSeconds": 0.7384730577468872,
+              "prefillTokensPerSecond": 81.2487325984005,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 15815131136,
+              "residentMemoryBeforeBytes": 15814950912,
+              "ttftSeconds": 0.7388830184936523
+            },
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 16.762156009674072,
+              "decodeTokensPerSecond": 15.272498349988673,
+              "elapsedSeconds": 17.824727058410645,
+              "endToEndTokensPerSecond": 14.362071248614475,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.059265971183776855,
+              "generatedTokens": 256,
+              "loadSeconds": 6.604194641113281e-05,
+              "name": "baseline",
+              "outputSHA256": "f0eee860afeee246903ecb69993c7b7fee39cc16b60c5bf6535276f31f58bcda",
+              "policy": "disabled",
+              "prefillSeconds": 1.0589549541473389,
+              "prefillTokensPerSecond": 56.65963388245486,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 15427043328,
+              "residentMemoryBeforeBytes": 15426945024,
+              "ttftSeconds": 1.1182869672775269
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        }
+      ]
+    },
+    {
+      "id": "finish-selection/qwen-current/qwen-code",
+      "model": "vision-chat-q38-27b-4bit",
+      "rawReceiptSHA256": "0a93f096b27d690d0e3974c1bc302fd92ee8edb9594f7e5ff71baa28ce497fa8",
+      "receipt": {
+        "after": {
+          "gpuDeviceUtilizationPercent": 0,
+          "loadAverage": [
+            9.98681640625,
+            8.39208984375,
+            8.03271484375
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7276.25M  free = 915.75M  (encrypted)",
+          "swapUsedMiB": 7276.25
+        },
+        "before": {
+          "gpuDeviceUtilizationPercent": 0,
+          "loadAverage": [
+            6.60400390625,
+            6.55078125,
+            7.37744140625
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7276.25M  free = 915.75M  (encrypted)",
+          "swapUsedMiB": 7276.25
+        },
+        "binarySHA256": "cdec91928873110a516e18abcf0db7904cde7398977a7e5b9317c0776a3c1737",
+        "buildSourceRevision": "f847be2ef7ca2f8896829c3cc0b6a1a55ea72ea9",
+        "collectorSHA256": "c5d800333764ac360dd08c27bd99ccf3bc3be6afb203f82ac9fddef41d7ce682",
+        "command": [
+          "mere.run",
+          "model",
+          "benchmark",
+          "q36-mtp",
+          "--model",
+          "vision-chat-q38-27b-4bit",
+          "--prompt",
+          "Write a complete Python implementation of an LRU cache using a dictionary and a doubly linked list, with get and put operations, type hints, and a short usage example. Return the code directly without introductory prose.",
+          "--decode-tokens",
+          "256",
+          "--context-size",
+          "8192",
+          "--temperature",
+          "0",
+          "--top-p",
+          "1",
+          "--json",
+          "--variants",
+          "baseline,adaptive",
+          "--warmups",
+          "1",
+          "--warmup-tokens",
+          "256",
+          "--repetitions",
+          "3",
+          "--mtp-block-size",
+          "8"
+        ],
+        "competingInferenceProcessCount": 0,
+        "gpuSamples": [
+          {
+            "deviceUtilizationPercent": 0,
+            "elapsedSeconds": 0.08145713806152344,
+            "loadAverage": [
+              6.60400390625,
+              6.55078125,
+              7.37744140625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 43,
+            "elapsedSeconds": 2.1803479194641113,
+            "loadAverage": [
+              6.60400390625,
+              6.55078125,
+              7.37744140625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 92,
+            "elapsedSeconds": 4.291781187057495,
+            "loadAverage": [
+              6.39501953125,
+              6.50830078125,
+              7.357421875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 99,
+            "elapsedSeconds": 6.412467002868652,
+            "loadAverage": [
+              6.39501953125,
+              6.50830078125,
+              7.357421875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 33,
+            "elapsedSeconds": 8.56551718711853,
+            "loadAverage": [
+              6.39501953125,
+              6.50830078125,
+              7.357421875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 2,
+            "elapsedSeconds": 10.715137004852295,
+            "loadAverage": [
+              6.5234375,
+              6.53271484375,
+              7.36083984375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 4,
+            "elapsedSeconds": 12.898132085800171,
+            "loadAverage": [
+              6.5234375,
+              6.53271484375,
+              7.36083984375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 35,
+            "elapsedSeconds": 15.06649899482727,
+            "loadAverage": [
+              8.5634765625,
+              6.955078125,
+              7.5048828125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 54,
+            "elapsedSeconds": 17.18791389465332,
+            "loadAverage": [
+              8.5634765625,
+              6.955078125,
+              7.5048828125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 54,
+            "elapsedSeconds": 19.311448097229004,
+            "loadAverage": [
+              8.35791015625,
+              6.93896484375,
+              7.49560546875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 54,
+            "elapsedSeconds": 21.422831058502197,
+            "loadAverage": [
+              8.35791015625,
+              6.93896484375,
+              7.49560546875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 56,
+            "elapsedSeconds": 23.53557300567627,
+            "loadAverage": [
+              8.35791015625,
+              6.93896484375,
+              7.49560546875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 57,
+            "elapsedSeconds": 25.675463914871216,
+            "loadAverage": [
+              8.2490234375,
+              6.93994140625,
+              7.49267578125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 49,
+            "elapsedSeconds": 27.800579071044922,
+            "loadAverage": [
+              8.2490234375,
+              6.93994140625,
+              7.49267578125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 54,
+            "elapsedSeconds": 29.962523937225342,
+            "loadAverage": [
+              8.06884765625,
+              6.92431640625,
+              7.48388671875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 61,
+            "elapsedSeconds": 32.118709087371826,
+            "loadAverage": [
+              8.06884765625,
+              6.92431640625,
+              7.48388671875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 55,
+            "elapsedSeconds": 34.25584411621094,
+            "loadAverage": [
+              8.22314453125,
+              6.97509765625,
+              7.49853515625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 57,
+            "elapsedSeconds": 36.388510942459106,
+            "loadAverage": [
+              8.22314453125,
+              6.97509765625,
+              7.49853515625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 86,
+            "elapsedSeconds": 39.00379300117493,
+            "loadAverage": [
+              10.927734375,
+              7.55615234375,
+              7.70068359375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 92,
+            "elapsedSeconds": 41.446017026901245,
+            "loadAverage": [
+              10.927734375,
+              7.55615234375,
+              7.70068359375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 92,
+            "elapsedSeconds": 43.961341857910156,
+            "loadAverage": [
+              13.33544921875,
+              8.111328125,
+              7.8955078125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 92,
+            "elapsedSeconds": 46.43530297279358,
+            "loadAverage": [
+              13.33544921875,
+              8.111328125,
+              7.8955078125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 91,
+            "elapsedSeconds": 48.917296171188354,
+            "loadAverage": [
+              16.27099609375,
+              8.806640625,
+              8.14208984375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 90,
+            "elapsedSeconds": 51.45944023132324,
+            "loadAverage": [
+              16.27099609375,
+              8.806640625,
+              8.14208984375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 92,
+            "elapsedSeconds": 53.66731905937195,
+            "loadAverage": [
+              16.27099609375,
+              8.806640625,
+              8.14208984375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 60,
+            "elapsedSeconds": 55.78848195075989,
+            "loadAverage": [
+              15.5283203125,
+              8.7763671875,
+              8.13525390625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 53,
+            "elapsedSeconds": 57.935641050338745,
+            "loadAverage": [
+              15.5283203125,
+              8.7763671875,
+              8.13525390625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 53,
+            "elapsedSeconds": 60.06643199920654,
+            "loadAverage": [
+              14.76513671875,
+              8.72998046875,
+              8.12255859375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 56,
+            "elapsedSeconds": 62.18958806991577,
+            "loadAverage": [
+              14.76513671875,
+              8.72998046875,
+              8.12255859375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 48,
+            "elapsedSeconds": 64.33413600921631,
+            "loadAverage": [
+              14.30322265625,
+              8.734375,
+              8.12744140625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 53,
+            "elapsedSeconds": 66.48514008522034,
+            "loadAverage": [
+              14.30322265625,
+              8.734375,
+              8.12744140625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 57,
+            "elapsedSeconds": 68.64633393287659,
+            "loadAverage": [
+              14.30322265625,
+              8.734375,
+              8.12744140625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 55,
+            "elapsedSeconds": 70.75287818908691,
+            "loadAverage": [
+              14.03857421875,
+              8.77197265625,
+              8.14404296875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 52,
+            "elapsedSeconds": 72.91491293907166,
+            "loadAverage": [
+              14.03857421875,
+              8.77197265625,
+              8.14404296875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 52,
+            "elapsedSeconds": 75.06115889549255,
+            "loadAverage": [
+              13.234375,
+              8.6923828125,
+              8.11962890625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 56,
+            "elapsedSeconds": 77.17303919792175,
+            "loadAverage": [
+              13.234375,
+              8.6923828125,
+              8.11962890625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 73,
+            "elapsedSeconds": 79.2857551574707,
+            "loadAverage": [
+              12.57470703125,
+              8.630859375,
+              8.10107421875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 59,
+            "elapsedSeconds": 81.42498898506165,
+            "loadAverage": [
+              12.57470703125,
+              8.630859375,
+              8.10107421875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 64,
+            "elapsedSeconds": 83.61014914512634,
+            "loadAverage": [
+              12.57470703125,
+              8.630859375,
+              8.10107421875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 67,
+            "elapsedSeconds": 85.77714610099792,
+            "loadAverage": [
+              12.2880859375,
+              8.63671875,
+              8.10595703125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 59,
+            "elapsedSeconds": 87.91169619560242,
+            "loadAverage": [
+              12.2880859375,
+              8.63671875,
+              8.10595703125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 76,
+            "elapsedSeconds": 90.05510807037354,
+            "loadAverage": [
+              11.5439453125,
+              8.54296875,
+              8.07568359375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 64,
+            "elapsedSeconds": 92.21657609939575,
+            "loadAverage": [
+              11.5439453125,
+              8.54296875,
+              8.07568359375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 63,
+            "elapsedSeconds": 94.34531712532043,
+            "loadAverage": [
+              11.01953125,
+              8.48388671875,
+              8.0576171875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 57,
+            "elapsedSeconds": 96.44545888900757,
+            "loadAverage": [
+              11.01953125,
+              8.48388671875,
+              8.0576171875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 72,
+            "elapsedSeconds": 98.54156112670898,
+            "loadAverage": [
+              11.01953125,
+              8.48388671875,
+              8.0576171875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 60,
+            "elapsedSeconds": 100.63730502128601,
+            "loadAverage": [
+              10.376953125,
+              8.392578125,
+              8.02783203125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 64,
+            "elapsedSeconds": 102.76449799537659,
+            "loadAverage": [
+              10.376953125,
+              8.392578125,
+              8.02783203125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 64,
+            "elapsedSeconds": 104.91477704048157,
+            "loadAverage": [
+              10.0263671875,
+              8.3525390625,
+              8.015625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 58,
+            "elapsedSeconds": 107.02461910247803,
+            "loadAverage": [
+              10.0263671875,
+              8.3525390625,
+              8.015625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 96,
+            "elapsedSeconds": 109.15956997871399,
+            "loadAverage": [
+              9.46337890625,
+              8.263671875,
+              7.98583984375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 98,
+            "elapsedSeconds": 111.29512190818787,
+            "loadAverage": [
+              9.46337890625,
+              8.263671875,
+              7.98583984375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 96,
+            "elapsedSeconds": 113.46925806999207,
+            "loadAverage": [
+              9.46337890625,
+              8.263671875,
+              7.98583984375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 88,
+            "elapsedSeconds": 115.66775798797607,
+            "loadAverage": [
+              9.98681640625,
+              8.39208984375,
+              8.03271484375
+            ]
+          }
+        ],
+        "knownRenderingWorkerCount": 0,
+        "maxPressureLevel": 1,
+        "measurementMode": "desktop-load",
+        "peakResidentBytes": 15839952896,
+        "processSeconds": 117.77565002441406,
+        "profiled": false,
+        "prompt": "Write a complete Python implementation of an LRU cache using a dictionary and a doubly linked list, with get and put operations, type hints, and a short usage example. Return the code directly without introductory prose.",
+        "runtimeOverrides": {
+          "MERERUN_Q35_ASYNC_DECODE_BLOCKS": "0",
+          "MERERUN_Q35_MTP_HEAD_COST_RATIO": "0.18",
+          "MERERUN_Q35_MTP_PIPELINED_FALLBACK": "0",
+          "MERERUN_Q35_SCOPED_COMPILE": "0"
+        },
+        "sourceHead": "9319a217579cff3e3bbea002fb93451fe719a868",
+        "startedUnixSeconds": 1788621902.651583,
+        "uncontended": false,
+        "workload": "code"
+      },
+      "scenarios": [
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 2.5776087322452335
+          },
+          "endToEndSpeedups": {
+            "adaptive": 2.49221627764203
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 220,
+          "repetition": 1,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 22.356317043304443,
+              "decodeTokensPerSecond": 11.450902199325812,
+              "elapsedSeconds": 23.05906903743744,
+              "endToEndTokensPerSecond": 11.101922613804245,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.08319807052612305,
+              "generatedTokens": 256,
+              "loadSeconds": 5.4001808166503906e-05,
+              "name": "baseline",
+              "outputSHA256": "ca2c0ddf75b621ec62d587ff04b6f89f528aafe8d744b0730c298166deb5f461",
+              "policy": "disabled",
+              "prefillSeconds": 0.6990020275115967,
+              "prefillTokensPerSecond": 77.25299480494586,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 15399993344,
+              "residentMemoryBeforeBytes": 15396880384,
+              "ttftSeconds": 0.7822540998458862
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.7236363636363636,
+                "acceptedDraftTokens": 199,
+                "draftHistoryTokens": 53,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 275,
+                "rounds": 57,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 8.673277974128723,
+              "decodeTokensPerSecond": 29.515945501068362,
+              "elapsedSeconds": 9.252434968948364,
+              "endToEndTokensPerSecond": 27.668392251245088,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0003470182418823242,
+              "generatedTokens": 256,
+              "loadSeconds": 6.592273712158203e-05,
+              "name": "adaptive",
+              "outputSHA256": "ca2c0ddf75b621ec62d587ff04b6f89f528aafe8d744b0730c298166deb5f461",
+              "policy": "adaptive",
+              "prefillSeconds": 0.5769939422607422,
+              "prefillTokensPerSecond": 93.58850421968127,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 15839313920,
+              "residentMemoryBeforeBytes": 15838871552,
+              "ttftSeconds": 0.5774068832397461
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 1.6794321428141084
+          },
+          "endToEndSpeedups": {
+            "adaptive": 1.6228639454897986
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 220,
+          "repetition": 2,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 14.338712930679321,
+              "decodeTokensPerSecond": 17.853764228186662,
+              "elapsedSeconds": 14.703480005264282,
+              "endToEndTokensPerSecond": 17.410844229280716,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.04106104373931885,
+              "generatedTokens": 256,
+              "loadSeconds": 2.7894973754882812e-05,
+              "name": "baseline",
+              "outputSHA256": "ca2c0ddf75b621ec62d587ff04b6f89f528aafe8d744b0730c298166deb5f461",
+              "policy": "disabled",
+              "prefillSeconds": 0.36246800422668457,
+              "prefillTokensPerSecond": 148.97866672454995,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 15400173568,
+              "residentMemoryBeforeBytes": 15400108032,
+              "ttftSeconds": 0.4035569429397583
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.7236363636363636,
+                "acceptedDraftTokens": 199,
+                "draftHistoryTokens": 53,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 275,
+                "rounds": 57,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 8.53783404827118,
+              "decodeTokensPerSecond": 29.984185515041403,
+              "elapsedSeconds": 9.060204982757568,
+              "endToEndTokensPerSecond": 28.255431360238795,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0002770423889160156,
+              "generatedTokens": 256,
+              "loadSeconds": 1.800060272216797e-05,
+              "name": "adaptive",
+              "outputSHA256": "ca2c0ddf75b621ec62d587ff04b6f89f528aafe8d744b0730c298166deb5f461",
+              "policy": "adaptive",
+              "prefillSeconds": 0.5208230018615723,
+              "prefillTokensPerSecond": 103.68205668142221,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 15839870976,
+              "residentMemoryBeforeBytes": 15839313920,
+              "ttftSeconds": 0.5211180448532104
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 3.0422307982424552
+          },
+          "endToEndSpeedups": {
+            "adaptive": 2.9501458836273957
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 220,
+          "repetition": 3,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 24.706866025924683,
+              "decodeTokensPerSecond": 10.361492215620613,
+              "elapsedSeconds": 25.486027002334595,
+              "endToEndTokensPerSecond": 10.044719797893553,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.08480799198150635,
+              "generatedTokens": 256,
+              "loadSeconds": 4.303455352783203e-05,
+              "name": "baseline",
+              "outputSHA256": "ca2c0ddf75b621ec62d587ff04b6f89f528aafe8d744b0730c298166deb5f461",
+              "policy": "disabled",
+              "prefillSeconds": 0.7702270746231079,
+              "prefillTokensPerSecond": 70.1091947805439,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 15400763392,
+              "residentMemoryBeforeBytes": 15400173568,
+              "ttftSeconds": 0.8550781011581421
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.7236363636363636,
+                "acceptedDraftTokens": 199,
+                "draftHistoryTokens": 53,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 275,
+                "rounds": 57,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 8.121299028396606,
+              "decodeTokensPerSecond": 31.522050734110483,
+              "elapsedSeconds": 8.638903975486755,
+              "endToEndTokensPerSecond": 29.63338876394627,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0004470348358154297,
+              "generatedTokens": 256,
+              "loadSeconds": 2.205371856689453e-05,
+              "name": "adaptive",
+              "outputSHA256": "ca2c0ddf75b621ec62d587ff04b6f89f528aafe8d744b0730c298166deb5f461",
+              "policy": "adaptive",
+              "prefillSeconds": 0.5154309272766113,
+              "prefillTokensPerSecond": 104.76670518263322,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 15839838208,
+              "residentMemoryBeforeBytes": 15839870976,
+              "ttftSeconds": 0.5159000158309937
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        }
+      ]
+    },
+    {
+      "id": "finish-selection/qwen-current/qwen-prose",
+      "model": "vision-chat-q38-27b-4bit",
+      "rawReceiptSHA256": "6c0d268019b0e400c732c139a61c38fc8f0e94666531e3b1d2c097dd2aefed2a",
+      "receipt": {
+        "after": {
+          "gpuDeviceUtilizationPercent": 13,
+          "loadAverage": [
+            12.73046875,
+            10.03955078125,
+            8.75439453125
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7276.25M  free = 915.75M  (encrypted)",
+          "swapUsedMiB": 7276.25
+        },
+        "before": {
+          "gpuDeviceUtilizationPercent": 0,
+          "loadAverage": [
+            9.98681640625,
+            8.39208984375,
+            8.03271484375
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7276.25M  free = 915.75M  (encrypted)",
+          "swapUsedMiB": 7276.25
+        },
+        "binarySHA256": "cdec91928873110a516e18abcf0db7904cde7398977a7e5b9317c0776a3c1737",
+        "buildSourceRevision": "f847be2ef7ca2f8896829c3cc0b6a1a55ea72ea9",
+        "collectorSHA256": "c5d800333764ac360dd08c27bd99ccf3bc3be6afb203f82ac9fddef41d7ce682",
+        "command": [
+          "mere.run",
+          "model",
+          "benchmark",
+          "q36-mtp",
+          "--model",
+          "vision-chat-q38-27b-4bit",
+          "--prompt",
+          "Explain how a small community could turn an abandoned railway station into a public library. Discuss the building, accessibility, staffing, the collection, and a realistic opening-day scene. Write approximately 400 words of clear, connected prose.",
+          "--decode-tokens",
+          "256",
+          "--context-size",
+          "8192",
+          "--temperature",
+          "0",
+          "--top-p",
+          "1",
+          "--json",
+          "--variants",
+          "adaptive,baseline",
+          "--warmups",
+          "1",
+          "--warmup-tokens",
+          "256",
+          "--repetitions",
+          "3",
+          "--mtp-block-size",
+          "8"
+        ],
+        "competingInferenceProcessCount": 0,
+        "gpuSamples": [
+          {
+            "deviceUtilizationPercent": 0,
+            "elapsedSeconds": 0.08612608909606934,
+            "loadAverage": [
+              9.98681640625,
+              8.39208984375,
+              8.03271484375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 85,
+            "elapsedSeconds": 2.236851215362549,
+            "loadAverage": [
+              10.14794921875,
+              8.45166015625,
+              8.0556640625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 96,
+            "elapsedSeconds": 4.485138177871704,
+            "loadAverage": [
+              10.14794921875,
+              8.45166015625,
+              8.0556640625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 96,
+            "elapsedSeconds": 6.675924062728882,
+            "loadAverage": [
+              15.9013671875,
+              9.67236328125,
+              8.48876953125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 97,
+            "elapsedSeconds": 8.870368003845215,
+            "loadAverage": [
+              15.9013671875,
+              9.67236328125,
+              8.48876953125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 91,
+            "elapsedSeconds": 11.029417037963867,
+            "loadAverage": [
+              15.4287109375,
+              9.677734375,
+              8.49755859375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 93,
+            "elapsedSeconds": 13.128684997558594,
+            "loadAverage": [
+              15.4287109375,
+              9.677734375,
+              8.49755859375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 79,
+            "elapsedSeconds": 15.224062204360962,
+            "loadAverage": [
+              15.4287109375,
+              9.677734375,
+              8.49755859375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 89,
+            "elapsedSeconds": 17.330445051193237,
+            "loadAverage": [
+              14.35302734375,
+              9.5498046875,
+              8.45947265625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 79,
+            "elapsedSeconds": 19.428237915039062,
+            "loadAverage": [
+              14.35302734375,
+              9.5498046875,
+              8.45947265625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 88,
+            "elapsedSeconds": 21.526108026504517,
+            "loadAverage": [
+              15.12548828125,
+              9.78955078125,
+              8.55029296875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 97,
+            "elapsedSeconds": 23.6200909614563,
+            "loadAverage": [
+              15.12548828125,
+              9.78955078125,
+              8.55029296875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 90,
+            "elapsedSeconds": 25.713225841522217,
+            "loadAverage": [
+              15.12548828125,
+              9.78955078125,
+              8.55029296875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 77,
+            "elapsedSeconds": 27.80753803253174,
+            "loadAverage": [
+              14.07421875,
+              9.66015625,
+              8.51171875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 86,
+            "elapsedSeconds": 29.90483808517456,
+            "loadAverage": [
+              14.07421875,
+              9.66015625,
+              8.51171875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 88,
+            "elapsedSeconds": 32.00054311752319,
+            "loadAverage": [
+              13.42724609375,
+              9.59912109375,
+              8.49658203125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 88,
+            "elapsedSeconds": 34.10477614402771,
+            "loadAverage": [
+              13.42724609375,
+              9.59912109375,
+              8.49658203125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 69,
+            "elapsedSeconds": 36.20142722129822,
+            "loadAverage": [
+              12.751953125,
+              9.5224609375,
+              8.47607421875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 52,
+            "elapsedSeconds": 38.29452705383301,
+            "loadAverage": [
+              12.751953125,
+              9.5224609375,
+              8.47607421875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 91,
+            "elapsedSeconds": 40.388498067855835,
+            "loadAverage": [
+              12.751953125,
+              9.5224609375,
+              8.47607421875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 69,
+            "elapsedSeconds": 42.48245120048523,
+            "loadAverage": [
+              11.970703125,
+              9.4140625,
+              8.44384765625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 76,
+            "elapsedSeconds": 44.57988119125366,
+            "loadAverage": [
+              11.970703125,
+              9.4140625,
+              8.44384765625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 80,
+            "elapsedSeconds": 46.673940896987915,
+            "loadAverage": [
+              11.091796875,
+              9.27392578125,
+              8.39990234375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 89,
+            "elapsedSeconds": 48.76945900917053,
+            "loadAverage": [
+              11.091796875,
+              9.27392578125,
+              8.39990234375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 94,
+            "elapsedSeconds": 50.8612539768219,
+            "loadAverage": [
+              10.5234375,
+              9.18603515625,
+              8.3740234375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 83,
+            "elapsedSeconds": 52.955260038375854,
+            "loadAverage": [
+              10.5234375,
+              9.18603515625,
+              8.3740234375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 77,
+            "elapsedSeconds": 55.06524610519409,
+            "loadAverage": [
+              10.5234375,
+              9.18603515625,
+              8.3740234375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 70,
+            "elapsedSeconds": 57.16499900817871,
+            "loadAverage": [
+              9.9208984375,
+              9.0830078125,
+              8.34228515625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 51,
+            "elapsedSeconds": 59.29031205177307,
+            "loadAverage": [
+              9.9208984375,
+              9.0830078125,
+              8.34228515625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 55,
+            "elapsedSeconds": 61.44402599334717,
+            "loadAverage": [
+              9.6865234375,
+              9.04833984375,
+              8.333984375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 55,
+            "elapsedSeconds": 63.557234048843384,
+            "loadAverage": [
+              9.6865234375,
+              9.04833984375,
+              8.333984375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 50,
+            "elapsedSeconds": 65.66324281692505,
+            "loadAverage": [
+              9.6865234375,
+              9.04833984375,
+              8.333984375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 55,
+            "elapsedSeconds": 67.79022097587585,
+            "loadAverage": [
+              9.23095703125,
+              8.96435546875,
+              8.30810546875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 56,
+            "elapsedSeconds": 69.89347195625305,
+            "loadAverage": [
+              9.23095703125,
+              8.96435546875,
+              8.30810546875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 52,
+            "elapsedSeconds": 71.99014687538147,
+            "loadAverage": [
+              8.65185546875,
+              8.8486328125,
+              8.27099609375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 55,
+            "elapsedSeconds": 74.10067009925842,
+            "loadAverage": [
+              8.65185546875,
+              8.8486328125,
+              8.27099609375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 65,
+            "elapsedSeconds": 76.19799590110779,
+            "loadAverage": [
+              8.119140625,
+              8.73486328125,
+              8.23388671875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 78.29105496406555,
+            "loadAverage": [
+              8.119140625,
+              8.73486328125,
+              8.23388671875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 80.39119911193848,
+            "loadAverage": [
+              8.119140625,
+              8.73486328125,
+              8.23388671875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 82.48514914512634,
+            "loadAverage": [
+              7.62890625,
+              8.623046875,
+              8.197265625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 84.58470320701599,
+            "loadAverage": [
+              7.62890625,
+              8.623046875,
+              8.197265625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 86.69453001022339,
+            "loadAverage": [
+              7.498046875,
+              8.5791015625,
+              8.18408203125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 88.79426288604736,
+            "loadAverage": [
+              7.498046875,
+              8.5791015625,
+              8.18408203125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 93,
+            "elapsedSeconds": 90.89651203155518,
+            "loadAverage": [
+              7.1376953125,
+              8.486328125,
+              8.1533203125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 93.04852294921875,
+            "loadAverage": [
+              7.1376953125,
+              8.486328125,
+              8.1533203125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 95,
+            "elapsedSeconds": 95.91297912597656,
+            "loadAverage": [
+              10.56982421875,
+              9.17529296875,
+              8.3984375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 75,
+            "elapsedSeconds": 98.89063215255737,
+            "loadAverage": [
+              10.56982421875,
+              9.17529296875,
+              8.3984375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 92,
+            "elapsedSeconds": 101.30351614952087,
+            "loadAverage": [
+              14.60791015625,
+              10.03564453125,
+              8.70654296875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 91,
+            "elapsedSeconds": 103.61294412612915,
+            "loadAverage": [
+              14.60791015625,
+              10.03564453125,
+              8.70654296875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 95,
+            "elapsedSeconds": 105.97643899917603,
+            "loadAverage": [
+              15.43994140625,
+              10.28369140625,
+              8.8017578125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 86,
+            "elapsedSeconds": 108.1181390285492,
+            "loadAverage": [
+              15.43994140625,
+              10.28369140625,
+              8.8017578125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 59,
+            "elapsedSeconds": 110.22887396812439,
+            "loadAverage": [
+              15.43994140625,
+              10.28369140625,
+              8.8017578125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 60,
+            "elapsedSeconds": 112.3315041065216,
+            "loadAverage": [
+              14.443359375,
+              10.16259765625,
+              8.767578125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 53,
+            "elapsedSeconds": 114.4274468421936,
+            "loadAverage": [
+              14.443359375,
+              10.16259765625,
+              8.767578125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 50,
+            "elapsedSeconds": 116.54293489456177,
+            "loadAverage": [
+              13.76708984375,
+              10.09326171875,
+              8.7509765625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 53,
+            "elapsedSeconds": 118.64443683624268,
+            "loadAverage": [
+              13.76708984375,
+              10.09326171875,
+              8.7509765625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 57,
+            "elapsedSeconds": 120.74023604393005,
+            "loadAverage": [
+              13.76708984375,
+              10.09326171875,
+              8.7509765625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 51,
+            "elapsedSeconds": 122.8449981212616,
+            "loadAverage": [
+              13.46533203125,
+              10.09130859375,
+              8.7578125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 54,
+            "elapsedSeconds": 124.93718218803406,
+            "loadAverage": [
+              13.46533203125,
+              10.09130859375,
+              8.7578125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 50,
+            "elapsedSeconds": 127.026602268219,
+            "loadAverage": [
+              12.70703125,
+              9.98974609375,
+              8.7294921875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 53,
+            "elapsedSeconds": 129.26920795440674,
+            "loadAverage": [
+              12.70703125,
+              9.98974609375,
+              8.7294921875
+            ]
+          }
+        ],
+        "knownRenderingWorkerCount": 0,
+        "maxPressureLevel": 1,
+        "measurementMode": "desktop-load",
+        "peakResidentBytes": 15806726144,
+        "processSeconds": 131.38125705718994,
+        "profiled": false,
+        "prompt": "Explain how a small community could turn an abandoned railway station into a public library. Discuss the building, accessibility, staffing, the collection, and a realistic opening-day scene. Write approximately 400 words of clear, connected prose.",
+        "runtimeOverrides": {
+          "MERERUN_Q35_ASYNC_DECODE_BLOCKS": "0",
+          "MERERUN_Q35_MTP_HEAD_COST_RATIO": "0.18",
+          "MERERUN_Q35_MTP_PIPELINED_FALLBACK": "0",
+          "MERERUN_Q35_SCOPED_COMPILE": "0"
+        },
+        "sourceHead": "9319a217579cff3e3bbea002fb93451fe719a868",
+        "startedUnixSeconds": 1788622020.551878,
+        "uncontended": false,
+        "workload": "prose"
+      },
+      "scenarios": [
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 1.027829201567322
+          },
+          "endToEndSpeedups": {
+            "adaptive": 1.0105509252242135
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 247,
+          "repetition": 1,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "acceptanceRate": 0.4074074074074074,
+                "acceptedDraftTokens": 132,
+                "draftHistoryTokens": 59,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 324,
+                "rounds": 124,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 13.456549048423767,
+              "decodeTokensPerSecond": 19.02419402469213,
+              "elapsedSeconds": 14.077518105506897,
+              "endToEndTokensPerSecond": 18.185023672593037,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0003839731216430664,
+              "generatedTokens": 256,
+              "loadSeconds": 1.800060272216797e-05,
+              "name": "adaptive",
+              "outputSHA256": "f0eee860afeee246903ecb69993c7b7fee39cc16b60c5bf6535276f31f58bcda",
+              "policy": "adaptive",
+              "prefillSeconds": 0.6193029880523682,
+              "prefillTokensPerSecond": 96.8831107834513,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 15806087168,
+              "residentMemoryBeforeBytes": 15803072512,
+              "ttftSeconds": 0.6197049617767334
+            },
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 13.831034064292908,
+              "decodeTokensPerSecond": 18.509100535071788,
+              "elapsedSeconds": 14.226048946380615,
+              "endToEndTokensPerSecond": 17.995158105028974,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.03724396228790283,
+              "generatedTokens": 256,
+              "loadSeconds": 2.5033950805664062e-05,
+              "name": "baseline",
+              "outputSHA256": "f0eee860afeee246903ecb69993c7b7fee39cc16b60c5bf6535276f31f58bcda",
+              "policy": "disabled",
+              "prefillSeconds": 0.3913620710372925,
+              "prefillTokensPerSecond": 153.31071772226662,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 15430025216,
+              "residentMemoryBeforeBytes": 15429943296,
+              "ttftSeconds": 0.428631067276001
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 1.3797964162489222
+          },
+          "endToEndSpeedups": {
+            "adaptive": 1.3431540599329819
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 247,
+          "repetition": 2,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "acceptanceRate": 0.4074074074074074,
+                "acceptedDraftTokens": 132,
+                "draftHistoryTokens": 59,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 324,
+                "rounds": 124,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 11.17688000202179,
+              "decodeTokensPerSecond": 22.90442412853069,
+              "elapsedSeconds": 12.036491990089417,
+              "endToEndTokensPerSecond": 21.268655369918807,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0003679990768432617,
+              "generatedTokens": 256,
+              "loadSeconds": 2.110004425048828e-05,
+              "name": "adaptive",
+              "outputSHA256": "f0eee860afeee246903ecb69993c7b7fee39cc16b60c5bf6535276f31f58bcda",
+              "policy": "adaptive",
+              "prefillSeconds": 0.8579670190811157,
+              "prefillTokensPerSecond": 69.93275809629618,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 15806513152,
+              "residentMemoryBeforeBytes": 15806201856,
+              "ttftSeconds": 0.8583561182022095
+            },
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 15.421818971633911,
+              "decodeTokensPerSecond": 16.59985767378498,
+              "elapsedSeconds": 16.166863083839417,
+              "endToEndTokensPerSecond": 15.834859160519555,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.03908097743988037,
+              "generatedTokens": 256,
+              "loadSeconds": 5.1021575927734375e-05,
+              "name": "baseline",
+              "outputSHA256": "f0eee860afeee246903ecb69993c7b7fee39cc16b60c5bf6535276f31f58bcda",
+              "policy": "disabled",
+              "prefillSeconds": 0.7414500713348389,
+              "prefillTokensPerSecond": 80.92250890472165,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 15430107136,
+              "residentMemoryBeforeBytes": 15430041600,
+              "ttftSeconds": 0.780582070350647
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 1.9375156545679537
+          },
+          "endToEndSpeedups": {
+            "adaptive": 1.8784972694003337
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 247,
+          "repetition": 3,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "acceptanceRate": 0.4074074074074074,
+                "acceptedDraftTokens": 132,
+                "draftHistoryTokens": 59,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 324,
+                "rounds": 124,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 11.35870099067688,
+              "decodeTokensPerSecond": 22.53778845046828,
+              "elapsedSeconds": 12.081281900405884,
+              "endToEndTokensPerSecond": 21.18980436930285,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0003879070281982422,
+              "generatedTokens": 256,
+              "loadSeconds": 2.205371856689453e-05,
+              "name": "adaptive",
+              "outputSHA256": "f0eee860afeee246903ecb69993c7b7fee39cc16b60c5bf6535276f31f58bcda",
+              "policy": "adaptive",
+              "prefillSeconds": 0.7209110260009766,
+              "prefillTokensPerSecond": 83.22802375881365,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 15806709760,
+              "residentMemoryBeforeBytes": 15806529536,
+              "ttftSeconds": 0.7213209867477417
+            },
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 22.00766098499298,
+              "decodeTokensPerSecond": 11.632312955682403,
+              "elapsedSeconds": 22.694655060768127,
+              "endToEndTokensPerSecond": 11.280189071590824,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.08577299118041992,
+              "generatedTokens": 256,
+              "loadSeconds": 6.794929504394531e-05,
+              "name": "baseline",
+              "outputSHA256": "f0eee860afeee246903ecb69993c7b7fee39cc16b60c5bf6535276f31f58bcda",
+              "policy": "disabled",
+              "prefillSeconds": 0.6828999519348145,
+              "prefillTokensPerSecond": 87.86060070733062,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 15430434816,
+              "residentMemoryBeforeBytes": 15430107136,
+              "ttftSeconds": 0.7687408924102783
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        }
+      ]
+    },
+    {
+      "id": "final-greedy/ornith-chat",
+      "model": "text-agent-ornith-35b-mlx-4bit",
+      "rawReceiptSHA256": "d799f13d05f14e5baf396753bfd2f6a27420a1e1c8aa09d864a5a49f8e0e7212",
+      "receipt": {
+        "after": {
+          "gpuDeviceUtilizationPercent": 59,
+          "loadAverage": [
+            3.95751953125,
+            5.8369140625,
+            6.72509765625
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7268.25M  free = 923.75M  (encrypted)",
+          "swapUsedMiB": 7268.25
+        },
+        "before": {
+          "gpuDeviceUtilizationPercent": 44,
+          "loadAverage": [
+            4.10595703125,
+            6.13623046875,
+            6.8701171875
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7268.25M  free = 923.75M  (encrypted)",
+          "swapUsedMiB": 7268.25
+        },
+        "binarySHA256": "37ae108285410acec9ee3863de69475fb74ce9b472bf23c05e0e0df8ce26414c",
+        "buildSourceRevision": "c3ef55db5f09b2bcc6526bec4dd2a78eaa27aee6",
+        "collectorSHA256": "dec1ae60840c738d2c8ef678adf8c1fc39b7eecaab018032ff2c596b51599f2c",
+        "command": [
+          "mere.run",
+          "model",
+          "benchmark",
+          "q36-mtp",
+          "--model",
+          "text-agent-ornith-35b-mlx-4bit",
+          "--prompt",
+          "I'm trying to get back into reading after a busy year. I have about twenty minutes most evenings, enjoy mysteries and science fiction, and keep abandoning books when I miss a few days. Help me make a gentle, realistic four-week plan. Talk to me conversationally, suggest ways to choose books without buying a stack, and explain what to do when I fall behind. Give enough practical detail that I can start tonight.",
+          "--decode-tokens",
+          "256",
+          "--context-size",
+          "8192",
+          "--temperature",
+          "0",
+          "--top-p",
+          "1",
+          "--json",
+          "--variants",
+          "adaptive,baseline",
+          "--warmups",
+          "1",
+          "--warmup-tokens",
+          "256",
+          "--repetitions",
+          "3"
+        ],
+        "competingInferenceProcessCount": 0,
+        "gpuSamples": [
+          {
+            "deviceUtilizationPercent": 44,
+            "elapsedSeconds": 0.08710670471191406,
+            "loadAverage": [
+              4.10595703125,
+              6.13623046875,
+              6.8701171875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 48,
+            "elapsedSeconds": 2.186091899871826,
+            "loadAverage": [
+              3.93701171875,
+              6.0673828125,
+              6.84130859375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 88,
+            "elapsedSeconds": 4.302156686782837,
+            "loadAverage": [
+              3.93701171875,
+              6.0673828125,
+              6.84130859375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 76,
+            "elapsedSeconds": 6.434554815292358,
+            "loadAverage": [
+              3.93701171875,
+              6.0673828125,
+              6.84130859375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 89,
+            "elapsedSeconds": 8.602156639099121,
+            "loadAverage": [
+              3.94189453125,
+              6.03271484375,
+              6.82421875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 79,
+            "elapsedSeconds": 10.78649377822876,
+            "loadAverage": [
+              3.94189453125,
+              6.03271484375,
+              6.82421875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 70,
+            "elapsedSeconds": 12.975947856903076,
+            "loadAverage": [
+              3.8662109375,
+              5.98193359375,
+              6.8017578125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 69,
+            "elapsedSeconds": 15.163794755935669,
+            "loadAverage": [
+              3.8662109375,
+              5.98193359375,
+              6.8017578125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 62,
+            "elapsedSeconds": 17.369791984558105,
+            "loadAverage": [
+              3.95654296875,
+              5.96533203125,
+              6.791015625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 61,
+            "elapsedSeconds": 19.527888774871826,
+            "loadAverage": [
+              3.95654296875,
+              5.96533203125,
+              6.791015625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 48,
+            "elapsedSeconds": 21.636314868927002,
+            "loadAverage": [
+              3.95654296875,
+              5.96533203125,
+              6.791015625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 74,
+            "elapsedSeconds": 23.759453773498535,
+            "loadAverage": [
+              4.1201171875,
+              5.9658203125,
+              6.7861328125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 61,
+            "elapsedSeconds": 25.92161273956299,
+            "loadAverage": [
+              4.1201171875,
+              5.9658203125,
+              6.7861328125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 69,
+            "elapsedSeconds": 28.098074674606323,
+            "loadAverage": [
+              3.9501953125,
+              5.89990234375,
+              6.7578125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 67,
+            "elapsedSeconds": 30.285287857055664,
+            "loadAverage": [
+              3.9501953125,
+              5.89990234375,
+              6.7578125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 68,
+            "elapsedSeconds": 32.47701382637024,
+            "loadAverage": [
+              3.9541015625,
+              5.8681640625,
+              6.7412109375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 62,
+            "elapsedSeconds": 34.65864586830139,
+            "loadAverage": [
+              3.9541015625,
+              5.8681640625,
+              6.7412109375
+            ]
+          }
+        ],
+        "knownRenderingWorkerCount": 0,
+        "maxPressureLevel": 1,
+        "measurementMode": "desktop-load",
+        "peakResidentBytes": 9464102912,
+        "processSeconds": 36.816322803497314,
+        "profiled": false,
+        "prompt": "I'm trying to get back into reading after a busy year. I have about twenty minutes most evenings, enjoy mysteries and science fiction, and keep abandoning books when I miss a few days. Help me make a gentle, realistic four-week plan. Talk to me conversationally, suggest ways to choose books without buying a stack, and explain what to do when I fall behind. Give enough practical detail that I can start tonight.",
+        "runtimeOverrides": {},
+        "sourceHead": "c3ef55db5f09b2bcc6526bec4dd2a78eaa27aee6",
+        "startedUnixSeconds": 1788624135.6288462,
+        "uncontended": false,
+        "workload": "chat"
+      },
+      "scenarios": [
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 0.9066142418009261
+          },
+          "endToEndSpeedups": {
+            "adaptive": 0.9365809555342175
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 413,
+          "repetition": 1,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "acceptanceRate": 0.30120481927710846,
+                "acceptedDraftTokens": 50,
+                "draftHistoryTokens": 96,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 166,
+                "rounds": 99,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 4.568674087524414,
+              "decodeTokensPerSecond": 56.03376277135943,
+              "elapsedSeconds": 4.85992693901062,
+              "endToEndTokensPerSecond": 52.67568899957913,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0005400180816650391,
+              "generatedTokens": 256,
+              "loadSeconds": 1.2993812561035156e-05,
+              "name": "adaptive",
+              "outputSHA256": "d1f8455830507237affb86ec31863cc982d098dd55ce897ae205dcfa8f89000e",
+              "policy": "adaptive",
+              "prefillSeconds": 0.2889150381088257,
+              "prefillTokensPerSecond": 335.73884085418564,
+              "promptTokens": 97,
+              "residentMemoryAfterBytes": 9463889920,
+              "residentMemoryBeforeBytes": 9462841344,
+              "ttftSeconds": 0.28946805000305176
+            },
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 4.142024993896484,
+              "decodeTokensPerSecond": 61.80551792353521,
+              "elapsedSeconds": 4.551715016365051,
+              "endToEndTokensPerSecond": 56.24253695136624,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.03979003429412842,
+              "generatedTokens": 256,
+              "loadSeconds": 7.987022399902344e-06,
+              "name": "baseline",
+              "outputSHA256": "d1f8455830507237affb86ec31863cc982d098dd55ce897ae205dcfa8f89000e",
+              "policy": "disabled",
+              "prefillSeconds": 0.4073280096054077,
+              "prefillTokensPerSecond": 238.13731860464776,
+              "promptTokens": 97,
+              "residentMemoryAfterBytes": 9335062528,
+              "residentMemoryBeforeBytes": 9334571008,
+              "ttftSeconds": 0.44712603092193604
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 0.893343424563443
+          },
+          "endToEndSpeedups": {
+            "adaptive": 0.8932543727167191
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 413,
+          "repetition": 2,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "acceptanceRate": 0.30120481927710846,
+                "acceptedDraftTokens": 50,
+                "draftHistoryTokens": 96,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 166,
+                "rounds": 99,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 4.114128947257996,
+              "decodeTokensPerSecond": 62.22459317193257,
+              "elapsedSeconds": 4.3158780336380005,
+              "endToEndTokensPerSecond": 59.31585601000149,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0002579689025878906,
+              "generatedTokens": 256,
+              "loadSeconds": 1.2993812561035156e-05,
+              "name": "adaptive",
+              "outputSHA256": "d1f8455830507237affb86ec31863cc982d098dd55ce897ae205dcfa8f89000e",
+              "policy": "adaptive",
+              "prefillSeconds": 0.1984010934829712,
+              "prefillTokensPerSecond": 488.9085956994765,
+              "promptTokens": 97,
+              "residentMemoryAfterBytes": 9464037376,
+              "residentMemoryBeforeBytes": 9463988224,
+              "ttftSeconds": 0.19867205619812012
+            },
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 3.6753300428390503,
+              "decodeTokensPerSecond": 69.65360852388916,
+              "elapsedSeconds": 3.8551769256591797,
+              "endToEndTokensPerSecond": 66.40421566546591,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.012106060981750488,
+              "generatedTokens": 256,
+              "loadSeconds": 1.2993812561035156e-05,
+              "name": "baseline",
+              "outputSHA256": "d1f8455830507237affb86ec31863cc982d098dd55ce897ae205dcfa8f89000e",
+              "policy": "disabled",
+              "prefillSeconds": 0.17681705951690674,
+              "prefillTokensPerSecond": 548.5896002626666,
+              "promptTokens": 97,
+              "residentMemoryAfterBytes": 9335078912,
+              "residentMemoryBeforeBytes": 9335062528,
+              "ttftSeconds": 0.18893611431121826
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 0.8703461287593358
+          },
+          "endToEndSpeedups": {
+            "adaptive": 0.875117628072822
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 413,
+          "repetition": 3,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "acceptanceRate": 0.30120481927710846,
+                "acceptedDraftTokens": 50,
+                "draftHistoryTokens": 96,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 166,
+                "rounds": 99,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 4.576416015625,
+              "decodeTokensPerSecond": 55.93897039210456,
+              "elapsedSeconds": 4.740123987197876,
+              "endToEndTokensPerSecond": 54.007026122397775,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.000514984130859375,
+              "generatedTokens": 256,
+              "loadSeconds": 1.2993812561035156e-05,
+              "name": "adaptive",
+              "outputSHA256": "d1f8455830507237affb86ec31863cc982d098dd55ce897ae205dcfa8f89000e",
+              "policy": "adaptive",
+              "prefillSeconds": 0.16047203540802002,
+              "prefillTokensPerSecond": 604.4666894974285,
+              "promptTokens": 97,
+              "residentMemoryAfterBytes": 9464102912,
+              "residentMemoryBeforeBytes": 9464037376,
+              "ttftSeconds": 0.16100001335144043
+            },
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 3.983065962791443,
+              "decodeTokensPerSecond": 64.27209651847897,
+              "elapsedSeconds": 4.148166060447693,
+              "endToEndTokensPerSecond": 61.71401922428608,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.017727971076965332,
+              "generatedTokens": 256,
+              "loadSeconds": 1.2040138244628906e-05,
+              "name": "baseline",
+              "outputSHA256": "d1f8455830507237affb86ec31863cc982d098dd55ce897ae205dcfa8f89000e",
+              "policy": "disabled",
+              "prefillSeconds": 0.16223406791687012,
+              "prefillTokensPerSecond": 597.9015458683036,
+              "promptTokens": 97,
+              "residentMemoryAfterBytes": 9335144448,
+              "residentMemoryBeforeBytes": 9335078912,
+              "ttftSeconds": 0.17997407913208008
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        }
+      ]
+    },
+    {
+      "id": "final-greedy/ornith-code",
+      "model": "text-agent-ornith-35b-mlx-4bit",
+      "rawReceiptSHA256": "ef695a3833e370f758ea044912029211908a4781e30178cd3707329b9755a7aa",
+      "receipt": {
+        "after": {
+          "gpuDeviceUtilizationPercent": 90,
+          "loadAverage": [
+            4.66650390625,
+            7.09130859375,
+            7.27392578125
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7268.25M  free = 923.75M  (encrypted)",
+          "swapUsedMiB": 7268.25
+        },
+        "before": {
+          "gpuDeviceUtilizationPercent": 72,
+          "loadAverage": [
+            5.85205078125,
+            7.72509765625,
+            7.498046875
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7268.25M  free = 923.75M  (encrypted)",
+          "swapUsedMiB": 7268.25
+        },
+        "binarySHA256": "37ae108285410acec9ee3863de69475fb74ce9b472bf23c05e0e0df8ce26414c",
+        "buildSourceRevision": "c3ef55db5f09b2bcc6526bec4dd2a78eaa27aee6",
+        "collectorSHA256": "dec1ae60840c738d2c8ef678adf8c1fc39b7eecaab018032ff2c596b51599f2c",
+        "command": [
+          "mere.run",
+          "model",
+          "benchmark",
+          "q36-mtp",
+          "--model",
+          "text-agent-ornith-35b-mlx-4bit",
+          "--prompt",
+          "Write a complete Python implementation of an LRU cache using a dictionary and a doubly linked list, with get and put operations, type hints, and a short usage example. Return the code directly without introductory prose.",
+          "--decode-tokens",
+          "256",
+          "--context-size",
+          "8192",
+          "--temperature",
+          "0",
+          "--top-p",
+          "1",
+          "--json",
+          "--variants",
+          "baseline,adaptive",
+          "--warmups",
+          "1",
+          "--warmup-tokens",
+          "256",
+          "--repetitions",
+          "3"
+        ],
+        "competingInferenceProcessCount": 0,
+        "gpuSamples": [
+          {
+            "deviceUtilizationPercent": 44,
+            "elapsedSeconds": 0.134735107421875,
+            "loadAverage": [
+              5.85205078125,
+              7.72509765625,
+              7.498046875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 43,
+            "elapsedSeconds": 2.227550983428955,
+            "loadAverage": [
+              5.38330078125,
+              7.5966796875,
+              7.4541015625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 42,
+            "elapsedSeconds": 4.322177886962891,
+            "loadAverage": [
+              5.38330078125,
+              7.5966796875,
+              7.4541015625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 43,
+            "elapsedSeconds": 6.417167901992798,
+            "loadAverage": [
+              5.38330078125,
+              7.5966796875,
+              7.4541015625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 43,
+            "elapsedSeconds": 8.509385824203491,
+            "loadAverage": [
+              5.2724609375,
+              7.53662109375,
+              7.43359375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 44,
+            "elapsedSeconds": 10.600883960723877,
+            "loadAverage": [
+              5.2724609375,
+              7.53662109375,
+              7.43359375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 43,
+            "elapsedSeconds": 12.69225788116455,
+            "loadAverage": [
+              5.01025390625,
+              7.4443359375,
+              7.4013671875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 44,
+            "elapsedSeconds": 14.787984848022461,
+            "loadAverage": [
+              5.01025390625,
+              7.4443359375,
+              7.4013671875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 46,
+            "elapsedSeconds": 16.883733987808228,
+            "loadAverage": [
+              5.08935546875,
+              7.419921875,
+              7.39306640625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 47,
+            "elapsedSeconds": 18.976210832595825,
+            "loadAverage": [
+              5.08935546875,
+              7.419921875,
+              7.39306640625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 44,
+            "elapsedSeconds": 21.069261074066162,
+            "loadAverage": [
+              5.08935546875,
+              7.419921875,
+              7.39306640625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 57,
+            "elapsedSeconds": 23.171536922454834,
+            "loadAverage": [
+              5.001953125,
+              7.36279296875,
+              7.373046875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 66,
+            "elapsedSeconds": 25.28164291381836,
+            "loadAverage": [
+              5.001953125,
+              7.36279296875,
+              7.373046875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 99,
+            "elapsedSeconds": 27.39118194580078,
+            "loadAverage": [
+              4.92138671875,
+              7.306640625,
+              7.35302734375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 95,
+            "elapsedSeconds": 29.50066089630127,
+            "loadAverage": [
+              4.92138671875,
+              7.306640625,
+              7.35302734375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 41,
+            "elapsedSeconds": 31.60195302963257,
+            "loadAverage": [
+              4.92138671875,
+              7.306640625,
+              7.35302734375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 44,
+            "elapsedSeconds": 33.70350003242493,
+            "loadAverage": [
+              4.92724609375,
+              7.26806640625,
+              7.3388671875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 87,
+            "elapsedSeconds": 35.814661741256714,
+            "loadAverage": [
+              4.92724609375,
+              7.26806640625,
+              7.3388671875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 94,
+            "elapsedSeconds": 37.91559076309204,
+            "loadAverage": [
+              4.8525390625,
+              7.21337890625,
+              7.31884765625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 84,
+            "elapsedSeconds": 40.0178427696228,
+            "loadAverage": [
+              4.8525390625,
+              7.21337890625,
+              7.31884765625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 86,
+            "elapsedSeconds": 42.12201189994812,
+            "loadAverage": [
+              4.4638671875,
+              7.09326171875,
+              7.27587890625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 86,
+            "elapsedSeconds": 44.22876596450806,
+            "loadAverage": [
+              4.4638671875,
+              7.09326171875,
+              7.27587890625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 88,
+            "elapsedSeconds": 46.3476459980011,
+            "loadAverage": [
+              4.4638671875,
+              7.09326171875,
+              7.27587890625
+            ]
+          }
+        ],
+        "knownRenderingWorkerCount": 0,
+        "maxPressureLevel": 1,
+        "measurementMode": "desktop-load",
+        "peakResidentBytes": 9467723776,
+        "processSeconds": 48.45229697227478,
+        "profiled": false,
+        "prompt": "Write a complete Python implementation of an LRU cache using a dictionary and a doubly linked list, with get and put operations, type hints, and a short usage example. Return the code directly without introductory prose.",
+        "runtimeOverrides": {},
+        "sourceHead": "c3ef55db5f09b2bcc6526bec4dd2a78eaa27aee6",
+        "startedUnixSeconds": 1788623955.434987,
+        "uncontended": false,
+        "workload": "code"
+      },
+      "scenarios": [
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 0.5032358009761664
+          },
+          "endToEndSpeedups": {
+            "adaptive": 0.5097982709707708
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 220,
+          "repetition": 1,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 1.9574549198150635,
+              "decodeTokensPerSecond": 130.78206675849597,
+              "elapsedSeconds": 2.0365079641342163,
+              "endToEndTokensPerSecond": 125.70537631500679,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.007560014724731445,
+              "generatedTokens": 256,
+              "loadSeconds": 1.0967254638671875e-05,
+              "name": "baseline",
+              "outputSHA256": "cd134369dacefc1cc1bc8bceceb5cfb2dc106e35c077361b20e79108d05fabb4",
+              "policy": "disabled",
+              "prefillSeconds": 0.07733690738677979,
+              "prefillTokensPerSecond": 698.2435918976369,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 7700643840,
+              "residentMemoryBeforeBytes": 7700594688,
+              "ttftSeconds": 0.0849078893661499
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.5186721991701245,
+                "acceptedDraftTokens": 125,
+                "draftHistoryTokens": 53,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 241,
+                "rounds": 131,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 3.8897370100021362,
+              "decodeTokensPerSecond": 65.81421811853018,
+              "elapsedSeconds": 3.994732975959778,
+              "endToEndTokensPerSecond": 64.08438349712054,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.00018906593322753906,
+              "generatedTokens": 256,
+              "loadSeconds": 5.9604644775390625e-06,
+              "name": "adaptive",
+              "outputSHA256": "cd134369dacefc1cc1bc8bceceb5cfb2dc106e35c077361b20e79108d05fabb4",
+              "policy": "adaptive",
+              "prefillSeconds": 0.10337197780609131,
+              "prefillTokensPerSecond": 522.3852841559735,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 9467576320,
+              "residentMemoryBeforeBytes": 9467084800,
+              "ttftSeconds": 0.10356700420379639
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 0.5145088326544027
+          },
+          "endToEndSpeedups": {
+            "adaptive": 0.5127918045602642
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 220,
+          "repetition": 2,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 1.9333399534225464,
+              "decodeTokensPerSecond": 132.41333969579907,
+              "elapsedSeconds": 2.012495994567871,
+              "endToEndTokensPerSecond": 127.20522211770616,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.008253931999206543,
+              "generatedTokens": 256,
+              "loadSeconds": 5.9604644775390625e-06,
+              "name": "baseline",
+              "outputSHA256": "cd134369dacefc1cc1bc8bceceb5cfb2dc106e35c077361b20e79108d05fabb4",
+              "policy": "disabled",
+              "prefillSeconds": 0.07761597633361816,
+              "prefillTokensPerSecond": 695.7330507303138,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 7700873216,
+              "residentMemoryBeforeBytes": 7700758528,
+              "ttftSeconds": 0.08587586879730225
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.5186721991701245,
+                "acceptedDraftTokens": 125,
+                "draftHistoryTokens": 53,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 241,
+                "rounds": 131,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 3.757641911506653,
+              "decodeTokensPerSecond": 68.12783283475646,
+              "elapsedSeconds": 3.9245868921279907,
+              "endToEndTokensPerSecond": 65.22979539922777,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0002689361572265625,
+              "generatedTokens": 256,
+              "loadSeconds": 6.9141387939453125e-06,
+              "name": "adaptive",
+              "outputSHA256": "cd134369dacefc1cc1bc8bceceb5cfb2dc106e35c077361b20e79108d05fabb4",
+              "policy": "adaptive",
+              "prefillSeconds": 0.1652590036392212,
+              "prefillTokensPerSecond": 326.75980618815794,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 9467641856,
+              "residentMemoryBeforeBytes": 9467576320,
+              "ttftSeconds": 0.1655348539352417
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 0.5086490251551099
+          },
+          "endToEndSpeedups": {
+            "adaptive": 0.5048625286941151
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 220,
+          "repetition": 3,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 1.976104974746704,
+              "decodeTokensPerSecond": 129.5477736615758,
+              "elapsedSeconds": 2.055469036102295,
+              "endToEndTokensPerSecond": 124.5457827403923,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.007930994033813477,
+              "generatedTokens": 256,
+              "loadSeconds": 1.0967254638671875e-05,
+              "name": "baseline",
+              "outputSHA256": "cd134369dacefc1cc1bc8bceceb5cfb2dc106e35c077361b20e79108d05fabb4",
+              "policy": "disabled",
+              "prefillSeconds": 0.07777106761932373,
+              "prefillTokensPerSecond": 694.3456178886588,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 7700987904,
+              "residentMemoryBeforeBytes": 7700873216,
+              "ttftSeconds": 0.08571302890777588
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.5186721991701245,
+                "acceptedDraftTokens": 125,
+                "draftHistoryTokens": 53,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 241,
+                "rounds": 131,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 3.885006904602051,
+              "decodeTokensPerSecond": 65.89434878397536,
+              "elapsedSeconds": 4.071344017982483,
+              "endToEndTokensPerSecond": 62.87849881250233,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0004469156265258789,
+              "generatedTokens": 256,
+              "loadSeconds": 5.9604644775390625e-06,
+              "name": "adaptive",
+              "outputSHA256": "cd134369dacefc1cc1bc8bceceb5cfb2dc106e35c077361b20e79108d05fabb4",
+              "policy": "adaptive",
+              "prefillSeconds": 0.18459808826446533,
+              "prefillTokensPerSecond": 292.527406473661,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 9467674624,
+              "residentMemoryBeforeBytes": 9467641856,
+              "ttftSeconds": 0.18505096435546875
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        }
+      ]
+    },
+    {
+      "id": "final-greedy/ornith-math",
+      "model": "text-agent-ornith-35b-mlx-4bit",
+      "rawReceiptSHA256": "c1cd43252f5da34c6cdd838116b5fd87df15e316a094aac21972e21acce3a292",
+      "receipt": {
+        "after": {
+          "gpuDeviceUtilizationPercent": 52,
+          "loadAverage": [
+            5.79248046875,
+            5.6796875,
+            6.28564453125
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7268.25M  free = 923.75M  (encrypted)",
+          "swapUsedMiB": 7268.25
+        },
+        "before": {
+          "gpuDeviceUtilizationPercent": 59,
+          "loadAverage": [
+            5.52734375,
+            5.56689453125,
+            6.271484375
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7268.25M  free = 923.75M  (encrypted)",
+          "swapUsedMiB": 7268.25
+        },
+        "binarySHA256": "37ae108285410acec9ee3863de69475fb74ce9b472bf23c05e0e0df8ce26414c",
+        "buildSourceRevision": "c3ef55db5f09b2bcc6526bec4dd2a78eaa27aee6",
+        "collectorSHA256": "dec1ae60840c738d2c8ef678adf8c1fc39b7eecaab018032ff2c596b51599f2c",
+        "command": [
+          "mere.run",
+          "model",
+          "benchmark",
+          "q36-mtp",
+          "--model",
+          "text-agent-ornith-35b-mlx-4bit",
+          "--prompt",
+          "Derive the sum of the first n squares using induction. Explain the base case and inductive step, then check your formula for n=10. Show each algebraic step.",
+          "--decode-tokens",
+          "256",
+          "--context-size",
+          "8192",
+          "--temperature",
+          "0",
+          "--top-p",
+          "1",
+          "--json",
+          "--variants",
+          "adaptive,baseline",
+          "--warmups",
+          "1",
+          "--warmup-tokens",
+          "256",
+          "--repetitions",
+          "3"
+        ],
+        "competingInferenceProcessCount": 0,
+        "gpuSamples": [
+          {
+            "deviceUtilizationPercent": 65,
+            "elapsedSeconds": 0.08813071250915527,
+            "loadAverage": [
+              5.52734375,
+              5.56689453125,
+              6.271484375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 64,
+            "elapsedSeconds": 2.1917686462402344,
+            "loadAverage": [
+              5.48486328125,
+              5.55712890625,
+              6.263671875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 87,
+            "elapsedSeconds": 4.293680906295776,
+            "loadAverage": [
+              5.48486328125,
+              5.55712890625,
+              6.263671875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 66,
+            "elapsedSeconds": 6.672083854675293,
+            "loadAverage": [
+              6.72705078125,
+              5.8134765625,
+              6.349609375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 60,
+            "elapsedSeconds": 8.901358842849731,
+            "loadAverage": [
+              6.72705078125,
+              5.8134765625,
+              6.349609375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 66,
+            "elapsedSeconds": 11.092183828353882,
+            "loadAverage": [
+              6.90869140625,
+              5.8662109375,
+              6.36474609375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 75,
+            "elapsedSeconds": 13.286022901535034,
+            "loadAverage": [
+              6.90869140625,
+              5.8662109375,
+              6.36474609375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 69,
+            "elapsedSeconds": 15.469047784805298,
+            "loadAverage": [
+              6.59521484375,
+              5.818359375,
+              6.3447265625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 54,
+            "elapsedSeconds": 17.649840831756592,
+            "loadAverage": [
+              6.59521484375,
+              5.818359375,
+              6.3447265625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 59,
+            "elapsedSeconds": 19.754568815231323,
+            "loadAverage": [
+              6.59521484375,
+              5.818359375,
+              6.3447265625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 99,
+            "elapsedSeconds": 21.876179933547974,
+            "loadAverage": [
+              6.38720703125,
+              5.7880859375,
+              6.33056640625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 48,
+            "elapsedSeconds": 24.025762796401978,
+            "loadAverage": [
+              6.38720703125,
+              5.7880859375,
+              6.33056640625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 61,
+            "elapsedSeconds": 26.196739673614502,
+            "loadAverage": [
+              6.03564453125,
+              5.72509765625,
+              6.30517578125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 85,
+            "elapsedSeconds": 28.384493827819824,
+            "loadAverage": [
+              6.03564453125,
+              5.72509765625,
+              6.30517578125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 65,
+            "elapsedSeconds": 30.5664119720459,
+            "loadAverage": [
+              5.79248046875,
+              5.6796875,
+              6.28564453125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 49,
+            "elapsedSeconds": 32.74526882171631,
+            "loadAverage": [
+              5.79248046875,
+              5.6796875,
+              6.28564453125
+            ]
+          }
+        ],
+        "knownRenderingWorkerCount": 0,
+        "maxPressureLevel": 1,
+        "measurementMode": "desktop-load",
+        "peakResidentBytes": 9463414784,
+        "processSeconds": 34.885260820388794,
+        "profiled": false,
+        "prompt": "Derive the sum of the first n squares using induction. Explain the base case and inductive step, then check your formula for n=10. Show each algebraic step.",
+        "runtimeOverrides": {},
+        "sourceHead": "c3ef55db5f09b2bcc6526bec4dd2a78eaa27aee6",
+        "startedUnixSeconds": 1788624512.0353742,
+        "uncontended": false,
+        "workload": "math"
+      },
+      "scenarios": [
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 0.7936179556854549
+          },
+          "endToEndSpeedups": {
+            "adaptive": 0.8759878992545894
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 156,
+          "repetition": 1,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "acceptanceRate": 0.5975103734439834,
+                "acceptedDraftTokens": 144,
+                "draftHistoryTokens": 48,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 241,
+                "rounds": 111,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 4.880236029624939,
+              "decodeTokensPerSecond": 52.45647924526191,
+              "elapsedSeconds": 5.136402010917664,
+              "endToEndTokensPerSecond": 49.840335599873214,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0005780458450317383,
+              "generatedTokens": 256,
+              "loadSeconds": 1.2040138244628906e-05,
+              "name": "adaptive",
+              "outputSHA256": "b754509c3e8b857df33b3149639a416f0c2b9800c69f82c20bd0c24dcbb0ab3d",
+              "policy": "adaptive",
+              "prefillSeconds": 0.2538108825683594,
+              "prefillTokensPerSecond": 193.05712782745923,
+              "promptTokens": 49,
+              "residentMemoryAfterBytes": 9463283712,
+              "residentMemoryBeforeBytes": 9462497280,
+              "ttftSeconds": 0.25440096855163574
+            },
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 3.873042941093445,
+              "decodeTokensPerSecond": 66.09789870486837,
+              "elapsedSeconds": 4.499426007270813,
+              "endToEndTokensPerSecond": 56.89614621649934,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.07702696323394775,
+              "generatedTokens": 256,
+              "loadSeconds": 7.987022399902344e-06,
+              "name": "baseline",
+              "outputSHA256": "b754509c3e8b857df33b3149639a416f0c2b9800c69f82c20bd0c24dcbb0ab3d",
+              "policy": "disabled",
+              "prefillSeconds": 0.624398946762085,
+              "prefillTokensPerSecond": 78.47546869528993,
+              "promptTokens": 49,
+              "residentMemoryAfterBytes": 9350840320,
+              "residentMemoryBeforeBytes": 9350529024,
+              "ttftSeconds": 0.7014338970184326
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 1.0945506845878075
+          },
+          "endToEndSpeedups": {
+            "adaptive": 1.1068687813203837
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 156,
+          "repetition": 2,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "acceptanceRate": 0.5975103734439834,
+                "acceptedDraftTokens": 144,
+                "draftHistoryTokens": 48,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 241,
+                "rounds": 111,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 3.1709870100021362,
+              "decodeTokensPerSecond": 80.73196111889072,
+              "elapsedSeconds": 3.269270896911621,
+              "endToEndTokensPerSecond": 78.30492121097559,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0005669593811035156,
+              "generatedTokens": 256,
+              "loadSeconds": 1.2993812561035156e-05,
+              "name": "adaptive",
+              "outputSHA256": "b754509c3e8b857df33b3149639a416f0c2b9800c69f82c20bd0c24dcbb0ab3d",
+              "policy": "adaptive",
+              "prefillSeconds": 0.0955209732055664,
+              "prefillTokensPerSecond": 512.9763480795918,
+              "promptTokens": 49,
+              "residentMemoryAfterBytes": 9463398400,
+              "residentMemoryBeforeBytes": 9463382016,
+              "ttftSeconds": 0.09610092639923096
+            },
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 3.4708060026168823,
+              "decodeTokensPerSecond": 73.75808380156764,
+              "elapsedSeconds": 3.618653893470764,
+              "endToEndTokensPerSecond": 70.74453858709941,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.013299942016601562,
+              "generatedTokens": 256,
+              "loadSeconds": 1.0967254638671875e-05,
+              "name": "baseline",
+              "outputSHA256": "b754509c3e8b857df33b3149639a416f0c2b9800c69f82c20bd0c24dcbb0ab3d",
+              "policy": "disabled",
+              "prefillSeconds": 0.1454859972000122,
+              "prefillTokensPerSecond": 336.8021730134994,
+              "promptTokens": 49,
+              "residentMemoryAfterBytes": 9350889472,
+              "residentMemoryBeforeBytes": 9350840320,
+              "ttftSeconds": 0.15879690647125244
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 1.1660492631455546
+          },
+          "endToEndSpeedups": {
+            "adaptive": 1.1596014396946597
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 156,
+          "repetition": 3,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "acceptanceRate": 0.5975103734439834,
+                "acceptedDraftTokens": 144,
+                "draftHistoryTokens": 48,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 241,
+                "rounds": 111,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 3.123867988586426,
+              "decodeTokensPerSecond": 81.94968575347576,
+              "elapsedSeconds": 3.2323830127716064,
+              "endToEndTokensPerSecond": 79.19853525665351,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0002549886703491211,
+              "generatedTokens": 256,
+              "loadSeconds": 1.4066696166992188e-05,
+              "name": "adaptive",
+              "outputSHA256": "b754509c3e8b857df33b3149639a416f0c2b9800c69f82c20bd0c24dcbb0ab3d",
+              "policy": "adaptive",
+              "prefillSeconds": 0.10540890693664551,
+              "prefillTokensPerSecond": 464.8563525039752,
+              "promptTokens": 49,
+              "residentMemoryAfterBytes": 9463414784,
+              "residentMemoryBeforeBytes": 9463398400,
+              "ttftSeconds": 0.10567796230316162
+            },
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 3.642583966255188,
+              "decodeTokensPerSecond": 70.2797800604126,
+              "elapsedSeconds": 3.7482759952545166,
+              "endToEndTokensPerSecond": 68.298065650477,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.01730799674987793,
+              "generatedTokens": 256,
+              "loadSeconds": 1.2993812561035156e-05,
+              "name": "baseline",
+              "outputSHA256": "b754509c3e8b857df33b3149639a416f0c2b9800c69f82c20bd0c24dcbb0ab3d",
+              "policy": "disabled",
+              "prefillSeconds": 0.10316002368927002,
+              "prefillTokensPerSecond": 474.99019724533696,
+              "promptTokens": 49,
+              "residentMemoryAfterBytes": 9350922240,
+              "residentMemoryBeforeBytes": 9350889472,
+              "ttftSeconds": 0.12048101425170898
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        }
+      ]
+    },
+    {
+      "id": "final-greedy/ornith-prose",
+      "model": "text-agent-ornith-35b-mlx-4bit",
+      "rawReceiptSHA256": "76fe20e1067bd851ec3e7c84a2492d2caaac0c0feb9d572d6ce2eabcc65d6095",
+      "receipt": {
+        "after": {
+          "gpuDeviceUtilizationPercent": 56,
+          "loadAverage": [
+            6.251953125,
+            5.73681640625,
+            6.47265625
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7268.25M  free = 923.75M  (encrypted)",
+          "swapUsedMiB": 7268.25
+        },
+        "before": {
+          "gpuDeviceUtilizationPercent": 49,
+          "loadAverage": [
+            6.59130859375,
+            5.75830078125,
+            6.50830078125
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7268.25M  free = 923.75M  (encrypted)",
+          "swapUsedMiB": 7268.25
+        },
+        "binarySHA256": "37ae108285410acec9ee3863de69475fb74ce9b472bf23c05e0e0df8ce26414c",
+        "buildSourceRevision": "c3ef55db5f09b2bcc6526bec4dd2a78eaa27aee6",
+        "collectorSHA256": "dec1ae60840c738d2c8ef678adf8c1fc39b7eecaab018032ff2c596b51599f2c",
+        "command": [
+          "mere.run",
+          "model",
+          "benchmark",
+          "q36-mtp",
+          "--model",
+          "text-agent-ornith-35b-mlx-4bit",
+          "--prompt",
+          "Explain how a small community could turn an abandoned railway station into a public library. Discuss the building, accessibility, staffing, the collection, and a realistic opening-day scene. Write approximately 400 words of clear, connected prose.",
+          "--decode-tokens",
+          "256",
+          "--context-size",
+          "8192",
+          "--temperature",
+          "0",
+          "--top-p",
+          "1",
+          "--json",
+          "--variants",
+          "baseline,adaptive",
+          "--warmups",
+          "1",
+          "--warmup-tokens",
+          "256",
+          "--repetitions",
+          "3"
+        ],
+        "competingInferenceProcessCount": 0,
+        "gpuSamples": [
+          {
+            "deviceUtilizationPercent": 49,
+            "elapsedSeconds": 0.15110278129577637,
+            "loadAverage": [
+              6.59130859375,
+              5.75830078125,
+              6.50830078125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 51,
+            "elapsedSeconds": 2.25698184967041,
+            "loadAverage": [
+              6.59130859375,
+              5.75830078125,
+              6.50830078125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 94,
+            "elapsedSeconds": 4.368875026702881,
+            "loadAverage": [
+              6.59130859375,
+              5.75830078125,
+              6.50830078125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 77,
+            "elapsedSeconds": 6.513379096984863,
+            "loadAverage": [
+              6.3837890625,
+              5.72900390625,
+              6.4931640625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 54,
+            "elapsedSeconds": 8.674722909927368,
+            "loadAverage": [
+              6.3837890625,
+              5.72900390625,
+              6.4931640625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 54,
+            "elapsedSeconds": 10.857219696044922,
+            "loadAverage": [
+              6.03271484375,
+              5.6669921875,
+              6.466796875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 60,
+            "elapsedSeconds": 13.038350105285645,
+            "loadAverage": [
+              6.03271484375,
+              5.6669921875,
+              6.466796875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 60,
+            "elapsedSeconds": 15.301129817962646,
+            "loadAverage": [
+              6.27001953125,
+              5.72216796875,
+              6.4814453125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 62,
+            "elapsedSeconds": 17.438050985336304,
+            "loadAverage": [
+              6.27001953125,
+              5.72216796875,
+              6.4814453125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 52,
+            "elapsedSeconds": 19.541571855545044,
+            "loadAverage": [
+              6.27001953125,
+              5.72216796875,
+              6.4814453125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 91,
+            "elapsedSeconds": 21.651201963424683,
+            "loadAverage": [
+              5.927734375,
+              5.66015625,
+              6.455078125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 82,
+            "elapsedSeconds": 23.82900595664978,
+            "loadAverage": [
+              5.927734375,
+              5.66015625,
+              6.455078125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 87,
+            "elapsedSeconds": 25.974029064178467,
+            "loadAverage": [
+              6.01318359375,
+              5.68212890625,
+              6.4580078125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 82,
+            "elapsedSeconds": 28.15084481239319,
+            "loadAverage": [
+              6.01318359375,
+              5.68212890625,
+              6.4580078125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 65,
+            "elapsedSeconds": 30.312415838241577,
+            "loadAverage": [
+              6.251953125,
+              5.73681640625,
+              6.47265625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 73,
+            "elapsedSeconds": 32.49711203575134,
+            "loadAverage": [
+              6.251953125,
+              5.73681640625,
+              6.47265625
+            ]
+          }
+        ],
+        "knownRenderingWorkerCount": 0,
+        "maxPressureLevel": 1,
+        "measurementMode": "desktop-load",
+        "peakResidentBytes": 9467789312,
+        "processSeconds": 34.68603181838989,
+        "profiled": false,
+        "prompt": "Explain how a small community could turn an abandoned railway station into a public library. Discuss the building, accessibility, staffing, the collection, and a realistic opening-day scene. Write approximately 400 words of clear, connected prose.",
+        "runtimeOverrides": {},
+        "sourceHead": "c3ef55db5f09b2bcc6526bec4dd2a78eaa27aee6",
+        "startedUnixSeconds": 1788624322.635404,
+        "uncontended": false,
+        "workload": "prose"
+      },
+      "scenarios": [
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 0.9274857928765436
+          },
+          "endToEndSpeedups": {
+            "adaptive": 0.9237074993346861
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 247,
+          "repetition": 1,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 3.8196980953216553,
+              "decodeTokensPerSecond": 67.02100365302361,
+              "elapsedSeconds": 3.9254270792007446,
+              "endToEndTokensPerSecond": 65.21583380224811,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.008144021034240723,
+              "generatedTokens": 256,
+              "loadSeconds": 9.894371032714844e-06,
+              "name": "baseline",
+              "outputSHA256": "ca3ac87c453ea9cb8fdd5fe572ce7e0e9930e17487f37393e45606052e4db11e",
+              "policy": "disabled",
+              "prefillSeconds": 0.10330605506896973,
+              "prefillTokensPerSecond": 580.798482334288,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 7684177920,
+              "residentMemoryBeforeBytes": 7683833856,
+              "ttftSeconds": 0.11145997047424316
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.25892857142857145,
+                "acceptedDraftTokens": 29,
+                "draftHistoryTokens": 59,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 112,
+                "rounds": 69,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 4.118335962295532,
+              "decodeTokensPerSecond": 62.16102871250634,
+              "elapsedSeconds": 4.249642968177795,
+              "endToEndTokensPerSecond": 60.2403547585011,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0002300739288330078,
+              "generatedTokens": 256,
+              "loadSeconds": 7.987022399902344e-06,
+              "name": "adaptive",
+              "outputSHA256": "ca3ac87c453ea9cb8fdd5fe572ce7e0e9930e17487f37393e45606052e4db11e",
+              "policy": "adaptive",
+              "prefillSeconds": 0.12905800342559814,
+              "prefillTokensPerSecond": 464.90723866335003,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 9467707392,
+              "residentMemoryBeforeBytes": 9467117568,
+              "ttftSeconds": 0.12929606437683105
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 0.985096498568095
+          },
+          "endToEndSpeedups": {
+            "adaptive": 0.9866084036958582
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 247,
+          "repetition": 2,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 3.7071239948272705,
+              "decodeTokensPerSecond": 69.05622805096597,
+              "elapsedSeconds": 3.8291209936141968,
+              "endToEndTokensPerSecond": 66.85607491299693,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.014528036117553711,
+              "generatedTokens": 256,
+              "loadSeconds": 1.0967254638671875e-05,
+              "name": "baseline",
+              "outputSHA256": "ca3ac87c453ea9cb8fdd5fe572ce7e0e9930e17487f37393e45606052e4db11e",
+              "policy": "disabled",
+              "prefillSeconds": 0.11905992031097412,
+              "prefillTokensPerSecond": 503.94792675222055,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 7684374528,
+              "residentMemoryBeforeBytes": 7684276224,
+              "ttftSeconds": 0.1335989236831665
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.25892857142857145,
+                "acceptedDraftTokens": 29,
+                "draftHistoryTokens": 59,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 112,
+                "rounds": 69,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 3.7632089853286743,
+              "decodeTokensPerSecond": 68.02704845732644,
+              "elapsedSeconds": 3.881095051765442,
+              "endToEndTokensPerSecond": 65.96076534728262,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.00022101402282714844,
+              "generatedTokens": 256,
+              "loadSeconds": 1.0013580322265625e-05,
+              "name": "adaptive",
+              "outputSHA256": "ca3ac87c453ea9cb8fdd5fe572ce7e0e9930e17487f37393e45606052e4db11e",
+              "policy": "adaptive",
+              "prefillSeconds": 0.11526799201965332,
+              "prefillTokensPerSecond": 520.5261143940977,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 9467772928,
+              "residentMemoryBeforeBytes": 9467707392,
+              "ttftSeconds": 0.11549901962280273
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 1.1059734078328523
+          },
+          "endToEndSpeedups": {
+            "adaptive": 1.1010550176757645
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 247,
+          "repetition": 3,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 4.395290970802307,
+              "decodeTokensPerSecond": 58.24415304938738,
+              "elapsedSeconds": 4.496928930282593,
+              "endToEndTokensPerSecond": 56.92773979061142,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.016224980354309082,
+              "generatedTokens": 256,
+              "loadSeconds": 1.2993812561035156e-05,
+              "name": "baseline",
+              "outputSHA256": "ca3ac87c453ea9cb8fdd5fe572ce7e0e9930e17487f37393e45606052e4db11e",
+              "policy": "disabled",
+              "prefillSeconds": 0.09855794906616211,
+              "prefillTokensPerSecond": 608.778901838977,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 7684472832,
+              "residentMemoryBeforeBytes": 7684390912,
+              "ttftSeconds": 0.11479592323303223
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.25892857142857145,
+                "acceptedDraftTokens": 29,
+                "draftHistoryTokens": 59,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 112,
+                "rounds": 69,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 3.974138021469116,
+              "decodeTokensPerSecond": 64.41648443436917,
+              "elapsedSeconds": 4.084200024604797,
+              "endToEndTokensPerSecond": 62.680573541392974,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.00022304058074951172,
+              "generatedTokens": 256,
+              "loadSeconds": 1.1086463928222656e-05,
+              "name": "adaptive",
+              "outputSHA256": "ca3ac87c453ea9cb8fdd5fe572ce7e0e9930e17487f37393e45606052e4db11e",
+              "policy": "adaptive",
+              "prefillSeconds": 0.10719001293182373,
+              "prefillTokensPerSecond": 559.7536408374343,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 9467805696,
+              "residentMemoryBeforeBytes": 9467772928,
+              "ttftSeconds": 0.10742413997650146
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        }
+      ]
+    },
+    {
+      "id": "final-greedy/ornith-summary",
+      "model": "text-agent-ornith-35b-mlx-4bit",
+      "rawReceiptSHA256": "f5535d654d17756b60f2d7f1f8bface5f5c5e853ed0f50bc89819863363d3afa",
+      "receipt": {
+        "after": {
+          "gpuDeviceUtilizationPercent": 64,
+          "loadAverage": [
+            8.35107421875,
+            6.3984375,
+            6.40625
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7268.25M  free = 923.75M  (encrypted)",
+          "swapUsedMiB": 7268.25
+        },
+        "before": {
+          "gpuDeviceUtilizationPercent": 47,
+          "loadAverage": [
+            6.49072265625,
+            5.58837890625,
+            6.125
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7268.25M  free = 923.75M  (encrypted)",
+          "swapUsedMiB": 7268.25
+        },
+        "binarySHA256": "37ae108285410acec9ee3863de69475fb74ce9b472bf23c05e0e0df8ce26414c",
+        "buildSourceRevision": "c3ef55db5f09b2bcc6526bec4dd2a78eaa27aee6",
+        "collectorSHA256": "dec1ae60840c738d2c8ef678adf8c1fc39b7eecaab018032ff2c596b51599f2c",
+        "command": [
+          "mere.run",
+          "model",
+          "benchmark",
+          "q36-mtp",
+          "--model",
+          "text-agent-ornith-35b-mlx-4bit",
+          "--prompt",
+          "Summarize this fictional incident report for a manager. Explain the timeline, user impact, cause, recovery, and three concrete follow-up actions. Distinguish confirmed facts from open questions. Use clear paragraphs and a short action list.\n\n09:02: The team deployed version 2.8 of the document search service. 09:07: Monitoring showed the 95th percentile search latency rising from 180 milliseconds to 4.2 seconds. 09:10: Support received six reports of slow searches; document uploads and downloads remained available. 09:13: The on-call engineer paused the rollout at 40 percent of traffic. 09:17: Logs showed repeated cache misses for queries containing a language filter. A new cache key included a randomly generated request identifier. 09:21: The engineer rolled traffic back to version 2.7. 09:26: Latency returned below 250 milliseconds. 09:32: The team confirmed no documents were lost or modified. Approximately 1,800 search requests experienced elevated latency; 73 timed out. The exact number of affected users is still being calculated. The release tests covered result correctness but did not assert cache reuse. A separate warning about database connection count appeared at 09:15; the team has not established whether it was a cause or an effect. Proposed follow-ups include a deterministic cache-key unit test, a staging workload with repeated filtered queries, and an automatic rollback threshold for latency.",
+          "--decode-tokens",
+          "256",
+          "--context-size",
+          "8192",
+          "--temperature",
+          "0",
+          "--top-p",
+          "1",
+          "--json",
+          "--variants",
+          "baseline,adaptive",
+          "--warmups",
+          "1",
+          "--warmup-tokens",
+          "256",
+          "--repetitions",
+          "3"
+        ],
+        "competingInferenceProcessCount": 0,
+        "gpuSamples": [
+          {
+            "deviceUtilizationPercent": 54,
+            "elapsedSeconds": 0.16057491302490234,
+            "loadAverage": [
+              6.49072265625,
+              5.58837890625,
+              6.125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 60,
+            "elapsedSeconds": 2.2684128284454346,
+            "loadAverage": [
+              9.333984375,
+              6.1923828125,
+              6.3349609375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 77,
+            "elapsedSeconds": 4.801259994506836,
+            "loadAverage": [
+              9.333984375,
+              6.1923828125,
+              6.3349609375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 53,
+            "elapsedSeconds": 7.117790937423706,
+            "loadAverage": [
+              10.50830078125,
+              6.48779296875,
+              6.43798828125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 83,
+            "elapsedSeconds": 9.274858951568604,
+            "loadAverage": [
+              10.50830078125,
+              6.48779296875,
+              6.43798828125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 80,
+            "elapsedSeconds": 11.460591793060303,
+            "loadAverage": [
+              9.98681640625,
+              6.4462890625,
+              6.42333984375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 94,
+            "elapsedSeconds": 13.61159610748291,
+            "loadAverage": [
+              9.98681640625,
+              6.4462890625,
+              6.42333984375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 86,
+            "elapsedSeconds": 15.815939903259277,
+            "loadAverage": [
+              9.74755859375,
+              6.455078125,
+              6.42626953125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 76,
+            "elapsedSeconds": 18.004486799240112,
+            "loadAverage": [
+              9.74755859375,
+              6.455078125,
+              6.42626953125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 61,
+            "elapsedSeconds": 20.177622079849243,
+            "loadAverage": [
+              9.74755859375,
+              6.455078125,
+              6.42626953125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 58,
+            "elapsedSeconds": 22.31479287147522,
+            "loadAverage": [
+              9.767578125,
+              6.513671875,
+              6.44677734375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 70,
+            "elapsedSeconds": 24.434377908706665,
+            "loadAverage": [
+              9.767578125,
+              6.513671875,
+              6.44677734375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 94,
+            "elapsedSeconds": 26.571160793304443,
+            "loadAverage": [
+              9.3056640625,
+              6.4716796875,
+              6.43212890625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 95,
+            "elapsedSeconds": 28.69957184791565,
+            "loadAverage": [
+              9.3056640625,
+              6.4716796875,
+              6.43212890625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 92,
+            "elapsedSeconds": 30.863296031951904,
+            "loadAverage": [
+              8.96044921875,
+              6.44677734375,
+              6.42333984375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 93,
+            "elapsedSeconds": 33.00080990791321,
+            "loadAverage": [
+              8.96044921875,
+              6.44677734375,
+              6.42333984375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 85,
+            "elapsedSeconds": 35.19631385803223,
+            "loadAverage": [
+              8.96044921875,
+              6.44677734375,
+              6.42333984375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 83,
+            "elapsedSeconds": 37.36798691749573,
+            "loadAverage": [
+              8.64306640625,
+              6.42236328125,
+              6.41455078125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 84,
+            "elapsedSeconds": 39.561599016189575,
+            "loadAverage": [
+              8.64306640625,
+              6.42236328125,
+              6.41455078125
+            ]
+          }
+        ],
+        "knownRenderingWorkerCount": 1,
+        "maxPressureLevel": 1,
+        "measurementMode": "desktop-load",
+        "peakResidentBytes": 9470541824,
+        "processSeconds": 41.72237682342529,
+        "profiled": false,
+        "prompt": "Summarize this fictional incident report for a manager. Explain the timeline, user impact, cause, recovery, and three concrete follow-up actions. Distinguish confirmed facts from open questions. Use clear paragraphs and a short action list.\n\n09:02: The team deployed version 2.8 of the document search service. 09:07: Monitoring showed the 95th percentile search latency rising from 180 milliseconds to 4.2 seconds. 09:10: Support received six reports of slow searches; document uploads and downloads remained available. 09:13: The on-call engineer paused the rollout at 40 percent of traffic. 09:17: Logs showed repeated cache misses for queries containing a language filter. A new cache key included a randomly generated request identifier. 09:21: The engineer rolled traffic back to version 2.7. 09:26: Latency returned below 250 milliseconds. 09:32: The team confirmed no documents were lost or modified. Approximately 1,800 search requests experienced elevated latency; 73 timed out. The exact number of affected users is still being calculated. The release tests covered result correctness but did not assert cache reuse. A separate warning about database connection count appeared at 09:15; the team has not established whether it was a cause or an effect. Proposed follow-ups include a deterministic cache-key unit test, a staging workload with repeated filtered queries, and an automatic rollback threshold for latency.",
+        "runtimeOverrides": {},
+        "sourceHead": "c3ef55db5f09b2bcc6526bec4dd2a78eaa27aee6",
+        "startedUnixSeconds": 1788624697.16877,
+        "uncontended": false,
+        "workload": "summary"
+      },
+      "scenarios": [
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 1.2238893212688902
+          },
+          "endToEndSpeedups": {
+            "adaptive": 0.9635954531881853
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 1428,
+          "repetition": 1,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 3.5036720037460327,
+              "decodeTokensPerSecond": 73.06620018263457,
+              "elapsedSeconds": 3.8215569257736206,
+              "endToEndTokensPerSecond": 66.988404195543,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.010655999183654785,
+              "generatedTokens": 256,
+              "loadSeconds": 1.4066696166992188e-05,
+              "name": "baseline",
+              "outputSHA256": "a69b578276c6d560db5ba4730e6a6716506a19f3e2f0b8ee3af6cb09f3bb0aa7",
+              "policy": "disabled",
+              "prefillSeconds": 0.3154240846633911,
+              "prefillTokensPerSecond": 1068.4028784917737,
+              "promptTokens": 337,
+              "residentMemoryAfterBytes": 7701495808,
+              "residentMemoryBeforeBytes": 7701397504,
+              "ttftSeconds": 0.3260941505432129
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.5375494071146245,
+                "acceptedDraftTokens": 136,
+                "draftHistoryTokens": 336,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 253,
+                "rounds": 120,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 2.8627359867095947,
+              "decodeTokensPerSecond": 89.4249421492215,
+              "elapsedSeconds": 3.965934991836548,
+              "endToEndTokensPerSecond": 64.54972169915759,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.00028896331787109375,
+              "generatedTokens": 256,
+              "loadSeconds": 1.0013580322265625e-05,
+              "name": "adaptive",
+              "outputSHA256": "a69b578276c6d560db5ba4730e6a6716506a19f3e2f0b8ee3af6cb09f3bb0aa7",
+              "policy": "adaptive",
+              "prefillSeconds": 1.1002739667892456,
+              "prefillTokensPerSecond": 306.28735221593354,
+              "promptTokens": 337,
+              "residentMemoryAfterBytes": 9470197760,
+              "residentMemoryBeforeBytes": 9470132224,
+              "ttftSeconds": 1.100572943687439
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 0.9305908973135506
+          },
+          "endToEndSpeedups": {
+            "adaptive": 0.8083005551328226
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 1428,
+          "repetition": 2,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 3.052298069000244,
+              "decodeTokensPerSecond": 83.87123217092974,
+              "elapsedSeconds": 3.5733100175857544,
+              "endToEndTokensPerSecond": 71.64225850545205,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.010917067527770996,
+              "generatedTokens": 256,
+              "loadSeconds": 1.2993812561035156e-05,
+              "name": "baseline",
+              "outputSHA256": "a69b578276c6d560db5ba4730e6a6716506a19f3e2f0b8ee3af6cb09f3bb0aa7",
+              "policy": "disabled",
+              "prefillSeconds": 0.5182070732116699,
+              "prefillTokensPerSecond": 650.3191820817678,
+              "promptTokens": 337,
+              "residentMemoryAfterBytes": 7702331392,
+              "residentMemoryBeforeBytes": 7701594112,
+              "ttftSeconds": 0.529137134552002
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.5375494071146245,
+                "acceptedDraftTokens": 136,
+                "draftHistoryTokens": 336,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 253,
+                "rounds": 120,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 3.2799569368362427,
+              "decodeTokensPerSecond": 78.04980520473865,
+              "elapsedSeconds": 4.420768976211548,
+              "endToEndTokensPerSecond": 57.908477320926075,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0002969503402709961,
+              "generatedTokens": 256,
+              "loadSeconds": 0.00012493133544921875,
+              "name": "adaptive",
+              "outputSHA256": "a69b578276c6d560db5ba4730e6a6716506a19f3e2f0b8ee3af6cb09f3bb0aa7",
+              "policy": "adaptive",
+              "prefillSeconds": 1.1369750499725342,
+              "prefillTokensPerSecond": 296.4005234839066,
+              "promptTokens": 337,
+              "residentMemoryAfterBytes": 9470476288,
+              "residentMemoryBeforeBytes": 9470197760,
+              "ttftSeconds": 1.1373969316482544
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 1.3058649824450512
+          },
+          "endToEndSpeedups": {
+            "adaptive": 1.179889300697985
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 1428,
+          "repetition": 3,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 4.09818696975708,
+              "decodeTokensPerSecond": 62.46664729773771,
+              "elapsedSeconds": 4.672605991363525,
+              "endToEndTokensPerSecond": 54.7874142337638,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.021971940994262695,
+              "generatedTokens": 256,
+              "loadSeconds": 1.5020370483398438e-05,
+              "name": "baseline",
+              "outputSHA256": "a69b578276c6d560db5ba4730e6a6716506a19f3e2f0b8ee3af6cb09f3bb0aa7",
+              "policy": "disabled",
+              "prefillSeconds": 0.5709220170974731,
+              "prefillTokensPerSecond": 590.2732595833035,
+              "promptTokens": 337,
+              "residentMemoryAfterBytes": 7702347776,
+              "residentMemoryBeforeBytes": 7702331392,
+              "ttftSeconds": 0.5929089784622192
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.5375494071146245,
+                "acceptedDraftTokens": 136,
+                "draftHistoryTokens": 336,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 253,
+                "rounds": 120,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 3.1382930278778076,
+              "decodeTokensPerSecond": 81.57300727686146,
+              "elapsedSeconds": 3.9602071046829224,
+              "endToEndTokensPerSecond": 64.6430838673264,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0003420114517211914,
+              "generatedTokens": 256,
+              "loadSeconds": 1.2993812561035156e-05,
+              "name": "adaptive",
+              "outputSHA256": "a69b578276c6d560db5ba4730e6a6716506a19f3e2f0b8ee3af6cb09f3bb0aa7",
+              "policy": "adaptive",
+              "prefillSeconds": 0.8189549446105957,
+              "prefillTokensPerSecond": 411.5000492001912,
+              "promptTokens": 337,
+              "residentMemoryAfterBytes": 9470541824,
+              "residentMemoryBeforeBytes": 9470476288,
+              "ttftSeconds": 0.8193099498748779
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        }
+      ]
+    },
+    {
+      "id": "final-greedy/qwen-chat",
+      "model": "vision-chat-q38-27b-4bit",
+      "rawReceiptSHA256": "c454db9ef4eef5183d8b9f20d9b5d196dd3e417e87b344072c86bf757bdc56ee",
+      "receipt": {
+        "after": {
+          "gpuDeviceUtilizationPercent": 93,
+          "loadAverage": [
+            6.3818359375,
+            5.70361328125,
+            6.49365234375
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7268.25M  free = 923.75M  (encrypted)",
+          "swapUsedMiB": 7268.25
+        },
+        "before": {
+          "gpuDeviceUtilizationPercent": 46,
+          "loadAverage": [
+            3.95751953125,
+            5.8369140625,
+            6.72509765625
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7268.25M  free = 923.75M  (encrypted)",
+          "swapUsedMiB": 7268.25
+        },
+        "binarySHA256": "37ae108285410acec9ee3863de69475fb74ce9b472bf23c05e0e0df8ce26414c",
+        "buildSourceRevision": "c3ef55db5f09b2bcc6526bec4dd2a78eaa27aee6",
+        "collectorSHA256": "dec1ae60840c738d2c8ef678adf8c1fc39b7eecaab018032ff2c596b51599f2c",
+        "command": [
+          "mere.run",
+          "model",
+          "benchmark",
+          "q36-mtp",
+          "--model",
+          "vision-chat-q38-27b-4bit",
+          "--prompt",
+          "I'm trying to get back into reading after a busy year. I have about twenty minutes most evenings, enjoy mysteries and science fiction, and keep abandoning books when I miss a few days. Help me make a gentle, realistic four-week plan. Talk to me conversationally, suggest ways to choose books without buying a stack, and explain what to do when I fall behind. Give enough practical detail that I can start tonight.",
+          "--decode-tokens",
+          "256",
+          "--context-size",
+          "8192",
+          "--temperature",
+          "0",
+          "--top-p",
+          "1",
+          "--json",
+          "--variants",
+          "adaptive,baseline",
+          "--warmups",
+          "1",
+          "--warmup-tokens",
+          "256",
+          "--repetitions",
+          "3"
+        ],
+        "competingInferenceProcessCount": 0,
+        "gpuSamples": [
+          {
+            "deviceUtilizationPercent": 45,
+            "elapsedSeconds": 0.1225290298461914,
+            "loadAverage": [
+              3.95751953125,
+              5.8369140625,
+              6.72509765625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 80,
+            "elapsedSeconds": 2.2237277030944824,
+            "loadAverage": [
+              3.95751953125,
+              5.8369140625,
+              6.72509765625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 95,
+            "elapsedSeconds": 4.3388848304748535,
+            "loadAverage": [
+              3.95751953125,
+              5.8369140625,
+              6.72509765625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 98,
+            "elapsedSeconds": 6.441427946090698,
+            "loadAverage": [
+              3.80029296875,
+              5.77294921875,
+              6.697265625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 94,
+            "elapsedSeconds": 8.532967805862427,
+            "loadAverage": [
+              3.80029296875,
+              5.77294921875,
+              6.697265625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 89,
+            "elapsedSeconds": 10.648180961608887,
+            "loadAverage": [
+              3.49560546875,
+              5.6767578125,
+              6.65771484375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 94,
+            "elapsedSeconds": 12.75586199760437,
+            "loadAverage": [
+              3.49560546875,
+              5.6767578125,
+              6.65771484375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 84,
+            "elapsedSeconds": 14.868896007537842,
+            "loadAverage": [
+              3.37548828125,
+              5.615234375,
+              6.63037109375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 97,
+            "elapsedSeconds": 16.982999801635742,
+            "loadAverage": [
+              3.37548828125,
+              5.615234375,
+              6.63037109375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 94,
+            "elapsedSeconds": 19.097590923309326,
+            "loadAverage": [
+              3.37548828125,
+              5.615234375,
+              6.63037109375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 94,
+            "elapsedSeconds": 21.209198713302612,
+            "loadAverage": [
+              3.18505859375,
+              5.53857421875,
+              6.59716796875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 98,
+            "elapsedSeconds": 23.33631992340088,
+            "loadAverage": [
+              3.18505859375,
+              5.53857421875,
+              6.59716796875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 87,
+            "elapsedSeconds": 25.453585863113403,
+            "loadAverage": [
+              3.009765625,
+              5.462890625,
+              6.56396484375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 90,
+            "elapsedSeconds": 27.572118997573853,
+            "loadAverage": [
+              3.009765625,
+              5.462890625,
+              6.56396484375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 95,
+            "elapsedSeconds": 29.673107862472534,
+            "loadAverage": [
+              3.0888671875,
+              5.4384765625,
+              6.548828125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 98,
+            "elapsedSeconds": 31.780720710754395,
+            "loadAverage": [
+              3.0888671875,
+              5.4384765625,
+              6.548828125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 93,
+            "elapsedSeconds": 33.89406991004944,
+            "loadAverage": [
+              3.0888671875,
+              5.4384765625,
+              6.548828125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 95,
+            "elapsedSeconds": 36.007766008377075,
+            "loadAverage": [
+              3.08154296875,
+              5.39794921875,
+              6.52783203125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 91,
+            "elapsedSeconds": 38.12344193458557,
+            "loadAverage": [
+              3.08154296875,
+              5.39794921875,
+              6.52783203125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 90,
+            "elapsedSeconds": 40.2421817779541,
+            "loadAverage": [
+              3.31494140625,
+              5.40771484375,
+              6.5244140625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 87,
+            "elapsedSeconds": 42.35401177406311,
+            "loadAverage": [
+              3.31494140625,
+              5.40771484375,
+              6.5244140625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 98,
+            "elapsedSeconds": 44.47113871574402,
+            "loadAverage": [
+              3.31494140625,
+              5.40771484375,
+              6.5244140625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 85,
+            "elapsedSeconds": 46.58198881149292,
+            "loadAverage": [
+              3.28955078125,
+              5.36767578125,
+              6.50341796875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 92,
+            "elapsedSeconds": 48.680743932724,
+            "loadAverage": [
+              3.28955078125,
+              5.36767578125,
+              6.50341796875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 85,
+            "elapsedSeconds": 50.78514099121094,
+            "loadAverage": [
+              3.26611328125,
+              5.328125,
+              6.482421875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 92,
+            "elapsedSeconds": 52.89529585838318,
+            "loadAverage": [
+              3.26611328125,
+              5.328125,
+              6.482421875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 90,
+            "elapsedSeconds": 55.01364874839783,
+            "loadAverage": [
+              3.24462890625,
+              5.2890625,
+              6.4619140625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 90,
+            "elapsedSeconds": 57.14417362213135,
+            "loadAverage": [
+              3.24462890625,
+              5.2890625,
+              6.4619140625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 74,
+            "elapsedSeconds": 59.29050970077515,
+            "loadAverage": [
+              3.24462890625,
+              5.2890625,
+              6.4619140625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 52,
+            "elapsedSeconds": 61.41256880760193,
+            "loadAverage": [
+              3.14453125,
+              5.234375,
+              6.435546875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 52,
+            "elapsedSeconds": 63.53537368774414,
+            "loadAverage": [
+              3.14453125,
+              5.234375,
+              6.435546875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 54,
+            "elapsedSeconds": 65.65082287788391,
+            "loadAverage": [
+              3.052734375,
+              5.1806640625,
+              6.4091796875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 54,
+            "elapsedSeconds": 67.76627564430237,
+            "loadAverage": [
+              3.052734375,
+              5.1806640625,
+              6.4091796875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 54,
+            "elapsedSeconds": 69.88871598243713,
+            "loadAverage": [
+              3.12841796875,
+              5.16064453125,
+              6.39501953125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 55,
+            "elapsedSeconds": 72.02046585083008,
+            "loadAverage": [
+              3.12841796875,
+              5.16064453125,
+              6.39501953125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 48,
+            "elapsedSeconds": 74.21225380897522,
+            "loadAverage": [
+              3.12841796875,
+              5.16064453125,
+              6.39501953125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 66,
+            "elapsedSeconds": 76.91539096832275,
+            "loadAverage": [
+              3.35791015625,
+              5.17431640625,
+              6.392578125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 92,
+            "elapsedSeconds": 79.14467287063599,
+            "loadAverage": [
+              3.35791015625,
+              5.17431640625,
+              6.392578125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 99,
+            "elapsedSeconds": 81.30665493011475,
+            "loadAverage": [
+              3.4091796875,
+              5.15478515625,
+              6.37841796875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 60,
+            "elapsedSeconds": 83.43819284439087,
+            "loadAverage": [
+              3.4091796875,
+              5.15478515625,
+              6.37841796875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 49,
+            "elapsedSeconds": 85.605299949646,
+            "loadAverage": [
+              3.9365234375,
+              5.23486328125,
+              6.3994140625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 60,
+            "elapsedSeconds": 87.86327981948853,
+            "loadAverage": [
+              3.9365234375,
+              5.23486328125,
+              6.3994140625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 73,
+            "elapsedSeconds": 90.07246899604797,
+            "loadAverage": [
+              4.58203125,
+              5.34716796875,
+              6.43212890625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 85,
+            "elapsedSeconds": 92.35756492614746,
+            "loadAverage": [
+              4.58203125,
+              5.34716796875,
+              6.43212890625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 94.55609083175659,
+            "loadAverage": [
+              4.58203125,
+              5.34716796875,
+              6.43212890625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 96.70883870124817,
+            "loadAverage": [
+              4.6953125,
+              5.35791015625,
+              6.42919921875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 98.86573791503906,
+            "loadAverage": [
+              4.6953125,
+              5.35791015625,
+              6.42919921875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 101.02082991600037,
+            "loadAverage": [
+              4.71923828125,
+              5.3515625,
+              6.42041015625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 99,
+            "elapsedSeconds": 103.16042184829712,
+            "loadAverage": [
+              4.71923828125,
+              5.3515625,
+              6.42041015625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 97,
+            "elapsedSeconds": 105.80573678016663,
+            "loadAverage": [
+              4.74169921875,
+              5.345703125,
+              6.41162109375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 87,
+            "elapsedSeconds": 108.7969388961792,
+            "loadAverage": [
+              4.74169921875,
+              5.345703125,
+              6.41162109375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 98,
+            "elapsedSeconds": 111.00913381576538,
+            "loadAverage": [
+              6.20361328125,
+              5.638671875,
+              6.5087890625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 113.20657277107239,
+            "loadAverage": [
+              6.20361328125,
+              5.638671875,
+              6.5087890625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 115.35015988349915,
+            "loadAverage": [
+              5.78662109375,
+              5.5615234375,
+              6.47607421875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 117.49540281295776,
+            "loadAverage": [
+              5.78662109375,
+              5.5615234375,
+              6.47607421875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 119.62505865097046,
+            "loadAverage": [
+              5.78662109375,
+              5.5615234375,
+              6.47607421875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 121.7389669418335,
+            "loadAverage": [
+              5.80322265625,
+              5.568359375,
+              6.47314453125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 123.87202572822571,
+            "loadAverage": [
+              5.80322265625,
+              5.568359375,
+              6.47314453125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 125.99005270004272,
+            "loadAverage": [
+              5.73876953125,
+              5.55859375,
+              6.46435546875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 99,
+            "elapsedSeconds": 128.10197496414185,
+            "loadAverage": [
+              5.73876953125,
+              5.55859375,
+              6.46435546875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 99,
+            "elapsedSeconds": 130.22027802467346,
+            "loadAverage": [
+              5.51904296875,
+              5.51611328125,
+              6.44384765625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 132.33953261375427,
+            "loadAverage": [
+              5.51904296875,
+              5.51611328125,
+              6.44384765625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 134.45818781852722,
+            "loadAverage": [
+              5.51904296875,
+              5.51611328125,
+              6.44384765625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 136.58158373832703,
+            "loadAverage": [
+              5.71728515625,
+              5.55712890625,
+              6.45263671875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 138.7027838230133,
+            "loadAverage": [
+              5.71728515625,
+              5.55712890625,
+              6.45263671875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 140.85735988616943,
+            "loadAverage": [
+              5.97998046875,
+              5.6142578125,
+              6.46728515625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 142.98833465576172,
+            "loadAverage": [
+              5.97998046875,
+              5.6142578125,
+              6.46728515625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 145.1077697277069,
+            "loadAverage": [
+              6.3818359375,
+              5.70361328125,
+              6.49365234375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 147.29294681549072,
+            "loadAverage": [
+              6.3818359375,
+              5.70361328125,
+              6.49365234375
+            ]
+          }
+        ],
+        "knownRenderingWorkerCount": 0,
+        "maxPressureLevel": 1,
+        "measurementMode": "desktop-load",
+        "peakResidentBytes": 15827206144,
+        "processSeconds": 149.49549794197083,
+        "profiled": false,
+        "prompt": "I'm trying to get back into reading after a busy year. I have about twenty minutes most evenings, enjoy mysteries and science fiction, and keep abandoning books when I miss a few days. Help me make a gentle, realistic four-week plan. Talk to me conversationally, suggest ways to choose books without buying a stack, and explain what to do when I fall behind. Give enough practical detail that I can start tonight.",
+        "runtimeOverrides": {},
+        "sourceHead": "c3ef55db5f09b2bcc6526bec4dd2a78eaa27aee6",
+        "startedUnixSeconds": 1788624172.7486222,
+        "uncontended": false,
+        "workload": "chat"
+      },
+      "scenarios": [
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 1.8913936343538604
+          },
+          "endToEndSpeedups": {
+            "adaptive": 1.8296950936715874
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 413,
+          "repetition": 1,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "acceptanceRate": 0.5,
+                "acceptedDraftTokens": 157,
+                "draftHistoryTokens": 96,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 314,
+                "rounds": 99,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 12.370083928108215,
+              "decodeTokensPerSecond": 20.695089983851926,
+              "elapsedSeconds": 13.723363041877747,
+              "endToEndTokensPerSecond": 18.654319587611223,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.00038492679595947266,
+              "generatedTokens": 256,
+              "loadSeconds": 5.793571472167969e-05,
+              "name": "adaptive",
+              "outputSHA256": "c0587748994cafccd1ad8141f9498b0b4764bbffa861c938d49541f2b38ec781",
+              "policy": "adaptive",
+              "prefillSeconds": 1.3501660823822021,
+              "prefillTokensPerSecond": 71.84301343791381,
+              "promptTokens": 97,
+              "residentMemoryAfterBytes": 15826944000,
+              "residentMemoryBeforeBytes": 15826763776,
+              "ttftSeconds": 1.3506089448928833
+            },
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 23.396697998046875,
+              "decodeTokensPerSecond": 10.941714938636663,
+              "elapsedSeconds": 25.109570026397705,
+              "endToEndTokensPerSecond": 10.195315958451978,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.08413410186767578,
+              "generatedTokens": 256,
+              "loadSeconds": 0.00012099742889404297,
+              "name": "baseline",
+              "outputSHA256": "c0587748994cafccd1ad8141f9498b0b4764bbffa861c938d49541f2b38ec781",
+              "policy": "disabled",
+              "prefillSeconds": 1.707082986831665,
+              "prefillTokensPerSecond": 56.82207645923024,
+              "promptTokens": 97,
+              "residentMemoryAfterBytes": 15424700416,
+              "residentMemoryBeforeBytes": 15424585728,
+              "ttftSeconds": 1.7913380861282349
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 1.776184549280887
+          },
+          "endToEndSpeedups": {
+            "adaptive": 1.7247195170497995
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 413,
+          "repetition": 2,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "acceptanceRate": 0.5,
+                "acceptedDraftTokens": 157,
+                "draftHistoryTokens": 96,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 314,
+                "rounds": 99,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 12.231046080589294,
+              "decodeTokensPerSecond": 20.9303438408488,
+              "elapsedSeconds": 13.762189030647278,
+              "endToEndTokensPerSecond": 18.601691884184177,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.00037801265716552734,
+              "generatedTokens": 256,
+              "loadSeconds": 3.600120544433594e-05,
+              "name": "adaptive",
+              "outputSHA256": "c0587748994cafccd1ad8141f9498b0b4764bbffa861c938d49541f2b38ec781",
+              "policy": "adaptive",
+              "prefillSeconds": 1.5273250341415405,
+              "prefillTokensPerSecond": 63.50972964606746,
+              "promptTokens": 97,
+              "residentMemoryAfterBytes": 15827156992,
+              "residentMemoryBeforeBytes": 15827042304,
+              "ttftSeconds": 1.5277390480041504
+            },
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 21.724595069885254,
+              "decodeTokensPerSecond": 11.783879017145342,
+              "elapsedSeconds": 23.735916018486023,
+              "endToEndTokensPerSecond": 10.785343182063077,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.32595109939575195,
+              "generatedTokens": 256,
+              "loadSeconds": 4.601478576660156e-05,
+              "name": "baseline",
+              "outputSHA256": "c0587748994cafccd1ad8141f9498b0b4764bbffa861c938d49541f2b38ec781",
+              "policy": "disabled",
+              "prefillSeconds": 2.0090110301971436,
+              "prefillTokensPerSecond": 48.28246263559908,
+              "promptTokens": 97,
+              "residentMemoryAfterBytes": 15424716800,
+              "residentMemoryBeforeBytes": 15424700416,
+              "ttftSeconds": 2.335008144378662
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 1.676130533389858
+          },
+          "endToEndSpeedups": {
+            "adaptive": 1.6225488091370728
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 413,
+          "repetition": 3,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "acceptanceRate": 0.5,
+                "acceptedDraftTokens": 157,
+                "draftHistoryTokens": 96,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 314,
+                "rounds": 99,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 11.994428038597107,
+              "decodeTokensPerSecond": 21.343243644149812,
+              "elapsedSeconds": 13.437964916229248,
+              "endToEndTokensPerSecond": 19.050503673426373,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0003629922866821289,
+              "generatedTokens": 256,
+              "loadSeconds": 4.208087921142578e-05,
+              "name": "adaptive",
+              "outputSHA256": "c0587748994cafccd1ad8141f9498b0b4764bbffa861c938d49541f2b38ec781",
+              "policy": "adaptive",
+              "prefillSeconds": 1.440614938735962,
+              "prefillTokensPerSecond": 67.33235744807052,
+              "promptTokens": 97,
+              "residentMemoryAfterBytes": 15827206144,
+              "residentMemoryBeforeBytes": 15827156992,
+              "ttftSeconds": 1.4410200119018555
+            },
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 20.10422706604004,
+              "decodeTokensPerSecond": 12.733640500531052,
+              "elapsedSeconds": 21.803753972053528,
+              "endToEndTokensPerSecond": 11.741097442583614,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.06784498691558838,
+              "generatedTokens": 256,
+              "loadSeconds": 2.6106834411621094e-05,
+              "name": "baseline",
+              "outputSHA256": "c0587748994cafccd1ad8141f9498b0b4764bbffa861c938d49541f2b38ec781",
+              "policy": "disabled",
+              "prefillSeconds": 1.697072982788086,
+              "prefillTokensPerSecond": 57.157235418738864,
+              "promptTokens": 97,
+              "residentMemoryAfterBytes": 15424733184,
+              "residentMemoryBeforeBytes": 15424716800,
+              "ttftSeconds": 1.764944076538086
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        }
+      ]
+    },
+    {
+      "id": "final-greedy/qwen-code",
+      "model": "vision-chat-q38-27b-4bit",
+      "rawReceiptSHA256": "f00a0b29aa697cadb975f010c20de531cb9a49f50f7d9ec9ef26a4600a9091b2",
+      "receipt": {
+        "after": {
+          "gpuDeviceUtilizationPercent": 84,
+          "loadAverage": [
+            4.10595703125,
+            6.13623046875,
+            6.8701171875
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7268.25M  free = 923.75M  (encrypted)",
+          "swapUsedMiB": 7268.25
+        },
+        "before": {
+          "gpuDeviceUtilizationPercent": 0,
+          "loadAverage": [
+            4.66650390625,
+            7.09130859375,
+            7.27392578125
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7268.25M  free = 923.75M  (encrypted)",
+          "swapUsedMiB": 7268.25
+        },
+        "binarySHA256": "37ae108285410acec9ee3863de69475fb74ce9b472bf23c05e0e0df8ce26414c",
+        "buildSourceRevision": "c3ef55db5f09b2bcc6526bec4dd2a78eaa27aee6",
+        "collectorSHA256": "dec1ae60840c738d2c8ef678adf8c1fc39b7eecaab018032ff2c596b51599f2c",
+        "command": [
+          "mere.run",
+          "model",
+          "benchmark",
+          "q36-mtp",
+          "--model",
+          "vision-chat-q38-27b-4bit",
+          "--prompt",
+          "Write a complete Python implementation of an LRU cache using a dictionary and a doubly linked list, with get and put operations, type hints, and a short usage example. Return the code directly without introductory prose.",
+          "--decode-tokens",
+          "256",
+          "--context-size",
+          "8192",
+          "--temperature",
+          "0",
+          "--top-p",
+          "1",
+          "--json",
+          "--variants",
+          "baseline,adaptive",
+          "--warmups",
+          "1",
+          "--warmup-tokens",
+          "256",
+          "--repetitions",
+          "3"
+        ],
+        "competingInferenceProcessCount": 0,
+        "gpuSamples": [
+          {
+            "deviceUtilizationPercent": 30,
+            "elapsedSeconds": 0.09901285171508789,
+            "loadAverage": [
+              4.66650390625,
+              7.09130859375,
+              7.27392578125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 81,
+            "elapsedSeconds": 2.2083797454833984,
+            "loadAverage": [
+              4.66650390625,
+              7.09130859375,
+              7.27392578125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 55,
+            "elapsedSeconds": 4.360245943069458,
+            "loadAverage": [
+              4.45263671875,
+              7.00634765625,
+              7.24267578125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 59,
+            "elapsedSeconds": 6.486861944198608,
+            "loadAverage": [
+              4.45263671875,
+              7.00634765625,
+              7.24267578125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 65,
+            "elapsedSeconds": 8.591266870498657,
+            "loadAverage": [
+              4.49609375,
+              6.97265625,
+              7.2294921875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 65,
+            "elapsedSeconds": 10.706994771957397,
+            "loadAverage": [
+              4.49609375,
+              6.97265625,
+              7.2294921875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 65,
+            "elapsedSeconds": 12.825426816940308,
+            "loadAverage": [
+              4.49609375,
+              6.97265625,
+              7.2294921875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 68,
+            "elapsedSeconds": 14.97171401977539,
+            "loadAverage": [
+              4.4560546875,
+              6.9228515625,
+              7.21044921875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 64,
+            "elapsedSeconds": 17.09374165534973,
+            "loadAverage": [
+              4.4560546875,
+              6.9228515625,
+              7.21044921875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 64,
+            "elapsedSeconds": 19.213916778564453,
+            "loadAverage": [
+              4.25927734375,
+              6.8408203125,
+              7.1796875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 66,
+            "elapsedSeconds": 21.340367794036865,
+            "loadAverage": [
+              4.25927734375,
+              6.8408203125,
+              7.1796875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 61,
+            "elapsedSeconds": 23.457843780517578,
+            "loadAverage": [
+              4.638671875,
+              6.87646484375,
+              7.18994140625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 80,
+            "elapsedSeconds": 25.567312717437744,
+            "loadAverage": [
+              4.638671875,
+              6.87646484375,
+              7.18994140625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 61,
+            "elapsedSeconds": 27.688270092010498,
+            "loadAverage": [
+              4.638671875,
+              6.87646484375,
+              7.18994140625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 65,
+            "elapsedSeconds": 29.8018798828125,
+            "loadAverage": [
+              4.66748046875,
+              6.84521484375,
+              7.1767578125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 59,
+            "elapsedSeconds": 31.92505168914795,
+            "loadAverage": [
+              4.66748046875,
+              6.84521484375,
+              7.1767578125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 66,
+            "elapsedSeconds": 34.04775881767273,
+            "loadAverage": [
+              5.09423828125,
+              6.8974609375,
+              7.19287109375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 61,
+            "elapsedSeconds": 36.17003893852234,
+            "loadAverage": [
+              5.09423828125,
+              6.8974609375,
+              7.19287109375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 62,
+            "elapsedSeconds": 38.297491788864136,
+            "loadAverage": [
+              5.24658203125,
+              6.89892578125,
+              7.19140625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 58,
+            "elapsedSeconds": 40.418861627578735,
+            "loadAverage": [
+              5.24658203125,
+              6.89892578125,
+              7.19140625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 58,
+            "elapsedSeconds": 42.53457474708557,
+            "loadAverage": [
+              5.24658203125,
+              6.89892578125,
+              7.19140625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 61,
+            "elapsedSeconds": 44.65687274932861,
+            "loadAverage": [
+              5.2265625,
+              6.8671875,
+              7.17822265625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 65,
+            "elapsedSeconds": 46.76511478424072,
+            "loadAverage": [
+              5.2265625,
+              6.8671875,
+              7.17822265625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 99,
+            "elapsedSeconds": 48.8657808303833,
+            "loadAverage": [
+              5.5283203125,
+              6.90234375,
+              7.1884765625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 57,
+            "elapsedSeconds": 50.98022699356079,
+            "loadAverage": [
+              5.5283203125,
+              6.90234375,
+              7.1884765625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 58,
+            "elapsedSeconds": 53.08919072151184,
+            "loadAverage": [
+              5.5283203125,
+              6.90234375,
+              7.1884765625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 58,
+            "elapsedSeconds": 55.21355700492859,
+            "loadAverage": [
+              5.72607421875,
+              6.92041015625,
+              7.19287109375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 66,
+            "elapsedSeconds": 57.33139181137085,
+            "loadAverage": [
+              5.72607421875,
+              6.92041015625,
+              7.19287109375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 56,
+            "elapsedSeconds": 59.44509696960449,
+            "loadAverage": [
+              5.58740234375,
+              6.87158203125,
+              7.173828125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 56,
+            "elapsedSeconds": 61.56398892402649,
+            "loadAverage": [
+              5.58740234375,
+              6.87158203125,
+              7.173828125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 60,
+            "elapsedSeconds": 63.68010687828064,
+            "loadAverage": [
+              5.4599609375,
+              6.82373046875,
+              7.15478515625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 56,
+            "elapsedSeconds": 65.78901600837708,
+            "loadAverage": [
+              5.4599609375,
+              6.82373046875,
+              7.15478515625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 60,
+            "elapsedSeconds": 67.91829299926758,
+            "loadAverage": [
+              5.4599609375,
+              6.82373046875,
+              7.15478515625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 84,
+            "elapsedSeconds": 70.03332877159119,
+            "loadAverage": [
+              5.3427734375,
+              6.7763671875,
+              7.13623046875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 80,
+            "elapsedSeconds": 72.15995693206787,
+            "loadAverage": [
+              5.3427734375,
+              6.7763671875,
+              7.13623046875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 60,
+            "elapsedSeconds": 74.27985978126526,
+            "loadAverage": [
+              5.07470703125,
+              6.69677734375,
+              7.10595703125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 56,
+            "elapsedSeconds": 76.39697194099426,
+            "loadAverage": [
+              5.07470703125,
+              6.69677734375,
+              7.10595703125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 58,
+            "elapsedSeconds": 78.52141284942627,
+            "loadAverage": [
+              4.908203125,
+              6.63525390625,
+              7.08154296875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 53,
+            "elapsedSeconds": 80.63940501213074,
+            "loadAverage": [
+              4.908203125,
+              6.63525390625,
+              7.08154296875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 55,
+            "elapsedSeconds": 82.75234484672546,
+            "loadAverage": [
+              4.908203125,
+              6.63525390625,
+              7.08154296875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 58,
+            "elapsedSeconds": 84.86209464073181,
+            "loadAverage": [
+              4.99560546875,
+              6.62451171875,
+              7.0751953125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 54,
+            "elapsedSeconds": 86.97828984260559,
+            "loadAverage": [
+              4.99560546875,
+              6.62451171875,
+              7.0751953125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 55,
+            "elapsedSeconds": 89.09441685676575,
+            "loadAverage": [
+              4.67529296875,
+              6.53076171875,
+              7.03955078125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 60,
+            "elapsedSeconds": 91.19868993759155,
+            "loadAverage": [
+              4.67529296875,
+              6.53076171875,
+              7.03955078125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 83,
+            "elapsedSeconds": 93.32188177108765,
+            "loadAverage": [
+              4.701171875,
+              6.5048828125,
+              7.02734375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 98,
+            "elapsedSeconds": 95.43754386901855,
+            "loadAverage": [
+              4.701171875,
+              6.5048828125,
+              7.02734375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 93,
+            "elapsedSeconds": 97.54706883430481,
+            "loadAverage": [
+              4.701171875,
+              6.5048828125,
+              7.02734375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 93,
+            "elapsedSeconds": 99.650869846344,
+            "loadAverage": [
+              4.40478515625,
+              6.4130859375,
+              6.99169921875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 99,
+            "elapsedSeconds": 101.76723575592041,
+            "loadAverage": [
+              4.40478515625,
+              6.4130859375,
+              6.99169921875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 93,
+            "elapsedSeconds": 103.88547992706299,
+            "loadAverage": [
+              4.1318359375,
+              6.32275390625,
+              6.95654296875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 93,
+            "elapsedSeconds": 105.99157094955444,
+            "loadAverage": [
+              4.1318359375,
+              6.32275390625,
+              6.95654296875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 98,
+            "elapsedSeconds": 108.10663390159607,
+            "loadAverage": [
+              4.1318359375,
+              6.32275390625,
+              6.95654296875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 88,
+            "elapsedSeconds": 110.22886490821838,
+            "loadAverage": [
+              3.9609375,
+              6.2509765625,
+              6.92724609375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 96,
+            "elapsedSeconds": 112.34249067306519,
+            "loadAverage": [
+              3.9609375,
+              6.2509765625,
+              6.92724609375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 88,
+            "elapsedSeconds": 114.46061086654663,
+            "loadAverage": [
+              3.9638671875,
+              6.21337890625,
+              6.90966796875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 95,
+            "elapsedSeconds": 116.56583499908447,
+            "loadAverage": [
+              3.9638671875,
+              6.21337890625,
+              6.90966796875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 94,
+            "elapsedSeconds": 118.67221879959106,
+            "loadAverage": [
+              4.04638671875,
+              6.19287109375,
+              6.8984375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 88,
+            "elapsedSeconds": 120.78474283218384,
+            "loadAverage": [
+              4.04638671875,
+              6.19287109375,
+              6.8984375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 86,
+            "elapsedSeconds": 122.89125871658325,
+            "loadAverage": [
+              4.04638671875,
+              6.19287109375,
+              6.8984375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 90,
+            "elapsedSeconds": 124.99504089355469,
+            "loadAverage": [
+              4.20263671875,
+              6.189453125,
+              6.89306640625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 95,
+            "elapsedSeconds": 127.11200284957886,
+            "loadAverage": [
+              4.20263671875,
+              6.189453125,
+              6.89306640625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 93,
+            "elapsedSeconds": 129.23091292381287,
+            "loadAverage": [
+              4.10595703125,
+              6.13623046875,
+              6.8701171875
+            ]
+          }
+        ],
+        "knownRenderingWorkerCount": 0,
+        "maxPressureLevel": 1,
+        "measurementMode": "desktop-load",
+        "peakResidentBytes": 15830417408,
+        "processSeconds": 131.32760977745056,
+        "profiled": false,
+        "prompt": "Write a complete Python implementation of an LRU cache using a dictionary and a doubly linked list, with get and put operations, type hints, and a short usage example. Return the code directly without introductory prose.",
+        "runtimeOverrides": {},
+        "sourceHead": "c3ef55db5f09b2bcc6526bec4dd2a78eaa27aee6",
+        "startedUnixSeconds": 1788624004.1133142,
+        "uncontended": false,
+        "workload": "code"
+      },
+      "scenarios": [
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 2.5224490637272377
+          },
+          "endToEndSpeedups": {
+            "adaptive": 2.4369467935271687
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 220,
+          "repetition": 1,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 21.443959951400757,
+              "decodeTokensPerSecond": 11.93809355082654,
+              "elapsedSeconds": 22.58056604862213,
+              "endToEndTokensPerSecond": 11.337182577653811,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.0707850456237793,
+              "generatedTokens": 256,
+              "loadSeconds": 2.5987625122070312e-05,
+              "name": "baseline",
+              "outputSHA256": "ca2c0ddf75b621ec62d587ff04b6f89f528aafe8d744b0730c298166deb5f461",
+              "policy": "disabled",
+              "prefillSeconds": 1.1344571113586426,
+              "prefillTokensPerSecond": 47.59986028500346,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 15397060608,
+              "residentMemoryBeforeBytes": 15396929536,
+              "ttftSeconds": 1.205268144607544
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.7236363636363636,
+                "acceptedDraftTokens": 199,
+                "draftHistoryTokens": 53,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 275,
+                "rounds": 57,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 8.501245975494385,
+              "decodeTokensPerSecond": 30.11323289997058,
+              "elapsedSeconds": 9.26592493057251,
+              "endToEndTokensPerSecond": 27.628110730245538,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0002989768981933594,
+              "generatedTokens": 256,
+              "loadSeconds": 2.09808349609375e-05,
+              "name": "adaptive",
+              "outputSHA256": "ca2c0ddf75b621ec62d587ff04b6f89f528aafe8d744b0730c298166deb5f461",
+              "policy": "adaptive",
+              "prefillSeconds": 0.7626460790634155,
+              "prefillTokensPerSecond": 70.80610716089421,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 15829991424,
+              "residentMemoryBeforeBytes": 15829893120,
+              "ttftSeconds": 0.7629660367965698
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 2.375324440852814
+          },
+          "endToEndSpeedups": {
+            "adaptive": 2.311770912662055
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 220,
+          "repetition": 2,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 21.099429965019226,
+              "decodeTokensPerSecond": 12.133029206211862,
+              "elapsedSeconds": 22.095813989639282,
+              "endToEndTokensPerSecond": 11.585904919367907,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.059158921241760254,
+              "generatedTokens": 256,
+              "loadSeconds": 2.09808349609375e-05,
+              "name": "baseline",
+              "outputSHA256": "ca2c0ddf75b621ec62d587ff04b6f89f528aafe8d744b0730c298166deb5f461",
+              "policy": "disabled",
+              "prefillSeconds": 0.9940139055252075,
+              "prefillTokensPerSecond": 54.325195754145916,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 15397289984,
+              "residentMemoryBeforeBytes": 15397175296,
+              "ttftSeconds": 1.0531938076019287
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.7236363636363636,
+                "acceptedDraftTokens": 199,
+                "draftHistoryTokens": 53,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 275,
+                "rounds": 57,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 8.882757067680359,
+              "decodeTokensPerSecond": 28.81988081509605,
+              "elapsedSeconds": 9.557960033416748,
+              "endToEndTokensPerSecond": 26.78395798946294,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.00045096874237060547,
+              "generatedTokens": 256,
+              "loadSeconds": 2.5987625122070312e-05,
+              "name": "adaptive",
+              "outputSHA256": "ca2c0ddf75b621ec62d587ff04b6f89f528aafe8d744b0730c298166deb5f461",
+              "policy": "adaptive",
+              "prefillSeconds": 0.6724839210510254,
+              "prefillTokensPerSecond": 80.29931766339243,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 15830056960,
+              "residentMemoryBeforeBytes": 15829991424,
+              "ttftSeconds": 0.6729608774185181
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 2.271887326268773
+          },
+          "endToEndSpeedups": {
+            "adaptive": 2.2170458263220043
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 220,
+          "repetition": 3,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 20.500563979148865,
+              "decodeTokensPerSecond": 12.487461333277356,
+              "elapsedSeconds": 21.570683002471924,
+              "endToEndTokensPerSecond": 11.867959858789048,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.06422305107116699,
+              "generatedTokens": 256,
+              "loadSeconds": 2.5033950805664062e-05,
+              "name": "baseline",
+              "outputSHA256": "ca2c0ddf75b621ec62d587ff04b6f89f528aafe8d744b0730c298166deb5f461",
+              "policy": "disabled",
+              "prefillSeconds": 1.0670969486236572,
+              "prefillTokensPerSecond": 50.60458664945978,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 15397552128,
+              "residentMemoryBeforeBytes": 15397289984,
+              "ttftSeconds": 1.1313450336456299
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.7236363636363636,
+                "acceptedDraftTokens": 199,
+                "draftHistoryTokens": 53,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 275,
+                "rounds": 57,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 9.023583054542542,
+              "decodeTokensPerSecond": 28.37010514034418,
+              "elapsedSeconds": 9.72947096824646,
+              "endToEndTokensPerSecond": 26.311810871885342,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0004260540008544922,
+              "generatedTokens": 256,
+              "loadSeconds": 6.198883056640625e-05,
+              "name": "adaptive",
+              "outputSHA256": "ca2c0ddf75b621ec62d587ff04b6f89f528aafe8d744b0730c298166deb5f461",
+              "policy": "adaptive",
+              "prefillSeconds": 0.7028970718383789,
+              "prefillTokensPerSecond": 76.82490390629557,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 15830384640,
+              "residentMemoryBeforeBytes": 15830056960,
+              "ttftSeconds": 0.7033851146697998
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        }
+      ]
+    },
+    {
+      "id": "final-greedy/qwen-math",
+      "model": "vision-chat-q38-27b-4bit",
+      "rawReceiptSHA256": "7323b39000a65bfdc76c74abcddf2aae36ad8d67ec63852ad30a6350ddfc268e",
+      "receipt": {
+        "after": {
+          "gpuDeviceUtilizationPercent": 64,
+          "loadAverage": [
+            6.49072265625,
+            5.58837890625,
+            6.125
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7268.25M  free = 923.75M  (encrypted)",
+          "swapUsedMiB": 7268.25
+        },
+        "before": {
+          "gpuDeviceUtilizationPercent": 57,
+          "loadAverage": [
+            5.79248046875,
+            5.6796875,
+            6.28564453125
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7268.25M  free = 923.75M  (encrypted)",
+          "swapUsedMiB": 7268.25
+        },
+        "binarySHA256": "37ae108285410acec9ee3863de69475fb74ce9b472bf23c05e0e0df8ce26414c",
+        "buildSourceRevision": "c3ef55db5f09b2bcc6526bec4dd2a78eaa27aee6",
+        "collectorSHA256": "dec1ae60840c738d2c8ef678adf8c1fc39b7eecaab018032ff2c596b51599f2c",
+        "command": [
+          "mere.run",
+          "model",
+          "benchmark",
+          "q36-mtp",
+          "--model",
+          "vision-chat-q38-27b-4bit",
+          "--prompt",
+          "Derive the sum of the first n squares using induction. Explain the base case and inductive step, then check your formula for n=10. Show each algebraic step.",
+          "--decode-tokens",
+          "256",
+          "--context-size",
+          "8192",
+          "--temperature",
+          "0",
+          "--top-p",
+          "1",
+          "--json",
+          "--variants",
+          "adaptive,baseline",
+          "--warmups",
+          "1",
+          "--warmup-tokens",
+          "256",
+          "--repetitions",
+          "3"
+        ],
+        "competingInferenceProcessCount": 0,
+        "gpuSamples": [
+          {
+            "deviceUtilizationPercent": 61,
+            "elapsedSeconds": 0.13121700286865234,
+            "loadAverage": [
+              5.79248046875,
+              5.6796875,
+              6.28564453125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 76,
+            "elapsedSeconds": 2.242560863494873,
+            "loadAverage": [
+              6.04931640625,
+              5.734375,
+              6.30126953125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 93,
+            "elapsedSeconds": 4.336018085479736,
+            "loadAverage": [
+              6.04931640625,
+              5.734375,
+              6.30126953125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 86,
+            "elapsedSeconds": 6.433802843093872,
+            "loadAverage": [
+              6.044921875,
+              5.73876953125,
+              6.29931640625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 99,
+            "elapsedSeconds": 8.533766031265259,
+            "loadAverage": [
+              6.044921875,
+              5.73876953125,
+              6.29931640625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 92,
+            "elapsedSeconds": 10.627536058425903,
+            "loadAverage": [
+              5.640625,
+              5.65966796875,
+              6.26806640625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 95,
+            "elapsedSeconds": 12.720891952514648,
+            "loadAverage": [
+              5.640625,
+              5.65966796875,
+              6.26806640625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 89,
+            "elapsedSeconds": 14.816335916519165,
+            "loadAverage": [
+              5.640625,
+              5.65966796875,
+              6.26806640625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 92,
+            "elapsedSeconds": 16.91425085067749,
+            "loadAverage": [
+              5.9091796875,
+              5.71484375,
+              6.28369140625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 99,
+            "elapsedSeconds": 19.0136821269989,
+            "loadAverage": [
+              5.9091796875,
+              5.71484375,
+              6.28369140625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 92,
+            "elapsedSeconds": 21.111894845962524,
+            "loadAverage": [
+              5.755859375,
+              5.68603515625,
+              6.27001953125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 90,
+            "elapsedSeconds": 23.21132779121399,
+            "loadAverage": [
+              5.755859375,
+              5.68603515625,
+              6.27001953125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 90,
+            "elapsedSeconds": 25.307176113128662,
+            "loadAverage": [
+              5.775390625,
+              5.69091796875,
+              6.26806640625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 96,
+            "elapsedSeconds": 27.403681993484497,
+            "loadAverage": [
+              5.775390625,
+              5.69091796875,
+              6.26806640625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 92,
+            "elapsedSeconds": 29.501554012298584,
+            "loadAverage": [
+              5.775390625,
+              5.69091796875,
+              6.26806640625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 99,
+            "elapsedSeconds": 31.597473859786987,
+            "loadAverage": [
+              5.6328125,
+              5.66259765625,
+              6.25439453125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 96,
+            "elapsedSeconds": 33.6899847984314,
+            "loadAverage": [
+              5.6328125,
+              5.66259765625,
+              6.25439453125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 88,
+            "elapsedSeconds": 35.78790903091431,
+            "loadAverage": [
+              5.421875,
+              5.6181640625,
+              6.23486328125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 93,
+            "elapsedSeconds": 37.8883581161499,
+            "loadAverage": [
+              5.421875,
+              5.6181640625,
+              6.23486328125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 93,
+            "elapsedSeconds": 39.984498023986816,
+            "loadAverage": [
+              5.421875,
+              5.6181640625,
+              6.23486328125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 92,
+            "elapsedSeconds": 42.080820083618164,
+            "loadAverage": [
+              5.2275390625,
+              5.57421875,
+              6.2158203125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 93,
+            "elapsedSeconds": 44.17714500427246,
+            "loadAverage": [
+              5.2275390625,
+              5.57421875,
+              6.2158203125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 99,
+            "elapsedSeconds": 46.27063703536987,
+            "loadAverage": [
+              4.96875,
+              5.5146484375,
+              6.19091796875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 81,
+            "elapsedSeconds": 48.364442110061646,
+            "loadAverage": [
+              4.96875,
+              5.5146484375,
+              6.19091796875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 84,
+            "elapsedSeconds": 50.49424600601196,
+            "loadAverage": [
+              4.97119140625,
+              5.505859375,
+              6.18359375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 46,
+            "elapsedSeconds": 52.61847114562988,
+            "loadAverage": [
+              4.97119140625,
+              5.505859375,
+              6.18359375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 54,
+            "elapsedSeconds": 54.73383116722107,
+            "loadAverage": [
+              4.97119140625,
+              5.505859375,
+              6.18359375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 62,
+            "elapsedSeconds": 56.844104051589966,
+            "loadAverage": [
+              4.89306640625,
+              5.48046875,
+              6.17041015625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 64,
+            "elapsedSeconds": 58.96553683280945,
+            "loadAverage": [
+              4.89306640625,
+              5.48046875,
+              6.17041015625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 59,
+            "elapsedSeconds": 61.07891917228699,
+            "loadAverage": [
+              4.6611328125,
+              5.42236328125,
+              6.1455078125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 59,
+            "elapsedSeconds": 63.1900200843811,
+            "loadAverage": [
+              4.6611328125,
+              5.42236328125,
+              6.1455078125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 65,
+            "elapsedSeconds": 65.30997395515442,
+            "loadAverage": [
+              4.44775390625,
+              5.365234375,
+              6.12109375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 60,
+            "elapsedSeconds": 67.41373896598816,
+            "loadAverage": [
+              4.44775390625,
+              5.365234375,
+              6.12109375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 65,
+            "elapsedSeconds": 69.53113102912903,
+            "loadAverage": [
+              4.44775390625,
+              5.365234375,
+              6.12109375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 62,
+            "elapsedSeconds": 71.63934206962585,
+            "loadAverage": [
+              4.41162109375,
+              5.34228515625,
+              6.1083984375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 66,
+            "elapsedSeconds": 73.75040292739868,
+            "loadAverage": [
+              4.41162109375,
+              5.34228515625,
+              6.1083984375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 99,
+            "elapsedSeconds": 75.85357403755188,
+            "loadAverage": [
+              4.13818359375,
+              5.27001953125,
+              6.078125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 99,
+            "elapsedSeconds": 77.95282506942749,
+            "loadAverage": [
+              4.13818359375,
+              5.27001953125,
+              6.078125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 50,
+            "elapsedSeconds": 80.10093808174133,
+            "loadAverage": [
+              4.13818359375,
+              5.27001953125,
+              6.078125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 67,
+            "elapsedSeconds": 82.22709894180298,
+            "loadAverage": [
+              4.126953125,
+              5.24853515625,
+              6.06591796875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 58,
+            "elapsedSeconds": 84.34500288963318,
+            "loadAverage": [
+              4.126953125,
+              5.24853515625,
+              6.06591796875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 63,
+            "elapsedSeconds": 86.45307779312134,
+            "loadAverage": [
+              4.43701171875,
+              5.2939453125,
+              6.0771484375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 58,
+            "elapsedSeconds": 88.56861400604248,
+            "loadAverage": [
+              4.43701171875,
+              5.2939453125,
+              6.0771484375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 62,
+            "elapsedSeconds": 90.67175197601318,
+            "loadAverage": [
+              4.48193359375,
+              5.2890625,
+              6.07080078125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 66,
+            "elapsedSeconds": 92.79061007499695,
+            "loadAverage": [
+              4.48193359375,
+              5.2890625,
+              6.07080078125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 59,
+            "elapsedSeconds": 94.89083003997803,
+            "loadAverage": [
+              4.48193359375,
+              5.2890625,
+              6.07080078125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 62,
+            "elapsedSeconds": 96.99864101409912,
+            "loadAverage": [
+              4.36279296875,
+              5.2509765625,
+              6.052734375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 64,
+            "elapsedSeconds": 99.11559891700745,
+            "loadAverage": [
+              4.36279296875,
+              5.2509765625,
+              6.052734375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 59,
+            "elapsedSeconds": 101.21855807304382,
+            "loadAverage": [
+              4.57373046875,
+              5.27978515625,
+              6.05810546875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 96,
+            "elapsedSeconds": 103.33095908164978,
+            "loadAverage": [
+              4.57373046875,
+              5.27978515625,
+              6.05810546875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 105.4318299293518,
+            "loadAverage": [
+              4.767578125,
+              5.30810546875,
+              6.0634765625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 107.53883790969849,
+            "loadAverage": [
+              4.767578125,
+              5.30810546875,
+              6.0634765625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 109.65546607971191,
+            "loadAverage": [
+              4.767578125,
+              5.30810546875,
+              6.0634765625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 111.75772500038147,
+            "loadAverage": [
+              4.7060546875,
+              5.2861328125,
+              6.05126953125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 113.86665415763855,
+            "loadAverage": [
+              4.7060546875,
+              5.2861328125,
+              6.05126953125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 115.97425603866577,
+            "loadAverage": [
+              4.6494140625,
+              5.2646484375,
+              6.0390625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 118.0734920501709,
+            "loadAverage": [
+              4.6494140625,
+              5.2646484375,
+              6.0390625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 120.18933892250061,
+            "loadAverage": [
+              4.6494140625,
+              5.2646484375,
+              6.0390625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 122.29121398925781,
+            "loadAverage": [
+              4.51708984375,
+              5.22705078125,
+              6.02099609375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 124.39167094230652,
+            "loadAverage": [
+              4.51708984375,
+              5.22705078125,
+              6.02099609375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 99,
+            "elapsedSeconds": 126.48527097702026,
+            "loadAverage": [
+              4.5556640625,
+              5.22314453125,
+              6.0146484375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 99,
+            "elapsedSeconds": 128.58461093902588,
+            "loadAverage": [
+              4.5556640625,
+              5.22314453125,
+              6.0146484375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 130.6853301525116,
+            "loadAverage": [
+              4.2705078125,
+              5.15283203125,
+              5.98486328125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 132.78867101669312,
+            "loadAverage": [
+              4.2705078125,
+              5.15283203125,
+              5.98486328125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 134.88951301574707,
+            "loadAverage": [
+              4.2705078125,
+              5.15283203125,
+              5.98486328125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 137.0003170967102,
+            "loadAverage": [
+              4.24853515625,
+              5.13330078125,
+              5.97314453125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 139.10114097595215,
+            "loadAverage": [
+              4.24853515625,
+              5.13330078125,
+              5.97314453125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 77,
+            "elapsedSeconds": 141.6176369190216,
+            "loadAverage": [
+              5.75,
+              5.4296875,
+              6.07275390625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 81,
+            "elapsedSeconds": 144.51293301582336,
+            "loadAverage": [
+              5.75,
+              5.4296875,
+              6.07275390625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 76,
+            "elapsedSeconds": 147.306391954422,
+            "loadAverage": [
+              6.49072265625,
+              5.58837890625,
+              6.125
+            ]
+          }
+        ],
+        "knownRenderingWorkerCount": 0,
+        "maxPressureLevel": 1,
+        "measurementMode": "desktop-load",
+        "peakResidentBytes": 15807676416,
+        "processSeconds": 149.56943202018738,
+        "profiled": false,
+        "prompt": "Derive the sum of the first n squares using induction. Explain the base case and inductive step, then check your formula for n=10. Show each algebraic step.",
+        "runtimeOverrides": {},
+        "sourceHead": "c3ef55db5f09b2bcc6526bec4dd2a78eaa27aee6",
+        "startedUnixSeconds": 1788624547.208699,
+        "uncontended": false,
+        "workload": "math"
+      },
+      "scenarios": [
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 2.3530700637421837
+          },
+          "endToEndSpeedups": {
+            "adaptive": 2.283659621683949
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 156,
+          "repetition": 1,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "acceptanceRate": 0.706959706959707,
+                "acceptedDraftTokens": 193,
+                "draftHistoryTokens": 48,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 273,
+                "rounds": 63,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 10.775597095489502,
+              "decodeTokensPerSecond": 23.757384183114794,
+              "elapsedSeconds": 11.670462965965271,
+              "endToEndTokensPerSecond": 21.935719323781434,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0006320476531982422,
+              "generatedTokens": 256,
+              "loadSeconds": 2.002716064453125e-05,
+              "name": "adaptive",
+              "outputSHA256": "e89711cb589e92df06a8ff48eace2ae459591085ced5c2da40b212eec5cd4fd5",
+              "policy": "adaptive",
+              "prefillSeconds": 0.8934379816055298,
+              "prefillTokensPerSecond": 54.84432160802679,
+              "promptTokens": 49,
+              "residentMemoryAfterBytes": 15807299584,
+              "residentMemoryBeforeBytes": 15807021056,
+              "ttftSeconds": 0.8940900564193726
+            },
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 25.355734944343567,
+              "decodeTokensPerSecond": 10.096335229955905,
+              "elapsedSeconds": 26.651365041732788,
+              "endToEndTokensPerSecond": 9.605511747677285,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.13247692584991455,
+              "generatedTokens": 256,
+              "loadSeconds": 4.398822784423828e-05,
+              "name": "baseline",
+              "outputSHA256": "e89711cb589e92df06a8ff48eace2ae459591085ced5c2da40b212eec5cd4fd5",
+              "policy": "disabled",
+              "prefillSeconds": 1.2924760580062866,
+              "prefillTokensPerSecond": 37.91172741380225,
+              "promptTokens": 49,
+              "residentMemoryAfterBytes": 15428976640,
+              "residentMemoryBeforeBytes": 15428911104,
+              "ttftSeconds": 1.4249969720840454
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 2.137897091686745
+          },
+          "endToEndSpeedups": {
+            "adaptive": 2.083269417935927
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 156,
+          "repetition": 2,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "acceptanceRate": 0.706959706959707,
+                "acceptedDraftTokens": 193,
+                "draftHistoryTokens": 48,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 273,
+                "rounds": 63,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 10.71203899383545,
+              "decodeTokensPerSecond": 23.898344670638576,
+              "elapsedSeconds": 11.53477692604065,
+              "endToEndTokensPerSecond": 22.193753866367388,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0002900362014770508,
+              "generatedTokens": 256,
+              "loadSeconds": 2.002716064453125e-05,
+              "name": "adaptive",
+              "outputSHA256": "e89711cb589e92df06a8ff48eace2ae459591085ced5c2da40b212eec5cd4fd5",
+              "policy": "adaptive",
+              "prefillSeconds": 0.8212320804595947,
+              "prefillTokensPerSecond": 59.666446508735525,
+              "promptTokens": 49,
+              "residentMemoryAfterBytes": 15807594496,
+              "residentMemoryBeforeBytes": 15807414272,
+              "ttftSeconds": 0.8215421438217163
+            },
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 22.90123701095581,
+              "decodeTokensPerSecond": 11.178435465190425,
+              "elapsedSeconds": 24.03004801273346,
+              "endToEndTokensPerSecond": 10.653328693490177,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.07827401161193848,
+              "generatedTokens": 256,
+              "loadSeconds": 2.5987625122070312e-05,
+              "name": "baseline",
+              "outputSHA256": "e89711cb589e92df06a8ff48eace2ae459591085ced5c2da40b212eec5cd4fd5",
+              "policy": "disabled",
+              "prefillSeconds": 1.1273119449615479,
+              "prefillTokensPerSecond": 43.46622975033886,
+              "promptTokens": 49,
+              "residentMemoryAfterBytes": 15429025792,
+              "residentMemoryBeforeBytes": 15428993024,
+              "ttftSeconds": 1.2056119441986084
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 2.024663030502862
+          },
+          "endToEndSpeedups": {
+            "adaptive": 1.9775546966261714
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 156,
+          "repetition": 3,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "acceptanceRate": 0.706959706959707,
+                "acceptedDraftTokens": 193,
+                "draftHistoryTokens": 48,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 273,
+                "rounds": 63,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 10.782731056213379,
+              "decodeTokensPerSecond": 23.74166606450636,
+              "elapsedSeconds": 11.638966083526611,
+              "endToEndTokensPerSecond": 21.995080848489927,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0002969503402709961,
+              "generatedTokens": 256,
+              "loadSeconds": 2.002716064453125e-05,
+              "name": "adaptive",
+              "outputSHA256": "e89711cb589e92df06a8ff48eace2ae459591085ced5c2da40b212eec5cd4fd5",
+              "policy": "adaptive",
+              "prefillSeconds": 0.8548060655593872,
+              "prefillTokensPerSecond": 57.32294373453501,
+              "promptTokens": 49,
+              "residentMemoryAfterBytes": 15807643648,
+              "residentMemoryBeforeBytes": 15807594496,
+              "ttftSeconds": 0.8551230430603027
+            },
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 21.8313969373703,
+              "decodeTokensPerSecond": 11.726230837834624,
+              "elapsedSeconds": 23.01669204235077,
+              "endToEndTokensPerSecond": 11.12236282820135,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.06294500827789307,
+              "generatedTokens": 256,
+              "loadSeconds": 2.193450927734375e-05,
+              "name": "baseline",
+              "outputSHA256": "e89711cb589e92df06a8ff48eace2ae459591085ced5c2da40b212eec5cd4fd5",
+              "policy": "disabled",
+              "prefillSeconds": 1.1814539432525635,
+              "prefillTokensPerSecond": 41.474320924523,
+              "promptTokens": 49,
+              "residentMemoryAfterBytes": 15429091328,
+              "residentMemoryBeforeBytes": 15429025792,
+              "ttftSeconds": 1.2444208860397339
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        }
+      ]
+    },
+    {
+      "id": "final-greedy/qwen-prose",
+      "model": "vision-chat-q38-27b-4bit",
+      "rawReceiptSHA256": "5e4d9c51333a70a47a45a43ae3587349c73515060beb54ce6c72c370e4eeda32",
+      "receipt": {
+        "after": {
+          "gpuDeviceUtilizationPercent": 61,
+          "loadAverage": [
+            5.52734375,
+            5.56689453125,
+            6.271484375
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7268.25M  free = 923.75M  (encrypted)",
+          "swapUsedMiB": 7268.25
+        },
+        "before": {
+          "gpuDeviceUtilizationPercent": 49,
+          "loadAverage": [
+            6.3115234375,
+            5.75732421875,
+            6.4755859375
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7268.25M  free = 923.75M  (encrypted)",
+          "swapUsedMiB": 7268.25
+        },
+        "binarySHA256": "37ae108285410acec9ee3863de69475fb74ce9b472bf23c05e0e0df8ce26414c",
+        "buildSourceRevision": "c3ef55db5f09b2bcc6526bec4dd2a78eaa27aee6",
+        "collectorSHA256": "dec1ae60840c738d2c8ef678adf8c1fc39b7eecaab018032ff2c596b51599f2c",
+        "command": [
+          "mere.run",
+          "model",
+          "benchmark",
+          "q36-mtp",
+          "--model",
+          "vision-chat-q38-27b-4bit",
+          "--prompt",
+          "Explain how a small community could turn an abandoned railway station into a public library. Discuss the building, accessibility, staffing, the collection, and a realistic opening-day scene. Write approximately 400 words of clear, connected prose.",
+          "--decode-tokens",
+          "256",
+          "--context-size",
+          "8192",
+          "--temperature",
+          "0",
+          "--top-p",
+          "1",
+          "--json",
+          "--variants",
+          "baseline,adaptive",
+          "--warmups",
+          "1",
+          "--warmup-tokens",
+          "256",
+          "--repetitions",
+          "3"
+        ],
+        "competingInferenceProcessCount": 0,
+        "gpuSamples": [
+          {
+            "deviceUtilizationPercent": 50,
+            "elapsedSeconds": 0.13635516166687012,
+            "loadAverage": [
+              6.3115234375,
+              5.75732421875,
+              6.4755859375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 63,
+            "elapsedSeconds": 2.2430362701416016,
+            "loadAverage": [
+              6.3115234375,
+              5.75732421875,
+              6.4755859375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 37,
+            "elapsedSeconds": 4.368925333023071,
+            "loadAverage": [
+              6.3115234375,
+              5.75732421875,
+              6.4755859375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 64,
+            "elapsedSeconds": 6.484771251678467,
+            "loadAverage": [
+              6.2861328125,
+              5.76123046875,
+              6.47265625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 61,
+            "elapsedSeconds": 8.598513126373291,
+            "loadAverage": [
+              6.2861328125,
+              5.76123046875,
+              6.47265625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 58,
+            "elapsedSeconds": 10.707463264465332,
+            "loadAverage": [
+              6.02294921875,
+              5.71533203125,
+              6.4521484375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 63,
+            "elapsedSeconds": 12.824186086654663,
+            "loadAverage": [
+              6.02294921875,
+              5.71533203125,
+              6.4521484375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 57,
+            "elapsedSeconds": 14.935338020324707,
+            "loadAverage": [
+              5.86083984375,
+              5.6865234375,
+              6.4375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 62,
+            "elapsedSeconds": 17.055726051330566,
+            "loadAverage": [
+              5.86083984375,
+              5.6865234375,
+              6.4375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 57,
+            "elapsedSeconds": 19.176573991775513,
+            "loadAverage": [
+              5.86083984375,
+              5.6865234375,
+              6.4375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 60,
+            "elapsedSeconds": 21.28590726852417,
+            "loadAverage": [
+              5.95166015625,
+              5.7080078125,
+              6.4404296875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 98,
+            "elapsedSeconds": 23.393944025039673,
+            "loadAverage": [
+              5.95166015625,
+              5.7080078125,
+              6.4404296875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 25.497557163238525,
+            "loadAverage": [
+              5.71484375,
+              5.66259765625,
+              6.419921875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 27.60605001449585,
+            "loadAverage": [
+              5.71484375,
+              5.66259765625,
+              6.419921875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 29.714590072631836,
+            "loadAverage": [
+              5.4169921875,
+              5.6015625,
+              6.3935546875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 31.828978300094604,
+            "loadAverage": [
+              5.4169921875,
+              5.6015625,
+              6.3935546875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 33.98128628730774,
+            "loadAverage": [
+              5.4169921875,
+              5.6015625,
+              6.3935546875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 36.10975909233093,
+            "loadAverage": [
+              5.46337890625,
+              5.60791015625,
+              6.39111328125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 38.22799015045166,
+            "loadAverage": [
+              5.46337890625,
+              5.60791015625,
+              6.39111328125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 40.36394214630127,
+            "loadAverage": [
+              5.26611328125,
+              5.564453125,
+              6.37109375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 99,
+            "elapsedSeconds": 42.473140001297,
+            "loadAverage": [
+              5.26611328125,
+              5.564453125,
+              6.37109375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 99,
+            "elapsedSeconds": 44.57291007041931,
+            "loadAverage": [
+              5.26611328125,
+              5.564453125,
+              6.37109375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 67,
+            "elapsedSeconds": 46.693432092666626,
+            "loadAverage": [
+              5.40478515625,
+              5.587890625,
+              6.37451171875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 57,
+            "elapsedSeconds": 48.82114005088806,
+            "loadAverage": [
+              5.40478515625,
+              5.587890625,
+              6.37451171875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 56,
+            "elapsedSeconds": 50.941697120666504,
+            "loadAverage": [
+              5.9326171875,
+              5.6943359375,
+              6.4072265625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 57,
+            "elapsedSeconds": 53.05119204521179,
+            "loadAverage": [
+              5.9326171875,
+              5.6943359375,
+              6.4072265625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 54,
+            "elapsedSeconds": 55.16583299636841,
+            "loadAverage": [
+              6.09814453125,
+              5.732421875,
+              6.41650390625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 56,
+            "elapsedSeconds": 57.28836727142334,
+            "loadAverage": [
+              6.09814453125,
+              5.732421875,
+              6.41650390625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 58,
+            "elapsedSeconds": 59.4020471572876,
+            "loadAverage": [
+              6.09814453125,
+              5.732421875,
+              6.41650390625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 54,
+            "elapsedSeconds": 61.50659203529358,
+            "loadAverage": [
+              6.009765625,
+              5.72021484375,
+              6.408203125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 92,
+            "elapsedSeconds": 63.61092400550842,
+            "loadAverage": [
+              6.009765625,
+              5.72021484375,
+              6.408203125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 65.71856713294983,
+            "loadAverage": [
+              5.6083984375,
+              5.6416015625,
+              6.37646484375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 67.82051515579224,
+            "loadAverage": [
+              5.6083984375,
+              5.6416015625,
+              6.37646484375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 69.93814826011658,
+            "loadAverage": [
+              5.2392578125,
+              5.564453125,
+              6.3447265625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 72.04796600341797,
+            "loadAverage": [
+              5.2392578125,
+              5.564453125,
+              6.3447265625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 74.1594340801239,
+            "loadAverage": [
+              5.2392578125,
+              5.564453125,
+              6.3447265625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 76.27951121330261,
+            "loadAverage": [
+              4.9794921875,
+              5.5048828125,
+              6.31884765625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 78.39089822769165,
+            "loadAverage": [
+              4.9794921875,
+              5.5048828125,
+              6.31884765625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 80.51183795928955,
+            "loadAverage": [
+              5.14111328125,
+              5.529296875,
+              6.32275390625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 98,
+            "elapsedSeconds": 82.61635613441467,
+            "loadAverage": [
+              5.14111328125,
+              5.529296875,
+              6.32275390625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 87,
+            "elapsedSeconds": 84.73375916481018,
+            "loadAverage": [
+              4.96923828125,
+              5.4873046875,
+              6.30322265625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 86,
+            "elapsedSeconds": 86.84868931770325,
+            "loadAverage": [
+              4.96923828125,
+              5.4873046875,
+              6.30322265625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 92,
+            "elapsedSeconds": 88.94682812690735,
+            "loadAverage": [
+              4.96923828125,
+              5.4873046875,
+              6.30322265625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 79,
+            "elapsedSeconds": 91.04559016227722,
+            "loadAverage": [
+              4.8115234375,
+              5.44580078125,
+              6.28369140625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 86,
+            "elapsedSeconds": 93.14368104934692,
+            "loadAverage": [
+              4.8115234375,
+              5.44580078125,
+              6.28369140625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 96,
+            "elapsedSeconds": 95.2387101650238,
+            "loadAverage": [
+              4.826171875,
+              5.43798828125,
+              6.27587890625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 82,
+            "elapsedSeconds": 97.34384417533875,
+            "loadAverage": [
+              4.826171875,
+              5.43798828125,
+              6.27587890625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 96,
+            "elapsedSeconds": 99.44666504859924,
+            "loadAverage": [
+              4.826171875,
+              5.43798828125,
+              6.27587890625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 88,
+            "elapsedSeconds": 101.54118418693542,
+            "loadAverage": [
+              5.0,
+              5.4638671875,
+              6.27978515625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 98,
+            "elapsedSeconds": 103.64293193817139,
+            "loadAverage": [
+              5.0,
+              5.4638671875,
+              6.27978515625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 94,
+            "elapsedSeconds": 105.74261212348938,
+            "loadAverage": [
+              4.83984375,
+              5.4228515625,
+              6.26025390625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 90,
+            "elapsedSeconds": 107.85158205032349,
+            "loadAverage": [
+              4.83984375,
+              5.4228515625,
+              6.26025390625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 91,
+            "elapsedSeconds": 109.95608401298523,
+            "loadAverage": [
+              5.1728515625,
+              5.48193359375,
+              6.27587890625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 97,
+            "elapsedSeconds": 112.06396698951721,
+            "loadAverage": [
+              5.1728515625,
+              5.48193359375,
+              6.27587890625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 94,
+            "elapsedSeconds": 114.17619824409485,
+            "loadAverage": [
+              5.1728515625,
+              5.48193359375,
+              6.27587890625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 96,
+            "elapsedSeconds": 116.2763421535492,
+            "loadAverage": [
+              5.39892578125,
+              5.5234375,
+              6.28564453125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 99,
+            "elapsedSeconds": 118.37764811515808,
+            "loadAverage": [
+              5.39892578125,
+              5.5234375,
+              6.28564453125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 93,
+            "elapsedSeconds": 120.48455619812012,
+            "loadAverage": [
+              6.00732421875,
+              5.6474609375,
+              6.32470703125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 90,
+            "elapsedSeconds": 122.58062410354614,
+            "loadAverage": [
+              6.00732421875,
+              5.6474609375,
+              6.32470703125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 91,
+            "elapsedSeconds": 124.6838002204895,
+            "loadAverage": [
+              6.00732421875,
+              5.6474609375,
+              6.32470703125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 83,
+            "elapsedSeconds": 126.78776121139526,
+            "loadAverage": [
+              6.40673828125,
+              5.73583984375,
+              6.35205078125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 92,
+            "elapsedSeconds": 128.88950300216675,
+            "loadAverage": [
+              6.40673828125,
+              5.73583984375,
+              6.35205078125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 92,
+            "elapsedSeconds": 130.99153900146484,
+            "loadAverage": [
+              5.8935546875,
+              5.64013671875,
+              6.314453125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 90,
+            "elapsedSeconds": 133.08962607383728,
+            "loadAverage": [
+              5.8935546875,
+              5.64013671875,
+              6.314453125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 93,
+            "elapsedSeconds": 135.18944001197815,
+            "loadAverage": [
+              5.74169921875,
+              5.61279296875,
+              6.30078125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 93,
+            "elapsedSeconds": 137.29600620269775,
+            "loadAverage": [
+              5.74169921875,
+              5.61279296875,
+              6.30078125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 89,
+            "elapsedSeconds": 139.45655512809753,
+            "loadAverage": [
+              5.74169921875,
+              5.61279296875,
+              6.30078125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 98,
+            "elapsedSeconds": 141.56350016593933,
+            "loadAverage": [
+              5.44189453125,
+              5.552734375,
+              6.275390625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 84,
+            "elapsedSeconds": 143.66803812980652,
+            "loadAverage": [
+              5.44189453125,
+              5.552734375,
+              6.275390625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 96,
+            "elapsedSeconds": 145.76345920562744,
+            "loadAverage": [
+              5.486328125,
+              5.56005859375,
+              6.2734375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 97,
+            "elapsedSeconds": 147.86328125,
+            "loadAverage": [
+              5.486328125,
+              5.56005859375,
+              6.2734375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 95,
+            "elapsedSeconds": 149.9568099975586,
+            "loadAverage": [
+              5.52734375,
+              5.56689453125,
+              6.271484375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 96,
+            "elapsedSeconds": 152.05420422554016,
+            "loadAverage": [
+              5.52734375,
+              5.56689453125,
+              6.271484375
+            ]
+          }
+        ],
+        "knownRenderingWorkerCount": 0,
+        "maxPressureLevel": 1,
+        "measurementMode": "desktop-load",
+        "peakResidentBytes": 15824977920,
+        "processSeconds": 154.14823722839355,
+        "profiled": false,
+        "prompt": "Explain how a small community could turn an abandoned railway station into a public library. Discuss the building, accessibility, staffing, the collection, and a realistic opening-day scene. Write approximately 400 words of clear, connected prose.",
+        "runtimeOverrides": {},
+        "sourceHead": "c3ef55db5f09b2bcc6526bec4dd2a78eaa27aee6",
+        "startedUnixSeconds": 1788624357.6931489,
+        "uncontended": false,
+        "workload": "prose"
+      },
+      "scenarios": [
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 1.2150808420673067
+          },
+          "endToEndSpeedups": {
+            "adaptive": 1.215459090113719
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 247,
+          "repetition": 1,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 19.4006769657135,
+              "decodeTokensPerSecond": 13.19541583277865,
+              "elapsedSeconds": 20.4760639667511,
+              "endToEndTokensPerSecond": 12.50240282584051,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.06372296810150146,
+              "generatedTokens": 256,
+              "loadSeconds": 2.396106719970703e-05,
+              "name": "baseline",
+              "outputSHA256": "f0eee860afeee246903ecb69993c7b7fee39cc16b60c5bf6535276f31f58bcda",
+              "policy": "disabled",
+              "prefillSeconds": 1.073531985282898,
+              "prefillTokensPerSecond": 55.890276975947536,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 15414591488,
+              "residentMemoryBeforeBytes": 15414509568,
+              "ttftSeconds": 1.1372789144515991
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.4074074074074074,
+                "acceptedDraftTokens": 132,
+                "draftHistoryTokens": 59,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 324,
+                "rounds": 124,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 15.966572999954224,
+              "decodeTokensPerSecond": 16.033496981520955,
+              "elapsedSeconds": 16.846362113952637,
+              "endToEndTokensPerSecond": 15.196159162931297,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0002650022506713867,
+              "generatedTokens": 256,
+              "loadSeconds": 2.002716064453125e-05,
+              "name": "adaptive",
+              "outputSHA256": "f0eee860afeee246903ecb69993c7b7fee39cc16b60c5bf6535276f31f58bcda",
+              "policy": "adaptive",
+              "prefillSeconds": 0.8781039714813232,
+              "prefillTokensPerSecond": 68.32903841532867,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 15824912384,
+              "residentMemoryBeforeBytes": 15824076800,
+              "ttftSeconds": 0.8783890008926392
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 1.0700793948901455
+          },
+          "endToEndSpeedups": {
+            "adaptive": 1.0607492434011625
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 247,
+          "repetition": 2,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 19.021972060203552,
+              "decodeTokensPerSecond": 13.45812091352954,
+              "elapsedSeconds": 19.944918990135193,
+              "endToEndTokensPerSecond": 12.835349199794607,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.0533519983291626,
+              "generatedTokens": 256,
+              "loadSeconds": 2.6941299438476562e-05,
+              "name": "baseline",
+              "outputSHA256": "f0eee860afeee246903ecb69993c7b7fee39cc16b60c5bf6535276f31f58bcda",
+              "policy": "disabled",
+              "prefillSeconds": 0.9209740161895752,
+              "prefillTokensPerSecond": 65.14841781122463,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 15414837248,
+              "residentMemoryBeforeBytes": 15414706176,
+              "ttftSeconds": 0.9743529558181763
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.4074074074074074,
+                "acceptedDraftTokens": 132,
+                "draftHistoryTokens": 59,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 324,
+                "rounds": 124,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 17.776224970817566,
+              "decodeTokensPerSecond": 14.4012578835081,
+              "elapsedSeconds": 18.80267095565796,
+              "endToEndTokensPerSecond": 13.615086952471845,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0005480051040649414,
+              "generatedTokens": 256,
+              "loadSeconds": 2.9087066650390625e-05,
+              "name": "adaptive",
+              "outputSHA256": "f0eee860afeee246903ecb69993c7b7fee39cc16b60c5bf6535276f31f58bcda",
+              "policy": "adaptive",
+              "prefillSeconds": 1.0247420072555542,
+              "prefillTokensPerSecond": 58.551322747752806,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 15824928768,
+              "residentMemoryBeforeBytes": 15824928768,
+              "ttftSeconds": 1.0253190994262695
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 1.0922572375419586
+          },
+          "endToEndSpeedups": {
+            "adaptive": 1.0961168168568942
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 247,
+          "repetition": 3,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 19.20444905757904,
+              "decodeTokensPerSecond": 13.330244425781615,
+              "elapsedSeconds": 20.29848301410675,
+              "endToEndTokensPerSecond": 12.611779896167057,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.06122004985809326,
+              "generatedTokens": 256,
+              "loadSeconds": 3.409385681152344e-05,
+              "name": "baseline",
+              "outputSHA256": "f0eee860afeee246903ecb69993c7b7fee39cc16b60c5bf6535276f31f58bcda",
+              "policy": "disabled",
+              "prefillSeconds": 1.0918149948120117,
+              "prefillTokensPerSecond": 54.95436524054222,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 15414870016,
+              "residentMemoryBeforeBytes": 15414837248,
+              "ttftSeconds": 1.1530691385269165
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.4074074074074074,
+                "acceptedDraftTokens": 132,
+                "draftHistoryTokens": 59,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 324,
+                "rounds": 124,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 17.58235001564026,
+              "decodeTokensPerSecond": 14.560055952263319,
+              "elapsedSeconds": 18.518539905548096,
+              "endToEndTokensPerSecond": 13.823984034686408,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0004259347915649414,
+              "generatedTokens": 256,
+              "loadSeconds": 2.205371856689453e-05,
+              "name": "adaptive",
+              "outputSHA256": "f0eee860afeee246903ecb69993c7b7fee39cc16b60c5bf6535276f31f58bcda",
+              "policy": "adaptive",
+              "prefillSeconds": 0.9345439672470093,
+              "prefillTokensPerSecond": 64.20243680642304,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 15824945152,
+              "residentMemoryBeforeBytes": 15824928768,
+              "ttftSeconds": 0.9349919557571411
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        }
+      ]
+    },
+    {
+      "id": "final-greedy/qwen-summary",
+      "model": "vision-chat-q38-27b-4bit",
+      "rawReceiptSHA256": "0f40a578a16212e6b5529054a833883e4ab06aaf9ebf3d39140d9376edfb3d15",
+      "receipt": {
+        "after": {
+          "gpuDeviceUtilizationPercent": 87,
+          "loadAverage": [
+            5.3916015625,
+            6.2470703125,
+            6.35302734375
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7268.25M  free = 923.75M  (encrypted)",
+          "swapUsedMiB": 7268.25
+        },
+        "before": {
+          "gpuDeviceUtilizationPercent": 59,
+          "loadAverage": [
+            8.35107421875,
+            6.3984375,
+            6.40625
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7268.25M  free = 923.75M  (encrypted)",
+          "swapUsedMiB": 7268.25
+        },
+        "binarySHA256": "37ae108285410acec9ee3863de69475fb74ce9b472bf23c05e0e0df8ce26414c",
+        "buildSourceRevision": "c3ef55db5f09b2bcc6526bec4dd2a78eaa27aee6",
+        "collectorSHA256": "dec1ae60840c738d2c8ef678adf8c1fc39b7eecaab018032ff2c596b51599f2c",
+        "command": [
+          "mere.run",
+          "model",
+          "benchmark",
+          "q36-mtp",
+          "--model",
+          "vision-chat-q38-27b-4bit",
+          "--prompt",
+          "Summarize this fictional incident report for a manager. Explain the timeline, user impact, cause, recovery, and three concrete follow-up actions. Distinguish confirmed facts from open questions. Use clear paragraphs and a short action list.\n\n09:02: The team deployed version 2.8 of the document search service. 09:07: Monitoring showed the 95th percentile search latency rising from 180 milliseconds to 4.2 seconds. 09:10: Support received six reports of slow searches; document uploads and downloads remained available. 09:13: The on-call engineer paused the rollout at 40 percent of traffic. 09:17: Logs showed repeated cache misses for queries containing a language filter. A new cache key included a randomly generated request identifier. 09:21: The engineer rolled traffic back to version 2.7. 09:26: Latency returned below 250 milliseconds. 09:32: The team confirmed no documents were lost or modified. Approximately 1,800 search requests experienced elevated latency; 73 timed out. The exact number of affected users is still being calculated. The release tests covered result correctness but did not assert cache reuse. A separate warning about database connection count appeared at 09:15; the team has not established whether it was a cause or an effect. Proposed follow-ups include a deterministic cache-key unit test, a staging workload with repeated filtered queries, and an automatic rollback threshold for latency.",
+          "--decode-tokens",
+          "256",
+          "--context-size",
+          "8192",
+          "--temperature",
+          "0",
+          "--top-p",
+          "1",
+          "--json",
+          "--variants",
+          "baseline,adaptive",
+          "--warmups",
+          "1",
+          "--warmup-tokens",
+          "256",
+          "--repetitions",
+          "3"
+        ],
+        "competingInferenceProcessCount": 0,
+        "gpuSamples": [
+          {
+            "deviceUtilizationPercent": 43,
+            "elapsedSeconds": 0.1393280029296875,
+            "loadAverage": [
+              8.35107421875,
+              6.3984375,
+              6.40625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 77,
+            "elapsedSeconds": 2.2418088912963867,
+            "loadAverage": [
+              8.35107421875,
+              6.3984375,
+              6.40625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 99,
+            "elapsedSeconds": 4.363068103790283,
+            "loadAverage": [
+              8.08251953125,
+              6.375,
+              6.39794921875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 99,
+            "elapsedSeconds": 6.464037895202637,
+            "loadAverage": [
+              8.08251953125,
+              6.375,
+              6.39794921875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 8.563050031661987,
+            "loadAverage": [
+              7.67529296875,
+              6.31884765625,
+              6.3779296875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 10.678048849105835,
+            "loadAverage": [
+              7.67529296875,
+              6.31884765625,
+              6.3779296875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 12.786223888397217,
+            "loadAverage": [
+              7.67529296875,
+              6.31884765625,
+              6.3779296875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 14.887305974960327,
+            "loadAverage": [
+              7.380859375,
+              6.2802734375,
+              6.36376953125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 17.005151987075806,
+            "loadAverage": [
+              7.380859375,
+              6.2802734375,
+              6.36376953125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 19.108398914337158,
+            "loadAverage": [
+              7.27001953125,
+              6.275390625,
+              6.361328125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 21.21261501312256,
+            "loadAverage": [
+              7.27001953125,
+              6.275390625,
+              6.361328125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 23.31520915031433,
+            "loadAverage": [
+              7.16796875,
+              6.2705078125,
+              6.35888671875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 25.419042825698853,
+            "loadAverage": [
+              7.16796875,
+              6.2705078125,
+              6.35888671875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 99,
+            "elapsedSeconds": 27.51328182220459,
+            "loadAverage": [
+              7.16796875,
+              6.2705078125,
+              6.35888671875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 29.61873698234558,
+            "loadAverage": [
+              6.75390625,
+              6.19921875,
+              6.3330078125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 99,
+            "elapsedSeconds": 31.74898910522461,
+            "loadAverage": [
+              6.75390625,
+              6.19921875,
+              6.3330078125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 66,
+            "elapsedSeconds": 33.86541819572449,
+            "loadAverage": [
+              6.29296875,
+              6.11279296875,
+              6.3017578125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 53,
+            "elapsedSeconds": 35.96995997428894,
+            "loadAverage": [
+              6.29296875,
+              6.11279296875,
+              6.3017578125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 60,
+            "elapsedSeconds": 38.073760986328125,
+            "loadAverage": [
+              6.29296875,
+              6.11279296875,
+              6.3017578125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 62,
+            "elapsedSeconds": 40.17427396774292,
+            "loadAverage": [
+              6.18896484375,
+              6.09423828125,
+              6.2939453125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 62,
+            "elapsedSeconds": 42.27608108520508,
+            "loadAverage": [
+              6.18896484375,
+              6.09423828125,
+              6.2939453125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 63,
+            "elapsedSeconds": 44.395549058914185,
+            "loadAverage": [
+              6.013671875,
+              6.05908203125,
+              6.2802734375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 59,
+            "elapsedSeconds": 46.52087688446045,
+            "loadAverage": [
+              6.013671875,
+              6.05908203125,
+              6.2802734375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 54,
+            "elapsedSeconds": 48.62930107116699,
+            "loadAverage": [
+              5.53173828125,
+              5.9580078125,
+              6.2431640625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 58,
+            "elapsedSeconds": 50.74443984031677,
+            "loadAverage": [
+              5.53173828125,
+              5.9580078125,
+              6.2431640625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 76,
+            "elapsedSeconds": 52.836498975753784,
+            "loadAverage": [
+              5.53173828125,
+              5.9580078125,
+              6.2431640625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 54.93623089790344,
+            "loadAverage": [
+              5.08837890625,
+              5.85888671875,
+              6.20654296875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 96,
+            "elapsedSeconds": 57.76303195953369,
+            "loadAverage": [
+              5.08837890625,
+              5.85888671875,
+              6.20654296875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 84,
+            "elapsedSeconds": 60.438982009887695,
+            "loadAverage": [
+              5.4013671875,
+              5.91064453125,
+              6.22265625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 94,
+            "elapsedSeconds": 62.988378047943115,
+            "loadAverage": [
+              5.4013671875,
+              5.91064453125,
+              6.22265625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 79,
+            "elapsedSeconds": 65.85784888267517,
+            "loadAverage": [
+              6.41015625,
+              6.111328125,
+              6.29150390625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 84,
+            "elapsedSeconds": 68.44013977050781,
+            "loadAverage": [
+              6.6171875,
+              6.1591796875,
+              6.30712890625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 73,
+            "elapsedSeconds": 71.55483984947205,
+            "loadAverage": [
+              6.6171875,
+              6.1591796875,
+              6.30712890625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 62,
+            "elapsedSeconds": 74.65407180786133,
+            "loadAverage": [
+              8.4091796875,
+              6.5380859375,
+              6.43994140625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 81,
+            "elapsedSeconds": 77.62806296348572,
+            "loadAverage": [
+              8.4091796875,
+              6.5380859375,
+              6.43994140625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 79.8785650730133,
+            "loadAverage": [
+              8.9365234375,
+              6.67822265625,
+              6.48974609375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 81,
+            "elapsedSeconds": 82.77118992805481,
+            "loadAverage": [
+              8.9365234375,
+              6.67822265625,
+              6.48974609375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 63,
+            "elapsedSeconds": 86.34701609611511,
+            "loadAverage": [
+              8.62109375,
+              6.64990234375,
+              6.48095703125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 65,
+            "elapsedSeconds": 89.35654091835022,
+            "loadAverage": [
+              10.3330078125,
+              7.037109375,
+              6.61865234375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 72,
+            "elapsedSeconds": 92.22482109069824,
+            "loadAverage": [
+              10.3330078125,
+              7.037109375,
+              6.61865234375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 94,
+            "elapsedSeconds": 94.44527506828308,
+            "loadAverage": [
+              10.14599609375,
+              7.052734375,
+              6.62646484375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 96.58075881004333,
+            "loadAverage": [
+              10.14599609375,
+              7.052734375,
+              6.62646484375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 98.69560313224792,
+            "loadAverage": [
+              9.57373046875,
+              6.9853515625,
+              6.60498046875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 100.79797601699829,
+            "loadAverage": [
+              9.57373046875,
+              6.9853515625,
+              6.60498046875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 102.90862202644348,
+            "loadAverage": [
+              9.57373046875,
+              6.9853515625,
+              6.60498046875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 74,
+            "elapsedSeconds": 105.01938390731812,
+            "loadAverage": [
+              9.046875,
+              6.9189453125,
+              6.58349609375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 107.12016487121582,
+            "loadAverage": [
+              9.046875,
+              6.9189453125,
+              6.58349609375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 99,
+            "elapsedSeconds": 109.21345591545105,
+            "loadAverage": [
+              8.8828125,
+              6.919921875,
+              6.58544921875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 85,
+            "elapsedSeconds": 111.30961894989014,
+            "loadAverage": [
+              8.8828125,
+              6.919921875,
+              6.58544921875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 92,
+            "elapsedSeconds": 113.40875887870789,
+            "loadAverage": [
+              8.57177734375,
+              6.8876953125,
+              6.57568359375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 96,
+            "elapsedSeconds": 115.50743103027344,
+            "loadAverage": [
+              8.57177734375,
+              6.8876953125,
+              6.57568359375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 94,
+            "elapsedSeconds": 117.60276007652283,
+            "loadAverage": [
+              8.57177734375,
+              6.8876953125,
+              6.57568359375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 92,
+            "elapsedSeconds": 119.69578790664673,
+            "loadAverage": [
+              8.04541015625,
+              6.80615234375,
+              6.548828125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 121.79111695289612,
+            "loadAverage": [
+              8.04541015625,
+              6.80615234375,
+              6.548828125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 93,
+            "elapsedSeconds": 123.88933205604553,
+            "loadAverage": [
+              7.64111328125,
+              6.74267578125,
+              6.52783203125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 92,
+            "elapsedSeconds": 125.99483299255371,
+            "loadAverage": [
+              7.64111328125,
+              6.74267578125,
+              6.52783203125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 96,
+            "elapsedSeconds": 128.09067296981812,
+            "loadAverage": [
+              7.64111328125,
+              6.74267578125,
+              6.52783203125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 90,
+            "elapsedSeconds": 130.18932485580444,
+            "loadAverage": [
+              7.26904296875,
+              6.68017578125,
+              6.5068359375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 91,
+            "elapsedSeconds": 132.28633880615234,
+            "loadAverage": [
+              7.26904296875,
+              6.68017578125,
+              6.5068359375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 99,
+            "elapsedSeconds": 134.3813338279724,
+            "loadAverage": [
+              6.7666015625,
+              6.58544921875,
+              6.47412109375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 136.48352003097534,
+            "loadAverage": [
+              6.7666015625,
+              6.58544921875,
+              6.47412109375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 87,
+            "elapsedSeconds": 138.5828959941864,
+            "loadAverage": [
+              6.224609375,
+              6.47607421875,
+              6.43603515625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 85,
+            "elapsedSeconds": 140.6810760498047,
+            "loadAverage": [
+              6.224609375,
+              6.47607421875,
+              6.43603515625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 95,
+            "elapsedSeconds": 142.77963495254517,
+            "loadAverage": [
+              6.224609375,
+              6.47607421875,
+              6.43603515625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 99,
+            "elapsedSeconds": 144.87397694587708,
+            "loadAverage": [
+              5.88623046875,
+              6.4013671875,
+              6.40966796875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 87,
+            "elapsedSeconds": 146.9753019809723,
+            "loadAverage": [
+              5.88623046875,
+              6.4013671875,
+              6.40966796875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 99,
+            "elapsedSeconds": 149.07011604309082,
+            "loadAverage": [
+              5.57470703125,
+              6.328125,
+              6.3837890625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 151.16134595870972,
+            "loadAverage": [
+              5.57470703125,
+              6.328125,
+              6.3837890625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 92,
+            "elapsedSeconds": 153.25694799423218,
+            "loadAverage": [
+              5.57470703125,
+              6.328125,
+              6.3837890625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 92,
+            "elapsedSeconds": 155.35435509681702,
+            "loadAverage": [
+              5.4482421875,
+              6.2890625,
+              6.36962890625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 96,
+            "elapsedSeconds": 157.4474561214447,
+            "loadAverage": [
+              5.4482421875,
+              6.2890625,
+              6.36962890625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 87,
+            "elapsedSeconds": 159.54077196121216,
+            "loadAverage": [
+              5.251953125,
+              6.234375,
+              6.349609375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 93,
+            "elapsedSeconds": 161.6666510105133,
+            "loadAverage": [
+              5.251953125,
+              6.234375,
+              6.349609375
+            ]
+          }
+        ],
+        "knownRenderingWorkerCount": 1,
+        "maxPressureLevel": 1,
+        "measurementMode": "desktop-load",
+        "peakResidentBytes": 15824715776,
+        "processSeconds": 163.83803296089172,
+        "profiled": false,
+        "prompt": "Summarize this fictional incident report for a manager. Explain the timeline, user impact, cause, recovery, and three concrete follow-up actions. Distinguish confirmed facts from open questions. Use clear paragraphs and a short action list.\n\n09:02: The team deployed version 2.8 of the document search service. 09:07: Monitoring showed the 95th percentile search latency rising from 180 milliseconds to 4.2 seconds. 09:10: Support received six reports of slow searches; document uploads and downloads remained available. 09:13: The on-call engineer paused the rollout at 40 percent of traffic. 09:17: Logs showed repeated cache misses for queries containing a language filter. A new cache key included a randomly generated request identifier. 09:21: The engineer rolled traffic back to version 2.7. 09:26: Latency returned below 250 milliseconds. 09:32: The team confirmed no documents were lost or modified. Approximately 1,800 search requests experienced elevated latency; 73 timed out. The exact number of affected users is still being calculated. The release tests covered result correctness but did not assert cache reuse. A separate warning about database connection count appeared at 09:15; the team has not established whether it was a cause or an effect. Proposed follow-ups include a deterministic cache-key unit test, a staging workload with repeated filtered queries, and an automatic rollback threshold for latency.",
+        "runtimeOverrides": {},
+        "sourceHead": "c3ef55db5f09b2bcc6526bec4dd2a78eaa27aee6",
+        "startedUnixSeconds": 1788624739.227365,
+        "uncontended": false,
+        "workload": "summary"
+      },
+      "scenarios": [
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 1.9972201099688833
+          },
+          "endToEndSpeedups": {
+            "adaptive": 1.7700554388315375
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 1428,
+          "repetition": 1,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 21.65985405445099,
+              "decodeTokensPerSecond": 11.819100874661402,
+              "elapsedSeconds": 25.363741993904114,
+              "endToEndTokensPerSecond": 10.093147929888527,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.08659505844116211,
+              "generatedTokens": 256,
+              "loadSeconds": 2.205371856689453e-05,
+              "name": "baseline",
+              "outputSHA256": "132da8ac8fd12147253a9a43470a0d7ece9db9db889d8ea4ccd40e1bf193e511",
+              "policy": "disabled",
+              "prefillSeconds": 3.7024641036987305,
+              "prefillTokensPerSecond": 91.02046382119947,
+              "promptTokens": 337,
+              "residentMemoryAfterBytes": 15414312960,
+              "residentMemoryBeforeBytes": 15414116352,
+              "ttftSeconds": 3.7890812158584595
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.5889967637540453,
+                "acceptedDraftTokens": 182,
+                "draftHistoryTokens": 336,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 309,
+                "rounds": 73,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 10.845000982284546,
+              "decodeTokensPerSecond": 23.60534594862457,
+              "elapsedSeconds": 14.329348921775818,
+              "endToEndTokensPerSecond": 17.865431388230462,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.00028705596923828125,
+              "generatedTokens": 256,
+              "loadSeconds": 2.002716064453125e-05,
+              "name": "adaptive",
+              "outputSHA256": "132da8ac8fd12147253a9a43470a0d7ece9db9db889d8ea4ccd40e1bf193e511",
+              "policy": "adaptive",
+              "prefillSeconds": 3.4826589822769165,
+              "prefillTokensPerSecond": 96.76514459640657,
+              "promptTokens": 337,
+              "residentMemoryAfterBytes": 15824519168,
+              "residentMemoryBeforeBytes": 15824388096,
+              "ttftSeconds": 3.4829660654067993
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 1.969463776507501
+          },
+          "endToEndSpeedups": {
+            "adaptive": 1.7276676598727985
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 1428,
+          "repetition": 2,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 21.422978043556213,
+              "decodeTokensPerSecond": 11.949785855146404,
+              "elapsedSeconds": 24.794650077819824,
+              "endToEndTokensPerSecond": 10.32480794028249,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.10324704647064209,
+              "generatedTokens": 256,
+              "loadSeconds": 2.4080276489257812e-05,
+              "name": "baseline",
+              "outputSHA256": "132da8ac8fd12147253a9a43470a0d7ece9db9db889d8ea4ccd40e1bf193e511",
+              "policy": "disabled",
+              "prefillSeconds": 3.3696060180664062,
+              "prefillTokensPerSecond": 100.01169222548516,
+              "promptTokens": 337,
+              "residentMemoryAfterBytes": 15414509568,
+              "residentMemoryBeforeBytes": 15414427648,
+              "ttftSeconds": 3.4728771448135376
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.5889967637540453,
+                "acceptedDraftTokens": 182,
+                "draftHistoryTokens": 336,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 309,
+                "rounds": 73,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 10.87756896018982,
+              "decodeTokensPerSecond": 23.534670378732553,
+              "elapsedSeconds": 14.351516008377075,
+              "endToEndTokensPerSecond": 17.837836772823938,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.00037097930908203125,
+              "generatedTokens": 256,
+              "loadSeconds": 1.800060272216797e-05,
+              "name": "adaptive",
+              "outputSHA256": "132da8ac8fd12147253a9a43470a0d7ece9db9db889d8ea4ccd40e1bf193e511",
+              "policy": "adaptive",
+              "prefillSeconds": 3.472319006919861,
+              "prefillTokensPerSecond": 97.05329473714964,
+              "promptTokens": 337,
+              "residentMemoryAfterBytes": 15824617472,
+              "residentMemoryBeforeBytes": 15824519168,
+              "ttftSeconds": 3.472707986831665
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 2.0225575195070036
+          },
+          "endToEndSpeedups": {
+            "adaptive": 1.7601250972052673
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 1428,
+          "repetition": 3,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 22.97916603088379,
+              "decodeTokensPerSecond": 11.140526146855736,
+              "elapsedSeconds": 26.31876504421234,
+              "endToEndTokensPerSecond": 9.7269001630567,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.16310596466064453,
+              "generatedTokens": 256,
+              "loadSeconds": 0.00010597705841064453,
+              "name": "baseline",
+              "outputSHA256": "132da8ac8fd12147253a9a43470a0d7ece9db9db889d8ea4ccd40e1bf193e511",
+              "policy": "disabled",
+              "prefillSeconds": 3.332718014717102,
+              "prefillTokensPerSecond": 101.11866605930243,
+              "promptTokens": 337,
+              "residentMemoryAfterBytes": 15414607872,
+              "residentMemoryBeforeBytes": 15414509568,
+              "ttftSeconds": 3.4959299564361572
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.5889967637540453,
+                "acceptedDraftTokens": 182,
+                "draftHistoryTokens": 336,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 309,
+                "rounds": 73,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 11.361440062522888,
+              "decodeTokensPerSecond": 22.532354929587456,
+              "elapsedSeconds": 14.952780961990356,
+              "endToEndTokensPerSecond": 17.120561095006103,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0005140304565429688,
+              "generatedTokens": 256,
+              "loadSeconds": 2.300739288330078e-05,
+              "name": "adaptive",
+              "outputSHA256": "132da8ac8fd12147253a9a43470a0d7ece9db9db889d8ea4ccd40e1bf193e511",
+              "policy": "adaptive",
+              "prefillSeconds": 3.589138984680176,
+              "prefillTokensPerSecond": 93.89438565584824,
+              "promptTokens": 337,
+              "residentMemoryAfterBytes": 15824715776,
+              "residentMemoryBeforeBytes": 15824617472,
+              "ttftSeconds": 3.589676022529602
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        }
+      ]
+    },
+    {
+      "id": "final-reversed/ornith-code",
+      "model": "text-agent-ornith-35b-mlx-4bit",
+      "rawReceiptSHA256": "7a363e5e29d3b5de5158e7c0fdec88a13a2e8b64988690a1962f07e1ca168c42",
+      "receipt": {
+        "after": {
+          "gpuDeviceUtilizationPercent": 56,
+          "loadAverage": [
+            7.4853515625,
+            6.65234375,
+            6.49365234375
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7268.25M  free = 923.75M  (encrypted)",
+          "swapUsedMiB": 7268.25
+        },
+        "before": {
+          "gpuDeviceUtilizationPercent": 41,
+          "loadAverage": [
+            5.3916015625,
+            6.2470703125,
+            6.35302734375
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7268.25M  free = 923.75M  (encrypted)",
+          "swapUsedMiB": 7268.25
+        },
+        "binarySHA256": "37ae108285410acec9ee3863de69475fb74ce9b472bf23c05e0e0df8ce26414c",
+        "buildSourceRevision": "c3ef55db5f09b2bcc6526bec4dd2a78eaa27aee6",
+        "collectorSHA256": "dec1ae60840c738d2c8ef678adf8c1fc39b7eecaab018032ff2c596b51599f2c",
+        "command": [
+          "mere.run",
+          "model",
+          "benchmark",
+          "q36-mtp",
+          "--model",
+          "text-agent-ornith-35b-mlx-4bit",
+          "--prompt",
+          "Write a complete Python implementation of an LRU cache using a dictionary and a doubly linked list, with get and put operations, type hints, and a short usage example. Return the code directly without introductory prose.",
+          "--decode-tokens",
+          "256",
+          "--context-size",
+          "8192",
+          "--temperature",
+          "0",
+          "--top-p",
+          "1",
+          "--json",
+          "--variants",
+          "adaptive,baseline",
+          "--warmups",
+          "1",
+          "--warmup-tokens",
+          "256",
+          "--repetitions",
+          "3"
+        ],
+        "competingInferenceProcessCount": 0,
+        "gpuSamples": [
+          {
+            "deviceUtilizationPercent": 46,
+            "elapsedSeconds": 0.16013693809509277,
+            "loadAverage": [
+              5.3916015625,
+              6.2470703125,
+              6.35302734375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 57,
+            "elapsedSeconds": 2.2693281173706055,
+            "loadAverage": [
+              5.3916015625,
+              6.2470703125,
+              6.35302734375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 80,
+            "elapsedSeconds": 4.380108118057251,
+            "loadAverage": [
+              5.43994140625,
+              6.24267578125,
+              6.3505859375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 79,
+            "elapsedSeconds": 6.880384922027588,
+            "loadAverage": [
+              5.43994140625,
+              6.24267578125,
+              6.3505859375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 61,
+            "elapsedSeconds": 9.110204219818115,
+            "loadAverage": [
+              5.43994140625,
+              6.24267578125,
+              6.3505859375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 61,
+            "elapsedSeconds": 11.383702993392944,
+            "loadAverage": [
+              5.484375,
+              6.23828125,
+              6.34814453125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 61,
+            "elapsedSeconds": 13.67365026473999,
+            "loadAverage": [
+              5.484375,
+              6.23828125,
+              6.34814453125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 58,
+            "elapsedSeconds": 15.937946081161499,
+            "loadAverage": [
+              6.005859375,
+              6.33349609375,
+              6.380859375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 61,
+            "elapsedSeconds": 18.26474905014038,
+            "loadAverage": [
+              6.005859375,
+              6.33349609375,
+              6.380859375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 60,
+            "elapsedSeconds": 20.63537096977234,
+            "loadAverage": [
+              6.16552734375,
+              6.36083984375,
+              6.39013671875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 56,
+            "elapsedSeconds": 22.894519090652466,
+            "loadAverage": [
+              6.16552734375,
+              6.36083984375,
+              6.39013671875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 54,
+            "elapsedSeconds": 25.011109113693237,
+            "loadAverage": [
+              6.15185546875,
+              6.3544921875,
+              6.3876953125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 78,
+            "elapsedSeconds": 27.13076400756836,
+            "loadAverage": [
+              6.15185546875,
+              6.3544921875,
+              6.3876953125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 79,
+            "elapsedSeconds": 29.56958508491516,
+            "loadAverage": [
+              7.1806640625,
+              6.56396484375,
+              6.46142578125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 56,
+            "elapsedSeconds": 31.767003059387207,
+            "loadAverage": [
+              7.1806640625,
+              6.56396484375,
+              6.46142578125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 46,
+            "elapsedSeconds": 33.94800901412964,
+            "loadAverage": [
+              7.1806640625,
+              6.56396484375,
+              6.46142578125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 56,
+            "elapsedSeconds": 36.37644600868225,
+            "loadAverage": [
+              7.0859375,
+              6.55419921875,
+              6.45849609375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 58,
+            "elapsedSeconds": 38.58680486679077,
+            "loadAverage": [
+              7.0859375,
+              6.55419921875,
+              6.45849609375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 63,
+            "elapsedSeconds": 40.85073804855347,
+            "loadAverage": [
+              6.91845703125,
+              6.5283203125,
+              6.44970703125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 58,
+            "elapsedSeconds": 43.1207320690155,
+            "loadAverage": [
+              6.91845703125,
+              6.5283203125,
+              6.44970703125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 57,
+            "elapsedSeconds": 45.34003925323486,
+            "loadAverage": [
+              7.4853515625,
+              6.65234375,
+              6.49365234375
+            ]
+          }
+        ],
+        "knownRenderingWorkerCount": 0,
+        "maxPressureLevel": 1,
+        "measurementMode": "desktop-load",
+        "peakResidentBytes": 9464430592,
+        "processSeconds": 47.43175292015076,
+        "profiled": false,
+        "prompt": "Write a complete Python implementation of an LRU cache using a dictionary and a doubly linked list, with get and put operations, type hints, and a short usage example. Return the code directly without introductory prose.",
+        "runtimeOverrides": {},
+        "sourceHead": "c3ef55db5f09b2bcc6526bec4dd2a78eaa27aee6",
+        "startedUnixSeconds": 1788624903.449096,
+        "uncontended": false,
+        "workload": "code"
+      },
+      "scenarios": [
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 0.9697399745616944
+          },
+          "endToEndSpeedups": {
+            "adaptive": 0.9696557702055493
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 220,
+          "repetition": 1,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "acceptanceRate": 0.5186721991701245,
+                "acceptedDraftTokens": 125,
+                "draftHistoryTokens": 53,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 241,
+                "rounds": 131,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 4.8227680921554565,
+              "decodeTokensPerSecond": 53.08154883424739,
+              "elapsedSeconds": 5.072595000267029,
+              "endToEndTokensPerSecond": 50.46726576565324,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0014580488204956055,
+              "generatedTokens": 256,
+              "loadSeconds": 2.7060508728027344e-05,
+              "name": "adaptive",
+              "outputSHA256": "cd134369dacefc1cc1bc8bceceb5cfb2dc106e35c077361b20e79108d05fabb4",
+              "policy": "adaptive",
+              "prefillSeconds": 0.24440503120422363,
+              "prefillTokensPerSecond": 220.9447151473648,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 9463283712,
+              "residentMemoryBeforeBytes": 9463054336,
+              "ttftSeconds": 0.24589014053344727
+            },
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 4.676831007003784,
+              "decodeTokensPerSecond": 54.737919676085674,
+              "elapsedSeconds": 4.918671011924744,
+              "endToEndTokensPerSecond": 52.046579122563365,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.043910980224609375,
+              "generatedTokens": 256,
+              "loadSeconds": 1.5974044799804688e-05,
+              "name": "baseline",
+              "outputSHA256": "cd134369dacefc1cc1bc8bceceb5cfb2dc106e35c077361b20e79108d05fabb4",
+              "policy": "disabled",
+              "prefillSeconds": 0.2331550121307373,
+              "prefillTokensPerSecond": 231.60557221785356,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 9334571008,
+              "residentMemoryBeforeBytes": 9334554624,
+              "ttftSeconds": 0.2770819664001465
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 0.9509105511634649
+          },
+          "endToEndSpeedups": {
+            "adaptive": 0.9494191091210825
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 220,
+          "repetition": 2,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "acceptanceRate": 0.5186721991701245,
+                "acceptedDraftTokens": 125,
+                "draftHistoryTokens": 53,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 241,
+                "rounds": 131,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 5.3581401109695435,
+              "decodeTokensPerSecond": 47.77777264090195,
+              "elapsedSeconds": 5.470210075378418,
+              "endToEndTokensPerSecond": 46.79893394812455,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0004889965057373047,
+              "generatedTokens": 256,
+              "loadSeconds": 1.3113021850585938e-05,
+              "name": "adaptive",
+              "outputSHA256": "cd134369dacefc1cc1bc8bceceb5cfb2dc106e35c077361b20e79108d05fabb4",
+              "policy": "adaptive",
+              "prefillSeconds": 0.10776698589324951,
+              "prefillTokensPerSecond": 501.08110153039496,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 9463529472,
+              "residentMemoryBeforeBytes": 9463382016,
+              "ttftSeconds": 0.1082690954208374
+            },
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 5.095111966133118,
+              "decodeTokensPerSecond": 50.24423441557626,
+              "elapsedSeconds": 5.193521976470947,
+              "endToEndTokensPerSecond": 49.29217613014794,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.01553201675415039,
+              "generatedTokens": 256,
+              "loadSeconds": 1.2993812561035156e-05,
+              "name": "baseline",
+              "outputSHA256": "cd134369dacefc1cc1bc8bceceb5cfb2dc106e35c077361b20e79108d05fabb4",
+              "policy": "disabled",
+              "prefillSeconds": 0.09571802616119385,
+              "prefillTokensPerSecond": 564.1570576169357,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 9334620160,
+              "residentMemoryBeforeBytes": 9334571008,
+              "ttftSeconds": 0.11126303672790527
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 0.964649261806438
+          },
+          "endToEndSpeedups": {
+            "adaptive": 0.9639872399683244
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 220,
+          "repetition": 3,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "acceptanceRate": 0.5186721991701245,
+                "acceptedDraftTokens": 125,
+                "draftHistoryTokens": 53,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 241,
+                "rounds": 131,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 5.836509943008423,
+              "decodeTokensPerSecond": 43.861828815465884,
+              "elapsedSeconds": 5.948752999305725,
+              "endToEndTokensPerSecond": 43.034229195577225,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0003819465637207031,
+              "generatedTokens": 256,
+              "loadSeconds": 1.3947486877441406e-05,
+              "name": "adaptive",
+              "outputSHA256": "cd134369dacefc1cc1bc8bceceb5cfb2dc106e35c077361b20e79108d05fabb4",
+              "policy": "adaptive",
+              "prefillSeconds": 0.10719597339630127,
+              "prefillTokensPerSecond": 503.75026495037395,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 9464315904,
+              "residentMemoryBeforeBytes": 9463529472,
+              "ttftSeconds": 0.10759186744689941
+            },
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 5.630185008049011,
+              "decodeTokensPerSecond": 45.469198549251566,
+              "elapsedSeconds": 5.734521985054016,
+              "endToEndTokensPerSecond": 44.64190749764622,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.01823902130126953,
+              "generatedTokens": 256,
+              "loadSeconds": 1.3947486877441406e-05,
+              "name": "baseline",
+              "outputSHA256": "cd134369dacefc1cc1bc8bceceb5cfb2dc106e35c077361b20e79108d05fabb4",
+              "policy": "disabled",
+              "prefillSeconds": 0.10044896602630615,
+              "prefillTokensPerSecond": 537.586419613898,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 9334636544,
+              "residentMemoryBeforeBytes": 9334620160,
+              "ttftSeconds": 0.11870193481445312
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        }
+      ]
+    },
+    {
+      "id": "final-reversed/ornith-prose",
+      "model": "text-agent-ornith-35b-mlx-4bit",
+      "rawReceiptSHA256": "205ea121e5356a8f58e18a2f65a65a573212390cd74b08861ef50860ac8ae1f0",
+      "receipt": {
+        "after": {
+          "gpuDeviceUtilizationPercent": 58,
+          "loadAverage": [
+            9.16796875,
+            7.2255859375,
+            6.71240234375
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7268.25M  free = 923.75M  (encrypted)",
+          "swapUsedMiB": 7268.25
+        },
+        "before": {
+          "gpuDeviceUtilizationPercent": 55,
+          "loadAverage": [
+            7.4853515625,
+            6.65234375,
+            6.49365234375
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7268.25M  free = 923.75M  (encrypted)",
+          "swapUsedMiB": 7268.25
+        },
+        "binarySHA256": "37ae108285410acec9ee3863de69475fb74ce9b472bf23c05e0e0df8ce26414c",
+        "buildSourceRevision": "c3ef55db5f09b2bcc6526bec4dd2a78eaa27aee6",
+        "collectorSHA256": "dec1ae60840c738d2c8ef678adf8c1fc39b7eecaab018032ff2c596b51599f2c",
+        "command": [
+          "mere.run",
+          "model",
+          "benchmark",
+          "q36-mtp",
+          "--model",
+          "text-agent-ornith-35b-mlx-4bit",
+          "--prompt",
+          "Explain how a small community could turn an abandoned railway station into a public library. Discuss the building, accessibility, staffing, the collection, and a realistic opening-day scene. Write approximately 400 words of clear, connected prose.",
+          "--decode-tokens",
+          "256",
+          "--context-size",
+          "8192",
+          "--temperature",
+          "0",
+          "--top-p",
+          "1",
+          "--json",
+          "--variants",
+          "adaptive,baseline",
+          "--warmups",
+          "1",
+          "--warmup-tokens",
+          "256",
+          "--repetitions",
+          "3"
+        ],
+        "competingInferenceProcessCount": 0,
+        "gpuSamples": [
+          {
+            "deviceUtilizationPercent": 57,
+            "elapsedSeconds": 0.09006428718566895,
+            "loadAverage": [
+              7.4853515625,
+              6.65234375,
+              6.49365234375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 59,
+            "elapsedSeconds": 2.1915950775146484,
+            "loadAverage": [
+              7.2861328125,
+              6.62451171875,
+              6.48486328125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 63,
+            "elapsedSeconds": 4.300493240356445,
+            "loadAverage": [
+              7.2861328125,
+              6.62451171875,
+              6.48486328125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 73,
+            "elapsedSeconds": 6.476424217224121,
+            "loadAverage": [
+              7.2861328125,
+              6.62451171875,
+              6.48486328125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 81,
+            "elapsedSeconds": 8.656381368637085,
+            "loadAverage": [
+              7.10302734375,
+              6.59716796875,
+              6.47607421875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 54,
+            "elapsedSeconds": 10.838325023651123,
+            "loadAverage": [
+              7.10302734375,
+              6.59716796875,
+              6.47607421875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 65,
+            "elapsedSeconds": 13.098226308822632,
+            "loadAverage": [
+              7.0947265625,
+              6.603515625,
+              6.47900390625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 52,
+            "elapsedSeconds": 15.462062120437622,
+            "loadAverage": [
+              7.0947265625,
+              6.603515625,
+              6.47900390625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 45,
+            "elapsedSeconds": 17.661643028259277,
+            "loadAverage": [
+              8.8486328125,
+              6.97509765625,
+              6.61083984375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 51,
+            "elapsedSeconds": 19.870218992233276,
+            "loadAverage": [
+              8.8486328125,
+              6.97509765625,
+              6.61083984375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 48,
+            "elapsedSeconds": 22.082136154174805,
+            "loadAverage": [
+              10.1416015625,
+              7.27392578125,
+              6.71826171875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 49,
+            "elapsedSeconds": 24.289380073547363,
+            "loadAverage": [
+              10.1416015625,
+              7.27392578125,
+              6.71826171875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 83,
+            "elapsedSeconds": 26.425503253936768,
+            "loadAverage": [
+              10.1416015625,
+              7.27392578125,
+              6.71826171875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 77,
+            "elapsedSeconds": 28.54460120201111,
+            "loadAverage": [
+              9.8095703125,
+              7.25244140625,
+              6.7138671875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 80,
+            "elapsedSeconds": 30.671943187713623,
+            "loadAverage": [
+              9.8095703125,
+              7.25244140625,
+              6.7138671875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 67,
+            "elapsedSeconds": 32.81610131263733,
+            "loadAverage": [
+              9.18408203125,
+              7.1650390625,
+              6.68603515625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 85,
+            "elapsedSeconds": 34.93916320800781,
+            "loadAverage": [
+              9.18408203125,
+              7.1650390625,
+              6.68603515625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 90,
+            "elapsedSeconds": 37.10272932052612,
+            "loadAverage": [
+              9.0087890625,
+              7.162109375,
+              6.6875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 60,
+            "elapsedSeconds": 39.2621853351593,
+            "loadAverage": [
+              9.0087890625,
+              7.162109375,
+              6.6875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 90,
+            "elapsedSeconds": 41.42637634277344,
+            "loadAverage": [
+              9.0087890625,
+              7.162109375,
+              6.6875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 67,
+            "elapsedSeconds": 43.607195138931274,
+            "loadAverage": [
+              9.16796875,
+              7.2255859375,
+              6.71240234375
+            ]
+          }
+        ],
+        "knownRenderingWorkerCount": 0,
+        "maxPressureLevel": 1,
+        "measurementMode": "desktop-load",
+        "peakResidentBytes": 9465462784,
+        "processSeconds": 45.714460134506226,
+        "profiled": false,
+        "prompt": "Explain how a small community could turn an abandoned railway station into a public library. Discuss the building, accessibility, staffing, the collection, and a realistic opening-day scene. Write approximately 400 words of clear, connected prose.",
+        "runtimeOverrides": {},
+        "sourceHead": "c3ef55db5f09b2bcc6526bec4dd2a78eaa27aee6",
+        "startedUnixSeconds": 1788624951.0699048,
+        "uncontended": false,
+        "workload": "prose"
+      },
+      "scenarios": [
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 0.7290370582813314
+          },
+          "endToEndSpeedups": {
+            "adaptive": 0.7245269797054104
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 247,
+          "repetition": 1,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "acceptanceRate": 0.25892857142857145,
+                "acceptedDraftTokens": 29,
+                "draftHistoryTokens": 59,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 112,
+                "rounds": 69,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 4.183992981910706,
+              "decodeTokensPerSecond": 61.185571081692494,
+              "elapsedSeconds": 4.51315701007843,
+              "endToEndTokensPerSecond": 56.72304318868605,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0004290342330932617,
+              "generatedTokens": 256,
+              "loadSeconds": 1.9073486328125e-05,
+              "name": "adaptive",
+              "outputSHA256": "ca3ac87c453ea9cb8fdd5fe572ce7e0e9930e17487f37393e45606052e4db11e",
+              "policy": "adaptive",
+              "prefillSeconds": 0.32599902153015137,
+              "prefillTokensPerSecond": 184.0496321687599,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 9463300096,
+              "residentMemoryBeforeBytes": 9463218176,
+              "ttftSeconds": 0.32644712924957275
+            },
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 3.0502859354019165,
+              "decodeTokensPerSecond": 83.9265581724123,
+              "elapsedSeconds": 3.2699040174484253,
+              "endToEndTokensPerSecond": 78.28975977091895,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.011642932891845703,
+              "generatedTokens": 256,
+              "loadSeconds": 1.0013580322265625e-05,
+              "name": "baseline",
+              "outputSHA256": "ca3ac87c453ea9cb8fdd5fe572ce7e0e9930e17487f37393e45606052e4db11e",
+              "policy": "disabled",
+              "prefillSeconds": 0.21694302558898926,
+              "prefillTokensPerSecond": 276.5703107398962,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 9351397376,
+              "residentMemoryBeforeBytes": 9351364608,
+              "ttftSeconds": 0.22859597206115723
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 0.3269960939039667
+          },
+          "endToEndSpeedups": {
+            "adaptive": 0.3500277158650747
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 247,
+          "repetition": 2,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "acceptanceRate": 0.25892857142857145,
+                "acceptedDraftTokens": 29,
+                "draftHistoryTokens": 59,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 112,
+                "rounds": 69,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 9.989682078361511,
+              "decodeTokensPerSecond": 25.626441161177436,
+              "elapsedSeconds": 10.10204291343689,
+              "endToEndTokensPerSecond": 25.34140888072157,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0004950761795043945,
+              "generatedTokens": 256,
+              "loadSeconds": 1.2040138244628906e-05,
+              "name": "adaptive",
+              "outputSHA256": "ca3ac87c453ea9cb8fdd5fe572ce7e0e9930e17487f37393e45606052e4db11e",
+              "policy": "adaptive",
+              "prefillSeconds": 0.108254075050354,
+              "prefillTokensPerSecond": 554.2516526245429,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 9465380864,
+              "residentMemoryBeforeBytes": 9463398400,
+              "ttftSeconds": 0.10876119136810303
+            },
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 3.266587018966675,
+              "decodeTokensPerSecond": 78.36925773401896,
+              "elapsedSeconds": 3.5359950065612793,
+              "endToEndTokensPerSecond": 72.39829228405996,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.016772985458374023,
+              "generatedTokens": 256,
+              "loadSeconds": 1.0967254638671875e-05,
+              "name": "baseline",
+              "outputSHA256": "ca3ac87c453ea9cb8fdd5fe572ce7e0e9930e17487f37393e45606052e4db11e",
+              "policy": "disabled",
+              "prefillSeconds": 0.26670897006988525,
+              "prefillTokensPerSecond": 224.9643121649726,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 9351430144,
+              "residentMemoryBeforeBytes": 9351397376,
+              "ttftSeconds": 0.28349292278289795
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 0.621524216585805
+          },
+          "endToEndSpeedups": {
+            "adaptive": 0.6275601397565709
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 247,
+          "repetition": 3,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "acceptanceRate": 0.25892857142857145,
+                "acceptedDraftTokens": 29,
+                "draftHistoryTokens": 59,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 112,
+                "rounds": 69,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 5.7626200914382935,
+              "decodeTokensPerSecond": 44.42423688147468,
+              "elapsedSeconds": 6.014245986938477,
+              "endToEndTokensPerSecond": 42.56560183204538,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0011860132217407227,
+              "generatedTokens": 256,
+              "loadSeconds": 1.5020370483398438e-05,
+              "name": "adaptive",
+              "outputSHA256": "ca3ac87c453ea9cb8fdd5fe572ce7e0e9930e17487f37393e45606052e4db11e",
+              "policy": "adaptive",
+              "prefillSeconds": 0.2456960678100586,
+              "prefillTokensPerSecond": 244.20415245059795,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 9465479168,
+              "residentMemoryBeforeBytes": 9465380864,
+              "ttftSeconds": 0.24689710140228271
+            },
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 3.581607937812805,
+              "decodeTokensPerSecond": 71.4762767016684,
+              "elapsedSeconds": 3.774301052093506,
+              "endToEndTokensPerSecond": 67.82712784874526,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.01258695125579834,
+              "generatedTokens": 256,
+              "loadSeconds": 1.0967254638671875e-05,
+              "name": "baseline",
+              "outputSHA256": "ca3ac87c453ea9cb8fdd5fe572ce7e0e9930e17487f37393e45606052e4db11e",
+              "policy": "disabled",
+              "prefillSeconds": 0.1898289918899536,
+              "prefillTokensPerSecond": 316.0739537340155,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 9351430144,
+              "residentMemoryBeforeBytes": 9351430144,
+              "ttftSeconds": 0.20242691040039062
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        }
+      ]
+    },
+    {
+      "id": "final-reversed/qwen-code",
+      "model": "vision-chat-q38-27b-4bit",
+      "rawReceiptSHA256": "abb92db3c11dfc7b9ef212bd2a6f82323e5d7ba4aeefe4512ef315db424f0d8a",
+      "receipt": {
+        "after": {
+          "gpuDeviceUtilizationPercent": 56,
+          "loadAverage": [
+            24.96533203125,
+            13.49462890625,
+            9.2548828125
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7268.25M  free = 923.75M  (encrypted)",
+          "swapUsedMiB": 7268.25
+        },
+        "before": {
+          "gpuDeviceUtilizationPercent": 52,
+          "loadAverage": [
+            9.16796875,
+            7.2255859375,
+            6.71240234375
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7268.25M  free = 923.75M  (encrypted)",
+          "swapUsedMiB": 7268.25
+        },
+        "binarySHA256": "37ae108285410acec9ee3863de69475fb74ce9b472bf23c05e0e0df8ce26414c",
+        "buildSourceRevision": "c3ef55db5f09b2bcc6526bec4dd2a78eaa27aee6",
+        "collectorSHA256": "dec1ae60840c738d2c8ef678adf8c1fc39b7eecaab018032ff2c596b51599f2c",
+        "command": [
+          "mere.run",
+          "model",
+          "benchmark",
+          "q36-mtp",
+          "--model",
+          "vision-chat-q38-27b-4bit",
+          "--prompt",
+          "Write a complete Python implementation of an LRU cache using a dictionary and a doubly linked list, with get and put operations, type hints, and a short usage example. Return the code directly without introductory prose.",
+          "--decode-tokens",
+          "256",
+          "--context-size",
+          "8192",
+          "--temperature",
+          "0",
+          "--top-p",
+          "1",
+          "--json",
+          "--variants",
+          "adaptive,baseline",
+          "--warmups",
+          "1",
+          "--warmup-tokens",
+          "256",
+          "--repetitions",
+          "3"
+        ],
+        "competingInferenceProcessCount": 0,
+        "gpuSamples": [
+          {
+            "deviceUtilizationPercent": 54,
+            "elapsedSeconds": 0.09082221984863281,
+            "loadAverage": [
+              9.16796875,
+              7.2255859375,
+              6.71240234375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 80,
+            "elapsedSeconds": 2.187695026397705,
+            "loadAverage": [
+              8.75390625,
+              7.171875,
+              6.6962890625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 98,
+            "elapsedSeconds": 4.282471179962158,
+            "loadAverage": [
+              8.75390625,
+              7.171875,
+              6.6962890625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 96,
+            "elapsedSeconds": 6.375388145446777,
+            "loadAverage": [
+              8.373046875,
+              7.119140625,
+              6.68017578125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 99,
+            "elapsedSeconds": 8.471826076507568,
+            "loadAverage": [
+              8.373046875,
+              7.119140625,
+              6.68017578125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 97,
+            "elapsedSeconds": 10.568481922149658,
+            "loadAverage": [
+              8.373046875,
+              7.119140625,
+              6.68017578125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 96,
+            "elapsedSeconds": 12.666258096694946,
+            "loadAverage": [
+              7.9423828125,
+              7.05029296875,
+              6.658203125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 92,
+            "elapsedSeconds": 14.761430025100708,
+            "loadAverage": [
+              7.9423828125,
+              7.05029296875,
+              6.658203125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 94,
+            "elapsedSeconds": 16.857935190200806,
+            "loadAverage": [
+              7.70654296875,
+              7.01611328125,
+              6.6484375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 94,
+            "elapsedSeconds": 18.955432176589966,
+            "loadAverage": [
+              7.70654296875,
+              7.01611328125,
+              6.6484375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 96,
+            "elapsedSeconds": 21.05484700202942,
+            "loadAverage": [
+              7.48974609375,
+              6.982421875,
+              6.638671875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 92,
+            "elapsedSeconds": 23.15466809272766,
+            "loadAverage": [
+              7.48974609375,
+              6.982421875,
+              6.638671875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 97,
+            "elapsedSeconds": 25.271913290023804,
+            "loadAverage": [
+              7.48974609375,
+              6.982421875,
+              6.638671875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 91,
+            "elapsedSeconds": 28.085982084274292,
+            "loadAverage": [
+              7.2099609375,
+              6.9326171875,
+              6.623046875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 83,
+            "elapsedSeconds": 31.07688808441162,
+            "loadAverage": [
+              8.55419921875,
+              7.2158203125,
+              6.724609375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 82,
+            "elapsedSeconds": 33.949666023254395,
+            "loadAverage": [
+              8.55419921875,
+              7.2158203125,
+              6.724609375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 91,
+            "elapsedSeconds": 36.49758005142212,
+            "loadAverage": [
+              9.310546875,
+              7.39453125,
+              6.79052734375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 83,
+            "elapsedSeconds": 39.03070521354675,
+            "loadAverage": [
+              9.310546875,
+              7.39453125,
+              6.79052734375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 84,
+            "elapsedSeconds": 41.936532974243164,
+            "loadAverage": [
+              9.92626953125,
+              7.5537109375,
+              6.85009765625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 88,
+            "elapsedSeconds": 44.47289705276489,
+            "loadAverage": [
+              9.92626953125,
+              7.5537109375,
+              6.85009765625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 74,
+            "elapsedSeconds": 46.673907995224,
+            "loadAverage": [
+              10.09228515625,
+              7.62744140625,
+              6.8798828125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 72,
+            "elapsedSeconds": 48.845974922180176,
+            "loadAverage": [
+              10.09228515625,
+              7.62744140625,
+              6.8798828125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 80,
+            "elapsedSeconds": 51.771377086639404,
+            "loadAverage": [
+              14.48876953125,
+              8.57958984375,
+              7.22021484375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 70,
+            "elapsedSeconds": 55.16762590408325,
+            "loadAverage": [
+              14.48876953125,
+              8.57958984375,
+              7.22021484375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 60,
+            "elapsedSeconds": 58.616517066955566,
+            "loadAverage": [
+              16.69140625,
+              9.13427734375,
+              7.423828125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 58,
+            "elapsedSeconds": 61.96666693687439,
+            "loadAverage": [
+              17.5966796875,
+              9.447265625,
+              7.5439453125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 62,
+            "elapsedSeconds": 64.98756289482117,
+            "loadAverage": [
+              17.5966796875,
+              9.447265625,
+              7.5439453125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 58,
+            "elapsedSeconds": 68.51158595085144,
+            "loadAverage": [
+              18.029296875,
+              9.671875,
+              7.63427734375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 55,
+            "elapsedSeconds": 71.71408987045288,
+            "loadAverage": [
+              18.02685546875,
+              9.81005859375,
+              7.69482421875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 65,
+            "elapsedSeconds": 75.1402440071106,
+            "loadAverage": [
+              18.02685546875,
+              9.81005859375,
+              7.69482421875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 67,
+            "elapsedSeconds": 78.40740299224854,
+            "loadAverage": [
+              18.3447265625,
+              10.01220703125,
+              7.7783203125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 82,
+            "elapsedSeconds": 81.12364506721497,
+            "loadAverage": [
+              17.83642578125,
+              10.044921875,
+              7.802734375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 76,
+            "elapsedSeconds": 84.23508501052856,
+            "loadAverage": [
+              17.83642578125,
+              10.044921875,
+              7.802734375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 64,
+            "elapsedSeconds": 87.3729362487793,
+            "loadAverage": [
+              18.81005859375,
+              10.3759765625,
+              7.9326171875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 64,
+            "elapsedSeconds": 90.80643916130066,
+            "loadAverage": [
+              19.3056640625,
+              10.61865234375,
+              8.0322265625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 67,
+            "elapsedSeconds": 94.0080680847168,
+            "loadAverage": [
+              19.3056640625,
+              10.61865234375,
+              8.0322265625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 71,
+            "elapsedSeconds": 96.96449518203735,
+            "loadAverage": [
+              18.80029296875,
+              10.65771484375,
+              8.06103515625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 62,
+            "elapsedSeconds": 100.20592999458313,
+            "loadAverage": [
+              18.80029296875,
+              10.65771484375,
+              8.06103515625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 61,
+            "elapsedSeconds": 103.37519717216492,
+            "loadAverage": [
+              20.81787109375,
+              11.2109375,
+              8.271484375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 61,
+            "elapsedSeconds": 106.22744917869568,
+            "loadAverage": [
+              21.712890625,
+              11.5556640625,
+              8.41015625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 73,
+            "elapsedSeconds": 109.31918215751648,
+            "loadAverage": [
+              21.712890625,
+              11.5556640625,
+              8.41015625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 72,
+            "elapsedSeconds": 112.36410212516785,
+            "loadAverage": [
+              22.21630859375,
+              11.82861328125,
+              8.52490234375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 71,
+            "elapsedSeconds": 115.42504000663757,
+            "loadAverage": [
+              22.21630859375,
+              11.82861328125,
+              8.52490234375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 73,
+            "elapsedSeconds": 118.15333819389343,
+            "loadAverage": [
+              22.99951171875,
+              12.1630859375,
+              8.662109375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 80,
+            "elapsedSeconds": 120.84269094467163,
+            "loadAverage": [
+              22.59912109375,
+              12.259765625,
+              8.716796875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 82,
+            "elapsedSeconds": 123.56349301338196,
+            "loadAverage": [
+              22.59912109375,
+              12.259765625,
+              8.716796875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 78,
+            "elapsedSeconds": 126.41029405593872,
+            "loadAverage": [
+              22.310546875,
+              12.37158203125,
+              8.77685546875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 79,
+            "elapsedSeconds": 128.8889079093933,
+            "loadAverage": [
+              22.310546875,
+              12.37158203125,
+              8.77685546875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 91,
+            "elapsedSeconds": 131.7235550880432,
+            "loadAverage": [
+              21.16455078125,
+              12.298828125,
+              8.77197265625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 76,
+            "elapsedSeconds": 134.71923208236694,
+            "loadAverage": [
+              21.16455078125,
+              12.298828125,
+              8.77197265625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 75,
+            "elapsedSeconds": 137.55205392837524,
+            "loadAverage": [
+              20.1904296875,
+              12.24365234375,
+              8.77294921875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 81,
+            "elapsedSeconds": 140.4294581413269,
+            "loadAverage": [
+              20.1904296875,
+              12.24365234375,
+              8.77294921875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 95,
+            "elapsedSeconds": 142.81683921813965,
+            "loadAverage": [
+              20.1748046875,
+              12.3720703125,
+              8.83837890625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 87,
+            "elapsedSeconds": 145.87299609184265,
+            "loadAverage": [
+              24.96533203125,
+              13.49462890625,
+              9.2548828125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 82,
+            "elapsedSeconds": 148.3839132785797,
+            "loadAverage": [
+              24.96533203125,
+              13.49462890625,
+              9.2548828125
+            ]
+          }
+        ],
+        "knownRenderingWorkerCount": 0,
+        "maxPressureLevel": 1,
+        "measurementMode": "desktop-load",
+        "peakResidentBytes": 15827419136,
+        "processSeconds": 150.48906326293945,
+        "profiled": false,
+        "prompt": "Write a complete Python implementation of an LRU cache using a dictionary and a doubly linked list, with get and put operations, type hints, and a short usage example. Return the code directly without introductory prose.",
+        "runtimeOverrides": {},
+        "sourceHead": "c3ef55db5f09b2bcc6526bec4dd2a78eaa27aee6",
+        "startedUnixSeconds": 1788624996.980743,
+        "uncontended": false,
+        "workload": "code"
+      },
+      "scenarios": [
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 2.7062322161950907
+          },
+          "endToEndSpeedups": {
+            "adaptive": 2.564296334232043
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 220,
+          "repetition": 1,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "acceptanceRate": 0.7236363636363636,
+                "acceptedDraftTokens": 199,
+                "draftHistoryTokens": 53,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 275,
+                "rounds": 57,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 10.30733609199524,
+              "decodeTokensPerSecond": 24.836679207425057,
+              "elapsedSeconds": 11.090577006340027,
+              "endToEndTokensPerSecond": 23.082658355255578,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.00039505958557128906,
+              "generatedTokens": 256,
+              "loadSeconds": 1.800060272216797e-05,
+              "name": "adaptive",
+              "outputSHA256": "ca2c0ddf75b621ec62d587ff04b6f89f528aafe8d744b0730c298166deb5f461",
+              "policy": "adaptive",
+              "prefillSeconds": 0.7816139459609985,
+              "prefillTokensPerSecond": 69.08781538385514,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 15823011840,
+              "residentMemoryBeforeBytes": 15822815232,
+              "ttftSeconds": 0.782027006149292
+            },
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 27.894044995307922,
+              "decodeTokensPerSecond": 9.177586113561585,
+              "elapsedSeconds": 28.439525961875916,
+              "endToEndTokensPerSecond": 9.001556507769367,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.08211696147918701,
+              "generatedTokens": 256,
+              "loadSeconds": 6.604194641113281e-05,
+              "name": "baseline",
+              "outputSHA256": "ca2c0ddf75b621ec62d587ff04b6f89f528aafe8d744b0730c298166deb5f461",
+              "policy": "disabled",
+              "prefillSeconds": 0.5338560342788696,
+              "prefillTokensPerSecond": 101.1508656504051,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 15438200832,
+              "residentMemoryBeforeBytes": 15438020608,
+              "ttftSeconds": 0.6160390377044678
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 1.829251187701691
+          },
+          "endToEndSpeedups": {
+            "adaptive": 1.7434668121087449
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 220,
+          "repetition": 2,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "acceptanceRate": 0.7236363636363636,
+                "acceptedDraftTokens": 199,
+                "draftHistoryTokens": 53,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 275,
+                "rounds": 57,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 11.163246035575867,
+              "decodeTokensPerSecond": 22.932397905068118,
+              "elapsedSeconds": 11.991575002670288,
+              "endToEndTokensPerSecond": 21.348321629393457,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0006200075149536133,
+              "generatedTokens": 256,
+              "loadSeconds": 2.396106719970703e-05,
+              "name": "adaptive",
+              "outputSHA256": "ca2c0ddf75b621ec62d587ff04b6f89f528aafe8d744b0730c298166deb5f461",
+              "policy": "adaptive",
+              "prefillSeconds": 0.8256739377975464,
+              "prefillTokensPerSecond": 65.40111965268389,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 15825649664,
+              "residentMemoryBeforeBytes": 15823110144,
+              "ttftSeconds": 0.8263179063796997
+            },
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 20.42038106918335,
+              "decodeTokensPerSecond": 12.536494746727953,
+              "elapsedSeconds": 20.90691304206848,
+              "endToEndTokensPerSecond": 12.24475366042236,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.13705599308013916,
+              "generatedTokens": 256,
+              "loadSeconds": 4.8995018005371094e-05,
+              "name": "baseline",
+              "outputSHA256": "ca2c0ddf75b621ec62d587ff04b6f89f528aafe8d744b0730c298166deb5f461",
+              "policy": "disabled",
+              "prefillSeconds": 0.47617292404174805,
+              "prefillTokensPerSecond": 113.40418002277173,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 15438200832,
+              "residentMemoryBeforeBytes": 15438200832,
+              "ttftSeconds": 0.6132779121398926
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 1.6927014061685024
+          },
+          "endToEndSpeedups": {
+            "adaptive": 1.6781877368114007
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 220,
+          "repetition": 3,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "acceptanceRate": 0.7236363636363636,
+                "acceptedDraftTokens": 199,
+                "draftHistoryTokens": 53,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 275,
+                "rounds": 57,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 10.624022006988525,
+              "decodeTokensPerSecond": 24.096335628032598,
+              "elapsedSeconds": 11.259902954101562,
+              "endToEndTokensPerSecond": 22.73554230827085,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.001961946487426758,
+              "generatedTokens": 256,
+              "loadSeconds": 4.8995018005371094e-05,
+              "name": "adaptive",
+              "outputSHA256": "ca2c0ddf75b621ec62d587ff04b6f89f528aafe8d744b0730c298166deb5f461",
+              "policy": "adaptive",
+              "prefillSeconds": 0.610366940498352,
+              "prefillTokensPerSecond": 88.47137093616196,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 15827419136,
+              "residentMemoryBeforeBytes": 15825666048,
+              "ttftSeconds": 0.6123778820037842
+            },
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 17.983296990394592,
+              "decodeTokensPerSecond": 14.23543191978296,
+              "elapsedSeconds": 18.896231055259705,
+              "endToEndTokensPerSecond": 13.547675155503734,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.05465507507324219,
+              "generatedTokens": 256,
+              "loadSeconds": 6.496906280517578e-05,
+              "name": "baseline",
+              "outputSHA256": "ca2c0ddf75b621ec62d587ff04b6f89f528aafe8d744b0730c298166deb5f461",
+              "policy": "disabled",
+              "prefillSeconds": 0.9047880172729492,
+              "prefillTokensPerSecond": 59.68248801830641,
+              "promptTokens": 54,
+              "residentMemoryAfterBytes": 15438233600,
+              "residentMemoryBeforeBytes": 15438200832,
+              "ttftSeconds": 0.9595080614089966
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        }
+      ]
+    },
+    {
+      "id": "final-reversed/qwen-prose",
+      "model": "vision-chat-q38-27b-4bit",
+      "rawReceiptSHA256": "71622d0f9f1246a5daae8cc7eca62881adf88fe866319e8fe6fde6338fc2635b",
+      "receipt": {
+        "after": {
+          "gpuDeviceUtilizationPercent": 69,
+          "loadAverage": [
+            45.1962890625,
+            25.31640625,
+            14.9296875
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7268.25M  free = 923.75M  (encrypted)",
+          "swapUsedMiB": 7268.25
+        },
+        "before": {
+          "gpuDeviceUtilizationPercent": 37,
+          "loadAverage": [
+            23.3662109375,
+            13.353515625,
+            9.2294921875
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7268.25M  free = 923.75M  (encrypted)",
+          "swapUsedMiB": 7268.25
+        },
+        "binarySHA256": "37ae108285410acec9ee3863de69475fb74ce9b472bf23c05e0e0df8ce26414c",
+        "buildSourceRevision": "c3ef55db5f09b2bcc6526bec4dd2a78eaa27aee6",
+        "collectorSHA256": "dec1ae60840c738d2c8ef678adf8c1fc39b7eecaab018032ff2c596b51599f2c",
+        "command": [
+          "mere.run",
+          "model",
+          "benchmark",
+          "q36-mtp",
+          "--model",
+          "vision-chat-q38-27b-4bit",
+          "--prompt",
+          "Explain how a small community could turn an abandoned railway station into a public library. Discuss the building, accessibility, staffing, the collection, and a realistic opening-day scene. Write approximately 400 words of clear, connected prose.",
+          "--decode-tokens",
+          "256",
+          "--context-size",
+          "8192",
+          "--temperature",
+          "0",
+          "--top-p",
+          "1",
+          "--json",
+          "--variants",
+          "adaptive,baseline",
+          "--warmups",
+          "1",
+          "--warmup-tokens",
+          "256",
+          "--repetitions",
+          "3"
+        ],
+        "competingInferenceProcessCount": 0,
+        "gpuSamples": [
+          {
+            "deviceUtilizationPercent": 34,
+            "elapsedSeconds": 0.09883594512939453,
+            "loadAverage": [
+              23.3662109375,
+              13.353515625,
+              9.2294921875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 72,
+            "elapsedSeconds": 2.203329086303711,
+            "loadAverage": [
+              23.3662109375,
+              13.353515625,
+              9.2294921875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 84,
+            "elapsedSeconds": 4.335525274276733,
+            "loadAverage": [
+              23.3662109375,
+              13.353515625,
+              9.2294921875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 83,
+            "elapsedSeconds": 6.521083116531372,
+            "loadAverage": [
+              21.89501953125,
+              13.21435546875,
+              9.20458984375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 94,
+            "elapsedSeconds": 8.710731029510498,
+            "loadAverage": [
+              21.89501953125,
+              13.21435546875,
+              9.20458984375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 92,
+            "elapsedSeconds": 10.94186019897461,
+            "loadAverage": [
+              20.5419921875,
+              13.07763671875,
+              9.1796875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 96,
+            "elapsedSeconds": 13.139568090438843,
+            "loadAverage": [
+              20.5419921875,
+              13.07763671875,
+              9.1796875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 88,
+            "elapsedSeconds": 15.344344139099121,
+            "loadAverage": [
+              19.69775390625,
+              13.0263671875,
+              9.18408203125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 93,
+            "elapsedSeconds": 17.541656017303467,
+            "loadAverage": [
+              19.69775390625,
+              13.0263671875,
+              9.18408203125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 92,
+            "elapsedSeconds": 19.913045167922974,
+            "loadAverage": [
+              19.4814453125,
+              13.09228515625,
+              9.2294921875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 88,
+            "elapsedSeconds": 22.21728205680847,
+            "loadAverage": [
+              19.4814453125,
+              13.09228515625,
+              9.2294921875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 81,
+            "elapsedSeconds": 24.702322244644165,
+            "loadAverage": [
+              19.4814453125,
+              13.09228515625,
+              9.2294921875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 78,
+            "elapsedSeconds": 27.480812072753906,
+            "loadAverage": [
+              18.72216796875,
+              13.04052734375,
+              9.23388671875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 71,
+            "elapsedSeconds": 30.117607355117798,
+            "loadAverage": [
+              20.265625,
+              13.45458984375,
+              9.40234375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 70,
+            "elapsedSeconds": 32.73131322860718,
+            "loadAverage": [
+              20.265625,
+              13.45458984375,
+              9.40234375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 57,
+            "elapsedSeconds": 35.086735248565674,
+            "loadAverage": [
+              22.88671875,
+              14.11083984375,
+              9.65771484375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 57,
+            "elapsedSeconds": 37.52501034736633,
+            "loadAverage": [
+              22.88671875,
+              14.11083984375,
+              9.65771484375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 57,
+            "elapsedSeconds": 39.94181513786316,
+            "loadAverage": [
+              26.3388671875,
+              14.97216796875,
+              9.98779296875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 63,
+            "elapsedSeconds": 42.311331033706665,
+            "loadAverage": [
+              26.3388671875,
+              14.97216796875,
+              9.98779296875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 60,
+            "elapsedSeconds": 44.7534441947937,
+            "loadAverage": [
+              26.3388671875,
+              14.97216796875,
+              9.98779296875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 66,
+            "elapsedSeconds": 47.112189292907715,
+            "loadAverage": [
+              30.1552734375,
+              15.95166015625,
+              10.36279296875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 58,
+            "elapsedSeconds": 49.54869723320007,
+            "loadAverage": [
+              30.1552734375,
+              15.95166015625,
+              10.36279296875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 63,
+            "elapsedSeconds": 52.02789306640625,
+            "loadAverage": [
+              33.666015625,
+              16.9150390625,
+              10.7353515625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 54,
+            "elapsedSeconds": 54.4402060508728,
+            "loadAverage": [
+              33.666015625,
+              16.9150390625,
+              10.7353515625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 67,
+            "elapsedSeconds": 56.98220705986023,
+            "loadAverage": [
+              38.2568359375,
+              18.14453125,
+              11.20556640625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 91,
+            "elapsedSeconds": 59.370721101760864,
+            "loadAverage": [
+              38.2568359375,
+              18.14453125,
+              11.20556640625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 80,
+            "elapsedSeconds": 62.32659411430359,
+            "loadAverage": [
+              36.39404296875,
+              18.09228515625,
+              11.2275390625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 89,
+            "elapsedSeconds": 64.5657651424408,
+            "loadAverage": [
+              36.39404296875,
+              18.09228515625,
+              11.2275390625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 94,
+            "elapsedSeconds": 66.91111922264099,
+            "loadAverage": [
+              34.4404296875,
+              17.99072265625,
+              11.23193359375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 85,
+            "elapsedSeconds": 69.82606625556946,
+            "loadAverage": [
+              34.4404296875,
+              17.99072265625,
+              11.23193359375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 73,
+            "elapsedSeconds": 72.70674300193787,
+            "loadAverage": [
+              32.64306640625,
+              17.89111328125,
+              11.236328125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 44,
+            "elapsedSeconds": 74.94132828712463,
+            "loadAverage": [
+              32.03076171875,
+              18.0087890625,
+              11.31689453125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 69,
+            "elapsedSeconds": 77.11666321754456,
+            "loadAverage": [
+              32.03076171875,
+              18.0087890625,
+              11.31689453125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 84,
+            "elapsedSeconds": 80.20499300956726,
+            "loadAverage": [
+              32.50830078125,
+              18.34033203125,
+              11.47314453125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 63,
+            "elapsedSeconds": 83.24004411697388,
+            "loadAverage": [
+              32.50830078125,
+              18.34033203125,
+              11.47314453125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 67,
+            "elapsedSeconds": 86.16507601737976,
+            "loadAverage": [
+              31.34619140625,
+              18.33447265625,
+              11.51123046875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 70,
+            "elapsedSeconds": 89.49692702293396,
+            "loadAverage": [
+              31.34619140625,
+              18.33447265625,
+              11.51123046875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 67,
+            "elapsedSeconds": 92.49102115631104,
+            "loadAverage": [
+              31.318359375,
+              18.54443359375,
+              11.625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 63,
+            "elapsedSeconds": 95.74700808525085,
+            "loadAverage": [
+              30.73193359375,
+              18.634765625,
+              11.697265625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 57,
+            "elapsedSeconds": 98.98880004882812,
+            "loadAverage": [
+              30.73193359375,
+              18.634765625,
+              11.697265625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 60,
+            "elapsedSeconds": 102.21768116950989,
+            "loadAverage": [
+              30.6728515625,
+              18.8232421875,
+              11.80419921875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 76,
+            "elapsedSeconds": 105.45421528816223,
+            "loadAverage": [
+              30.93896484375,
+              19.0751953125,
+              11.93408203125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 74,
+            "elapsedSeconds": 108.9528341293335,
+            "loadAverage": [
+              30.93896484375,
+              19.0751953125,
+              11.93408203125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 67,
+            "elapsedSeconds": 113.08783006668091,
+            "loadAverage": [
+              31.02392578125,
+              19.28955078125,
+              12.05126953125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 72,
+            "elapsedSeconds": 116.20992612838745,
+            "loadAverage": [
+              29.26025390625,
+              19.11865234375,
+              12.033203125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 67,
+            "elapsedSeconds": 119.49017119407654,
+            "loadAverage": [
+              29.26025390625,
+              19.11865234375,
+              12.033203125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 53,
+            "elapsedSeconds": 122.69335603713989,
+            "loadAverage": [
+              30.6806640625,
+              19.5810546875,
+              12.23779296875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 61,
+            "elapsedSeconds": 125.75804805755615,
+            "loadAverage": [
+              30.3857421875,
+              19.7041015625,
+              12.32421875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 71,
+            "elapsedSeconds": 128.8421173095703,
+            "loadAverage": [
+              30.3857421875,
+              19.7041015625,
+              12.32421875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 65,
+            "elapsedSeconds": 132.4070770740509,
+            "loadAverage": [
+              31.5556640625,
+              20.1240234375,
+              12.515625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 70,
+            "elapsedSeconds": 135.78558111190796,
+            "loadAverage": [
+              32.3115234375,
+              20.47021484375,
+              12.68212890625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 59,
+            "elapsedSeconds": 139.08193016052246,
+            "loadAverage": [
+              32.3115234375,
+              20.47021484375,
+              12.68212890625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 56,
+            "elapsedSeconds": 142.30391025543213,
+            "loadAverage": [
+              32.6064453125,
+              20.72802734375,
+              12.818359375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 67,
+            "elapsedSeconds": 145.63004517555237,
+            "loadAverage": [
+              32.7978515625,
+              20.96484375,
+              12.9482421875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 66,
+            "elapsedSeconds": 148.7469711303711,
+            "loadAverage": [
+              32.7978515625,
+              20.96484375,
+              12.9482421875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 54,
+            "elapsedSeconds": 151.5499472618103,
+            "loadAverage": [
+              33.85498046875,
+              21.38037109375,
+              13.1416015625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 68,
+            "elapsedSeconds": 154.47599911689758,
+            "loadAverage": [
+              33.85498046875,
+              21.38037109375,
+              13.1416015625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 76,
+            "elapsedSeconds": 157.22787714004517,
+            "loadAverage": [
+              33.9462890625,
+              21.6064453125,
+              13.26953125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 73,
+            "elapsedSeconds": 160.0602991580963,
+            "loadAverage": [
+              33.5498046875,
+              21.72900390625,
+              13.361328125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 85,
+            "elapsedSeconds": 162.94475317001343,
+            "loadAverage": [
+              33.5498046875,
+              21.72900390625,
+              13.361328125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 67,
+            "elapsedSeconds": 166.2506172657013,
+            "loadAverage": [
+              33.02490234375,
+              21.81640625,
+              13.44091796875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 61,
+            "elapsedSeconds": 169.33834218978882,
+            "loadAverage": [
+              33.02490234375,
+              21.81640625,
+              13.44091796875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 63,
+            "elapsedSeconds": 172.93372702598572,
+            "loadAverage": [
+              32.6220703125,
+              21.9189453125,
+              13.52587890625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 67,
+            "elapsedSeconds": 176.97347927093506,
+            "loadAverage": [
+              32.73193359375,
+              22.119140625,
+              13.6455078125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 53,
+            "elapsedSeconds": 180.91829299926758,
+            "loadAverage": [
+              32.3525390625,
+              22.21630859375,
+              13.7294921875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 55,
+            "elapsedSeconds": 184.44381999969482,
+            "loadAverage": [
+              32.3525390625,
+              22.21630859375,
+              13.7294921875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 57,
+            "elapsedSeconds": 187.68330812454224,
+            "loadAverage": [
+              40.251953125,
+              24.02197265625,
+              14.41650390625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 58,
+            "elapsedSeconds": 191.89226913452148,
+            "loadAverage": [
+              45.1962890625,
+              25.31640625,
+              14.9296875
+            ]
+          }
+        ],
+        "knownRenderingWorkerCount": 1,
+        "maxPressureLevel": 1,
+        "measurementMode": "desktop-load",
+        "peakResidentBytes": 15810560000,
+        "processSeconds": 194.2303249835968,
+        "profiled": false,
+        "prompt": "Explain how a small community could turn an abandoned railway station into a public library. Discuss the building, accessibility, staffing, the collection, and a realistic opening-day scene. Write approximately 400 words of clear, connected prose.",
+        "runtimeOverrides": {},
+        "sourceHead": "c3ef55db5f09b2bcc6526bec4dd2a78eaa27aee6",
+        "startedUnixSeconds": 1788625147.6817238,
+        "uncontended": false,
+        "workload": "prose"
+      },
+      "scenarios": [
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 1.9923312310201227
+          },
+          "endToEndSpeedups": {
+            "adaptive": 1.9345236327992004
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 247,
+          "repetition": 1,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "acceptanceRate": 0.4074074074074074,
+                "acceptedDraftTokens": 132,
+                "draftHistoryTokens": 59,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 324,
+                "rounds": 124,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 14.611358046531677,
+              "decodeTokensPerSecond": 17.52061643994599,
+              "elapsedSeconds": 15.333928942680359,
+              "endToEndTokensPerSecond": 16.69500367172377,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0005730390548706055,
+              "generatedTokens": 256,
+              "loadSeconds": 4.601478576660156e-05,
+              "name": "adaptive",
+              "outputSHA256": "f0eee860afeee246903ecb69993c7b7fee39cc16b60c5bf6535276f31f58bcda",
+              "policy": "adaptive",
+              "prefillSeconds": 0.7161870002746582,
+              "prefillTokensPerSecond": 83.77700234294947,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 15808299008,
+              "residentMemoryBeforeBytes": 15805693952,
+              "ttftSeconds": 0.7168060541152954
+            },
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 29.11066496372223,
+              "decodeTokensPerSecond": 8.794027904172843,
+              "elapsedSeconds": 29.66384792327881,
+              "endToEndTokensPerSecond": 8.630033455609214,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.14921605587005615,
+              "generatedTokens": 256,
+              "loadSeconds": 0.00011408329010009766,
+              "name": "baseline",
+              "outputSHA256": "f0eee860afeee246903ecb69993c7b7fee39cc16b60c5bf6535276f31f58bcda",
+              "policy": "disabled",
+              "prefillSeconds": 0.5307199954986572,
+              "prefillTokensPerSecond": 113.05396538456182,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 15420030976,
+              "residentMemoryBeforeBytes": 15419932672,
+              "ttftSeconds": 0.6800501346588135
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 1.040428722509336
+          },
+          "endToEndSpeedups": {
+            "adaptive": 1.0399402427823943
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 247,
+          "repetition": 2,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "acceptanceRate": 0.4074074074074074,
+                "acceptedDraftTokens": 132,
+                "draftHistoryTokens": 59,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 324,
+                "rounds": 124,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 25.984102964401245,
+              "decodeTokensPerSecond": 9.852177708452174,
+              "elapsedSeconds": 26.39515507221222,
+              "endToEndTokensPerSecond": 9.698749611420421,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0010169744491577148,
+              "generatedTokens": 256,
+              "loadSeconds": 4.8995018005371094e-05,
+              "name": "adaptive",
+              "outputSHA256": "f0eee860afeee246903ecb69993c7b7fee39cc16b60c5bf6535276f31f58bcda",
+              "policy": "adaptive",
+              "prefillSeconds": 0.4018000364303589,
+              "prefillTokensPerSecond": 149.32801035322794,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 15810428928,
+              "residentMemoryBeforeBytes": 15808397312,
+              "ttftSeconds": 0.402866005897522
+            },
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 27.03460705280304,
+              "decodeTokensPerSecond": 9.469344218689395,
+              "elapsedSeconds": 27.449383974075317,
+              "endToEndTokensPerSecond": 9.32625665631623,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.23631703853607178,
+              "generatedTokens": 256,
+              "loadSeconds": 0.0005550384521484375,
+              "name": "baseline",
+              "outputSHA256": "f0eee860afeee246903ecb69993c7b7fee39cc16b60c5bf6535276f31f58bcda",
+              "policy": "disabled",
+              "prefillSeconds": 0.4052619934082031,
+              "prefillTokensPerSecond": 148.05237346687125,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 15420063744,
+              "residentMemoryBeforeBytes": 15420047360,
+              "ttftSeconds": 0.6421340703964233
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 1.9230810988761795
+          },
+          "endToEndSpeedups": {
+            "adaptive": 1.9213973760606717
+          },
+          "greedyOutputParity": true,
+          "promptCharacters": 247,
+          "repetition": 3,
+          "requestedDecodeTokens": 256,
+          "temperature": 0,
+          "variants": [
+            {
+              "acceleration": {
+                "acceptanceRate": 0.4074074074074074,
+                "acceptedDraftTokens": 132,
+                "draftHistoryTokens": 59,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 324,
+                "rounds": 124,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 15.953748941421509,
+              "decodeTokensPerSecond": 16.046385143703404,
+              "elapsedSeconds": 16.352140069007874,
+              "endToEndTokensPerSecond": 15.655443197015874,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0006709098815917969,
+              "generatedTokens": 256,
+              "loadSeconds": 5.698204040527344e-05,
+              "name": "adaptive",
+              "outputSHA256": "f0eee860afeee246903ecb69993c7b7fee39cc16b60c5bf6535276f31f58bcda",
+              "policy": "adaptive",
+              "prefillSeconds": 0.3868929147720337,
+              "prefillTokensPerSecond": 155.08167172136868,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 15810527232,
+              "residentMemoryBeforeBytes": 15810428928,
+              "ttftSeconds": 0.38762080669403076
+            },
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 30.680353045463562,
+              "decodeTokensPerSecond": 8.344102156212069,
+              "elapsedSeconds": 31.4189590215683,
+              "endToEndTokensPerSecond": 8.147946589327248,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.10634195804595947,
+              "generatedTokens": 256,
+              "loadSeconds": 5.3048133850097656e-05,
+              "name": "baseline",
+              "outputSHA256": "f0eee860afeee246903ecb69993c7b7fee39cc16b60c5bf6535276f31f58bcda",
+              "policy": "disabled",
+              "prefillSeconds": 0.7313799858093262,
+              "prefillTokensPerSecond": 82.03669934118521,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 15420112896,
+              "residentMemoryBeforeBytes": 15420063744,
+              "ttftSeconds": 0.8377749919891357
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        }
+      ]
+    },
+    {
+      "id": "final-sampled/ornith-chat",
+      "model": "text-agent-ornith-35b-mlx-4bit",
+      "rawReceiptSHA256": "51867457047c74db52cc1a60abb0e8d28c3d6a013dddd439b08cbe2dafaf3975",
+      "receipt": {
+        "after": {
+          "gpuDeviceUtilizationPercent": 55,
+          "loadAverage": [
+            31.673828125,
+            25.80517578125,
+            15.90966796875
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7268.25M  free = 923.75M  (encrypted)",
+          "swapUsedMiB": 7268.25
+        },
+        "before": {
+          "gpuDeviceUtilizationPercent": 38,
+          "loadAverage": [
+            45.1962890625,
+            25.31640625,
+            14.9296875
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7268.25M  free = 923.75M  (encrypted)",
+          "swapUsedMiB": 7268.25
+        },
+        "binarySHA256": "37ae108285410acec9ee3863de69475fb74ce9b472bf23c05e0e0df8ce26414c",
+        "buildSourceRevision": "c3ef55db5f09b2bcc6526bec4dd2a78eaa27aee6",
+        "collectorSHA256": "dec1ae60840c738d2c8ef678adf8c1fc39b7eecaab018032ff2c596b51599f2c",
+        "command": [
+          "mere.run",
+          "model",
+          "benchmark",
+          "q36-mtp",
+          "--model",
+          "text-agent-ornith-35b-mlx-4bit",
+          "--prompt",
+          "I'm trying to get back into reading after a busy year. I have about twenty minutes most evenings, enjoy mysteries and science fiction, and keep abandoning books when I miss a few days. Help me make a gentle, realistic four-week plan. Talk to me conversationally, suggest ways to choose books without buying a stack, and explain what to do when I fall behind. Give enough practical detail that I can start tonight.",
+          "--decode-tokens",
+          "256",
+          "--context-size",
+          "8192",
+          "--temperature",
+          "0.7",
+          "--top-p",
+          "0.9",
+          "--json",
+          "--variants",
+          "baseline,adaptive",
+          "--warmups",
+          "1",
+          "--warmup-tokens",
+          "256",
+          "--repetitions",
+          "3"
+        ],
+        "competingInferenceProcessCount": 0,
+        "gpuSamples": [
+          {
+            "deviceUtilizationPercent": 37,
+            "elapsedSeconds": 0.23145008087158203,
+            "loadAverage": [
+              42.69775390625,
+              25.12841796875,
+              14.923828125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 53,
+            "elapsedSeconds": 2.6275441646575928,
+            "loadAverage": [
+              42.69775390625,
+              25.12841796875,
+              14.923828125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 56,
+            "elapsedSeconds": 4.822941064834595,
+            "loadAverage": [
+              42.69775390625,
+              25.12841796875,
+              14.923828125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 58,
+            "elapsedSeconds": 7.084103107452393,
+            "loadAverage": [
+              41.3603515625,
+              25.142578125,
+              14.98828125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 55,
+            "elapsedSeconds": 9.28956913948059,
+            "loadAverage": [
+              41.3603515625,
+              25.142578125,
+              14.98828125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 64,
+            "elapsedSeconds": 11.569926977157593,
+            "loadAverage": [
+              40.1298828125,
+              25.15673828125,
+              15.052734375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 59,
+            "elapsedSeconds": 13.851749897003174,
+            "loadAverage": [
+              40.1298828125,
+              25.15673828125,
+              15.052734375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 56,
+            "elapsedSeconds": 16.082265853881836,
+            "loadAverage": [
+              43.802734375,
+              26.16650390625,
+              15.46826171875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 62,
+            "elapsedSeconds": 18.473559141159058,
+            "loadAverage": [
+              43.802734375,
+              26.16650390625,
+              15.46826171875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 53,
+            "elapsedSeconds": 21.090827226638794,
+            "loadAverage": [
+              45.66015625,
+              26.84423828125,
+              15.77001953125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 48,
+            "elapsedSeconds": 23.562591075897217,
+            "loadAverage": [
+              45.66015625,
+              26.84423828125,
+              15.77001953125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 54,
+            "elapsedSeconds": 26.099173069000244,
+            "loadAverage": [
+              46.32763671875,
+              27.294921875,
+              15.99365234375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 61,
+            "elapsedSeconds": 28.355140209197998,
+            "loadAverage": [
+              46.32763671875,
+              27.294921875,
+              15.99365234375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 60,
+            "elapsedSeconds": 30.595892190933228,
+            "loadAverage": [
+              43.57861328125,
+              27.04052734375,
+              15.97021484375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 58,
+            "elapsedSeconds": 32.94844603538513,
+            "loadAverage": [
+              43.57861328125,
+              27.04052734375,
+              15.97021484375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 54,
+            "elapsedSeconds": 35.2240731716156,
+            "loadAverage": [
+              42.9716796875,
+              27.18896484375,
+              16.08740234375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 55,
+            "elapsedSeconds": 37.419830083847046,
+            "loadAverage": [
+              42.9716796875,
+              27.18896484375,
+              16.08740234375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 61,
+            "elapsedSeconds": 39.66512608528137,
+            "loadAverage": [
+              42.9716796875,
+              27.18896484375,
+              16.08740234375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 75,
+            "elapsedSeconds": 41.80920720100403,
+            "loadAverage": [
+              40.7314453125,
+              26.986328125,
+              16.08056640625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 87,
+            "elapsedSeconds": 43.933741092681885,
+            "loadAverage": [
+              40.7314453125,
+              26.986328125,
+              16.08056640625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 80,
+            "elapsedSeconds": 46.0774941444397,
+            "loadAverage": [
+              38.0302734375,
+              26.654296875,
+              16.02734375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 83,
+            "elapsedSeconds": 48.19802713394165,
+            "loadAverage": [
+              38.0302734375,
+              26.654296875,
+              16.02734375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 78,
+            "elapsedSeconds": 50.3784761428833,
+            "loadAverage": [
+              35.78564453125,
+              26.37744140625,
+              15.99169921875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 61,
+            "elapsedSeconds": 52.59400296211243,
+            "loadAverage": [
+              35.78564453125,
+              26.37744140625,
+              15.99169921875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 63,
+            "elapsedSeconds": 54.80043601989746,
+            "loadAverage": [
+              35.78564453125,
+              26.37744140625,
+              15.99169921875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 57,
+            "elapsedSeconds": 56.97805404663086,
+            "loadAverage": [
+              33.560546875,
+              26.072265625,
+              15.94482421875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 70,
+            "elapsedSeconds": 59.15190625190735,
+            "loadAverage": [
+              33.560546875,
+              26.072265625,
+              15.94482421875
+            ]
+          }
+        ],
+        "knownRenderingWorkerCount": 1,
+        "maxPressureLevel": 1,
+        "measurementMode": "desktop-load",
+        "peakResidentBytes": 9471770624,
+        "processSeconds": 61.24811029434204,
+        "profiled": false,
+        "prompt": "I'm trying to get back into reading after a busy year. I have about twenty minutes most evenings, enjoy mysteries and science fiction, and keep abandoning books when I miss a few days. Help me make a gentle, realistic four-week plan. Talk to me conversationally, suggest ways to choose books without buying a stack, and explain what to do when I fall behind. Give enough practical detail that I can start tonight.",
+        "runtimeOverrides": {},
+        "sourceHead": "c3ef55db5f09b2bcc6526bec4dd2a78eaa27aee6",
+        "startedUnixSeconds": 1788625342.704321,
+        "uncontended": false,
+        "workload": "chat"
+      },
+      "scenarios": [
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 1.1710532943249339
+          },
+          "endToEndSpeedups": {
+            "adaptive": 1.139826179847793
+          },
+          "promptCharacters": 413,
+          "repetition": 1,
+          "requestedDecodeTokens": 256,
+          "temperature": 0.7,
+          "variants": [
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 5.787040948867798,
+              "decodeTokensPerSecond": 44.236770097520214,
+              "elapsedSeconds": 5.953824996948242,
+              "endToEndTokensPerSecond": 42.9975688118509,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.025865912437438965,
+              "generatedTokens": 256,
+              "loadSeconds": 1.800060272216797e-05,
+              "name": "baseline",
+              "outputSHA256": "c8a6979d6467df2d9d8bf076069bd770aaf35e39ffbd0184230b4622e2be3ae3",
+              "policy": "disabled",
+              "prefillSeconds": 0.16346395015716553,
+              "prefillTokensPerSecond": 593.4030096956393,
+              "promptTokens": 97,
+              "residentMemoryAfterBytes": 7706771456,
+              "residentMemoryBeforeBytes": 7706591232,
+              "ttftSeconds": 0.18934786319732666
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.2265625,
+                "acceptedDraftTokens": 29,
+                "draftHistoryTokens": 0,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 128,
+                "rounds": 128,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 4.941740036010742,
+              "decodeTokensPerSecond": 51.80361535299578,
+              "elapsedSeconds": 5.223449945449829,
+              "endToEndTokensPerSecond": 49.00975460155462,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0011650323867797852,
+              "generatedTokens": 256,
+              "loadSeconds": 7.987022399902344e-06,
+              "name": "adaptive",
+              "outputSHA256": "3de851f8ebd538e1ec22ad34d647ef21aefe55d11c4125329a8893293a21daab",
+              "policy": "adaptive",
+              "prefillSeconds": 0.2797049283981323,
+              "prefillTokensPerSecond": 346.7940323952036,
+              "promptTokens": 97,
+              "residentMemoryAfterBytes": 9471770624,
+              "residentMemoryBeforeBytes": 9471590400,
+              "ttftSeconds": 0.280877947807312
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 1.6639627200302183
+          },
+          "endToEndSpeedups": {
+            "adaptive": 1.6336748691410523
+          },
+          "promptCharacters": 413,
+          "repetition": 2,
+          "requestedDecodeTokens": 256,
+          "temperature": 0.7,
+          "variants": [
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 9.581638097763062,
+              "decodeTokensPerSecond": 26.717769695326524,
+              "elapsedSeconds": 9.778503060340881,
+              "endToEndTokensPerSecond": 26.179876246935056,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.033918023109436035,
+              "generatedTokens": 256,
+              "loadSeconds": 1.704692840576172e-05,
+              "name": "baseline",
+              "outputSHA256": "d192d769b30d7f0ba00d8325d1ea0d444cf8ce19004a8f593e5c0d3499e4bb2a",
+              "policy": "disabled",
+              "prefillSeconds": 0.19339895248413086,
+              "prefillTokensPerSecond": 501.5539058204528,
+              "promptTokens": 97,
+              "residentMemoryAfterBytes": 7706853376,
+              "residentMemoryBeforeBytes": 7706869760,
+              "ttftSeconds": 0.22733402252197266
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.25,
+                "acceptedDraftTokens": 32,
+                "draftHistoryTokens": 0,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 128,
+                "rounds": 128,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 5.758324980735779,
+              "decodeTokensPerSecond": 44.45737273537646,
+              "elapsedSeconds": 5.985587000846863,
+              "endToEndTokensPerSecond": 42.76940590184057,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0019429922103881836,
+              "generatedTokens": 256,
+              "loadSeconds": 7.987022399902344e-06,
+              "name": "adaptive",
+              "outputSHA256": "c1a3962ad74497ad01f89c0245ea26e6c5c3bf1125010b761009d1489c206d4f",
+              "policy": "adaptive",
+              "prefillSeconds": 0.22514593601226807,
+              "prefillTokensPerSecond": 430.83167175051534,
+              "promptTokens": 97,
+              "residentMemoryAfterBytes": 9471737856,
+              "residentMemoryBeforeBytes": 9471770624,
+              "ttftSeconds": 0.22709691524505615
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 0.9800947292274851
+          },
+          "endToEndSpeedups": {
+            "adaptive": 0.9858870038453017
+          },
+          "promptCharacters": 413,
+          "repetition": 3,
+          "requestedDecodeTokens": 256,
+          "temperature": 0.7,
+          "variants": [
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 4.8860780000686646,
+              "decodeTokensPerSecond": 52.393760393592245,
+              "elapsedSeconds": 5.071536898612976,
+              "endToEndTokensPerSecond": 50.47779501910237,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.022485017776489258,
+              "generatedTokens": 256,
+              "loadSeconds": 1.4066696166992188e-05,
+              "name": "baseline",
+              "outputSHA256": "1436427f286030608a6040514f79a62a7857a007ddc7deeef87c3215821c232c",
+              "policy": "disabled",
+              "prefillSeconds": 0.18234801292419434,
+              "prefillTokensPerSecond": 531.9498602944734,
+              "promptTokens": 97,
+              "residentMemoryAfterBytes": 7706886144,
+              "residentMemoryBeforeBytes": 7706853376,
+              "ttftSeconds": 0.20484709739685059
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.3671875,
+                "acceptedDraftTokens": 47,
+                "draftHistoryTokens": 0,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 128,
+                "rounds": 128,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 4.985311985015869,
+              "decodeTokensPerSecond": 51.35084840616752,
+              "elapsedSeconds": 5.144136071205139,
+              "endToEndTokensPerSecond": 49.76540209210013,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0009720325469970703,
+              "generatedTokens": 256,
+              "loadSeconds": 1.1920928955078125e-05,
+              "name": "adaptive",
+              "outputSHA256": "deb0276d265c1c5d920740186a4a5eea31b8c8b240ebfe5900e99386506727f0",
+              "policy": "adaptive",
+              "prefillSeconds": 0.15602898597717285,
+              "prefillTokensPerSecond": 621.6793590787751,
+              "promptTokens": 97,
+              "residentMemoryAfterBytes": 9471754240,
+              "residentMemoryBeforeBytes": 9471737856,
+              "ttftSeconds": 0.157012939453125
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        }
+      ]
+    },
+    {
+      "id": "final-sampled/ornith-prose",
+      "model": "text-agent-ornith-35b-mlx-4bit",
+      "rawReceiptSHA256": "6848a36376a03d0aec32b0d5134443de42c0941e4461e6f3549c7525cd70a93d",
+      "receipt": {
+        "after": {
+          "gpuDeviceUtilizationPercent": 64,
+          "loadAverage": [
+            19.76708984375,
+            23.4599609375,
+            15.451171875
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7260.25M  free = 931.75M  (encrypted)",
+          "swapUsedMiB": 7260.25
+        },
+        "before": {
+          "gpuDeviceUtilizationPercent": 65,
+          "loadAverage": [
+            31.673828125,
+            25.80517578125,
+            15.90966796875
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7268.25M  free = 923.75M  (encrypted)",
+          "swapUsedMiB": 7268.25
+        },
+        "binarySHA256": "37ae108285410acec9ee3863de69475fb74ce9b472bf23c05e0e0df8ce26414c",
+        "buildSourceRevision": "c3ef55db5f09b2bcc6526bec4dd2a78eaa27aee6",
+        "collectorSHA256": "dec1ae60840c738d2c8ef678adf8c1fc39b7eecaab018032ff2c596b51599f2c",
+        "command": [
+          "mere.run",
+          "model",
+          "benchmark",
+          "q36-mtp",
+          "--model",
+          "text-agent-ornith-35b-mlx-4bit",
+          "--prompt",
+          "Explain how a small community could turn an abandoned railway station into a public library. Discuss the building, accessibility, staffing, the collection, and a realistic opening-day scene. Write approximately 400 words of clear, connected prose.",
+          "--decode-tokens",
+          "256",
+          "--context-size",
+          "8192",
+          "--temperature",
+          "0.7",
+          "--top-p",
+          "0.9",
+          "--json",
+          "--variants",
+          "baseline,adaptive",
+          "--warmups",
+          "1",
+          "--warmup-tokens",
+          "256",
+          "--repetitions",
+          "3"
+        ],
+        "competingInferenceProcessCount": 0,
+        "gpuSamples": [
+          {
+            "deviceUtilizationPercent": 66,
+            "elapsedSeconds": 0.10001420974731445,
+            "loadAverage": [
+              31.673828125,
+              25.80517578125,
+              15.90966796875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 63,
+            "elapsedSeconds": 2.2100141048431396,
+            "loadAverage": [
+              31.673828125,
+              25.80517578125,
+              15.90966796875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 99,
+            "elapsedSeconds": 4.325017213821411,
+            "loadAverage": [
+              29.53759765625,
+              25.45947265625,
+              15.845703125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 99,
+            "elapsedSeconds": 6.465065002441406,
+            "loadAverage": [
+              29.53759765625,
+              25.45947265625,
+              15.845703125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 99,
+            "elapsedSeconds": 8.59277606010437,
+            "loadAverage": [
+              27.33203125,
+              25.06982421875,
+              15.76416015625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 99,
+            "elapsedSeconds": 10.722113132476807,
+            "loadAverage": [
+              27.33203125,
+              25.06982421875,
+              15.76416015625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 90,
+            "elapsedSeconds": 12.86846113204956,
+            "loadAverage": [
+              27.33203125,
+              25.06982421875,
+              15.76416015625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 67,
+            "elapsedSeconds": 14.981714963912964,
+            "loadAverage": [
+              25.38330078125,
+              24.703125,
+              15.68896484375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 62,
+            "elapsedSeconds": 17.09501314163208,
+            "loadAverage": [
+              25.38330078125,
+              24.703125,
+              15.68896484375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 75,
+            "elapsedSeconds": 19.271420001983643,
+            "loadAverage": [
+              23.5908203125,
+              24.3427734375,
+              15.6142578125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 65,
+            "elapsedSeconds": 21.451090097427368,
+            "loadAverage": [
+              23.5908203125,
+              24.3427734375,
+              15.6142578125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 71,
+            "elapsedSeconds": 23.571006059646606,
+            "loadAverage": [
+              22.10205078125,
+              24.021484375,
+              15.5517578125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 74,
+            "elapsedSeconds": 25.690943002700806,
+            "loadAverage": [
+              22.10205078125,
+              24.021484375,
+              15.5517578125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 79,
+            "elapsedSeconds": 27.8071551322937,
+            "loadAverage": [
+              22.10205078125,
+              24.021484375,
+              15.5517578125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 76,
+            "elapsedSeconds": 29.9275860786438,
+            "loadAverage": [
+              21.052734375,
+              23.77197265625,
+              15.51318359375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 71,
+            "elapsedSeconds": 32.04764008522034,
+            "loadAverage": [
+              21.052734375,
+              23.77197265625,
+              15.51318359375
+            ]
+          }
+        ],
+        "knownRenderingWorkerCount": 0,
+        "maxPressureLevel": 1,
+        "measurementMode": "desktop-load",
+        "peakResidentBytes": 9472868352,
+        "processSeconds": 34.14914011955261,
+        "profiled": false,
+        "prompt": "Explain how a small community could turn an abandoned railway station into a public library. Discuss the building, accessibility, staffing, the collection, and a realistic opening-day scene. Write approximately 400 words of clear, connected prose.",
+        "runtimeOverrides": {},
+        "sourceHead": "c3ef55db5f09b2bcc6526bec4dd2a78eaa27aee6",
+        "startedUnixSeconds": 1788625404.169546,
+        "uncontended": false,
+        "workload": "prose"
+      },
+      "scenarios": [
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 0.8168138827620122
+          },
+          "endToEndSpeedups": {
+            "adaptive": 0.8172509842405772
+          },
+          "promptCharacters": 247,
+          "repetition": 1,
+          "requestedDecodeTokens": 256,
+          "temperature": 0.7,
+          "variants": [
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 3.3585410118103027,
+              "decodeTokensPerSecond": 76.22357419479962,
+              "elapsedSeconds": 3.4765350818634033,
+              "endToEndTokensPerSecond": 73.63653579551553,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.00860297679901123,
+              "generatedTokens": 256,
+              "loadSeconds": 8.940696716308594e-06,
+              "name": "baseline",
+              "outputSHA256": "9c637eb44bc467e869cca2004c5264e75e5a57cc6bdbd7bdc650d1b02f3bef7c",
+              "policy": "disabled",
+              "prefillSeconds": 0.1161949634552002,
+              "prefillTokensPerSecond": 516.3735003293274,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 7686668288,
+              "residentMemoryBeforeBytes": 7686307840,
+              "ttftSeconds": 0.12480688095092773
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.1875,
+                "acceptedDraftTokens": 24,
+                "draftHistoryTokens": 0,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 128,
+                "rounds": 128,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 4.11175799369812,
+              "decodeTokensPerSecond": 62.2604735960526,
+              "elapsedSeconds": 4.25393807888031,
+              "endToEndTokensPerSecond": 60.17953135495156,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.001341104507446289,
+              "generatedTokens": 256,
+              "loadSeconds": 1.2993812561035156e-05,
+              "name": "adaptive",
+              "outputSHA256": "7278a5cd4efcbfd1d599abcc0a3150c07a1b07cef220e7c7e6f57d49dc33077c",
+              "policy": "adaptive",
+              "prefillSeconds": 0.13899600505828857,
+              "prefillTokensPerSecond": 431.66708262470377,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 9472720896,
+              "residentMemoryBeforeBytes": 9472720896,
+              "ttftSeconds": 0.1403501033782959
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 0.5973224910825723
+          },
+          "endToEndSpeedups": {
+            "adaptive": 0.6158143223943471
+          },
+          "promptCharacters": 247,
+          "repetition": 2,
+          "requestedDecodeTokens": 256,
+          "temperature": 0.7,
+          "variants": [
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 2.415068030357361,
+              "decodeTokensPerSecond": 106.00115474267585,
+              "elapsedSeconds": 2.5554779767990112,
+              "endToEndTokensPerSecond": 100.17695410573066,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.008687973022460938,
+              "generatedTokens": 256,
+              "loadSeconds": 8.940696716308594e-06,
+              "name": "baseline",
+              "outputSHA256": "62edf067f1420f338e07e2eabef1aff78e970ee722971f6b56028249210c6a5c",
+              "policy": "disabled",
+              "prefillSeconds": 0.13842999935150146,
+              "prefillTokensPerSecond": 433.43206155515463,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 7686864896,
+              "residentMemoryBeforeBytes": 7686766592,
+              "ttftSeconds": 0.1471269130706787
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.1640625,
+                "acceptedDraftTokens": 21,
+                "draftHistoryTokens": 0,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 128,
+                "rounds": 128,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 4.043156027793884,
+              "decodeTokensPerSecond": 63.31687380852436,
+              "elapsedSeconds": 4.149754047393799,
+              "endToEndTokensPerSecond": 61.69040311215013,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0007259845733642578,
+              "generatedTokens": 256,
+              "loadSeconds": 7.033348083496094e-06,
+              "name": "adaptive",
+              "outputSHA256": "5557f1ef4138505a8fd9854828fa96d3a2e55f8de14d9165aecfea20d3c4582d",
+              "policy": "adaptive",
+              "prefillSeconds": 0.10468709468841553,
+              "prefillTokensPerSecond": 573.1365473326053,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 9472835584,
+              "residentMemoryBeforeBytes": 9472737280,
+              "ttftSeconds": 0.10542011260986328
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 0.7585506573085363
+          },
+          "endToEndSpeedups": {
+            "adaptive": 0.7730849449724378
+          },
+          "promptCharacters": 247,
+          "repetition": 3,
+          "requestedDecodeTokens": 256,
+          "temperature": 0.7,
+          "variants": [
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 2.8538800477981567,
+              "decodeTokensPerSecond": 89.70243868431356,
+              "elapsedSeconds": 2.995473027229309,
+              "endToEndTokensPerSecond": 85.46229516103826,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.01191103458404541,
+              "generatedTokens": 256,
+              "loadSeconds": 7.987022399902344e-06,
+              "name": "baseline",
+              "outputSHA256": "aa8ca721886760d8e4bc11751ff818db7077d19cf8df9d53e1e5de543324f16d",
+              "policy": "disabled",
+              "prefillSeconds": 0.1395360231399536,
+              "prefillTokensPerSecond": 429.99648871904884,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 7686897664,
+              "residentMemoryBeforeBytes": 7686864896,
+              "ttftSeconds": 0.15145504474639893
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.1953125,
+                "acceptedDraftTokens": 25,
+                "draftHistoryTokens": 0,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 128,
+                "rounds": 128,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 3.7622801065444946,
+              "decodeTokensPerSecond": 68.04384382616473,
+              "elapsedSeconds": 3.8747010231018066,
+              "endToEndTokensPerSecond": 66.0696137517895,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0007650852203369141,
+              "generatedTokens": 256,
+              "loadSeconds": 7.987022399902344e-06,
+              "name": "adaptive",
+              "outputSHA256": "8e412cc844555ac899bd0c6a6476cf23f22c68fe878f1334c11530b114af47b4",
+              "policy": "adaptive",
+              "prefillSeconds": 0.11035001277923584,
+              "prefillTokensPerSecond": 543.724449946688,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 9472868352,
+              "residentMemoryBeforeBytes": 9472835584,
+              "ttftSeconds": 0.11112308502197266
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        }
+      ]
+    },
+    {
+      "id": "final-sampled/qwen-chat",
+      "model": "vision-chat-q38-27b-4bit",
+      "rawReceiptSHA256": "0a24489464d2fea6ef659d224bea6c6af7bca44c827a31bcb8c41069cc0b35ed",
+      "receipt": {
+        "after": {
+          "gpuDeviceUtilizationPercent": 74,
+          "loadAverage": [
+            30.96826171875,
+            31.13037109375,
+            20.046875
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7260.25M  free = 931.75M  (encrypted)",
+          "swapUsedMiB": 7260.25
+        },
+        "before": {
+          "gpuDeviceUtilizationPercent": 35,
+          "loadAverage": [
+            19.76708984375,
+            23.4599609375,
+            15.451171875
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7260.25M  free = 931.75M  (encrypted)",
+          "swapUsedMiB": 7260.25
+        },
+        "binarySHA256": "37ae108285410acec9ee3863de69475fb74ce9b472bf23c05e0e0df8ce26414c",
+        "buildSourceRevision": "c3ef55db5f09b2bcc6526bec4dd2a78eaa27aee6",
+        "collectorSHA256": "dec1ae60840c738d2c8ef678adf8c1fc39b7eecaab018032ff2c596b51599f2c",
+        "command": [
+          "mere.run",
+          "model",
+          "benchmark",
+          "q36-mtp",
+          "--model",
+          "vision-chat-q38-27b-4bit",
+          "--prompt",
+          "I'm trying to get back into reading after a busy year. I have about twenty minutes most evenings, enjoy mysteries and science fiction, and keep abandoning books when I miss a few days. Help me make a gentle, realistic four-week plan. Talk to me conversationally, suggest ways to choose books without buying a stack, and explain what to do when I fall behind. Give enough practical detail that I can start tonight.",
+          "--decode-tokens",
+          "256",
+          "--context-size",
+          "8192",
+          "--temperature",
+          "0.7",
+          "--top-p",
+          "0.9",
+          "--json",
+          "--variants",
+          "baseline,adaptive",
+          "--warmups",
+          "1",
+          "--warmup-tokens",
+          "256",
+          "--repetitions",
+          "3"
+        ],
+        "competingInferenceProcessCount": 0,
+        "gpuSamples": [
+          {
+            "deviceUtilizationPercent": 34,
+            "elapsedSeconds": 0.09610867500305176,
+            "loadAverage": [
+              19.76708984375,
+              23.4599609375,
+              15.451171875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 83,
+            "elapsedSeconds": 2.2024757862091064,
+            "loadAverage": [
+              19.76708984375,
+              23.4599609375,
+              15.451171875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 93,
+            "elapsedSeconds": 4.309813022613525,
+            "loadAverage": [
+              18.74462890625,
+              23.1865234375,
+              15.4013671875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 49,
+            "elapsedSeconds": 6.426228046417236,
+            "loadAverage": [
+              18.74462890625,
+              23.1865234375,
+              15.4013671875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 40,
+            "elapsedSeconds": 8.543068885803223,
+            "loadAverage": [
+              18.74462890625,
+              23.1865234375,
+              15.4013671875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 42,
+            "elapsedSeconds": 10.650874853134155,
+            "loadAverage": [
+              17.2431640625,
+              22.80126953125,
+              15.31103515625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 46,
+            "elapsedSeconds": 12.766998052597046,
+            "loadAverage": [
+              17.2431640625,
+              22.80126953125,
+              15.31103515625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 37,
+            "elapsedSeconds": 14.880131721496582,
+            "loadAverage": [
+              16.1025390625,
+              22.47216796875,
+              15.23876953125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 43,
+            "elapsedSeconds": 17.00480079650879,
+            "loadAverage": [
+              16.1025390625,
+              22.47216796875,
+              15.23876953125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 61,
+            "elapsedSeconds": 19.116302728652954,
+            "loadAverage": [
+              15.13330078125,
+              22.1650390625,
+              15.1728515625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 94,
+            "elapsedSeconds": 22.17778205871582,
+            "loadAverage": [
+              15.13330078125,
+              22.1650390625,
+              15.1728515625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 59,
+            "elapsedSeconds": 25.07042098045349,
+            "loadAverage": [
+              20.40771484375,
+              23.1416015625,
+              15.55810546875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 61,
+            "elapsedSeconds": 27.768784761428833,
+            "loadAverage": [
+              20.40771484375,
+              23.1416015625,
+              15.55810546875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 63,
+            "elapsedSeconds": 30.382980823516846,
+            "loadAverage": [
+              21.255859375,
+              23.27197265625,
+              15.6484375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 62,
+            "elapsedSeconds": 32.970921993255615,
+            "loadAverage": [
+              21.255859375,
+              23.27197265625,
+              15.6484375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 57,
+            "elapsedSeconds": 35.55562686920166,
+            "loadAverage": [
+              27.8017578125,
+              24.59521484375,
+              16.16015625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 62,
+            "elapsedSeconds": 38.126168727874756,
+            "loadAverage": [
+              27.8017578125,
+              24.59521484375,
+              16.16015625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 57,
+            "elapsedSeconds": 40.74195885658264,
+            "loadAverage": [
+              35.1845703125,
+              26.1787109375,
+              16.7685546875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 59,
+            "elapsedSeconds": 43.40412974357605,
+            "loadAverage": [
+              35.1845703125,
+              26.1787109375,
+              16.7685546875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 57,
+            "elapsedSeconds": 46.04906868934631,
+            "loadAverage": [
+              43.17724609375,
+              27.98486328125,
+              17.4609375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 84,
+            "elapsedSeconds": 48.768786907196045,
+            "loadAverage": [
+              43.17724609375,
+              27.98486328125,
+              17.4609375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 98,
+            "elapsedSeconds": 50.89795994758606,
+            "loadAverage": [
+              40.11962890625,
+              27.60302734375,
+              17.3876953125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 53.03210687637329,
+            "loadAverage": [
+              40.11962890625,
+              27.60302734375,
+              17.3876953125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 55.26501679420471,
+            "loadAverage": [
+              37.06689453125,
+              27.177734375,
+              17.29736328125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 93,
+            "elapsedSeconds": 57.66056776046753,
+            "loadAverage": [
+              37.06689453125,
+              27.177734375,
+              17.29736328125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 90,
+            "elapsedSeconds": 60.14572596549988,
+            "loadAverage": [
+              40.0244140625,
+              27.95458984375,
+              17.62939453125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 90,
+            "elapsedSeconds": 62.64059805870056,
+            "loadAverage": [
+              40.0244140625,
+              27.95458984375,
+              17.62939453125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 83,
+            "elapsedSeconds": 65.1672739982605,
+            "loadAverage": [
+              44.02587890625,
+              28.984375,
+              18.05322265625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 94,
+            "elapsedSeconds": 67.45871996879578,
+            "loadAverage": [
+              44.02587890625,
+              28.984375,
+              18.05322265625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 96,
+            "elapsedSeconds": 70.02162098884583,
+            "loadAverage": [
+              47.546875,
+              29.9638671875,
+              18.462890625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 85,
+            "elapsedSeconds": 72.77603197097778,
+            "loadAverage": [
+              47.546875,
+              29.9638671875,
+              18.462890625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 73,
+            "elapsedSeconds": 75.50239491462708,
+            "loadAverage": [
+              56.8720703125,
+              32.18896484375,
+              19.3154296875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 79,
+            "elapsedSeconds": 78.14628887176514,
+            "loadAverage": [
+              56.8720703125,
+              32.18896484375,
+              19.3154296875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 80,
+            "elapsedSeconds": 80.80446791648865,
+            "loadAverage": [
+              64.1689453125,
+              34.111328125,
+              20.0693359375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 80,
+            "elapsedSeconds": 83.42289471626282,
+            "loadAverage": [
+              64.1689453125,
+              34.111328125,
+              20.0693359375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 93,
+            "elapsedSeconds": 85.86873388290405,
+            "loadAverage": [
+              69.7607421875,
+              35.76953125,
+              20.73681640625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 61,
+            "elapsedSeconds": 88.15562295913696,
+            "loadAverage": [
+              69.7607421875,
+              35.76953125,
+              20.73681640625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 87,
+            "elapsedSeconds": 90.44096183776855,
+            "loadAverage": [
+              69.53955078125,
+              36.28759765625,
+              21.0078125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 86,
+            "elapsedSeconds": 92.71558570861816,
+            "loadAverage": [
+              69.53955078125,
+              36.28759765625,
+              21.0078125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 90,
+            "elapsedSeconds": 94.8958158493042,
+            "loadAverage": [
+              65.572265625,
+              36.01708984375,
+              21.00146484375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 86,
+            "elapsedSeconds": 97.03430390357971,
+            "loadAverage": [
+              65.572265625,
+              36.01708984375,
+              21.00146484375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 87,
+            "elapsedSeconds": 99.14502882957458,
+            "loadAverage": [
+              60.7216796875,
+              35.501953125,
+              20.9072265625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 91,
+            "elapsedSeconds": 101.24752998352051,
+            "loadAverage": [
+              60.7216796875,
+              35.501953125,
+              20.9072265625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 84,
+            "elapsedSeconds": 103.35191774368286,
+            "loadAverage": [
+              60.7216796875,
+              35.501953125,
+              20.9072265625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 98,
+            "elapsedSeconds": 105.46239686012268,
+            "loadAverage": [
+              56.09912109375,
+              34.9619140625,
+              20.80224609375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 84,
+            "elapsedSeconds": 107.57416296005249,
+            "loadAverage": [
+              56.09912109375,
+              34.9619140625,
+              20.80224609375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 89,
+            "elapsedSeconds": 109.6816828250885,
+            "loadAverage": [
+              51.7666015625,
+              34.41455078125,
+              20.69189453125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 91,
+            "elapsedSeconds": 111.78833270072937,
+            "loadAverage": [
+              51.7666015625,
+              34.41455078125,
+              20.69189453125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 94,
+            "elapsedSeconds": 113.90815377235413,
+            "loadAverage": [
+              51.7666015625,
+              34.41455078125,
+              20.69189453125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 94,
+            "elapsedSeconds": 116.01881980895996,
+            "loadAverage": [
+              47.861328125,
+              33.892578125,
+              20.587890625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 94,
+            "elapsedSeconds": 118.1219847202301,
+            "loadAverage": [
+              47.861328125,
+              33.892578125,
+              20.587890625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 87,
+            "elapsedSeconds": 120.23059892654419,
+            "loadAverage": [
+              44.3486328125,
+              33.39599609375,
+              20.490234375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 87,
+            "elapsedSeconds": 122.33595395088196,
+            "loadAverage": [
+              44.3486328125,
+              33.39599609375,
+              20.490234375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 89,
+            "elapsedSeconds": 124.4567129611969,
+            "loadAverage": [
+              41.27734375,
+              32.94091796875,
+              20.4052734375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 93,
+            "elapsedSeconds": 126.5682020187378,
+            "loadAverage": [
+              41.27734375,
+              32.94091796875,
+              20.4052734375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 94,
+            "elapsedSeconds": 128.67641186714172,
+            "loadAverage": [
+              41.27734375,
+              32.94091796875,
+              20.4052734375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 91,
+            "elapsedSeconds": 130.79330897331238,
+            "loadAverage": [
+              38.4521484375,
+              32.49365234375,
+              20.32080078125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 95,
+            "elapsedSeconds": 132.90493178367615,
+            "loadAverage": [
+              38.4521484375,
+              32.49365234375,
+              20.32080078125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 92,
+            "elapsedSeconds": 135.03748202323914,
+            "loadAverage": [
+              35.85302734375,
+              32.0537109375,
+              20.23681640625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 89,
+            "elapsedSeconds": 137.23707795143127,
+            "loadAverage": [
+              35.85302734375,
+              32.0537109375,
+              20.23681640625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 88,
+            "elapsedSeconds": 139.48133993148804,
+            "loadAverage": [
+              33.14208984375,
+              31.5546875,
+              20.1298828125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 82,
+            "elapsedSeconds": 141.90272688865662,
+            "loadAverage": [
+              33.14208984375,
+              31.5546875,
+              20.1298828125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 70,
+            "elapsedSeconds": 144.35601162910461,
+            "loadAverage": [
+              30.96826171875,
+              31.13037109375,
+              20.046875
+            ]
+          }
+        ],
+        "knownRenderingWorkerCount": 1,
+        "maxPressureLevel": 1,
+        "measurementMode": "desktop-load",
+        "peakResidentBytes": 15822356480,
+        "processSeconds": 146.51112294197083,
+        "profiled": false,
+        "prompt": "I'm trying to get back into reading after a busy year. I have about twenty minutes most evenings, enjoy mysteries and science fiction, and keep abandoning books when I miss a few days. Help me make a gentle, realistic four-week plan. Talk to me conversationally, suggest ways to choose books without buying a stack, and explain what to do when I fall behind. Give enough practical detail that I can start tonight.",
+        "runtimeOverrides": {},
+        "sourceHead": "c3ef55db5f09b2bcc6526bec4dd2a78eaa27aee6",
+        "startedUnixSeconds": 1788625438.5240471,
+        "uncontended": false,
+        "workload": "chat"
+      },
+      "scenarios": [
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 2.3077025055929505
+          },
+          "endToEndSpeedups": {
+            "adaptive": 2.1891414517251944
+          },
+          "promptCharacters": 413,
+          "repetition": 1,
+          "requestedDecodeTokens": 256,
+          "temperature": 0.7,
+          "variants": [
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 28.18172299861908,
+              "decodeTokensPerSecond": 9.083901648332295,
+              "elapsedSeconds": 29.62769591808319,
+              "endToEndTokensPerSecond": 8.640563907089078,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.06806004047393799,
+              "generatedTokens": 256,
+              "loadSeconds": 3.0994415283203125e-05,
+              "name": "baseline",
+              "outputSHA256": "030943934673e47f89f279eb31e426f1569c10ae0f088ba8f24977c6f4f96a36",
+              "policy": "disabled",
+              "prefillSeconds": 1.4430179595947266,
+              "prefillTokensPerSecond": 67.22023059729803,
+              "promptTokens": 97,
+              "residentMemoryAfterBytes": 15425191936,
+              "residentMemoryBeforeBytes": 15425060864,
+              "ttftSeconds": 1.5111089944839478
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.734375,
+                "acceptedDraftTokens": 94,
+                "draftHistoryTokens": 0,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 128,
+                "rounds": 128,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 12.212026000022888,
+              "decodeTokensPerSecond": 20.962942594416372,
+              "elapsedSeconds": 13.533933997154236,
+              "endToEndTokensPerSecond": 18.915416615289303,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0012871026992797852,
+              "generatedTokens": 256,
+              "loadSeconds": 2.110004425048828e-05,
+              "name": "adaptive",
+              "outputSHA256": "2960122f27932e23a40c1245074765bc2c1f253a7cebce8a0a4824516c0f0206",
+              "policy": "adaptive",
+              "prefillSeconds": 1.3202329874038696,
+              "prefillTokensPerSecond": 73.47188028587483,
+              "promptTokens": 97,
+              "residentMemoryAfterBytes": 15822159872,
+              "residentMemoryBeforeBytes": 15822143488,
+              "ttftSeconds": 1.3215411901474
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 1.295944099143189
+          },
+          "endToEndSpeedups": {
+            "adaptive": 1.2866043340925313
+          },
+          "promptCharacters": 413,
+          "repetition": 2,
+          "requestedDecodeTokens": 256,
+          "temperature": 0.7,
+          "variants": [
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 16.61055600643158,
+              "decodeTokensPerSecond": 15.411886266834008,
+              "elapsedSeconds": 18.426818013191223,
+              "endToEndTokensPerSecond": 13.892794719996532,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.08396899700164795,
+              "generatedTokens": 256,
+              "loadSeconds": 4.601478576660156e-05,
+              "name": "baseline",
+              "outputSHA256": "2f41865da94d1bf783b8a2e0c3c0c5a2d1ff6beabb30c0dca76084b28c587536",
+              "policy": "disabled",
+              "prefillSeconds": 1.8113800287246704,
+              "prefillTokensPerSecond": 53.55033094203557,
+              "promptTokens": 97,
+              "residentMemoryAfterBytes": 15425404928,
+              "residentMemoryBeforeBytes": 15425306624,
+              "ttftSeconds": 1.895395040512085
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.703125,
+                "acceptedDraftTokens": 90,
+                "draftHistoryTokens": 0,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 128,
+                "rounds": 128,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 12.817339897155762,
+              "decodeTokensPerSecond": 19.972943064169485,
+              "elapsedSeconds": 14.322054982185364,
+              "endToEndTokensPerSecond": 17.874529899405374,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0024329423904418945,
+              "generatedTokens": 256,
+              "loadSeconds": 2.5987625122070312e-05,
+              "name": "adaptive",
+              "outputSHA256": "f7918e68f9608c6e8ff1085a552b9ae62ad0da48ee4a39d2523842e5ba7d5fb4",
+              "policy": "adaptive",
+              "prefillSeconds": 1.5028769969940186,
+              "prefillTokensPerSecond": 64.54287356451304,
+              "promptTokens": 97,
+              "residentMemoryAfterBytes": 15822290944,
+              "residentMemoryBeforeBytes": 15822176256,
+              "ttftSeconds": 1.5053359270095825
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 1.4218051498383406
+          },
+          "endToEndSpeedups": {
+            "adaptive": 1.4056751270498349
+          },
+          "promptCharacters": 413,
+          "repetition": 3,
+          "requestedDecodeTokens": 256,
+          "temperature": 0.7,
+          "variants": [
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 17.938609957695007,
+              "decodeTokensPerSecond": 14.270893932346489,
+              "elapsedSeconds": 19.537933945655823,
+              "endToEndTokensPerSecond": 13.10271601450063,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.14965295791625977,
+              "generatedTokens": 256,
+              "loadSeconds": 5.4001808166503906e-05,
+              "name": "baseline",
+              "outputSHA256": "af2b3923f060aa46e13e5c2909129e3ad1a31d4dfc53919688950f1439773e82",
+              "policy": "disabled",
+              "prefillSeconds": 1.59026300907135,
+              "prefillTokensPerSecond": 60.996199651681586,
+              "promptTokens": 97,
+              "residentMemoryAfterBytes": 15425421312,
+              "residentMemoryBeforeBytes": 15425404928,
+              "ttftSeconds": 1.7399699687957764
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.7421875,
+                "acceptedDraftTokens": 95,
+                "draftHistoryTokens": 0,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 128,
+                "rounds": 128,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 12.616785049438477,
+              "decodeTokensPerSecond": 20.290430485806965,
+              "elapsedSeconds": 13.8993239402771,
+              "endToEndTokensPerSecond": 18.418161998381077,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0010840892791748047,
+              "generatedTokens": 256,
+              "loadSeconds": 1.800060272216797e-05,
+              "name": "adaptive",
+              "outputSHA256": "d20fd0828ec9afeed0c296cd394be86561240544d9230c57a04297df0fea7233",
+              "policy": "adaptive",
+              "prefillSeconds": 1.2787469625473022,
+              "prefillTokensPerSecond": 75.85550765006167,
+              "promptTokens": 97,
+              "residentMemoryAfterBytes": 15822356480,
+              "residentMemoryBeforeBytes": 15822290944,
+              "ttftSeconds": 1.2798490524291992
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        }
+      ]
+    },
+    {
+      "id": "final-sampled/qwen-prose",
+      "model": "vision-chat-q38-27b-4bit",
+      "rawReceiptSHA256": "1770b1bd8bf7ee1271fe9ebfb41ad61bb2822573412631c611bc3cfc1d913188",
+      "receipt": {
+        "after": {
+          "gpuDeviceUtilizationPercent": 48,
+          "loadAverage": [
+            11.69970703125,
+            23.03759765625,
+            18.41015625
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7260.25M  free = 931.75M  (encrypted)",
+          "swapUsedMiB": 7260.25
+        },
+        "before": {
+          "gpuDeviceUtilizationPercent": 34,
+          "loadAverage": [
+            30.96826171875,
+            31.13037109375,
+            20.046875
+          ],
+          "pressureLevel": 1,
+          "swap": "total = 8192.00M  used = 7260.25M  free = 931.75M  (encrypted)",
+          "swapUsedMiB": 7260.25
+        },
+        "binarySHA256": "37ae108285410acec9ee3863de69475fb74ce9b472bf23c05e0e0df8ce26414c",
+        "buildSourceRevision": "c3ef55db5f09b2bcc6526bec4dd2a78eaa27aee6",
+        "collectorSHA256": "dec1ae60840c738d2c8ef678adf8c1fc39b7eecaab018032ff2c596b51599f2c",
+        "command": [
+          "mere.run",
+          "model",
+          "benchmark",
+          "q36-mtp",
+          "--model",
+          "vision-chat-q38-27b-4bit",
+          "--prompt",
+          "Explain how a small community could turn an abandoned railway station into a public library. Discuss the building, accessibility, staffing, the collection, and a realistic opening-day scene. Write approximately 400 words of clear, connected prose.",
+          "--decode-tokens",
+          "256",
+          "--context-size",
+          "8192",
+          "--temperature",
+          "0.7",
+          "--top-p",
+          "0.9",
+          "--json",
+          "--variants",
+          "baseline,adaptive",
+          "--warmups",
+          "1",
+          "--warmup-tokens",
+          "256",
+          "--repetitions",
+          "3"
+        ],
+        "competingInferenceProcessCount": 0,
+        "gpuSamples": [
+          {
+            "deviceUtilizationPercent": 34,
+            "elapsedSeconds": 0.12845993041992188,
+            "loadAverage": [
+              30.96826171875,
+              31.13037109375,
+              20.046875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 85,
+            "elapsedSeconds": 2.267130136489868,
+            "loadAverage": [
+              30.96826171875,
+              31.13037109375,
+              20.046875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 82,
+            "elapsedSeconds": 4.552784204483032,
+            "loadAverage": [
+              30.169921875,
+              30.9619140625,
+              20.05224609375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 82,
+            "elapsedSeconds": 7.190841197967529,
+            "loadAverage": [
+              30.169921875,
+              30.9619140625,
+              20.05224609375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 87,
+            "elapsedSeconds": 10.172383069992065,
+            "loadAverage": [
+              28.154296875,
+              30.53076171875,
+              19.9638671875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 85,
+            "elapsedSeconds": 12.505019903182983,
+            "loadAverage": [
+              26.5400390625,
+              30.15625,
+              19.8935546875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 96,
+            "elapsedSeconds": 14.7086820602417,
+            "loadAverage": [
+              26.5400390625,
+              30.15625,
+              19.8935546875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 16.84237003326416,
+            "loadAverage": [
+              26.5400390625,
+              30.15625,
+              19.8935546875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 98,
+            "elapsedSeconds": 19.27529287338257,
+            "loadAverage": [
+              24.89501953125,
+              29.7548828125,
+              19.81201171875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 82,
+            "elapsedSeconds": 22.054347038269043,
+            "loadAverage": [
+              24.89501953125,
+              29.7548828125,
+              19.81201171875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 75,
+            "elapsedSeconds": 24.89551615715027,
+            "loadAverage": [
+              25.3837890625,
+              29.775390625,
+              19.87744140625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 76,
+            "elapsedSeconds": 27.4933021068573,
+            "loadAverage": [
+              24.47216796875,
+              29.51318359375,
+              19.8427734375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 84,
+            "elapsedSeconds": 30.2139630317688,
+            "loadAverage": [
+              24.47216796875,
+              29.51318359375,
+              19.8427734375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 78,
+            "elapsedSeconds": 33.09423303604126,
+            "loadAverage": [
+              24.91455078125,
+              29.52099609375,
+              19.90185546875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 94,
+            "elapsedSeconds": 35.37997484207153,
+            "loadAverage": [
+              24.91455078125,
+              29.52099609375,
+              19.90185546875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 99,
+            "elapsedSeconds": 37.51497292518616,
+            "loadAverage": [
+              23.39990234375,
+              29.13037109375,
+              19.8203125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 39.63887000083923,
+            "loadAverage": [
+              23.39990234375,
+              29.13037109375,
+              19.8203125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 41.767460107803345,
+            "loadAverage": [
+              23.39990234375,
+              29.13037109375,
+              19.8203125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 43.88966608047485,
+            "loadAverage": [
+              21.76611328125,
+              28.6962890625,
+              19.7216796875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 46.00091600418091,
+            "loadAverage": [
+              21.76611328125,
+              28.6962890625,
+              19.7216796875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 48.119051933288574,
+            "loadAverage": [
+              20.34326171875,
+              28.2861328125,
+              19.62939453125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 50.23794412612915,
+            "loadAverage": [
+              20.34326171875,
+              28.2861328125,
+              19.62939453125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 52.3533570766449,
+            "loadAverage": [
+              18.9541015625,
+              27.8662109375,
+              19.53173828125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 99,
+            "elapsedSeconds": 54.47069692611694,
+            "loadAverage": [
+              18.9541015625,
+              27.8662109375,
+              19.53173828125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 56.58545994758606,
+            "loadAverage": [
+              18.9541015625,
+              27.8662109375,
+              19.53173828125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 58.710379123687744,
+            "loadAverage": [
+              17.91650390625,
+              27.5029296875,
+              19.4521484375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 60.82476806640625,
+            "loadAverage": [
+              17.91650390625,
+              27.5029296875,
+              19.4521484375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 62.93484115600586,
+            "loadAverage": [
+              16.5615234375,
+              27.0625,
+              19.34375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 65.05341601371765,
+            "loadAverage": [
+              16.5615234375,
+              27.0625,
+              19.34375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 67.16626000404358,
+            "loadAverage": [
+              16.5615234375,
+              27.0625,
+              19.34375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 100,
+            "elapsedSeconds": 69.28089809417725,
+            "loadAverage": [
+              15.39501953125,
+              26.64599609375,
+              19.24169921875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 95,
+            "elapsedSeconds": 71.38575315475464,
+            "loadAverage": [
+              15.39501953125,
+              26.64599609375,
+              19.24169921875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 86,
+            "elapsedSeconds": 73.5024061203003,
+            "loadAverage": [
+              14.322265625,
+              26.23681640625,
+              19.140625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 89,
+            "elapsedSeconds": 75.62739109992981,
+            "loadAverage": [
+              14.322265625,
+              26.23681640625,
+              19.140625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 86,
+            "elapsedSeconds": 77.73383092880249,
+            "loadAverage": [
+              13.73583984375,
+              25.9169921875,
+              19.0693359375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 92,
+            "elapsedSeconds": 79.83405590057373,
+            "loadAverage": [
+              13.73583984375,
+              25.9169921875,
+              19.0693359375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 83,
+            "elapsedSeconds": 81.94128012657166,
+            "loadAverage": [
+              13.73583984375,
+              25.9169921875,
+              19.0693359375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 91,
+            "elapsedSeconds": 84.04478788375854,
+            "loadAverage": [
+              12.7158203125,
+              25.5029296875,
+              18.96337890625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 97,
+            "elapsedSeconds": 86.16982102394104,
+            "loadAverage": [
+              12.7158203125,
+              25.5029296875,
+              18.96337890625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 89,
+            "elapsedSeconds": 88.27676010131836,
+            "loadAverage": [
+              11.9375,
+              25.12890625,
+              18.86962890625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 92,
+            "elapsedSeconds": 90.38184404373169,
+            "loadAverage": [
+              11.9375,
+              25.12890625,
+              18.86962890625
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 91,
+            "elapsedSeconds": 92.48637890815735,
+            "loadAverage": [
+              11.1416015625,
+              24.74462890625,
+              18.7705078125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 88,
+            "elapsedSeconds": 94.59166216850281,
+            "loadAverage": [
+              11.1416015625,
+              24.74462890625,
+              18.7705078125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 90,
+            "elapsedSeconds": 96.69545125961304,
+            "loadAverage": [
+              11.1416015625,
+              24.74462890625,
+              18.7705078125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 89,
+            "elapsedSeconds": 98.80967092514038,
+            "loadAverage": [
+              10.7294921875,
+              24.43310546875,
+              18.6953125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 90,
+            "elapsedSeconds": 100.94465708732605,
+            "loadAverage": [
+              10.7294921875,
+              24.43310546875,
+              18.6953125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 96,
+            "elapsedSeconds": 103.07289814949036,
+            "loadAverage": [
+              10.0302734375,
+              24.060546875,
+              18.59716796875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 90,
+            "elapsedSeconds": 105.25833797454834,
+            "loadAverage": [
+              10.0302734375,
+              24.060546875,
+              18.59716796875
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 93,
+            "elapsedSeconds": 107.3992350101471,
+            "loadAverage": [
+              10.42822265625,
+              23.90966796875,
+              18.57568359375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 86,
+            "elapsedSeconds": 109.55516314506531,
+            "loadAverage": [
+              10.42822265625,
+              23.90966796875,
+              18.57568359375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 85,
+            "elapsedSeconds": 111.68390083312988,
+            "loadAverage": [
+              10.42822265625,
+              23.90966796875,
+              18.57568359375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 84,
+            "elapsedSeconds": 113.81305694580078,
+            "loadAverage": [
+              9.8330078125,
+              23.5625,
+              18.484375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 89,
+            "elapsedSeconds": 115.9674301147461,
+            "loadAverage": [
+              9.8330078125,
+              23.5625,
+              18.484375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 95,
+            "elapsedSeconds": 118.08792495727539,
+            "loadAverage": [
+              9.44580078125,
+              23.25390625,
+              18.4052734375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 89,
+            "elapsedSeconds": 120.32083821296692,
+            "loadAverage": [
+              9.44580078125,
+              23.25390625,
+              18.4052734375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 86,
+            "elapsedSeconds": 122.51242113113403,
+            "loadAverage": [
+              9.32958984375,
+              23.00048828125,
+              18.34423828125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 86,
+            "elapsedSeconds": 124.64841604232788,
+            "loadAverage": [
+              9.32958984375,
+              23.00048828125,
+              18.34423828125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 87,
+            "elapsedSeconds": 126.78138709068298,
+            "loadAverage": [
+              9.32958984375,
+              23.00048828125,
+              18.34423828125
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 91,
+            "elapsedSeconds": 128.93759989738464,
+            "loadAverage": [
+              9.0625,
+              22.7177734375,
+              18.271484375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 82,
+            "elapsedSeconds": 131.08228087425232,
+            "loadAverage": [
+              9.0625,
+              22.7177734375,
+              18.271484375
+            ]
+          },
+          {
+            "deviceUtilizationPercent": 91,
+            "elapsedSeconds": 133.4050612449646,
+            "loadAverage": [
+              11.69970703125,
+              23.03759765625,
+              18.41015625
+            ]
+          }
+        ],
+        "knownRenderingWorkerCount": 1,
+        "maxPressureLevel": 1,
+        "measurementMode": "desktop-load",
+        "peakResidentBytes": 15813574656,
+        "processSeconds": 135.5230951309204,
+        "profiled": false,
+        "prompt": "Explain how a small community could turn an abandoned railway station into a public library. Discuss the building, accessibility, staffing, the collection, and a realistic opening-day scene. Write approximately 400 words of clear, connected prose.",
+        "runtimeOverrides": {},
+        "sourceHead": "c3ef55db5f09b2bcc6526bec4dd2a78eaa27aee6",
+        "startedUnixSeconds": 1788625585.329428,
+        "uncontended": false,
+        "workload": "prose"
+      },
+      "scenarios": [
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 1.194476340097812
+          },
+          "endToEndSpeedups": {
+            "adaptive": 1.1644696775327341
+          },
+          "promptCharacters": 247,
+          "repetition": 1,
+          "requestedDecodeTokens": 256,
+          "temperature": 0.7,
+          "variants": [
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 17.37777090072632,
+              "decodeTokensPerSecond": 14.731463630315224,
+              "elapsedSeconds": 18.300414085388184,
+              "endToEndTokensPerSecond": 13.988754506074326,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.05843091011047363,
+              "generatedTokens": 256,
+              "loadSeconds": 3.3020973205566406e-05,
+              "name": "baseline",
+              "outputSHA256": "fd840c9ce0dded20126c282d297184ec253d65dcc0220bf2d7f0b33f431fb214",
+              "policy": "disabled",
+              "prefillSeconds": 0.9197919368743896,
+              "prefillTokensPerSecond": 65.23214391712355,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 15416639488,
+              "residentMemoryBeforeBytes": 15416492032,
+              "ttftSeconds": 0.9782558679580688
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.59375,
+                "acceptedDraftTokens": 76,
+                "draftHistoryTokens": 0,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 128,
+                "rounds": 128,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 14.548442959785461,
+              "decodeTokensPerSecond": 17.596384761422957,
+              "elapsedSeconds": 15.71566390991211,
+              "endToEndTokensPerSecond": 16.289480448772952,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0017069578170776367,
+              "generatedTokens": 256,
+              "loadSeconds": 2.09808349609375e-05,
+              "name": "adaptive",
+              "outputSHA256": "f895946b0ceb6caedd3cf2a123ad3b030d5d939fc21d9174ecc5a6f1c063b6d1",
+              "policy": "adaptive",
+              "prefillSeconds": 1.1648629903793335,
+              "prefillTokensPerSecond": 51.50820353598942,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 15813525504,
+              "residentMemoryBeforeBytes": 15813443584,
+              "ttftSeconds": 1.166590929031372
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 1.0662801923110918
+          },
+          "endToEndSpeedups": {
+            "adaptive": 1.0587489328114812
+          },
+          "promptCharacters": 247,
+          "repetition": 2,
+          "requestedDecodeTokens": 256,
+          "temperature": 0.7,
+          "variants": [
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 16.027796030044556,
+              "decodeTokensPerSecond": 15.972252174916674,
+              "elapsedSeconds": 16.82800006866455,
+              "endToEndTokensPerSecond": 15.212740608237699,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.04798603057861328,
+              "generatedTokens": 256,
+              "loadSeconds": 4.303455352783203e-05,
+              "name": "baseline",
+              "outputSHA256": "6cfce9b7b8d08c57b68c1156be005d86931fb1108c883cdf561f59429e0bf306",
+              "policy": "disabled",
+              "prefillSeconds": 0.7972429990768433,
+              "prefillTokensPerSecond": 75.25936266543097,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 15416901632,
+              "residentMemoryBeforeBytes": 15416770560,
+              "ttftSeconds": 0.8452720642089844
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.609375,
+                "acceptedDraftTokens": 78,
+                "draftHistoryTokens": 0,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 128,
+                "rounds": 128,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 15.03150498867035,
+              "decodeTokensPerSecond": 17.030896120711407,
+              "elapsedSeconds": 15.894230961799622,
+              "endToEndTokensPerSecond": 16.106472884109547,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0013859272003173828,
+              "generatedTokens": 256,
+              "loadSeconds": 3.3974647521972656e-05,
+              "name": "adaptive",
+              "outputSHA256": "293ac99a5c8a78ab366c88082071b654a9954eb9a39004aa4b10b68a8d19306b",
+              "policy": "adaptive",
+              "prefillSeconds": 0.8606880903244019,
+              "prefillTokensPerSecond": 69.71166520659698,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 15813509120,
+              "residentMemoryBeforeBytes": 15813525504,
+              "ttftSeconds": 0.8621079921722412
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        },
+        {
+          "contextSize": 8192,
+          "decodeSpeedups": {
+            "adaptive": 1.061922776422489
+          },
+          "endToEndSpeedups": {
+            "adaptive": 1.0694411856037307
+          },
+          "promptCharacters": 247,
+          "repetition": 3,
+          "requestedDecodeTokens": 256,
+          "temperature": 0.7,
+          "variants": [
+            {
+              "acceleration": {
+                "route": "final-target-pipelined"
+              },
+              "decodeSeconds": 16.32183802127838,
+              "decodeTokensPerSecond": 15.684508060076265,
+              "elapsedSeconds": 17.259183049201965,
+              "endToEndTokensPerSecond": 14.832683521010399,
+              "expectedMTPActive": false,
+              "firstTokenSeconds": 0.056159019470214844,
+              "generatedTokens": 256,
+              "loadSeconds": 2.300739288330078e-05,
+              "name": "baseline",
+              "outputSHA256": "0e7ce9825ea4f93667d9eca5869f55c46370e1d65371a1c2bbdbaa979ca6a738",
+              "policy": "disabled",
+              "prefillSeconds": 0.9345680475234985,
+              "prefillTokensPerSecond": 64.20078255295945,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 15417032704,
+              "residentMemoryBeforeBytes": 15416901632,
+              "ttftSeconds": 0.9907500743865967
+            },
+            {
+              "acceleration": {
+                "acceptanceRate": 0.625,
+                "acceptedDraftTokens": 80,
+                "draftHistoryTokens": 0,
+                "draftModel": "qwen-mtp",
+                "draftedTokens": 128,
+                "rounds": 128,
+                "route": "mtp-speculative"
+              },
+              "decodeSeconds": 15.37007999420166,
+              "decodeTokensPerSecond": 16.655736345977093,
+              "elapsedSeconds": 16.138506054878235,
+              "endToEndTokensPerSecond": 15.862682650394278,
+              "expectedMTPActive": true,
+              "firstTokenSeconds": 0.0013599395751953125,
+              "generatedTokens": 256,
+              "loadSeconds": 2.5987625122070312e-05,
+              "name": "adaptive",
+              "outputSHA256": "8d7c098af3a84cf1f2f0ee117ac987aab2d2e7b7a43867e85f662d1601da970b",
+              "policy": "adaptive",
+              "prefillSeconds": 0.7659449577331543,
+              "prefillTokensPerSecond": 78.33461059339365,
+              "promptTokens": 60,
+              "residentMemoryAfterBytes": 15813574656,
+              "residentMemoryBeforeBytes": 15813525504,
+              "ttftSeconds": 0.7673308849334717
+            }
+          ],
+          "warmupTokens": 256,
+          "warmups": 1
+        }
+      ]
+    }
+  ],
+  "releaseBuild": {
+    "binarySHA256": "37ae108285410acec9ee3863de69475fb74ce9b472bf23c05e0e0df8ce26414c",
+    "command": "swift build -c release --product mere.run --disable-index-store",
+    "completedUnixSeconds": 1788623568.49564,
+    "sourceRevision": "c3ef55db5f09b2bcc6526bec4dd2a78eaa27aee6",
+    "swiftVersion": "Apple Swift version 6.3 (swiftlang-6.3.0.123.5 clang-2100.0.123.102)\nTarget: arm64-apple-macosx26.0"
+  },
+  "schemaVersion": 1,
+  "validation": {
+    "localGate": {
+      "logSHA256": "bf60ac01795cda368cb89b4291f76c674738891648e9146738a4299c419cf625",
+      "passed": true,
+      "skipped": 309,
+      "swiftTestingChecks": 51,
+      "xctestCases": 3909
+    },
+    "ornithCheckpoint": {
+      "logSHA256": "fa9c5faf6540a49c4a1d772fdfdc7c387008c00edf34fac15e50ab63bf7e37fc",
+      "passed": true
+    },
+    "qwenCheckpoint": {
+      "logSHA256": "4eac1ffe41ed31323ddd21e95c034981c723aa0435205a30cbd7c12292041f1e",
+      "passed": true
+    },
+    "targetedMetal": {
+      "logSHA256": "9bd330a41ffcb9d9cf93d63dbe789ada7bd44d8d5f8990e2d0014a6e3fafcfc4",
+      "passed": true,
+      "tests": 8
+    }
+  }
+}


### PR DESCRIPTION
Publish complete Qwen3.8 27B Q4 and Ornith 1.5 Q4 generation measurements with all repetition ranges, serial/MTP comparisons, sampled and reversed-order controls, model/build provenance, and downloadable receipts. The report distinguishes shared-workstation observations from causal speedup claims. The docs build now copies benchmark receipt assets so the download links work.

A separate Ornith upstream audit checks the MTP architecture against pinned vLLM and llama.cpp references and compares the stock head with a pinned Shisa replacement using unchanged target weights and runtime. At three drafts per round, code acceptance improves from 34.8% to 70.7%, and prose from 13.4% to 31.0%. All 40 additional measured outputs match serial exactly. The replacement remains experimental; this change does not alter model defaults.

Validation: documentation build and example/link-text checks passed. Both reports and receipt downloads return HTTP 200 locally; served receipt bytes match the recorded SHA-256 hashes. All original 84 final greedy requests and 72 selection requests preserve exact output hashes; the 24 sampled requests remain separate. The head comparison also retains timing, load observations, model provenance, and tensor conversion hashes. Runtime validation is recorded in PR #443.
