### PR TITLE
Promote Ornith distilled MTP and isolate Qwen sampling state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ The format is based on Keep a Changelog.
 
 ### Runtime
 
+- fixed sampled Qwen-family requests retaining random state from another
+  thread's GPU stream. Each request now owns its random state and applies its
+  seed to both token sampling and MTP acceptance draws.
+- upgraded the managed Ornith 1.5 Q4 bundle to Shisa's Ornith-distilled BF16
+  MTP head, with higher measured draft acceptance and a 1.69 GB head component
+  replacing the 4.38 GB shard. The target and vision weights are unchanged.
+  Existing compact and legacy MTP indexes remain supported. Update an installed
+  Q4 bundle with `mere.run model pull text-agent-ornith-35b-mlx-4bit --force`.
 - stabilized repeated Qwen3.8 27B Q4 and Ornith 1.5 Q4 requests by keeping
   compiled activation graphs on each request's MLX stream. These managed
   targets also use asynchronous short decoder blocks and pipelined target

--- a/Sources/MereRunCLI/Commands/TextChatCommand.swift
+++ b/Sources/MereRunCLI/Commands/TextChatCommand.swift
@@ -193,7 +193,7 @@ struct TextChat: AsyncParsableCommand {
     @Flag(name: [.customLong("stats")], help: "Print generation timing and tokens/sec.")
     var stats: Bool = false
 
-    @Option(name: [.customLong("seed")], help: "Deterministic DiffusionGemma canvas seed.")
+    @Option(name: [.customLong("seed")], help: "Seed for Qwen-family sampling and DiffusionGemma canvas generation.")
     var seed: UInt64?
 
     @Flag(name: [.customLong("stream")], help: "Stream generated text to stdout as tokens arrive.")

--- a/Sources/MereRunCore/Q35/Q35Generator.swift
+++ b/Sources/MereRunCore/Q35/Q35Generator.swift
@@ -739,6 +739,18 @@ public actor Q35Generator: ChatGenerator {
         progressHandler: (@Sendable (ChatProgress) -> Void)?,
         maxContextLength: Int
     ) async throws -> ChatResponse {
+        try await Q35Sampling.withRequestState(seed: request.seed) {
+            try await generateWithRequestState(
+                request, progressHandler: progressHandler, maxContextLength: maxContextLength
+            )
+        }
+    }
+
+    private func generateWithRequestState(
+        _ request: ChatRequest,
+        progressHandler: (@Sendable (ChatProgress) -> Void)?,
+        maxContextLength: Int
+    ) async throws -> ChatResponse {
         guard let model,
               let tokenizerAndTemplate,
               let loadedConfig else {
@@ -1610,7 +1622,7 @@ public actor Q35Generator: ChatGenerator {
                     let targetProb = targetProbs[draft].item(Float.self)
                     let acceptProbability = min(1.0, targetProb / draftProb)
 
-                    if Float.random(in: 0..<1) <= acceptProbability {
+                    if Q35Sampling.acceptsDraft(probability: acceptProbability) {
                         mtpAcceptedTokens += 1
                         if eosSet.contains(draft) {
                             break

--- a/Sources/MereRunCore/Q35/Q35Resources.swift
+++ b/Sources/MereRunCore/Q35/Q35Resources.swift
@@ -169,8 +169,8 @@ public struct Q35Resources: Sendable, Hashable {
     public static let ornith35BMLX4BitUpstreamRevision = "19504d912fa8fc7622bf6b1de3db5d5d890b1f02"
     public static let ornith35BMLX4BitEstimatedDownloadBytes: Int64 = 19_530_936_278
     public static let ornith35BMLX4BitBundleRepoId = "Sawfwair/Ornith-1.5-35B-A3B-MLX-4bit-Vision-MTP"
-    public static let ornith35BMLX4BitBundleRevision = "2323acfa0fd0a01c452c89991558e6bbd86f0f05"
-    public static let ornith35BMLX4BitBundleEstimatedDownloadBytes: Int64 = 28_652_830_929
+    public static let ornith35BMLX4BitBundleRevision = "19a8ee57cb185cb487fa29ff7175c5e1544ebf1c"
+    public static let ornith35BMLX4BitBundleEstimatedDownloadBytes: Int64 = 25_963_186_364
     public static let ornith35BMLX6BitUpstreamRepoId = "ornith-ai/Ornith-1.5-35B-A3B-MLX-6bit"
     public static let ornith35BMLX6BitUpstreamRevision = "585b7867b0517980293ece857b26d64e84491352"
     public static let ornith35BMLX6BitEstimatedDownloadBytes: Int64 = 28_190_535_198
@@ -199,13 +199,22 @@ public struct Q35Resources: Sendable, Hashable {
         ornith35BMTPShardFilename,
     ]
     public static let ornith35BMTPEstimatedDownloadBytes: Int64 = 4_379_189_705
+    public static let ornith35BMLX4BitMTPShardFilename = "model-mtp.safetensors"
+    public static let ornith35BMLX4BitMTPSnapshotPatterns = [
+        "README.md",
+        "LICENSE",
+        "NOTICE",
+        "PROVENANCE.json",
+        "model.safetensors.index.json",
+        ornith35BMLX4BitMTPShardFilename,
+    ]
     public static let ornith35BMLX4BitBundleSnapshotPatterns = snapshotPatterns + [
         "generation_config.json",
         "README.md",
         "mererun_model.json",
         "SHA256SUMS",
     ] + ornith35BVisionComponentSnapshotPatterns.map { "\(ornith35BVisionComponentPath)/\($0)" }
-        + ornith35BMTPSnapshotPatterns.map { "\(ornith35BMTPComponentPath)/\($0)" }
+        + ornith35BMLX4BitMTPSnapshotPatterns.map { "\(ornith35BMTPComponentPath)/\($0)" }
     public static let ornith35BMLXContextLength = 262_144
     public static let infinityParser2ProUpstreamRepoId = "infly/Infinity-Parser2-Pro"
     public static let infinityParser2ProUpstreamRevision = "1d070df7db5acca0ffa75596229070a047704f89"
@@ -510,10 +519,7 @@ public struct Q35Resources: Sendable, Hashable {
             Self.ornith35BMTPComponentPath,
             isDirectory: true
         )
-        return [
-            componentRoot.appendingPathComponent("model.safetensors.index.json", isDirectory: false),
-            componentRoot.appendingPathComponent(Self.ornith35BMTPShardFilename, isDirectory: false),
-        ].filter { !fileManager.fileExists(atPath: $0.path) }
+        return Q35Resources(rootURL: componentRoot).validateOrnith35BMTPCompanion(fileManager: fileManager)
     }
 
     public func validateQ38VisionComponent(fileManager: FileManager = .default) -> [URL] {
@@ -524,10 +530,17 @@ public struct Q35Resources: Sendable, Hashable {
     }
 
     public func validateOrnith35BMTPCompanion(fileManager: FileManager = .default) -> [URL] {
-        [
-            modelIndexURL,
-            rootURL.appendingPathComponent(Self.ornith35BMTPShardFilename, isDirectory: false),
-        ].filter { !fileManager.fileExists(atPath: $0.path) }
+        let index: HFSafetensorsIndex
+        do {
+            index = try JSONDecoder().decode(HFSafetensorsIndex.self, from: Data(contentsOf: modelIndexURL))
+        } catch {
+            return [modelIndexURL]
+        }
+        // Legacy indexes also describe target shards that are not part of the MTP component.
+        let shards = Set(index.weightMap.filter { $0.key.hasPrefix("mtp.") }.values).sorted()
+        guard !shards.isEmpty else { return [modelIndexURL] }
+        return shards.map { rootURL.appendingPathComponent($0, isDirectory: false) }
+            .filter { !fileManager.fileExists(atPath: $0.path) }
     }
 
     public static func normalizedRootURL(_ rootURL: URL, fileManager: FileManager = .default) -> URL {

--- a/Sources/MereRunCore/Q35/Q35Sampling.swift
+++ b/Sources/MereRunCore/Q35/Q35Sampling.swift
@@ -1,0 +1,17 @@
+import MLX
+
+enum Q35Sampling {
+    static func acceptsDraft(probability: Float) -> Bool {
+        MLXRandom.uniform().item(Float.self) < probability
+    }
+
+    /// Create keys on the request's stream instead of extending a global lazy
+    /// random-state graph that can belong to another thread's GPU stream.
+    static func withRequestState<Result: Sendable>(
+        seed: UInt64?,
+        _ operation: @Sendable () async throws -> Result
+    ) async rethrows -> Result {
+        let state = seed.map { MLXRandom.RandomState(seed: $0) } ?? MLXRandom.RandomState()
+        return try await withRandomState(state, body: operation)
+    }
+}

--- a/Sources/MereRunCore/Q35/README.md
+++ b/Sources/MereRunCore/Q35/README.md
@@ -29,9 +29,16 @@ path; that precision still requires separate serial-output qualification.
 Qwen3.6 hybrid MoE keeps the existing adaptive long-context threshold.
 
 Ornith 1.5's official MLX quants omit the MTP tensors advertised by their
-configuration. Managed Q4/Q6/Q8/BF16 pulls therefore install one shared,
-revision-pinned final shard from the authoritative Ornith base checkpoint; the
-runtime reads only its `mtp.*` tensors. Routed-expert gate/up fusion is prepared
+configuration. The managed Q4 bundle contains Shisa's Ornith-distilled BF16 head
+at revision `2b19b31bfe1659c6b0d9459ec3cbd87e34a322ef`, packaged as 785 indexed
+raw-HF tensors in `mtp/model-mtp.safetensors`. The conversion preserves every
+BF16 value and the zero-centered norm convention. The component includes its
+Apache-2.0 license, notice, and per-tensor provenance. Q6/Q8/BF16 pulls retain
+the shared, revision-pinned final shard from the authoritative Ornith base
+checkpoint. Validation reads the MTP index, accepting both compact and legacy
+components while ignoring unrelated target shard entries.
+
+Routed-expert gate/up fusion is prepared
 one decoder layer at a time after target weights load. Each evaluated fused
 stack replaces its two source arrays before the MLX cache is cleared, bounding
 transient preparation memory instead of retaining a model-wide duplicate.
@@ -59,7 +66,11 @@ Speculative rows execute on a disposable fork. The exact target projection still
 every emitted token. Per-request acceptance estimates adapt the draft depth and
 can fall back to target-only rounds when proposals stop paying for their repair
 cost. Sampled MTP keeps the full-vocabulary probability path and doesn't prime
-greedy draft history. `MERERUN_Q35_MTP_STREAM_HISTORY=0` restores the earlier
+greedy draft history. Each generation request owns its random state, initialized
+from the request seed when supplied. Token draws and MTP acceptance draws use
+that state, so cached seeded replays do not extend another thread's lazy GPU
+random graph. The same seed is reproducible within a route; MTP and target-only
+sampling consume different draws and need not produce identical text. `MERERUN_Q35_MTP_STREAM_HISTORY=0` restores the earlier
 history strategy for Qwen 27B and Ornith: dense prompts up to 4,096 tokens retain
 hidden history; longer dense prompts and Ornith start without prompt history.
 Set the value to `none` to omit prompt history entirely for benchmark ablation.

--- a/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
@@ -899,6 +899,11 @@ final class ManagedModelCatalogTests: XCTestCase {
         XCTAssertEqual(spec.hubFallback?.repoId, Q35Resources.ornith35BMLX4BitBundleRepoId)
         XCTAssertEqual(spec.hubFallback?.revision, Q35Resources.ornith35BMLX4BitBundleRevision)
         XCTAssertEqual(spec.hubFallback?.patterns, Q35Resources.ornith35BMLX4BitBundleSnapshotPatterns)
+        XCTAssertTrue(spec.hubFallback?.patterns.contains("mtp/model-mtp.safetensors") == true)
+        XCTAssertTrue(spec.hubFallback?.patterns.contains("mtp/LICENSE") == true)
+        XCTAssertTrue(spec.hubFallback?.patterns.contains("mtp/NOTICE") == true)
+        XCTAssertTrue(spec.hubFallback?.patterns.contains("mtp/PROVENANCE.json") == true)
+        XCTAssertFalse(spec.hubFallback?.patterns.contains("mtp/model-00016-of-00016.safetensors") == true)
         XCTAssertTrue(spec.mountedHubFallbacks.isEmpty)
         XCTAssertTrue(spec.companionModelIDs.isEmpty)
         XCTAssertEqual(spec.estimatedDownloadBytes, Q35Resources.ornith35BMLX4BitBundleEstimatedDownloadBytes)
@@ -1042,7 +1047,6 @@ final class ManagedModelCatalogTests: XCTestCase {
         }
         let expectedMTP = [
             "\(Q35Resources.ornith35BMTPComponentPath)/model.safetensors.index.json",
-            "\(Q35Resources.ornith35BMTPComponentPath)/\(Q35Resources.ornith35BMTPShardFilename)",
         ]
         XCTAssertEqual(missing, Set(expectedVision + expectedMTP))
 
@@ -1053,7 +1057,7 @@ final class ManagedModelCatalogTests: XCTestCase {
             ),
             (
                 Q35Resources.ornith35BMTPComponentPath,
-                ["model.safetensors.index.json", Q35Resources.ornith35BMTPShardFilename]
+                [Q35Resources.ornith35BMLX4BitMTPShardFilename]
             ),
         ] {
             let componentRoot = root.appendingPathComponent(directory, isDirectory: true)
@@ -1062,7 +1066,34 @@ final class ManagedModelCatalogTests: XCTestCase {
                 try Data().write(to: componentRoot.appendingPathComponent(filename))
             }
         }
+        let mtpRoot = root.appendingPathComponent(Q35Resources.ornith35BMTPComponentPath)
+        try JSONEncoder().encode(HFSafetensorsIndex(metadata: nil, weightMap: [
+            "mtp.norm.weight": Q35Resources.ornith35BMLX4BitMTPShardFilename,
+        ])).write(to: mtpRoot.appendingPathComponent("model.safetensors.index.json"))
         XCTAssertTrue(spec.missingPaths(in: root).isEmpty)
+    }
+
+    func testOrnithMTPValidationUsesOnlyIndexedMTPShards() throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let resources = Q35Resources(rootURL: root)
+        for filename in [Q35Resources.ornith35BMTPShardFilename, Q35Resources.ornith35BMLX4BitMTPShardFilename] {
+            let index = HFSafetensorsIndex(metadata: nil, weightMap: [
+                "mtp.norm.weight": filename,
+                "model.language_model.norm.weight": "unused-target.safetensors",
+            ])
+            try JSONEncoder().encode(index).write(to: resources.modelIndexURL)
+            let shard = root.appendingPathComponent(filename)
+            XCTAssertEqual(resources.validateOrnith35BMTPCompanion(), [shard])
+            try Data().write(to: shard)
+            XCTAssertTrue(resources.validateOrnith35BMTPCompanion().isEmpty)
+            try FileManager.default.removeItem(at: shard)
+        }
+        for invalid in ["{}", "not json", "{\"weight_map\":{}}",
+                        "{\"weight_map\":{\"model.norm.weight\":\"target.safetensors\"}}"] {
+            try Data(invalid.utf8).write(to: resources.modelIndexURL)
+            XCTAssertEqual(resources.validateOrnith35BMTPCompanion(), [resources.modelIndexURL])
+        }
     }
 
     func testQ38TwentySevenB4BitValidationRequiresMountedComponents() throws {
@@ -1248,9 +1279,9 @@ final class ManagedModelCatalogTests: XCTestCase {
             isDirectory: true
         )
         try FileManager.default.createDirectory(at: companionRoot, withIntermediateDirectories: true)
-        try Data("{}".utf8).write(
-            to: companionRoot.appendingPathComponent("model.safetensors.index.json")
-        )
+        try JSONEncoder().encode(HFSafetensorsIndex(metadata: nil, weightMap: [
+            "mtp.norm.weight": Q35Resources.ornith35BMTPShardFilename,
+        ])).write(to: companionRoot.appendingPathComponent("model.safetensors.index.json"))
         try Data([0]).write(
             to: companionRoot.appendingPathComponent(Q35Resources.ornith35BMTPShardFilename)
         )

--- a/Tests/MereRunCoreTests/Q35SamplingTests.swift
+++ b/Tests/MereRunCoreTests/Q35SamplingTests.swift
@@ -1,0 +1,36 @@
+import MLX
+import XCTest
+@testable import MereRunCore
+
+final class Q35SamplingTests: MereRunCoreTestCase {
+    func testRequestSeedsReplayAcrossStreamsAndInterveningRandomWork() async {
+        defer { MLXRandom.seed(0) }
+        let first = await samples(seed: 7)
+        let differentSeed = await samples(seed: 42)
+        MLXRandom.seed(991)
+        MLX.eval(MLXRandom.uniform(0 ..< 1, [128]))
+        let replay = await samples(seed: 7)
+        XCTAssertEqual(first, replay)
+        XCTAssertNotEqual(first, differentSeed)
+        XCTAssertTrue(first.allSatisfy { (0..<8).contains($0) })
+    }
+
+    private func samples(seed: UInt64) async -> [Int] {
+        await Q35CompiledOperations.withNewDefaultStream(scoped: true) {
+            await Q35Sampling.withRequestState(seed: seed) {
+                let logits = MLXArray([Float(1), 1, 1, 1, -20])
+                let config = GenerationConfig(temperature: 0.7, topK: 4, topP: 0.9, minP: 0.05)
+                var result: [Int] = []
+                XCTAssertFalse(Q35Sampling.acceptsDraft(probability: 0))
+                XCTAssertTrue(Q35Sampling.acceptsDraft(probability: 1))
+                for _ in 0..<32 {
+                    let token = sampleToken(logits: logits, config: config, previousTokens: [])
+                    let accepted = Q35Sampling.acceptsDraft(probability: 0.5)
+                    result.append(token + (accepted ? 4 : 0))
+                    await Task.yield()
+                }
+                return result
+            }
+        }
+    }
+}

--- a/Tests/MereRunCoreTests/Q35TransferCheckpointTests.swift
+++ b/Tests/MereRunCoreTests/Q35TransferCheckpointTests.swift
@@ -23,9 +23,62 @@ final class Q35TransferCheckpointTests: MereRunCoreTestCase {
         await generator.unload()
     }
 
-    private func qualify(_ generator: Q35Generator, root: String) async throws {
+    func testInstalledExtendedContextReplay() async throws {
+        let env = ProcessInfo.processInfo.environment
+        try XCTSkipUnless(env["MERERUN_TEST_Q35_TRANSFER"] == "1", "Installed Qwen transfer qualification is opt-in.")
+        let root = try XCTUnwrap(env["MERERUN_TEST_Q35_TRANSFER_MODEL_ROOT"])
+        try XCTSkipUnless(env["MERERUN_TEST_Q35_TRANSFER_MODEL_ID"] == Q35Resources.ornith35BMLX4BitModelId,
+                          "This qualification selects the Ornith Q4 head.")
+        let generator = Q35Generator(modelId: Q35Resources.ornith35BMLX4BitModelId,
+                                     prefixKVCacheEnabled: true, continuousBatchingEnabled: false)
+        do {
+            try await qualify(generator, root: root, archiveRows: 1_700, minimumPromptTokens: 32_768)
+        } catch {
+            await generator.unload()
+            throw error
+        }
+        await generator.unload()
+    }
+
+    func testInstalledToolsSamplingAndThinking() async throws {
+        let env = ProcessInfo.processInfo.environment
+        try XCTSkipUnless(env["MERERUN_TEST_Q35_TRANSFER"] == "1", "Installed Qwen transfer qualification is opt-in.")
+        let root = try XCTUnwrap(env["MERERUN_TEST_Q35_TRANSFER_MODEL_ROOT"])
+        try XCTSkipUnless(env["MERERUN_TEST_Q35_TRANSFER_MODEL_ID"] == Q35Resources.ornith35BMLX4BitModelId,
+                          "This qualification selects the Ornith Q4 head.")
+        let generator = Q35Generator(modelId: Q35Resources.ornith35BMLX4BitModelId,
+                                     prefixKVCacheEnabled: true, continuousBatchingEnabled: false)
+        do {
+            try await qualifyTools(generator, root: root)
+            try await qualifySampling(generator, root: root)
+            var thinkingRequest = request([ChatMessage(role: .user, content:
+                "What is 17 plus 25? Think briefly, then answer with the number.")])
+            thinkingRequest.maxTokens = 256
+            thinkingRequest.showThinking = true
+            let candidate = try await generator.chat(thinkingRequest, modelPath: root, progressHandler: nil)
+            trace("thinking-mtp", candidate)
+            thinkingRequest.logprobCapture = .tokens
+            let target = try await generator.chat(thinkingRequest, modelPath: root, progressHandler: nil)
+            trace("thinking-serial", target)
+            XCTAssertEqual(candidate.acceleration?.route, "mtp-speculative")
+            XCTAssertEqual(target.acceleration?.route, "final-target-pipelined")
+            XCTAssertTrue(candidate.response.contains("42"))
+            XCTAssertFalse(candidate.reasoningContent?.isEmpty ?? true)
+            XCTAssertEqual(candidate.response, target.response)
+            XCTAssertEqual(candidate.reasoningContent, target.reasoningContent)
+            XCTAssertEqual(candidate.tokensGenerated, target.tokensGenerated)
+        } catch {
+            await generator.unload()
+            throw error
+        }
+        await generator.unload()
+    }
+
+    private func qualify(
+        _ generator: Q35Generator, root: String, archiveRows: Int = 250, minimumPromptTokens: Int = 4_096
+    ) async throws {
         let marker = "spruce-lantern-7429"
-        let filler = (1...250).map { index in
+        let filler = (1...archiveRows).map { index in
             "Archive \(index): routine weather observations, equipment checks, and inventory counts were recorded."
         }.joined(separator: "\n")
         let messages = [ChatMessage(role: .user, content:
@@ -34,7 +87,7 @@ final class Q35TransferCheckpointTests: MereRunCoreTestCase {
         let cold = try await generator.chat(request(messages), modelPath: root, progressHandler: nil)
         trace("cold", cold)
         let promptTokens = try XCTUnwrap(cold.promptTokens)
-        XCTAssertGreaterThan(promptTokens, 4_096)
+        XCTAssertGreaterThan(promptTokens, minimumPromptTokens)
         XCTAssertEqual(cold.acceleration?.route, "mtp-speculative")
         XCTAssertEqual(cold.acceleration?.draftHistoryTokens, promptTokens - 1)
         XCTAssertTrue(cold.response.contains(marker))
@@ -73,7 +126,7 @@ final class Q35TransferCheckpointTests: MereRunCoreTestCase {
 
     private func request(_ messages: [ChatMessage]) -> ChatRequest {
         ChatRequest(messages: messages, maxTokens: 64, temperature: 0, topP: 1,
-                    showThinking: false, maxContextTokens: 16_384)
+                    showThinking: false, maxContextTokens: 65_536)
     }
 
     private func qualifyGenerationCases(_ generator: Q35Generator, root: String) async throws {
@@ -105,7 +158,92 @@ final class Q35TransferCheckpointTests: MereRunCoreTestCase {
         XCTAssertEqual(candidate.reasoningContent, target.reasoningContent)
     }
 
+    private func qualifyTools(_ generator: Q35Generator, root: String) async throws {
+        let tool = ToolDefinition(name: "lookup_project", description: "Look up a project passphrase.",
+                                  parameters: ["project": ToolParameterProperty(type: "string", description: "Project name")])
+        var toolRequest = request([ChatMessage(role: .user, content:
+            "Use lookup_project to get the passphrase for cobalt-harbor. Do not guess the passphrase.")])
+        toolRequest.maxTokens = 128
+        toolRequest.tools = [tool]
+        toolRequest.toolChoice = .function(tool.name)
+        let candidate = try await generator.chat(toolRequest, modelPath: root, progressHandler: nil)
+        trace("tool-default", candidate)
+        let expected = [ToolCall(name: tool.name, arguments: ["project": "cobalt-harbor"])]
+        XCTAssertEqual(candidate.toolCalls, expected)
+        // Tool requests intentionally bypass MTP; changing the installed head must preserve this route.
+        XCTAssertEqual(candidate.acceleration?.route, "final-target-pipelined")
+        XCTAssertNil(candidate.acceleration?.acceptedDraftTokens)
+        toolRequest.logprobCapture = .tokens
+        let target = try await generator.chat(toolRequest, modelPath: root, progressHandler: nil)
+        trace("tool-serial", target)
+        XCTAssertEqual(target.acceleration?.route, "final-target-pipelined")
+        XCTAssertEqual(candidate.toolCalls, target.toolCalls)
+        XCTAssertEqual(candidate.response, target.response)
+        XCTAssertEqual(candidate.tokensGenerated, target.tokensGenerated)
+        toolRequest.messages += [
+            ChatMessage(role: .assistant, content: candidate.response, toolCalls: [
+                ChatMessageToolCall(id: "call_qualification", name: tool.name,
+                                    arguments: ["project": .string("cobalt-harbor")]),
+            ]),
+            ChatMessage(role: .tool, content: "{\"passphrase\":\"spruce-lantern-7429\"}", name: tool.name,
+                        toolCallID: "call_qualification"),
+            ChatMessage(role: .user, content: "Return only the exact passphrase from the tool result."),
+        ]
+        toolRequest.toolChoice = .auto
+        toolRequest.logprobCapture = .none
+        let before = await generator.prefixKVCacheStats()
+        let followup = try await generator.chat(toolRequest, modelPath: root, progressHandler: nil)
+        trace("tool-followup-default", followup)
+        let after = await generator.prefixKVCacheStats()
+        XCTAssertGreaterThan(after.hits, before.hits)
+        XCTAssertTrue(followup.response.contains("spruce-lantern-7429"))
+        XCTAssertEqual(followup.acceleration?.route, "final-target-pipelined")
+        toolRequest.logprobCapture = .tokens
+        let serialFollowup = try await generator.chat(toolRequest, modelPath: root, progressHandler: nil)
+        trace("tool-followup-serial", serialFollowup)
+        XCTAssertEqual(followup.response, serialFollowup.response)
+        XCTAssertEqual(followup.toolCalls, serialFollowup.toolCalls)
+    }
+
+    private func qualifySampling(_ generator: Q35Generator, root: String) async throws {
+        for seed: UInt64 in [7, 42, 2_026] {
+            var sampledRequest = ChatRequest(
+                messages: [ChatMessage(role: .user, content:
+                    "Describe how volunteers could turn an abandoned railway station into a public library.")],
+                maxTokens: 96, temperature: 0.7, topP: 0.9, topK: 20, minP: 0.05,
+                seed: seed, showThinking: false, stopOnEOS: false, maxContextTokens: 8_192
+            )
+            let candidate = try await generator.chat(sampledRequest, modelPath: root, progressHandler: nil)
+            trace("sample-\(seed)-mtp", candidate)
+            XCTAssertEqual(candidate.acceleration?.route, "mtp-speculative")
+            XCTAssertGreaterThan(candidate.acceleration?.draftedTokens ?? 0, 0)
+            XCTAssertGreaterThanOrEqual(candidate.acceleration?.acceptanceRate ?? -1, 0)
+            XCTAssertLessThanOrEqual(candidate.acceleration?.acceptanceRate ?? 2, 1)
+            if seed == 7 {
+                let replay = try await generator.chat(sampledRequest, modelPath: root, progressHandler: nil)
+                trace("sample-\(seed)-mtp-replay", replay)
+                XCTAssertEqual(candidate.response, replay.response, "The same request seed must replay after a cache hit")
+                XCTAssertEqual(candidate.tokensGenerated, replay.tokensGenerated)
+            }
+            sampledRequest.logprobCapture = .tokens
+            let target = try await generator.chat(sampledRequest, modelPath: root, progressHandler: nil)
+            trace("sample-\(seed)-serial", target)
+            XCTAssertEqual(target.acceleration?.route, "final-target-pipelined")
+            // Rejection sampling consumes different random draws; same-seed text equality is not expected.
+            for response in [candidate, target] {
+                XCTAssertEqual(response.tokensGenerated, 96)
+                XCTAssertFalse(response.response.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                XCTAssertFalse(response.response.contains("\u{FFFD}"))
+                XCTAssertTrue(response.timing?.decodeSeconds.isFinite == true)
+            }
+        }
+    }
+
     private func trace(_ label: String, _ response: ChatResponse) {
+        struct ToolRecord: Encodable {
+            let name: String
+            let arguments: [String: String]
+        }
         struct Record: Encodable {
             let label: String
             let promptTokens: Int?
@@ -114,11 +252,16 @@ final class Q35TransferCheckpointTests: MereRunCoreTestCase {
             let decodeSeconds: Double?
             let acceleration: ChatAccelerationDiagnostics?
             let output: String
+            let reasoning: String?
+            let toolCalls: [ToolRecord]?
             let activeMemory: Int
         }
         let record = Record(label: label, promptTokens: response.promptTokens, tokens: response.tokensGenerated,
                             prefillSeconds: response.timing?.prefillSeconds, decodeSeconds: response.timing?.decodeSeconds,
-                            acceleration: response.acceleration, output: response.response, activeMemory: Memory.activeMemory)
+                            acceleration: response.acceleration, output: response.response,
+                            reasoning: response.reasoningContent,
+                            toolCalls: response.toolCalls?.map { ToolRecord(name: $0.name, arguments: $0.arguments) },
+                            activeMemory: Memory.activeMemory)
         let encoder = JSONEncoder()
         encoder.outputFormatting = [.sortedKeys]
         if let data = try? encoder.encode(record) {

--- a/docs/benchmarks/ornith-mtp-promotion-2026-09-05.md
+++ b/docs/benchmarks/ornith-mtp-promotion-2026-09-05.md
@@ -1,0 +1,102 @@
+# Ornith Q4 distilled MTP promotion
+
+The managed `text-agent-ornith-35b-mlx-4bit` bundle now uses Shisa's
+Ornith-distilled BF16 draft head. The target, tokenizer, configuration, and
+vision files retain their previous hashes. The compact head is 1,689,376,032
+bytes, replacing a 4,378,994,104-byte shard that also contained unused target
+weights. Q6, Q8, and BF16 companion selection is unchanged.
+
+The [preceding head comparison](ornith-mtp-upstream-check-2026-09-05.md)
+established better drafting on its two prompts. With three proposals per round,
+code acceptance increased from 34.8% to 70.7% and prose acceptance from 13.4%
+to 31.0%. All 40 measured requests retained the target's greedy output hash.
+This promotion adds compatibility checks around that result.
+
+## Artifact and provenance
+
+The [published bundle](https://huggingface.co/Sawfwair/Ornith-1.5-35B-A3B-MLX-4bit-Vision-MTP/tree/19a8ee57cb185cb487fa29ff7175c5e1544ebf1c)
+is pinned to `19a8ee57cb185cb487fa29ff7175c5e1544ebf1c`. The selected download payload is
+25,963,186,364 bytes (about 24.2 GiB). The prior immutable bundle revision,
+`2323acfa0fd0a01c452c89991558e6bbd86f0f05`, remains available for rollback.
+
+The replacement source is
+[`shisa-ai/Ornith-1.5-35B-A3B-MTP-ONLY`](https://huggingface.co/shisa-ai/Ornith-1.5-35B-A3B-MTP-ONLY/tree/2b19b31bfe1659c6b0d9459ec3cbd87e34a322ef),
+revision `2b19b31bfe1659c6b0d9459ec3cbd87e34a322ef`. Its original file SHA-256 is
+`73c6e839971fff3c6d78dbcb6a15895bbab340a2898e98aa6943070751de712e`.
+
+The layout conversion splits 19 fused BF16 tensors into 785 indexed tensors.
+It copies every tensor value unchanged, including raw-HF zero-centered RMSNorm
+weights. The packaged file SHA-256 is
+`d1b500efb9ed14e3c855ef87a118c1d4a7de27029ed5f27e7e4fae48a1d34028`.
+The bundle includes its Apache-2.0 license, notice of modifications, per-tensor
+hashes in `mtp/PROVENANCE.json`, and a complete `SHA256SUMS`. The target and
+vision components retain their upstream MIT declaration.
+
+## Compatibility checks
+
+The installed-checkpoint tests run on an Apple M4 Max with 128 GiB unified
+memory. They use the exact compact head layout and the same target and vision
+bytes as the published bundle.
+
+| Case | Check |
+|---|---|
+| Long context | Retrieve an exact passphrase from a 34,645-token prompt, replay all cached prompt tokens, and match target-only greedy output. |
+| Follow-up | Retrieve the passphrase in a 34,674-token conversation using a cache hit, then confirm the original checkpoint is unchanged. |
+| Tools | Parse the requested `lookup_project` call with the exact argument, supply a fixture tool result, and match the target-only follow-up answer. |
+| Sampling | Generate 96 tokens with temperature 0.7, top-p 0.9, top-k 20, and min-p 0.05 for seeds 7, 42, and 2026, using both MTP and target-only routes. Replay seed 7 with MTP after a cache hit and require identical output. |
+| Thinking | Match both reasoning content and the final greedy answer with thinking enabled. |
+| Vision | Load all 333 indexed vision tensors, validate their runtime mapping, and identify a red circle and blue square in the image fixture. |
+| Random state | Repeat seeded token and acceptance draws across request streams, task suspension, and intervening global random work; check acceptance probabilities zero and one. |
+
+Tool and image requests intentionally use target-only decoding. Their tests
+confirm preserved behavior; this head does not accelerate those routes.
+Sampling checks establish request execution, seed replay, and routing. They are
+not a statistical distribution-equivalence or downstream quality benchmark.
+MTP and target-only sampling consume different random draws, so equal seeds
+need not produce identical text across those routes.
+
+## Sampling correction found during qualification
+
+A combined run exposed an existing shared-random-state failure after changing
+request modes: MLX attempted to evaluate a lazy key graph belonging to another
+thread's GPU stream. The Qwen generation path also did not apply `ChatRequest.seed`,
+and MTP acceptance used a separate system random draw.
+
+Generation now creates request-local MLX random state after model loading,
+using the supplied seed when present. Token sampling and MTP acceptance share
+that state. The acceptance comparison excludes probability zero. The focused
+GPU regression and installed checkpoint replay check cover this correction.
+
+An earlier tool assertion incorrectly expected MTP routing despite the existing
+tool exclusion. The assertion was corrected to check the intended target-only
+route, while retaining exact tool-call and follow-up checks.
+
+## Reproduce and upgrade
+
+After updating mere.run, replace an older managed Q4 bundle with:
+
+```bash
+mere.run model pull text-agent-ornith-35b-mlx-4bit --force
+```
+
+Existing complete installs are preserved until explicitly replaced. Validation
+accepts both the legacy final-shard index and the compact head index.
+
+From a source checkout, set the two model-root variables to the same downloaded
+Q4 bundle and run the opt-in checks:
+
+```bash
+MERERUN_TEST_MLX_DEVICE=gpu \
+MERERUN_TEST_Q35_TRANSFER=1 \
+MERERUN_TEST_Q35_TRANSFER_MODEL_ID=text-agent-ornith-35b-mlx-4bit \
+MERERUN_TEST_Q35_TRANSFER_MODEL_ROOT=/path/to/ornith \
+MERERUN_TEST_ORNITH_VISION_4BIT_MODEL_ROOT=/path/to/ornith \
+swift test --filter 'Q35SamplingTests|Q35TransferCheckpointTests/testInstalledExtendedContextReplay|Q35TransferCheckpointTests/testInstalledToolsSamplingAndThinking|OrnithVisionCheckpointTests'
+```
+
+The [promotion receipt](receipts/ornith-mtp-promotion-2026-09-05.json) retains
+outputs, routes, token counts, timings, artifact hashes, and source hashes.
+These compatibility runs occurred with other desktop work active. Their timings
+are operational evidence, not a controlled speedup measurement. This promotion
+does not certify the full advertised 262,144-token context, concurrent serving,
+other Ornith precisions, or other inference engines.

--- a/docs/benchmarks/ornith-mtp-upstream-check-2026-09-05.md
+++ b/docs/benchmarks/ornith-mtp-upstream-check-2026-09-05.md
@@ -9,9 +9,10 @@ limiting factor on these prompts; they do not establish that the runtime has
 no remaining performance issues.
 
 This is a follow-up to the [complete generation workload report](ornith-qwen-generation-tuning-2026-09-05.md).
-The replacement head remains an experiment. The scheduling defaults in
-[PR #443](https://github.com/sawfwair/mere-run/pull/443) retain the installed
-model weights and head selection.
+The replacement was evaluated as an experiment in this comparison. The
+[subsequent promotion qualification](ornith-mtp-promotion-2026-09-05.md)
+records the compatibility checks and Q4 default update. The scheduling changes
+in [PR #443](https://github.com/sawfwair/mere-run/pull/443) preceded that head update.
 
 ## References and implementation checks
 
@@ -109,4 +110,5 @@ This check covers two short text prompts with greedy, fixed-length generation.
 It does not qualify replacement-head behavior for long contexts, tools,
 multimodal input, sampling, or concurrent serving. Exact output checks establish
 the tested verifier behavior; they do not measure downstream answer quality.
-The replacement needs broader model qualification before becoming a default.
+The subsequent promotion qualification covers those additional request modes;
+concurrent serving remains outside these checkpoint measurements.

--- a/docs/benchmarks/receipts/ornith-mtp-promotion-2026-09-05.json
+++ b/docs/benchmarks/receipts/ornith-mtp-promotion-2026-09-05.json
@@ -1,0 +1,518 @@
+{
+  "schemaVersion": 1,
+  "date": "2026-09-05",
+  "hardware": {
+    "chip": "Apple M4 Max",
+    "unifiedMemoryBytes": 137438953472,
+    "device": "gpu"
+  },
+  "scope": {
+    "managedModelID": "text-agent-ornith-35b-mlx-4bit",
+    "runtime": "mere.run native Qwen",
+    "maxTestedPromptTokens": 34674,
+    "concurrentServingQualified": false,
+    "fullAdvertisedContextQualified": false,
+    "timingUse": "Operational compatibility only; other desktop work active."
+  },
+  "head": {
+    "sourceRepository": "shisa-ai/Ornith-1.5-35B-A3B-MTP-ONLY",
+    "sourceRevision": "2b19b31bfe1659c6b0d9459ec3cbd87e34a322ef",
+    "sourceSHA256": "73c6e839971fff3c6d78dbcb6a15895bbab340a2898e98aa6943070751de712e",
+    "packagedFilename": "mtp/model-mtp.safetensors",
+    "packagedSHA256": "d1b500efb9ed14e3c855ef87a118c1d4a7de27029ed5f27e7e4fae48a1d34028",
+    "packagedBytes": 1689376032,
+    "tensorCount": 785,
+    "conversion": "Split fused expert axes; preserve every BF16 byte and raw-HF zero-centered norm weights.",
+    "conversionReceiptSHA256": "86c2a2113a4fec60d74a2ea6d78b275273e7632f916fba2d3e7c332b851fbe9e"
+  },
+  "source": {
+    "baseCommit": "22452620c4b09f5499df9c1b67f405a464256ba8",
+    "qualificationSourceFileSHA256": {
+      "Sources/MereRunCore/Q35/Q35Generator.swift": "29c7c48eac1ff0dc64cac9c43833a7a26be2d7edaaa0d5d2bc1db9e0ab692b34",
+      "Sources/MereRunCore/Q35/Q35CompiledOperations.swift": "ee3578d813d3ac6e25522a40beeeee4bf1773790b950e974204707bce789e04a",
+      "Sources/MereRunCore/Q35/Q35Sampling.swift": "beef68e88fa9fccf8ab687db8c0617ac6bbdad45a1be1456caab58c4433a47e1",
+      "Sources/MereRunCore/Q35/Q35Resources.swift": "1444554bd3c8e4e005ab91023b1d2e0776bd3a8324e7c21eb93ed84facb6c10c",
+      "Tests/MereRunCoreTests/Q35SamplingTests.swift": "68c064a141d14172b6f5c1821aae561a25de7d8aaaf9e86ea0be985e1cb4fc0d",
+      "Tests/MereRunCoreTests/Q35TransferCheckpointTests.swift": "81f342ded62b56669148481bd18da9864aea06be7b299c37887dc9443fd4ed1a",
+      "Tests/MereRunCoreTests/OrnithVisionCheckpointTests.swift": "50701c499f67a78c58cda84d23715eeb6a6253bc2be4da3b9797266689d99dfa"
+    },
+    "testExecutableSHA256": "68cbc05ad8915625be5ee034b6391235f615e4d0c8e59c08cae71e5c93b61f54"
+  },
+  "qualification": {
+    "tests": 4,
+    "failures": 0,
+    "logSHA256": "2b25428a200bc52261e8f1482e51beda934270cbdae57386d3e2ad9a666087f8",
+    "textRequests": 18,
+    "visionRequests": 1,
+    "samplingSeeds": [
+      7,
+      42,
+      2026
+    ],
+    "samplingConfiguration": {
+      "temperature": 0.7,
+      "topP": 0.9,
+      "topK": 20,
+      "minP": 0.05,
+      "maxTokens": 96
+    },
+    "samplingRouteEqualityExpected": false,
+    "sameSeedWithinRouteReplayPassed": true
+  },
+  "correctedFindings": [
+    {
+      "finding": "Shared lazy MLX random state retained another thread GPU stream; Qwen generation did not apply ChatRequest.seed.",
+      "correction": "Request-local random state after loading, shared by token and MTP acceptance draws."
+    },
+    {
+      "finding": "Initial tool test expected MTP despite an existing route exclusion.",
+      "correction": "Assert target-only routing, exact parsed call, and exact cached tool-result follow-up."
+    }
+  ],
+  "requests": [
+    {
+      "acceleration": {
+        "acceptanceRate": 0.5,
+        "acceptedDraftTokens": 6,
+        "draftHistoryTokens": 34644,
+        "draftModel": "qwen-mtp",
+        "draftedTokens": 12,
+        "rounds": 4,
+        "route": "mtp-speculative"
+      },
+      "activeMemory": 23120973756,
+      "decodeSeconds": 0.4941279888153076,
+      "label": "cold",
+      "output": "spruce-lantern-7429",
+      "prefillSeconds": 75.27326703071594,
+      "promptTokens": 34645,
+      "tokens": 10,
+      "outputSHA256": "9db62c4ceeda0e7f0918927622b557c815c4e0cb4b40686c3813b8c2d84832db"
+    },
+    {
+      "acceleration": {
+        "acceptanceRate": 0.5,
+        "acceptedDraftTokens": 6,
+        "draftHistoryTokens": 34644,
+        "draftModel": "qwen-mtp",
+        "draftedTokens": 12,
+        "rounds": 4,
+        "route": "mtp-speculative"
+      },
+      "activeMemory": 23120973756,
+      "decodeSeconds": 0.36071300506591797,
+      "label": "replay",
+      "output": "spruce-lantern-7429",
+      "prefillSeconds": 0.4900670051574707,
+      "promptTokens": 34645,
+      "tokens": 10,
+      "outputSHA256": "9db62c4ceeda0e7f0918927622b557c815c4e0cb4b40686c3813b8c2d84832db"
+    },
+    {
+      "acceleration": {
+        "route": "final-target-pipelined"
+      },
+      "activeMemory": 23121506240,
+      "decodeSeconds": 0.5227088928222656,
+      "label": "serial",
+      "output": "spruce-lantern-7429",
+      "prefillSeconds": 0.5486600399017334,
+      "promptTokens": 34645,
+      "tokens": 10,
+      "outputSHA256": "9db62c4ceeda0e7f0918927622b557c815c4e0cb4b40686c3813b8c2d84832db"
+    },
+    {
+      "acceleration": {
+        "acceptanceRate": 0.4666666666666667,
+        "acceptedDraftTokens": 7,
+        "draftHistoryTokens": 34673,
+        "draftModel": "qwen-mtp",
+        "draftedTokens": 15,
+        "rounds": 5,
+        "route": "mtp-speculative"
+      },
+      "activeMemory": 24691445692,
+      "decodeSeconds": 11.613809943199158,
+      "label": "followup",
+      "output": "spruce-lantern-7429",
+      "prefillSeconds": 1.2235360145568848,
+      "promptTokens": 34674,
+      "tokens": 10,
+      "outputSHA256": "9db62c4ceeda0e7f0918927622b557c815c4e0cb4b40686c3813b8c2d84832db"
+    },
+    {
+      "acceleration": {
+        "acceptanceRate": 0.5,
+        "acceptedDraftTokens": 6,
+        "draftHistoryTokens": 34644,
+        "draftModel": "qwen-mtp",
+        "draftedTokens": 12,
+        "rounds": 4,
+        "route": "mtp-speculative"
+      },
+      "activeMemory": 24691445692,
+      "decodeSeconds": 1.365172028541565,
+      "label": "original-after-followup",
+      "output": "spruce-lantern-7429",
+      "prefillSeconds": 0.5371179580688477,
+      "promptTokens": 34645,
+      "tokens": 10,
+      "outputSHA256": "9db62c4ceeda0e7f0918927622b557c815c4e0cb4b40686c3813b8c2d84832db"
+    },
+    {
+      "acceleration": {
+        "route": "final-target-pipelined"
+      },
+      "activeMemory": 22060955032,
+      "decodeSeconds": 1.138084053993225,
+      "label": "tool-default",
+      "output": "",
+      "prefillSeconds": 1.8203200101852417,
+      "promptTokens": 279,
+      "tokens": 30,
+      "toolCalls": [
+        {
+          "arguments": {
+            "project": "cobalt-harbor"
+          },
+          "name": "lookup_project"
+        }
+      ],
+      "outputSHA256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "acceleration": {
+        "route": "final-target-pipelined"
+      },
+      "activeMemory": 22060438932,
+      "decodeSeconds": 1.2112970352172852,
+      "label": "tool-serial",
+      "output": "",
+      "prefillSeconds": 0.00412297248840332,
+      "promptTokens": 279,
+      "tokens": 30,
+      "toolCalls": [
+        {
+          "arguments": {
+            "project": "cobalt-harbor"
+          },
+          "name": "lookup_project"
+        }
+      ],
+      "outputSHA256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+    },
+    {
+      "acceleration": {
+        "route": "final-target-pipelined"
+      },
+      "activeMemory": 22249108888,
+      "decodeSeconds": 0.41303205490112305,
+      "label": "tool-followup-default",
+      "output": "spruce-lantern-7429",
+      "prefillSeconds": 0.19774401187896729,
+      "promptTokens": 354,
+      "tokens": 10,
+      "outputSHA256": "9db62c4ceeda0e7f0918927622b557c815c4e0cb4b40686c3813b8c2d84832db"
+    },
+    {
+      "acceleration": {
+        "route": "final-target-pipelined"
+      },
+      "activeMemory": 22249108888,
+      "decodeSeconds": 0.4516409635543823,
+      "label": "tool-followup-serial",
+      "output": "spruce-lantern-7429",
+      "prefillSeconds": 0.009665966033935547,
+      "promptTokens": 354,
+      "tokens": 10,
+      "outputSHA256": "9db62c4ceeda0e7f0918927622b557c815c4e0cb4b40686c3813b8c2d84832db"
+    },
+    {
+      "acceleration": {
+        "acceptanceRate": 0.625,
+        "acceptedDraftTokens": 30,
+        "draftHistoryTokens": 0,
+        "draftModel": "qwen-mtp",
+        "draftedTokens": 48,
+        "rounds": 48,
+        "route": "mtp-speculative"
+      },
+      "activeMemory": 22331648404,
+      "decodeSeconds": 3.485366940498352,
+      "label": "sample-7-mtp",
+      "output": "# Turning an Abandoned Railway Station into a Public Library\n\n## Assessment and Planning Phase\n\n**Structure Evaluation**\n- Hire a structural engineer to assess the building's integrity, especially old brick arches, high ceilings, and roof condition\n- Check for hazardous materials common in older buildings (asbestos, lead paint)\n- Document historical features worth preserving\n\n**Community Engagement**\n- Hold public meetings to gather input on desired services\n- Survey residents about book preferences and programming",
+      "prefillSeconds": 0.09214293956756592,
+      "promptTokens": 26,
+      "tokens": 96,
+      "outputSHA256": "d3410d1eb1d9d50ff9f4677e90938b2052fb442b02d5a9cc27474a18b42cfdb2"
+    },
+    {
+      "acceleration": {
+        "acceptanceRate": 0.625,
+        "acceptedDraftTokens": 30,
+        "draftHistoryTokens": 0,
+        "draftModel": "qwen-mtp",
+        "draftedTokens": 48,
+        "rounds": 48,
+        "route": "mtp-speculative"
+      },
+      "activeMemory": 22331648404,
+      "decodeSeconds": 3.4638760089874268,
+      "label": "sample-7-mtp-replay",
+      "output": "# Turning an Abandoned Railway Station into a Public Library\n\n## Assessment and Planning Phase\n\n**Structure Evaluation**\n- Hire a structural engineer to assess the building's integrity, especially old brick arches, high ceilings, and roof condition\n- Check for hazardous materials common in older buildings (asbestos, lead paint)\n- Document historical features worth preserving\n\n**Community Engagement**\n- Hold public meetings to gather input on desired services\n- Survey residents about book preferences and programming",
+      "prefillSeconds": 0.0008729696273803711,
+      "promptTokens": 26,
+      "tokens": 96,
+      "outputSHA256": "d3410d1eb1d9d50ff9f4677e90938b2052fb442b02d5a9cc27474a18b42cfdb2"
+    },
+    {
+      "acceleration": {
+        "route": "final-target-pipelined"
+      },
+      "activeMemory": 22331648404,
+      "decodeSeconds": 3.647966980934143,
+      "label": "sample-7-serial",
+      "output": "# Turning an Abandoned Railway Station into a Public Library\n\n## Assessment and Planning Phase\n\n**Structural evaluation**\n- Hire engineers to assess the building's integrity, focusing on the large clear spans that railway stations excel at\n- Check the roof, foundation, and any heritage listing restrictions\n- Test for hazardous materials like asbestos (common in older stations)\n\n**Community engagement**\n- Hold meetings with residents to understand what services they want\n- Survey local groups, schools",
+      "prefillSeconds": 0.0008869171142578125,
+      "promptTokens": 26,
+      "tokens": 96,
+      "outputSHA256": "3b57235f1df229d5e92c049df17b7ad2ba9345d97e0fb8399e8a74ba410c31e2"
+    },
+    {
+      "acceleration": {
+        "acceptanceRate": 0.7291666666666666,
+        "acceptedDraftTokens": 35,
+        "draftHistoryTokens": 0,
+        "draftModel": "qwen-mtp",
+        "draftedTokens": 48,
+        "rounds": 48,
+        "route": "mtp-speculative"
+      },
+      "activeMemory": 22331648404,
+      "decodeSeconds": 3.2573360204696655,
+      "label": "sample-42-mtp",
+      "output": "# Turning an Abandoned Railway Station into a Public Library\n\nHere's a comprehensive guide on how volunteers could accomplish this transformation:\n\n## 1. Assessment and Planning\n\n**Initial Evaluation:**\n- Conduct a structural survey to identify safety concerns (roof, foundations, load-bearing walls)\n- Document the station's architectural features worth preserving (platforms, ticket halls, clock towers, vaulted ceilings)\n- Assess utilities: water, electricity, heating/cooling, and",
+      "prefillSeconds": 0.0009020566940307617,
+      "promptTokens": 26,
+      "tokens": 96,
+      "outputSHA256": "45bee82a792964473929e170533782d7ae778a6465a43a94841bdf5543e72a8a"
+    },
+    {
+      "acceleration": {
+        "route": "final-target-pipelined"
+      },
+      "activeMemory": 22331648404,
+      "decodeSeconds": 3.7334139347076416,
+      "label": "sample-42-serial",
+      "output": "# Transforming an Abandoned Railway Station into a Public Library\n\n## Phase 1: Assessment and Planning\n\n**Evaluate the building's condition**\n- Conduct structural surveys to identify what's salvageable\n- Check for hazardous materials (asbestos, lead paint common in older stations)\n- Assess the roof, walls, windows, and foundation\n- Document architectural features worth preserving (high ceilings, original tiling, ironwork, clocks)\n\n**Community engagement**\n-",
+      "prefillSeconds": 0.0008139610290527344,
+      "promptTokens": 26,
+      "tokens": 96,
+      "outputSHA256": "273a1af856e06ac0a09b2df5eb9219d2a384b7b35d04ba9aea0c0092916235d3"
+    },
+    {
+      "acceleration": {
+        "acceptanceRate": 0.625,
+        "acceptedDraftTokens": 30,
+        "draftHistoryTokens": 0,
+        "draftModel": "qwen-mtp",
+        "draftedTokens": 48,
+        "rounds": 48,
+        "route": "mtp-speculative"
+      },
+      "activeMemory": 22331648404,
+      "decodeSeconds": 3.5033609867095947,
+      "label": "sample-2026-mtp",
+      "output": "# Turning an Abandoned Railway Station into a Public Library\n\nHere's a practical roadmap for how volunteers could accomplish this transformation:\n\n## 1. Assessment and Planning\n\n**Evaluate the building first:**\n- Structure integrity, roof condition, and foundation\n- Electrical, plumbing, and HVAC systems\n- Accessibility compliance (ramps, elevators, restrooms)\n- Historical preservation requirements (many stations are listed buildings)\n\n**Form a core committee** with diverse skills:",
+      "prefillSeconds": 0.000903010368347168,
+      "promptTokens": 26,
+      "tokens": 96,
+      "outputSHA256": "e78e0cf8a02f0892580bdb9352df9bff2e25ed61db5ce87414672b50c5b202ba"
+    },
+    {
+      "acceleration": {
+        "route": "final-target-pipelined"
+      },
+      "activeMemory": 22331648404,
+      "decodeSeconds": 3.682597041130066,
+      "label": "sample-2026-serial",
+      "output": "# Transforming an Abandoned Railway Station into a Public Library\n\n## Phase 1: Assessment and Planning\n\n**Structural Evaluation**\n- Hire engineers to assess the building's structural integrity\n- Check the roof, foundations, load-bearing walls, and any damage from years of abandonment\n- Identify hazardous materials (asbestos was common in older stations)\n\n**Community Engagement**\n- Hold public meetings to gauge interest and gather input\n- Survey residents about desired services (children",
+      "prefillSeconds": 0.0008219480514526367,
+      "promptTokens": 26,
+      "tokens": 96,
+      "outputSHA256": "1aed8d7caa9d68feef7ee7f671115028b38f56ab84cab4b614d826989312936c"
+    },
+    {
+      "acceleration": {
+        "acceptanceRate": 0.7333333333333333,
+        "acceptedDraftTokens": 11,
+        "draftHistoryTokens": 28,
+        "draftModel": "qwen-mtp",
+        "draftedTokens": 15,
+        "rounds": 5,
+        "route": "mtp-speculative"
+      },
+      "activeMemory": 22202575252,
+      "decodeSeconds": 0.3262810707092285,
+      "label": "thinking-mtp",
+      "output": "17 + 25 = 42\n</think>\n\n42",
+      "prefillSeconds": 0.08607900142669678,
+      "promptTokens": 29,
+      "reasoning": "17 + 25 = 42",
+      "tokens": 15,
+      "outputSHA256": "f7c2ee724aa38b861f60692bd390990cc1fa9646802e4d8eef5c9f7b14911699"
+    },
+    {
+      "acceleration": {
+        "route": "final-target-pipelined"
+      },
+      "activeMemory": 22212705128,
+      "decodeSeconds": 0.6296030282974243,
+      "label": "thinking-serial",
+      "output": "17 + 25 = 42\n</think>\n\n42",
+      "prefillSeconds": 0.00067901611328125,
+      "promptTokens": 29,
+      "reasoning": "17 + 25 = 42",
+      "tokens": 15,
+      "outputSHA256": "f7c2ee724aa38b861f60692bd390990cc1fa9646802e4d8eef5c9f7b14911699"
+    }
+  ],
+  "vision": {
+    "checkpointTensors": 333,
+    "runtimeTensors": 333,
+    "promptTokens": 85,
+    "outputTokens": 31,
+    "elapsedSeconds": 5.127750039100647,
+    "output": "From left to right:\n\n1. **Red circle** – A red circular shape.\n2. **Blue square** – A blue square shape.",
+    "route": "final-target-pipelined",
+    "acceptedDraftTokens": null
+  },
+  "unchangedInstalledFiles": [
+    {
+      "path": "chat_template.jinja",
+      "sha256": "182e77dd83bd8e9ca818b240b82e28f243762cd5dda32e6eef327df7b1cd107e",
+      "bytes": 7536
+    },
+    {
+      "path": "config.json",
+      "sha256": "fc27b922c3506e955271c68120be9079ad8bba7266c8086c02dfbb8c98723bd5",
+      "bytes": 23203
+    },
+    {
+      "path": "generation_config.json",
+      "sha256": "e70c136c1b78ddc1fb0905bac8e733a4dc448d4f852a5dd75143fffc70be550e",
+      "bytes": 202
+    },
+    {
+      "path": "model-00001-of-00004.safetensors",
+      "sha256": "f0b2b03fb3eecf84096ee5abb213c99e9c3725f9947004a01999dc5cc55ebdd9",
+      "bytes": 5343699466
+    },
+    {
+      "path": "model-00002-of-00004.safetensors",
+      "sha256": "971b1935112c4221616ddab04ead15d50b3c489754e619d74304dc4f64d034dc",
+      "bytes": 5368472837
+    },
+    {
+      "path": "model-00003-of-00004.safetensors",
+      "sha256": "041377369466c48cb486ce2911c3cce638b8702080bb39113a7cf190632f5529",
+      "bytes": 5368324245
+    },
+    {
+      "path": "model-00004-of-00004.safetensors",
+      "sha256": "d1088c7f6e9d705a253d3049bf7308704ccf1f4099cf40678ff077da88f0184b",
+      "bytes": 3428527653
+    },
+    {
+      "path": "model.safetensors.index.json",
+      "sha256": "c118f13c0dcb729e4ca2e3d653ab193067551eb1a6410badb5192eb426104f36",
+      "bytes": 187263
+    },
+    {
+      "path": "tokenizer.json",
+      "sha256": "06b9509352d2af50381ab2247e083b80d32d5c0aba91c272ca9ff729b6a0e523",
+      "bytes": 19989325
+    },
+    {
+      "path": "tokenizer_config.json",
+      "sha256": "386ba246ba3dfa4d3a21d8bc8712eba38de558e5ac94c2c90436d8f94d519d5e",
+      "bytes": 1160
+    },
+    {
+      "path": "vision/config.json",
+      "sha256": "af198ccbe6c17dd973da98bbf6c92ce1c3ec7261c2e2fbc4c4f5150018418ea8",
+      "bytes": 3295
+    },
+    {
+      "path": "vision/model-00001-of-00016.safetensors",
+      "sha256": "250b3b09199be0dcd0f96df2a35dabad07e2ba709bb7687ef7490d0f248eb94e",
+      "bytes": 4744232576
+    },
+    {
+      "path": "vision/model.safetensors.index.json",
+      "sha256": "0ad9fbfbb1a7514773ed881d3c9403019bd7ae9ff4c6af3cfc65ca7da784d78f",
+      "bytes": 165731
+    },
+    {
+      "path": "vision/preprocessor_config.json",
+      "sha256": "27225450ac9c6529872ee1924fcb0962ff5634834f817040f444118116f4e516",
+      "bytes": 390
+    },
+    {
+      "path": "vision/video_preprocessor_config.json",
+      "sha256": "7768af27c1fafa9cc9011c1dc20067e03f8915e03b63504550e11d5066986d13",
+      "bytes": 385
+    }
+  ],
+  "previousHeadComparison": {
+    "path": "ornith-mtp-head-comparison-2026-09-05.json",
+    "sha256": "7505b6706c2da8effd233aafc82a698bb659ae146b441086bf459fd1317f42ba",
+    "requests": 40
+  },
+  "publication": {
+    "repository": "Sawfwair/Ornith-1.5-35B-A3B-MLX-4bit-Vision-MTP",
+    "revision": "19a8ee57cb185cb487fa29ff7175c5e1544ebf1c",
+    "parentRevision": "2323acfa0fd0a01c452c89991558e6bbd86f0f05",
+    "commitURL": "https://huggingface.co/Sawfwair/Ornith-1.5-35B-A3B-MLX-4bit-Vision-MTP/commit/19a8ee57cb185cb487fa29ff7175c5e1544ebf1c",
+    "selectedPayloadBytes": 25963186364,
+    "unchangedFiles": [
+      ".gitattributes",
+      "chat_template.jinja",
+      "config.json",
+      "generation_config.json",
+      "model-00001-of-00004.safetensors",
+      "model-00002-of-00004.safetensors",
+      "model-00003-of-00004.safetensors",
+      "model-00004-of-00004.safetensors",
+      "model.safetensors.index.json",
+      "tokenizer.json",
+      "tokenizer_config.json",
+      "vision/config.json",
+      "vision/model-00001-of-00016.safetensors",
+      "vision/model.safetensors.index.json",
+      "vision/preprocessor_config.json",
+      "vision/video_preprocessor_config.json"
+    ],
+    "verified": true
+  },
+  "postQualificationValidation": {
+    "localGate": {
+      "command": "./scripts/check.sh",
+      "exitCode": 0,
+      "xctestCases": 3913,
+      "skipped": 311,
+      "failures": 0,
+      "swiftTestingCases": 51,
+      "logSHA256": "482f0138104c459bb8ba6c6e2daade98c41ebb3f253439ab0f7c3a19733fcc86"
+    },
+    "randomStateRegression": {
+      "device": "gpu",
+      "tests": 1,
+      "failures": 0,
+      "logSHA256": "c3997caecbbde042dcda6f823afae3665b88cd9d6bb190a879828f8389ebbec5",
+      "testFileSHA256": "27ab8a55ebcd33a0ecd35c7ec1e7fe2ba48b1e4c0a4274bf11102c75f15d6ed6",
+      "note": "Restore a stream-neutral global seed when the interference test ends so later fixture tests do not inherit its lazy graph."
+    },
+    "docsBuildPassed": true
+  }
+}

--- a/docs/model-sources.md
+++ b/docs/model-sources.md
@@ -338,11 +338,20 @@ metadata; the MLX conversion repository does not duplicate the license file.
 single packaging snapshot combines the official
 `Ornith-1.5-35B-A3B-MLX-4bit` text target with the
 authoritative base checkpoint's `model-00001-of-00016.safetensors` vision
-shard, vision configuration, processor metadata, and BF16 MTP head. The
-complete snapshot is about 26.7 GiB and records every packaged file in
-`SHA256SUMS`. Image requests
+shard, vision configuration, processor metadata, and
+[Shisa's Ornith-distilled BF16 MTP head](https://huggingface.co/shisa-ai/Ornith-1.5-35B-A3B-MTP-ONLY/tree/2b19b31bfe1659c6b0d9459ec3cbd87e34a322ef).
+The head's 19 fused tensors are packaged as 785 indexed tensors with every BF16
+value preserved. Its Apache-2.0 license, notice, and per-tensor hashes are
+included under `mtp/`; the target and vision components retain their upstream
+MIT declaration. The complete snapshot is about 24.2 GiB and records packaged
+files in `SHA256SUMS`. Image requests
 use target-only decoding because MTP speculation is disabled when image
 embeddings are present; text and code requests retain verified MTP.
+
+The [promotion qualification](benchmarks/ornith-mtp-promotion-2026-09-05.md)
+records the head comparison and compatibility checks. After updating mere.run,
+run `mere.run model pull text-agent-ornith-35b-mlx-4bit --force` to replace an
+older Q4 bundle. Existing complete installs are otherwise preserved.
 
 `vision-chat-ornith-35b` installs the authoritative full BF16 base checkpoint
 at immutable revision `10fbf86fed7ecee4a061f8b499a618f46001cac1`. Unlike


### PR DESCRIPTION
## Summary

Promote the Ornith-distilled Shisa BF16 MTP head to the managed Ornith Q4 bundle. The prior comparison measured higher draft acceptance with exact greedy output preservation; the promotion adds 34K-context cache replay, tool calls, seeded sampling, thinking, and vision qualification. The published bundle is pinned to `19a8ee57cb185cb487fa29ff7175c5e1544ebf1c`, with unchanged target/tokenizer/vision hashes and a 1.69 GB head replacing the 4.38 GB final shard. Preserve compact and legacy indexed installs and include the head's Apache-2.0 attribution.

Qualification also exposed Qwen sampling retaining another thread's lazy GPU random state. Give each generation request its own random state, honor its seed for token and MTP acceptance draws, and test seeded replay across streams. Tool and image requests retain target-only routing. Existing Q4 installs can upgrade with `mere.run model pull text-agent-ornith-35b-mlx-4bit --force`; other Ornith precision companions retain their pins.

## Validation

- [x] `./scripts/check.sh`: 3,913 XCTest cases, 311 opt-in skips, zero failures; 51 Swift Testing checks passed.
- [x] Four explicit GPU checks with the compact installed checkpoint: 18 text requests and one image request. Includes 34,645-token cold/replay and 34,674-token follow-up, exact tool arguments and response, three sampling seeds with exact same-seed replay, greedy thinking parity, and all 333 vision tensors.
- [x] `pnpm docs:build`; promotion report and machine-readable receipt added.
- [x] Installed the optimized CLI and promoted the local Q4 bundle. Four additional 256-token code requests preserve the prior output SHA-256; both adaptive repeats accept 172/240 drafts in 84 rounds. Release CLI SHA-256: `e0996e257000b11427d7febc9b9e930bf249a4de3719cd6b72fea97ca29ee5c6`.
- [x] Published bundle tree, selected byte count, unchanged file hashes, converted head hash, and installed target/vision bytes verified.
- Not applicable: no vendored artifacts or dependency pins changed.

These are compatibility checks on an M4 Max with desktop work active, not a controlled speedup or statistical quality benchmark. Full 262K context, concurrent serving, other precisions, and other runtimes are outside this qualification.
