### PR TITLE
Teach and validate mere.run workflows and preflight reports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+- Image generation and text chat preflights now report insufficient memory,
+  disk headroom, and critical memory pressure as structured blockers alongside
+  other request diagnostics. They no longer reserve inference permits or exit
+  through the execution admission gate before producing their report.
+
 ## 0.51.1 - 2026-09-05
 
 - fixed a `gate --all-installed` issue that rechecked required models only in

--- a/Sources/MereRunCLI/Commands/ImageGenerateCommand.swift
+++ b/Sources/MereRunCLI/Commands/ImageGenerateCommand.swift
@@ -1,6 +1,7 @@
 import ArgumentParser
 import Foundation
 import MereRunCore
+import MereRunRelayKit
 
 // MARK: - Image Generate Command
 
@@ -587,7 +588,8 @@ struct ImageGenerate: AsyncParsableCommand {
     func makePreflightEnvelope(
         outputURL: URL,
         fileManager: FileManager = .default,
-        now: @escaping () -> Date = Date.init
+        now: @escaping () -> Date = Date.init,
+        resourceDiagnostics: [PreflightDiagnostic] = []
     ) -> ImageGenerationPreflightEnvelope {
         let input = ImageGenerationPreflightInput(
             prompt: prompt,
@@ -626,11 +628,16 @@ struct ImageGenerate: AsyncParsableCommand {
             input: input,
             fileManager: fileManager,
             now: now
-        ).envelope()
+        ).envelope(resourceDiagnostics: resourceDiagnostics)
     }
 
     private func runPreflight(outputURL: URL) throws {
-        let envelope = makePreflightEnvelope(outputURL: outputURL)
+        let envelope = makePreflightEnvelope(
+            outputURL: outputURL,
+            resourceDiagnostics: MachineInferencePreflight.diagnostics(
+                arguments: generationActionArguments(outputURL: outputURL)
+            )
+        )
         if json {
             print(try StructuredRunOutput.encode(envelope))
         } else {

--- a/Sources/MereRunCLI/Commands/TextChatCommand.swift
+++ b/Sources/MereRunCLI/Commands/TextChatCommand.swift
@@ -735,7 +735,29 @@ struct TextChat: AsyncParsableCommand {
     }
 
     private func emitPreflight(modelID: String, installedModelPath: String?) throws {
-        var diagnostics: [PreflightDiagnostic] = []
+        let report = makePreflightReport(
+            modelID: modelID,
+            installedModelPath: installedModelPath,
+            resourceDiagnostics: MachineInferencePreflight.diagnostics(
+                arguments: ["mere.run", "text", "chat", "--model", modelID]
+            )
+        )
+        if json {
+            print(try StructuredRunOutput.encode(report))
+        } else {
+            print(report.summary)
+            for diagnostic in report.diagnostics {
+                print("[\(diagnostic.severity.rawValue)] \(diagnostic.title): \(diagnostic.message)")
+            }
+        }
+    }
+
+    func makePreflightReport(
+        modelID: String,
+        installedModelPath: String?,
+        resourceDiagnostics: [PreflightDiagnostic] = []
+    ) -> TextChatPreflightReport {
+        var diagnostics = resourceDiagnostics
         if modelID.isEmpty || ManagedModelCatalog.spec(for: modelID) == nil {
             diagnostics.append(.init(
                 id: "text_chat_model_unknown",
@@ -778,7 +800,7 @@ struct TextChat: AsyncParsableCommand {
                 ))
             }
         }
-        let report = TextChatPreflightReport(
+        return TextChatPreflightReport(
             schemaVersion: 1,
             status: StructuredRunOutput.status(for: diagnostics),
             model: modelID,
@@ -786,11 +808,6 @@ struct TextChat: AsyncParsableCommand {
             modelPath: installedModelPath,
             diagnostics: diagnostics
         )
-        if json {
-            print(try StructuredRunOutput.encode(report))
-        } else {
-            print(report.summary)
-        }
     }
 
     static func formatGemma4MTPStats(_ stats: Gemma4MTPStats) -> String {
@@ -1043,7 +1060,7 @@ struct TextChat: AsyncParsableCommand {
     }
 }
 
-private struct TextChatPreflightReport: Codable, Equatable {
+struct TextChatPreflightReport: Codable, Equatable {
     let schemaVersion: Int
     let status: StructuredRunStatus
     let model: String

--- a/Sources/MereRunCLI/Support/ImageGenerationPreflight.swift
+++ b/Sources/MereRunCLI/Support/ImageGenerationPreflight.swift
@@ -286,8 +286,8 @@ struct ImageGenerationPreflightAnalyzer {
         self.now = now
     }
 
-    func envelope() -> ImageGenerationPreflightEnvelope {
-        var diagnostics: [PreflightDiagnostic] = []
+    func envelope(resourceDiagnostics: [PreflightDiagnostic] = []) -> ImageGenerationPreflightEnvelope {
+        var diagnostics = resourceDiagnostics
         let createdAt = now()
         validatePrompt(diagnostics: &diagnostics)
         validateSampling(diagnostics: &diagnostics)

--- a/Sources/MereRunCLI/Support/MachineInferenceAdmission.swift
+++ b/Sources/MereRunCLI/Support/MachineInferenceAdmission.swift
@@ -443,7 +443,7 @@ struct MachineInferenceCoordinator: Sendable {
         return lhs.id.uuidString < rhs.id.uuidString
     }
 
-    private static func currentHostSnapshot() -> MachineInferenceHostSnapshot {
+    static func currentHostSnapshot() -> MachineInferenceHostSnapshot {
         let memory = RuntimeMemorySample.current()
         let disk = availableDiskBytes(
             at: MereRunModelPaths.applicationSupportBase.deletingLastPathComponent()
@@ -575,6 +575,11 @@ enum CLIInferenceAdmissionClassifier {
         let subcommand = commandTokens.dropFirst().first
         let nestedSubcommand = commandTokens.dropFirst(2).first
         let label = [topLevel, subcommand].compactMap { $0 }.joined(separator: " ")
+        // These preflights report resource blockers without reserving inference
+        // permits. Other preflight implementations retain their existing gate.
+        if tokens.contains("--preflight"), ["image generate", "text chat"].contains(label) {
+            return nil
+        }
 
         // These orchestration commands either acquire a workload-specific
         // lease internally or spawn a child process that does. Classifying

--- a/Sources/MereRunCLI/Support/MachineInferencePreflight.swift
+++ b/Sources/MereRunCLI/Support/MachineInferencePreflight.swift
@@ -1,0 +1,37 @@
+import Foundation
+import MereRunRelayKit
+
+enum MachineInferencePreflight {
+    static func diagnostics(
+        arguments: [String],
+        host: MachineInferenceHostSnapshot = MachineInferenceCoordinator.currentHostSnapshot()
+    ) -> [PreflightDiagnostic] {
+        guard let request = CLIInferenceAdmissionClassifier.request(arguments: arguments) else { return [] }
+        var diagnostics: [PreflightDiagnostic] = []
+        let minimumDisk = MachineInferenceCoordinator.minimumDiskBytes(physicalMemoryBytes: host.physicalMemoryBytes)
+        if let available = host.availableDiskBytes, available < minimumDisk {
+            diagnostics.append(.init(
+                id: "machine_insufficient_disk", severity: .blocker, title: "Insufficient disk headroom",
+                message: MachineInferenceAdmissionError.insufficientDisk(
+                    available: available, required: minimumDisk
+                ).localizedDescription
+            ))
+        }
+        let minimumMemory = request.resourceClass.minimumAvailableBytes
+        if let available = host.availableMemoryBytes, available < minimumMemory {
+            diagnostics.append(.init(
+                id: "machine_insufficient_memory", severity: .blocker, title: "Insufficient memory headroom",
+                message: MachineInferenceAdmissionError.insufficientMemory(
+                    available: available, required: minimumMemory
+                ).localizedDescription
+            ))
+        }
+        if host.memoryPressure == .critical {
+            diagnostics.append(.init(
+                id: "machine_critical_memory_pressure", severity: .blocker, title: "Critical memory pressure",
+                message: MachineInferenceAdmissionError.criticalMemoryPressure.localizedDescription
+            ))
+        }
+        return diagnostics
+    }
+}

--- a/Tests/MereRunCLITests/ImageGenerateCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/ImageGenerateCommandParsingTests.swift
@@ -710,6 +710,28 @@ final class ImageGenerateCommandParsingTests: XCTestCase {
         XCTAssertEqual(startGeneration.disabledReason, "Resolve hard blockers first.")
     }
 
+    func testImageGenerationResourceBlockerDisablesAnOtherwiseReadyRequest() throws {
+        let temp = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: temp) }
+        let model = temp.appendingPathComponent("model", isDirectory: true)
+        try writeManifest(id: "local-zimage", family: .zimage, to: model)
+        let command = try ImageGenerate.parse(["--prompt", "test", "--model", model.path])
+        let resources = MachineInferencePreflight.diagnostics(
+            arguments: ["mere.run", "image", "generate", "--model", model.path],
+            host: MachineInferenceHostSnapshot(
+                physicalMemoryBytes: 8_589_934_592, availableMemoryBytes: 4_294_967_296,
+                memoryPressure: .nominal, availableDiskBytes: 100_000_000_000
+            )
+        )
+        let envelope = command.makePreflightEnvelope(
+            outputURL: temp.appendingPathComponent("render.png"), resourceDiagnostics: resources
+        )
+        XCTAssertEqual(envelope.status, .blocked)
+        XCTAssertTrue(envelope.result.model.installed)
+        XCTAssertEqual(envelope.diagnostics.map(\.id), ["machine_insufficient_memory"])
+        XCTAssertFalse(try XCTUnwrap(envelope.actions.first { $0.id == "start-generation" }).enabled)
+    }
+
     func testImageGenerationPreflightBlocksUnsupportedModelFamily() throws {
         let temp = try makeTemporaryDirectory()
         defer { try? FileManager.default.removeItem(at: temp) }

--- a/Tests/MereRunCLITests/MachineInferenceAdmissionTests.swift
+++ b/Tests/MereRunCLITests/MachineInferenceAdmissionTests.swift
@@ -413,6 +413,21 @@ final class MachineInferenceAdmissionTests: XCTestCase {
         )
     }
 
+    func testImageAndChatPreflightsDoNotReserveInferenceResources() {
+        let requests = [
+            ["image", "generate", "--model", "image-zimage-nano", "--prompt", "test"],
+            ["text", "chat", "--model", "text-chat-gemma4-12b-4bit", "--prompt", "test"],
+            ["text", "chat", "--model", "text-chat-deepseek-v4-flash", "--prompt", "test"],
+        ]
+        for request in requests {
+            let arguments = ["mere.run", "--models-root", "/tmp/preflight-models"] + request
+            XCTAssertNotNil(CLIInferenceAdmissionClassifier.request(arguments: arguments))
+            XCTAssertNil(CLIInferenceAdmissionClassifier.request(
+                arguments: arguments + ["--preflight", "--json"]
+            ), request.joined(separator: " "))
+        }
+    }
+
     func testOfflineGuidesNeverReserveInferenceMemory() {
         for model in ["text-agent-ornith-35b-mlx", "text-chat-deepseek-v4-flash"] {
             for path in [[], ["text", "chat"]] {

--- a/Tests/MereRunCLITests/MachineInferencePreflightTests.swift
+++ b/Tests/MereRunCLITests/MachineInferencePreflightTests.swift
@@ -1,0 +1,67 @@
+import XCTest
+@testable import MereRunCLI
+
+final class MachineInferencePreflightTests: XCTestCase {
+    private let gibibyte = UInt64(1_073_741_824)
+    private let imageArguments = ["mere.run", "image", "generate", "--prompt", "test"]
+
+    func testResourceChecksReportAllCurrentBlockers() {
+        let diagnostics = MachineInferencePreflight.diagnostics(
+            arguments: imageArguments,
+            host: MachineInferenceHostSnapshot(
+                physicalMemoryBytes: 128 * gibibyte,
+                availableMemoryBytes: 4 * gibibyte,
+                memoryPressure: .critical,
+                availableDiskBytes: gibibyte
+            )
+        )
+        XCTAssertEqual(Set(diagnostics.map(\.id)), [
+            "machine_insufficient_disk", "machine_insufficient_memory", "machine_critical_memory_pressure",
+        ])
+        XCTAssertTrue(diagnostics.allSatisfy { $0.severity == .blocker })
+    }
+
+    func testResourceChecksUseTheExecutionThresholdsAndModelClass() {
+        let host = MachineInferenceHostSnapshot(
+            physicalMemoryBytes: 128 * gibibyte,
+            availableMemoryBytes: MachineInferenceClass.standard.minimumAvailableBytes,
+            memoryPressure: .nominal,
+            availableDiskBytes: MachineInferenceCoordinator.minimumDiskBytes(physicalMemoryBytes: 128 * gibibyte)
+        )
+        XCTAssertTrue(MachineInferencePreflight.diagnostics(arguments: imageArguments, host: host).isEmpty)
+        let diagnostics = MachineInferencePreflight.diagnostics(
+            arguments: ["mere.run", "text", "chat", "--model", "text-chat-deepseek-v4-flash"],
+            host: host
+        )
+        XCTAssertEqual(diagnostics.map(\.id), ["machine_insufficient_memory"])
+    }
+
+    func testChatReportKeepsResourceAndMissingModelBlockersTogether() throws {
+        let command = try TextChat.parse([
+            "--model", "text-chat-gemma4-12b-4bit", "--require-installed", "--prompt", "test",
+        ])
+        let resources = MachineInferencePreflight.diagnostics(
+            arguments: ["mere.run", "text", "chat", "--model", command.model],
+            host: MachineInferenceHostSnapshot(
+                physicalMemoryBytes: 8 * gibibyte, availableMemoryBytes: 4 * gibibyte,
+                memoryPressure: .nominal, availableDiskBytes: gibibyte
+            )
+        )
+        let report = command.makePreflightReport(
+            modelID: command.model, installedModelPath: nil, resourceDiagnostics: resources
+        )
+        XCTAssertEqual(report.status, .blocked)
+        XCTAssertEqual(Set(report.diagnostics.map(\.id)), [
+            "machine_insufficient_disk", "machine_insufficient_memory", "text_chat_model_not_installed",
+        ])
+        let encoded = try StructuredRunOutput.encode(report)
+        let decoded = try JSONDecoder().decode(TextChatPreflightReport.self, from: Data(encoded.utf8))
+        XCTAssertEqual(decoded, report)
+        let installed = command.makePreflightReport(
+            modelID: command.model, installedModelPath: "/model", resourceDiagnostics: resources
+        )
+        XCTAssertEqual(installed.status, .blocked)
+        XCTAssertTrue(installed.installed)
+        XCTAssertEqual(installed.diagnostics, resources)
+    }
+}

--- a/Tests/MereRunCLITests/SkillContractTests.swift
+++ b/Tests/MereRunCLITests/SkillContractTests.swift
@@ -1,6 +1,7 @@
 import ArgumentParser
 import Foundation
 import MereRunContract
+import MereRunRelayKit
 import XCTest
 @testable import MereRunCLI
 @testable import MereRunCore
@@ -20,10 +21,10 @@ final class SkillContractTests: XCTestCase {
     }
 
     func testSkillExamplesMatchCLIAndModelContracts() throws {
-        for skill in ["mere-run", "use-mere-run"] {
-            let examples = try examples(in: skill)
-            XCTAssertFalse(examples.isEmpty, "No CLI examples found in \(skill)")
-            var pulledModels: [Int: String] = [:]
+        for document in try skillDocuments() {
+            let examples = try examples(in: document)
+            var pulledModels = Set<String>()
+            var preflights: [String: [String]] = [:]
             for example in examples {
                 do {
                     // Parse the leaf directly: root validation bootstraps machine-local state.
@@ -32,10 +33,19 @@ final class SkillContractTests: XCTestCase {
                     if let pull = command as? ModelPull {
                         let model = try XCTUnwrap(pull.target, example.location)
                         try checkModel(model, location: example.location)
-                        pulledModels[example.block] = model
+                        if !pull.preflight { pulledModels.insert(model) }
                     }
                     try checkDiscovery(command, location: example.location)
-                    try checkRecipe(command, example: example, pulledModel: pulledModels[example.block])
+                    try checkRecipe(command, example: example, pulledModels: pulledModels)
+                    if let command, try recipeModel(command, example: example) != nil {
+                        let key = example.arguments.prefix(2).joined(separator: " ")
+                        if example.arguments.contains("--preflight") {
+                            preflights[key] = example.arguments
+                        } else if type(of: command).helpMessage().contains("--preflight") {
+                            let checked = try XCTUnwrap(preflights[key], "\(example.location): missing request preflight")
+                            try matchingRequest(checked, execution: example.arguments)
+                        }
+                    }
                 } catch {
                     XCTFail("\(example.location): \(error)")
                 }
@@ -43,13 +53,191 @@ final class SkillContractTests: XCTestCase {
         }
     }
 
-    func testRecipeCheckRejectsImplicitOrMismatchedImageModels() throws {
-        let example = Example(location: "regression fixture", arguments: [], block: 0)
-        let implicit = try ImageGenerate.parse(["--prompt", "a mug"])
-        let different = try ImageGenerate.parse(["--prompt", "a mug", "--model", "image-zimage-nano"])
-        XCTAssertThrowsError(try recipeModel(implicit, example: example))
-        XCTAssertThrowsError(try matchingModel("image-zimage-nano", pulledModel: "image-klein-max"))
-        XCTAssertEqual(try recipeModel(different, example: example), "image-zimage-nano")
+    func testRecipeCheckRejectsRegressionsInDocumentedImageRequest() throws {
+        let document = repositoryRoot.appendingPathComponent("skills/use-mere-run/references/preflight-and-actions.md")
+        let examples = try examples(in: document)
+        let example = try XCTUnwrap(examples.first {
+            $0.arguments.starts(with: ["image", "generate"]) && !$0.arguments.contains("--preflight")
+        })
+        let checked = try XCTUnwrap(examples.first {
+            $0.arguments.starts(with: ["image", "generate"]) && $0.arguments.contains("--preflight")
+        })
+        let modelIndex = try XCTUnwrap(example.arguments.firstIndex(of: "--model"))
+        var implicit = example.arguments
+        implicit.removeSubrange(modelIndex...modelIndex + 1)
+        XCTAssertThrowsError(try recipeModel(parse(implicit), example: example))
+
+        var mismatched = example.arguments
+        mismatched[modelIndex + 1] = "image-klein-max"
+        XCTAssertThrowsError(try checkRecipe(
+            parse(mismatched), example: example, pulledModels: ["image-zimage-nano"]
+        ))
+        var changedSeed = example.arguments
+        let seedIndex = try XCTUnwrap(changedSeed.firstIndex(of: "--seed"))
+        changedSeed[seedIndex + 1] = "99"
+        XCTAssertThrowsError(try matchingRequest(checked.arguments, execution: changedSeed))
+        XCTAssertNoThrow(try matchingRequest(checked.arguments, execution: example.arguments))
+    }
+
+    func testBundledReferencesResolveAndExampleGraphValidates() throws {
+        let root = repositoryRoot.appendingPathComponent("skills/use-mere-run")
+        let skill = try String(contentsOf: root.appendingPathComponent("SKILL.md"), encoding: .utf8)
+        let links = try NSRegularExpression(pattern: #"\]\((references/[^)]+)\)"#)
+        let matches = links.matches(in: skill, range: NSRange(skill.startIndex..., in: skill))
+        let linked = try Set(matches.map { match -> String in
+            let range = try XCTUnwrap(Range(match.range(at: 1), in: skill))
+            let relative = String(skill[range])
+            XCTAssertTrue(FileManager.default.fileExists(atPath: root.appendingPathComponent(relative).path))
+            return relative
+        })
+        let referenceFiles = try FileManager.default.subpathsOfDirectory(atPath: root.appendingPathComponent("references").path)
+            .filter { $0.hasSuffix(".md") }.map { "references/\($0)" }
+        XCTAssertEqual(linked, Set(referenceFiles), "Every bundled operational reference must be discoverable")
+
+        let workflow = try String(contentsOf: root.appendingPathComponent("references/workflows-and-services.md"), encoding: .utf8)
+        let graphJSON = try XCTUnwrap(workflow.components(separatedBy: "```json\n").dropFirst().first?
+            .components(separatedBy: "```").first)
+        let graph = try WorkflowBundleCodec.decoder().decode(WorkflowGraphDocument.self, from: Data(graphJSON.utf8))
+        let result = WorkflowGraphValidator.validate(graph: graph, inputs: .init(values: [:]))
+        XCTAssertNotEqual(result.status, .blocked)
+        XCTAssertEqual(result.order, ["message"])
+    }
+
+    func testDocumentedResultAndProgressJSONMatchEmitters() throws {
+        let document = repositoryRoot.appendingPathComponent("skills/use-mere-run/references/execution-and-results.md")
+        let markdown = try String(contentsOf: document, encoding: .utf8)
+        let json = markdown.components(separatedBy: "```json\n").dropFirst().compactMap {
+            $0.components(separatedBy: "```").first
+        }
+        XCTAssertEqual(json.count, 2)
+        let receipt = try JSONDecoder().decode(RunReceipt.self, from: Data(try XCTUnwrap(json.first).utf8))
+        XCTAssertEqual(receipt, RunReceipt(outputs: receipt.outputs))
+        struct Progress: Decodable, Equatable {
+            let event: String
+            let stage: String
+            let step: Int
+            let total_steps: Int
+        }
+        let progress = try JSONDecoder().decode(Progress.self, from: Data(try XCTUnwrap(json.last).utf8))
+        let emitted = CLIGenerationProgressPrinter.progressJSONLine(
+            stage: progress.stage, step: progress.step, totalSteps: progress.total_steps
+        )
+        XCTAssertEqual(progress, try JSONDecoder().decode(Progress.self, from: Data(emitted.utf8)))
+    }
+
+    func testDocumentedPreflightsExposeBlockersWithoutInference() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent("skill-preflight-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let recipes = try examples(in: repositoryRoot.appendingPathComponent(
+            "skills/use-mere-run/references/preflight-and-actions.md"
+        ))
+        let serviceRecipes = try examples(in: repositoryRoot.appendingPathComponent(
+            "skills/use-mere-run/references/workflows-and-services.md"
+        ))
+        struct Report: Decodable {
+            let status: String
+            let diagnostics: [Diagnostic]
+            struct Diagnostic: Decodable { let id: String; let severity: String }
+        }
+        for (path, diagnostic, expectedExit) in [
+            (["image", "generate"], "model_missing", Int32(1)),
+            (["text", "chat"], "text_chat_model_not_installed", Int32(0)),
+            (["api", "serve"], "api_key_required_for_non_loopback", Int32(1)),
+        ] {
+            let example = try XCTUnwrap((recipes + serviceRecipes).first {
+                $0.arguments.starts(with: path) && $0.arguments.contains("--preflight")
+            })
+            var arguments = example.arguments
+            if path == ["api", "serve"] {
+                let host = try XCTUnwrap(arguments.firstIndex(of: "--host"))
+                arguments[host + 1] = "0.0.0.0"
+            }
+            let output = try runCLI(arguments, in: root)
+            let report = try JSONDecoder().decode(Report.self, from: output.stdout)
+            XCTAssertEqual(output.exit, expectedExit, String(decoding: output.stderr, as: UTF8.self))
+            XCTAssertEqual(report.status, "blocked")
+            XCTAssertTrue(report.diagnostics.contains { $0.id == diagnostic && $0.severity == "blocker" })
+        }
+        XCTAssertFalse(FileManager.default.fileExists(atPath: root.appendingPathComponent("mug.png").path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: root.appendingPathComponent("models").path))
+    }
+
+    func testDocumentedGraphRunsInspectsAndResumesWithoutModels() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent("skill-graph-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let document = repositoryRoot.appendingPathComponent("skills/use-mere-run/references/workflows-and-services.md")
+        let markdown = try String(contentsOf: document, encoding: .utf8)
+        let json = try XCTUnwrap(markdown.components(separatedBy: "```json\n").dropFirst().first?
+            .components(separatedBy: "```").first)
+        try json.write(to: root.appendingPathComponent("workflow.json"), atomically: true, encoding: .utf8)
+        let examples = try examples(in: document)
+        struct Report: Decodable {
+            let state: String
+            let job_id: String
+            let nodes: [Node]
+            let outputs: [Output]
+            struct Node: Decodable { let attempt: Int }
+            struct Output: Decodable { let path: String }
+        }
+        for path in [["graph", "validate"], ["graph", "preflight"], ["graph", "run"]] {
+            let example = try XCTUnwrap(examples.first { $0.arguments.starts(with: path) })
+            let result = try runCLI(example.arguments, in: root)
+            XCTAssertEqual(result.exit, 0, String(decoding: result.stderr, as: UTF8.self))
+        }
+        let inspect = try XCTUnwrap(examples.first { $0.arguments.starts(with: ["run", "inspect"]) })
+        let inspection = try runCLI(inspect.arguments, in: root)
+        XCTAssertEqual(inspection.exit, 0)
+        let first = try JSONDecoder().decode(Report.self, from: inspection.stdout)
+        XCTAssertEqual(first.state, "finished")
+        let output = try XCTUnwrap(first.outputs.first)
+        let artifact = root.appendingPathComponent("runs/message-check").appendingPathComponent(output.path)
+        let value = try JSONDecoder().decode(String.self, from: Data(contentsOf: artifact))
+        XCTAssertEqual(value, "Workflow execution verified.")
+
+        let run = try XCTUnwrap(examples.first { $0.arguments.starts(with: ["graph", "run"]) })
+        XCTAssertEqual(try runCLI(run.arguments + ["--resume"], in: root).exit, 0)
+        let resumed = try JSONDecoder().decode(Report.self, from: runCLI(inspect.arguments, in: root).stdout)
+        XCTAssertEqual(resumed.state, "finished")
+        XCTAssertEqual(resumed.job_id, first.job_id)
+        XCTAssertEqual(resumed.nodes.map(\.attempt), first.nodes.map(\.attempt), "Resume must reuse the finished node")
+    }
+
+    private func runCLI(_ arguments: [String], in directory: URL) throws -> (exit: Int32, stdout: Data, stderr: Data) {
+        let binary = repositoryRoot.appendingPathComponent(".build/debug/mere.run")
+        let outputURL = directory.appendingPathComponent("stdout-\(UUID().uuidString)")
+        let errorURL = directory.appendingPathComponent("stderr-\(UUID().uuidString)")
+        _ = FileManager.default.createFile(atPath: outputURL.path, contents: nil)
+        _ = FileManager.default.createFile(atPath: errorURL.path, contents: nil)
+        let output = try FileHandle(forWritingTo: outputURL)
+        let errors = try FileHandle(forWritingTo: errorURL)
+        defer { try? output.close(); try? errors.close() }
+        let process = Process()
+        process.executableURL = binary
+        process.currentDirectoryURL = directory
+        process.arguments = ["--models-root", directory.appendingPathComponent("models").path] + arguments
+        var environment = ProcessInfo.processInfo.environment
+        environment.removeValue(forKey: "MERERUN_API_KEY")
+        environment["MERERUN_HUB_CACHE"] = directory.appendingPathComponent("hub").path
+        process.environment = environment
+        process.standardOutput = output
+        process.standardError = errors
+        try process.run()
+        let deadline = Date().addingTimeInterval(30)
+        while process.isRunning && Date() < deadline { Thread.sleep(forTimeInterval: 0.02) }
+        guard !process.isRunning else {
+            process.terminate()
+            throw ValidationError("Skill command exceeded 30 seconds: \(arguments.joined(separator: " "))")
+        }
+        return (process.terminationStatus, try Data(contentsOf: outputURL), try Data(contentsOf: errorURL))
+    }
+
+    private func matchingRequest(_ preflight: [String], execution: [String]) throws {
+        let outputFlags: Set<String> = ["--preflight", "--json", "--receipt", "--progress-json", "--stream"]
+        guard preflight.filter({ !outputFlags.contains($0) }) == execution.filter({ !outputFlags.contains($0) }) else {
+            throw ValidationError("Execution changes the preflighted request: \(execution.joined(separator: " "))")
+        }
     }
 
     private func checkDiscovery(_ command: ParsableCommand?, location: String) throws {
@@ -74,12 +262,13 @@ final class SkillContractTests: XCTestCase {
         _ = try XCTUnwrap(ManagedModelCatalog.allSpecs.first { $0.id == model }, "\(location): unknown model \(model)")
     }
 
-    private func checkRecipe(_ command: ParsableCommand?, example: Example, pulledModel: String?) throws {
+    private func checkRecipe(_ command: ParsableCommand?, example: Example, pulledModels: Set<String>) throws {
         guard let model = try recipeModel(command, example: example) else { return }
         XCTAssertTrue(example.arguments.contains("--model"), "\(example.location): select the model explicitly")
         try checkModel(model, location: example.location)
-        let pulled = try XCTUnwrap(pulledModel, "\(example.location): recipe needs its model pull in the same block")
-        try matchingModel(model, pulledModel: pulled)
+        guard pulledModels.contains(model) else {
+            throw ValidationError("\(example.location): recipe selects \(model) without a preceding pull for it")
+        }
         if let server = command as? APIServe {
             let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: model))
             XCTAssertEqual(spec.defaultRuntimeServingEngine, server.engine.runtimeServingEngine, example.location)
@@ -102,12 +291,6 @@ final class SkillContractTests: XCTestCase {
             return try XCTUnwrap(server.model, "\(example.location): API recipe must select its model explicitly")
         default:
             return nil
-        }
-    }
-
-    private func matchingModel(_ selected: String, pulledModel: String) throws {
-        guard selected == pulledModel else {
-            throw ValidationError("Recipe pulls \(pulledModel) but selects \(selected)")
         }
     }
 
@@ -134,9 +317,15 @@ final class SkillContractTests: XCTestCase {
         }
     }
 
-    private func examples(in skill: String) throws -> [Example] {
-        let path = "skills/\(skill)/SKILL.md"
-        let markdown = try String(contentsOf: repositoryRoot.appendingPathComponent(path), encoding: .utf8)
+    private func skillDocuments() throws -> [URL] {
+        let root = repositoryRoot.appendingPathComponent("skills")
+        return try FileManager.default.subpathsOfDirectory(atPath: root.path)
+            .filter { $0.hasSuffix(".md") }.sorted().map { root.appendingPathComponent($0) }
+    }
+
+    private func examples(in document: URL) throws -> [Example] {
+        let path = document.path
+        let markdown = try String(contentsOf: document, encoding: .utf8)
         let lines = markdown.components(separatedBy: "\n")
         var inBash = false
         var block = 0

--- a/Tests/MereRunCLITests/SkillContractTests.swift
+++ b/Tests/MereRunCLITests/SkillContractTests.swift
@@ -154,8 +154,17 @@ final class SkillContractTests: XCTestCase {
                 arguments[host + 1] = "0.0.0.0"
             }
             let output = try runCLI(arguments, in: root)
-            let report = try JSONDecoder().decode(Report.self, from: output.stdout)
-            XCTAssertEqual(output.exit, expectedExit, String(decoding: output.stderr, as: UTF8.self))
+            let context = "Command: \(arguments.joined(separator: " "))\n"
+                + "Exit: \(output.exit)\nStderr: \(String(decoding: output.stderr, as: UTF8.self))\n"
+                + "Stdout: \(String(decoding: output.stdout, as: UTF8.self))"
+            XCTAssertEqual(output.exit, expectedExit, context)
+            let report: Report
+            do {
+                report = try JSONDecoder().decode(Report.self, from: output.stdout)
+            } catch {
+                XCTFail("Preflight did not emit its JSON report: \(error)\n\(context)")
+                continue
+            }
             XCTAssertEqual(report.status, "blocked")
             XCTAssertTrue(report.diagnostics.contains { $0.id == diagnostic && $0.severity == "blocker" })
         }
@@ -229,6 +238,12 @@ final class SkillContractTests: XCTestCase {
         guard !process.isRunning else {
             process.terminate()
             throw ValidationError("Skill command exceeded 30 seconds: \(arguments.joined(separator: " "))")
+        }
+        guard process.terminationReason == .exit else {
+            throw ValidationError(
+                "Skill command terminated by signal \(process.terminationStatus): \(arguments.joined(separator: " "))\n"
+                    + String(decoding: try Data(contentsOf: errorURL), as: UTF8.self)
+            )
         }
         return (process.terminationStatus, try Data(contentsOf: outputURL), try Data(contentsOf: errorURL))
     }

--- a/Tests/MereRunCLITests/SkillContractTests.swift
+++ b/Tests/MereRunCLITests/SkillContractTests.swift
@@ -1,0 +1,179 @@
+import ArgumentParser
+import Foundation
+import MereRunContract
+import XCTest
+@testable import MereRunCLI
+@testable import MereRunCore
+
+final class SkillContractTests: XCTestCase {
+    private struct Example {
+        let location: String
+        let arguments: [String]
+        let block: Int
+    }
+
+    private var repositoryRoot: URL {
+        URL(fileURLWithPath: #filePath)
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+            .deletingLastPathComponent()
+    }
+
+    func testSkillExamplesMatchCLIAndModelContracts() throws {
+        for skill in ["mere-run", "use-mere-run"] {
+            let examples = try examples(in: skill)
+            XCTAssertFalse(examples.isEmpty, "No CLI examples found in \(skill)")
+            var pulledModels: [Int: String] = [:]
+            for example in examples {
+                do {
+                    // Parse the leaf directly: root validation bootstraps machine-local state.
+                    // Never invoke run(), model resolution, or a shell for documentation checks.
+                    let command = try parse(example.arguments)
+                    if let pull = command as? ModelPull {
+                        let model = try XCTUnwrap(pull.target, example.location)
+                        try checkModel(model, location: example.location)
+                        pulledModels[example.block] = model
+                    }
+                    try checkDiscovery(command, location: example.location)
+                    try checkRecipe(command, example: example, pulledModel: pulledModels[example.block])
+                } catch {
+                    XCTFail("\(example.location): \(error)")
+                }
+            }
+        }
+    }
+
+    func testRecipeCheckRejectsImplicitOrMismatchedImageModels() throws {
+        let example = Example(location: "regression fixture", arguments: [], block: 0)
+        let implicit = try ImageGenerate.parse(["--prompt", "a mug"])
+        let different = try ImageGenerate.parse(["--prompt", "a mug", "--model", "image-zimage-nano"])
+        XCTAssertThrowsError(try recipeModel(implicit, example: example))
+        XCTAssertThrowsError(try matchingModel("image-zimage-nano", pulledModel: "image-klein-max"))
+        XCTAssertEqual(try recipeModel(different, example: example), "image-zimage-nano")
+    }
+
+    private func checkDiscovery(_ command: ParsableCommand?, location: String) throws {
+        if let catalog = command as? CatalogCommand, let identifier = catalog.id {
+            XCTAssertNotNil(MereRunCapabilityCatalog.command(id: identifier), "\(location): unknown capability")
+        }
+        if let guide = command as? GuideCommand {
+            if let model = guide.model {
+                try checkModel(model, location: location)
+            }
+            if !guide.commandPath.isEmpty {
+                let entry = try GuideCommand.resolveEntry(commandPath: guide.commandPath, model: guide.model)
+                XCTAssertFalse(try GuideRegistry.content(for: entry, model: guide.model).isEmpty, location)
+            } else if let model = guide.model {
+                let handbook = try ModelGuideRegistry.guide(for: model)
+                XCTAssertFalse(try GuideRegistry.content(for: handbook.entry).isEmpty, location)
+            }
+        }
+    }
+
+    private func checkModel(_ model: String, location: String) throws {
+        _ = try XCTUnwrap(ManagedModelCatalog.allSpecs.first { $0.id == model }, "\(location): unknown model \(model)")
+    }
+
+    private func checkRecipe(_ command: ParsableCommand?, example: Example, pulledModel: String?) throws {
+        guard let model = try recipeModel(command, example: example) else { return }
+        XCTAssertTrue(example.arguments.contains("--model"), "\(example.location): select the model explicitly")
+        try checkModel(model, location: example.location)
+        let pulled = try XCTUnwrap(pulledModel, "\(example.location): recipe needs its model pull in the same block")
+        try matchingModel(model, pulledModel: pulled)
+        if let server = command as? APIServe {
+            let spec = try XCTUnwrap(ManagedModelCatalog.spec(for: model))
+            XCTAssertEqual(spec.defaultRuntimeServingEngine, server.engine.runtimeServingEngine, example.location)
+            XCTAssertEqual(server.defaultRuntimeModelID(modelPath: model), model, example.location)
+        }
+    }
+
+    private func recipeModel(_ command: ParsableCommand?, example: Example) throws -> String? {
+        switch command {
+        case let image as ImageGenerate:
+            guard let model = image.model else {
+                throw ValidationError("\(example.location): image recipe must select its model explicitly")
+            }
+            return model
+        case let chat as TextChat:
+            return chat.model
+        case let speech as SpeechSynthesize:
+            return speech.model
+        case let server as APIServe:
+            return try XCTUnwrap(server.model, "\(example.location): API recipe must select its model explicitly")
+        default:
+            return nil
+        }
+    }
+
+    private func matchingModel(_ selected: String, pulledModel: String) throws {
+        guard selected == pulledModel else {
+            throw ValidationError("Recipe pulls \(pulledModel) but selects \(selected)")
+        }
+    }
+
+    private func parse(_ arguments: [String]) throws -> ParsableCommand? {
+        var remaining = arguments[...]
+        var commandType: ParsableCommand.Type = MereRunCLI.self
+        while let name = remaining.first,
+              let child = commandType.configuration.subcommands.first(where: { $0.configuration.commandName == name }) {
+            commandType = child
+            remaining = remaining.dropFirst()
+        }
+        // Only help/version examples may target the root, avoiding its bootstrap validation.
+        if commandType == MereRunCLI.self {
+            guard remaining == ["--help"] || remaining == ["--version"] else {
+                throw ValidationError("Unknown root command in skill: \(arguments.joined(separator: " "))")
+            }
+            return nil
+        }
+        do {
+            return try commandType.parseAsRoot(Array(remaining))
+        } catch {
+            if commandType.exitCode(for: error) == .success { return nil }
+            throw error
+        }
+    }
+
+    private func examples(in skill: String) throws -> [Example] {
+        let path = "skills/\(skill)/SKILL.md"
+        let markdown = try String(contentsOf: repositoryRoot.appendingPathComponent(path), encoding: .utf8)
+        let lines = markdown.components(separatedBy: "\n")
+        var inBash = false
+        var block = 0
+        var pending = ""
+        var examples: [Example] = []
+        for (offset, line) in lines.enumerated() {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if trimmed.hasPrefix("```") {
+                inBash = trimmed == "```bash"
+                block += 1
+                continue
+            }
+            guard inBash, !trimmed.isEmpty else { continue }
+            if trimmed.hasSuffix("\\") {
+                pending += trimmed.dropLast() + " "
+                continue
+            }
+            let invocation = pending + trimmed
+            pending = ""
+            var words = try tokenize(invocation)
+            if words.starts(with: ["swift", "run"]) { words.removeFirst(2) }
+            guard words.first == "mere.run" else { continue }
+            examples.append(Example(location: "\(path):\(offset + 1)", arguments: Array(words.dropFirst()), block: block))
+        }
+        XCTAssertTrue(pending.isEmpty, "\(path): unfinished command continuation")
+        return examples
+    }
+
+    private func tokenize(_ command: String) throws -> [String] {
+        // Skill examples use literal arguments and quoted prompts, with no shell evaluation.
+        let pattern = #""[^"]*"|'[^']*'|[^\s"']+"#
+        let expression = try NSRegularExpression(pattern: pattern)
+        return try expression.matches(in: command, range: NSRange(command.startIndex..., in: command)).map { match in
+            let range = try XCTUnwrap(Range(match.range, in: command))
+            let word = String(command[range])
+            if word.first == "\"" || word.first == "'" { return String(word.dropFirst().dropLast()) }
+            return word
+        }
+    }
+}

--- a/skills/mere-run/SKILL.md
+++ b/skills/mere-run/SKILL.md
@@ -1,99 +1,119 @@
 ---
 name: mere-run
-description: Develop, inspect, test, or modify the public `mere.run` Swift CLI in this OSS repository. Use when Codex needs to run source-checkout commands such as `swift run mere.run`, inspect the modality-first command tree as code, change CLI parsing, model resolution, local API behavior, or command output, update CLI docs/tests, validate with `./scripts/check.sh`, or distinguish the public `mere.run` inference CLI from the separate root `mere` portfolio command plane. For helping an end user operate the CLI without editing this repo, use the `use-mere-run` skill instead.
+description: Develop and validate the public mere.run CLI, runtime libraries, and Studio clients in the OSS source repository. Use for command parsing, model integration, workflow contracts, app integration, tests, or CLI documentation. For operating an installed CLI without source changes, use use-mere-run.
 ---
 
-# mere.run CLI
+# Develop mere.run
 
-## Overview
+Work from the public `mere.run` source checkout. The separate root `mere`
+portfolio CLI is outside this skill's scope. For operator help without code
+changes, use the `use-mere-run` skill when available.
 
-Use this skill for developing the public OSS `mere.run` CLI built by the Swift package in this repo. Keep it separate from the root `mere` portfolio CLI; this repo's command is `swift run mere.run ...` during development and `mere.run ...` only when testing an installed binary. For newcomer/operator help, use the companion `use-mere-run` skill.
+## Establish the source and runtime
 
-## First Moves
+Read `AGENTS.md`, `Package.swift`, `CODEBASE.md`, and the closest module README.
+Use `docs/repository-tour.md` and `docs/architecture.md` to find runtime owners.
+Inspect Git status before editing and preserve unrelated work.
 
-- Work from the repo root.
-- Read `AGENTS.md` for the repo contract when it is not already loaded.
-- For code changes, read `Package.swift`, `CODEBASE.md`, `Sources/MereRunCLI/MereRunCLI.swift`, the closest command file under `Sources/MereRunCLI/Commands/`, and the closest tests under `Tests/MereRunCLITests/` or `Tests/MereRunCoreTests/`.
-- For CLI usage or command discovery, start with `swift run mere.run --help`, then inspect the relevant subcommand help.
-- Treat `README.md`, `docs/cli.md`, `docs/model-sources.md`, and the managed model registry as the canonical public surface.
-
-## Command Surface
-
-Prefer the source checkout command while developing:
+Use the source CLI when testing changes:
 
 ```bash
+swift run mere.run --version
 swift run mere.run --help
-swift run mere.run guide --list
-swift run mere.run model capabilities
-swift run mere.run model list
+swift run mere.run catalog --json
 ```
 
-Keep the public command tree modality-first:
+An installed `mere.run` can differ from the checkout. Record which executable
+and version produced each result; installed-binary success does not validate
+source changes. Use command help for parsing and the catalog for structured
+capabilities, options, and output contracts. The catalog is not a replacement
+for the full command tree.
 
-- `image generate`, `image validate`
-- `guide`, `guide --list`, `guide <command path>`, `guide <command path> --model <model-id>`, `guide <command path> --json`
-- `text chat`, `text code`, `text embed`, `text anonymize`
-- `speech synthesize`, `speech transcribe`, `speech profile`
-- `vision caption`, `vision inspect`, `vision ground`, `vision segment`, `vision track`, `vision track-live`, `vision ocr`
-- `music generate`
-- `video generate`, `video export-latents`
-- `model list`, `model capabilities`, `model info`, `model pull`, `model remove`, `model repair-manifests`
-- `api serve`
-- `setup`
-- `agent onboard`, `agent install-pi`, `agent start`
+## Find the contract that owns the change
 
-Use managed model IDs from `docs/cli.md`, `docs/model-sources.md`, or `Sources/MereRunCore/ManagedModelCatalog.swift`; avoid guessing retired or private identifiers.
+| Change | Start here |
+| --- | --- |
+| Commands, flags, stdout, and diagnostics | `Sources/MereRunCLI/MereRunCLI.swift`, `Sources/MereRunCLI/Commands/`, `Sources/MereRunCLI/Support/` |
+| Capability metadata shared with Studio | `Sources/MereRunContract/`, `Tests/MereRunCLITests/CapabilityCatalogTests.swift` |
+| Model IDs, availability, and storage | `Sources/MereRunCore/ManagedModelCatalog.swift`, `ManagedModelSupport.swift`, `ModelResolver.swift` |
+| Prompting and model-specific workflows | `Sources/MereRunCLI/Guides/`, `GuideCommand.swift` and `ModelGuideRegistry.swift` under `Sources/MereRunCLI/Commands/` |
+| Graphs, executors, relay, and durable runs | Relevant CLI command, `Sources/MereRunRelayKit/`, `docs/workflows.md` |
+| Evaluation packs and results | `Sources/MereRunEvaluation/`, `docs/evaluation-packs.md` |
+| macOS Studio | `apps/macos/StudioKit/`, `apps/macos/StudioUI/`, `apps/macos/StudioKitTests/` |
+| iOS Studio | `apps/ios/`, `Sources/MereRunRelayKit/`, `docs/ios-studio.md` |
 
-## Runtime State
+Discover command additions from `--help` instead of maintaining a second
+command inventory in this skill. This also covers plugins, adapters, world
+sessions, geospatial inference, audio, and model optimization.
 
-Use the default model store unless isolation matters:
-
-```text
-~/Library/Application Support/MereRun/models
-```
-
-For isolated tests or reproductions, pass a model root explicitly:
+For a model or command change, inspect its cookbook and handbook:
 
 ```bash
-swift run mere.run --models-root /tmp/mererun-models model list
+swift run mere.run guide --list
+swift run mere.run guide --list-models --json
+swift run mere.run catalog image.generate --json
+swift run mere.run guide image generate
+swift run mere.run guide --model image-zimage-nano
 ```
 
-Respect the related environment overrides: `MERERUN_MODELS_DIR`, `MERERUN_HUB_CACHE`, and `MERERUN_MODEL_CACHE_HOME`.
+Handbooks explain provider guidance and validation limits. They do not prove
+that a checkpoint has passed local inference. Resolve canonical model IDs from
+the managed catalog; do not infer support from a runtime type name or alias.
 
-## Implementation Rules
+## Implement at the owning boundary
 
-- Keep stdout machine-readable and stderr diagnostic/progress-oriented in CLI implementations.
-- Use typed decoding at config and tokenizer boundaries. Keep dynamic compatibility shims narrow and close to the ingestion point.
-- Update the closest CLI or core test when changing command parsing, model resolution, compatibility behavior, API behavior, or output shape.
-- Update `README.md`, `docs/`, or `CHANGELOG.md` when changing public CLI behavior, setup, model guidance, or security-sensitive defaults.
-- Preserve the public OSS boundary: no hosted-service, billing, app-store, or private-deployment surfaces.
-- Leave `vendor/` unchanged unless explicitly required; update `THIRD_PARTY_NOTICES.md` in the same change if vendor artifacts change.
-- Preserve API safety defaults. `api serve` may bind loopback without auth; non-loopback hosts require `--api-key` or `MERERUN_API_KEY`.
-- Preserve tool-loop safety. `text chat` tool execution requires interactive approval unless the user opts into supported auto-approval behavior.
+- Keep runtime behavior in the owning library. Studio consumes CLI and shared
+  contracts; it must not become a second runtime implementation.
+- Use typed decoding at configuration and tokenizer boundaries. Keep stdout
+  consistent with the command's declared output; send diagnostics to stderr.
+- Update the closest CLI or core tests when changing parsing, model resolution,
+  compatibility, API behavior, or output shape.
+- When command paths or abstracts change, run
+  `./scripts/update-docs-command-reference.sh`. When capabilities change,
+  update the shared catalog and its parity tests.
+- Keep managed model entries, support metadata, and model handbooks aligned.
+  Use `ModelGuideTests` to check handbook coverage.
+- Preserve loopback API defaults and required authentication for non-loopback
+  binds. Preserve the supported tool-execution approval behavior.
+- Follow the repository's OSS boundary and vendor rules. Public macOS and iOS
+  clients are in scope; private deployment and store distribution machinery
+  belong elsewhere.
 
-## Validation
+## Validate the change
 
-Use the repo gate before treating a change as ready:
+Use focused tests while iterating. Before opening a PR, run the repository gate:
 
 ```bash
 ./scripts/check.sh
 ```
 
-That gate runs SwiftLint strict mode, build, tests, CLI `--help` smoke coverage, and hygiene scans for legacy names, old model IDs, retired command vocabulary, and debug prints. If the hygiene scan fails, inspect the rejected pattern and use current docs, tests, or the managed model registry for the canonical replacement.
+The gate owns lint, build, tests, CLI help checks, and hygiene checks. Never
+remove a rejected pattern from a hygiene check to make the change pass.
+Consult the managed catalog, docs, and tests for the supported replacement.
 
-Use narrower checks while iterating:
-
-```bash
-swift build
-swift test
-swift run mere.run --help
-```
-
-Add runtime smoke only when the task needs it and the machine has the needed assets:
+Use runtime smoke when relevant and the machine has the required assets:
 
 ```bash
 MERERUN_RUN_E2E=core ./scripts/check.sh
 MERERUN_RUN_E2E=installed ./scripts/check.sh
 ```
 
-When real checkpoint assets, GPU-only behavior, or non-loopback network validation is required, run the local gate first and call out the remaining validation gap explicitly.
+Follow `AGENTS.md` for asset, GPU, and network validation limits. Report parsing,
+local tests, real inference, hosted checks, and deployment as separate evidence.
+
+## Maintain the distributed skills
+
+`skills/mere-run/` owns this developer skill. `skills/use-mere-run/` owns the
+operator skill copied into the macOS app by `scripts/build_mere_run_app.sh`.
+Installed skills are copies and can drift from the repository.
+
+When updating skills, keep examples explicit about model selection. Run:
+
+```bash
+swift test --filter SkillContractTests
+```
+
+This test reads the skill examples, parses their commands, resolves catalog and
+handbook references, and checks that pull/run recipes select the same model.
+It does not download models or run inference. Update installed copies at their
+actual discovered locations when requested; preserve unrelated local files.

--- a/skills/mere-run/agents/openai.yaml
+++ b/skills/mere-run/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "mere.run CLI"
-  short_description: "Operate the public mere.run CLI safely"
-  default_prompt: "Use $mere-run to inspect the public CLI command tree and run the right validation."
+  short_description: "Develop the mere.run CLI and Studio clients"
+  default_prompt: "Use $mere-run to inspect the owning source contract, implement my change, and validate it."

--- a/skills/use-mere-run/SKILL.md
+++ b/skills/use-mere-run/SKILL.md
@@ -1,35 +1,49 @@
 ---
 name: use-mere-run
-description: Operate the public mere.run CLI for local AI, model setup, media generation and analysis, workflow graphs, or API serving. Use for choosing supported models, running workflows, and troubleshooting an installed CLI. Source-code development belongs to the mere-run skill.
+description: Operate the public mere.run CLI from discovery and model setup through preflight, execution, artifact verification, and recovery. Use for local AI, media, training, workflow graphs, plugins, or API and relay services. Source-code development belongs to the mere-run skill.
 ---
 
 # Use mere.run
 
-Help the user get an output from the public `mere.run` CLI. Start with their
-requested result and discover the matching commands on their machine.
+Help the user produce and verify the requested result with the public
+`mere.run` CLI. Use the executable's contracts and bundled model handbooks to
+resolve details that vary by version, model, hardware, or execution host.
 
-## Identify the executable
+## Establish the execution context
 
-Use the installed binary for operator tasks:
+Locate the executable with `command -v mere.run`, then inspect it:
 
 ```bash
 mere.run --version
 mere.run --help
 ```
 
-In a source checkout, use `swift run mere.run` when the user wants to run that
-checkout. Do not silently substitute an installed release for changed source.
-If the binary is missing outside a checkout, use the installation instructions
-on the [mere.run releases page](https://mere.run/releases). Do not assume a
-Swift toolchain or source repository is available to an end user.
+For a requested source checkout, use `swift run mere.run` from that checkout.
+Do not substitute an installed release for changed source. Outside a checkout,
+use the [mere.run installation instructions](https://mere.run/releases) when the
+binary is missing; do not assume an end user has Swift or repository sources.
 
-Examples in this skill are starting points. The selected binary's `--help`
-owns accepted flags and defaults. If a discovery command is unavailable, use
-that version's help and explain the version gap.
+Keep the same executable, working directory, model store, cache, and executor
+through discovery, preflight, and execution. A global `--models-root` goes
+before the subcommand. A generated action may omit that override: preserve it
+when adapting the action. Record the version and explicit model in the result.
 
-## Discover a workflow and its models
+## Load the operational reference for the task
 
-Run the discovery commands relevant to the task:
+Read the relevant reference before its first operation. These files ship with
+this skill and work without a source checkout.
+
+| Task | Reference |
+| --- | --- |
+| Every expensive run or model download | [Preflight and actions](references/preflight-and-actions.md): preparation checks, report schemas, blockers, and follow-up actions |
+| Run, monitor, verify, cancel, or recover | [Execution and results](references/execution-and-results.md): stdout, receipts, progress, tool loops, and failure handling |
+| Install models, manage storage, use adapters or plugins | [Models, storage, and plugins](references/models-storage-and-plugins.md): support, terms, caches, bindings, and installation modes |
+| Build graphs, use remote workers, or serve an API | [Workflows and services](references/workflows-and-services.md): graph schemas, job identity, remote lifecycle, and API compatibility |
+| Choose modality controls, train, or evaluate | [Modalities and training](references/modalities-and-training.md): input constraints, model guidance, and quality checks |
+
+## Discover the supported workflow
+
+Run only the discovery commands relevant to the user's task:
 
 ```bash
 mere.run catalog --json
@@ -39,14 +53,13 @@ mere.run guide --list
 mere.run guide --list-models --json
 ```
 
-`catalog` describes command capabilities. `model capabilities` describes
-hardware support; `model list` describes installation status. A supported model
-is not necessarily installed or suitable for the user's quality and latency
-requirements. Use `model capabilities --all --json` for models outside the
-recommended set and read the reported restrictions.
+Use `--help` for accepted arguments and the full command tree. Use `catalog`
+for structured capability metadata; it is not a complete replacement for help.
+Use `model capabilities --all --json` to inspect support and restrictions beyond
+the recommended set. Support, installation, runtime readiness, and suitability
+for the user's goal are separate facts.
 
-Load the command cookbook for workflow controls and the model handbook for
-provider-specific prompting, input requirements, and validation limits:
+Load both the command cookbook and the selected model handbook:
 
 ```bash
 mere.run catalog image.generate --json
@@ -55,16 +68,41 @@ mere.run guide image generate
 mere.run guide --model image-zimage-nano
 ```
 
-Use `guide --model` without a command path to select a model handbook. Command
-cookbooks can cover several models; a guide example is not evidence that a
-particular checkpoint was tested on this machine.
+`guide --model` without a command path selects the model handbook. Its provider
+advice and examples do not certify inference on this machine. If a discovery
+command is missing in an older release, use that release's help and explain the
+gap. Do not invent flags or silently upgrade the user's installation.
 
-## Route tasks to the right command family
+## Follow the operating loop
 
-Discover subcommands with `mere.run <group> --help`; this table is a starting
-map, not a complete command list.
+1. Identify the user's inputs, output requirements, execution host, and quality
+   constraints. Inspect input files and choose a fresh output location.
+2. Select a supported model from live discovery. Read its handbook before
+   choosing model-specific flags, prompts, reference inputs, or sampling values.
+3. Preflight the needed model pull. Inspect download size, storage locations,
+   runtime readiness, companion models, and any terms that need acceptance.
+   Pull only the selected dependencies within the user's authorized task.
+4. Preflight the exact run where supported. Read stdout, stderr, and process
+   exit status. Inspect JSON `status` and diagnostics even when exit is zero.
+   Resolve blockers and repeat the check with the same request and context.
+5. Run the checked request. Remove preflight-only flags; add receipts and
+   structured progress only where help advertises them. Capture both streams
+   separately and retain the process or remote job identity.
+6. Wait for completion, verify the declared artifacts or response, and inspect
+   quality against the request. Report unresolved warnings or validation gaps.
+   Recover from saved state before retrying work that may already have run.
 
-| Desired result | Command families to inspect |
+These are task decisions, not a requirement to execute every command on every
+turn. Continue already-authorized work without repeated confirmations. An
+unresolved blocker or missing permission requires a concrete next step; it is
+not a reason to guess a bypass flag.
+
+## Route to a command family
+
+Use `mere.run <group> --help` for subcommands. This is a starting map, not a
+frozen list of supported models or every leaf command.
+
+| Desired result | Command families |
 | --- | --- |
 | Chat, code, embeddings, anonymization, or text training | `text` |
 | Image generation, editing, training, or 3D reconstruction | `image` |
@@ -73,90 +111,22 @@ map, not a complete command list.
 | Earth-observation inference | `geo` |
 | Audio enhancement, music, or sound effects | `audio`, `music`, `sfx` |
 | Video generation, animation, editing, or world sessions | `video`, `world` |
-| Repeatable pipelines, remote execution, or saved results | `graph`, `executor`, `relay`, `run` |
+| Pipelines, remote execution, or saved results | `graph`, `executor`, `relay`, `run` |
 | Evaluation packs and reproducible comparisons | `eval` |
-| Model storage, adapters, configuration, or health | `model`, `adapter`, `config`, `status` |
+| Models, adapters, configuration, or health | `model`, `adapter`, `config`, `status` |
 | Local API or a companion interface | `api`, `open-webui` |
 | Companion plugins or guided setup | `plugin`, `setup`, `agent` |
 
-For graph tasks, start with `graph catalog`, `graph validate`, and `graph
-preflight` help. Inspect the selected executor and authentication before
-submitting work. A graph that validates has not executed successfully.
+Use `gate --help` when the user requests installed-model qualification. An
+operating task does not require running the repository's development gate.
 
-## Select a model explicitly
+## Completion standard
 
-Check support and available storage before a large download. Pull only the
-model needed for the task, then pass that same ID to the inference command.
-Do not rely on a default to select the model you just downloaded. Some commands
-accept only local paths; inspect their help before passing a managed ID.
+A successful pull is not a successful model load. A passing preflight is not
+inference. A queued job is not finished. A receipt identifies outputs; inspecting
+those outputs establishes whether they satisfy the user's request.
 
-The following examples generate files or start a server when run. Adapt the
-model choice using the machine's capability report and the user's request.
-
-Generate an image:
-
-```bash
-mere.run model pull image-zimage-nano
-mere.run image generate --model image-zimage-nano \
-    --prompt "a ceramic mug in soft morning light" --output ./mug.png
-```
-
-Chat with an explicit model:
-
-```bash
-mere.run model pull text-chat-gemma4-12b-4bit
-mere.run text chat --model text-chat-gemma4-12b-4bit \
-    --prompt "Explain local inference in one paragraph." --stream
-```
-
-Generate speech:
-
-```bash
-mere.run model pull speech-tts-qwen3-nano
-mere.run speech synthesize "Hello from mere.run" \
-    --model speech-tts-qwen3-nano --output ./hello.wav
-```
-
-Serve a selected local chat model:
-
-```bash
-mere.run model pull text-chat-gemma4
-mere.run api serve --engine text-chat-gemma4 --model text-chat-gemma4
-```
-
-For API work, inspect `api serve --help` for supported engines, endpoints, and
-preflight options. Model IDs and engine names are different contracts. Keep
-loopback binding unless the user requests network access. Non-loopback binds
-require `--api-key` or `MERERUN_API_KEY`; do not use a sample key as a credential.
-
-For music and video, read the selected model's handbook before choosing steps,
-frame counts, reference inputs, or output modes. These controls differ across
-families. For speech transcription, inspect backend and execution-provider
-options instead of assuming one runtime fits every audio file.
-
-## Storage and troubleshooting
-
-The default model store is
-`~/Library/Application Support/MereRun/models`. Use `--models-root` or
-`MERERUN_MODELS_DIR` to select another store. `MERERUN_HUB_CACHE` controls the
-Hugging Face download cache; changing the model store does not move that cache.
-Inspect `model storage --help` before planning a move or cleanup.
-
-- Missing command or option: record the executable path and version, then read
-  its help. Do not guess flags from another release.
-- Missing model: inspect `model list` and `model info` before pulling the
-  selected ID or supplying a command-supported local model path.
-- Unsupported hardware or memory pressure: inspect `model capabilities --all`
-  and choose a supported model. A forced pull does not establish runtime support.
-- Download failure: check free space, model-store and cache locations, and any
-  model access requirements reported by the CLI.
-- Weak output: use the cookbook and handbook to adjust the prompt and relevant
-  model controls. Keep the seed fixed when comparing one change.
-- API failure: use `status`, server diagnostics, and the requested engine's
-  compatibility information. A healthy server does not prove every endpoint
-  or model works.
-
-Use `--json` where the command supports it and keep stderr diagnostics separate
-from machine-readable stdout. After generation, inspect the resulting artifact
-and report what was actually verified. Use `run inspect` for durable workflow
-reports; successful parsing or preflight alone is not successful inference.
+Finish with the output paths or job reference, what you verified, and any
+remaining limitation. Preserve useful diagnostics and intermediate work when a
+run fails. Avoid claims of model quality or runtime readiness from help, catalog
+metadata, or a generated filename alone.

--- a/skills/use-mere-run/SKILL.md
+++ b/skills/use-mere-run/SKILL.md
@@ -1,166 +1,162 @@
 ---
 name: use-mere-run
-description: Help a newcomer use the public `mere.run` CLI without needing to know the repo internals. Use when the user wants to install or launch `mere.run`, understand what commands exist, choose and pull a model, run a first image/text/speech/vision/music/video workflow, configure model storage, serve the local API, or troubleshoot beginner CLI errors such as command-not-found, missing models, unsupported hardware, disk/cache location, or API key requirements.
+description: Operate the public mere.run CLI for local AI, model setup, media generation and analysis, workflow graphs, or API serving. Use for choosing supported models, running workflows, and troubleshooting an installed CLI. Source-code development belongs to the mere-run skill.
 ---
 
 # Use mere.run
 
-## Overview
+Help the user get an output from the public `mere.run` CLI. Start with their
+requested result and discover the matching commands on their machine.
 
-Help the user get useful output from the public local-first `mere.run` CLI. Optimize for a person who does not know the command tree, model IDs, or where models live.
+## Identify the executable
 
-## Operating Stance
-
-- Start with the user's desired result: image, chat, code, speech, transcription, image/video understanding, segmentation/tracking, music, video, model management, API serving, or general setup.
-- Prefer doing a tiny diagnostic command over explaining abstractly. Use `--help`, `model capabilities`, and `model list` to discover the local truth.
-- If the user has an installed binary, use `mere.run ...`. If they are in a source checkout or the binary is missing, use `swift run mere.run ...`.
-- Do not assume a model is installed. Check `mere.run model list` or pull the needed model first.
-- Keep commands copy-pasteable and minimal. Add advanced flags only when the user asked for them or the error points there.
-- Explain stderr/progress as normal diagnostic output; preserve stdout when the user needs machine-readable results.
-- When the user asks for a good creative or advanced result, not just a command, run `mere.run guide <command path>` or read the matching `Sources/MereRunCLI/Guides/*.md` resource first. Use the guide to translate their vague request into concrete prompt ingredients, model pulls, flags, and an iteration plan.
-
-## First Five Minutes
-
-Run these in order, adapting `mere.run` to `swift run mere.run` inside a checkout:
+Use the installed binary for operator tasks:
 
 ```bash
+mere.run --version
 mere.run --help
+```
+
+In a source checkout, use `swift run mere.run` when the user wants to run that
+checkout. Do not silently substitute an installed release for changed source.
+If the binary is missing outside a checkout, use the installation instructions
+on the [mere.run releases page](https://mere.run/releases). Do not assume a
+Swift toolchain or source repository is available to an end user.
+
+Examples in this skill are starting points. The selected binary's `--help`
+owns accepted flags and defaults. If a discovery command is unavailable, use
+that version's help and explain the version gap.
+
+## Discover a workflow and its models
+
+Run the discovery commands relevant to the task:
+
+```bash
+mere.run catalog --json
+mere.run model capabilities --recommended --json
+mere.run model list --json
 mere.run guide --list
-mere.run model capabilities
-mere.run model list
+mere.run guide --list-models --json
 ```
 
-If the user wants guided setup instead of picking commands manually:
+`catalog` describes command capabilities. `model capabilities` describes
+hardware support; `model list` describes installation status. A supported model
+is not necessarily installed or suitable for the user's quality and latency
+requirements. Use `model capabilities --all --json` for models outside the
+recommended set and read the reported restrictions.
+
+Load the command cookbook for workflow controls and the model handbook for
+provider-specific prompting, input requirements, and validation limits:
 
 ```bash
-mere.run setup
+mere.run catalog image.generate --json
+mere.run image generate --help
+mere.run guide image generate
+mere.run guide --model image-zimage-nano
 ```
 
-When helping from a source checkout:
+Use `guide --model` without a command path to select a model handbook. Command
+cookbooks can cover several models; a guide example is not evidence that a
+particular checkpoint was tested on this machine.
 
-```bash
-swift run mere.run --help
-swift run mere.run guide --list
-swift run mere.run model capabilities
-swift run mere.run setup
-```
+## Route tasks to the right command family
 
-## Choose The Command
+Discover subcommands with `mere.run <group> --help`; this table is a starting
+map, not a complete command list.
 
-Use `model capabilities` as the recommendation source before large downloads. Common public pullable IDs include:
+| Desired result | Command families to inspect |
+| --- | --- |
+| Chat, code, embeddings, anonymization, or text training | `text` |
+| Image generation, editing, training, or 3D reconstruction | `image` |
+| Speech, transcription, diarization, or voice profiles | `speech` |
+| Captioning, OCR, grounding, tracking, faces, pose, depth, or geometry | `vision` |
+| Earth-observation inference | `geo` |
+| Audio enhancement, music, or sound effects | `audio`, `music`, `sfx` |
+| Video generation, animation, editing, or world sessions | `video`, `world` |
+| Repeatable pipelines, remote execution, or saved results | `graph`, `executor`, `relay`, `run` |
+| Evaluation packs and reproducible comparisons | `eval` |
+| Model storage, adapters, configuration, or health | `model`, `adapter`, `config`, `status` |
+| Local API or a companion interface | `api`, `open-webui` |
+| Companion plugins or guided setup | `plugin`, `setup`, `agent` |
 
-- Image: `image-klein-base`, `image-klein-max`, `image-zimage-max`
-- Text chat: `text-chat-gemma4`, `text-chat-gemma4-nano`, `text-chat-gemma4-max`, `text-chat-q36-nano`
-- Code/agent: `text-code-qwen3`, `text-agent-qwen35-9b`
-- Embeddings: `text-embed-qwen3-0.6b`
-- Speech: `speech-tts-qwen3-nano`, `speech-tts-qwen3-customvoice`, `speech-asr-qwen3`, `speech-asr-parakeet`
-- Vision: `vision-ocr-lighton`, `vision-segment-sam31`, `vision-ground-falcon-perception`
-- Music: `music-acestep`
-- Video: `video-ltx23-av-mlx`
+For graph tasks, start with `graph catalog`, `graph validate`, and `graph
+preflight` help. Inspect the selected executor and authentication before
+submitting work. A graph that validates has not executed successfully.
 
-Avoid local-path-only IDs for first-time users unless they already have the model files.
+## Select a model explicitly
 
-## Common Workflows
+Check support and available storage before a large download. Pull only the
+model needed for the task, then pass that same ID to the inference command.
+Do not rely on a default to select the model you just downloaded. Some commands
+accept only local paths; inspect their help before passing a managed ID.
 
-Pull and inspect:
-
-```bash
-mere.run model capabilities
-mere.run model pull text-chat-gemma4
-mere.run model info text-chat-gemma4
-```
-
-Chat:
-
-```bash
-mere.run text chat --stream --prompt "Explain local inference in one paragraph."
-```
+The following examples generate files or start a server when run. Adapt the
+model choice using the machine's capability report and the user's request.
 
 Generate an image:
 
 ```bash
-mere.run model pull image-klein-max
-mere.run image generate --prompt "a ceramic mug in soft morning light" --output ./mug.png
+mere.run model pull image-zimage-nano
+mere.run image generate --model image-zimage-nano \
+    --prompt "a ceramic mug in soft morning light" --output ./mug.png
 ```
 
-Speech:
+Chat with an explicit model:
+
+```bash
+mere.run model pull text-chat-gemma4-12b-4bit
+mere.run text chat --model text-chat-gemma4-12b-4bit \
+    --prompt "Explain local inference in one paragraph." --stream
+```
+
+Generate speech:
 
 ```bash
 mere.run model pull speech-tts-qwen3-nano
-mere.run speech synthesize "Hello from mere.run" --output ./hello.wav
+mere.run speech synthesize "Hello from mere.run" \
+    --model speech-tts-qwen3-nano --output ./hello.wav
 ```
 
-Vision:
-
-```bash
-mere.run vision inspect ./image.png "Describe this image."
-mere.run model pull vision-segment-sam31
-mere.run vision segment ./photo.jpg --prompt "a person" --output ./mask.png
-```
-
-Local API:
+Serve a selected local chat model:
 
 ```bash
 mere.run model pull text-chat-gemma4
-mere.run api serve --engine text-chat-gemma4
+mere.run api serve --engine text-chat-gemma4 --model text-chat-gemma4
 ```
 
-For non-loopback API serving, require an explicit key:
+For API work, inspect `api serve --help` for supported engines, endpoints, and
+preflight options. Model IDs and engine names are different contracts. Keep
+loopback binding unless the user requests network access. Non-loopback binds
+require `--api-key` or `MERERUN_API_KEY`; do not use a sample key as a credential.
 
-```bash
-export MERERUN_API_KEY=change-me
-mere.run api serve --host 0.0.0.0 --api-key "$MERERUN_API_KEY"
-```
+For music and video, read the selected model's handbook before choosing steps,
+frame counts, reference inputs, or output modes. These controls differ across
+families. For speech transcription, inspect backend and execution-provider
+options instead of assuming one runtime fits every audio file.
 
-## Command Cookbooks
+## Storage and troubleshooting
 
-The CLI ships offline cookbooks. Load the relevant guide before coaching creative, model-specific, or advanced workflows:
+The default model store is
+`~/Library/Application Support/MereRun/models`. Use `--models-root` or
+`MERERUN_MODELS_DIR` to select another store. `MERERUN_HUB_CACHE` controls the
+Hugging Face download cache; changing the model store does not move that cache.
+Inspect `model storage --help` before planning a move or cleanup.
 
-```bash
-mere.run guide --list
-mere.run guide image generate
-mere.run guide music generate --model music-acestep
-mere.run guide video generate --json
-```
+- Missing command or option: record the executable path and version, then read
+  its help. Do not guess flags from another release.
+- Missing model: inspect `model list` and `model info` before pulling the
+  selected ID or supplying a command-supported local model path.
+- Unsupported hardware or memory pressure: inspect `model capabilities --all`
+  and choose a supported model. A forced pull does not establish runtime support.
+- Download failure: check free space, model-store and cache locations, and any
+  model access requirements reported by the CLI.
+- Weak output: use the cookbook and handbook to adjust the prompt and relevant
+  model controls. Keep the seed fixed when comparing one change.
+- API failure: use `status`, server diagnostics, and the requested engine's
+  compatibility information. A healthy server does not prove every endpoint
+  or model works.
 
-Inside a source checkout, use:
-
-```bash
-swift run mere.run guide <command path>
-```
-
-If the binary cannot run yet, read the corresponding resource under `Sources/MereRunCLI/Guides/`. The guide command is canonical for per-command purpose, required models, install/check commands, parameters, prompting patterns, examples, iteration tips, troubleshooting, and source links.
-
-## Model Storage
-
-Default model store:
-
-```text
-~/Library/Application Support/MereRun/models
-```
-
-Use an external disk for a session:
-
-```bash
-export MERERUN_MODELS_DIR=/Volumes/Models/mere.run
-mere.run model list
-```
-
-Move the Hugging Face snapshot cache when downloads are large:
-
-```bash
-export MERERUN_HUB_CACHE=/Volumes/Models/huggingface
-mere.run model pull image-zimage-max
-```
-
-## Troubleshooting
-
-- `mere.run: command not found`: check `which mere.run`; from a repo checkout use `swift run mere.run ...`.
-- Model missing or "not found": run `mere.run model list`, then `mere.run model pull <id>`, or pass a local model path with the command-specific `--model` or `--model-root`.
-- Pull blocked by hardware support: run `mere.run model capabilities --all`, choose a smaller recommended model, or use `--allow-unsupported` only when the user explicitly accepts the risk.
-- Download or disk-space problems: set `MERERUN_MODELS_DIR` and optionally `MERERUN_HUB_CACHE` to a larger disk, then retry the pull.
-- API works locally but not remotely: non-loopback binds require `--api-key` or `MERERUN_API_KEY`.
-- A creative command produces weak results: load `mere.run guide <command path>` and iterate prompt, seed, model, and command-specific controls from the guide.
-- A command is unfamiliar: run `mere.run <group> --help` and then `mere.run <group> <command> --help`.
-
-When the user is stuck, ask for the exact command they ran, the first error line, and the output of `mere.run model list`.
+Use `--json` where the command supports it and keep stderr diagnostics separate
+from machine-readable stdout. After generation, inspect the resulting artifact
+and report what was actually verified. Use `run inspect` for durable workflow
+reports; successful parsing or preflight alone is not successful inference.

--- a/skills/use-mere-run/agents/openai.yaml
+++ b/skills/use-mere-run/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Use mere.run"
-  short_description: "Help newcomers run the mere.run CLI"
-  default_prompt: "Use $use-mere-run to help me run a first local mere.run workflow."
+  short_description: "Discover and run local mere.run workflows"
+  default_prompt: "Use $use-mere-run to choose a supported model and run my workflow using the installed CLI and its offline guides."

--- a/skills/use-mere-run/agents/openai.yaml
+++ b/skills/use-mere-run/agents/openai.yaml
@@ -1,4 +1,4 @@
 interface:
   display_name: "Use mere.run"
-  short_description: "Discover and run local mere.run workflows"
-  default_prompt: "Use $use-mere-run to choose a supported model and run my workflow using the installed CLI and its offline guides."
+  short_description: "Preflight, run, and verify mere.run workflows"
+  default_prompt: "Use $use-mere-run to prepare my workflow, resolve preflight blockers, execute it, and verify the results."

--- a/skills/use-mere-run/references/execution-and-results.md
+++ b/skills/use-mere-run/references/execution-and-results.md
@@ -1,0 +1,126 @@
+# Execution and results
+
+Run only after inspecting the request and its preparation checks. Set explicit
+output paths and retain the request arguments, seed, model, version, and input
+identity. Use a fresh destination when a file already exists unless replacing
+it is part of the user's request; not every command prevents overwrites.
+
+## Keep output channels distinct
+
+| Mode | stdout | stderr |
+| --- | --- | --- |
+| Default command | Its documented text, path, or result | Diagnostics and progress |
+| Supported `--json` | Usually one JSON document; inspect the command's schema | Diagnostics |
+| `--receipt` | Normal output followed by a final result JSON line | Diagnostics and progress |
+| `--progress-json` | Unchanged command output | Progress JSON lines, possibly mixed with other diagnostics |
+| Remote `run watch --json-stream` | Worker NDJSON events | Diagnostics |
+
+Do not combine the streams when parsing. `--quiet` is not a JSON mode. A
+`--json` option on a discovery command does not imply that generation accepts
+it. Text chat's `--response-format json_object`, where supported by the model,
+controls generated content; it is not the preflight report or a receipt.
+
+## Interpret receipts and progress
+
+Where help advertises `--receipt`, parse the last stdout line after successful
+process completion. A typical receipt is:
+
+```json
+{"event":"result","exit":0,"outputs":[{"kind":"image","path":"/abs/mug.png"}]}
+```
+
+Check `event`, `exit`, and the process exit code. `outputs[0]` is the primary
+artifact when present. Sidecars follow with a `role`; preserve them instead of
+assuming a run produces only one file. Output kinds include `image`, `video`,
+`audio`, `text`, `json`, and `directory`. A transcription printed only to stdout
+can have an empty output list. Failures do not emit a success receipt.
+
+`--receipt` is supported by image/video/music/SFX generation, speech synthesis
+and transcription, grounding, segmentation, and tracking. Confirm support in
+the installed release before adding it. It conflicts with `--preflight`.
+
+Where supported, `--progress-json` emits events such as:
+
+```json
+{"event":"progress","stage":"denoising","step":2,"total_steps":4}
+```
+
+`step` is zero-based during a stage. `step == total_steps` completes that
+stage, not necessarily the whole run. A stage can restart for another window.
+`total_steps: 0` means indeterminate progress and has no terminal stage event.
+Use process completion and the receipt to decide whether the job finished.
+
+Progress flags are command-level but callbacks can be model-specific. LTX
+video and ACE-Step music do not emit these per-step events. Silence alone does
+not justify killing a process or launching a duplicate. Inspect its status,
+logs, and expected model behavior. `--progress-json` takes precedence over
+`--quiet` for progress; retain non-JSON stderr lines as diagnostics.
+
+For speech, prepare the model with a pull preflight first:
+
+```bash
+mere.run model pull speech-tts-qwen3-nano --preflight --json
+```
+
+After resolving blockers, run the selected model with a receipt:
+
+```bash
+mere.run model pull speech-tts-qwen3-nano
+mere.run speech synthesize "Hello from mere.run" \
+    --model speech-tts-qwen3-nano --output ./hello.wav \
+    --receipt --progress-json
+```
+
+## Verify the result
+
+Check the declared files exist, are nonempty, and can be opened as the intended
+format. Then inspect the content against the user's request:
+
+- Images: subject, composition, edits, dimensions, and unwanted artifacts.
+- Audio/video: decode and play or inspect representative segments; check duration,
+  audio presence, synchronization, clipping, and requested content.
+- Transcripts, OCR, and model text: inspect actual content, truncation, language,
+  and required structure. Validate generated JSON when the task requires it.
+- Masks, geometry, and geospatial results: check coordinate conventions,
+  dimensions, alignment, units, CRS where relevant, and sidecar metadata.
+- Training/evaluation: inspect the saved report and checkpoint, then compare
+  outputs using a reproducible evaluation. Training loss alone is not quality.
+
+If an appropriate viewer, decoder, or playback tool is unavailable, report that
+specific verification gap. Do not describe an uninspected artifact as correct.
+
+## Recover without duplicating work
+
+Retain the process handle, PID, output paths, or returned remote job reference.
+For a local subprocess, use that process's wait/cancel mechanism. `run watch`
+accepts SSH and relay job references; it is not a generic local-process monitor.
+Inspect local durable directories with `run inspect` and their `events.jsonl`.
+
+After a timeout or disconnect, inspect the existing job before resubmitting.
+A request can succeed remotely even when the client loses its response. For
+relay jobs, inspect placement blockers while queued and fetch verified results
+after completion. Use the workflow reference for resume, cancellation, and
+retry differences. Do not delete partial outputs, caches, or checkpoints as a
+first response to an error.
+
+For memory pressure, inspect other loaded models, reduce the relevant context,
+resolution, duration, or batch size, or select a supported smaller model.
+Avoid speculative force flags or launching more work while the first process
+still holds memory. Change one variable, repeat preparation checks, then retry.
+
+## Model-driven tool execution
+
+Ordinary chat does not need a tool loop. When the user requests model-driven
+file or shell work, inspect `text chat --help` for `--tools`, `--tool-loop`,
+`--sandbox-dir`, and iteration limits. Keep writes in an explicit task directory.
+
+`write_file` and `shell_exec` have different approval behavior.
+`--auto-approve-tools` can permit supported file writes without a prompt;
+`shell_exec` additionally requires `--allow-shell-exec` and **always requires
+interactive approval**, even with auto-approval enabled. A noninteractive
+shell tool call is denied. `--allow-absolute-tool-paths` expands file-write scope
+outside the sandbox; do not enable it merely to avoid a path error.
+
+Treat tool execution as an additional capability to configure within the user's
+request. Never promise unattended shell execution from these flags, and do not
+confuse a generated tool call with a tool that actually ran.

--- a/skills/use-mere-run/references/modalities-and-training.md
+++ b/skills/use-mere-run/references/modalities-and-training.md
@@ -1,0 +1,125 @@
+# Modalities and training
+
+Use the command cookbook for CLI controls and the selected model handbook for
+provider guidance. The same command can route to different architectures with
+different inputs and constraints. Do not transfer a default, flag, schedule,
+coordinate format, or prompt recipe from one model family to another.
+
+For unfamiliar work, discover the leaf command and then read its help. The
+following distinctions guide that discovery; they are not a frozen model list.
+
+## Text, code, and embeddings
+
+Select chat versus GGUF code generation versus embedding output deliberately.
+Use `text chat --require-installed` when downloads must be explicit. Inspect
+support before combining reasoning controls, structured responses, tool loops,
+images, audio, or video with a model. Maximum output tokens and context capacity
+are separate limits. Long requests must leave room for the response.
+
+Use a modest first generation, inspect truncation and requested format, then
+adjust. Keep stdout text separate from reasoning/stats on stderr. For embeddings,
+verify vector shape and downstream model compatibility; vectors from different
+encoders do not become comparable because their dimensions match.
+
+## Images, editing, and reconstruction
+
+Choose generation, reference editing, masked editing, or reconstruction from
+the actual input and desired output. `--input`, `--ref-image`, masks, strength,
+CFG, steps, and LoRA behavior depend on the selected family. Inspect required
+shared encoders/VAEs and any structured-prompt companion model before pulling.
+
+Preserve source inputs. Check mask conventions, aspect ratio, output extension,
+and reference count in the handbook and preflight. Use explicit seeds when
+comparing changes. An annotated image, depth map, point cloud, and textured mesh
+are different deliverables; inspect units, camera conventions, required view
+counts, and export formats before claiming one satisfies another.
+
+## Speech and general audio
+
+Choose synthesis, cloning, transcription, translation, diarization, microphone
+capture, or enhancement explicitly. Voice profiles and reference audio are not
+interchangeable with a voice-description prompt. Read the model's requirements
+for reference transcripts and sampling before cloning.
+
+For transcription, distinguish the ASR backend from its execution provider.
+Parakeet Core ML needs compatible packaged encoder/decoder assets and does not
+replace Qwen's translation path. Inspect `speech transcribe --help` before
+selecting `--backend`, `--provider`, or packaged asset paths. For stdin/streaming,
+match the advertised input format, sample rate, channels, and JSONL mode; a raw
+PCM stream is not a WAV file.
+
+Speech commands do not universally support preflight. Check the model pull and
+inputs first, run a short sample, then listen or inspect the transcript before
+processing a long recording. Confirm output duration, speaker identity where
+relevant, clipping, language, and timestamps.
+
+## Music and sound effects
+
+Separate music generation, separation, transcription, analysis, realtime
+sessions, and SFX. Read the selected model handbook for caption/lyrics roles,
+duration, seeds, candidate selection, required rewriters, and reference audio.
+Do not assume a lyrics option or a progress callback exists in every lane.
+
+Inspect generated audio and all declared stems, lyrics, candidates, recipes, or
+DAW bundles. For a realtime session, retain its process and control identity and
+stop it explicitly when the task finishes. SFX conditioned on video can have
+different required inputs and preparation checks from text-to-audio generation.
+
+## Video and world sessions
+
+Determine whether the user wants text-to-video, image-to-video, references,
+keyframes, animation, retakes, audio conditioning, or a persistent world session.
+Choose the model and output mode from that requirement, then read its handbook.
+
+Frame-count divisibility, frame rate, duration, dimensions, windowing, reference
+syntax, adapter schedules, and memory use differ by model. LTX output quality
+and output mode are separate choices; video-only output does not promise a
+soundtrack. Distinguish generated audio from preserving source audio.
+Do not mix compatibility `--variant` with `--quality` or `--output-mode` when
+the command rejects that combination. Check reference assets and masks before
+expensive generation, and inspect representative frames plus audio afterward.
+
+World/session commands retain state. Discover their lifecycle and save/stop
+behavior rather than treating every call as a stateless video export.
+
+## Vision and geospatial inference
+
+Select captioning, OCR, grounding, segmentation, tracking, identity, pose,
+flow, depth, or geometry by the requested measurement. Some commands accept
+local model roots only. Read coordinates, normalization, labels, thresholds,
+frame ranges, and output-sidecar formats before passing prompts or boxes.
+
+Trackers need the correct initialization frame and object identity. Masks and
+bounding boxes are candidates to inspect, not automatically verified findings.
+For metric outputs, inspect scale/units, coordinate systems, and required camera
+or multiview inputs. Preserve detection, tracking, and mask sidecars.
+
+Geospatial models require their documented bands, temporal inputs, resolutions,
+and georeferencing; an arbitrary RGB screenshot is not equivalent. Inspect the
+`geo` subcommand help, model handbook, and preflight. Verify raster alignment,
+CRS, nodata handling, and requested map extent in the result.
+
+## Training and evaluation
+
+Training needs a prepared dataset, a compatible trainable base, a bounded
+budget, and a distinct output/checkpoint location. Discover dataset candidates,
+inspect captions and manifest statistics, and preflight image LoRA training.
+Do not train on generated previews accidentally included in the source folder.
+Read the selected recipe and the base-versus-distilled inference guidance.
+
+Text training and some benchmarks use `--dry-run`. Verify what that mode writes,
+its data schema, model binding, checkpoint/resume requirements, and expected
+runtime before starting. Keep training data and outputs separate. Compare a
+baseline and adapted model on held-out examples, not loss alone.
+
+`eval` consumes external, content-addressed packs. Start with `eval pack
+validate`, then `eval run --dry-run --json` using explicit model/adapter slots.
+Inspect the full plan and any external scorer requirement. Executing a pinned
+external scorer is an additional action represented by `--allow-external-scorer`;
+apply it only within the user's authorization.
+
+Use an explicit checkpoint for resumable evaluations; `--resume` requires the
+same plan. A stopped partial report is not a passing evaluation. `eval promote`
+creates a receipt for a complete, gate-passing report; it does not deploy a
+model. Keep local evaluation, installed-model qualification, and published
+release status as separate evidence.

--- a/skills/use-mere-run/references/models-storage-and-plugins.md
+++ b/skills/use-mere-run/references/models-storage-and-plugins.md
@@ -1,0 +1,113 @@
+# Models, storage, and plugins
+
+## Separate support, installation, and readiness
+
+Use live inventory instead of a copied model list:
+
+```bash
+mere.run model capabilities --all --json
+mere.run model list --json
+mere.run model location list --json
+mere.run model storage --json
+```
+
+Hardware support does not prove a checkpoint is installed. A manifest or
+installed path does not prove runtime-ready payloads exist. Use the model-pull
+preflight, command preflight, and `model info` together. Check conversion
+requirements, external bindings, companion models, and component paths when a
+model appears installed but cannot load.
+
+Prefer a supported model suitable for the user's latency, quality, and storage
+constraints. Treat managed IDs, API engine names, runtime aliases, local roots,
+GGUF files, and Hugging Face repository IDs as different values. Read the leaf
+command's accepted model input before using one. `--model-root` is not a global
+synonym for `--model`.
+
+Some runtime paths auto-download; others require explicit assets. Preflight
+and pull deliberately before expensive work. Use `text chat --require-installed`
+when its implicit downloads must be prevented. Do not recommend `model pull
+--all` as normal setup, or promise every catalog entry has a download source.
+
+## Model terms and authentication
+
+`model pull --preflight --json` reports component `usage_terms` and whether they
+are acknowledged. Some gated or restricted models require
+`--accept-model-license` (alias `--accept-license-terms`). That flag represents
+acceptance of the listed terms; download authorization alone does not establish
+acceptance. Reuse explicit acceptance already given for those terms. Otherwise,
+show the actual terms and obtain the missing acceptance before passing the flag.
+
+A Hugging Face access token and license acceptance solve different blockers.
+Check the reported source and access requirements. `config get` and `config
+list` mask secrets; `config set --from-env` avoids putting a token value directly
+in argv. `HF_TOKEN`, then `HUGGING_FACE_HUB_TOKEN`, override persisted token
+configuration. Do not print token values or record them in a shared report.
+
+`--allow-unsupported` bypasses hardware checks, not missing runtime support or
+license terms. Use it only for an explicitly intended unsupported experiment.
+`--force` is command-specific: it can re-download, reinstall, or delete. Read
+help and the planned effect instead of treating it as a generic repair option.
+
+## Storage and cache ownership
+
+The default writable store is
+`~/Library/Application Support/MereRun/models`. `--models-root` or
+`MERERUN_MODELS_DIR` selects another store. Registered search roots and explicit
+bindings can provide models elsewhere; inspect `model location list --json`.
+
+`MERERUN_HUB_CACHE` selects the Hub cache. For a specific pull, `--cache-dir`
+selects its cache and is reflected in the preflight. Model-store entries can
+link to cache payloads. Disconnecting the cache volume can make a model
+unavailable even while its install entry exists. Changing the store does not
+move the cache or repair a disconnected binding.
+
+Inspect disk usage with `model storage --json` before moving or removing data.
+`model gc --json` is a read-only plan; `--force` deletes a freshly computed plan.
+`model remove --json` requires `--force`; it is **not** a read-only preview.
+`--keep-cache` retains unshared Hub payloads when removing model links.
+
+Check sharing, external roots, and active runs before removal. A successful
+preflight or an apparently duplicate directory does not establish that files
+are disposable. Use documented location/binding commands for existing payloads;
+do not manufacture manifests or move caches blindly. Read the help before
+repairing manifests; that command can expose a dry-run mode.
+
+## Adapters and training checkpoints
+
+Use `adapter list --json` to select cataloged adapters. Read `adapter pull
+--help` for its license flag and source requirements; adapter acceptance flags
+are not necessarily spelled like model acceptance flags. Cataloged downloads
+verify byte count and SHA-256 before installation.
+
+Match the adapter's base family, quantization, target modules, and required
+sampling schedule. A turbo adapter can require a specific step count or CFG.
+A `.safetensors` extension alone does not prove compatibility. Use the matching
+model handbook and cookbook before adding `--lora` or a family-specific adapter
+option. Preserve the adapter ID or path and scale in preflight and execution.
+
+## Companion plugins
+
+These are out-of-process `mere.run` executables, separate from Codex skills and
+Codex plugins. Discover the catalog and local verification state:
+
+```bash
+mere.run plugin list --json
+mere.run plugin info mere-doc-tools --json
+```
+
+`plugin install ID` previews installation; `--yes` executes it. Inspect the
+selected channel, artifact, entrypoint, and install mode before installation.
+When the channel advertises a signed macOS bundle, the CLI verifies signatures,
+hashes, notarization, manifests, and provider contracts. A source channel can
+require pipx and Python. `--source` deliberately chooses that lane; do not fall
+back to it to bypass a failed bundle verification.
+
+After installation, use `plugin doctor ID`. For managed bundles, invoke
+`plugin run ENTRYPOINT -- ...` or a registered graph node; a bare PATH command
+can still select an older source installation. Plugin arguments after `--`
+belong to the plugin, so inspect its own help rather than assuming core flags.
+
+A bundle rollback can affect multiple entrypoints in the same package. Inspect
+`plugin rollback --help` and the shared package before applying it. Preserve
+unrelated PATH installs and use the reported repair procedure for a broken
+source environment instead of repeatedly reinstalling it.

--- a/skills/use-mere-run/references/preflight-and-actions.md
+++ b/skills/use-mere-run/references/preflight-and-actions.md
@@ -1,0 +1,123 @@
+# Preflight and actions
+
+Use preflight before a download or expensive run when that command supports
+it. Discover support from the selected command's `--help`; do not append the
+same flags to every modality.
+
+## Choose the preparation mode
+
+| Surface | How to prepare |
+| --- | --- |
+| `model pull` | `--preflight --json` inspects support, terms, sources, disk, and installation without downloading. |
+| Image/video generation, image training, supported vision/geo operations, API serving | Use their advertised `--preflight --json`; checks and schema differ by command. |
+| `text chat` | `--preflight --json`; add `--require-installed` to both check and run when downloads must be explicit. |
+| Workflow graphs | `graph validate` checks the document; `graph preflight` also probes the selected executor. |
+| Reconstruction, geometry, text training, evaluation, benchmarks | Some use `--dry-run`. Read that command's semantics; dry runs can prepare files and are not interchangeable with preflight. |
+| Speech synthesis/transcription, music generation, other commands without preflight | Preflight the model pull, inspect inputs, read help and the handbook, and select a bounded first run. Do not invent `--preflight`. |
+
+`--json` can be restricted to preflight. During generation, a result receipt is
+a different output contract. Never combine `--receipt` with `--preflight`.
+
+## Read the report, including failed checks
+
+Capture stdout and stderr separately and retain the exit code. A blocked check
+can print valid JSON and then exit nonzero; do not discard its stdout because a
+shell command failed. Syntax errors can instead produce only stderr.
+
+For the shared envelope, inspect:
+
+- `schema_version`, `command`, and `mode` to identify the contract.
+- `status`: `blocked` prevents execution; `warning` requires reading the warning,
+  and `ok` means only that the implemented checks passed.
+- `diagnostics`: read `severity`, `id`, `message`, locations, and
+  `suggested_action_ids`. Resolve blockers; use warnings and estimates to adjust
+  the plan when they affect the user's requirements.
+- `request` and `result`: confirm model, inputs, output path, dimensions, seed,
+  resolved settings, download behavior, and execution host.
+- `actions`: suggested follow-up operations, not permission to execute them.
+
+Do not assume every JSON command has this envelope. In particular, text-chat
+preflight returns a compact report with `schema_version`, `status`, `model`,
+`installed`, optional `model_path`, and `diagnostics`. It can return **exit 0
+with `status: "blocked"`**. Without `--require-installed`, an uninstalled chat
+model can have `status: "ok"`. Check both installation and report status.
+
+Model-pull reports include `result.models` entries with `supported`,
+`installed`, `runtime_ready`, `conversion_required`, `has_download_source`,
+`will_download`, `companion_model_ids`, and `usage_terms`. A download-ready
+report does not mean the model is ready for inference. Inspect both the model
+store and Hub cache paths and headroom. Byte estimates can be absent or differ
+from eventual use; missing estimates do not mean zero bytes.
+
+## Work an image request through preparation
+
+Adapt the model to the machine and the prompt to the user's request. First
+inspect the download; this command does not pull the model:
+
+```bash
+mere.run model pull image-zimage-nano --preflight --json
+```
+
+After resolving the reported blockers, download the selected model and check
+the exact generation request:
+
+```bash
+mere.run model pull image-zimage-nano
+mere.run image generate --model image-zimage-nano \
+    --prompt "a ceramic mug in soft morning light" --seed 42 \
+    --output ./mug.png --preflight --json
+```
+
+Read the report before proceeding. If it permits the run and the output path
+is suitable, keep the same generation arguments and change only output modes:
+
+```bash
+mere.run image generate --model image-zimage-nano \
+    --prompt "a ceramic mug in soft morning light" --seed 42 \
+    --output ./mug.png --receipt --progress-json
+```
+
+Do not carry preflight's `--json` into a command that accepts it only with
+`--preflight`. Preserve a global model-store override, working directory, cache
+settings, environment, and selected executable across all three stages.
+
+For chat, explicitly prevent a hidden download after installation:
+
+```bash
+mere.run model pull text-chat-gemma4-12b-4bit --preflight --json
+```
+
+After the pull preflight passes:
+
+```bash
+mere.run model pull text-chat-gemma4-12b-4bit
+mere.run text chat --model text-chat-gemma4-12b-4bit --require-installed \
+    --prompt "Explain local inference in one paragraph." --preflight --json
+```
+
+After reading the chat report and resolving blockers:
+
+```bash
+mere.run text chat --model text-chat-gemma4-12b-4bit --require-installed \
+    --prompt "Explain local inference in one paragraph." --stream
+```
+
+## Apply follow-up actions deliberately
+
+An action can include `enabled`, `disabled_reason`, `requires`, `confirmation`,
+`destructive`, `secrets_masked`, and a `command` containing `argv` and `cwd`.
+Read these fields before using it. Choose an enabled action relevant to the
+user's task and existing authorization; do not run every offered action.
+
+Treat `command.argv` as literal arguments to a process, not shell code. Do not
+join it into a string and evaluate it. Preserve `cwd`, the selected executable,
+global overrides, and required environment. A masked action can omit secrets;
+reconstruct required credentials from the authorized environment rather than
+running placeholder values or exposing them in logs.
+
+A suggested pull on an SSH or relay worker must target that worker's model
+store. Running it locally does not repair the remote preflight. A suggested
+`--allow-unsupported`, license-acceptance flag, deletion, or force option is not
+automatic authorization. Resolve the concrete requirement, then preflight the
+original request again. If the same blocker repeats unchanged, report it and
+the exact dependency instead of retrying indefinitely.

--- a/skills/use-mere-run/references/preflight-and-actions.md
+++ b/skills/use-mere-run/references/preflight-and-actions.md
@@ -24,6 +24,12 @@ Capture stdout and stderr separately and retain the exit code. A blocked check
 can print valid JSON and then exit nonzero; do not discard its stdout because a
 shell command failed. Syntax errors can instead produce only stderr.
 
+Image generation and text chat preflights report current machine memory and
+disk headroom as blockers without reserving inference capacity. These are
+point-in-time checks: execution checks resources again. Older CLI versions can
+reject these requests through the execution gate before printing a report;
+retain stderr when stdout contains no JSON.
+
 For the shared envelope, inspect:
 
 - `schema_version`, `command`, and `mode` to identify the contract.

--- a/skills/use-mere-run/references/workflows-and-services.md
+++ b/skills/use-mere-run/references/workflows-and-services.md
@@ -1,0 +1,157 @@
+# Workflows and services
+
+## Author a portable graph
+
+Read `graph catalog --json` for node kinds, typed inputs/outputs, model
+requirements, and provider identity. CLI capability IDs and graph node kinds
+are separate catalogs. Graph v2 is the runtime name; its serialized graph still
+uses `schema_version: 1` and `kind: "mere.run/workflow-graph"`.
+
+Use complete JSON references such as `{"$ref":"nodes.message.outputs.text"}`,
+not shell substitutions or interpolated reference strings. Node references add
+dependencies. `depends_on` adds ordering-only edges. Pin explicit model IDs and
+use the catalog's input types for files, directories, and collections.
+
+For a model-free first workflow, save this document as `workflow.json` in a
+fresh task directory:
+
+```json
+{
+  "schema_version": 1,
+  "kind": "mere.run/workflow-graph",
+  "name": "message-check",
+  "inputs": {},
+  "nodes": [
+    {
+      "id": "message",
+      "kind": "text.value",
+      "arguments": {"value": "Workflow execution verified."}
+    }
+  ],
+  "outputs": {"message": {"$ref": "nodes.message.outputs.text"}}
+}
+```
+
+Inspect the catalog, validate, and check the selected executor:
+
+```bash
+mere.run graph catalog --json
+mere.run graph validate ./workflow.json --json
+mere.run graph preflight ./workflow.json --executor local --json
+```
+
+After the report permits execution, run and inspect the result:
+
+```bash
+mere.run graph run ./workflow.json --run-dir ./runs/message-check --json
+mere.run run inspect ./runs/message-check --json
+```
+
+For graphs with required inputs, provide the corresponding `--inputs-json`
+file consistently at validation, preflight, and execution. Discover dataset
+candidates with `graph dataset discover` when relevant. Worker preflight checks
+installed models, node/provider contracts, accelerator resources, storage,
+network requirements, and secret availability. Graph workers do not implicitly
+pull missing models; provision them on the selected worker and repeat preflight.
+
+## Bundles, resume, and output identity
+
+`graph materialize` creates an immutable job bundle in a run directory.
+`graph export-job` exports one for later `graph run-job` or `graph submit-job`.
+The bundle includes `job.json`, `graph.json`, `inputs.json`, `assets.json`, and
+content-addressed assets. Executor profiles and credentials remain external.
+
+For an exported bundle, use a separate, non-nested mutable run directory.
+Do not edit a bundle after hashing or submission. `--resume` on local
+`graph run`/`run-job` reuses finished nodes only when arguments, provider/model
+provenance, referenced inputs, and output digests still match. Reusing a folder
+alone is not proof that work can resume.
+
+A run directory contains `run.json`, `events.jsonl`, node records, and
+`outputs/`. Preserve it for inspection and recovery. Check final state and
+verify the declared outputs. For a local graph, `run inspect --json` returns
+the run record: read `contract_version`, `state`, `job_id`, `nodes`, and
+`outputs`, rather than expecting a preflight-style `status` envelope. Resolve
+relative artifact paths against the run directory. Parallelism is explicit in
+the graph and should fit the executor's memory budget; more independent nodes do not imply spare GPU
+capacity.
+
+## SSH and relay execution
+
+Use `executor list --json`, `executor inspect`, `executor probe`, and, for relay,
+`executor auth-status` before submission. Use `executor login` when the selected
+relay profile needs its supported authorization flow. Do not print credentials.
+SSH uses system SSH configuration, batch authentication, and host-key checks.
+
+After configuring and preflighting the requested executor, submit with
+`graph submit` or `graph submit-job`. Preserve the returned job reference.
+Profile selection uses `ssh:PROFILE` or `relay:PROFILE`; remote job references
+use `ssh://PROFILE/JOB_ID` or `relay://PROFILE/JOB_ID`.
+
+| Operation | Contract |
+| --- | --- |
+| Inspect | `run inspect` supports local directories/reports and remote references. |
+| Watch | `run watch` accepts SSH/relay references. `--json-stream` emits events; `--json` emits a final job object. |
+| Fetch | `run fetch` verifies sizes and SHA-256. An interrupted fetch can reuse verified local files. |
+| Cancel | `run cancel` targets SSH/relay jobs. Inspect afterward to confirm terminal cancellation. |
+| Retry | `run retry` accepts relay references and reuses the immutable bundle. Track the returned retry identity. |
+| Resume local | Use the graph command's `--resume`, not `run retry`. |
+
+A successful submit means accepted or queued, not finished. If a relay job
+stays queued, inspect its placement report for concrete worker/model/resource
+blockers instead of submitting duplicates. After a lost response, inspect/list
+existing work before deciding to resubmit.
+
+Fetch defaults to reports, manifests, and final outputs. Use `--artifact` for
+selected artifacts or `--all-artifacts` for node artifacts; do not combine
+those two modes. Check that the completed result matches the graph and inputs
+the user actually requested, especially after editing the source workflow.
+
+`relay serve` hosts the graph-job protocol on a machine. It is different from
+`api serve` and from a persistent `world` session. Use its help for pairing,
+binding, spool, and lifecycle options; preserve its authentication boundary.
+
+## Serve and verify an API
+
+Choose an engine compatible with the selected model. First inspect its pull:
+
+```bash
+mere.run model pull text-chat-gemma4 --preflight --json
+```
+
+After resolving blockers, pull and inspect the serving request:
+
+```bash
+mere.run model pull text-chat-gemma4
+mere.run api serve --engine text-chat-gemma4 --model text-chat-gemma4 \
+    --host 127.0.0.1 --port 8080 --preflight --json
+```
+
+After reading the report, start the same configuration as a retained service
+process, then check it from another terminal:
+
+```bash
+mere.run api serve --engine text-chat-gemma4 --model text-chat-gemma4 \
+    --host 127.0.0.1 --port 8080
+mere.run status --host 127.0.0.1 --port 8080 --json
+```
+
+API preflight does not bind a port, load a model, or verify an HTTP request.
+It can report that runtime auto-download is allowed even with no model
+installed. Inspect model state before starting. Resolve port conflicts by
+checking the existing service; do not stop an unrelated server.
+
+Use a loopback bind for local work. Non-loopback binds require `--api-key` or
+`MERERUN_API_KEY`; reuse the authorized credential without logging it. A bind
+address such as `0.0.0.0` is not the remote client's destination. Use the actual
+reachable host and port, and `/v1` where the client's base-URL setting expects it.
+
+After startup, check health, `/v1/models`, and a small request to the intended
+endpoint/model. OpenAI compatibility varies by engine: inspect tools,
+structured-output, vision, sampling, and other capability fields before using
+them. A healthy server or model listing alone does not prove a request works.
+
+`/runtime/status` exposes loaded runtime state. `model runtime get/set` manages
+persistent per-model aliases, pinning, TTL, and supported generation defaults.
+Inspect before changing settings; request concurrency and large contexts can
+raise memory demand. Stop only the service process owned by this task.


### PR DESCRIPTION
## Summary

The mere.run skills had drifted from the CLI and did not teach the full operating workflow. The image example pulled one model and ran another, and preflight was only mentioned without explaining blockers, execution context, output formats, or recovery.

Refresh both skills around live command discovery and bundled model handbooks. The operator skill now links five self-contained references covering preparation and declarative actions; models, storage, licenses, adapters, and plugins; execution, progress, receipts, and recovery; local/remote graphs and services; and modality-specific inputs, training, and evaluation.

The examples preserve explicit models and checked request arguments. Guidance accounts for compact text preflight reports that can be blocked with exit zero, preflight actions that omit global model-store overrides, model-specific progress availability, local versus remote retry/resume, and tool approval behavior. The references ship through the existing recursive skill bundle copy.

Extend `SkillContractTests` to read every bundled Markdown file, resolve reference links, parse CLI examples, validate model/engine and preflight/run consistency, and check result/progress examples against the emitters. Tests also execute documented blocked preflights in isolated model stores and validate, execute, inspect, and resume the documented model-free graph, checking output content and node reuse.

Image generation and text chat preflights previously entered the inference admission gate. On a host with insufficient memory or disk, the CLI could exit before producing its JSON report. These preflights now inspect the same resource thresholds without reserving permits or waiting for inference capacity. Their reports combine resource blockers with request diagnostics, and image execution actions remain disabled when blocked. Execution retains its admission checks. Text preflight retains its existing exit-zero contract, so callers must inspect `status`.

## Validation

- [x] `./scripts/check.sh`: full local lint, build, tests, CLI help, and hygiene gate passed.
- [x] 72 focused tests passed, including regression coverage for preflight admission, memory and disk thresholds, combined blockers, and disabled image execution actions.
- [x] Six `SkillContractTests` passed, including no-download blocked cases and the model-free graph lifecycle.
- [x] Skill frontmatter validation, bundled-reference checks, and `git diff --check` passed.
- [x] All 38 operator CLI examples are covered by the parser/contract checks.
- [x] The documented graph also passed a separate CLI smoke run in a temporary directory, including artifact inspection and resume.

Model inference and external SSH/relay execution were not run. The full gate's asset-dependent skips remain unvalidated; the operational tests use isolated stores and require no checkpoint downloads. The resource-report correction covers image generation and text chat; other preflight implementations retain their existing behavior. No dependencies or vendor artifacts changed.
