### PR TITLE
Add durable image run records and local retries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+- Add opt-in durable image records with `image generate --run-dir` and
+  `api serve --image-run-records`. Records separate requested and effective
+  settings, retain input and output fingerprints, and distinguish terminal
+  outcomes from process interruption. Use `run list`, `run inspect`, and
+  `run retry` to inspect records and start a new run from resolved settings.
+
 - Fix approved shell tools hanging on large output. Shell execution now drains
   output while running, retains up to 256 KiB, and stops the owned process group
   on cancellation or after five minutes. Code benchmark sandboxes use the same

--- a/Sources/MereRunCLI/Commands/APIServeCommand.swift
+++ b/Sources/MereRunCLI/Commands/APIServeCommand.swift
@@ -13,6 +13,9 @@ import MediaIO
 import MereRunCore
 
 struct APIServe: AsyncParsableCommand {
+    @Option(name: [.customLong("image-run-records")], help: "Keep durable image run directories under this root.")
+    var imageRunRecords: String?
+
     static let apiKeyEnvironmentKey = "MERERUN_API_KEY"
 
     static let configuration = CommandConfiguration(
@@ -249,6 +252,7 @@ struct APIServe: AsyncParsableCommand {
             contextSize: contextSize,
             gemma4KVCacheQuantization: gemma4KVCacheQuantization,
             memoryPressurePolicy: memoryPressurePolicy,
+            imageRunRecords: imageRunRecords.map { URL(fileURLWithPath: $0).standardizedFileURL },
             warmupDefaultModel: warmup
         )
         try await server.run(host: host, port: port)
@@ -3889,6 +3893,7 @@ actor CodeGenServer {
     private let pool: RuntimeModelPool
     private let sidecarPool: APISidecarModelPool
     private let artifactCleanupScheduler: APIArtifactDirectoryCleanupScheduler
+    private let imageRunRecords: URL?
     private var processTelemetrySampler = RuntimeProcessTelemetrySampler()
 
     init(
@@ -3903,8 +3908,10 @@ actor CodeGenServer {
         gemma4KVCacheQuantization: Gemma4KVCacheQuantization = Gemma4KVCacheQuantization(),
         memoryPressurePolicy: RuntimeMemoryPressurePolicy = .default,
         artifactCleanupScheduler: APIArtifactDirectoryCleanupScheduler = APIArtifactDirectoryCleanupScheduler(),
+        imageRunRecords: URL? = nil,
         warmupDefaultModel: Bool = true
     ) async throws {
+        self.imageRunRecords = imageRunRecords
         self.apiKey = apiKey
         self.contextSize = contextSize
         self.fallbackLoraPath = fallbackLoraPath
@@ -5296,9 +5303,20 @@ actor CodeGenServer {
         let operation = try plan.operationPlan(
             modelRoot: modelRoot, outputURL: outputURL, manifest: manifest, qwenEditDefaults: qwenEdit
         )
-        try MLXBundleSupport.ensureAvailable(quiet: true)
+        let recording = try imageRunRecords.map { root in
+            var requested = operation.options
+            requested.mask = plan.maskImage
+            return try ImageRunSession(directory: root.appendingPathComponent("image-\(UUID().uuidString.lowercased())"),
+                                requested: requested, modelSelector: plan.modelID)
+        }
+        do {
+            try MLXBundleSupport.ensureAvailable(quiet: true)
+        } catch {
+            try recording?.fail(error)
+            throw error
+        }
         let pool = sidecarPool
-        let outcome = try await ImageGenerationOperation.execute(operation, executor: { kind, request, _ in
+        let outcome = try await ImageGenerationOperation.execute(operation, recording: recording, executor: { kind, request, _ in
             try await pool.generateImage(kind: kind, modelID: modelID, modelPath: modelRoot.path, request: request)
         })
         return outcome.result.outputURL

--- a/Sources/MereRunCLI/Commands/ImageGenerateCommand.swift
+++ b/Sources/MereRunCLI/Commands/ImageGenerateCommand.swift
@@ -157,19 +157,43 @@ struct ImageGenerate: AsyncParsableCommand {
     @Flag(name: [.customLong(RunReceipt.flagName)], help: RunReceipt.flagHelp)
     var receipt: Bool = false
 
+    @Option(name: [.customLong("run-dir")], help: "Create a new durable image run directory with settings, inputs, and output.")
+    var runDirectory: String?
+
     func validate() throws {
         try RunReceipt.validate(receipt: receipt, preflight: preflight)
+        if let runDirectory, let structuredPromptOutput {
+            let root = URL(fileURLWithPath: runDirectory).standardizedFileURL.resolvingSymlinksInPath().path
+            let target = URL(fileURLWithPath: structuredPromptOutput).standardizedFileURL.resolvingSymlinksInPath().path
+            if target == root || target.hasPrefix(root + "/") {
+                throw ValidationError("Write --structured-prompt-output outside --run-dir. The expanded prompt is included in the run record.")
+            }
+        }
     }
 
     func run() async throws {
         let outputURL = CLIOutput.resolveOutputURL(output, defaultPrefix: "mererun-image", defaultExtension: "png")
-        var options = try operationOptions(outputURL: outputURL)
+        let options = try operationOptions(outputURL: outputURL)
         if let issue = ImageGenerationPlan.issues(options).first { throw ValidationError(issue.message) }
         if preflight {
             try runPreflight(outputURL: outputURL)
             return
         }
 
+        let recording = try runDirectory.map {
+            try ImageRunSession(directory: URL(fileURLWithPath: $0), requested: options,
+                                modelSelector: model ?? Self.defaultManagedModelID.rawValue)
+        }
+        do {
+            try await generate(options: options, outputURL: outputURL, recording: recording)
+        } catch {
+            try recording?.fail(error)
+            throw error
+        }
+    }
+
+    private func generate(options suppliedOptions: ImageGenerationOptions, outputURL: URL, recording: ImageRunSession?) async throws {
+        var options = suppliedOptions
         let modelRoot = try resolveModelRoot()
         let manifest = try MereRunModelManifest.loadRequired(from: modelRoot)
         let initialPlan = try ImageGenerationPlan.resolve(options, modelRoot: modelRoot, manifest: manifest)
@@ -246,7 +270,7 @@ struct ImageGenerate: AsyncParsableCommand {
                 CLIStderr.write("[runtime] image backend: \(NativeMLXRuntime.backendDescription)\n")
             }
 
-            let outcome = try await ImageGenerationOperation.execute(plan, progressHandler: progressHandler)
+            let outcome = try await ImageGenerationOperation.execute(plan, recording: recording, progressHandler: progressHandler)
             let result = outcome.result
 
             try runEventLogger?.record(
@@ -364,7 +388,8 @@ struct ImageGenerate: AsyncParsableCommand {
             kreaConditioningLayerWeights: kreaConditioningLayerWeights,
             kreaBaseQuantizationBits: kreaBaseQuantizationBits,
             generationArgv: generationActionArguments(outputURL: outputURL),
-            cwd: fileManager.currentDirectoryPath
+            cwd: fileManager.currentDirectoryPath,
+            runDirectory: runDirectory
         )
         return ImageGenerationPreflightAnalyzer(
             input: input,
@@ -395,6 +420,7 @@ struct ImageGenerate: AsyncParsableCommand {
 
     private func generationActionArguments(outputURL: URL) -> [String] {
         var args = ["mere.run", "image", "generate", "--prompt", prompt, "--output", outputURL.path]
+        if let runDirectory { args += ["--run-dir", runDirectory] }
         args += ["--width", String(width), "--height", String(height)]
         if let negativePrompt {
             args += ["--negative-prompt", negativePrompt]

--- a/Sources/MereRunCLI/Commands/RunCommand.swift
+++ b/Sources/MereRunCLI/Commands/RunCommand.swift
@@ -1,5 +1,6 @@
 import ArgumentParser
 import MereRunRelayKit
+import MereRunCore
 import Foundation
 #if canImport(Darwin)
 import Darwin
@@ -139,7 +140,13 @@ struct RunInspect: AsyncParsableCommand {
             print(try StructuredRunOutput.encode(envelope))
         } else {
             print(envelope.summary)
-            if let runDirectory = envelope.result.runDirectory {
+            if let image = envelope.result.imageRun {
+                print("Status: \(image.state.rawValue)")
+                print("Model: \(image.modelManifest?.id ?? image.modelSelector)")
+                if let seed = image.effective?.seed { print("Seed: \(seed)") }
+                for artifact in image.artifacts { print("Output: \(artifact.url.path)") }
+                if let issue = image.issue { stderr("[\(issue.code)] \(issue.message)") }
+            } else if let runDirectory = envelope.result.runDirectory {
                 print("Status: \(runDirectory.status)")
                 if let manifest = runDirectory.manifest {
                     print("Format: \(manifest.format)")
@@ -280,11 +287,30 @@ struct RunCancel: AsyncParsableCommand {
 }
 
 struct RunRetry: AsyncParsableCommand {
-    static let configuration = CommandConfiguration(commandName: "retry", abstract: "Retry an immutable relay graph job.")
-    @Argument(help: "relay:// job reference.") var reference: String
+    static let configuration = CommandConfiguration(commandName: "retry", abstract: "Retry a recorded local image run or an immutable relay graph job.")
+    @Argument(help: "Local image run directory, image-run.json path, or relay:// job reference.") var reference: String
     @Flag(name: [.customLong("json")], help: "Emit the retry job as JSON.") var json = false
 
     func run() async throws {
+        if !reference.hasPrefix("relay://") && !reference.hasPrefix("ssh://") {
+            let retry = try ImageRunSession.retryPlan(at: URL(fileURLWithPath: reference))
+            do {
+                let lease = try await MachineInferenceCoordinator.shared.acquire(
+                    CLIInferenceAdmissionClassifier.imageGenerationRequest(modelID: retry.plan.manifest.id)
+                ) { snapshot in
+                    CLIStderr.write("Image retry queued by machine admission (\(snapshot.activePermits)/\(snapshot.capacityPermits) permits active).\n")
+                }
+                defer { lease.release() }
+                try MLXBundleSupport.ensureAvailable(quiet: true)
+                _ = try await ImageGenerationOperation.execute(retry.plan, recording: retry.session)
+            } catch {
+                try retry.session.fail(error)
+                throw error
+            }
+            let record = try ImageRunRecord.inspect(at: retry.session.directory)
+            if json { print(try StructuredRunOutput.encode(record)) } else { print(retry.session.directory.path) }
+            return
+        }
         let job = try await WorkflowRemoteJobController.retry(mapRelayErrors { try WorkflowRemoteReference(reference) })
         if json { print(try StructuredRunOutput.encode(job)) } else { print("[\(job.state.rawValue)] \(job.jobReference)") }
     }

--- a/Sources/MereRunCLI/Support/ImageGenerationPreflight.swift
+++ b/Sources/MereRunCLI/Support/ImageGenerationPreflight.swift
@@ -35,6 +35,7 @@ struct ImageGenerationPreflightInput {
     let kreaBaseQuantizationBits: Int?
     let generationArgv: [String]
     let cwd: String
+    var runDirectory: String? = nil
 }
 
 struct ImageGenerationPreflightRequest: Codable, Equatable {
@@ -289,6 +290,21 @@ struct ImageGenerationPreflightAnalyzer {
 
     func envelope(resourceDiagnostics: [PreflightDiagnostic] = []) -> ImageGenerationPreflightEnvelope {
         var diagnostics = resourceDiagnostics
+        if let directory = input.runDirectory, fileManager.fileExists(atPath: directory) {
+            diagnostics.append(PreflightDiagnostic(
+                id: "image_run_directory_exists", severity: .blocker, title: "Run directory already exists",
+                message: "Choose a new --run-dir path. Image recording preserves existing directories.",
+                locations: [.init(kind: "directory", path: directory)]
+            ))
+        }
+        if let directory = input.runDirectory {
+            do {
+                try ImageRunSession.validateOutput(input.outputURL, in: URL(fileURLWithPath: directory))
+            } catch {
+                diagnostics.append(PreflightDiagnostic(id: "image_run_output_conflict", severity: .blocker,
+                                                      title: "Output conflicts with run files", message: error.localizedDescription))
+            }
+        }
         let createdAt = now()
         let (model, manifest) = modelSummary(diagnostics: &diagnostics)
         let output = outputSummary(
@@ -802,7 +818,8 @@ struct ImageGenerationPreflightAnalyzer {
                 kreaConditioningMultiplier: input.kreaConditioningMultiplier,
                 kreaConditioningLayerWeights: input.kreaConditioningLayerWeights,
                 kreaBaseQuantizationBits: input.kreaBaseQuantizationBits,
-                quiet: input.generationArgv.contains("--quiet")
+                quiet: input.generationArgv.contains("--quiet"),
+                runDirectory: input.runDirectory
             ),
             resolved: resolved
         )

--- a/Sources/MereRunCLI/Support/ImageGenerationRunPlan.swift
+++ b/Sources/MereRunCLI/Support/ImageGenerationRunPlan.swift
@@ -96,6 +96,7 @@ struct ImageGenerationRunPlanArguments: Codable, Equatable {
     let kreaConditioningLayerWeights: String?
     let kreaBaseQuantizationBits: Int?
     let quiet: Bool
+    var runDirectory: String? = nil
 
     enum CodingKeys: String, CodingKey {
         case prompt
@@ -126,6 +127,7 @@ struct ImageGenerationRunPlanArguments: Codable, Equatable {
         case kreaConditioningLayerWeights = "krea_conditioning_layer_weights"
         case kreaBaseQuantizationBits = "krea_base_quantization_bits"
         case quiet
+        case runDirectory = "run_directory"
     }
 
     func executableArgv() -> [String] {
@@ -168,7 +170,8 @@ struct ImageGenerationRunPlanArguments: Codable, Equatable {
             kreaConditioningMultiplier: kreaConditioningMultiplier,
             kreaConditioningLayerWeights: kreaConditioningLayerWeights,
             kreaBaseQuantizationBits: kreaBaseQuantizationBits,
-            quiet: quiet
+            quiet: quiet,
+            runDirectory: runDirectory
         )
     }
 
@@ -207,6 +210,7 @@ struct ImageGenerationRunPlanArguments: Codable, Equatable {
         appendOption("--krea-conditioning-layer-weights", kreaConditioningLayerWeights, to: &args)
         appendOption("--krea-base-quantization-bits", kreaBaseQuantizationBits, to: &args)
         appendBoolFlag("--quiet", when: quiet, to: &args)
+        appendOption("--run-dir", runDirectory, to: &args)
         return args
     }
 

--- a/Sources/MereRunCLI/Support/MachineInferenceAdmission.swift
+++ b/Sources/MereRunCLI/Support/MachineInferenceAdmission.swift
@@ -651,6 +651,10 @@ enum CLIInferenceAdmissionClassifier {
         }
     }
 
+    static func imageGenerationRequest(modelID: String) -> MachineInferenceRequest {
+        MachineInferenceRequest(label: "image generate", resourceClass: isLargeModel(modelID) ? .large : .standard)
+    }
+
     static func apiServerRequest(engine: APIEngine, modelID: String? = nil) -> MachineInferenceRequest {
         let resourceClass: MachineInferenceClass = engine == .textChatDeepseekV4Flash || isLargeModel(modelID)
             ? .large

--- a/Sources/MereRunCLI/Support/RunInspection.swift
+++ b/Sources/MereRunCLI/Support/RunInspection.swift
@@ -16,10 +16,12 @@ struct RunInspectionResult: Codable, Equatable {
     let runDirectory: RunDirectoryInspectionSummary?
     let report: StructuredReportInspectionSummary?
     let plan: RunPlanInspectionSummary?
+    var imageRun: ImageRunRecord? = nil
 
     enum CodingKeys: String, CodingKey {
         case kind
         case path
+        case imageRun = "image_run"
         case runDirectory = "run_directory"
         case report
         case plan
@@ -362,6 +364,26 @@ struct RunInspectionAnalyzer {
                 )
             )
             return RunInspectionResult(kind: "missing", path: targetURL.path, runDirectory: nil, report: nil, plan: nil)
+        }
+        let imageURL = ImageRunRecord.recordURL(at: targetURL)
+        if fileManager.fileExists(atPath: imageURL.path) {
+            do {
+                let record = try ImageRunRecord.inspect(at: imageURL)
+                for artifact in record.artifacts where !fileManager.fileExists(atPath: artifact.url.path) {
+                    diagnostics.append(PreflightDiagnostic(
+                        id: "image_run_artifact_missing", severity: .warning, title: "Recorded output missing",
+                        message: "The image run completed, but its retained output was removed.",
+                        locations: [.init(kind: "file", path: artifact.url.path)]
+                    ))
+                }
+                return RunInspectionResult(kind: "image_run", path: targetURL.path, runDirectory: nil, report: nil, plan: nil, imageRun: record)
+            } catch {
+                diagnostics.append(PreflightDiagnostic(
+                    id: "image_run_unreadable", severity: .blocker, title: "Image run unreadable",
+                    message: error.localizedDescription, locations: [.init(kind: "file", path: imageURL.path)]
+                ))
+                return RunInspectionResult(kind: "image_run", path: targetURL.path, runDirectory: nil, report: nil, plan: nil)
+            }
         }
         if isDirectory.boolValue {
             return RunInspectionResult(
@@ -845,6 +867,13 @@ struct RunInspectionAnalyzer {
 
     private func actions(for result: RunInspectionResult, cwd: String) -> [DeclarativeAction] {
         var actions: [DeclarativeAction] = []
+        if let image = result.imageRun {
+            actions.append(DeclarativeAction(
+                id: "retry-image-run", label: "Retry image run", kind: .command, style: .primary,
+                enabled: image.state.isTerminal && image.resolvedOptions != nil,
+                command: DeclarativeCommand(argv: ["mere.run", "run", "retry", result.path], cwd: cwd, commandPath: ["run", "retry"])
+            ))
+        }
         if result.kind == "run_directory" {
             actions.append(
                 DeclarativeAction(
@@ -879,6 +908,9 @@ struct RunInspectionAnalyzer {
         result: RunInspectionResult,
         diagnostics: [PreflightDiagnostic]
     ) -> String {
+        if let image = result.imageRun {
+            return "Image run \(image.id.uuidString.lowercased()): \(image.state.rawValue), \(image.artifacts.count) artifact(s)."
+        }
         switch status {
         case .ok:
             return "Inspected \(result.kind) at \(result.path)."
@@ -1098,18 +1130,18 @@ struct RunListAnalyzer {
             fileManager: fileManager,
             now: now
         ).envelope()
-        guard ["run_directory", "report_file", "plan_file"].contains(envelope.result.kind) else {
+        guard ["run_directory", "report_file", "plan_file", "image_run"].contains(envelope.result.kind) else {
             return nil
         }
         let relativePath = Self.relativePath(for: url, root: root)
         let runDirectory = envelope.result.runDirectory
         let report = envelope.result.report
         let plan = envelope.result.plan
-        let manifestCreatedAt = runDirectory?.manifest?.createdAt
+        let manifestCreatedAt = envelope.result.imageRun?.createdAt ?? runDirectory?.manifest?.createdAt
         let legacyCreatedAt = runDirectory?.legacyManifest?.createdAt
         let reportCreatedAt = report?.createdAt
         let planCreatedAt = plan?.createdAt
-        let eventCreatedAt = runDirectory?.events.latest?.createdAt
+        let eventCreatedAt = envelope.result.imageRun?.updatedAt ?? runDirectory?.events.latest?.createdAt
         let legacyUpdatedAt = runDirectory?.legacyManifest?.updatedAt
         let createdAt = manifestCreatedAt ??
             legacyCreatedAt ??
@@ -1128,23 +1160,23 @@ struct RunListAnalyzer {
             relativePath: relativePath,
             depth: depth,
             status: envelope.status,
-            state: runDirectory?.status ?? report?.status.rawValue,
+            state: envelope.result.imageRun?.state.rawValue ?? runDirectory?.status ?? report?.status.rawValue,
             createdAt: createdAt,
             updatedAt: updatedAt,
             summary: envelope.summary,
-            command: report?.command ?? plan?.command,
-            format: runDirectory?.manifest?.format ?? plan?.kind,
+            command: envelope.result.imageRun == nil ? report?.command ?? plan?.command : ["image", "generate"],
+            format: envelope.result.imageRun == nil ? runDirectory?.manifest?.format ?? plan?.kind : "image.generate",
             eventCount: runDirectory?.events.count,
-            artifactCount: runDirectory?.artifacts.count,
+            artifactCount: envelope.result.imageRun?.artifacts.count ?? runDirectory?.artifacts.count,
             diagnosticCount: envelope.diagnostics.count,
             blockerCount: envelope.diagnostics.filter { $0.severity == .blocker }.count,
-            actions: entryActions(path: url.path, kind: envelope.result.kind)
+            actions: entryActions(path: url.path, kind: envelope.result.kind) + envelope.actions.filter { $0.id == "retry-image-run" }
         )
     }
 
     private func isRunDirectoryCandidate(_ url: URL, contents: [URL]) -> Bool {
         let names = Set(contents.map(\.lastPathComponent))
-        if names.contains(LoRATrainingRunManifest.filename) {
+        if names.contains(ImageRunRecord.filename) || names.contains(LoRATrainingRunManifest.filename) {
             return true
         }
         let hasPlan = names.contains("plan.json")
@@ -1214,7 +1246,7 @@ struct RunListAnalyzer {
                 )
             ),
         ]
-        if kind == "run_directory" {
+        if kind == "run_directory" || (kind == "image_run" && URL(fileURLWithPath: path).lastPathComponent != ImageRunRecord.filename) {
             actions.append(
                 DeclarativeAction(
                     id: "open",

--- a/Sources/MereRunContract/CommandCapabilityContract.swift
+++ b/Sources/MereRunContract/CommandCapabilityContract.swift
@@ -730,6 +730,7 @@ public enum MereRunCapabilityCatalog {
         title: "Generate and edit images",
         summary: "Generate, transform, or personalize images with references, structured prompts, and LoRAs.",
         options: [
+            .init(flag: "--run-dir", label: "Run directory", kind: .directory, group: Group.output, tier: .expert),
             .init(
                 flag: "--sigmas", label: "Sigma schedule", kind: .string, group: Group.sampling, tier: .expert
             ),
@@ -2762,10 +2763,10 @@ public enum MereRunCapabilityCatalog {
     public static let runRetry = MereRunCommandCapability(
         id: "run.retry",
         command: ["run", "retry"],
-        title: "Retry Relay run",
-        summary: "Retry one immutable Relay graph job with the same bundle.",
+        title: "Retry run",
+        summary: "Retry a recorded local image run or an immutable Relay graph job.",
         arguments: [
-            .init(name: "reference", label: "Relay run reference", kind: .string, required: true)
+            .init(name: "reference", label: "Run reference", kind: .string, required: true)
         ],
         options: [
             .init(flag: "--json", label: "JSON", kind: .boolean)
@@ -3703,6 +3704,7 @@ public enum MereRunCapabilityCatalog {
         title: "API server",
         summary: "Serve installed models through OpenAI-compatible local APIs.",
         options: [
+            .init(flag: "--image-run-records", label: "Image run records", kind: .directory, group: Group.output, tier: .expert),
             .init(
                 flag: "--warmup", label: "Warm model before serving", kind: .boolean, group: Group.run, tier: .expert
             ),

--- a/Sources/MereRunCore/Flux1/Flux1Generator.swift
+++ b/Sources/MereRunCore/Flux1/Flux1Generator.swift
@@ -92,7 +92,7 @@ public actor Flux1Generator: ImageGenerator {
         try await applyAdapters(request.loras, to: transformer, progressHandler: progressHandler)
         progressHandler?(GenerationProgress(stage: .loadingTransformer, stepIndex: 3, totalSteps: 3))
 
-        let seed = request.seed ?? deterministicSeed(prompt: request.prompt)
+        let seed = ImageGenerationSeed.resolve(request.seed, prompt: request.prompt, backend: .flux1)
         let resolution = Flux1SampleBuilder.alignedResolution(width: request.width, height: request.height)
         let latentHeight = resolution.height / Flux1SampleBuilder.vaeCompression
         let latentWidth = resolution.width / Flux1SampleBuilder.vaeCompression
@@ -327,15 +327,6 @@ public actor Flux1Generator: ImageGenerator {
             return try ModelResolver().resolve(modelID).rootURL
         }
         throw Flux1Error.modelNotFound(spec)
-    }
-
-    private func deterministicSeed(prompt: String) -> UInt64 {
-        var hash: UInt64 = 0xcbf2_9ce4_8422_2325
-        for byte in prompt.utf8 {
-            hash ^= UInt64(byte)
-            hash &*= 0x0000_0100_0000_01b3
-        }
-        return hash
     }
 
     private static func adapterScale(_ adapter: LoRA) -> Float {

--- a/Sources/MereRunCore/Flux2Klein/Flux2KleinGenerator+Generation.swift
+++ b/Sources/MereRunCore/Flux2Klein/Flux2KleinGenerator+Generation.swift
@@ -97,7 +97,7 @@ extension Flux2KleinGenerator {
         }()
 
         // 2. Prepare latent dimensions
-        let seed = request.seed ?? UInt64.random(in: 0..<UInt64.max)
+        let seed = ImageGenerationSeed.resolve(request.seed, prompt: request.prompt, backend: .flux2Klein)
         let vaeScaleFactor = vae.configuration.vaeScaleFactor
         let latentHeight = request.height / vaeScaleFactor
         let latentWidth = request.width / vaeScaleFactor

--- a/Sources/MereRunCore/Flux2Klein/Flux2KleinGeneratoriOS.swift
+++ b/Sources/MereRunCore/Flux2Klein/Flux2KleinGeneratoriOS.swift
@@ -48,7 +48,7 @@ public actor Flux2KleinGeneratoriOS: ImageGenerator {
         _ request: GenerationRequest,
         progressHandler: (@Sendable (GenerationProgress) -> Void)?
     ) async throws -> GenerationResult {
-        let seed = request.seed ?? UInt64.random(in: 0..<UInt64.max)
+        let seed = ImageGenerationSeed.resolve(request.seed, prompt: request.prompt, backend: .flux2Klein)
         let modelSpec = request.model ?? ModelResolver.ModelID.kleinNano.rawValue
         let modelPath = try resolveModelPath(from: modelSpec)
 
@@ -95,7 +95,7 @@ public actor Flux2KleinGeneratoriOS: ImageGenerator {
         let textEncoderQuantization = try ModelWeightsLoader.QuantizationParams.fromManifest(textEncoderComponent.sourceManifest)
 
         // 1. Prepare latent dimensions
-        let seed = request.seed ?? UInt64.random(in: 0..<UInt64.max)
+        let seed = ImageGenerationSeed.resolve(request.seed, prompt: request.prompt, backend: .flux2Klein)
         let vaeScaleFactor = 8  // Standard for FLUX VAE
         let latentHeight = request.height / vaeScaleFactor
         let latentWidth = request.width / vaeScaleFactor

--- a/Sources/MereRunCore/Generation.swift
+++ b/Sources/MereRunCore/Generation.swift
@@ -1,11 +1,11 @@
 import Foundation
 
-public enum LoRA: Sendable, Hashable {
+public enum LoRA: Codable, Sendable, Hashable {
     case local(path: String, scale: Double)
     case remote(reference: String, scale: Double)
 }
 
-public struct Krea2ConditioningRebalance: Sendable, Hashable {
+public struct Krea2ConditioningRebalance: Codable, Sendable, Hashable {
     public var multiplier: Float
     public var layerWeights: [Float]
 
@@ -15,7 +15,7 @@ public struct Krea2ConditioningRebalance: Sendable, Hashable {
     }
 }
 
-public struct GenerationRequest: Sendable, Hashable {
+public struct GenerationRequest: Codable, Sendable, Hashable {
     public var prompt: String
     public var negativePrompt: String?
     /// Reference images for model families that support edit or personalization modes.

--- a/Sources/MereRunCore/HiDreamO1/HiDreamO1Generator.swift
+++ b/Sources/MereRunCore/HiDreamO1/HiDreamO1Generator.swift
@@ -140,7 +140,7 @@ public final class HiDreamO1Generator: ImageGenerator {
             HiDreamO1Denoiser.Conditioning(sample: $0, visionConditions: visionConditions)
         }
 
-        let seed = request.seed ?? deterministicSeed(prompt: request.prompt)
+        let seed = ImageGenerationSeed.resolve(request.seed, prompt: request.prompt, backend: .hiDreamO1)
         let image: MLXArray
         if references.isEmpty {
             let patches = try HiDreamO1Denoiser.runTextOnly(
@@ -252,15 +252,6 @@ public final class HiDreamO1Generator: ImageGenerator {
         if !FileManager.default.fileExists(atPath: directory.path) {
             try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         }
-    }
-
-    private func deterministicSeed(prompt: String) -> UInt64 {
-        var hash: UInt64 = 0xcbf2_9ce4_8422_2325
-        for byte in prompt.utf8 {
-            hash ^= UInt64(byte)
-            hash &*= 0x0000_0100_0000_01b3
-        }
-        return hash
     }
 
     private func resizedReferenceSizes(

--- a/Sources/MereRunCore/Ideogram4/Ideogram4Generator.swift
+++ b/Sources/MereRunCore/Ideogram4/Ideogram4Generator.swift
@@ -100,7 +100,7 @@ public final class Ideogram4Generator: ImageGenerator {
         eval(llmFeatures)
         progressHandler?(GenerationProgress(stage: .encodingText, stepIndex: 1, totalSteps: 1))
 
-        let seed = request.seed ?? deterministicSeed(prompt: request.prompt)
+        let seed = ImageGenerationSeed.resolve(request.seed, prompt: request.prompt, backend: .ideogram4)
         let gridSample = try Ideogram4SampleBuilder.textToImageSample(
             llmFeatures: llmFeatures,
             imageWidth: request.width,
@@ -263,15 +263,6 @@ public final class Ideogram4Generator: ImageGenerator {
         if !FileManager.default.fileExists(atPath: directory.path) {
             try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         }
-    }
-
-    private func deterministicSeed(prompt: String) -> UInt64 {
-        var hash: UInt64 = 0xcbf2_9ce4_8422_2325
-        for byte in prompt.utf8 {
-            hash ^= UInt64(byte)
-            hash &*= 0x0000_0100_0000_01b3
-        }
-        return hash
     }
 
     private func clearGPUMemory(synchronize: Bool = true) {

--- a/Sources/MereRunCore/ImageGenerationOperation.swift
+++ b/Sources/MereRunCore/ImageGenerationOperation.swift
@@ -28,10 +28,12 @@ public enum ImageGenerationOperation {
     public static func execute(
         _ plan: ImageGenerationPlan,
         id: UUID = UUID(),
+        recording: ImageRunSession? = nil,
         progressHandler: (@Sendable (GenerationProgress) -> Void)? = nil,
         eventHandler: (@Sendable (ImageGenerationEvent) -> Void)? = nil,
         executor: Executor = generate
     ) async throws -> ImageGenerationOutcome {
+        let id = recording?.id ?? id
         eventHandler?(.started(id))
         let progress: (@Sendable (GenerationProgress) -> Void)?
         if progressHandler != nil || eventHandler != nil {
@@ -43,13 +45,17 @@ public enum ImageGenerationOperation {
             progress = nil
         }
         do {
-            let outcome = try await perform(plan, id: id, progressHandler: progress, executor: executor)
+            let effectivePlan = try recording?.prepare(plan) ?? plan
+            let outcome = try await perform(effectivePlan, id: id, progressHandler: progress, executor: executor)
+            try recording?.succeed(outcome)
             eventHandler?(.succeeded(outcome))
             return outcome
         } catch is CancellationError {
+            try recording?.fail(CancellationError())
             eventHandler?(.cancelled(id))
             throw CancellationError()
         } catch {
+            try recording?.fail(error)
             let issue = error as? ImageGenerationIssue
                 ?? ImageGenerationIssue("generation_failed", error.localizedDescription)
             eventHandler?(.failed(id, issue))

--- a/Sources/MereRunCore/ImageGenerationOptions.swift
+++ b/Sources/MereRunCore/ImageGenerationOptions.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// User-supplied image settings before model defaults and adapter recipes are applied.
-public struct ImageGenerationOptions: Sendable, Hashable {
+public struct ImageGenerationOptions: Codable, Sendable, Hashable {
     public var prompt: String
     public var negativePrompt: String?
     public var outputURL: URL
@@ -71,7 +71,7 @@ public struct ImageGenerationOptions: Sendable, Hashable {
     }
 }
 
-public struct ImageLoRAReference: Sendable, Hashable {
+public struct ImageLoRAReference: Codable, Sendable, Hashable {
     public let raw: String
     public let reference: String
     public let scale: Double
@@ -110,7 +110,7 @@ public struct ImageLoRAReference: Sendable, Hashable {
 }
 
 /// Stable diagnostic identifiers let transports present errors without parsing prose.
-public struct ImageGenerationIssue: LocalizedError, Equatable, Sendable {
+public struct ImageGenerationIssue: Codable, LocalizedError, Equatable, Sendable {
     public let code: String
     public let message: String
     public var errorDescription: String? { message }
@@ -141,7 +141,7 @@ public enum ImageGenerationBackend: String, CaseIterable, Codable, Sendable {
 }
 
 /// Compatibility choices belong to the caller, while their implementation has one owner.
-public struct ImageGenerationPolicy: Sendable, Hashable {
+public struct ImageGenerationPolicy: Codable, Sendable, Hashable {
     public var kleinUsesManifestDefaults: Bool
     public var kleinInputAsReference: Bool
     public var fallbackSteps: Int

--- a/Sources/MereRunCore/ImageGenerationSeed.swift
+++ b/Sources/MereRunCore/ImageGenerationSeed.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+/// Preserve each runtime's default seed policy when a run records its seed
+/// before inference. Prompt-derived seeds use the existing FNV-1a algorithm.
+enum ImageGenerationSeed {
+    static func resolve(_ seed: UInt64?, prompt: String, backend: ImageGenerationBackend) -> UInt64 {
+        if let seed { return seed }
+        switch backend {
+        case .flux2Klein, .zImageTurbo, .qwenImageEdit:
+            return UInt64.random(in: 0..<UInt64.max)
+        case .flux1, .hiDreamO1, .senseNovaU15, .krea2, .ideogram4:
+            return prompt.utf8.reduce(UInt64(0xcbf2_9ce4_8422_2325)) { ($0 ^ UInt64($1)) &* 0x100_0000_01b3 }
+        }
+    }
+}

--- a/Sources/MereRunCore/ImageRunLease.swift
+++ b/Sources/MereRunCore/ImageRunLease.swift
@@ -1,0 +1,43 @@
+import Foundation
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+/// Nonblocking process lease. The descriptor is never inherited across exec.
+final class ImageRunLease: @unchecked Sendable {
+    private let mutex = NSLock()
+    private var descriptor: Int32
+
+    private init(_ descriptor: Int32) { self.descriptor = descriptor }
+    deinit { release() }
+
+    static func createDirectory(_ directory: URL) throws {
+        guard directory.path.withCString({ mkdir($0, S_IRWXU) }) == 0 else {
+            throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+        }
+    }
+
+    static func acquire(in directory: URL) throws -> ImageRunLease? {
+        let path = directory.appendingPathComponent(".image-run.lock").path
+        let descriptor = path.withCString { open($0, O_CREAT | O_RDWR | O_CLOEXEC | O_NOFOLLOW, S_IRUSR | S_IWUSR) }
+        guard descriptor >= 0 else { throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO) }
+        guard flock(descriptor, LOCK_EX | LOCK_NB) == 0 else {
+            let code = errno
+            close(descriptor)
+            if code == EWOULDBLOCK || code == EAGAIN { return nil }
+            throw POSIXError(POSIXErrorCode(rawValue: code) ?? .EIO)
+        }
+        return ImageRunLease(descriptor)
+    }
+
+    func release() {
+        mutex.withLock {
+            guard descriptor >= 0 else { return }
+            _ = flock(descriptor, LOCK_UN)
+            close(descriptor)
+            descriptor = -1
+        }
+    }
+}

--- a/Sources/MereRunCore/ImageRunRecord.swift
+++ b/Sources/MereRunCore/ImageRunRecord.swift
@@ -1,0 +1,100 @@
+import Crypto
+import Foundation
+
+/// Versioned image history. Requested settings retain omissions; resolved settings
+/// contain the values submitted to the runtime, including a seed chosen before execution.
+public struct ImageRunRecord: Codable, Equatable, Sendable {
+    public static let filename = "image-run.json"
+    public enum State: String, Codable, Sendable {
+        case preparing, running, succeeded, failed, cancelled, interrupted
+        public var isTerminal: Bool { self != .preparing && self != .running }
+    }
+
+    public let schemaVersion: Int
+    public let id: UUID
+    public let parentID: UUID?
+    public let createdAt: Date
+    public var updatedAt: Date
+    public var state: State
+    public let modelSelector: String
+    public let requested: ImageGenerationOptions
+    public var resolvedOptions: ImageGenerationOptions?
+    public var effective: GenerationRequest?
+    public var policy: ImageGenerationPolicy?
+    public var modelRoot: URL?
+    public var modelManifest: MereRunModelManifest?
+    public var manifestDigest: String?
+    public var installedManifestDigest: String?
+    public var backend: ImageGenerationBackend?
+    public var inputs: [Artifact]
+    public var artifacts: [Artifact]
+    public var issue: ImageGenerationIssue?
+
+    public struct Artifact: Codable, Equatable, Sendable {
+        public let url: URL
+        public let sha256: String
+        public let byteCount: UInt64
+
+        public static func read(_ url: URL) throws -> Self {
+            let handle = try FileHandle(forReadingFrom: url)
+            defer { try? handle.close() }
+            var hash = SHA256()
+            var byteCount: UInt64 = 0
+            while let bytes = try handle.read(upToCount: 1_048_576), !bytes.isEmpty {
+                hash.update(data: bytes)
+                byteCount += UInt64(bytes.count)
+            }
+            return Self(url: url, sha256: hash.finalize().map { String(format: "%02x", $0) }.joined(), byteCount: byteCount)
+        }
+    }
+
+    public static func recordURL(at url: URL) -> URL {
+        url.lastPathComponent == filename ? url : url.appendingPathComponent(filename)
+    }
+
+    /// A lock held by the executing process is the source of liveness. Reading an
+    /// abandoned nonterminal record persists an interrupted state, even after reboot.
+    public static func inspect(at url: URL) throws -> Self {
+        let recordURL = recordURL(at: url)
+        let lease = try ImageRunLease.acquire(in: recordURL.deletingLastPathComponent())
+        defer { lease?.release() }
+        var record = try decode(Data(contentsOf: recordURL))
+        if lease != nil, !record.state.isTerminal {
+            record.state = .interrupted
+            record.updatedAt = timestamp()
+            record.issue = ImageGenerationIssue("process_interrupted", "The image process stopped before recording a terminal result.")
+            try record.write(to: recordURL)
+        }
+        return record
+    }
+
+    static func decode(_ data: Data) throws -> Self {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let record = try decoder.decode(Self.self, from: data)
+        guard record.schemaVersion == 1 else {
+            throw ImageGenerationIssue("run_version_unsupported", "Unsupported image run record version: \(record.schemaVersion).")
+        }
+        return record
+    }
+
+    static func timestamp() -> Date {
+        Date(timeIntervalSince1970: Date().timeIntervalSince1970.rounded(.down))
+    }
+
+    static func encoder() -> JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }
+
+    static func digest(_ manifest: MereRunModelManifest) throws -> String {
+        SHA256.hash(data: try encoder().encode(manifest)).map { String(format: "%02x", $0) }.joined()
+    }
+
+    func write(to url: URL) throws {
+        try Self.encoder().encode(self).write(to: url, options: [.atomic, .completeFileProtectionUnlessOpen])
+        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
+    }
+}

--- a/Sources/MereRunCore/ImageRunSession.swift
+++ b/Sources/MereRunCore/ImageRunSession.swift
@@ -1,0 +1,160 @@
+import Foundation
+
+/// Owns one run directory and its process lease. All mutations are serialized;
+/// terminal records release the lease only after their atomic write succeeds.
+public final class ImageRunSession: @unchecked Sendable {
+    public let directory: URL
+    public let id: UUID
+    private let mutex = NSLock()
+    private let lease: ImageRunLease
+    private var record: ImageRunRecord
+
+    public init(directory: URL, requested: ImageGenerationOptions, modelSelector: String, parentID: UUID? = nil) throws {
+        self.directory = directory.standardizedFileURL
+        self.id = UUID()
+        try Self.validateOutput(requested.outputURL, in: self.directory)
+        let manager = FileManager.default
+        try manager.createDirectory(at: self.directory.deletingLastPathComponent(), withIntermediateDirectories: true)
+        // Refuse existing directories, including earlier runs and unrelated user files.
+        try ImageRunLease.createDirectory(self.directory)
+        guard let lease = try ImageRunLease.acquire(in: self.directory) else {
+            throw ImageGenerationIssue("run_active", "The image run directory is already in use.")
+        }
+        self.lease = lease
+        let now = ImageRunRecord.timestamp()
+        record = ImageRunRecord(
+            schemaVersion: 1, id: id, parentID: parentID, createdAt: now, updatedAt: now,
+            state: .preparing, modelSelector: modelSelector, requested: requested, inputs: [], artifacts: []
+        )
+        try record.write(to: self.directory.appendingPathComponent(ImageRunRecord.filename))
+    }
+
+    /// Snapshot edit inputs before an HTTP upload directory can be cleaned up.
+    /// Local adapters stay in place and are fingerprinted for retry validation.
+    func prepare(_ plan: ImageGenerationPlan) throws -> ImageGenerationPlan {
+        try mutex.withLock {
+            guard record.state == .preparing else {
+                throw ImageGenerationIssue("run_state_invalid", "This image run has already started.")
+            }
+            try Self.validateOutput(plan.options.outputURL, in: directory)
+            var options = plan.options
+            let inputDirectory = directory.appendingPathComponent("inputs")
+            try FileManager.default.createDirectory(at: inputDirectory, withIntermediateDirectories: false)
+            func snapshot(_ source: URL, name: String) throws -> URL {
+                let target = inputDirectory.appendingPathComponent(name).appendingPathExtension(source.pathExtension)
+                try FileManager.default.copyItem(at: source, to: target)
+                record.inputs.append(try .read(target))
+                return target
+            }
+            options.inputImage = try options.inputImage.map { try snapshot($0, name: "input") }
+            options.mask = try options.mask.map { try snapshot($0, name: "mask") }
+            options.referenceImages = try options.referenceImages.enumerated().map { try snapshot($0.element, name: "reference-\($0.offset)") }
+            options.seed = ImageGenerationSeed.resolve(plan.request.seed, prompt: plan.request.prompt, backend: plan.backend)
+            options.steps = plan.request.steps
+            options.guidanceScale = plan.request.guidanceScale
+            options.sigmaShift = plan.request.sigmaShift
+            options.sigmas = plan.request.sigmas
+            options.loras = try plan.request.loras.map { adapter in
+                switch adapter {
+                case .local(let path, let scale):
+                    record.inputs.append(try .read(URL(fileURLWithPath: path)))
+                    return ImageLoRAReference(raw: path, reference: path, scale: scale)
+                case .remote:
+                    throw ImageGenerationIssue("run_adapter_unresolved", "Recorded image runs require locally resolved adapters.")
+                }
+            }
+            let resolved = try ImageGenerationPlan.resolve(options, modelRoot: plan.modelRoot, manifest: plan.manifest, policy: plan.policy)
+            record.resolvedOptions = options
+            record.effective = resolved.request
+            record.policy = plan.policy
+            record.modelRoot = plan.modelRoot
+            record.modelManifest = plan.manifest
+            record.manifestDigest = try ImageRunRecord.digest(plan.manifest)
+            record.installedManifestDigest = try MereRunModelManifest.loadIfPresent(from: plan.modelRoot).map(ImageRunRecord.digest)
+            record.backend = plan.backend
+            record.state = .running
+            try save()
+            return resolved
+        }
+    }
+
+    func succeed(_ outcome: ImageGenerationOutcome) throws {
+        try mutex.withLock {
+            guard record.state == .running else { throw ImageGenerationIssue("run_state_invalid", "The image run is not running.") }
+            let target = directory.appendingPathComponent("output.png")
+            if outcome.result.outputURL.standardizedFileURL != target.standardizedFileURL {
+                try FileManager.default.copyItem(at: outcome.result.outputURL, to: target)
+            }
+            record.artifacts = [try .read(target)]
+            record.effective = outcome.effectiveRequest
+            try Task.checkCancellation()
+            record.state = .succeeded
+            do {
+                try save()
+            } catch {
+                record.state = .running
+                throw error
+            }
+            lease.release()
+        }
+    }
+
+    public func fail(_ error: Error) throws {
+        try mutex.withLock {
+            guard !record.state.isTerminal else { return }
+            let previousState = record.state
+            record.state = error is CancellationError ? .cancelled : .failed
+            record.issue = error as? ImageGenerationIssue ?? ImageGenerationIssue(
+                error is CancellationError ? "cancelled" : "generation_failed", error.localizedDescription
+            )
+            do {
+                try save()
+            } catch {
+                record.state = previousState
+                throw error
+            }
+            lease.release()
+        }
+    }
+
+    public static func validateOutput(_ output: URL, in directory: URL) throws {
+        let root = directory.standardizedFileURL.resolvingSymlinksInPath()
+        let target = output.standardizedFileURL.resolvingSymlinksInPath()
+        if target.path == root.path || target.path.hasPrefix(root.path + "/") {
+            guard target == root.appendingPathComponent("output.png") else {
+                throw ImageGenerationIssue("run_output_conflict", "An output inside --run-dir must be named output.png. Choose another output path.")
+            }
+        }
+    }
+
+    private func save() throws {
+        record.updatedAt = ImageRunRecord.timestamp()
+        try record.write(to: directory.appendingPathComponent(ImageRunRecord.filename))
+    }
+
+    /// Replays resolved settings in a new sibling directory. It does not resume
+    /// denoising or re-expand a structured prompt. The parent record is immutable.
+    public static func retryPlan(at url: URL) throws -> (session: ImageRunSession, plan: ImageGenerationPlan) {
+        let parent = try ImageRunRecord.inspect(at: url)
+        guard parent.state.isTerminal else { throw ImageGenerationIssue("run_active", "Wait for the image run to stop before retrying.") }
+        guard var options = parent.resolvedOptions, let root = parent.modelRoot,
+              let manifest = parent.modelManifest, let digest = parent.manifestDigest, let policy = parent.policy else {
+            throw ImageGenerationIssue("run_not_prepared", "This run stopped before resolving its settings. Repeat the original image command.")
+        }
+        let installedDigest = try MereRunModelManifest.loadIfPresent(from: root).map(ImageRunRecord.digest)
+        guard installedDigest == parent.installedManifestDigest, try ImageRunRecord.digest(manifest) == digest else {
+            throw ImageGenerationIssue("run_model_changed", "The installed model manifest changed. Start a new image command to use it.")
+        }
+        for input in parent.inputs {
+            guard try ImageRunRecord.Artifact.read(input.url) == input else {
+                throw ImageGenerationIssue("run_input_changed", "A recorded image input or adapter changed: \(input.url.path).")
+            }
+        }
+        let parentDirectory = ImageRunRecord.recordURL(at: url).deletingLastPathComponent()
+        let directory = parentDirectory.deletingLastPathComponent().appendingPathComponent("image-\(UUID().uuidString.lowercased())")
+        options.outputURL = directory.appendingPathComponent("output.png")
+        let plan = try ImageGenerationPlan.resolve(options, modelRoot: root, manifest: manifest, policy: policy)
+        let session = try ImageRunSession(directory: directory, requested: options, modelSelector: parent.modelSelector, parentID: parent.id)
+        return (session, plan)
+    }
+}

--- a/Sources/MereRunCore/Krea2/Krea2Generator.swift
+++ b/Sources/MereRunCore/Krea2/Krea2Generator.swift
@@ -230,7 +230,7 @@ public final class Krea2Generator: ImageGenerator {
         text: (hiddenStates: MLXArray, attentionMask: MLXArray),
         progressHandler: (@Sendable (GenerationProgress) -> Void)?
     ) throws -> (latents: MLXArray, seed: UInt64) {
-        let seed = request.seed ?? deterministicSeed(prompt: request.prompt)
+        let seed = ImageGenerationSeed.resolve(request.seed, prompt: request.prompt, backend: .krea2)
         let aligned = Krea2SampleBuilder.alignedResolution(width: request.width, height: request.height)
         let initialLatents = MLXRandom.normal(
             [
@@ -552,15 +552,6 @@ public final class Krea2Generator: ImageGenerator {
         if !FileManager.default.fileExists(atPath: directory.path) {
             try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
         }
-    }
-
-    private func deterministicSeed(prompt: String) -> UInt64 {
-        var hash: UInt64 = 0xcbf2_9ce4_8422_2325
-        for byte in prompt.utf8 {
-            hash ^= UInt64(byte)
-            hash &*= 0x0000_0100_0000_01b3
-        }
-        return hash
     }
 
     private func clearGPUMemory(synchronize: Bool = true) {

--- a/Sources/MereRunCore/QwenImageEdit/QwenImageEditGenerator.swift
+++ b/Sources/MereRunCore/QwenImageEdit/QwenImageEditGenerator.swift
@@ -163,7 +163,7 @@ public actor QwenImageEditGenerator: ImageGenerator {
         try ensureTransformerLoaded(model: &model, progressHandler: progressHandler)
         loaded = model
 
-        let seed = request.seed ?? UInt64.random(in: 0..<UInt64.max)
+        let seed = ImageGenerationSeed.resolve(request.seed, prompt: request.prompt, backend: .qwenImageEdit)
         let noise = QwenImageEditLatentCreator.createNoise(
             batchSize: 1,
             height: inferenceConfig.height,

--- a/Sources/MereRunCore/SenseNovaU15/SenseNovaU15Generator.swift
+++ b/Sources/MereRunCore/SenseNovaU15/SenseNovaU15Generator.swift
@@ -82,7 +82,7 @@ public final class SenseNovaU15Generator: ImageGenerator {
         }
         progressHandler?(GenerationProgress(stage: .encodingText, stepIndex: 1, totalSteps: 1))
 
-        let seed = request.seed ?? deterministicSeed(request.prompt)
+        let seed = ImageGenerationSeed.resolve(request.seed, prompt: request.prompt, backend: .senseNovaU15)
         let result = denoise(
             model: loaded.model,
             config: loaded.config,
@@ -373,10 +373,6 @@ public final class SenseNovaU15Generator: ImageGenerator {
             searched: [MereRunModelPaths.modelDir(SenseNovaU15Resources.modelID)],
             upstreamRepoId: SenseNovaU15Resources.repository
         )
-    }
-
-    private func deterministicSeed(_ prompt: String) -> UInt64 {
-        prompt.utf8.reduce(UInt64(0xcbf2_9ce4_8422_2325)) { ($0 ^ UInt64($1)) &* 0x100_0000_01b3 }
     }
 
     private func clearMemory() {

--- a/Sources/MereRunCore/ZImageTurbo/ZImageTurboGenerator.swift
+++ b/Sources/MereRunCore/ZImageTurbo/ZImageTurboGenerator.swift
@@ -90,7 +90,7 @@ public actor ZImageTurboGenerator: ImageGenerator, ChatGenerator {
         var model = try await loadModelIfNeeded(modelSpec: modelSpec, progressHandler: progressHandler)
         model = try await applyTransformerLoRAIfNeeded(request.lora, model: model, progressHandler: progressHandler)
         let outputURL = request.outputURL
-        let seed = request.seed ?? UInt64.random(in: 0..<UInt64.max)
+        let seed = ImageGenerationSeed.resolve(request.seed, prompt: request.prompt, backend: .zImageTurbo)
 
         do {
             do {

--- a/Tests/MereRunCLITests/ImageGenerationAdapterTests.swift
+++ b/Tests/MereRunCLITests/ImageGenerationAdapterTests.swift
@@ -41,6 +41,37 @@ final class ImageGenerationAdapterTests: XCTestCase {
         }
     }
 
+    func testRecordedAPIRequestsRetainEffectiveSettingsForEveryBackend() async throws {
+        let root = try temporaryDirectory()
+        let input = root.appendingPathComponent("upload.png")
+        try Data("fixture".utf8).write(to: input)
+        let families: [(MereRunModelManifest.Family, MereRunModelManifest.Engine)] = [
+            (.flux1, .flux1), (.klein, .flux2Klein), (.zimage, .zimageTurbo), (.hidream, .hidreamO1),
+            (.senseNova, .senseNovaU15), (.krea, .krea2), (.ideogram, .ideogram4), (.qwen, .qwenImageEdit)
+        ]
+        for (index, pair) in families.enumerated() {
+            let manifest = MereRunModelManifest(id: "fixture", engine: pair.1, family: pair.0, defaults: .init(steps: 28, cfg: 4))
+            let plan = try apiPlan(input: pair.0 == .qwen ? input : nil).operationPlan(
+                modelRoot: root, outputURL: root.appendingPathComponent("output-\(index).png"), manifest: manifest
+            )
+            let session = try ImageRunSession(directory: root.appendingPathComponent("run-\(index)"), requested: plan.options, modelSelector: "fixture")
+            _ = try await ImageGenerationOperation.execute(plan, recording: session, executor: { _, request, _ in
+                XCTAssertEqual(request.steps, plan.request.steps)
+                XCTAssertEqual(request.guidanceScale, plan.request.guidanceScale)
+                XCTAssertEqual(request.seed, 42)
+                try Data("fixture output".utf8).write(to: request.outputURL)
+                return GenerationResult(outputURL: request.outputURL, seed: 42)
+            })
+            let record = try ImageRunRecord.inspect(at: session.directory)
+            XCTAssertEqual(record.state, .succeeded)
+            XCTAssertNil(record.requested.steps)
+            XCTAssertNil(record.requested.guidanceScale)
+            XCTAssertEqual(record.effective?.steps, plan.request.steps)
+            XCTAssertEqual(record.effective?.guidanceScale, plan.request.guidanceScale)
+            XCTAssertEqual(record.policy, plan.policy)
+        }
+    }
+
     func testAPIV1KleinCompatibilityIsExplicit() throws {
         let root = try temporaryDirectory()
         let input = root.appendingPathComponent("input.png")

--- a/Tests/MereRunCLITests/ImageRunCommandTests.swift
+++ b/Tests/MereRunCLITests/ImageRunCommandTests.swift
@@ -1,0 +1,103 @@
+import Foundation
+import XCTest
+@testable import MereRunCLI
+@testable import MereRunCore
+
+final class ImageRunCommandTests: XCTestCase {
+    func testFlagsAreOptInAndPreflightDoesNotCreateRecord() throws {
+        let root = try temporaryDirectory()
+        try MereRunModelManifest(id: "fixture", family: .zimage).write(to: root)
+        let directory = root.appendingPathComponent("run")
+        let command = try ImageGenerate.parse([
+            "--prompt", "A camera", "--model", root.path, "--run-dir", directory.path, "--preflight", "--json"
+        ])
+        XCTAssertEqual(command.runDirectory, directory.path)
+        let envelope = command.makePreflightEnvelope(outputURL: root.appendingPathComponent("output.png"))
+        XCTAssertEqual(envelope.status, .ok)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: directory.path))
+        let replay = try ImageGenerate.parse(envelope.result.runPlan.arguments.generateArguments())
+        XCTAssertEqual(replay.runDirectory, directory.path)
+        XCTAssertTrue(envelope.actions.contains { $0.command?.argv.contains("--run-dir") == true })
+        XCTAssertNil(try ImageGenerate.parse(["--prompt", "A camera"]).runDirectory)
+        XCTAssertNil(try APIServe.parse([]).imageRunRecords)
+        XCTAssertEqual(try APIServe.parse(["--image-run-records", root.path]).imageRunRecords, root.path)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: false)
+        XCTAssertTrue(command.makePreflightEnvelope(outputURL: root.appendingPathComponent("output.png"))
+            .diagnostics.contains { $0.id == "image_run_directory_exists" && $0.severity == .blocker })
+    }
+
+    func testModelResolutionFailureIsRecordedWithoutLoadingRuntime() async throws {
+        let root = try temporaryDirectory()
+        let directory = root.appendingPathComponent("run")
+        let command = try ImageGenerate.parse([
+            "--prompt", "A camera", "--model", root.appendingPathComponent("missing-model").path, "--run-dir", directory.path
+        ])
+        do {
+            try await command.run()
+            XCTFail("Expected missing model failure")
+        } catch {
+            let record = try ImageRunRecord.inspect(at: directory)
+            XCTAssertEqual(record.state, .failed)
+            XCTAssertNil(record.effective)
+            XCTAssertEqual(record.requested.prompt, "A camera")
+            XCTAssertTrue(record.artifacts.isEmpty)
+        }
+    }
+
+    func testListInspectAndRetryActionRecognizeRecordWithoutChangingLegacyEncoding() throws {
+        let root = try temporaryDirectory()
+        let directory = root.appendingPathComponent("run")
+        let options = ImageGenerationOptions(prompt: "A camera", outputURL: root.appendingPathComponent("output.png"))
+        let session = try ImageRunSession(directory: directory, requested: options, modelSelector: "fixture")
+        _ = try session.prepare(ImageGenerationPlan.resolve(options, modelRoot: root, manifest: .init(id: "fixture", family: .zimage)))
+        let active = try RunInspect.parse([directory.path, "--json"]).makeInspectionEnvelope()
+        XCTAssertEqual(active.result.kind, "image_run")
+        XCTAssertEqual(active.result.imageRun?.state, .running)
+        XCTAssertEqual(active.actions.first { $0.id == "retry-image-run" }?.enabled, false)
+        try session.fail(ImageGenerationIssue("fixture_failure", "Fixture failed"))
+        let inspection = try RunInspect.parse([directory.path, "--json"]).makeInspectionEnvelope(now: { Date(timeIntervalSince1970: 10) })
+        XCTAssertEqual(inspection.result.imageRun?.state, .failed)
+        XCTAssertEqual(inspection.actions.first { $0.id == "retry-image-run" }?.enabled, true)
+        let list = try RunList.parse(["--root", root.path, "--json"]).makeListEnvelope()
+        XCTAssertEqual(list.result.entryCount, 1)
+        XCTAssertEqual(list.result.entries.first?.kind, "image_run")
+        XCTAssertEqual(list.result.entries.first?.state, "failed")
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        XCTAssertEqual(try decoder.decode(RunInspectionEnvelope.self, from: Data(StructuredRunOutput.encode(inspection).utf8)), inspection)
+        let legacy = RunInspectionResult(kind: "missing", path: "/missing", runDirectory: nil, report: nil, plan: nil)
+        XCTAssertFalse(try StructuredRunOutput.encode(legacy).contains("image_run"))
+        let retry = try RunRetry.parse([directory.path, "--json"])
+        XCTAssertEqual(retry.reference, directory.path)
+        XCTAssertTrue(retry.json)
+    }
+
+    func testCorruptRecordBlocksInspectionAndIsListedForReview() throws {
+        let root = try temporaryDirectory()
+        let directory = root.appendingPathComponent("run")
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try Data("broken".utf8).write(to: ImageRunRecord.recordURL(at: directory))
+        let inspection = try RunInspect.parse([directory.path]).makeInspectionEnvelope()
+        XCTAssertEqual(inspection.status, .blocked)
+        XCTAssertEqual(inspection.diagnostics.first?.id, "image_run_unreadable")
+        let list = try RunList.parse(["--root", root.path]).makeListEnvelope()
+        XCTAssertEqual(list.result.entryCount, 1)
+        XCTAssertEqual(list.result.entries.first?.status, .blocked)
+    }
+
+    func testRetryUsesImageAdmissionClassForInstalledModelProfiles() {
+        for id in ["image-zimage-nano", "image-klein-nano", "image-flux2-dev", "image-krea2"] {
+            XCTAssertEqual(CLIInferenceAdmissionClassifier.imageGenerationRequest(modelID: id).resourceClass,
+                           CLIInferenceAdmissionClassifier.request(arguments: ["mere.run", "image", "generate", "--model", id])?.resourceClass)
+        }
+        XCTAssertNil(CLIInferenceAdmissionClassifier.request(arguments: ["mere.run", "run", "retry", "/tmp/run"]))
+        XCTAssertNil(CLIInferenceAdmissionClassifier.request(arguments: ["mere.run", "run", "retry", "relay://fleet/job"]))
+    }
+
+    private func temporaryDirectory() throws -> URL {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: root) }
+        return root
+    }
+}

--- a/Tests/MereRunCoreTests/ImageGenerationOperationTests.swift
+++ b/Tests/MereRunCoreTests/ImageGenerationOperationTests.swift
@@ -124,6 +124,28 @@ final class ImageGenerationOperationTests: XCTestCase {
         XCTAssertEqual(image.rgba8, [255, 0, 0, 255, 0, 0, 255, 255])
     }
 
+    func testRecordedMaskSurvivesOriginalInputCleanupAndRetry() async throws {
+        let plan = try maskedPlan()
+        let directory = plan.modelRoot.appendingPathComponent("run")
+        let session = try ImageRunSession(directory: directory, requested: plan.options, modelSelector: "fixture")
+        let executor: ImageGenerationOperation.Executor = { _, request, _ in
+            try MediaImageIO.writePNG(
+                try MediaImage(width: 2, height: 1, rgba8: [0, 0, 255, 255, 0, 0, 255, 255]), to: request.outputURL
+            )
+            return GenerationResult(outputURL: request.outputURL, seed: try XCTUnwrap(request.seed))
+        }
+        _ = try await ImageGenerationOperation.execute(plan, recording: session, executor: executor)
+        try FileManager.default.removeItem(at: XCTUnwrap(plan.options.inputImage))
+        try FileManager.default.removeItem(at: XCTUnwrap(plan.options.mask))
+        let retry = try ImageRunSession.retryPlan(at: directory)
+        _ = try await ImageGenerationOperation.execute(retry.plan, recording: retry.session, executor: executor)
+        let record = try ImageRunRecord.inspect(at: retry.session.directory)
+        let output = try XCTUnwrap(record.artifacts.first?.url)
+        XCTAssertEqual(try MediaImageIO.decode(output).rgba8, [255, 0, 0, 255, 0, 0, 255, 255])
+        XCTAssertNotNil(record.resolvedOptions?.mask)
+        XCTAssertEqual(record.resolvedOptions?.maskFeather, 0)
+    }
+
     func testExecutionWithoutObserversDoesNotEnableRuntimeProgress() async throws {
         let root = try temporaryDirectory()
         let plan = try ImageGenerationPlan.resolve(

--- a/Tests/MereRunCoreTests/ImageRunRecordTests.swift
+++ b/Tests/MereRunCoreTests/ImageRunRecordTests.swift
@@ -1,0 +1,246 @@
+import Foundation
+import XCTest
+@testable import MereRunCore
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+final class ImageRunRecordTests: XCTestCase {
+    func testOutputCannotOverwriteRecordOrLock() throws {
+        let root = try temporaryDirectory()
+        let directory = root.appendingPathComponent("run")
+        for name in [ImageRunRecord.filename, ".image-run.lock", "inputs/input.png"] {
+            let options = ImageGenerationOptions(prompt: "A camera", outputURL: directory.appendingPathComponent(name))
+            XCTAssertThrowsError(try ImageRunSession(directory: directory, requested: options, modelSelector: "fixture")) {
+                XCTAssertEqual(($0 as? ImageGenerationIssue)?.code, "run_output_conflict")
+            }
+            XCTAssertFalse(FileManager.default.fileExists(atPath: directory.path))
+        }
+        XCTAssertNoThrow(try ImageRunSession.validateOutput(directory.appendingPathComponent("output.png"), in: directory))
+    }
+
+    func testDefaultSeedPolicyPreservesRuntimeBehavior() {
+        for backend in ImageGenerationBackend.allCases {
+            XCTAssertEqual(ImageGenerationSeed.resolve(0, prompt: "hello", backend: backend), 0)
+            XCTAssertEqual(ImageGenerationSeed.resolve(UInt64.max, prompt: "hello", backend: backend), UInt64.max)
+        }
+        for backend: ImageGenerationBackend in [.flux1, .hiDreamO1, .senseNovaU15, .krea2, .ideogram4] {
+            XCTAssertEqual(ImageGenerationSeed.resolve(nil, prompt: "hello", backend: backend), 0xa430_d846_80aa_bd0b)
+        }
+    }
+
+    func testRecordsRequestedAndEffectiveSettingsBeforeInferenceAndKeepsArtifact() async throws {
+        let root = try temporaryDirectory()
+        let manifest = MereRunModelManifest(
+            id: "fixture", family: .klein, defaults: .init(steps: 28, cfg: 4),
+            sources: [.init(role: "weights", repository: "example/model", revision: "abc123")]
+        )
+        try manifest.write(to: root)
+        let options = ImageGenerationOptions(prompt: "Original prompt", outputURL: root.appendingPathComponent("result.png"))
+        let directory = root.appendingPathComponent("run")
+        let session = try ImageRunSession(directory: directory, requested: options, modelSelector: "fixture")
+        var expanded = options
+        expanded.prompt = "Expanded prompt"
+        let plan = try ImageGenerationPlan.resolve(expanded, modelRoot: root, manifest: manifest)
+        let outcome = try await ImageGenerationOperation.execute(plan, recording: session, executor: { _, request, _ in
+            let active = try ImageRunRecord.inspect(at: directory)
+            XCTAssertEqual(active.state, .running)
+            XCTAssertEqual(active.requested.prompt, "Original prompt")
+            XCTAssertNil(active.requested.steps)
+            XCTAssertNil(active.requested.seed)
+            XCTAssertEqual(active.effective, request)
+            XCTAssertEqual(request.prompt, "Expanded prompt")
+            XCTAssertEqual(request.steps, 28)
+            XCTAssertEqual(request.guidanceScale, 4)
+            let seed = try XCTUnwrap(request.seed)
+            try Data("rendered fixture".utf8).write(to: request.outputURL)
+            return GenerationResult(outputURL: request.outputURL, seed: seed)
+        })
+        let record = try ImageRunRecord.inspect(at: directory)
+        XCTAssertEqual(record.state, .succeeded)
+        XCTAssertEqual(record.id, outcome.id)
+        XCTAssertEqual(record.effective?.seed, outcome.result.seed)
+        XCTAssertEqual(record.modelManifest?.sources?.first?.revision, "abc123")
+        XCTAssertEqual(record.backend, .flux2Klein)
+        XCTAssertEqual(record.artifacts.count, 1)
+        let artifact = try XCTUnwrap(record.artifacts.first)
+        try FileManager.default.removeItem(at: options.outputURL)
+        XCTAssertEqual(try ImageRunRecord.Artifact.read(artifact.url), artifact)
+        XCTAssertEqual(try ImageRunRecord.decode(ImageRunRecord.encoder().encode(record)), record)
+    }
+
+    func testFailureAndCancellationPersistDifferentTerminalStates() async throws {
+        let root = try temporaryDirectory()
+        let options = ImageGenerationOptions(prompt: "A camera", outputURL: root.appendingPathComponent("result.png"), seed: 42)
+        let plan = try ImageGenerationPlan.resolve(options, modelRoot: root, manifest: .init(id: "fixture", family: .zimage))
+        for cancelled in [false, true] {
+            let directory = root.appendingPathComponent(cancelled ? "cancelled" : "failed")
+            let session = try ImageRunSession(directory: directory, requested: options, modelSelector: "fixture")
+            do {
+                _ = try await ImageGenerationOperation.execute(plan, recording: session, executor: { _, _, _ in
+                    if cancelled { throw CancellationError() }
+                    throw ImageGenerationIssue("fixture_failure", "Checkpoint rejected")
+                })
+                XCTFail("Expected failure")
+            } catch {
+                XCTAssertEqual(error is CancellationError, cancelled)
+            }
+            let record = try ImageRunRecord.inspect(at: directory)
+            XCTAssertEqual(record.state, cancelled ? .cancelled : .failed)
+            XCTAssertEqual(record.issue?.code, cancelled ? "cancelled" : "fixture_failure")
+            XCTAssertEqual(record.effective?.seed, 42)
+            XCTAssertTrue(record.artifacts.isEmpty)
+        }
+    }
+
+    func testOutputFailureCannotCreateSuccessfulRecord() async throws {
+        let root = try temporaryDirectory()
+        let options = ImageGenerationOptions(prompt: "A camera", outputURL: root.appendingPathComponent("missing.png"), seed: 1)
+        let directory = root.appendingPathComponent("run")
+        let session = try ImageRunSession(directory: directory, requested: options, modelSelector: "fixture")
+        let plan = try ImageGenerationPlan.resolve(options, modelRoot: root, manifest: .init(id: "fixture", family: .zimage))
+        do {
+            _ = try await ImageGenerationOperation.execute(plan, recording: session, executor: { _, request, _ in
+                GenerationResult(outputURL: request.outputURL, seed: 1)
+            })
+            XCTFail("A missing artifact cannot be successful")
+        } catch {
+            XCTAssertEqual(try ImageRunRecord.inspect(at: directory).state, .failed)
+        }
+    }
+
+    func testRetrySnapshotsUploadsAndPreservesParentAndResolvedPolicy() async throws {
+        let root = try temporaryDirectory()
+        let upload = root.appendingPathComponent("upload.png")
+        try Data("input fixture".utf8).write(to: upload)
+        let manifest = MereRunModelManifest(id: "fixture", family: .klein, defaults: .init(steps: 28, cfg: 4))
+        try manifest.write(to: root)
+        let options = ImageGenerationOptions(prompt: "A camera", outputURL: root.appendingPathComponent("result.png"), seed: 42, inputImage: upload)
+        let directory = root.appendingPathComponent("run")
+        let session = try ImageRunSession(directory: directory, requested: options, modelSelector: "fixture")
+        let policy = ImageGenerationPolicy(kleinUsesManifestDefaults: false, kleinInputAsReference: false)
+        let plan = try ImageGenerationPlan.resolve(options, modelRoot: root, manifest: manifest, policy: policy)
+        _ = try await ImageGenerationOperation.execute(plan, recording: session, executor: fixtureExecutor)
+        let parentData = try Data(contentsOf: ImageRunRecord.recordURL(at: directory))
+        try FileManager.default.removeItem(at: upload)
+        let retry = try ImageRunSession.retryPlan(at: directory)
+        XCTAssertNotEqual(retry.session.directory, directory)
+        XCTAssertEqual(retry.plan.request.seed, 42)
+        XCTAssertEqual(retry.plan.request.steps, 4)
+        XCTAssertEqual(retry.plan.request.guidanceScale, 1)
+        XCTAssertNotNil(retry.plan.request.inputImage)
+        XCTAssertEqual(retry.plan.policy, policy)
+        _ = try await ImageGenerationOperation.execute(retry.plan, recording: retry.session, executor: fixtureExecutor)
+        let retried = try ImageRunRecord.inspect(at: retry.session.directory)
+        XCTAssertEqual(retried.parentID, session.id)
+        XCTAssertEqual(retried.state, .succeeded)
+        XCTAssertEqual(try Data(contentsOf: ImageRunRecord.recordURL(at: directory)), parentData)
+    }
+
+    func testRetryRejectsChangedInputAndModelWithoutCreatingDirectory() async throws {
+        let root = try temporaryDirectory()
+        let input = root.appendingPathComponent("input.png")
+        try Data("original".utf8).write(to: input)
+        var manifest = MereRunModelManifest(id: "fixture", family: .klein)
+        try manifest.write(to: root)
+        let options = ImageGenerationOptions(prompt: "A camera", outputURL: root.appendingPathComponent("result.png"), inputImage: input)
+        let directory = root.appendingPathComponent("run")
+        let session = try ImageRunSession(directory: directory, requested: options, modelSelector: "fixture")
+        let plan = try ImageGenerationPlan.resolve(options, modelRoot: root, manifest: manifest)
+        _ = try await ImageGenerationOperation.execute(plan, recording: session, executor: fixtureExecutor)
+        let contents = try FileManager.default.contentsOfDirectory(atPath: root.path)
+        let record = try ImageRunRecord.inspect(at: directory)
+        let snapshot = try XCTUnwrap(record.inputs.first?.url)
+        try Data("changed".utf8).write(to: snapshot)
+        XCTAssertThrowsError(try ImageRunSession.retryPlan(at: directory)) {
+            XCTAssertEqual(($0 as? ImageGenerationIssue)?.code, "run_input_changed")
+        }
+        try Data("original".utf8).write(to: snapshot)
+        manifest.defaults = .init(steps: 100, cfg: 4)
+        try manifest.write(to: root)
+        XCTAssertThrowsError(try ImageRunSession.retryPlan(at: directory)) {
+            XCTAssertEqual(($0 as? ImageGenerationIssue)?.code, "run_model_changed")
+        }
+        try FileManager.default.removeItem(at: root.appendingPathComponent(MereRunModelManifest.filename))
+        XCTAssertThrowsError(try ImageRunSession.retryPlan(at: directory)) {
+            XCTAssertEqual(($0 as? ImageGenerationIssue)?.code, "run_model_changed")
+        }
+        XCTAssertEqual(Set(try FileManager.default.contentsOfDirectory(atPath: root.path)), Set(contents).subtracting([MereRunModelManifest.filename]))
+    }
+
+    func testActiveAndAbandonedRunsUseLeaseInsteadOfAge() throws {
+        let root = try temporaryDirectory()
+        let directory = root.appendingPathComponent("run")
+        let options = ImageGenerationOptions(prompt: "A camera", outputURL: root.appendingPathComponent("result.png"))
+        var session: ImageRunSession? = try ImageRunSession(directory: directory, requested: options, modelSelector: "fixture")
+        XCTAssertEqual(try ImageRunRecord.inspect(at: directory).state, .preparing)
+        XCTAssertThrowsError(try ImageRunSession.retryPlan(at: directory)) {
+            XCTAssertEqual(($0 as? ImageGenerationIssue)?.code, "run_active")
+        }
+        XCTAssertNotNil(session)
+        session = nil
+        let recovered = try ImageRunRecord.inspect(at: directory)
+        XCTAssertEqual(recovered.state, .interrupted)
+        XCTAssertEqual(recovered.issue?.code, "process_interrupted")
+        XCTAssertEqual(try ImageRunRecord.inspect(at: directory), recovered)
+    }
+
+    func testLeaseIsReleasedWhenOwningProcessIsKilled() throws {
+        let root = try temporaryDirectory()
+        let directory = root.appendingPathComponent("run")
+        let options = ImageGenerationOptions(prompt: "A camera", outputURL: root.appendingPathComponent("result.png"))
+        var session: ImageRunSession? = try ImageRunSession(directory: directory, requested: options, modelSelector: "fixture")
+        XCTAssertNotNil(session)
+        session = nil
+        let child = Process()
+        child.executableURL = URL(fileURLWithPath: "/usr/bin/python3")
+        child.arguments = ["-c", "import fcntl,sys,signal; f=open(sys.argv[1],'r+'); fcntl.flock(f,fcntl.LOCK_EX); sys.stdout.write('1'); sys.stdout.flush(); signal.pause()", directory.appendingPathComponent(".image-run.lock").path]
+        let output = Pipe()
+        child.standardOutput = output
+        try child.run()
+        defer { if child.isRunning { kill(child.processIdentifier, SIGKILL); child.waitUntilExit() } }
+        XCTAssertEqual(try output.fileHandleForReading.read(upToCount: 1), Data("1".utf8))
+        XCTAssertEqual(try ImageRunRecord.inspect(at: directory).state, .preparing)
+        kill(child.processIdentifier, SIGKILL)
+        child.waitUntilExit()
+        XCTAssertEqual(try ImageRunRecord.inspect(at: directory).state, .interrupted)
+    }
+
+    func testExistingDirectoryAndUnsupportedOrCorruptRecordsArePreserved() throws {
+        let root = try temporaryDirectory()
+        let options = ImageGenerationOptions(prompt: "A camera", outputURL: root.appendingPathComponent("result.png"))
+        XCTAssertThrowsError(try ImageRunSession(directory: root, requested: options, modelSelector: "fixture"))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: root.appendingPathComponent(ImageRunRecord.filename).path))
+        let directory = root.appendingPathComponent("run")
+        let session = try ImageRunSession(directory: directory, requested: options, modelSelector: "fixture")
+        try session.fail(ImageGenerationIssue("fixture", "failure"))
+        let url = ImageRunRecord.recordURL(at: directory)
+        let original = try String(contentsOf: url, encoding: .utf8)
+        let future = original.replacingOccurrences(of: "\"schemaVersion\" : 1", with: "\"schemaVersion\" : 99")
+        XCTAssertNotEqual(future, original)
+        try Data(future.utf8).write(to: url)
+        XCTAssertThrowsError(try ImageRunRecord.inspect(at: directory)) {
+            XCTAssertEqual(($0 as? ImageGenerationIssue)?.code, "run_version_unsupported")
+        }
+        XCTAssertEqual(try String(contentsOf: url, encoding: .utf8), future)
+        try Data("broken".utf8).write(to: url)
+        XCTAssertThrowsError(try ImageRunRecord.inspect(at: directory))
+        XCTAssertEqual(try String(contentsOf: url, encoding: .utf8), "broken")
+    }
+
+    private var fixtureExecutor: ImageGenerationOperation.Executor {
+        { _, request, _ in
+            try Data("fixture output".utf8).write(to: request.outputURL)
+            return GenerationResult(outputURL: request.outputURL, seed: try XCTUnwrap(request.seed))
+        }
+    }
+
+    private func temporaryDirectory() throws -> URL {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: root) }
+        return root
+    }
+}

--- a/apps/macos/StudioKit/Catalog/CommandFlags.swift
+++ b/apps/macos/StudioKit/Catalog/CommandFlags.swift
@@ -167,6 +167,7 @@ extension CommandFlags {
             "--lora-scale": "1.0"
         ]
 
+        package static let runDir = "--run-dir"
         package static let sigmas = "--sigmas"
         package static let prompt = "--prompt"
         package static let negativePrompt = "--negative-prompt"
@@ -1563,7 +1564,7 @@ extension CommandFlags {
 // MARK: - run retry
 
 extension CommandFlags {
-    /// `mere.run run retry` — Retry Relay run
+    /// `mere.run run retry` — Retry run
     package enum RunRetry: CommandFlagNamespace {
         package static let command = ["run", "retry"]
 
@@ -2672,6 +2673,7 @@ extension CommandFlags {
     package enum APIServe: CommandFlagNamespace {
         package static let command = ["api", "serve"]
 
+        package static let imageRunRecords = "--image-run-records"
         package static let warmup = "--warmup"
         package static let noWarmup = "--no-warmup"
         package static let port = "--port"

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -150,7 +150,7 @@ Public tree:
   - `mere.run run watch` — Watch the worker event stream for an SSH or relay graph job.
   - `mere.run run fetch` — Fetch a remote graph run into the standard local run-directory format.
   - `mere.run run cancel` — Cancel a graph run.
-  - `mere.run run retry` — Retry an immutable relay graph job.
+  - `mere.run run retry` — Retry a recorded local image run or an immutable relay graph job.
 - [`mere.run eval`](/evaluation-packs) — Run reproducible evaluations from external, content-addressed packs.
   - `mere.run eval pack` — Inspect external evaluation packs without running models.
     - `mere.run eval pack validate` — Validate and hash an external evaluation pack.
@@ -498,6 +498,7 @@ Key options:
   load the text encoder, transformer, and VAE sequentially to reduce peak memory
 - `--preflight`: inspect the generation request without loading the model or writing an image
 - `--json`: with `--preflight`, emit a structured JSON report
+- `--run-dir`: create a new [image run directory](/runtime/image#record-and-retry-an-image-run) with settings, input snapshots, and output
 - `--quiet`
 - `--progress-json`: stream progress to stderr as JSON lines instead of
   human-readable text, one object per event, e.g.
@@ -762,6 +763,14 @@ top-level report also includes an
 `inspect-selected` action for UI pickers. Legacy/plugin run folders are listed
 as warning-level entries when their `run.json` can be identified but is not a
 native mere.run training manifest.
+
+### `mere.run run retry`
+
+Retry a recorded image run with `mere.run run retry ./runs/camera`. The command
+creates a sibling directory and prints its path. Add `--json` to print the new
+record. See [image run recording and retry](/runtime/image#record-and-retry-an-image-run)
+for input checks and replay limits. A `relay://` reference retains its existing
+immutable graph retry behavior.
 
 ### `mere.run run inspect`
 

--- a/docs/internals/image-generation-operation.md
+++ b/docs/internals/image-generation-operation.md
@@ -12,6 +12,7 @@ checkpoint loading.
 | `ImageGenerationModelSelection` | Classify local paths and managed IDs; resolve installed model roots without downloading. |
 | `ImageGenerationPlan` | Validate options and files, resolve adapters and effective sampling, and build `GenerationRequest`. |
 | `ImageGenerationOperation` | Prepare edit inputs, invoke an executor, restore protected pixels, clean up temporary files, and report a typed outcome. |
+| `ImageRunSession` | Own an optional versioned record, process lease, input snapshots, and verified output copy. |
 | CLI adapter | Parse arguments, expand structured prompts, present progress and installation guidance, and emit existing receipts and run-plan events. |
 | API adapter | Decode HTTP requests, choose API v1 compatibility settings, and provide the resident-pool executor. |
 | Runtime | Check checkpoint integrity, load weights, run inference, and write the generated image. |
@@ -51,9 +52,20 @@ files are removed.
 
 These Swift events do not change a CLI wire format. Existing `--receipt`,
 `--progress-json`, preflight JSON, run-plan files, and API response shapes retain
-their compatibility behavior. A durable protocol for failure and interruption
-records is a separate migration; an uncatchable process termination cannot emit
-a terminal Swift event.
+their compatibility behavior. Optional `ImageRunSession` recording writes
+`image-run.json` atomically. Its held, non-inherited file lock distinguishes
+active work from abandoned records after termination or reboot. Inspection can
+persist an interrupted state without relying on process IDs or timestamps.
+An uncatchable process termination cannot emit a terminal Swift event.
+
+Recording snapshots input images and masks, fingerprints local adapters, and
+saves resolved options and the seed before calling the executor. Successful
+runs retain a fingerprinted output copy. Retry verifies inputs and the installed
+manifest, preserves the API compatibility policy, and starts a new sibling run
+with a parent ID. It uses the same machine admission class as image generation.
+It does not re-expand structured prompts or resume runtime state. See
+[Record and retry an image run](../runtime/image.md#record-and-retry-an-image-run)
+for retention and replay limits.
 
 ## Validation
 
@@ -63,6 +75,11 @@ cleanup, and input changes between planning and execution. It injects an
 executor and needs no model weights. `ImageGenerationAdapterTests` compares
 explicit CLI and API requests across all supported image backends, checks API
 compatibility policies, and compares preflight with execution validation.
+
+`ImageRunRecordTests` checks atomic state snapshots, active and abandoned leases,
+process termination, input retention, retry validation, and terminal outcomes.
+`ImageRunCommandTests` checks opt-in flags, observational preflight, run-plan
+round trips, local inspection, legacy JSON compatibility, and admission classes.
 
 These tests establish orchestration behavior. Checkpoint, numerical, GPU-memory,
 and platform acceptance still use the existing family tests and runtime gates.

--- a/docs/runtime/api-server.md
+++ b/docs/runtime/api-server.md
@@ -14,6 +14,29 @@ machine.
 | `mere.run model runtime set` | Update typed API runtime settings for a managed model. |
 | `mere.run status` | Show local server, loaded model, and installed model status. |
 
+## Keep image run records
+
+To retain accepted image operations for local inspection and retry, start the
+server with `--image-run-records`:
+
+```bash
+mere.run api serve --image-run-records ./runs/api-images
+mere.run run list --root ./runs/api-images --json
+```
+
+Each resolved image operation creates its own directory. The shared image
+operation records success, failure, and cancellation, copies uploaded edit
+inputs before request cleanup, and retains the output. Image requests rejected
+before their operation plan is resolved do not create records. API response
+shapes, authentication, request admission, and API v1 image defaults are unchanged.
+The image endpoints still treat accepted mask uploads as whole-image edits;
+recording does not enable strict masking.
+
+Recording is off by default. Enabling it retains prompts and uploaded images
+on the server until you remove the run directories. It does not record API keys
+or HTTP headers. Use the local [`run inspect` and `run retry` commands](image.md#record-and-retry-an-image-run)
+to inspect or retry a record; there is no HTTP run-history endpoint.
+
 ## macOS Server domain
 
 MereRun Studio exposes this control plane as the **Server** domain in its

--- a/docs/runtime/image.md
+++ b/docs/runtime/image.md
@@ -21,6 +21,53 @@ Dev, FLUX.2 Dev and Klein, HiDream O1, SenseNova U1.5, Krea 2, Qwen Image Edit
 | `mere.run image reconstruct-3d-trellis2` | Reconstruct a 512-resolution PBR O-Voxel mesh with native MLX TRELLIS.2. |
 | `mere.run image reconstruct-3d-multiview` | Reconstruct a colored mesh from four or six supplied views with native InstantMesh. |
 
+## Record and retry an image run
+
+To keep the settings, inputs, and result of an image operation, pass a new
+`--run-dir` path:
+
+```bash
+mere.run image generate --model image-zimage-nano \
+  --prompt "A brass camera on a wooden desk" \
+  --output ./camera.png --run-dir ./runs/camera
+mere.run run inspect ./runs/camera --json
+mere.run run list --root ./runs --json
+mere.run run retry ./runs/camera --json
+```
+
+The directory must not exist. If you place the output inside it, use `output.png`.
+Write structured-prompt sidecars outside the directory. Recording is optional;
+preflight does not create a record. Existing output paths, receipts, progress streams, and run-plan files
+keep their formats. A saved preflight plan retains an explicit `--run-dir`.
+
+`image-run.json` uses schema version 1. It separates your requested settings
+from resolved settings, including model defaults, expanded prompts, adapter
+paths, and the seed chosen before inference. It stores the model manifest,
+source revisions when available, the backend, and SHA-256 fingerprints of
+retained inputs and outputs. Missing source provenance remains unknown.
+Manifest fingerprints do not certify the contents of every model weight file.
+
+The states are `preparing`, `running`, `succeeded`, `failed`, `cancelled`, and
+`interrupted`. Inspection marks an unfinished record as interrupted when its
+process no longer holds the run lock. Process termination, including a forced
+stop or reboot, can therefore be distinguished from an observed cancellation.
+Argument parsing and static option errors occur before a run is created.
+
+Retry starts generation from the recorded resolved settings and seed in a new
+sibling directory. It prints that directory, or the new record with `--json`.
+It retains the parent ID and preserves the original record and output. It
+checks the installed model manifest, copied image inputs, and local adapter
+fingerprints before starting. If these changed, start a new image command.
+A run that stopped before resolving its settings must also be started with the
+original command. Retry does not resume denoising or expand a prompt again;
+identical pixels across runtime versions or hardware are not guaranteed.
+
+Run directories contain prompts and copies of input images, masks, and outputs.
+They are created with access restricted to your account and retained until you
+remove them. Keep the directory in its original location for inspection and
+retry: schema version 1 stores absolute paths. Adapter and model files remain
+in their installed locations.
+
 ## macOS Studio
 
 **Image ▸ Generate** covers text-to-image, image-to-image, and multi-reference


### PR DESCRIPTION
## Summary

Image operations can now retain an inspectable record after failure or process termination. `image generate --run-dir` and `api serve --image-run-records` opt into a versioned record with separate requested and effective settings, model provenance, the actual seed, copied edit inputs, and fingerprinted outputs. A process lease distinguishes active work from interrupted runs after restart.

`run list` and `run inspect` recognize these records. Local `run retry` verifies retained inputs, adapters, and the installed model manifest, then starts a new sibling run with the resolved settings and parent ID. It preserves API compatibility policies, default seed behavior, and image admission limits. Existing directories and reserved record paths are protected from overwrite. Command catalog, generated Studio flags, preflight run-plan round trips, and docs are updated.

## Validation

- [x] `./scripts/check.sh`: lint, build, CLI help, hygiene, 3,969 XCTest cases (311 skipped, zero failures), and 51 Swift Testing cases passed.
- [x] Focused recording and compatibility tests: process termination, cancellation, missing outputs, retained uploads and masks, immutable retries, changed inputs/model manifests, all eight API image backends, seed policies, and admission classes.
- [x] `pnpm docs:build` and `git diff --check` passed. Gitleaks found no secrets in the complete staged patch.
- [x] Built-CLI smoke: missing-model failure persisted; `run list` and `run inspect` returned the record; unresolved retry was rejected without creating another directory; directory/record permissions were 0700/0600.
- [x] Public behavior and retention/retry limits documented. No vendored artifacts or package pins changed; third-party notice changes are not applicable.

Real-checkpoint generation and live API image requests were not exercised, following the repository's local-gate boundary. Orchestration tests use injected executors; they do not establish GPU-memory or image-quality acceptance. Retry replays from the beginning and checks manifest provenance, not every model weight byte. Records retain absolute paths and user content until removed.
