### PR TITLE
Release v0.51.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,17 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+## 0.51.1 - 2026-09-05
+
+- fixed a `gate --all-installed` issue that rechecked required models only in
+  the primary model store. Release smokes now use one verified inventory for
+  planning and execution, including registered bindings, search roots, and
+  compatible fallback models.
+- fixed a Cosmos3-Edge issue that rejected its legacy
+  `modular_model_index.json` file as an invalid Cosmos3-Super distilled
+  configuration. The runtime decodes distilled scheduler metadata only when
+  the typed `is_distilled` marker is `true`.
+
 ## 0.51.0 - 2026-09-05
 
 This release rebuilds macOS Studio around persistent navigation, task, and

--- a/Sources/MereRunCLI/Commands/GateCommand.swift
+++ b/Sources/MereRunCLI/Commands/GateCommand.swift
@@ -92,26 +92,22 @@ struct Gate: AsyncParsableCommand {
             throw ValidationError("--skip-model is valid only with --all-installed.")
         }
 
+        let installedModelIDs = ModelInventory.snapshot(mode: .verified).installedModelIDs
         let checks: [GateCheck]
         if allInstalled {
-            let installedIDs = Set(
-                ModelInventory.snapshot(mode: .verified).rows
-                    .filter(\.isInstalled)
-                    .map(\.id)
-            )
-            guard !installedIDs.isEmpty else {
+            guard !installedModelIDs.isEmpty else {
                 throw ValidationError("--all-installed found no installed managed models.")
             }
-            let invalidSkips = skippedModelIDs.subtracting(installedIDs)
+            let invalidSkips = skippedModelIDs.subtracting(installedModelIDs)
             guard invalidSkips.isEmpty else {
                 throw ValidationError(
                     "--skip-model IDs are not installed managed models: "
                         + invalidSkips.sorted().joined(separator: ", ")
                 )
             }
-            let installedSpecs = ManagedModelCatalog.allSpecs.filter { installedIDs.contains($0.id) }
+            let installedSpecs = ManagedModelCatalog.allSpecs.filter { installedModelIDs.contains($0.id) }
             let unmapped = installedSpecs.filter {
-                InstalledModelSmokePlans.plan(for: $0, installedIDs: installedIDs) == nil
+                InstalledModelSmokePlans.plan(for: $0, installedIDs: installedModelIDs) == nil
             }
             guard unmapped.isEmpty else {
                 throw ValidationError(
@@ -120,7 +116,7 @@ struct Gate: AsyncParsableCommand {
                 )
             }
             checks = installedSpecs.compactMap {
-                InstalledModelSmokePlans.plan(for: $0, installedIDs: installedIDs)?.check
+                InstalledModelSmokePlans.plan(for: $0, installedIDs: installedModelIDs)?.check
             }
         } else {
             checks = GateChecks.all
@@ -165,7 +161,7 @@ struct Gate: AsyncParsableCommand {
                 ))
                 continue
             }
-            guard check.requiredModels.allSatisfy(GateRunner.modelInstalled) else {
+            guard check.requiredModels.allSatisfy(installedModelIDs.contains) else {
                 results.append(GateResult(
                     id: check.id,
                     status: requireAll ? .failed : .skipped,

--- a/Sources/MereRunCLI/Support/GateSupport.swift
+++ b/Sources/MereRunCLI/Support/GateSupport.swift
@@ -590,28 +590,6 @@ struct GateRunner: Sendable {
         )
     }
 
-    static func modelInstalled(_ id: String) -> Bool {
-        let root = ProcessInfo.processInfo.environment["MERERUN_MODELS_DIR"]
-            .map { URL(fileURLWithPath: $0) }
-            ?? GateBaselineStore.applicationSupport.appendingPathComponent("models", isDirectory: true)
-        return modelInstalled(id, root: root)
-    }
-
-    static func modelInstalled(_ id: String, root: URL) -> Bool {
-        let directURL = root.appendingPathComponent(id, isDirectory: true)
-        if FileManager.default.fileExists(atPath: directURL.path) {
-            return true
-        }
-        guard let spec = ManagedModelCatalog.spec(for: id) else {
-            return false
-        }
-        return spec.resolutionFallbackIDs.contains { fallbackID in
-            FileManager.default.fileExists(
-                atPath: root.appendingPathComponent(fallbackID, isDirectory: true).path
-            )
-        }
-    }
-
     static func hardwareModel() -> String {
         #if canImport(Darwin)
         var size = 0

--- a/Sources/MereRunCore/Cosmos3/Cosmos3Resources.swift
+++ b/Sources/MereRunCore/Cosmos3/Cosmos3Resources.swift
@@ -285,6 +285,14 @@ public struct Cosmos3DistilledConfiguration: Decodable, Hashable, Sendable {
     }
 }
 
+private struct Cosmos3DistilledMarker: Decodable {
+    let isDistilled: Bool?
+
+    enum CodingKeys: String, CodingKey {
+        case isDistilled = "is_distilled"
+    }
+}
+
 public struct Cosmos3VAEConfiguration: Codable, Hashable, Sendable {
     public let baseDimension: Int
     public let decoderBaseDimension: Int
@@ -563,6 +571,14 @@ public struct Cosmos3Resources: Hashable, Sendable {
 
     public func loadDistilledConfiguration() throws -> Cosmos3DistilledConfiguration? {
         guard FileManager.default.fileExists(atPath: modularModelIndexURL.path) else {
+            return nil
+        }
+        let marker = try Self.loadConfiguration(
+            Cosmos3DistilledMarker.self,
+            from: modularModelIndexURL,
+            validate: { _ in [] }
+        )
+        guard marker.isDistilled == true else {
             return nil
         }
         return try Self.loadConfiguration(

--- a/Sources/MereRunRelayKit/MereRunCLIVersion.swift
+++ b/Sources/MereRunRelayKit/MereRunCLIVersion.swift
@@ -2,7 +2,7 @@
 /// contract version floors, worker probes, and the built-in node catalog
 /// identity.
 public enum MereRunCLIVersion {
-    public static let current = "0.51.0"
+    public static let current = "0.51.1"
 }
 
 /// Lenient three-component version-floor comparison used by worker

--- a/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
+++ b/Tests/MereRunCLITests/CLIModelStoreBootstrapTests.swift
@@ -130,7 +130,7 @@ final class CLIModelStoreBootstrapTests: XCTestCase {
     }
 
     func testMereRunCLIExposesReleaseVersion() {
-        XCTAssertEqual(MereRunCLIVersion.current, "0.51.0")
+        XCTAssertEqual(MereRunCLIVersion.current, "0.51.1")
         XCTAssertEqual(MereRunCLI.configuration.version, MereRunCLIVersion.current)
     }
 

--- a/Tests/MereRunCLITests/GateSupportTests.swift
+++ b/Tests/MereRunCLITests/GateSupportTests.swift
@@ -184,20 +184,6 @@ final class GateSupportTests: XCTestCase {
         )
     }
 
-    func testCompatibleFallbackCountsAsInstalledForRequiredReleaseCheck() throws {
-        let root = FileManager.default.temporaryDirectory
-            .appendingPathComponent(UUID().uuidString, isDirectory: true)
-        try FileManager.default.createDirectory(
-            at: root.appendingPathComponent("video-ltx23-a2vid-mlx", isDirectory: true),
-            withIntermediateDirectories: true
-        )
-        defer { try? FileManager.default.removeItem(at: root) }
-
-        XCTAssertTrue(GateRunner.modelInstalled("video-ltx23-full-mlx", root: root))
-        XCTAssertTrue(GateRunner.modelInstalled("video-ltx23-a2vid-mlx", root: root))
-        XCTAssertFalse(GateRunner.modelInstalled("video-ltx23-av-mlx", root: root))
-    }
-
     func testA2VidFixtureIsDecodableAndNonSilent() throws {
         let directory = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)

--- a/Tests/MereRunCLITests/ModelInventoryTests.swift
+++ b/Tests/MereRunCLITests/ModelInventoryTests.swift
@@ -78,4 +78,66 @@ final class ModelInventoryTests: XCTestCase {
         XCTAssertEqual(row.verification, .notChecked)
         XCTAssertTrue(snapshot.installedModelIDs.isEmpty)
     }
+
+    func testVerifiedInstalledIDsIncludeBindingsAndSearchRoots() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("mere-run-external-inventory-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        let bindingRoot = root.appendingPathComponent("arbitrary-binding", isDirectory: true)
+        let searchRoot = root.appendingPathComponent("catalog", isDirectory: true)
+        let searchedModelRoot = searchRoot.appendingPathComponent(
+            ModelResolver.ModelID.zetaMax.rawValue,
+            isDirectory: true
+        )
+        try writeMinimalZImageModel(at: bindingRoot, modelID: nil)
+        try writeMinimalZImageModel(at: searchedModelRoot, modelID: .zetaMax)
+
+        let snapshot = ModelInventory.snapshot(
+            mode: .verified,
+            locations: ModelLocationSnapshot(
+                primaryRoot: root.appendingPathComponent("primary", isDirectory: true),
+                searchRoots: [searchRoot],
+                bindings: [
+                    .init(modelID: ModelResolver.ModelID.zetaNano.rawValue, path: bindingRoot.path),
+                ]
+            )
+        )
+
+        XCTAssertTrue(
+            snapshot.installedModelIDs.contains(ModelResolver.ModelID.zetaNano.rawValue)
+        )
+        XCTAssertTrue(
+            snapshot.installedModelIDs.contains(ModelResolver.ModelID.zetaMax.rawValue)
+        )
+    }
+
+    private func writeMinimalZImageModel(
+        at root: URL,
+        modelID: ModelResolver.ModelID?
+    ) throws {
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        if let modelID {
+            try MereRunModelManifest.template(for: modelID, createdAt: Date(timeIntervalSince1970: 0))
+                .write(to: root)
+        }
+        try Data("{}".utf8).write(to: root.appendingPathComponent("model_index.json"))
+
+        for component in ["text_encoder", "transformer", "vae"] {
+            let directory = root.appendingPathComponent(component, isDirectory: true)
+            try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+            try Data("{}".utf8).write(to: directory.appendingPathComponent("config.json"))
+            try Data().write(to: directory.appendingPathComponent("model.safetensors"))
+        }
+
+        let tokenizer = root.appendingPathComponent("tokenizer", isDirectory: true)
+        try FileManager.default.createDirectory(at: tokenizer, withIntermediateDirectories: true)
+        for filename in ["tokenizer.json", "tokenizer_config.json", "merges.txt", "vocab.json"] {
+            try Data("{}".utf8).write(to: tokenizer.appendingPathComponent(filename))
+        }
+
+        let scheduler = root.appendingPathComponent("scheduler", isDirectory: true)
+        try FileManager.default.createDirectory(at: scheduler, withIntermediateDirectories: true)
+        try Data("{}".utf8).write(to: scheduler.appendingPathComponent("scheduler_config.json"))
+    }
 }

--- a/Tests/MereRunCoreTests/Cosmos3EdgeTests.swift
+++ b/Tests/MereRunCoreTests/Cosmos3EdgeTests.swift
@@ -55,6 +55,49 @@ final class Cosmos3EdgeTests: MereRunCoreTestCase {
         XCTAssertEqual(vaeConfig.temporalScaleFactor, 4)
     }
 
+    func testLegacyEdgeModularIndexIsNotDecodedAsDistilledConfiguration() throws {
+        let root = try TestFileSystem.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try TestFileSystem.writeFile(
+            root.appendingPathComponent("modular_model_index.json"),
+            contents: Data(#"{"_class_name":"Cosmos3EdgePipeline"}"#.utf8)
+        )
+
+        XCTAssertNil(try Cosmos3Resources(rootURL: root).loadDistilledConfiguration())
+    }
+
+    func testDecodesMarkedDistilledConfiguration() throws {
+        let root = try TestFileSystem.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+        try TestFileSystem.writeFile(
+            root.appendingPathComponent("modular_model_index.json"),
+            contents: Data(#"{"is_distilled":true,"distilled_sigmas":[1.0,0.5,0.25]}"#.utf8)
+        )
+
+        let configuration = try XCTUnwrap(
+            Cosmos3Resources(rootURL: root).loadDistilledConfiguration()
+        )
+
+        XCTAssertTrue(configuration.isDistilled)
+        XCTAssertEqual(configuration.sigmas, [1.0, 0.5, 0.25])
+    }
+
+    func testMalformedModularIndexThrowsInvalidConfiguration() throws {
+        let root = try TestFileSystem.makeTempDir()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let indexURL = root.appendingPathComponent("modular_model_index.json")
+        try TestFileSystem.writeFile(indexURL, contents: Data("{".utf8))
+
+        XCTAssertThrowsError(
+            try Cosmos3Resources(rootURL: root).loadDistilledConfiguration()
+        ) { error in
+            guard case .invalidConfiguration(let url, _) = error as? Cosmos3ResourcesError else {
+                return XCTFail("Expected invalid Cosmos3 configuration, got \(error)")
+            }
+            XCTAssertEqual(url, indexURL)
+        }
+    }
+
     func testDecodesPublishedReasonerConfiguration() throws {
         let root = try TestFileSystem.makeTempDir()
         defer { try? FileManager.default.removeItem(at: root) }

--- a/scripts/build_mere_run_app.sh
+++ b/scripts/build_mere_run_app.sh
@@ -15,7 +15,7 @@ cd "$repo_root"
 
 # Version/build derive from git when not provided, so the bundle has a single source of
 # truth in CI. Fall back to a pinned value when git metadata is unavailable.
-default_version="0.51.0"
+default_version="0.51.1"
 if git_version="$(git describe --tags --exact-match 2>/dev/null)"; then
   default_version="${git_version#v}"
 fi


### PR DESCRIPTION
## Summary

- release mere.run 0.51.1
- use one verified model inventory throughout `gate`, so registered bindings and search-root models remain available during execution
- treat legacy Cosmos3-Edge modular metadata as non-distilled unless the typed `is_distilled` marker is `true`
- preserve typed configuration errors for malformed or invalid distilled metadata

## Why 0.51.1

The unpublished 0.51.0 artifact smoke found two release blockers: six externally located installed models were incorrectly reported missing during gate execution, and an existing Cosmos3-Edge checkpoint was decoded as a Cosmos3-Super distilled configuration. No 0.51.0 GitHub release or update feed was published.

## Validation

- `./scripts/check.sh` — pass (3,915 XCTest tests, 311 fixture/GPU opt-in skips, 0 failures; 51 Swift Testing tests, 0 failures)
- `swift test --filter Cosmos3EdgeTests` — 41 passed, 0 failures
- targeted model inventory, gate support, and CLI version/bootstrap suites — pass
- `git diff --check` — pass

Publication remains gated on fresh exact-tag macOS and Linux artifacts, Linux package lifecycle verification, and the full packaged installed-model smoke with zero failures, warnings, or skips.
