### PR TITLE
Consolidate Core/CLI execution and capability contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+- Fix approved shell tools hanging on large output. Shell execution now drains
+  output while running, retains up to 256 KiB, and stops the owned process group
+  on cancellation or after five minutes. Code benchmark sandboxes use the same
+  bounded process runner.
+- Reconcile the capability catalog with every displayed CLI option group,
+  including aliases, Boolean inversions, array values, positional arguments,
+  static defaults, and enum choices. Catalog v1 adds backward-compatible
+  positional `repeatable` metadata. Parity tests discover commands from the
+  parser instead of a manual fixture list.
+- Share image model selection, sampling, validation, adapter resolution, input
+  preparation, and execution through Core. CLI preflight uses the same rules;
+  unsupported combinations fail before loading weights, including reference
+  images and LoRA adapters that a selected backend previously ignored. Typed
+  Swift events distinguish success, failure, and cancellation and report the actual seed.
+  Existing CLI output formats and API v1 defaults remain compatible.
+
 - Refresh the bundled DwarfStar runtime to upstream `b6af0adf8ca9`, including
   session snapshot and native tool handling fixes. Preserve the DeepSeek V4
   Flash 0731 Q2 imatrix model pin and bundle the Iris decoder license.

--- a/CODEBASE.md
+++ b/CODEBASE.md
@@ -26,6 +26,7 @@ GUI shell.
 - `Sources/MereRunRelayKit/`: portable relay client, executor profiles/auth, and workflow wire types shared by the CLI and app shells
 - `apps/ios/`: the iOS Studio app, a relay client over `MereRunRelayKit` (see `docs/ios-studio.md`)
 - `Sources/MereRunCore/`: model paths, manifests, source config, shared runtime helpers, and modality runtime implementations
+- `Sources/MereRunCore/ImageGeneration*.swift`: shared image options, model selection, validation, execution, and typed outcomes
 - `Sources/MereRunCore/LTX/`: native video generation and MP4 output
 - `Sources/MereRunCore/Cosmos3/`: native Cosmos3-Edge omnimodal generation,
   reasoner, learned action, and persistent world runtime

--- a/Sources/MereRunCLI/Commands/APIServeCommand.swift
+++ b/Sources/MereRunCLI/Commands/APIServeCommand.swift
@@ -5270,144 +5270,38 @@ actor CodeGenServer {
     }
 
     private func generateImage(_ plan: APIServerContract.ImageGenerationPlan) async throws -> URL {
+        let modelID: String
+        let modelRoot: URL
+        let manifest: MereRunModelManifest
+        let qwenEdit = plan.inputImage != nil && QwenImageEditRepository.canonicalModelId(for: plan.modelID) != nil
+        if qwenEdit {
+            guard let canonicalID = QwenImageEditRepository.canonicalModelId(for: plan.modelID),
+                  let root = QwenImageEditRepository.resolveInstalledModelRoot(modelSpec: canonicalID) else {
+                throw APIRequestValidationError.invalidField(
+                    "model", "\(plan.modelID) is not installed; pull it before serving image edits"
+                )
+            }
+            modelID = canonicalID
+            modelRoot = root
+            // Older managed Qwen edit installs did not require a manifest.
+            manifest = try MereRunModelManifest.loadIfPresent(from: root)
+                ?? MereRunModelManifest(id: canonicalID, engine: .qwenImageEdit, family: .qwen)
+        } else {
+            let resolved = try resolveImageModel(plan.modelID)
+            modelID = resolved.modelID
+            modelRoot = resolved.rootURL
+            manifest = resolved.manifest
+        }
+        let outputURL = try temporaryOutputURL(directoryName: "mere-run-api-images", extension: "png")
+        let operation = try plan.operationPlan(
+            modelRoot: modelRoot, outputURL: outputURL, manifest: manifest, qwenEditDefaults: qwenEdit
+        )
         try MLXBundleSupport.ensureAvailable(quiet: true)
-        if plan.inputImage != nil,
-           QwenImageEditRepository.canonicalModelId(for: plan.modelID) != nil {
-            return try await generateQwenImageEdit(plan)
-        }
-        let resolved = try resolveImageModel(plan.modelID)
-        let effectiveSteps = plan.steps
-            ?? ((resolved.manifest.family == .hidream || resolved.manifest.family == .senseNova
-                    || resolved.manifest.family == .krea || resolved.manifest.family == .ideogram
-                    || resolved.manifest.family == .flux1)
-                ? (resolved.manifest.defaults?.steps ?? 4)
-                : 4)
-        let effectiveCFG = plan.guidanceScale
-            ?? ((resolved.manifest.family == .hidream || resolved.manifest.family == .senseNova
-                    || resolved.manifest.family == .krea || resolved.manifest.family == .ideogram
-                    || resolved.manifest.family == .flux1)
-                ? (resolved.manifest.defaults?.cfg ?? 1.0)
-                : 1.0)
-        let outputURL = try temporaryOutputURL(directoryName: "mere-run-api-images", extension: "png")
-        let request = GenerationRequest(
-            prompt: plan.prompt,
-            negativePrompt: plan.negativePrompt,
-            referenceImages: plan.additionalInputImages,
-            width: plan.width,
-            height: plan.height,
-            steps: effectiveSteps,
-            guidanceScale: effectiveCFG,
-            seed: plan.seed,
-            outputURL: outputURL,
-            model: resolved.rootURL.path,
-            maxSequenceLength: 512,
-            lora: nil,
-            enhancePrompt: false,
-            inputImage: plan.inputImage,
-            strength: plan.strength ?? 0.75,
-            keepOriginalAspect: false,
-            useBetaSigmas: false,
-            sigmaShift: resolved.manifest.defaults?.sigmaShift.map { Float($0) }
-        )
-
-        switch resolved.manifest.family {
-        case .flux1:
-            _ = try await sidecarPool.generateImage(
-                kind: .flux1,
-                modelID: resolved.modelID,
-                modelPath: resolved.rootURL.path,
-                request: request
-            )
-        case .klein:
-            _ = try await sidecarPool.generateImage(
-                kind: .flux2Klein,
-                modelID: resolved.modelID,
-                modelPath: resolved.rootURL.path,
-                request: request
-            )
-        case .zimage:
-            _ = try await sidecarPool.generateImage(
-                kind: .zImageTurbo,
-                modelID: resolved.modelID,
-                modelPath: resolved.rootURL.path,
-                request: request
-            )
-        case .hidream:
-            _ = try await sidecarPool.generateImage(
-                kind: .hiDreamO1,
-                modelID: resolved.modelID,
-                modelPath: resolved.rootURL.path,
-                request: request
-            )
-        case .senseNova:
-            _ = try await sidecarPool.generateImage(
-                kind: .senseNovaU15,
-                modelID: resolved.modelID,
-                modelPath: resolved.rootURL.path,
-                request: request
-            )
-        case .krea:
-            _ = try await sidecarPool.generateImage(
-                kind: .krea2,
-                modelID: resolved.modelID,
-                modelPath: resolved.rootURL.path,
-                request: request
-            )
-        case .ideogram:
-            _ = try await sidecarPool.generateImage(
-                kind: .ideogram4,
-                modelID: resolved.modelID,
-                modelPath: resolved.rootURL.path,
-                request: request
-            )
-        case .gemma, .laguna, .liquid, .qwen, .sam, .falcon, .terramind, .tessera, .olmoEarth,
-             .face, .geometry, .depth, .threeD,
-             .tts, .asr, .embed, .code, .ocr, .audio, .music, .sfx, .video, .psi, .privacy, .deepseek,
-             .inkling, .muse, .nemotron, nil:
-            throw APIRequestValidationError.invalidField(
-                "model",
-                "model \(resolved.modelID) is not an image generation model"
-            )
-        }
-        return outputURL
-    }
-
-    private func generateQwenImageEdit(_ plan: APIServerContract.ImageGenerationPlan) async throws -> URL {
-        guard let canonicalModelID = QwenImageEditRepository.canonicalModelId(for: plan.modelID),
-              let modelRoot = QwenImageEditRepository.resolveInstalledModelRoot(
-                modelSpec: canonicalModelID
-              ) else {
-            throw APIRequestValidationError.invalidField(
-                "model",
-                "\(plan.modelID) is not installed; pull it before serving image edits"
-            )
-        }
-        let manifest = try MereRunModelManifest.loadIfPresent(from: modelRoot)
-        let defaultSteps = manifest?.defaults?.steps ?? 20
-        let defaultCFG = manifest?.defaults?.cfg ?? 4
-        let outputURL = try temporaryOutputURL(directoryName: "mere-run-api-images", extension: "png")
-        let request = GenerationRequest(
-            prompt: plan.prompt,
-            negativePrompt: plan.negativePrompt,
-            referenceImages: plan.additionalInputImages,
-            width: plan.width,
-            height: plan.height,
-            steps: plan.steps ?? defaultSteps,
-            guidanceScale: plan.guidanceScale ?? defaultCFG,
-            seed: plan.seed,
-            outputURL: outputURL,
-            model: modelRoot.path,
-            maxSequenceLength: 512,
-            inputImage: plan.inputImage,
-            strength: plan.strength ?? 0.75
-        )
-        _ = try await sidecarPool.generateImage(
-            kind: .qwenImageEdit,
-            modelID: canonicalModelID,
-            modelPath: modelRoot.path,
-            request: request
-        )
-        return outputURL
+        let pool = sidecarPool
+        let outcome = try await ImageGenerationOperation.execute(operation, executor: { kind, request, _ in
+            try await pool.generateImage(kind: kind, modelID: modelID, modelPath: modelRoot.path, request: request)
+        })
+        return outcome.result.outputURL
     }
 
     private func synthesizeSpeech(_ plan: APIServerContract.SpeechPlan) async throws -> URL {
@@ -5469,21 +5363,14 @@ actor CodeGenServer {
     private func resolveImageModel(
         _ requestedModel: String
     ) throws -> (modelID: String, rootURL: URL, manifest: MereRunModelManifest) {
-        let normalized = requestedModel.trimmingCharacters(in: .whitespacesAndNewlines)
-        let asPath = URL(fileURLWithPath: normalized).standardizedFileURL
-        if FileManager.default.fileExists(atPath: asPath.path) {
-            let manifest = try MereRunModelManifest.loadRequired(from: asPath)
-            return (manifest.id, asPath, manifest)
+        let selection = ImageGenerationModelSelection(requestedModel.trimmingCharacters(in: .whitespacesAndNewlines))
+        if case .unknown = selection {
+            throw APIRequestValidationError.invalidField("model", "use a mere.run image model id or a local model path")
         }
-        guard let modelID = ModelResolver.ModelID(rawValue: normalized) else {
-            throw APIRequestValidationError.invalidField(
-                "model",
-                "use a mere.run image model id or a local model path"
-            )
-        }
-        let resolution = try ModelResolver().resolve(modelID)
-        let manifest = try MereRunModelManifest.loadRequired(from: resolution.rootURL)
-        return (modelID.rawValue, resolution.rootURL, manifest)
+        let root = try selection.resolveRoot()
+        let manifest = try MereRunModelManifest.loadRequired(from: root)
+        if case .managed(let id) = selection { return (id.rawValue, root, manifest) }
+        return (manifest.id, root, manifest)
     }
 
     private func resolveSpeechModel(
@@ -6198,6 +6085,12 @@ actor CodeGenServer {
                 status: .serviceUnavailable,
                 message: error.localizedDescription,
                 type: "memory_pressure_error"
+            )
+        case let error as ImageGenerationIssue:
+            return makeErrorResponse(
+                status: .badRequest,
+                message: error.localizedDescription,
+                type: "invalid_request_error"
             )
         case let error as APIRequestValidationError:
             return makeErrorResponse(

--- a/Sources/MereRunCLI/Commands/ImageGenerateCommand.swift
+++ b/Sources/MereRunCLI/Commands/ImageGenerateCommand.swift
@@ -162,171 +162,31 @@ struct ImageGenerate: AsyncParsableCommand {
     }
 
     func run() async throws {
-        try validateStaticOptions()
-        let kreaConditioningRebalance = try Self.resolveKreaConditioningRebalance(
-            multiplier: kreaConditioningMultiplier,
-            layerWeights: kreaConditioningLayerWeights
-        )
-        let explicitSigmas = try Self.parseSigmaList(sigmaList)
-        let parsedLoRAs = try Self.parseLoRAArguments(
-            loraArguments,
-            defaultScale: loraScale
-        )
-
         let outputURL = CLIOutput.resolveOutputURL(output, defaultPrefix: "mererun-image", defaultExtension: "png")
-
+        var options = try operationOptions(outputURL: outputURL)
+        if let issue = ImageGenerationPlan.issues(options).first { throw ValidationError(issue.message) }
         if preflight {
             try runPreflight(outputURL: outputURL)
             return
         }
 
+        let modelRoot = try resolveModelRoot()
+        let manifest = try MereRunModelManifest.loadRequired(from: modelRoot)
+        let initialPlan = try ImageGenerationPlan.resolve(options, modelRoot: modelRoot, manifest: manifest)
         try MLXBundleSupport.ensureAvailable(quiet: quiet)
-
-        try FileManager.default.createDirectory(
-            at: outputURL.deletingLastPathComponent(),
-            withIntermediateDirectories: true
-        )
-
-        let inputURL: URL?
-        if let input {
-            let url = URL(fileURLWithPath: input).standardizedFileURL
-            guard FileManager.default.fileExists(atPath: url.path) else {
-                throw ValidationError("Input image not found: \(url.path)")
-            }
-            inputURL = url
-        } else {
-            inputURL = nil
-        }
-        let maskURL: URL?
-        if let mask {
-            let url = URL(fileURLWithPath: mask).standardizedFileURL
-            guard FileManager.default.fileExists(atPath: url.path) else {
-                throw ValidationError("Mask image not found: \(url.path)")
-            }
-            maskURL = url
-        } else {
-            maskURL = nil
-        }
-        let outpaintInsets = try outpaint.map(ImageOutpaintInsets.parse)
-        let editPreparation: ImageEditPreparation?
-        if maskURL != nil || outpaintInsets != nil {
-            guard let inputURL else {
-                throw ValidationError("--mask and --outpaint require --input.")
-            }
-            editPreparation = try ImageEditPreparation.make(
-                inputURL: inputURL,
-                maskURL: maskURL,
-                outpaint: outpaintInsets,
-                width: width,
-                height: height,
-                featherPixels: maskFeather
-            )
-        } else {
-            editPreparation = nil
-        }
-        defer { editPreparation?.cleanup() }
-        let effectiveInputURL = editPreparation?.generationInputURL ?? inputURL
-
-        let referenceImageURLs = try referenceImages.map { path in
-            let url = URL(fileURLWithPath: path).standardizedFileURL
-            guard FileManager.default.fileExists(atPath: url.path) else {
-                throw ValidationError("Reference image not found: \(url.path)")
-            }
-            return url
-        }
-
-        let resolvedModel: String?
-        let resolver = ModelResolver()
-
-        if let model {
-            let url = URL(fileURLWithPath: model).standardizedFileURL
-            if FileManager.default.fileExists(atPath: url.path) {
-                resolvedModel = url.path
-            } else if let id = ModelResolver.ModelID(rawValue: model) {
-                do {
-                    resolvedModel = try resolver.resolve(id).rootURL.path
-                } catch {
-                    throw ValidationError(
-                        "Model \(id.rawValue) not found. Pull it with `\(CLICommandDisplay.modelPullCommand(for: id.rawValue))` or point --model at a local path."
-                    )
-                }
-            } else {
-                throw ValidationError(
-                    "Model path not found: \(model). Pass a local model path or a known model id."
-                )
-            }
-        } else {
-            do {
-                resolvedModel = try resolver.resolve(Self.defaultManagedModelID).rootURL.path
-            } catch {
-                let modelID = Self.defaultManagedModelID.rawValue
-                throw ValidationError(
-                    "Image model \(modelID) not found. Pull it with `\(CLICommandDisplay.modelPullCommand(for: modelID))` or point --model at a local path."
-                )
-            }
-        }
-
-        let manifest = try MereRunModelManifest.loadRequired(from: URL(fileURLWithPath: resolvedModel!))
-        if parsedLoRAs.count > 1, manifest.family != .klein, manifest.family != .flux1 {
-            throw ValidationError("Stacked image LoRAs are supported only for FLUX.1 and FLUX.2 models.")
-        }
-        if explicitSigmas != nil, manifest.family != .klein {
-            throw ValidationError("--sigmas is supported only for FLUX.2 models.")
-        }
-        let loraConfigs = try Self.resolveLoRAs(
-            parsedLoRAs,
-            baseModelID: manifest.id
-        )
-        let usesTurboRecipe = parsedLoRAs.contains {
-            ManagedAdapterCatalog.spec(for: $0.reference)?.id
-                == ManagedAdapterCatalog.flux2DevTurboEightStepID
-        }
-        let effectiveSigmas = explicitSigmas
-            ?? (usesTurboRecipe ? Flux2DevTurboRecipe.sigmas : nil)
-        if kreaBaseQuantizationBits != nil, manifest.family != .krea {
-            throw ValidationError("--krea-base-quantization-bits is only supported for Krea 2 generation")
-        }
-        let conditioning = Self.resolveConditioningInputs(
-            family: manifest.family,
-            inputImage: effectiveInputURL,
-            referenceImages: referenceImageURLs,
-            strength: strength
-        )
-        let usesManifestImageDefaults = manifest.engine == .qwenImageEdit
-            || manifest.family == .hidream || manifest.family == .senseNova
-            || manifest.family == .krea || manifest.family == .ideogram
-            || manifest.family == .klein || manifest.family == .flux1
-        let effectiveSteps = steps
-            ?? effectiveSigmas?.count
-            ?? (usesManifestImageDefaults
-                ? (manifest.defaults?.steps ?? 4)
-                : 4)
-        if let effectiveSigmas, effectiveSigmas.count != effectiveSteps {
-            throw ValidationError(
-                "--steps must equal the number of non-terminal --sigmas values "
-                    + "(\(effectiveSigmas.count))."
-            )
-        }
-        let effectiveCFG = cfgScale
-            ?? (usesTurboRecipe ? Flux2DevTurboRecipe.guidanceScale : nil)
-            ?? (usesManifestImageDefaults
-                ? (manifest.defaults?.cfg ?? 1.0)
-                : 1.0)
-        let effectiveSigmaShift = sigmaShift.map { Float($0) }
-            ?? manifest.defaults?.sigmaShift.map { Float($0) }
 
         let runEventLogger = try makeRunEventLoggerIfNeeded(
             outputURL: outputURL,
-            modelRoot: URL(fileURLWithPath: resolvedModel!),
+            modelRoot: modelRoot,
             modelManifest: manifest,
-            effectiveSteps: effectiveSteps,
-            effectiveCFGScale: effectiveCFG,
-            effectiveSigmaShift: effectiveSigmaShift,
-            effectiveSigmas: effectiveSigmas,
+            effectiveSteps: initialPlan.request.steps,
+            effectiveCFGScale: initialPlan.request.guidanceScale,
+            effectiveSigmaShift: initialPlan.request.sigmaShift,
+            effectiveSigmas: initialPlan.request.sigmas,
             inputMode: Self.inputMode(
                 family: manifest.family,
-                inputImage: inputURL,
-                referenceImages: referenceImageURLs
+                inputImage: options.inputImage,
+                referenceImages: options.referenceImages
             )
         )
 
@@ -370,31 +230,9 @@ struct ImageGenerate: AsyncParsableCommand {
                 }
             }
 
-            let request = GenerationRequest(
-                prompt: effectivePrompt,
-                negativePrompt: negativePrompt,
-                referenceImages: conditioning.referenceImages,
-                referenceStrength: conditioning.referenceStrength,
-                width: width,
-                height: height,
-                steps: effectiveSteps,
-                guidanceScale: effectiveCFG,
-                seed: seed,
-                outputURL: outputURL,
-                model: resolvedModel,
-                maxSequenceLength: effectiveMaxSequenceLength,
-                lora: loraConfigs.first,
-                loras: loraConfigs,
-                enhancePrompt: false,
-                inputImage: conditioning.inputImage,
-                strength: conditioning.strength,
-                keepOriginalAspect: keepOriginalAspect,
-                useBetaSigmas: false,
-                sigmaShift: effectiveSigmaShift,
-                sigmas: effectiveSigmas,
-                kreaConditioningRebalance: kreaConditioningRebalance,
-                kreaBaseQuantizationBits: kreaBaseQuantizationBits
-            )
+            options.prompt = effectivePrompt
+            options.maxSequenceLength = effectiveMaxSequenceLength
+            let plan = try ImageGenerationPlan.resolve(options, modelRoot: modelRoot, manifest: manifest)
 
             let progressHandler: (@Sendable (GenerationProgress) -> Void)?
             if progressJson {
@@ -408,49 +246,14 @@ struct ImageGenerate: AsyncParsableCommand {
                 CLIStderr.write("[runtime] image backend: \(NativeMLXRuntime.backendDescription)\n")
             }
 
-            let result: GenerationResult
-            switch manifest.family {
-            case .flux1:
-                let generator = Flux1Generator()
-                result = try await generator.generate(request, progressHandler: progressHandler)
-            case .klein:
-                let generator = Flux2KleinGenerator()
-                result = try await generator.generate(request, progressHandler: progressHandler)
-            case .zimage:
-                let generator = ZImageTurboGenerator()
-                result = try await generator.generate(request, progressHandler: progressHandler)
-            case .hidream:
-                let generator = HiDreamO1Generator()
-                defer { generator.unload() }
-                result = try await generator.generate(request, progressHandler: progressHandler)
-            case .senseNova:
-                let generator = SenseNovaU15Generator()
-                defer { generator.unload() }
-                result = try await generator.generate(request, progressHandler: progressHandler)
-            case .krea:
-                let generator = Krea2Generator()
-                defer { generator.unload() }
-                result = try await generator.generate(request, progressHandler: progressHandler)
-            case .ideogram:
-                let generator = Ideogram4Generator()
-                defer { generator.unload() }
-                result = try await generator.generate(request, progressHandler: progressHandler)
-            case .qwen where manifest.engine == .qwenImageEdit:
-                let generator = QwenImageEditGenerator()
-                result = try await generator.generate(request, progressHandler: progressHandler)
-            case .gemma, .laguna, .liquid, .qwen, .sam, .falcon, .terramind, .tessera, .olmoEarth,
-                 .face, .geometry, .depth, .threeD,
-                 .tts, .asr, .embed, .code, .ocr, .audio, .music, .sfx, .video, .psi, .privacy, .deepseek,
-                 .inkling, .muse, .nemotron, nil:
-                throw ValidationError("Unsupported image model family for `mere.run image generate`: \(manifest.id)")
-            }
-            try editPreparation?.finish(generatedURL: result.outputURL)
+            let outcome = try await ImageGenerationOperation.execute(plan, progressHandler: progressHandler)
+            let result = outcome.result
 
             try runEventLogger?.record(
                 type: "run_finished",
                 stage: "finished",
-                step: effectiveSteps,
-                totalSteps: effectiveSteps,
+                step: plan.request.steps,
+                totalSteps: plan.request.steps,
                 fraction: 1,
                 path: result.outputURL.path
             )
@@ -474,115 +277,53 @@ struct ImageGenerate: AsyncParsableCommand {
         }
     }
 
-    private func validateStaticOptions() throws {
-        if let steps, steps <= 0 {
-            throw ValidationError("--steps must be >= 1")
-        }
-        guard width > 0, height > 0 else {
-            throw ValidationError("--width/--height must be > 0")
-        }
-        if let strength, !(0.0...1.0).contains(strength) {
-            throw ValidationError("--strength must be between 0.0 and 1.0")
-        }
-        if (mask != nil || outpaint != nil), input == nil {
-            throw ValidationError("--mask and --outpaint require --input")
-        }
-        if maskFeather < 0 {
-            throw ValidationError("--mask-feather must be >= 0")
-        }
-        if let outpaint {
-            _ = try ImageOutpaintInsets.parse(outpaint)
-        }
-        if let kreaBaseQuantizationBits, kreaBaseQuantizationBits != 4, kreaBaseQuantizationBits != 8 {
-            throw ValidationError("--krea-base-quantization-bits must be 4 or 8")
-        }
-        guard loraScale.isFinite else {
-            throw ValidationError("--lora-scale must be finite")
-        }
-        if sigmaList != nil, sigmaShift != nil {
-            throw ValidationError("--sigmas cannot be combined with --sigma-shift")
+    private func resolveModelRoot() throws -> URL {
+        let selection = ImageGenerationModelSelection(model ?? Self.defaultManagedModelID.rawValue)
+        switch selection {
+        case .local(let url): return url
+        case .managed(let id):
+            do { return try selection.resolveRoot() } catch {
+                let prefix = model == nil ? "Image model" : "Model"
+                throw ValidationError(
+                    "\(prefix) \(id.rawValue) not found. Pull it with `\(CLICommandDisplay.modelPullCommand(for: id.rawValue))` or point --model at a local path."
+                )
+            }
+        case .unknown(let selector):
+            throw ValidationError("Model path not found: \(selector). Pass a local model path or a known model id.")
         }
     }
 
-    struct LoRAArgument: Equatable {
-        let raw: String
-        let reference: String
-        let scale: Double
+    func operationOptions(outputURL: URL) throws -> ImageGenerationOptions {
+        func url(_ path: String) -> URL { URL(fileURLWithPath: path).standardizedFileURL }
+        return try ImageGenerationOptions(
+            prompt: prompt, negativePrompt: negativePrompt, outputURL: outputURL,
+            width: width, height: height, steps: steps, guidanceScale: cfgScale, seed: seed,
+            inputImage: input.map(url), referenceImages: referenceImages.map(url), strength: strength,
+            keepOriginalAspect: keepOriginalAspect, maxSequenceLength: maxSequenceLength,
+            loras: Self.parseLoRAArguments(loraArguments, defaultScale: loraScale),
+            sigmaShift: sigmaShift.map(Float.init), sigmas: Self.parseSigmaList(sigmaList),
+            kreaConditioningRebalance: Self.resolveKreaConditioningRebalance(
+                multiplier: kreaConditioningMultiplier, layerWeights: kreaConditioningLayerWeights
+            ),
+            kreaBaseQuantizationBits: kreaBaseQuantizationBits,
+            mask: mask.map(url), outpaint: outpaint.map(ImageOutpaintInsets.parse), maskFeather: maskFeather
+        )
     }
 
-    static func parseLoRAArguments(
-        _ arguments: [String],
-        defaultScale: Double
-    ) throws -> [LoRAArgument] {
-        guard defaultScale.isFinite else {
-            throw ValidationError("--lora-scale must be finite")
-        }
-        return try arguments.map { raw in
-            let separator = raw.lastIndex(of: "=")
-            let reference: String
-            let scale: Double
-            if let separator {
-                reference = String(raw[..<separator])
-                let rawScale = String(raw[raw.index(after: separator)...])
-                guard let parsed = Double(rawScale), parsed.isFinite else {
-                    throw ValidationError("--lora scale must be finite (got \(rawScale)).")
-                }
-                scale = parsed
-            } else {
-                reference = raw
-                scale = defaultScale
-            }
-            guard !reference.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
-                throw ValidationError("--lora must be PATH_OR_ID[=SCALE].")
-            }
-            return LoRAArgument(raw: raw, reference: reference, scale: scale)
-        }
+    typealias LoRAArgument = ImageLoRAReference
+
+    static func parseLoRAArguments(_ arguments: [String], defaultScale: Double) throws -> [LoRAArgument] {
+        try ImageLoRAReference.parse(arguments, defaultScale: defaultScale)
     }
 
     static func resolveLoRAs(
-        _ arguments: [LoRAArgument],
-        baseModelID: String,
-        fileManager: FileManager = .default
+        _ arguments: [LoRAArgument], baseModelID: String, fileManager: FileManager = .default
     ) throws -> [LoRA] {
-        var resolvedPaths = Set<String>()
-        return try arguments.map { argument in
-            let resolved = try ManagedAdapterArgumentResolver.resolve(
-                argument.reference,
-                baseModelID: baseModelID,
-                fileManager: fileManager
-            ) ?? argument.reference
-            let url = URL(fileURLWithPath: resolved).standardizedFileURL
-            guard fileManager.fileExists(atPath: url.path) else {
-                throw ValidationError("LoRA file not found: \(url.path)")
-            }
-            guard resolvedPaths.insert(url.path).inserted else {
-                throw ValidationError("Duplicate LoRA adapter: \(url.path)")
-            }
-            return .local(path: url.path, scale: argument.scale)
-        }
+        try ImageGenerationPlan.resolveLoRAs(arguments, baseModelID: baseModelID, fileManager: fileManager)
     }
 
     static func parseSigmaList(_ raw: String?) throws -> [Float]? {
-        guard let raw else { return nil }
-        var values = try raw.split(separator: ",", omittingEmptySubsequences: false).map { item in
-            let trimmed = item.trimmingCharacters(in: .whitespacesAndNewlines)
-            guard let value = Float(trimmed), value.isFinite else {
-                throw ValidationError("--sigmas must contain finite comma-separated values.")
-            }
-            return value
-        }
-        if values.last == 0 {
-            values.removeLast()
-        }
-        guard !values.isEmpty else {
-            throw ValidationError("--sigmas must include at least one non-terminal value.")
-        }
-        do {
-            try Flux2EulerScheduler.validateCustomSigmas(values, expectedSteps: values.count)
-        } catch {
-            throw ValidationError(error.localizedDescription)
-        }
-        return values
+        try ImageGenerationSampling.parseSigmas(raw)
     }
 
     func makePreflightEnvelope(
@@ -592,6 +333,7 @@ struct ImageGenerate: AsyncParsableCommand {
         resourceDiagnostics: [PreflightDiagnostic] = []
     ) -> ImageGenerationPreflightEnvelope {
         let input = ImageGenerationPreflightInput(
+            operationOptions: Result { try operationOptions(outputURL: outputURL) },
             prompt: prompt,
             negativePrompt: negativePrompt,
             outputURL: outputURL,
@@ -860,62 +602,16 @@ struct ImageGenerate: AsyncParsableCommand {
         }
     }
 
-    struct ConditioningInputs: Equatable {
-        var inputImage: URL?
-        var referenceImages: [URL]
-        var strength: Double
-        var referenceStrength: Double
-    }
+    typealias ConditioningInputs = ImageGenerationConditioning
 
     static func resolveConditioningInputs(
-        family: MereRunModelManifest.Family?,
-        inputImage: URL?,
-        referenceImages: [URL],
-        strength: Double?
+        family: MereRunModelManifest.Family?, inputImage: URL?, referenceImages: [URL], strength: Double?
     ) -> ConditioningInputs {
-        let explicitStrength = strength
-        let defaultInputStrength = 0.75
-
-        guard family == .klein else {
-            return ConditioningInputs(
-                inputImage: inputImage,
-                referenceImages: referenceImages,
-                strength: explicitStrength ?? defaultInputStrength,
-                referenceStrength: 0.0
-            )
-        }
-
-        var resolvedReferences = referenceImages
-        if let inputImage {
-            resolvedReferences.insert(inputImage, at: 0)
-        }
-
-        return ConditioningInputs(
-            inputImage: nil,
-            referenceImages: resolvedReferences,
-            strength: explicitStrength ?? defaultInputStrength,
-            referenceStrength: explicitStrength ?? (inputImage == nil ? 0.0 : defaultInputStrength)
-        )
+        ImageGenerationConditioning.resolve(family: family, inputImage: inputImage, referenceImages: referenceImages, strength: strength)
     }
 
-    static func inputMode(
-        family: MereRunModelManifest.Family?,
-        inputImage: URL?,
-        referenceImages: [URL]
-    ) -> String {
-        let hasInput = inputImage != nil
-        let hasReferences = !referenceImages.isEmpty
-        guard hasInput || hasReferences else { return "text_to_image" }
-        if family == .klein {
-            return "reference_image"
-        }
-        if hasInput && hasReferences {
-            return "image_to_image_with_references"
-        }
-        if hasInput {
-            return "image_to_image"
-        }
-        return "reference_image"
+    static func inputMode(family: MereRunModelManifest.Family?, inputImage: URL?, referenceImages: [URL]) -> String {
+        ImageGenerationConditioning.inputMode(family: family, inputImage: inputImage, referenceImages: referenceImages)
     }
 
     static func resolveKreaConditioningRebalance(

--- a/Sources/MereRunCLI/Support/APIImageGeneration.swift
+++ b/Sources/MereRunCLI/Support/APIImageGeneration.swift
@@ -1,0 +1,36 @@
+import Foundation
+import MereRunCore
+
+extension APIServerContract.ImageGenerationPlan {
+    /// Preserve the v1 API's four-step Klein default and input conditioning.
+    /// Equivalent explicit text-to-image settings otherwise use the CLI's plan.
+    func operationPlan(
+        modelRoot: URL,
+        outputURL: URL,
+        manifest: MereRunModelManifest,
+        qwenEditDefaults: Bool = false
+    ) throws -> MereRunCore.ImageGenerationPlan {
+        var effectiveManifest = manifest
+        if qwenEditDefaults {
+            // A recognized managed Qwen installation supplied the backend before
+            // manifests carried family/engine fields. Preserve that legacy input.
+            effectiveManifest.family = manifest.family ?? .qwen
+            effectiveManifest.engine = manifest.engine ?? .qwenImageEdit
+        }
+        let options = ImageGenerationOptions(
+            prompt: prompt, negativePrompt: negativePrompt, outputURL: outputURL,
+            width: width, height: height, steps: steps, guidanceScale: guidanceScale,
+            seed: seed, inputImage: inputImage, referenceImages: additionalInputImages, strength: strength
+        )
+        // The v1 endpoint accepts mask parts for compatibility but conditions on
+        // the whole image, as documented. Strict masking remains a CLI feature.
+        return try MereRunCore.ImageGenerationPlan.resolve(
+            options, modelRoot: modelRoot, manifest: effectiveManifest,
+            policy: ImageGenerationPolicy(
+                kleinUsesManifestDefaults: false, kleinInputAsReference: false,
+                fallbackSteps: qwenEditDefaults ? 20 : 4,
+                fallbackGuidanceScale: qwenEditDefaults ? 4 : 1
+            )
+        )
+    }
+}

--- a/Sources/MereRunCLI/Support/APISidecarModelPool.swift
+++ b/Sources/MereRunCLI/Support/APISidecarModelPool.swift
@@ -530,16 +530,7 @@ actor APISidecarResidentSlot<Key: Equatable & Sendable, Value: Sendable> {
     }
 }
 
-enum APISidecarImageKind: String, Hashable, Sendable {
-    case flux1
-    case flux2Klein
-    case zImageTurbo
-    case hiDreamO1
-    case senseNovaU15
-    case krea2
-    case ideogram4
-    case qwenImageEdit
-}
+typealias APISidecarImageKind = ImageGenerationBackend
 
 private struct APISidecarImageKey: Hashable, Sendable {
     let kind: APISidecarImageKind

--- a/Sources/MereRunCLI/Support/BoundedProcessRunner.swift
+++ b/Sources/MereRunCLI/Support/BoundedProcessRunner.swift
@@ -1,0 +1,172 @@
+import Foundation
+#if os(Linux)
+import Glibc
+#else
+import Darwin
+#endif
+
+/// Runs an already configured child while draining both output streams. Capture
+/// limits bound retained bytes, never how much output the child can write.
+enum BoundedProcessRunner {
+    enum Completion: Equatable, Sendable {
+        case exited
+        case timedOut
+        case cancelled
+    }
+
+    struct Capture: Sendable {
+        let text: String
+        let truncated: Bool
+    }
+
+    struct Result: Sendable {
+        let completion: Completion
+        let status: Int32
+        let seconds: Double
+        let stdout: Capture
+        let stderr: Capture
+    }
+
+    enum RunError: LocalizedError {
+        case invalidLimits
+        case outputIO(Int32)
+
+        var errorDescription: String? {
+            switch self {
+            case .invalidLimits:
+                return "Process timeout must be positive and finite, and output limit must be nonnegative."
+            case .outputIO(let code):
+                return "Could not read child process output (errno \(code))."
+            }
+        }
+    }
+
+    static func run(
+        _ process: Process,
+        timeout: TimeInterval,
+        outputLimitBytes: Int = 256 * 1024,
+        combineOutput: Bool = false,
+        isCancelled: () -> Bool = { Task.isCancelled }
+    ) throws -> Result {
+        guard timeout.isFinite, timeout > 0, outputLimitBytes >= 0 else {
+            throw RunError.invalidLimits
+        }
+        let stdout = try Output(limitBytes: outputLimitBytes)
+        defer { stdout.close() }
+        let stderr = try combineOutput ? nil : Output(limitBytes: outputLimitBytes)
+        defer { stderr?.close() }
+        process.standardOutput = stdout.pipe
+        process.standardError = stderr?.pipe ?? stdout.pipe
+
+        if isCancelled() { throw CancellationError() }
+        let start = ProcessInfo.processInfo.systemUptime
+        try process.run()
+        // Only the child owns writers after launch; parent copies would prevent EOF.
+        stdout.closeWriter()
+        stderr?.closeWriter()
+
+        var completion = Completion.exited
+        do {
+            while true {
+                // One chunk per stream keeps a noisy stdout from starving stderr,
+                // cancellation, or the deadline. Reads themselves never block.
+                let readOutput = try stdout.drain()
+                let readError = try stderr?.drain() ?? false
+                if !process.isRunning, stdout.atEnd, stderr?.atEnd ?? true { break }
+                if isCancelled() {
+                    completion = .cancelled
+                    break
+                }
+                if ProcessInfo.processInfo.systemUptime - start >= timeout {
+                    completion = .timedOut
+                    break
+                }
+                if !readOutput, !readError { Thread.sleep(forTimeInterval: 0.01) }
+            }
+            if completion != .exited { stop(process) }
+            process.waitUntilExit()
+            // Retain available tail output after termination without waiting for
+            // a deliberately detached descendant that still holds a pipe open.
+            for _ in 0..<16 {
+                let readOutput = try stdout.drain()
+                let readError = try stderr?.drain() ?? false
+                if !readOutput, !readError { break }
+            }
+        } catch {
+            stop(process)
+            process.waitUntilExit()
+            throw error
+        }
+        return Result(
+            completion: completion,
+            status: process.terminationStatus,
+            seconds: ProcessInfo.processInfo.systemUptime - start,
+            stdout: stdout.capture,
+            stderr: stderr?.capture ?? Capture(text: "", truncated: false)
+        )
+    }
+
+    private static func stop(_ process: Process) {
+        // Foundation launches Process in its own process group on macOS and
+        // Linux. Signal the group even if its leader exited but a child retains
+        // stdout/stderr; never signal the caller's group.
+        let pid = process.processIdentifier
+        kill(-pid, SIGTERM)
+        if process.isRunning { process.terminate() }
+        Thread.sleep(forTimeInterval: 0.2)
+        kill(-pid, SIGKILL)
+        if process.isRunning { kill(pid, SIGKILL) }
+    }
+
+    private final class Output {
+        let pipe = Pipe()
+        private(set) var atEnd = false
+        private let limitBytes: Int
+        private var bytes = Data()
+        private var truncated = false
+        private var buffer = [UInt8](repeating: 0, count: 64 * 1024)
+
+        init(limitBytes: Int) throws {
+            self.limitBytes = limitBytes
+            let fd = pipe.fileHandleForReading.fileDescriptor
+            let flags = fcntl(fd, F_GETFL)
+            guard flags != -1, fcntl(fd, F_SETFL, flags | O_NONBLOCK) != -1 else {
+                let code = errno
+                close()
+                throw RunError.outputIO(code)
+            }
+        }
+
+        func drain() throws -> Bool {
+            guard !atEnd else { return false }
+            let count = buffer.withUnsafeMutableBytes {
+                read(pipe.fileHandleForReading.fileDescriptor, $0.baseAddress, $0.count)
+            }
+            if count == 0 {
+                atEnd = true
+                return false
+            }
+            if count < 0 {
+                let code = errno
+                if code == EAGAIN || code == EWOULDBLOCK || code == EINTR { return false }
+                throw RunError.outputIO(code)
+            }
+            let retained = min(count, limitBytes - bytes.count)
+            bytes.append(contentsOf: buffer.prefix(retained))
+            if retained < count { truncated = true }
+            return true
+        }
+
+        var capture: Capture {
+            let text = String(decoding: bytes, as: UTF8.self)
+            return Capture(text: truncated ? text + "\n[output truncated]" : text, truncated: truncated)
+        }
+
+        func closeWriter() { try? pipe.fileHandleForWriting.close() }
+
+        func close() {
+            closeWriter()
+            try? pipe.fileHandleForReading.close()
+        }
+    }
+}

--- a/Sources/MereRunCLI/Support/BuiltinTools.swift
+++ b/Sources/MereRunCLI/Support/BuiltinTools.swift
@@ -6,6 +6,8 @@ enum BuiltinTools {
         let sandboxDir: URL
         let allowShellExec: Bool
         let allowAbsolutePaths: Bool
+        var shellTimeout: TimeInterval = 300
+        var shellOutputLimitBytes: Int = 256 * 1024
     }
 
     static let writeFile = ToolDefinition(
@@ -90,21 +92,22 @@ enum BuiltinTools {
         process.arguments = ["-c", command]
         process.currentDirectoryURL = policy.sandboxDir
 
-        let pipe = Pipe()
-        process.standardOutput = pipe
-        process.standardError = pipe
-
-        try process.run()
-        process.waitUntilExit()
-
-        let data = pipe.fileHandleForReading.readDataToEndOfFile()
-        let output = String(data: data, encoding: .utf8) ?? ""
-        let status = process.terminationStatus
-
-        if status == 0 {
+        let result = try BoundedProcessRunner.run(
+            process,
+            timeout: policy.shellTimeout,
+            outputLimitBytes: policy.shellOutputLimitBytes,
+            combineOutput: true
+        )
+        let output = result.stdout.text
+        switch result.completion {
+        case .cancelled:
+            throw CancellationError()
+        case .timedOut:
+            return "Timed out after \(policy.shellTimeout) seconds.\n\(output)"
+        case .exited where result.status == 0:
             return output.isEmpty ? "(no output)" : output
-        } else {
-            return "Exit code \(status)\n\(output)"
+        case .exited:
+            return "Exit code \(result.status)\n\(output)"
         }
     }
 

--- a/Sources/MereRunCLI/Support/CodeExecutionSandbox.swift
+++ b/Sources/MereRunCLI/Support/CodeExecutionSandbox.swift
@@ -126,37 +126,21 @@ enum CodeExecutionSandbox {
             process.arguments = Array(invocation.dropFirst())
         }
 
-        let stdout = LimitedOutputPipe(limitBytes: outputLimitBytes)
-        let stderr = LimitedOutputPipe(limitBytes: outputLimitBytes)
-        process.standardOutput = stdout.pipe
-        process.standardError = stderr.pipe
-
-        let start = Date()
-        try process.run()
-        var timedOut = false
-        while process.isRunning {
-            if Date().timeIntervalSince(start) > timeout {
-                timedOut = true
-                terminate(process)
-                break
-            }
-            Thread.sleep(forTimeInterval: 0.05)
-        }
-        process.waitUntilExit()
-        let seconds = Date().timeIntervalSince(start)
-        let stdoutCapture = stdout.finish()
-        let stderrCapture = stderr.finish()
+        let result = try BoundedProcessRunner.run(
+            process, timeout: timeout, outputLimitBytes: outputLimitBytes
+        )
+        if result.completion == .cancelled { throw CancellationError() }
 
         return CodeExecutionSandboxResult(
             backend: backend,
-            passed: !timedOut && process.terminationStatus == 0,
-            seconds: seconds,
-            timedOut: timedOut,
-            status: process.terminationStatus,
-            stdout: stdoutCapture.text,
-            stderr: stderrCapture.text,
-            stdoutTruncated: stdoutCapture.truncated,
-            stderrTruncated: stderrCapture.truncated
+            passed: result.completion == .exited && result.status == 0,
+            seconds: result.seconds,
+            timedOut: result.completion == .timedOut,
+            status: result.status,
+            stdout: result.stdout.text,
+            stderr: result.stderr.text,
+            stdoutTruncated: result.stdout.truncated,
+            stderrTruncated: result.stderr.truncated
         )
     }
 
@@ -284,69 +268,4 @@ enum CodeExecutionSandbox {
             && FileManager.default.isExecutableFile(atPath: path)
     }
 
-    private static func terminate(_ process: Process) {
-        process.terminate()
-        Thread.sleep(forTimeInterval: 0.2)
-        guard process.isRunning else {
-            return
-        }
-        #if os(macOS) || os(Linux)
-        kill(pid_t(process.processIdentifier), SIGKILL)
-        #else
-        process.terminate()
-        #endif
-    }
-}
-
-private final class LimitedOutputPipe: @unchecked Sendable {
-    struct Capture {
-        let text: String
-        let truncated: Bool
-    }
-
-    let pipe = Pipe()
-
-    private let limitBytes: Int
-    private let lock = NSLock()
-    private var data = Data()
-    private var truncated = false
-
-    init(limitBytes: Int) {
-        self.limitBytes = limitBytes
-        let handler: @Sendable (FileHandle) -> Void = { [weak self] handle in
-            let chunk = handle.availableData
-            guard !chunk.isEmpty else {
-                return
-            }
-            self?.append(chunk)
-        }
-        pipe.fileHandleForReading.readabilityHandler = handler
-    }
-
-    func finish() -> Capture {
-        pipe.fileHandleForReading.readabilityHandler = nil
-        append(pipe.fileHandleForReading.readDataToEndOfFile())
-        let text = String(data: data, encoding: .utf8) ?? String(decoding: data, as: UTF8.self)
-        return Capture(
-            text: truncated ? text + "\n[output truncated]" : text,
-            truncated: truncated
-        )
-    }
-
-    private func append(_ chunk: Data) {
-        guard !chunk.isEmpty else {
-            return
-        }
-        lock.lock()
-        defer {
-            lock.unlock()
-        }
-        let remaining = max(0, limitBytes - data.count)
-        if remaining > 0 {
-            data.append(chunk.prefix(remaining))
-        }
-        if chunk.count > remaining {
-            truncated = true
-        }
-    }
 }

--- a/Sources/MereRunCLI/Support/ImageGenerationPreflight.swift
+++ b/Sources/MereRunCLI/Support/ImageGenerationPreflight.swift
@@ -3,6 +3,7 @@ import MereRunRelayKit
 import MereRunCore
 
 struct ImageGenerationPreflightInput {
+    let operationOptions: Result<ImageGenerationOptions, Error>
     let prompt: String
     let negativePrompt: String?
     let outputURL: URL
@@ -289,9 +290,7 @@ struct ImageGenerationPreflightAnalyzer {
     func envelope(resourceDiagnostics: [PreflightDiagnostic] = []) -> ImageGenerationPreflightEnvelope {
         var diagnostics = resourceDiagnostics
         let createdAt = now()
-        validatePrompt(diagnostics: &diagnostics)
-        validateSampling(diagnostics: &diagnostics)
-        let model = modelSummary(diagnostics: &diagnostics)
+        let (model, manifest) = modelSummary(diagnostics: &diagnostics)
         let output = outputSummary(
             for: input.outputURL,
             expectedExtension: "png",
@@ -302,8 +301,9 @@ struct ImageGenerationPreflightAnalyzer {
         )
         let inputs = inputSummary(diagnostics: &diagnostics)
         let loras = loraSummaries(model: model, diagnostics: &diagnostics)
+        let options = resolvedOperationOptions(modelPath: model.path, manifest: manifest, diagnostics: &diagnostics)
         let structuredPrompt = structuredPromptSummary(diagnostics: &diagnostics)
-        let plan = planSummary(model: model)
+        let plan = planSummary(model: model, manifest: manifest, options: options)
         let runPlan = runPlan(resolved: plan, createdAt: createdAt)
         let status = StructuredRunOutput.status(for: diagnostics)
         let actions = actions(status: status, model: model, output: output, inputs: inputs, loras: loras)
@@ -371,63 +371,47 @@ struct ImageGenerationPreflightAnalyzer {
         input.model ?? ImageGenerate.defaultManagedModelID.rawValue
     }
 
-    private func validatePrompt(diagnostics: inout [PreflightDiagnostic]) {
-        if input.prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            diagnostics.append(
-                PreflightDiagnostic(
-                    id: "prompt_empty",
-                    severity: .blocker,
-                    title: "Prompt is empty",
-                    message: "--prompt must include non-whitespace text."
-                )
-            )
-        }
-    }
-
-    private func validateSampling(diagnostics: inout [PreflightDiagnostic]) {
-        if input.sigmaList != nil, input.sigmaShift != nil {
-            diagnostics.append(
-                PreflightDiagnostic(
-                    id: "sigma_options_conflict",
-                    severity: .blocker,
-                    title: "Sigma options conflict",
-                    message: "--sigmas cannot be combined with --sigma-shift."
-                )
-            )
+    private func resolvedOperationOptions(
+        modelPath: String?, manifest: MereRunModelManifest?, diagnostics: inout [PreflightDiagnostic]
+    ) -> ImageGenerationOptions? {
+        func record(_ error: Error) {
+            let issue = error as? ImageGenerationIssue
+                ?? ImageGenerationIssue("image_options_invalid", error.localizedDescription)
+            let alreadyReported = diagnostics.contains { diagnostic in
+                diagnostic.id == issue.code
+                    || (issue.code.hasPrefix("lora_") && diagnostic.id == "lora_argument_invalid")
+            }
+            guard !alreadyReported else { return }
+            diagnostics.append(.init(id: issue.code, severity: .blocker, title: "Image request is invalid", message: issue.message))
         }
         do {
-            _ = try ImageGenerate.parseSigmaList(input.sigmaList)
+            let options = try input.operationOptions.get()
+            for issue in ImageGenerationPlan.issues(options, manifest: manifest) { record(issue) }
+            if let manifest, !diagnostics.contains(where: { $0.severity == .blocker }) {
+                // The same observational resolver execution uses: no weights,
+                // output directory, edit canvas, or model download is created.
+                if let modelPath {
+                    let root = URL(fileURLWithPath: modelPath)
+                    do {
+                        _ = try ImageGenerationPlan.resolve(options, modelRoot: root, manifest: manifest, fileManager: fileManager)
+                    } catch { record(error) }
+                }
+            }
+            return options
         } catch {
-            diagnostics.append(
-                PreflightDiagnostic(
-                    id: "sigma_schedule_invalid",
-                    severity: .blocker,
-                    title: "Sigma schedule is invalid",
-                    message: error.localizedDescription
-                )
-            )
-        }
-        if let sigmas = resolvedSigmas(),
-           let steps = input.steps,
-           steps != sigmas.count {
-            diagnostics.append(
-                PreflightDiagnostic(
-                    id: "sigma_step_count_mismatch",
-                    severity: .blocker,
-                    title: "Sigma count doesn't match the step count",
-                    message: "--steps must equal the number of non-terminal --sigmas values."
-                )
-            )
+            record(error)
+            return nil
         }
     }
 
     private func modelSummary(
         diagnostics: inout [PreflightDiagnostic]
-    ) -> ImageGenerationModelPreflightSummary {
+    ) -> (ImageGenerationModelPreflightSummary, MereRunModelManifest?) {
         let requested = requestedModel
-        let localURL = URL(fileURLWithPath: requested).standardizedFileURL
-        var isDirectory: ObjCBool = false
-        if fileManager.fileExists(atPath: localURL.path, isDirectory: &isDirectory) {
+        let selection = ImageGenerationModelSelection(requested, fileManager: fileManager)
+        if case .local(let localURL) = selection {
+            var isDirectory: ObjCBool = false
+            _ = fileManager.fileExists(atPath: localURL.path, isDirectory: &isDirectory)
             guard isDirectory.boolValue else {
                 diagnostics.append(
                     PreflightDiagnostic(
@@ -438,24 +422,24 @@ struct ImageGenerationPreflightAnalyzer {
                         locations: [.init(kind: "file", path: localURL.path)]
                     )
                 )
-                return modelResult(requested: requested, kind: "local_path", installed: false, path: localURL.path)
+                return (modelResult(requested: requested, kind: "local_path", installed: false, path: localURL.path), nil)
             }
             let manifest = loadManifest(at: localURL, diagnostics: &diagnostics)
-            return modelResult(
+            return (modelResult(
                 requested: requested,
                 kind: "local_path",
                 installed: manifest != nil,
                 path: localURL.path,
                 id: manifest?.id,
                 family: manifest?.family?.rawValue
-            )
+            ), manifest)
         }
 
-        if let modelID = ModelResolver.ModelID(rawValue: requested) {
+        if case .managed(let modelID) = selection {
             let spec = ManagedModelCatalog.spec(for: modelID.rawValue)
             if let resolution = ModelResolver(fileManager: fileManager).resolveIfPresent(modelID) {
                 let manifest = loadManifest(at: resolution.rootURL, diagnostics: &diagnostics)
-                return modelResult(
+                return (modelResult(
                     requested: requested,
                     kind: "managed_model",
                     installed: manifest != nil,
@@ -464,7 +448,7 @@ struct ImageGenerationPreflightAnalyzer {
                     family: manifest?.family?.rawValue,
                     upstreamRepoID: spec?.upstreamRepoId,
                     estimatedDownloadBytes: spec?.estimatedDownloadBytes
-                )
+                ), manifest)
             }
 
             diagnostics.append(
@@ -476,13 +460,13 @@ struct ImageGenerationPreflightAnalyzer {
                     suggestedActionIDs: ["pull-model"]
                 )
             )
-            return modelResult(
+            return (modelResult(
                 requested: requested,
                 kind: "managed_model",
                 installed: false,
                 upstreamRepoID: spec?.upstreamRepoId,
                 estimatedDownloadBytes: spec?.estimatedDownloadBytes
-            )
+            ), nil)
         }
 
         diagnostics.append(
@@ -493,7 +477,7 @@ struct ImageGenerationPreflightAnalyzer {
                 message: "Model path not found and not a known model id: \(requested)."
             )
         )
-        return modelResult(requested: requested, kind: "unknown", installed: false)
+        return (modelResult(requested: requested, kind: "unknown", installed: false), nil)
     }
 
     private func outputSummary(
@@ -630,19 +614,6 @@ struct ImageGenerationPreflightAnalyzer {
             return []
         }
 
-        if parsed.count > 1,
-           model.family != MereRunModelManifest.Family.klein.rawValue,
-           model.family != MereRunModelManifest.Family.flux1.rawValue {
-            diagnostics.append(
-                PreflightDiagnostic(
-                    id: "lora_stack_model_unsupported",
-                    severity: .blocker,
-                    title: "Model doesn't support stacked LoRAs",
-                    message: "Stacked image LoRAs require a FLUX.1 or FLUX.2 model."
-                )
-            )
-        }
-
         let baseModelID = model.id ?? model.requested
         return parsed.enumerated().map { index, argument in
             let resolved: String
@@ -762,13 +733,11 @@ struct ImageGenerationPreflightAnalyzer {
     }
 
     private func planSummary(
-        model: ImageGenerationModelPreflightSummary
+        model: ImageGenerationModelPreflightSummary,
+        manifest: MereRunModelManifest?,
+        options: ImageGenerationOptions?
     ) -> ImageGenerationPlanPreflightSummary {
-        let family = model.family.flatMap(MereRunModelManifest.Family.init(rawValue:))
-        let effectiveSteps = effectiveSteps(for: family, modelPath: model.path)
-        let effectiveCFG = effectiveCFGScale(for: family, modelPath: model.path)
-        let effectiveSigma = input.sigmaShift ?? manifestDefaultSigmaShift(modelPath: model.path)
-        let effectiveSigmas = resolvedSigmas()
+        let sampling = options.map { ImageGenerationSampling.resolve($0, manifest: manifest) }
         let effectiveMaxSequenceLength = input.structuredPrompt
             ? max(input.maxSequenceLength, StructuredImagePromptAdapter.recommendedImagePromptTokens)
             : input.maxSequenceLength
@@ -778,16 +747,20 @@ struct ImageGenerationPreflightAnalyzer {
             width: input.width,
             height: input.height,
             requestedSteps: input.steps,
-            effectiveSteps: effectiveSteps,
+            effectiveSteps: sampling?.steps,
             requestedCFGScale: input.cfgScale,
-            effectiveCFGScale: effectiveCFG,
+            effectiveCFGScale: sampling?.guidanceScale,
             requestedSigmaShift: input.sigmaShift,
-            effectiveSigmaShift: effectiveSigma,
+            effectiveSigmaShift: sampling?.sigmaShift.map(Double.init),
             requestedSigmas: input.sigmaList,
-            effectiveSigmas: effectiveSigmas,
+            effectiveSigmas: sampling?.sigmas,
             maxSequenceLength: input.maxSequenceLength,
             effectiveMaxSequenceLength: effectiveMaxSequenceLength,
-            inputMode: inputMode(family: family)
+            inputMode: ImageGenerationConditioning.inputMode(
+                family: manifest?.family,
+                inputImage: input.input.map { URL(fileURLWithPath: $0) },
+                referenceImages: input.referenceImages.map { URL(fileURLWithPath: $0) }
+            )
         )
     }
 
@@ -1006,7 +979,7 @@ struct ImageGenerationPreflightAnalyzer {
     ) -> MereRunModelManifest? {
         do {
             let manifest = try MereRunModelManifest.loadRequired(from: modelRoot, fileManager: fileManager)
-            if !Self.supportsImageGeneration(manifest) {
+            if (try? ImageGenerationBackend(manifest: manifest)) == nil {
                 let family = manifest.family?.rawValue ?? "unknown"
                 diagnostics.append(
                     PreflightDiagnostic(
@@ -1033,88 +1006,4 @@ struct ImageGenerationPreflightAnalyzer {
         }
     }
 
-    private func effectiveSteps(for family: MereRunModelManifest.Family?, modelPath: String?) -> Int? {
-        if let steps = input.steps { return steps }
-        if let sigmas = resolvedSigmas() { return sigmas.count }
-        guard let family else { return nil }
-        if Self.familyUsesManifestDefaults(family) {
-            return manifestDefaults(modelPath: modelPath)?.steps ?? 4
-        }
-        return 4
-    }
-
-    private func effectiveCFGScale(for family: MereRunModelManifest.Family?, modelPath: String?) -> Double? {
-        if let cfgScale = input.cfgScale { return cfgScale }
-        if usesTurboRecipe { return Flux2DevTurboRecipe.guidanceScale }
-        guard let family else { return nil }
-        if Self.familyUsesManifestDefaults(family) {
-            return manifestDefaults(modelPath: modelPath)?.cfg ?? 1.0
-        }
-        return 1.0
-    }
-
-    private func manifestDefaultSigmaShift(modelPath: String?) -> Double? {
-        guard let modelPath else { return nil }
-        return manifestDefaults(modelPath: modelPath)?.sigmaShift
-    }
-
-    private var usesTurboRecipe: Bool {
-        (try? ImageGenerate.parseLoRAArguments(input.loras, defaultScale: input.loraScale))?
-            .contains {
-                ManagedAdapterCatalog.spec(for: $0.reference)?.id
-                    == ManagedAdapterCatalog.flux2DevTurboEightStepID
-            } == true
-    }
-
-    private func resolvedSigmas() -> [Float]? {
-        if let parsed = try? ImageGenerate.parseSigmaList(input.sigmaList) {
-            return parsed
-        }
-        return usesTurboRecipe ? Flux2DevTurboRecipe.sigmas : nil
-    }
-
-    private func manifestDefaults(modelPath: String?) -> MereRunModelManifest.Defaults? {
-        guard let modelPath else { return nil }
-        return try? MereRunModelManifest
-            .loadRequired(from: URL(fileURLWithPath: modelPath), fileManager: fileManager)
-            .defaults
-    }
-
-    private func inputMode(family: MereRunModelManifest.Family?) -> String {
-        let hasInput = input.input != nil
-        let hasReferences = !input.referenceImages.isEmpty
-        guard hasInput || hasReferences else { return "text_to_image" }
-        if family == .klein || family == .senseNova {
-            return "reference_image"
-        }
-        if hasInput && hasReferences {
-            return "image_to_image_with_references"
-        }
-        if hasInput {
-            return "image_to_image"
-        }
-        return "reference_image"
-    }
-
-    private static func familyUsesManifestDefaults(_ family: MereRunModelManifest.Family) -> Bool {
-        family == .hidream || family == .krea || family == .qwen || family == .ideogram
-            || family == .senseNova || family == .klein || family == .flux1
-    }
-
-    private static func supportsImageGeneration(_ manifest: MereRunModelManifest) -> Bool {
-        if manifest.family == .qwen {
-            return manifest.engine == .qwenImageEdit
-        }
-        return supportedImageFamilies.contains(manifest.family)
-    }
-
-    private static let supportedImageFamilies: Set<MereRunModelManifest.Family?> = [
-        .flux1,
-        .klein,
-        .zimage,
-        .hidream,
-        .krea,
-        .ideogram,
-        .senseNova,
-    ]
 }

--- a/Sources/MereRunCLI/Support/README.md
+++ b/Sources/MereRunCLI/Support/README.md
@@ -7,7 +7,13 @@ Shared helpers for the public command surface.
 - `TerminalMarkdownPresentation.swift` and `TerminalMarkdownStream.swift`:
   safe, append-only Markdown presentation for interactive token streams while
   preserving raw piped output.
-- `BuiltinTools.swift`: local tool execution guardrails.
+- `BuiltinTools.swift`: local tool authorization and execution policy.
+- `BoundedProcessRunner.swift`: concurrent output drainage, bounded capture,
+  monotonic deadlines, and cancellation cleanup for approved shell tools and
+  code benchmark sandboxes.
+- `APIImageGeneration.swift`: API v1 compatibility settings for the Core image
+  operation. `ImageGenerationPreflight.swift` presents the same Core resolver's
+  diagnostics as an observational report.
 - `MachineInferenceAdmission.swift`: crash-safe weighted admission shared by
   heavyweight CLI and API-server processes on one machine.
 

--- a/Sources/MereRunContract/CommandCapabilityContract.swift
+++ b/Sources/MereRunContract/CommandCapabilityContract.swift
@@ -1566,7 +1566,9 @@ public enum MereRunCapabilityCatalog {
                 flag: "--compose", label: "Compose with a chat model", kind: .boolean, group: Group.prompt, tier: .expert
             ),
             .init(
-                flag: "--composer-model", label: "Composer model", kind: .string, defaultValue: "text-chat-gemma4-12b-4bit",
+                // Defaults to the hardware-aware chat model the CLI picks for the
+                // current machine, so the catalog advertises no fixed value.
+                flag: "--composer-model", label: "Composer model", kind: .string,
                 group: Group.modelAndAdapters, tier: .expert
             ),
             .init(

--- a/Sources/MereRunContract/CommandCapabilityContract.swift
+++ b/Sources/MereRunContract/CommandCapabilityContract.swift
@@ -49,12 +49,27 @@ public struct MereRunCapabilityArgument: Codable, Equatable, Sendable {
     public let label: String
     public let kind: MereRunCapabilityValueKind
     public let required: Bool
+    public let repeatable: Bool
 
-    public init(name: String, label: String, kind: MereRunCapabilityValueKind, required: Bool) {
+    public init(name: String, label: String, kind: MereRunCapabilityValueKind, required: Bool, repeatable: Bool = false) {
         self.name = name
         self.label = label
         self.kind = kind
         self.required = required
+        self.repeatable = repeatable
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case name, label, kind, required, repeatable
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        name = try container.decode(String.self, forKey: .name)
+        label = try container.decode(String.self, forKey: .label)
+        kind = try container.decode(MereRunCapabilityValueKind.self, forKey: .kind)
+        required = try container.decode(Bool.self, forKey: .required)
+        repeatable = try container.decodeIfPresent(Bool.self, forKey: .repeatable) ?? false
     }
 }
 
@@ -484,6 +499,18 @@ public enum MereRunCapabilityCatalog {
         title: "Chat",
         summary: "Run local chat, vision, JSON, LoRA, reasoning, and tool workflows.",
         options: [
+            .init(
+                flag: "--audio", label: "Audio", kind: .file, group: Group.inputs, tier: .expert
+            ),
+            .init(
+                flag: "--video", label: "Video", kind: .file, group: Group.inputs, tier: .expert
+            ),
+            .init(
+                flag: "--seed", label: "Seed", kind: .integer, group: Group.sampling, tier: .expert
+            ),
+            .init(
+                flag: "--show-unmasking", label: "Show canvas drafts", kind: .boolean, group: Group.run, tier: .expert
+            ),
             .init(flag: "--prompt", label: "Prompt", kind: .string, required: true, group: Group.prompt, tier: .essential),
             .init(flag: "--image", label: "Image", kind: .file, group: Group.inputs, tier: .standard),
             .init(flag: "--system", label: "System prompt", kind: .string, group: Group.prompt, tier: .standard),
@@ -632,7 +659,7 @@ public enum MereRunCapabilityCatalog {
         title: "Embeddings",
         summary: "Generate native Qwen3 text embeddings.",
         arguments: [
-            .init(name: "texts", label: "Texts", kind: .string, required: true)
+            .init(name: "texts", label: "Texts", kind: .string, required: true, repeatable: true)
         ],
         options: [
             .init(flag: "--model", label: "Model", kind: .string),
@@ -649,7 +676,7 @@ public enum MereRunCapabilityCatalog {
         title: "Anonymize",
         summary: "Detect and redact PII with the native OpenAI Privacy Filter.",
         arguments: [
-            .init(name: "texts", label: "Texts", kind: .string, required: false)
+            .init(name: "texts", label: "Texts", kind: .string, required: false, repeatable: true)
         ],
         options: [
             .init(flag: "--model", label: "Model", kind: .string),
@@ -668,6 +695,12 @@ public enum MereRunCapabilityCatalog {
         title: "Train text LoRA",
         summary: "Train a native text LoRA from OpenAI-style chat SFT JSONL.",
         options: [
+            .init(
+                flag: "--resume-from", label: "Resume checkpoint", kind: .file, group: Group.inputs, tier: .expert
+            ),
+            .init(
+                flag: "--resume-step", label: "Resume step", kind: .integer, group: Group.run, tier: .expert
+            ),
             .init(flag: "--data", label: "Dataset", kind: .file, required: true),
             .init(flag: "--output", label: "Output", kind: .file, required: true),
             .init(flag: "--model", label: "Base model", kind: .string),
@@ -697,6 +730,9 @@ public enum MereRunCapabilityCatalog {
         title: "Generate and edit images",
         summary: "Generate, transform, or personalize images with references, structured prompts, and LoRAs.",
         options: [
+            .init(
+                flag: "--sigmas", label: "Sigma schedule", kind: .string, group: Group.sampling, tier: .expert
+            ),
             .init(flag: "--prompt", label: "Prompt", kind: .string, required: true, group: Group.prompt, tier: .essential),
             .init(flag: "--negative-prompt", label: "Negative prompt", kind: .string, group: Group.prompt, tier: .standard),
             .init(
@@ -766,7 +802,7 @@ public enum MereRunCapabilityCatalog {
                 flag: "--structured-prompt-output", label: "Structured prompt output", kind: .file,
                 group: Group.prompt, tier: .expert, dependsOn: "--structured-prompt"
             ),
-            .init(flag: "--lora", label: "LoRA", kind: .file, group: Group.modelAndAdapters, tier: .standard),
+            .init(flag: "--lora", label: "LoRA", kind: .file, repeatable: true, group: Group.modelAndAdapters, tier: .standard),
             .init(
                 flag: "--lora-scale", label: "LoRA scale", kind: .number,
                 defaultValue: "1.0", group: Group.modelAndAdapters, tier: .standard,
@@ -1017,7 +1053,8 @@ public enum MereRunCapabilityCatalog {
         command: ["vision", "inspect"],
         title: "Inspect image",
         summary: "Describe or answer questions about an image with a local VLM.",
-        arguments: [.init(name: "image", label: "Image", kind: .file, required: true)],
+        arguments: [.init(name: "image", label: "Image", kind: .file, required: true),
+            .init(name: "prompt-words", label: "Prompt words", kind: .string, required: false, repeatable: true)],
         options: [
             .init(flag: "--prompt", label: "Prompt", kind: .string, group: Group.prompt, tier: .essential),
             .init(flag: "--model", label: "Model", kind: .string, group: Group.modelAndAdapters, tier: .essential),
@@ -1063,7 +1100,7 @@ public enum MereRunCapabilityCatalog {
         command: ["vision", "caption"],
         title: "Caption images",
         summary: "Generate training-friendly captions for one or more images.",
-        arguments: [.init(name: "images", label: "Images", kind: .file, required: true)],
+        arguments: [.init(name: "images", label: "Images", kind: .file, required: true, repeatable: true)],
         options: [
             .init(flag: "--model", label: "Model", kind: .string, group: Group.modelAndAdapters, tier: .essential),
             .init(flag: "--output-dir", label: "Output directory", kind: .directory, group: Group.output, tier: .standard),
@@ -1092,7 +1129,7 @@ public enum MereRunCapabilityCatalog {
         command: ["vision", "ocr"],
         title: "OCR",
         summary: "Extract text with native LightOn/Infinity or external GLM/Infinity runtimes.",
-        arguments: [.init(name: "images", label: "Images", kind: .file, required: true)],
+        arguments: [.init(name: "images", label: "Images", kind: .file, required: true, repeatable: true)],
         options: [
             .init(
                 flag: "--backend", label: "Backend", kind: .choice, choices: ["lighton", "glm", "infinity"],
@@ -1334,7 +1371,7 @@ public enum MereRunCapabilityCatalog {
         command: ["vision", "face", "batch"],
         title: "Batch faces",
         summary: "Analyze many images in one warm face session.",
-        arguments: [.init(name: "images", label: "Images", kind: .file, required: false)],
+        arguments: [.init(name: "images", label: "Images", kind: .file, required: false, repeatable: true)],
         options: [
             .init(flag: "--input-list", label: "Input list", kind: .file),
             .init(flag: "--model", label: "Model", kind: .string),
@@ -1432,7 +1469,7 @@ public enum MereRunCapabilityCatalog {
         command: ["vision", "geometry-multiview"],
         title: "Multi-view geometry",
         summary: "Solve relative geometry, confidence, and cameras from ordered views.",
-        arguments: [.init(name: "images", label: "Images", kind: .file, required: true)],
+        arguments: [.init(name: "images", label: "Images", kind: .file, required: true, repeatable: true)],
         options: [
             .init(flag: "--output", label: "Output directory", kind: .directory),
             .init(flag: "--model", label: "Model", kind: .string),
@@ -1499,7 +1536,7 @@ public enum MereRunCapabilityCatalog {
             .init(flag: "--prompt-enhancer-model", label: "Prompt enhancer", kind: .string),
             .init(flag: "--prompt-enhancer-model-root", label: "Prompt enhancer root", kind: .directory),
             .init(flag: "--duration", label: "Duration", kind: .number),
-            .init(flag: "--auto-duration", label: "Auto duration range", kind: .string),
+            .init(flag: "--auto-duration", label: "Auto duration range", kind: .string, repeatable: true),
             .init(flag: "--num-frames", label: "Video-clock frames", kind: .integer),
             .init(flag: "--fps", label: "Video-clock rate", kind: .integer),
             .init(flag: "--steps", label: "Denoising steps", kind: .integer),
@@ -1525,6 +1562,80 @@ public enum MereRunCapabilityCatalog {
             .init(name: "caption", label: "Music prompt", kind: .string, required: true)
         ],
         options: [
+            .init(
+                flag: "--compose", label: "Compose with a chat model", kind: .boolean, group: Group.prompt, tier: .expert
+            ),
+            .init(
+                flag: "--composer-model", label: "Composer model", kind: .string, defaultValue: "text-chat-gemma4-12b-4bit",
+                group: Group.modelAndAdapters, tier: .expert
+            ),
+            .init(
+                flag: "--composer-model-root", label: "Composer model root", kind: .directory,
+                group: Group.modelAndAdapters, tier: .expert
+            ),
+            .init(
+                flag: "--require-composer-installed", label: "Require installed composer", kind: .boolean,
+                group: Group.modelAndAdapters, tier: .expert
+            ),
+            .init(
+                flag: "--composition-output", label: "Composition output", kind: .file, group: Group.output, tier: .expert
+            ),
+            .init(
+                flag: "--lyrics-preflight", label: "Lyric duration checks", kind: .choice,
+                choices: ["off", "warn", "strict"], defaultValue: "warn", group: Group.prompt, tier: .expert
+            ),
+            .init(
+                flag: "--minimum-duration", label: "Minimum duration", kind: .number, group: Group.sampling, tier: .expert
+            ),
+            .init(
+                flag: "--min-frames", label: "Minimum acoustic frames", kind: .integer, group: Group.sampling,
+                tier: .expert
+            ),
+            .init(
+                flag: "--max-frames", label: "Maximum acoustic frames", kind: .integer, group: Group.sampling,
+                tier: .expert
+            ),
+            .init(
+                flag: "--sample-rate", label: "Sample rate", kind: .integer, group: Group.output, tier: .expert
+            ),
+            .init(
+                flag: "--memory-mode", label: "Memory mode", kind: .choice, choices: ["staged", "resident"],
+                group: Group.run, tier: .expert
+            ),
+            .init(
+                flag: "--performance-mode", label: "Performance mode", kind: .choice,
+                choices: ["reference", "optimized", "q8", "q4", "q8-lm", "q4-lm"], group: Group.run, tier: .expert
+            ),
+            .init(
+                flag: "--sampling-tier", label: "Sampling tier", kind: .choice, choices: ["quality", "fast", "draft"],
+                group: Group.sampling, tier: .expert
+            ),
+            .init(
+                flag: "--flow-strategy", label: "Flow strategy", kind: .choice, choices: ["sequential", "overlap-average"],
+                group: Group.sampling, tier: .expert
+            ),
+            .init(
+                flag: "--flow-solver", label: "Flow solver", kind: .choice, choices: ["euler", "ab2"],
+                group: Group.sampling, tier: .expert
+            ),
+            .init(
+                flag: "--ar-cfg-frames", label: "Autoregressive CFG frames", kind: .integer, group: Group.sampling,
+                tier: .expert
+            ),
+            .init(
+                flag: "--flow-cfg-end", label: "Flow CFG cutoff", kind: .number, group: Group.sampling, tier: .expert
+            ),
+            .init(
+                flag: "--seed-strategy", label: "Seed strategy", kind: .choice, choices: ["legacy", "stage-separated-v1"],
+                group: Group.sampling, tier: .expert
+            ),
+            .init(
+                flag: "--profile-output", label: "Profile output", kind: .file, group: Group.output, tier: .expert
+            ),
+            .init(
+                flag: "--no-lm-caption-rewrite", label: "Preserve input caption", kind: .boolean, group: Group.prompt,
+                tier: .expert
+            ),
             .init(flag: "--lyrics", label: "Lyrics", kind: .string, group: Group.prompt, tier: .standard),
             .init(flag: "--lyrics-file", label: "Lyrics file", kind: .file, group: Group.prompt, tier: .expert),
             .init(flag: "--instrumental", label: "Instrumental", kind: .boolean, group: Group.prompt, tier: .standard),
@@ -1887,6 +1998,7 @@ public enum MereRunCapabilityCatalog {
             .init(name: "prompt", label: "Prompt", kind: .string, required: false)
         ],
         options: [
+            .init(flag: "--play", label: "Play audio", kind: .boolean),
             .init(flag: "--model", label: "Model", kind: .string),
             .init(flag: "--duration", label: "Duration", kind: .number),
             .init(flag: "--output", label: "Output", kind: .file),
@@ -1925,7 +2037,7 @@ public enum MereRunCapabilityCatalog {
             .init(flag: "--model", label: "Model", kind: .string),
             .init(flag: "--dataset", label: "Dataset", kind: .file, required: true),
             .init(flag: "--output", label: "Output", kind: .file, required: true),
-            .init(flag: "--kind", label: "Adapter kind", kind: .choice, choices: ["lora", "lokr"]),
+            .init(flag: "--kind", label: "Adapter kind", kind: .choice, choices: ["auto", "lora", "lokr"]),
             .init(flag: "--rank", label: "Rank", kind: .integer),
             .init(flag: "--alpha", label: "Alpha", kind: .number),
             .init(flag: "--factor", label: "LoKr factor", kind: .integer),
@@ -1949,6 +2061,14 @@ public enum MereRunCapabilityCatalog {
         title: "Serve resident music",
         summary: "Keep ACE-Step, its language model, and adapter stack warm behind a local API.",
         options: [
+            .init(
+                flag: "--memory-mode", label: "Memory mode", kind: .choice, choices: ["staged", "resident"],
+                group: Group.run, tier: .expert
+            ),
+            .init(
+                flag: "--performance-mode", label: "Performance mode", kind: .choice,
+                choices: ["reference", "optimized", "q8", "q4", "q8-lm", "q4-lm"], group: Group.run, tier: .expert
+            ),
             .init(flag: "--host", label: "Host", kind: .string),
             .init(flag: "--port", label: "Port", kind: .integer),
             .init(flag: "--model", label: "Model", kind: .string),
@@ -1975,6 +2095,53 @@ public enum MereRunCapabilityCatalog {
             .init(name: "prompt", label: "Prompt", kind: .string, required: true)
         ],
         options: [
+            .init(
+                flag: "--variant", label: "Compatibility variant", kind: .choice, choices: ["unified-av", "distilled"],
+                group: Group.sampling, tier: .expert
+            ),
+            .init(
+                flag: "--ltx-transformer-execution", label: "LTX transformer execution", kind: .choice,
+                choices: ["eager", "compiled"], defaultValue: "eager", group: Group.run, tier: .expert
+            ),
+            .init(
+                flag: "--ltx-guidance-projection-cache", label: "LTX guidance projection cache", kind: .choice,
+                choices: ["automatic", "disabled", "enabled"], defaultValue: "disabled", group: Group.run, tier: .expert
+            ),
+            .init(
+                flag: "--ltx-teacache", label: "Enable LTX TeaCache", kind: .boolean, group: Group.run, tier: .expert
+            ),
+            .init(
+                flag: "--ltx-teacache-threshold", label: "LTX TeaCache threshold", kind: .number, group: Group.run,
+                tier: .expert
+            ),
+            .init(
+                flag: "--ltx-teacache-calibration-output", label: "LTX TeaCache calibration output", kind: .file,
+                group: Group.output, tier: .expert
+            ),
+            .init(
+                flag: "--h3-render-width", label: "H3 render width", kind: .integer, group: Group.output, tier: .expert
+            ),
+            .init(
+                flag: "--h3-render-height", label: "H3 render height", kind: .integer, group: Group.output, tier: .expert
+            ),
+            .init(
+                flag: "--h3-adapter", label: "H3 adapter", kind: .string, group: Group.modelAndAdapters, tier: .expert
+            ),
+            .init(
+                flag: "--h3-adapter-strength", label: "H3 adapter strength", kind: .number, defaultValue: "1.0",
+                group: Group.modelAndAdapters, tier: .expert
+            ),
+            .init(
+                flag: "--h3-frame", label: "H3 timed frame", kind: .string, repeatable: true, group: Group.inputs,
+                tier: .expert
+            ),
+            .init(
+                flag: "--h3-window-frames", label: "H3 window frames", kind: .integer, group: Group.sampling, tier: .expert
+            ),
+            .init(
+                flag: "--h3-window-overlap", label: "H3 window overlap", kind: .integer, defaultValue: "18",
+                group: Group.sampling, tier: .expert
+            ),
             .init(flag: "--output", label: "Output", kind: .file, group: Group.output, tier: .standard),
             .init(flag: "--model", label: "Model", kind: .string, group: Group.modelAndAdapters, tier: .essential),
             .init(
@@ -1992,7 +2159,7 @@ public enum MereRunCapabilityCatalog {
                 group: Group.output, tier: .essential
             ),
             .init(flag: "--model-root", label: "Model root", kind: .directory, group: Group.modelAndAdapters, tier: .expert),
-            .init(flag: "--auto-duration", label: "Auto duration range", kind: .string, group: Group.sampling, tier: .expert),
+            .init(flag: "--auto-duration", label: "Auto duration range", kind: .string, repeatable: true, group: Group.sampling, tier: .expert),
             .init(
                 flag: "--video-decoder", label: "Video decoder", kind: .choice, choices: ["diffusion", "convolutional"],
                 group: Group.run, tier: .expert
@@ -2110,7 +2277,7 @@ public enum MereRunCapabilityCatalog {
                 defaultValue: "standard", group: Group.sampling, tier: .expert
             ),
             .init(
-                flag: "--ltx-pipeline", label: "LTX pipeline", kind: .choice, choices: ["two-stage", "dev-one-stage"],
+                flag: "--ltx-pipeline", label: "LTX pipeline", kind: .choice, choices: ["two-stage", "keyframe-interpolation", "dev-one-stage"],
                 defaultValue: "two-stage", group: Group.sampling, tier: .expert
             ),
             .init(
@@ -2118,8 +2285,8 @@ public enum MereRunCapabilityCatalog {
                 choices: ["euler", "res2s", "euler-ancestral", "cfg-plus-plus", "gradient-estimating-euler"],
                 group: Group.sampling, tier: .expert
             ),
-            .init(flag: "--ltx-sigmas", label: "Stage one sigmas", kind: .string, group: Group.sampling, tier: .expert),
-            .init(flag: "--ltx-stage-2-sigmas", label: "Stage two sigmas", kind: .string, group: Group.sampling, tier: .expert),
+            .init(flag: "--ltx-sigmas", label: "Stage one sigmas", kind: .string, repeatable: true, group: Group.sampling, tier: .expert),
+            .init(flag: "--ltx-stage-2-sigmas", label: "Stage two sigmas", kind: .string, repeatable: true, group: Group.sampling, tier: .expert),
             .init(
                 flag: "--distilled-lora-strength-stage-1", label: "Stage one distilled strength", kind: .number,
                 group: Group.sampling, tier: .expert, range: .init(min: 0, max: 1, step: 0.05)
@@ -2265,7 +2432,7 @@ public enum MereRunCapabilityCatalog {
             .init(flag: "--prompt-enhancer-model", label: "Prompt enhancer", kind: .string),
             .init(flag: "--prompt-enhancer-model-root", label: "Prompt enhancer root", kind: .directory),
             .init(flag: "--steps", label: "Denoising steps", kind: .integer),
-            .init(flag: "--sigmas", label: "Sigma schedule", kind: .string),
+            .init(flag: "--sigmas", label: "Sigma schedule", kind: .string, repeatable: true),
             .init(flag: "--lora", label: "LTX LoRA", kind: .string, repeatable: true),
             .init(flag: "--video-cfg-guidance-scale", label: "Video CFG", kind: .number),
             .init(flag: "--video-stg-scale", label: "Video STG", kind: .number),
@@ -2309,8 +2476,8 @@ public enum MereRunCapabilityCatalog {
             .init(flag: "--height", label: "Height", kind: .integer),
             .init(flag: "--seed", label: "Seed", kind: .integer),
             .init(flag: "--image-conditioning", label: "Timed image guide", kind: .string, repeatable: true),
-            .init(flag: "--stage-1-sigmas", label: "Stage one sigmas", kind: .string),
-            .init(flag: "--stage-2-sigmas", label: "Stage two sigmas", kind: .string),
+            .init(flag: "--stage-1-sigmas", label: "Stage one sigmas", kind: .string, repeatable: true),
+            .init(flag: "--stage-2-sigmas", label: "Stage two sigmas", kind: .string, repeatable: true),
             .init(flag: "--enhance-prompt", label: "Enhance prompt", kind: .boolean),
             .init(flag: "--prompt-enhancer-model", label: "Prompt enhancer", kind: .string),
             .init(flag: "--prompt-enhancer-model-root", label: "Prompt enhancer root", kind: .directory),
@@ -2335,7 +2502,7 @@ public enum MereRunCapabilityCatalog {
             .init(flag: "--driving-mask", label: "Driving mask", kind: .file, required: true),
             .init(flag: "--additional-reference", label: "Additional reference", kind: .file, repeatable: true),
             .init(flag: "--additional-reference-mask", label: "Additional reference mask", kind: .file, repeatable: true),
-            .init(flag: "--output", label: "Output", kind: .file, required: true),
+            .init(flag: "--output", label: "Output", kind: .file),
             .init(flag: "--model", label: "Model", kind: .string),
             .init(flag: "--model-root", label: "Model root", kind: .directory),
             .init(flag: "--mode", label: "Mode", kind: .choice, choices: ["animation", "replacement"]),
@@ -2395,7 +2562,7 @@ public enum MereRunCapabilityCatalog {
             .init(flag: "--schedule", label: "Schedule", kind: .choice, choices: ["nvidia", "published-karras"]),
             .init(flag: "--seed", label: "Seed", kind: .integer),
             .init(flag: "--fps", label: "Frames per second", kind: .integer),
-            .init(flag: "--condition-latent-frame", label: "Conditioned frames", kind: .string),
+            .init(flag: "--condition-latent-frame", label: "Conditioned frames", kind: .string, repeatable: true),
             .init(flag: "--keep-video-tail", label: "Keep video tail", kind: .boolean),
             .init(flag: "--action-domain", label: "Action domain", kind: .string),
             .init(flag: "--action-file", label: "Action file", kind: .file),
@@ -2455,6 +2622,29 @@ public enum MereRunCapabilityCatalog {
         title: "Resident LTX session",
         summary: "Keep an LTX 2.3 runtime resident for JSONL generation requests.",
         options: [
+            .init(
+                flag: "--video-decoder", label: "Video decoder", kind: .choice, choices: ["convolutional", "diffusion"],
+                group: Group.modelAndAdapters, tier: .expert
+            ),
+            .init(
+                flag: "--ltx-transformer-execution", label: "LTX transformer execution", kind: .choice,
+                choices: ["eager", "compiled"], defaultValue: "eager", group: Group.run, tier: .expert
+            ),
+            .init(
+                flag: "--ltx-guidance-projection-cache", label: "LTX guidance projection cache", kind: .choice,
+                choices: ["automatic", "disabled", "enabled"], defaultValue: "disabled", group: Group.run, tier: .expert
+            ),
+            .init(
+                flag: "--ltx-teacache", label: "Enable LTX TeaCache", kind: .boolean, group: Group.run, tier: .expert
+            ),
+            .init(
+                flag: "--ltx-teacache-threshold", label: "LTX TeaCache threshold", kind: .number, group: Group.run,
+                tier: .expert
+            ),
+            .init(
+                flag: "--prompt-cache-capacity", label: "Prompt cache capacity", kind: .integer, defaultValue: "8",
+                group: Group.run, tier: .expert
+            ),
             .init(flag: "--model", label: "Model", kind: .string),
             .init(flag: "--model-root", label: "Model root", kind: .directory),
             .init(flag: "--quiet", label: "Quiet", kind: .boolean)
@@ -2482,6 +2672,9 @@ public enum MereRunCapabilityCatalog {
             .init(name: "target", label: "Adapter id", kind: .string, required: true)
         ],
         options: [
+            .init(
+                flag: "--accept-license", label: "Accept adapter terms", kind: .boolean, group: Group.run, tier: .expert
+            ),
             .init(flag: "--force", label: "Replace install", kind: .boolean),
             .init(flag: "--quiet", label: "Quiet", kind: .boolean)
         ],
@@ -2584,6 +2777,38 @@ public enum MereRunCapabilityCatalog {
         title: "World session",
         summary: "Serve one warm DreamX or Cosmos3 conditioned-video world session.",
         options: [
+            .init(
+                flag: "--disable-scene-memory", label: "Disable scene memory", kind: .boolean, group: Group.run,
+                tier: .expert
+            ),
+            .init(
+                flag: "--scene-memory-strength", label: "Scene memory strength", kind: .number, defaultValue: "0.08",
+                group: Group.sampling, tier: .expert
+            ),
+            .init(
+                flag: "--scene-memory-max-frames", label: "Scene memory frame limit", kind: .integer, defaultValue: "96",
+                group: Group.run, tier: .expert
+            ),
+            .init(
+                flag: "--scene-memory-minimum-gap", label: "Scene memory minimum gap", kind: .integer, defaultValue: "3",
+                group: Group.sampling, tier: .expert
+            ),
+            .init(
+                flag: "--scene-memory-max-yaw", label: "Scene memory maximum yaw", kind: .number, defaultValue: "2.0",
+                group: Group.sampling, tier: .expert
+            ),
+            .init(
+                flag: "--scene-memory-max-translation", label: "Scene memory maximum translation", kind: .number,
+                defaultValue: "0.1", group: Group.sampling, tier: .expert
+            ),
+            .init(
+                flag: "--scene-memory-exact-yaw", label: "Scene restore yaw tolerance", kind: .number, defaultValue: "0.01",
+                group: Group.sampling, tier: .expert
+            ),
+            .init(
+                flag: "--scene-memory-exact-translation", label: "Scene restore translation tolerance", kind: .number,
+                defaultValue: "0.001", group: Group.sampling, tier: .expert
+            ),
             .init(flag: "--host", label: "Host", kind: .string),
             .init(flag: "--port", label: "Port", kind: .integer),
             .init(flag: "--api-key", label: "API key", kind: .string),
@@ -2617,6 +2842,16 @@ public enum MereRunCapabilityCatalog {
         title: "Quality gate",
         summary: "Run installed-model correctness, determinism, and performance checks.",
         options: [
+            .init(
+                flag: "--require-all", label: "Require selected models", kind: .boolean, group: Group.run, tier: .expert
+            ),
+            .init(
+                flag: "--all-installed", label: "Check all installed models", kind: .boolean, group: Group.run,
+                tier: .expert
+            ),
+            .init(
+                flag: "--skip-model", label: "Quarantined models", kind: .string, group: Group.run, tier: .expert
+            ),
             .init(flag: "--suite", label: "Suites", kind: .string),
             .init(flag: "--update-baselines", label: "Update baselines", kind: .boolean),
             .init(flag: "--strict-perf", label: "Strict performance", kind: .boolean),
@@ -2649,7 +2884,7 @@ public enum MereRunCapabilityCatalog {
             .init(name: "pack", label: "Evaluation pack", kind: .directory, required: true)
         ],
         options: [
-            .init(flag: "--model", label: "Model slot binding", kind: .string, required: true, repeatable: true),
+            .init(flag: "--model", label: "Model slot binding", kind: .string, repeatable: true),
             .init(flag: "--adapter", label: "Adapter slot binding", kind: .string, repeatable: true),
             .init(flag: "--trials", label: "Trials", kind: .integer),
             .init(flag: "--max-tokens", label: "Max tokens", kind: .integer),
@@ -2755,9 +2990,18 @@ public enum MereRunCapabilityCatalog {
                 label: "Engine",
                 kind: .choice,
                 choices: [
-                    "text-code", "text-chat-klein", "text-chat-gemma4", "text-chat-q36",
-                    "text-chat-q35", "text-chat-laguna", "text-chat-lfm2",
-                    "text-chat-deepseek-v4-flash"
+                    "text-code",
+                    "text-chat-klein",
+                    "text-chat-gemma4",
+                    "text-chat-diffusiongemma",
+                    "text-chat-laguna",
+                    "text-chat-q36",
+                    "text-chat-q35",
+                    "text-chat-lfm2",
+                    "text-chat-deepseek-v4-flash",
+                    "text-chat-muse-glimmer",
+                    "text-chat-nemotron-h",
+                    "text-chat-nemotron-omni"
                 ]
             ),
             .init(flag: "--clear-engine", label: "Clear engine", kind: .boolean),
@@ -2839,6 +3083,16 @@ public enum MereRunCapabilityCatalog {
         title: "Start setup agent",
         summary: "Start a guided Pi session against the local API.",
         options: [
+            .init(
+                flag: "--pi-argument", label: "Pi argument", kind: .string, repeatable: true, group: Group.run,
+                tier: .expert
+            ),
+            .init(
+                flag: "--working-directory", label: "Working directory", kind: .directory, group: Group.run, tier: .expert
+            ),
+            .init(
+                flag: "--inline", label: "Run in active terminal", kind: .boolean, group: Group.run, tier: .expert
+            ),
             .init(flag: "--host", label: "API host", kind: .string),
             .init(flag: "--port", label: "API port", kind: .integer),
             .init(flag: "--pi-path", label: "Pi executable", kind: .file),
@@ -2886,6 +3140,9 @@ public enum MereRunCapabilityCatalog {
             .init(name: "target", label: "Model", kind: .string, required: false)
         ],
         options: [
+            .init(
+                flag: "--cache-dir", label: "Download cache", kind: .directory, group: Group.output, tier: .expert
+            ),
             .init(flag: "--all", label: "All models", kind: .boolean),
             .init(flag: "--force", label: "Force download", kind: .boolean),
             .init(flag: "--quiet", label: "Quiet", kind: .boolean),
@@ -2934,6 +3191,13 @@ public enum MereRunCapabilityCatalog {
         title: "Repair manifests",
         summary: "Restore missing manifests for known local models.",
         options: [
+            .init(
+                flag: "--accept-model-license", label: "Accept model terms", kind: .boolean, group: Group.run,
+                tier: .expert
+            ),
+            .init(
+                flag: "--model", label: "Model", kind: .string, group: Group.modelAndAdapters, tier: .expert
+            ),
             .init(flag: "--dry-run", label: "Dry run", kind: .boolean),
             .init(flag: "--json", label: "JSON", kind: .boolean)
         ],
@@ -2949,6 +3213,10 @@ public enum MereRunCapabilityCatalog {
             .init(name: "target", label: "Model or local root", kind: .string, required: true)
         ],
         options: [
+            .init(
+                flag: "--text-encoder-only", label: "Optimize text encoder only", kind: .boolean, group: Group.run,
+                tier: .expert
+            ),
             .init(flag: "--force", label: "Replace cache", kind: .boolean),
             .init(flag: "--output", label: "Standalone checkpoint", kind: .directory),
             .init(flag: "--json", label: "JSON", kind: .boolean)
@@ -2962,6 +3230,22 @@ public enum MereRunCapabilityCatalog {
         title: "Qwen-family MTP benchmark",
         summary: "Run prompt, decode-length, and temperature matrices for Qwen-family MTP.",
         options: [
+            .init(
+                flag: "--repetitions", label: "Repetitions", kind: .integer, defaultValue: "1", group: Group.run,
+                tier: .expert
+            ),
+            .init(
+                flag: "--warmups", label: "Warmup requests", kind: .integer, defaultValue: "1", group: Group.run,
+                tier: .expert
+            ),
+            .init(
+                flag: "--warmup-tokens", label: "Warmup tokens", kind: .integer, defaultValue: "16", group: Group.run,
+                tier: .expert
+            ),
+            .init(
+                flag: "--variants", label: "Variants", kind: .string, defaultValue: "baseline,adaptive,forced",
+                group: Group.run, tier: .expert
+            ),
             .init(flag: "--model", label: "Model", kind: .string),
             .init(flag: "--model-root", label: "Model root", kind: .directory),
             .init(flag: "--prompt", label: "Prompt", kind: .string),
@@ -3091,6 +3375,7 @@ public enum MereRunCapabilityCatalog {
             .init(name: "audio", label: "Audio", kind: .file, required: true)
         ],
         options: [
+            .init(flag: "--timestamps", label: "Include timestamps", kind: .boolean),
             .init(flag: "--output", label: "Output", kind: .file, group: Group.output, tier: .standard),
             .init(flag: "--model", label: "Model", kind: .string, group: Group.modelAndAdapters, tier: .standard),
             .init(
@@ -3335,6 +3620,16 @@ public enum MereRunCapabilityCatalog {
         summary: "Plan or execute an official plugin installation.",
         arguments: [.init(name: "id", label: "Plugin id", kind: .string, required: true)],
         options: [
+            .init(
+                flag: "--source", label: "Install from source", kind: .boolean, group: Group.run, tier: .expert
+            ),
+            .init(
+                flag: "--bundle-manifest", label: "Signed bundle manifest", kind: .string, group: Group.inputs,
+                tier: .expert
+            ),
+            .init(
+                flag: "--bundle-archive", label: "Signed bundle archive", kind: .file, group: Group.inputs, tier: .expert
+            ),
             .init(flag: "--catalog-url", label: "Catalog", kind: .string),
             .init(flag: "--channel", label: "Channel", kind: .string),
             .init(flag: "--yes", label: "Execute", kind: .boolean),
@@ -3406,6 +3701,12 @@ public enum MereRunCapabilityCatalog {
         title: "API server",
         summary: "Serve installed models through OpenAI-compatible local APIs.",
         options: [
+            .init(
+                flag: "--warmup", label: "Warm model before serving", kind: .boolean, group: Group.run, tier: .expert
+            ),
+            .init(
+                flag: "--no-warmup", label: "Skip model warmup", kind: .boolean, group: Group.run, tier: .expert
+            ),
             .init(flag: "--port", label: "Port", kind: .integer),
             .init(flag: "--host", label: "Host", kind: .string),
             .init(flag: "--model", label: "Model", kind: .string),
@@ -3441,7 +3742,7 @@ public enum MereRunCapabilityCatalog {
         title: "Offline guides",
         summary: "List or read CLI-owned offline workflow guides.",
         arguments: [
-            .init(name: "command-path", label: "Command path", kind: .string, required: false)
+            .init(name: "command-path", label: "Command path", kind: .string, required: false, repeatable: true)
         ],
         options: [
             .init(flag: "--list", label: "List topics", kind: .boolean),
@@ -3940,7 +4241,8 @@ public enum MereRunCapabilityCatalog {
         title: "Run plugin",
         summary: "Run an installed plugin without changing PATH.",
         arguments: [
-            .init(name: "entrypoint", label: "Entrypoint", kind: .string, required: true)
+            .init(name: "entrypoint", label: "Entrypoint", kind: .string, required: true),
+            .init(name: "arguments", label: "Plugin arguments", kind: .string, required: false, repeatable: true)
         ],
         options: [],
         output: .init(kind: .text)

--- a/Sources/MereRunContract/README.md
+++ b/Sources/MereRunContract/README.md
@@ -21,6 +21,12 @@ where the pipeline reports steps, `--progress-json`; the line shapes are
 documented on `MereRunCapabilityCatalog.resultReceiptExample` and
 `progressEventExample`.
 
+Positional arguments also expose `repeatable`. Earlier v1 documents that omit
+this field decode it as `false`. `capabilityPositionalsMatchArgumentParser`
+checks argument order, names, cardinality, and required values. Narrow, documented
+exceptions retain existing serialized keys and requirements enforced by command
+validation rather than by the parser.
+
 Each capability's `output` says what one successful run leaves behind. `kind`
 describes the run with no destination named: `text` prints to stdout, `service`
 runs until it is stopped, and `file` or `directory` always writes the artifact.
@@ -35,8 +41,9 @@ When extending the contract:
 
 - Add only public CLI capabilities that a shell needs to discover or invoke.
 - Only record a `default_value` when the CLI default is static; machine- or
-  model-specific defaults stay `nil`. `capabilityDefaultValuesMatchArgumentParserHelp`
-  checks every recorded default against the CLI help.
+  model-specific defaults stay `nil`. `capabilityOptionsMatchArgumentParser`
+  checks recorded defaults, cardinality, choices, aliases, and Boolean inversions
+  against the pinned parser metadata format.
 - Prefer typed enums for bounded choices shared by more than one target.
 - Preserve existing identifiers and serialized values. Bump the schema version
   when making a breaking catalog change.
@@ -46,3 +53,14 @@ When extending the contract:
 Contract tests live in `Tests/MereRunContractTests`, CLI serialization and help
 coverage in `Tests/MereRunCLITests`, and shell command-generation coverage in
 `apps/macos/StudioKitTests`.
+
+`CapabilityCatalogTests` walks the parser's complete public command tree. Every
+leaf is cataloged or has a documented command exemption; every displayed option
+group of a cataloged command is represented. Only the parser's built-in help and
+version flags are omitted. Long aliases share an option group; positive and
+negative Boolean forms each need a catalog entry. The adapter decodes version 0
+of ArgumentParser's help metadata and fails if that format changes.
+
+After changing options, regenerate the shell's derived constants with
+`./scripts/update-studio-command-flags.sh`. Command documentation inventory checks
+continue to read the live command declarations.

--- a/Sources/MereRunCore/ImageGenerationOperation.swift
+++ b/Sources/MereRunCore/ImageGenerationOperation.swift
@@ -1,0 +1,166 @@
+import Foundation
+
+public struct ImageGenerationOutcome: Sendable {
+    public let id: UUID
+    public let result: GenerationResult
+    public let modelID: String
+    public let backend: ImageGenerationBackend
+    /// Includes the actual seed and durable input paths, never temporary edit files.
+    public let effectiveRequest: GenerationRequest
+}
+
+public enum ImageGenerationEvent: Sendable {
+    case started(UUID)
+    case progress(UUID, GenerationProgress)
+    case succeeded(ImageGenerationOutcome)
+    case failed(UUID, ImageGenerationIssue)
+    case cancelled(UUID)
+}
+
+/// Owns the image operation's preparation, execution, and terminal result. The
+/// executor owns admission and runtime residency; this layer never acquires a
+/// second machine permit or unloads a runtime borrowed from a resident pool.
+public enum ImageGenerationOperation {
+    public typealias Executor = @Sendable (
+        ImageGenerationBackend, GenerationRequest, (@Sendable (GenerationProgress) -> Void)?
+    ) async throws -> GenerationResult
+
+    public static func execute(
+        _ plan: ImageGenerationPlan,
+        id: UUID = UUID(),
+        progressHandler: (@Sendable (GenerationProgress) -> Void)? = nil,
+        eventHandler: (@Sendable (ImageGenerationEvent) -> Void)? = nil,
+        executor: Executor = generate
+    ) async throws -> ImageGenerationOutcome {
+        eventHandler?(.started(id))
+        let progress: (@Sendable (GenerationProgress) -> Void)?
+        if progressHandler != nil || eventHandler != nil {
+            progress = { value in
+                progressHandler?(value)
+                eventHandler?(.progress(id, value))
+            }
+        } else {
+            progress = nil
+        }
+        do {
+            let outcome = try await perform(plan, id: id, progressHandler: progress, executor: executor)
+            eventHandler?(.succeeded(outcome))
+            return outcome
+        } catch is CancellationError {
+            eventHandler?(.cancelled(id))
+            throw CancellationError()
+        } catch {
+            let issue = error as? ImageGenerationIssue
+                ?? ImageGenerationIssue("generation_failed", error.localizedDescription)
+            eventHandler?(.failed(id, issue))
+            throw error
+        }
+    }
+
+    private static func perform(
+        _ plan: ImageGenerationPlan,
+        id: UUID,
+        progressHandler: (@Sendable (GenerationProgress) -> Void)?,
+        executor: Executor
+    ) async throws -> ImageGenerationOutcome {
+        try Task.checkCancellation()
+        // A preflight plan is observational. Recheck mutable inputs and adapters
+        // at execution; the owning runtime checks checkpoint integrity on load.
+        try ImageGenerationPlan.validateFiles(plan.options, fileManager: .default)
+        var request = plan.request
+        request.loras = try ImageGenerationPlan.resolveLoRAs(plan.options.loras, baseModelID: plan.manifest.id)
+        try FileManager.default.createDirectory(at: request.outputURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+
+        let preparation: ImageEditPreparation?
+        if plan.options.mask != nil || plan.options.outpaint != nil {
+            guard let input = plan.options.inputImage else {
+                throw ImageGenerationIssue("edit_input_missing", "Mask and outpaint require an input image.")
+            }
+            preparation = try ImageEditPreparation.make(
+                inputURL: input, maskURL: plan.options.mask, outpaint: plan.options.outpaint,
+                width: request.width, height: request.height, featherPixels: plan.options.maskFeather
+            )
+        } else {
+            preparation = nil
+        }
+        defer { preparation?.cleanup() }
+        if let preparation {
+            let conditioning = ImageGenerationConditioning.resolve(
+                family: plan.manifest.family, inputImage: preparation.generationInputURL,
+                referenceImages: plan.options.referenceImages, strength: plan.options.strength, policy: plan.policy
+            )
+            request.inputImage = conditioning.inputImage
+            request.referenceImages = conditioning.referenceImages
+            request.strength = conditioning.strength
+            request.referenceStrength = conditioning.referenceStrength
+        }
+        try Task.checkCancellation()
+        let result = try await executor(plan.backend, request, progressHandler)
+        try Task.checkCancellation()
+        try preparation?.finish(generatedURL: result.outputURL)
+        try Task.checkCancellation()
+        var effective = plan.request
+        effective.loras = request.loras
+        effective.seed = result.seed
+        return ImageGenerationOutcome(id: id, result: result, modelID: plan.manifest.id, backend: plan.backend, effectiveRequest: effective)
+    }
+
+    public static func generate(
+        backend: ImageGenerationBackend,
+        request: GenerationRequest,
+        progressHandler: (@Sendable (GenerationProgress) -> Void)?
+    ) async throws -> GenerationResult {
+        switch backend {
+        case .flux1:
+            let generator = Flux1Generator()
+            return try await withCleanup {
+                try await generator.generate(request, progressHandler: progressHandler)
+            } cleanup: { await generator.unload() }
+        case .flux2Klein:
+            let generator = Flux2KleinGenerator()
+            return try await withCleanup {
+                try await generator.generate(request, progressHandler: progressHandler)
+            } cleanup: { await generator.unload() }
+        case .zImageTurbo:
+            let generator = ZImageTurboGenerator()
+            return try await withCleanup {
+                try await generator.generate(request, progressHandler: progressHandler)
+            } cleanup: { await generator.unload() }
+        case .hiDreamO1:
+            let generator = HiDreamO1Generator()
+            defer { generator.unload() }
+            return try await generator.generate(request, progressHandler: progressHandler)
+        case .senseNovaU15:
+            let generator = SenseNovaU15Generator()
+            defer { generator.unload() }
+            return try await generator.generate(request, progressHandler: progressHandler)
+        case .krea2:
+            let generator = Krea2Generator()
+            defer { generator.unload() }
+            return try await generator.generate(request, progressHandler: progressHandler)
+        case .ideogram4:
+            let generator = Ideogram4Generator()
+            defer { generator.unload() }
+            return try await generator.generate(request, progressHandler: progressHandler)
+        case .qwenImageEdit:
+            let generator = QwenImageEditGenerator()
+            return try await withCleanup {
+                try await generator.generate(request, progressHandler: progressHandler)
+            } cleanup: { await generator.clearCache() }
+        }
+    }
+
+    private static func withCleanup(
+        operation: () async throws -> GenerationResult,
+        cleanup: () async -> Void
+    ) async throws -> GenerationResult {
+        do {
+            let result = try await operation()
+            await cleanup()
+            return result
+        } catch {
+            await cleanup()
+            throw error
+        }
+    }
+}

--- a/Sources/MereRunCore/ImageGenerationOptions.swift
+++ b/Sources/MereRunCore/ImageGenerationOptions.swift
@@ -1,0 +1,191 @@
+import Foundation
+
+/// User-supplied image settings before model defaults and adapter recipes are applied.
+public struct ImageGenerationOptions: Sendable, Hashable {
+    public var prompt: String
+    public var negativePrompt: String?
+    public var outputURL: URL
+    public var width: Int
+    public var height: Int
+    public var steps: Int?
+    public var guidanceScale: Double?
+    public var seed: UInt64?
+    public var inputImage: URL?
+    public var referenceImages: [URL]
+    public var strength: Double?
+    public var keepOriginalAspect: Bool
+    public var maxSequenceLength: Int
+    public var loras: [ImageLoRAReference]
+    public var sigmaShift: Float?
+    public var sigmas: [Float]?
+    public var kreaConditioningRebalance: Krea2ConditioningRebalance?
+    public var kreaBaseQuantizationBits: Int?
+    public var mask: URL?
+    public var outpaint: ImageOutpaintInsets?
+    public var maskFeather: Int
+
+    public init(
+        prompt: String,
+        negativePrompt: String? = nil,
+        outputURL: URL,
+        width: Int = 1024,
+        height: Int = 1024,
+        steps: Int? = nil,
+        guidanceScale: Double? = nil,
+        seed: UInt64? = nil,
+        inputImage: URL? = nil,
+        referenceImages: [URL] = [],
+        strength: Double? = nil,
+        keepOriginalAspect: Bool = false,
+        maxSequenceLength: Int = 512,
+        loras: [ImageLoRAReference] = [],
+        sigmaShift: Float? = nil,
+        sigmas: [Float]? = nil,
+        kreaConditioningRebalance: Krea2ConditioningRebalance? = nil,
+        kreaBaseQuantizationBits: Int? = nil,
+        mask: URL? = nil,
+        outpaint: ImageOutpaintInsets? = nil,
+        maskFeather: Int = 8
+    ) {
+        self.prompt = prompt
+        self.negativePrompt = negativePrompt
+        self.outputURL = outputURL
+        self.width = width
+        self.height = height
+        self.steps = steps
+        self.guidanceScale = guidanceScale
+        self.seed = seed
+        self.inputImage = inputImage
+        self.referenceImages = referenceImages
+        self.strength = strength
+        self.keepOriginalAspect = keepOriginalAspect
+        self.maxSequenceLength = maxSequenceLength
+        self.loras = loras
+        self.sigmaShift = sigmaShift
+        self.sigmas = sigmas
+        self.kreaConditioningRebalance = kreaConditioningRebalance
+        self.kreaBaseQuantizationBits = kreaBaseQuantizationBits
+        self.mask = mask
+        self.outpaint = outpaint
+        self.maskFeather = maskFeather
+    }
+}
+
+public struct ImageLoRAReference: Sendable, Hashable {
+    public let raw: String
+    public let reference: String
+    public let scale: Double
+
+    public init(raw: String, reference: String, scale: Double) {
+        self.raw = raw
+        self.reference = reference
+        self.scale = scale
+    }
+
+    public static func parse(_ arguments: [String], defaultScale: Double) throws -> [Self] {
+        guard defaultScale.isFinite else {
+            throw ImageGenerationIssue("lora_scale_invalid", "--lora-scale must be finite")
+        }
+        return try arguments.map { raw in
+            let separator = raw.lastIndex(of: "=")
+            let reference: String
+            let scale: Double
+            if let separator {
+                reference = String(raw[..<separator])
+                let rawScale = String(raw[raw.index(after: separator)...])
+                guard let parsed = Double(rawScale), parsed.isFinite else {
+                    throw ImageGenerationIssue("lora_scale_invalid", "--lora scale must be finite (got \(rawScale)).")
+                }
+                scale = parsed
+            } else {
+                reference = raw
+                scale = defaultScale
+            }
+            guard !reference.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                throw ImageGenerationIssue("lora_reference_invalid", "--lora must be PATH_OR_ID[=SCALE].")
+            }
+            return Self(raw: raw, reference: reference, scale: scale)
+        }
+    }
+}
+
+/// Stable diagnostic identifiers let transports present errors without parsing prose.
+public struct ImageGenerationIssue: LocalizedError, Equatable, Sendable {
+    public let code: String
+    public let message: String
+    public var errorDescription: String? { message }
+
+    public init(_ code: String, _ message: String) {
+        self.code = code
+        self.message = message
+    }
+}
+
+public enum ImageGenerationBackend: String, CaseIterable, Codable, Sendable {
+    case flux1, flux2Klein, zImageTurbo, hiDreamO1, senseNovaU15, krea2, ideogram4, qwenImageEdit
+
+    public init(manifest: MereRunModelManifest) throws {
+        switch manifest.family {
+        case .flux1: self = .flux1
+        case .klein: self = .flux2Klein
+        case .zimage: self = .zImageTurbo
+        case .hidream: self = .hiDreamO1
+        case .senseNova: self = .senseNovaU15
+        case .krea: self = .krea2
+        case .ideogram: self = .ideogram4
+        case .qwen where manifest.engine == .qwenImageEdit: self = .qwenImageEdit
+        default:
+            throw ImageGenerationIssue("model_family_unsupported", "Unsupported image generation model: \(manifest.id).")
+        }
+    }
+}
+
+/// Compatibility choices belong to the caller, while their implementation has one owner.
+public struct ImageGenerationPolicy: Sendable, Hashable {
+    public var kleinUsesManifestDefaults: Bool
+    public var kleinInputAsReference: Bool
+    public var fallbackSteps: Int
+    public var fallbackGuidanceScale: Double
+
+    public init(
+        kleinUsesManifestDefaults: Bool = true,
+        kleinInputAsReference: Bool = true,
+        fallbackSteps: Int = 4,
+        fallbackGuidanceScale: Double = 1
+    ) {
+        self.kleinUsesManifestDefaults = kleinUsesManifestDefaults
+        self.kleinInputAsReference = kleinInputAsReference
+        self.fallbackSteps = fallbackSteps
+        self.fallbackGuidanceScale = fallbackGuidanceScale
+    }
+
+    public static let manifestDefaults = Self()
+}
+
+/// Classifies a local path or managed identifier without downloading anything.
+/// Callers retain their own missing-model guidance and observational behavior.
+public enum ImageGenerationModelSelection: Sendable {
+    case local(URL)
+    case managed(ModelResolver.ModelID)
+    case unknown(String)
+
+    public init(_ selector: String, fileManager: FileManager = .default) {
+        let path = URL(fileURLWithPath: selector).standardizedFileURL
+        if fileManager.fileExists(atPath: path.path) {
+            self = .local(path)
+        } else if let id = ModelResolver.ModelID(rawValue: selector) {
+            self = .managed(id)
+        } else {
+            self = .unknown(selector)
+        }
+    }
+
+    public func resolveRoot(fileManager: FileManager = .default) throws -> URL {
+        switch self {
+        case .local(let url): return url
+        case .managed(let id): return try ModelResolver(fileManager: fileManager).resolve(id).rootURL
+        case .unknown(let selector):
+            throw ImageGenerationIssue("model_unknown", "Model path not found and not a known model id: \(selector).")
+        }
+    }
+}

--- a/Sources/MereRunCore/ImageGenerationPlan.swift
+++ b/Sources/MereRunCore/ImageGenerationPlan.swift
@@ -1,0 +1,284 @@
+import Foundation
+
+/// Model-dependent sampling values. An observational plan for a missing model
+/// leaves unknown defaults unset instead of inventing a runnable configuration.
+public struct ImageGenerationSampling: Sendable, Equatable {
+    public let steps: Int?
+    public let guidanceScale: Double?
+    public let sigmaShift: Float?
+    public let sigmas: [Float]?
+
+    public static func resolve(
+        _ options: ImageGenerationOptions,
+        manifest: MereRunModelManifest?,
+        policy: ImageGenerationPolicy = .manifestDefaults
+    ) -> Self {
+        let turbo = options.loras.contains {
+            ManagedAdapterCatalog.spec(for: $0.reference)?.id == ManagedAdapterCatalog.flux2DevTurboEightStepID
+        }
+        let sigmas = options.sigmas ?? (turbo ? Flux2DevTurboRecipe.sigmas : nil)
+        let usesManifest: Bool
+        switch manifest?.family {
+        case .klein: usesManifest = policy.kleinUsesManifestDefaults
+        case .hidream, .senseNova, .krea, .ideogram, .flux1: usesManifest = true
+        case .qwen: usesManifest = manifest?.engine == .qwenImageEdit
+        default: usesManifest = false
+        }
+        let defaultSteps = manifest == nil ? nil
+            : (usesManifest ? manifest?.defaults?.steps : nil) ?? policy.fallbackSteps
+        let defaultCFG = manifest == nil ? nil
+            : (usesManifest ? manifest?.defaults?.cfg : nil) ?? policy.fallbackGuidanceScale
+        return Self(
+            steps: options.steps ?? sigmas?.count ?? defaultSteps,
+            guidanceScale: options.guidanceScale ?? (turbo ? Flux2DevTurboRecipe.guidanceScale : nil) ?? defaultCFG,
+            sigmaShift: options.sigmaShift ?? manifest?.defaults?.sigmaShift.map(Float.init),
+            sigmas: sigmas
+        )
+    }
+
+    public static func parseSigmas(_ raw: String?) throws -> [Float]? {
+        guard let raw else { return nil }
+        var values = try raw.split(separator: ",", omittingEmptySubsequences: false).map { item in
+            let trimmed = item.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard let value = Float(trimmed), value.isFinite else {
+                throw ImageGenerationIssue("sigma_schedule_invalid", "--sigmas must contain finite comma-separated values.")
+            }
+            return value
+        }
+        if values.last == 0 { values.removeLast() }
+        guard !values.isEmpty else {
+            throw ImageGenerationIssue("sigma_schedule_invalid", "--sigmas must include at least one non-terminal value.")
+        }
+        do {
+            try Flux2EulerScheduler.validateCustomSigmas(values, expectedSteps: values.count)
+        } catch {
+            throw ImageGenerationIssue("sigma_schedule_invalid", error.localizedDescription)
+        }
+        return values
+    }
+}
+
+public struct ImageGenerationConditioning: Sendable, Equatable {
+    public let inputImage: URL?
+    public let referenceImages: [URL]
+    public let strength: Double
+    public let referenceStrength: Double
+
+    public static func resolve(
+        family: MereRunModelManifest.Family?,
+        inputImage: URL?,
+        referenceImages: [URL],
+        strength: Double?,
+        policy: ImageGenerationPolicy = .manifestDefaults
+    ) -> Self {
+        guard family == .klein, policy.kleinInputAsReference else {
+            return Self(
+                inputImage: inputImage, referenceImages: referenceImages,
+                strength: strength ?? 0.75, referenceStrength: 0
+            )
+        }
+        return Self(
+            inputImage: nil,
+            referenceImages: inputImage.map { [$0] + referenceImages } ?? referenceImages,
+            strength: strength ?? 0.75,
+            referenceStrength: strength ?? (inputImage == nil ? 0 : 0.75)
+        )
+    }
+
+    public static func inputMode(
+        family: MereRunModelManifest.Family?, inputImage: URL?, referenceImages: [URL]
+    ) -> String {
+        guard inputImage != nil || !referenceImages.isEmpty else { return "text_to_image" }
+        if family == .klein { return "reference_image" }
+        if inputImage != nil, !referenceImages.isEmpty { return "image_to_image_with_references" }
+        return inputImage == nil ? "reference_image" : "image_to_image"
+    }
+}
+
+/// A validated operation, independent of command parsing, HTTP, and runtime residency.
+/// Resolving a plan reads local metadata and checks paths; it never downloads or loads weights.
+public struct ImageGenerationPlan: Sendable {
+    public let options: ImageGenerationOptions
+    public let modelRoot: URL
+    public let manifest: MereRunModelManifest
+    public let backend: ImageGenerationBackend
+    public let policy: ImageGenerationPolicy
+    public let request: GenerationRequest
+
+    public static func resolve(
+        _ options: ImageGenerationOptions,
+        modelRoot: URL,
+        manifest: MereRunModelManifest,
+        policy: ImageGenerationPolicy = .manifestDefaults,
+        fileManager: FileManager = .default
+    ) throws -> Self {
+        if let issue = issues(options, manifest: manifest, policy: policy).first { throw issue }
+        let backend = try ImageGenerationBackend(manifest: manifest)
+        try validateFiles(options, fileManager: fileManager)
+        let loras = try resolveLoRAs(options.loras, baseModelID: manifest.id, fileManager: fileManager)
+        let sampling = ImageGenerationSampling.resolve(options, manifest: manifest, policy: policy)
+        let conditioning = ImageGenerationConditioning.resolve(
+            family: manifest.family, inputImage: options.inputImage,
+            referenceImages: options.referenceImages, strength: options.strength, policy: policy
+        )
+        // A present, supported manifest always resolves both values.
+        guard let steps = sampling.steps, let guidance = sampling.guidanceScale else {
+            throw ImageGenerationIssue("model_defaults_missing", "Image model defaults could not be resolved.")
+        }
+        return Self(
+            options: options, modelRoot: modelRoot.standardizedFileURL, manifest: manifest,
+            backend: backend, policy: policy,
+            request: GenerationRequest(
+                prompt: options.prompt, negativePrompt: options.negativePrompt,
+                referenceImages: conditioning.referenceImages, referenceStrength: conditioning.referenceStrength,
+                width: options.width, height: options.height, steps: steps, guidanceScale: guidance,
+                seed: options.seed, outputURL: options.outputURL, model: modelRoot.standardizedFileURL.path,
+                maxSequenceLength: options.maxSequenceLength, loras: loras,
+                inputImage: conditioning.inputImage, strength: conditioning.strength,
+                keepOriginalAspect: options.keepOriginalAspect, sigmaShift: sampling.sigmaShift,
+                sigmas: sampling.sigmas, kreaConditioningRebalance: options.kreaConditioningRebalance,
+                kreaBaseQuantizationBits: options.kreaBaseQuantizationBits
+            )
+        )
+    }
+
+    /// Diagnostics are shared with preflight, including requests whose model is missing.
+    public static func issues(
+        _ options: ImageGenerationOptions,
+        manifest: MereRunModelManifest? = nil,
+        policy: ImageGenerationPolicy = .manifestDefaults
+    ) -> [ImageGenerationIssue] {
+        var issues: [ImageGenerationIssue] = []
+        func reject(_ condition: Bool, _ code: String, _ message: String) {
+            if condition { issues.append(ImageGenerationIssue(code, message)) }
+        }
+        reject(options.prompt.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty, "prompt_empty", "Prompt is empty.")
+        reject(options.width <= 0 || options.height <= 0, "dimensions_invalid", "--width/--height must be > 0")
+        reject(options.steps.map { $0 <= 0 } == true, "steps_invalid", "--steps must be >= 1")
+        reject(options.guidanceScale?.isFinite == false, "cfg_invalid", "--cfg must be finite")
+        reject(options.sigmaShift?.isFinite == false, "sigma_shift_invalid", "--sigma-shift must be finite")
+        reject(options.strength.map { !(0...1).contains($0) } == true, "strength_invalid", "--strength must be between 0.0 and 1.0")
+        reject(options.maxSequenceLength <= 0, "sequence_length_invalid", "--max-sequence-length must be > 0")
+        reject(options.maskFeather < 0, "mask_feather_invalid", "--mask-feather must be >= 0")
+        reject(
+            (options.mask != nil || options.outpaint != nil) && options.inputImage == nil,
+            "image_edit_input_missing", "--mask and --outpaint require --input"
+        )
+        reject(
+            options.kreaBaseQuantizationBits.map { $0 != 4 && $0 != 8 } == true,
+            "krea_quantization_invalid", "--krea-base-quantization-bits must be 4 or 8"
+        )
+        reject(options.loras.contains { !$0.scale.isFinite }, "lora_scale_invalid", "--lora scale must be finite")
+        reject(
+            options.sigmas != nil && options.sigmaShift != nil,
+            "sigma_options_conflict", "--sigmas cannot be combined with --sigma-shift"
+        )
+        if let rebalance = options.kreaConditioningRebalance {
+            reject(
+                !rebalance.multiplier.isFinite || rebalance.layerWeights.contains { !$0.isFinite },
+                "krea_conditioning_invalid", "Krea conditioning values must be finite."
+            )
+        }
+        if options.width > 0, options.height > 0 {
+            reject(options.width > Int.max / options.height / 4, "dimensions_invalid", "Image dimensions are too large.")
+        }
+        if let padding = options.outpaint {
+            let edges = [padding.top, padding.right, padding.bottom, padding.left]
+            reject(edges.contains { $0 < 0 } || !edges.contains { $0 > 0 }, "image_edit_invalid", "Outpaint padding is invalid.")
+            // Compare each edge before subtracting to avoid overflow in untrusted dimensions.
+            let fitsWidth = padding.left >= 0 && padding.left < options.width
+                && padding.right >= 0 && padding.right < options.width - padding.left
+            let fitsHeight = padding.top >= 0 && padding.top < options.height
+                && padding.bottom >= 0 && padding.bottom < options.height - padding.top
+            reject(!fitsWidth || !fitsHeight, "image_edit_invalid", "Outpaint padding must leave a positive source region.")
+        }
+        let sampling = ImageGenerationSampling.resolve(options, manifest: manifest, policy: policy)
+        if let sigmas = sampling.sigmas {
+            do {
+                try Flux2EulerScheduler.validateCustomSigmas(sigmas, expectedSteps: sigmas.count)
+            } catch {
+                issues.append(ImageGenerationIssue("sigma_schedule_invalid", error.localizedDescription))
+            }
+            reject(
+                sampling.steps != sigmas.count, "sigma_step_count_mismatch",
+                "--steps must equal the number of non-terminal --sigmas values (\(sigmas.count))."
+            )
+        }
+        reject(sampling.steps.map { $0 <= 0 } == true, "model_steps_invalid", "Effective image steps must be positive.")
+        reject(sampling.guidanceScale?.isFinite == false, "model_cfg_invalid", "Effective image guidance must be finite.")
+        reject(sampling.sigmaShift?.isFinite == false, "model_sigma_shift_invalid", "Effective sigma shift must be finite.")
+        guard let manifest else { return issues }
+        do { _ = try ImageGenerationBackend(manifest: manifest) } catch let issue as ImageGenerationIssue { issues.append(issue) } catch {
+            issues.append(ImageGenerationIssue("model_family_unsupported", error.localizedDescription))
+        }
+        reject(
+            options.loras.count > 1 && manifest.family != .klein && manifest.family != .flux1,
+            "lora_stack_model_unsupported", "Stacked image LoRAs are supported only for FLUX.1 and FLUX.2 models."
+        )
+        reject(options.sigmas != nil && manifest.family != .klein, "sigma_model_unsupported", "--sigmas is supported only for FLUX.2 models.")
+        reject(
+            options.kreaBaseQuantizationBits != nil && manifest.family != .krea,
+            "krea_quantization_unsupported", "--krea-base-quantization-bits is only supported for Krea 2 generation"
+        )
+        if [.flux1, .krea, .ideogram].contains(manifest.family) {
+            reject(options.inputImage != nil, "input_mode_unsupported", "\(manifest.id) does not support image-to-image generation.")
+            reject(!options.referenceImages.isEmpty, "references_unsupported", "\(manifest.id) does not support reference images.")
+        }
+        reject(
+            manifest.family == .flux1 && options.negativePrompt?.isEmpty == false,
+            "negative_prompt_unsupported", "FLUX.1-dev native generation does not support negative prompts."
+        )
+        reject(
+            manifest.family == .zimage && !options.referenceImages.isEmpty,
+            "references_unsupported", "ZImage does not support reference images; use an input image for image-to-image generation."
+        )
+        reject(
+            !options.loras.isEmpty && ![.flux1, .klein, .zimage, .krea].contains(manifest.family),
+            "lora_unsupported", "\(manifest.id) does not support image LoRA adapters."
+        )
+        reject(
+            manifest.family == .senseNova && (!options.width.isMultiple(of: 32) || !options.height.isMultiple(of: 32)),
+            "dimensions_invalid", "SenseNova image dimensions must be multiples of 32."
+        )
+        if manifest.engine == .qwenImageEdit {
+            let count = Set(([options.inputImage].compactMap { $0 } + options.referenceImages).map { $0.standardizedFileURL }).count
+            reject(count == 0, "edit_input_missing", "Qwen-Image-Edit requires at least one input or reference image.")
+            reject(count > QwenImageEditConditioningPlan.maximumReferenceCount, "reference_count_invalid", "Qwen-Image-Edit supports up to 3 ordered images.")
+        }
+        return issues
+    }
+
+    public static func resolveLoRAs(
+        _ arguments: [ImageLoRAReference], baseModelID: String, fileManager: FileManager = .default
+    ) throws -> [LoRA] {
+        var resolvedPaths = Set<String>()
+        return try arguments.map { argument in
+            guard argument.scale.isFinite else { throw ImageGenerationIssue("lora_scale_invalid", "LoRA scale must be finite.") }
+            let resolved = try ManagedAdapterArgumentResolver.resolve(
+                argument.reference, baseModelID: baseModelID, fileManager: fileManager
+            ) ?? argument.reference
+            let url = URL(fileURLWithPath: resolved).standardizedFileURL
+            try validateFile(url, label: "LoRA file", fileManager: fileManager)
+            guard resolvedPaths.insert(url.resolvingSymlinksInPath().path).inserted else {
+                throw ImageGenerationIssue("lora_duplicate", "Duplicate LoRA adapter: \(url.path)")
+            }
+            return .local(path: url.path, scale: argument.scale)
+        }
+    }
+
+    static func validateFiles(_ options: ImageGenerationOptions, fileManager: FileManager) throws {
+        if let url = options.inputImage { try validateFile(url, label: "Input image", fileManager: fileManager) }
+        if let url = options.mask { try validateFile(url, label: "Mask image", fileManager: fileManager) }
+        for url in options.referenceImages { try validateFile(url, label: "Reference image", fileManager: fileManager) }
+    }
+
+    private static func validateFile(_ url: URL, label: String, fileManager: FileManager) throws {
+        var directory: ObjCBool = false
+        guard fileManager.fileExists(atPath: url.path, isDirectory: &directory) else {
+            throw ImageGenerationIssue("input_missing", "\(label) not found: \(url.path)")
+        }
+        guard !directory.boolValue else {
+            throw ImageGenerationIssue("input_not_file", "\(label) is a directory: \(url.path)")
+        }
+    }
+}

--- a/Sources/MereRunCore/ImageMaskEditing.swift
+++ b/Sources/MereRunCore/ImageMaskEditing.swift
@@ -1,14 +1,20 @@
-import ArgumentParser
 import Foundation
 import MediaIO
 
-struct ImageOutpaintInsets: Codable, Equatable {
-    let top: Int
-    let right: Int
-    let bottom: Int
-    let left: Int
+public struct ImageOutpaintInsets: Codable, Hashable, Sendable {
+    public let top: Int
+    public let right: Int
+    public let bottom: Int
+    public let left: Int
 
-    static func parse(_ value: String) throws -> Self {
+    public init(top: Int, right: Int, bottom: Int, left: Int) {
+        self.top = top
+        self.right = right
+        self.bottom = bottom
+        self.left = left
+    }
+
+    public static func parse(_ value: String) throws -> Self {
         let parts = value
             .split(separator: ",", omittingEmptySubsequences: false)
             .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
@@ -18,15 +24,15 @@ struct ImageOutpaintInsets: Codable, Equatable {
               let bottom = Int(parts[2]),
               let left = Int(parts[3]),
               [top, right, bottom, left].allSatisfy({ $0 >= 0 }) else {
-            throw ValidationError("--outpaint must be top,right,bottom,left using nonnegative pixel values.")
+            throw ImageGenerationIssue("image_edit_invalid", "--outpaint must be top,right,bottom,left using nonnegative pixel values.")
         }
-        guard top + right + bottom + left > 0 else {
-            throw ValidationError("--outpaint must expand at least one edge.")
+        guard [top, right, bottom, left].contains(where: { $0 > 0 }) else {
+            throw ImageGenerationIssue("image_edit_invalid", "--outpaint must expand at least one edge.")
         }
         return Self(top: top, right: right, bottom: bottom, left: left)
     }
 
-    var description: String {
+    public var description: String {
         "\(top),\(right),\(bottom),\(left)"
     }
 }
@@ -51,14 +57,14 @@ struct ImageEditPreparation {
         fileManager: FileManager = .default
     ) throws -> Self {
         guard featherPixels >= 0 else {
-            throw ValidationError("--mask-feather must be >= 0")
+            throw ImageGenerationIssue("image_edit_invalid", "--mask-feather must be >= 0")
         }
         let source = try MediaImageIO.decode(inputURL)
         let insets = outpaint ?? ImageOutpaintInsets(top: 0, right: 0, bottom: 0, left: 0)
         let availableWidth = width - insets.left - insets.right
         let availableHeight = height - insets.top - insets.bottom
         guard availableWidth > 0, availableHeight > 0 else {
-            throw ValidationError("--outpaint padding must leave a positive source region inside --width/--height.")
+            throw ImageGenerationIssue("image_edit_invalid", "--outpaint padding must leave a positive source region inside --width/--height.")
         }
 
         // The padding contract is exact: each requested edge remains the specified number of
@@ -114,7 +120,12 @@ struct ImageEditPreparation {
             .appendingPathComponent("mererun-image-edit-\(UUID().uuidString)", isDirectory: true)
         try fileManager.createDirectory(at: temporaryDirectory, withIntermediateDirectories: true)
         let generationInputURL = temporaryDirectory.appendingPathComponent("conditioning.png")
-        try MediaImageIO.writePNG(baseImage, to: generationInputURL)
+        do {
+            try MediaImageIO.writePNG(baseImage, to: generationInputURL)
+        } catch {
+            try? fileManager.removeItem(at: temporaryDirectory)
+            throw error
+        }
 
         return Self(
             generationInputURL: generationInputURL,

--- a/Sources/MereRunCore/ManagedAdapterArgumentResolver.swift
+++ b/Sources/MereRunCore/ManagedAdapterArgumentResolver.swift
@@ -1,8 +1,7 @@
 import Foundation
-import MereRunCore
 
-enum ManagedAdapterArgumentResolver {
-    static func resolve(
+public enum ManagedAdapterArgumentResolver {
+    public static func resolve(
         _ reference: String?,
         baseModelID: String,
         adaptersRoot: URL = MereRunModelPaths.adaptersDir,

--- a/Sources/MereRunCore/README.md
+++ b/Sources/MereRunCore/README.md
@@ -4,6 +4,14 @@ Shared model resolution, manifests, generation protocols, and native runtime
 families.
 
 - `Generation.swift`: image and chat request/response contracts.
+- `ImageGenerationOptions.swift` and `ImageGenerationPlan.swift`: typed image
+  inputs, model selection, effective sampling, conditioning, and validation.
+- `ImageGenerationOperation.swift`: image preparation, executor invocation,
+  cleanup, typed events, and results. The caller's executor owns admission and
+  runtime residency.
+- `ImageMaskEditing.swift`: mask/outpaint preparation and pixel restoration.
+- `ManagedAdapterArgumentResolver.swift`: installed adapter lookup and base-model
+  compatibility shared by image, text, video, and evaluation adapters.
 - `ManagedModel*.swift`: public managed-model catalog and install metadata.
 - `MereRunModel*.swift`: manifests, paths, and validation.
 - Runtime family directories own model-specific loading, inference, and decode

--- a/Tests/MereRunCLITests/BoundedProcessRunnerTests.swift
+++ b/Tests/MereRunCLITests/BoundedProcessRunnerTests.swift
@@ -1,0 +1,94 @@
+import Foundation
+import XCTest
+@testable import MereRunCLI
+
+final class BoundedProcessRunnerTests: XCTestCase {
+    func testDrainsBothStreamsAfterCaptureLimitsAreReached() throws {
+        let process = Self.shell(
+            "head -c 1048576 /dev/zero & head -c 1048576 /dev/zero >&2 & wait"
+        )
+        let result = try BoundedProcessRunner.run(process, timeout: 5, outputLimitBytes: 4096)
+
+        XCTAssertEqual(result.completion, .exited)
+        XCTAssertEqual(result.status, 0)
+        XCTAssertTrue(result.stdout.truncated)
+        XCTAssertTrue(result.stderr.truncated)
+        XCTAssertEqual(result.stdout.text, String(repeating: "\0", count: 4096) + "\n[output truncated]")
+        XCTAssertEqual(result.stderr.text, result.stdout.text)
+    }
+
+    func testCapturesSplitUTF8AndFinalOutputInOrder() throws {
+        let process = Self.shell("printf '\\342'; sleep 0.02; printf '\\230'; sleep 0.02; printf '\\203\\nfinished'")
+        let result = try BoundedProcessRunner.run(process, timeout: 5)
+
+        XCTAssertEqual(result.completion, .exited)
+        XCTAssertEqual(result.stdout.text, "☃\nfinished")
+        XCTAssertFalse(result.stdout.truncated)
+        XCTAssertEqual(result.stderr.text, "")
+    }
+
+    func testCombinedOutputPreservesOrdinaryToolResponseAndExitStatus() throws {
+        let result = try BoundedProcessRunner.run(
+            Self.shell("printf first; printf second >&2; printf third; exit 7"),
+            timeout: 5, combineOutput: true
+        )
+        XCTAssertEqual(result.completion, .exited)
+        XCTAssertEqual(result.status, 7)
+        XCTAssertEqual(result.stdout.text, "firstsecondthird")
+        XCTAssertEqual(result.stderr.text, "")
+    }
+
+    func testTimeoutStopsChildrenEvenAfterTheShellLeaderExits() throws {
+        let root = try temporaryDirectory()
+        let process = Self.shell("(trap '' TERM; sleep 1; printf leaked > escaped.txt) & exit 0")
+        process.currentDirectoryURL = root
+        let result = try BoundedProcessRunner.run(process, timeout: 0.15)
+
+        XCTAssertEqual(result.completion, .timedOut)
+        XCTAssertLessThan(result.seconds, 2)
+        Thread.sleep(forTimeInterval: 1)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: root.appendingPathComponent("escaped.txt").path))
+    }
+
+    func testTaskCancellationStopsAnAlreadyRunningChild() async throws {
+        let root = try temporaryDirectory()
+        let started = root.appendingPathComponent("started.txt")
+        let task = Task.detached { () throws -> BoundedProcessRunner.Result in
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: "/bin/sh")
+            process.arguments = ["-c", "printf started > started.txt; exec sleep 30"]
+            process.currentDirectoryURL = root
+            return try BoundedProcessRunner.run(process, timeout: 5)
+        }
+        defer { task.cancel() }
+        for _ in 0..<200 {
+            if FileManager.default.fileExists(atPath: started.path) { break }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTAssertTrue(FileManager.default.fileExists(atPath: started.path))
+        task.cancel()
+        let result = try await task.value
+        XCTAssertEqual(result.completion, .cancelled)
+        XCTAssertLessThan(result.seconds, 3)
+    }
+
+    func testLaunchFailureThrowsWithoutWaitingForOutput() {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/mererun-test-missing-executable")
+        XCTAssertThrowsError(try BoundedProcessRunner.run(process, timeout: 1))
+    }
+
+    private static func shell(_ command: String) -> Process {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/bin/sh")
+        process.arguments = ["-c", command]
+        return process
+    }
+
+    private func temporaryDirectory() throws -> URL {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: root) }
+        return root
+    }
+}

--- a/Tests/MereRunCLITests/BuiltinToolsTests.swift
+++ b/Tests/MereRunCLITests/BuiltinToolsTests.swift
@@ -112,6 +112,29 @@ final class BuiltinToolsTests: XCTestCase {
         )
     }
 
+    func testAllowedShellExecDrainsLargeOutputAndReportsTruncation() throws {
+        let policy = BuiltinTools.ToolExecutionPolicy(
+            sandboxDir: try makeSandbox(), allowShellExec: true, allowAbsolutePaths: false,
+            shellTimeout: 5, shellOutputLimitBytes: 128
+        )
+        let result = try BuiltinTools.execute(
+            ToolCall(name: "shell_exec", arguments: ["command": "head -c 1048576 /dev/zero"]),
+            policy: policy
+        )
+        XCTAssertEqual(result, String(repeating: "\0", count: 128) + "\n[output truncated]")
+    }
+
+    func testAllowedShellExecReportsTimeout() throws {
+        let policy = BuiltinTools.ToolExecutionPolicy(
+            sandboxDir: try makeSandbox(), allowShellExec: true, allowAbsolutePaths: false,
+            shellTimeout: 0.1
+        )
+        let result = try BuiltinTools.execute(
+            ToolCall(name: "shell_exec", arguments: ["command": "sleep 30"]), policy: policy
+        )
+        XCTAssertTrue(result.hasPrefix("Timed out after 0.1 seconds."))
+    }
+
     private func makeSandbox() throws -> URL {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent(UUID().uuidString, isDirectory: true)

--- a/Tests/MereRunCLITests/CapabilityCatalogTests.swift
+++ b/Tests/MereRunCLITests/CapabilityCatalogTests.swift
@@ -5,263 +5,135 @@ import Testing
 
 @testable import MereRunCLI
 
-private func capabilityHelpMessages() -> [String: String] {
-    [
-        "text.chat": TextChat.helpMessage(),
-        "text.code": TextCode.helpMessage(),
-        "text.embed": TextEmbed.helpMessage(),
-        "text.anonymize": TextAnonymize.helpMessage(),
-        "text.train-lora": TextTrainLoRA.helpMessage(),
-        "image.generate": ImageGenerate.helpMessage(),
-        "image.train-lora": ImageTrainLoRA.helpMessage(),
-        "image.validate": ImageValidate.helpMessage(),
-        "image.dataset.discover": ImageDatasetDiscover.helpMessage(),
-        "image.run-plan": ImageRunPlan.helpMessage(),
-        "image.visualize-run": ImageVisualizeRun.helpMessage(),
-        "image.reconstruct-3d": ImageReconstruct3D.helpMessage(),
-        "image.reconstruct-3d-trellis2": ImageReconstruct3DTrellis2.helpMessage(),
-        "image.reconstruct-3d-multiview": ImageReconstruct3DMultiview.helpMessage(),
-        "vision.embed": VisionEmbed.helpMessage(),
-        "vision.inspect": VisionInspect.helpMessage(),
-        "vision.caption": VisionCaption.helpMessage(),
-        "vision.ocr": VisionOCR.helpMessage(),
-        "vision.ground": VisionGround.helpMessage(),
-        "vision.segment": VisionSegment.helpMessage(),
-        "vision.track": VisionTrack.helpMessage(),
-        "vision.track-live": VisionTrackLive.helpMessage(),
-        "vision.face.detect": VisionFaceDetect.helpMessage(),
-        "vision.face.embed": VisionFaceEmbed.helpMessage(),
-        "vision.face.compare": VisionFaceCompare.helpMessage(),
-        "vision.face.batch": VisionFaceBatch.helpMessage(),
-        "vision.pose": VisionPose.helpMessage(),
-        "vision.flow": VisionFlow.helpMessage(),
-        "vision.depth-video": VisionDepthVideo.helpMessage(),
-        "vision.geometry": VisionGeometry.helpMessage(),
-        "vision.geometry-multiview": VisionGeometryMultiView.helpMessage(),
-        "audio.enhance": AudioEnhance.helpMessage(),
-        "audio.generate": AudioGenerate.helpMessage(),
-        "music.generate": MusicGenerate.helpMessage(),
-        "music.analyze": MusicAnalyze.helpMessage(),
-        "music.transcribe": MusicTranscribe.helpMessage(),
-        "music.separate": MusicSeparate.helpMessage(),
-        "music.realtime": MusicRealtime.helpMessage(),
-        "music.train-adapter": MusicTrainAdapter.helpMessage(),
-        "music.serve": MusicServe.helpMessage(),
-        "video.generate": VideoGenerate.helpMessage(),
-        "video.retake": VideoRetake.helpMessage(),
-        "video.dub-it": VideoDubIt.helpMessage(),
-        "video.animate": VideoAnimate.helpMessage(),
-        "video.cosmos3": VideoCosmos3.helpMessage(),
-        "video.prepare-masks": VideoPrepareMasks.helpMessage(),
-        "video.export-latents": VideoExportLatents.helpMessage(),
-        "video.session": VideoSession.helpMessage(),
-        "adapter.list": AdapterList.helpMessage(),
-        "adapter.pull": AdapterPull.helpMessage(),
-        "run.list": RunList.helpMessage(),
-        "run.inspect": RunInspect.helpMessage(),
-        "run.watch": RunWatch.helpMessage(),
-        "run.fetch": RunFetch.helpMessage(),
-        "run.cancel": RunCancel.helpMessage(),
-        "run.retry": RunRetry.helpMessage(),
-        "eval.pack.validate": EvaluationPackValidateCommand.helpMessage(),
-        "eval.run": EvaluationRunCommand.helpMessage(),
-        "eval.promote": EvaluationPromoteCommand.helpMessage(),
-        "world.serve": WorldServe.helpMessage(),
-        "status": Status.helpMessage(),
-        "gate": Gate.helpMessage(),
-        "model.storage": ModelStorage.helpMessage(),
-        "model.gc": ModelGarbageCollect.helpMessage(),
-        "model.runtime.get": ModelRuntimeGet.helpMessage(),
-        "model.runtime.set": ModelRuntimeSet.helpMessage(),
-        "setup": Setup.helpMessage(),
-        "agent.onboard": AgentOnboard.helpMessage(),
-        "agent.status": AgentStatus.helpMessage(),
-        "agent.install-pi": AgentInstallPi.helpMessage(),
-        "agent.start": AgentStart.helpMessage(),
-        "model.list": ModelList.helpMessage(),
-        "model.capabilities": ModelCapabilities.helpMessage(),
-        "model.pull": ModelPull.helpMessage(),
-        "model.info": ModelInfo.helpMessage(),
-        "model.remove": ModelRemove.helpMessage(),
-        "model.repair-manifests": ModelRepairManifests.helpMessage(),
-        "model.optimize": ModelOptimize.helpMessage(),
-        "model.benchmark.q36-mtp": ModelBenchmarkQ36MTP.helpMessage(),
-        "model.benchmark.laguna-dflash": ModelBenchmarkLagunaDFlash.helpMessage(),
-        "model.benchmark.parakeet-coreml": ModelBenchmarkParakeetCoreML.helpMessage(),
-        "speech.synthesize": SpeechSynthesize.helpMessage(),
-        "speech.transcribe": SpeechTranscribe.helpMessage(),
-        "speech.diarize": SpeechDiarize.helpMessage(),
-        "speech.profile.list": SpeechProfileList.helpMessage(),
-        "speech.profile.create": SpeechProfileCreate.helpMessage(),
-        "speech.profile.delete": SpeechProfileDelete.helpMessage(),
-        "sfx.generate": SFXGenerate.helpMessage(),
-        "sfx.video.generate": SFXVideoGenerate.helpMessage(),
-        "sfx.ae.encode": SFXAEEncode.helpMessage(),
-        "sfx.ae.decode": SFXAEDecode.helpMessage(),
-        "sfx.clap.score": SFXCLAPScoreCommand.helpMessage(),
-        "sfx.condition.text": SFXConditionText.helpMessage(),
-        "plugin.list": PluginList.helpMessage(),
-        "plugin.install": PluginInstall.helpMessage(),
-        "plugin.doctor": PluginDoctor.helpMessage(),
-        "open-webui.quickstart": OpenWebUIQuickstart.helpMessage(),
-        "api.serve": APIServe.helpMessage(),
-        "guide": GuideCommand.helpMessage(),
-        "config.set": Config.SetCmd.helpMessage(),
-        "config.get": Config.GetCmd.helpMessage(),
-        "config.unset": Config.UnsetCmd.helpMessage(),
-        "config.list": Config.ListCmd.helpMessage(),
-        "config.path": Config.PathCmd.helpMessage(),
-        "geo.flood": GeoFlood.helpMessage(),
-        "geo.fire": GeoFire.helpMessage(),
-        "geo.tessera": GeoTESSERA.helpMessage(),
-        "geo.olmoearth": GeoOlmoEarth.helpMessage(),
-        "model.location.list": ModelLocationList.helpMessage(),
-        "model.location.add": ModelLocationAdd.helpMessage(),
-        "model.location.remove": ModelLocationRemove.helpMessage(),
-        "model.location.bind": ModelLocationBind.helpMessage(),
-        "model.location.unbind": ModelLocationUnbind.helpMessage(),
-        "model.benchmark.chat": ModelBenchmarkChat.helpMessage(),
-        "model.benchmark.code": ModelBenchmarkCode.helpMessage(),
-        "model.benchmark.fused": ModelBenchmarkFused.helpMessage(),
-        "model.benchmark.fused-fixture": ModelBenchmarkFusedFixture.helpMessage(),
-        "model.benchmark.vlm": ModelBenchmarkVLM.helpMessage(),
-        "model.benchmark.tool-calls": ModelBenchmarkToolCalls.helpMessage(),
-        "model.benchmark.tool-continuations": ModelBenchmarkToolContinuations.helpMessage(),
-        "model.benchmark.gemma4-kv": ModelBenchmarkGemma4KV.helpMessage(),
-        "model.benchmark.gemma4-mtp": ModelBenchmarkGemma4MTP.helpMessage(),
-        "model.benchmark.api-workload": ModelBenchmarkAPIWorkload.helpMessage(),
-        "plugin.info": PluginInfo.helpMessage(),
-        "plugin.run": PluginRun.helpMessage(),
-        "plugin.rollback": PluginRollback.helpMessage(),
-        "speech.listen": SpeechListen.helpMessage(),
-        "vision.serve": VisionServe.helpMessage()
-    ]
+/// Decode the pinned ArgumentParser help format at the test boundary. Core and
+/// the shared catalog remain independent of the parser and its metadata format.
+private struct ParserHelp: Decodable {
+    let serializationVersion: Int
+    let command: Command
+
+    struct Command: Decodable {
+        let commandName: String
+        let arguments: [Argument]?
+        let subcommands: [Command]?
+    }
+
+    struct Argument: Decodable {
+        enum Kind: String, Decodable { case positional, option, flag }
+        let kind: Kind
+        let shouldDisplay: Bool
+        let isOptional: Bool
+        let isRepeating: Bool
+        let valueName: String?
+        let names: [Name]?
+        let defaultValue: String?
+        let allValues: [String]?
+
+        var flags: Set<String> {
+            Set((names ?? []).filter { $0.kind == .long }.map { "--" + $0.name })
+        }
+    }
+
+    struct Name: Decodable {
+        enum Kind: String, Decodable { case long, short, longWithSingleDash }
+        let kind: Kind
+        let name: String
+    }
 }
 
-@Test func capabilityFlagsMatchArgumentParserHelp() {
-    let helpByID = capabilityHelpMessages()
-
-    for capability in MereRunCapabilityCatalog.document.commands {
-        let help = helpByID[capability.id]
-        #expect(help != nil, "Missing help fixture for \(capability.id)")
-        let declaredFlags = Set(capability.options.map(\.flag))
-        let helpFlags = longOptionFlags(in: help ?? "")
-        if exactCapabilityOptionIDs.contains(capability.id) {
-            #expect(
-                declaredFlags == helpFlags,
-                "\(capability.id) contract flags \(declaredFlags.sorted()) do not match CLI help \(helpFlags.sorted())"
-            )
-        } else {
-            for option in capability.options {
-                #expect(
-                    help?.contains(option.flag) == true,
-                    "\(capability.id) advertises \(option.flag), but the CLI help does not"
-                )
+private func parserCommands() throws -> [String: ParserHelp.Command] {
+    let help = try JSONDecoder().decode(ParserHelp.self, from: Data(MereRunCLI._dumpHelp().utf8))
+    #expect(help.serializationVersion == 0, "Review the parser adapter before adopting a new help format.")
+    var commands: [String: ParserHelp.Command] = [:]
+    func walk(_ command: ParserHelp.Command, path: [String]) {
+        for child in command.subcommands ?? [] {
+            let next = path + [child.commandName]
+            if child.subcommands?.isEmpty ?? true {
+                commands[next.joined(separator: ".")] = child
+            } else {
+                walk(child, path: next)
             }
+        }
+    }
+    walk(help.command, path: [])
+    return commands
+}
+
+@Test func capabilityOptionsMatchArgumentParser() throws {
+    let commands = try parserCommands()
+    for capability in MereRunCapabilityCatalog.document.commands {
+        let command = try #require(commands[capability.id], "Unrecognized capability: \(capability.id)")
+        let arguments = (command.arguments ?? []).filter { $0.shouldDisplay }
+        // ArgumentParser adds these transport-wide flags to every leaf.
+        let builtins: Set<String> = ["--help", "--version"]
+        let options = arguments.filter { $0.kind != .positional && $0.flags.isDisjoint(with: builtins) }
+        let declared = Set(capability.options.map(\.flag))
+        let parsed = options.reduce(into: Set<String>()) { $0.formUnion($1.flags) }
+        #expect(declared.isSubset(of: parsed), "\(capability.id) declares unknown flags: \(declared.subtracting(parsed))")
+        #expect(capability.command.joined(separator: ".") == capability.id)
+        for option in options {
+            // Long aliases share a value. An inverted Boolean has two values,
+            // so require both polarities (with any equivalent spelling).
+            let negative: Set<String> = option.kind == .flag ? option.flags.filter { $0.hasPrefix("--no-") } : []
+            let positive = option.flags.subtracting(negative)
+            for aliases in [positive, negative] where !aliases.isEmpty {
+                #expect(!declared.isDisjoint(with: aliases), "\(capability.id) omits \(aliases.sorted())")
+            }
+        }
+        for option in capability.options {
+            let parsed = try #require(options.first { $0.flags.contains(option.flag) })
+            let context = "\(capability.id) \(option.flag)"
+            #expect(option.required == !parsed.isOptional, "\(context): required")
+            #expect(option.repeatable == parsed.isRepeating, "\(context): repeatable")
+            #expect((option.kind == .boolean) == (parsed.kind == .flag), "\(context): flag or value")
+            if let value = option.defaultValue {
+                #expect(value == parsed.defaultValue, "\(context): default")
+            }
+            if option.kind == .choice, let values = parsed.allValues {
+                #expect(Set(option.choices) == Set(values), "\(context): choices")
+            }
+        }
+        if let flag = capability.output.flag {
+            #expect(parsed.contains(flag), "\(capability.id) output flag is not parsed: \(flag)")
         }
     }
 }
 
-/// Newly cataloged capabilities begin with exact option parity. Older entries retain
-/// their existing compatibility aliases until those contracts are migrated deliberately.
-private let exactCapabilityOptionIDs: Set<String> = [
-    "geo.flood", "geo.fire", "geo.tessera", "geo.olmoearth",
-    "model.location.list", "model.location.add", "model.location.remove",
-    "model.location.bind", "model.location.unbind",
-    "model.benchmark.chat", "model.benchmark.code", "model.benchmark.fused",
-    "model.benchmark.fused-fixture", "model.benchmark.vlm", "model.benchmark.tool-calls",
-    "model.benchmark.tool-continuations", "model.benchmark.gemma4-kv",
-    "model.benchmark.gemma4-mtp", "model.benchmark.api-workload",
-    "plugin.info", "plugin.run", "plugin.rollback", "speech.listen", "vision.serve"
+/// Array positionals can be empty at the parser boundary yet be required by the
+/// command's validation. Keep these semantic requirements explicit and narrow.
+private let requiredPositionalOverrides: [String: String] = [
+    "text.embed.texts": "Requires text unless --list-models is set.",
+    "vision.caption.images": "Requires at least one image.",
+    "vision.ocr.images": "Requires at least one image.",
+    "vision.geometry-multiview.images": "Requires multiple images for geometry reconstruction."
 ]
 
-/// A capability that declares an artifact has to name a flag the CLI really
-/// parses, so the contract cannot promise shells a destination the command
-/// would reject. `adapter pull` and `image run-plan` choose their own paths and
-/// declare no flag; `capabilityFileOutputsDeclareADestinationFlag` covers them.
-@Test func capabilityOutputFlagsAreAcceptedByTheCLI() {
-    let helpByID = capabilityHelpMessages()
+/// Preserve existing catalog keys used by stored shell drafts.
+private let positionalNameAliases: [String: String] = [
+    "model.location.bind.modelID": "model-id",
+    "model.location.unbind.modelID": "model-id"
+]
 
+@Test func capabilityPositionalsMatchArgumentParser() throws {
+    let commands = try parserCommands()
+    var usedOverrides: Set<String> = []
+    var usedAliases: Set<String> = []
     for capability in MereRunCapabilityCatalog.document.commands {
-        guard let flag = capability.output.flag else { continue }
-        guard let help = helpByID[capability.id] else {
-            Issue.record("Missing help fixture for \(capability.id)")
-            continue
-        }
-        let path = capability.command.joined(separator: " ")
-        #expect(
-            longOptionFlags(in: help).contains(flag),
-            "\(capability.id) writes its output to \(flag), which `mere.run \(path) --help` does not advertise"
-        )
-    }
-}
-
-/// Every `default_value` the contract advertises must be the default
-/// ArgumentParser renders in `--help`, so a CLI default change that forgets the
-/// contract fails here instead of drifting into the shells' forms.
-@Test func capabilityDefaultValuesMatchArgumentParserHelp() {
-    let helpByID = capabilityHelpMessages()
-
-    for capability in MereRunCapabilityCatalog.document.commands {
-        guard let help = helpByID[capability.id] else { continue }
-        for option in capability.options {
-            guard let defaultValue = option.defaultValue else { continue }
-            let block = helpBlock(for: option.flag, in: help)
-            #expect(block != nil, "\(capability.id) \(option.flag) is missing from the CLI help")
-            // ArgumentParser renders `(default: x)` for plain options and
-            // `(values: a, b; default: x)` for enum-backed ones.
-            #expect(
-                block?.contains("default: \(defaultValue))") == true,
-                "\(capability.id) \(option.flag) declares default \(defaultValue) but the CLI help says: \(block ?? "")"
-            )
+        let command = try #require(commands[capability.id])
+        let parsed = (command.arguments ?? []).filter { $0.shouldDisplay && $0.kind == .positional }
+        #expect(capability.arguments.count == parsed.count, "\(capability.id): positional count")
+        for (argument, parser) in zip(capability.arguments, parsed) {
+            let key = "\(capability.id).\(argument.name)"
+            let name = positionalNameAliases[key] ?? argument.name
+            if positionalNameAliases[key] != nil { usedAliases.insert(key) }
+            let required = requiredPositionalOverrides[key] != nil || !parser.isOptional
+            if requiredPositionalOverrides[key] != nil { usedOverrides.insert(key) }
+            #expect(name == parser.valueName, "\(key): positional name or order")
+            #expect(argument.required == required, "\(key): required")
+            #expect(argument.repeatable == parser.isRepeating, "\(key): repeatable")
         }
     }
-}
-
-/// The help text for one option: its `  --flag ...` line plus the wrapped
-/// continuation lines up to the next option or section, re-flowed onto one
-/// line so wrapped `(default: …)` clauses can be matched.
-private func helpBlock(for flag: String, in help: String) -> String? {
-    let lines = help.split(separator: "\n", omittingEmptySubsequences: false).map(String.init)
-    guard let start = lines.firstIndex(where: { line in
-        guard line.hasPrefix("  -") else { return false }
-        for token in line.trimmingCharacters(in: .whitespaces).split(whereSeparator: \.isWhitespace) {
-            guard token.hasPrefix("-") else { break }
-            for alias in token.split(whereSeparator: { $0 == "," || $0 == "/" }) {
-                let name = alias.prefix { $0 == "-" || $0.isLetter || $0.isNumber }
-                if name == flag { return true }
-            }
-        }
-        return false
-    }) else { return nil }
-
-    var block = [lines[start]]
-    for line in lines[(start + 1)...] {
-        guard line.hasPrefix(" "), !line.hasPrefix("  -") else { break }
-        block.append(line)
-    }
-    return block
-        .joined(separator: " ")
-        .split(whereSeparator: \.isWhitespace)
-        .joined(separator: " ")
-}
-
-private func longOptionFlags(in help: String) -> Set<String> {
-    Set(help.split(separator: "\n").flatMap { line -> [String] in
-        guard line.hasPrefix("  -") else { return [] }
-        let trimmed = line.trimmingCharacters(in: .whitespaces)
-        var flags: [String] = []
-        for token in trimmed.split(whereSeparator: \.isWhitespace) {
-            guard token.hasPrefix("-") else { break }
-            for alias in token.split(separator: ",") where alias.hasPrefix("--") {
-                let flag = alias.prefix { character in
-                    character == "-" || character.isLetter || character.isNumber
-                }
-                if flag != "--help" { flags.append(String(flag)) }
-            }
-        }
-        return flags
-    })
+    #expect(usedOverrides == Set(requiredPositionalOverrides.keys), "Remove stale positional requirements.")
+    #expect(usedAliases == Set(positionalNameAliases.keys), "Remove stale positional aliases.")
 }
 
 @Test func catalogCommandParsesASelectedCapability() throws {
@@ -274,7 +146,7 @@ private func longOptionFlags(in help: String) -> Set<String> {
 /// Every public CLI leaf command must either be described by the shared
 /// capability contract or appear in `contractExemptCommandIDs` with the reason
 /// it is deliberately absent. Without this the CLI can grow a command that no
-/// shell ever surfaces: `capabilityFlagsMatchArgumentParserHelp` only walks the
+/// shell ever surfaces: `capabilityOptionsMatchArgumentParser` only walks the
 /// contract, and the app's inverse coverage test is keyed to the contract too,
 /// so an uncataloged command is invisible to both.
 let contractExemptCommandIDs: [String: String] = [
@@ -312,29 +184,9 @@ let contractExemptCommandIDs: [String: String] = [
     "vision.image-to-3d-multiview": "VFX alias of image.reconstruct-3d-multiview."
 ]
 
-private func publicLeafCommandIDs() -> [String] {
-    var identifiers: [String] = []
-
-    func walk(_ commandTypes: [ParsableCommand.Type], path: [String]) {
-        for commandType in commandTypes {
-            let configuration = commandType.configuration
-            guard configuration.shouldDisplay, let name = configuration.commandName else { continue }
-            let next = path + [name]
-            if configuration.subcommands.isEmpty {
-                identifiers.append(next.joined(separator: "."))
-            } else {
-                walk(configuration.subcommands, path: next)
-            }
-        }
-    }
-
-    walk(MereRunCLI.configuration.subcommands, path: [])
-    return identifiers
-}
-
-@Test func everyPublicCLICommandIsCatalogedOrExplicitlyExempt() {
+@Test func everyPublicCLICommandIsCatalogedOrExplicitlyExempt() throws {
     let cataloged = Set(MereRunCapabilityCatalog.document.commands.map(\.id))
-    let leaves = publicLeafCommandIDs()
+    let leaves = try parserCommands().keys
 
     for id in leaves {
         #expect(

--- a/Tests/MereRunCLITests/ImageGenerateCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/ImageGenerateCommandParsingTests.swift
@@ -354,7 +354,7 @@ final class ImageGenerateCommandParsingTests: XCTestCase {
         defer { try? FileManager.default.removeItem(at: temp) }
 
         let model = temp.appendingPathComponent("model", isDirectory: true)
-        try writeManifest(id: "local-zimage", family: .zimage, to: model)
+        try writeManifest(id: "local-klein", family: .klein, to: model)
 
         let input = temp.appendingPathComponent("input.png")
         let reference = temp.appendingPathComponent("reference.png")
@@ -385,14 +385,14 @@ final class ImageGenerateCommandParsingTests: XCTestCase {
         XCTAssertEqual(envelope.status, .ok)
         XCTAssertEqual(envelope.command, ["image", "generate"])
         XCTAssertEqual(envelope.result.model.kind, "local_path")
-        XCTAssertEqual(envelope.result.model.family, "zimage")
+        XCTAssertEqual(envelope.result.model.family, "klein")
         XCTAssertEqual(envelope.result.output.path, output.path)
         XCTAssertEqual(envelope.result.inputs.inputImage?.path, input.path)
         XCTAssertEqual(envelope.result.inputs.referenceImages.first?.path, reference.path)
         XCTAssertEqual(envelope.result.lora?.path, lora.path)
         XCTAssertEqual(envelope.result.lora?.scale, 0.8)
         XCTAssertEqual(envelope.result.plan.effectiveSteps, 6)
-        XCTAssertEqual(envelope.result.plan.inputMode, "image_to_image_with_references")
+        XCTAssertEqual(envelope.result.plan.inputMode, "reference_image")
         XCTAssertEqual(envelope.result.runPlan.kind, ImageGenerationRunPlan.kind)
         XCTAssertEqual(envelope.result.runPlan.command, ["image", "generate"])
         XCTAssertEqual(envelope.result.runPlan.arguments.prompt, "turn this into a matte catalog image")
@@ -418,7 +418,7 @@ final class ImageGenerateCommandParsingTests: XCTestCase {
         decoder.dateDecodingStrategy = .iso8601
         let decoded = try decoder.decode(ImageGenerationPreflightEnvelope.self, from: Data(encoded.utf8))
         XCTAssertEqual(decoded.status, .ok)
-        XCTAssertEqual(decoded.result.model.family, "zimage")
+        XCTAssertEqual(decoded.result.model.family, "klein")
         XCTAssertFalse(decoded.result.structuredPrompt.backend.contains("default device"))
 
         let encodedPlan = try StructuredRunOutput.encode(envelope.result.runPlan)

--- a/Tests/MereRunCLITests/ImageGenerationAdapterTests.swift
+++ b/Tests/MereRunCLITests/ImageGenerationAdapterTests.swift
@@ -1,0 +1,145 @@
+import Foundation
+import XCTest
+@testable import MereRunCLI
+@testable import MereRunCore
+
+final class ImageGenerationAdapterTests: XCTestCase {
+    func testCLIAndAPIResolveEquivalentExplicitSettingsAcrossImageBackends() throws {
+        let root = try temporaryDirectory()
+        let input = root.appendingPathComponent("input.png")
+        try Data("fixture".utf8).write(to: input)
+        let output = root.appendingPathComponent("result.png")
+        let families: [(MereRunModelManifest.Family, MereRunModelManifest.Engine)] = [
+            (.flux1, .flux1), (.klein, .flux2Klein), (.zimage, .zimageTurbo), (.hidream, .hidreamO1),
+            (.senseNova, .senseNovaU15), (.krea, .krea2), (.ideogram, .ideogram4), (.qwen, .qwenImageEdit)
+        ]
+        for (family, engine) in families {
+            let manifest = MereRunModelManifest(
+                id: "fixture", engine: engine, family: family,
+                defaults: .init(steps: 27, cfg: 3, sigmaShift: 2)
+            )
+            try manifest.write(to: root)
+            let inputImage = family == .qwen ? input : nil
+            var argv = [
+                "--prompt", "A brass camera", "--model", root.path, "--output", output.path,
+                "--width", "512", "--height", "512", "--steps", "12", "--cfg", "2.5", "--seed", "42"
+            ]
+            if let inputImage { argv += ["--input", inputImage.path] }
+            let command = try ImageGenerate.parse(argv)
+            let cli = try MereRunCore.ImageGenerationPlan.resolve(
+                command.operationOptions(outputURL: output), modelRoot: root, manifest: manifest
+            )
+            let api = try apiPlan(steps: 12, guidance: 2.5, input: inputImage)
+                .operationPlan(modelRoot: root, outputURL: output, manifest: manifest)
+            XCTAssertEqual(cli.request, api.request, "Equivalent explicit settings for \(family)")
+            XCTAssertEqual(cli.backend, api.backend)
+            let preflight = command.makePreflightEnvelope(outputURL: output)
+            XCTAssertEqual(preflight.status, .ok, "Preflight for \(family)")
+            XCTAssertEqual(preflight.result.plan.effectiveSteps, cli.request.steps)
+            XCTAssertEqual(preflight.result.plan.effectiveCFGScale, cli.request.guidanceScale)
+            XCTAssertEqual(preflight.result.plan.effectiveSigmaShift, cli.request.sigmaShift.map(Double.init))
+        }
+    }
+
+    func testAPIV1KleinCompatibilityIsExplicit() throws {
+        let root = try temporaryDirectory()
+        let input = root.appendingPathComponent("input.png")
+        try Data("fixture".utf8).write(to: input)
+        let output = root.appendingPathComponent("result.png")
+        let manifest = MereRunModelManifest(id: "fixture", family: .klein, defaults: .init(steps: 28, cfg: 4))
+        let api = try apiPlan(input: input).operationPlan(modelRoot: root, outputURL: output, manifest: manifest)
+        let command = try ImageGenerate.parse(["--prompt", "A brass camera", "--input", input.path])
+        let cli = try MereRunCore.ImageGenerationPlan.resolve(command.operationOptions(outputURL: output), modelRoot: root, manifest: manifest)
+        XCTAssertEqual(api.request.steps, 4)
+        XCTAssertEqual(api.request.guidanceScale, 1)
+        XCTAssertEqual(api.request.inputImage, input)
+        XCTAssertEqual(api.request.referenceStrength, 0)
+        XCTAssertEqual(cli.request.steps, 28)
+        XCTAssertEqual(cli.request.guidanceScale, 4)
+        XCTAssertNil(cli.request.inputImage)
+        XCTAssertEqual(cli.request.referenceImages, [input])
+        XCTAssertEqual(cli.request.referenceStrength, 0.75)
+    }
+
+    func testQwenAPILegacyDefaultsAndWholeImageMaskCompatibility() throws {
+        let root = try temporaryDirectory()
+        let input = root.appendingPathComponent("input.png")
+        try Data("fixture".utf8).write(to: input)
+        let output = root.appendingPathComponent("result.png")
+        let manifest = MereRunModelManifest(id: "fixture", engine: .qwenImageEdit, family: .qwen)
+        let api = APIServerContract.ImageGenerationPlan(
+            modelID: "fixture", prompt: "A brass camera", width: 512, height: 512, responseFormat: "url",
+            seed: 42, negativePrompt: nil, steps: nil, guidanceScale: nil, inputImage: input,
+            maskImage: root.appendingPathComponent("compatibility-mask.png"), strength: nil
+        )
+        let operation = try api.operationPlan(modelRoot: root, outputURL: output, manifest: manifest, qwenEditDefaults: true)
+        XCTAssertEqual(operation.request.steps, 20)
+        XCTAssertEqual(operation.request.guidanceScale, 4)
+        XCTAssertNil(operation.options.mask)
+        XCTAssertEqual(operation.request.inputImage, input)
+        let legacy = try api.operationPlan(
+            modelRoot: root, outputURL: output, manifest: .init(id: "fixture"), qwenEditDefaults: true
+        )
+        XCTAssertEqual(legacy.backend, .qwenImageEdit)
+        XCTAssertEqual(legacy.request.steps, 20)
+    }
+
+    func testCLIAndPreflightRejectUnsupportedSigmasBeforeLoadingWeights() async throws {
+        let root = try temporaryDirectory()
+        let manifest = MereRunModelManifest(id: "fixture", family: .zimage)
+        try manifest.write(to: root)
+        let output = root.appendingPathComponent("new/result.png")
+        let command = try ImageGenerate.parse([
+            "--prompt", "A brass camera", "--model", root.path,
+            "--sigmas", "1,0.5", "--output", output.path
+        ])
+        let preflight = command.makePreflightEnvelope(outputURL: output)
+        XCTAssertEqual(preflight.status, .blocked)
+        XCTAssertTrue(preflight.diagnostics.contains { $0.id == "sigma_model_unsupported" })
+        do {
+            try await command.run()
+            XCTFail("Unsupported sigmas must fail before loading weights")
+        } catch let error as ImageGenerationIssue {
+            XCTAssertEqual(error.code, "sigma_model_unsupported")
+        }
+        XCTAssertFalse(FileManager.default.fileExists(atPath: output.deletingLastPathComponent().path))
+    }
+
+    func testPreflightUsesExecutionConditioningModeForSenseNova() throws {
+        let root = try temporaryDirectory()
+        let manifest = MereRunModelManifest(id: "fixture", family: .senseNova)
+        try manifest.write(to: root)
+        let input = root.appendingPathComponent("input.png")
+        try Data("fixture".utf8).write(to: input)
+        let command = try ImageGenerate.parse(["--prompt", "A brass camera", "--model", root.path, "--input", input.path])
+        let output = root.appendingPathComponent("result.png")
+        let preflight = command.makePreflightEnvelope(outputURL: output)
+        XCTAssertEqual(preflight.result.plan.inputMode, "image_to_image")
+        XCTAssertEqual(preflight.status, .ok)
+    }
+
+    func testMissingInputKeepsOneActionablePreflightDiagnostic() throws {
+        let root = try temporaryDirectory()
+        try MereRunModelManifest(id: "fixture", family: .zimage).write(to: root)
+        let command = try ImageGenerate.parse([
+            "--prompt", "A camera", "--model", root.path, "--input", root.appendingPathComponent("missing.png").path
+        ])
+        let preflight = command.makePreflightEnvelope(outputURL: root.appendingPathComponent("result.png"))
+        XCTAssertEqual(preflight.status, .blocked)
+        XCTAssertEqual(preflight.diagnostics.filter { $0.severity == .blocker }.map(\.id), ["input_image_missing"])
+    }
+
+    private func apiPlan(steps: Int? = nil, guidance: Double? = nil, input: URL? = nil) -> APIServerContract.ImageGenerationPlan {
+        APIServerContract.ImageGenerationPlan(
+            modelID: "fixture", prompt: "A brass camera", width: 512, height: 512, responseFormat: "url",
+            seed: 42, negativePrompt: nil, steps: steps, guidanceScale: guidance, inputImage: input, strength: nil
+        )
+    }
+
+    private func temporaryDirectory() throws -> URL {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: root) }
+        return root
+    }
+}

--- a/Tests/MereRunContractTests/CommandCapabilityContractTests.swift
+++ b/Tests/MereRunContractTests/CommandCapabilityContractTests.swift
@@ -402,7 +402,9 @@ private let selfLocatingOutputCapabilityIDs: [String: String] = [
 
     #expect(quality?.choices == LTXVideoQuality.allCases.map(\.rawValue))
     #expect(outputMode?.choices == LTXVideoOutputMode.allCases.map(\.rawValue))
-    #expect(!generate.options.contains { $0.flag == "--variant" })
+    let compatibilityVariant = generate.options.first { $0.flag == "--variant" }
+    #expect(compatibilityVariant?.choices == ["unified-av", "distilled"])
+    #expect(compatibilityVariant?.tier == .expert)
     #expect(generate.options.first { $0.flag == "--h3-weight-mode" }?.choices == [
         "auto", "quantized", "resident-bf16"
     ])
@@ -417,4 +419,14 @@ private let selfLocatingOutputCapabilityIDs: [String: String] = [
     #expect(MereRunCapabilityCatalog.textTrainLoRA.options.contains { $0.flag == "--reasoning-effort" })
     #expect(MereRunCapabilityCatalog.evaluationRun.command == ["eval", "run"])
     #expect(MereRunCapabilityCatalog.evaluationRun.options.contains { $0.flag == "--adapter" })
+}
+
+@Test func capabilityPositionalsDecodeEarlierV1Documents() throws {
+    let legacy = Data(#"{"name":"texts","label":"Texts","kind":"string","required":true}"#.utf8)
+    let argument = try JSONDecoder().decode(MereRunCapabilityArgument.self, from: legacy)
+    #expect(!argument.repeatable)
+    let repeating = try #require(MereRunCapabilityCatalog.command(id: "text.embed")?.arguments.first)
+    #expect(repeating.repeatable)
+    let encoded = try JSONEncoder().encode(repeating)
+    #expect(try JSONDecoder().decode(MereRunCapabilityArgument.self, from: encoded) == repeating)
 }

--- a/Tests/MereRunCoreTests/ImageGenerationOperationTests.swift
+++ b/Tests/MereRunCoreTests/ImageGenerationOperationTests.swift
@@ -1,0 +1,253 @@
+import Foundation
+import MediaIO
+import XCTest
+@testable import MereRunCore
+
+final class ImageGenerationOperationTests: XCTestCase {
+    func testSamplingUsesManifestDefaultsForEverySupportedBackend() throws {
+        let options = ImageGenerationOptions(prompt: "A brass camera", outputURL: URL(fileURLWithPath: "/tmp/image.png"))
+        let families: [(MereRunModelManifest.Family, MereRunModelManifest.Engine, ImageGenerationBackend)] = [
+            (.flux1, .flux1, .flux1), (.klein, .flux2Klein, .flux2Klein), (.zimage, .zimageTurbo, .zImageTurbo),
+            (.hidream, .hidreamO1, .hiDreamO1), (.senseNova, .senseNovaU15, .senseNovaU15),
+            (.krea, .krea2, .krea2), (.ideogram, .ideogram4, .ideogram4), (.qwen, .qwenImageEdit, .qwenImageEdit)
+        ]
+        for (family, engine, backend) in families {
+            let manifest = MereRunModelManifest(id: "fixture", engine: engine, family: family, defaults: .init(steps: 27, cfg: 3, sigmaShift: 2))
+            let sampling = ImageGenerationSampling.resolve(options, manifest: manifest)
+            XCTAssertEqual(try ImageGenerationBackend(manifest: manifest), backend)
+            XCTAssertEqual(sampling.steps, family == .zimage ? 4 : 27)
+            XCTAssertEqual(sampling.guidanceScale, family == .zimage ? 1 : 3)
+            XCTAssertEqual(sampling.sigmaShift, 2)
+        }
+        let unknown = ImageGenerationSampling.resolve(options, manifest: nil)
+        XCTAssertNil(unknown.steps)
+        XCTAssertNil(unknown.guidanceScale)
+    }
+
+    func testModelSelectionPreservesLocalPathsAndKnownIDs() throws {
+        let root = try temporaryDirectory()
+        let local = ImageGenerationModelSelection(root.path)
+        guard case .local = local else { return XCTFail("Expected local selection") }
+        XCTAssertEqual(try local.resolveRoot().standardizedFileURL, root.standardizedFileURL)
+        guard case .managed(.kleinNano) = ImageGenerationModelSelection("image-klein-nano") else {
+            return XCTFail("Expected managed selection")
+        }
+        let unknown = ImageGenerationModelSelection(root.appendingPathComponent("missing-model").path)
+        XCTAssertThrowsError(try unknown.resolveRoot()) { error in
+            XCTAssertEqual((error as? ImageGenerationIssue)?.code, "model_unknown")
+        }
+    }
+
+    func testTurboRecipeAndExplicitOverridesUseOneSamplingResolver() throws {
+        var options = ImageGenerationOptions(
+            prompt: "A camera", outputURL: URL(fileURLWithPath: "/tmp/image.png"),
+            loras: try ImageLoRAReference.parse([ManagedAdapterCatalog.flux2DevTurboEightStepID], defaultScale: 1)
+        )
+        let manifest = MereRunModelManifest(id: "image-flux2-dev", family: .klein, defaults: .init(steps: 50, cfg: 4))
+        let recipe = ImageGenerationSampling.resolve(options, manifest: manifest)
+        XCTAssertEqual(recipe.sigmas, Flux2DevTurboRecipe.sigmas)
+        XCTAssertEqual(recipe.steps, Flux2DevTurboRecipe.sigmas.count)
+        XCTAssertEqual(recipe.guidanceScale, Flux2DevTurboRecipe.guidanceScale)
+        options.sigmas = try ImageGenerationSampling.parseSigmas("1,0.5,0")
+        options.steps = 2
+        options.guidanceScale = 2.5
+        let explicit = ImageGenerationSampling.resolve(options, manifest: manifest)
+        XCTAssertEqual(explicit.sigmas, [1, 0.5])
+        XCTAssertEqual(explicit.steps, 2)
+        XCTAssertEqual(explicit.guidanceScale, 2.5)
+        options.steps = 3
+        XCTAssertTrue(ImageGenerationPlan.issues(options, manifest: manifest).contains { $0.code == "sigma_step_count_mismatch" })
+    }
+
+    func testUnsupportedModesAndNonfiniteSettingsFailBeforePreparation() throws {
+        let root = try temporaryDirectory()
+        var options = ImageGenerationOptions(
+            prompt: "A camera", outputURL: root.appendingPathComponent("new/result.png"),
+            inputImage: root.appendingPathComponent("missing.png")
+        )
+        let manifest = MereRunModelManifest(id: "fixture", family: .flux1)
+        XCTAssertThrowsError(try ImageGenerationPlan.resolve(options, modelRoot: root, manifest: manifest)) { error in
+            XCTAssertEqual((error as? ImageGenerationIssue)?.code, "input_mode_unsupported")
+        }
+        XCTAssertFalse(FileManager.default.fileExists(atPath: options.outputURL.deletingLastPathComponent().path))
+        options.guidanceScale = .infinity
+        options.width = Int.max
+        options.height = Int.max
+        options.strength = .nan
+        let codes = Set(ImageGenerationPlan.issues(options).map(\.code))
+        XCTAssertTrue(codes.isSuperset(of: ["cfg_invalid", "dimensions_invalid", "strength_invalid"]))
+        XCTAssertThrowsError(try ImageGenerationSampling.parseSigmas("1,nan,0"))
+        XCTAssertThrowsError(try ImageGenerationSampling.parseSigmas("0.2,0.8"))
+    }
+
+    func testPreviouslyIgnoredInputsAreRejectedByPreflightRules() {
+        let output = URL(fileURLWithPath: "/tmp/image.png")
+        let reference = URL(fileURLWithPath: "/tmp/reference.png")
+        var options = ImageGenerationOptions(prompt: "A camera", outputURL: output, referenceImages: [reference])
+        XCTAssertTrue(ImageGenerationPlan.issues(options, manifest: .init(id: "zimage", family: .zimage))
+            .contains { $0.code == "references_unsupported" })
+        options.referenceImages = []
+        options.loras = [.init(raw: "style", reference: "style.safetensors", scale: 1)]
+        let families: [MereRunModelManifest.Family] = [.hidream, .senseNova, .qwen, .ideogram]
+        for family in families {
+            XCTAssertTrue(ImageGenerationPlan.issues(options, manifest: .init(id: "fixture", family: family))
+                .contains { $0.code == "lora_unsupported" })
+        }
+        options.loras = []
+        options.width = 16
+        XCTAssertTrue(ImageGenerationPlan.issues(options, manifest: .init(id: "sensenova", family: .senseNova))
+            .contains { $0.code == "dimensions_invalid" })
+    }
+
+    func testSuccessfulMaskedOperationPreservesPixelsAndReportsActualSeed() async throws {
+        let plan = try maskedPlan()
+        let recorder = ImageOperationRecorder()
+        let id = UUID()
+        let outcome = try await ImageGenerationOperation.execute(plan, id: id, eventHandler: recorder.record) { _, request, progress in
+            let prepared = try XCTUnwrap(request.inputImage)
+            XCTAssertTrue(FileManager.default.fileExists(atPath: prepared.path))
+            recorder.prepared(prepared)
+            progress?(GenerationProgress(stage: .denoising, stepIndex: 0, totalSteps: request.steps))
+            try MediaImageIO.writePNG(
+                try MediaImage(width: 2, height: 1, rgba8: [0, 0, 255, 255, 0, 0, 255, 255]), to: request.outputURL
+            )
+            return GenerationResult(outputURL: request.outputURL, seed: 42)
+        }
+        XCTAssertEqual(outcome.id, id)
+        XCTAssertEqual(outcome.effectiveRequest.seed, 42)
+        XCTAssertEqual(outcome.effectiveRequest.inputImage, plan.options.inputImage)
+        XCTAssertEqual(outcome.result.outputURL, plan.request.outputURL)
+        XCTAssertEqual(recorder.events, ["started", "progress", "succeeded"])
+        let prepared = try XCTUnwrap(recorder.preparedURL)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: prepared.deletingLastPathComponent().path))
+        let image = try MediaImageIO.decode(outcome.result.outputURL)
+        XCTAssertEqual(image.rgba8, [255, 0, 0, 255, 0, 0, 255, 255])
+    }
+
+    func testExecutionWithoutObserversDoesNotEnableRuntimeProgress() async throws {
+        let root = try temporaryDirectory()
+        let plan = try ImageGenerationPlan.resolve(
+            .init(prompt: "A camera", outputURL: root.appendingPathComponent("result.png")),
+            modelRoot: root, manifest: .init(id: "fixture", family: .zimage)
+        )
+        _ = try await ImageGenerationOperation.execute(plan, executor: { _, request, progress in
+            XCTAssertNil(progress)
+            return GenerationResult(outputURL: request.outputURL, seed: 42)
+        })
+    }
+
+    func testFailedGenerationReleasesPreparationAndEmitsOneTerminalEvent() async throws {
+        let plan = try maskedPlan()
+        let recorder = ImageOperationRecorder()
+        do {
+            _ = try await ImageGenerationOperation.execute(plan, eventHandler: recorder.record) { _, request, _ in
+                recorder.prepared(try XCTUnwrap(request.inputImage))
+                throw ImageGenerationIssue("fixture_failure", "Fixture runtime failed.")
+            }
+            XCTFail("Expected generation failure")
+        } catch let error as ImageGenerationIssue {
+            XCTAssertEqual(error.code, "fixture_failure")
+        }
+        XCTAssertEqual(recorder.events, ["started", "failed"])
+        let prepared = try XCTUnwrap(recorder.preparedURL)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: prepared.deletingLastPathComponent().path))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: plan.request.outputURL.path))
+    }
+
+    func testCancellationDuringGenerationReleasesPreparationAndStaysDistinctFromFailure() async throws {
+        let plan = try maskedPlan()
+        let recorder = ImageOperationRecorder()
+        let task = Task.detached {
+            try await ImageGenerationOperation.execute(plan, eventHandler: recorder.record) { _, request, _ in
+                recorder.prepared(try XCTUnwrap(request.inputImage))
+                try await Task.sleep(nanoseconds: 30_000_000_000)
+                return GenerationResult(outputURL: request.outputURL, seed: 1)
+            }
+        }
+        defer { task.cancel() }
+        for _ in 0..<200 {
+            if recorder.preparedURL != nil { break }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        let prepared = try XCTUnwrap(recorder.preparedURL)
+        task.cancel()
+        do {
+            _ = try await task.value
+            XCTFail("Expected cancellation")
+        } catch is CancellationError { }
+        XCTAssertEqual(recorder.events, ["started", "cancelled"])
+        XCTAssertFalse(FileManager.default.fileExists(atPath: prepared.deletingLastPathComponent().path))
+    }
+
+    func testExecutionRechecksInputsChangedAfterPreflight() async throws {
+        let plan = try maskedPlan()
+        try FileManager.default.removeItem(at: XCTUnwrap(plan.options.inputImage))
+        let recorder = ImageOperationRecorder()
+        do {
+            _ = try await ImageGenerationOperation.execute(plan, eventHandler: recorder.record) { _, request, _ in
+                XCTFail("Unavailable input must fail before entering the runtime")
+                return GenerationResult(outputURL: request.outputURL, seed: 1)
+            }
+            XCTFail("Expected missing input")
+        } catch let error as ImageGenerationIssue {
+            XCTAssertEqual(error.code, "input_missing")
+        }
+        XCTAssertEqual(recorder.events, ["started", "failed"])
+    }
+
+    func testDuplicateAdapterSymlinksAreRejected() throws {
+        let root = try temporaryDirectory()
+        let first = root.appendingPathComponent("first.safetensors")
+        let alias = root.appendingPathComponent("alias.safetensors")
+        try Data().write(to: first)
+        try FileManager.default.createSymbolicLink(at: alias, withDestinationURL: first)
+        let loras = try ImageLoRAReference.parse([first.path, alias.path], defaultScale: 1)
+        XCTAssertThrowsError(try ImageGenerationPlan.resolveLoRAs(loras, baseModelID: "fixture")) { error in
+            XCTAssertEqual((error as? ImageGenerationIssue)?.code, "lora_duplicate")
+        }
+    }
+
+    private func maskedPlan() throws -> ImageGenerationPlan {
+        let root = try temporaryDirectory()
+        let input = root.appendingPathComponent("input.png")
+        let mask = root.appendingPathComponent("mask.png")
+        try MediaImageIO.writePNG(try MediaImage(width: 2, height: 1, rgba8: [255, 0, 0, 255, 0, 255, 0, 255]), to: input)
+        try MediaImageIO.writePNG(try MediaImage(width: 2, height: 1, rgba8: [0, 0, 0, 255, 255, 255, 255, 255]), to: mask)
+        let options = ImageGenerationOptions(
+            prompt: "Blue", outputURL: root.appendingPathComponent("new/result.png"), width: 2, height: 1,
+            inputImage: input, mask: mask, maskFeather: 0
+        )
+        let plan = try ImageGenerationPlan.resolve(options, modelRoot: root, manifest: .init(id: "fixture", family: .zimage))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: options.outputURL.deletingLastPathComponent().path))
+        return plan
+    }
+
+    private func temporaryDirectory() throws -> URL {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: root) }
+        return root
+    }
+}
+
+private final class ImageOperationRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var recordedEvents: [String] = []
+    private var recordedURL: URL?
+
+    var events: [String] { lock.withLock { recordedEvents } }
+    var preparedURL: URL? { lock.withLock { recordedURL } }
+    func prepared(_ url: URL) { lock.withLock { recordedURL = url } }
+
+    func record(_ event: ImageGenerationEvent) {
+        lock.withLock {
+            switch event {
+            case .started: recordedEvents.append("started")
+            case .progress: recordedEvents.append("progress")
+            case .succeeded: recordedEvents.append("succeeded")
+            case .failed: recordedEvents.append("failed")
+            case .cancelled: recordedEvents.append("cancelled")
+            }
+        }
+    }
+}

--- a/apps/macos/StudioKit/Catalog/CommandFlags.swift
+++ b/apps/macos/StudioKit/Catalog/CommandFlags.swift
@@ -811,7 +811,6 @@ extension CommandFlags {
     package enum MusicGenerate: CommandFlagNamespace {
         package static let command = ["music", "generate"]
         package static let defaultValues = [
-            "--composer-model": "text-chat-gemma4-12b-4bit",
             "--lyrics-preflight": "warn",
             "--export-format": "pcm24",
             "--normalize": "peak",

--- a/apps/macos/StudioKit/Catalog/CommandFlags.swift
+++ b/apps/macos/StudioKit/Catalog/CommandFlags.swift
@@ -22,6 +22,10 @@ extension CommandFlags {
             "--markdown": "auto"
         ]
 
+        package static let audio = "--audio"
+        package static let video = "--video"
+        package static let seed = "--seed"
+        package static let showUnmasking = "--show-unmasking"
         package static let prompt = "--prompt"
         package static let image = "--image"
         package static let system = "--system"
@@ -123,6 +127,8 @@ extension CommandFlags {
     package enum TextTrainLoRA: CommandFlagNamespace {
         package static let command = ["text", "train-lora"]
 
+        package static let resumeFrom = "--resume-from"
+        package static let resumeStep = "--resume-step"
         package static let data = "--data"
         package static let output = "--output"
         package static let model = "--model"
@@ -161,6 +167,7 @@ extension CommandFlags {
             "--lora-scale": "1.0"
         ]
 
+        package static let sigmas = "--sigmas"
         package static let prompt = "--prompt"
         package static let negativePrompt = "--negative-prompt"
         package static let cfg = "--cfg"
@@ -804,6 +811,8 @@ extension CommandFlags {
     package enum MusicGenerate: CommandFlagNamespace {
         package static let command = ["music", "generate"]
         package static let defaultValues = [
+            "--composer-model": "text-chat-gemma4-12b-4bit",
+            "--lyrics-preflight": "warn",
             "--export-format": "pcm24",
             "--normalize": "peak",
             "--target-peak-db": "-1.0",
@@ -846,6 +855,26 @@ extension CommandFlags {
             "--prefill-duration": "1.64"
         ]
 
+        package static let compose = "--compose"
+        package static let composerModel = "--composer-model"
+        package static let composerModelRoot = "--composer-model-root"
+        package static let requireComposerInstalled = "--require-composer-installed"
+        package static let compositionOutput = "--composition-output"
+        package static let lyricsPreflight = "--lyrics-preflight"
+        package static let minimumDuration = "--minimum-duration"
+        package static let minFrames = "--min-frames"
+        package static let maxFrames = "--max-frames"
+        package static let sampleRate = "--sample-rate"
+        package static let memoryMode = "--memory-mode"
+        package static let performanceMode = "--performance-mode"
+        package static let samplingTier = "--sampling-tier"
+        package static let flowStrategy = "--flow-strategy"
+        package static let flowSolver = "--flow-solver"
+        package static let arCfgFrames = "--ar-cfg-frames"
+        package static let flowCfgEnd = "--flow-cfg-end"
+        package static let seedStrategy = "--seed-strategy"
+        package static let profileOutput = "--profile-output"
+        package static let noLMCaptionRewrite = "--no-lm-caption-rewrite"
         package static let lyrics = "--lyrics"
         package static let lyricsFile = "--lyrics-file"
         package static let instrumental = "--instrumental"
@@ -1018,6 +1047,7 @@ extension CommandFlags {
     package enum MusicRealtime: CommandFlagNamespace {
         package static let command = ["music", "realtime"]
 
+        package static let play = "--play"
         package static let model = "--model"
         package static let duration = "--duration"
         package static let output = "--output"
@@ -1080,6 +1110,8 @@ extension CommandFlags {
     package enum MusicServe: CommandFlagNamespace {
         package static let command = ["music", "serve"]
 
+        package static let memoryMode = "--memory-mode"
+        package static let performanceMode = "--performance-mode"
         package static let host = "--host"
         package static let port = "--port"
         package static let model = "--model"
@@ -1103,6 +1135,10 @@ extension CommandFlags {
     package enum VideoGenerate: CommandFlagNamespace {
         package static let command = ["video", "generate"]
         package static let defaultValues = [
+            "--ltx-transformer-execution": "eager",
+            "--ltx-guidance-projection-cache": "disabled",
+            "--h3-adapter-strength": "1.0",
+            "--h3-window-overlap": "18",
             "--spatial-overlap": "256",
             "--h3-weight-mode": "auto",
             "--h3-acceleration": "quality",
@@ -1132,6 +1168,19 @@ extension CommandFlags {
             "--temporal-upsample-rounds": "0"
         ]
 
+        package static let variant = "--variant"
+        package static let ltxTransformerExecution = "--ltx-transformer-execution"
+        package static let ltxGuidanceProjectionCache = "--ltx-guidance-projection-cache"
+        package static let ltxTeacache = "--ltx-teacache"
+        package static let ltxTeacacheThreshold = "--ltx-teacache-threshold"
+        package static let ltxTeacacheCalibrationOutput = "--ltx-teacache-calibration-output"
+        package static let h3RenderWidth = "--h3-render-width"
+        package static let h3RenderHeight = "--h3-render-height"
+        package static let h3Adapter = "--h3-adapter"
+        package static let h3AdapterStrength = "--h3-adapter-strength"
+        package static let h3Frame = "--h3-frame"
+        package static let h3WindowFrames = "--h3-window-frames"
+        package static let h3WindowOverlap = "--h3-window-overlap"
         package static let output = "--output"
         package static let model = "--model"
         package static let quality = "--quality"
@@ -1406,7 +1455,18 @@ extension CommandFlags {
     /// `mere.run video session` — Resident LTX session
     package enum VideoSession: CommandFlagNamespace {
         package static let command = ["video", "session"]
+        package static let defaultValues = [
+            "--ltx-transformer-execution": "eager",
+            "--ltx-guidance-projection-cache": "disabled",
+            "--prompt-cache-capacity": "8"
+        ]
 
+        package static let videoDecoder = "--video-decoder"
+        package static let ltxTransformerExecution = "--ltx-transformer-execution"
+        package static let ltxGuidanceProjectionCache = "--ltx-guidance-projection-cache"
+        package static let ltxTeacache = "--ltx-teacache"
+        package static let ltxTeacacheThreshold = "--ltx-teacache-threshold"
+        package static let promptCacheCapacity = "--prompt-cache-capacity"
         package static let model = "--model"
         package static let modelRoot = "--model-root"
         package static let quiet = "--quiet"
@@ -1431,6 +1491,7 @@ extension CommandFlags {
     package enum AdapterPull: CommandFlagNamespace {
         package static let command = ["adapter", "pull"]
 
+        package static let acceptLicense = "--accept-license"
         package static let force = "--force"
         package static let quiet = "--quiet"
     }
@@ -1565,7 +1626,24 @@ extension CommandFlags {
     /// `mere.run world serve` — World session
     package enum WorldServe: CommandFlagNamespace {
         package static let command = ["world", "serve"]
+        package static let defaultValues = [
+            "--scene-memory-strength": "0.08",
+            "--scene-memory-max-frames": "96",
+            "--scene-memory-minimum-gap": "3",
+            "--scene-memory-max-yaw": "2.0",
+            "--scene-memory-max-translation": "0.1",
+            "--scene-memory-exact-yaw": "0.01",
+            "--scene-memory-exact-translation": "0.001"
+        ]
 
+        package static let disableSceneMemory = "--disable-scene-memory"
+        package static let sceneMemoryStrength = "--scene-memory-strength"
+        package static let sceneMemoryMaxFrames = "--scene-memory-max-frames"
+        package static let sceneMemoryMinimumGap = "--scene-memory-minimum-gap"
+        package static let sceneMemoryMaxYaw = "--scene-memory-max-yaw"
+        package static let sceneMemoryMaxTranslation = "--scene-memory-max-translation"
+        package static let sceneMemoryExactYaw = "--scene-memory-exact-yaw"
+        package static let sceneMemoryExactTranslation = "--scene-memory-exact-translation"
         package static let host = "--host"
         package static let port = "--port"
         package static let apiKey = "--api-key"
@@ -1618,6 +1696,9 @@ extension CommandFlags {
     package enum Gate: CommandFlagNamespace {
         package static let command = ["gate"]
 
+        package static let requireAll = "--require-all"
+        package static let allInstalled = "--all-installed"
+        package static let skipModel = "--skip-model"
         package static let suite = "--suite"
         package static let updateBaselines = "--update-baselines"
         package static let strictPerf = "--strict-perf"
@@ -1807,6 +1888,9 @@ extension CommandFlags {
     package enum AgentStart: CommandFlagNamespace {
         package static let command = ["agent", "start"]
 
+        package static let piArgument = "--pi-argument"
+        package static let workingDirectory = "--working-directory"
+        package static let inline = "--inline"
         package static let host = "--host"
         package static let port = "--port"
         package static let piPath = "--pi-path"
@@ -1851,6 +1935,7 @@ extension CommandFlags {
     package enum ModelPull: CommandFlagNamespace {
         package static let command = ["model", "pull"]
 
+        package static let cacheDir = "--cache-dir"
         package static let all = "--all"
         package static let force = "--force"
         package static let quiet = "--quiet"
@@ -1893,6 +1978,8 @@ extension CommandFlags {
     package enum ModelRepairManifests: CommandFlagNamespace {
         package static let command = ["model", "repair-manifests"]
 
+        package static let acceptModelLicense = "--accept-model-license"
+        package static let model = "--model"
         package static let dryRun = "--dry-run"
         package static let json = "--json"
     }
@@ -1905,6 +1992,7 @@ extension CommandFlags {
     package enum ModelOptimize: CommandFlagNamespace {
         package static let command = ["model", "optimize"]
 
+        package static let textEncoderOnly = "--text-encoder-only"
         package static let force = "--force"
         package static let output = "--output"
         package static let json = "--json"
@@ -1917,7 +2005,17 @@ extension CommandFlags {
     /// `mere.run model benchmark q36-mtp` — Qwen-family MTP benchmark
     package enum ModelBenchmarkQ36MTP: CommandFlagNamespace {
         package static let command = ["model", "benchmark", "q36-mtp"]
+        package static let defaultValues = [
+            "--repetitions": "1",
+            "--warmups": "1",
+            "--warmup-tokens": "16",
+            "--variants": "baseline,adaptive,forced"
+        ]
 
+        package static let repetitions = "--repetitions"
+        package static let warmups = "--warmups"
+        package static let warmupTokens = "--warmup-tokens"
+        package static let variants = "--variants"
         package static let model = "--model"
         package static let modelRoot = "--model-root"
         package static let prompt = "--prompt"
@@ -2267,6 +2365,7 @@ extension CommandFlags {
             "--stream-decode-ms": "2000"
         ]
 
+        package static let timestamps = "--timestamps"
         package static let output = "--output"
         package static let model = "--model"
         package static let backend = "--backend"
@@ -2489,6 +2588,9 @@ extension CommandFlags {
     package enum PluginInstall: CommandFlagNamespace {
         package static let command = ["plugin", "install"]
 
+        package static let source = "--source"
+        package static let bundleManifest = "--bundle-manifest"
+        package static let bundleArchive = "--bundle-archive"
         package static let catalogURL = "--catalog-url"
         package static let channel = "--channel"
         package static let yes = "--yes"
@@ -2571,6 +2673,8 @@ extension CommandFlags {
     package enum APIServe: CommandFlagNamespace {
         package static let command = ["api", "serve"]
 
+        package static let warmup = "--warmup"
+        package static let noWarmup = "--no-warmup"
         package static let port = "--port"
         package static let host = "--host"
         package static let model = "--model"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -21,6 +21,11 @@ file, and then use the table to open the family entry point.
 
 ## Image families
 
+Read the [shared image operation](./internals/image-generation-operation.md)
+before following a family implementation. CLI, API, and preflight adapters use
+`ImageGenerationPlan` for resolution and validation, and execution passes the
+resolved request to `ImageGenerationOperation`.
+
 Klein image generation:
 
 - CLI: `Sources/MereRunCLI/Commands/ImageGenerateCommand.swift`

--- a/docs/internals/image-generation-operation.md
+++ b/docs/internals/image-generation-operation.md
@@ -1,0 +1,68 @@
+# Shared image operation
+
+CLI image generation, its preflight report, and the API image endpoints share
+one Core operation. Model-family runtimes still own numerical inference and
+checkpoint loading.
+
+## Ownership
+
+| Component | Responsibility |
+| --- | --- |
+| `ImageGenerationOptions` | Typed user settings before defaults and adapter recipes apply. |
+| `ImageGenerationModelSelection` | Classify local paths and managed IDs; resolve installed model roots without downloading. |
+| `ImageGenerationPlan` | Validate options and files, resolve adapters and effective sampling, and build `GenerationRequest`. |
+| `ImageGenerationOperation` | Prepare edit inputs, invoke an executor, restore protected pixels, clean up temporary files, and report a typed outcome. |
+| CLI adapter | Parse arguments, expand structured prompts, present progress and installation guidance, and emit existing receipts and run-plan events. |
+| API adapter | Decode HTTP requests, choose API v1 compatibility settings, and provide the resident-pool executor. |
+| Runtime | Check checkpoint integrity, load weights, run inference, and write the generated image. |
+
+`ImageGenerationSampling` owns manifest defaults and the FLUX.2 Turbo adapter
+recipe. `ImageGenerationConditioning` owns input/reference interpretation. Both
+preflight and execution use these definitions. The API selects explicit policy
+values to preserve its existing Klein and legacy Qwen defaults; see
+[API image compatibility](../runtime/api-server.md#openai-imageaudio-compatibility).
+
+## Preflight and execution
+
+Resolving a plan reads metadata and checks input and adapter paths. It does not
+create output directories, prepare masks, reserve an inference permit, download
+models, or load weights. Preflight presents these results through its existing
+versioned report, including actionable installation and file diagnostics.
+
+Execution rechecks mutable input and adapter availability. It scopes temporary
+mask and outpaint files to the operation and cleans them up after success,
+failure, or cancellation. A caller can inject an executor for a resident runtime
+or for tests. The executor owns admission and residency: the shared operation
+never acquires another machine permit or unloads a borrowed pool member. Its
+default executor creates and releases the native generator for one operation.
+
+Structured prompt expansion remains a CLI preparation step. The image options
+are validated before expansion, and the final expanded prompt is resolved into
+the execution request. API routing, authentication, request limits, and response
+encoding remain at the API boundary.
+
+## Typed results
+
+Swift callers can observe `ImageGenerationEvent`: started, progress, succeeded,
+failed, or cancelled. An execution emits one terminal event. Its success outcome
+contains the run ID, backend, model ID, image result, and effective request with
+the actual seed. Durable input paths remain in that request after temporary edit
+files are removed.
+
+These Swift events do not change a CLI wire format. Existing `--receipt`,
+`--progress-json`, preflight JSON, run-plan files, and API response shapes retain
+their compatibility behavior. A durable protocol for failure and interruption
+records is a separate migration; an uncatchable process termination cannot emit
+a terminal Swift event.
+
+## Validation
+
+`ImageGenerationOperationTests` exercises shared defaults and adapter recipes,
+unsupported options, pixel restoration, failure, cancellation, temporary-file
+cleanup, and input changes between planning and execution. It injects an
+executor and needs no model weights. `ImageGenerationAdapterTests` compares
+explicit CLI and API requests across all supported image backends, checks API
+compatibility policies, and compares preflight with execution validation.
+
+These tests establish orchestration behavior. Checkpoint, numerical, GPU-memory,
+and platform acceptance still use the existing family tests and runtime gates.

--- a/docs/macos-studio-capability-review.md
+++ b/docs/macos-studio-capability-review.md
@@ -36,7 +36,8 @@ reading.
 | Guard | Where | What it proves |
 |---|---|---|
 | `everyPublicCLICommandIsCatalogedOrExplicitlyExempt` | `Tests/MereRunCLITests/CapabilityCatalogTests.swift` | Every public CLI leaf command is either in the contract or in `contractExemptCommandIDs` with the reason it stays CLI-only. It also rejects a stale exemption, so the list cannot rot. |
-| `capabilityFlagsMatchArgumentParserHelp` | same file | Every flag the contract declares is one the command's ArgumentParser help accepts. |
+| `capabilityOptionsMatchArgumentParser` | same file | Every displayed option group of a cataloged command is represented. Aliases, Boolean inversions, cardinality, advertised defaults, and enum choices agree with parser metadata. |
+| `capabilityPositionalsMatchArgumentParser` | same file | Positional order, names, cardinality, and requirements match, with explicit compatibility exceptions. |
 | `testEverySharedCLICapabilityHasAnAppOwnedSurface` | `apps/macos/StudioUITests/StudioTypesTests.swift` | Set equality between the app's capability IDs and the contract's, in both directions. |
 | `testEveryCommandTemplateMapsToADomain` | `apps/macos/StudioUITests/NavigationModelTests.swift` | Every command template files into exactly one domain, and every domain owns at least one command. |
 | `CommandContractGuardTests` | `apps/macos/StudioKitTests` | Every flag the app can emit, from a sweep of maximal drafts, is one the contract declares, under the subcommand path the contract names. |
@@ -53,14 +54,15 @@ task assertion safe.
 
 ## Exemptions
 
-Thirty-one leaf commands stay CLI-only, each named in `contractExemptCommandIDs`
+Thirty-two leaf commands stay CLI-only, each named in `contractExemptCommandIDs`
 with its reason: the twelve `executor` commands and `relay serve` (the Relay
 console owns node identity, placement, scheduling, and fleet telemetry), the
 fourteen `graph` commands (Graph Studio owns workflow authoring and execution,
 and the worker verbs are a machine-to-machine protocol), the three
 `vision image-to-3d` aliases (surfaced through the 3D domain as
 `image reconstruct-3d`), and `catalog` (it emits the contract that the shells
-compile against).
+compile against), plus the research-only `model benchmark q38-verification`
+command.
 
 ---
 

--- a/docs/runtime/api-server.md
+++ b/docs/runtime/api-server.md
@@ -670,6 +670,14 @@ Qwen3 embedding model has a fixed vector size and returns float vectors.
 - local extensions: `strength`, `seed`, `negative_prompt`, `steps` (1 through
   100), and `guidance_scale`
 
+Image endpoints use the Core image operation for validation and execution. The
+v1 API retains its existing Klein defaults: four steps and guidance 1 when you
+omit them, with input images passed as image-to-image conditioning. The CLI uses
+the Klein manifest defaults and promotes its input image to a reference. Set
+`steps` and `guidance_scale` explicitly when comparing text-to-image results
+across the two entry points. Legacy Qwen edit installations without manifest
+defaults use 20 steps and guidance 4.
+
 Masks are accepted for client compatibility. Native edit models use
 whole-image conditioning rather than strict masked inpainting.
 

--- a/docs/runtime/image.md
+++ b/docs/runtime/image.md
@@ -113,6 +113,11 @@ swift run mere.run image generate \
   --json
 ```
 
+Preflight and execution share model-dependent defaults, sigma schedules, LoRA
+compatibility, and input validation. Preflight reads local metadata and files;
+it does not prepare an edit canvas, load weights, or download models. Execution
+rechecks input and adapter availability before entering the runtime.
+
 The JSON report uses the shared structured-run envelope and includes
 diagnostics plus declarative actions such as `start-generation`, `pull-model`,
 and `open-output-directory`. It also includes `result.run_plan`, a normalized

--- a/docs/runtime/text.md
+++ b/docs/runtime/text.md
@@ -527,6 +527,12 @@ targets absolute paths outside the sandbox with `--allow-absolute-tool-paths`.
 `--auto-approve-tools` skips confirmation for `write_file` only; `shell_exec`
 always requires interactive approval even when that flag is set.
 
+Each approved shell call has a five-minute deadline. The tool drains stdout and
+stderr while the command runs and retains the first 256 KiB of their combined
+output. If output exceeds that limit, the result includes `[output truncated]`.
+Reaching the capture limit does not stop the command. A timeout or task
+cancellation terminates the owned process group.
+
 ```bash
 swift run mere.run text chat \
   --model text-chat-gemma4-12b-4bit \


### PR DESCRIPTION
## Summary

Approved shell tools can hang when their output fills a pipe, the capability catalog omits existing CLI options, and CLI/API image generation resolve settings independently. This change completes the first Core/CLI consolidation milestone:

- Share a bounded process runner between shell tools and code sandboxes. It continues draining both streams after capture limits, handles launch failures, and stops owned processes on timeout or cancellation. Shell tools retain up to 256 KiB of combined output and have a five-minute deadline.
- Add 78 existing flags across 19 commands to the capability catalog. Discover all public commands and option groups from typed parser metadata; enforce aliases, Boolean inversions, cardinality, advertised defaults, choices, and positional order. Add backward-compatible positional `repeatable` metadata and regenerate Studio constants.
- Move image model selection, defaults, adapter resolution, validation, mask preparation, and execution into Core. CLI preflight and API requests consume the shared rules. Typed Swift events and outcomes distinguish terminal states, report the actual seed, and keep temporary edit files scoped to execution.

The complete parser help metadata matches the baseline across all 160 public leaf commands. Command names, flags, parser defaults, and existing output formats remain compatible. API v1 explicitly retains its Klein and legacy Qwen defaults and whole-image mask behavior. Unsupported image inputs or LoRA adapters that some backends previously ignored now fail before weight loading. The API retains ownership of admission and its resident model pool.

## Validation

- [x] `./scripts/check.sh` — strict lint, build, 3,952 XCTest cases (311 skipped), 51 Swift Testing tests, CLI help checks, and hygiene checks; zero failures.
- [x] Focused process, image operation/adapter, parser, catalog, and Studio command tests.
- [x] `pnpm docs:build`.
- [x] Public behavior and operation ownership documented.
- [x] Gitleaks: all three outgoing commits scanned, no leaks found.
- [x] Baseline/current parser metadata comparison: identical, 160 public leaf commands.
- Vendored artifacts and package pins are unchanged; no third-party notice update is needed.

Image operation tests inject executors and cover all eight backend policies, early validation, pixel restoration, cleanup after success/failure/cancellation, and changing inputs. No checkpoint inference, GPU numerical parity, Linux execution, or live HTTP acceptance was performed. Existing asset-dependent tests retain their skips.

Durable versioned failure/interruption records, dependency-target separation, and the next operation migrations remain later milestones. The typed Swift events in this change do not introduce a new wire protocol.
