### PR TITLE
Support native PCM24 export from the resident MiniMax music API

### DIFF
--- a/Sources/MereRunCLI/Commands/MiniMaxMusic3Serve.swift
+++ b/Sources/MereRunCLI/Commands/MiniMaxMusic3Serve.swift
@@ -25,6 +25,12 @@ struct MiniMaxMusic3SpeechRequest: Codable, Sendable {
     var numInferenceSteps: Int?
     var guidanceScale: Float?
     var sampleRate: Int?
+    var exportFormat: ACEStepAudioFormat?
+    var normalization: ACEStepNormalizationMode?
+    var targetPeakDB: Float?
+    var fadeInMilliseconds: Float?
+    var fadeOutMilliseconds: Float?
+    var dither: Bool?
 
     enum CodingKeys: String, CodingKey {
         case model
@@ -47,6 +53,35 @@ struct MiniMaxMusic3SpeechRequest: Codable, Sendable {
         case numInferenceSteps = "num_inference_steps"
         case guidanceScale = "guidance_scale"
         case sampleRate = "sample_rate"
+        case exportFormat = "export_format"
+        case normalization
+        case targetPeakDB = "target_peak_db"
+        case fadeInMilliseconds = "fade_in_ms"
+        case fadeOutMilliseconds = "fade_out_ms"
+        case dither
+    }
+}
+
+extension MiniMaxMusic3SpeechRequest {
+    // Preserve the speech API's original PCM16 defaults unless requested.
+    func exportOptions() throws -> ACEStepAudioExportOptions {
+        let peak = targetPeakDB ?? 0
+        let fadeIn = fadeInMilliseconds ?? 0
+        let fadeOut = fadeOutMilliseconds ?? 0
+        guard peak.isFinite, peak <= 0 else {
+            throw ValidationError("target_peak_db must be finite and at most 0.")
+        }
+        guard fadeIn.isFinite, fadeOut.isFinite, fadeIn >= 0, fadeOut >= 0 else {
+            throw ValidationError("fade_in_ms and fade_out_ms must be finite and nonnegative.")
+        }
+        return .init(
+            format: exportFormat ?? .pcm16,
+            normalization: normalization ?? .none,
+            targetPeakDB: peak,
+            fadeInMilliseconds: fadeIn,
+            fadeOutMilliseconds: fadeOut,
+            dither: dither ?? false
+        )
     }
 }
 
@@ -60,6 +95,7 @@ private struct MiniMaxMusic3HealthResponse: Codable {
     var depthDecoderPrecision: MiniMaxMusic3WeightPrecision
     var nativeSampleRate: Int
     var speechSampleRate: Int
+    var exportFormats: [ACEStepAudioFormat] = ACEStepAudioFormat.allCases
 
     enum CodingKeys: String, CodingKey {
         case status
@@ -71,6 +107,7 @@ private struct MiniMaxMusic3HealthResponse: Codable {
         case depthDecoderPrecision = "depth_decoder_precision"
         case nativeSampleRate = "native_sample_rate"
         case speechSampleRate = "speech_sample_rate"
+        case exportFormats = "export_formats"
     }
 }
 
@@ -94,6 +131,7 @@ private actor MiniMaxMusic3ServerSession {
         modelID: String
     ) throws -> Data {
         let options = try Self.options(from: request, modelID: modelID)
+        let export = try request.exportOptions()
         let result = try pipeline.generate(options: options.generation)
         let waveform = try ACEStepWAVWriter.resample(
             result.waveform.transposed(0, 2, 1),
@@ -103,14 +141,7 @@ private actor MiniMaxMusic3ServerSession {
         return try ACEStepWAVWriter.wavData(
             waveform,
             sampleRate: options.sampleRate,
-            options: .init(
-                format: .pcm16,
-                normalization: .none,
-                targetPeakDB: 0,
-                fadeInMilliseconds: 0,
-                fadeOutMilliseconds: 0,
-                dither: false
-            )
+            options: export
         )
     }
 

--- a/Tests/MereRunCLITests/MusicServeAndExportTests.swift
+++ b/Tests/MereRunCLITests/MusicServeAndExportTests.swift
@@ -6,6 +6,59 @@ import XCTest
 @testable import MereRunCore
 
 final class MusicServeAndExportTests: XCTestCase {
+    func testMiniMaxSpeechExportPreservesDefaultsAndNativePCM24() throws {
+        let legacy = try JSONDecoder().decode(
+            MiniMaxMusic3SpeechRequest.self,
+            from: Data(#"{"input":"[Instrumental]","instructions":"piano"}"#.utf8)
+        )
+        let defaults = try legacy.exportOptions()
+        XCTAssertEqual(defaults.format, .pcm16)
+        XCTAssertEqual(defaults.normalization, .none)
+        XCTAssertFalse(defaults.dither)
+
+        let request = try JSONDecoder().decode(
+            MiniMaxMusic3SpeechRequest.self,
+            from: Data(
+                #"""
+                {"input":"[Instrumental]","instructions":"piano",
+                 "export_format":"pcm24","normalization":"peak","target_peak_db":-1,
+                 "fade_in_ms":5,"fade_out_ms":20,"dither":true}
+                """#.utf8
+            )
+        )
+        let options = try request.exportOptions()
+        XCTAssertEqual(options.format, .pcm24)
+        XCTAssertEqual(options.normalization, .peak)
+        XCTAssertEqual(options.targetPeakDB, -1)
+        XCTAssertEqual(options.fadeInMilliseconds, 5)
+        XCTAssertEqual(options.fadeOutMilliseconds, 20)
+        XCTAssertTrue(options.dither)
+        let audio = MLXArray([Float(0.25), Float(-0.25), Float(0.5), Float(-0.5)], [1, 2, 2])
+        let wav = try ACEStepWAVWriter.wavData(audio, sampleRate: 44_100, options: options)
+        XCTAssertEqual(readUInt16(wav, offset: 34), 24)
+        XCTAssertEqual(wav.count, 44 + 4 * 3)
+    }
+
+    func testMiniMaxSpeechRejectsInvalidExportOptions() throws {
+        for field in [#""export_format":"mp3""#, #""normalization":"unknown""#] {
+            let json = "{\"input\":\"x\",\"instructions\":\"x\",\(field)}"
+            XCTAssertThrowsError(
+                try JSONDecoder().decode(MiniMaxMusic3SpeechRequest.self, from: Data(json.utf8))
+            )
+        }
+        var request = try JSONDecoder().decode(
+            MiniMaxMusic3SpeechRequest.self,
+            from: Data(#"{"input":"x","instructions":"x","target_peak_db":1}"#.utf8)
+        )
+        XCTAssertThrowsError(try request.exportOptions())
+        request.targetPeakDB = 0
+        request.fadeInMilliseconds = -1
+        XCTAssertThrowsError(try request.exportOptions())
+        request.fadeInMilliseconds = 0
+        request.fadeOutMilliseconds = .infinity
+        XCTAssertThrowsError(try request.exportOptions())
+    }
+
     func testMusicCommandExposesResidentServe() {
         let names = Set(Music.configuration.subcommands.map {
             $0.configuration.commandName

--- a/docs/runtime/music.md
+++ b/docs/runtime/music.md
@@ -539,3 +539,33 @@ tokens, matching upstream's high-level Python `.mlxfn` generator more closely.
   an unsupported-runtime error for Magenta.
 - Model resolution and storage follow the same canonical public rules as the
   rest of the repository.
+
+### MiniMax speech WAV export
+
+`music serve --model music-minimax-music3` keeps the selected model loaded.
+Its `/health` response lists `export_formats` (`pcm16`, `pcm24`, `float32`).
+The `/v1/audio/speech` request accepts `export_format`, `normalization`
+(`none` or `peak`), `target_peak_db`, `fade_in_ms`, `fade_out_ms`, and `dither`.
+Omitting them retains the existing unnormalized PCM16 speech response.
+
+For the same WAV export settings as `music generate`, request:
+
+```json
+{
+  "instructions": "Warm jazz piano and soft drums",
+  "input": "[Instrumental]",
+  "response_format": "wav",
+  "sample_rate": 44100,
+  "export_format": "pcm24",
+  "normalization": "peak",
+  "target_peak_db": -1,
+  "fade_in_ms": 5,
+  "fade_out_ms": 20,
+  "dither": true
+}
+```
+
+Export settings are applied to the generated waveform before WAV encoding;
+24-bit output is not obtained by padding a 16-bit response. Invalid formats,
+positive or nonfinite peak targets, and negative or nonfinite fades are rejected
+before generation begins.


### PR DESCRIPTION
The resident MiniMax Music 3 speech endpoint currently always exports PCM16, so clients preserving `music generate` audio quality cannot reuse its loaded model. Add typed WAV export settings and advertise supported formats in `/health`, allowing native PCM24 generation with the CLI's normalization, fade, and dither settings. Requests that omit the new options keep the existing PCM16 behavior.

The export writer operates on the generated waveform before encoding. Invalid formats and peak/fade values are rejected before inference; this does not pad a 16-bit response to 24 bits. Documented request fields are `export_format`, `normalization`, `target_peak_db`, `fade_in_ms`, `fade_out_ms`, and `dither`.

Validation: the complete `./scripts/check.sh` gate passed on macOS: strict SwiftLint (1,582 files), build, Metal provenance verification, 3,971 XCTest cases (313 asset/platform skips; zero failures), 51 Swift Testing cases, and CLI/help/hygiene checks. All 18 `MusicServeAndExportTests` passed, including actual PCM24 WAV bit-depth and byte-width assertions, legacy defaults, and invalid option rejection. No model-weight generation smoke test was run.

This is a draft for review. The consuming loader draft https://github.com/palapa-ai/ai-server/pull/65 requires `pcm24` in the advertised capabilities before using resident music generation; the installed runtime has not been replaced.
