### PR TITLE
Add durable speech runs and shared execution storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+- Add optional durable file-transcription records through `speech transcribe
+  --run-dir` and `api serve --transcription-run-records`. Retain audio, resolved
+  settings, and transcript artifacts; inspect terminal or interrupted outcomes
+  and retry in a new directory through the existing run commands.
+- Share run leases, atomic writes, file hashes, and terminal states in the
+  portable `MereRunExecution` library. Preserve the image history schema and
+  existing transcription stdout, receipt, and API response formats.
+
 - Separate H3, Laguna, and shared BigVGAN computation from Core runtime adapters.
   Split generator stages and share routed quantization primitives with isolated
   model tests and enforced dependency boundaries.

--- a/CODEBASE.md
+++ b/CODEBASE.md
@@ -13,7 +13,7 @@ lookup. `AudioCore` and `AudioCodecs` own audio primitives; `AudioSTT` and
 3. `apps/macos/StudioKit` and `apps/macos/StudioUI` for Studio
 4. `docs/repository-tour.md` for top-level ownership
 5. `docs/architecture.md` for runtime reading order
-6. the module README inside the subsystem you are editing
+6. the subsystem README
 
 ## Key modules
 
@@ -22,7 +22,7 @@ lookup. `AudioCore` and `AudioCodecs` own audio primitives; `AudioSTT` and
 - `Sources/MereRunEvaluation/`: external evaluation-pack schema, validation, and content hashing
 - `Sources/MereRunRelayKit/`: portable relay client, executor profiles/auth, and workflow wire types shared by the CLI and app shells
 - `apps/ios/`: the iOS Studio app, a relay client over `MereRunRelayKit` (see `docs/ios-studio.md`)
-- `Sources/MereRunAdmission/` and `Sources/MereRunResidency/`: reservations, queues, model generations, leases, and eviction
+- `Sources/MereRunAdmission/`, `Sources/MereRunResidency/`, and `Sources/MereRunExecution/`: reservations, residency, leases, eviction, and durable storage
 - `Sources/MereRunModelKit/`: model identities, manifests, storage paths, registered locations, artifact pins, and installed lookup
 - `Sources/MereRunCore/`: catalog assembly, downloads, and runtime orchestration
 - `Sources/MereRunQwenModel/` and `Sources/MereRunGemmaModel/`: text/vision layers, caches, and draft state
@@ -51,7 +51,7 @@ lookup. `AudioCore` and `AudioCodecs` own audio primitives; `AudioSTT` and
 ## Review before editing
 
 - Do not modify `vendor/` without reviewing the vendored runtime requirements.
-- Before editing model definitions, read the local module README.
+- Read the subsystem README before editing model definitions.
 - When you change canonical model IDs, migration vocabulary, or hosted-default
   hygiene checks, update the documentation and tests together.
 

--- a/Package.swift
+++ b/Package.swift
@@ -342,6 +342,7 @@ audioRuntimeDependencies.append(contentsOf: mlxDependency("MLXNN"))
 audioRuntimeDependencies.append(contentsOf: mlxDependency("MLXRandom"))
 
 var mereRunCLIDependencies: [Target.Dependency] = [
+  "MereRunExecution",
   "MereRunAdmission",
   "MereRunResidency",
   "MereRunContract",

--- a/Package.swift
+++ b/Package.swift
@@ -331,6 +331,7 @@ if hasMediaIOTarget {
 
 var audioRuntimeDependencies: [Target.Dependency] = [
   "MereRunCore",
+  "MereRunExecution",
   "AudioCore",
   "AudioCodecs",
   .product(name: "Transformers", package: "swift-transformers")
@@ -697,7 +698,7 @@ targets.append(
 targets.append(
   .target(
     name: "AudioCore",
-    dependencies: [],
+    dependencies: ["MereRunExecution"],
     path: "Sources/AudioCore",
     exclude: [
       "README.md"
@@ -899,7 +900,7 @@ targets.append(
 targets.append(
   .testTarget(
     name: "AudioCoreTests",
-    dependencies: ["AudioCore"],
+    dependencies: ["AudioCore", "MereRunExecution"],
     path: "Tests/AudioCoreTests"
   )
 )

--- a/Package.swift
+++ b/Package.swift
@@ -129,6 +129,7 @@ let prebuiltMLXLinkerSettings: [LinkerSetting] = useLinuxPrebuiltMLX
   : []
 
 var products: [Product] = [
+  .library(name: "MereRunExecution", targets: ["MereRunExecution"]),
   .library(name: "MereRunLagunaModel", targets: ["MereRunLagunaModel"]),
   .library(name: "MereRunH3Model", targets: ["MereRunH3Model"]),
   .library(name: "MereRunAudioModels", targets: ["MereRunAudioModels"]),
@@ -172,6 +173,7 @@ mereRunCoreDependencies.append("MereRunAudioModels")
 mereRunCoreDependencies.append("MereRunH3Model")
 mereRunCoreDependencies.append("MereRunLagunaModel")
 mereRunCoreDependencies.append("MereRunModelKit")
+mereRunCoreDependencies.append("MereRunExecution")
 mereRunCoreDependencies.append("MereRunTensor")
 mereRunCoreDependencies.append("MereRunTextEncoder")
 mereRunCoreDependencies.append("MereRunImageModels")
@@ -1065,6 +1067,23 @@ if !isLinuxPackage {
     .package(url: "https://github.com/sparkle-project/Sparkle", exact: "2.9.5")
   )
 }
+
+targets.append(
+  .target(
+    name: "MereRunExecution",
+    dependencies: [.product(name: "Crypto", package: "swift-crypto")],
+    path: "Sources/MereRunExecution",
+    exclude: ["README.md"]
+  )
+)
+
+targets.append(
+  .testTarget(
+    name: "MereRunExecutionTests",
+    dependencies: ["MereRunExecution"],
+    path: "Tests/MereRunExecutionTests"
+  )
+)
 
 let package = Package(
   name: "MereRun",

--- a/Sources/AudioCore/ASRBackendRouting.swift
+++ b/Sources/AudioCore/ASRBackendRouting.swift
@@ -25,7 +25,7 @@ public struct ASRBackendAvailability: Sendable, Hashable {
     }
 }
 
-public struct ASRBackendDecision: Sendable, Hashable {
+public struct ASRBackendDecision: Sendable, Hashable, Codable {
     public let backend: ASRResolvedBackend
     public let reason: String
     public let normalizedLanguageHint: String?

--- a/Sources/AudioCore/AudioGeneration.swift
+++ b/Sources/AudioCore/AudioGeneration.swift
@@ -140,7 +140,7 @@ public extension TTSGenerator {
 
 // MARK: - ASR Types
 
-public struct ASRRequest: Sendable, Hashable {
+public struct ASRRequest: Sendable, Hashable, Codable {
     public var audioURL: URL
     public var language: String?
     public var task: ASRTask

--- a/Sources/AudioCore/ParakeetExecutionProvider.swift
+++ b/Sources/AudioCore/ParakeetExecutionProvider.swift
@@ -1,0 +1,8 @@
+import Foundation
+
+/// Selects the execution engine for the Parakeet encoder. AudioSTT resolves
+/// and validates the model assets for the selected provider.
+public enum ParakeetExecutionProvider: Codable, Sendable, Hashable {
+    case mlx
+    case coreML(artifactURL: URL)
+}

--- a/Sources/AudioCore/README.md
+++ b/Sources/AudioCore/README.md
@@ -6,7 +6,13 @@ speech transcription, and CLI streaming sessions.
 - `AudioGeneration.swift`: request, response, progress, and streaming protocols.
 - `ASRBackendRouting.swift`: speech-to-text backend selection policy.
 - `SpeechTranscriptionOperation.swift`: typed file transcription plans, validation, executors, events, and outcomes.
+- `SpeechTranscriptionRunRecord.swift` and `SpeechTranscriptionRunSession.swift`: retained file inputs, versioned outcomes, recovery, and retry.
+- `ParakeetExecutionProvider.swift`: portable provider selection; AudioSTT resolves the assets.
 - `StreamingSessionUtilities.swift`: cadence and partial/final emission helpers.
 
 Keep this module backend-neutral. Runtime-specific model code belongs in
 `AudioSTT` or `AudioTTS`.
+
+Run storage uses `MereRunExecution` for process leases, atomic writes, file hashes,
+and terminal states. `AudioCoreTests` and `MereRunExecutionTests` run without
+model runtimes, Core, or CLI dependencies.

--- a/Sources/AudioCore/SpeechTranscriptionOperation.swift
+++ b/Sources/AudioCore/SpeechTranscriptionOperation.swift
@@ -1,17 +1,25 @@
 import Foundation
+import MereRunExecution
 
 /// Resolved backend and model inputs for one file transcription or translation.
-public struct SpeechTranscriptionPlan: Sendable, Hashable {
+public struct SpeechTranscriptionPlan: Sendable, Hashable, Codable {
     public let request: ASRRequest
     public let decision: ASRBackendDecision
     public let modelID: String
     public let modelPath: String?
+    public let provider: ParakeetExecutionProvider
+    public let modelMetadata: [RunFileSnapshot]
 
-    public init(request: ASRRequest, decision: ASRBackendDecision, modelID: String, modelPath: String?) {
+    public init(
+        request: ASRRequest, decision: ASRBackendDecision, modelID: String, modelPath: String?,
+        provider: ParakeetExecutionProvider = .mlx, modelMetadata: [RunFileSnapshot] = []
+    ) {
         self.request = request
         self.decision = decision
         self.modelID = modelID
         self.modelPath = modelPath
+        self.provider = provider
+        self.modelMetadata = modelMetadata
     }
 
     /// Checks inputs without loading a checkpoint or acquiring resources.
@@ -21,6 +29,9 @@ public struct SpeechTranscriptionPlan: Sendable, Hashable {
         }
         guard request.task != .translate || decision.backend == .qwen else {
             throw SpeechTranscriptionIssue("unsupported_task", "Translation requires the Qwen backend.")
+        }
+        if case .coreML = provider, decision.backend != .parakeet || request.task != .transcribe {
+            throw SpeechTranscriptionIssue("incompatible_execution_provider", "Core ML execution requires Parakeet transcription.")
         }
         guard !modelID.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             throw SpeechTranscriptionIssue("model_missing", "A transcription model ID is required.")
@@ -34,7 +45,7 @@ public struct SpeechTranscriptionPlan: Sendable, Hashable {
     }
 }
 
-public struct SpeechTranscriptionIssue: Error, LocalizedError, Sendable, Equatable {
+public struct SpeechTranscriptionIssue: Error, LocalizedError, Sendable, Equatable, Codable {
     public let code: String
     public let message: String
     public var errorDescription: String? { message }
@@ -81,15 +92,19 @@ public enum SpeechTranscriptionOperation {
     public static func execute(
         _ plan: SpeechTranscriptionPlan,
         id: UUID = UUID(),
+        recording: SpeechTranscriptionRunSession? = nil,
         progressHandler: (@Sendable (ASRProgress) -> Void)? = nil,
         eventHandler: (@Sendable (SpeechTranscriptionEvent) -> Void)? = nil,
         executor: any SpeechTranscriptionExecutor
     ) async throws -> SpeechTranscriptionOutcome {
+        let id = recording?.id ?? id
         eventHandler?(.started(id))
         do {
             try Task.checkCancellation()
             // Files can disappear after observational resolution or preflight.
             try plan.validate()
+            let plan = try recording?.prepare(plan) ?? plan
+            try Task.checkCancellation()
             let progress: (@Sendable (ASRProgress) -> Void)?
             if progressHandler != nil || eventHandler != nil {
                 progress = { value in
@@ -114,13 +129,16 @@ public enum SpeechTranscriptionOperation {
             }
             try Task.checkCancellation()
             let outcome = SpeechTranscriptionOutcome(id: id, result: result, plan: plan)
+            try recording?.succeed(outcome)
             eventHandler?(.succeeded(outcome))
             return outcome
         } catch {
             if error is CancellationError || Task.isCancelled {
+                try recording?.fail(CancellationError())
                 eventHandler?(.cancelled(id))
                 throw CancellationError()
             }
+            try recording?.fail(error)
             let issue = error as? SpeechTranscriptionIssue
                 ?? SpeechTranscriptionIssue("transcription_failed", error.localizedDescription)
             eventHandler?(.failed(id, issue))

--- a/Sources/AudioCore/SpeechTranscriptionRunRecord.swift
+++ b/Sources/AudioCore/SpeechTranscriptionRunRecord.swift
@@ -1,0 +1,70 @@
+import Foundation
+import MereRunExecution
+
+/// Supplied file-transcription settings before backend and model resolution.
+public struct SpeechTranscriptionRunOptions: Codable, Equatable, Sendable {
+    public let request: ASRRequest
+    public let preferredBackend: ASRBackend
+    public let modelOverride: String?
+    public let provider: ParakeetExecutionProvider
+
+    public init(
+        request: ASRRequest, preferredBackend: ASRBackend, modelOverride: String? = nil,
+        provider: ParakeetExecutionProvider = .mlx
+    ) {
+        self.request = request
+        self.preferredBackend = preferredBackend
+        self.modelOverride = modelOverride
+        self.provider = provider
+    }
+}
+
+/// Versioned history for one file transcription or translation. Live stdin
+/// sessions retain their own streaming protocol and are not recorded here.
+public struct SpeechTranscriptionRunRecord: Codable, Equatable, Sendable {
+    public static let filename = "transcription-run.json"
+    static let lockFilename = ".transcription-run.lock"
+
+    public let schemaVersion: Int
+    public let id: UUID
+    public let parentID: UUID?
+    public let createdAt: Date
+    public var updatedAt: Date
+    public var state: RunState
+    public let requested: SpeechTranscriptionRunOptions
+    public var effective: SpeechTranscriptionPlan?
+    public var input: RunArtifact?
+    public var artifacts: [RunArtifact]
+    public var issue: SpeechTranscriptionIssue?
+
+    public var canRetry: Bool {
+        state.isTerminal && input != nil && effective?.modelPath != nil && effective?.modelMetadata.contains(where: { $0.artifact != nil }) == true
+    }
+
+    public static func recordURL(at url: URL) -> URL {
+        url.lastPathComponent == filename ? url : url.appendingPathComponent(filename)
+    }
+
+    /// Recovers an abandoned run only while holding its process lease.
+    public static func inspect(at url: URL) throws -> Self {
+        let recordURL = recordURL(at: url)
+        let lease = try RunDirectoryLease.acquire(in: recordURL.deletingLastPathComponent(), filename: lockFilename)
+        defer { lease?.release() }
+        var record = try decode(Data(contentsOf: recordURL))
+        if lease != nil, !record.state.isTerminal {
+            record.state = .interrupted
+            record.updatedAt = RunRecordCodec.timestamp()
+            record.issue = SpeechTranscriptionIssue("process_interrupted", "The transcription process stopped before recording a terminal result.")
+            try RunRecordCodec.write(record, to: recordURL)
+        }
+        return record
+    }
+
+    static func decode(_ data: Data) throws -> Self {
+        let record = try RunRecordCodec.decoder().decode(Self.self, from: data)
+        guard record.schemaVersion == 1 else {
+            throw SpeechTranscriptionIssue("run_version_unsupported", "Unsupported transcription run record version: \(record.schemaVersion).")
+        }
+        return record
+    }
+}

--- a/Sources/AudioCore/SpeechTranscriptionRunSession.swift
+++ b/Sources/AudioCore/SpeechTranscriptionRunSession.swift
@@ -1,0 +1,134 @@
+import Foundation
+import MereRunExecution
+
+/// Owns a file-transcription record, retained audio, and terminal result files.
+/// The process lease remains held until a terminal record is written atomically.
+public final class SpeechTranscriptionRunSession: @unchecked Sendable {
+    public let directory: URL
+    public let id: UUID
+    private let mutex = NSLock()
+    private let lease: RunDirectoryLease
+    private var record: SpeechTranscriptionRunRecord
+
+    public init(directory: URL, requested: SpeechTranscriptionRunOptions, parentID: UUID? = nil) throws {
+        self.directory = directory.standardizedFileURL
+        self.id = UUID()
+        try FileManager.default.createDirectory(at: self.directory.deletingLastPathComponent(), withIntermediateDirectories: true)
+        try RunDirectoryLease.createDirectory(self.directory)
+        guard let lease = try RunDirectoryLease.acquire(in: self.directory, filename: SpeechTranscriptionRunRecord.lockFilename) else {
+            throw SpeechTranscriptionIssue("run_active", "The transcription run directory is already in use.")
+        }
+        self.lease = lease
+        let now = RunRecordCodec.timestamp()
+        record = SpeechTranscriptionRunRecord(
+            schemaVersion: 1, id: id, parentID: parentID, createdAt: now, updatedAt: now,
+            state: .preparing, requested: requested, artifacts: []
+        )
+        try save()
+    }
+
+    func prepare(_ plan: SpeechTranscriptionPlan) throws -> SpeechTranscriptionPlan {
+        try mutex.withLock {
+            guard record.state == .preparing else {
+                throw SpeechTranscriptionIssue("run_state_invalid", "This transcription run has already started.")
+            }
+            try plan.validate()
+            for file in plan.modelMetadata where try !file.isUnchanged() {
+                throw SpeechTranscriptionIssue("run_model_changed", "Model metadata changed before transcription: \(file.url.path).")
+            }
+            let inputs = directory.appendingPathComponent("inputs")
+            try FileManager.default.createDirectory(at: inputs, withIntermediateDirectories: false)
+            let target = inputs.appendingPathComponent("audio").appendingPathExtension(plan.request.audioURL.pathExtension)
+            try FileManager.default.copyItem(at: plan.request.audioURL, to: target)
+            record.input = try RunArtifact.read(target)
+            var request = plan.request
+            request.audioURL = target
+            let effective = SpeechTranscriptionPlan(
+                request: request, decision: plan.decision, modelID: plan.modelID, modelPath: plan.modelPath,
+                provider: plan.provider, modelMetadata: plan.modelMetadata
+            )
+            record.effective = effective
+            record.state = .running
+            try save()
+            return effective
+        }
+    }
+
+    func succeed(_ outcome: SpeechTranscriptionOutcome) throws {
+        try mutex.withLock {
+            guard record.state == .running else {
+                throw SpeechTranscriptionIssue("run_state_invalid", "The transcription run is not running.")
+            }
+            let resultURL = directory.appendingPathComponent("result.json")
+            let transcriptURL = directory.appendingPathComponent("transcript.txt")
+            try RunRecordCodec.write(outcome.result, to: resultURL)
+            try outcome.result.text.write(to: transcriptURL, atomically: true, encoding: .utf8)
+            try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: transcriptURL.path)
+            record.artifacts = try [resultURL, transcriptURL].map(RunArtifact.read)
+            try Task.checkCancellation()
+            record.state = .succeeded
+            do { try save() } catch {
+                record.state = .running
+                throw error
+            }
+            lease.release()
+        }
+    }
+
+    public func fail(_ error: Error) throws {
+        try mutex.withLock {
+            guard !record.state.isTerminal else { return }
+            let previousState = record.state
+            record.state = error is CancellationError ? .cancelled : .failed
+            record.issue = error as? SpeechTranscriptionIssue ?? SpeechTranscriptionIssue(
+                error is CancellationError ? "cancelled" : "transcription_failed", error.localizedDescription
+            )
+            do { try save() } catch {
+                record.state = previousState
+                throw error
+            }
+            lease.release()
+        }
+    }
+
+    /// Keeps optional CLI presentation files out of the owned run directory.
+    public static func validateOutput(_ output: URL, in directory: URL) throws {
+        let root = directory.standardizedFileURL.resolvingSymlinksInPath()
+        let target = output.standardizedFileURL.resolvingSymlinksInPath()
+        guard target.path != root.path, !target.path.hasPrefix(root.path + "/") else {
+            throw SpeechTranscriptionIssue("run_output_conflict", "Choose an --output path outside --run-dir. The run already retains transcript.txt and result.json.")
+        }
+    }
+
+    /// Starts a new sibling run with saved settings. It does not resume a
+    /// partial decoder state, reroute the backend, or modify its parent.
+    public static func retryPlan(at url: URL) throws -> (session: SpeechTranscriptionRunSession, plan: SpeechTranscriptionPlan) {
+        let parent = try SpeechTranscriptionRunRecord.inspect(at: url)
+        guard parent.state.isTerminal else {
+            throw SpeechTranscriptionIssue("run_active", "Wait for the transcription run to stop before retrying.")
+        }
+        guard parent.canRetry, let plan = parent.effective, let input = parent.input else {
+            throw SpeechTranscriptionIssue("run_not_prepared", "This run has no retained input or local model metadata. Repeat the original transcription command.")
+        }
+        guard try RunArtifact.read(input.url) == input else {
+            throw SpeechTranscriptionIssue("run_input_changed", "The recorded audio input changed: \(input.url.path).")
+        }
+        for file in plan.modelMetadata where try !file.isUnchanged() {
+            throw SpeechTranscriptionIssue("run_model_changed", "Recorded model metadata changed: \(file.url.path). Start a new transcription command to use it.")
+        }
+        try plan.validate()
+        let parentDirectory = SpeechTranscriptionRunRecord.recordURL(at: url).deletingLastPathComponent()
+        let directory = parentDirectory.deletingLastPathComponent().appendingPathComponent("transcription-\(UUID().uuidString.lowercased())")
+        let requested = SpeechTranscriptionRunOptions(
+            request: plan.request, preferredBackend: parent.requested.preferredBackend,
+            modelOverride: parent.requested.modelOverride, provider: plan.provider
+        )
+        let session = try SpeechTranscriptionRunSession(directory: directory, requested: requested, parentID: parent.id)
+        return (session, plan)
+    }
+
+    private func save() throws {
+        record.updatedAt = RunRecordCodec.timestamp()
+        try RunRecordCodec.write(record, to: directory.appendingPathComponent(SpeechTranscriptionRunRecord.filename))
+    }
+}

--- a/Sources/AudioSTT/Parakeet/ParakeetExecutionProvider.swift
+++ b/Sources/AudioSTT/Parakeet/ParakeetExecutionProvider.swift
@@ -1,14 +1,10 @@
 import Foundation
+import AudioCore
 
-/// Selects the execution engine for the compute-heavy Parakeet encoder.
-///
-/// Schema 1 Core ML artifacts are encoder-only and use a separate Parakeet
-/// checkpoint. Schema 2 artifacts also carry Mere's compact MLX decoder and
-/// can serve as the complete model root.
-public enum ParakeetExecutionProvider: Sendable, Hashable {
-    case mlx
-    case coreML(artifactURL: URL)
+public typealias ParakeetExecutionProvider = AudioCore.ParakeetExecutionProvider
 
+/// Resolves Core ML artifacts that bundle a complete Parakeet model.
+extension ParakeetExecutionProvider {
     public var bundledModelURL: URL? {
         guard case .coreML(let artifactURL) = self else { return nil }
         let root = artifactURL.standardizedFileURL

--- a/Sources/AudioSTT/SpeechTranscriptionResolver.swift
+++ b/Sources/AudioSTT/SpeechTranscriptionResolver.swift
@@ -1,6 +1,7 @@
 import Foundation
 import AudioCore
 import MereRunCore
+import MereRunExecution
 
 /// Resolves model locations and backend policy without loading a generator.
 public enum SpeechTranscriptionResolver {
@@ -8,7 +9,8 @@ public enum SpeechTranscriptionResolver {
         request: ASRRequest,
         preferredBackend: ASRBackend,
         modelOverride: String? = nil,
-        parakeetExecutionProvider: ParakeetExecutionProvider = .mlx
+        parakeetExecutionProvider: ParakeetExecutionProvider = .mlx,
+        captureModelMetadata: Bool = false
     ) throws -> SpeechTranscriptionPlan {
         let normalizedOverride = normalized(
             modelOverride ?? parakeetExecutionProvider.bundledModelURL?.path
@@ -61,23 +63,43 @@ public enum SpeechTranscriptionResolver {
         let effectiveOverride = try compatibleModelOverride(
             normalizedOverride, inferredBackend: inferredBackend, selectedBackend: decision.backend
         )
-        let plan: SpeechTranscriptionPlan
+        var plan: SpeechTranscriptionPlan
         switch decision.backend {
         case .qwen:
             plan = SpeechTranscriptionPlan(
                 request: request, decision: decision,
                 modelID: qwenModelId(modelOverride: effectiveOverride),
-                modelPath: qwenModelPath(modelOverride: effectiveOverride, localRoot: qwenRoot, localAvailable: qwenLocalAvailable)
+                modelPath: qwenModelPath(modelOverride: effectiveOverride, localRoot: qwenRoot, localAvailable: qwenLocalAvailable),
+                provider: parakeetExecutionProvider
             )
         case .parakeet:
             plan = SpeechTranscriptionPlan(
                 request: request, decision: decision,
                 modelID: parakeetModelId(modelOverride: effectiveOverride),
-                modelPath: parakeetModelPath(modelOverride: effectiveOverride, localRoot: parakeetRoot, localAvailable: parakeetLocalAvailable)
+                modelPath: parakeetModelPath(modelOverride: effectiveOverride, localRoot: parakeetRoot, localAvailable: parakeetLocalAvailable),
+                provider: parakeetExecutionProvider
             )
         }
         try plan.validate()
+        if captureModelMetadata { plan = try recordingPlan(plan) }
         return plan
+    }
+
+    /// Fingerprints local configuration and installation metadata, not tensor
+    /// weights. Native model loading still owns checkpoint integrity checks.
+    private static func recordingPlan(_ plan: SpeechTranscriptionPlan) throws -> SpeechTranscriptionPlan {
+        guard let modelPath = plan.modelPath else { return plan }
+        let root = URL(fileURLWithPath: modelPath)
+        let modelRoot = plan.decision.backend == .parakeet ? ParakeetResources.resolveNestedIfNeeded(base: root) : root
+        var files = ["config.json", "tokenizer.json", "tokenizer_config.json", MereRunModelManifest.filename]
+            .map { modelRoot.appendingPathComponent($0) }
+        if case .coreML(let artifactURL) = plan.provider {
+            files.append(artifactURL.appendingPathComponent(ParakeetCoreMLManifest.filename))
+        }
+        return SpeechTranscriptionPlan(
+            request: plan.request, decision: plan.decision, modelID: plan.modelID, modelPath: plan.modelPath,
+            provider: plan.provider, modelMetadata: try files.map(RunFileSnapshot.capture)
+        )
     }
 
     private static func compatibleModelOverride(

--- a/Sources/MereRunCLI/Commands/APIServeCommand.swift
+++ b/Sources/MereRunCLI/Commands/APIServeCommand.swift
@@ -13,6 +13,9 @@ struct APIServe: AsyncParsableCommand {
     @Option(name: [.customLong("image-run-records")], help: "Keep durable image run directories under this root.")
     var imageRunRecords: String?
 
+    @Option(name: [.customLong("transcription-run-records")], help: "Keep durable file-transcription runs and uploaded audio under this root.")
+    var transcriptionRunRecords: String?
+
     static let apiKeyEnvironmentKey = "MERERUN_API_KEY"
 
     static let configuration = CommandConfiguration(
@@ -251,6 +254,7 @@ struct APIServe: AsyncParsableCommand {
                 gemma4KVCacheQuantization: gemma4KVCacheQuantization,
                 memoryPressurePolicy: memoryPressurePolicy,
                 imageRunRecords: imageRunRecords.map { URL(fileURLWithPath: $0).standardizedFileURL },
+                transcriptionRunRecords: transcriptionRunRecords.map { URL(fileURLWithPath: $0).standardizedFileURL },
                 warmupDefaultModel: warmup
             )
             try await server.run(host: host, port: port)

--- a/Sources/MereRunCLI/Commands/RunCommand.swift
+++ b/Sources/MereRunCLI/Commands/RunCommand.swift
@@ -1,4 +1,6 @@
 import ArgumentParser
+import AudioCore
+import AudioSTT
 import MereRunRelayKit
 import MereRunCore
 import Foundation
@@ -146,6 +148,14 @@ struct RunInspect: AsyncParsableCommand {
                 if let seed = image.effective?.seed { print("Seed: \(seed)") }
                 for artifact in image.artifacts { print("Output: \(artifact.url.path)") }
                 if let issue = image.issue { stderr("[\(issue.code)] \(issue.message)") }
+            } else if let transcription = envelope.result.transcriptionRun {
+                print("Status: \(transcription.state.rawValue)")
+                if let plan = transcription.effective {
+                    print("Model: \(plan.modelID)")
+                    print("Backend: \(plan.decision.backend.rawValue)")
+                }
+                for artifact in transcription.artifacts { print("Output: \(artifact.url.path)") }
+                if let issue = transcription.issue { stderr("[\(issue.code)] \(issue.message)") }
             } else if let runDirectory = envelope.result.runDirectory {
                 print("Status: \(runDirectory.status)")
                 if let manifest = runDirectory.manifest {
@@ -287,12 +297,20 @@ struct RunCancel: AsyncParsableCommand {
 }
 
 struct RunRetry: AsyncParsableCommand {
-    static let configuration = CommandConfiguration(commandName: "retry", abstract: "Retry a recorded local image run or an immutable relay graph job.")
-    @Argument(help: "Local image run directory, image-run.json path, or relay:// job reference.") var reference: String
+    static let configuration = CommandConfiguration(commandName: "retry", abstract: "Retry a recorded image or transcription run, or an immutable relay graph job.")
+    @Argument(help: "Local image or transcription run directory, record JSON path, or relay:// job reference.") var reference: String
     @Flag(name: [.customLong("json")], help: "Emit the retry job as JSON.") var json = false
 
     func run() async throws {
         if !reference.hasPrefix("relay://") && !reference.hasPrefix("ssh://") {
+            let url = URL(fileURLWithPath: reference)
+            if FileManager.default.fileExists(atPath: SpeechTranscriptionRunRecord.recordURL(at: url).path) {
+                let record = try await Self.retryTranscription(at: url)
+                if json { print(try StructuredRunOutput.encode(record)) } else {
+                    print(record.artifacts[0].url.deletingLastPathComponent().path)
+                }
+                return
+            }
             let retry = try ImageRunSession.retryPlan(at: URL(fileURLWithPath: reference))
             do {
                 let lease = try await MachineInferenceCoordinator.shared.acquire(
@@ -314,6 +332,31 @@ struct RunRetry: AsyncParsableCommand {
         let job = try await WorkflowRemoteJobController.retry(mapRelayErrors { try WorkflowRemoteReference(reference) })
         if json { print(try StructuredRunOutput.encode(job)) } else { print("[\(job.state.rawValue)] \(job.jobReference)") }
     }
+
+    static func retryTranscription(
+        at url: URL, executor: (any SpeechTranscriptionExecutor)? = nil,
+        admission: MachineInferenceCoordinator = .shared
+    ) async throws -> SpeechTranscriptionRunRecord {
+        let retry = try SpeechTranscriptionRunSession.retryPlan(at: url)
+        do {
+            let lease = try await admission.acquire(
+                CLIInferenceAdmissionClassifier.speechTranscriptionRequest(modelID: retry.plan.modelID)
+            ) { snapshot in
+                CLIStderr.write("Transcription retry queued by machine admission (\(snapshot.activePermits)/\(snapshot.capacityPermits) permits active).\n")
+            }
+            defer { lease.release() }
+            if executor == nil { try MLXBundleSupport.ensureAvailable(quiet: true) }
+            _ = try await SpeechTranscriptionOperation.execute(
+                retry.plan, recording: retry.session,
+                executor: executor ?? NativeSpeechTranscriptionExecutor(parakeetExecutionProvider: retry.plan.provider)
+            )
+        } catch {
+            try retry.session.fail(error)
+            throw error
+        }
+        return try SpeechTranscriptionRunRecord.inspect(at: retry.session.directory)
+    }
+
 }
 
 private struct RemoteRunListResult: Codable {

--- a/Sources/MereRunCLI/Commands/SpeechTranscribeCommand.swift
+++ b/Sources/MereRunCLI/Commands/SpeechTranscribeCommand.swift
@@ -62,6 +62,9 @@ struct SpeechTranscribe: AsyncParsableCommand {
     @Option(name: [.customShort("o"), .long], help: "Output file for transcript (optional, prints to stdout if omitted).")
     var output: String?
 
+    @Option(name: [.customLong("run-dir")], help: "Keep a durable file-transcription run in a new directory.")
+    var runDirectory: String?
+
     @Option(name: [.customShort("m"), .long], help: "Model ID or local model path override for the selected backend.")
     var model: String?
 
@@ -133,6 +136,16 @@ struct SpeechTranscribe: AsyncParsableCommand {
             throw ValidationError("--max-tokens must be positive.")
         }
         let readsStandardInput = audio == "-"
+        if let runDirectory {
+            guard !stream, !readsStandardInput else {
+                throw ValidationError("--run-dir supports non-streaming audio files only.")
+            }
+            if let output {
+                try SpeechTranscriptionRunSession.validateOutput(
+                    URL(fileURLWithPath: output), in: URL(fileURLWithPath: runDirectory)
+                )
+            }
+        }
         if receipt && readsStandardInput {
             throw ValidationError("--receipt is not available for raw streaming stdin ('-'); use --jsonl.")
         }
@@ -191,7 +204,7 @@ struct SpeechTranscribe: AsyncParsableCommand {
     func run() async throws {
         let readsStandardInput = audio == "-"
 
-        if transcriptionExecutor == nil {
+        if transcriptionExecutor == nil, readsStandardInput || stream {
             try MLXBundleSupport.ensureAvailable(quiet: quiet)
         }
         if readsStandardInput {
@@ -242,14 +255,7 @@ struct SpeechTranscribe: AsyncParsableCommand {
             return
         }
 
-        let execution = try await CLIASRRouting.transcribe(
-            request: request,
-            preferredBackend: backend.backend,
-            modelOverride: model,
-            parakeetExecutionProvider: try resolvedParakeetExecutionProvider(),
-            progressHandler: progressHandler,
-            executor: transcriptionExecutor
-        )
+        let execution = try await transcribeFile(request, progressHandler: progressHandler)
         let result = execution.result
         let outputText = renderOutput(result: result, includeTimestamps: timestamps)
 
@@ -269,11 +275,39 @@ struct SpeechTranscribe: AsyncParsableCommand {
         try emitReceipt(transcriptURL: transcriptURL)
     }
 
+    private func transcribeFile(
+        _ request: ASRRequest, progressHandler: (@Sendable (ASRProgress) -> Void)?
+    ) async throws -> SpeechTranscriptionOutcome {
+        let executionProvider = try resolvedParakeetExecutionProvider()
+        let recording = try runDirectory.map { directory in
+            try SpeechTranscriptionRunSession(
+                directory: URL(fileURLWithPath: directory),
+                requested: SpeechTranscriptionRunOptions(
+                    request: request, preferredBackend: backend.backend, modelOverride: model, provider: executionProvider
+                )
+            )
+        }
+        do {
+            if transcriptionExecutor == nil { try MLXBundleSupport.ensureAvailable(quiet: quiet) }
+            return try await CLIASRRouting.transcribe(
+                request: request, preferredBackend: backend.backend, modelOverride: model,
+                parakeetExecutionProvider: executionProvider, progressHandler: progressHandler,
+                recording: recording, executor: transcriptionExecutor
+            )
+        } catch {
+            try recording?.fail(error)
+            throw error
+        }
+    }
+
     /// Writes the transcript to `--output` when set and returns its URL. The
     /// receipt lists no outputs when the transcript only went to stdout.
     private func writeTranscriptIfRequested(_ outputText: String) throws -> URL? {
         guard let outputPath = output else { return nil }
         let outputURL = URL(fileURLWithPath: outputPath).standardizedFileURL
+        if let runDirectory {
+            try SpeechTranscriptionRunSession.validateOutput(outputURL, in: URL(fileURLWithPath: runDirectory))
+        }
         let outputDir = outputURL.deletingLastPathComponent()
         try FileManager.default.createDirectory(at: outputDir, withIntermediateDirectories: true)
         try outputText.write(to: outputURL, atomically: true, encoding: .utf8)

--- a/Sources/MereRunCLI/Support/APIServer.swift
+++ b/Sources/MereRunCLI/Support/APIServer.swift
@@ -156,6 +156,7 @@ actor CodeGenServer {
     private var sidecarPool: APISidecarModelPool { services.media }
     private let artifactCleanupScheduler: APIArtifactDirectoryCleanupScheduler
     private let imageRunRecords: URL?
+    private let transcriptionRunRecords: URL?
     private var processTelemetrySampler = RuntimeProcessTelemetrySampler()
 
     init(
@@ -171,9 +172,11 @@ actor CodeGenServer {
         memoryPressurePolicy: RuntimeMemoryPressurePolicy = .default,
         artifactCleanupScheduler: APIArtifactDirectoryCleanupScheduler = APIArtifactDirectoryCleanupScheduler(),
         imageRunRecords: URL? = nil,
+        transcriptionRunRecords: URL? = nil,
         warmupDefaultModel: Bool = true
     ) async throws {
         self.imageRunRecords = imageRunRecords
+        self.transcriptionRunRecords = transcriptionRunRecords
         self.apiKey = apiKey
         self.contextSize = contextSize
         self.fallbackLoraPath = fallbackLoraPath
@@ -1560,8 +1563,9 @@ actor CodeGenServer {
         audioURL: URL,
         plan: APIServerContract.TranscriptionPlan
     ) async throws -> ASRResult {
-        let resolved = try APITranscription.plan(audioURL: audioURL, options: plan)
-        return try await services.transcribe(resolved).result
+        try await APITranscription.execute(
+            audioURL: audioURL, options: plan, recordingRoot: transcriptionRunRecords, services: services
+        ).result
     }
 
     private func resolveImageModel(

--- a/Sources/MereRunCLI/Support/APITranscription.swift
+++ b/Sources/MereRunCLI/Support/APITranscription.swift
@@ -5,12 +5,30 @@ import MereRunCore
 
 /// Applies API model-allowlist policy before using the shared speech resolver.
 enum APITranscription {
-    static func plan(audioURL: URL, options: APIServerContract.TranscriptionPlan) throws -> SpeechTranscriptionPlan {
+    static func plan(
+        audioURL: URL, options: APIServerContract.TranscriptionPlan, captureModelMetadata: Bool = false
+    ) throws -> SpeechTranscriptionPlan {
         let selection = try resolveModel(options.modelID)
         return try SpeechTranscriptionResolver.resolve(
             request: ASRRequest(audioURL: audioURL, language: options.language, task: options.task, maxTokens: options.maxTokens),
-            preferredBackend: selection.backend, modelOverride: selection.modelOverride
+            preferredBackend: selection.backend, modelOverride: selection.modelOverride,
+            captureModelMetadata: captureModelMetadata
         )
+    }
+
+    static func execute(
+        audioURL: URL, options: APIServerContract.TranscriptionPlan, recordingRoot: URL?, services: RuntimeServingServices
+    ) async throws -> SpeechTranscriptionOutcome {
+        let resolved = try plan(audioURL: audioURL, options: options, captureModelMetadata: recordingRoot != nil)
+        let recording = try recordingRoot.map { root in
+            try SpeechTranscriptionRunSession(
+                directory: root.appendingPathComponent("transcription-\(UUID().uuidString.lowercased())"),
+                requested: SpeechTranscriptionRunOptions(
+                    request: resolved.request, preferredBackend: .auto, modelOverride: options.modelID
+                )
+            )
+        }
+        return try await services.transcribe(resolved, recording: recording)
     }
 
     private static func resolveModel(

--- a/Sources/MereRunCLI/Support/CLIASRRouting.swift
+++ b/Sources/MereRunCLI/Support/CLIASRRouting.swift
@@ -13,22 +13,27 @@ enum CLIASRRouting {
         modelOverride: String? = nil,
         parakeetExecutionProvider: ParakeetExecutionProvider = .mlx,
         progressHandler: (@Sendable (ASRProgress) -> Void)? = nil,
+        recording: SpeechTranscriptionRunSession? = nil,
         executor: (any SpeechTranscriptionExecutor)? = nil
     ) async throws -> SpeechTranscriptionOutcome {
         do {
             let plan = try SpeechTranscriptionResolver.resolve(
                 request: request, preferredBackend: preferredBackend, modelOverride: modelOverride,
-                parakeetExecutionProvider: parakeetExecutionProvider
+                parakeetExecutionProvider: parakeetExecutionProvider, captureModelMetadata: recording != nil
             )
             return try await SpeechTranscriptionOperation.execute(
-                plan, progressHandler: progressHandler,
+                plan, recording: recording, progressHandler: progressHandler,
                 executor: executor ?? NativeSpeechTranscriptionExecutor(parakeetExecutionProvider: parakeetExecutionProvider)
             )
         } catch let issue as SpeechTranscriptionIssue {
+            try recording?.fail(issue)
             if issue.code == "incompatible_execution_provider" {
                 throw ValidationError(issue.message + " Use --backend qwen without --provider coreml or --coreml-encoder.")
             }
             throw ValidationError(issue.message)
+        } catch {
+            try recording?.fail(error)
+            throw error
         }
     }
 }

--- a/Sources/MereRunCLI/Support/MachineInferenceAdmission.swift
+++ b/Sources/MereRunCLI/Support/MachineInferenceAdmission.swift
@@ -111,6 +111,10 @@ enum CLIInferenceAdmissionClassifier {
         }
     }
 
+    static func speechTranscriptionRequest(modelID: String) -> MachineInferenceRequest {
+        MachineInferenceRequest(label: "speech transcribe", resourceClass: isLargeModel(modelID) ? .large : .small)
+    }
+
     static func imageGenerationRequest(modelID: String) -> MachineInferenceRequest {
         MachineInferenceRequest(label: "image generate", estimatedModelBytes: estimatedModelBytes(modelID))
     }

--- a/Sources/MereRunCLI/Support/README.md
+++ b/Sources/MereRunCLI/Support/README.md
@@ -25,7 +25,10 @@ Shared helpers and runtime adapters for the public command surface.
 - `RuntimeServingServices.swift`: text/media composition, pressure coordination,
   request admission, maintenance, and transcription service ownership.
 - `APITranscription.swift` and `CLIASRRouting.swift`: API policy and CLI
-  presentation adapters over the shared speech resolver and operation.
+  presentation adapters over the shared speech resolver, operation, and optional
+  durable records.
+- `RecordedOperationRun.swift`: typed image/transcription history presentation
+  shared by local run inspection and listing.
 
 Keep stdout machine-readable when a command can be scripted; diagnostics and
 progress belong on stderr.

--- a/Sources/MereRunCLI/Support/RecordedOperationRun.swift
+++ b/Sources/MereRunCLI/Support/RecordedOperationRun.swift
@@ -1,0 +1,122 @@
+import AudioCore
+import Foundation
+import MereRunCore
+import MereRunExecution
+
+/// Presents typed operation records to local run inspection and listing.
+/// Wire responses retain each family's versioned record and compatibility key.
+enum RecordedOperationRun {
+    case image(ImageRunRecord)
+    case transcription(SpeechTranscriptionRunRecord)
+
+    enum Kind: String {
+        case image = "image_run"
+        case transcription = "transcription_run"
+
+        var filename: String {
+            switch self {
+            case .image: return ImageRunRecord.filename
+            case .transcription: return SpeechTranscriptionRunRecord.filename
+            }
+        }
+
+        var label: String { self == .image ? "Image" : "Transcription" }
+        var command: [String] { self == .image ? ["image", "generate"] : ["speech", "transcribe"] }
+        var retryActionID: String { self == .image ? "retry-image-run" : "retry-transcription-run" }
+    }
+
+    static let kinds: [Kind] = [.image, .transcription]
+
+    static func location(at url: URL, fileManager: FileManager = .default) -> (kind: Kind, url: URL)? {
+        for kind in kinds {
+            let recordURL = url.lastPathComponent == kind.filename ? url : url.appendingPathComponent(kind.filename)
+            if fileManager.fileExists(atPath: recordURL.path) { return (kind, recordURL) }
+        }
+        return nil
+    }
+
+    static func inspect(kind: Kind, at url: URL) throws -> Self {
+        switch kind {
+        case .image: return .image(try ImageRunRecord.inspect(at: url))
+        case .transcription: return .transcription(try SpeechTranscriptionRunRecord.inspect(at: url))
+        }
+    }
+
+    var kind: Kind {
+        switch self {
+        case .image: return .image
+        case .transcription: return .transcription
+        }
+    }
+
+    var id: UUID {
+        switch self {
+        case .image(let record): return record.id
+        case .transcription(let record): return record.id
+        }
+    }
+
+    var state: RunState {
+        switch self {
+        case .image(let record): return record.state
+        case .transcription(let record): return record.state
+        }
+    }
+
+    var createdAt: Date {
+        switch self {
+        case .image(let record): return record.createdAt
+        case .transcription(let record): return record.createdAt
+        }
+    }
+
+    var updatedAt: Date {
+        switch self {
+        case .image(let record): return record.updatedAt
+        case .transcription(let record): return record.updatedAt
+        }
+    }
+
+    var artifacts: [RunArtifact] {
+        switch self {
+        case .image(let record): return record.artifacts
+        case .transcription(let record): return record.artifacts
+        }
+    }
+
+    var canRetry: Bool {
+        switch self {
+        case .image(let record): return record.state.isTerminal && record.resolvedOptions != nil
+        case .transcription(let record): return record.canRetry
+        }
+    }
+
+    var summary: String {
+        "\(kind.label) run \(id.uuidString.lowercased()): \(state.rawValue), \(artifacts.count) artifact(s)."
+    }
+
+    func inspectionResult(path: String) -> RunInspectionResult {
+        var result = RunInspectionResult(kind: kind.rawValue, path: path, runDirectory: nil, report: nil, plan: nil)
+        switch self {
+        case .image(let record): result.imageRun = record
+        case .transcription(let record): result.transcriptionRun = record
+        }
+        return result
+    }
+
+    func retryAction(path: String, cwd: String) -> DeclarativeAction {
+        DeclarativeAction(
+            id: kind.retryActionID, label: "Retry \(kind.label.lowercased()) run", kind: .command, style: .primary,
+            enabled: canRetry,
+            command: DeclarativeCommand(argv: ["mere.run", "run", "retry", path], cwd: cwd, commandPath: ["run", "retry"])
+        )
+    }
+}
+
+extension RunInspectionResult {
+    var recordedOperation: RecordedOperationRun? {
+        if let imageRun { return .image(imageRun) }
+        if let transcriptionRun { return .transcription(transcriptionRun) }
+        return nil
+    }
+}

--- a/Sources/MereRunCLI/Support/RunInspection.swift
+++ b/Sources/MereRunCLI/Support/RunInspection.swift
@@ -1,4 +1,5 @@
 import Foundation
+import AudioCore
 import MereRunRelayKit
 import MereRunCore
 
@@ -17,11 +18,13 @@ struct RunInspectionResult: Codable, Equatable {
     let report: StructuredReportInspectionSummary?
     let plan: RunPlanInspectionSummary?
     var imageRun: ImageRunRecord? = nil
+    var transcriptionRun: SpeechTranscriptionRunRecord? = nil
 
     enum CodingKeys: String, CodingKey {
         case kind
         case path
         case imageRun = "image_run"
+        case transcriptionRun = "transcription_run"
         case runDirectory = "run_directory"
         case report
         case plan
@@ -365,24 +368,23 @@ struct RunInspectionAnalyzer {
             )
             return RunInspectionResult(kind: "missing", path: targetURL.path, runDirectory: nil, report: nil, plan: nil)
         }
-        let imageURL = ImageRunRecord.recordURL(at: targetURL)
-        if fileManager.fileExists(atPath: imageURL.path) {
+        if let location = RecordedOperationRun.location(at: targetURL, fileManager: fileManager) {
             do {
-                let record = try ImageRunRecord.inspect(at: imageURL)
-                for artifact in record.artifacts where !fileManager.fileExists(atPath: artifact.url.path) {
+                let run = try RecordedOperationRun.inspect(kind: location.kind, at: location.url)
+                for artifact in run.artifacts where !fileManager.fileExists(atPath: artifact.url.path) {
                     diagnostics.append(PreflightDiagnostic(
-                        id: "image_run_artifact_missing", severity: .warning, title: "Recorded output missing",
-                        message: "The image run completed, but its retained output was removed.",
+                        id: "\(run.kind.rawValue)_artifact_missing", severity: .warning, title: "Recorded output missing",
+                        message: "A retained \(run.kind.label.lowercased()) output was removed.",
                         locations: [.init(kind: "file", path: artifact.url.path)]
                     ))
                 }
-                return RunInspectionResult(kind: "image_run", path: targetURL.path, runDirectory: nil, report: nil, plan: nil, imageRun: record)
+                return run.inspectionResult(path: targetURL.path)
             } catch {
                 diagnostics.append(PreflightDiagnostic(
-                    id: "image_run_unreadable", severity: .blocker, title: "Image run unreadable",
-                    message: error.localizedDescription, locations: [.init(kind: "file", path: imageURL.path)]
+                    id: "\(location.kind.rawValue)_unreadable", severity: .blocker, title: "\(location.kind.label) run unreadable",
+                    message: error.localizedDescription, locations: [.init(kind: "file", path: location.url.path)]
                 ))
-                return RunInspectionResult(kind: "image_run", path: targetURL.path, runDirectory: nil, report: nil, plan: nil)
+                return RunInspectionResult(kind: location.kind.rawValue, path: targetURL.path, runDirectory: nil, report: nil, plan: nil)
             }
         }
         if isDirectory.boolValue {
@@ -867,12 +869,8 @@ struct RunInspectionAnalyzer {
 
     private func actions(for result: RunInspectionResult, cwd: String) -> [DeclarativeAction] {
         var actions: [DeclarativeAction] = []
-        if let image = result.imageRun {
-            actions.append(DeclarativeAction(
-                id: "retry-image-run", label: "Retry image run", kind: .command, style: .primary,
-                enabled: image.state.isTerminal && image.resolvedOptions != nil,
-                command: DeclarativeCommand(argv: ["mere.run", "run", "retry", result.path], cwd: cwd, commandPath: ["run", "retry"])
-            ))
+        if let run = result.recordedOperation {
+            actions.append(run.retryAction(path: result.path, cwd: cwd))
         }
         if result.kind == "run_directory" {
             actions.append(
@@ -908,9 +906,7 @@ struct RunInspectionAnalyzer {
         result: RunInspectionResult,
         diagnostics: [PreflightDiagnostic]
     ) -> String {
-        if let image = result.imageRun {
-            return "Image run \(image.id.uuidString.lowercased()): \(image.state.rawValue), \(image.artifacts.count) artifact(s)."
-        }
+        if let run = result.recordedOperation { return run.summary }
         switch status {
         case .ok:
             return "Inspected \(result.kind) at \(result.path)."
@@ -1130,18 +1126,20 @@ struct RunListAnalyzer {
             fileManager: fileManager,
             now: now
         ).envelope()
-        guard ["run_directory", "report_file", "plan_file", "image_run"].contains(envelope.result.kind) else {
+        guard ["run_directory", "report_file", "plan_file"].contains(envelope.result.kind)
+            || RecordedOperationRun.Kind(rawValue: envelope.result.kind) != nil else {
             return nil
         }
         let relativePath = Self.relativePath(for: url, root: root)
         let runDirectory = envelope.result.runDirectory
         let report = envelope.result.report
         let plan = envelope.result.plan
-        let manifestCreatedAt = envelope.result.imageRun?.createdAt ?? runDirectory?.manifest?.createdAt
+        let operation = envelope.result.recordedOperation
+        let manifestCreatedAt = operation?.createdAt ?? runDirectory?.manifest?.createdAt
         let legacyCreatedAt = runDirectory?.legacyManifest?.createdAt
         let reportCreatedAt = report?.createdAt
         let planCreatedAt = plan?.createdAt
-        let eventCreatedAt = envelope.result.imageRun?.updatedAt ?? runDirectory?.events.latest?.createdAt
+        let eventCreatedAt = operation?.updatedAt ?? runDirectory?.events.latest?.createdAt
         let legacyUpdatedAt = runDirectory?.legacyManifest?.updatedAt
         let createdAt = manifestCreatedAt ??
             legacyCreatedAt ??
@@ -1160,23 +1158,23 @@ struct RunListAnalyzer {
             relativePath: relativePath,
             depth: depth,
             status: envelope.status,
-            state: envelope.result.imageRun?.state.rawValue ?? runDirectory?.status ?? report?.status.rawValue,
+            state: operation?.state.rawValue ?? runDirectory?.status ?? report?.status.rawValue,
             createdAt: createdAt,
             updatedAt: updatedAt,
             summary: envelope.summary,
-            command: envelope.result.imageRun == nil ? report?.command ?? plan?.command : ["image", "generate"],
-            format: envelope.result.imageRun == nil ? runDirectory?.manifest?.format ?? plan?.kind : "image.generate",
+            command: operation?.kind.command ?? report?.command ?? plan?.command,
+            format: operation?.kind.command.joined(separator: ".") ?? runDirectory?.manifest?.format ?? plan?.kind,
             eventCount: runDirectory?.events.count,
-            artifactCount: envelope.result.imageRun?.artifacts.count ?? runDirectory?.artifacts.count,
+            artifactCount: operation?.artifacts.count ?? runDirectory?.artifacts.count,
             diagnosticCount: envelope.diagnostics.count,
             blockerCount: envelope.diagnostics.filter { $0.severity == .blocker }.count,
-            actions: entryActions(path: url.path, kind: envelope.result.kind) + envelope.actions.filter { $0.id == "retry-image-run" }
+            actions: entryActions(path: url.path, kind: envelope.result.kind) + envelope.actions.filter { $0.id == operation?.kind.retryActionID }
         )
     }
 
     private func isRunDirectoryCandidate(_ url: URL, contents: [URL]) -> Bool {
         let names = Set(contents.map(\.lastPathComponent))
-        if names.contains(ImageRunRecord.filename) || names.contains(LoRATrainingRunManifest.filename) {
+        if RecordedOperationRun.kinds.contains(where: { names.contains($0.filename) }) || names.contains(LoRATrainingRunManifest.filename) {
             return true
         }
         let hasPlan = names.contains("plan.json")
@@ -1246,7 +1244,8 @@ struct RunListAnalyzer {
                 )
             ),
         ]
-        if kind == "run_directory" || (kind == "image_run" && URL(fileURLWithPath: path).lastPathComponent != ImageRunRecord.filename) {
+        let recordKind = RecordedOperationRun.Kind(rawValue: kind)
+        if kind == "run_directory" || (recordKind != nil && URL(fileURLWithPath: path).lastPathComponent != recordKind?.filename) {
             actions.append(
                 DeclarativeAction(
                     id: "open",

--- a/Sources/MereRunCLI/Support/RuntimeServingServices.swift
+++ b/Sources/MereRunCLI/Support/RuntimeServingServices.swift
@@ -97,10 +97,17 @@ struct RuntimeServingServices: Sendable {
         }
     }
 
-    func transcribe(_ plan: SpeechTranscriptionPlan) async throws -> SpeechTranscriptionOutcome {
-        try await withRuntimeRequestAdmission(using: admission) {
-            try ensureAvailable()
-            return try await SpeechTranscriptionOperation.execute(plan, executor: transcriptionExecutor)
+    func transcribe(
+        _ plan: SpeechTranscriptionPlan, recording: SpeechTranscriptionRunSession? = nil
+    ) async throws -> SpeechTranscriptionOutcome {
+        do {
+            return try await withRuntimeRequestAdmission(using: admission) {
+                try ensureAvailable()
+                return try await SpeechTranscriptionOperation.execute(plan, recording: recording, executor: transcriptionExecutor)
+            }
+        } catch {
+            try recording?.fail(error)
+            throw error
         }
     }
 }

--- a/Sources/MereRunContract/CommandCapabilityContract.swift
+++ b/Sources/MereRunContract/CommandCapabilityContract.swift
@@ -2764,7 +2764,7 @@ public enum MereRunCapabilityCatalog {
         id: "run.retry",
         command: ["run", "retry"],
         title: "Retry run",
-        summary: "Retry a recorded local image run or an immutable Relay graph job.",
+        summary: "Retry a recorded image or transcription run, or an immutable Relay graph job.",
         arguments: [
             .init(name: "reference", label: "Run reference", kind: .string, required: true)
         ],
@@ -3378,6 +3378,7 @@ public enum MereRunCapabilityCatalog {
             .init(name: "audio", label: "Audio", kind: .file, required: true)
         ],
         options: [
+            .init(flag: "--run-dir", label: "Run directory", kind: .directory, group: Group.output, tier: .expert),
             .init(flag: "--timestamps", label: "Include timestamps", kind: .boolean),
             .init(flag: "--output", label: "Output", kind: .file, group: Group.output, tier: .standard),
             .init(flag: "--model", label: "Model", kind: .string, group: Group.modelAndAdapters, tier: .standard),
@@ -3705,6 +3706,7 @@ public enum MereRunCapabilityCatalog {
         summary: "Serve installed models through OpenAI-compatible local APIs.",
         options: [
             .init(flag: "--image-run-records", label: "Image run records", kind: .directory, group: Group.output, tier: .expert),
+            .init(flag: "--transcription-run-records", label: "Transcription run records", kind: .directory, group: Group.output, tier: .expert),
             .init(
                 flag: "--warmup", label: "Warm model before serving", kind: .boolean, group: Group.run, tier: .expert
             ),

--- a/Sources/MereRunCore/ImageRunRecord.swift
+++ b/Sources/MereRunCore/ImageRunRecord.swift
@@ -1,14 +1,12 @@
-import Crypto
+import MereRunExecution
 import Foundation
 
 /// Versioned image history. Requested settings retain omissions; resolved settings
 /// contain the values submitted to the runtime, including a seed chosen before execution.
 public struct ImageRunRecord: Codable, Equatable, Sendable {
     public static let filename = "image-run.json"
-    public enum State: String, Codable, Sendable {
-        case preparing, running, succeeded, failed, cancelled, interrupted
-        public var isTerminal: Bool { self != .preparing && self != .running }
-    }
+    public typealias State = RunState
+    public typealias Artifact = RunArtifact
 
     public let schemaVersion: Int
     public let id: UUID
@@ -30,24 +28,6 @@ public struct ImageRunRecord: Codable, Equatable, Sendable {
     public var artifacts: [Artifact]
     public var issue: ImageGenerationIssue?
 
-    public struct Artifact: Codable, Equatable, Sendable {
-        public let url: URL
-        public let sha256: String
-        public let byteCount: UInt64
-
-        public static func read(_ url: URL) throws -> Self {
-            let handle = try FileHandle(forReadingFrom: url)
-            defer { try? handle.close() }
-            var hash = SHA256()
-            var byteCount: UInt64 = 0
-            while let bytes = try handle.read(upToCount: 1_048_576), !bytes.isEmpty {
-                hash.update(data: bytes)
-                byteCount += UInt64(bytes.count)
-            }
-            return Self(url: url, sha256: hash.finalize().map { String(format: "%02x", $0) }.joined(), byteCount: byteCount)
-        }
-    }
-
     public static func recordURL(at url: URL) -> URL {
         url.lastPathComponent == filename ? url : url.appendingPathComponent(filename)
     }
@@ -56,7 +36,7 @@ public struct ImageRunRecord: Codable, Equatable, Sendable {
     /// abandoned nonterminal record persists an interrupted state, even after reboot.
     public static func inspect(at url: URL) throws -> Self {
         let recordURL = recordURL(at: url)
-        let lease = try ImageRunLease.acquire(in: recordURL.deletingLastPathComponent())
+        let lease = try RunDirectoryLease.acquire(in: recordURL.deletingLastPathComponent(), filename: ".image-run.lock")
         defer { lease?.release() }
         var record = try decode(Data(contentsOf: recordURL))
         if lease != nil, !record.state.isTerminal {
@@ -69,9 +49,7 @@ public struct ImageRunRecord: Codable, Equatable, Sendable {
     }
 
     static func decode(_ data: Data) throws -> Self {
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
-        let record = try decoder.decode(Self.self, from: data)
+        let record = try RunRecordCodec.decoder().decode(Self.self, from: data)
         guard record.schemaVersion == 1 else {
             throw ImageGenerationIssue("run_version_unsupported", "Unsupported image run record version: \(record.schemaVersion).")
         }
@@ -79,22 +57,18 @@ public struct ImageRunRecord: Codable, Equatable, Sendable {
     }
 
     static func timestamp() -> Date {
-        Date(timeIntervalSince1970: Date().timeIntervalSince1970.rounded(.down))
+        RunRecordCodec.timestamp()
     }
 
     static func encoder() -> JSONEncoder {
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
-        encoder.dateEncodingStrategy = .iso8601
-        return encoder
+        RunRecordCodec.encoder()
     }
 
     static func digest(_ manifest: MereRunModelManifest) throws -> String {
-        SHA256.hash(data: try encoder().encode(manifest)).map { String(format: "%02x", $0) }.joined()
+        try RunRecordCodec.digest(manifest)
     }
 
     func write(to url: URL) throws {
-        try Self.encoder().encode(self).write(to: url, options: [.atomic, .completeFileProtectionUnlessOpen])
-        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
+        try RunRecordCodec.write(self, to: url)
     }
 }

--- a/Sources/MereRunCore/ImageRunSession.swift
+++ b/Sources/MereRunCore/ImageRunSession.swift
@@ -1,4 +1,5 @@
 import Foundation
+import MereRunExecution
 
 /// Owns one run directory and its process lease. All mutations are serialized;
 /// terminal records release the lease only after their atomic write succeeds.
@@ -6,7 +7,7 @@ public final class ImageRunSession: @unchecked Sendable {
     public let directory: URL
     public let id: UUID
     private let mutex = NSLock()
-    private let lease: ImageRunLease
+    private let lease: RunDirectoryLease
     private var record: ImageRunRecord
 
     public init(directory: URL, requested: ImageGenerationOptions, modelSelector: String, parentID: UUID? = nil) throws {
@@ -16,8 +17,8 @@ public final class ImageRunSession: @unchecked Sendable {
         let manager = FileManager.default
         try manager.createDirectory(at: self.directory.deletingLastPathComponent(), withIntermediateDirectories: true)
         // Refuse existing directories, including earlier runs and unrelated user files.
-        try ImageRunLease.createDirectory(self.directory)
-        guard let lease = try ImageRunLease.acquire(in: self.directory) else {
+        try RunDirectoryLease.createDirectory(self.directory)
+        guard let lease = try RunDirectoryLease.acquire(in: self.directory, filename: ".image-run.lock") else {
             throw ImageGenerationIssue("run_active", "The image run directory is already in use.")
         }
         self.lease = lease

--- a/Sources/MereRunExecution/README.md
+++ b/Sources/MereRunExecution/README.md
@@ -1,0 +1,18 @@
+# Durable execution storage
+
+Use this library for run-directory leases, file fingerprints, atomic record
+writes, and terminal states. It depends on Foundation, platform file APIs, and
+Crypto. It does not load models or define CLI or HTTP behavior.
+
+Operation families own their versioned records, preparation rules, outputs,
+and retry policies. Image and file transcription runs use the same storage
+primitives while preserving their separate schemas.
+
+`RunDirectoryLease` uses a nonblocking process lock to distinguish active runs
+from abandoned records. The descriptor closes across process execution and
+when its owner releases it. Recovery acquires the same lease before changing
+a nonterminal record to interrupted.
+
+`RunArtifact` hashes file contents in bounded chunks. `RunRecordCodec` writes
+records atomically with private file permissions. Callers validate the record
+version before recovery; an unknown version must remain untouched.

--- a/Sources/MereRunExecution/RunArtifact.swift
+++ b/Sources/MereRunExecution/RunArtifact.swift
@@ -1,0 +1,27 @@
+import Crypto
+import Foundation
+
+/// A file's location, content digest, and size at the time it was recorded.
+public struct RunArtifact: Codable, Hashable, Sendable {
+    public let url: URL
+    public let sha256: String
+    public let byteCount: UInt64
+
+    public init(url: URL, sha256: String, byteCount: UInt64) {
+        self.url = url
+        self.sha256 = sha256
+        self.byteCount = byteCount
+    }
+
+    public static func read(_ url: URL) throws -> Self {
+        let handle = try FileHandle(forReadingFrom: url)
+        defer { try? handle.close() }
+        var hash = SHA256()
+        var byteCount: UInt64 = 0
+        while let bytes = try handle.read(upToCount: 1_048_576), !bytes.isEmpty {
+            hash.update(data: bytes)
+            byteCount += UInt64(bytes.count)
+        }
+        return Self(url: url, sha256: hash.finalize().map { String(format: "%02x", $0) }.joined(), byteCount: byteCount)
+    }
+}

--- a/Sources/MereRunExecution/RunDirectoryLease.swift
+++ b/Sources/MereRunExecution/RunDirectoryLease.swift
@@ -6,21 +6,21 @@ import Glibc
 #endif
 
 /// Nonblocking process lease. The descriptor is never inherited across exec.
-final class ImageRunLease: @unchecked Sendable {
+public final class RunDirectoryLease: @unchecked Sendable {
     private let mutex = NSLock()
     private var descriptor: Int32
 
     private init(_ descriptor: Int32) { self.descriptor = descriptor }
     deinit { release() }
 
-    static func createDirectory(_ directory: URL) throws {
+    public static func createDirectory(_ directory: URL) throws {
         guard directory.path.withCString({ mkdir($0, S_IRWXU) }) == 0 else {
             throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
         }
     }
 
-    static func acquire(in directory: URL) throws -> ImageRunLease? {
-        let path = directory.appendingPathComponent(".image-run.lock").path
+    public static func acquire(in directory: URL, filename: String) throws -> RunDirectoryLease? {
+        let path = directory.appendingPathComponent(filename).path
         let descriptor = path.withCString { open($0, O_CREAT | O_RDWR | O_CLOEXEC | O_NOFOLLOW, S_IRUSR | S_IWUSR) }
         guard descriptor >= 0 else { throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO) }
         guard flock(descriptor, LOCK_EX | LOCK_NB) == 0 else {
@@ -29,10 +29,10 @@ final class ImageRunLease: @unchecked Sendable {
             if code == EWOULDBLOCK || code == EAGAIN { return nil }
             throw POSIXError(POSIXErrorCode(rawValue: code) ?? .EIO)
         }
-        return ImageRunLease(descriptor)
+        return RunDirectoryLease(descriptor)
     }
 
-    func release() {
+    public func release() {
         mutex.withLock {
             guard descriptor >= 0 else { return }
             _ = flock(descriptor, LOCK_UN)

--- a/Sources/MereRunExecution/RunFileSnapshot.swift
+++ b/Sources/MereRunExecution/RunFileSnapshot.swift
@@ -1,0 +1,16 @@
+import Foundation
+
+/// Records a metadata file, including its absence, for later change detection.
+public struct RunFileSnapshot: Codable, Hashable, Sendable {
+    public let url: URL
+    public let artifact: RunArtifact?
+
+    public static func capture(_ url: URL) throws -> Self {
+        let artifact = FileManager.default.fileExists(atPath: url.path) ? try RunArtifact.read(url) : nil
+        return Self(url: url, artifact: artifact)
+    }
+
+    public func isUnchanged() throws -> Bool {
+        try Self.capture(url) == self
+    }
+}

--- a/Sources/MereRunExecution/RunRecordCodec.swift
+++ b/Sources/MereRunExecution/RunRecordCodec.swift
@@ -1,0 +1,32 @@
+import Crypto
+import Foundation
+
+/// Shared encoding and atomic file writes. Each operation owns its record schema
+/// and validates supported versions before recovering or retrying a run.
+public enum RunRecordCodec {
+    public static func timestamp() -> Date {
+        Date(timeIntervalSince1970: Date().timeIntervalSince1970.rounded(.down))
+    }
+
+    public static func encoder() -> JSONEncoder {
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys, .withoutEscapingSlashes]
+        encoder.dateEncodingStrategy = .iso8601
+        return encoder
+    }
+
+    public static func decoder() -> JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }
+
+    public static func digest(_ value: some Encodable) throws -> String {
+        SHA256.hash(data: try encoder().encode(value)).map { String(format: "%02x", $0) }.joined()
+    }
+
+    public static func write(_ value: some Encodable, to url: URL) throws {
+        try encoder().encode(value).write(to: url, options: [.atomic, .completeFileProtectionUnlessOpen])
+        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
+    }
+}

--- a/Sources/MereRunExecution/RunState.swift
+++ b/Sources/MereRunExecution/RunState.swift
@@ -1,0 +1,6 @@
+/// Durable execution states shared by operation families.
+public enum RunState: String, Codable, Sendable {
+    case preparing, running, succeeded, failed, cancelled, interrupted
+
+    public var isTerminal: Bool { self != .preparing && self != .running }
+}

--- a/Tests/AudioCoreTests/SpeechTranscriptionRunTests.swift
+++ b/Tests/AudioCoreTests/SpeechTranscriptionRunTests.swift
@@ -1,0 +1,254 @@
+import Foundation
+import XCTest
+import MereRunExecution
+@testable import AudioCore
+
+final class SpeechTranscriptionRunTests: XCTestCase {
+    func testBothBackendsRetainAudioResolvedSettingsAndStructuredAlignment() async throws {
+        for backend in [ASRResolvedBackend.qwen, .parakeet] {
+            let fixture = try fixture(backend: backend)
+            let session = try session(fixture)
+            let expected = ASRResult(
+                text: "Retained transcript", language: "en", duration: 2,
+                tokenAlignments: [.init(text: "Retained", startSeconds: 0.2, durationSeconds: 0.4)],
+                sentenceAlignments: [.init(text: "Retained transcript", startSeconds: 0.2, durationSeconds: 1.5, tokens: [])]
+            )
+            let events = TranscriptionRunEvents()
+            let executor = TranscriptionRunExecutor { request in
+                XCTAssertNotEqual(request.audioURL, fixture.plan.request.audioURL)
+                XCTAssertEqual(try Data(contentsOf: request.audioURL), Data("audio fixture".utf8))
+                let active = try SpeechTranscriptionRunRecord.inspect(at: session.directory)
+                XCTAssertEqual(active.state, .running)
+                XCTAssertEqual(active.requested.request.audioURL, fixture.plan.request.audioURL)
+                XCTAssertEqual(active.effective?.request, request)
+                return expected
+            }
+            let outcome = try await SpeechTranscriptionOperation.execute(
+                fixture.plan, recording: session, eventHandler: { events.append($0) }, executor: executor
+            )
+            XCTAssertEqual(outcome.id, session.id)
+            let record = try SpeechTranscriptionRunRecord.inspect(at: session.directory)
+            XCTAssertEqual(record.state, .succeeded)
+            XCTAssertEqual(record.effective?.decision.backend, backend)
+            XCTAssertEqual(record.artifacts.count, 2)
+            XCTAssertEqual(events.values(), ["started", "succeeded"])
+            let json = session.directory.appendingPathComponent("result.json")
+            XCTAssertEqual(try RunRecordCodec.decoder().decode(ASRResult.self, from: Data(contentsOf: json)), expected)
+            try FileManager.default.removeItem(at: fixture.plan.request.audioURL)
+            XCTAssertEqual(try RunArtifact.read(XCTUnwrap(record.input).url), record.input)
+            XCTAssertEqual(try String(contentsOf: session.directory.appendingPathComponent("transcript.txt"), encoding: .utf8), expected.text)
+        }
+    }
+
+    func testFailureCancellationAndOutputFailureNeverRecordSuccess() async throws {
+        for mode in ["failure", "cancelled", "output"] {
+            let fixture = try fixture()
+            let session = try session(fixture)
+            let events = TranscriptionRunEvents()
+            let executor = TranscriptionRunExecutor { _ in
+                if mode == "cancelled" { throw CancellationError() }
+                if mode == "failure" { throw SpeechTranscriptionIssue("fixture", "Expected failure") }
+                try FileManager.default.createDirectory(at: session.directory.appendingPathComponent("result.json"), withIntermediateDirectories: false)
+                return ASRResult(text: "Cannot save")
+            }
+            do {
+                _ = try await SpeechTranscriptionOperation.execute(
+                    fixture.plan, recording: session, eventHandler: { events.append($0) }, executor: executor
+                )
+                XCTFail("Expected a terminal error")
+            } catch {
+                XCTAssertEqual(error is CancellationError, mode == "cancelled")
+            }
+            let record = try SpeechTranscriptionRunRecord.inspect(at: session.directory)
+            XCTAssertEqual(record.state, mode == "cancelled" ? .cancelled : .failed)
+            XCTAssertEqual(events.values(), ["started", mode == "cancelled" ? "cancelled" : "failed"])
+            XCTAssertTrue(record.artifacts.isEmpty)
+            XCTAssertNotNil(record.effective)
+        }
+    }
+
+    func testCancellationBeforePreparationDoesNotInvokeTheExecutor() async throws {
+        let fixture = try fixture()
+        let session = try session(fixture)
+        let gate = TranscriptionRunGate()
+        let task = Task {
+            await gate.wait()
+            return try await SpeechTranscriptionOperation.execute(fixture.plan, recording: session, executor: TranscriptionRunExecutor { _ in
+                XCTFail("Cancelled request executed")
+                return ASRResult(text: "Unexpected")
+            })
+        }
+        try await gate.waitUntilEntered()
+        task.cancel()
+        await gate.open()
+        do { _ = try await task.value; XCTFail("Cancelled request succeeded") } catch is CancellationError {}
+        let record = try SpeechTranscriptionRunRecord.inspect(at: session.directory)
+        XCTAssertEqual(record.state, .cancelled)
+        XCTAssertNil(record.effective)
+        XCTAssertNil(record.input)
+        XCTAssertFalse(record.canRetry)
+    }
+
+    func testCancellationAfterExecutorReturnsRetainsPreparedInputWithoutSuccess() async throws {
+        let fixture = try fixture()
+        let session = try session(fixture)
+        let gate = TranscriptionRunGate()
+        let task = Task {
+            try await SpeechTranscriptionOperation.execute(fixture.plan, recording: session, executor: TranscriptionRunExecutor { _ in
+                await gate.wait()
+                return ASRResult(text: "Completed after cancellation")
+            })
+        }
+        try await gate.waitUntilEntered()
+        task.cancel()
+        await gate.open()
+        do { _ = try await task.value; XCTFail("Cancelled request succeeded") } catch is CancellationError {}
+        let record = try SpeechTranscriptionRunRecord.inspect(at: session.directory)
+        XCTAssertEqual(record.state, .cancelled)
+        XCTAssertNotNil(record.input)
+        XCTAssertTrue(record.artifacts.isEmpty)
+    }
+
+    func testRetryUsesRetainedAudioProviderAndSettingsInNewDirectory() async throws {
+        let fixture = try fixture(backend: .parakeet, provider: .coreML(artifactURL: URL(fileURLWithPath: "/fixture/coreml")))
+        let session = try session(fixture)
+        _ = try await SpeechTranscriptionOperation.execute(fixture.plan, recording: session, executor: TranscriptionRunExecutor())
+        let parentURL = SpeechTranscriptionRunRecord.recordURL(at: session.directory)
+        let parentBytes = try Data(contentsOf: parentURL)
+        try FileManager.default.removeItem(at: fixture.plan.request.audioURL)
+        let retry = try SpeechTranscriptionRunSession.retryPlan(at: session.directory)
+        XCTAssertNotEqual(retry.session.id, session.id)
+        XCTAssertNotEqual(retry.session.directory, session.directory)
+        XCTAssertEqual(retry.plan.provider, fixture.plan.provider)
+        XCTAssertEqual(retry.plan.request.maxTokens, 37)
+        XCTAssertEqual(retry.plan.decision, fixture.plan.decision)
+        _ = try await SpeechTranscriptionOperation.execute(retry.plan, recording: retry.session, executor: TranscriptionRunExecutor())
+        let child = try SpeechTranscriptionRunRecord.inspect(at: retry.session.directory)
+        XCTAssertEqual(child.parentID, session.id)
+        XCTAssertEqual(child.state, .succeeded)
+        XCTAssertEqual(try Data(contentsOf: parentURL), parentBytes)
+        XCTAssertNotEqual(child.input?.url, retry.plan.request.audioURL)
+    }
+
+    func testRetryRejectsChangedInputAndChangedOrNewMetadataBeforeCreatingDirectory() async throws {
+        for mode in ["input", "config", "new-manifest"] {
+            let fixture = try fixture()
+            let session = try session(fixture)
+            _ = try await SpeechTranscriptionOperation.execute(fixture.plan, recording: session, executor: TranscriptionRunExecutor())
+            let record = try SpeechTranscriptionRunRecord.inspect(at: session.directory)
+            let target: URL
+            switch mode {
+            case "input": target = try XCTUnwrap(record.input?.url)
+            case "config": target = fixture.root.appendingPathComponent("config.json")
+            default: target = fixture.root.appendingPathComponent("manifest.json")
+            }
+            try Data("changed".utf8).write(to: target)
+            let siblings = try FileManager.default.contentsOfDirectory(atPath: fixture.root.path)
+            XCTAssertThrowsError(try SpeechTranscriptionRunSession.retryPlan(at: session.directory)) {
+                XCTAssertEqual(($0 as? SpeechTranscriptionIssue)?.code, mode == "input" ? "run_input_changed" : "run_model_changed")
+            }
+            XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: fixture.root.path), siblings)
+        }
+    }
+
+    func testActiveAbandonedFutureAndCorruptRecordsAreHandledWithoutDataLoss() throws {
+        let fixture = try fixture()
+        var session: SpeechTranscriptionRunSession? = try session(fixture)
+        let directory = try XCTUnwrap(session?.directory)
+        XCTAssertEqual(try SpeechTranscriptionRunRecord.inspect(at: directory).state, .preparing)
+        XCTAssertThrowsError(try SpeechTranscriptionRunSession.retryPlan(at: directory)) {
+            XCTAssertEqual(($0 as? SpeechTranscriptionIssue)?.code, "run_active")
+        }
+        _ = try XCTUnwrap(session).prepare(fixture.plan)
+        XCTAssertEqual(try SpeechTranscriptionRunRecord.inspect(at: directory).state, .running)
+        session = nil
+        let interrupted = try SpeechTranscriptionRunRecord.inspect(at: directory)
+        XCTAssertEqual(interrupted.state, .interrupted)
+        XCTAssertTrue(interrupted.canRetry)
+        XCTAssertEqual(try SpeechTranscriptionRunRecord.inspect(at: directory), interrupted)
+        let recordURL = SpeechTranscriptionRunRecord.recordURL(at: directory)
+        let original = try String(contentsOf: recordURL, encoding: .utf8)
+        let future = original.replacingOccurrences(of: "\"schemaVersion\" : 1", with: "\"schemaVersion\" : 99")
+        XCTAssertNotEqual(future, original)
+        for bytes in [Data(future.utf8), Data("broken".utf8)] {
+            try bytes.write(to: recordURL)
+            XCTAssertThrowsError(try SpeechTranscriptionRunRecord.inspect(at: directory))
+            XCTAssertEqual(try Data(contentsOf: recordURL), bytes)
+        }
+        XCTAssertThrowsError(try self.session(fixture))
+        XCTAssertEqual(try Data(contentsOf: recordURL), Data("broken".utf8))
+    }
+
+    private func fixture(
+        backend: ASRResolvedBackend = .qwen, provider: ParakeetExecutionProvider = .mlx
+    ) throws -> (root: URL, plan: SpeechTranscriptionPlan) {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: root) }
+        let audio = root.appendingPathComponent("source.wav")
+        try Data("audio fixture".utf8).write(to: audio)
+        let config = root.appendingPathComponent("config.json")
+        try Data("{}".utf8).write(to: config)
+        let metadata = try [config, root.appendingPathComponent("manifest.json")].map(RunFileSnapshot.capture)
+        return (root, SpeechTranscriptionPlan(
+            request: .init(audioURL: audio, language: "en", maxTokens: 37),
+            decision: .init(backend: backend, reason: "fixture selection", normalizedLanguageHint: "en"),
+            modelID: "fixture-model", modelPath: root.path, provider: provider, modelMetadata: metadata
+        ))
+    }
+
+    private func session(_ fixture: (root: URL, plan: SpeechTranscriptionPlan)) throws -> SpeechTranscriptionRunSession {
+        try SpeechTranscriptionRunSession(
+            directory: fixture.root.appendingPathComponent("run"),
+            requested: .init(request: fixture.plan.request, preferredBackend: .auto, provider: fixture.plan.provider)
+        )
+    }
+}
+
+private struct TranscriptionRunExecutor: SpeechTranscriptionExecutor {
+    var execute: @Sendable (ASRRequest) async throws -> ASRResult = { _ in ASRResult(text: "Fixture transcript") }
+
+    func transcribeQwen(
+        request: ASRRequest, modelID: String, modelPath: String?, progressHandler: (@Sendable (ASRProgress) -> Void)?
+    ) async throws -> ASRResult { try await execute(request) }
+
+    func transcribeParakeet(
+        request: ASRRequest, modelID: String, modelPath: String?, progressHandler: (@Sendable (ASRProgress) -> Void)?
+    ) async throws -> ASRResult { try await execute(request) }
+}
+
+private actor TranscriptionRunGate {
+    private var continuation: CheckedContinuation<Void, Never>?
+    private var entered = false
+    func wait() async {
+        entered = true
+        await withCheckedContinuation { continuation = $0 }
+    }
+    func waitUntilEntered() async throws {
+        let start = ContinuousClock.now
+        while !entered {
+            guard start.duration(to: .now) < .seconds(3) else {
+                throw SpeechTranscriptionIssue("fixture_timeout", "The fixture executor did not start.")
+            }
+            try await Task.sleep(for: .milliseconds(1))
+        }
+    }
+    func open() { continuation?.resume(); continuation = nil }
+}
+
+private final class TranscriptionRunEvents: @unchecked Sendable {
+    private let lock = NSLock()
+    private var events: [String] = []
+    func append(_ event: SpeechTranscriptionEvent) {
+        lock.withLock {
+            switch event {
+            case .started: events.append("started")
+            case .progress: events.append("progress")
+            case .succeeded: events.append("succeeded")
+            case .failed: events.append("failed")
+            case .cancelled: events.append("cancelled")
+            }
+        }
+    }
+    func values() -> [String] { lock.withLock { events } }
+}

--- a/Tests/MereRunCLITests/ReceiptCommandRunTests.swift
+++ b/Tests/MereRunCLITests/ReceiptCommandRunTests.swift
@@ -120,6 +120,23 @@ final class ReceiptCommandRunTests: XCTestCase {
         XCTAssertEqual(stdout, "hello from the fixture\n{\"event\":\"result\",\"exit\":0,\"outputs\":[]}\n")
     }
 
+    func testRecordedTranscriptionPreservesStdoutAndReceiptContract() async throws {
+        let directory = temporaryDirectory.appendingPathComponent("recorded-run")
+        let transcript = temporaryDirectory.appendingPathComponent("copy.txt")
+        let command = try transcribeCommand(["--run-dir", directory.path, "--receipt", "--output", transcript.path])
+        let stdout = try await capturingStandardOutput { try await command.run() }
+        XCTAssertTrue(stdout.hasPrefix("hello from the fixture\n"))
+        XCTAssertEqual(stdout.split(separator: "\n").count, 2)
+        let record = try SpeechTranscriptionRunRecord.inspect(at: directory)
+        XCTAssertEqual(record.state, .succeeded)
+        XCTAssertEqual(record.artifacts.count, 2)
+        XCTAssertEqual(try String(contentsOf: transcript, encoding: .utf8), "hello from the fixture")
+        let receipt = try receipt(fromLastLineOf: stdout)
+        let outputs = try XCTUnwrap(receipt["outputs"] as? [[String: Any]])
+        XCTAssertEqual(outputs.count, 1)
+        XCTAssertEqual(outputs[0]["path"] as? String, transcript.path)
+    }
+
     // MARK: - speech synthesize
 
     private func synthesizeCommand(_ extra: [String]) throws -> (SpeechSynthesize, URL) {

--- a/Tests/MereRunCLITests/TranscriptionRunCommandTests.swift
+++ b/Tests/MereRunCLITests/TranscriptionRunCommandTests.swift
@@ -1,0 +1,211 @@
+import AudioCore
+import AudioSTT
+import Foundation
+import MereRunCore
+import MereRunExecution
+import XCTest
+@testable import MereRunCLI
+
+final class TranscriptionRunCommandTests: XCTestCase {
+    func testRecordingFlagsAreOptInAndDoNotOverlapLiveStdinOrOutputFiles() throws {
+        let root = try root()
+        let run = root.appendingPathComponent("run")
+        XCTAssertNil(try SpeechTranscribe.parse(["audio.wav"]).runDirectory)
+        XCTAssertNil(try APIServe.parse([]).transcriptionRunRecords)
+        XCTAssertEqual(try SpeechTranscribe.parse(["audio.wav", "--run-dir", run.path]).runDirectory, run.path)
+        XCTAssertEqual(try APIServe.parse(["--transcription-run-records", root.path]).transcriptionRunRecords, root.path)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: run.path))
+        XCTAssertThrowsError(try SpeechTranscribe.parse(["audio.wav", "--run-dir", run.path, "--stream"]))
+        XCTAssertThrowsError(try SpeechTranscribe.parse([
+            "-", "--stream", "--input-format", "pcm-s16le", "--sample-rate", "16000", "--jsonl", "--run-dir", run.path
+        ]))
+        for name in ["transcription-run.json", ".transcription-run.lock", "inputs/audio.wav", "result.json", "transcript.txt"] {
+            XCTAssertThrowsError(try SpeechTranscribe.parse([
+                "audio.wav", "--run-dir", run.path, "--output", run.appendingPathComponent(name).path
+            ]))
+        }
+    }
+
+    func testCLIAndAPIRecordingKeepEquivalentSettingsAndRetainTemporaryUpload() async throws {
+        let fixture = try fixture()
+        let request = ASRRequest(audioURL: fixture.audio, language: "en", maxTokens: 29)
+        let cli = try session(root: fixture.root, name: "cli", request: request, model: fixture.model)
+        let apiRoot = fixture.root.appendingPathComponent("api-runs")
+        let cliOutcome = try await CLIASRRouting.transcribe(
+            request: request, preferredBackend: .auto, modelOverride: fixture.model.path,
+            recording: cli, executor: RecordedTranscriptionExecutor()
+        )
+        let services = makeServices(root: fixture.root, executor: RecordedTranscriptionExecutor())
+        let apiOutcome = try await APITranscription.execute(
+            audioURL: fixture.audio,
+            options: .init(modelID: fixture.model.path, language: "en", responseFormat: "verbose_json", task: .transcribe, maxTokens: 29),
+            recordingRoot: apiRoot, services: services
+        )
+        let apiDirectories = try FileManager.default.contentsOfDirectory(at: apiRoot, includingPropertiesForKeys: nil)
+        XCTAssertEqual(apiDirectories.count, 1)
+        let apiDirectory = try XCTUnwrap(apiDirectories.first)
+        XCTAssertEqual(cliOutcome.plan.decision, apiOutcome.plan.decision)
+        XCTAssertEqual(cliOutcome.plan.modelID, apiOutcome.plan.modelID)
+        XCTAssertEqual(cliOutcome.plan.modelPath, apiOutcome.plan.modelPath)
+        XCTAssertEqual(cliOutcome.plan.modelMetadata, apiOutcome.plan.modelMetadata)
+        XCTAssertEqual(cliOutcome.plan.provider, apiOutcome.plan.provider)
+        XCTAssertEqual(cliOutcome.plan.request.maxTokens, apiOutcome.plan.request.maxTokens)
+        XCTAssertEqual(cliOutcome.result, apiOutcome.result)
+        try FileManager.default.removeItem(at: fixture.audio)
+        for directory in [cli.directory, apiDirectory] {
+            let record = try SpeechTranscriptionRunRecord.inspect(at: directory)
+            XCTAssertTrue(record.canRetry)
+            XCTAssertEqual(record.state, .succeeded)
+            XCTAssertEqual(try RunArtifact.read(XCTUnwrap(record.input).url), record.input)
+        }
+        let admission = await services.admission.snapshot()
+        XCTAssertEqual(admission.activeRequests, 0)
+        XCTAssertEqual(admission.totalAdmittedRequests, 1)
+    }
+
+    func testResolutionAndRuntimeAdmissionFailuresPersistFailureRecords() async throws {
+        let fixture = try fixture()
+        try Data("{\"target\":\"parakeet\",\"preprocessor\":{},\"encoder\":{}}".utf8)
+            .write(to: fixture.model.appendingPathComponent("config.json"))
+        let request = ASRRequest(audioURL: fixture.audio, task: .translate)
+        let cli = try session(root: fixture.root, name: "invalid-model", request: request, model: fixture.model)
+        do {
+            _ = try await CLIASRRouting.transcribe(
+                request: request, preferredBackend: .auto, modelOverride: fixture.model.path,
+                recording: cli, executor: RecordedTranscriptionExecutor()
+            )
+            XCTFail("Incompatible local model was accepted")
+        } catch {}
+        XCTAssertEqual(try SpeechTranscriptionRunRecord.inspect(at: cli.directory).issue?.code, "model_backend_mismatch")
+        let api = try session(root: fixture.root, name: "unavailable", request: request, model: fixture.model)
+        let services = makeServices(root: fixture.root, executor: RecordedTranscriptionExecutor(), ensureAvailable: {
+            throw SpeechTranscriptionIssue("fixture_runtime_missing", "Runtime unavailable")
+        })
+        let plan = SpeechTranscriptionPlan(
+            request: request, decision: .init(backend: .qwen, reason: "fixture", normalizedLanguageHint: nil),
+            modelID: "fixture", modelPath: fixture.model.path
+        )
+        do { _ = try await services.transcribe(plan, recording: api); XCTFail("Expected runtime failure") } catch {}
+        let record = try SpeechTranscriptionRunRecord.inspect(at: api.directory)
+        XCTAssertEqual(record.state, .failed)
+        XCTAssertEqual(record.issue?.code, "fixture_runtime_missing")
+        let admission = await services.admission.snapshot()
+        XCTAssertEqual(admission.activeRequests, 0)
+    }
+
+    func testInspectionListingAndRetryShareRecordedOperationIdentity() async throws {
+        let fixture = try fixture()
+        let request = ASRRequest(audioURL: fixture.audio, language: "en", maxTokens: 19)
+        let recording = try session(root: fixture.root, name: "run", request: request, model: fixture.model)
+        _ = try await CLIASRRouting.transcribe(
+            request: request, preferredBackend: .auto, modelOverride: fixture.model.path,
+            recording: recording, executor: RecordedTranscriptionExecutor()
+        )
+        let envelope = RunInspectionAnalyzer(path: recording.directory.path).envelope()
+        XCTAssertEqual(envelope.status, .ok)
+        XCTAssertEqual(envelope.result.kind, "transcription_run")
+        XCTAssertEqual(envelope.result.transcriptionRun?.id, recording.id)
+        XCTAssertTrue(envelope.actions.contains { $0.id == "retry-transcription-run" && $0.enabled })
+        let list = RunListAnalyzer(root: fixture.root.path).envelope()
+        let entry = try XCTUnwrap(list.result.entries.first { $0.kind == "transcription_run" })
+        XCTAssertEqual(entry.command, ["speech", "transcribe"])
+        XCTAssertEqual(entry.format, "speech.transcribe")
+        XCTAssertEqual(entry.artifactCount, 2)
+        let coordinator = MachineInferenceCoordinator(
+            stateDirectory: fixture.root.appendingPathComponent("admission"),
+            hostSnapshot: {
+                MachineInferenceHostSnapshot(
+                    physicalMemoryBytes: 64 * 1_073_741_824, availableMemoryBytes: 48 * 1_073_741_824,
+                    memoryPressure: .nominal, availableDiskBytes: 128 * 1_073_741_824
+                )
+            }
+        )
+        let child = try await RunRetry.retryTranscription(
+            at: recording.directory, executor: RecordedTranscriptionExecutor(), admission: coordinator
+        )
+        XCTAssertEqual(child.parentID, recording.id)
+        XCTAssertEqual(child.state, .succeeded)
+        XCTAssertEqual(child.effective?.request.maxTokens, 19)
+        XCTAssertEqual(try coordinator.snapshot().activePermits, 0)
+        XCTAssertNil(CLIInferenceAdmissionClassifier.request(arguments: ["mere.run", "run", "retry", recording.directory.path]))
+        for model in ["speech-asr-qwen3", "speech-asr-parakeet"] {
+            XCTAssertEqual(
+                CLIInferenceAdmissionClassifier.speechTranscriptionRequest(modelID: model).resourceClass,
+                CLIInferenceAdmissionClassifier.request(arguments: ["mere.run", "speech", "transcribe", "audio.wav", "--model", model])?.resourceClass
+            )
+        }
+    }
+
+    func testInspectionReportsUnreadableRecordsAndMissingOutputs() async throws {
+        let fixture = try fixture()
+        let recording = try session(root: fixture.root, name: "run", request: .init(audioURL: fixture.audio), model: fixture.model)
+        _ = try await CLIASRRouting.transcribe(
+            request: .init(audioURL: fixture.audio), preferredBackend: .auto, modelOverride: fixture.model.path,
+            recording: recording, executor: RecordedTranscriptionExecutor()
+        )
+        try FileManager.default.removeItem(at: recording.directory.appendingPathComponent("transcript.txt"))
+        XCTAssertTrue(RunInspectionAnalyzer(path: recording.directory.path).envelope().diagnostics.contains {
+            $0.id == "transcription_run_artifact_missing"
+        })
+        let recordURL = SpeechTranscriptionRunRecord.recordURL(at: recording.directory)
+        try Data("broken".utf8).write(to: recordURL)
+        let envelope = RunInspectionAnalyzer(path: recordURL.path).envelope()
+        XCTAssertEqual(envelope.status, .blocked)
+        XCTAssertNil(envelope.result.transcriptionRun)
+        XCTAssertTrue(envelope.diagnostics.contains { $0.id == "transcription_run_unreadable" })
+        XCTAssertEqual(try Data(contentsOf: recordURL), Data("broken".utf8))
+    }
+
+    private func makeServices(
+        root: URL, executor: any SpeechTranscriptionExecutor, ensureAvailable: @escaping @Sendable () throws -> Void = {}
+    ) -> RuntimeServingServices {
+        let models = RuntimeModelPool(
+            defaultModelID: "fixture.gguf", defaultEngine: .textCode, startupModelPath: nil,
+            settingsStore: RuntimeModelSettingsStore(modelsDir: root), ensureMLXAvailable: {},
+            prepareLoadedModel: { _ in }, unloadLoadedModel: { _ in }, clearMLXCache: {}
+        )
+        return RuntimeServingServices(
+            models: models, media: APISidecarModelPool(settingsURL: root.appendingPathComponent("settings.json")),
+            admission: RuntimeRequestAdmission(maxActiveRequests: 1), ensureAvailable: ensureAvailable, transcriptionExecutor: executor
+        )
+    }
+
+    private func session(root: URL, name: String, request: ASRRequest, model: URL) throws -> SpeechTranscriptionRunSession {
+        try SpeechTranscriptionRunSession(
+            directory: root.appendingPathComponent(name),
+            requested: .init(request: request, preferredBackend: .auto, modelOverride: model.path)
+        )
+    }
+
+    private func fixture() throws -> (root: URL, audio: URL, model: URL) {
+        let root = try root()
+        let audio = root.appendingPathComponent("upload.wav")
+        try Data("audio fixture".utf8).write(to: audio)
+        let model = root.appendingPathComponent("model")
+        try FileManager.default.createDirectory(at: model, withIntermediateDirectories: false)
+        try Data("{}".utf8).write(to: model.appendingPathComponent("config.json"))
+        return (root, audio, model)
+    }
+
+    private func root() throws -> URL {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: root) }
+        return root
+    }
+}
+
+private struct RecordedTranscriptionExecutor: SpeechTranscriptionExecutor {
+    func transcribeQwen(
+        request: ASRRequest, modelID: String, modelPath: String?, progressHandler: (@Sendable (ASRProgress) -> Void)?
+    ) async throws -> ASRResult {
+        XCTAssertEqual(try Data(contentsOf: request.audioURL), Data("audio fixture".utf8))
+        return ASRResult(text: "Recorded transcript", language: request.language)
+    }
+
+    func transcribeParakeet(
+        request: ASRRequest, modelID: String, modelPath: String?, progressHandler: (@Sendable (ASRProgress) -> Void)?
+    ) async throws -> ASRResult {
+        try await transcribeQwen(request: request, modelID: modelID, modelPath: modelPath, progressHandler: progressHandler)
+    }
+}

--- a/Tests/MereRunExecutionTests/RunStorageTests.swift
+++ b/Tests/MereRunExecutionTests/RunStorageTests.swift
@@ -1,0 +1,71 @@
+import Foundation
+import XCTest
+import MereRunExecution
+
+final class RunStorageTests: XCTestCase {
+    func testLeaseExcludesOtherOwnersAndReleasesOnDeinit() throws {
+        let directory = try root().appendingPathComponent("run")
+        try RunDirectoryLease.createDirectory(directory)
+        var owner: RunDirectoryLease? = try XCTUnwrap(RunDirectoryLease.acquire(in: directory, filename: ".run.lock"))
+        XCTAssertNotNil(owner)
+        XCTAssertNil(try RunDirectoryLease.acquire(in: directory, filename: ".run.lock"))
+        owner = nil
+        let successor = try XCTUnwrap(RunDirectoryLease.acquire(in: directory, filename: ".run.lock"))
+        successor.release()
+        successor.release()
+        XCTAssertNotNil(try RunDirectoryLease.acquire(in: directory, filename: ".run.lock"))
+    }
+
+    func testDirectoryCreationPreservesExistingContentAndUsesPrivatePermissions() throws {
+        let directory = try root()
+        let file = directory.appendingPathComponent("keep.txt")
+        try Data("keep".utf8).write(to: file)
+        XCTAssertThrowsError(try RunDirectoryLease.createDirectory(directory))
+        XCTAssertEqual(try Data(contentsOf: file), Data("keep".utf8))
+        let run = directory.appendingPathComponent("run")
+        try RunDirectoryLease.createDirectory(run)
+        XCTAssertEqual(try FileManager.default.attributesOfItem(atPath: run.path)[.posixPermissions] as? Int, 0o700)
+    }
+
+    func testArtifactHashAndMetadataAbsenceDetectChanges() throws {
+        let file = try root().appendingPathComponent("metadata.json")
+        let absent = try RunFileSnapshot.capture(file)
+        XCTAssertNil(absent.artifact)
+        try Data("abc".utf8).write(to: file)
+        XCTAssertFalse(try absent.isUnchanged())
+        let original = try RunFileSnapshot.capture(file)
+        XCTAssertEqual(original.artifact?.byteCount, 3)
+        XCTAssertEqual(original.artifact?.sha256, "ba7816bf8f01cfea414140de5dae2223b00361a396177a9cb410ff61f20015ad")
+        XCTAssertTrue(try original.isUnchanged())
+        try Data("abcd".utf8).write(to: file)
+        XCTAssertFalse(try original.isUnchanged())
+        try FileManager.default.removeItem(at: file)
+        XCTAssertFalse(try original.isUnchanged())
+        XCTAssertTrue(try absent.isUnchanged())
+    }
+
+    func testRecordCodecPreservesWireFormattingAndPrivatePermissions() throws {
+        struct Fixture: Codable, Equatable {
+            let createdAt: Date
+            let state: RunState
+        }
+        let file = try root().appendingPathComponent("record.json")
+        let value = Fixture(createdAt: Date(timeIntervalSince1970: 0), state: .interrupted)
+        try RunRecordCodec.write(value, to: file)
+        XCTAssertEqual(try String(contentsOf: file, encoding: .utf8), """
+        {
+          "createdAt" : "1970-01-01T00:00:00Z",
+          "state" : "interrupted"
+        }
+        """)
+        XCTAssertEqual(try RunRecordCodec.decoder().decode(Fixture.self, from: Data(contentsOf: file)), value)
+        XCTAssertEqual(try FileManager.default.attributesOfItem(atPath: file.path)[.posixPermissions] as? Int, 0o600)
+    }
+
+    private func root() throws -> URL {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: root) }
+        return root
+    }
+}

--- a/apps/macos/StudioKit/Catalog/CommandFlags.swift
+++ b/apps/macos/StudioKit/Catalog/CommandFlags.swift
@@ -2365,6 +2365,7 @@ extension CommandFlags {
             "--stream-decode-ms": "2000"
         ]
 
+        package static let runDir = "--run-dir"
         package static let timestamps = "--timestamps"
         package static let output = "--output"
         package static let model = "--model"
@@ -2674,6 +2675,7 @@ extension CommandFlags {
         package static let command = ["api", "serve"]
 
         package static let imageRunRecords = "--image-run-records"
+        package static let transcriptionRunRecords = "--transcription-run-records"
         package static let warmup = "--warmup"
         package static let noWarmup = "--no-warmup"
         package static let port = "--port"

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -21,6 +21,15 @@ For the broader documentation set, start at the
 If you want to understand what a command does end to end, start at the command
 file, and then use the table to open the family entry point.
 
+## Durable operation history
+
+`MereRunExecution` owns run-directory leases, file fingerprints, atomic record
+writes, and terminal states. Core owns image records; AudioCore owns file
+transcription records. CLI inspection and listing use one typed operation-record
+adapter. See [shared transcription](./internals/speech-transcription-operation.md)
+and [shared image generation](./internals/image-generation-operation.md) for
+preparation, recovery, and retry responsibilities.
+
 ## Shared autoregressive decoding
 
 Read [shared decode boundaries](./internals/decode-runtime-boundaries.md) before

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -150,7 +150,7 @@ Public tree:
   - `mere.run run watch` — Watch the worker event stream for an SSH or relay graph job.
   - `mere.run run fetch` — Fetch a remote graph run into the standard local run-directory format.
   - `mere.run run cancel` — Cancel a graph run.
-  - `mere.run run retry` — Retry a recorded local image run or an immutable relay graph job.
+  - `mere.run run retry` — Retry a recorded image or transcription run, or an immutable relay graph job.
 - [`mere.run eval`](/evaluation-packs) — Run reproducible evaluations from external, content-addressed packs.
   - `mere.run eval pack` — Inspect external evaluation packs without running models.
     - `mere.run eval pack validate` — Validate and hash an external evaluation pack.

--- a/docs/internals/image-generation-operation.md
+++ b/docs/internals/image-generation-operation.md
@@ -53,7 +53,8 @@ files are removed.
 These Swift events do not change a CLI wire format. Existing `--receipt`,
 `--progress-json`, preflight JSON, run-plan files, and API response shapes retain
 their compatibility behavior. Optional `ImageRunSession` recording writes
-`image-run.json` atomically. Its held, non-inherited file lock distinguishes
+`image-run.json` atomically. `MereRunExecution` supplies the shared storage
+primitives without changing the image schema. Its held, non-inherited file lock distinguishes
 active work from abandoned records after termination or reboot. Inspection can
 persist an interrupted state without relying on process IDs or timestamps.
 An uncatchable process termination cannot emit a terminal Swift event.

--- a/docs/internals/speech-transcription-operation.md
+++ b/docs/internals/speech-transcription-operation.md
@@ -44,8 +44,46 @@ text, SRT, and VTT response formats. Its runtime service owns the request slot,
 and the transport removes the temporary upload after processing.
 
 Raw stdin and live streaming continue to use the existing ASR session protocol.
-The shared file operation's events do not add a CLI event mode or durable
-transcription run records.
+The shared file operation's events do not add a CLI event mode.
+
+## Retain and retry a file operation
+
+Pass an optional `SpeechTranscriptionRunSession` to the operation to retain its
+input and outcome. The session creates a private directory and takes a process
+lease before writing a versioned `transcription-run.json` record. Existing
+directories are rejected without rewriting their files.
+
+`SpeechTranscriptionRunOptions` preserves supplied settings. The resolved plan
+records the backend decision, model ID and local path, provider, language,
+task, and token limit. Before inference, the session copies the input audio and
+writes the effective plan. The executor reads that retained copy, so temporary
+HTTP uploads can be removed after the response.
+
+Success retains `result.json`, including available alignments, and
+`transcript.txt`, containing plain text. Both files have content fingerprints.
+Cancellation and failure retain their own terminal states. If the process ends
+without a terminal write, inspection takes the abandoned lease and records an
+interrupted outcome. Unknown schema versions and corrupt records remain untouched.
+
+Retry verifies the retained audio and local metadata, then starts a new sibling
+run with a parent ID. It uses the saved backend and provider without rerouting,
+and leaves the parent unchanged. The CLI obtains one machine reservation for
+the retry; API requests use their existing request slot and resident executor.
+
+Metadata checks cover the captured configuration, tokenizer files, installation
+manifest, and Core ML manifest when applicable. They record absent metadata
+files too, so a newly added manifest counts as a change. These checks do not
+hash tensor weights or establish identical numerical results. Native loading
+still owns checkpoint validation. Runs without captured local model metadata
+can be inspected but cannot be retried through `run retry`.
+
+`MereRunExecution` owns the storage primitives shared with image history.
+Operation families retain their typed schemas and retry policy. The CLI's
+`RecordedOperationRun` adapter presents both families to inspection and listing;
+existing `image_run` JSON fields and `image-run.json` records keep their format.
+
+For commands and retention behavior, see
+[Record and retry a transcription](../runtime/speech.md#record-and-retry-a-transcription).
 
 ## Validate the boundary
 
@@ -57,5 +95,7 @@ swift build --target AudioCoreTests
 
 The repository gate executes operation tests with fixture executors and
 CLI/API plan-parity tests. These tests cover backend dispatch, effective inputs,
-validation, terminal events, cancellation, and resident request cleanup.
+validation, terminal events, cancellation, and resident request cleanup. Durable
+run tests cover retained uploads, output failures, metadata changes, abandoned
+leases, future schemas, retry lineage, and existing receipt behavior.
 Real-model decoding remains a separate runtime validation step.

--- a/docs/repository-tour.md
+++ b/docs/repository-tour.md
@@ -27,6 +27,7 @@ mere-run/
 - `MereRunRelayKit`
 - `MereRunAdmission`
 - `MereRunResidency`
+- `MereRunExecution`
 - `MereRunModelKit`
 - `MereRunQwenModel`
 - `MereRunGemmaModel`

--- a/docs/runtime/api-server.md
+++ b/docs/runtime/api-server.md
@@ -37,6 +37,27 @@ on the server until you remove the run directories. It does not record API keys
 or HTTP headers. Use the local [`run inspect` and `run retry` commands](image.md#record-and-retry-an-image-run)
 to inspect or retry a record; there is no HTTP run-history endpoint.
 
+## Keep transcription run records
+
+To retain file transcriptions and translations, set a transcription record root:
+
+```bash
+mere.run api serve --transcription-run-records ./runs/api-transcriptions
+mere.run run list --root ./runs/api-transcriptions --json
+```
+
+Each resolved operation creates a private run directory. It retains the uploaded
+audio before temporary-file cleanup, records terminal outcomes, and saves the
+structured result and plain transcript. Requests rejected before their operation
+plan resolves do not create records. JSON, text, SRT, and VTT responses keep
+their existing formats.
+
+Recording is off by default. Enabling it retains uploaded audio, transcription
+settings, and results until you remove the run directories. It does not record
+API keys or HTTP headers. Use the local
+[inspection and retry commands](speech.md#record-and-retry-a-transcription)
+to work with saved runs. The API does not expose an HTTP history endpoint.
+
 ## macOS Server domain
 
 MereRun Studio exposes this control plane as the **Server** domain in its

--- a/docs/runtime/speech.md
+++ b/docs/runtime/speech.md
@@ -88,6 +88,39 @@ swift run mere.run speech listen --device <core-audio-uid>
 
 `speech listen` remains the Qwen-backed macOS microphone convenience command.
 
+#### Record and retry a transcription
+
+To keep the input audio and result for later inspection, use a new run directory:
+
+```bash
+mere.run speech transcribe ./meeting.wav --run-dir ./runs/meeting
+mere.run run inspect ./runs/meeting --json
+mere.run run list --root ./runs --json
+mere.run run retry ./runs/meeting --json
+```
+
+The directory contains `transcription-run.json`, a retained audio copy under
+`inputs`, `result.json` with available alignments, and a plain `transcript.txt`.
+Recording is optional. It preserves normal transcript output and the existing
+`--receipt` format. An optional `--output` file must be outside the run directory.
+
+Records distinguish success, failure, cancellation, and process interruption.
+Inspection marks an abandoned nonterminal record as interrupted. Retry creates
+a new sibling directory with the original run ID recorded as its parent; it
+does not modify the original or resume a partially completed decoder.
+
+Retry uses the saved model path, backend, provider, task, language, and token
+limit. It verifies retained audio and captured model metadata before executing.
+If either changed, start a new transcription command. Runs without captured
+local model metadata cannot be retried; install the model before recording if
+you need that behavior. Model metadata checks do not fingerprint tensor weights
+or guarantee identical recognition results.
+
+The API can retain uploaded audio and transcripts with
+[`--transcription-run-records`](api-server.md#keep-transcription-run-records).
+Run directories remain until you remove them. `--run-dir` supports non-streaming
+file input; live stdin and streamed-file sessions keep their existing protocol.
+
 #### Optional Parakeet Core ML/MLX package
 
 Parakeet uses MLX by default. For controlled Apple-platform experiments, Mere

--- a/scripts/check-model-boundaries.swift
+++ b/scripts/check-model-boundaries.swift
@@ -140,6 +140,24 @@ func checkBoundary(_ manifest: PackageManifest) -> [String] {
             )
         }
     }
+    let portableBoundaries: [String: Set<String>] = [
+        "MereRunExecution": [],
+        "MereRunExecutionTests": ["MereRunExecution"],
+        "AudioCore": ["MereRunExecution"],
+        "AudioCoreTests": ["AudioCore", "MereRunExecution"]
+    ]
+    for (root, allowedDependencies) in portableBoundaries.sorted(by: { $0.key < $1.key }) {
+        guard targets[root] != nil else {
+            failures.append("Missing execution boundary target: \(root)")
+            continue
+        }
+        let closure = dependencyClosure([root], targets: targets)
+        let unexpected = closure.local.subtracting(allowedDependencies.union([root]))
+            .union(closure.products.subtracting(["Crypto"]))
+        if !unexpected.isEmpty {
+            failures.append("\(root) has unexpected dependencies: " + unexpected.sorted().joined(separator: ", "))
+        }
+    }
     for product in manifest.products {
         let closure = dependencyClosure(product.targets, targets: targets)
         if closure.local.contains("MereRunMLXTestSupport") {


### PR DESCRIPTION
File transcription currently loses its operation history after the command or HTTP request ends. This adds optional durable runs that retain audio, resolved backend settings, structured results, transcripts, and terminal failures. `run inspect`, `run list`, and `run retry` now consume those records.

Three focused commits cover:
- Shared `MereRunExecution` storage primitives, reused by image runs while preserving their existing record schema.
- AudioCore transcription records, process leases, cancellation and interruption handling, and retries that verify retained audio and saved model metadata before creating a new sibling run.
- CLI `speech transcribe --run-dir`, API `serve --transcription-run-records`, history/retry integration, generated Studio flags, and public documentation.

Retries retain the saved backend and provider, including Parakeet CoreML, and use the existing inference admission path. Streaming stdin behavior and normal CLI/API output formats remain unchanged. Model metadata hashes do not fingerprint checkpoint weights or guarantee identical numerical output.

Validation: `./scripts/check.sh` passed with 4,113 XCTest cases (314 existing skips, zero failures) and 51 Swift Testing cases. The independent storage/AudioCore harness passed 17 tests without Core, CLI, or model targets; its arm64 iOS 18 simulator build passed. Docs build, final strict lint, and the three-commit secret scan passed. Darwin, Linux, and CUDA-prebuilt manifest boundary checks passed, and all four injected dependency violations were rejected.

Real-checkpoint inference, GPU numerical/performance qualification, and complete app journeys were not run. Manifest checks were evaluated on macOS and do not establish Linux source compilation; hosted CI remains separate validation.

Rebased the three speech execution commits onto `main` after #465 merged as `3ed0a15826605c77d9017e33c0a40c9e4e1d1952`. The complete source tree is identical to the previously validated head, and `git range-diff` confirms all three patches are unchanged. Hosted checks rerun for the new commit IDs.

