### PR TITLE
Repair native agent streaming, tool history, memory, and sampling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,18 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+- Reuse Qwen-family CPU and GPU streams across completed requests. This bounds
+  stream allocation by overlapping requests instead of accumulating command
+  queues throughout a long-running API session.
+- Reclaim reusable Qwen-family MLX buffers at 4 GiB during generation and at
+  request boundaries. Growing agent conversations no longer retain disposable
+  buffers until the device-wide memory limit approaches total system RAM.
+- Preserve complete function parameter schemas in native API prompts, including
+  nested properties, array items, enums, and constraints. Reject non-null, non-object
+  parameter schemas instead of replacing them with an empty schema.
+- Update the chat-template interpreter to preserve adjacent tool-result groups
+  in official templates that use `loop.previtem` and `loop.nextitem`.
+
 - Refresh the bundled DwarfStar runtime to upstream `b6af0adf8ca9`, including
   session snapshot and native tool handling fixes. Preserve the DeepSeek V4
   Flash 0731 Q2 imatrix model pin and bundle the Iris decoder license.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ The format is based on Keep a Changelog.
 - Refresh the bundled DwarfStar runtime to upstream `b6af0adf8ca9`, including
   session snapshot and native tool handling fixes. Preserve the DeepSeek V4
   Flash 0731 Q2 imatrix model pin and bundle the Iris decoder license.
+- Laguna API requests now enable reasoning by default. Buffered streaming tool
+  replies preserve `reasoning_content`, and buffered answers keep reasoning
+  separate from visible message content.
 
 - Image generation and text chat preflights now report insufficient memory,
   disk headroom, and critical memory pressure as structured blockers alongside

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ The format is based on Keep a Changelog.
 - Laguna API requests now enable reasoning by default. Buffered streaming tool
   replies preserve `reasoning_content`, and buffered answers keep reasoning
   separate from visible message content.
+- Qwen, Ornith, Laguna, Gemma 4, and Muse API conversations now pass assistant
+  tool history to their native templates without injecting duplicate tool markup
+  into message content.
 
 - Image generation and text chat preflights now report insufficient memory,
   disk headroom, and critical memory pressure as structured blockers alongside

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+- Accept explicit `top_k` in supported native chat APIs and preserve model
+  sampling defaults independently when clients override temperature or min-p.
+- Add presence, frequency, and repetition penalty controls to Qwen-family API
+  generation, including Ornith. Apply penalties consistently in serial,
+  streaming, and batched sampling; use target-only decode for active penalties.
+
 - Reuse Qwen-family CPU and GPU streams across completed requests. This bounds
   stream allocation by overlapping requests instead of accumulating command
   queues throughout a long-running API session.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ The format is based on Keep a Changelog.
 - Qwen, Ornith, Laguna, Gemma 4, and Muse API conversations now pass assistant
   tool history to their native templates without injecting duplicate tool markup
   into message content.
+- Streaming chat responses now send SSE keepalive comments while generation is
+  buffered, preventing clients from timing out during long tool-call responses.
 
 - Image generation and text chat preflights now report insufficient memory,
   disk headroom, and critical memory pressure as structured blockers alongside

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "df7b39bd26e0a4063f3313cb47fbe8f4317cf7577dc00ec51720414b9f8797b2",
+  "originHash" : "9ad37f612071abb2f5da8abd376d1b15d549697b97800a310061f9c4fc0ea30e",
   "pins" : [
     {
       "identity" : "async-http-client",
@@ -33,7 +33,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sawfwair/mlx-swift",
       "state" : {
-        "revision" : "7558b9cff75746e3ce25802aecbdc498b240af7f"
+        "revision" : "001d1aa3e5655d7efc073fb9632f952f57cdf528"
       }
     },
     {
@@ -167,8 +167,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-jinja.git",
       "state" : {
-        "revision" : "0aeefadec459ce8e11a333769950fb86183aca43",
-        "version" : "2.3.5"
+        "revision" : "12ea4955e380dae6b0cd98299effe48c7fe584fc",
+        "version" : "2.5.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -276,6 +276,7 @@ var mereRunCoreTestDependencies: [Target.Dependency] = [
   "AudioCodecs",
   "AudioSTT",
   "AudioTTS",
+  .product(name: "Jinja", package: "swift-jinja"),
   .product(name: "Crypto", package: "swift-crypto")
 ]
 if hasMediaIOTarget {
@@ -612,13 +613,15 @@ if !isLinuxPackage {
 var packageDependencies: [Package.Dependency] = (useLinuxPrebuiltMLX ? [] : [
   .package(
     url: "https://github.com/sawfwair/mlx-swift",
-    revision: "7558b9cff75746e3ce25802aecbdc498b240af7f"
+    revision: "001d1aa3e5655d7efc073fb9632f952f57cdf528"
   )
 ]) + [
   .package(
     url: "https://github.com/huggingface/swift-transformers",
     from: "1.3.0"
   ),
+  // Checkpoint templates use neighboring loop items and Python-compatible JSON.
+  .package(url: "https://github.com/huggingface/swift-jinja.git", from: "2.5.0"),
   .package(url: "https://github.com/apple/swift-crypto.git", "4.0.0"..<"4.4.0"),
   .package(url: "https://github.com/apple/swift-argument-parser.git", from: "1.4.0"),
   .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0")

--- a/Sources/MereRunCLI/Commands/APIServeCommand.swift
+++ b/Sources/MereRunCLI/Commands/APIServeCommand.swift
@@ -593,6 +593,8 @@ struct APIEngineCapabilities: Equatable, Sendable {
     var supportsStopSequences: Bool = false
     var supportsSeed: Bool = false
     var supportsPenalties: Bool = false
+    var supportsTopK: Bool = false
+    var supportsRepetitionPenalty: Bool = false
     var supportsLogprobs: Bool = false
     var supportsProviderThinkingControls: Bool = false
 
@@ -615,6 +617,10 @@ struct APIEngineCapabilities: Equatable, Sendable {
             supportsStopSequences: profile.supportsStopSequences,
             supportsSeed: profile.supportsSeed,
             supportsPenalties: profile.supportsPenalties,
+            supportsTopK: [.textChatQ35, .textChatQ36, .textChatLaguna, .textChatLFM2,
+                          .textChatMuseGlimmer, .textChatNemotronH, .textChatNemotronOmni,
+                          .textChatDiffusionGemma].contains(profile.servingEngine),
+            supportsRepetitionPenalty: [.textChatQ35, .textChatQ36].contains(profile.servingEngine),
             supportsLogprobs: profile.supportsLogprobs,
             supportsProviderThinkingControls: profile.supportsProviderThinkingControls
         )
@@ -2585,16 +2591,12 @@ enum APIServerContract {
             lora = nil
         }
 
-        // R1-style lanes degenerate without reasoning; their published top_k
-        // applies only when the client did not set explicit sampling.
+        // Resolve each omitted sampling field independently.
         let laneModelID = servedModelID ?? ""
         let resolvedAPIProfile = apiProfile
             ?? servedModelID.flatMap { ManagedModelCatalog.apiProfile(for: $0) }
         let recommendedSampling = Q35Resources.recommendedSampling(forModelId: laneModelID)
         let isLaguna = LagunaResources.handles(modelSpec: laneModelID)
-        let usesExplicitSampling = openaiRequest.temperature != nil
-            || openaiRequest.top_p != nil
-            || openaiRequest.min_p != nil
         let reasoningEffort = try reasoningEffort(
             from: openaiRequest.reasoning_effort,
             capabilities: capabilities,
@@ -2636,12 +2638,14 @@ enum APIServerContract {
                 ? (isLaguna ? LagunaResources.recommendedTopP : recommendedSampling?.topP)
                     ?? topP
                 : topP,
-            topK: isLaguna
-                ? LagunaResources.recommendedTopK
-                : (usesExplicitSampling ? nil : recommendedSampling?.topK),
+            topK: openaiRequest.top_k
+                ?? (isLaguna ? LagunaResources.recommendedTopK : recommendedSampling?.topK),
             minP: openaiRequest.min_p == nil && isLaguna
                 ? LagunaResources.recommendedMinP
                 : minP,
+            presencePenalty: openaiRequest.presence_penalty ?? 0,
+            frequencyPenalty: openaiRequest.frequency_penalty ?? 0,
+            repetitionPenalty: openaiRequest.repetition_penalty ?? 1,
             seed: openaiRequest.seed.map(UInt64.init),
             reasoningEffort: reasoningEffort,
             showThinking: requiresJSON
@@ -2867,6 +2871,7 @@ enum APIServerContract {
         if let seed = request.seed, seed < 0 {
             throw APIRequestValidationError.invalidField("seed", "must be an unsigned integer")
         }
+        try validateSamplingControls(request, capabilities: capabilities)
         if let penalty = request.presence_penalty, penalty != 0, !capabilities.supportsPenalties {
             throw APIRequestValidationError.invalidField("presence_penalty", "presence penalties are not supported by this engine")
         }
@@ -3179,6 +3184,36 @@ enum APIServerContract {
             )
         }
         return value
+    }
+
+    private static func validateSamplingControls(
+        _ request: OpenAIChatRequest,
+        capabilities: APIEngineCapabilities
+    ) throws {
+        if let topK = request.top_k {
+            guard topK >= 0 else {
+                throw APIRequestValidationError.invalidField("top_k", "must be zero or greater")
+            }
+            if topK != 0, !capabilities.supportsTopK {
+                throw APIRequestValidationError.invalidField("top_k", "top-k sampling is not supported by this engine")
+            }
+        }
+        for (field, value) in [("presence_penalty", request.presence_penalty),
+                               ("frequency_penalty", request.frequency_penalty)] {
+            if let value, !value.isFinite || !(-2...2).contains(value) {
+                throw APIRequestValidationError.invalidField(field, "must be between -2 and 2")
+            }
+        }
+        if let penalty = request.repetition_penalty {
+            guard penalty.isFinite, Float(penalty).isFinite, Float(penalty) > 0 else {
+                throw APIRequestValidationError.invalidField("repetition_penalty", "must be a finite positive sampler value")
+            }
+            if penalty != 1, !capabilities.supportsRepetitionPenalty {
+                throw APIRequestValidationError.invalidField(
+                    "repetition_penalty", "repetition penalties are not supported by this engine"
+                )
+            }
+        }
     }
 
     private static func validateTemperature(_ rawValue: Double?) throws -> Double {

--- a/Sources/MereRunCLI/Commands/APIServeCommand.swift
+++ b/Sources/MereRunCLI/Commands/APIServeCommand.swift
@@ -579,6 +579,7 @@ enum APIEngine: String, ExpressibleByArgument {
 struct APIEngineCapabilities: Equatable, Sendable {
     var supportsRawProxy: Bool = false
     var supportsTools: Bool = false
+    var usesNativeToolHistory: Bool = false
     var supportsToolChoice: Bool = false
     var supportsDeveloperRole: Bool = true
     var supportsStructuredOutputs: Bool = false
@@ -599,6 +600,8 @@ struct APIEngineCapabilities: Equatable, Sendable {
         APIEngineCapabilities(
             supportsRawProxy: profile.supportsRawProxy,
             supportsTools: profile.toolCall,
+            usesNativeToolHistory: [.textChatQ36, .textChatLaguna, .textChatGemma4, .textChatMuseGlimmer]
+                .contains(profile.servingEngine),
             supportsToolChoice: profile.supportsToolChoice,
             supportsDeveloperRole: profile.compatibility.supportsDeveloperRole,
             supportsStructuredOutputs: profile.structuredOutput,
@@ -2706,7 +2709,7 @@ enum APIServerContract {
         let imageURL = try firstImageURL(from: msg, capabilities: capabilities)
         let audioURL = try firstAudioURL(from: msg, capabilities: capabilities)
         let videoURL = try firstVideoURL(from: msg, capabilities: capabilities)
-        let content = renderMessageContent(msg)
+        let content = capabilities.usesNativeToolHistory ? msg.content : renderMessageContent(msg)
         let toolCalls = try chatMessageToolCalls(from: msg)
         return ChatMessage(
             role: role,

--- a/Sources/MereRunCLI/Commands/APIServeCommand.swift
+++ b/Sources/MereRunCLI/Commands/APIServeCommand.swift
@@ -5810,8 +5810,10 @@ actor CodeGenServer {
 
         // Create async stream for SSE
         let (stream, continuation) = AsyncStream<ByteBuffer>.makeStream()
+        let heartbeatTask = Self.startStreamingKeepalive(continuation: continuation)
 
         let generationTask = Task {
+            defer { heartbeatTask.cancel() }
             do {
                 let streamedContent = StreamingContentTracker()
                 let shouldBufferForToolCalls = request.tools?.isEmpty == false
@@ -5968,6 +5970,7 @@ actor CodeGenServer {
             }
         }
         continuation.onTermination = { termination in
+            heartbeatTask.cancel()
             if case .cancelled = termination {
                 admissionLease.observeClientDisconnect()
                 generationTask.cancel()
@@ -5983,6 +5986,27 @@ actor CodeGenServer {
             ],
             body: .init(asyncSequence: stream)
         )
+    }
+
+    nonisolated static func startStreamingKeepalive(
+        continuation: AsyncStream<ByteBuffer>.Continuation,
+        interval: Duration = .seconds(15)
+    ) -> Task<Void, Never> {
+        Task {
+            do {
+                while !Task.isCancelled {
+                    try await Task.sleep(for: interval)
+                    guard !Task.isCancelled else { return }
+                    // SSE comments keep buffered tool responses alive without
+                    // exposing unfinished tool arguments or reasoning as text.
+                    if case .terminated = continuation.yield(ByteBuffer(string: ": keep-alive\n\n")) {
+                        return
+                    }
+                }
+            } catch {
+                // Cancellation ends the keepalive loop.
+            }
+        }
     }
 
     private nonisolated func openAIToolCalls(

--- a/Sources/MereRunCLI/Commands/APIServeCommand.swift
+++ b/Sources/MereRunCLI/Commands/APIServeCommand.swift
@@ -3012,22 +3012,20 @@ enum APIServerContract {
             throw APIRequestValidationError.invalidField("tools", "only function tools are supported")
         }
 
-        let schema = function.parameters?.objectValue ?? [:]
-        let properties = schema["properties"]?.objectValue ?? [:]
-        var converted: [String: ToolParameterProperty] = [:]
-        for (name, rawProperty) in properties {
-            guard let property = rawProperty.objectValue else { continue }
-            let type = property["type"]?.stringValue ?? "string"
-            let description = property["description"]?.stringValue ?? ""
-            converted[name] = ToolParameterProperty(type: type, description: description)
+        let schema: [String: OpenAIJSONValue]
+        if let parameters = function.parameters, parameters != .null {
+            guard let object = parameters.objectValue else {
+                throw APIRequestValidationError.invalidField("tools", "function parameters must be a JSON object")
+            }
+            schema = object
+        } else {
+            schema = ["type": .string("object"), "properties": .object([:]), "required": .array([])]
         }
-        let required = schema["required"]?.arrayValue?.compactMap(\.stringValue) ?? []
 
         return ToolDefinition(
             name: function.name,
             description: function.description ?? "",
-            parameters: converted,
-            required: required
+            parameterSchema: schema
         )
     }
 

--- a/Sources/MereRunCLI/Commands/APIServeCommand.swift
+++ b/Sources/MereRunCLI/Commands/APIServeCommand.swift
@@ -5876,10 +5876,7 @@ actor CodeGenServer {
                         choices: [
                             OpenAIChatChoice(
                                 index: 0,
-                                delta: OpenAIChatDelta(
-                                    role: "assistant",
-                                    tool_calls: toolCalls.enumerated().map(OpenAIChatToolCallDelta.init(indexAndToolCall:))
-                                ),
+                                delta: Self.openAIBufferedDelta(for: result, toolCalls: toolCalls),
                                 finish_reason: nil
                             )
                         ]
@@ -5897,10 +5894,7 @@ actor CodeGenServer {
                         choices: [
                             OpenAIChatChoice(
                                 index: 0,
-                                delta: OpenAIChatDelta(
-                                    content: result.response,
-                                    reasoning_content: result.reasoningContent
-                                ),
+                                delta: Self.openAIBufferedDelta(for: result, toolCalls: []),
                                 finish_reason: nil
                             )
                         ]
@@ -6032,7 +6026,23 @@ actor CodeGenServer {
         for result: ChatResponse,
         hasToolCalls: Bool
     ) -> String {
-        hasToolCalls ? "" : result.response
+        guard !hasToolCalls else { return "" }
+        guard result.reasoningContent != nil else { return result.response }
+        return ChatReasoningMarkup.splitThinkBlocks(in: result.response).visibleContent
+    }
+
+    nonisolated static func openAIBufferedDelta(
+        for result: ChatResponse,
+        toolCalls: [OpenAIChatToolCall]
+    ) -> OpenAIChatDelta {
+        OpenAIChatDelta(
+            role: toolCalls.isEmpty ? nil : "assistant",
+            content: toolCalls.isEmpty ? openAIMessageContent(for: result, hasToolCalls: false) : nil,
+            reasoning_content: result.reasoningContent,
+            tool_calls: toolCalls.isEmpty
+                ? nil
+                : toolCalls.enumerated().map(OpenAIChatToolCallDelta.init(indexAndToolCall:))
+        )
     }
 
     /// Generators that don't report a prompt token count fall back to zero

--- a/Sources/MereRunCLI/Support/MLXBundleSupport.swift
+++ b/Sources/MereRunCLI/Support/MLXBundleSupport.swift
@@ -33,7 +33,7 @@ enum MLXBundleSupport {
       coreRevision: "11da2b33a51772c023e2f7d7bc4ba9b3ff7e03ef",
       upstreamTag: "v0.32.1",
       upstreamRevision: "3a6219917e4535575ce5bce2fc2ba27a483a709b",
-      swiftRevision: "7558b9cff75746e3ce25802aecbdc498b240af7f",
+      swiftRevision: "001d1aa3e5655d7efc073fb9632f952f57cdf528",
       kernelSourcesSHA256: "36412403ff4f0117579f0bc4471a17083411422bfc446f9f11420614ddbeb9ee"
     )
 

--- a/Sources/MereRunCore/CodeGen/OpenAITypes.swift
+++ b/Sources/MereRunCore/CodeGen/OpenAITypes.swift
@@ -86,6 +86,7 @@ public struct OpenAIChatRequest: Codable, Sendable {
     public var messages: [OpenAIChatMessage]
     public var temperature: Double?
     public var top_p: Double?
+    public var top_k: Int?
     public var min_p: Double?
     public var max_tokens: Int?
     public var max_completion_tokens: Int?
@@ -94,6 +95,7 @@ public struct OpenAIChatRequest: Codable, Sendable {
     public var seed: Int?
     public var presence_penalty: Double?
     public var frequency_penalty: Double?
+    public var repetition_penalty: Double?
     public var logprobs: Bool?
     public var top_logprobs: Int?
     public var reasoning_effort: String?
@@ -121,6 +123,7 @@ public struct OpenAIChatRequest: Codable, Sendable {
         case messages
         case temperature
         case top_p
+        case top_k
         case min_p
         case max_tokens
         case max_completion_tokens
@@ -129,6 +132,7 @@ public struct OpenAIChatRequest: Codable, Sendable {
         case seed
         case presence_penalty
         case frequency_penalty
+        case repetition_penalty
         case logprobs
         case top_logprobs
         case reasoning_effort
@@ -156,6 +160,7 @@ public struct OpenAIChatRequest: Codable, Sendable {
         messages: [OpenAIChatMessage],
         temperature: Double? = nil,
         top_p: Double? = nil,
+        top_k: Int? = nil,
         min_p: Double? = nil,
         max_tokens: Int? = nil,
         max_completion_tokens: Int? = nil,
@@ -164,6 +169,7 @@ public struct OpenAIChatRequest: Codable, Sendable {
         seed: Int? = nil,
         presence_penalty: Double? = nil,
         frequency_penalty: Double? = nil,
+        repetition_penalty: Double? = nil,
         logprobs: Bool? = nil,
         top_logprobs: Int? = nil,
         reasoning_effort: String? = nil,
@@ -189,6 +195,7 @@ public struct OpenAIChatRequest: Codable, Sendable {
         self.messages = messages
         self.temperature = temperature
         self.top_p = top_p
+        self.top_k = top_k
         self.min_p = min_p
         self.max_tokens = max_tokens
         self.max_completion_tokens = max_completion_tokens
@@ -197,6 +204,7 @@ public struct OpenAIChatRequest: Codable, Sendable {
         self.seed = seed
         self.presence_penalty = presence_penalty
         self.frequency_penalty = frequency_penalty
+        self.repetition_penalty = repetition_penalty
         self.logprobs = logprobs
         self.top_logprobs = top_logprobs
         self.reasoning_effort = reasoning_effort
@@ -226,6 +234,7 @@ public struct OpenAIChatRequest: Codable, Sendable {
         messages = try container.decode([OpenAIChatMessage].self, forKey: .messages)
         temperature = try container.decodeIfPresent(Double.self, forKey: .temperature)
         top_p = try container.decodeIfPresent(Double.self, forKey: .top_p)
+        top_k = try container.decodeIfPresent(Int.self, forKey: .top_k)
         min_p = try container.decodeIfPresent(Double.self, forKey: .min_p)
         max_tokens = try container.decodeIfPresent(Int.self, forKey: .max_tokens)
         max_completion_tokens = try container.decodeIfPresent(Int.self, forKey: .max_completion_tokens)
@@ -234,6 +243,7 @@ public struct OpenAIChatRequest: Codable, Sendable {
         seed = try container.decodeIfPresent(Int.self, forKey: .seed)
         presence_penalty = try container.decodeIfPresent(Double.self, forKey: .presence_penalty)
         frequency_penalty = try container.decodeIfPresent(Double.self, forKey: .frequency_penalty)
+        repetition_penalty = try container.decodeIfPresent(Double.self, forKey: .repetition_penalty)
         logprobs = try container.decodeIfPresent(Bool.self, forKey: .logprobs)
         top_logprobs = try container.decodeIfPresent(Int.self, forKey: .top_logprobs)
         reasoning_effort = try container.decodeIfPresent(String.self, forKey: .reasoning_effort)
@@ -270,6 +280,7 @@ public struct OpenAIChatRequest: Codable, Sendable {
         try container.encode(messages, forKey: .messages)
         try container.encodeIfPresent(temperature, forKey: .temperature)
         try container.encodeIfPresent(top_p, forKey: .top_p)
+        try container.encodeIfPresent(top_k, forKey: .top_k)
         try container.encodeIfPresent(min_p, forKey: .min_p)
         try container.encodeIfPresent(max_tokens, forKey: .max_tokens)
         try container.encodeIfPresent(max_completion_tokens, forKey: .max_completion_tokens)
@@ -278,6 +289,7 @@ public struct OpenAIChatRequest: Codable, Sendable {
         try container.encodeIfPresent(seed, forKey: .seed)
         try container.encodeIfPresent(presence_penalty, forKey: .presence_penalty)
         try container.encodeIfPresent(frequency_penalty, forKey: .frequency_penalty)
+        try container.encodeIfPresent(repetition_penalty, forKey: .repetition_penalty)
         try container.encodeIfPresent(logprobs, forKey: .logprobs)
         try container.encodeIfPresent(top_logprobs, forKey: .top_logprobs)
         try container.encodeIfPresent(reasoning_effort, forKey: .reasoning_effort)

--- a/Sources/MereRunCore/Generation.swift
+++ b/Sources/MereRunCore/Generation.swift
@@ -500,6 +500,11 @@ public struct ChatRequest: Sendable, Hashable {
     public var topK: Int?
     /// Min-p sampling cutoff relative to the most likely token; zero disables it.
     public var minP: Double
+    /// Additive penalties over tokens generated in this response. Zero disables them.
+    public var presencePenalty: Double
+    public var frequencyPenalty: Double
+    /// Sign-aware penalty over prompt and generated tokens. One disables it.
+    public var repetitionPenalty: Double
     /// Optional deterministic seed for runtimes with an explicit random canvas or sampler.
     public var seed: UInt64?
     /// Model-specific reasoning budget. Inkling-Small accepts values from 0 through 0.99.
@@ -532,6 +537,9 @@ public struct ChatRequest: Sendable, Hashable {
         topP: Double = 0.9,
         topK: Int? = nil,
         minP: Double = 0,
+        presencePenalty: Double = 0,
+        frequencyPenalty: Double = 0,
+        repetitionPenalty: Double = 1,
         seed: UInt64? = nil,
         reasoningEffort: Double? = nil,
         showThinking: Bool = true,
@@ -555,6 +563,9 @@ public struct ChatRequest: Sendable, Hashable {
         self.topP = topP
         self.topK = topK
         self.minP = minP
+        self.presencePenalty = presencePenalty
+        self.frequencyPenalty = frequencyPenalty
+        self.repetitionPenalty = repetitionPenalty
         self.seed = seed
         self.reasoningEffort = reasoningEffort
         self.showThinking = showThinking

--- a/Sources/MereRunCore/Generation.swift
+++ b/Sources/MereRunCore/Generation.swift
@@ -223,32 +223,62 @@ public struct ToolDefinition: Sendable, Hashable, Codable {
     public let description: String
     public let parameters: [String: ToolParameterProperty]
     public let required: [String]
+    /// The complete schema supplied by an API client, including nested constraints.
+    public let parameterSchema: [String: OpenAIJSONValue]?
 
     public init(name: String, description: String, parameters: [String: ToolParameterProperty], required: [String]? = nil) {
         self.name = name
         self.description = description
         self.parameters = parameters
         self.required = required ?? Array(parameters.keys)
+        self.parameterSchema = nil
+    }
+
+    public init(name: String, description: String, parameterSchema: [String: OpenAIJSONValue]) {
+        self.name = name
+        self.description = description
+        self.parameterSchema = parameterSchema
+        self.parameters = (parameterSchema["properties"]?.objectValue ?? [:]).mapValues { schema in
+            let property = schema.objectValue ?? [:]
+            return ToolParameterProperty(
+                type: property["type"]?.stringValue ?? "string",
+                description: property["description"]?.stringValue ?? ""
+            )
+        }
+        self.required = parameterSchema["required"]?.arrayValue?.compactMap(\.stringValue) ?? []
+    }
+
+    public var parametersJSONSchema: [String: OpenAIJSONValue] {
+        parameterSchema ?? [
+            "type": .string("object"),
+            "properties": .object(parameters.mapValues { property in
+                .object(["type": .string(property.type), "description": .string(property.description)])
+            }),
+            "required": .array(required.map(OpenAIJSONValue.string)),
+        ]
     }
 
     /// Convert to the ToolSpec format expected by swift-transformers applyChatTemplate.
     public func toToolSpec() -> [String: any Sendable] {
-        var properties: [String: any Sendable] = [:]
-        for (key, prop) in parameters {
-            properties[key] = ["type": prop.type, "description": prop.description] as [String: String]
-        }
         return [
             "type": "function",
             "function": [
                 "name": name,
                 "description": description,
-                "parameters": [
-                    "type": "object",
-                    "properties": properties,
-                    "required": required,
-                ] as [String: any Sendable],
+                "parameters": parametersJSONSchema.mapValues(Self.templateValue),
             ] as [String: any Sendable],
         ] as [String: any Sendable]
+    }
+
+    private static func templateValue(_ value: OpenAIJSONValue) -> any Sendable {
+        switch value {
+        case .string(let value): value
+        case .number(let value): value
+        case .bool(let value): value
+        case .object(let value): value.mapValues(templateValue)
+        case .array(let value): value.map(templateValue)
+        case .null: Optional<String>.none
+        }
     }
 
     public func promptSchemaJSONString() throws -> String {
@@ -271,22 +301,13 @@ private struct ToolPromptSchema: Encodable {
 private struct ToolFunctionSchema: Encodable {
     let name: String
     let description: String
-    let parameters: ToolParametersSchema
+    let parameters: [String: OpenAIJSONValue]
 
     init(definition: ToolDefinition) {
         self.name = definition.name
         self.description = definition.description
-        self.parameters = ToolParametersSchema(
-            properties: definition.parameters,
-            required: definition.required
-        )
+        self.parameters = definition.parametersJSONSchema
     }
-}
-
-private struct ToolParametersSchema: Encodable {
-    let type = "object"
-    let properties: [String: ToolParameterProperty]
-    let required: [String]
 }
 
 public struct ToolCall: Sendable, Hashable {

--- a/Sources/MereRunCore/Inkling/InklingTokenizerAndTemplate.swift
+++ b/Sources/MereRunCore/Inkling/InklingTokenizerAndTemplate.swift
@@ -172,24 +172,13 @@ public final class InklingTokenizerAndTemplate: @unchecked Sendable {
 private struct InklingToolDeclaration: Encodable {
     let description: String
     let name: String
-    let parameters: InklingToolParameters
+    let parameters: [String: OpenAIJSONValue]
     let type = "function"
 
     init(_ definition: ToolDefinition) {
         description = definition.description
         name = definition.name
-        parameters = InklingToolParameters(definition)
-    }
-}
-
-private struct InklingToolParameters: Encodable {
-    let properties: [String: ToolParameterProperty]
-    let required: [String]
-    let type = "object"
-
-    init(_ definition: ToolDefinition) {
-        properties = definition.parameters
-        required = definition.required
+        parameters = definition.parametersJSONSchema
     }
 }
 

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -228,6 +228,7 @@ public extension ManagedModelAPIProfile {
             servingEngine: .textChatLaguna,
             contextWindow: contextWindow,
             maximumOutputTokens: 4_096,
+            thinkingLevels: [.high],
             toolCall: true,
             supportsStopSequences: true,
             supportsLogprobs: true

--- a/Sources/MereRunCore/ManagedModelCatalog.swift
+++ b/Sources/MereRunCore/ManagedModelCatalog.swift
@@ -247,6 +247,7 @@ public extension ManagedModelAPIProfile {
             thinkingLevels: fixedReasoning ? [.high] : [],
             toolCall: true,
             structuredOutput: true,
+            supportsPenalties: true,
             supportsLogprobs: true
         )
     }
@@ -272,6 +273,7 @@ public extension ManagedModelAPIProfile {
             compatibility: ManagedModelOpenAICompatibilityProfile(
                 supportsReasoningEffort: true
             ),
+            supportsPenalties: true,
             supportsLogprobs: true
         )
     }

--- a/Sources/MereRunCore/Q35/Q35CompiledOperations.swift
+++ b/Sources/MereRunCore/Q35/Q35CompiledOperations.swift
@@ -40,6 +40,18 @@ final class Q35CompiledOperations: @unchecked Sendable {
             return try await $scoped.withValue(Q35CompiledOperations(), operation: operation)
         }
     }
+
+    static func withDefaultStream<Result>(
+        _ context: MLX.Stream.Context,
+        scoped enabled: Bool,
+        isolation _: isolated (any Actor)? = #isolation,
+        _ operation: () async throws -> Result
+    ) async rethrows -> Result {
+        try await Stream.withDefaultStream(context) {
+            guard enabled else { return try await operation() }
+            return try await $scoped.withValue(Q35CompiledOperations(), operation: operation)
+        }
+    }
 }
 
 @inline(__always)

--- a/Sources/MereRunCore/Q35/Q35DebugDump.swift
+++ b/Sources/MereRunCore/Q35/Q35DebugDump.swift
@@ -38,3 +38,27 @@ enum Q35DebugLayerDump {
         lines.removeAll()
     }
 }
+
+/// Request-boundary allocator measurements for diagnosing long-running sessions.
+enum Q35MemoryTrace {
+    private static let enabled = ProcessInfo.processInfo.environment["MERERUN_Q35_DEBUG_MEMORY"] == "1"
+
+    private struct Record: Encodable {
+        let model: String
+        let memory: Memory.Snapshot
+        let memoryLimit: Int
+        let cacheLimit: Int
+    }
+
+    static func record(modelID: String) {
+        guard enabled else { return }
+        let record = Record(
+            model: modelID,
+            memory: Memory.snapshot(),
+            memoryLimit: Memory.memoryLimit,
+            cacheLimit: Memory.cacheLimit
+        )
+        guard let data = try? JSONEncoder().encode(record) else { return }
+        FileHandle.standardError.write(Data("[q35-memory] ".utf8) + data + Data("\n".utf8))
+    }
+}

--- a/Sources/MereRunCore/Q35/Q35Generator.swift
+++ b/Sources/MereRunCore/Q35/Q35Generator.swift
@@ -143,7 +143,7 @@ public actor Q35Generator: ChatGenerator {
     private static let contendedPrefillChunkSize = 512
     private static let q38LowPrefillHeadroomBytes = UInt64(16) * 1_024 * 1_024 * 1_024
     private static let minimumReclaimableCacheBytes = 256 * 1_024 * 1_024
-    private static let flashNextReusableCacheBytes = 4 * 1_024 * 1_024 * 1_024
+    private static let maximumReusableCacheBytes = 4 * 1_024 * 1_024 * 1_024
     private static let prefixKVCacheMaxEntries = 4
     private static let defaultMTPBlockSize = 4
     /// One committed token plus up to seven Qwen3.8 proposal tokens. Wider
@@ -286,6 +286,7 @@ public actor Q35Generator: ChatGenerator {
     private var activeDecodeRows: [Q35BatchedDecodeRow] = []
     private var decodeLoopRunning = false
     private var activeChatRequestCount = 0
+    private var availableStreamContexts: [MLX.Stream.Context] = []
     private var batchedDecodeSteps = 0
     private var samePositionBatchedSteps = 0
     private var variablePositionBatchedSteps = 0
@@ -356,18 +357,17 @@ public actor Q35Generator: ChatGenerator {
     static func shouldClearMLXCache(
         activeMemory: Int,
         cacheMemory: Int,
-        memoryLimit: Int,
-        isFlashNext: Bool = false
+        memoryLimit: Int
     ) -> Bool {
         guard activeMemory >= 0,
               cacheMemory >= minimumReclaimableCacheBytes,
               memoryLimit > 0 else {
             return false
         }
-        // Growing QSA shapes leave buffers that later chunks cannot reuse.
+        // Growing prompts leave buffers that later chunks cannot reuse.
         // The device-wide limit does not reserve headroom for other processes;
         // reclaim disposable buffers without evicting live prefix/KV state.
-        if isFlashNext, cacheMemory >= flashNextReusableCacheBytes {
+        if cacheMemory >= maximumReusableCacheBytes {
             return true
         }
         let total = activeMemory.addingReportingOverflow(cacheMemory)
@@ -380,8 +380,7 @@ public actor Q35Generator: ChatGenerator {
         if Self.shouldClearMLXCache(
             activeMemory: snapshot.activeMemory,
             cacheMemory: snapshot.cacheMemory,
-            memoryLimit: Memory.memoryLimit,
-            isFlashNext: loadedConfig?.textConfig.isQwen4Exp == true
+            memoryLimit: Memory.memoryLimit
         ) {
             Memory.clearCache()
         }
@@ -451,15 +450,34 @@ public actor Q35Generator: ChatGenerator {
         return min(configuredMaximum, contextMaximum)
     }
 
+    /// Lease a context until the request ends. Actor reentrancy can admit another
+    /// request while this one is suspended, so active requests need distinct
+    /// contexts. Completed requests reuse them instead of accumulating MLX
+    /// backend streams, which live until process exit.
+    func withRequestStream<Result>(
+        _ operation: () async throws -> Result
+    ) async rethrows -> Result {
+        let context = availableStreamContexts.popLast() ?? MLX.Stream.Context()
+        defer {
+            context.synchronize()
+            clearMLXCacheUnderPressureIfNeeded()
+            Q35MemoryTrace.record(modelID: modelId)
+            availableStreamContexts.append(context)
+        }
+        return try await Q35CompiledOperations.withDefaultStream(
+            context,
+            scoped: Q35RuntimeTuning.isEnabled(.scopedCompilation, modelID: modelId),
+            operation
+        )
+    }
+
     public func chat(
         _ request: ChatRequest,
         progressHandler: (@Sendable (ChatProgress) -> Void)?
     ) async throws -> ChatResponse {
         activeChatRequestCount += 1
         defer { activeChatRequestCount = max(0, activeChatRequestCount - 1) }
-        return try await Q35CompiledOperations.withNewDefaultStream(
-            scoped: Q35RuntimeTuning.isEnabled(.scopedCompilation, modelID: modelId)
-        ) {
+        return try await withRequestStream {
             let rootURL = try await resolveModelRoot(modelPath: nil, progressHandler: progressHandler)
             let loadStart = Date()
             try await ensureLoaded(rootURL: rootURL, progressHandler: progressHandler)
@@ -488,9 +506,7 @@ public actor Q35Generator: ChatGenerator {
     ) async throws -> ChatResponse {
         activeChatRequestCount += 1
         defer { activeChatRequestCount = max(0, activeChatRequestCount - 1) }
-        return try await Q35CompiledOperations.withNewDefaultStream(
-            scoped: Q35RuntimeTuning.isEnabled(.scopedCompilation, modelID: modelId)
-        ) {
+        return try await withRequestStream {
             let rootURL = try await resolveModelRoot(modelPath: modelPath, progressHandler: progressHandler)
             let loadStart = Date()
             try await ensureLoaded(rootURL: rootURL, progressHandler: progressHandler)
@@ -516,9 +532,7 @@ public actor Q35Generator: ChatGenerator {
         modelPath: String? = nil,
         progressHandler: (@Sendable (ChatProgress) -> Void)? = nil
     ) async throws {
-        try await Q35CompiledOperations.withNewDefaultStream(
-            scoped: Q35RuntimeTuning.isEnabled(.scopedCompilation, modelID: modelId)
-        ) {
+        try await withRequestStream {
             let rootURL = try await resolveModelRoot(
                 modelPath: modelPath,
                 progressHandler: progressHandler
@@ -758,9 +772,7 @@ public actor Q35Generator: ChatGenerator {
         }
         // An exact prefix-cache hit skips the prefill loop entirely. Reclaim
         // disposable buffers from the previous request before forking its KV.
-        if loadedConfig.textConfig.isQwen4Exp {
-            clearMLXCacheUnderPressureIfNeeded()
-        }
+        clearMLXCacheUnderPressureIfNeeded()
 
         let messages = request.messages
         let jsonConstrained = request.requiresJSON

--- a/Sources/MereRunCore/Q35/Q35Generator.swift
+++ b/Sources/MereRunCore/Q35/Q35Generator.swift
@@ -870,16 +870,9 @@ public actor Q35Generator: ChatGenerator {
                     + [tokenizerAndTemplate.eosTokenId].compactMap { $0 }
             )
             : Set<Int>()
-        let generationConfig = GenerationConfig(
-            maxTokens: request.maxTokens,
-            temperature: Float(request.temperature),
-            topK: request.topK ?? 0,
-            topP: Float(request.topP),
-            minP: Float(request.minP),
-            repetitionPenalty: nil,
-            repetitionContextSize: 64
-        )
+        let generationConfig = Q35Sampling.generationConfig(for: request, promptTokenCount: promptTokens.count)
         let mtpSpeculationEligible = !request.logprobCapture.isEnabled
+            && !generationConfig.hasActivePenalties
             && !jsonConstrained
             && request.tools?.isEmpty != false
             && imageURLs.isEmpty
@@ -1216,6 +1209,7 @@ public actor Q35Generator: ChatGenerator {
             return Q35BatchedDecodeResult(generatedTokens: [], decodeSeconds: 0)
         }
         let speculationMTP = !logprobCapture.isEnabled
+            && !generationConfig.hasActivePenalties
             && !jsonConstrained && !stopAtCompletedToolCall && Self.shouldSpeculate(
             modelId: modelId,
             usesMoE: model.config.textConfig.usesMoE,
@@ -1419,7 +1413,10 @@ public actor Q35Generator: ChatGenerator {
             if jsonConstrained {
                 guard let constrained = jsonConstrainedToken(
                     initial: next,
-                    logits: logits[0, -1, 0...],
+                    logits: applyingSamplingPenalties(
+                        logits[0, -1, 0...], config: generationConfig,
+                        history: repetitionHistoryArray(promptTokens: repetitionHistory, config: generationConfig)
+                    ),
                     config: generationConfig,
                     eosSet: eosSet,
                     grammar: &jsonGrammar,

--- a/Sources/MereRunCore/Q35/Q35Sampling.swift
+++ b/Sources/MereRunCore/Q35/Q35Sampling.swift
@@ -1,6 +1,21 @@
 import MLX
 
 enum Q35Sampling {
+    static func generationConfig(for request: ChatRequest, promptTokenCount: Int) -> GenerationConfig {
+        GenerationConfig(
+            maxTokens: request.maxTokens,
+            temperature: Float(request.temperature),
+            topK: request.topK ?? 0,
+            topP: Float(request.topP),
+            minP: Float(request.minP),
+            repetitionPenalty: request.repetitionPenalty == 1 ? nil : Float(request.repetitionPenalty),
+            repetitionContextSize: Int.max,
+            presencePenalty: Float(request.presencePenalty),
+            frequencyPenalty: Float(request.frequencyPenalty),
+            penaltyPromptTokenCount: promptTokenCount
+        )
+    }
+
     static func acceptsDraft(probability: Float) -> Bool {
         MLXRandom.uniform().item(Float.self) < probability
     }

--- a/Sources/MereRunCore/Q35/README.md
+++ b/Sources/MereRunCore/Q35/README.md
@@ -6,7 +6,7 @@ Qwen 3.5/3.6/3.8 dense and hybrid MoE text and vision-language runtime.
 - `Q35TokenizerAndTemplate.swift`: checkpoint-native chat-template rendering,
   image-token expansion, and tokenization.
 - `Q35Model.swift`: native model entry point.
-- `Q35CompiledOperations.swift`: compiled activations and request-stream scopes.
+- `Q35CompiledOperations.swift`: compiled activations and request stream scopes.
 - `Q35MTPProfile.swift`: optional synchronized speculation diagnostics.
 - `Q35RuntimeTuning.swift`: scheduling defaults for the qualified managed Q4 targets.
 - Attention and MoE files own model math only.
@@ -47,7 +47,12 @@ Verified Q4 measurements showed a short-prompt decode win, so managed Ornith
 
 Managed Qwen3.8 27B Q4 and Ornith 1.5 Q4 requests own their compiled
 activation graphs. This prevents reuse of graphs traced on a previous
-request's MLX stream. Supported short decode and verification blocks submit
+request's MLX stream. The generator leases CPU and GPU stream contexts for
+active requests, then synchronizes and reuses them after completion or failure.
+Overlapping requests use separate contexts. MLX retains backend streams until
+process exit, so allocating streams per request accumulates command queues in
+long-running API sessions. Graph owners remain separate for each request even
+when the stream context is reused. Supported short decode and verification blocks submit
 asynchronously, and permanent greedy MTP fallback uses the pipelined target
 decoder. Other model IDs keep their existing scheduling defaults. Set
 `MERERUN_Q35_SCOPED_COMPILE=0`, `MERERUN_Q35_ASYNC_DECODE_BLOCKS=0`, or
@@ -204,12 +209,14 @@ not every intermediate prefill chunk. The four-entry retention bound remains
 in force. The full prompt's hidden history is no longer retained or re-primed
 on every eligible request.
 
-Flash-Next also reclaims reusable MLX buffers when they reach 4 GiB at a
-prefill chunk boundary, decode round, or new request (including exact prefix
-replay, which skips prefill). Growing QSA shapes otherwise accumulate differently
-sized temporary buffers until the much larger device-wide limit. This does
+Qwen-family generators reclaim reusable MLX buffers when they reach 4 GiB at a
+prefill chunk boundary, decode round, or request boundary (including exact prefix
+replay, which skips prefill). Growing prompt and QSA shapes otherwise accumulate
+differently sized temporary buffers until the much larger device-wide limit. This does
 not evict model tensors, target/draft KV history, or prefix-cache entries, and
 does not change the process-wide MLX allocation limits.
+Set `MERERUN_Q35_DEBUG_MEMORY=1` to record process-wide live allocations, reusable
+buffers, and configured MLX limits on stderr when a request completes or fails.
 
 `Q38FlashNextCheckpointTests` provides explicit installed-model gates for 32k, 64k, and 128k
 retrieval, exact prompt replay, a cached follow-up turn, and MTP agreement with

--- a/Sources/MereRunCore/Q35/README.md
+++ b/Sources/MereRunCore/Q35/README.md
@@ -339,3 +339,10 @@ encoder diagnostics without loading the language model. Set
 `MERERUN_TEST_Q38_VISION_ORACLE_DTYPE=fp32` optionally upcasts the encoder
 for a precision diagnostic; the default export uses the runtime's BF16 weights.
 The export refuses to overwrite existing evidence; it is not an OCR-quality gate.
+
+Qwen-family API requests expose temperature, top-p, top-k, min-p, and penalty
+controls through `ChatRequest`. Presence and frequency penalties count only
+newly generated tokens; repetition penalties cover the prompt and output.
+`SamplingPenalties.swift` applies them before filtering in the shared sampler.
+Active penalties disable MTP so draft verification cannot bypass the history
+transform. Neutral defaults preserve the accelerated path.

--- a/Sources/MereRunCore/TextSFTDataset.swift
+++ b/Sources/MereRunCore/TextSFTDataset.swift
@@ -372,7 +372,13 @@ public enum TextSFTDataset {
 
     fileprivate static func canonicalTools(_ tools: [ToolDefinition]?) -> [ToolDefinition]? {
         tools?.map { tool in
-            ToolDefinition(
+            if var schema = tool.parameterSchema {
+                if schema["required"] != nil {
+                    schema["required"] = .array(tool.required.sorted().map(OpenAIJSONValue.string))
+                }
+                return ToolDefinition(name: tool.name, description: tool.description, parameterSchema: schema)
+            }
+            return ToolDefinition(
                 name: tool.name,
                 description: tool.description,
                 parameters: tool.parameters,

--- a/Sources/MereRunCore/ZImageTurbo/Model/TextEncoder/LLMGeneration/Sampling.swift
+++ b/Sources/MereRunCore/ZImageTurbo/Model/TextEncoder/LLMGeneration/Sampling.swift
@@ -13,6 +13,22 @@ public struct GenerationConfig: Sendable {
     public var minP: Float
     public var repetitionPenalty: Float?
     public var repetitionContextSize: Int
+    public var presencePenalty: Float
+    public var frequencyPenalty: Float
+    /// Prompt tokens excluded from presence and frequency penalties.
+    public var penaltyPromptTokenCount: Int
+
+    var penaltyHistorySize: Int {
+        presencePenalty != 0 || frequencyPenalty != 0 ? Int.max : repetitionContextSize
+    }
+
+    var hasActivePenalties: Bool {
+        (repetitionPenalty != nil && repetitionPenalty != 1) || presencePenalty != 0 || frequencyPenalty != 0
+    }
+
+    var needsPenaltyHistory: Bool {
+        repetitionPenalty != nil || presencePenalty != 0 || frequencyPenalty != 0
+    }
     /// Token ids that must never be sampled. Applied as a -inf logit mask.
     public var bannedTokens: [Int]
     /// Per-request top-p candidate limit. Nil uses the process policy; zero
@@ -27,6 +43,9 @@ public struct GenerationConfig: Sendable {
         minP: Float = 0,
         repetitionPenalty: Float? = 1.05,
         repetitionContextSize: Int = 20,
+        presencePenalty: Float = 0,
+        frequencyPenalty: Float = 0,
+        penaltyPromptTokenCount: Int = 0,
         bannedTokens: [Int] = [],
         topPPrefilter: Int? = nil
     ) {
@@ -37,6 +56,9 @@ public struct GenerationConfig: Sendable {
         self.minP = minP
         self.repetitionPenalty = repetitionPenalty
         self.repetitionContextSize = repetitionContextSize
+        self.presencePenalty = presencePenalty
+        self.frequencyPenalty = frequencyPenalty
+        self.penaltyPromptTokenCount = penaltyPromptTokenCount
         self.bannedTokens = bannedTokens
         self.topPPrefilter = topPPrefilter
     }
@@ -72,12 +94,12 @@ public func repetitionHistoryArray(
     promptTokens: [Int],
     config: GenerationConfig
 ) -> MLXArray? {
-    guard config.repetitionPenalty != nil,
-          config.repetitionContextSize > 0,
+    guard config.needsPenaltyHistory,
+          config.penaltyHistorySize > 0,
           !promptTokens.isEmpty else {
         return nil
     }
-    return MLXArray(promptTokens.suffix(config.repetitionContextSize).map { Int32($0) })
+    return MLXArray(promptTokens.suffix(config.penaltyHistorySize).map { Int32($0) })
 }
 
 /// Appends a still-on-GPU token to the repetition window, trimming to
@@ -87,7 +109,7 @@ public func appendingRepetitionHistory(
     token: MLXArray,
     config: GenerationConfig
 ) -> MLXArray? {
-    guard config.repetitionPenalty != nil, config.repetitionContextSize > 0 else {
+    guard config.needsPenaltyHistory, config.penaltyHistorySize > 0 else {
         return nil
     }
 
@@ -97,7 +119,7 @@ public func appendingRepetitionHistory(
     }
 
     let combined = concatenated([history, nextToken], axis: 0)
-    let overflow = combined.dim(0) - config.repetitionContextSize
+    let overflow = combined.dim(0) - config.penaltyHistorySize
     guard overflow > 0 else {
         return combined
     }
@@ -151,15 +173,7 @@ public func sampledTokenArray(
         logits = logits + banMask
     }
 
-    if let penalty = config.repetitionPenalty,
-       let previousTokenIndices,
-       previousTokenIndices.dim(0) > 0 {
-        logits = applyRepetitionPenalty(
-            logits: logits,
-            tokenIndices: previousTokenIndices,
-            penalty: penalty
-        )
-    }
+    logits = applyingSamplingPenalties(logits, config: config, history: previousTokenIndices)
 
     if config.temperature == 0 {
         return argMax(logits, axis: -1).asType(.int32)
@@ -239,9 +253,7 @@ public func greedySampleTokenArray(
     config: GenerationConfig,
     previousTokens: [Int]
 ) -> MLXArray {
-    let contextTokens = previousTokens.isEmpty || config.repetitionPenalty == nil
-        ? nil
-        : MLXArray(previousTokens.suffix(config.repetitionContextSize).map { Int32($0) })
+    let contextTokens = repetitionHistoryArray(promptTokens: previousTokens, config: config)
     return greedySampleTokenArray(
         logits: logits,
         config: config,
@@ -258,15 +270,7 @@ public func greedySampleTokenArray(
 
     logits = applyTokenBan(logits: logits, tokens: config.bannedTokens)
 
-    if let penalty = config.repetitionPenalty,
-       let previousTokenIndices,
-       previousTokenIndices.dim(0) > 0 {
-        logits = applyRepetitionPenalty(
-            logits: logits,
-            tokenIndices: previousTokenIndices,
-            penalty: penalty
-        )
-    }
+    logits = applyingSamplingPenalties(logits, config: config, history: previousTokenIndices)
 
     return argMax(logits, axis: -1).asType(.int32)
 }
@@ -390,10 +394,10 @@ public func sampleToken(
 
     logits = applyTokenBan(logits: logits, tokens: config.bannedTokens)
 
-    if let penalty = config.repetitionPenalty, !previousTokens.isEmpty {
-        let contextTokens = Array(previousTokens.suffix(config.repetitionContextSize))
-        logits = applyRepetitionPenalty(logits: logits, tokens: contextTokens, penalty: penalty)
-    }
+    logits = applyingSamplingPenalties(
+        logits, config: config,
+        history: repetitionHistoryArray(promptTokens: previousTokens, config: config)
+    )
 
     if config.temperature == 0 {
         return argMaxSample(logits: logits)
@@ -454,10 +458,10 @@ public func samplingProbabilities(
 
     logits = applyTokenBan(logits: logits, tokens: config.bannedTokens)
 
-    if let penalty = config.repetitionPenalty, !previousTokens.isEmpty {
-        let contextTokens = Array(previousTokens.suffix(config.repetitionContextSize))
-        logits = applyRepetitionPenalty(logits: logits, tokens: contextTokens, penalty: penalty)
-    }
+    logits = applyingSamplingPenalties(
+        logits, config: config,
+        history: repetitionHistoryArray(promptTokens: previousTokens, config: config)
+    )
 
     if logits.dtype == .bfloat16 {
         logits = logits.asType(.float32)

--- a/Sources/MereRunCore/ZImageTurbo/Model/TextEncoder/LLMGeneration/SamplingPenalties.swift
+++ b/Sources/MereRunCore/ZImageTurbo/Model/TextEncoder/LLMGeneration/SamplingPenalties.swift
@@ -1,0 +1,31 @@
+import MLX
+
+/// Applies repetition to the configured history window, then additive penalties
+/// to generated tokens only. The caller's logits remain unchanged.
+func applyingSamplingPenalties(
+    _ logits: MLXArray,
+    config: GenerationConfig,
+    history: MLXArray?
+) -> MLXArray {
+    guard let history, history.size > 0 else { return logits }
+    var result = logits
+    if let penalty = config.repetitionPenalty, penalty != 1, config.repetitionContextSize > 0 {
+        let start = max(0, history.size - config.repetitionContextSize)
+        let indices = history[start...]
+        let selected = logits[indices]
+        let penalized = MLX.where(selected .< 0, selected * penalty, selected / penalty)
+        // Index assignment mutates an MLXArray wrapper, so use a separate wrapper.
+        result = logits + MLXArray.zeros(like: logits)
+        result[indices] = penalized
+    }
+    if (config.presencePenalty != 0 || config.frequencyPenalty != 0),
+       history.size > config.penaltyPromptTokenCount {
+        let generated = history[config.penaltyPromptTokenCount...]
+        let counts = MLXArray.zeros([logits.dim(-1)], dtype: .float32)
+            .at[generated].add(MLXArray.ones([generated.size], dtype: .float32))
+        result = result.asType(.float32)
+            - (counts .> 0).asType(.float32) * config.presencePenalty
+            - counts * config.frequencyPenalty
+    }
+    return result
+}

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -953,7 +953,7 @@ limitations under the License.
 - source project: [`sawfwair/mlx-swift`](https://github.com/sawfwair/mlx-swift),
   based on upstream [`ml-explore/mlx-swift`](https://github.com/ml-explore/mlx-swift)
   0.32.1
-- pinned package revision: `7558b9cff75746e3ce25802aecbdc498b240af7f`
+- pinned package revision: `001d1aa3e5655d7efc073fb9632f952f57cdf528`
 - embedded MLX revision: `11da2b33a51772c023e2f7d7bc4ba9b3ff7e03ef`
 - incorporated upstream MLX v0.32.1 revision:
   `3a6219917e4535575ce5bce2fc2ba27a483a709b`

--- a/Tests/MereRunCLITests/APISamplingControlTests.swift
+++ b/Tests/MereRunCLITests/APISamplingControlTests.swift
@@ -1,0 +1,99 @@
+import Foundation
+import XCTest
+import MereRunCore
+@testable import MereRunCLI
+
+final class APISamplingControlTests: XCTestCase {
+    private let modelID = Q35Resources.ornith35BMLX4BitModelId
+
+    private func resolve(_ request: OpenAIChatRequest) throws -> ChatRequest {
+        try APIServerContract.chatRequest(
+            from: request,
+            fallbackLoraPath: nil,
+            contextSize: 4_096,
+            capabilities: RuntimeServingEngine.textChatQ36.openAICompatibility,
+            servedModelID: modelID
+        )
+    }
+
+    func testCodingProfileSurvivesWireRoundTripAndReachesRuntime() throws {
+        let data = Data("""
+        {"model":"text-agent-ornith-35b-mlx-4bit","messages":[{"role":"user","content":"hello"}],
+         "temperature":0.6,"top_p":0.95,"top_k":20,"min_p":0,
+         "presence_penalty":0,"frequency_penalty":0,"repetition_penalty":1}
+        """.utf8)
+        let wire = try JSONDecoder().decode(OpenAIChatRequest.self, from: data)
+        XCTAssertTrue(wire.unknownFields.isEmpty)
+        let roundTrip = try JSONDecoder().decode(OpenAIChatRequest.self, from: JSONEncoder().encode(wire))
+        let request = try resolve(roundTrip)
+        XCTAssertEqual(request.temperature, 0.6)
+        XCTAssertEqual(request.topP, 0.95)
+        XCTAssertEqual(request.topK, 20)
+        XCTAssertEqual(request.minP, 0)
+        XCTAssertEqual(request.presencePenalty, 0)
+        XCTAssertEqual(request.frequencyPenalty, 0)
+        XCTAssertEqual(request.repetitionPenalty, 1)
+    }
+
+    func testSamplingOverridesAreIndependentAndZeroDisablesTopK() throws {
+        var wire = OpenAIChatRequest(model: modelID, messages: [.init(role: "user", content: "hello")])
+        wire.temperature = 0.6
+        XCTAssertEqual(try resolve(wire).topK, 20)
+        wire.top_p = 0.8
+        wire.min_p = 0.05
+        XCTAssertEqual(try resolve(wire).topK, 20)
+        wire.top_k = 0
+        XCTAssertEqual(try resolve(wire).topK, 0)
+        wire.top_k = 7
+        wire.presence_penalty = 1.5
+        wire.frequency_penalty = -0.5
+        wire.repetition_penalty = 1.1
+        let request = try resolve(wire)
+        XCTAssertEqual(request.topK, 7)
+        XCTAssertEqual(request.topP, 0.8)
+        XCTAssertEqual(request.minP, 0.05)
+        XCTAssertEqual(request.presencePenalty, 1.5)
+        XCTAssertEqual(request.frequencyPenalty, -0.5)
+        XCTAssertEqual(request.repetitionPenalty, 1.1)
+    }
+
+    func testRejectsInvalidSamplerValuesBeforeGeneration() throws {
+        let wire = OpenAIChatRequest(model: modelID, messages: [.init(role: "user", content: "hello")])
+        var invalid = wire
+        invalid.top_k = -1
+        XCTAssertThrowsError(try resolve(invalid))
+        for value in [-2.1, 2.1, Double.infinity, Double.nan] {
+            invalid = wire
+            invalid.presence_penalty = value
+            XCTAssertThrowsError(try resolve(invalid))
+            invalid = wire
+            invalid.frequency_penalty = value
+            XCTAssertThrowsError(try resolve(invalid))
+        }
+        for value in [0, -1, Double.infinity, Double.nan, Double.greatestFiniteMagnitude] {
+            invalid = wire
+            invalid.repetition_penalty = value
+            XCTAssertThrowsError(try resolve(invalid))
+        }
+        for value in [-2.0, 2.0] {
+            invalid = wire
+            invalid.presence_penalty = value
+            invalid.frequency_penalty = value
+            XCTAssertNoThrow(try resolve(invalid))
+        }
+    }
+
+    func testUnsupportedEnginesRejectActiveControls() throws {
+        var request = OpenAIChatRequest(model: "test-model", messages: [.init(role: "user", content: "hello")])
+        request.top_k = 20
+        XCTAssertThrowsError(try APIServerContract.chatRequest(from: request, fallbackLoraPath: nil, contextSize: 4_096))
+        request.top_k = 0
+        request.repetition_penalty = 1.1
+        XCTAssertThrowsError(try APIServerContract.chatRequest(from: request, fallbackLoraPath: nil, contextSize: 4_096))
+        request.repetition_penalty = 1
+        request.presence_penalty = 1.5
+        XCTAssertThrowsError(try APIServerContract.chatRequest(from: request, fallbackLoraPath: nil, contextSize: 4_096))
+        request.presence_penalty = 0
+        XCTAssertNoThrow(try APIServerContract.chatRequest(from: request, fallbackLoraPath: nil, contextSize: 4_096))
+    }
+}

--- a/Tests/MereRunCLITests/APIServeCommandTests.swift
+++ b/Tests/MereRunCLITests/APIServeCommandTests.swift
@@ -3135,6 +3135,35 @@ final class APIServeCommandTests: XCTestCase {
         XCTAssertTrue(chatRequest.showThinking)
     }
 
+    func testBufferedStreamingKeepaliveEmitsOnlySSEComments() async throws {
+        let (stream, continuation) = AsyncStream<ByteBuffer>.makeStream()
+        let heartbeat = CodeGenServer.startStreamingKeepalive(
+            continuation: continuation,
+            interval: .milliseconds(5)
+        )
+        defer { heartbeat.cancel() }
+        var iterator = stream.makeAsyncIterator()
+        let first = await iterator.next()
+        let buffer = try XCTUnwrap(first)
+        XCTAssertEqual(String(buffer: buffer), ": keep-alive\n\n")
+        continuation.finish()
+        await heartbeat.value
+    }
+
+    func testStreamingKeepaliveCancellationDoesNotLeaveAPendingWriter() async {
+        let (stream, continuation) = AsyncStream<ByteBuffer>.makeStream()
+        let heartbeat = CodeGenServer.startStreamingKeepalive(
+            continuation: continuation,
+            interval: .seconds(60)
+        )
+        heartbeat.cancel()
+        await heartbeat.value
+        continuation.finish()
+        var iterator = stream.makeAsyncIterator()
+        let next = await iterator.next()
+        XCTAssertNil(next)
+    }
+
     func testStreamingUsageOptionHonorsCapabilities() throws {
         let request = OpenAIChatRequest(
             model: "mererun-test-model",

--- a/Tests/MereRunCLITests/APIServeCommandTests.swift
+++ b/Tests/MereRunCLITests/APIServeCommandTests.swift
@@ -3398,7 +3398,7 @@ final class APIServeCommandTests: XCTestCase {
         XCTAssertTrue(chatRequest.showThinking)
     }
 
-    func testChatRequestExplicitSamplingSkipsRecommendedTopK() throws {
+    func testChatRequestExplicitTemperaturePreservesRecommendedTopK() throws {
         var request = OpenAIChatRequest(
             model: Q35Resources.ornith35BMLXModelId,
             messages: [OpenAIChatMessage(role: "user", content: "hello")]
@@ -3413,7 +3413,7 @@ final class APIServeCommandTests: XCTestCase {
         )
 
         XCTAssertTrue(chatRequest.showThinking)
-        XCTAssertNil(chatRequest.topK)
+        XCTAssertEqual(chatRequest.topK, 20)
         XCTAssertEqual(chatRequest.temperature, 0.2)
     }
 
@@ -3432,7 +3432,7 @@ final class APIServeCommandTests: XCTestCase {
         )
 
         XCTAssertEqual(chatRequest.minP, 0.05)
-        XCTAssertNil(chatRequest.topK)
+        XCTAssertEqual(chatRequest.topK, 20)
     }
 
     func testChatRequestKeepsNoThinkDefaultForNonOrnithLanes() throws {

--- a/Tests/MereRunCLITests/APIServeCommandTests.swift
+++ b/Tests/MereRunCLITests/APIServeCommandTests.swift
@@ -2863,6 +2863,48 @@ final class APIServeCommandTests: XCTestCase {
         )
     }
 
+    func testBufferedToolDeltaPreservesReasoningOnTheWire() throws {
+        let result = ChatResponse(
+            response: "<think>Inspect the source.</think>",
+            tokensGenerated: 12,
+            reasoningContent: "Inspect the source."
+        )
+        let toolCall = OpenAIChatToolCall(
+            id: "call_read",
+            function: OpenAIChatToolCallFunction(name: "read", arguments: #"{"path":"main.swift"}"#)
+        )
+        let encoded = try JSONEncoder().encode(
+            CodeGenServer.openAIBufferedDelta(for: result, toolCalls: [toolCall])
+        )
+        let delta = try JSONDecoder().decode(OpenAIChatDelta.self, from: encoded)
+        XCTAssertEqual(delta.role, "assistant")
+        XCTAssertNil(delta.content)
+        XCTAssertEqual(delta.reasoning_content, "Inspect the source.")
+        XCTAssertEqual(delta.tool_calls?.first?.id, "call_read")
+        XCTAssertEqual(delta.tool_calls?.first?.function?.name, "read")
+    }
+
+    func testBufferedAnswerSeparatesReasoningFromVisibleContent() {
+        for response in ["<think>Check units.</think>42", "Check units.</think>42"] {
+            let result = ChatResponse(
+                response: response,
+                tokensGenerated: 12,
+                reasoningContent: "Check units."
+            )
+            let delta = CodeGenServer.openAIBufferedDelta(for: result, toolCalls: [])
+            XCTAssertEqual(delta.content, "42")
+            XCTAssertEqual(delta.reasoning_content, "Check units.")
+            XCTAssertNil(delta.tool_calls)
+            XCTAssertEqual(CodeGenServer.openAIMessageContent(for: result, hasToolCalls: false), "42")
+        }
+        let reasoningOnly = ChatResponse(
+            response: "<think>Still checking",
+            tokensGenerated: 12,
+            reasoningContent: "Still checking"
+        )
+        XCTAssertEqual(CodeGenServer.openAIBufferedDelta(for: reasoningOnly, toolCalls: []).content, "")
+    }
+
     func testChatRequestRejectsUnsupportedHighImpactFields() {
         let request = OpenAIChatRequest(
             model: "mererun-test-model",
@@ -3282,6 +3324,22 @@ final class APIServeCommandTests: XCTestCase {
         XCTAssertEqual(chatRequest.topK, LagunaResources.recommendedTopK)
         XCTAssertEqual(chatRequest.minP, LagunaResources.recommendedMinP)
         XCTAssertFalse(chatRequest.requiresJSON)
+        XCTAssertTrue(chatRequest.showThinking)
+    }
+
+    func testLagunaXSAPIEnablesReasoning() throws {
+        let request = OpenAIChatRequest(
+            model: LagunaResources.xsModelID,
+            messages: [OpenAIChatMessage(role: "user", content: "hello")]
+        )
+        let chatRequest = try APIServerContract.chatRequest(
+            from: request,
+            fallbackLoraPath: nil,
+            contextSize: LagunaResources.defaultContextLength,
+            capabilities: RuntimeServingEngine.textChatLaguna.openAICompatibility,
+            servedModelID: LagunaResources.xsModelID
+        )
+        XCTAssertTrue(chatRequest.showThinking)
     }
 
     func testChatRequestExplicitSamplingSkipsRecommendedTopK() throws {

--- a/Tests/MereRunCLITests/APIServeCommandTests.swift
+++ b/Tests/MereRunCLITests/APIServeCommandTests.swift
@@ -2357,6 +2357,7 @@ final class APIServeCommandTests: XCTestCase {
         )
 
         XCTAssertEqual(chatRequest.messages[0].reasoningContent, "I should write the file.")
+        XCTAssertEqual(chatRequest.messages[0].content, "Working...")
         XCTAssertEqual(
             chatRequest.messages[0].toolCalls,
             [
@@ -2372,6 +2373,32 @@ final class APIServeCommandTests: XCTestCase {
         )
         XCTAssertEqual(chatRequest.messages[1].name, "write_file")
         XCTAssertEqual(chatRequest.messages[1].toolCallID, "call_123")
+    }
+
+    func testNativeToolHistoryDoesNotInjectAnotherModelsMarkup() throws {
+        for engine: RuntimeServingEngine in [.textChatQ36, .textChatLaguna, .textChatGemma4, .textChatMuseGlimmer] {
+            let request = OpenAIChatRequest(
+                model: "mererun-test-model",
+                messages: [OpenAIChatMessage(
+                    role: "assistant",
+                    reasoning_content: "Read the task.",
+                    tool_calls: [OpenAIChatToolCall(
+                        id: "call_read",
+                        function: OpenAIChatToolCallFunction(name: "read", arguments: #"{"path":"TASK.md"}"#)
+                    )]
+                )]
+            )
+            let mapped = try APIServerContract.chatRequest(
+                from: request,
+                fallbackLoraPath: nil,
+                contextSize: 4_096,
+                capabilities: engine.openAICompatibility
+            )
+            XCTAssertEqual(mapped.messages[0].content, "", engine.rawValue)
+            XCTAssertEqual(mapped.messages[0].reasoningContent, "Read the task.")
+            XCTAssertEqual(mapped.messages[0].toolCalls?.first?.name, "read")
+            XCTAssertEqual(mapped.messages[0].toolCalls?.first?.arguments, ["path": .string("TASK.md")])
+        }
     }
 
     func testChatRequestRejectsInvalidToolCallArguments() {

--- a/Tests/MereRunCLITests/APIToolSchemaTests.swift
+++ b/Tests/MereRunCLITests/APIToolSchemaTests.swift
@@ -1,0 +1,93 @@
+import Foundation
+import MereRunCore
+import XCTest
+@testable import MereRunCLI
+
+final class APIToolSchemaTests: XCTestCase {
+    func testAPIRequestPreservesCompleteToolSchemaInNativePrompt() throws {
+        let data = Data(#"""
+        {
+          "model": "mererun-test-model",
+          "messages": [{"role": "user", "content": "Edit the page."}],
+          "tools": [{
+            "type": "function",
+            "function": {
+              "name": "edit",
+              "parameters": {
+                "type": "object",
+                "properties": {
+                  "action": {"type": "string", "enum": ["replace", "append"]},
+                  "edits": {"type": "array", "items": {
+                    "type": "object",
+                    "properties": {"oldText": {"type": "string"}, "newText": {"type": "string"}},
+                    "required": ["oldText", "newText"],
+                    "additionalProperties": false
+                  }},
+                  "limit": {"type": "integer", "minimum": 1, "maximum": 10}
+                },
+                "required": ["action", "edits"],
+                "additionalProperties": false
+              }
+            }
+          }]
+        }
+        """#.utf8)
+        let request = try JSONDecoder().decode(OpenAIChatRequest.self, from: data)
+        let expected = try XCTUnwrap(request.tools?.first?.function?.parameters)
+        let converted = try APIServerContract.chatRequest(
+            from: request, fallbackLoraPath: nil, contextSize: 4_096,
+            capabilities: .localTextWithTools
+        )
+        let tool = try XCTUnwrap(converted.tools?.first)
+        let prompt = try JSONDecoder().decode(
+            OpenAIJSONValue.self, from: Data(tool.promptSchemaJSONString().utf8)
+        )
+        XCTAssertEqual(prompt.objectValue?["function"]?.objectValue?["parameters"], expected)
+        XCTAssertEqual(tool.required, ["action", "edits"])
+        XCTAssertEqual(tool.parameters["edits"]?.type, "array")
+    }
+
+    func testNonObjectToolSchemaIsRejectedInsteadOfSilentlyReplaced() {
+        for parameters in [OpenAIJSONValue.string("invalid"), .array([]), .bool(true)] {
+            let request = OpenAIChatRequest(
+                model: "mererun-test-model",
+                messages: [OpenAIChatMessage(role: "user", content: "Inspect the page.")],
+                tools: [OpenAIChatTool(function: OpenAIChatToolFunction(name: "inspect", parameters: parameters))]
+            )
+            XCTAssertThrowsError(try APIServerContract.chatRequest(
+                from: request, fallbackLoraPath: nil, contextSize: 4_096,
+                capabilities: .localTextWithTools
+            )) { error in
+                XCTAssertTrue(error.localizedDescription.contains("function parameters must be a JSON object"))
+            }
+        }
+    }
+
+    func testOmittedParametersStillSupportsAZeroArgumentTool() throws {
+        let request = OpenAIChatRequest(
+            model: "mererun-test-model",
+            messages: [OpenAIChatMessage(role: "user", content: "Inspect the page.")],
+            tools: [OpenAIChatTool(function: OpenAIChatToolFunction(name: "inspect"))]
+        )
+        let converted = try APIServerContract.chatRequest(
+            from: request, fallbackLoraPath: nil, contextSize: 4_096,
+            capabilities: .localTextWithTools
+        )
+        XCTAssertEqual(converted.tools?.first?.parametersJSONSchema, [
+            "type": .string("object"), "properties": .object([:]), "required": .array([]),
+        ])
+    }
+
+    func testNullParametersKeepsTheOmittedParameterBehavior() throws {
+        let request = try JSONDecoder().decode(OpenAIChatRequest.self, from: Data(#"""
+        {"model":"mererun-test-model","messages":[{"role":"user","content":"Inspect."}],
+         "tools":[{"type":"function","function":{"name":"inspect","parameters":null}}]}
+        """#.utf8))
+        let converted = try APIServerContract.chatRequest(
+            from: request, fallbackLoraPath: nil, contextSize: 4_096,
+            capabilities: .localTextWithTools
+        )
+        XCTAssertEqual(converted.tools?.first?.required, [])
+        XCTAssertEqual(converted.tools?.first?.parametersJSONSchema["type"], .string("object"))
+    }
+}

--- a/Tests/MereRunCoreTests/ChatTemplateLoopContextTests.swift
+++ b/Tests/MereRunCoreTests/ChatTemplateLoopContextTests.swift
@@ -1,0 +1,60 @@
+import Jinja
+import XCTest
+@testable import MereRunCore
+
+final class ChatTemplateLoopContextTests: XCTestCase {
+    // These neighbor checks are the tool-result grouping contract used by Ornith 1.5.
+    private let templateSource = #"""
+    {%- for message in messages %}
+        {%- if message.role == "tool" %}
+            {%- if loop.previtem and loop.previtem.role != "tool" %}
+                {{- '<|im_start|>user' }}
+            {%- endif %}
+            {{- '\n<tool_response>\n' + message.content + '\n</tool_response>' }}
+            {%- if not loop.last and loop.nextitem.role != "tool" %}
+                {{- '<|im_end|>\n' }}
+            {%- elif loop.last %}
+                {{- '<|im_end|>\n' }}
+            {%- endif %}
+        {%- else %}
+            {{- '<|im_start|>' + message.role + '\n' + message.content + '<|im_end|>\n' }}
+        {%- endif %}
+    {%- endfor %}
+    {{- '<|im_start|>assistant\n' }}
+    """#
+
+    func testSingleAndConsecutiveToolResultsRetainRoleBoundaries() throws {
+        let messages = [
+            ChatMessage(role: .user, content: "Inspect the site."),
+            ChatMessage(role: .assistant, content: "Read two files."),
+            ChatMessage(role: .tool, content: "First file."),
+            ChatMessage(role: .tool, content: "Second file."),
+            ChatMessage(role: .assistant, content: "Open the page."),
+            ChatMessage(role: .tool, content: "Page opened."),
+        ]
+        let rendered = try Template(templateSource).render([
+            "messages": Value(any: Q35TokenizerAndTemplate.renderMessages(messages)),
+        ])
+        XCTAssertEqual(rendered, """
+        <|im_start|>user
+        Inspect the site.<|im_end|>
+        <|im_start|>assistant
+        Read two files.<|im_end|>
+        <|im_start|>user
+        <tool_response>
+        First file.
+        </tool_response>
+        <tool_response>
+        Second file.
+        </tool_response><|im_end|>
+        <|im_start|>assistant
+        Open the page.<|im_end|>
+        <|im_start|>user
+        <tool_response>
+        Page opened.
+        </tool_response><|im_end|>
+        <|im_start|>assistant
+
+        """)
+    }
+}

--- a/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
+++ b/Tests/MereRunCoreTests/ManagedModelCatalogTests.swift
@@ -62,6 +62,12 @@ final class ManagedModelCatalogTests: XCTestCase {
     }
 
     func testCatalogProfilesOwnHarnessSpecificCapabilities() throws {
+        for modelID in [LagunaResources.modelID, LagunaResources.xsModelID] {
+            let laguna = try XCTUnwrap(ManagedModelCatalog.apiProfile(for: modelID))
+            XCTAssertEqual(laguna.thinkingLevels, [.high])
+            XCTAssertTrue(laguna.toolCall)
+        }
+
         let ornith = try XCTUnwrap(
             ManagedModelCatalog.apiProfile(for: Q35Resources.ornith9BModelId)
         )

--- a/Tests/MereRunCoreTests/Q35ConfigDecodingTests.swift
+++ b/Tests/MereRunCoreTests/Q35ConfigDecodingTests.swift
@@ -1557,23 +1557,23 @@ final class Q35ConfigDecodingTests: MereRunCoreTestCase {
         ))
     }
 
-    func testFlashNextBoundsReusableBuffersBelowDeviceLimit() {
+    func testQ35BoundsReusableBuffersBelowDeviceLimit() {
         let gib = 1_024 * 1_024 * 1_024
         XCTAssertFalse(Q35Generator.shouldClearMLXCache(
             activeMemory: 71 * gib, cacheMemory: 4 * gib - 1,
-            memoryLimit: 121 * gib, isFlashNext: true
+            memoryLimit: 121 * gib
         ))
         XCTAssertTrue(Q35Generator.shouldClearMLXCache(
             activeMemory: 71 * gib, cacheMemory: 4 * gib,
-            memoryLimit: 121 * gib, isFlashNext: true
+            memoryLimit: 121 * gib
         ))
         XCTAssertTrue(Q35Generator.shouldClearMLXCache(
             activeMemory: 71 * gib, cacheMemory: 8 * gib,
-            memoryLimit: 121 * gib, isFlashNext: true
+            memoryLimit: 121 * gib
         ))
-        XCTAssertFalse(Q35Generator.shouldClearMLXCache(
-            activeMemory: 71 * gib, cacheMemory: 8 * gib,
-            memoryLimit: 121 * gib, isFlashNext: false
+        XCTAssertTrue(Q35Generator.shouldClearMLXCache(
+            activeMemory: 23 * gib, cacheMemory: 8 * gib,
+            memoryLimit: 121 * gib
         ))
     }
 

--- a/Tests/MereRunCoreTests/Q35RequestStreamTests.swift
+++ b/Tests/MereRunCoreTests/Q35RequestStreamTests.swift
@@ -1,0 +1,56 @@
+import MLX
+import XCTest
+@testable import MereRunCore
+
+final class Q35RequestStreamTests: MereRunCoreTestCase {
+    func testSequentialRequestsReuseStreamsAfterExecutorHops() async {
+        let generator = Q35Generator()
+        var firstStream: MLX.Stream?
+        for index in 0..<200 {
+            let stream = await generator.withRequestStream {
+                let stream = StreamOrDevice.default.stream
+                let result = MLXArray([Float(index)]) * 2
+                await Task.yield()
+                XCTAssertEqual(StreamOrDevice.default.stream, stream)
+                XCTAssertEqual(result.asArray(Float.self), [Float(index * 2)])
+                return stream
+            }
+            if let firstStream {
+                XCTAssertEqual(stream, firstStream, "Sequential requests must not allocate more backend streams")
+            } else {
+                firstStream = stream
+            }
+        }
+    }
+
+    func testOverlappingRequestsHaveDistinctStreamsAndRestoreParentScope() async {
+        let generator = Q35Generator()
+        await generator.withRequestStream {
+            let parent = StreamOrDevice.default.stream
+            await generator.withRequestStream {
+                XCTAssertNotEqual(StreamOrDevice.default.stream, parent)
+                await Task.yield()
+                XCTAssertNotEqual(StreamOrDevice.default.stream, parent)
+            }
+            XCTAssertEqual(StreamOrDevice.default.stream, parent)
+        }
+    }
+
+    func testThrownRequestReturnsItsStreamForReuse() async {
+        let generator = Q35Generator()
+        let first = await generator.withRequestStream { StreamOrDevice.default.stream }
+        do {
+            try await generator.withRequestStream {
+                XCTAssertEqual(StreamOrDevice.default.stream, first)
+                throw CancellationError()
+            }
+            XCTFail("Expected cancellation")
+        } catch is CancellationError {
+            // Cancellation must release the lease just like successful completion.
+        } catch {
+            XCTFail("Unexpected error: \(error)")
+        }
+        let next = await generator.withRequestStream { StreamOrDevice.default.stream }
+        XCTAssertEqual(next, first)
+    }
+}

--- a/Tests/MereRunCoreTests/Q35SamplingTests.swift
+++ b/Tests/MereRunCoreTests/Q35SamplingTests.swift
@@ -3,6 +3,30 @@ import XCTest
 @testable import MereRunCore
 
 final class Q35SamplingTests: MereRunCoreTestCase {
+    func testRequestControlsReachSamplerWithoutEnablingNeutralPenalties() {
+        var request = ChatRequest(
+            messages: [], temperature: 0.6, topP: 0.95, topK: 20, minP: 0,
+            presencePenalty: 0, frequencyPenalty: 0, repetitionPenalty: 1
+        )
+        let coding = Q35Sampling.generationConfig(for: request, promptTokenCount: 128)
+        XCTAssertEqual(coding.temperature, 0.6)
+        XCTAssertEqual(coding.topP, 0.95)
+        XCTAssertEqual(coding.topK, 20)
+        XCTAssertEqual(coding.minP, 0)
+        XCTAssertFalse(coding.hasActivePenalties)
+        XCTAssertNil(coding.repetitionPenalty)
+        request.presencePenalty = 1.5
+        request.frequencyPenalty = 0.25
+        request.repetitionPenalty = 1.1
+        let general = Q35Sampling.generationConfig(for: request, promptTokenCount: 128)
+        XCTAssertTrue(general.hasActivePenalties)
+        XCTAssertEqual(general.presencePenalty, 1.5)
+        XCTAssertEqual(general.frequencyPenalty, 0.25)
+        XCTAssertEqual(general.repetitionPenalty, 1.1)
+        XCTAssertEqual(general.penaltyPromptTokenCount, 128)
+        XCTAssertEqual(general.repetitionContextSize, Int.max)
+    }
+
     func testRequestSeedsReplayAcrossStreamsAndInterveningRandomWork() async {
         defer { MLXRandom.seed(0) }
         let first = await samples(seed: 7)

--- a/Tests/MereRunCoreTests/QwenTokenizerCompatibilityTests.swift
+++ b/Tests/MereRunCoreTests/QwenTokenizerCompatibilityTests.swift
@@ -57,4 +57,52 @@ final class QwenTokenizerCompatibilityTests: MereRunCoreTestCase {
 
         XCTAssertEqual(config["chat_template"].string(), "hello {{ messages }}")
     }
+
+    func testInstalledOrnithTemplatePreservesToolGroupsAndCompleteSchemaWhenAvailable() throws {
+        guard let root = ProcessInfo.processInfo.environment["MERERUN_ORNITH_TOKENIZER_ROOT"] else {
+            throw XCTSkip("Set MERERUN_ORNITH_TOKENIZER_ROOT to check the installed Ornith tokenizer without model weights.")
+        }
+        let schema: [String: OpenAIJSONValue] = [
+            "type": .string("object"),
+            "properties": .object([
+                "action": .object(["type": .string("string"), "enum": .array([.string("navigate"), .string("screenshot")])]),
+                "values": .object(["type": .string("array"), "items": .object(["type": .string("string")])]),
+            ]),
+            "required": .array([.string("action")]), "additionalProperties": .bool(false),
+        ]
+        let tool = ToolDefinition(name: "browser", description: "Inspect a page.", parameterSchema: schema)
+        let template = try Q35TokenizerAndTemplate.load(from: URL(fileURLWithPath: root), maxLengthOverride: 8_192)
+        let messages = [
+            ChatMessage(role: .user, content: "Inspect the site."),
+            ChatMessage(role: .assistant, content: "", reasoningContent: "Open both pages.", toolCalls: [
+                ChatMessageToolCall(id: "first", name: "browser", arguments: ["action": .string("navigate")]),
+                ChatMessageToolCall(id: "second", name: "browser", arguments: ["action": .string("navigate")]),
+            ]),
+            ChatMessage(role: .tool, content: "First page opened.", toolCallID: "first"),
+            ChatMessage(role: .tool, content: "Second page opened.", toolCallID: "second"),
+            ChatMessage(role: .assistant, content: "", reasoningContent: "Inspect the image.", toolCalls: [
+                ChatMessageToolCall(id: "third", name: "browser", arguments: ["action": .string("screenshot")]),
+            ]),
+            ChatMessage(role: .tool, content: "Screenshot available.", toolCallID: "third"),
+        ]
+        let tokens = try template.encodeForGeneration(messages: messages, tools: [tool], maxLength: 8_192)
+        let prompt = template.decode(tokens: tokens)
+        XCTAssertEqual(prompt.components(separatedBy: "<|im_start|>user").count - 1, 3)
+        XCTAssertTrue(prompt.contains("""
+        <|im_start|>user
+        <tool_response>
+        First page opened.
+        </tool_response>
+        <tool_response>
+        Second page opened.
+        </tool_response><|im_end|>
+        """))
+        XCTAssertTrue(prompt.contains("<|im_start|>user\n<tool_response>\nScreenshot available."))
+        XCTAssertTrue(prompt.contains("<think>\nInspect the image.\n</think>"))
+        XCTAssertTrue(prompt.hasSuffix("<|im_start|>assistant\n<think>\n"))
+        let start = try XCTUnwrap(prompt.range(of: "<tools>\n")?.upperBound)
+        let end = try XCTUnwrap(prompt.range(of: "\n</tools>", range: start..<prompt.endIndex)?.lowerBound)
+        let declaration = try JSONDecoder().decode(OpenAIJSONValue.self, from: Data(prompt[start..<end].utf8))
+        XCTAssertEqual(declaration.objectValue?["function"]?.objectValue?["parameters"], .object(schema))
+    }
 }

--- a/Tests/MereRunCoreTests/SamplingPenaltyTests.swift
+++ b/Tests/MereRunCoreTests/SamplingPenaltyTests.swift
@@ -1,0 +1,74 @@
+import MLX
+import XCTest
+@testable import MereRunCore
+
+final class SamplingPenaltyTests: MereRunCoreTestCase {
+    func testPresenceCountsOnceAndFrequencyCountsOccurrencesExcludingPrompt() {
+        let logits = MLXArray([Float(5), 4, 3, 2])
+        let config = GenerationConfig(
+            repetitionPenalty: nil, presencePenalty: 1.5, frequencyPenalty: 0.5,
+            penaltyPromptTokenCount: 2
+        )
+        let history = MLXArray([Int32(0), 0, 1, 1, 2])
+        let result = applyingSamplingPenalties(logits, config: config, history: history)
+        XCTAssertEqual(result.asArray(Float.self), [5, 1.5, 1, 2])
+        XCTAssertEqual(logits.asArray(Float.self), [5, 4, 3, 2])
+    }
+
+    func testRepetitionIsSignAwareAndDoesNotCompoundDuplicateTokensOrMutateLogits() {
+        let logits = MLXArray([Float(4), -2, 3, 0])
+        let config = GenerationConfig(repetitionPenalty: 2, repetitionContextSize: Int.max)
+        let history = MLXArray([Int32(0), 0, 1])
+        let first = applyingSamplingPenalties(logits, config: config, history: history)
+        let second = applyingSamplingPenalties(logits, config: config, history: history)
+        XCTAssertEqual(first.asArray(Float.self), [2, -4, 3, 0])
+        XCTAssertEqual(second.asArray(Float.self), [2, -4, 3, 0])
+        XCTAssertEqual(logits.asArray(Float.self), [4, -2, 3, 0])
+    }
+
+    func testPenaltiesPrecedeTopKAndMatchGreedyAndPolicySamplers() {
+        let logits = MLXArray([Float(4), 3, 2])
+        let config = GenerationConfig(
+            temperature: 0, topK: 1, topP: 1, repetitionPenalty: nil, presencePenalty: 2
+        )
+        let history = [0]
+        XCTAssertEqual(sampleToken(logits: logits, config: config, previousTokens: history), 1)
+        XCTAssertEqual(greedySampleTokenArray(logits: logits, config: config, previousTokens: history).item(Int.self), 1)
+        XCTAssertEqual(sampledTokenArray(
+            logits: logits, config: config,
+            previousTokenIndices: MLXArray(history.map(Int32.init)), banMask: nil
+        ).item(Int.self), 1)
+        var stochastic = config
+        stochastic.temperature = 0.6
+        XCTAssertEqual(samplingProbabilities(
+            logits: logits, config: stochastic, previousTokens: history
+        ).asArray(Float.self), [0, 1, 0])
+        XCTAssertEqual(sampleToken(logits: logits, config: stochastic, previousTokens: history), 1)
+    }
+
+    func testPipelinedDecodePenalizesGeneratedTokensAndResetsBetweenRequests() throws {
+        let config = GenerationConfig(
+            temperature: 0, topP: 1, repetitionPenalty: nil,
+            presencePenalty: 2, penaltyPromptTokenCount: 2
+        )
+        for _ in 0..<2 {
+            let request = AutoregressiveDecodeRequest(
+                initialLogits: MLXArray([Float(4), 3.5, 3]).reshaped(1, 1, 3),
+                generationConfig: config, eosTokens: [], tokenBudget: 3, historySeedTokens: [0, 0]
+            )
+            let result = try AutoregressiveDecodeEngine.decode(request, stepForward: { _ in
+                MLXArray([Float(4), 3.5, 3]).reshaped(1, 1, 3)
+            })
+            XCTAssertEqual(result.generatedTokens, [0, 1, 2])
+        }
+    }
+
+    func testEmptyPromptHistoryAndNegativePresencePenalty() {
+        let config = GenerationConfig(repetitionPenalty: nil, presencePenalty: -1)
+        let empty = repetitionHistoryArray(promptTokens: [], config: config)
+        XCTAssertNil(empty)
+        let history = appendingRepetitionHistory(empty, token: MLXArray(Int32(1)), config: config)
+        let result = applyingSamplingPenalties(MLXArray([Float(1), 1]), config: config, history: history)
+        XCTAssertEqual(result.asArray(Float.self), [1, 2])
+    }
+}

--- a/Tests/MereRunCoreTests/ToolSchemaRenderingTests.swift
+++ b/Tests/MereRunCoreTests/ToolSchemaRenderingTests.swift
@@ -1,0 +1,88 @@
+import Foundation
+import Jinja
+import XCTest
+@testable import MereRunCore
+
+final class ToolSchemaRenderingTests: XCTestCase {
+    private func schema() throws -> [String: OpenAIJSONValue] {
+        let json = #"""
+        {
+          "type": "object",
+          "additionalProperties": false,
+          "$defs": {"label": {"type": "string", "minLength": 1}},
+          "properties": {
+            "action": {"type": "string", "enum": ["navigate", "screenshot"]},
+            "width": {"type": "integer", "minimum": 200, "maximum": 2000},
+            "edits": {
+              "type": "array",
+              "items": {
+                "type": "object",
+                "properties": {"oldText": {"$ref": "#/$defs/label"}, "newText": {"type": "string"}},
+                "required": ["oldText", "newText"],
+                "additionalProperties": false
+              }
+            },
+            "selection": {"anyOf": [{"type": "string"}, {"type": "null"}], "default": null}
+          },
+          "required": ["action"]
+        }
+        """#
+        return try JSONDecoder().decode([String: OpenAIJSONValue].self, from: Data(json.utf8))
+    }
+
+    func testCompleteSchemaSurvivesBothPromptEncodersAndCodable() throws {
+        let expected = try schema()
+        let tool = ToolDefinition(name: "browser", description: "Inspect a page.", parameterSchema: expected)
+        let restored = try JSONDecoder().decode(ToolDefinition.self, from: JSONEncoder().encode(tool))
+        XCTAssertEqual(restored, tool)
+        XCTAssertEqual(restored.required, ["action"])
+        XCTAssertEqual(restored.parameters["edits"]?.type, "array")
+
+        let template = try Template("{{ tool | tojson }}")
+        let rendered = try template.render(["tool": Value(any: restored.toToolSpec())])
+        for json in [rendered, try restored.promptSchemaJSONString()] {
+            let declaration = try JSONDecoder().decode(OpenAIJSONValue.self, from: Data(json.utf8))
+            XCTAssertEqual(declaration.objectValue?["function"]?.objectValue?["parameters"], .object(expected))
+        }
+    }
+
+    func testLegacyToolDefinitionStillDecodesAndBuildsItsSchema() throws {
+        let json = #"{"name":"read","description":"Read a file.","parameters":{"path":{"type":"string","description":"File path"}},"required":["path"]}"#
+        let tool = try JSONDecoder().decode(ToolDefinition.self, from: Data(json.utf8))
+        XCTAssertNil(tool.parameterSchema)
+        XCTAssertEqual(tool.parametersJSONSchema["required"], .array([.string("path")]))
+        XCTAssertEqual(
+            tool.parametersJSONSchema["properties"]?.objectValue?["path"],
+            .object(["type": .string("string"), "description": .string("File path")])
+        )
+    }
+
+    func testInklingDeclarationKeepsCompleteSchema() throws {
+        let expected = try schema()
+        let prompt = try InklingTokenizerAndTemplate.renderPrompt(
+            messages: [],
+            tools: [ToolDefinition(name: "browser", description: "Inspect a page.", parameterSchema: expected)],
+            addGenerationPrompt: false,
+            reasoningEffort: 0
+        )
+        let start = try XCTUnwrap(prompt.range(of: "<|content_xml|>")?.upperBound)
+        let end = try XCTUnwrap(prompt.range(of: "<|end_message|>", range: start..<prompt.endIndex)?.lowerBound)
+        let declarations = try JSONDecoder().decode([OpenAIJSONValue].self, from: Data(prompt[start..<end].utf8))
+        XCTAssertEqual(declarations.first?.objectValue?["parameters"], .object(expected))
+    }
+
+    func testDatasetFingerprintIncludesNestedSchemaConstraints() throws {
+        let first = try schema()
+        var second = first
+        second["additionalProperties"] = .bool(true)
+        func example(_ schema: [String: OpenAIJSONValue]) -> TextSFTExample {
+            TextSFTExample(
+                id: "schema-test", sources: ["test"],
+                messages: [ChatMessage(role: .user, content: "Inspect the page."),
+                           ChatMessage(role: .assistant, content: "Ready.")],
+                tools: [ToolDefinition(name: "browser", description: "Inspect a page.", parameterSchema: schema)]
+            )
+        }
+        XCTAssertNotEqual(TextSFTDataset.fingerprint([example(first)]), TextSFTDataset.fingerprint([example(second)]))
+    }
+}

--- a/docs/mlx-swift-fork.md
+++ b/docs/mlx-swift-fork.md
@@ -1,7 +1,7 @@
 # mlx-swift fork policy and compiled-call overhead
 
 `mere.run` pins the public `sawfwair/mlx-swift` fork at
-`7558b9cff75746e3ce25802aecbdc498b240af7f`. It contains upstream
+`001d1aa3e5655d7efc073fb9632f952f57cdf528`. It contains upstream
 `mlx-swift` through `97cf19efeaa4e929415e75982e999adb34f62c0d`. The embedded
 `sawfwair/mlx` revision is
 `11da2b33a51772c023e2f7d7bc4ba9b3ff7e03ef`, which contains the exact
@@ -17,6 +17,14 @@ cache bridging. The obsolete unaligned
 fast dispatch; the fork instead tests matching host/kernel alignment directly.
 Changes stay scoped to their bit width, group size, quantization mode, and
 backend so stock 2-bit and wider models keep their existing paths.
+
+The pin exposes `Stream.Context` and `Stream.withDefaultStream` for reusable
+task-local CPU and GPU streams. MLX retains backend streams until process exit.
+Long-running servers can lease a context to each active operation, synchronize
+it when the operation ends, and reuse it for a later operation. Callers must
+serialize graph construction and evaluation on each context; overlapping
+operations need distinct contexts. Existing `withNewDefaultStream` calls retain
+their allocation behavior.
 
 The pin also lets an MLXFast custom Metal kernel explicitly request
 the core quantized helper headers. The source marker

--- a/docs/runtime/api-server.md
+++ b/docs/runtime/api-server.md
@@ -528,6 +528,18 @@ supported fields into `ChatRequest` or return an OpenAI-style
 `metadata`, `user`, and `service_tier` are accepted as request context but do
 not change local generation.
 
+For function tools, supply `parameters` as a JSON Schema object. Native prompts
+retain the complete schema, including nested properties, array items, enums,
+references, and constraints such as `additionalProperties`. If you omit
+`parameters` or set it to `null`, the API supplies an empty object schema.
+Other non-object values return `invalid_request_error`. Schema preservation
+does not add full JSON Schema validation of generated arguments; check arguments
+before executing a tool.
+
+Checkpoint templates that use `loop.previtem` and `loop.nextitem` retain the
+role boundaries around individual and consecutive tool results. You do not
+need to edit the installed chat template.
+
 For non-streaming chat responses, native runtimes split `<think>...</think>`
 blocks out of `message.content` and expose them as OpenAI-compatible
 `message.reasoning_content` when present. Tool-capable streaming requests buffer

--- a/docs/runtime/api-server.md
+++ b/docs/runtime/api-server.md
@@ -60,6 +60,9 @@ that preserve reasoning across tool turns should send that field back on the
 assistant message alongside its `tool_calls`.
 Qwen, Ornith, Laguna, Gemma 4, and Muse use their native templates to render
 `tool_calls`; the API keeps assistant `content` separate from those calls.
+Streaming responses send SSE keepalive comments during long generations, including
+buffered tool calls. Clients should ignore comment frames and wait for response
+data and the final usage chunk.
 
 ## What it is for
 

--- a/docs/runtime/api-server.md
+++ b/docs/runtime/api-server.md
@@ -58,6 +58,8 @@ Laguna chat requests enable reasoning by default. Chat responses return reasonin
 in `reasoning_content`, including buffered streaming tool-call replies. Clients
 that preserve reasoning across tool turns should send that field back on the
 assistant message alongside its `tool_calls`.
+Qwen, Ornith, Laguna, Gemma 4, and Muse use their native templates to render
+`tool_calls`; the API keeps assistant `content` separate from those calls.
 
 ## What it is for
 

--- a/docs/runtime/api-server.md
+++ b/docs/runtime/api-server.md
@@ -454,11 +454,51 @@ swift run mere.run api serve \
   form and text posts are rejected before the request body is processed.
 - Chat requests are validated before generation; `max_tokens`,
   `max_completion_tokens`, `temperature`, `top_p`, and the supported `min_p`
-  extension must stay within bounded ranges.
+  extension must stay within bounded ranges. `top_k` accepts nonnegative
+  integers on engines that support top-k sampling; `0` disables the cutoff.
 - LoRA adapters are configured at server startup with `--lora`; request bodies
   cannot select local LoRA paths.
 - Streaming and JSON error paths are sanitized so the local server does not
   reflect raw internal runtime details back to clients.
+
+## Ornith sampling controls
+
+To use Ornith's precise coding profile, include these fields in your
+`/v1/chat/completions` request:
+
+```json
+{
+  "model": "text-agent-ornith-35b-mlx-4bit",
+  "messages": [{ "role": "user", "content": "Write a Python function that sorts dates." }],
+  "temperature": 0.6,
+  "top_p": 0.95,
+  "top_k": 20,
+  "min_p": 0.0,
+  "presence_penalty": 0.0,
+  "repetition_penalty": 1.0
+}
+```
+
+The [Ornith sampling guide](https://github.com/ornith-ai/Ornith-1#quickstart)
+also provides a general-task profile with temperature `1.0` and
+`presence_penalty: 1.5`. The other fields in this example stay the same.
+These settings configure sampling; they do not establish agent task quality.
+
+The Qwen-family runtime, including Ornith, supports these penalties:
+
+- `presence_penalty`: subtracts the value once from each token's logit if the
+  token has appeared in the generated response. Accepts `-2` through `2`.
+- `frequency_penalty`: subtracts the value multiplied by the token's occurrence
+  count in the generated response. Accepts `-2` through `2`.
+- `repetition_penalty`: divides positive logits and multiplies negative logits
+  for tokens in the prompt or generated response. Accepts finite positive
+  values representable by the sampler; `1.0` disables it.
+
+Presence and frequency penalties exclude the prompt and default to `0`.
+Repetition penalties default to `1.0`. Penalties apply before sampling filters
+and reset for each request. Requests with active penalties use target-only
+decode, including streaming and batched requests. Other native engines reject
+active penalty controls they do not support.
 
 ## Runtime control endpoints
 
@@ -613,8 +653,9 @@ Engine compatibility:
 - The Ornith lanes serve with thinking-enabled generation by default (the
   models degenerate without it); the reasoning arrives in the response's
   `reasoning_content` field while `content` carries only the visible answer.
-  When a request sets no explicit `temperature`/`top_p`/`min_p`, these lanes
-  also apply the model's published top-k of 20.
+  Each omitted sampling field retains its model default independently. Ornith
+  uses temperature `1.0`, top-p `0.95`, and top-k `20`; setting `temperature`
+  or `min_p` does not remove the top-k cutoff. Set `top_k: 0` to disable it.
 - `text-chat-lfm25-a1b-8bit`: uses the LFM2 serving engine with the
   LiquidAI LFM2.5 8B-A1B MLX 8-bit weights, accepts function tools, and rejects
   image content parts.

--- a/docs/runtime/api-server.md
+++ b/docs/runtime/api-server.md
@@ -54,6 +54,11 @@ lifecycle. API keys still cross the process boundary only through
 - `POST /v1/audio/speech`
 - `POST /v1/audio/transcriptions`
 
+Laguna chat requests enable reasoning by default. Chat responses return reasoning
+in `reasoning_content`, including buffered streaming tool-call replies. Clients
+that preserve reasoning across tool turns should send that field back on the
+assistant message alongside its `tool_calls`.
+
 ## What it is for
 
 Use the server for repeated requests so the model stays loaded. It supports:

--- a/vendor/mlx-swift_Cmlx.bundle/Contents/Resources/default.metallib.version
+++ b/vendor/mlx-swift_Cmlx.bundle/Contents/Resources/default.metallib.version
@@ -3,7 +3,7 @@ mlx-core-revision: 11da2b33a51772c023e2f7d7bc4ba9b3ff7e03ef
 mlx-upstream-tag: v0.32.1
 mlx-upstream-revision: 3a6219917e4535575ce5bce2fc2ba27a483a709b
 mlx-swift-version: unknown
-mlx-swift-revision: 7558b9cff75746e3ce25802aecbdc498b240af7f
+mlx-swift-revision: 001d1aa3e5655d7efc073fb9632f952f57cdf528
 kernel-sources-sha256: 36412403ff4f0117579f0bc4471a17083411422bfc446f9f11420614ddbeb9ee
-built-at: 2026-08-20T00:31:31Z
+built-at: 2026-09-07T22:57:58Z
 metal-compiler: Apple metal version 32023.883 (metalfe-32023.883)


### PR DESCRIPTION
## Summary

Long-running native agent conversations could end with an empty stream after macOS terminated inference for lack of paging space. Per-request MLX streams accumulated command queues, and disposable Qwen-family buffers grew toward a device-wide memory limit. Reuse synchronized stream contexts and reclaim reusable buffers at the existing 4 GiB threshold during generation and request completion. Live model tensors and prefix/KV state remain resident; the threshold is a reclamation trigger, not a hard process-memory cap.

This repair also preserves the information and sampling settings used by agent requests:

- Preserve reasoning across buffered tool turns, keep native tool history out of assistant text, retain complete function parameter schemas, and support adjacent tool-result groups in checkpoint chat templates.
- Send SSE keepalive comments while generation is buffered.
- Accept explicit `top_k` and resolve omitted sampling fields independently. A request with `temperature: 0.6` now retains Ornith's default `top_k: 20`; `top_k: 0` explicitly removes the cutoff.
- Support presence, frequency, and repetition penalties in Qwen-family API generation. Presence and frequency count generated tokens; repetition covers prompt and output. Apply penalties before sampling filters and use target-only decoding when penalties are active. Unsupported engines reject active controls.

Dependency: https://github.com/sawfwair/mlx-swift/pull/10. The package pins its published runtime implementation at `001d1aa3e5655d7efc073fb9632f952f57cdf528`; the dependency PR's later commit only formats a test. Fork provenance, bundled Metal provenance metadata, and third-party notices are updated together.

## Validation

- [x] `./scripts/check.sh`: passed on `31da1bab482b2e77dcdecbc09a9ad791e211db05`'s source tree. 3,998 XCTest cases, 312 skipped, zero failures; all 51 Swift Testing cases passed. Includes strict lint, build, Metal provenance, CLI help, and hygiene checks.
- [x] Focused API, sampler, and pipelined decode tests. Coverage includes typed wire round trips, request-to-sampler propagation, independent defaults, explicit zero, invalid values, unsupported engines, penalty semantics, filter ordering, and request isolation.
- [x] Public behavior documented; `pnpm docs:build` passed.
- [x] `THIRD_PARTY_NOTICES.md` updated for the dependency pin.

The PR incorporates `main` through durable image records PR #451 (`bdb48fae`). The changelog conflict was resolved by preserving both sets of entries, then all local validation was rerun.

Validation paired Xcode's Swift 6.3 compiler with its macOS 26.4 SDK. A four-job precompile preceded the unchanged repository gate.

## Runtime evidence and remaining gap

Before the sampling follow-up, the combined memory repair completed 148/148 archived requests with HTTP 200 and SSE completion, peaking at 28.27 GiB physical footprint. The process remained alive until intentional cleanup. That diagnostic used saved histories, temperature 0, a 64-token response cap, and no tool execution; it predates the sampling changes and is not a fresh agent-quality result.

The repeated ineffective Bash calls occurred in raw generated text and also reproduced upstream on captured histories. Those histories already contained ineffective tool calls, and the original agent sampling differed from both the diagnostic and the recommended profile. The first bad tool choice remains unexplained. No fresh agent benchmark was run to establish whether these sampling and history repairs resolve that trajectory.
