### PR TITLE
Consolidate chat request resolution and execution ownership

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,11 @@ The format is based on Keep a Changelog.
 ## Unreleased
 
 - Share chat sampling resolution, numeric validation, native invocation, and
-  cleanup between `text chat` and the API. Reject invalid CLI sampling values
-  before generation and report them in preflight. Preserve existing defaults
-  for each entry point and retain one runtime through CLI tool conversations.
+  cleanup between `text chat` and the API. `text chat` now range-checks sampling
+  values that it previously passed straight to the generator, rejecting them
+  before generation and reporting them in preflight; `--max-tokens` clamps to a
+  smaller `--context-size` rather than failing. Preserve existing defaults for
+  each entry point and retain one runtime through CLI tool conversations.
 - Keep API chat model residency and request admission under one session. Cancel
   upstream proxy reads when a streaming client disconnects, and await lease
   release on completion, failure, or cancellation.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+- Share chat sampling resolution, numeric validation, native invocation, and
+  cleanup between `text chat` and the API. Reject invalid CLI sampling values
+  before generation and report them in preflight. Preserve existing defaults
+  for each entry point and retain one runtime through CLI tool conversations.
+- Keep API chat model residency and request admission under one session. Cancel
+  upstream proxy reads when a streaming client disconnects, and await lease
+  release on completion, failure, or cancellation.
+
 - Add optional durable file-transcription records through `speech transcribe
   --run-dir` and `api serve --transcription-run-records`. Retain audio, resolved
   settings, and transcript artifacts; inspect terminal or interrupted outcomes

--- a/Sources/MereRunCLI/Commands/TextChatCommand.swift
+++ b/Sources/MereRunCLI/Commands/TextChatCommand.swift
@@ -343,13 +343,21 @@ struct TextChat: AsyncParsableCommand {
         var lastMuseDFlashStats: MuseGlimmerDFlashStats?
         var lastNemotronDSparkStats: NemotronHDSparkStats?
         var lastLFM2DSparkStats: LFM2DSparkStats?
-        let runtime = try NativeChatRuntime.command(
-            modelID: normalizedModelId,
-            modelPath: LagunaResources.handles(modelSpec: normalizedModelId)
-                ? (modelRoot ?? installedModelPath) : runtimeModelRoot,
-            gemma4KVCacheQuantization: Gemma4Resources.handles(modelSpec: normalizedModelId)
-                ? resolveGemma4KVCacheQuantization(for: normalizedModelId) : Gemma4KVCacheQuantization()
-        )
+        let runtime: NativeChatRuntime
+        do {
+            // Selection reports missing models as request issues; the command surfaces
+            // them as argument validation failures, as it did before this path moved.
+            runtime = try NativeChatRuntime.command(
+                modelID: normalizedModelId,
+                modelPath: LagunaResources.handles(modelSpec: normalizedModelId)
+                    ? (modelRoot ?? installedModelPath) : runtimeModelRoot,
+                gemma4KVCacheQuantization: Gemma4Resources.handles(modelSpec: normalizedModelId)
+                    ? resolveGemma4KVCacheQuantization(for: normalizedModelId)
+                    : Gemma4KVCacheQuantization()
+            )
+        } catch let issue as ChatRequestIssue {
+            throw ValidationError(issue.localizedDescription)
+        }
         let chatOnce: (ChatRequest) async throws -> ChatResponse = { request in
             let response = try await runtime.chat(request, progressHandler: progressHandler)
             let diagnostics = await runtime.diagnostics()
@@ -536,8 +544,15 @@ struct TextChat: AsyncParsableCommand {
     func resolvedChatRequest(
         modelID: String, messages: [ChatMessage], tools: [ToolDefinition]? = nil, lora: LoRA? = nil
     ) throws -> ChatRequest {
+        // `--max-tokens` defaults to 2048 independently of `--context-size`, and the
+        // command previously left the generator to cap generation against the context.
+        // Clamp instead of rejecting so lowering the context alone keeps working, and
+        // leave a non-positive context to the resolver so it reports that field.
+        let requestedMaxTokens =
+            contextSize.map { $0 > 0 ? min(maxTokens, $0) : maxTokens } ?? maxTokens
         let request = ChatRequest(
-            messages: messages, maxTokens: maxTokens, seed: seed, reasoningEffort: reasoningEffort,
+            messages: messages, maxTokens: requestedMaxTokens, seed: seed,
+            reasoningEffort: reasoningEffort,
             lora: lora, requiresJSON: responseFormat == .jsonObject, tools: tools,
             kvCacheMode: try resolveQ35KVCacheMode(for: modelID),
             maxContextTokens: contextSize, showUnmasking: showUnmasking

--- a/Sources/MereRunCLI/Commands/TextChatCommand.swift
+++ b/Sources/MereRunCLI/Commands/TextChatCommand.swift
@@ -315,92 +315,8 @@ struct TextChat: AsyncParsableCommand {
             lora = nil
         }
 
-        let recommendedSampling = Q35Resources.recommendedSampling(forModelId: model)
-        let isLaguna = LagunaResources.handles(modelSpec: normalizedModelId)
-        let isMuseGlimmer = MuseGlimmerResources.handles(modelSpec: normalizedModelId)
-        let isNemotronH = NemotronHResources.handles(modelSpec: normalizedModelId)
-        let isNemotronOmni = NemotronOmniResources.handles(modelSpec: normalizedModelId)
-        let isLFM2Vision = normalizedModelId == LFM2Resources.visionModelId
-        let q35KVCacheMode = try resolveQ35KVCacheMode(for: normalizedModelId)
-        if let contextSize, contextSize <= 0 {
-            throw ValidationError("--context-size must be greater than zero.")
-        }
-        let requiresJSON = responseFormat == .jsonObject
-        let resolvedTemperature: Double
-        if let temperature {
-            resolvedTemperature = temperature
-        } else if isLFM2Vision {
-            resolvedTemperature = 0.2
-        } else if isNemotronOmni {
-            resolvedTemperature = NemotronOmniResources.thinkingTemperature
-        } else if isNemotronH {
-            resolvedTemperature = NemotronHResources.recommendedTemperature
-        } else if isMuseGlimmer {
-            resolvedTemperature = MuseGlimmerResources.recommendedTemperature
-        } else if isLaguna {
-            resolvedTemperature = LagunaResources.recommendedTemperature
-        } else {
-            resolvedTemperature = recommendedSampling?.temperature ?? 0.7
-        }
-
-        let resolvedTopP: Double
-        if let topP {
-            resolvedTopP = topP
-        } else if isNemotronOmni {
-            resolvedTopP = NemotronOmniResources.thinkingTopP
-        } else if isNemotronH {
-            resolvedTopP = NemotronHResources.recommendedTopP
-        } else if isMuseGlimmer {
-            resolvedTopP = MuseGlimmerResources.recommendedTopP
-        } else if isLaguna {
-            resolvedTopP = LagunaResources.recommendedTopP
-        } else {
-            resolvedTopP = recommendedSampling?.topP ?? 0.9
-        }
-
-        let resolvedTopK: Int?
-        if let topK {
-            resolvedTopK = topK
-        } else if isLFM2Vision {
-            resolvedTopK = 50
-        } else if isMuseGlimmer {
-            resolvedTopK = MuseGlimmerResources.recommendedTopK
-        } else if isLaguna {
-            resolvedTopK = LagunaResources.recommendedTopK
-        } else {
-            resolvedTopK = recommendedSampling?.topK
-        }
-
-        let resolvedMinP = minP ?? (isLaguna ? LagunaResources.recommendedMinP : 0)
-        let resolvedShowThinking: Bool
-        if requiresJSON {
-            resolvedShowThinking = false
-        } else if let thinking {
-            resolvedShowThinking = thinking
-        } else if isNemotronOmni {
-            resolvedShowThinking = true
-        } else if isMuseGlimmer {
-            resolvedShowThinking = false
-        } else {
-            resolvedShowThinking = Q35Resources.thinkingDefault(forModelId: model)
-        }
-
-        let request = ChatRequest(
-            messages: messages,
-            maxTokens: maxTokens,
-            temperature: resolvedTemperature,
-            topP: resolvedTopP,
-            topK: resolvedTopK,
-            minP: resolvedMinP,
-            seed: seed,
-            reasoningEffort: reasoningEffort,
-            showThinking: resolvedShowThinking,
-            lora: lora,
-            requiresJSON: requiresJSON,
-            tools: toolDefs,
-            kvCacheMode: q35KVCacheMode,
-            maxContextTokens: contextSize,
-            showUnmasking: showUnmasking
+        let request = try resolvedChatRequest(
+            modelID: normalizedModelId, messages: messages, tools: toolDefs, lora: lora
         )
 
         let markdownPresentation = TerminalMarkdownPresentation.resolve(
@@ -427,283 +343,214 @@ struct TextChat: AsyncParsableCommand {
         var lastMuseDFlashStats: MuseGlimmerDFlashStats?
         var lastNemotronDSparkStats: NemotronHDSparkStats?
         var lastLFM2DSparkStats: LFM2DSparkStats?
-        let lagunaGenerator = isLaguna
-            ? LagunaGenerator(
-                dflashModelPath: LagunaResources.installedDFlashPath(
-                    for: normalizedModelId
-                )
-            )
-            : nil
-        let nemotronGenerator = isNemotronH ? NemotronHGenerator() : nil
-        let nemotronOmniGenerator = isNemotronOmni ? NemotronOmniGenerator() : nil
-        let lfm2Generator = LFM2Resources.handles(modelSpec: normalizedModelId)
-            ? LFM2Generator(
-                modelId: normalizedModelId.isEmpty
-                    ? LFM2Resources.defaultModelId
-                    : normalizedModelId
-            )
-            : nil
-
-        let chatOnce: (ChatRequest) async throws -> ChatResponse = { req in
-            if normalizedModelId == Psi3ChatResources.defaultModelId {
-                let generator = Psi3ChatGenerator(modelId: Psi3ChatResources.defaultModelId)
-                return try await generator.chat(req, modelPath: runtimeModelRoot, progressHandler: progressHandler)
-            } else if normalizedModelId == DiffusionGemmaResources.modelID {
-                let generator = DiffusionGemmaGenerator(modelID: normalizedModelId)
-                return try await generator.chat(
-                    req,
-                    modelPath: runtimeModelRoot,
-                    progressHandler: progressHandler
-                )
-            } else if Gemma4Resources.handles(modelSpec: normalizedModelId) {
-                let effectiveModelId = normalizedModelId.isEmpty ? Gemma4Resources.defaultModelId : normalizedModelId
-                let kvQuantization = try self.resolveGemma4KVCacheQuantization(for: effectiveModelId)
-                let generator = Gemma4Generator(
-                    modelId: effectiveModelId,
-                    kvCacheQuantization: kvQuantization
-                )
-                let response = try await generator.chat(req, modelPath: runtimeModelRoot, progressHandler: progressHandler)
-                lastGemma4MTPStats = await generator.mtpStats()
-                return response
-            } else if LagunaResources.handles(modelSpec: normalizedModelId) {
-                guard let lagunaModelPath = self.modelRoot ?? installedModelPath else {
-                    let requestedID = LagunaResources.managedModelID(for: normalizedModelId)
-                        ?? normalizedModelId
-                    throw ValidationError(
-                        "Model '\(requestedID)' is not installed. Run "
-                            + "'mere.run model pull \(requestedID)' first."
-                    )
-                }
-                guard let generator = lagunaGenerator else {
-                    throw LagunaError.modelNotLoaded
-                }
-                let response = try await generator.chat(
-                    req,
-                    modelPath: lagunaModelPath,
-                    progressHandler: progressHandler
-                )
-                lastLagunaDFlashStats = await generator.dflashStats()
-                return response
-            } else if ManagedModelCatalog.spec(for: normalizedModelId)?.validationKind == .codegenGGUF {
-                // GGUF chat models run through the llama.cpp engine (the same path
-                // `text code` uses). On Linux CUDA this is the GB10-optimized
-                // llama.cpp runtime, which has fast quantized-MoE kernels MLX lacks.
-                let generator = CodeGenGenerator(modelId: normalizedModelId)
-                return try await generator.chat(req, modelPath: runtimeModelRoot, progressHandler: progressHandler)
-            } else if InklingResources.handles(modelSpec: normalizedModelId) {
-                let generator = InklingGenerator(modelID: normalizedModelId)
-                return try await generator.chat(req, modelPath: runtimeModelRoot, progressHandler: progressHandler)
-            } else if MuseGlimmerResources.handles(modelSpec: normalizedModelId) {
-                let generator = MuseGlimmerGenerator(modelID: normalizedModelId)
-                let response = try await generator.chat(
-                    req,
-                    modelPath: runtimeModelRoot,
-                    progressHandler: progressHandler
-                )
-                lastMuseDFlashStats = await generator.dflashStats()
-                return response
-            } else if NemotronOmniResources.handles(modelSpec: normalizedModelId) {
-                guard let generator = nemotronOmniGenerator else {
-                    throw NemotronOmniError.generationFailed("generator is unavailable")
-                }
-                return try await generator.chat(
-                    req,
-                    modelPath: runtimeModelRoot,
-                    progressHandler: progressHandler
-                )
-            } else if NemotronHResources.handles(modelSpec: normalizedModelId) {
-                guard let generator = nemotronGenerator else {
-                    throw NemotronHError.generationFailed("generator is unavailable")
-                }
-                let response = try await generator.chat(
-                    req,
-                    modelPath: runtimeModelRoot,
-                    progressHandler: progressHandler
-                )
-                lastNemotronDSparkStats = await generator.dsparkStats()
-                return response
-            } else if LFM2Resources.handles(modelSpec: normalizedModelId) {
-                guard let generator = lfm2Generator else {
-                    throw LFM2Error.generationFailed("generator is unavailable")
-                }
-                let response = try await generator.chat(
-                    req,
-                    modelPath: runtimeModelRoot,
-                    progressHandler: progressHandler
-                )
-                lastLFM2DSparkStats = await generator.dsparkStats()
-                return response
-            } else {
-                let effectiveModelId = normalizedModelId.isEmpty ? Q35Resources.defaultModelId : normalizedModelId
-                let generator = Q35Generator(modelId: effectiveModelId)
-                return try await generator.chat(req, modelPath: runtimeModelRoot, progressHandler: progressHandler)
-            }
+        let runtime = try NativeChatRuntime.command(
+            modelID: normalizedModelId,
+            modelPath: LagunaResources.handles(modelSpec: normalizedModelId)
+                ? (modelRoot ?? installedModelPath) : runtimeModelRoot,
+            gemma4KVCacheQuantization: Gemma4Resources.handles(modelSpec: normalizedModelId)
+                ? resolveGemma4KVCacheQuantization(for: normalizedModelId) : Gemma4KVCacheQuantization()
+        )
+        let chatOnce: (ChatRequest) async throws -> ChatResponse = { request in
+            let response = try await runtime.chat(request, progressHandler: progressHandler)
+            let diagnostics = await runtime.diagnostics()
+            lastGemma4MTPStats = diagnostics.gemma4MTP
+            lastLagunaDFlashStats = diagnostics.lagunaDFlash
+            lastMuseDFlashStats = diagnostics.museDFlash
+            lastNemotronDSparkStats = diagnostics.nemotronDSpark
+            lastLFM2DSparkStats = diagnostics.lfm2DSpark
+            return response
         }
 
-        if toolLoop, let toolDefs, !toolDefs.isEmpty {
-            let sandbox: URL
-            if let sandboxDir {
-                sandbox = URL(fileURLWithPath: sandboxDir).standardizedFileURL
-            } else {
-                sandbox = FileManager.default.temporaryDirectory
-                    .appendingPathComponent("mererun-tools-\(ProcessInfo.processInfo.processIdentifier)")
-            }
-            try FileManager.default.createDirectory(at: sandbox, withIntermediateDirectories: true)
-            if !quiet { CLIStderr.write("[tool-loop] Sandbox: \(sandbox.path)\n") }
-            let toolPolicy = BuiltinTools.ToolExecutionPolicy(
-                sandboxDir: sandbox,
-                allowShellExec: allowShellExec,
-                allowAbsolutePaths: allowAbsoluteToolPaths
-            )
-
-            var loopMessages = messages
-            let maxIterations = 10
-
-            for iteration in 0..<maxIterations {
-                var req = request
-                req.messages = loopMessages
-
-                let result = try await chatOnce(req)
-
-                guard let calls = result.toolCalls, !calls.isEmpty else {
-                    if stream && streamingOutput.hasWritten {
-                        streamingOutput.finishLine()
-                    } else {
-                        print(cleanResponse(result.response, showThinking: request.showThinking))
-                    }
-                    return
-                }
-
-                // Show the model's response (may contain text before/after tool calls)
-                let textBeforeTools = result.response
-                    .replacingOccurrences(
-                        of: "<\\|tool_call>.*?<tool_call\\|>",
-                        with: "",
-                        options: String.CompareOptions.regularExpression
-                    )
-                    .trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
-                if !textBeforeTools.isEmpty {
-                    CLIStderr.write(cleanResponse(textBeforeTools, showThinking: request.showThinking) + "\n")
-                }
-
-                loopMessages.append(ChatMessage(
-                    role: .assistant,
-                    content: result.response,
-                    reasoningContent: result.reasoningContent
-                ))
-
-                for call in calls {
-                    if !quiet { CLIStderr.write("[tool] \(call.name)(\(call.arguments.map { "\($0.key)=\($0.value.prefix(80))" }.joined(separator: ", ")))\n") }
-                    let approved = BuiltinTools.canAutoApprove(call, autoApproveTools: autoApproveTools)
-                        || confirmToolCall(
-                            call,
-                            sandbox: sandbox,
-                            autoApproveToolsRequested: autoApproveTools
-                        )
-                    let output: String
-                    if approved {
-                        do {
-                            output = try BuiltinTools.execute(call, policy: toolPolicy)
-                        } catch {
-                            output = "Error: \(error.localizedDescription)"
-                        }
-                    } else {
-                        output = "Denied: tool execution was not approved."
-                    }
-                    if !quiet { CLIStderr.write("[tool] → \(output.prefix(200))\n") }
-                    loopMessages.append(ChatMessage(role: .tool, content: output, name: call.name))
-                }
-
-                if !quiet { CLIStderr.write("[tool-loop] Iteration \(iteration + 1)/\(maxIterations)\n") }
-            }
-
-            CLIStderr.write("[tool-loop] Hit iteration limit (\(maxIterations))\n")
-        } else {
-            let result = try await chatOnce(request)
-            let wroteStreamedOutput = stream && streamingOutput.hasWritten
-            if wroteStreamedOutput {
-                // Finalize terminal presentation before diagnostics so, for
-                // example, --stats cannot appear inside an open code fence.
-                streamingOutput.finishLine()
-            }
-
-            let elapsed = Date().timeIntervalSince(startTime)
-            if stats {
-                let e2eTps = elapsed > 0 ? Double(result.tokensGenerated) / elapsed : 0
-                if let timing = result.timing {
-                    let decodeTps = timing.decodeTokensPerSecond
-                        ?? (timing.decodeSeconds > 0 ? Double(result.tokensGenerated) / timing.decodeSeconds : 0)
-                    var line = String(
-                        format: "time=%.2fs load=%.2fs prefill=%.2fs decode=%.2fs tokens=%d decode_tps=%.2f e2e_tps=%.2f",
-                        elapsed,
-                        timing.loadSeconds,
-                        timing.prefillSeconds,
-                        timing.decodeSeconds,
-                        result.tokensGenerated,
-                        decodeTps,
-                        e2eTps
-                    )
-                    if let prefillTps = timing.prefillTokensPerSecond {
-                        line += String(format: " prefill_tps=%.2f", prefillTps)
-                    }
-                    if let firstToken = timing.firstTokenSeconds,
-                       let ttft = Self.ttftSeconds(for: timing) {
-                        line += String(format: " ttft_s=%.3f first_token_s=%.3f", ttft, firstToken)
-                    }
-                    if let diffusion = result.diffusion {
-                        line += String(
-                            format: " seed=%llu canvas_tokens=%d denoise_steps=%d work_tokens=%d canvas_tps=%.2f work_tps=%.2f",
-                            diffusion.seed,
-                            diffusion.canvasTokens,
-                            diffusion.denoisingSteps,
-                            diffusion.workTokens,
-                            diffusion.canvasTokensPerSecond,
-                            diffusion.workTokensPerSecond
-                        )
-                        if let firstDraftSeconds = diffusion.firstDraftSeconds {
-                            line += String(format: " first_draft_s=%.3f", firstDraftSeconds)
-                        }
-                    }
-                    CLIStderr.write("\(line)\n")
-                    if let mtp = lastGemma4MTPStats {
-                        CLIStderr.write(Self.formatGemma4MTPStats(mtp) + "\n")
-                    }
-                    if let dflash = lastLagunaDFlashStats {
-                        CLIStderr.write(Self.formatLagunaDFlashStats(dflash) + "\n")
-                    }
-                    if let dflash = lastMuseDFlashStats {
-                        CLIStderr.write(Self.formatMuseDFlashStats(dflash) + "\n")
-                    }
-                    if let dspark = lastNemotronDSparkStats {
-                        CLIStderr.write(Self.formatNemotronDSparkStats(dspark) + "\n")
-                    }
-                    if let dspark = lastLFM2DSparkStats {
-                        CLIStderr.write(Self.formatLFM2DSparkStats(dspark) + "\n")
-                    }
+        try await ChatGenerationOperation.withCleanup {
+            if toolLoop, let toolDefs, !toolDefs.isEmpty {
+                let sandbox: URL
+                if let sandboxDir {
+                    sandbox = URL(fileURLWithPath: sandboxDir).standardizedFileURL
                 } else {
-                    let line = String(format: "time=%.2fs tokens=%d tps=%.2f", elapsed, result.tokensGenerated, e2eTps)
-                    CLIStderr.write("\(line)\n")
-                    if let mtp = lastGemma4MTPStats {
-                        CLIStderr.write(Self.formatGemma4MTPStats(mtp) + "\n")
+                    sandbox = FileManager.default.temporaryDirectory
+                        .appendingPathComponent("mererun-tools-\(ProcessInfo.processInfo.processIdentifier)")
+                }
+                try FileManager.default.createDirectory(at: sandbox, withIntermediateDirectories: true)
+                if !quiet { CLIStderr.write("[tool-loop] Sandbox: \(sandbox.path)\n") }
+                let toolPolicy = BuiltinTools.ToolExecutionPolicy(
+                    sandboxDir: sandbox,
+                    allowShellExec: allowShellExec,
+                    allowAbsolutePaths: allowAbsoluteToolPaths
+                )
+
+                var loopMessages = messages
+                let maxIterations = 10
+
+                for iteration in 0..<maxIterations {
+                    var req = request
+                    req.messages = loopMessages
+
+                    let result = try await chatOnce(req)
+
+                    guard let calls = result.toolCalls, !calls.isEmpty else {
+                        if stream && streamingOutput.hasWritten {
+                            streamingOutput.finishLine()
+                        } else {
+                            print(cleanResponse(result.response, showThinking: request.showThinking))
+                        }
+                        return
                     }
-                    if let dflash = lastLagunaDFlashStats {
-                        CLIStderr.write(Self.formatLagunaDFlashStats(dflash) + "\n")
+
+                    // Show the model's response (may contain text before/after tool calls)
+                    let textBeforeTools = result.response
+                        .replacingOccurrences(
+                            of: "<\\|tool_call>.*?<tool_call\\|>",
+                            with: "",
+                            options: String.CompareOptions.regularExpression
+                        )
+                        .trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
+                    if !textBeforeTools.isEmpty {
+                        CLIStderr.write(cleanResponse(textBeforeTools, showThinking: request.showThinking) + "\n")
                     }
-                    if let dflash = lastMuseDFlashStats {
-                        CLIStderr.write(Self.formatMuseDFlashStats(dflash) + "\n")
+
+                    loopMessages.append(ChatMessage(
+                        role: .assistant,
+                        content: result.response,
+                        reasoningContent: result.reasoningContent
+                    ))
+
+                    for call in calls {
+                        if !quiet { CLIStderr.write("[tool] \(call.name)(\(call.arguments.map { "\($0.key)=\($0.value.prefix(80))" }.joined(separator: ", ")))\n") }
+                        let approved = BuiltinTools.canAutoApprove(call, autoApproveTools: autoApproveTools)
+                            || confirmToolCall(
+                                call,
+                                sandbox: sandbox,
+                                autoApproveToolsRequested: autoApproveTools
+                            )
+                        let output: String
+                        if approved {
+                            do {
+                                output = try BuiltinTools.execute(call, policy: toolPolicy)
+                            } catch {
+                                output = "Error: \(error.localizedDescription)"
+                            }
+                        } else {
+                            output = "Denied: tool execution was not approved."
+                        }
+                        if !quiet { CLIStderr.write("[tool] → \(output.prefix(200))\n") }
+                        loopMessages.append(ChatMessage(role: .tool, content: output, name: call.name))
                     }
-                    if let dspark = lastNemotronDSparkStats {
-                        CLIStderr.write(Self.formatNemotronDSparkStats(dspark) + "\n")
-                    }
-                    if let dspark = lastLFM2DSparkStats {
-                        CLIStderr.write(Self.formatLFM2DSparkStats(dspark) + "\n")
+
+                    if !quiet { CLIStderr.write("[tool-loop] Iteration \(iteration + 1)/\(maxIterations)\n") }
+                }
+
+                CLIStderr.write("[tool-loop] Hit iteration limit (\(maxIterations))\n")
+            } else {
+                let result = try await chatOnce(request)
+                let wroteStreamedOutput = stream && streamingOutput.hasWritten
+                if wroteStreamedOutput {
+                    // Finalize terminal presentation before diagnostics so, for
+                    // example, --stats cannot appear inside an open code fence.
+                    streamingOutput.finishLine()
+                }
+
+                let elapsed = Date().timeIntervalSince(startTime)
+                if stats {
+                    let e2eTps = elapsed > 0 ? Double(result.tokensGenerated) / elapsed : 0
+                    if let timing = result.timing {
+                        let decodeTps = timing.decodeTokensPerSecond
+                            ?? (timing.decodeSeconds > 0 ? Double(result.tokensGenerated) / timing.decodeSeconds : 0)
+                        var line = String(
+                            format: "time=%.2fs load=%.2fs prefill=%.2fs decode=%.2fs tokens=%d decode_tps=%.2f e2e_tps=%.2f",
+                            elapsed,
+                            timing.loadSeconds,
+                            timing.prefillSeconds,
+                            timing.decodeSeconds,
+                            result.tokensGenerated,
+                            decodeTps,
+                            e2eTps
+                        )
+                        if let prefillTps = timing.prefillTokensPerSecond {
+                            line += String(format: " prefill_tps=%.2f", prefillTps)
+                        }
+                        if let firstToken = timing.firstTokenSeconds,
+                           let ttft = Self.ttftSeconds(for: timing) {
+                            line += String(format: " ttft_s=%.3f first_token_s=%.3f", ttft, firstToken)
+                        }
+                        if let diffusion = result.diffusion {
+                            line += String(
+                                format: " seed=%llu canvas_tokens=%d denoise_steps=%d work_tokens=%d canvas_tps=%.2f work_tps=%.2f",
+                                diffusion.seed,
+                                diffusion.canvasTokens,
+                                diffusion.denoisingSteps,
+                                diffusion.workTokens,
+                                diffusion.canvasTokensPerSecond,
+                                diffusion.workTokensPerSecond
+                            )
+                            if let firstDraftSeconds = diffusion.firstDraftSeconds {
+                                line += String(format: " first_draft_s=%.3f", firstDraftSeconds)
+                            }
+                        }
+                        CLIStderr.write("\(line)\n")
+                        if let mtp = lastGemma4MTPStats {
+                            CLIStderr.write(Self.formatGemma4MTPStats(mtp) + "\n")
+                        }
+                        if let dflash = lastLagunaDFlashStats {
+                            CLIStderr.write(Self.formatLagunaDFlashStats(dflash) + "\n")
+                        }
+                        if let dflash = lastMuseDFlashStats {
+                            CLIStderr.write(Self.formatMuseDFlashStats(dflash) + "\n")
+                        }
+                        if let dspark = lastNemotronDSparkStats {
+                            CLIStderr.write(Self.formatNemotronDSparkStats(dspark) + "\n")
+                        }
+                        if let dspark = lastLFM2DSparkStats {
+                            CLIStderr.write(Self.formatLFM2DSparkStats(dspark) + "\n")
+                        }
+                    } else {
+                        let line = String(format: "time=%.2fs tokens=%d tps=%.2f", elapsed, result.tokensGenerated, e2eTps)
+                        CLIStderr.write("\(line)\n")
+                        if let mtp = lastGemma4MTPStats {
+                            CLIStderr.write(Self.formatGemma4MTPStats(mtp) + "\n")
+                        }
+                        if let dflash = lastLagunaDFlashStats {
+                            CLIStderr.write(Self.formatLagunaDFlashStats(dflash) + "\n")
+                        }
+                        if let dflash = lastMuseDFlashStats {
+                            CLIStderr.write(Self.formatMuseDFlashStats(dflash) + "\n")
+                        }
+                        if let dspark = lastNemotronDSparkStats {
+                            CLIStderr.write(Self.formatNemotronDSparkStats(dspark) + "\n")
+                        }
+                        if let dspark = lastLFM2DSparkStats {
+                            CLIStderr.write(Self.formatLFM2DSparkStats(dspark) + "\n")
+                        }
                     }
                 }
-            }
 
-            if !wroteStreamedOutput {
-                print(cleanResponse(result.response, showThinking: request.showThinking))
+                if !wroteStreamedOutput {
+                    print(cleanResponse(result.response, showThinking: request.showThinking))
+                }
             }
+        } cleanup: {
+            await runtime.unload()
+        }
+
+    }
+
+    func resolvedChatRequest(
+        modelID: String, messages: [ChatMessage], tools: [ToolDefinition]? = nil, lora: LoRA? = nil
+    ) throws -> ChatRequest {
+        let request = ChatRequest(
+            messages: messages, maxTokens: maxTokens, seed: seed, reasoningEffort: reasoningEffort,
+            lora: lora, requiresJSON: responseFormat == .jsonObject, tools: tools,
+            kvCacheMode: try resolveQ35KVCacheMode(for: modelID),
+            maxContextTokens: contextSize, showUnmasking: showUnmasking
+        )
+        do {
+            return try ChatRequestResolver.resolve(
+                request, modelID: modelID,
+                sampling: ChatSamplingOptions(
+                    temperature: temperature, topP: topP, topK: topK, minP: minP, thinking: thinking
+                ), policy: .command
+            )
+        } catch let issue as ChatRequestIssue {
+            throw ValidationError(issue.localizedDescription)
         }
     }
 
@@ -799,6 +646,14 @@ struct TextChat: AsyncParsableCommand {
                     message: "\(label) file not found: \(url.path)"
                 ))
             }
+        }
+        do {
+            _ = try resolvedChatRequest(modelID: modelID, messages: [ChatMessage(role: .user, content: prompt)])
+        } catch {
+            diagnostics.append(.init(
+                id: "text_chat_request_invalid", severity: .blocker,
+                title: "Invalid chat request", message: error.localizedDescription
+            ))
         }
         return TextChatPreflightReport(
             schemaVersion: 1,

--- a/Sources/MereRunCLI/Support/APIServer.swift
+++ b/Sources/MereRunCLI/Support/APIServer.swift
@@ -440,68 +440,32 @@ actor CodeGenServer {
             return makeErrorResponse(status: .badRequest, message: "Invalid request payload.", type: "invalid_request_error")
         }
 
-        let admissionLease = try await requestAdmission.acquire()
-        let plan: RuntimeChatPlan
+        let session: RuntimeChatSession
         do {
-            plan = try await pool.makeChatPlan(
-                for: openaiRequest,
-                fallbackLoraPath: fallbackLoraPath,
-                serverContextSize: contextSize
+            session = try await services.startChat(
+                openaiRequest, fallbackLoraPath: fallbackLoraPath, contextSize: contextSize
             )
         } catch {
-            await admissionLease.release()
             return runtimeErrorResponse(error)
         }
-        await admissionLease.configure(
-            modelID: plan.modelID,
-            streaming: openaiRequest.stream == true,
-            requestedMaxTokens: plan.request.maxTokens,
-            toolCount: plan.request.tools?.count ?? 0
-        )
-
-        if plan.engine == .textChatDeepseekV4Flash {
-            do {
-                return try await proxyDeepseekV4FlashChatCompletions(
-                    body: body,
-                    contentType: request.headers[.contentType],
-                    lease: plan.lease,
-                    admissionLease: admissionLease
-                )
-            } catch {
-                await plan.lease.release()
-                await admissionLease.release()
-                return makeErrorResponse(status: .internalServerError, message: "Request failed.", type: "server_error")
-            }
-        }
 
         do {
-            if openaiRequest.stream == true {
-                return try await handleStreamingChat(
-                    plan.request,
-                    modelID: plan.modelID,
-                    includeUsage: plan.includeUsage,
-                    lease: plan.lease,
-                    admissionLease: admissionLease
-                )
-            } else {
-                return handleNonStreamingChat(
-                    plan.request,
-                    modelID: plan.modelID,
-                    lease: plan.lease,
-                    admissionLease: admissionLease
+            if session.engine == .textChatDeepseekV4Flash {
+                return try await proxyDeepseekV4FlashChatCompletions(
+                    body: body, contentType: request.headers[.contentType], session: session
                 )
             }
+            if openaiRequest.stream == true {
+                return try await handleStreamingChat(session)
+            }
+            return handleNonStreamingChat(session)
         } catch let error as APIRequestValidationError {
-            await plan.lease.release()
-            await admissionLease.release()
+            await session.finish(cancelled: Task.isCancelled)
             return makeErrorResponse(
-                status: .badRequest,
-                message: error.localizedDescription,
-                type: "invalid_request_error"
+                status: .badRequest, message: error.localizedDescription, type: "invalid_request_error"
             )
         } catch {
-            await plan.lease.release()
-            await admissionLease.release()
+            await session.finish(cancelled: Task.isCancelled || error is CancellationError)
             return makeErrorResponse(status: .internalServerError, message: "Request failed.", type: "server_error")
         }
     }
@@ -1299,12 +1263,9 @@ actor CodeGenServer {
         }
     }
 
-    private func handleNonStreamingChat(
-        _ request: ChatRequest,
-        modelID: String,
-        lease: RuntimeModelLease,
-        admissionLease: RuntimeRequestAdmissionLease
-    ) -> Response {
+    private func handleNonStreamingChat(_ session: RuntimeChatSession) -> Response {
+        let request = session.request
+        let modelID = session.modelID
         let (stream, continuation) = AsyncStream<NonStreamingChatEvent>.makeStream()
         let heartbeatTask = Task<Void, Never> {
             do {
@@ -1319,9 +1280,7 @@ actor CodeGenServer {
         }
         let generationTask = Task {
             do {
-                let result = try await lease.chat(request) { progress in
-                    admissionLease.observe(progress)
-                }
+                let result = try await session.chat()
                 let responseToolCalls = openAIToolCalls(
                     from: result.toolCalls,
                     tools: request.tools,
@@ -1358,8 +1317,7 @@ actor CodeGenServer {
                 let data = try JSONEncoder().encode(response)
                 var trailers = Self.openAITimingHeaders(for: result)
                 trailers["x-mere-runtime-status"] = "200"
-                await lease.release()
-                await admissionLease.release()
+                await session.finish()
                 heartbeatTask.cancel()
                 continuation.yield(.completion(NonStreamingChatPayload(
                     data: data,
@@ -1367,8 +1325,7 @@ actor CodeGenServer {
                 )))
                 continuation.finish()
             } catch {
-                await lease.release()
-                await admissionLease.release(
+                await session.finish(
                     cancelled: Task.isCancelled || error is CancellationError
                 )
                 heartbeatTask.cancel()
@@ -1386,7 +1343,7 @@ actor CodeGenServer {
         }
         continuation.onTermination = { termination in
             if case .cancelled = termination {
-                admissionLease.observeClientDisconnect()
+                session.observeClientDisconnect()
                 heartbeatTask.cancel()
                 generationTask.cancel()
             }
@@ -1397,7 +1354,7 @@ actor CodeGenServer {
             .trailer: Self.openAITimingTrailerNames.joined(separator: ", "),
         ]
         if let requestIDName = HTTPField.Name("x-mere-request-id") {
-            headers[requestIDName] = admissionLease.requestID.uuidString
+            headers[requestIDName] = session.requestID.uuidString
         }
 
         return Response(
@@ -1421,7 +1378,7 @@ actor CodeGenServer {
                     }
                     try await writer.finish(nil)
                 } catch {
-                    admissionLease.observeClientDisconnect()
+                    session.observeClientDisconnect()
                     heartbeatTask.cancel()
                     generationTask.cancel()
                     throw error
@@ -1717,10 +1674,9 @@ actor CodeGenServer {
     private func proxyDeepseekV4FlashChatCompletions(
         body: ByteBuffer,
         contentType: String?,
-        lease: RuntimeModelLease,
-        admissionLease: RuntimeRequestAdmissionLease
+        session: RuntimeChatSession
     ) async throws -> Response {
-        let upstreamURL = try await lease.deepseekChatCompletionsURL(progressHandler: nil)
+        let upstreamURL = try await session.deepseekChatCompletionsURL()
         let data = Data(body.readableBytesView)
 
         if !DeepseekV4FlashClient.requestWantsStreamingResponse(data) {
@@ -1732,12 +1688,10 @@ actor CodeGenServer {
                     contentType: contentType
                 )
             } catch {
-                await lease.release()
-                await admissionLease.release()
+                await session.finish()
                 throw error
             }
-            await lease.release()
-            await admissionLease.release()
+            await session.finish()
             var headers: HTTPFields = [:]
             headers[.contentType] = upstreamResponse.contentType
             return Response(
@@ -1760,13 +1714,10 @@ actor CodeGenServer {
         if DeepseekV4FlashClient.isEventStreamContentType(headers[.contentType]) {
             headers[.init("Cache-Control")!] = "no-cache"
             headers[.connection] = "keep-alive"
+            await session.finish()
             let stream = AsyncStream<ByteBuffer> { continuation in
                 if !upstreamData.isEmpty {
                     continuation.yield(ByteBuffer(bytes: upstreamData))
-                }
-                Task {
-                    await lease.release()
-                    await admissionLease.release()
                 }
                 continuation.finish()
             }
@@ -1780,8 +1731,7 @@ actor CodeGenServer {
             upstreamData,
             contentType: headers[.contentType]
         )
-        await lease.release()
-        await admissionLease.release()
+        await session.finish()
         return Response(
             status: .init(code: http?.statusCode ?? 502),
             headers: headers,
@@ -1795,31 +1745,7 @@ actor CodeGenServer {
         if DeepseekV4FlashClient.isEventStreamContentType(headers[.contentType]) {
             headers[.init("Cache-Control")!] = "no-cache"
             headers[.connection] = "keep-alive"
-            let stream = AsyncStream<ByteBuffer> { continuation in
-                Task {
-                    var buffer = Data()
-                    buffer.reserveCapacity(4_096)
-                    do {
-                        for try await byte in upstreamBytes {
-                            buffer.append(byte)
-                            if byte == 10 || buffer.count >= 4_096 {
-                                continuation.yield(ByteBuffer(bytes: buffer))
-                                buffer.removeAll(keepingCapacity: true)
-                            }
-                        }
-                        if !buffer.isEmpty {
-                            continuation.yield(ByteBuffer(bytes: buffer))
-                        }
-                        await lease.release()
-                        await admissionLease.release()
-                        continuation.finish()
-                    } catch {
-                        await lease.release()
-                        await admissionLease.release()
-                        continuation.finish()
-                    }
-                }
-            }
+            let stream = RuntimeChatProxyStream.make(from: upstreamBytes, session: session)
             return Response(
                 status: .init(code: http?.statusCode ?? 502),
                 headers: headers,
@@ -1833,12 +1759,10 @@ actor CodeGenServer {
                 upstreamData.append(byte)
             }
         } catch {
-            await lease.release()
-            await admissionLease.release()
+            await session.finish()
             throw error
         }
-        await lease.release()
-        await admissionLease.release()
+        await session.finish()
         let repairedData = DeepseekV4FlashClient.normalizedChatCompletionBody(
             upstreamData,
             contentType: headers[.contentType]
@@ -1851,13 +1775,10 @@ actor CodeGenServer {
 #endif
     }
 
-    private func handleStreamingChat(
-        _ request: ChatRequest,
-        modelID: String,
-        includeUsage: Bool,
-        lease: RuntimeModelLease,
-        admissionLease: RuntimeRequestAdmissionLease
-    ) async throws -> Response {
+    private func handleStreamingChat(_ session: RuntimeChatSession) async throws -> Response {
+        let request = session.request
+        let modelID = session.modelID
+        let includeUsage = session.includeUsage
         let id = "chatcmpl-\(UUID().uuidString.prefix(8))"
         let encoder = JSONEncoder()
 
@@ -1870,8 +1791,7 @@ actor CodeGenServer {
             do {
                 let streamedContent = StreamingContentTracker()
                 let shouldBufferForToolCalls = request.tools?.isEmpty == false
-                let result = try await lease.chat(request) { progress in
-                    admissionLease.observe(progress)
+                let result = try await session.chat { progress in
                     guard !shouldBufferForToolCalls else { return }
                     if let diffusion = progress.diffusion {
                         let chunk = OpenAIChatResponse(
@@ -2002,8 +1922,7 @@ actor CodeGenServer {
                 }
 
                 continuation.yield(ByteBuffer(string: "data: [DONE]\n\n"))
-                await lease.release()
-                await admissionLease.release()
+                await session.finish()
                 continuation.finish()
             } catch {
                 if !Task.isCancelled {
@@ -2015,8 +1934,7 @@ actor CodeGenServer {
                         continuation.yield(ByteBuffer(string: "data: \(json)\n\n"))
                     }
                 }
-                await lease.release()
-                await admissionLease.release(
+                await session.finish(
                     cancelled: Task.isCancelled || error is CancellationError
                 )
                 continuation.finish()
@@ -2025,7 +1943,7 @@ actor CodeGenServer {
         continuation.onTermination = { termination in
             heartbeatTask.cancel()
             if case .cancelled = termination {
-                admissionLease.observeClientDisconnect()
+                session.observeClientDisconnect()
                 generationTask.cancel()
             }
         }

--- a/Sources/MereRunCLI/Support/APIServerContract.swift
+++ b/Sources/MereRunCLI/Support/APIServerContract.swift
@@ -1973,15 +1973,11 @@ enum APIServerContract {
             )
         }
 
-        let maxTokens = try validateMaxTokens(
+        let maxTokens = try resolveMaxTokens(
             maxTokens: openaiRequest.max_tokens,
             maxCompletionTokens: openaiRequest.max_completion_tokens,
-            contextSize: contextSize,
             capabilities: capabilities
         )
-        let temperature = try validateTemperature(openaiRequest.temperature)
-        let topP = try validateTopP(openaiRequest.top_p)
-        let minP = try validateMinP(openaiRequest.min_p)
         let tools = try toolDefinitions(from: openaiRequest, capabilities: capabilities)
         let toolChoice = try chatToolChoice(from: openaiRequest, capabilities: capabilities)
         let parallelToolCalls = openaiRequest.parallel_tool_calls ?? true
@@ -2019,8 +2015,6 @@ enum APIServerContract {
         let laneModelID = servedModelID ?? ""
         let resolvedAPIProfile = apiProfile
             ?? servedModelID.flatMap { ManagedModelCatalog.apiProfile(for: $0) }
-        let recommendedSampling = Q35Resources.recommendedSampling(forModelId: laneModelID)
-        let isLaguna = LagunaResources.handles(modelSpec: laneModelID)
         let reasoningEffort = try reasoningEffort(
             from: openaiRequest.reasoning_effort,
             capabilities: capabilities,
@@ -2051,31 +2045,14 @@ enum APIServerContract {
             }
         }
 
-        return ChatRequest(
+        let request = ChatRequest(
             messages: messages,
             maxTokens: maxTokens,
-            temperature: openaiRequest.temperature == nil
-                ? (isLaguna ? LagunaResources.recommendedTemperature : recommendedSampling?.temperature)
-                    ?? temperature
-                : temperature,
-            topP: openaiRequest.top_p == nil
-                ? (isLaguna ? LagunaResources.recommendedTopP : recommendedSampling?.topP)
-                    ?? topP
-                : topP,
-            topK: openaiRequest.top_k
-                ?? (isLaguna ? LagunaResources.recommendedTopK : recommendedSampling?.topK),
-            minP: openaiRequest.min_p == nil && isLaguna
-                ? LagunaResources.recommendedMinP
-                : minP,
             presencePenalty: openaiRequest.presence_penalty ?? 0,
             frequencyPenalty: openaiRequest.frequency_penalty ?? 0,
             repetitionPenalty: openaiRequest.repetition_penalty ?? 1,
             seed: openaiRequest.seed.map(UInt64.init),
             reasoningEffort: reasoningEffort,
-            showThinking: requiresJSON
-                ? false
-                : Q35Resources.thinkingDefault(forModelId: laneModelID)
-                    || resolvedAPIProfile?.thinkingLevels == [.high],
             lora: lora,
             requiresJSON: requiresJSON,
             tools: tools,
@@ -2086,7 +2063,21 @@ enum APIServerContract {
             logprobCapture: logprobCapture,
             showUnmasking: openaiRequest.mere_show_unmasking == true
         )
+        do {
+            let resolved = try ChatRequestResolver.resolve(
+                request, modelID: laneModelID,
+                sampling: ChatSamplingOptions(
+                    temperature: openaiRequest.temperature, topP: openaiRequest.top_p,
+                    topK: openaiRequest.top_k, minP: openaiRequest.min_p
+                ), policy: .openAI, apiProfile: resolvedAPIProfile
+            )
+            try validateSamplingCapabilities(openaiRequest, capabilities: capabilities)
+            return resolved
+        } catch let issue as ChatRequestIssue {
+            throw APIRequestValidationError.invalidField(issue.field, issue.message)
+        }
     }
+
 
     static func includeUsageInStreaming(
         _ openaiRequest: OpenAIChatRequest,
@@ -2295,13 +2286,6 @@ enum APIServerContract {
         if let seed = request.seed, seed < 0 {
             throw APIRequestValidationError.invalidField("seed", "must be an unsigned integer")
         }
-        try validateSamplingControls(request, capabilities: capabilities)
-        if let penalty = request.presence_penalty, penalty != 0, !capabilities.supportsPenalties {
-            throw APIRequestValidationError.invalidField("presence_penalty", "presence penalties are not supported by this engine")
-        }
-        if let penalty = request.frequency_penalty, penalty != 0, !capabilities.supportsPenalties {
-            throw APIRequestValidationError.invalidField("frequency_penalty", "frequency penalties are not supported by this engine")
-        }
         if request.logprobs == true, !capabilities.supportsLogprobs {
             throw APIRequestValidationError.invalidField("logprobs", "token log probabilities are not supported by this engine")
         }
@@ -2508,10 +2492,9 @@ enum APIServerContract {
         }
     }
 
-    private static func validateMaxTokens(
+    private static func resolveMaxTokens(
         maxTokens: Int?,
         maxCompletionTokens: Int?,
-        contextSize: Int,
         capabilities: APIEngineCapabilities
     ) throws -> Int {
         if maxCompletionTokens != nil, !capabilities.supportsMaxCompletionTokens {
@@ -2526,7 +2509,7 @@ enum APIServerContract {
                 "must match max_tokens when both are provided"
             )
         }
-        return try validateMaxTokens(maxCompletionTokens ?? maxTokens, contextSize: contextSize)
+        return maxCompletionTokens ?? maxTokens ?? defaultMaxTokens
     }
 
     private static func reasoningEffort(
@@ -2595,73 +2578,24 @@ enum APIServerContract {
         }
     }
 
-    private static func validateMaxTokens(_ rawValue: Int?, contextSize: Int) throws -> Int {
-        let value = rawValue ?? defaultMaxTokens
-        let upperBound = min(contextSize, Int(Int32.max))
-        guard upperBound > 0 else {
-            throw APIRequestValidationError.invalidField("context_size", "must be greater than zero")
-        }
-        guard (1...upperBound).contains(value) else {
-            throw APIRequestValidationError.invalidField(
-                "max_tokens",
-                "must be between 1 and \(upperBound)"
-            )
-        }
-        return value
-    }
-
-    private static func validateSamplingControls(
+    private static func validateSamplingCapabilities(
         _ request: OpenAIChatRequest,
         capabilities: APIEngineCapabilities
     ) throws {
-        if let topK = request.top_k {
-            guard topK >= 0 else {
-                throw APIRequestValidationError.invalidField("top_k", "must be zero or greater")
-            }
-            if topK != 0, !capabilities.supportsTopK {
-                throw APIRequestValidationError.invalidField("top_k", "top-k sampling is not supported by this engine")
-            }
+        if let topK = request.top_k, topK != 0, !capabilities.supportsTopK {
+            throw APIRequestValidationError.invalidField("top_k", "top-k sampling is not supported by this engine")
         }
-        for (field, value) in [("presence_penalty", request.presence_penalty),
-                               ("frequency_penalty", request.frequency_penalty)] {
-            if let value, !value.isFinite || !(-2...2).contains(value) {
-                throw APIRequestValidationError.invalidField(field, "must be between -2 and 2")
-            }
+        if let penalty = request.presence_penalty, penalty != 0, !capabilities.supportsPenalties {
+            throw APIRequestValidationError.invalidField("presence_penalty", "presence penalties are not supported by this engine")
         }
-        if let penalty = request.repetition_penalty {
-            guard penalty.isFinite, Float(penalty).isFinite, Float(penalty) > 0 else {
-                throw APIRequestValidationError.invalidField("repetition_penalty", "must be a finite positive sampler value")
-            }
-            if penalty != 1, !capabilities.supportsRepetitionPenalty {
-                throw APIRequestValidationError.invalidField(
-                    "repetition_penalty", "repetition penalties are not supported by this engine"
-                )
-            }
+        if let penalty = request.frequency_penalty, penalty != 0, !capabilities.supportsPenalties {
+            throw APIRequestValidationError.invalidField("frequency_penalty", "frequency penalties are not supported by this engine")
         }
-    }
-
-    private static func validateTemperature(_ rawValue: Double?) throws -> Double {
-        let value = rawValue ?? 1.0
-        guard value.isFinite, (0...2).contains(value) else {
-            throw APIRequestValidationError.invalidField("temperature", "must be between 0 and 2")
+        if let penalty = request.repetition_penalty, penalty != 1, !capabilities.supportsRepetitionPenalty {
+            throw APIRequestValidationError.invalidField(
+                "repetition_penalty", "repetition penalties are not supported by this engine"
+            )
         }
-        return value
-    }
-
-    private static func validateTopP(_ rawValue: Double?) throws -> Double {
-        let value = rawValue ?? 0.95
-        guard value.isFinite, (0...1).contains(value) else {
-            throw APIRequestValidationError.invalidField("top_p", "must be between 0 and 1")
-        }
-        return value
-    }
-
-    private static func validateMinP(_ rawValue: Double?) throws -> Double {
-        let value = rawValue ?? 0
-        guard value.isFinite, (0...1).contains(value) else {
-            throw APIRequestValidationError.invalidField("min_p", "must be between 0 and 1")
-        }
-        return value
     }
 
     private static func imageSize(from rawValue: String?) throws -> (width: Int, height: Int) {

--- a/Sources/MereRunCLI/Support/README.md
+++ b/Sources/MereRunCLI/Support/README.md
@@ -23,7 +23,11 @@ Shared helpers and runtime adapters for the public command surface.
 - `RuntimeModelPool.swift` and `APISidecarModelPool.swift`: loaded-model
   runtime adapters, batching, and caches over `MereRunResidency`.
 - `RuntimeServingServices.swift`: text/media composition, pressure coordination,
-  request admission, maintenance, and transcription service ownership.
+  request admission, maintenance, and chat/transcription service ownership.
+- `RuntimeChatSession.swift`: paired model and admission leases for one chat
+  request, with awaited release after generation or proxy consumption.
+- `RuntimeChatProxyStream.swift`: upstream byte streaming and cancellation
+  when the downstream consumer disconnects.
 - `APITranscription.swift` and `CLIASRRouting.swift`: API policy and CLI
   presentation adapters over the shared speech resolver, operation, and optional
   durable records.

--- a/Sources/MereRunCLI/Support/RuntimeChatProxyStream.swift
+++ b/Sources/MereRunCLI/Support/RuntimeChatProxyStream.swift
@@ -1,0 +1,39 @@
+import Foundation
+import NIOCore
+
+enum RuntimeChatProxyStream {
+    /// Keeps the upstream producer and both request leases attached to the
+    /// downstream stream. Cancelling its consumer also cancels upstream reads.
+    static func make<Source: AsyncSequence & Sendable>(
+        from source: Source, session: RuntimeChatSession
+    ) -> AsyncStream<ByteBuffer> where Source.Element == UInt8 {
+        AsyncStream { continuation in
+            let producer = Task {
+                var buffer = Data()
+                buffer.reserveCapacity(4_096)
+                do {
+                    for try await byte in source {
+                        try Task.checkCancellation()
+                        buffer.append(byte)
+                        if byte == 10 || buffer.count >= 4_096 {
+                            continuation.yield(ByteBuffer(bytes: buffer))
+                            buffer.removeAll(keepingCapacity: true)
+                        }
+                    }
+                    try Task.checkCancellation()
+                    if !buffer.isEmpty { continuation.yield(ByteBuffer(bytes: buffer)) }
+                    await session.finish()
+                } catch {
+                    await session.finish(cancelled: Task.isCancelled || error is CancellationError)
+                }
+                continuation.finish()
+            }
+            continuation.onTermination = { termination in
+                if case .cancelled = termination {
+                    session.observeClientDisconnect()
+                    producer.cancel()
+                }
+            }
+        }
+    }
+}

--- a/Sources/MereRunCLI/Support/RuntimeChatSession.swift
+++ b/Sources/MereRunCLI/Support/RuntimeChatSession.swift
@@ -1,0 +1,67 @@
+import Foundation
+import MereRunCore
+
+protocol RuntimeChatModelLease: Sendable {
+    func chat(_ request: ChatRequest, progressHandler: (@Sendable (ChatProgress) -> Void)?) async throws -> ChatResponse
+    func deepseekChatCompletionsURL(progressHandler: (@Sendable (ChatProgress) -> Void)?) async throws -> URL
+    func release() async
+}
+
+/// One admitted request and its resident model. HTTP response producers retain
+/// this session until generation or proxy consumption ends, including errors.
+final class RuntimeChatSession: @unchecked Sendable {
+    let request: ChatRequest
+    let modelID: String
+    let engine: RuntimeServingEngine
+    let includeUsage: Bool
+    var requestID: UUID { admission.requestID }
+
+    private let model: any RuntimeChatModelLease
+    private let admission: RuntimeRequestAdmissionLease
+    private let lock = NSLock()
+    private var completion: Task<Void, Never>?
+
+    init(plan: RuntimeChatPlan, admission: RuntimeRequestAdmissionLease) {
+        self.request = plan.request
+        self.modelID = plan.modelID
+        self.engine = plan.engine
+        self.includeUsage = plan.includeUsage
+        self.model = plan.lease
+        self.admission = admission
+    }
+
+    deinit { _ = completionTask(cancelled: true) }
+
+    func chat(progressHandler: (@Sendable (ChatProgress) -> Void)? = nil) async throws -> ChatResponse {
+        let admission = admission
+        return try await model.chat(request) { progress in
+            admission.observe(progress)
+            progressHandler?(progress)
+        }
+    }
+
+    func deepseekChatCompletionsURL() async throws -> URL {
+        try Task.checkCancellation()
+        return try await model.deepseekChatCompletionsURL(progressHandler: nil)
+    }
+
+    func observeClientDisconnect() { admission.observeClientDisconnect() }
+
+    func finish(cancelled: Bool = false) async {
+        await completionTask(cancelled: cancelled || Task.isCancelled).value
+    }
+
+    private func completionTask(cancelled: Bool) -> Task<Void, Never> {
+        lock.withLock {
+            if let completion { return completion }
+            let model = model
+            let admission = admission
+            let task = Task {
+                await model.release()
+                await admission.release(cancelled: cancelled)
+            }
+            completion = task
+            return task
+        }
+    }
+}

--- a/Sources/MereRunCLI/Support/RuntimeModelPool.swift
+++ b/Sources/MereRunCLI/Support/RuntimeModelPool.swift
@@ -515,7 +515,7 @@ struct RuntimeModelStartupTiming: Codable, Equatable, Sendable {
 }
 
 struct RuntimeChatPlan: Sendable {
-    let lease: RuntimeModelLease
+    let lease: any RuntimeChatModelLease
     let request: ChatRequest
     let modelID: String
     let engine: RuntimeServingEngine
@@ -1166,84 +1166,31 @@ actor RuntimeModelPool {
     }
 
     private nonisolated func makeLoadedModel(for resolved: ResolvedModel) -> RuntimeLoadedModel {
+        let prefixCache: Bool?
+        let batching: Bool?
         switch resolved.engine {
-        case .textCode:
-            return .textCode(
-                CodeGenGenerator(modelId: resolved.id),
-                modelPath: resolved.installPath
-            )
-        case .textChatKlein:
-            let useStandalone = resolved.id == ModelResolver.ModelID.mebot.rawValue
-                && resolved.installPath == MeBotModelCatalog.resolveModelPath()
-            return .textChatKlein(
-                Flux2KleinGenerator(),
-                modelPath: resolved.installPath,
-                useStandalone: useStandalone
-            )
         case .textChatGemma4:
-            return .textChatGemma4(
-                Gemma4Generator(
-                    modelId: resolved.id,
-                    kvCacheQuantization: gemma4KVCacheQuantization,
-                    prefixKVCacheEnabled: gemma4PrefixKVCacheEnabled,
-                    continuousBatchingEnabled: gemma4ContinuousBatchingEnabled
-                ),
-                modelPath: resolved.installPath
-            )
-        case .textChatDiffusionGemma:
-            return .textChatDiffusionGemma(
-                DiffusionGemmaGenerator(modelID: resolved.id),
-                modelPath: resolved.installPath
-            )
+            prefixCache = gemma4PrefixKVCacheEnabled
+            batching = gemma4ContinuousBatchingEnabled
         case .textChatLaguna:
-            return .textChatLaguna(
-                LagunaGenerator(
-                    continuousBatchingEnabled: lagunaContinuousBatchingEnabled,
-                    dflashModelPath: LagunaResources.installedDFlashPath(
-                        for: resolved.id
-                    )
-                ),
-                modelPath: resolved.installPath
-            )
-        case .textChatQ36, .textChatQ35:
-            return .textChatQ35(
-                Q35Generator(
-                    modelId: resolved.id,
-                    prefixKVCacheEnabled: q35PrefixKVCacheEnabled,
-                    continuousBatchingEnabled: q35ContinuousBatchingEnabled
-                ),
-                modelPath: resolved.installPath
-            )
+            prefixCache = nil
+            batching = lagunaContinuousBatchingEnabled
+        case .textChatQ35, .textChatQ36:
+            prefixCache = q35PrefixKVCacheEnabled
+            batching = q35ContinuousBatchingEnabled
         case .textChatLFM2:
-            return .textChatLFM2(
-                LFM2Generator(
-                    modelId: resolved.id,
-                    prefixKVCacheEnabled: lfm2PrefixKVCacheEnabled,
-                    continuousBatchingEnabled: lfm2ContinuousBatchingEnabled
-                ),
-                modelPath: resolved.installPath
-            )
-        case .textChatDeepseekV4Flash:
-            return .textChatDeepseekV4Flash(
-                DeepseekV4FlashGenerator(modelId: resolved.id),
-                modelPath: resolved.installPath
-            )
-        case .textChatMuseGlimmer:
-            return .textChatMuseGlimmer(
-                MuseGlimmerGenerator(modelID: resolved.id),
-                modelPath: resolved.installPath
-            )
-        case .textChatNemotronH:
-            return .textChatNemotronH(
-                NemotronHGenerator(),
-                modelPath: resolved.installPath
-            )
-        case .textChatNemotronOmni:
-            return .textChatNemotronOmni(
-                NemotronOmniGenerator(),
-                modelPath: resolved.installPath
-            )
+            prefixCache = lfm2PrefixKVCacheEnabled
+            batching = lfm2ContinuousBatchingEnabled
+        case .textCode, .textChatKlein, .textChatDiffusionGemma, .textChatDeepseekV4Flash,
+             .textChatMuseGlimmer, .textChatNemotronH, .textChatNemotronOmni:
+            prefixCache = nil
+            batching = nil
         }
+        return NativeChatRuntime.make(
+            engine: resolved.engine, modelID: resolved.id, modelPath: resolved.installPath,
+            gemma4KVCacheQuantization: gemma4KVCacheQuantization,
+            prefixKVCacheEnabled: prefixCache, continuousBatchingEnabled: batching
+        )
     }
 
     private func resolveModel(
@@ -1525,7 +1472,7 @@ actor RuntimeModelPool {
     #endif
 }
 
-final class RuntimeModelLease: @unchecked Sendable {
+final class RuntimeModelLease: RuntimeChatModelLease, @unchecked Sendable {
     let modelID: String
     let engine: RuntimeServingEngine
 
@@ -1577,7 +1524,10 @@ final class RuntimeModelLease: @unchecked Sendable {
     func deepseekChatCompletionsURL(
         progressHandler: (@Sendable (ChatProgress) -> Void)? = nil
     ) async throws -> URL {
-        try await loaded.deepseekChatCompletionsURL(progressHandler: progressHandler)
+        guard case .textChatDeepseekV4Flash = loaded else {
+            throw RuntimeModelPoolError.rawProxyUnavailable("")
+        }
+        return try await loaded.deepseekChatCompletionsURL(progressHandler: progressHandler)
     }
 
     func release() async {
@@ -1595,187 +1545,7 @@ final class RuntimeModelLease: @unchecked Sendable {
     }
 }
 
-enum RuntimeLoadedModel: Sendable {
-    case textCode(CodeGenGenerator, modelPath: String?)
-    case textChatKlein(Flux2KleinGenerator, modelPath: String?, useStandalone: Bool)
-    case textChatGemma4(Gemma4Generator, modelPath: String?)
-    case textChatDiffusionGemma(DiffusionGemmaGenerator, modelPath: String?)
-    case textChatLaguna(LagunaGenerator, modelPath: String?)
-    case textChatQ35(Q35Generator, modelPath: String?)
-    case textChatLFM2(LFM2Generator, modelPath: String?)
-    case textChatDeepseekV4Flash(DeepseekV4FlashGenerator, modelPath: String?)
-    case textChatMuseGlimmer(MuseGlimmerGenerator, modelPath: String?)
-    case textChatNemotronH(NemotronHGenerator, modelPath: String?)
-    case textChatNemotronOmni(NemotronOmniGenerator, modelPath: String?)
-
-    func prepare(progressHandler: (@Sendable (ChatProgress) -> Void)?) async throws {
-        switch self {
-        case .textCode(let generator, let modelPath):
-            try await generator.prepare(modelPath: modelPath, progressHandler: progressHandler)
-        case .textChatKlein(let generator, let modelPath, let useStandalone):
-            guard let modelPath else {
-                throw Flux2Error.modelNotFound(ModelResolver.ModelID.mebot.rawValue)
-            }
-            try await generator.prepareChat(
-                modelPath: modelPath,
-                standalone: useStandalone,
-                progressHandler: progressHandler
-            )
-        case .textChatGemma4(let generator, let modelPath):
-            try await generator.prepare(modelPath: modelPath, progressHandler: progressHandler)
-        case .textChatDiffusionGemma(let generator, let modelPath):
-            try await generator.prepare(modelPath: modelPath, progressHandler: progressHandler)
-        case .textChatLaguna(let generator, let modelPath):
-            guard let modelPath else {
-                throw LagunaError.modelPathRequired
-            }
-            try await generator.prepare(modelPath: modelPath, progressHandler: progressHandler)
-        case .textChatQ35(let generator, let modelPath):
-            try await generator.prepare(modelPath: modelPath, progressHandler: progressHandler)
-        case .textChatLFM2(let generator, let modelPath):
-            try await generator.prepare(modelPath: modelPath, progressHandler: progressHandler)
-        case .textChatDeepseekV4Flash(let generator, let modelPath):
-            try await generator.prepare(modelPath: modelPath, progressHandler: progressHandler)
-        case .textChatMuseGlimmer(let generator, let modelPath):
-            try await generator.prepare(modelPath: modelPath, progressHandler: progressHandler)
-        case .textChatNemotronH(let generator, let modelPath):
-            try await generator.prepare(modelPath: modelPath, progressHandler: progressHandler)
-        case .textChatNemotronOmni(let generator, let modelPath):
-            try await generator.prepare(modelPath: modelPath, progressHandler: progressHandler)
-        }
-    }
-
-    func unload() async {
-        switch self {
-        case .textCode(let generator, _):
-            await generator.unload()
-        case .textChatKlein(let generator, _, _):
-            await generator.unload()
-        case .textChatGemma4(let generator, _):
-            await generator.unload()
-        case .textChatDiffusionGemma(let generator, _):
-            await generator.unload()
-        case .textChatLaguna(let generator, _):
-            await generator.unload()
-        case .textChatQ35(let generator, _):
-            await generator.unload()
-        case .textChatLFM2(let generator, _):
-            await generator.unload()
-        case .textChatDeepseekV4Flash(let generator, _):
-            await generator.shutdown()
-        case .textChatMuseGlimmer(let generator, _):
-            await generator.unload()
-        case .textChatNemotronH(let generator, _):
-            await generator.unload()
-        case .textChatNemotronOmni(let generator, _):
-            await generator.unload()
-        }
-    }
-
-    func prefixKVCacheStats() async -> PrefixKVCacheStats? {
-        switch self {
-        case .textChatGemma4(let generator, _):
-            return await generator.prefixKVCacheStats()
-        case .textChatQ35(let generator, _):
-            return await generator.prefixKVCacheStats()
-        case .textChatLFM2(let generator, _):
-            return await generator.prefixKVCacheStats()
-        case .textCode, .textChatKlein, .textChatDiffusionGemma, .textChatLaguna, .textChatDeepseekV4Flash,
-             .textChatMuseGlimmer, .textChatNemotronH, .textChatNemotronOmni:
-            return nil
-        }
-    }
-
-    func continuousBatchingStats() async -> RuntimeDecodeBatchingStats? {
-        switch self {
-        case .textChatGemma4(let generator, _):
-            return await generator.continuousBatchingStats()
-        case .textChatLaguna(let generator, _):
-            return await generator.continuousBatchingStats()
-        case .textChatQ35(let generator, _):
-            return await generator.continuousBatchingStats()
-        case .textChatLFM2(let generator, _):
-            return await generator.continuousBatchingStats()
-        case .textCode, .textChatKlein, .textChatDiffusionGemma, .textChatDeepseekV4Flash, .textChatMuseGlimmer,
-             .textChatNemotronH, .textChatNemotronOmni:
-            return nil
-        }
-    }
-
-    func mtpStats() async -> Gemma4MTPStats? {
-        switch self {
-        case .textChatGemma4(let generator, _):
-            return await generator.mtpStats()
-        case .textCode, .textChatKlein, .textChatDiffusionGemma, .textChatLaguna, .textChatQ35, .textChatLFM2,
-             .textChatDeepseekV4Flash, .textChatMuseGlimmer, .textChatNemotronH,
-             .textChatNemotronOmni:
-            return nil
-        }
-    }
-
-    func chat(
-        _ request: ChatRequest,
-        progressHandler: (@Sendable (ChatProgress) -> Void)?
-    ) async throws -> ChatResponse {
-        switch self {
-        case .textCode(let generator, let modelPath):
-            return try await generator.chat(request, modelPath: modelPath, progressHandler: progressHandler)
-        case .textChatKlein(let generator, let modelPath, let useStandalone):
-            guard let modelPath else {
-                throw Flux2Error.modelNotFound(ModelResolver.ModelID.mebot.rawValue)
-            }
-            if useStandalone {
-                return try await generator.chatStandalone(
-                    request,
-                    modelPath: modelPath,
-                    progressHandler: progressHandler
-                )
-            }
-            return try await generator.chat(request, modelPath: modelPath, progressHandler: progressHandler)
-        case .textChatGemma4(let generator, let modelPath):
-            return try await generator.chat(request, modelPath: modelPath, progressHandler: progressHandler)
-        case .textChatDiffusionGemma(let generator, let modelPath):
-            return try await generator.chat(request, modelPath: modelPath, progressHandler: progressHandler)
-        case .textChatLaguna(let generator, let modelPath):
-            guard let modelPath else {
-                throw LagunaError.modelPathRequired
-            }
-            return try await generator.chat(
-                request,
-                modelPath: modelPath,
-                progressHandler: progressHandler
-            )
-        case .textChatQ35(let generator, let modelPath):
-            return try await generator.chat(request, modelPath: modelPath, progressHandler: progressHandler)
-        case .textChatLFM2(let generator, let modelPath):
-            return try await generator.chat(request, modelPath: modelPath, progressHandler: progressHandler)
-        case .textChatDeepseekV4Flash(let generator, let modelPath):
-            return try await generator.chat(request, modelPath: modelPath, progressHandler: progressHandler)
-        case .textChatMuseGlimmer(let generator, let modelPath):
-            return try await generator.chat(request, modelPath: modelPath, progressHandler: progressHandler)
-        case .textChatNemotronH(let generator, let modelPath):
-            return try await generator.chat(request, modelPath: modelPath, progressHandler: progressHandler)
-        case .textChatNemotronOmni(let generator, let modelPath):
-            return try await generator.chat(request, modelPath: modelPath, progressHandler: progressHandler)
-        }
-    }
-
-    func deepseekChatCompletionsURL(
-        progressHandler: (@Sendable (ChatProgress) -> Void)?
-    ) async throws -> URL {
-        switch self {
-        case .textChatDeepseekV4Flash(let generator, let modelPath):
-            return try await generator.chatCompletionsURL(
-                modelPath: modelPath,
-                progressHandler: progressHandler
-            )
-        case .textCode, .textChatKlein, .textChatGemma4, .textChatDiffusionGemma, .textChatLaguna, .textChatQ35,
-             .textChatLFM2, .textChatMuseGlimmer, .textChatNemotronH,
-             .textChatNemotronOmni:
-            throw RuntimeModelPoolError.rawProxyUnavailable("")
-        }
-    }
-}
+typealias RuntimeLoadedModel = NativeChatRuntime
 
 extension RuntimeServingEngine {
     var openAICompatibility: APIEngineCapabilities {

--- a/Sources/MereRunCLI/Support/RuntimeServingServices.swift
+++ b/Sources/MereRunCLI/Support/RuntimeServingServices.swift
@@ -97,6 +97,35 @@ struct RuntimeServingServices: Sendable {
         }
     }
 
+    func startChat(
+        _ request: OpenAIChatRequest, fallbackLoraPath: String?, contextSize: Int
+    ) async throws -> RuntimeChatSession {
+        let admitted = try await admission.acquire()
+        var session: RuntimeChatSession?
+        do {
+            try Task.checkCancellation()
+            let plan = try await models.makeChatPlan(
+                for: request, fallbackLoraPath: fallbackLoraPath, serverContextSize: contextSize
+            )
+            let prepared = RuntimeChatSession(plan: plan, admission: admitted)
+            session = prepared
+            await admitted.configure(
+                modelID: plan.modelID, streaming: request.stream == true,
+                requestedMaxTokens: plan.request.maxTokens, toolCount: plan.request.tools?.count ?? 0
+            )
+            try Task.checkCancellation()
+            return prepared
+        } catch {
+            let cancelled = Task.isCancelled || error is CancellationError
+            if let session {
+                await session.finish(cancelled: cancelled)
+            } else {
+                await admitted.release(cancelled: cancelled)
+            }
+            throw error
+        }
+    }
+
     func transcribe(
         _ plan: SpeechTranscriptionPlan, recording: SpeechTranscriptionRunSession? = nil
     ) async throws -> SpeechTranscriptionOutcome {

--- a/Sources/MereRunCore/ChatGenerationOperation.swift
+++ b/Sources/MereRunCore/ChatGenerationOperation.swift
@@ -1,0 +1,32 @@
+import Foundation
+
+/// One native response, including each response in a tool conversation.
+/// The owner retains its runtime or resident lease for the conversation scope.
+public enum ChatGenerationOperation {
+    public static func run(
+        _ request: ChatRequest,
+        generate: () async throws -> ChatResponse
+    ) async throws -> ChatResponse {
+        try Task.checkCancellation()
+        try ChatRequestResolver.validate(request)
+        let response = try await generate()
+        try Task.checkCancellation()
+        return response
+    }
+
+    /// Awaits cleanup on success, failure, and cancellation. This also keeps a
+    /// command's runtime alive across all iterations of its tool conversation.
+    public static func withCleanup<Result>(
+        _ operation: () async throws -> Result,
+        cleanup: () async -> Void
+    ) async rethrows -> Result {
+        do {
+            let result = try await operation()
+            await cleanup()
+            return result
+        } catch {
+            await cleanup()
+            throw error
+        }
+    }
+}

--- a/Sources/MereRunCore/ChatRequestResolution.swift
+++ b/Sources/MereRunCore/ChatRequestResolution.swift
@@ -1,0 +1,126 @@
+import Foundation
+
+/// Defaults are an entry-point compatibility policy. Explicit values take
+/// precedence independently; JSON output always suppresses thinking output.
+public enum ChatDefaultPolicy: Sendable {
+    case command
+    case openAI
+}
+
+public struct ChatSamplingOptions: Sendable, Hashable {
+    public var temperature: Double?
+    public var topP: Double?
+    public var topK: Int?
+    public var minP: Double?
+    public var thinking: Bool?
+
+    public init(
+        temperature: Double? = nil, topP: Double? = nil, topK: Int? = nil,
+        minP: Double? = nil, thinking: Bool? = nil
+    ) {
+        self.temperature = temperature
+        self.topP = topP
+        self.topK = topK
+        self.minP = minP
+        self.thinking = thinking
+    }
+}
+
+public struct ChatRequestIssue: Error, LocalizedError, Equatable, Sendable {
+    public let field: String
+    public let message: String
+    public var errorDescription: String? { "\(field) \(message)" }
+
+    public init(_ field: String, _ message: String) {
+        self.field = field
+        self.message = message
+    }
+}
+
+public enum ChatRequestResolver {
+    /// Preserves all non-sampling request fields, including tools, media,
+    /// cache policy, stop sequences, reasoning budgets, and diagnostics.
+    public static func resolve(
+        _ request: ChatRequest, modelID: String, sampling: ChatSamplingOptions,
+        policy: ChatDefaultPolicy, apiProfile: ManagedModelAPIProfile? = nil
+    ) throws -> ChatRequest {
+        let modelID = modelID.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        let recommended = Q35Resources.recommendedSampling(forModelId: modelID)
+        var temperature = recommended?.temperature ?? (policy == .command ? 0.7 : 1.0)
+        var topP = recommended?.topP ?? (policy == .command ? 0.9 : 0.95)
+        var topK = recommended?.topK
+        var minP = 0.0
+        var thinking = Q35Resources.thinkingDefault(forModelId: modelID)
+
+        if LagunaResources.handles(modelSpec: modelID) {
+            temperature = LagunaResources.recommendedTemperature
+            topP = LagunaResources.recommendedTopP
+            topK = LagunaResources.recommendedTopK
+            minP = LagunaResources.recommendedMinP
+        }
+        switch policy {
+        case .command:
+            if modelID == LFM2Resources.visionModelId {
+                temperature = 0.2
+                topK = 50
+            } else if NemotronOmniResources.handles(modelSpec: modelID) {
+                temperature = NemotronOmniResources.thinkingTemperature
+                topP = NemotronOmniResources.thinkingTopP
+                thinking = true
+            } else if NemotronHResources.handles(modelSpec: modelID) {
+                temperature = NemotronHResources.recommendedTemperature
+                topP = NemotronHResources.recommendedTopP
+            } else if MuseGlimmerResources.handles(modelSpec: modelID) {
+                temperature = MuseGlimmerResources.recommendedTemperature
+                topP = MuseGlimmerResources.recommendedTopP
+                topK = MuseGlimmerResources.recommendedTopK
+                thinking = false
+            }
+        case .openAI:
+            let profile = apiProfile ?? ManagedModelCatalog.apiProfile(for: modelID)
+            thinking = thinking || profile?.thinkingLevels == [.high]
+        }
+
+        var effective = request
+        effective.temperature = sampling.temperature ?? temperature
+        effective.topP = sampling.topP ?? topP
+        effective.topK = sampling.topK ?? topK
+        effective.minP = sampling.minP ?? minP
+        effective.showThinking = !request.requiresJSON && (sampling.thinking ?? thinking)
+        try validate(effective)
+        return effective
+    }
+
+    /// Shared numerical invariants, checked before native execution. Transport
+    /// capabilities and model-specific options remain adapter constraints.
+    public static func validate(_ request: ChatRequest) throws {
+        guard !request.messages.isEmpty else {
+            throw ChatRequestIssue("messages", "must contain at least one message")
+        }
+        let upperBound = min(request.maxContextTokens ?? Int(Int32.max), Int(Int32.max))
+        guard upperBound > 0 else {
+            throw ChatRequestIssue("context_size", "must be greater than zero")
+        }
+        guard (1...upperBound).contains(request.maxTokens) else {
+            throw ChatRequestIssue("max_tokens", "must be between 1 and \(upperBound)")
+        }
+        for (field, value, range) in [
+            ("temperature", request.temperature, 0.0...2.0),
+            ("top_p", request.topP, 0.0...1.0),
+            ("min_p", request.minP, 0.0...1.0),
+            ("presence_penalty", request.presencePenalty, -2.0...2.0),
+            ("frequency_penalty", request.frequencyPenalty, -2.0...2.0)
+        ] {
+            guard value.isFinite, range.contains(value) else {
+                throw ChatRequestIssue(field, "must be between \(Int(range.lowerBound)) and \(Int(range.upperBound))")
+            }
+        }
+        if let topK = request.topK, topK < 0 {
+            throw ChatRequestIssue("top_k", "must be zero or greater")
+        }
+        guard request.repetitionPenalty.isFinite,
+              Float(request.repetitionPenalty).isFinite, Float(request.repetitionPenalty) > 0 else {
+            throw ChatRequestIssue("repetition_penalty", "must be a finite positive sampler value")
+        }
+    }
+}

--- a/Sources/MereRunCore/NativeChatRuntime+Diagnostics.swift
+++ b/Sources/MereRunCore/NativeChatRuntime+Diagnostics.swift
@@ -1,0 +1,26 @@
+import Foundation
+
+public struct NativeChatDiagnostics: Sendable {
+    public var gemma4MTP: Gemma4MTPStats?
+    public var lagunaDFlash: LagunaDFlashStats?
+    public var museDFlash: MuseGlimmerDFlashStats?
+    public var nemotronDSpark: NemotronHDSparkStats?
+    public var lfm2DSpark: LFM2DSparkStats?
+}
+
+extension NativeChatRuntime {
+    public func diagnostics() async -> NativeChatDiagnostics {
+        var result = NativeChatDiagnostics()
+        switch self {
+        case .textChatGemma4(let generator, _): result.gemma4MTP = await generator.mtpStats()
+        case .textChatLaguna(let generator, _): result.lagunaDFlash = await generator.dflashStats()
+        case .textChatMuseGlimmer(let generator, _): result.museDFlash = await generator.dflashStats()
+        case .textChatNemotronH(let generator, _): result.nemotronDSpark = await generator.dsparkStats()
+        case .textChatLFM2(let generator, _): result.lfm2DSpark = await generator.dsparkStats()
+        case .textCode, .textChatKlein, .textChatDiffusionGemma, .textChatQ35,
+             .textChatDeepseekV4Flash, .textChatNemotronOmni, .textChatPsi, .textChatInkling:
+            break
+        }
+        return result
+    }
+}

--- a/Sources/MereRunCore/NativeChatRuntime+Diagnostics.swift
+++ b/Sources/MereRunCore/NativeChatRuntime+Diagnostics.swift
@@ -1,3 +1,4 @@
+#if os(macOS) || os(Linux)
 import Foundation
 
 public struct NativeChatDiagnostics: Sendable {
@@ -24,3 +25,4 @@ extension NativeChatRuntime {
         return result
     }
 }
+#endif

--- a/Sources/MereRunCore/NativeChatRuntime+Selection.swift
+++ b/Sources/MereRunCore/NativeChatRuntime+Selection.swift
@@ -1,0 +1,107 @@
+import Foundation
+
+extension NativeChatRuntime {
+    /// A command uses generator defaults; a server can explicitly override
+    /// cache and batching policy when creating a resident runtime.
+    public static func make(
+        engine: RuntimeServingEngine, modelID: String, modelPath: String?,
+        gemma4KVCacheQuantization: Gemma4KVCacheQuantization = Gemma4KVCacheQuantization(),
+        prefixKVCacheEnabled: Bool? = nil, continuousBatchingEnabled: Bool? = nil
+    ) -> Self {
+        func option(_ value: Bool?, _ key: String) -> Bool {
+            value ?? (ProcessInfo.processInfo.environment[key] == "1")
+        }
+        switch engine {
+        case .textCode:
+            return .textCode(CodeGenGenerator(modelId: modelID), modelPath: modelPath)
+        case .textChatKlein:
+            return .textChatKlein(
+                Flux2KleinGenerator(), modelPath: modelPath,
+                useStandalone: modelID == ModelResolver.ModelID.mebot.rawValue
+                    && modelPath == MeBotModelCatalog.resolveModelPath()
+            )
+        case .textChatGemma4:
+            return .textChatGemma4(
+                Gemma4Generator(
+                    modelId: modelID, kvCacheQuantization: gemma4KVCacheQuantization,
+                    prefixKVCacheEnabled: option(prefixKVCacheEnabled, "MERERUN_GEMMA4_PREFIX_KV_CACHE"),
+                    continuousBatchingEnabled: option(continuousBatchingEnabled, "MERERUN_GEMMA4_CONTINUOUS_BATCHING")
+                ), modelPath: modelPath
+            )
+        case .textChatDiffusionGemma:
+            return .textChatDiffusionGemma(DiffusionGemmaGenerator(modelID: modelID), modelPath: modelPath)
+        case .textChatLaguna:
+            return .textChatLaguna(
+                LagunaGenerator(
+                    continuousBatchingEnabled: option(continuousBatchingEnabled, "MERERUN_LAGUNA_CONTINUOUS_BATCHING"),
+                    dflashModelPath: LagunaResources.installedDFlashPath(for: modelID)
+                ), modelPath: modelPath
+            )
+        case .textChatQ35, .textChatQ36:
+            return .textChatQ35(
+                Q35Generator(
+                    modelId: modelID,
+                    prefixKVCacheEnabled: option(prefixKVCacheEnabled, "MERERUN_Q35_PREFIX_KV_CACHE"),
+                    continuousBatchingEnabled: option(continuousBatchingEnabled, "MERERUN_Q35_CONTINUOUS_BATCHING")
+                ), modelPath: modelPath
+            )
+        case .textChatLFM2:
+            return .textChatLFM2(
+                LFM2Generator(
+                    modelId: modelID,
+                    prefixKVCacheEnabled: option(prefixKVCacheEnabled, "MERERUN_LFM2_PREFIX_KV_CACHE"),
+                    continuousBatchingEnabled: option(continuousBatchingEnabled, "MERERUN_LFM2_CONTINUOUS_BATCHING")
+                ), modelPath: modelPath
+            )
+        case .textChatDeepseekV4Flash:
+            return .textChatDeepseekV4Flash(DeepseekV4FlashGenerator(modelId: modelID), modelPath: modelPath)
+        case .textChatMuseGlimmer:
+            return .textChatMuseGlimmer(MuseGlimmerGenerator(modelID: modelID), modelPath: modelPath)
+        case .textChatNemotronH:
+            return .textChatNemotronH(NemotronHGenerator(), modelPath: modelPath)
+        case .textChatNemotronOmni:
+            return .textChatNemotronOmni(NemotronOmniGenerator(), modelPath: modelPath)
+        }
+    }
+
+    /// Preserves command family selection, including command-only Psi and
+    /// Inkling runtimes. API selection uses its managed serving profile.
+    public static func command(
+        modelID: String, modelPath: String?,
+        gemma4KVCacheQuantization: Gemma4KVCacheQuantization = Gemma4KVCacheQuantization()
+    ) throws -> Self {
+        let engine: RuntimeServingEngine
+        if modelID == Psi3ChatResources.defaultModelId {
+            return .textChatPsi(Psi3ChatGenerator(modelId: modelID), modelPath: modelPath)
+        } else if modelID == DiffusionGemmaResources.modelID {
+            engine = .textChatDiffusionGemma
+        } else if Gemma4Resources.handles(modelSpec: modelID) {
+            engine = .textChatGemma4
+        } else if LagunaResources.handles(modelSpec: modelID) {
+            guard modelPath != nil else {
+                let id = LagunaResources.managedModelID(for: modelID) ?? modelID
+                throw ChatRequestIssue("model", "'\(id)' is not installed. Run 'mere.run model pull \(id)' first.")
+            }
+            engine = .textChatLaguna
+        } else if ManagedModelCatalog.spec(for: modelID)?.validationKind == .codegenGGUF {
+            engine = .textCode
+        } else if InklingResources.handles(modelSpec: modelID) {
+            return .textChatInkling(InklingGenerator(modelID: modelID), modelPath: modelPath)
+        } else if MuseGlimmerResources.handles(modelSpec: modelID) {
+            engine = .textChatMuseGlimmer
+        } else if NemotronOmniResources.handles(modelSpec: modelID) {
+            engine = .textChatNemotronOmni
+        } else if NemotronHResources.handles(modelSpec: modelID) {
+            engine = .textChatNemotronH
+        } else if LFM2Resources.handles(modelSpec: modelID) {
+            engine = .textChatLFM2
+        } else {
+            engine = .textChatQ35
+        }
+        let effectiveModelID = modelID.isEmpty ? Q35Resources.defaultModelId : modelID
+        return make(
+            engine: engine, modelID: effectiveModelID, modelPath: modelPath,
+            gemma4KVCacheQuantization: gemma4KVCacheQuantization
+        )
+    }
+}

--- a/Sources/MereRunCore/NativeChatRuntime+Selection.swift
+++ b/Sources/MereRunCore/NativeChatRuntime+Selection.swift
@@ -1,3 +1,4 @@
+#if os(macOS) || os(Linux)
 import Foundation
 
 extension NativeChatRuntime {
@@ -105,3 +106,4 @@ extension NativeChatRuntime {
         )
     }
 }
+#endif

--- a/Sources/MereRunCore/NativeChatRuntime+Selection.swift
+++ b/Sources/MereRunCore/NativeChatRuntime+Selection.swift
@@ -99,7 +99,15 @@ extension NativeChatRuntime {
         } else {
             engine = .textChatQ35
         }
-        let effectiveModelID = modelID.isEmpty ? Q35Resources.defaultModelId : modelID
+        // Gemma4 claims an empty spec, so an empty ID must fall back to the selected
+        // engine's own default rather than a Q35 ID the Gemma4 generator cannot use.
+        let effectiveModelID: String
+        if modelID.isEmpty {
+            effectiveModelID = engine == .textChatGemma4
+                ? Gemma4Resources.defaultModelId : Q35Resources.defaultModelId
+        } else {
+            effectiveModelID = modelID
+        }
         return make(
             engine: engine, modelID: effectiveModelID, modelPath: modelPath,
             gemma4KVCacheQuantization: gemma4KVCacheQuantization

--- a/Sources/MereRunCore/NativeChatRuntime.swift
+++ b/Sources/MereRunCore/NativeChatRuntime.swift
@@ -1,0 +1,207 @@
+import Foundation
+
+/// Native runtime invocation shared by command sessions and resident API models.
+public enum NativeChatRuntime: Sendable {
+    case textChatPsi(Psi3ChatGenerator, modelPath: String?)
+    case textChatInkling(InklingGenerator, modelPath: String?)
+    case textCode(CodeGenGenerator, modelPath: String?)
+    case textChatKlein(Flux2KleinGenerator, modelPath: String?, useStandalone: Bool)
+    case textChatGemma4(Gemma4Generator, modelPath: String?)
+    case textChatDiffusionGemma(DiffusionGemmaGenerator, modelPath: String?)
+    case textChatLaguna(LagunaGenerator, modelPath: String?)
+    case textChatQ35(Q35Generator, modelPath: String?)
+    case textChatLFM2(LFM2Generator, modelPath: String?)
+    case textChatDeepseekV4Flash(DeepseekV4FlashGenerator, modelPath: String?)
+    case textChatMuseGlimmer(MuseGlimmerGenerator, modelPath: String?)
+    case textChatNemotronH(NemotronHGenerator, modelPath: String?)
+    case textChatNemotronOmni(NemotronOmniGenerator, modelPath: String?)
+
+    public func prepare(progressHandler: (@Sendable (ChatProgress) -> Void)?) async throws {
+        switch self {
+        case .textChatPsi(let generator, let modelPath):
+            try await generator.prepare(modelPath: modelPath, progressHandler: progressHandler)
+        case .textChatInkling(let generator, let modelPath):
+            try await generator.prepare(modelPath: modelPath, progressHandler: progressHandler)
+        case .textCode(let generator, let modelPath):
+            try await generator.prepare(modelPath: modelPath, progressHandler: progressHandler)
+        case .textChatKlein(let generator, let modelPath, let useStandalone):
+            guard let modelPath else {
+                throw Flux2Error.modelNotFound(ModelResolver.ModelID.mebot.rawValue)
+            }
+            try await generator.prepareChat(
+                modelPath: modelPath,
+                standalone: useStandalone,
+                progressHandler: progressHandler
+            )
+        case .textChatGemma4(let generator, let modelPath):
+            try await generator.prepare(modelPath: modelPath, progressHandler: progressHandler)
+        case .textChatDiffusionGemma(let generator, let modelPath):
+            try await generator.prepare(modelPath: modelPath, progressHandler: progressHandler)
+        case .textChatLaguna(let generator, let modelPath):
+            guard let modelPath else {
+                throw LagunaError.modelPathRequired
+            }
+            try await generator.prepare(modelPath: modelPath, progressHandler: progressHandler)
+        case .textChatQ35(let generator, let modelPath):
+            try await generator.prepare(modelPath: modelPath, progressHandler: progressHandler)
+        case .textChatLFM2(let generator, let modelPath):
+            try await generator.prepare(modelPath: modelPath, progressHandler: progressHandler)
+        case .textChatDeepseekV4Flash(let generator, let modelPath):
+            try await generator.prepare(modelPath: modelPath, progressHandler: progressHandler)
+        case .textChatMuseGlimmer(let generator, let modelPath):
+            try await generator.prepare(modelPath: modelPath, progressHandler: progressHandler)
+        case .textChatNemotronH(let generator, let modelPath):
+            try await generator.prepare(modelPath: modelPath, progressHandler: progressHandler)
+        case .textChatNemotronOmni(let generator, let modelPath):
+            try await generator.prepare(modelPath: modelPath, progressHandler: progressHandler)
+        }
+    }
+
+    public func unload() async {
+        switch self {
+        case .textChatPsi(let generator, _):
+            await generator.unload()
+        case .textChatInkling(let generator, _):
+            await generator.unload()
+        case .textCode(let generator, _):
+            await generator.unload()
+        case .textChatKlein(let generator, _, _):
+            await generator.unload()
+        case .textChatGemma4(let generator, _):
+            await generator.unload()
+        case .textChatDiffusionGemma(let generator, _):
+            await generator.unload()
+        case .textChatLaguna(let generator, _):
+            await generator.unload()
+        case .textChatQ35(let generator, _):
+            await generator.unload()
+        case .textChatLFM2(let generator, _):
+            await generator.unload()
+        case .textChatDeepseekV4Flash(let generator, _):
+            await generator.shutdown()
+        case .textChatMuseGlimmer(let generator, _):
+            await generator.unload()
+        case .textChatNemotronH(let generator, _):
+            await generator.unload()
+        case .textChatNemotronOmni(let generator, _):
+            await generator.unload()
+        }
+    }
+
+    public func prefixKVCacheStats() async -> PrefixKVCacheStats? {
+        switch self {
+        case .textChatGemma4(let generator, _):
+            return await generator.prefixKVCacheStats()
+        case .textChatQ35(let generator, _):
+            return await generator.prefixKVCacheStats()
+        case .textChatLFM2(let generator, _):
+            return await generator.prefixKVCacheStats()
+        case .textChatPsi, .textChatInkling, .textCode, .textChatKlein, .textChatDiffusionGemma, .textChatLaguna, .textChatDeepseekV4Flash,
+             .textChatMuseGlimmer, .textChatNemotronH, .textChatNemotronOmni:
+            return nil
+        }
+    }
+
+    public func continuousBatchingStats() async -> RuntimeDecodeBatchingStats? {
+        switch self {
+        case .textChatGemma4(let generator, _):
+            return await generator.continuousBatchingStats()
+        case .textChatLaguna(let generator, _):
+            return await generator.continuousBatchingStats()
+        case .textChatQ35(let generator, _):
+            return await generator.continuousBatchingStats()
+        case .textChatLFM2(let generator, _):
+            return await generator.continuousBatchingStats()
+        case .textChatPsi, .textChatInkling, .textCode, .textChatKlein, .textChatDiffusionGemma, .textChatDeepseekV4Flash, .textChatMuseGlimmer,
+             .textChatNemotronH, .textChatNemotronOmni:
+            return nil
+        }
+    }
+
+    public func mtpStats() async -> Gemma4MTPStats? {
+        switch self {
+        case .textChatGemma4(let generator, _):
+            return await generator.mtpStats()
+        case .textChatPsi, .textChatInkling, .textCode, .textChatKlein, .textChatDiffusionGemma, .textChatLaguna, .textChatQ35, .textChatLFM2,
+             .textChatDeepseekV4Flash, .textChatMuseGlimmer, .textChatNemotronH,
+             .textChatNemotronOmni:
+            return nil
+        }
+    }
+
+    public func chat(
+        _ request: ChatRequest,
+        progressHandler: (@Sendable (ChatProgress) -> Void)?
+    ) async throws -> ChatResponse {
+        try await ChatGenerationOperation.run(request) {
+            try await generate(request, progressHandler: progressHandler)
+        }
+    }
+
+    private func generate(
+        _ request: ChatRequest,
+        progressHandler: (@Sendable (ChatProgress) -> Void)?
+    ) async throws -> ChatResponse {
+        switch self {
+        case .textChatPsi(let generator, let modelPath):
+            return try await generator.chat(request, modelPath: modelPath, progressHandler: progressHandler)
+        case .textChatInkling(let generator, let modelPath):
+            return try await generator.chat(request, modelPath: modelPath, progressHandler: progressHandler)
+        case .textCode(let generator, let modelPath):
+            return try await generator.chat(request, modelPath: modelPath, progressHandler: progressHandler)
+        case .textChatKlein(let generator, let modelPath, let useStandalone):
+            guard let modelPath else {
+                throw Flux2Error.modelNotFound(ModelResolver.ModelID.mebot.rawValue)
+            }
+            if useStandalone {
+                return try await generator.chatStandalone(
+                    request,
+                    modelPath: modelPath,
+                    progressHandler: progressHandler
+                )
+            }
+            return try await generator.chat(request, modelPath: modelPath, progressHandler: progressHandler)
+        case .textChatGemma4(let generator, let modelPath):
+            return try await generator.chat(request, modelPath: modelPath, progressHandler: progressHandler)
+        case .textChatDiffusionGemma(let generator, let modelPath):
+            return try await generator.chat(request, modelPath: modelPath, progressHandler: progressHandler)
+        case .textChatLaguna(let generator, let modelPath):
+            guard let modelPath else {
+                throw LagunaError.modelPathRequired
+            }
+            return try await generator.chat(
+                request,
+                modelPath: modelPath,
+                progressHandler: progressHandler
+            )
+        case .textChatQ35(let generator, let modelPath):
+            return try await generator.chat(request, modelPath: modelPath, progressHandler: progressHandler)
+        case .textChatLFM2(let generator, let modelPath):
+            return try await generator.chat(request, modelPath: modelPath, progressHandler: progressHandler)
+        case .textChatDeepseekV4Flash(let generator, let modelPath):
+            return try await generator.chat(request, modelPath: modelPath, progressHandler: progressHandler)
+        case .textChatMuseGlimmer(let generator, let modelPath):
+            return try await generator.chat(request, modelPath: modelPath, progressHandler: progressHandler)
+        case .textChatNemotronH(let generator, let modelPath):
+            return try await generator.chat(request, modelPath: modelPath, progressHandler: progressHandler)
+        case .textChatNemotronOmni(let generator, let modelPath):
+            return try await generator.chat(request, modelPath: modelPath, progressHandler: progressHandler)
+        }
+    }
+
+    public func deepseekChatCompletionsURL(
+        progressHandler: (@Sendable (ChatProgress) -> Void)?
+    ) async throws -> URL {
+        switch self {
+        case .textChatDeepseekV4Flash(let generator, let modelPath):
+            return try await generator.chatCompletionsURL(
+                modelPath: modelPath,
+                progressHandler: progressHandler
+            )
+        case .textChatPsi, .textChatInkling, .textCode, .textChatKlein, .textChatGemma4, .textChatDiffusionGemma, .textChatLaguna, .textChatQ35,
+             .textChatLFM2, .textChatMuseGlimmer, .textChatNemotronH,
+             .textChatNemotronOmni:
+            throw ChatRequestIssue("engine", "does not expose a raw chat proxy")
+        }
+    }
+}

--- a/Sources/MereRunCore/NativeChatRuntime.swift
+++ b/Sources/MereRunCore/NativeChatRuntime.swift
@@ -1,3 +1,4 @@
+#if os(macOS) || os(Linux)
 import Foundation
 
 /// Native runtime invocation shared by command sessions and resident API models.
@@ -205,3 +206,4 @@ public enum NativeChatRuntime: Sendable {
         }
     }
 }
+#endif

--- a/Sources/MereRunCore/README.md
+++ b/Sources/MereRunCore/README.md
@@ -14,6 +14,10 @@ live in `MereRunQwenModel`. Gemma layers, caches, and draft computation live in
 Core retains resource loading and generation for these families.
 
 - `Generation.swift`: image and chat request/response contracts.
+- `ChatRequestResolution.swift`: shared chat sampling defaults and numeric
+  validation, with explicit CLI and OpenAI compatibility policies.
+- `NativeChatRuntime*.swift` and `ChatGenerationOperation.swift`: shared native
+  chat selection, invocation, diagnostics, and awaited operation cleanup.
 - `ImageGenerationOptions.swift` and `ImageGenerationPlan.swift`: typed image
   inputs, model selection, effective sampling, conditioning, and validation.
 - `ImageGenerationOperation.swift`: image preparation, executor invocation,

--- a/Tests/MereRunCLITests/ChatExecutionIntegrationTests.swift
+++ b/Tests/MereRunCLITests/ChatExecutionIntegrationTests.swift
@@ -39,6 +39,36 @@ final class ChatExecutionIntegrationTests: XCTestCase {
         }
     }
 
+    func testCommandClampsMaxTokensToASmallerContextInsteadOfRejecting() throws {
+        let id = Q35Resources.ornith35BMLX4BitModelId
+        // The default --max-tokens (2048) must not turn a smaller --context-size into a
+        // blocker; the command capped generation against the context before this moved.
+        let defaulted = try TextChat.parse(["--prompt", "hello", "--model", id, "--context-size", "1024"])
+        let defaultedRequest = try defaulted.resolvedChatRequest(
+            modelID: id, messages: [.init(role: .user, content: "hello")]
+        )
+        XCTAssertEqual(defaultedRequest.maxTokens, 1024)
+        XCTAssertEqual(defaultedRequest.maxContextTokens, 1024)
+        let report = defaulted.makePreflightReport(modelID: id, installedModelPath: nil)
+        XCTAssertFalse(report.diagnostics.contains { $0.id == "text_chat_request_invalid" })
+
+        let explicit = try TextChat.parse([
+            "--prompt", "hello", "--model", id, "--max-tokens", "4096", "--context-size", "512"
+        ])
+        let explicitRequest = try explicit.resolvedChatRequest(
+            modelID: id, messages: [.init(role: .user, content: "hello")]
+        )
+        XCTAssertEqual(explicitRequest.maxTokens, 512)
+
+        // Clamping must not swallow the values the command still rejects.
+        for arguments in [["--max-tokens", "0"], ["--context-size", "0"]] {
+            let invalid = try TextChat.parse(["--prompt", "hello", "--model", id] + arguments)
+            XCTAssertThrowsError(try invalid.resolvedChatRequest(
+                modelID: id, messages: [.init(role: .user, content: "hello")]
+            ), arguments.joined(separator: " "))
+        }
+    }
+
     func testSessionRetainsLeasesThroughResponseConstructionAndCoalescesCleanup() async throws {
         let releaseStarted = expectation(description: "model release started")
         let releaseGate = ChatSessionTestGate()

--- a/Tests/MereRunCLITests/ChatExecutionIntegrationTests.swift
+++ b/Tests/MereRunCLITests/ChatExecutionIntegrationTests.swift
@@ -1,0 +1,267 @@
+import Foundation
+import XCTest
+import MereRunCore
+@testable import MereRunCLI
+
+final class ChatExecutionIntegrationTests: XCTestCase {
+    func testCLIAndAPIResolveEquivalentExplicitRequests() throws {
+        for id in [Q35Resources.ornith35BMLX4BitModelId, LagunaResources.modelID, Gemma4Resources.defaultModelId] {
+            let thinking = Q35Resources.thinkingDefault(forModelId: id)
+                || ManagedModelCatalog.apiProfile(for: id)?.thinkingLevels == [.high]
+            let command = try TextChat.parse([
+                "--prompt", "hello", "--model", id, "--max-tokens", "19", "--context-size", "128",
+                "--temperature", "0", "--top-p", "1", "--top-k", "0", "--min-p", "0.1", thinking ? "--thinking" : "--no-thinking"
+            ])
+            let cli = try command.resolvedChatRequest(modelID: id, messages: [.init(role: .user, content: "hello")])
+            var wire = OpenAIChatRequest(model: id, messages: [.init(role: "user", content: "hello")])
+            wire.max_tokens = 19
+            wire.temperature = 0
+            wire.top_p = 1
+            wire.top_k = 0
+            wire.min_p = 0.1
+            wire.parallel_tool_calls = false
+            let api = try APIServerContract.chatRequest(
+                from: wire, fallbackLoraPath: nil, contextSize: 128,
+                capabilities: .catalog(try XCTUnwrap(ManagedModelCatalog.apiProfile(for: id))), servedModelID: id
+            )
+            XCTAssertEqual(cli, api, id)
+        }
+    }
+
+    func testCLIExecutionAndPreflightRejectTheSameInvalidOptions() throws {
+        for arguments in [["--max-tokens", "0"], ["--temperature", "nan"], ["--top-k=-1"], ["--context-size", "0"]] {
+            let command = try TextChat.parse(["--prompt", "hello"] + arguments)
+            XCTAssertThrowsError(try command.resolvedChatRequest(
+                modelID: command.model, messages: [.init(role: .user, content: "hello")]
+            ))
+            let report = command.makePreflightReport(modelID: command.model, installedModelPath: nil)
+            XCTAssertTrue(report.diagnostics.contains { $0.id == "text_chat_request_invalid" && $0.severity == .blocker })
+        }
+    }
+
+    func testSessionRetainsLeasesThroughResponseConstructionAndCoalescesCleanup() async throws {
+        let releaseStarted = expectation(description: "model release started")
+        let releaseGate = ChatSessionTestGate()
+        let model = ChatSessionTestModel(onRelease: {
+            releaseStarted.fulfill()
+            await releaseGate.wait()
+        })
+        let admission = RuntimeRequestAdmission(maxActiveRequests: 1)
+        let session = try await makeSession(model: model, admission: admission)
+        let response = try await session.chat()
+        XCTAssertEqual(response.response, "hello")
+        let active = await admission.snapshot()
+        XCTAssertEqual(active.activeRequests, 1)
+        let first = Task { await session.finish() }
+        let second = Task { await session.finish() }
+        await fulfillment(of: [releaseStarted], timeout: 2)
+        let releasing = await admission.snapshot()
+        XCTAssertEqual(releasing.activeRequests, 1, "Admission remains held until model release completes")
+        await releaseGate.open()
+        await first.value
+        await second.value
+        let finished = await admission.snapshot()
+        let releases = await model.releases
+        XCTAssertEqual(releases, 1)
+        XCTAssertEqual(finished.activeRequests, 0)
+        XCTAssertEqual(finished.totalAdmittedRequests, 1)
+        XCTAssertEqual(finished.totalCompletedRequests, 1)
+    }
+
+    func testServicePreservesAliasSettingsAndExplicitOverridesWithoutDoubleAdmission() async throws {
+        let root = try temporaryDirectory()
+        let store = RuntimeModelSettingsStore(modelsDir: root)
+        let id = Q35Resources.ornith35BMLX4BitModelId
+        try store.save(.init(models: [id: .init(
+            alias: "fixture", maxContextTokens: 256, maxTokens: 29,
+            temperature: 0.3, topP: 0.7, minP: 0.1, kvCacheMode: .affine8
+        )]))
+        let services = makeServices(root: root)
+        var wire = OpenAIChatRequest(model: "fixture", messages: [.init(role: "user", content: "hello")])
+        wire.temperature = 0
+        let session = try await services.startChat(wire, fallbackLoraPath: nil, contextSize: 4_096)
+        XCTAssertEqual(session.modelID, id)
+        XCTAssertEqual(session.request.maxTokens, 29)
+        XCTAssertEqual(session.request.maxContextTokens, 256)
+        XCTAssertEqual(session.request.temperature, 0)
+        XCTAssertEqual(session.request.topP, 0.7)
+        XCTAssertEqual(session.request.minP, 0.1)
+        XCTAssertEqual(session.request.kvCacheMode, .affine8)
+        do {
+            _ = try await services.models.unloadModel(idOrAlias: id)
+            XCTFail("An active request allowed model eviction")
+        } catch RuntimeModelPoolError.unloadConflict(_, let active) {
+            XCTAssertEqual(active, 1)
+        }
+        await session.finish()
+        let unloaded = try await services.models.unloadModel(idOrAlias: id)
+        let admitted = await services.admission.snapshot()
+        XCTAssertFalse(unloaded.loaded)
+        XCTAssertEqual(admitted.totalAdmittedRequests, 1)
+        XCTAssertEqual(admitted.activeRequests, 0)
+    }
+
+    func testCancellationDuringPreparationReleasesAdmissionAndResidency() async throws {
+        let preparing = expectation(description: "model preparation started")
+        let gate = ChatSessionTestGate()
+        let services = makeServices(root: try temporaryDirectory(), onPrepare: {
+            preparing.fulfill()
+            await gate.wait()
+        })
+        let id = Q35Resources.ornith35BMLX4BitModelId
+        let task = Task {
+            try await services.startChat(
+                .init(model: id, messages: [.init(role: "user", content: "hello")]),
+                fallbackLoraPath: nil, contextSize: 4_096
+            )
+        }
+        await fulfillment(of: [preparing], timeout: 2)
+        task.cancel()
+        await gate.open()
+        do {
+            let session = try await task.value
+            await session.finish()
+            XCTFail("A cancelled request returned a session")
+        } catch is CancellationError {}
+        let snapshot = await services.admission.snapshot()
+        XCTAssertEqual(snapshot.activeRequests, 0)
+        XCTAssertEqual(snapshot.totalCancelledRequests, 1)
+        _ = try await services.models.unloadModel(idOrAlias: id)
+    }
+
+    func testResolutionAndPreparationFailureReleaseAdmission() async throws {
+        let root = try temporaryDirectory()
+        let services = makeServices(root: root, failPreparation: true)
+        for model in ["missing-fixture-model", Q35Resources.ornith35BMLX4BitModelId] {
+            do {
+                _ = try await services.startChat(
+                    .init(model: model, messages: [.init(role: "user", content: "hello")]),
+                    fallbackLoraPath: nil, contextSize: 4_096
+                )
+                XCTFail("Invalid or unprepared model was admitted")
+            } catch {}
+            let snapshot = await services.admission.snapshot()
+            XCTAssertEqual(snapshot.activeRequests, 0)
+        }
+    }
+
+    func testProxyStreamsExactBytesAndReleasesAfterCompletionOrFailure() async throws {
+        for fail in [false, true] {
+            let model = ChatSessionTestModel()
+            let admission = RuntimeRequestAdmission(maxActiveRequests: 1)
+            let session = try await makeSession(model: model, admission: admission)
+            let (source, continuation) = AsyncThrowingStream<UInt8, Error>.makeStream()
+            let bytes = Array("data: first\n\nlast".utf8)
+            bytes.forEach { continuation.yield($0) }
+            if fail { continuation.finish(throwing: ChatSessionTestError.expected) } else { continuation.finish() }
+            var actual: [UInt8] = []
+            for await buffer in RuntimeChatProxyStream.make(from: source, session: session) {
+                actual.append(contentsOf: buffer.readableBytesView)
+            }
+            XCTAssertEqual(actual, fail ? Array("data: first\n\n".utf8) : bytes)
+            let releases = await model.releases
+            let snapshot = await admission.snapshot()
+            XCTAssertEqual(releases, 1)
+            XCTAssertEqual(snapshot.activeRequests, 0)
+        }
+    }
+
+    func testProxyDisconnectCancelsUpstreamAndReleasesBothLeases() async throws {
+        let received = expectation(description: "first bytes received")
+        let upstreamCancelled = expectation(description: "upstream cancelled")
+        let modelReleased = expectation(description: "model released")
+        let model = ChatSessionTestModel(onRelease: { modelReleased.fulfill() })
+        let admission = RuntimeRequestAdmission(maxActiveRequests: 1)
+        let session = try await makeSession(model: model, admission: admission)
+        let (source, continuation) = AsyncThrowingStream<UInt8, Error>.makeStream()
+        continuation.onTermination = { termination in
+            if case .cancelled = termination { upstreamCancelled.fulfill() }
+        }
+        let stream = RuntimeChatProxyStream.make(from: source, session: session)
+        let reader = Task {
+            for await _ in stream { received.fulfill() }
+        }
+        for byte in "data: first\n".utf8 { continuation.yield(byte) }
+        await fulfillment(of: [received], timeout: 2)
+        reader.cancel()
+        await reader.value
+        await fulfillment(of: [upstreamCancelled, modelReleased], timeout: 2)
+        await session.finish(cancelled: true)
+        let snapshot = await admission.snapshot()
+        XCTAssertEqual(snapshot.activeRequests, 0)
+        XCTAssertEqual(snapshot.totalCancelledRequests, 1)
+    }
+
+    private func makeSession(model: ChatSessionTestModel, admission: RuntimeRequestAdmission) async throws -> RuntimeChatSession {
+        RuntimeChatSession(
+            plan: .init(
+                lease: model, request: .init(messages: [.init(role: .user, content: "hello")]),
+                modelID: "fixture", engine: .textChatQ35, includeUsage: true
+            ), admission: try await admission.acquire()
+        )
+    }
+
+    private func makeServices(
+        root: URL, failPreparation: Bool = false,
+        onPrepare: @escaping @Sendable () async -> Void = {}
+    ) -> RuntimeServingServices {
+        let models = RuntimeModelPool(
+            defaultModelID: Q35Resources.ornith35BMLX4BitModelId, defaultEngine: .textChatQ35,
+            startupModelPath: root.path, settingsStore: RuntimeModelSettingsStore(modelsDir: root), ensureMLXAvailable: {},
+            prepareLoadedModel: { _ in
+                await onPrepare()
+                if failPreparation { throw ChatSessionTestError.expected }
+            },
+            unloadLoadedModel: { _ in }, clearMLXCache: {}
+        )
+        let media = APISidecarModelPool(settingsURL: root.appendingPathComponent("media-settings.json"))
+        return RuntimeServingServices(
+            models: models, media: media, admission: RuntimeRequestAdmission(maxActiveRequests: 1),
+            ensureAvailable: {}, transcriptionExecutor: media
+        )
+    }
+
+    private func temporaryDirectory() throws -> URL {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        addTeardownBlock { try FileManager.default.removeItem(at: root) }
+        return root
+    }
+}
+
+private enum ChatSessionTestError: Error { case expected }
+
+private actor ChatSessionTestModel: RuntimeChatModelLease {
+    private let onRelease: @Sendable () async -> Void
+    var releases = 0
+
+    init(onRelease: @escaping @Sendable () async -> Void = {}) { self.onRelease = onRelease }
+
+    func chat(_ request: ChatRequest, progressHandler: (@Sendable (ChatProgress) -> Void)?) async throws -> ChatResponse {
+        progressHandler?(.init(stage: .generating, message: "hello"))
+        return ChatResponse(response: "hello", tokensGenerated: 1)
+    }
+
+    func deepseekChatCompletionsURL(progressHandler: (@Sendable (ChatProgress) -> Void)?) async throws -> URL {
+        URL(string: "http://127.0.0.1:1/v1/chat/completions")!
+    }
+
+    func release() async {
+        releases += 1
+        await onRelease()
+    }
+}
+
+private actor ChatSessionTestGate {
+    private var isOpen = false
+    private var waiting: [CheckedContinuation<Void, Never>] = []
+    func wait() async {
+        if isOpen { return }
+        await withCheckedContinuation { waiting.append($0) }
+    }
+    func open() {
+        isOpen = true
+        waiting.forEach { $0.resume() }
+        waiting.removeAll()
+    }
+}

--- a/Tests/MereRunCoreTests/ChatExecutionTests.swift
+++ b/Tests/MereRunCoreTests/ChatExecutionTests.swift
@@ -1,0 +1,159 @@
+import Foundation
+import XCTest
+@testable import MereRunCore
+
+final class ChatExecutionTests: XCTestCase {
+    func testCompatibilityDefaultsKeepCommandAndOpenAIBehavior() throws {
+        let request = ChatRequest(messages: [.init(role: .user, content: "hello")])
+        let fixtures: [(String, Double, Double, Int?, Double)] = [
+            ("fixture", 0.7, 0.9, nil, 0),
+            (LFM2Resources.visionModelId, 0.2, 0.9, 50, 0),
+            (LagunaResources.modelID, 1, 1, 20, 0.02),
+            (MuseGlimmerResources.modelId, 1, 0.95, 64, 0),
+            (NemotronHResources.modelID, 1, 0.95, nil, 0),
+            (NemotronOmniResources.modelID, 0.6, 0.95, nil, 0)
+        ]
+        for (id, temperature, topP, topK, minP) in fixtures {
+            let command = try ChatRequestResolver.resolve(request, modelID: id, sampling: .init(), policy: .command)
+            XCTAssertEqual(command.temperature, temperature, id)
+            XCTAssertEqual(command.topP, topP, id)
+            XCTAssertEqual(command.topK, topK, id)
+            XCTAssertEqual(command.minP, minP, id)
+        }
+        let api = try ChatRequestResolver.resolve(request, modelID: "fixture", sampling: .init(), policy: .openAI)
+        XCTAssertEqual(api.temperature, 1)
+        XCTAssertEqual(api.topP, 0.95)
+        let muse = try ChatRequestResolver.resolve(request, modelID: MuseGlimmerResources.modelId, sampling: .init(), policy: .openAI)
+        XCTAssertNil(muse.topK, "The v1 API keeps its existing omitted top-k behavior")
+    }
+
+    func testCommandSelectionPreservesFamiliesAndModelPaths() throws {
+        let path = "/fixture/model"
+        let fixtures = [
+            Psi3ChatResources.defaultModelId, InklingResources.modelID,
+            DiffusionGemmaResources.modelID, Gemma4Resources.defaultModelId,
+            LagunaResources.modelID, Q35Resources.ornith35BMLX4BitModelId,
+            LFM2Resources.visionModelId
+        ]
+        for id in fixtures {
+            let runtime = try NativeChatRuntime.command(modelID: id, modelPath: path)
+            let selected: String
+            let selectedPath: String?
+            switch runtime {
+            case .textChatPsi(_, let value): (selected, selectedPath) = (fixtures[0], value)
+            case .textChatInkling(_, let value): (selected, selectedPath) = (fixtures[1], value)
+            case .textChatDiffusionGemma(_, let value): (selected, selectedPath) = (fixtures[2], value)
+            case .textChatGemma4(_, let value): (selected, selectedPath) = (fixtures[3], value)
+            case .textChatLaguna(_, let value): (selected, selectedPath) = (fixtures[4], value)
+            case .textChatQ35(_, let value): (selected, selectedPath) = (fixtures[5], value)
+            case .textChatLFM2(_, let value): (selected, selectedPath) = (fixtures[6], value)
+            default: XCTFail("Unexpected runtime for \(id)"); continue
+            }
+            XCTAssertEqual(selected, id)
+            XCTAssertEqual(selectedPath, path)
+        }
+        XCTAssertThrowsError(try NativeChatRuntime.command(modelID: LagunaResources.modelID, modelPath: nil))
+    }
+
+    func testExplicitOptionsPreserveToolMediaAndDiagnosticRequests() throws {
+        let request = ChatRequest(
+            messages: [.init(role: .user, content: "inspect", imageUrl: "/image.png", audioUrl: "/audio.wav")],
+            maxTokens: 19, presencePenalty: 0.3, frequencyPenalty: -0.2, repetitionPenalty: 1.1,
+            seed: 42, reasoningEffort: 0.4, lora: .local(path: "/adapter", scale: 0.7), requiresJSON: true,
+            tools: [.init(name: "lookup", description: "Look up a value", parameters: [:])],
+            toolChoice: .required, parallelToolCalls: true, stopSequences: ["STOP"],
+            kvCacheMode: .affine8, maxContextTokens: 32, logprobCapture: .top(3), showUnmasking: true
+        )
+        var expected = request
+        expected.temperature = 0
+        expected.topP = 1
+        expected.topK = 0
+        expected.minP = 0.1
+        expected.showThinking = false
+        for policy in [ChatDefaultPolicy.command, .openAI] {
+            let effective = try ChatRequestResolver.resolve(
+                request, modelID: LagunaResources.modelID,
+                sampling: .init(temperature: 0, topP: 1, topK: 0, minP: 0.1, thinking: true), policy: policy
+            )
+            XCTAssertEqual(effective, expected)
+        }
+    }
+
+    func testInvalidRequestsNeverReachAnExecutor() async throws {
+        let valid = ChatRequest(messages: [.init(role: .user, content: "hello")], maxTokens: 10, maxContextTokens: 20)
+        let invalid: [(String, (inout ChatRequest) -> Void)] = [
+            ("messages", { $0.messages = [] }), ("max_tokens", { $0.maxTokens = 0 }),
+            ("max_tokens", { $0.maxTokens = 21 }), ("context_size", { $0.maxContextTokens = 0 }),
+            ("temperature", { $0.temperature = .nan }), ("top_p", { $0.topP = 1.1 }),
+            ("top_k", { $0.topK = -1 }), ("min_p", { $0.minP = .infinity }),
+            ("presence_penalty", { $0.presencePenalty = 3 }),
+            ("repetition_penalty", { $0.repetitionPenalty = .greatestFiniteMagnitude })
+        ]
+        for (field, change) in invalid {
+            var request = valid
+            change(&request)
+            do {
+                _ = try await ChatGenerationOperation.run(request) {
+                    XCTFail("Invalid request reached generation")
+                    return ChatResponse(response: "unexpected", tokensGenerated: 1)
+                }
+                XCTFail("Invalid request succeeded")
+            } catch let issue as ChatRequestIssue {
+                XCTAssertEqual(issue.field, field)
+            }
+        }
+    }
+
+    func testConversationRetainsRuntimeUntilAllResponsesAndAwaitsCleanup() async throws {
+        let trace = ChatExecutionTrace()
+        let request = ChatRequest(messages: [.init(role: .user, content: "hello")])
+        let response = ChatResponse(response: "done", tokensGenerated: 2, toolCalls: [.init(name: "lookup", arguments: [:])])
+        let result = try await ChatGenerationOperation.withCleanup {
+            for turn in 1...2 {
+                let actual = try await ChatGenerationOperation.run(request) {
+                    await trace.append("turn-\(turn)")
+                    return response
+                }
+                XCTAssertEqual(actual, response)
+            }
+            return response
+        } cleanup: {
+            await trace.append("released")
+        }
+        XCTAssertEqual(result, response)
+        let events = await trace.events
+        XCTAssertEqual(events, ["turn-1", "turn-2", "released"])
+    }
+
+    func testFailureAndCancellationBeforeOrAfterGenerationAwaitCleanup() async throws {
+        for mode in 0...2 {
+            let trace = ChatExecutionTrace()
+            let task = Task {
+                try await ChatGenerationOperation.withCleanup {
+                    if mode == 0 { withUnsafeCurrentTask { $0?.cancel() } }
+                    return try await ChatGenerationOperation.run(.init(messages: [.init(role: .user, content: "hello")])) {
+                        await trace.append("generated")
+                        if mode == 1 { throw ChatRequestIssue("fixture", "failed") }
+                        withUnsafeCurrentTask { $0?.cancel() }
+                        return ChatResponse(response: "must not succeed", tokensGenerated: 1)
+                    }
+                } cleanup: {
+                    await trace.append("released")
+                }
+            }
+            do {
+                _ = try await task.value
+                XCTFail("Interrupted operation succeeded")
+            } catch {
+                XCTAssertTrue(mode == 1 ? error is ChatRequestIssue : error is CancellationError)
+            }
+            let events = await trace.events
+            XCTAssertEqual(events, mode == 0 ? ["released"] : ["generated", "released"])
+        }
+    }
+}
+
+private actor ChatExecutionTrace {
+    var events: [String] = []
+    func append(_ event: String) { events.append(event) }
+}

--- a/Tests/MereRunCoreTests/ChatExecutionTests.swift
+++ b/Tests/MereRunCoreTests/ChatExecutionTests.swift
@@ -55,6 +55,15 @@ final class ChatExecutionTests: XCTestCase {
         XCTAssertThrowsError(try NativeChatRuntime.command(modelID: LagunaResources.modelID, modelPath: nil))
     }
 
+    func testEmptyModelSelectionKeepsTheSelectedEngineDefault() throws {
+        // Gemma4 claims an empty spec, so the substituted ID has to stay in its family.
+        let runtime = try NativeChatRuntime.command(modelID: "", modelPath: nil)
+        guard case .textChatGemma4(let generator, _) = runtime else {
+            return XCTFail("An empty model spec should keep selecting the Gemma4 family")
+        }
+        XCTAssertEqual(generator.modelId, Gemma4Resources.defaultModelId)
+    }
+
     func testExplicitOptionsPreserveToolMediaAndDiagnosticRequests() throws {
         let request = ChatRequest(
             messages: [.init(role: .user, content: "inspect", imageUrl: "/image.png", audioUrl: "/audio.wav")],

--- a/Tests/MereRunCoreTests/ChatExecutionTests.swift
+++ b/Tests/MereRunCoreTests/ChatExecutionTests.swift
@@ -55,13 +55,14 @@ final class ChatExecutionTests: XCTestCase {
         XCTAssertThrowsError(try NativeChatRuntime.command(modelID: LagunaResources.modelID, modelPath: nil))
     }
 
-    func testEmptyModelSelectionKeepsTheSelectedEngineDefault() throws {
+    func testEmptyModelSelectionKeepsTheSelectedEngineDefault() async throws {
         // Gemma4 claims an empty spec, so the substituted ID has to stay in its family.
         let runtime = try NativeChatRuntime.command(modelID: "", modelPath: nil)
         guard case .textChatGemma4(let generator, _) = runtime else {
             return XCTFail("An empty model spec should keep selecting the Gemma4 family")
         }
-        XCTAssertEqual(generator.modelId, Gemma4Resources.defaultModelId)
+        let modelID = await generator.modelId
+        XCTAssertEqual(modelID, Gemma4Resources.defaultModelId)
     }
 
     func testExplicitOptionsPreserveToolMediaAndDiagnosticRequests() throws {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -30,6 +30,13 @@ adapter. See [shared transcription](./internals/speech-transcription-operation.m
 and [shared image generation](./internals/image-generation-operation.md) for
 preparation, recovery, and retry responsibilities.
 
+## Shared chat execution
+
+Read [shared chat execution](./internals/chat-execution.md) for request resolution,
+native runtime selection, and cleanup. Core owns the common request and
+generation path. CLI and API adapters own presentation, tool authorization,
+wire compatibility, and admission or model-residency scope.
+
 ## Shared autoregressive decoding
 
 Read [shared decode boundaries](./internals/decode-runtime-boundaries.md) before

--- a/docs/internals/chat-execution.md
+++ b/docs/internals/chat-execution.md
@@ -1,0 +1,60 @@
+# Shared chat execution
+
+`text chat` and `/v1/chat/completions` share request resolution and native runtime
+invocation in `MereRunCore`. Start with `ChatRequestResolution.swift`, then read
+`NativeChatRuntime.swift` and its selection and diagnostics extensions.
+
+## Request resolution
+
+`ChatRequestResolver` resolves each omitted sampling field independently. Its
+`command` and `openAI` policies preserve the existing entry-point defaults. For
+example, an unrecognized model ID receives temperature `0.7` and top-p `0.9`
+under the command policy, and `1.0` and `0.95` under the API policy. This fallback
+does not make an unknown model available for execution.
+
+Explicit sampling values override their corresponding defaults. JSON output
+suppresses thinking output. The resolver preserves message media, tools, LoRA,
+stop sequences, cache settings, reasoning budgets, and diagnostic options.
+
+Both adapters use the same numeric checks. These reject empty message lists,
+invalid token or context limits, non-finite sampling values, out-of-range
+probabilities and penalties, negative top-k values, and repetition penalties
+that cannot be represented as a finite positive sampler value. CLI preflight
+reports these failures through `text_chat_request_invalid`.
+
+The API adapter still validates wire fields and model capabilities, resolves
+aliases, and applies stored server settings before common resolution. CLI tool
+authorization and media-input checks remain in the command adapter.
+
+## Generation and cleanup
+
+`NativeChatRuntime` selects and invokes native generators. Commands use the
+existing family selection rules, including command-only Psi and Inkling
+runtimes. The API selects its engine from the serving profile and passes its
+cache and batching settings to the same runtime factory.
+
+`ChatGenerationOperation.run` validates the effective request and checks
+cancellation before and after generation. A CLI command retains one runtime
+through its tool conversation and awaits unload when the conversation completes,
+fails, or is cancelled. Family generators continue to own loading and inference.
+
+`RuntimeServingServices.startChat` acquires API request admission, resolves the
+request, and acquires model residency. `RuntimeChatSession` owns both leases.
+Response producers retain the session through native generation or upstream
+proxy consumption. Its completion task releases model residency before request
+admission; concurrent completion calls await the same cleanup task.
+
+HTTP response formatting remains in `APIServer.swift`. Native streaming retains
+its text, tool-call, usage, and completion events. The macOS proxy stream forwards
+upstream bytes and cancels its producer when the downstream consumer disconnects.
+The Linux proxy path buffers upstream data and awaits cleanup before returning
+that buffered response.
+
+## Validation boundaries
+
+`ChatExecutionTests` exercises defaults, request-field preservation, invalid
+requests, tool-conversation lifetime, and awaited cancellation cleanup.
+`ChatExecutionIntegrationTests` exercises CLI/API resolution, preflight, server
+settings and aliases, admission and residency cleanup, and proxy byte streaming
+and disconnects. These fixtures do not load model checkpoints. Use installed
+model tests separately to assess generation output and performance.

--- a/docs/internals/chat-execution.md
+++ b/docs/internals/chat-execution.md
@@ -28,9 +28,11 @@ authorization and media-input checks remain in the command adapter.
 
 ## Generation and cleanup
 
-`NativeChatRuntime` selects and invokes native generators. Commands use the
-existing family selection rules, including command-only Psi and Inkling
-runtimes. The API selects its engine from the serving profile and passes its
+`NativeChatRuntime` selects and invokes native generators on macOS and Linux.
+This command/server adapter includes desktop-only GGUF and process-backed
+runtimes; the iOS app continues to select its on-device generators directly.
+Commands use the existing family selection rules, including command-only Psi
+and Inkling runtimes. The API selects its engine from the serving profile and passes its
 cache and batching settings to the same runtime factory.
 
 `ChatGenerationOperation.run` validates the effective request and checks

--- a/docs/runtime/text.md
+++ b/docs/runtime/text.md
@@ -941,3 +941,11 @@ If you want to understand the text stack:
 
 For repository orientation, pair this page with
 [CLI and runtime internals](../internals/cli-and-runtime.md).
+
+## Request validation and lifetime
+
+`text chat` checks numeric sampling and token limits before generation. Its
+preflight report uses the same checks. During a tool conversation, the command
+retains one native runtime and unloads it after completion, failure, or
+cancellation. See [shared chat execution](../internals/chat-execution.md) for the
+request and runtime boundaries shared with the API.


### PR DESCRIPTION
## Summary

`text chat` and API chat had separate sampling validation and generator dispatch, while HTTP handlers repeatedly paired model and admission cleanup. Move common resolution and native invocation into Core, and let one API chat session own both leases. CLI tool conversations retain one runtime and await unload; disconnected macOS proxy streams cancel upstream reads.

Preserve each entry point's omitted defaults, server aliases and settings, response formatting, and built-in tool authorization. The CLI clamps its output budget to a smaller context, keeps missing-model failures as argument validation errors, and uses the selected engine's default for an empty model ID. For example, `mere.run text chat --prompt hello --context-size 1024` no longer fails because the omitted output budget defaults to 2048. Sampling values the CLI previously passed through now receive range checks, including in preflight.

The command/server runtime adapter is limited to macOS and Linux because it includes desktop-only generators. Common request validation remains available on iOS, whose app selects on-device generators directly. This PR targets `main`.

## Validation

- [x] `./scripts/check.sh` on the corrected regression tests: 4,129 XCTest cases, 314 skipped, zero failures; 51 Swift Testing cases passed. Includes lint, build, help sweep, hygiene, and dependency boundaries.
- [x] Regression tests cover defaults, smaller contexts, empty-model selection, request parity, settings, cleanup, and proxy cancellation. The empty-model assertion awaits actor-isolated state.
- [x] Rebuilt CLI probes: a 1024-token-context preflight exits 0 without a request-validation blocker; absent Laguna model exits 64 with usage, using an isolated empty model root.
- [x] `pnpm docs:build` passed.
- [x] iOS Release build and simulator unit tests passed locally on `b6ec986a` (20 tests, 7 skipped, zero failures), and that head passed hosted CI. Current-head hosted checks must pass independently.
- [x] Vendored artifacts and package pins unchanged; notices update not applicable.

Fixtures and local byte streams validate ownership and request behavior. Checkpoint-backed inference and performance were not run. A cancellation arriving after native generation completes still cancels the operation; its model completion timing can be omitted, while request cancellation and lease release remain accounted for. Eviction uses residency and last-access state rather than completion/failure counters.
