### PR TITLE
Consolidate training, workflows, and durable execution

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+- Share text LoRA option validation, dataset preparation, native execution, and
+  adapter-manifest publication in Core. Preserve CLI defaults and resume
+  formats, await dashboard shutdown, and prevent cancelled training from
+  publishing a successful manifest.
+- Record cancelled image execution as cancelled when the executor throws a
+  different error after task cancellation.
+- Preserve explicit speech model IDs during resolution instead of silently
+  loading an installed default checkpoint.
+
 - Share chat sampling resolution, numeric validation, native invocation, and
   cleanup between `text chat` and the API. `text chat` now range-checks sampling
   values that it previously passed straight to the generator, rejecting them

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+- Write durable run records on Apple volumes without file protection support.
+  Keep private permissions and atomic replacement on every filesystem; apply
+  `completeUnlessOpen` on volumes that support it.
 - Share text LoRA option validation, dataset preparation, native execution, and
   adapter-manifest publication in Core. Preserve CLI defaults and resume
   formats, await dashboard shutdown, and prevent cancelled training from

--- a/Sources/AudioCore/SpeechTranscriptionRunRecord.swift
+++ b/Sources/AudioCore/SpeechTranscriptionRunRecord.swift
@@ -50,7 +50,7 @@ public struct SpeechTranscriptionRunRecord: Codable, Equatable, Sendable {
         let recordURL = recordURL(at: url)
         let lease = try RunDirectoryLease.acquire(in: recordURL.deletingLastPathComponent(), filename: lockFilename)
         defer { lease?.release() }
-        var record = try decode(Data(contentsOf: recordURL))
+        var record = try decode(RunRecordCodec.readData(at: recordURL))
         if lease != nil, !record.state.isTerminal {
             record.state = .interrupted
             record.updatedAt = RunRecordCodec.timestamp()

--- a/Sources/AudioCore/SpeechTranscriptionRunSession.swift
+++ b/Sources/AudioCore/SpeechTranscriptionRunSession.swift
@@ -61,10 +61,10 @@ public final class SpeechTranscriptionRunSession: @unchecked Sendable {
             }
             let resultURL = directory.appendingPathComponent("result.json")
             let transcriptURL = directory.appendingPathComponent("transcript.txt")
-            try RunRecordCodec.write(outcome.result, to: resultURL)
+            let resultArtifact = try RunRecordCodec.writeArtifact(outcome.result, to: resultURL)
             try outcome.result.text.write(to: transcriptURL, atomically: true, encoding: .utf8)
             try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: transcriptURL.path)
-            record.artifacts = try [resultURL, transcriptURL].map(RunArtifact.read)
+            record.artifacts = [resultArtifact, try RunArtifact.read(transcriptURL)]
             try Task.checkCancellation()
             record.state = .succeeded
             do { try save() } catch {

--- a/Sources/AudioSTT/SpeechTranscriptionResolver.swift
+++ b/Sources/AudioSTT/SpeechTranscriptionResolver.swift
@@ -178,7 +178,7 @@ public enum SpeechTranscriptionResolver {
         if let overridePath = existingPath(from: modelOverride) {
             return overridePath.path
         }
-        if localAvailable {
+        if localAvailable, modelOverride == nil || modelOverride == Qwen3ASRResources.defaultModelId {
             return localRoot.path
         }
         return nil
@@ -192,7 +192,7 @@ public enum SpeechTranscriptionResolver {
         if let overridePath = existingPath(from: modelOverride) {
             return overridePath.path
         }
-        if localAvailable {
+        if localAvailable, modelOverride == nil || modelOverride == ParakeetResources.defaultModelId {
             return localRoot.path
         }
         return nil

--- a/Sources/MereRunCLI/Commands/ImageTrainLoRACommand.swift
+++ b/Sources/MereRunCLI/Commands/ImageTrainLoRACommand.swift
@@ -3,13 +3,13 @@ import Foundation
 import MereRunCore
 
 struct ImageTrainLoRA: AsyncParsableCommand {
-    static let defaultManagedModelID: ModelResolver.ModelID = .krea2Raw
-    private static let defaultWidth = 1024
-    private static let defaultHeight = 1024
-    private static let defaultTrainingSteps = 1000
-    private static let defaultLearningRate: Float = 1e-4
-    private static let defaultRank = 16
-    private static let defaultCaptionDropout: Float = 0.05
+    static let defaultManagedModelID: ModelResolver.ModelID = ImageLoRATrainingOptions.defaultManagedModelID
+    private static let defaultWidth = ImageLoRATrainingOptions.defaultWidth
+    private static let defaultHeight = ImageLoRATrainingOptions.defaultHeight
+    private static let defaultTrainingSteps = ImageLoRATrainingOptions.defaultTrainingSteps
+    private static let defaultLearningRate: Float = ImageLoRATrainingOptions.defaultLearningRate
+    private static let defaultRank = ImageLoRATrainingOptions.defaultRank
+    private static let defaultCaptionDropout: Float = ImageLoRATrainingOptions.defaultCaptionDropout
 
     static let configuration = CommandConfiguration(
         commandName: "train-lora",
@@ -220,185 +220,105 @@ struct ImageTrainLoRA: AsyncParsableCommand {
     @Flag(name: [.short, .long], help: "Print only the output path.")
     var quiet: Bool = false
 
-    func run() async throws {
-        let resolvedOptions = try resolvedTrainingOptions()
-        try validateResolvedOptions(resolvedOptions)
+    func trainingOptions() -> ImageLoRATrainingOptions {
+        var options = ImageLoRATrainingOptions(data: data, output: output)
+        options.model = model
+        options.widthOverride = widthOverride
+        options.heightOverride = heightOverride
+        options.trainingStepsOverride = trainingStepsOverride
+        options.batchSize = batchSize
+        options.learningRateOverride = learningRateOverride
+        options.rankOverride = rankOverride
+        options.alphaOverride = alphaOverride
+        options.maxTextLength = maxTextLength
+        options.schedulerSteps = schedulerSteps
+        options.captionDropoutOverride = captionDropoutOverride
+        options.seed = seed
+        options.lite = lite
+        options.baseQuantizationBits = baseQuantizationBits
+        options.excludePreviewImages = excludePreviewImages
+        options.checkpointInterval = checkpointInterval
+        options.resumeFrom = resumeFrom
+        options.maxResolution = maxResolution
+        options.progressive = progressive
+        options.lowRam = lowRam
+        options.noCompile = noCompile
+        options.gradientCheckpointing = gradientCheckpointing
+        options.recipe = recipe
+        options.benchmarkSteps = benchmarkSteps
+        options.benchmarkWarmupSteps = benchmarkWarmupSteps
+        options.sampleInterval = sampleInterval
+        options.samplePrompt = samplePrompt
+        options.sampleModel = sampleModel
+        options.sampleSteps = sampleSteps
+        options.sampleGuidanceScale = sampleGuidanceScale
+        options.sampleLoRAScale = sampleLoRAScale
+        options.sampleSeed = sampleSeed
+        options.loraTargetRanks = loraTargetRanks
+        options.loraRankPreset = loraRankPreset
+        options.loraTargetPreset = loraTargetPreset
+        options.loraTargetMode = loraTargetMode
+        options.timestepSampling = timestepSampling
+        options.timestepLossWeighting = timestepLossWeighting
+        options.lossWeighting = lossWeighting
+        options.timestepLow = timestepLow
+        options.timestepHigh = timestepHigh
+        options.lrWarmupSteps = lrWarmupSteps
+        options.noCosineScheduler = noCosineScheduler
+        options.lrMinFactor = lrMinFactor
+        options.adamWeightDecay = adamWeightDecay
+        options.syntheticSamples = syntheticSamples
+        return options
+    }
 
+    func run() async throws {
+        do {
+            try await runTraining()
+        } catch let error as ImageLoRATrainingIssue {
+            throw ValidationError(error.message(modelPullCommand: CLICommandDisplay.modelPullCommand))
+        }
+    }
+
+    private func runTraining() async throws {
+        let input = trainingOptions()
+        let resolvedOptions = try input.resolve()
+        try input.validate(resolvedOptions)
+        if visualize, !(1...65535).contains(visualizePort) {
+            throw ValidationError("--visualize-port must be between 1 and 65535")
+        }
         if preflight {
             try runPreflight(options: resolvedOptions)
             return
         }
-
         try MLXBundleSupport.ensureAvailable(quiet: quiet)
-
-        let outputURL = URL(fileURLWithPath: output).standardizedFileURL
-        guard outputURL.pathExtension.lowercased() == "safetensors" else {
-            throw ValidationError("--output must end in .safetensors")
-        }
-        try FileManager.default.createDirectory(
-            at: outputURL.deletingLastPathComponent(),
-            withIntermediateDirectories: true
-        )
-
-        let modelRoot = try resolveModelRoot(model: resolvedOptions.model)
-        let modelManifest = try MereRunModelManifest.loadRequired(from: modelRoot)
+        let outputURL = try ImageLoRATrainingPlan.outputURL(for: output)
+        try FileManager.default.createDirectory(at: outputURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        let plan = try ImageLoRATrainingPlan.resolve(input)
         let runContext = try startRunContextIfNeeded(
-            outputURL: outputURL,
-            modelRoot: modelRoot,
-            modelManifest: modelManifest,
-            options: resolvedOptions
+            outputURL: outputURL, modelRoot: plan.modelRoot,
+            modelManifest: plan.modelManifest, options: resolvedOptions
         )
-        defer { runContext?.stop() }
-
+        let outcome: ImageLoRATrainingOutcome
         do {
-            switch modelManifest.family {
-            case .krea:
-                try await runKreaTraining(
-                    modelRoot: modelRoot,
-                    outputURL: outputURL,
-                    options: resolvedOptions,
-                    eventLogger: runContext?.logger
-                )
-            case .klein:
-                try await runKleinTraining(
-                    modelRoot: modelRoot,
-                    outputURL: outputURL,
-                    options: resolvedOptions,
-                    eventLogger: runContext?.logger
-                )
-            default:
-                let family = modelManifest.family?.rawValue ?? "unknown"
-                throw ValidationError("Unsupported LoRA training model family: \(family). Use a Krea 2 Raw or FLUX.2 Klein base model.")
+            if !quiet {
+                CLIStderr.write("[runtime] image training backend: \(NativeMLXRuntime.backendDescription)\n")
             }
+            outcome = try await ImageLoRATrainingOperation.execute(
+                plan, progress: makeTrainingProgressHandler(eventLogger: runContext?.logger)
+            )
             try runContext?.logger.record(
-                type: "run_finished",
-                stage: "finished",
-                step: resolvedOptions.trainingSteps,
-                totalSteps: resolvedOptions.trainingSteps,
-                fraction: 1,
-                path: outputURL.path
+                type: "run_finished", stage: "finished", step: resolvedOptions.trainingSteps,
+                totalSteps: resolvedOptions.trainingSteps, fraction: 1, path: outputURL.path
             )
         } catch {
             try? runContext?.logger.record(
-                type: "run_failed",
-                stage: "failed",
-                message: error.localizedDescription,
-                path: outputURL.path
+                type: "run_failed", stage: "failed", message: error.localizedDescription, path: outputURL.path
             )
+            await runContext?.stop()
             throw error
         }
-
-        if benchmarkSteps == nil {
-            print(outputURL.path)
-        }
-    }
-
-    private func validateResolvedOptions(_ resolvedOptions: ResolvedLoRATrainingOptions) throws {
-        guard resolvedOptions.width > 0,
-              resolvedOptions.height > 0,
-              resolvedOptions.width % 16 == 0,
-              resolvedOptions.height % 16 == 0 else {
-            throw ValidationError("--width/--height must be > 0 and divisible by 16")
-        }
-        guard resolvedOptions.trainingSteps >= 1 else {
-            throw ValidationError("--training-steps must be >= 1")
-        }
-        guard batchSize >= 1 else {
-            throw ValidationError("--batch-size must be >= 1")
-        }
-        guard schedulerSteps >= 1 else {
-            throw ValidationError("--scheduler-steps must be >= 1")
-        }
-        guard resolvedOptions.rank >= 1 else {
-            throw ValidationError("--rank must be >= 1")
-        }
-        guard (0.0...1.0).contains(resolvedOptions.captionDropout) else {
-            throw ValidationError("--caption-dropout must be between 0.0 and 1.0")
-        }
-        if let syntheticSamples, syntheticSamples < 1 {
-            throw ValidationError("--synthetic-samples must be >= 1")
-        }
-        if let checkpointInterval = resolvedOptions.checkpointInterval, checkpointInterval < 1 {
-            throw ValidationError("--checkpoint-interval must be >= 1")
-        }
-        if let resumeFrom {
-            let resumeURL = URL(fileURLWithPath: resumeFrom).standardizedFileURL
-            guard FileManager.default.fileExists(atPath: resumeURL.path) else {
-                throw ValidationError("--resume-from checkpoint not found: \(resumeURL.path)")
-            }
-        }
-        if let maxResolution = resolvedOptions.maxResolution, maxResolution < 1 {
-            throw ValidationError("--max-resolution must be >= 1")
-        }
-        if let benchmarkSteps, benchmarkSteps < 1 {
-            throw ValidationError("--benchmark-steps must be >= 1")
-        }
-        guard benchmarkWarmupSteps >= 0 else {
-            throw ValidationError("--benchmark-warmup-steps must be >= 0")
-        }
-        if resolvedOptions.maxResolution != nil, progressive {
-            throw ValidationError("--max-resolution cannot be combined with --progressive")
-        }
-        if let sampleInterval, sampleInterval < 1 {
-            throw ValidationError("--sample-interval must be >= 1")
-        }
-        guard sampleSteps >= 1 else {
-            throw ValidationError("--sample-steps must be >= 1")
-        }
-        guard sampleGuidanceScale >= 0 else {
-            throw ValidationError("--sample-cfg must be >= 0")
-        }
-        guard sampleLoRAScale >= 0 else {
-            throw ValidationError("--sample-lora-scale must be >= 0")
-        }
-        if visualize, !(1...65535).contains(visualizePort) {
-            throw ValidationError("--visualize-port must be between 1 and 65535")
-        }
-        if loraTargetRanks != nil, loraRankPreset != nil {
-            throw ValidationError("--lora-target-ranks cannot be combined with --lora-rank-preset")
-        }
-        if let loraTargetPreset = resolvedOptions.loraTargetPreset {
-            if lite {
-                throw ValidationError("--lite cannot be combined with --lora-target-preset")
-            }
-            if loraTargetRanks != nil || loraRankPreset != nil {
-                throw ValidationError("--lora-target-preset cannot be combined with --lora-target-ranks or --lora-rank-preset")
-            }
-            _ = try Self.resolveKleinTargetPreset(loraTargetPreset, rank: resolvedOptions.rank)
-        }
-        let parsedLoRATargetMode = try Self.resolveKleinLoRATargetMode(loraTargetMode)
-        if parsedLoRATargetMode == .transformerLinearWalk {
-            if lite {
-                throw ValidationError("--lite cannot be combined with --lora-target-mode transformer-linear-walk")
-            }
-            if loraTargetRanks != nil || loraRankPreset != nil || resolvedOptions.loraTargetPreset != nil {
-                throw ValidationError("--lora-target-mode transformer-linear-walk cannot be combined with LoRA target/rank presets")
-            }
-        }
-        if let timestepLow, timestepLow < 0 {
-            throw ValidationError("--timestep-low must be >= 0")
-        }
-        if let timestepHigh, timestepHigh < 1 {
-            throw ValidationError("--timestep-high must be >= 1")
-        }
-        if let timestepLow, let timestepHigh, timestepHigh <= timestepLow {
-            throw ValidationError("--timestep-high must be greater than --timestep-low")
-        }
-        if let timestepHigh, timestepHigh > schedulerSteps {
-            throw ValidationError("--timestep-high must be <= --scheduler-steps")
-        }
-        if let lrWarmupSteps, lrWarmupSteps < 0 {
-            throw ValidationError("--lr-warmup-steps must be >= 0")
-        }
-        if let lrMinFactor, !(0.0...1.0).contains(lrMinFactor) {
-            throw ValidationError("--lr-min-factor must be between 0.0 and 1.0")
-        }
-        if let adamWeightDecay, adamWeightDecay < 0 {
-            throw ValidationError("--adam-weight-decay must be >= 0")
-        }
-        if let baseQuantizationBits, baseQuantizationBits != 4, baseQuantizationBits != 8 {
-            throw ValidationError("--base-quantization-bits must be 4 or 8")
-        }
+        await runContext?.stop()
+        if case .saved(let url) = outcome { print(url.path) }
     }
 
     func makePreflightEnvelope(
@@ -596,500 +516,21 @@ struct ImageTrainLoRA: AsyncParsableCommand {
         return args
     }
 
-    private func runKreaTraining(
-        modelRoot: URL,
-        outputURL: URL,
-        options: ResolvedLoRATrainingOptions,
-        eventLogger: LoRATrainingEventLogger?
-    ) async throws {
-        if options.checkpointInterval != nil {
-            throw ValidationError("--checkpoint-interval is only supported for FLUX.2 Klein LoRA training")
-        }
-        if hasKleinOnlyTrainingOptions(options: options) {
-            throw ValidationError("Klein training options require a FLUX.2 Klein base model.")
-        }
-
-        let examples: [Krea2LoRATrainingExample]
-        let datasetRoot: String?
-        if syntheticSamples != nil {
-            examples = []
-            datasetRoot = nil
-        } else {
-            guard let data else {
-                throw ValidationError("--data is required unless --synthetic-samples is set")
-            }
-            let dataURL = URL(fileURLWithPath: data).standardizedFileURL
-            let pairs = try DatasetLoader.loadImageCaptionPairs(
-                from: dataURL,
-                excludePreviewImages: excludePreviewImages
-            )
-            examples = pairs.map { pair in
-                Krea2LoRATrainingExample(imageURL: pair.imageURL, caption: pair.caption)
-            }
-            datasetRoot = dataURL.path
-        }
-
-        var config = Krea2LoRATrainingConfig()
-        config.width = options.width
-        config.height = options.height
-        config.maxTextLength = maxTextLength
-        config.schedulerSteps = schedulerSteps
-        config.trainingSteps = options.trainingSteps
-        config.batchSize = batchSize
-        config.learningRate = options.learningRate
-        config.seed = seed
-        config.loraRank = options.rank
-        config.loraAlpha = options.alpha
-        config.captionDropout = options.captionDropout
-        config.loraTargetSuffixes = lite ? Krea2LoRAInjector.liteTargetSuffixes : nil
-        config.baseQuantizationBits = baseQuantizationBits
-        config.syntheticSampleCount = syntheticSamples
-        config.datasetRoot = datasetRoot
-        config.useCompile = !options.noCompile
-        if let lrWarmupSteps = options.lrWarmupSteps {
-            config.lrWarmupSteps = lrWarmupSteps
-        }
-        if let useCosineScheduler = options.useCosineScheduler {
-            config.useCosineScheduler = useCosineScheduler
-        }
-        if let lrMinFactor = options.lrMinFactor {
-            config.lrMinFactor = lrMinFactor
-        }
-
-        let stderrProgressHandler = quiet ? nil : Self.makeProgressHandler()
-        let progressHandler = Self.makeKreaProgressHandler(
-            stderrProgressHandler: stderrProgressHandler,
-            eventLogger: eventLogger
-        )
-        if !quiet {
-            CLIStderr.write("[runtime] image training backend: \(NativeMLXRuntime.backendDescription)\n")
-        }
-
-        try await Krea2LoRATrainer.train(
-            modelPath: modelRoot.path,
-            examples: examples,
-            outputURL: outputURL,
-            config: config,
-            progressHandler: progressHandler
-        )
-    }
-
-    private func runKleinTraining(
-        modelRoot: URL,
-        outputURL: URL,
-        options: ResolvedLoRATrainingOptions,
-        eventLogger: LoRATrainingEventLogger?
-    ) async throws {
-        if baseQuantizationBits != nil {
-            throw ValidationError("--base-quantization-bits is only supported for Krea 2 LoRA training")
-        }
-        if syntheticSamples != nil {
-            throw ValidationError("--synthetic-samples is only supported for Krea 2 LoRA smoke tests")
-        }
-        guard let data else {
-            throw ValidationError("--data is required")
-        }
-
-        let dataURL = URL(fileURLWithPath: data).standardizedFileURL
-        let pairs = try DatasetLoader.loadImageCaptionPairs(
-            from: dataURL,
-            excludePreviewImages: excludePreviewImages
-        )
-        let examples = pairs.map { pair in
-            Flux2KleinLoRATrainingExample(imageURL: pair.imageURL, caption: pair.caption)
-        }
-
-        var config = Flux2KleinLoRATrainingConfig()
-        let rankPreset = try Self.resolveKleinRankPreset(loraRankPreset)
-        let resolvedRank = rankPreset?.rank ?? options.rank
-        let targetRanks = try Self.resolveKleinTargetPreset(options.loraTargetPreset, rank: resolvedRank)
-        let targetRankSuffixes = try loraTargetRanks.map(Self.parseKleinTargetRankSuffixes) ?? rankPreset?.targetRankSuffixes
-        config.width = options.width
-        config.height = options.height
-        config.maxResolution = options.maxResolution
-        config.maxTextLength = maxTextLength
-        config.schedulerSteps = schedulerSteps
-        config.trainingSteps = benchmarkSteps.map { benchmarkWarmupSteps + $0 } ?? options.trainingSteps
-        config.batchSize = batchSize
-        config.learningRate = options.learningRate
-        config.seed = seed
-        config.loraRank = resolvedRank
-        config.loraAlpha = options.alpha ?? rankPreset?.alpha ?? Float(config.loraRank)
-        config.loraTargetMode = try Self.resolveKleinLoRATargetMode(loraTargetMode)
-        config.captionDropout = options.captionDropout
-        config.loraTargetSuffixes = lite ? Self.kleinLiteTargetSuffixes : nil
-        config.loraTargetRanks = targetRanks
-        config.loraTargetRankSuffixes = targetRankSuffixes
-        config.checkpointInterval = options.checkpointInterval
-        config.sampleInterval = sampleInterval
-        config.samplePrompt = samplePrompt
-        config.progressive = progressive
-        config.lowRam = options.lowRam
-        config.gradientCheckpointing = gradientCheckpointing
-        config.benchmarkSteps = benchmarkSteps
-        config.benchmarkWarmupSteps = benchmarkWarmupSteps
-        if options.noCompile || gradientCheckpointing {
-            config.useCompile = false
-        }
-        config.datasetRoot = dataURL.path
-        if let raw = timestepSampling {
-            guard let parsed = Flux2TimestepSamplingStrategy(rawValue: raw) else {
-                throw ValidationError("Unsupported --timestep-sampling '\(raw)'")
-            }
-            config.timestepSampling = parsed
-        }
-        if let raw = timestepLossWeighting {
-            guard let parsed = Flux2TimestepLossWeightingStrategy(rawValue: raw) else {
-                throw ValidationError("Unsupported --timestep-loss-weighting '\(raw)'")
-            }
-            config.timestepLossWeighting = parsed
-        }
-        if let raw = lossWeighting {
-            guard let parsed = Flux2LossWeightingStrategy(rawValue: raw) else {
-                throw ValidationError("Unsupported --loss-weighting '\(raw)'")
-            }
-            config.lossWeighting = parsed
-        }
-        if let timestepLow {
-            config.timestepLow = timestepLow
-        }
-        if let timestepHigh {
-            config.timestepHigh = timestepHigh
-        }
-        if let lrWarmupSteps {
-            config.lrWarmupSteps = lrWarmupSteps
-        }
-        if noCosineScheduler {
-            config.useCosineScheduler = false
-        }
-        if let lrMinFactor {
-            config.lrMinFactor = lrMinFactor
-        }
-        if let adamWeightDecay {
-            config.adamWeightDecay = adamWeightDecay
-        }
-
-        let stderrProgressHandler = quiet ? nil : Self.makeKleinProgressHandler()
-        let progressHandler = Self.makeKleinProgressHandler(
-            stderrProgressHandler: stderrProgressHandler,
-            eventLogger: eventLogger
-        )
-        let sampleHandler = try makeKleinSampleHandler(
-            outputURL: outputURL,
-            fallbackPrompt: examples.first?.caption ?? "",
-            width: options.width,
-            height: options.height,
-            eventLogger: eventLogger
-        )
-        if !quiet {
-            CLIStderr.write("[runtime] image training backend: \(NativeMLXRuntime.backendDescription)\n")
-        }
-
-        try await Flux2KleinLoRATrainer.train(
-            modelPath: modelRoot.path,
-            examples: examples,
-            outputURL: outputURL,
-            config: config,
-            resumeFromLoRA: resumeFrom.map { URL(fileURLWithPath: $0).standardizedFileURL },
-            progressHandler: progressHandler,
-            sampleHandler: sampleHandler
-        )
-    }
-
-    struct ResolvedLoRATrainingOptions {
-        let model: String?
-        let width: Int
-        let height: Int
-        let trainingSteps: Int
-        let learningRate: Float
-        let rank: Int
-        let alpha: Float?
-        let captionDropout: Float
-        let checkpointInterval: Int?
-        let maxResolution: Int?
-        let lowRam: Bool
-        let noCompile: Bool
-        let loraTargetPreset: String?
-        let lrWarmupSteps: Int?
-        let useCosineScheduler: Bool?
-        let lrMinFactor: Float?
-    }
-
-    private struct LoRATrainingRecipe {
-        let model: String?
-        let width: Int?
-        let height: Int?
-        let trainingSteps: Int?
-        let learningRate: Float?
-        let rank: Int?
-        let alpha: Float?
-        let captionDropout: Float?
-        let checkpointInterval: Int?
-        let maxResolution: Int?
-        let lowRam: Bool
-        let noCompile: Bool
-        let loraTargetPreset: String?
-        let lrWarmupSteps: Int?
-        let useCosineScheduler: Bool?
-        let lrMinFactor: Float?
-    }
+    typealias ResolvedLoRATrainingOptions = ImageLoRATrainingOptions.Resolved
 
     func resolvedTrainingOptions() throws -> ResolvedLoRATrainingOptions {
-        let recipe = try Self.resolveLoRATrainingRecipe(recipe)
-        let explicitSchedulerRequested = lrWarmupSteps != nil || lrMinFactor != nil
-        return ResolvedLoRATrainingOptions(
-            model: model ?? recipe?.model,
-            width: widthOverride ?? recipe?.width ?? Self.defaultWidth,
-            height: heightOverride ?? recipe?.height ?? Self.defaultHeight,
-            trainingSteps: trainingStepsOverride ?? recipe?.trainingSteps ?? Self.defaultTrainingSteps,
-            learningRate: learningRateOverride ?? recipe?.learningRate ?? Self.defaultLearningRate,
-            rank: rankOverride ?? recipe?.rank ?? Self.defaultRank,
-            alpha: alphaOverride ?? recipe?.alpha,
-            captionDropout: captionDropoutOverride ?? recipe?.captionDropout ?? Self.defaultCaptionDropout,
-            checkpointInterval: checkpointInterval ?? recipe?.checkpointInterval,
-            maxResolution: maxResolution ?? recipe?.maxResolution,
-            lowRam: lowRam || recipe?.lowRam == true,
-            noCompile: noCompile || recipe?.noCompile == true,
-            loraTargetPreset: loraTargetPreset ?? recipe?.loraTargetPreset,
-            lrWarmupSteps: lrWarmupSteps ?? recipe?.lrWarmupSteps,
-            useCosineScheduler: noCosineScheduler ? false : recipe?.useCosineScheduler ?? (explicitSchedulerRequested ? true : nil),
-            lrMinFactor: lrMinFactor ?? recipe?.lrMinFactor
-        )
-    }
-
-    private static func resolveLoRATrainingRecipe(_ raw: String?) throws -> LoRATrainingRecipe? {
-        guard let raw else { return nil }
-        switch raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
-        case "krea-fast-style", "local-krea-style", "fal-krea-style", "krea2-fast-style":
-            return LoRATrainingRecipe(
-                model: ModelResolver.ModelID.krea2Raw.rawValue,
-                width: 768,
-                height: 768,
-                trainingSteps: 100,
-                learningRate: 0.0005,
-                rank: 32,
-                alpha: 32,
-                captionDropout: Self.defaultCaptionDropout,
-                checkpointInterval: nil,
-                maxResolution: nil,
-                lowRam: false,
-                noCompile: false,
-                loraTargetPreset: nil,
-                lrWarmupSteps: 10,
-                useCosineScheduler: true,
-                lrMinFactor: 0
-            )
-        case "krea-cinematic-style", "krea-movie-style", "krea-wide-style":
-            return LoRATrainingRecipe(
-                model: ModelResolver.ModelID.krea2Raw.rawValue,
-                width: 768,
-                height: 416,
-                trainingSteps: 200,
-                learningRate: 0.0001,
-                rank: 32,
-                alpha: 32,
-                captionDropout: Self.defaultCaptionDropout,
-                checkpointInterval: nil,
-                maxResolution: nil,
-                lowRam: false,
-                noCompile: true,
-                loraTargetPreset: nil,
-                lrWarmupSteps: 20,
-                useCosineScheduler: true,
-                lrMinFactor: 0
-            )
-        case "klein-fast-style", "local-klein-style", "flux2-klein-fast-style":
-            return LoRATrainingRecipe(
-                model: ModelResolver.ModelID.kleinBase9B.rawValue,
-                width: nil,
-                height: nil,
-                trainingSteps: 1000,
-                learningRate: 0.00005,
-                rank: nil,
-                alpha: nil,
-                captionDropout: nil,
-                checkpointInterval: 250,
-                maxResolution: 512,
-                lowRam: true,
-                noCompile: true,
-                loraTargetPreset: "fal-klein-fast",
-                lrWarmupSteps: nil,
-                useCosineScheduler: nil,
-                lrMinFactor: nil
-            )
-        default:
-            throw ValidationError(
-                "Unsupported --recipe '\(raw)'. Supported recipes: krea-fast-style, krea-cinematic-style, klein-fast-style"
-            )
-        }
-    }
-
-    private struct KleinRankPreset {
-        let rank: Int
-        let alpha: Float
-        let targetRankSuffixes: [String: Int]
-    }
-
-    private static func resolveKleinRankPreset(_ raw: String?) throws -> KleinRankPreset? {
-        guard let raw else { return nil }
-        switch raw.lowercased() {
-        case "flux2-style-128", "style-128":
-            return KleinRankPreset(
-                rank: 128,
-                alpha: 64,
-                targetRankSuffixes: Dictionary(
-                    uniqueKeysWithValues: Flux2LoRAInjector.defaultTargetSuffixes.map { ($0, 128) }
-                )
-            )
-        default:
-            throw ValidationError("Unsupported --lora-rank-preset '\(raw)'. Supported preset: flux2-style-128")
-        }
-    }
-
-    private static func resolveKleinLoRATargetMode(_ raw: String?) throws -> Flux2LoRAInjector.TargetMode {
-        guard let raw else { return .suffix }
-        switch raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
-        case "suffix", "default":
-            return .suffix
-        case "transformer-linear-walk", "linear-walk", "all-linear", "walk":
-            return .transformerLinearWalk
-        default:
-            throw ValidationError("Unsupported --lora-target-mode '\(raw)'. Supported modes: suffix, transformer-linear-walk")
+        do {
+            return try trainingOptions().resolve()
+        } catch let error as ImageLoRATrainingIssue {
+            throw ValidationError(error.message(modelPullCommand: CLICommandDisplay.modelPullCommand))
         }
     }
 
     static func resolveKleinTargetPreset(_ raw: String?, rank: Int) throws -> [String: Int]? {
-        guard let raw else { return nil }
-        switch raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
-        case "fal-klein-fast", "fal-fast", "flux2-klein-fal-fast":
-            return falKleinFastTargetRanks(rank: rank)
-        default:
-            throw ValidationError("Unsupported --lora-target-preset '\(raw)'. Supported preset: fal-klein-fast")
-        }
-    }
-
-    private static func falKleinFastTargetRanks(rank: Int) -> [String: Int] {
-        var ranks: [String: Int] = [
-            "x_embedder": rank,
-            "context_embedder": rank,
-            "time_guidance_embed.timestep_embedder.linear_1": rank,
-            "time_guidance_embed.timestep_embedder.linear_2": rank,
-            "double_stream_modulation_img.linear": rank,
-            "double_stream_modulation_txt.linear": rank,
-            "single_stream_modulation.linear": rank,
-            "proj_out": rank,
-        ]
-
-        for block in 0..<8 {
-            for suffix in [
-                "attn.to_q",
-                "attn.to_k",
-                "attn.to_v",
-                "attn.to_out.0",
-                "attn.add_q_proj",
-                "attn.add_k_proj",
-                "attn.add_v_proj",
-                "attn.to_add_out",
-            ] {
-                ranks["transformer_blocks.\(block).\(suffix)"] = rank
-            }
-        }
-
-        for block in 0..<24 {
-            ranks["single_transformer_blocks.\(block).attn.to_qkv_mlp_proj"] = rank
-            ranks["single_transformer_blocks.\(block).attn.to_out"] = rank
-        }
-
-        return ranks
-    }
-
-    private static func parseKleinTargetRankSuffixes(_ raw: String) throws -> [String: Int] {
-        let entries = raw
-            .split(separator: ",")
-            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-            .filter { !$0.isEmpty }
-        guard !entries.isEmpty else {
-            throw ValidationError("--lora-target-ranks cannot be empty")
-        }
-
-        var ranks: [String: Int] = [:]
-        for entry in entries {
-            let parts = entry
-                .split(separator: "=", maxSplits: 1)
-                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-            guard parts.count == 2, !parts[0].isEmpty, let rank = Int(parts[1]) else {
-                throw ValidationError("Invalid --lora-target-ranks entry '\(entry)'; use suffix=rank")
-            }
-            guard rank >= 1 else {
-                throw ValidationError("--lora-target-ranks entry '\(entry)' must use rank >= 1")
-            }
-            ranks[parts[0]] = rank
-        }
-        return ranks
-    }
-
-    private func makeKleinSampleHandler(
-        outputURL: URL,
-        fallbackPrompt: String,
-        width: Int,
-        height: Int,
-        eventLogger: LoRATrainingEventLogger?
-    ) throws -> (@Sendable (Int, URL) async -> Void)? {
-        guard sampleInterval != nil else { return nil }
-
-        let modelPath = try resolveKleinSampleModelPath()
-        let prompt = (samplePrompt ?? fallbackPrompt).trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !prompt.isEmpty else {
-            throw ValidationError("--sample-prompt is empty and the first caption is empty")
-        }
-
-        let generator = Flux2KleinGenerator()
-        let outputBaseName = outputURL.deletingPathExtension().lastPathComponent
-        let sampleDirectory = outputURL.deletingLastPathComponent().appendingPathComponent("samples", isDirectory: true)
-        let sampleWidth = width
-        let sampleHeight = height
-        let steps = sampleSteps
-        let guidanceScale = sampleGuidanceScale
-        let loraScale = sampleLoRAScale
-        let seedValue = sampleSeed ?? (seed == 0 ? 42 : seed)
-        let quietMode = quiet
-
-        return { step, checkpointURL in
-            do {
-                try FileManager.default.createDirectory(at: sampleDirectory, withIntermediateDirectories: true)
-                let sampleURL = sampleDirectory.appendingPathComponent("\(outputBaseName)-step\(step)-sample.png")
-                let request = GenerationRequest(
-                    prompt: prompt,
-                    width: sampleWidth,
-                    height: sampleHeight,
-                    steps: steps,
-                    guidanceScale: guidanceScale,
-                    seed: seedValue,
-                    outputURL: sampleURL,
-                    model: modelPath,
-                    lora: .local(path: checkpointURL.path, scale: loraScale)
-                )
-                _ = try await generator.generate(request, progressHandler: nil)
-                try? eventLogger?.record(
-                    type: "sample_saved",
-                    stage: "sampling",
-                    step: step,
-                    path: sampleURL.path,
-                    metadata: ["checkpoint": checkpointURL.path]
-                )
-                if !quietMode {
-                    CLIStderr.write("[sample] \(sampleURL.path)\n")
-                }
-            } catch {
-                try? eventLogger?.record(
-                    type: "sample_failed",
-                    stage: "sampling",
-                    message: error.localizedDescription,
-                    step: step,
-                    metadata: ["checkpoint": checkpointURL.path]
-                )
-                CLIStderr.write("[sample] step \(step) failed: \(error.localizedDescription)\n")
-            }
+        do {
+            return try ImageLoRATrainingOptions.resolveKleinTargetPreset(raw, rank: rank)
+        } catch let error as ImageLoRATrainingIssue {
+            throw ValidationError(error.message(modelPullCommand: CLICommandDisplay.modelPullCommand))
         }
     }
 
@@ -1164,6 +605,13 @@ struct ImageTrainLoRA: AsyncParsableCommand {
         let viewer = LoRATrainingRunViewer(runDirectoryURL: runDirectoryURL)
         let host = "127.0.0.1"
         let port = visualizePort
+        try logger.record(
+            type: "viewer_started",
+            stage: "visualizing",
+            message: "LoRA training viewer started.",
+            path: runDirectoryURL.path,
+            metadata: ["viewer_url": "http://\(host):\(port)"]
+        )
         let task = Task {
             do {
                 try await viewer.run(host: host, port: port)
@@ -1173,98 +621,41 @@ struct ImageTrainLoRA: AsyncParsableCommand {
                 CLIStderr.write("[visualize] server stopped: \(error.localizedDescription)\n")
             }
         }
-        try logger.record(
-            type: "viewer_started",
-            stage: "visualizing",
-            message: "LoRA training viewer started.",
-            path: runDirectoryURL.path,
-            metadata: ["viewer_url": "http://\(host):\(port)"]
-        )
         return LoRATrainingRunContext(logger: logger, serverTask: task)
     }
 
-    private func resolveKleinSampleModelPath() throws -> String {
-        let spec = sampleModel ?? ModelResolver.ModelID.klein9B.rawValue
-        let url = URL(fileURLWithPath: spec).standardizedFileURL
-        if FileManager.default.fileExists(atPath: url.path) {
-            return url.path
-        }
-
-        if let id = ModelResolver.ModelID(rawValue: spec) {
-            do {
-                return try ModelResolver().resolve(id).rootURL.path
-            } catch {
-                throw ValidationError(
-                    "Sample model \(id.rawValue) not found. Pull it with `\(CLICommandDisplay.modelPullCommand(for: id.rawValue))` or pass --sample-model."
-                )
-            }
-        }
-
-        throw ValidationError("Sample model path not found: \(spec). Pass a local path or known model id.")
-    }
-
     private func hasKleinOnlyTrainingOptions(options: ResolvedLoRATrainingOptions) -> Bool {
-        options.maxResolution != nil ||
-            resumeFrom != nil ||
-            progressive ||
-            options.lowRam ||
-            gradientCheckpointing ||
-            benchmarkSteps != nil ||
-            benchmarkWarmupSteps != 5 ||
-            sampleInterval != nil ||
-            samplePrompt != nil ||
-            sampleModel != nil ||
-            sampleSteps != 8 ||
-            sampleGuidanceScale != 1.0 ||
-            sampleLoRAScale != 1.0 ||
-            sampleSeed != nil ||
-            loraTargetRanks != nil ||
-            loraRankPreset != nil ||
-            options.loraTargetPreset != nil ||
-            loraTargetMode != nil ||
-            timestepSampling != nil ||
-            timestepLossWeighting != nil ||
-            lossWeighting != nil ||
-            timestepLow != nil ||
-            timestepHigh != nil ||
-            adamWeightDecay != nil
+        trainingOptions().hasKleinOnlyTrainingOptions(options: options)
     }
 
-    private func resolveModelRoot(model: String?) throws -> URL {
-        let resolver = ModelResolver()
-        guard let model else {
-            do {
-                return try resolver.resolve(Self.defaultManagedModelID).rootURL
-            } catch {
-                let modelID = Self.defaultManagedModelID.rawValue
-                throw ValidationError(
-                    "Krea 2 Raw model \(modelID) not found. Pull it with `\(CLICommandDisplay.modelPullCommand(for: modelID))` or point --model at a local Raw model path."
+    private func makeTrainingProgressHandler(
+        eventLogger: LoRATrainingEventLogger?
+    ) -> @Sendable (ImageLoRATrainingProgress) -> Void {
+        let krea = Self.makeKreaProgressHandler(
+            stderrProgressHandler: quiet ? nil : Self.makeProgressHandler(), eventLogger: eventLogger
+        )
+        let klein = Self.makeKleinProgressHandler(
+            stderrProgressHandler: quiet ? nil : Self.makeKleinProgressHandler(), eventLogger: eventLogger
+        )
+        return { progress in
+            switch progress {
+            case .krea(let update): krea?(update)
+            case .klein(let update): klein?(update)
+            case .sampleSaved(let step, let url, let checkpoint):
+                try? eventLogger?.record(
+                    type: "sample_saved", stage: "sampling", step: step,
+                    path: url.path, metadata: ["checkpoint": checkpoint.path]
                 )
+                if !quiet { CLIStderr.write("[sample] \(url.path)\n") }
+            case .sampleFailed(let step, let message, let checkpoint):
+                try? eventLogger?.record(
+                    type: "sample_failed", stage: "sampling", message: message,
+                    step: step, metadata: ["checkpoint": checkpoint.path]
+                )
+                CLIStderr.write("[sample] step \(step) failed: \(message)\n")
             }
         }
-
-        let url = URL(fileURLWithPath: model).standardizedFileURL
-        if FileManager.default.fileExists(atPath: url.path) {
-            return url
-        }
-        if let id = ModelResolver.ModelID(rawValue: model) {
-            do {
-                return try resolver.resolve(id).rootURL
-            } catch {
-                throw ValidationError(
-                    "Model \(id.rawValue) not found. Pull it with `\(CLICommandDisplay.modelPullCommand(for: id.rawValue))` or point --model at a local path."
-                )
-            }
-        }
-        throw ValidationError("Model path not found: \(model). Pass a local model path or a known model id.")
     }
-
-    private static let kleinLiteTargetSuffixes: [String] = [
-        ".attn.to_q",
-        ".attn.to_v",
-        ".attn.add_q_proj",
-        ".attn.add_v_proj",
-    ]
 
     private static func makeProgressHandler() -> (@Sendable (Krea2LoRATrainingProgress) -> Void) {
         { progress in
@@ -1451,7 +842,8 @@ private struct LoRATrainingRunContext {
     let logger: LoRATrainingEventLogger
     let serverTask: Task<Void, Never>?
 
-    func stop() {
+    func stop() async {
         serverTask?.cancel()
+        await serverTask?.value
     }
 }

--- a/Sources/MereRunCLI/Commands/MusicTrainAdapterCommand.swift
+++ b/Sources/MereRunCLI/Commands/MusicTrainAdapterCommand.swift
@@ -71,222 +71,61 @@ struct MusicTrainAdapter: AsyncParsableCommand {
     @Option(name: [.customLong("log-every")], help: "Progress interval.")
     var logEvery: Int = 10
 
-    func run() async throws {
-        guard kind == .lora || kind == .lokr else {
-            throw ValidationError("--kind must be lora or lokr.")
-        }
-        guard maxDurationSeconds > 0, maxDurationSeconds <= 600 else {
-            throw ValidationError("--max-duration must be in (0, 600].")
-        }
-        guard logEvery > 0 else {
-            throw ValidationError("--log-every must be greater than zero.")
-        }
-
-        let manifestURL = ACEStepCLIHelper.resolveUserPath(dataset)
-        let records = try Self.loadManifest(from: manifestURL)
-        let examples = try records.enumerated().map { index, record in
-            let audioURL = Self.resolveAudioURL(
-                record.audio,
-                relativeTo: manifestURL.deletingLastPathComponent()
-            )
-            let decoded = try ACEStepCLIHelper.loadAudio48kHz(
-                audioURL.path,
-                label: "Dataset audio \(index + 1)"
-            )
-            let maxFrames = max(
-                1,
-                Int((maxDurationSeconds * 48_000).rounded())
-            )
-            let audio = decoded.dim(1) > maxFrames
-                ? decoded[0..., 0..<maxFrames, 0...]
-                : decoded
-            return ACEStepAdapterTrainingExample(
-                audio48kHz: audio,
-                caption: record.caption,
-                lyrics: record.lyrics ?? ""
-            )
-        }
-
-        let root = try await ACEStepCLIHelper.resolveCheckpointsRoot(
-            model: model,
-            checkpointsRoot: checkpointsRoot,
-            turboSubdirectory: decoderSubdirectory,
-            vaeSubdirectory: vaeSubdirectory,
-            lmSubdirectory: nil,
+    func trainingOptions() -> ACEStepAdapterTrainingOptions {
+        .init(
+            dataset: dataset, output: output, model: model,
+            configuration: .init(
+                kind: kind, rank: rank, alpha: alpha, factor: factor,
+                trainingSteps: steps, learningRate: learningRate,
+                weightDecay: weightDecay, seed: seed
+            ),
+            maxDurationSeconds: maxDurationSeconds, checkpointsRoot: checkpointsRoot,
+            decoderSubdirectory: decoderSubdirectory, vaeSubdirectory: vaeSubdirectory,
             textSubdirectory: textSubdirectory
         )
-        let decoder = try ACEStepCLIHelper.resolveTurboSubdirectory(
-            at: root,
-            explicit: decoderSubdirectory
-        )
-        guard let text = try ACEStepCLIHelper.resolveTextSubdirectory(
-            at: root,
-            explicit: textSubdirectory
-        ) else {
-            throw ValidationError("ACE-Step text encoder not found.")
-        }
-        let container = ACEStepModelContainer(
-            checkpointsRootURL: root,
-            turboSubdirectory: decoder,
-            vaeSubdirectory: vaeSubdirectory,
-            textEncoderSubdirectory: text
-        )
-        CLIStderr.write(
-            "Loading ACE-Step for \(kind.rawValue) training with "
-                + "\(examples.count) example(s)\n"
-        )
-        let resources = try await container.resources()
-        let pipeline = try ACEStepPipeline(
-            decoderResources: resources.decoderResources,
-            vaeResources: resources.vaeResources,
-            textEncoderResources: resources.textEncoderResources
-        )
-        let outputURL = ACEStepCLIHelper.resolveUserPath(output)
-        let eventLogger = try LoRATrainingEventLogger(baseOutputURL: outputURL)
-        try eventLogger.record(
-            type: "run_started",
-            stage: "training",
-            message: "ACE-Step \(kind.rawValue) training started.",
-            step: 0,
-            totalSteps: steps,
-            fraction: 0,
-            path: outputURL.path,
-            metadata: ["dataset": manifestURL.path, "model": model]
-        )
-        let report: ACEStepAdapterTrainingReport
+    }
+
+    func run() async throws {
         do {
-            report = try pipeline.trainAdapter(
-                examples: examples,
-                configuration: .init(
-                    kind: kind,
-                    rank: rank,
-                    alpha: alpha,
-                    factor: factor,
-                    trainingSteps: steps,
-                    learningRate: learningRate,
-                    weightDecay: weightDecay,
-                    seed: seed
-                ),
-                outputURL: outputURL
-            ) { progress in
-                try? eventLogger.record(
-                    type: "progress",
-                    stage: "training",
-                    step: progress.step,
-                    totalSteps: progress.totalSteps,
-                    loss: progress.loss,
-                    fraction: Float(progress.step) / Float(max(progress.totalSteps, 1)),
-                    path: outputURL.path
-                )
+            let options = trainingOptions()
+            try options.validate()
+            guard logEvery > 0 else {
+                throw ValidationError("--log-every must be greater than zero.")
+            }
+            let plan = try ACEStepAdapterTrainingPlan.resolve(options)
+            CLIStderr.write(
+                "Loading ACE-Step for \(kind.rawValue) training with "
+                    + "\(plan.records.count) example(s)\n"
+            )
+            let report = try await ACEStepAdapterTrainingOperation.execute(plan) { progress in
                 if progress.step == 1
                     || progress.step == progress.totalSteps
                     || progress.step.isMultiple(of: logEvery)
                 {
-                    CLIStderr.write(
-                        String(
-                            format: "ACE-Step adapter step %d/%d loss=%.6f\n",
-                            progress.step,
-                            progress.totalSteps,
-                            progress.loss
-                        )
-                    )
+                    CLIStderr.write(String(
+                        format: "ACE-Step adapter step %d/%d loss=%.6f\n",
+                        progress.step, progress.totalSteps, progress.loss
+                    ))
                 }
             }
-            try eventLogger.record(
-                type: "run_finished",
-                stage: "finished",
-                message: "ACE-Step adapter training finished.",
-                step: steps,
-                totalSteps: steps,
-                loss: report.finalLoss,
-                fraction: 1,
-                path: outputURL.path,
-                metadata: ["sha256": report.outputSHA256]
-            )
-        } catch {
-            try? eventLogger.record(
-                type: "run_failed",
-                stage: "failed",
-                message: error.localizedDescription,
-                path: outputURL.path
-            )
-            throw error
-        }
-        CLIStderr.write(
-            String(
+            CLIStderr.write(String(
                 format: "Saved %d-layer %@ adapter; loss %.6f -> %.6f; sha256=%@\n",
-                report.layerCount,
-                report.kind.rawValue,
-                report.initialLoss,
-                report.finalLoss,
-                report.outputSHA256
-            )
-        )
-        print(outputURL.path)
+                report.layerCount, report.kind.rawValue, report.initialLoss,
+                report.finalLoss, report.outputSHA256
+            ))
+            print(plan.outputURL.path)
+        } catch let error as ACEStepPreparationIssue {
+            throw ValidationError(error.message)
+        }
     }
 
-    struct ManifestRecord: Codable, Sendable {
-        var audio: String
-        var caption: String
-        var lyrics: String?
-    }
+    typealias ManifestRecord = ACEStepAdapterTrainingPlan.ManifestRecord
 
     static func loadManifest(from url: URL) throws -> [ManifestRecord] {
-        guard FileManager.default.fileExists(atPath: url.path) else {
-            throw ValidationError("Dataset manifest not found: \(url.path)")
+        do {
+            return try ACEStepAdapterTrainingPlan.loadManifest(from: url)
+        } catch let error as ACEStepPreparationIssue {
+            throw ValidationError(error.message)
         }
-        let data = try Data(contentsOf: url)
-        let decoder = JSONDecoder()
-        let records: [ManifestRecord]
-        if let decoded = try? decoder.decode([ManifestRecord].self, from: data) {
-            records = decoded
-        } else {
-            let text = String(decoding: data, as: UTF8.self)
-            records = try text.split(whereSeparator: \.isNewline)
-                .enumerated()
-                .map { lineNumber, line in
-                    do {
-                        return try decoder.decode(
-                            ManifestRecord.self,
-                            from: Data(line.utf8)
-                        )
-                    } catch {
-                        throw ValidationError(
-                            "Invalid dataset JSONL line \(lineNumber + 1): "
-                                + error.localizedDescription
-                        )
-                    }
-                }
-        }
-        guard !records.isEmpty else {
-            throw ValidationError("Dataset manifest contains no examples.")
-        }
-        for (index, record) in records.enumerated() {
-            if record.audio.trimmingCharacters(
-                in: .whitespacesAndNewlines
-            ).isEmpty {
-                throw ValidationError(
-                    "Dataset record \(index + 1) has an empty audio path."
-                )
-            }
-            if record.caption.trimmingCharacters(
-                in: .whitespacesAndNewlines
-            ).isEmpty {
-                throw ValidationError(
-                    "Dataset record \(index + 1) has an empty caption."
-                )
-            }
-        }
-        return records
-    }
-
-    private static func resolveAudioURL(
-        _ path: String,
-        relativeTo directory: URL
-    ) -> URL {
-        if path.hasPrefix("/") || path.hasPrefix("~") {
-            return ACEStepCLIHelper.resolveUserPath(path)
-        }
-        return directory.appendingPathComponent(path).standardizedFileURL
     }
 }

--- a/Sources/MereRunCLI/Commands/TextTrainLoRACommand.swift
+++ b/Sources/MereRunCLI/Commands/TextTrainLoRACommand.swift
@@ -98,196 +98,56 @@ struct TextTrainLoRA: AsyncParsableCommand {
 
     func run() async throws {
         try validateOptions()
-        let family = try resolvedTrainingFamily()
-        if family == .gemma4VLM, batchSize != 1 {
-            throw ValidationError("Gemma 4 VLM LoRA training currently requires --batch-size 1")
-        }
+        _ = try resolvedTrainingFamily()
         if !dryRun {
             try MLXBundleSupport.ensureAvailable(quiet: json)
         }
 
-        let dataURL = URL(fileURLWithPath: data).standardizedFileURL
-        let outputURL = URL(fileURLWithPath: output).standardizedFileURL
-        let mediaPolicy: TextSFTMediaPolicy = family == .gemma4VLM
-            ? .requireSingleLocalImage
-            : .forbid
-        let preparedDataset = try TextSFTDataset.loadForTraining(
-            from: dataURL,
-            mediaPolicy: mediaPolicy
-        )
-        let preparedEvaluationDataset = try eval.map {
-            try TextSFTDataset.loadForTraining(
-                from: URL(fileURLWithPath: $0).standardizedFileURL,
-                mediaPolicy: mediaPolicy
-            )
+        let plan: TextLoRATrainingPlan
+        do {
+            plan = try TextLoRATrainingPlan.resolve(trainingOptions)
+        } catch let issue as TextLoRATrainingIssue {
+            throw ValidationError(issue.message)
         }
-        let examples = preparedDataset.examples
-        let evaluationExamples = preparedEvaluationDataset?.examples ?? []
-        let summary = preparedDataset.summary
-        let evalCount = eval == nil ? nil : evaluationExamples.count
-        try FileManager.default.createDirectory(
-            at: outputURL.deletingLastPathComponent(),
-            withIntermediateDirectories: true
-        )
+        let dataURL = plan.dataURL
+        let outputURL = plan.outputURL
+        let summary = plan.dataset.summary
+        let evalCount = plan.evalPromptCount
         let visualization = try startVisualizationIfNeeded(
             dataURL: dataURL,
             outputURL: outputURL,
             datasetSummary: summary,
             evalPromptCount: evalCount
         )
-        defer { visualization?.stop() }
-
-        var report: TextLoRATrainingReport?
         do {
-            if !dryRun {
-                let config = TextLoRATrainingConfig(
-                    trainingSteps: trainingSteps,
-                    batchSize: batchSize,
-                    learningRate: learningRate,
-                    seed: seed,
-                    resumeFrom: resumeFrom.map {
-                        URL(fileURLWithPath: $0).standardizedFileURL
-                    },
-                    resumeStep: resumeStep
-                )
-                var metadata = [
-                    "adapter_name": adapterName,
-                    "dataset_fingerprint": summary.fingerprint,
-                ]
-                if let imageFingerprint = summary.imageFingerprint {
-                    metadata["dataset_image_fingerprint"] = imageFingerprint
-                }
-                switch family {
-                case .gemma4:
-                    report = try await Gemma4TextLoRATrainingPipeline.train(
-                        Gemma4TextLoRATrainingPipelineRequest(
-                            modelId: model,
-                            modelPath: modelPath,
-                            examples: examples,
-                            evaluationExamples: evaluationExamples,
-                            outputURL: outputURL,
-                            trainingConfig: config,
-                            maxSequenceLength: maxSequenceLength,
-                            rank: rank,
-                            alpha: alpha ?? Float(rank),
-                            targetSuffixes: resolvedTargetModules(),
-                            metadata: metadata
-                        ),
-                        progressHandler: makeChatProgressHandler(eventLogger: visualization?.logger),
-                        trainingProgressHandler: makeTrainingProgressHandler(eventLogger: visualization?.logger)
-                    )
-                case .gemma4VLM:
-                    report = try await Gemma4VLMLoRATrainingPipeline.train(
-                        Gemma4VLMLoRATrainingPipelineRequest(
-                            modelId: model,
-                            modelPath: modelPath,
-                            examples: examples,
-                            evaluationExamples: evaluationExamples,
-                            trainingImageDigestsByPath: preparedDataset.imageDigestsByPath,
-                            evaluationImageDigestsByPath: preparedEvaluationDataset?
-                                .imageDigestsByPath ?? [:],
-                            outputURL: outputURL,
-                            trainingConfig: config,
-                            maxSequenceLength: maxSequenceLength,
-                            rank: rank,
-                            alpha: alpha ?? Float(rank),
-                            targetSuffixes: resolvedTargetModules(),
-                            metadata: metadata
-                        ),
-                        progressHandler: makeChatProgressHandler(
-                            eventLogger: visualization?.logger
-                        ),
-                        trainingProgressHandler: makeTrainingProgressHandler(
-                            eventLogger: visualization?.logger
-                        )
-                    )
-                case .lagunaXS:
-                    report = try await LagunaTextLoRATrainingPipeline.train(
-                        LagunaTextLoRATrainingPipelineRequest(
-                            modelId: model,
-                            modelPath: modelPath,
-                            examples: examples,
-                            evaluationExamples: evaluationExamples,
-                            outputURL: outputURL,
-                            trainingConfig: config,
-                            maxSequenceLength: maxSequenceLength,
-                            rank: rank,
-                            alpha: alpha ?? Float(rank),
-                            targetSuffixes: resolvedTargetModules(),
-                            metadata: metadata
-                        ),
-                        progressHandler: makeChatProgressHandler(
-                            eventLogger: visualization?.logger
-                        ),
-                        trainingProgressHandler: makeTrainingProgressHandler(
-                            eventLogger: visualization?.logger
-                        )
-                    )
-                case .inkling:
-                    report = try await InklingTextLoRATrainingPipeline.train(
-                        InklingTextLoRATrainingPipelineRequest(
-                            modelId: model,
-                            modelPath: modelPath,
-                            examples: examples,
-                            evaluationExamples: evaluationExamples,
-                            outputURL: outputURL,
-                            trainingConfig: config,
-                            maxSequenceLength: maxSequenceLength,
-                            reasoningEffort: reasoningEffort,
-                            rank: rank,
-                            alpha: alpha ?? Float(rank),
-                            targetSuffixes: resolvedTargetModules(),
-                            metadata: metadata
-                        ),
-                        progressHandler: makeChatProgressHandler(
-                            eventLogger: visualization?.logger
-                        ),
-                        trainingProgressHandler: makeTrainingProgressHandler(
-                            eventLogger: visualization?.logger
-                        )
-                    )
-                case .lfm2A1B:
-                    report = try await LFM2TextLoRATrainingPipeline.train(
-                        LFM2TextLoRATrainingPipelineRequest(
-                            modelId: model,
-                            modelPath: modelPath,
-                            examples: examples,
-                            evaluationExamples: evaluationExamples,
-                            outputURL: outputURL,
-                            trainingConfig: config,
-                            maxSequenceLength: maxSequenceLength,
-                            rank: rank,
-                            alpha: alpha ?? Float(rank),
-                            targetSuffixes: resolvedTargetModules(),
-                            metadata: metadata
-                        ),
-                        progressHandler: makeChatProgressHandler(
-                            eventLogger: visualization?.logger
-                        ),
-                        trainingProgressHandler: makeTrainingProgressHandler(
-                            eventLogger: visualization?.logger
-                        )
-                    )
-                }
-            }
+            try await execute(plan, visualization: visualization)
+            await visualization?.stop()
+        } catch {
+            await visualization?.stop()
+            throw error
+        }
+    }
+
+    private func execute(_ plan: TextLoRATrainingPlan, visualization: TextLoRATrainingVisualization?) async throws {
+        let dataURL = plan.dataURL
+        let outputURL = plan.outputURL
+        let summary = plan.dataset.summary
+        let evalCount = plan.evalPromptCount
+        let outcome: TextLoRATrainingOutcome
+        do {
+            outcome = try await TextLoRATrainingOperation.execute(
+                plan,
+                progressHandler: makeChatProgressHandler(eventLogger: visualization?.logger),
+                trainingProgressHandler: makeTrainingProgressHandler(eventLogger: visualization?.logger)
+            )
         } catch {
             try? visualization?.logger.record(
-                type: "run_failed",
-                stage: "failed",
-                message: error.localizedDescription,
-                path: outputURL.path
+                type: "run_failed", stage: "failed", message: error.localizedDescription, path: outputURL.path
             )
             throw error
         }
-
-        let manifest = makeManifest(
-            family: family,
-            outputURL: outputURL,
-            datasetSummary: summary,
-            evalPromptCount: evalCount,
-            status: dryRun ? "prepared" : "trained"
-        )
-        try manifest.write(nextTo: outputURL)
+        let report = outcome.report
+        let manifest = outcome.manifest
         if !dryRun {
             try recordVisualizationRunManifest(
                 dataURL: dataURL,
@@ -340,59 +200,34 @@ struct TextTrainLoRA: AsyncParsableCommand {
         }
     }
 
+    var trainingOptions: TextLoRATrainingOptions {
+        TextLoRATrainingOptions(
+            data: data,
+            output: output,
+            model: model,
+            modelPath: modelPath,
+            eval: eval,
+            adapterName: adapterName,
+            trainingSteps: trainingSteps,
+            batchSize: batchSize,
+            learningRate: learningRate,
+            rank: rank,
+            alpha: alpha,
+            maxSequenceLength: maxSequenceLength,
+            reasoningEffort: reasoningEffort,
+            seed: seed,
+            resumeFrom: resumeFrom,
+            resumeStep: resumeStep,
+            targetModules: targetModules,
+            dryRun: dryRun
+        )
+    }
+
     private func validateOptions() throws {
-        guard trainingSteps >= 1 else {
-            throw ValidationError("--training-steps must be >= 1")
-        }
-        guard batchSize >= 1 else {
-            throw ValidationError("--batch-size must be >= 1")
-        }
-        guard learningRate > 0 else {
-            throw ValidationError("--learning-rate must be > 0")
-        }
-        guard rank >= 1 else {
-            throw ValidationError("--rank must be >= 1")
-        }
-        if let alpha {
-            guard alpha > 0 else {
-                throw ValidationError("--alpha must be > 0")
-            }
-        }
-        guard maxSequenceLength >= 128 else {
-            throw ValidationError("--max-sequence-length must be >= 128")
-        }
-        guard (0...0.99).contains(reasoningEffort) else {
-            throw ValidationError("--reasoning-effort must be between 0 and 0.99")
-        }
-        guard !resolvedTargetModules().isEmpty else {
-            throw ValidationError("--target-modules must include at least one target suffix")
-        }
-        if let resumeStep {
-            guard resumeFrom != nil else {
-                throw ValidationError("--resume-step requires --resume-from")
-            }
-            guard resumeStep > 0, resumeStep < trainingSteps else {
-                throw ValidationError(
-                    "--resume-step must be greater than zero and below --training-steps"
-                )
-            }
-        }
-        if let resumeFrom {
-            guard !dryRun else {
-                throw ValidationError("--resume-from cannot be combined with --dry-run")
-            }
-            let resumeURL = URL(fileURLWithPath: resumeFrom).standardizedFileURL
-            guard FileManager.default.fileExists(atPath: resumeURL.path) else {
-                throw ValidationError("--resume-from checkpoint does not exist: \(resumeURL.path)")
-            }
-            guard resumeURL.pathExtension.lowercased() == "safetensors"
-                    || resumeURL.pathExtension.lowercased() == "zip" else {
-                throw ValidationError("--resume-from must be a .safetensors or .zip checkpoint")
-            }
-            let outputURL = URL(fileURLWithPath: output).standardizedFileURL
-            guard resumeURL != outputURL else {
-                throw ValidationError("--resume-from and --output must be different files")
-            }
+        do {
+            try trainingOptions.validate()
+        } catch let issue as TextLoRATrainingIssue {
+            throw ValidationError(issue.message)
         }
         if visualize {
             guard !dryRun else {
@@ -404,74 +239,18 @@ struct TextTrainLoRA: AsyncParsableCommand {
         }
     }
 
-    private func makeManifest(
-        family: NativeTextLoRATrainingFamily,
-        outputURL: URL,
-        datasetSummary: TextSFTDatasetSummary,
-        evalPromptCount: Int?,
-        status: String
-    ) -> TextLoRATrainingManifest {
-        TextLoRATrainingManifest(
-            format: family.manifestFormat,
-            baseModel: model,
-            outputFile: outputURL.lastPathComponent,
-            adapterName: adapterName,
-            modality: family == .gemma4VLM ? "image" : nil,
-            trainingScope: family == .gemma4VLM ? "language_attention" : nil,
-            training: TextLoRATrainingManifest.Training(
-                trainingSteps: trainingSteps,
-                batchSize: batchSize,
-                learningRate: learningRate,
-                maxSequenceLength: maxSequenceLength,
-                reasoningEffort: family == .inkling ? reasoningEffort : nil,
-                seed: seed,
-                dataset: datasetSummary
-            ),
-            lora: TextLoRATrainingManifest.LoRA(
-                rank: rank,
-                alpha: alpha ?? Float(rank),
-                targetModules: resolvedTargetModules()
-            ),
-            evalPromptCount: evalPromptCount,
-            status: status
-        )
-    }
-
-    func resolvedTargetModules() -> [String] {
-        let value = targetModules ?? Self.defaultTargetModules(for: model).joined(separator: ",")
-        return value
-            .split(separator: ",")
-            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-            .filter { !$0.isEmpty }
-    }
+    func resolvedTargetModules() -> [String] { trainingOptions.resolvedTargetModules() }
 
     static func defaultTargetModules(for model: String) -> [String] {
-        if InklingResources.handles(modelSpec: model) {
-            return InklingTextLoRAInjector.defaultTargetSuffixes
-        }
-        if LFM2Resources.supportsTextLoRATraining(modelSpec: model) {
-            return LFM2TextLoRAInjector.defaultTargetSuffixes
-        }
-        return ["q_proj", "k_proj", "v_proj", "o_proj"]
+        TextLoRATrainingOptions.defaultTargetModules(for: model)
     }
 
-    private func resolvedTrainingFamily() throws -> NativeTextLoRATrainingFamily {
-        if Gemma4Resources.handles(modelSpec: model) {
-            return Gemma4Resources.supportsVision(modelSpec: model) ? .gemma4VLM : .gemma4
+    private func resolvedTrainingFamily() throws -> TextLoRATrainingFamily {
+        do {
+            return try trainingOptions.resolvedTrainingFamily()
+        } catch let issue as TextLoRATrainingIssue {
+            throw ValidationError(issue.message)
         }
-        if LagunaResources.managedModelID(for: model) == LagunaResources.xsModelID {
-            return .lagunaXS
-        }
-        if InklingResources.handles(modelSpec: model) {
-            return .inkling
-        }
-        if LFM2Resources.supportsTextLoRATraining(modelSpec: model) {
-            return .lfm2A1B
-        }
-        throw ValidationError(
-            "--model must be a supported Gemma 4 text or vision model, \(LagunaResources.xsModelID), "
-                + "\(InklingResources.modelID), or \(LFM2Resources.defaultModelId)."
-        )
     }
 
     private func startVisualizationIfNeeded(
@@ -481,6 +260,7 @@ struct TextTrainLoRA: AsyncParsableCommand {
         evalPromptCount: Int?
     ) throws -> TextLoRATrainingVisualization? {
         guard visualize else { return nil }
+        try FileManager.default.createDirectory(at: outputURL.deletingLastPathComponent(), withIntermediateDirectories: true)
 
         try recordVisualizationRunManifest(
             dataURL: dataURL,
@@ -495,15 +275,6 @@ struct TextTrainLoRA: AsyncParsableCommand {
         let viewer = LoRATrainingRunViewer(runDirectoryURL: outputURL.deletingLastPathComponent())
         let host = "127.0.0.1"
         let port = visualizePort
-        let task = Task {
-            do {
-                try await viewer.run(host: host, port: port)
-            } catch is CancellationError {
-                // The training command owns this helper server and cancels it when the run exits.
-            } catch {
-                CLIStderr.write("[visualize] server stopped: \(error.localizedDescription)\n")
-            }
-        }
         try logger.record(
             type: "run_started",
             stage: "starting",
@@ -521,6 +292,15 @@ struct TextTrainLoRA: AsyncParsableCommand {
                 "dataset_fingerprint": datasetSummary.fingerprint,
             ]
         )
+        let task = Task {
+            do {
+                try await viewer.run(host: host, port: port)
+            } catch is CancellationError {
+                // The training command owns this helper server and cancels it when the run exits.
+            } catch {
+                CLIStderr.write("[visualize] server stopped: \(error.localizedDescription)\n")
+            }
+        }
         return TextLoRATrainingVisualization(logger: logger, serverTask: task)
     }
 
@@ -636,35 +416,13 @@ struct TextTrainLoRA: AsyncParsableCommand {
     }
 }
 
-private enum NativeTextLoRATrainingFamily: Equatable {
-    case gemma4
-    case gemma4VLM
-    case lagunaXS
-    case inkling
-    case lfm2A1B
-
-    var manifestFormat: String {
-        switch self {
-        case .gemma4:
-            TextLoRATrainingManifest.gemma4Format
-        case .gemma4VLM:
-            TextLoRATrainingManifest.gemma4VLMFormat
-        case .lagunaXS:
-            TextLoRATrainingManifest.lagunaFormat
-        case .inkling:
-            TextLoRATrainingManifest.inklingFormat
-        case .lfm2A1B:
-            TextLoRATrainingManifest.lfm2Format
-        }
-    }
-}
-
-private struct TextLoRATrainingVisualization {
+struct TextLoRATrainingVisualization {
     let logger: LoRATrainingEventLogger
     let serverTask: Task<Void, Never>
 
-    func stop() {
+    func stop() async {
         serverTask.cancel()
+        await serverTask.value
     }
 }
 

--- a/Sources/MereRunCLI/Support/ACEStepCLIHelper.swift
+++ b/Sources/MereRunCLI/Support/ACEStepCLIHelper.swift
@@ -1,69 +1,26 @@
 import ArgumentParser
-import AudioCodecs
 import Foundation
 import MLX
 import MereRunCore
 
+/// Preserves command validation diagnostics over shared runtime preparation.
 enum ACEStepCLIHelper {
-    struct LMResolution: Hashable {
-        let rootURL: URL
-        let source: String
-    }
+    typealias LMResolution = ACEStepRuntimePreparation.LMResolution
 
     static func resolveUserPath(_ path: String) -> URL {
-        let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
-        if trimmed == "~" {
-            return URL(fileURLWithPath: NSHomeDirectory()).standardizedFileURL
-        }
-        if trimmed.hasPrefix("~/") {
-            let suffix = String(trimmed.dropFirst(2))
-            return URL(fileURLWithPath: NSHomeDirectory())
-                .appendingPathComponent(suffix)
-                .standardizedFileURL
-        }
-        return URL(fileURLWithPath: trimmed).standardizedFileURL
+        ACEStepRuntimePreparation.resolveUserPath(path)
     }
 
     static func loadAudio48kHz(_ path: String, label: String) throws -> MLXArray {
-        let url = resolveUserPath(path)
-        guard FileManager.default.fileExists(atPath: url.path) else {
-            throw ValidationError("\(label) not found: \(url.path)")
+        do {
+            return try ACEStepRuntimePreparation.loadAudio48kHz(path, label: label)
+        } catch let error as ACEStepPreparationIssue {
+            throw ValidationError(error.message)
         }
-
-        let buffer = try AudioReader.readAudioBuffer(from: url, sampleRate: 48_000, channels: 2)
-        guard buffer.isInterleaved else {
-            throw ValidationError("\(label) decoded to a non-interleaved buffer: \(url.path)")
-        }
-        guard buffer.channelCount == 2 else {
-            throw ValidationError("\(label) must decode to stereo at 48 kHz; got \(buffer.channelCount) channel(s).")
-        }
-        guard buffer.samples.count >= buffer.channelCount else {
-            throw ValidationError("\(label) contains no audio samples: \(url.path)")
-        }
-
-        let frames = buffer.samples.count / buffer.channelCount
-        let trimmedSampleCount = frames * buffer.channelCount
-        let samples = trimmedSampleCount == buffer.samples.count
-            ? buffer.samples
-            : Array(buffer.samples.prefix(trimmedSampleCount))
-        let clamped = samples.map { sample -> Float in
-            guard sample.isFinite else {
-                return 0
-            }
-            return max(-1.0, min(1.0, sample))
-        }
-        return MLXArray(clamped, [1, frames, buffer.channelCount]).asType(.float32)
     }
 
     static func durationSeconds(of audio48kHz: MLXArray, fallback: Float) -> Float {
-        guard audio48kHz.ndim >= 2 else {
-            return fallback
-        }
-        let frames = audio48kHz.dim(1)
-        guard frames > 0 else {
-            return fallback
-        }
-        return Float(frames) / 48_000.0
+        ACEStepRuntimePreparation.durationSeconds(of: audio48kHz, fallback: fallback)
     }
 
     static func resolveCheckpointsRoot(
@@ -74,146 +31,27 @@ enum ACEStepCLIHelper {
         lmSubdirectory: String?,
         textSubdirectory: String?
     ) async throws -> URL {
-        let candidates = buildCheckpointCandidates(
-            model: model,
-            checkpointsRoot: checkpointsRoot
-        )
-
-        for candidate in candidates {
-            if isUsableCheckpointsRoot(
-                candidate,
-                turboSubdirectory: turboSubdirectory,
-                vaeSubdirectory: vaeSubdirectory,
-                lmSubdirectory: lmSubdirectory,
-                textSubdirectory: textSubdirectory
-            ) {
-                return candidate
-            }
-            let nested = candidate.appendingPathComponent("checkpoints", isDirectory: true)
-            if isUsableCheckpointsRoot(
-                nested,
-                turboSubdirectory: turboSubdirectory,
-                vaeSubdirectory: vaeSubdirectory,
-                lmSubdirectory: lmSubdirectory,
-                textSubdirectory: textSubdirectory
-            ) {
-                return nested
-            }
-        }
-
-        if let explicit = checkpointsRoot?.trimmingCharacters(in: .whitespacesAndNewlines), !explicit.isEmpty {
-            throw ValidationError("Checkpoints root not found or incomplete: \(explicit)")
-        }
-
         do {
-            let resolved = try await ManagedModelResolver.resolveForRuntime(
-                requestedModel: model,
-                defaultModelID: ModelResolver.ModelID.aceStep.rawValue
-            )
-            let root = resolved.url
-            if isUsableCheckpointsRoot(
-                root,
-                turboSubdirectory: turboSubdirectory,
-                vaeSubdirectory: vaeSubdirectory,
-                lmSubdirectory: lmSubdirectory,
-                textSubdirectory: textSubdirectory
-            ) {
-                return root
-            }
-            let nested = root.appendingPathComponent("checkpoints", isDirectory: true)
-            if isUsableCheckpointsRoot(
-                nested,
-                turboSubdirectory: turboSubdirectory,
-                vaeSubdirectory: vaeSubdirectory,
-                lmSubdirectory: lmSubdirectory,
-                textSubdirectory: textSubdirectory
-            ) {
-                return nested
-            }
-        } catch let error as ManagedModelResolver.ResolverError {
-            throw ValidationError(error.localizedDescription)
+            return try await ACEStepRuntimePreparation.resolveCheckpointsRoot(model: model, checkpointsRoot: checkpointsRoot, turboSubdirectory: turboSubdirectory, vaeSubdirectory: vaeSubdirectory, lmSubdirectory: lmSubdirectory, textSubdirectory: textSubdirectory)
+        } catch let error as ACEStepPreparationIssue {
+            throw ValidationError(error.message)
         }
-
-        throw ValidationError("Music Acestep checkpoints not found. Add --checkpoints-root or set MERERUN_MUSIC_ACESTEP_ROOT.")
     }
 
     static func resolveTurboSubdirectory(at root: URL, explicit: String) throws -> String {
-        let fm = FileManager.default
-
-        let trimmed = explicit.trimmingCharacters(in: .whitespacesAndNewlines)
-        let upstreamDefault = "acestep-v15-turbo"
-        let compatibilityDefault = "music-acestep-v15-turbo"
-        let decoderDefaults = [
-            upstreamDefault,
-            compatibilityDefault,
-            "acestep-v15-xl-turbo",
-            "acestep-v15-xl-sft",
-            "acestep-v15-xl-base",
-            "acestep-v15-sft",
-            "acestep-v15-base",
-        ]
-        let candidates = trimmed == upstreamDefault
-            ? decoderDefaults
-            : [trimmed]
-
-        for candidate in candidates where isUsableDecoderDirectory(
-            root.appendingPathComponent(candidate, isDirectory: true),
-            fileManager: fm
-        ) {
-            return candidate
+        do {
+            return try ACEStepRuntimePreparation.resolveTurboSubdirectory(at: root, explicit: explicit)
+        } catch let error as ACEStepPreparationIssue {
+            throw ValidationError(error.message)
         }
-        throw ValidationError("--decoder-subdirectory not found: \(trimmed)")
     }
 
     static func resolveLMSubdirectory(at root: URL, explicit: String?) throws -> String? {
-        let fm = FileManager.default
-
-        if let explicit, !explicit.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            let explicitNormalized = explicit.trimmingCharacters(in: .whitespacesAndNewlines)
-            let explicitRoot = root.appendingPathComponent(explicitNormalized, isDirectory: true)
-            guard isUsableLMDirectory(explicitRoot, fileManager: fm) else {
-                throw ValidationError("--lm-subdirectory not found: \(explicitNormalized)")
-            }
-            return explicitNormalized
+        do {
+            return try ACEStepRuntimePreparation.resolveLMSubdirectory(at: root, explicit: explicit)
+        } catch let error as ACEStepPreparationIssue {
+            throw ValidationError(error.message)
         }
-
-        let preferredCandidates = [
-            "acestep-5Hz-lm-1.7B",
-            "acestep-5hz-lm-1.7b",
-            "acestep-5Hz-lm-4B",
-            "acestep-5hz-lm-4b",
-            "acestep-5Hz-lm",
-            "acestep-5hz-lm",
-            "music-acestep-5hz-lm-4b",
-            "music-acestep-5Hz-lm-4B",
-            "music-acestep-5hz-lm-1.7b",
-            "music-acestep-5Hz-lm-1.7B",
-            "music-acestep-5hz-lm",
-            "music-acestep-5Hz-lm",
-            "lm",
-            "music-acestep-lm"
-        ]
-
-        for candidate in preferredCandidates {
-            if isUsableLMDirectory(root.appendingPathComponent(candidate, isDirectory: true), fileManager: fm) {
-                return candidate
-            }
-        }
-
-        let discovered = (try? fm.contentsOfDirectoryResolvingSymlinks(
-            at: root,
-            includingPropertiesForKeys: [.isDirectoryKey],
-            options: [.skipsHiddenFiles]
-        ))?.first(where: { directory in
-            let isDirectory = (try? directory.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true
-            let name = directory.lastPathComponent.lowercased()
-            return isDirectory
-                && name.contains("lm")
-                && name.contains("5hz")
-                && isUsableLMDirectory(directory, fileManager: fm)
-        })
-
-        return discovered?.lastPathComponent
     }
 
     static func resolveLMResources(
@@ -221,245 +59,30 @@ enum ACEStepCLIHelper {
         lmModel: String?,
         lmSubdirectory: String?
     ) async throws -> LMResolution {
-        if let explicitSubdirectory = nonEmpty(lmSubdirectory) {
-            guard nonEmpty(lmModel) == nil else {
-                throw ValidationError("Pass either --lm-model or --lm-subdirectory, not both.")
-            }
-            guard let resolved = try resolveLMSubdirectory(
-                at: checkpointsRoot,
-                explicit: explicitSubdirectory
-            ) else {
-                throw ValidationError("--lm-subdirectory not found: \(explicitSubdirectory)")
-            }
-            return LMResolution(
-                rootURL: checkpointsRoot.appendingPathComponent(resolved, isDirectory: true),
-                source: resolved
-            )
+        do {
+            return try await ACEStepRuntimePreparation.resolveLMResources(checkpointsRoot: checkpointsRoot, lmModel: lmModel, lmSubdirectory: lmSubdirectory)
+        } catch let error as ACEStepPreparationIssue {
+            throw ValidationError(error.message)
         }
-
-        if let explicitModel = nonEmpty(lmModel) {
-            return try await resolveManagedLM(
-                requestedModel: explicitModel,
-                defaultModelID: ModelResolver.ModelID.aceStepLM17B.rawValue
-            )
-        }
-
-        if let local = try resolveLMSubdirectory(at: checkpointsRoot, explicit: nil) {
-            return LMResolution(
-                rootURL: checkpointsRoot.appendingPathComponent(local, isDirectory: true),
-                source: local
-            )
-        }
-
-        for installedModelID in [
-            ModelResolver.ModelID.aceStepLM17B.rawValue,
-            ModelResolver.ModelID.aceStep.rawValue,
-        ] {
-            guard let installedRoot = ManagedModelResolver.resolveInstalledModel(id: installedModelID),
-                  let resolvedRoot = resolveLMRoot(at: installedRoot)
-            else {
-                continue
-            }
-            return LMResolution(rootURL: resolvedRoot, source: installedModelID)
-        }
-
-        return try await resolveManagedLM(
-            requestedModel: nil,
-            defaultModelID: ModelResolver.ModelID.aceStepLM17B.rawValue
-        )
     }
 
     static func resolveLMRoot(at root: URL) -> URL? {
-        let normalized = root.standardizedFileURL
-        if isUsableLMDirectory(normalized, fileManager: .default) {
-            return normalized
-        }
-        guard let subdirectory = try? resolveLMSubdirectory(at: normalized, explicit: nil) else {
-            return nil
-        }
-        return normalized.appendingPathComponent(subdirectory, isDirectory: true)
-    }
-
-    private static func resolveManagedLM(
-        requestedModel: String?,
-        defaultModelID: String
-    ) async throws -> LMResolution {
-        do {
-            let resolution = try await ManagedModelResolver.resolveForRuntime(
-                requestedModel: requestedModel,
-                defaultModelID: defaultModelID
-            )
-            guard let root = resolveLMRoot(at: resolution.url) else {
-                throw ValidationError(
-                    "ACE-Step planner \(resolution.spec.id) does not contain a usable 5Hz LM."
-                )
-            }
-            let source = resolution.source == .explicitPath
-                ? "local"
-                : resolution.spec.id
-            return LMResolution(rootURL: root, source: source)
-        } catch let error as ManagedModelResolver.ResolverError {
-            throw ValidationError(error.localizedDescription)
-        }
-    }
-
-    private static func nonEmpty(_ value: String?) -> String? {
-        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        return trimmed.isEmpty ? nil : trimmed
+        ACEStepRuntimePreparation.resolveLMRoot(at: root)
     }
 
     static func resolveTextSubdirectory(at root: URL, explicit: String?) throws -> String? {
-        let fm = FileManager.default
-
-        if let explicit, !explicit.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-            let explicitNormalized = explicit.trimmingCharacters(in: .whitespacesAndNewlines)
-            let explicitRoot = root.appendingPathComponent(explicitNormalized, isDirectory: true)
-            guard isDirectory(explicitRoot, fileManager: fm) else {
-                throw ValidationError("--text-subdirectory not found: \(explicitNormalized)")
-            }
-            return explicitNormalized
+        do {
+            return try ACEStepRuntimePreparation.resolveTextSubdirectory(at: root, explicit: explicit)
+        } catch let error as ACEStepPreparationIssue {
+            throw ValidationError(error.message)
         }
-
-        let preferredCandidates = [
-            "Qwen3-Embedding-0.6B",
-            "qwen3-embedding-0.6b",
-            "Qwen3-Embedding-4B",
-            "qwen3-embedding-4b",
-            "Qwen3-Embedding",
-            "qwen3-embedding",
-            "text_encoder",
-            "text-encoder"
-        ]
-
-        for candidate in preferredCandidates {
-            if isDirectory(root.appendingPathComponent(candidate, isDirectory: true), fileManager: fm) {
-                return candidate
-            }
-        }
-
-        let discovered = (try? fm.contentsOfDirectoryResolvingSymlinks(
-            at: root,
-            includingPropertiesForKeys: [.isDirectoryKey],
-            options: [.skipsHiddenFiles]
-        ))?.first(where: { directory in
-            let isDirectory = (try? directory.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true
-            let name = directory.lastPathComponent.lowercased()
-            return isDirectory && (
-                (name.contains("qwen3") && name.contains("embedding"))
-                || name == "text_encoder"
-                || name == "text-encoder"
-            )
-        })
-
-        return discovered?.lastPathComponent
     }
 
     static func buildCheckpointCandidates(
         model: String,
         checkpointsRoot: String?
     ) -> [URL] {
-        var candidates: [URL] = []
-
-        if let explicit = checkpointsRoot?.trimmingCharacters(in: .whitespacesAndNewlines), !explicit.isEmpty {
-            candidates.append(URL(fileURLWithPath: explicit).standardizedFileURL)
-        }
-
-        var modelPathExists = false
-        let explicitModel = model.trimmingCharacters(in: .whitespacesAndNewlines)
-        if !explicitModel.isEmpty {
-            let url = URL(fileURLWithPath: explicitModel).standardizedFileURL
-            if FileManager.default.fileExists(atPath: url.path) {
-                modelPathExists = true
-                candidates.append(url)
-            }
-        }
-
-        if let envRoot = ProcessInfo.processInfo.environment["MERERUN_MUSIC_ACESTEP_ROOT"]?
-            .trimmingCharacters(in: .whitespacesAndNewlines),
-            !envRoot.isEmpty
-        {
-            candidates.append(URL(fileURLWithPath: envRoot).standardizedFileURL)
-        }
-
-        let managedModelID = explicitModel.lowercased()
-        if !managedModelID.isEmpty && !modelPathExists {
-            let requestedRoot = MereRunModelPaths.modelsDir
-                .appendingPathComponent(managedModelID, isDirectory: true)
-                .standardizedFileURL
-            candidates.append(requestedRoot)
-            candidates.append(requestedRoot.appendingPathComponent("checkpoints", isDirectory: true))
-        }
-
-        if managedModelID.isEmpty {
-            let localModelRoot = MereRunModelPaths.modelsDir
-                .appendingPathComponent(ModelResolver.ModelID.aceStep.rawValue, isDirectory: true)
-                .standardizedFileURL
-            candidates.append(localModelRoot)
-            candidates.append(localModelRoot.appendingPathComponent("checkpoints", isDirectory: true))
-        }
-
-        return candidates
+        ACEStepRuntimePreparation.buildCheckpointCandidates(model: model, checkpointsRoot: checkpointsRoot)
     }
 
-    private static func isUsableCheckpointsRoot(
-        _ root: URL,
-        turboSubdirectory: String,
-        vaeSubdirectory: String,
-        lmSubdirectory: String?,
-        textSubdirectory: String?
-    ) -> Bool {
-        let fm = FileManager.default
-
-        guard isDirectory(root, fileManager: fm) else {
-            return false
-        }
-        let turboCandidates = turboSubdirectory == "acestep-v15-turbo"
-            ? [
-                "acestep-v15-turbo",
-                "music-acestep-v15-turbo",
-                "acestep-v15-xl-turbo",
-                "acestep-v15-xl-sft",
-                "acestep-v15-xl-base",
-                "acestep-v15-sft",
-                "acestep-v15-base",
-            ]
-            : [turboSubdirectory]
-        guard turboCandidates.contains(where: {
-            isUsableDecoderDirectory(root.appendingPathComponent($0, isDirectory: true), fileManager: fm)
-        }) else {
-            return false
-        }
-        guard isDirectory(root.appendingPathComponent(vaeSubdirectory), fileManager: fm) else {
-            return false
-        }
-
-        if let lmSubdirectory, !lmSubdirectory.isEmpty {
-            guard isDirectory(root.appendingPathComponent(lmSubdirectory), fileManager: fm) else {
-                return false
-            }
-        }
-
-        if let textSubdirectory, !textSubdirectory.isEmpty {
-            guard isDirectory(root.appendingPathComponent(textSubdirectory), fileManager: fm) else {
-                return false
-            }
-        }
-
-        return true
-    }
-
-    private static func isUsableDecoderDirectory(_ url: URL, fileManager: FileManager) -> Bool {
-        isDirectory(url, fileManager: fileManager)
-            && ACEStepResources(rootURL: url).validate(fileManager: fileManager).isEmpty
-    }
-
-    private static func isUsableLMDirectory(_ url: URL, fileManager: FileManager) -> Bool {
-        isDirectory(url, fileManager: fileManager)
-            && ACEStep5HzLMResources(rootURL: url).validate(fileManager: fileManager).isEmpty
-    }
-
-    private static func isDirectory(_ url: URL, fileManager: FileManager) -> Bool {
-        var isDir: ObjCBool = false
-        return fileManager.fileExists(atPath: url.path, isDirectory: &isDir) && isDir.boolValue
-    }
 }

--- a/Sources/MereRunCLI/Support/BoundedProcessRunner.swift
+++ b/Sources/MereRunCLI/Support/BoundedProcessRunner.swift
@@ -43,12 +43,15 @@ enum BoundedProcessRunner {
 
     static func run(
         _ process: Process,
-        timeout: TimeInterval,
+        timeout: TimeInterval? = nil,
         outputLimitBytes: Int = 256 * 1024,
         combineOutput: Bool = false,
-        isCancelled: () -> Bool = { Task.isCancelled }
+        isCancelled: () -> Bool = { Task.isCancelled },
+        onStarted: ((Int32) throws -> Void)? = nil,
+        stdoutHandler: ((Data) throws -> Void)? = nil,
+        stderrHandler: ((Data) throws -> Void)? = nil
     ) throws -> Result {
-        guard timeout.isFinite, timeout > 0, outputLimitBytes >= 0 else {
+        guard timeout.map({ $0.isFinite && $0 > 0 }) ?? true, outputLimitBytes >= 0 else {
             throw RunError.invalidLimits
         }
         let stdout = try Output(limitBytes: outputLimitBytes)
@@ -67,17 +70,18 @@ enum BoundedProcessRunner {
 
         var completion = Completion.exited
         do {
+            try onStarted?(process.processIdentifier)
             while true {
                 // One chunk per stream keeps a noisy stdout from starving stderr,
                 // cancellation, or the deadline. Reads themselves never block.
-                let readOutput = try stdout.drain()
-                let readError = try stderr?.drain() ?? false
+                let readOutput = try stdout.drain(handler: stdoutHandler)
+                let readError = try stderr?.drain(handler: stderrHandler) ?? false
                 if !process.isRunning, stdout.atEnd, stderr?.atEnd ?? true { break }
                 if isCancelled() {
                     completion = .cancelled
                     break
                 }
-                if ProcessInfo.processInfo.systemUptime - start >= timeout {
+                if let timeout, ProcessInfo.processInfo.systemUptime - start >= timeout {
                     completion = .timedOut
                     break
                 }
@@ -88,8 +92,8 @@ enum BoundedProcessRunner {
             // Retain available tail output after termination without waiting for
             // a deliberately detached descendant that still holds a pipe open.
             for _ in 0..<16 {
-                let readOutput = try stdout.drain()
-                let readError = try stderr?.drain() ?? false
+                let readOutput = try stdout.drain(handler: stdoutHandler)
+                let readError = try stderr?.drain(handler: stderrHandler) ?? false
                 if !readOutput, !readError { break }
             }
         } catch {
@@ -111,6 +115,7 @@ enum BoundedProcessRunner {
         // Linux. Signal the group even if its leader exited but a child retains
         // stdout/stderr; never signal the caller's group.
         let pid = process.processIdentifier
+        guard pid > 0, pid != getpgrp() else { return }
         kill(-pid, SIGTERM)
         if process.isRunning { process.terminate() }
         Thread.sleep(forTimeInterval: 0.2)
@@ -137,7 +142,7 @@ enum BoundedProcessRunner {
             }
         }
 
-        func drain() throws -> Bool {
+        func drain(handler: ((Data) throws -> Void)?) throws -> Bool {
             guard !atEnd else { return false }
             let count = buffer.withUnsafeMutableBytes {
                 read(pipe.fileHandleForReading.fileDescriptor, $0.baseAddress, $0.count)
@@ -151,6 +156,7 @@ enum BoundedProcessRunner {
                 if code == EAGAIN || code == EWOULDBLOCK || code == EINTR { return false }
                 throw RunError.outputIO(code)
             }
+            try handler?(Data(buffer.prefix(count)))
             let retained = min(count, limitBytes - bytes.count)
             bytes.append(contentsOf: buffer.prefix(retained))
             if retained < count { truncated = true }

--- a/Sources/MereRunCLI/Support/LoRATrainingPreflight.swift
+++ b/Sources/MereRunCLI/Support/LoRATrainingPreflight.swift
@@ -9,7 +9,7 @@ struct LoRATrainingPreflightInput {
     let excludePreviewImages: Bool
     let syntheticSamples: Int?
     let requiresKleinModel: Bool
-    let options: ImageTrainLoRA.ResolvedLoRATrainingOptions
+    let options: ImageLoRATrainingOptions.Resolved
     let trainingArgv: [String]
     let runPlan: LoRATrainingRunPlan
     let cwd: String

--- a/Sources/MereRunCLI/Support/LoRATrainingRunPlan.swift
+++ b/Sources/MereRunCLI/Support/LoRATrainingRunPlan.swift
@@ -74,6 +74,7 @@ struct LoRATrainingRunPlanArguments: Codable, Equatable {
     let captionDropout: Float
     let seed: UInt64
     let lite: Bool
+    let baseQuantizationBits: Int?
     let excludePreviewImages: Bool
     let checkpointInterval: Int?
     let resumeFrom: String?
@@ -126,6 +127,7 @@ struct LoRATrainingRunPlanArguments: Codable, Equatable {
         case captionDropout = "caption_dropout"
         case seed
         case lite
+        case baseQuantizationBits = "base_quantization_bits"
         case excludePreviewImages = "exclude_preview_images"
         case checkpointInterval = "checkpoint_interval"
         case resumeFrom = "resume_from"
@@ -184,6 +186,7 @@ struct LoRATrainingRunPlanArguments: Codable, Equatable {
             captionDropout: captionDropout,
             seed: seed,
             lite: lite,
+            baseQuantizationBits: baseQuantizationBits,
             excludePreviewImages: excludePreviewImages,
             checkpointInterval: checkpointInterval,
             resumeFrom: resumeFrom,
@@ -246,6 +249,7 @@ struct LoRATrainingRunPlanArguments: Codable, Equatable {
             "--seed", String(seed),
         ]
         appendBoolFlag("--lite", when: lite, to: &args)
+        appendOption("--base-quantization-bits", baseQuantizationBits, to: &args)
         appendBoolFlag("--exclude-preview-images", when: excludePreviewImages, to: &args)
         appendOption("--checkpoint-interval", checkpointInterval, to: &args)
         appendOption("--resume-from", resumeFrom, to: &args)
@@ -364,6 +368,7 @@ extension ImageTrainLoRA {
                 captionDropout: options.captionDropout,
                 seed: seed,
                 lite: lite,
+                baseQuantizationBits: baseQuantizationBits,
                 excludePreviewImages: excludePreviewImages,
                 checkpointInterval: options.checkpointInterval,
                 resumeFrom: resumeFrom,

--- a/Sources/MereRunCLI/Support/README.md
+++ b/Sources/MereRunCLI/Support/README.md
@@ -13,7 +13,15 @@ Shared helpers and runtime adapters for the public command surface.
 - `BuiltinTools.swift`: local tool authorization and execution policy.
 - `BoundedProcessRunner.swift`: concurrent output drainage, bounded capture,
   monotonic deadlines, and cancellation cleanup for approved shell tools and
-  code benchmark sandboxes.
+  code benchmark sandboxes, and workflow children. Throwing start and output
+  callbacks terminate and await the child group before errors propagate.
+- `WorkflowRunner.swift`: node scheduling, retry policy, and ordered events.
+- `WorkflowRunStore.swift`: exclusive run ownership, resume validation, manifests,
+  and synchronized event persistence.
+- `WorkflowArtifactStore.swift`: input localization, output verification, cache
+  storage, and digest checks for reuse.
+- `WorkflowProcessRunner.swift`: child registration, bounded stdout, streaming
+  callbacks, and workflow cancellation over the shared process runner.
 - `APIImageGeneration.swift`: API v1 compatibility settings for the Core image
   operation. `ImageGenerationPreflight.swift` presents the same Core resolver's
   diagnostics as an observational report.

--- a/Sources/MereRunCLI/Support/WorkflowArtifactStore.swift
+++ b/Sources/MereRunCLI/Support/WorkflowArtifactStore.swift
@@ -1,0 +1,652 @@
+import ArgumentParser
+import Foundation
+import MereRunCore
+import MereRunRelayKit
+
+/// Owns localized inputs, verified outputs, cache entries, and output reuse.
+struct WorkflowArtifactStore {
+    let bundleDirectory: URL
+    let runDirectory: URL
+    let cacheDirectory: URL?
+    let resume: Bool
+    let fileManager: FileManager
+
+    func restoreCachedOutputs(
+        fingerprint: String,
+        invocation: WorkflowNodeInvocation,
+        node: WorkflowNode,
+        nodeDirectory: URL
+    ) throws -> WorkflowVerifiedNodeOutputs? {
+        guard let cacheDirectory else { return nil }
+        let entry = cacheDirectory.appendingPathComponent(fingerprint, isDirectory: true)
+        let manifestURL = entry.appendingPathComponent(WorkflowNodeCacheManifest.filename)
+        guard fileManager.fileExists(atPath: manifestURL.path) else { return nil }
+        do {
+            let manifest = try WorkflowBundleCodec.decoder().decode(
+                WorkflowNodeCacheManifest.self,
+                from: Data(contentsOf: manifestURL)
+            )
+            guard manifest.contractVersion == WorkflowNodeCacheManifest.contractVersion,
+                  manifest.fingerprint == fingerprint else {
+                throw ValidationError("Node cache manifest does not match its fingerprint.")
+            }
+            try clearAttemptOutputs(invocation.outputs, nodeDirectory: nodeDirectory)
+            var providerValues: [String: WorkflowValue] = [:]
+            let filesRoot = entry.appendingPathComponent("files", isDirectory: true)
+            for output in manifest.outputs {
+                guard let descriptor = invocation.outputs[output.name], descriptor.type == output.type else {
+                    throw ValidationError("Node cache output contract has changed for '\(output.name)'.")
+                }
+                if let relativePath = output.relativePath {
+                    guard let descriptorPath = descriptor.path else {
+                        throw ValidationError("Node cache output '\(output.name)' no longer has a path.")
+                    }
+                    let destination = try invocationOutputURL(descriptorPath, nodeDirectory: nodeDirectory)
+                    guard try nodeRelativePath(destination, nodeDirectory: nodeDirectory) == relativePath else {
+                        throw ValidationError("Node cache output path has changed for '\(output.name)'.")
+                    }
+                    let source = try confinedCacheURL(relativePath, root: filesRoot)
+                    try copyCacheItem(from: source, to: destination)
+                } else if let value = output.value {
+                    providerValues[output.name] = value
+                }
+            }
+            let verified = try verifyOutputs(
+                invocation.outputs,
+                providerValues: providerValues,
+                node: node,
+                nodeDirectory: nodeDirectory
+            )
+            let restoredRecords = try verified.outputs.map {
+                try cacheOutput($0, nodeDirectory: nodeDirectory)
+            }.sorted { $0.name < $1.name }
+            guard restoredRecords == manifest.outputs.sorted(by: { $0.name < $1.name }) else {
+                throw ValidationError("Node cache output hashes do not match its manifest.")
+            }
+            return verified
+        } catch {
+            try? clearAttemptOutputs(invocation.outputs, nodeDirectory: nodeDirectory)
+            try? fileManager.removeItem(at: entry)
+            return nil
+        }
+    }
+
+    func storeCachedOutputs(
+        _ verified: WorkflowVerifiedNodeOutputs,
+        fingerprint: String,
+        policy: WorkflowNodeCachePolicy,
+        nodeDirectory: URL
+    ) throws {
+        guard let cacheDirectory else { return }
+        try fileManager.createDirectory(at: cacheDirectory, withIntermediateDirectories: true)
+        let entry = cacheDirectory.appendingPathComponent(fingerprint, isDirectory: true)
+        if fileManager.fileExists(atPath: entry.path), policy == .automatic { return }
+        let staging = cacheDirectory.appendingPathComponent(".\(fingerprint).\(UUID().uuidString)", isDirectory: true)
+        defer { try? fileManager.removeItem(at: staging) }
+        let filesRoot = staging.appendingPathComponent("files", isDirectory: true)
+        try fileManager.createDirectory(at: filesRoot, withIntermediateDirectories: true)
+        let outputs = try verified.outputs.map { output -> WorkflowNodeCacheOutput in
+            let record = try cacheOutput(output, nodeDirectory: nodeDirectory)
+            if let relativePath = record.relativePath {
+                let source = try invocationOutputURL(relativePath, nodeDirectory: nodeDirectory)
+                let destination = try confinedCacheURL(relativePath, root: filesRoot)
+                try copyCacheItem(from: source, to: destination)
+            }
+            return record
+        }.sorted { $0.name < $1.name }
+        try WorkflowBundleCodec.write(
+            WorkflowNodeCacheManifest(
+                contractVersion: WorkflowNodeCacheManifest.contractVersion,
+                fingerprint: fingerprint,
+                outputs: outputs
+            ),
+            to: staging.appendingPathComponent(WorkflowNodeCacheManifest.filename)
+        )
+        if fileManager.fileExists(atPath: entry.path) {
+            try fileManager.removeItem(at: entry)
+        }
+        try fileManager.moveItem(at: staging, to: entry)
+    }
+
+    func cacheOutput(
+        _ output: GraphRunNodeOutput,
+        nodeDirectory: URL
+    ) throws -> WorkflowNodeCacheOutput {
+        guard let sha256 = output.sha256 else {
+            throw ValidationError("Workflow output '\(output.name)' has no cache fingerprint.")
+        }
+        let relativePath: String?
+        if let path = output.path {
+            relativePath = try nodeRelativePath(artifactURL(for: path), nodeDirectory: nodeDirectory)
+        } else {
+            relativePath = nil
+        }
+        return WorkflowNodeCacheOutput(
+            name: output.name,
+            type: output.type,
+            value: output.value,
+            relativePath: relativePath,
+            contentType: output.contentType,
+            sizeBytes: output.sizeBytes,
+            sha256: sha256
+        )
+    }
+
+    func nodeRelativePath(_ url: URL, nodeDirectory: URL) throws -> String {
+        let candidate = url.standardizedFileURL.path
+        let root = nodeDirectory.standardizedFileURL.path
+        guard candidate.hasPrefix(root + "/") else {
+            throw ValidationError("Workflow cache output escapes the node directory: \(candidate)")
+        }
+        return String(candidate.dropFirst(root.count + 1))
+    }
+
+    func confinedCacheURL(_ path: String, root: URL) throws -> URL {
+        guard isConfinedRelativeWorkflowPath(path) else {
+            throw ValidationError("Workflow cache contains an unconfined path: \(path)")
+        }
+        let candidate = root.appendingPathComponent(path).standardizedFileURL
+        guard candidate.path.hasPrefix(root.standardizedFileURL.path + "/") else {
+            throw ValidationError("Workflow cache path escapes its entry: \(path)")
+        }
+        try requireResolvedContainment(candidate, in: root)
+        return candidate
+    }
+
+    func copyCacheItem(from source: URL, to destination: URL) throws {
+        let values = try source.resourceValues(forKeys: [.isSymbolicLinkKey])
+        guard values.isSymbolicLink != true else {
+            throw ValidationError("Workflow cache items cannot be symbolic links: \(source.path)")
+        }
+        if fileManager.fileExists(atPath: destination.path) {
+            try fileManager.removeItem(at: destination)
+        }
+        try fileManager.createDirectory(
+            at: destination.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        try fileManager.copyItem(at: source, to: destination)
+    }
+
+    func clearAttemptOutputs(
+        _ outputs: [String: WorkflowInvocationOutput],
+        nodeDirectory: URL
+    ) throws {
+        for descriptor in outputs.values {
+            guard let path = descriptor.path else { continue }
+            let outputURL = try invocationOutputURL(path, nodeDirectory: nodeDirectory)
+            if fileManager.fileExists(atPath: outputURL.path) {
+                try fileManager.removeItem(at: outputURL)
+            }
+        }
+        let artifacts = nodeDirectory.appendingPathComponent("artifacts", isDirectory: true)
+        if fileManager.fileExists(atPath: artifacts.path) {
+            try fileManager.removeItem(at: artifacts)
+        }
+        let stdout = nodeDirectory.appendingPathComponent("stdout.txt")
+        if fileManager.fileExists(atPath: stdout.path) {
+            try fileManager.removeItem(at: stdout)
+        }
+    }
+
+    func verifyOutputs(
+        _ descriptors: [String: WorkflowInvocationOutput],
+        providerValues: [String: WorkflowValue]?,
+        node: WorkflowNode,
+        nodeDirectory: URL
+    ) throws -> WorkflowVerifiedNodeOutputs {
+        var artifacts: [GraphRunArtifact] = []
+        var records: [GraphRunNodeOutput] = []
+        var values: [String: WorkflowValue] = [:]
+        for name in descriptors.keys.sorted() {
+            guard let descriptor = descriptors[name] else { continue }
+            let providerValue = providerValues?[name]
+            switch descriptor.type {
+            case .asset, .assetCollection, .assetArray:
+                guard let path = descriptor.path else {
+                    throw ValidationError("Node '\(node.id)' output '\(name)' has no declared path.")
+                }
+                let url = try invocationOutputURL(path, nodeDirectory: nodeDirectory)
+                if providerValue == .null || !fileManager.fileExists(atPath: url.path) {
+                    if descriptor.optional { continue }
+                    throw ValidationError("Node '\(node.id)' did not produce declared output '\(name)'.")
+                }
+                if let providerPath = providerValue?.stringValue {
+                    let reported = try invocationOutputURL(providerPath, nodeDirectory: nodeDirectory)
+                    guard reported.standardizedFileURL == url.standardizedFileURL else {
+                        throw ValidationError("Node '\(node.id)' reported an unexpected path for output '\(name)'.")
+                    }
+                }
+                let outputArtifact = try artifact(
+                    name: name,
+                    nodeKind: node.kind,
+                    url: url,
+                    contentType: descriptor.contentTypes.first
+                )
+                artifacts.append(outputArtifact)
+                records.append(.init(
+                    name: name,
+                    type: descriptor.type,
+                    value: nil,
+                    path: outputArtifact.path,
+                    contentType: outputArtifact.contentType,
+                    sizeBytes: outputArtifact.sizeBytes,
+                    sha256: outputArtifact.sha256
+                ))
+                values[name] = .string(url.path)
+            case .assetDirectory:
+                guard let path = descriptor.path else {
+                    throw ValidationError("Node '\(node.id)' directory output '\(name)' has no declared path.")
+                }
+                let url = try invocationOutputURL(path, nodeDirectory: nodeDirectory)
+                var isDirectory: ObjCBool = false
+                if providerValue == .null || !fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory) {
+                    if descriptor.optional { continue }
+                    throw ValidationError("Node '\(node.id)' did not produce declared directory output '\(name)'.")
+                }
+                guard isDirectory.boolValue else {
+                    throw ValidationError("Node '\(node.id)' output '\(name)' is not a directory.")
+                }
+                if let providerPath = providerValue?.stringValue {
+                    let reported = try invocationOutputURL(providerPath, nodeDirectory: nodeDirectory)
+                    guard reported.standardizedFileURL == url.standardizedFileURL else {
+                        throw ValidationError("Node '\(node.id)' reported an unexpected path for output '\(name)'.")
+                    }
+                }
+                let directory = try directoryIdentity(url)
+                let manifestURL = nodeDirectory
+                    .appendingPathComponent("artifacts", isDirectory: true)
+                    .appendingPathComponent("\(name).manifest.json")
+                try WorkflowBundleCodec.write(directory.manifest, to: manifestURL)
+                let manifestArtifact = try artifact(
+                    name: "\(name)_manifest",
+                    nodeKind: node.kind,
+                    url: manifestURL,
+                    contentType: "application/json"
+                )
+                artifacts.append(manifestArtifact)
+                records.append(.init(
+                    name: name,
+                    type: .assetDirectory,
+                    value: nil,
+                    path: try portableArtifactPath(for: url),
+                    contentType: descriptor.contentTypes.first,
+                    sizeBytes: directory.sizeBytes,
+                    sha256: directory.sha256
+                ))
+                values[name] = .string(url.path)
+            case .string, .integer, .number, .boolean, .enumeration, .json:
+                guard let providerValue, providerValue != .null else {
+                    if descriptor.optional { continue }
+                    throw ValidationError("Node '\(node.id)' did not report declared value output '\(name)'.")
+                }
+                guard workflowValue(providerValue, matches: descriptor.type) else {
+                    throw ValidationError("Node '\(node.id)' output '\(name)' has the wrong value type.")
+                }
+                records.append(.init(
+                    name: name,
+                    type: descriptor.type,
+                    value: providerValue,
+                    path: nil,
+                    contentType: nil,
+                    sizeBytes: nil,
+                    sha256: try WorkflowBundleCodec.hash(providerValue)
+                ))
+                values[name] = providerValue
+            }
+        }
+        if let providerValues {
+            let undeclared = Set(providerValues.keys).subtracting(descriptors.keys)
+            guard undeclared.isEmpty else {
+                throw ValidationError(
+                    "Node '\(node.id)' reported undeclared outputs: \(undeclared.sorted().joined(separator: ", "))."
+                )
+            }
+        }
+        return WorkflowVerifiedNodeOutputs(artifacts: artifacts, outputs: records, values: values)
+    }
+
+    func invocationOutputURL(_ path: String, nodeDirectory: URL) throws -> URL {
+        let candidate: URL
+        if path.hasPrefix("/") {
+            candidate = URL(fileURLWithPath: path).standardizedFileURL
+        } else {
+            guard isConfinedRelativeWorkflowPath(path) else {
+                throw ValidationError("Workflow provider output path is not confined: \(path)")
+            }
+            candidate = nodeDirectory.appendingPathComponent(path).standardizedFileURL
+        }
+        let root = nodeDirectory.standardizedFileURL.path
+        guard candidate.path.hasPrefix(root + "/") else {
+            throw ValidationError("Workflow provider output path escapes the node directory: \(path)")
+        }
+        try requireResolvedContainment(candidate, in: nodeDirectory)
+        try requireResolvedContainment(candidate, in: runDirectory)
+        return candidate
+    }
+
+    func directoryIdentity(_ directory: URL) throws -> WorkflowDirectoryIdentity {
+        let root = directory.resolvingSymlinksInPath()
+        var entries: [WorkflowAssetEntry] = []
+        for path in try fileManager.subpathsOfDirectory(atPath: root.path).sorted() {
+            let url = root.appendingPathComponent(path)
+            let values = try url.resourceValues(forKeys: [.isRegularFileKey, .isSymbolicLinkKey])
+            if values.isSymbolicLink == true {
+                throw ValidationError("Workflow output directories cannot contain symbolic links: \(url.path)")
+            }
+            guard values.isRegularFile == true else { continue }
+            entries.append(WorkflowAssetEntry(
+                path: path,
+                digest: try ModelArtifactPin.fileSHA256(url),
+                sizeBytes: try ModelArtifactPin.fileByteCount(url),
+                contentType: contentType(for: url)
+            ))
+        }
+        let manifest = WorkflowOutputDirectoryManifest(contractVersion: "mere.run/output-directory.v1", entries: entries)
+        return WorkflowDirectoryIdentity(
+            manifest: manifest,
+            sizeBytes: entries.reduce(0) { $0 + $1.sizeBytes },
+            sha256: try WorkflowBundleCodec.hash(manifest)
+        )
+    }
+
+    func localizeInputs(
+        graph: WorkflowGraphDocument,
+        inputs: WorkflowInputsDocument,
+        assets: WorkflowAssetManifest
+    ) throws -> WorkflowInputsDocument {
+        var localized = inputs.values
+        let root = try artifactURL(for: "inputs")
+        try fileManager.createDirectory(at: root, withIntermediateDirectories: true)
+        var groupNames = Set<String>()
+        for group in assets.groups {
+            guard groupNames.insert(group.name).inserted,
+                  group.name.range(of: "^[a-z][a-z0-9-]{0,63}$", options: .regularExpression) != nil else {
+                throw ValidationError("Asset manifest contains an invalid or duplicate group '\(group.name)'.")
+            }
+            let groupRoot = root.appendingPathComponent(group.name, isDirectory: true)
+            if group.kind == .assetDirectory {
+                try fileManager.createDirectory(at: groupRoot, withIntermediateDirectories: true)
+            }
+            for entry in group.entries {
+                guard isConfinedRelativeWorkflowPath(entry.path),
+                      entry.digest.count == 64,
+                      entry.digest.allSatisfy({ $0.isHexDigit && !$0.isUppercase }) else {
+                    throw ValidationError("Workflow asset manifest contains an invalid path or digest.")
+                }
+                let source = bundleDirectory
+                    .appendingPathComponent("assets", isDirectory: true)
+                    .appendingPathComponent("sha256", isDirectory: true)
+                    .appendingPathComponent(entry.digest)
+                guard fileManager.fileExists(atPath: source.path),
+                      try ModelArtifactPin.fileByteCount(source) == entry.sizeBytes,
+                      try ModelArtifactPin.fileSHA256(source) == entry.digest else {
+                    throw ValidationError("Workflow asset digest verification failed for '\(group.name)/\(entry.path)'.")
+                }
+                let destination = group.kind == .asset
+                    ? root.appendingPathComponent("\(group.name)-\(entry.path)")
+                    : groupRoot.appendingPathComponent(entry.path)
+                try requireResolvedContainment(destination, in: runDirectory)
+                try fileManager.createDirectory(at: destination.deletingLastPathComponent(), withIntermediateDirectories: true)
+                if fileManager.fileExists(atPath: destination.path) {
+                    guard try ModelArtifactPin.fileByteCount(destination) == entry.sizeBytes,
+                          try ModelArtifactPin.fileSHA256(destination) == entry.digest else {
+                        throw ValidationError("Workflow localized input digest mismatch for '\(group.name)/\(entry.path)'.")
+                    }
+                } else {
+                    do {
+                        try fileManager.linkItem(at: source, to: destination)
+                    } catch {
+                        try fileManager.copyItem(at: source, to: destination)
+                    }
+                }
+            }
+            if group.kind == .asset, let entry = group.entries.first {
+                guard group.entries.count == 1 else {
+                    throw ValidationError("Asset group '\(group.name)' must contain exactly one file.")
+                }
+                localized[group.name] = .string(root.appendingPathComponent("\(group.name)-\(entry.path)").path)
+            } else {
+                localized[group.name] = .string(groupRoot.path)
+            }
+        }
+        return WorkflowInputsDocument(values: localized)
+    }
+
+    func shouldResume(
+        _ node: GraphRunNodeRecord,
+        expectedFingerprint: String,
+        nodeOutputs: inout [String: [String: WorkflowValue]]
+    ) throws -> Bool {
+        guard resume,
+              node.state == .finished,
+              node.fingerprint == expectedFingerprint,
+              !node.outputs.isEmpty || !node.artifacts.isEmpty else { return false }
+        var outputs: [String: WorkflowValue] = [:]
+        if !node.outputs.isEmpty {
+            for output in node.outputs {
+                if let value = output.value {
+                    guard try WorkflowBundleCodec.hash(value) == output.sha256 else { return false }
+                    outputs[output.name] = value
+                    continue
+                }
+                guard let path = output.path else { return false }
+                let url = try artifactURL(for: path)
+                if output.type == .assetDirectory {
+                    var isDirectory: ObjCBool = false
+                    guard fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory),
+                          isDirectory.boolValue,
+                          try directoryIdentity(url).sha256 == output.sha256 else { return false }
+                } else {
+                    guard fileManager.fileExists(atPath: url.path),
+                          try ModelArtifactPin.fileByteCount(url) == output.sizeBytes,
+                          try ModelArtifactPin.fileSHA256(url) == output.sha256 else { return false }
+                }
+                outputs[output.name] = .string(url.path)
+            }
+        } else {
+            for artifact in node.artifacts {
+                let url = try artifactURL(for: artifact.path)
+                guard fileManager.fileExists(atPath: url.path),
+                      try ModelArtifactPin.fileByteCount(url) == artifact.sizeBytes,
+                      try ModelArtifactPin.fileSHA256(url) == artifact.sha256 else {
+                    return false
+                }
+                outputs[artifact.name] = .string(url.path)
+            }
+        }
+        nodeOutputs[node.id] = outputs
+        return true
+    }
+
+    func materializeGraphOutputs(
+        graph: WorkflowGraphDocument,
+        nodeOutputs: [String: [String: WorkflowValue]]
+    ) throws -> [GraphRunArtifact] {
+        var artifacts: [GraphRunArtifact] = []
+        let outputsRoot = runDirectory.appendingPathComponent("outputs", isDirectory: true)
+        for name in graph.outputs.keys.sorted() {
+            guard case .reference(let rawReference)? = graph.outputs[name] else { continue }
+            let reference = try WorkflowReference(rawReference)
+            guard case .nodeOutput(let nodeID, let output) = reference.source,
+                  let sourceValue = nodeOutputs[nodeID]?[output],
+                  let node = graph.nodes.first(where: { $0.id == nodeID }),
+                  let outputContract = WorkflowNodeRegistry.output(node: node, name: output) else {
+                throw ValidationError("Workflow output '\(name)' was not produced.")
+            }
+            if outputContract.type != .asset && outputContract.type != .assetCollection && outputContract.type != .assetArray {
+                let destination = try artifactURL(for: outputsRoot.appendingPathComponent("\(name).json").path)
+                try WorkflowBundleCodec.encoder().encode(sourceValue).write(to: destination, options: .atomic)
+                artifacts.append(try artifact(
+                    name: name,
+                    nodeKind: "graph.output",
+                    url: destination,
+                    contentType: "application/json"
+                ))
+                continue
+            }
+            guard let sourcePath = sourceValue.stringValue else {
+                throw ValidationError("Workflow output '\(name)' did not resolve to an artifact path.")
+            }
+            let source = try artifactURL(for: sourcePath)
+            let suffix = source.pathExtension.isEmpty ? "" : ".\(source.pathExtension)"
+            let destination = try artifactURL(for: outputsRoot.appendingPathComponent("\(name)\(suffix)").path)
+            if fileManager.fileExists(atPath: destination.path) {
+                try fileManager.removeItem(at: destination)
+            }
+            do {
+                try fileManager.linkItem(at: source, to: destination)
+            } catch {
+                try fileManager.copyItem(at: source, to: destination)
+            }
+            artifacts.append(try artifact(name: name, nodeKind: "graph.output", url: destination))
+        }
+        return artifacts
+    }
+
+    func artifact(
+        name: String,
+        nodeKind: String,
+        url: URL,
+        contentType explicitContentType: String? = nil
+    ) throws -> GraphRunArtifact {
+        GraphRunArtifact(
+            name: name,
+            kind: nodeKind,
+            path: try portableArtifactPath(for: url),
+            contentType: explicitContentType ?? contentType(for: url),
+            sizeBytes: try ModelArtifactPin.fileByteCount(url),
+            sha256: try ModelArtifactPin.fileSHA256(url)
+        )
+    }
+
+    func artifactURL(for path: String) throws -> URL {
+        let candidate = path.hasPrefix("/")
+            ? URL(fileURLWithPath: path).standardizedFileURL
+            : runDirectory.appendingPathComponent(path).standardizedFileURL
+        let root = runDirectory.standardizedFileURL.path
+        guard candidate.path == root || candidate.path.hasPrefix(root + "/") else {
+            throw ValidationError("Workflow artifact path escapes the run directory: \(path)")
+        }
+        try requireResolvedContainment(candidate, in: runDirectory)
+        return candidate
+    }
+
+    func portableArtifactPath(for url: URL) throws -> String {
+        let candidate = url.standardizedFileURL.path
+        let root = runDirectory.standardizedFileURL.path
+        guard candidate.hasPrefix(root + "/") else {
+            throw ValidationError("Workflow artifact path escapes the run directory: \(candidate)")
+        }
+        try requireResolvedContainment(url, in: runDirectory)
+        return String(candidate.dropFirst(root.count + 1))
+    }
+
+    private func requireResolvedContainment(_ url: URL, in directory: URL) throws {
+        let root = directory.resolvingSymlinksInPath().standardizedFileURL.path
+        let resolved = url.resolvingSymlinksInPath().standardizedFileURL.path
+        guard resolved.hasPrefix(root + "/") else {
+            throw ValidationError("Workflow artifact resolves outside its owning directory: \(url.path)")
+        }
+    }
+
+    func contentType(for url: URL) -> String {
+        switch url.pathExtension.lowercased() {
+        case "png": "image/png"
+        case "jpg", "jpeg": "image/jpeg"
+        case "webp": "image/webp"
+        case "mp4": "video/mp4"
+        case "wav": "audio/wav"
+        case "tif", "tiff": "image/tiff"
+        case "json": "application/json"
+        case "txt": "text/plain"
+        case "safetensors": "application/x-safetensors"
+        default: "application/octet-stream"
+        }
+    }
+
+}
+
+struct WorkflowVerifiedNodeOutputs {
+    let artifacts: [GraphRunArtifact]
+    let outputs: [GraphRunNodeOutput]
+    let values: [String: WorkflowValue]
+}
+
+struct WorkflowNodeCacheManifest: Codable {
+    static let contractVersion = "mere.run/node-cache.v1"
+    static let filename = "cache.json"
+
+    let contractVersion: String
+    let fingerprint: String
+    let outputs: [WorkflowNodeCacheOutput]
+
+    enum CodingKeys: String, CodingKey {
+        case contractVersion = "contract_version"
+        case fingerprint
+        case outputs
+    }
+}
+
+struct WorkflowNodeCacheOutput: Codable, Equatable {
+    let name: String
+    let type: WorkflowPortType
+    let value: WorkflowValue?
+    let relativePath: String?
+    let contentType: String?
+    let sizeBytes: Int64?
+    let sha256: String
+
+    enum CodingKeys: String, CodingKey {
+        case name
+        case type
+        case value
+        case relativePath = "relative_path"
+        case contentType = "content_type"
+        case sizeBytes = "size_bytes"
+        case sha256
+    }
+}
+
+struct WorkflowOutputDirectoryManifest: Codable {
+    let contractVersion: String
+    let entries: [WorkflowAssetEntry]
+
+    enum CodingKeys: String, CodingKey {
+        case contractVersion = "contract_version"
+        case entries
+    }
+}
+
+struct WorkflowDirectoryIdentity {
+    let manifest: WorkflowOutputDirectoryManifest
+    let sizeBytes: Int64
+    let sha256: String
+}
+
+
+private func workflowValue(_ value: WorkflowValue, matches type: WorkflowPortType) -> Bool {
+    switch type {
+    case .string, .enumeration, .asset, .assetDirectory:
+        value.stringValue != nil
+    case .integer:
+        value.integerValue != nil
+    case .number:
+        value.numberValue != nil
+    case .boolean:
+        value.booleanValue != nil
+    case .json:
+        true
+    case .assetCollection, .assetArray:
+        if case .array = value { true } else { false }
+    }
+}
+
+private func isConfinedRelativeWorkflowPath(_ path: String) -> Bool {
+    !path.isEmpty
+        && !path.hasPrefix("/")
+        && path.split(separator: "/", omittingEmptySubsequences: false).allSatisfy { component in
+            !component.isEmpty && component != "." && component != ".."
+        }
+}
+

--- a/Sources/MereRunCLI/Support/WorkflowProcessRunner.swift
+++ b/Sources/MereRunCLI/Support/WorkflowProcessRunner.swift
@@ -1,0 +1,368 @@
+import Foundation
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+struct WorkflowProcessResult: Equatable {
+    let status: Int32
+    let stdout: String
+    let stderr: String
+    let terminationReason: WorkflowProcessTerminationReason
+
+    init(
+        status: Int32,
+        stdout: String,
+        stderr: String = "",
+        terminationReason: WorkflowProcessTerminationReason = .exit
+    ) {
+        self.status = status
+        self.stdout = stdout
+        self.stderr = stderr
+        self.terminationReason = terminationReason
+    }
+
+    var failureSummary: String {
+        var summary = terminationReason == .uncaughtSignal
+            ? "terminated by signal \(status)"
+            : "exited with status \(status)"
+        if !stderr.isEmpty {
+            summary += ". stderr: \(stderr)"
+        } else if !stdout.isEmpty {
+            summary += ". stdout: \(stdout.suffix(16 * 1_024))"
+        }
+        return summary
+    }
+}
+
+enum WorkflowProcessTerminationReason: String, Equatable {
+    case exit
+    case uncaughtSignal = "uncaught_signal"
+
+    init(_ reason: Process.TerminationReason) {
+        switch reason {
+        case .exit:
+            self = .exit
+        case .uncaughtSignal:
+            self = .uncaughtSignal
+        @unknown default:
+            self = .exit
+        }
+    }
+}
+
+private struct WorkflowProcessTimeoutError: LocalizedError {
+    let seconds: Int
+
+    var errorDescription: String? {
+        "Process timed out after \(seconds) seconds."
+    }
+}
+
+enum WorkflowChildProcessRegistry {
+    static let directoryName = "worker-child-pids"
+    static let legacyFilename = "worker-child.pid"
+    private static let lock = NSLock()
+
+    static func register(
+        _ processID: Int32,
+        in runDirectory: URL,
+        fileManager: FileManager = .default
+    ) throws {
+        lock.lock()
+        defer { lock.unlock() }
+        let directory = runDirectory.appendingPathComponent(directoryName, isDirectory: true)
+        let entry = directory.appendingPathComponent("\(processID).pid")
+        do {
+            try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+            try Data(String(processID).utf8).write(to: entry, options: .atomic)
+            try Data(String(processID).utf8).write(
+                to: runDirectory.appendingPathComponent(legacyFilename),
+                options: .atomic
+            )
+        } catch {
+            try? fileManager.removeItem(at: entry)
+            throw error
+        }
+    }
+
+    static func unregister(
+        _ processID: Int32,
+        in runDirectory: URL,
+        fileManager: FileManager = .default
+    ) {
+        lock.lock()
+        defer { lock.unlock() }
+        let entry = runDirectory
+            .appendingPathComponent(directoryName, isDirectory: true)
+            .appendingPathComponent("\(processID).pid")
+        try? fileManager.removeItem(at: entry)
+        let legacy = runDirectory.appendingPathComponent(legacyFilename)
+        if readProcessID(at: legacy, fileManager: fileManager) == processID {
+            try? fileManager.removeItem(at: legacy)
+        }
+    }
+
+    static func processIDs(
+        in runDirectory: URL,
+        fileManager: FileManager = .default
+    ) -> [Int32] {
+        let directory = runDirectory.appendingPathComponent(directoryName, isDirectory: true)
+        let entries = (try? fileManager.contentsOfDirectory(
+            at: directory,
+            includingPropertiesForKeys: [.isRegularFileKey, .isSymbolicLinkKey]
+        )) ?? []
+        var processIDs = Set(entries.compactMap { entry -> Int32? in
+            guard entry.pathExtension == "pid",
+                  let values = try? entry.resourceValues(forKeys: [.isRegularFileKey, .isSymbolicLinkKey]),
+                  values.isRegularFile == true,
+                  values.isSymbolicLink != true else {
+                return nil
+            }
+            return readProcessID(at: entry, fileManager: fileManager)
+        })
+        if let legacy = readProcessID(
+            at: runDirectory.appendingPathComponent(legacyFilename),
+            fileManager: fileManager
+        ) {
+            processIDs.insert(legacy)
+        }
+        return processIDs.sorted()
+    }
+
+    static func activeProcessIDs(in runDirectory: URL, fileManager: FileManager = .default) -> [Int32] {
+        processIDs(in: runDirectory, fileManager: fileManager).filter { pid in
+            kill(pid, 0) == 0 || errno == EPERM
+        }
+    }
+
+    @discardableResult
+    static func terminateAll(
+        in runDirectory: URL,
+        fileManager: FileManager = .default
+    ) -> [Int32] {
+        let processIDs = processIDs(in: runDirectory, fileManager: fileManager)
+        for processID in processIDs {
+            _ = kill(processID, SIGTERM)
+        }
+        return processIDs
+    }
+
+    static func clear(
+        in runDirectory: URL,
+        fileManager: FileManager = .default
+    ) throws {
+        lock.lock()
+        defer { lock.unlock() }
+        let legacy = runDirectory.appendingPathComponent(legacyFilename)
+        if fileManager.fileExists(atPath: legacy.path) {
+            try fileManager.removeItem(at: legacy)
+        }
+        let directory = runDirectory.appendingPathComponent(directoryName, isDirectory: true)
+        if fileManager.fileExists(atPath: directory.path) {
+            try fileManager.removeItem(at: directory)
+        }
+    }
+
+    private static func readProcessID(at url: URL, fileManager: FileManager) -> Int32? {
+        guard fileManager.fileExists(atPath: url.path),
+              let raw = try? String(contentsOf: url, encoding: .utf8)
+                .trimmingCharacters(in: .whitespacesAndNewlines),
+              let processID = Int32(raw),
+              processID > 1 else {
+            return nil
+        }
+        return processID
+    }
+}
+
+private final class WorkflowProcessStderrTail: @unchecked Sendable {
+    private static let maximumBytes = 16 * 1_024
+    private let lock = NSLock()
+    private var data = Data()
+
+    func append(_ newData: Data) {
+        lock.lock()
+        defer { lock.unlock() }
+        if newData.count >= Self.maximumBytes {
+            data = Data(newData.suffix(Self.maximumBytes))
+            return
+        }
+        data.append(newData)
+        if data.count > Self.maximumBytes {
+            data.removeFirst(data.count - Self.maximumBytes)
+        }
+    }
+
+    var string: String {
+        lock.lock()
+        defer { lock.unlock() }
+        return String(decoding: data, as: UTF8.self)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
+protocol WorkflowProcessRunning {
+    func run(arguments: [String], currentDirectory: URL) throws -> WorkflowProcessResult
+}
+
+protocol WorkflowStreamingProcessRunning {
+    func run(
+        executable: URL,
+        arguments: [String],
+        currentDirectory: URL,
+        timeoutSeconds: Int?,
+        stdoutLineHandler: ((String) throws -> Void)?
+    ) throws -> WorkflowProcessResult
+
+    func run(
+        executable: URL,
+        arguments: [String],
+        currentDirectory: URL,
+        timeoutSeconds: Int?,
+        stdoutLineHandler: ((String) throws -> Void)?,
+        stdoutChunkHandler: ((Data) throws -> Void)?
+    ) throws -> WorkflowProcessResult
+}
+
+extension WorkflowStreamingProcessRunning {
+    // Chunk delivery is opt-in for runners that support it; others keep
+    // line-based behavior and ignore raw chunks.
+    func run(
+        executable: URL,
+        arguments: [String],
+        currentDirectory: URL,
+        timeoutSeconds: Int?,
+        stdoutLineHandler: ((String) throws -> Void)?,
+        stdoutChunkHandler: ((Data) throws -> Void)?
+    ) throws -> WorkflowProcessResult {
+        try run(
+            executable: executable,
+            arguments: arguments,
+            currentDirectory: currentDirectory,
+            timeoutSeconds: timeoutSeconds,
+            stdoutLineHandler: stdoutLineHandler
+        )
+    }
+}
+
+struct WorkflowProcessRunner: WorkflowProcessRunning, WorkflowStreamingProcessRunning {
+    let maximumStdoutBytes: Int
+
+    init(maximumStdoutBytes: Int = 16 * 1024 * 1024) {
+        self.maximumStdoutBytes = maximumStdoutBytes
+    }
+
+    static func stdoutCaptureURL(in directory: URL) -> URL {
+        directory.appendingPathComponent(".workflow-stdout-\(UUID().uuidString)")
+    }
+
+    func run(arguments: [String], currentDirectory: URL) throws -> WorkflowProcessResult {
+        try run(
+            executable: CurrentExecutable.url(),
+            arguments: arguments,
+            currentDirectory: currentDirectory,
+            timeoutSeconds: nil,
+            stdoutLineHandler: nil
+        )
+    }
+
+    func run(
+        executable: URL,
+        arguments: [String],
+        currentDirectory: URL,
+        timeoutSeconds: Int?,
+        stdoutLineHandler: ((String) throws -> Void)?
+    ) throws -> WorkflowProcessResult {
+        try run(
+            executable: executable,
+            arguments: arguments,
+            currentDirectory: currentDirectory,
+            timeoutSeconds: timeoutSeconds,
+            stdoutLineHandler: stdoutLineHandler,
+            stdoutChunkHandler: nil
+        )
+    }
+
+    func run(
+        executable: URL,
+        arguments: [String],
+        currentDirectory: URL,
+        timeoutSeconds: Int?,
+        stdoutLineHandler: ((String) throws -> Void)?,
+        stdoutChunkHandler: ((Data) throws -> Void)?
+    ) throws -> WorkflowProcessResult {
+        let process = Process()
+        process.executableURL = executable
+        process.arguments = arguments
+        process.currentDirectoryURL = currentDirectory
+        process.standardInput = FileHandle.nullDevice
+        let runDirectory = currentDirectory.deletingLastPathComponent().deletingLastPathComponent()
+        let stderrTail = WorkflowProcessStderrTail()
+        var captured = Data()
+        var pending = Data()
+        defer {
+            if process.processIdentifier > 0 {
+                WorkflowChildProcessRegistry.unregister(process.processIdentifier, in: runDirectory)
+            }
+        }
+        let result: BoundedProcessRunner.Result
+        do {
+            result = try BoundedProcessRunner.run(
+                process, timeout: timeoutSeconds.map(TimeInterval.init), outputLimitBytes: 0,
+                isCancelled: {
+                    Task.isCancelled || FileManager.default.fileExists(atPath: runDirectory.appendingPathComponent("cancel.request").path)
+                },
+                onStarted: { try WorkflowChildProcessRegistry.register($0, in: runDirectory) },
+                stdoutHandler: { data in
+                    guard data.count <= maximumStdoutBytes - captured.count else {
+                        throw WorkflowProcessOutputLimitError(limit: maximumStdoutBytes)
+                    }
+                    captured.append(data)
+                    try stdoutChunkHandler?(data)
+                    guard stdoutLineHandler != nil else { return }
+                    pending.append(data)
+                    while let newline = pending.firstIndex(of: 0x0A) {
+                        let lineData = pending.prefix(upTo: newline)
+                        pending.removeSubrange(...newline)
+                        let line = String(decoding: lineData, as: UTF8.self)
+                            .trimmingCharacters(in: .whitespacesAndNewlines)
+                        if !line.isEmpty { try stdoutLineHandler?(line) }
+                    }
+                },
+                stderrHandler: { data in
+                    stderrTail.append(data)
+                    try? FileHandle.standardError.write(contentsOf: data)
+                }
+            )
+        } catch is CancellationError {
+            throw WorkflowCancellationError()
+        }
+        if !pending.isEmpty {
+            let line = String(decoding: pending, as: UTF8.self).trimmingCharacters(in: .whitespacesAndNewlines)
+            if !line.isEmpty { try stdoutLineHandler?(line) }
+        }
+        if result.completion == .cancelled
+            || FileManager.default.fileExists(atPath: runDirectory.appendingPathComponent("cancel.request").path) {
+            throw WorkflowCancellationError()
+        }
+        if result.completion == .timedOut, let timeoutSeconds {
+            throw WorkflowProcessTimeoutError(seconds: timeoutSeconds)
+        }
+        return WorkflowProcessResult(
+            status: result.status,
+            stdout: String(decoding: captured, as: UTF8.self).trimmingCharacters(in: .whitespacesAndNewlines),
+            stderr: stderrTail.string,
+            terminationReason: WorkflowProcessTerminationReason(process.terminationReason)
+        )
+    }
+}
+
+struct WorkflowProcessOutputLimitError: LocalizedError {
+    let limit: Int
+
+    var errorDescription: String? {
+        "Workflow child stdout exceeded the \(limit)-byte limit. Write large outputs as declared artifacts."
+    }
+}

--- a/Sources/MereRunCLI/Support/WorkflowRunStore.swift
+++ b/Sources/MereRunCLI/Support/WorkflowRunStore.swift
@@ -1,0 +1,162 @@
+import ArgumentParser
+import Foundation
+import MereRunExecution
+import MereRunRelayKit
+
+/// Serial run persistence. The execution driver retains the returned lease
+/// until every child and terminal record has completed.
+struct WorkflowRunStore {
+    struct Session {
+        let lease: RunDirectoryLease
+        let manifest: GraphRunManifest
+        let eventCount: Int
+    }
+
+    let bundleDirectory: URL
+    let runDirectory: URL
+    let resume: Bool
+    let executor: GraphRunExecutorRecord
+    let fileManager: FileManager
+    let now: () -> Date
+    let eventHandler: ((GraphRunEvent) -> Void)?
+
+    func prepare(graph: WorkflowGraphDocument, job: WorkflowJobManifest, order: [String]) throws -> Session {
+        if fileManager.fileExists(atPath: runDirectory.path) {
+            guard resume || bundleDirectory == runDirectory else {
+                throw ValidationError("Run directory already exists. Pass --resume to reuse it: \(runDirectory.path)")
+            }
+        } else {
+            try fileManager.createDirectory(at: runDirectory, withIntermediateDirectories: true)
+        }
+        guard let lease = try RunDirectoryLease.acquire(in: runDirectory, filename: ".workflow-run.lock") else {
+            throw ValidationError("Workflow run already has an active worker: \(runDirectory.path)")
+        }
+        let liveChildren = WorkflowChildProcessRegistry.activeProcessIDs(in: runDirectory, fileManager: fileManager)
+        guard liveChildren.isEmpty else {
+            throw ValidationError("Workflow run still has active child processes: \(liveChildren.map(String.init).joined(separator: ", ")). Wait for them to stop before resuming.")
+        }
+        let manifest = try initialManifest(graph: graph, job: job, order: order)
+        let eventCount = try existingEventCount()
+        try initializeDirectory()
+        return Session(lease: lease, manifest: manifest, eventCount: eventCount)
+    }
+
+    private func initializeDirectory() throws {
+        try fileManager.createDirectory(
+            at: runDirectory.appendingPathComponent("nodes", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        let cancellationURL = runDirectory.appendingPathComponent("cancel.request")
+        if fileManager.fileExists(atPath: cancellationURL.path) {
+            try fileManager.removeItem(at: cancellationURL)
+        }
+        try WorkflowChildProcessRegistry.clear(in: runDirectory, fileManager: fileManager)
+        try fileManager.createDirectory(
+            at: runDirectory.appendingPathComponent("outputs", isDirectory: true),
+            withIntermediateDirectories: true
+        )
+        for filename in ["graph.json", "inputs.json", WorkflowAssetManifest.filename, WorkflowJobManifest.filename] {
+            let source = bundleDirectory.appendingPathComponent(filename)
+            let destination = runDirectory.appendingPathComponent(filename)
+            if source != destination, !fileManager.fileExists(atPath: destination.path) {
+                try fileManager.copyItem(at: source, to: destination)
+            }
+        }
+        let actionsURL = runDirectory.appendingPathComponent("actions.json")
+        if !fileManager.fileExists(atPath: actionsURL.path) {
+            try WorkflowBundleCodec.write([DeclarativeAction](), to: actionsURL)
+        }
+    }
+
+    func initialManifest(
+        graph: WorkflowGraphDocument,
+        job: WorkflowJobManifest,
+        order: [String]
+    ) throws -> GraphRunManifest {
+        let manifestURL = runDirectory.appendingPathComponent(GraphRunManifest.filename)
+        if resume, fileManager.fileExists(atPath: manifestURL.path) {
+            var existing = try WorkflowBundleCodec.decoder().decode(
+                GraphRunManifest.self,
+                from: Data(contentsOf: manifestURL)
+            )
+            guard existing.contractVersion == GraphRunManifest.contractVersion else {
+                throw ValidationError("Cannot resume: unsupported workflow run contract '\(existing.contractVersion)'.")
+            }
+            guard existing.graphFingerprint == job.graphFingerprint else {
+                throw ValidationError("Cannot resume: workflow graph fingerprint changed.")
+            }
+            guard existing.sourceInputFingerprint == job.sourceInputFingerprint else {
+                throw ValidationError("Cannot resume: workflow input fingerprint changed.")
+            }
+            let previousJob = try WorkflowBundleCodec.decoder().decode(
+                WorkflowJobManifest.self,
+                from: Data(contentsOf: runDirectory.appendingPathComponent(WorkflowJobManifest.filename))
+            )
+            guard previousJob.inputFingerprint == job.inputFingerprint else {
+                throw ValidationError("Cannot resume: workflow input fingerprint changed.")
+            }
+            existing.attempt += 1
+            existing.state = .planned
+            existing.error = nil
+            existing.executor = executor
+            existing.updatedAt = now()
+            return existing
+        }
+        let nodesByID = Dictionary(uniqueKeysWithValues: graph.nodes.map { ($0.id, $0) })
+        return GraphRunManifest(
+            contractVersion: GraphRunManifest.contractVersion,
+            jobID: job.jobID,
+            graphName: graph.name,
+            graphFingerprint: job.graphFingerprint,
+            sourceGraphFingerprint: job.sourceGraphFingerprint,
+            sourceInputFingerprint: job.sourceInputFingerprint,
+            state: .planned,
+            createdAt: now(),
+            updatedAt: now(),
+            attempt: 1,
+            executor: executor,
+            nodes: order.compactMap { id in
+                nodesByID[id].map {
+                    GraphRunNodeRecord(
+                        id: id,
+                        kind: $0.kind,
+                        state: .planned,
+                        startedAt: nil,
+                        completedAt: nil,
+                        exitStatus: nil,
+                        attempt: 0,
+                        maxAttempts: $0.execution?.resolvedMaxAttempts ?? 1,
+                        fingerprint: "",
+                        artifacts: [],
+                        error: nil
+                    )
+                }
+            },
+            outputs: [],
+            error: nil
+        )
+    }
+
+    func persist(_ manifest: GraphRunManifest) throws {
+        try WorkflowBundleCodec.write(manifest, to: runDirectory.appendingPathComponent(GraphRunManifest.filename))
+    }
+
+    func record(_ event: GraphRunEvent) throws {
+        let data = try WorkflowBundleCodec.lineEncoder().encode(event)
+        let url = runDirectory.appendingPathComponent("events.jsonl")
+        if !fileManager.fileExists(atPath: url.path) {
+            try Data().write(to: url)
+        }
+        let handle = try FileHandle(forWritingTo: url)
+        defer { try? handle.close() }
+        try handle.seekToEnd()
+        try handle.write(contentsOf: data + Data("\n".utf8))
+        try handle.synchronize()
+        eventHandler?(event)
+    }
+
+    func existingEventCount() throws -> Int {
+        let url = runDirectory.appendingPathComponent("events.jsonl")
+        guard fileManager.fileExists(atPath: url.path) else { return 0 }
+        return try String(contentsOf: url, encoding: .utf8).split(separator: "\n").count
+    }}

--- a/Sources/MereRunCLI/Support/WorkflowRunner.swift
+++ b/Sources/MereRunCLI/Support/WorkflowRunner.swift
@@ -22,215 +22,6 @@ struct WorkflowRunOutcome: Codable, Equatable {
     }
 }
 
-struct WorkflowProcessResult: Equatable {
-    let status: Int32
-    let stdout: String
-    let stderr: String
-    let terminationReason: WorkflowProcessTerminationReason
-
-    init(
-        status: Int32,
-        stdout: String,
-        stderr: String = "",
-        terminationReason: WorkflowProcessTerminationReason = .exit
-    ) {
-        self.status = status
-        self.stdout = stdout
-        self.stderr = stderr
-        self.terminationReason = terminationReason
-    }
-
-    var failureSummary: String {
-        var summary = terminationReason == .uncaughtSignal
-            ? "terminated by signal \(status)"
-            : "exited with status \(status)"
-        if !stderr.isEmpty {
-            summary += ". stderr: \(stderr)"
-        } else if !stdout.isEmpty {
-            summary += ". stdout: \(stdout.suffix(16 * 1_024))"
-        }
-        return summary
-    }
-}
-
-enum WorkflowProcessTerminationReason: String, Equatable {
-    case exit
-    case uncaughtSignal = "uncaught_signal"
-
-    init(_ reason: Process.TerminationReason) {
-        switch reason {
-        case .exit:
-            self = .exit
-        case .uncaughtSignal:
-            self = .uncaughtSignal
-        @unknown default:
-            self = .exit
-        }
-    }
-}
-
-private struct WorkflowProcessTimeoutError: LocalizedError {
-    let seconds: Int
-
-    var errorDescription: String? {
-        "Process timed out after \(seconds) seconds."
-    }
-}
-
-private final class WorkflowProcessTimeoutState: @unchecked Sendable {
-    private let lock = NSLock()
-    private var timedOut = false
-
-    func markTimedOut() {
-        lock.lock()
-        timedOut = true
-        lock.unlock()
-    }
-
-    var didTimeOut: Bool {
-        lock.lock()
-        defer { lock.unlock() }
-        return timedOut
-    }
-}
-
-enum WorkflowChildProcessRegistry {
-    static let directoryName = "worker-child-pids"
-    static let legacyFilename = "worker-child.pid"
-    private static let lock = NSLock()
-
-    static func register(
-        _ processID: Int32,
-        in runDirectory: URL,
-        fileManager: FileManager = .default
-    ) throws {
-        lock.lock()
-        defer { lock.unlock() }
-        let directory = runDirectory.appendingPathComponent(directoryName, isDirectory: true)
-        let entry = directory.appendingPathComponent("\(processID).pid")
-        do {
-            try fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
-            try Data(String(processID).utf8).write(to: entry, options: .atomic)
-            try Data(String(processID).utf8).write(
-                to: runDirectory.appendingPathComponent(legacyFilename),
-                options: .atomic
-            )
-        } catch {
-            try? fileManager.removeItem(at: entry)
-            throw error
-        }
-    }
-
-    static func unregister(
-        _ processID: Int32,
-        in runDirectory: URL,
-        fileManager: FileManager = .default
-    ) {
-        lock.lock()
-        defer { lock.unlock() }
-        let entry = runDirectory
-            .appendingPathComponent(directoryName, isDirectory: true)
-            .appendingPathComponent("\(processID).pid")
-        try? fileManager.removeItem(at: entry)
-        let legacy = runDirectory.appendingPathComponent(legacyFilename)
-        if readProcessID(at: legacy, fileManager: fileManager) == processID {
-            try? fileManager.removeItem(at: legacy)
-        }
-    }
-
-    static func processIDs(
-        in runDirectory: URL,
-        fileManager: FileManager = .default
-    ) -> [Int32] {
-        let directory = runDirectory.appendingPathComponent(directoryName, isDirectory: true)
-        let entries = (try? fileManager.contentsOfDirectory(
-            at: directory,
-            includingPropertiesForKeys: [.isRegularFileKey, .isSymbolicLinkKey]
-        )) ?? []
-        var processIDs = Set(entries.compactMap { entry -> Int32? in
-            guard entry.pathExtension == "pid",
-                  let values = try? entry.resourceValues(forKeys: [.isRegularFileKey, .isSymbolicLinkKey]),
-                  values.isRegularFile == true,
-                  values.isSymbolicLink != true else {
-                return nil
-            }
-            return readProcessID(at: entry, fileManager: fileManager)
-        })
-        if let legacy = readProcessID(
-            at: runDirectory.appendingPathComponent(legacyFilename),
-            fileManager: fileManager
-        ) {
-            processIDs.insert(legacy)
-        }
-        return processIDs.sorted()
-    }
-
-    @discardableResult
-    static func terminateAll(
-        in runDirectory: URL,
-        fileManager: FileManager = .default
-    ) -> [Int32] {
-        let processIDs = processIDs(in: runDirectory, fileManager: fileManager)
-        for processID in processIDs {
-            _ = kill(processID, SIGTERM)
-        }
-        return processIDs
-    }
-
-    static func clear(
-        in runDirectory: URL,
-        fileManager: FileManager = .default
-    ) throws {
-        lock.lock()
-        defer { lock.unlock() }
-        let legacy = runDirectory.appendingPathComponent(legacyFilename)
-        if fileManager.fileExists(atPath: legacy.path) {
-            try fileManager.removeItem(at: legacy)
-        }
-        let directory = runDirectory.appendingPathComponent(directoryName, isDirectory: true)
-        if fileManager.fileExists(atPath: directory.path) {
-            try fileManager.removeItem(at: directory)
-        }
-    }
-
-    private static func readProcessID(at url: URL, fileManager: FileManager) -> Int32? {
-        guard fileManager.fileExists(atPath: url.path),
-              let raw = try? String(contentsOf: url, encoding: .utf8)
-                .trimmingCharacters(in: .whitespacesAndNewlines),
-              let processID = Int32(raw),
-              processID > 1 else {
-            return nil
-        }
-        return processID
-    }
-}
-
-private final class WorkflowProcessStderrTail: @unchecked Sendable {
-    private static let maximumBytes = 16 * 1_024
-    private let lock = NSLock()
-    private var data = Data()
-
-    func append(_ newData: Data) {
-        lock.lock()
-        defer { lock.unlock() }
-        if newData.count >= Self.maximumBytes {
-            data = Data(newData.suffix(Self.maximumBytes))
-            return
-        }
-        data.append(newData)
-        if data.count > Self.maximumBytes {
-            data.removeFirst(data.count - Self.maximumBytes)
-        }
-    }
-
-    var string: String {
-        lock.lock()
-        defer { lock.unlock() }
-        return String(decoding: data, as: UTF8.self)
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-    }
-}
-
 private struct WorkflowPreparedParallelNode: @unchecked Sendable {
     let node: WorkflowNode
     let index: Int
@@ -274,186 +65,6 @@ private final class WorkflowParallelOutcomeBox: @unchecked Sendable {
     }
 }
 
-protocol WorkflowProcessRunning {
-    func run(arguments: [String], currentDirectory: URL) throws -> WorkflowProcessResult
-}
-
-protocol WorkflowStreamingProcessRunning {
-    func run(
-        executable: URL,
-        arguments: [String],
-        currentDirectory: URL,
-        timeoutSeconds: Int?,
-        stdoutLineHandler: ((String) throws -> Void)?
-    ) throws -> WorkflowProcessResult
-
-    func run(
-        executable: URL,
-        arguments: [String],
-        currentDirectory: URL,
-        timeoutSeconds: Int?,
-        stdoutLineHandler: ((String) throws -> Void)?,
-        stdoutChunkHandler: ((Data) throws -> Void)?
-    ) throws -> WorkflowProcessResult
-}
-
-extension WorkflowStreamingProcessRunning {
-    // Chunk delivery is opt-in for runners that support it; others keep
-    // line-based behavior and ignore raw chunks.
-    func run(
-        executable: URL,
-        arguments: [String],
-        currentDirectory: URL,
-        timeoutSeconds: Int?,
-        stdoutLineHandler: ((String) throws -> Void)?,
-        stdoutChunkHandler: ((Data) throws -> Void)?
-    ) throws -> WorkflowProcessResult {
-        try run(
-            executable: executable,
-            arguments: arguments,
-            currentDirectory: currentDirectory,
-            timeoutSeconds: timeoutSeconds,
-            stdoutLineHandler: stdoutLineHandler
-        )
-    }
-}
-
-struct WorkflowProcessRunner: WorkflowProcessRunning, WorkflowStreamingProcessRunning {
-    static func stdoutCaptureURL(in directory: URL) -> URL {
-        directory.appendingPathComponent(".workflow-stdout-\(UUID().uuidString)")
-    }
-
-    func run(arguments: [String], currentDirectory: URL) throws -> WorkflowProcessResult {
-        try run(
-            executable: CurrentExecutable.url(),
-            arguments: arguments,
-            currentDirectory: currentDirectory,
-            timeoutSeconds: nil,
-            stdoutLineHandler: nil
-        )
-    }
-
-    func run(
-        executable: URL,
-        arguments: [String],
-        currentDirectory: URL,
-        timeoutSeconds: Int?,
-        stdoutLineHandler: ((String) throws -> Void)?
-    ) throws -> WorkflowProcessResult {
-        try run(
-            executable: executable,
-            arguments: arguments,
-            currentDirectory: currentDirectory,
-            timeoutSeconds: timeoutSeconds,
-            stdoutLineHandler: stdoutLineHandler,
-            stdoutChunkHandler: nil
-        )
-    }
-
-    func run(
-        executable: URL,
-        arguments: [String],
-        currentDirectory: URL,
-        timeoutSeconds: Int?,
-        stdoutLineHandler: ((String) throws -> Void)?,
-        stdoutChunkHandler: ((Data) throws -> Void)?
-    ) throws -> WorkflowProcessResult {
-        let process = Process()
-        process.executableURL = executable
-        process.arguments = arguments
-        process.currentDirectoryURL = currentDirectory
-        let stdout = Pipe()
-        let stderr = Pipe()
-        let stderrTail = WorkflowProcessStderrTail()
-        let runDirectory = currentDirectory.deletingLastPathComponent().deletingLastPathComponent()
-        process.standardInput = FileHandle.nullDevice
-        process.standardOutput = stdout
-        process.standardError = stderr
-        stderr.fileHandleForReading.readabilityHandler = { handle in
-            let data = handle.availableData
-            guard !data.isEmpty else { return }
-            stderrTail.append(data)
-            try? FileHandle.standardError.write(contentsOf: data)
-        }
-        try process.run()
-        do {
-            try WorkflowChildProcessRegistry.register(process.processIdentifier, in: runDirectory)
-        } catch {
-            process.terminate()
-            process.waitUntilExit()
-            throw error
-        }
-        defer {
-            WorkflowChildProcessRegistry.unregister(process.processIdentifier, in: runDirectory)
-        }
-        if FileManager.default.fileExists(atPath: runDirectory.appendingPathComponent("cancel.request").path) {
-            process.terminate()
-        }
-        let timeoutState = WorkflowProcessTimeoutState()
-        let timeoutWorkItem: DispatchWorkItem?
-        if let timeoutSeconds {
-            let workItem = DispatchWorkItem {
-                guard process.isRunning else { return }
-                timeoutState.markTimedOut()
-                process.terminate()
-                Thread.sleep(forTimeInterval: 2)
-                if process.isRunning {
-                    kill(process.processIdentifier, SIGKILL)
-                }
-            }
-            timeoutWorkItem = workItem
-            DispatchQueue.global(qos: .utility).asyncAfter(
-                deadline: .now() + .seconds(timeoutSeconds),
-                execute: workItem
-            )
-        } else {
-            timeoutWorkItem = nil
-        }
-        defer { timeoutWorkItem?.cancel() }
-        var captured = Data()
-        var pending = Data()
-        while true {
-            let data = stdout.fileHandleForReading.availableData
-            if data.isEmpty { break }
-            captured.append(data)
-            try stdoutChunkHandler?(data)
-            guard stdoutLineHandler != nil else { continue }
-            pending.append(data)
-            while let newline = pending.firstIndex(of: 0x0A) {
-                let lineData = pending.prefix(upTo: newline)
-                pending.removeSubrange(...newline)
-                let line = String(decoding: lineData, as: UTF8.self)
-                    .trimmingCharacters(in: .whitespacesAndNewlines)
-                if !line.isEmpty { try stdoutLineHandler?(line) }
-            }
-        }
-        process.waitUntilExit()
-        stderr.fileHandleForReading.readabilityHandler = nil
-        let remainingStderr = stderr.fileHandleForReading.readDataToEndOfFile()
-        if !remainingStderr.isEmpty {
-            stderrTail.append(remainingStderr)
-            try? FileHandle.standardError.write(contentsOf: remainingStderr)
-        }
-        if !pending.isEmpty {
-            let line = String(decoding: pending, as: UTF8.self)
-                .trimmingCharacters(in: .whitespacesAndNewlines)
-            if !line.isEmpty { try stdoutLineHandler?(line) }
-        }
-        if FileManager.default.fileExists(atPath: runDirectory.appendingPathComponent("cancel.request").path) {
-            throw WorkflowCancellationError()
-        }
-        if timeoutState.didTimeOut, let timeoutSeconds {
-            throw WorkflowProcessTimeoutError(seconds: timeoutSeconds)
-        }
-        return WorkflowProcessResult(
-            status: process.terminationStatus,
-            stdout: String(decoding: captured, as: UTF8.self).trimmingCharacters(in: .whitespacesAndNewlines),
-            stderr: stderrTail.string,
-            terminationReason: WorkflowProcessTerminationReason(process.terminationReason)
-        )
-    }
-}
-
 struct WorkflowRunner: @unchecked Sendable {
     let bundleDirectory: URL
     let runDirectory: URL
@@ -464,6 +75,8 @@ struct WorkflowRunner: @unchecked Sendable {
     let cacheDirectory: URL?
     let now: () -> Date
     let eventHandler: ((GraphRunEvent) -> Void)?
+    let artifactStore: WorkflowArtifactStore
+    let runStore: WorkflowRunStore
 
     init(
         bundleDirectory: URL,
@@ -489,6 +102,14 @@ struct WorkflowRunner: @unchecked Sendable {
                 : nil)
         self.now = now
         self.eventHandler = eventHandler
+        self.artifactStore = WorkflowArtifactStore(
+            bundleDirectory: self.bundleDirectory, runDirectory: self.runDirectory,
+            cacheDirectory: self.cacheDirectory, resume: resume, fileManager: fileManager
+        )
+        self.runStore = WorkflowRunStore(
+            bundleDirectory: self.bundleDirectory, runDirectory: self.runDirectory,
+            resume: resume, executor: executor, fileManager: fileManager, now: now, eventHandler: eventHandler
+        )
     }
 
     func execute() throws -> WorkflowRunOutcome {
@@ -541,12 +162,13 @@ struct WorkflowRunner: @unchecked Sendable {
             throw ValidationError(validation.diagnostics.map(\.message).joined(separator: " "))
         }
 
-        try prepareRunDirectory()
-        let localizedInputs = try localizeInputs(graph: graph, inputs: inputs, assets: assets)
-        var manifest = try initialManifest(graph: graph, job: job, order: validation.order)
-        var sequence = try existingEventCount()
-        try persist(manifest)
-        try record(
+        let session = try runStore.prepare(graph: graph, job: job, order: validation.order)
+        defer { session.lease.release() }
+        let localizedInputs = try artifactStore.localizeInputs(graph: graph, inputs: inputs, assets: assets)
+        var manifest = session.manifest
+        var sequence = session.eventCount
+        try runStore.persist(manifest)
+        try runStore.record(
             GraphRunEvent(
                 sequence: sequence,
                 createdAt: now(),
@@ -559,7 +181,7 @@ struct WorkflowRunner: @unchecked Sendable {
         sequence += 1
         manifest.state = .running
         manifest.updatedAt = now()
-        try persist(manifest)
+        try runStore.persist(manifest)
 
         var nodeOutputs: [String: [String: WorkflowValue]] = [:]
         do {
@@ -579,7 +201,7 @@ struct WorkflowRunner: @unchecked Sendable {
                       let nodeIndex = manifest.nodes.firstIndex(where: { $0.id == nodeID }) else {
                     throw ValidationError("Workflow execution order referenced missing node '\(nodeID)'.")
                 }
-                if fileManager.fileExists(atPath: runDirectory.appendingPathComponent("cancel.request").path) {
+                if Task.isCancelled || fileManager.fileExists(atPath: runDirectory.appendingPathComponent("cancel.request").path) {
                     throw WorkflowCancellationError()
                 }
 
@@ -613,12 +235,12 @@ struct WorkflowRunner: @unchecked Sendable {
                     models: nodeModels,
                     upstreamOutputs: upstreamOutputs
                 ))
-                if workflowNodeAllowsResumeReuse(node), try shouldResume(
+                if workflowNodeAllowsResumeReuse(node), try artifactStore.shouldResume(
                     manifest.nodes[nodeIndex],
                     expectedFingerprint: fingerprint,
                     nodeOutputs: &nodeOutputs
                 ) {
-                    try record(.init(
+                    try runStore.record(.init(
                         sequence: sequence,
                         createdAt: now(),
                         type: "node_resumed",
@@ -640,7 +262,7 @@ struct WorkflowRunner: @unchecked Sendable {
                 manifest.nodes[nodeIndex].models = nodeModels
                 manifest.nodes[nodeIndex].maxAttempts = node.execution?.resolvedMaxAttempts ?? 1
                 if (node.execution?.resolvedCache ?? .automatic) == .automatic,
-                   let cached = try restoreCachedOutputs(
+                   let cached = try artifactStore.restoreCachedOutputs(
                     fingerprint: fingerprint,
                     invocation: invocation,
                     node: node,
@@ -654,8 +276,8 @@ struct WorkflowRunner: @unchecked Sendable {
                     manifest.nodes[nodeIndex].startedAt = now()
                     manifest.nodes[nodeIndex].completedAt = now()
                     manifest.updatedAt = now()
-                    try persist(manifest)
-                    try record(.init(
+                    try runStore.persist(manifest)
+                    try runStore.record(.init(
                         sequence: sequence,
                         createdAt: now(),
                         type: "node_cache_hit",
@@ -669,8 +291,8 @@ struct WorkflowRunner: @unchecked Sendable {
                 manifest.nodes[nodeIndex].state = .preflighting
                 manifest.nodes[nodeIndex].startedAt = now()
                 manifest.updatedAt = now()
-                try persist(manifest)
-                try record(.init(
+                try runStore.persist(manifest)
+                try runStore.record(.init(
                     sequence: sequence,
                     createdAt: now(),
                     type: "node_preflight_started",
@@ -717,8 +339,8 @@ struct WorkflowRunner: @unchecked Sendable {
                     manifest.nodes[nodeIndex].exitStatus = nil
                     manifest.nodes[nodeIndex].error = nil
                     manifest.updatedAt = now()
-                    try persist(manifest)
-                    try record(.init(
+                    try runStore.persist(manifest)
+                    try runStore.record(.init(
                         sequence: sequence,
                         createdAt: now(),
                         type: "node_started",
@@ -752,19 +374,19 @@ struct WorkflowRunner: @unchecked Sendable {
                                 } else {
                                     let runArtifact: GraphRunEventArtifact?
                                     if let eventArtifact = event.artifact {
-                                        let artifactURL = try invocationOutputURL(
+                                        let artifactURL = try artifactStore.invocationOutputURL(
                                             eventArtifact.path,
                                             nodeDirectory: nodeDirectory
                                         )
                                         runArtifact = GraphRunEventArtifact(
                                             name: eventArtifact.name,
-                                            path: try portableArtifactPath(for: artifactURL),
+                                            path: try artifactStore.portableArtifactPath(for: artifactURL),
                                             contentType: eventArtifact.contentType
                                         )
                                     } else {
                                         runArtifact = nil
                                     }
-                                    try record(event.runEvent(
+                                    try runStore.record(event.runEvent(
                                         sequence: sequence,
                                         nodeID: nodeID,
                                         artifact: runArtifact
@@ -780,7 +402,7 @@ struct WorkflowRunner: @unchecked Sendable {
                                 let stamp = now()
                                 guard stamp.timeIntervalSince(lastDeltaAt) >= 0.3 else { return }
                                 lastDeltaAt = stamp
-                                try record(.init(
+                                try runStore.record(.init(
                                     sequence: sequence,
                                     createdAt: stamp,
                                     type: "node_output_delta",
@@ -804,7 +426,7 @@ struct WorkflowRunner: @unchecked Sendable {
                         guard result.status == 0 else {
                             throw ValidationError("Node '\(nodeID)' \(result.failureSummary).")
                         }
-                        verifiedOutputs = try verifyOutputs(
+                        verifiedOutputs = try artifactStore.verifyOutputs(
                             invocation.outputs,
                             providerValues: providerOutputs,
                             node: node,
@@ -816,9 +438,9 @@ struct WorkflowRunner: @unchecked Sendable {
                         let message = (error as? ValidationError)?.message ?? error.localizedDescription
                         manifest.nodes[nodeIndex].error = message
                         manifest.updatedAt = now()
-                        try persist(manifest)
+                        try runStore.persist(manifest)
                         guard attempt < maxAttempts else { throw error }
-                        try record(.init(
+                        try runStore.record(.init(
                             sequence: sequence,
                             createdAt: now(),
                             type: "node_retrying",
@@ -827,7 +449,7 @@ struct WorkflowRunner: @unchecked Sendable {
                             message: "Attempt \(attempt) failed: \(message)"
                         ))
                         sequence += 1
-                        try clearAttemptOutputs(invocation.outputs, nodeDirectory: nodeDirectory)
+                        try artifactStore.clearAttemptOutputs(invocation.outputs, nodeDirectory: nodeDirectory)
                     }
                 }
 
@@ -839,14 +461,14 @@ struct WorkflowRunner: @unchecked Sendable {
                 manifest.nodes[nodeIndex].outputs = verified.outputs
                 if node.execution?.resolvedCache != .never {
                     do {
-                        try storeCachedOutputs(
+                        try artifactStore.storeCachedOutputs(
                             verified,
                             fingerprint: fingerprint,
                             policy: node.execution?.resolvedCache ?? .automatic,
                             nodeDirectory: nodeDirectory
                         )
                         if cacheDirectory != nil {
-                            try record(.init(
+                            try runStore.record(.init(
                                 sequence: sequence,
                                 createdAt: now(),
                                 type: "node_cache_stored",
@@ -857,7 +479,7 @@ struct WorkflowRunner: @unchecked Sendable {
                             sequence += 1
                         }
                     } catch {
-                        try record(.init(
+                        try runStore.record(.init(
                             sequence: sequence,
                             createdAt: now(),
                             type: "node_cache_store_failed",
@@ -871,8 +493,8 @@ struct WorkflowRunner: @unchecked Sendable {
                 manifest.nodes[nodeIndex].state = .finished
                 manifest.nodes[nodeIndex].completedAt = now()
                 manifest.updatedAt = now()
-                try persist(manifest)
-                try record(.init(
+                try runStore.persist(manifest)
+                try runStore.record(.init(
                     sequence: sequence,
                     createdAt: now(),
                     type: "node_finished",
@@ -884,11 +506,11 @@ struct WorkflowRunner: @unchecked Sendable {
             }
             }
 
-            manifest.outputs = try materializeGraphOutputs(graph: graph, nodeOutputs: nodeOutputs)
+            manifest.outputs = try artifactStore.materializeGraphOutputs(graph: graph, nodeOutputs: nodeOutputs)
             manifest.state = .finished
             manifest.updatedAt = now()
-            try persist(manifest)
-            try record(.init(
+            try runStore.persist(manifest)
+            try runStore.record(.init(
                 sequence: sequence,
                 createdAt: now(),
                 type: "run_finished",
@@ -900,8 +522,8 @@ struct WorkflowRunner: @unchecked Sendable {
             manifest.state = .cancelled
             manifest.error = "Workflow cancellation requested."
             manifest.updatedAt = now()
-            try persist(manifest)
-            try record(.init(
+            try runStore.persist(manifest)
+            try runStore.record(.init(
                 sequence: sequence,
                 createdAt: now(),
                 type: "run_cancelled",
@@ -919,8 +541,8 @@ struct WorkflowRunner: @unchecked Sendable {
             manifest.state = .failed
             manifest.error = message
             manifest.updatedAt = now()
-            try persist(manifest)
-            try record(.init(
+            try runStore.persist(manifest)
+            try runStore.record(.init(
                 sequence: sequence,
                 createdAt: now(),
                 type: "run_failed",
@@ -998,12 +620,12 @@ struct WorkflowRunner: @unchecked Sendable {
                     models: models,
                     upstreamOutputs: upstreamOutputs
                 ))
-                if workflowNodeAllowsResumeReuse(node), try shouldResume(
+                if workflowNodeAllowsResumeReuse(node), try artifactStore.shouldResume(
                     manifest.nodes[nodeIndex],
                     expectedFingerprint: fingerprint,
                     nodeOutputs: &nodeOutputs
                 ) {
-                    try record(.init(
+                    try runStore.record(.init(
                         sequence: sequence,
                         createdAt: now(),
                         type: "node_resumed",
@@ -1028,7 +650,7 @@ struct WorkflowRunner: @unchecked Sendable {
                 manifest.nodes[nodeIndex].models = models
                 manifest.nodes[nodeIndex].maxAttempts = node.execution?.resolvedMaxAttempts ?? 1
                 if (node.execution?.resolvedCache ?? .automatic) == .automatic,
-                   let cached = try restoreCachedOutputs(
+                   let cached = try artifactStore.restoreCachedOutputs(
                     fingerprint: fingerprint,
                     invocation: invocation,
                     node: node,
@@ -1042,8 +664,8 @@ struct WorkflowRunner: @unchecked Sendable {
                     manifest.nodes[nodeIndex].startedAt = now()
                     manifest.nodes[nodeIndex].completedAt = now()
                     manifest.updatedAt = now()
-                    try persist(manifest)
-                    try record(.init(
+                    try runStore.persist(manifest)
+                    try runStore.record(.init(
                         sequence: sequence,
                         createdAt: now(),
                         type: "node_cache_hit",
@@ -1060,8 +682,8 @@ struct WorkflowRunner: @unchecked Sendable {
                 manifest.nodes[nodeIndex].state = .preflighting
                 manifest.nodes[nodeIndex].startedAt = now()
                 manifest.updatedAt = now()
-                try persist(manifest)
-                try record(.init(
+                try runStore.persist(manifest)
+                try runStore.record(.init(
                     sequence: sequence,
                     createdAt: now(),
                     type: "node_preflight_started",
@@ -1100,8 +722,8 @@ struct WorkflowRunner: @unchecked Sendable {
                 manifest.nodes[nodeIndex].error = nil
                 manifest.nodes[nodeIndex].exitStatus = nil
                 manifest.updatedAt = now()
-                try persist(manifest)
-                try record(.init(
+                try runStore.persist(manifest)
+                try runStore.record(.init(
                     sequence: sequence,
                     createdAt: now(),
                     type: "node_started",
@@ -1147,25 +769,25 @@ struct WorkflowRunner: @unchecked Sendable {
                     case .provider(let providerEvent):
                         let artifact: GraphRunEventArtifact?
                         if let eventArtifact = providerEvent.artifact {
-                            let artifactURL = try invocationOutputURL(
+                            let artifactURL = try artifactStore.invocationOutputURL(
                                 eventArtifact.path,
                                 nodeDirectory: item.directory
                             )
                             artifact = GraphRunEventArtifact(
                                 name: eventArtifact.name,
-                                path: try portableArtifactPath(for: artifactURL),
+                                path: try artifactStore.portableArtifactPath(for: artifactURL),
                                 contentType: eventArtifact.contentType
                             )
                         } else {
                             artifact = nil
                         }
-                        try record(providerEvent.runEvent(
+                        try runStore.record(providerEvent.runEvent(
                             sequence: sequence,
                             nodeID: item.node.id,
                             artifact: artifact
                         ))
                     case .retrying(let attempt, let message):
-                        try record(.init(
+                        try runStore.record(.init(
                             sequence: sequence,
                             createdAt: now(),
                             type: "node_retrying",
@@ -1174,7 +796,7 @@ struct WorkflowRunner: @unchecked Sendable {
                             message: "Attempt \(attempt) failed: \(message)"
                         ))
                     case .started(let attempt):
-                        try record(.init(
+                        try runStore.record(.init(
                             sequence: sequence,
                             createdAt: now(),
                             type: "node_started",
@@ -1200,14 +822,14 @@ struct WorkflowRunner: @unchecked Sendable {
                 manifest.nodes[item.index].outputs = verified.outputs
                 if item.node.execution?.resolvedCache != .never {
                     do {
-                        try storeCachedOutputs(
+                        try artifactStore.storeCachedOutputs(
                             verified,
                             fingerprint: item.fingerprint,
                             policy: item.node.execution?.resolvedCache ?? .automatic,
                             nodeDirectory: item.directory
                         )
                         if cacheDirectory != nil {
-                            try record(.init(
+                            try runStore.record(.init(
                                 sequence: sequence,
                                 createdAt: now(),
                                 type: "node_cache_stored",
@@ -1218,7 +840,7 @@ struct WorkflowRunner: @unchecked Sendable {
                             sequence += 1
                         }
                     } catch {
-                        try record(.init(
+                        try runStore.record(.init(
                             sequence: sequence,
                             createdAt: now(),
                             type: "node_cache_store_failed",
@@ -1234,7 +856,7 @@ struct WorkflowRunner: @unchecked Sendable {
                 manifest.nodes[item.index].error = nil
                 completed.insert(item.node.id)
                 pending.removeAll { $0 == item.node.id }
-                try record(.init(
+                try runStore.record(.init(
                     sequence: sequence,
                     createdAt: now(),
                     type: "node_finished",
@@ -1245,7 +867,7 @@ struct WorkflowRunner: @unchecked Sendable {
                 sequence += 1
             }
             manifest.updatedAt = now()
-            try persist(manifest)
+            try runStore.persist(manifest)
             if wasCancelled { throw WorkflowCancellationError() }
             if let firstFailure { throw ValidationError(firstFailure) }
         }
@@ -1298,7 +920,7 @@ struct WorkflowRunner: @unchecked Sendable {
                 guard result.status == 0 else {
                     throw ValidationError("Node '\(prepared.node.id)' \(result.failureSummary).")
                 }
-                let verified = try verifyOutputs(
+                let verified = try artifactStore.verifyOutputs(
                     prepared.invocation.outputs,
                     providerValues: providerOutputs,
                     node: prepared.node,
@@ -1336,7 +958,7 @@ struct WorkflowRunner: @unchecked Sendable {
                 events.append(.retrying(attempt: attempt, message: message))
                 events.append(.started(attempt: attempt + 1))
                 do {
-                    try clearAttemptOutputs(
+                    try artifactStore.clearAttemptOutputs(
                         prepared.invocation.outputs,
                         nodeDirectory: prepared.directory
                     )
@@ -1458,342 +1080,6 @@ struct WorkflowRunner: @unchecked Sendable {
         return result
     }
 
-    private func restoreCachedOutputs(
-        fingerprint: String,
-        invocation: WorkflowNodeInvocation,
-        node: WorkflowNode,
-        nodeDirectory: URL
-    ) throws -> WorkflowVerifiedNodeOutputs? {
-        guard let cacheDirectory else { return nil }
-        let entry = cacheDirectory.appendingPathComponent(fingerprint, isDirectory: true)
-        let manifestURL = entry.appendingPathComponent(WorkflowNodeCacheManifest.filename)
-        guard fileManager.fileExists(atPath: manifestURL.path) else { return nil }
-        do {
-            let manifest = try WorkflowBundleCodec.decoder().decode(
-                WorkflowNodeCacheManifest.self,
-                from: Data(contentsOf: manifestURL)
-            )
-            guard manifest.contractVersion == WorkflowNodeCacheManifest.contractVersion,
-                  manifest.fingerprint == fingerprint else {
-                throw ValidationError("Node cache manifest does not match its fingerprint.")
-            }
-            try clearAttemptOutputs(invocation.outputs, nodeDirectory: nodeDirectory)
-            var providerValues: [String: WorkflowValue] = [:]
-            let filesRoot = entry.appendingPathComponent("files", isDirectory: true)
-            for output in manifest.outputs {
-                guard let descriptor = invocation.outputs[output.name], descriptor.type == output.type else {
-                    throw ValidationError("Node cache output contract has changed for '\(output.name)'.")
-                }
-                if let relativePath = output.relativePath {
-                    guard let descriptorPath = descriptor.path else {
-                        throw ValidationError("Node cache output '\(output.name)' no longer has a path.")
-                    }
-                    let destination = try invocationOutputURL(descriptorPath, nodeDirectory: nodeDirectory)
-                    guard try nodeRelativePath(destination, nodeDirectory: nodeDirectory) == relativePath else {
-                        throw ValidationError("Node cache output path has changed for '\(output.name)'.")
-                    }
-                    let source = try confinedCacheURL(relativePath, root: filesRoot)
-                    try copyCacheItem(from: source, to: destination)
-                } else if let value = output.value {
-                    providerValues[output.name] = value
-                }
-            }
-            let verified = try verifyOutputs(
-                invocation.outputs,
-                providerValues: providerValues,
-                node: node,
-                nodeDirectory: nodeDirectory
-            )
-            let restoredRecords = try verified.outputs.map {
-                try cacheOutput($0, nodeDirectory: nodeDirectory)
-            }.sorted { $0.name < $1.name }
-            guard restoredRecords == manifest.outputs.sorted(by: { $0.name < $1.name }) else {
-                throw ValidationError("Node cache output hashes do not match its manifest.")
-            }
-            return verified
-        } catch {
-            try? clearAttemptOutputs(invocation.outputs, nodeDirectory: nodeDirectory)
-            try? fileManager.removeItem(at: entry)
-            return nil
-        }
-    }
-
-    private func storeCachedOutputs(
-        _ verified: WorkflowVerifiedNodeOutputs,
-        fingerprint: String,
-        policy: WorkflowNodeCachePolicy,
-        nodeDirectory: URL
-    ) throws {
-        guard let cacheDirectory else { return }
-        try fileManager.createDirectory(at: cacheDirectory, withIntermediateDirectories: true)
-        let entry = cacheDirectory.appendingPathComponent(fingerprint, isDirectory: true)
-        if fileManager.fileExists(atPath: entry.path), policy == .automatic { return }
-        let staging = cacheDirectory.appendingPathComponent(".\(fingerprint).\(UUID().uuidString)", isDirectory: true)
-        defer { try? fileManager.removeItem(at: staging) }
-        let filesRoot = staging.appendingPathComponent("files", isDirectory: true)
-        try fileManager.createDirectory(at: filesRoot, withIntermediateDirectories: true)
-        let outputs = try verified.outputs.map { output -> WorkflowNodeCacheOutput in
-            let record = try cacheOutput(output, nodeDirectory: nodeDirectory)
-            if let relativePath = record.relativePath {
-                let source = try invocationOutputURL(relativePath, nodeDirectory: nodeDirectory)
-                let destination = try confinedCacheURL(relativePath, root: filesRoot)
-                try copyCacheItem(from: source, to: destination)
-            }
-            return record
-        }.sorted { $0.name < $1.name }
-        try WorkflowBundleCodec.write(
-            WorkflowNodeCacheManifest(
-                contractVersion: WorkflowNodeCacheManifest.contractVersion,
-                fingerprint: fingerprint,
-                outputs: outputs
-            ),
-            to: staging.appendingPathComponent(WorkflowNodeCacheManifest.filename)
-        )
-        if fileManager.fileExists(atPath: entry.path) {
-            try fileManager.removeItem(at: entry)
-        }
-        try fileManager.moveItem(at: staging, to: entry)
-    }
-
-    private func cacheOutput(
-        _ output: GraphRunNodeOutput,
-        nodeDirectory: URL
-    ) throws -> WorkflowNodeCacheOutput {
-        guard let sha256 = output.sha256 else {
-            throw ValidationError("Workflow output '\(output.name)' has no cache fingerprint.")
-        }
-        let relativePath: String?
-        if let path = output.path {
-            relativePath = try nodeRelativePath(artifactURL(for: path), nodeDirectory: nodeDirectory)
-        } else {
-            relativePath = nil
-        }
-        return WorkflowNodeCacheOutput(
-            name: output.name,
-            type: output.type,
-            value: output.value,
-            relativePath: relativePath,
-            contentType: output.contentType,
-            sizeBytes: output.sizeBytes,
-            sha256: sha256
-        )
-    }
-
-    private func nodeRelativePath(_ url: URL, nodeDirectory: URL) throws -> String {
-        let candidate = url.standardizedFileURL.path
-        let root = nodeDirectory.standardizedFileURL.path
-        guard candidate.hasPrefix(root + "/") else {
-            throw ValidationError("Workflow cache output escapes the node directory: \(candidate)")
-        }
-        return String(candidate.dropFirst(root.count + 1))
-    }
-
-    private func confinedCacheURL(_ path: String, root: URL) throws -> URL {
-        guard isConfinedRelativeWorkflowPath(path) else {
-            throw ValidationError("Workflow cache contains an unconfined path: \(path)")
-        }
-        let candidate = root.appendingPathComponent(path).standardizedFileURL
-        guard candidate.path.hasPrefix(root.standardizedFileURL.path + "/") else {
-            throw ValidationError("Workflow cache path escapes its entry: \(path)")
-        }
-        return candidate
-    }
-
-    private func copyCacheItem(from source: URL, to destination: URL) throws {
-        let values = try source.resourceValues(forKeys: [.isSymbolicLinkKey])
-        guard values.isSymbolicLink != true else {
-            throw ValidationError("Workflow cache items cannot be symbolic links: \(source.path)")
-        }
-        if fileManager.fileExists(atPath: destination.path) {
-            try fileManager.removeItem(at: destination)
-        }
-        try fileManager.createDirectory(
-            at: destination.deletingLastPathComponent(),
-            withIntermediateDirectories: true
-        )
-        try fileManager.copyItem(at: source, to: destination)
-    }
-
-    private func clearAttemptOutputs(
-        _ outputs: [String: WorkflowInvocationOutput],
-        nodeDirectory: URL
-    ) throws {
-        for descriptor in outputs.values {
-            guard let path = descriptor.path else { continue }
-            let outputURL = try invocationOutputURL(path, nodeDirectory: nodeDirectory)
-            if fileManager.fileExists(atPath: outputURL.path) {
-                try fileManager.removeItem(at: outputURL)
-            }
-        }
-        let artifacts = nodeDirectory.appendingPathComponent("artifacts", isDirectory: true)
-        if fileManager.fileExists(atPath: artifacts.path) {
-            try fileManager.removeItem(at: artifacts)
-        }
-        let stdout = nodeDirectory.appendingPathComponent("stdout.txt")
-        if fileManager.fileExists(atPath: stdout.path) {
-            try fileManager.removeItem(at: stdout)
-        }
-    }
-
-    private func verifyOutputs(
-        _ descriptors: [String: WorkflowInvocationOutput],
-        providerValues: [String: WorkflowValue]?,
-        node: WorkflowNode,
-        nodeDirectory: URL
-    ) throws -> WorkflowVerifiedNodeOutputs {
-        var artifacts: [GraphRunArtifact] = []
-        var records: [GraphRunNodeOutput] = []
-        var values: [String: WorkflowValue] = [:]
-        for name in descriptors.keys.sorted() {
-            guard let descriptor = descriptors[name] else { continue }
-            let providerValue = providerValues?[name]
-            switch descriptor.type {
-            case .asset, .assetCollection, .assetArray:
-                guard let path = descriptor.path else {
-                    throw ValidationError("Node '\(node.id)' output '\(name)' has no declared path.")
-                }
-                let url = try invocationOutputURL(path, nodeDirectory: nodeDirectory)
-                if providerValue == .null || !fileManager.fileExists(atPath: url.path) {
-                    if descriptor.optional { continue }
-                    throw ValidationError("Node '\(node.id)' did not produce declared output '\(name)'.")
-                }
-                if let providerPath = providerValue?.stringValue {
-                    let reported = try invocationOutputURL(providerPath, nodeDirectory: nodeDirectory)
-                    guard reported.standardizedFileURL == url.standardizedFileURL else {
-                        throw ValidationError("Node '\(node.id)' reported an unexpected path for output '\(name)'.")
-                    }
-                }
-                let outputArtifact = try artifact(
-                    name: name,
-                    nodeKind: node.kind,
-                    url: url,
-                    contentType: descriptor.contentTypes.first
-                )
-                artifacts.append(outputArtifact)
-                records.append(.init(
-                    name: name,
-                    type: descriptor.type,
-                    value: nil,
-                    path: outputArtifact.path,
-                    contentType: outputArtifact.contentType,
-                    sizeBytes: outputArtifact.sizeBytes,
-                    sha256: outputArtifact.sha256
-                ))
-                values[name] = .string(url.path)
-            case .assetDirectory:
-                guard let path = descriptor.path else {
-                    throw ValidationError("Node '\(node.id)' directory output '\(name)' has no declared path.")
-                }
-                let url = try invocationOutputURL(path, nodeDirectory: nodeDirectory)
-                var isDirectory: ObjCBool = false
-                if providerValue == .null || !fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory) {
-                    if descriptor.optional { continue }
-                    throw ValidationError("Node '\(node.id)' did not produce declared directory output '\(name)'.")
-                }
-                guard isDirectory.boolValue else {
-                    throw ValidationError("Node '\(node.id)' output '\(name)' is not a directory.")
-                }
-                if let providerPath = providerValue?.stringValue {
-                    let reported = try invocationOutputURL(providerPath, nodeDirectory: nodeDirectory)
-                    guard reported.standardizedFileURL == url.standardizedFileURL else {
-                        throw ValidationError("Node '\(node.id)' reported an unexpected path for output '\(name)'.")
-                    }
-                }
-                let directory = try directoryIdentity(url)
-                let manifestURL = nodeDirectory
-                    .appendingPathComponent("artifacts", isDirectory: true)
-                    .appendingPathComponent("\(name).manifest.json")
-                try WorkflowBundleCodec.write(directory.manifest, to: manifestURL)
-                let manifestArtifact = try artifact(
-                    name: "\(name)_manifest",
-                    nodeKind: node.kind,
-                    url: manifestURL,
-                    contentType: "application/json"
-                )
-                artifacts.append(manifestArtifact)
-                records.append(.init(
-                    name: name,
-                    type: .assetDirectory,
-                    value: nil,
-                    path: try portableArtifactPath(for: url),
-                    contentType: descriptor.contentTypes.first,
-                    sizeBytes: directory.sizeBytes,
-                    sha256: directory.sha256
-                ))
-                values[name] = .string(url.path)
-            case .string, .integer, .number, .boolean, .enumeration, .json:
-                guard let providerValue, providerValue != .null else {
-                    if descriptor.optional { continue }
-                    throw ValidationError("Node '\(node.id)' did not report declared value output '\(name)'.")
-                }
-                guard workflowValue(providerValue, matches: descriptor.type) else {
-                    throw ValidationError("Node '\(node.id)' output '\(name)' has the wrong value type.")
-                }
-                records.append(.init(
-                    name: name,
-                    type: descriptor.type,
-                    value: providerValue,
-                    path: nil,
-                    contentType: nil,
-                    sizeBytes: nil,
-                    sha256: try WorkflowBundleCodec.hash(providerValue)
-                ))
-                values[name] = providerValue
-            }
-        }
-        if let providerValues {
-            let undeclared = Set(providerValues.keys).subtracting(descriptors.keys)
-            guard undeclared.isEmpty else {
-                throw ValidationError(
-                    "Node '\(node.id)' reported undeclared outputs: \(undeclared.sorted().joined(separator: ", "))."
-                )
-            }
-        }
-        return WorkflowVerifiedNodeOutputs(artifacts: artifacts, outputs: records, values: values)
-    }
-
-    private func invocationOutputURL(_ path: String, nodeDirectory: URL) throws -> URL {
-        let candidate: URL
-        if path.hasPrefix("/") {
-            candidate = URL(fileURLWithPath: path).standardizedFileURL
-        } else {
-            guard isConfinedRelativeWorkflowPath(path) else {
-                throw ValidationError("Workflow provider output path is not confined: \(path)")
-            }
-            candidate = nodeDirectory.appendingPathComponent(path).standardizedFileURL
-        }
-        let root = nodeDirectory.standardizedFileURL.path
-        guard candidate.path.hasPrefix(root + "/") else {
-            throw ValidationError("Workflow provider output path escapes the node directory: \(path)")
-        }
-        return candidate
-    }
-
-    private func directoryIdentity(_ directory: URL) throws -> WorkflowDirectoryIdentity {
-        let root = directory.resolvingSymlinksInPath()
-        var entries: [WorkflowAssetEntry] = []
-        for path in try fileManager.subpathsOfDirectory(atPath: root.path).sorted() {
-            let url = root.appendingPathComponent(path)
-            let values = try url.resourceValues(forKeys: [.isRegularFileKey, .isSymbolicLinkKey])
-            if values.isSymbolicLink == true {
-                throw ValidationError("Workflow output directories cannot contain symbolic links: \(url.path)")
-            }
-            guard values.isRegularFile == true else { continue }
-            entries.append(WorkflowAssetEntry(
-                path: path,
-                digest: try ModelArtifactPin.fileSHA256(url),
-                sizeBytes: try ModelArtifactPin.fileByteCount(url),
-                contentType: contentType(for: url)
-            ))
-        }
-        let manifest = WorkflowOutputDirectoryManifest(contractVersion: "mere.run/output-directory.v1", entries: entries)
-        return WorkflowDirectoryIdentity(
-            manifest: manifest,
-            sizeBytes: entries.reduce(0) { $0 + $1.sizeBytes },
-            sha256: try WorkflowBundleCodec.hash(manifest)
-        )
-    }
-
     private func modelProvenance(
         for node: WorkflowNode,
         arguments: [String: WorkflowValue],
@@ -1827,153 +1113,6 @@ struct WorkflowRunner: @unchecked Sendable {
                 installManifestSHA256: manifestDigest
             )
         }.sorted { $0.id < $1.id }
-    }
-
-    private func prepareRunDirectory() throws {
-        if fileManager.fileExists(atPath: runDirectory.path) {
-            guard resume || bundleDirectory == runDirectory else {
-                throw ValidationError("Run directory already exists. Pass --resume to reuse it: \(runDirectory.path)")
-            }
-        } else {
-            try fileManager.createDirectory(at: runDirectory, withIntermediateDirectories: true)
-        }
-        try fileManager.createDirectory(
-            at: runDirectory.appendingPathComponent("nodes", isDirectory: true),
-            withIntermediateDirectories: true
-        )
-        let cancellationURL = runDirectory.appendingPathComponent("cancel.request")
-        if fileManager.fileExists(atPath: cancellationURL.path) {
-            try fileManager.removeItem(at: cancellationURL)
-        }
-        try WorkflowChildProcessRegistry.clear(in: runDirectory, fileManager: fileManager)
-        try fileManager.createDirectory(
-            at: runDirectory.appendingPathComponent("outputs", isDirectory: true),
-            withIntermediateDirectories: true
-        )
-        for filename in ["graph.json", "inputs.json", WorkflowAssetManifest.filename, WorkflowJobManifest.filename] {
-            let source = bundleDirectory.appendingPathComponent(filename)
-            let destination = runDirectory.appendingPathComponent(filename)
-            if source != destination, !fileManager.fileExists(atPath: destination.path) {
-                try fileManager.copyItem(at: source, to: destination)
-            }
-        }
-        let actionsURL = runDirectory.appendingPathComponent("actions.json")
-        if !fileManager.fileExists(atPath: actionsURL.path) {
-            try WorkflowBundleCodec.write([DeclarativeAction](), to: actionsURL)
-        }
-    }
-
-    private func localizeInputs(
-        graph: WorkflowGraphDocument,
-        inputs: WorkflowInputsDocument,
-        assets: WorkflowAssetManifest
-    ) throws -> WorkflowInputsDocument {
-        var localized = inputs.values
-        let root = runDirectory.appendingPathComponent("inputs", isDirectory: true)
-        try fileManager.createDirectory(at: root, withIntermediateDirectories: true)
-        var groupNames = Set<String>()
-        for group in assets.groups {
-            guard groupNames.insert(group.name).inserted,
-                  group.name.range(of: "^[a-z][a-z0-9-]{0,63}$", options: .regularExpression) != nil else {
-                throw ValidationError("Asset manifest contains an invalid or duplicate group '\(group.name)'.")
-            }
-            let groupRoot = root.appendingPathComponent(group.name, isDirectory: true)
-            if group.kind == .assetDirectory {
-                try fileManager.createDirectory(at: groupRoot, withIntermediateDirectories: true)
-            }
-            for entry in group.entries {
-                guard isConfinedRelativeWorkflowPath(entry.path),
-                      entry.digest.count == 64,
-                      entry.digest.allSatisfy({ $0.isHexDigit && !$0.isUppercase }) else {
-                    throw ValidationError("Workflow asset manifest contains an invalid path or digest.")
-                }
-                let source = bundleDirectory
-                    .appendingPathComponent("assets", isDirectory: true)
-                    .appendingPathComponent("sha256", isDirectory: true)
-                    .appendingPathComponent(entry.digest)
-                guard fileManager.fileExists(atPath: source.path),
-                      try ModelArtifactPin.fileByteCount(source) == entry.sizeBytes,
-                      try ModelArtifactPin.fileSHA256(source) == entry.digest else {
-                    throw ValidationError("Workflow asset digest verification failed for '\(group.name)/\(entry.path)'.")
-                }
-                let destination = group.kind == .asset
-                    ? root.appendingPathComponent("\(group.name)-\(entry.path)")
-                    : groupRoot.appendingPathComponent(entry.path)
-                try fileManager.createDirectory(at: destination.deletingLastPathComponent(), withIntermediateDirectories: true)
-                if !fileManager.fileExists(atPath: destination.path) {
-                    do {
-                        try fileManager.linkItem(at: source, to: destination)
-                    } catch {
-                        try fileManager.copyItem(at: source, to: destination)
-                    }
-                }
-            }
-            if group.kind == .asset, let entry = group.entries.first {
-                guard group.entries.count == 1 else {
-                    throw ValidationError("Asset group '\(group.name)' must contain exactly one file.")
-                }
-                localized[group.name] = .string(root.appendingPathComponent("\(group.name)-\(entry.path)").path)
-            } else {
-                localized[group.name] = .string(groupRoot.path)
-            }
-        }
-        return WorkflowInputsDocument(values: localized)
-    }
-
-    private func initialManifest(
-        graph: WorkflowGraphDocument,
-        job: WorkflowJobManifest,
-        order: [String]
-    ) throws -> GraphRunManifest {
-        let manifestURL = runDirectory.appendingPathComponent(GraphRunManifest.filename)
-        if resume, fileManager.fileExists(atPath: manifestURL.path) {
-            var existing = try WorkflowBundleCodec.decoder().decode(
-                GraphRunManifest.self,
-                from: Data(contentsOf: manifestURL)
-            )
-            guard existing.graphFingerprint == job.graphFingerprint else {
-                throw ValidationError("Cannot resume: workflow graph fingerprint changed.")
-            }
-            existing.attempt += 1
-            existing.state = .planned
-            existing.error = nil
-            existing.executor = executor
-            existing.updatedAt = now()
-            return existing
-        }
-        let nodesByID = Dictionary(uniqueKeysWithValues: graph.nodes.map { ($0.id, $0) })
-        return GraphRunManifest(
-            contractVersion: GraphRunManifest.contractVersion,
-            jobID: job.jobID,
-            graphName: graph.name,
-            graphFingerprint: job.graphFingerprint,
-            sourceGraphFingerprint: job.sourceGraphFingerprint,
-            sourceInputFingerprint: job.sourceInputFingerprint,
-            state: .planned,
-            createdAt: now(),
-            updatedAt: now(),
-            attempt: 1,
-            executor: executor,
-            nodes: order.compactMap { id in
-                nodesByID[id].map {
-                    GraphRunNodeRecord(
-                        id: id,
-                        kind: $0.kind,
-                        state: .planned,
-                        startedAt: nil,
-                        completedAt: nil,
-                        exitStatus: nil,
-                        attempt: 0,
-                        maxAttempts: $0.execution?.resolvedMaxAttempts ?? 1,
-                        fingerprint: "",
-                        artifacts: [],
-                        error: nil
-                    )
-                }
-            },
-            outputs: [],
-            error: nil
-        )
     }
 
     private func resolve(
@@ -2029,177 +1168,13 @@ struct WorkflowRunner: @unchecked Sendable {
         }
     }
 
-    private func shouldResume(
-        _ node: GraphRunNodeRecord,
-        expectedFingerprint: String,
-        nodeOutputs: inout [String: [String: WorkflowValue]]
-    ) throws -> Bool {
-        guard resume,
-              node.state == .finished,
-              node.fingerprint == expectedFingerprint,
-              !node.outputs.isEmpty || !node.artifacts.isEmpty else { return false }
-        var outputs: [String: WorkflowValue] = [:]
-        if !node.outputs.isEmpty {
-            for output in node.outputs {
-                if let value = output.value {
-                    guard try WorkflowBundleCodec.hash(value) == output.sha256 else { return false }
-                    outputs[output.name] = value
-                    continue
-                }
-                guard let path = output.path else { return false }
-                let url = try artifactURL(for: path)
-                if output.type == .assetDirectory {
-                    var isDirectory: ObjCBool = false
-                    guard fileManager.fileExists(atPath: url.path, isDirectory: &isDirectory),
-                          isDirectory.boolValue,
-                          try directoryIdentity(url).sha256 == output.sha256 else { return false }
-                } else {
-                    guard fileManager.fileExists(atPath: url.path),
-                          try ModelArtifactPin.fileByteCount(url) == output.sizeBytes,
-                          try ModelArtifactPin.fileSHA256(url) == output.sha256 else { return false }
-                }
-                outputs[output.name] = .string(url.path)
-            }
-        } else {
-            for artifact in node.artifacts {
-                let url = try artifactURL(for: artifact.path)
-                guard fileManager.fileExists(atPath: url.path),
-                      try ModelArtifactPin.fileByteCount(url) == artifact.sizeBytes,
-                      try ModelArtifactPin.fileSHA256(url) == artifact.sha256 else {
-                    return false
-                }
-                outputs[artifact.name] = .string(url.path)
-            }
-        }
-        nodeOutputs[node.id] = outputs
-        return true
-    }
-
-    private func materializeGraphOutputs(
-        graph: WorkflowGraphDocument,
-        nodeOutputs: [String: [String: WorkflowValue]]
-    ) throws -> [GraphRunArtifact] {
-        var artifacts: [GraphRunArtifact] = []
-        let outputsRoot = runDirectory.appendingPathComponent("outputs", isDirectory: true)
-        for name in graph.outputs.keys.sorted() {
-            guard case .reference(let rawReference)? = graph.outputs[name] else { continue }
-            let reference = try WorkflowReference(rawReference)
-            guard case .nodeOutput(let nodeID, let output) = reference.source,
-                  let sourceValue = nodeOutputs[nodeID]?[output],
-                  let node = graph.nodes.first(where: { $0.id == nodeID }),
-                  let outputContract = WorkflowNodeRegistry.output(node: node, name: output) else {
-                throw ValidationError("Workflow output '\(name)' was not produced.")
-            }
-            if outputContract.type != .asset && outputContract.type != .assetCollection && outputContract.type != .assetArray {
-                let destination = outputsRoot.appendingPathComponent("\(name).json")
-                try WorkflowBundleCodec.encoder().encode(sourceValue).write(to: destination, options: .atomic)
-                artifacts.append(try artifact(
-                    name: name,
-                    nodeKind: "graph.output",
-                    url: destination,
-                    contentType: "application/json"
-                ))
-                continue
-            }
-            guard let sourcePath = sourceValue.stringValue else {
-                throw ValidationError("Workflow output '\(name)' did not resolve to an artifact path.")
-            }
-            let source = URL(fileURLWithPath: sourcePath)
-            let suffix = source.pathExtension.isEmpty ? "" : ".\(source.pathExtension)"
-            let destination = outputsRoot.appendingPathComponent("\(name)\(suffix)")
-            if fileManager.fileExists(atPath: destination.path) {
-                try fileManager.removeItem(at: destination)
-            }
-            do {
-                try fileManager.linkItem(at: source, to: destination)
-            } catch {
-                try fileManager.copyItem(at: source, to: destination)
-            }
-            artifacts.append(try artifact(name: name, nodeKind: "graph.output", url: destination))
-        }
-        return artifacts
-    }
-
-    private func artifact(
-        name: String,
-        nodeKind: String,
-        url: URL,
-        contentType explicitContentType: String? = nil
-    ) throws -> GraphRunArtifact {
-        GraphRunArtifact(
-            name: name,
-            kind: nodeKind,
-            path: try portableArtifactPath(for: url),
-            contentType: explicitContentType ?? contentType(for: url),
-            sizeBytes: try ModelArtifactPin.fileByteCount(url),
-            sha256: try ModelArtifactPin.fileSHA256(url)
-        )
-    }
-
     private func throwIfCancellationRequested() throws {
-        if fileManager.fileExists(atPath: runDirectory.appendingPathComponent("cancel.request").path) {
+        if Task.isCancelled || fileManager.fileExists(atPath: runDirectory.appendingPathComponent("cancel.request").path) {
             throw WorkflowCancellationError()
         }
     }
 
-    private func artifactURL(for path: String) throws -> URL {
-        let candidate = path.hasPrefix("/")
-            ? URL(fileURLWithPath: path).standardizedFileURL
-            : runDirectory.appendingPathComponent(path).standardizedFileURL
-        let root = runDirectory.standardizedFileURL.path
-        guard candidate.path == root || candidate.path.hasPrefix(root + "/") else {
-            throw ValidationError("Workflow artifact path escapes the run directory: \(path)")
-        }
-        return candidate
-    }
 
-    private func portableArtifactPath(for url: URL) throws -> String {
-        let candidate = url.standardizedFileURL.path
-        let root = runDirectory.standardizedFileURL.path
-        guard candidate.hasPrefix(root + "/") else {
-            throw ValidationError("Workflow artifact path escapes the run directory: \(candidate)")
-        }
-        return String(candidate.dropFirst(root.count + 1))
-    }
-
-    private func contentType(for url: URL) -> String {
-        switch url.pathExtension.lowercased() {
-        case "png": "image/png"
-        case "jpg", "jpeg": "image/jpeg"
-        case "webp": "image/webp"
-        case "mp4": "video/mp4"
-        case "wav": "audio/wav"
-        case "tif", "tiff": "image/tiff"
-        case "json": "application/json"
-        case "txt": "text/plain"
-        case "safetensors": "application/x-safetensors"
-        default: "application/octet-stream"
-        }
-    }
-
-    private func persist(_ manifest: GraphRunManifest) throws {
-        try WorkflowBundleCodec.write(manifest, to: runDirectory.appendingPathComponent(GraphRunManifest.filename))
-    }
-
-    private func record(_ event: GraphRunEvent) throws {
-        let data = try WorkflowBundleCodec.lineEncoder().encode(event)
-        let url = runDirectory.appendingPathComponent("events.jsonl")
-        if !fileManager.fileExists(atPath: url.path) {
-            try Data().write(to: url)
-        }
-        let handle = try FileHandle(forWritingTo: url)
-        defer { try? handle.close() }
-        try handle.seekToEnd()
-        try handle.write(contentsOf: data)
-        try handle.write(contentsOf: Data("\n".utf8))
-        eventHandler?(event)
-    }
-
-    private func existingEventCount() throws -> Int {
-        let url = runDirectory.appendingPathComponent("events.jsonl")
-        guard fileManager.fileExists(atPath: url.path) else { return 0 }
-        return try String(contentsOf: url, encoding: .utf8).split(separator: "\n").count
-    }
 }
 
 private struct WorkflowNodeFingerprint: Codable {
@@ -2237,63 +1212,6 @@ private struct WorkflowNodeOutputFingerprint: Codable {
         case value
         case sha256
     }
-}
-
-private struct WorkflowVerifiedNodeOutputs {
-    let artifacts: [GraphRunArtifact]
-    let outputs: [GraphRunNodeOutput]
-    let values: [String: WorkflowValue]
-}
-
-private struct WorkflowNodeCacheManifest: Codable {
-    static let contractVersion = "mere.run/node-cache.v1"
-    static let filename = "cache.json"
-
-    let contractVersion: String
-    let fingerprint: String
-    let outputs: [WorkflowNodeCacheOutput]
-
-    enum CodingKeys: String, CodingKey {
-        case contractVersion = "contract_version"
-        case fingerprint
-        case outputs
-    }
-}
-
-private struct WorkflowNodeCacheOutput: Codable, Equatable {
-    let name: String
-    let type: WorkflowPortType
-    let value: WorkflowValue?
-    let relativePath: String?
-    let contentType: String?
-    let sizeBytes: Int64?
-    let sha256: String
-
-    enum CodingKeys: String, CodingKey {
-        case name
-        case type
-        case value
-        case relativePath = "relative_path"
-        case contentType = "content_type"
-        case sizeBytes = "size_bytes"
-        case sha256
-    }
-}
-
-private struct WorkflowOutputDirectoryManifest: Codable {
-    let contractVersion: String
-    let entries: [WorkflowAssetEntry]
-
-    enum CodingKeys: String, CodingKey {
-        case contractVersion = "contract_version"
-        case entries
-    }
-}
-
-private struct WorkflowDirectoryIdentity {
-    let manifest: WorkflowOutputDirectoryManifest
-    let sizeBytes: Int64
-    let sha256: String
 }
 
 private struct WorkflowPluginNodePreflight: Codable {
@@ -2367,33 +1285,8 @@ private struct WorkflowPluginNodeEvent: Codable {
     }
 }
 
-private func workflowValue(_ value: WorkflowValue, matches type: WorkflowPortType) -> Bool {
-    switch type {
-    case .string, .enumeration, .asset, .assetDirectory:
-        value.stringValue != nil
-    case .integer:
-        value.integerValue != nil
-    case .number:
-        value.numberValue != nil
-    case .boolean:
-        value.booleanValue != nil
-    case .json:
-        true
-    case .assetCollection, .assetArray:
-        if case .array = value { true } else { false }
-    }
-}
-
 func workflowNodeAllowsResumeReuse(_ node: WorkflowNode) -> Bool {
     node.arguments.values.allSatisfy { $0.secretNames.isEmpty }
 }
 
-private func isConfinedRelativeWorkflowPath(_ path: String) -> Bool {
-    !path.isEmpty
-        && !path.hasPrefix("/")
-        && path.split(separator: "/", omittingEmptySubsequences: false).allSatisfy { component in
-            !component.isEmpty && component != "." && component != ".."
-        }
-}
-
-private struct WorkflowCancellationError: Error {}
+struct WorkflowCancellationError: Error {}

--- a/Sources/MereRunCore/ACEStep/ACEStepAdapterTrainer.swift
+++ b/Sources/MereRunCore/ACEStep/ACEStepAdapterTrainer.swift
@@ -196,6 +196,7 @@ enum ACEStepAdapterTrainer {
         outputURL: URL,
         progress: (@Sendable (ACEStepAdapterTrainingProgress) -> Void)?
     ) throws -> ACEStepAdapterTrainingReport {
+        try Task.checkCancellation()
         try validate(configuration, examples: examples)
         MLXRandom.seed(configuration.seed)
 
@@ -254,7 +255,8 @@ enum ACEStepAdapterTrainer {
         }
 
         let prepared = try examples.map {
-            try prepare($0, pipeline: pipeline)
+            try Task.checkCancellation()
+            return try prepare($0, pipeline: pipeline)
         }
         let optimizer = AdamW(
             learningRate: configuration.learningRate,
@@ -296,6 +298,7 @@ enum ACEStepAdapterTrainer {
             ).timesteps
 
         for step in 0..<configuration.trainingSteps {
+            try Task.checkCancellation()
             let example = prepared[step % prepared.count]
             let noise = MLXRandom.normal(
                 example.cleanLatents.shape,
@@ -330,6 +333,7 @@ enum ACEStepAdapterTrainer {
             )
         }
 
+        try Task.checkCancellation()
         try FileManager.default.createDirectory(
             at: outputURL.deletingLastPathComponent(),
             withIntermediateDirectories: true

--- a/Sources/MereRunCore/ACEStep/ACEStepAdapterTrainingOperation+Native.swift
+++ b/Sources/MereRunCore/ACEStep/ACEStepAdapterTrainingOperation+Native.swift
@@ -1,0 +1,60 @@
+import Foundation
+
+extension ACEStepAdapterTrainingOperation {
+    public static func train(
+        _ plan: ACEStepAdapterTrainingPlan,
+        progress: (@Sendable (ACEStepAdapterTrainingProgress) -> Void)?
+    ) async throws -> ACEStepAdapterTrainingReport {
+        try Task.checkCancellation()
+        let options = plan.options
+        let examples = try prepareExamples(plan)
+        try Task.checkCancellation()
+        let root = try await ACEStepRuntimePreparation.resolveCheckpointsRoot(
+            model: options.model, checkpointsRoot: options.checkpointsRoot,
+            turboSubdirectory: options.decoderSubdirectory,
+            vaeSubdirectory: options.vaeSubdirectory,
+            lmSubdirectory: nil, textSubdirectory: options.textSubdirectory
+        )
+        let decoder = try ACEStepRuntimePreparation.resolveTurboSubdirectory(
+            at: root, explicit: options.decoderSubdirectory
+        )
+        guard let text = try ACEStepRuntimePreparation.resolveTextSubdirectory(
+            at: root, explicit: options.textSubdirectory
+        ) else {
+            throw ACEStepPreparationIssue("ACE-Step text encoder not found.")
+        }
+        try Task.checkCancellation()
+        let container = ACEStepModelContainer(
+            checkpointsRootURL: root, turboSubdirectory: decoder,
+            vaeSubdirectory: options.vaeSubdirectory, textEncoderSubdirectory: text
+        )
+        let resources = try await container.resources()
+        try Task.checkCancellation()
+        let pipeline = try ACEStepPipeline(
+            decoderResources: resources.decoderResources,
+            vaeResources: resources.vaeResources,
+            textEncoderResources: resources.textEncoderResources
+        )
+        return try pipeline.trainAdapter(
+            examples: examples, configuration: options.configuration,
+            outputURL: plan.outputURL, progress: progress
+        )
+    }
+
+    static func prepareExamples(_ plan: ACEStepAdapterTrainingPlan) throws -> [ACEStepAdapterTrainingExample] {
+        let options = plan.options
+        return try plan.records.enumerated().map { index, record in
+            try Task.checkCancellation()
+            let decoded = try ACEStepRuntimePreparation.loadAudio48kHz(
+                plan.audioURL(for: record).path, label: "Dataset audio \(index + 1)"
+            )
+            let maxFrames = options.maximumAudioFrames
+            let audio = decoded.dim(1) > maxFrames
+                ? decoded[0..., 0..<maxFrames, 0...]
+                : decoded
+            return ACEStepAdapterTrainingExample(
+                audio48kHz: audio, caption: record.caption, lyrics: record.lyrics ?? ""
+            )
+        }
+    }
+}

--- a/Sources/MereRunCore/ACEStep/ACEStepAdapterTrainingOperation.swift
+++ b/Sources/MereRunCore/ACEStep/ACEStepAdapterTrainingOperation.swift
@@ -1,0 +1,56 @@
+import Foundation
+
+/// Owns execution and terminal training events. Callers own presentation and
+/// machine admission, as they do for the other native training operations.
+public enum ACEStepAdapterTrainingOperation {
+    public typealias Trainer = @Sendable (
+        ACEStepAdapterTrainingPlan,
+        (@Sendable (ACEStepAdapterTrainingProgress) -> Void)?
+    ) async throws -> ACEStepAdapterTrainingReport
+
+    public static func execute(
+        _ plan: ACEStepAdapterTrainingPlan,
+        progress: (@Sendable (ACEStepAdapterTrainingProgress) -> Void)? = nil,
+        trainer: Trainer = train
+    ) async throws -> ACEStepAdapterTrainingReport {
+        try Task.checkCancellation()
+        let configuration = plan.options.configuration
+        let logger = try LoRATrainingEventLogger(baseOutputURL: plan.outputURL)
+        try logger.record(
+            type: "run_started", stage: "training",
+            message: "ACE-Step \(configuration.kind.rawValue) training started.",
+            step: 0, totalSteps: configuration.trainingSteps, fraction: 0,
+            path: plan.outputURL.path,
+            metadata: ["dataset": plan.manifestURL.path, "model": plan.options.model]
+        )
+        do {
+            let report = try await trainer(plan) { update in
+                try? logger.record(
+                    type: "progress", stage: "training", step: update.step,
+                    totalSteps: update.totalSteps, loss: update.loss,
+                    fraction: Float(update.step) / Float(max(update.totalSteps, 1)),
+                    path: plan.outputURL.path
+                )
+                progress?(update)
+            }
+            try Task.checkCancellation()
+            try logger.record(
+                type: "run_finished", stage: "finished",
+                message: "ACE-Step adapter training finished.",
+                step: configuration.trainingSteps, totalSteps: configuration.trainingSteps,
+                loss: report.finalLoss, fraction: 1, path: plan.outputURL.path,
+                metadata: ["sha256": report.outputSHA256]
+            )
+            return report
+        } catch {
+            let cancelled = error is CancellationError || Task.isCancelled
+            try? logger.record(
+                type: "run_failed", stage: "failed",
+                message: cancelled ? "ACE-Step adapter training cancelled." : error.localizedDescription,
+                path: plan.outputURL.path
+            )
+            if cancelled { throw CancellationError() }
+            throw error
+        }
+    }
+}

--- a/Sources/MereRunCore/ACEStep/ACEStepAdapterTrainingOptions.swift
+++ b/Sources/MereRunCore/ACEStep/ACEStepAdapterTrainingOptions.swift
@@ -1,0 +1,47 @@
+import Foundation
+
+public struct ACEStepAdapterTrainingOptions: Sendable {
+    public let dataset: String
+    public let output: String
+    public let model: String
+    public let configuration: ACEStepAdapterTrainingConfiguration
+    public let maxDurationSeconds: Float
+    public let checkpointsRoot: String?
+    public let decoderSubdirectory: String
+    public let vaeSubdirectory: String
+    public let textSubdirectory: String?
+
+    public init(
+        dataset: String, output: String,
+        model: String = ModelResolver.ModelID.aceStep.rawValue,
+        configuration: ACEStepAdapterTrainingConfiguration = .init(),
+        maxDurationSeconds: Float = 30,
+        checkpointsRoot: String? = nil,
+        decoderSubdirectory: String = "acestep-v15-turbo",
+        vaeSubdirectory: String = "vae",
+        textSubdirectory: String? = nil
+    ) {
+        self.dataset = dataset
+        self.output = output
+        self.model = model
+        self.configuration = configuration
+        self.maxDurationSeconds = maxDurationSeconds
+        self.checkpointsRoot = checkpointsRoot
+        self.decoderSubdirectory = decoderSubdirectory
+        self.vaeSubdirectory = vaeSubdirectory
+        self.textSubdirectory = textSubdirectory
+    }
+
+    public func validate() throws {
+        guard configuration.kind == .lora || configuration.kind == .lokr else {
+            throw ACEStepPreparationIssue("--kind must be lora or lokr.")
+        }
+        guard maxDurationSeconds > 0, maxDurationSeconds <= 600 else {
+            throw ACEStepPreparationIssue("--max-duration must be in (0, 600].")
+        }
+    }
+
+    var maximumAudioFrames: Int {
+        max(1, Int((maxDurationSeconds * 48_000).rounded()))
+    }
+}

--- a/Sources/MereRunCore/ACEStep/ACEStepAdapterTrainingPlan.swift
+++ b/Sources/MereRunCore/ACEStep/ACEStepAdapterTrainingPlan.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+/// Validated manifest metadata; decoding audio and loading weights occur only
+/// when the operation executes.
+public struct ACEStepAdapterTrainingPlan: Sendable {
+    public let options: ACEStepAdapterTrainingOptions
+    public let manifestURL: URL
+    public let outputURL: URL
+    public let records: [ManifestRecord]
+
+    public static func resolve(_ options: ACEStepAdapterTrainingOptions) throws -> Self {
+        try options.validate()
+        let manifestURL = ACEStepRuntimePreparation.resolveUserPath(options.dataset)
+        return try Self(options: options, manifestURL: manifestURL,
+                        outputURL: ACEStepRuntimePreparation.resolveUserPath(options.output),
+                        records: loadManifest(from: manifestURL))
+    }
+
+    public func audioURL(for record: ManifestRecord) -> URL {
+        if record.audio.hasPrefix("/") || record.audio.hasPrefix("~") {
+            return ACEStepRuntimePreparation.resolveUserPath(record.audio)
+        }
+        return manifestURL.deletingLastPathComponent()
+            .appendingPathComponent(record.audio).standardizedFileURL
+    }
+
+    public struct ManifestRecord: Codable, Sendable {
+        public var audio: String
+        public var caption: String
+        public var lyrics: String?
+    }
+
+    public static func loadManifest(from url: URL) throws -> [ManifestRecord] {
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            throw ACEStepPreparationIssue("Dataset manifest not found: \(url.path)")
+        }
+        let data = try Data(contentsOf: url)
+        let decoder = JSONDecoder()
+        let records: [ManifestRecord]
+        if let decoded = try? decoder.decode([ManifestRecord].self, from: data) {
+            records = decoded
+        } else {
+            let text = String(decoding: data, as: UTF8.self)
+            records = try text.split(whereSeparator: \.isNewline)
+                .enumerated()
+                .map { lineNumber, line in
+                    do {
+                        return try decoder.decode(
+                            ManifestRecord.self,
+                            from: Data(line.utf8)
+                        )
+                    } catch {
+                        throw ACEStepPreparationIssue(
+                            "Invalid dataset JSONL line \(lineNumber + 1): "
+                                + error.localizedDescription
+                        )
+                    }
+                }
+        }
+        guard !records.isEmpty else {
+            throw ACEStepPreparationIssue("Dataset manifest contains no examples.")
+        }
+        for (index, record) in records.enumerated() {
+            if record.audio.trimmingCharacters(
+                in: .whitespacesAndNewlines
+            ).isEmpty {
+                throw ACEStepPreparationIssue(
+                    "Dataset record \(index + 1) has an empty audio path."
+                )
+            }
+            if record.caption.trimmingCharacters(
+                in: .whitespacesAndNewlines
+            ).isEmpty {
+                throw ACEStepPreparationIssue(
+                    "Dataset record \(index + 1) has an empty caption."
+                )
+            }
+        }
+        return records
+    }
+
+}

--- a/Sources/MereRunCore/ACEStep/ACEStepRuntimePreparation.swift
+++ b/Sources/MereRunCore/ACEStep/ACEStepRuntimePreparation.swift
@@ -1,0 +1,471 @@
+import AudioCodecs
+import Foundation
+import MLX
+
+public enum ACEStepRuntimePreparation {
+    public struct LMResolution: Hashable, Sendable {
+        public let rootURL: URL
+        public let source: String
+    }
+
+    public static func resolveUserPath(_ path: String) -> URL {
+        let trimmed = path.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed == "~" {
+            return URL(fileURLWithPath: NSHomeDirectory()).standardizedFileURL
+        }
+        if trimmed.hasPrefix("~/") {
+            let suffix = String(trimmed.dropFirst(2))
+            return URL(fileURLWithPath: NSHomeDirectory())
+                .appendingPathComponent(suffix)
+                .standardizedFileURL
+        }
+        return URL(fileURLWithPath: trimmed).standardizedFileURL
+    }
+
+    public static func loadAudio48kHz(_ path: String, label: String) throws -> MLXArray {
+        let url = resolveUserPath(path)
+        guard FileManager.default.fileExists(atPath: url.path) else {
+            throw ACEStepPreparationIssue("\(label) not found: \(url.path)")
+        }
+
+        let buffer = try AudioReader.readAudioBuffer(from: url, sampleRate: 48_000, channels: 2)
+        guard buffer.isInterleaved else {
+            throw ACEStepPreparationIssue("\(label) decoded to a non-interleaved buffer: \(url.path)")
+        }
+        guard buffer.channelCount == 2 else {
+            throw ACEStepPreparationIssue("\(label) must decode to stereo at 48 kHz; got \(buffer.channelCount) channel(s).")
+        }
+        guard buffer.samples.count >= buffer.channelCount else {
+            throw ACEStepPreparationIssue("\(label) contains no audio samples: \(url.path)")
+        }
+
+        let frames = buffer.samples.count / buffer.channelCount
+        let trimmedSampleCount = frames * buffer.channelCount
+        let samples = trimmedSampleCount == buffer.samples.count
+            ? buffer.samples
+            : Array(buffer.samples.prefix(trimmedSampleCount))
+        let clamped = samples.map { sample -> Float in
+            guard sample.isFinite else {
+                return 0
+            }
+            return max(-1.0, min(1.0, sample))
+        }
+        return MLXArray(clamped, [1, frames, buffer.channelCount]).asType(.float32)
+    }
+
+    public static func durationSeconds(of audio48kHz: MLXArray, fallback: Float) -> Float {
+        guard audio48kHz.ndim >= 2 else {
+            return fallback
+        }
+        let frames = audio48kHz.dim(1)
+        guard frames > 0 else {
+            return fallback
+        }
+        return Float(frames) / 48_000.0
+    }
+
+    public static func resolveCheckpointsRoot(
+        model: String,
+        checkpointsRoot: String?,
+        turboSubdirectory: String,
+        vaeSubdirectory: String,
+        lmSubdirectory: String?,
+        textSubdirectory: String?
+    ) async throws -> URL {
+        let candidates = buildCheckpointCandidates(
+            model: model,
+            checkpointsRoot: checkpointsRoot
+        )
+
+        for candidate in candidates {
+            if isUsableCheckpointsRoot(
+                candidate,
+                turboSubdirectory: turboSubdirectory,
+                vaeSubdirectory: vaeSubdirectory,
+                lmSubdirectory: lmSubdirectory,
+                textSubdirectory: textSubdirectory
+            ) {
+                return candidate
+            }
+            let nested = candidate.appendingPathComponent("checkpoints", isDirectory: true)
+            if isUsableCheckpointsRoot(
+                nested,
+                turboSubdirectory: turboSubdirectory,
+                vaeSubdirectory: vaeSubdirectory,
+                lmSubdirectory: lmSubdirectory,
+                textSubdirectory: textSubdirectory
+            ) {
+                return nested
+            }
+        }
+
+        if let explicit = checkpointsRoot?.trimmingCharacters(in: .whitespacesAndNewlines), !explicit.isEmpty {
+            throw ACEStepPreparationIssue("Checkpoints root not found or incomplete: \(explicit)")
+        }
+
+        do {
+            let resolved = try await ManagedModelResolver.resolveForRuntime(
+                requestedModel: model,
+                defaultModelID: ModelResolver.ModelID.aceStep.rawValue
+            )
+            let root = resolved.url
+            if isUsableCheckpointsRoot(
+                root,
+                turboSubdirectory: turboSubdirectory,
+                vaeSubdirectory: vaeSubdirectory,
+                lmSubdirectory: lmSubdirectory,
+                textSubdirectory: textSubdirectory
+            ) {
+                return root
+            }
+            let nested = root.appendingPathComponent("checkpoints", isDirectory: true)
+            if isUsableCheckpointsRoot(
+                nested,
+                turboSubdirectory: turboSubdirectory,
+                vaeSubdirectory: vaeSubdirectory,
+                lmSubdirectory: lmSubdirectory,
+                textSubdirectory: textSubdirectory
+            ) {
+                return nested
+            }
+        } catch let error as ManagedModelResolver.ResolverError {
+            throw ACEStepPreparationIssue(error.localizedDescription)
+        }
+
+        throw ACEStepPreparationIssue("Music Acestep checkpoints not found. Add --checkpoints-root or set MERERUN_MUSIC_ACESTEP_ROOT.")
+    }
+
+    public static func resolveTurboSubdirectory(at root: URL, explicit: String) throws -> String {
+        let fm = FileManager.default
+
+        let trimmed = explicit.trimmingCharacters(in: .whitespacesAndNewlines)
+        let upstreamDefault = "acestep-v15-turbo"
+        let compatibilityDefault = "music-acestep-v15-turbo"
+        let decoderDefaults = [
+            upstreamDefault,
+            compatibilityDefault,
+            "acestep-v15-xl-turbo",
+            "acestep-v15-xl-sft",
+            "acestep-v15-xl-base",
+            "acestep-v15-sft",
+            "acestep-v15-base",
+        ]
+        let candidates = trimmed == upstreamDefault
+            ? decoderDefaults
+            : [trimmed]
+
+        for candidate in candidates where isUsableDecoderDirectory(
+            root.appendingPathComponent(candidate, isDirectory: true),
+            fileManager: fm
+        ) {
+            return candidate
+        }
+        throw ACEStepPreparationIssue("--decoder-subdirectory not found: \(trimmed)")
+    }
+
+    public static func resolveLMSubdirectory(at root: URL, explicit: String?) throws -> String? {
+        let fm = FileManager.default
+
+        if let explicit, !explicit.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            let explicitNormalized = explicit.trimmingCharacters(in: .whitespacesAndNewlines)
+            let explicitRoot = root.appendingPathComponent(explicitNormalized, isDirectory: true)
+            guard isUsableLMDirectory(explicitRoot, fileManager: fm) else {
+                throw ACEStepPreparationIssue("--lm-subdirectory not found: \(explicitNormalized)")
+            }
+            return explicitNormalized
+        }
+
+        let preferredCandidates = [
+            "acestep-5Hz-lm-1.7B",
+            "acestep-5hz-lm-1.7b",
+            "acestep-5Hz-lm-4B",
+            "acestep-5hz-lm-4b",
+            "acestep-5Hz-lm",
+            "acestep-5hz-lm",
+            "music-acestep-5hz-lm-4b",
+            "music-acestep-5Hz-lm-4B",
+            "music-acestep-5hz-lm-1.7b",
+            "music-acestep-5Hz-lm-1.7B",
+            "music-acestep-5hz-lm",
+            "music-acestep-5Hz-lm",
+            "lm",
+            "music-acestep-lm"
+        ]
+
+        for candidate in preferredCandidates {
+            if isUsableLMDirectory(root.appendingPathComponent(candidate, isDirectory: true), fileManager: fm) {
+                return candidate
+            }
+        }
+
+        let discovered = (try? fm.contentsOfDirectoryResolvingSymlinks(
+            at: root,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        ))?.first(where: { directory in
+            let isDirectory = (try? directory.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true
+            let name = directory.lastPathComponent.lowercased()
+            return isDirectory
+                && name.contains("lm")
+                && name.contains("5hz")
+                && isUsableLMDirectory(directory, fileManager: fm)
+        })
+
+        return discovered?.lastPathComponent
+    }
+
+    public static func resolveLMResources(
+        checkpointsRoot: URL,
+        lmModel: String?,
+        lmSubdirectory: String?
+    ) async throws -> LMResolution {
+        if let explicitSubdirectory = nonEmpty(lmSubdirectory) {
+            guard nonEmpty(lmModel) == nil else {
+                throw ACEStepPreparationIssue("Pass either --lm-model or --lm-subdirectory, not both.")
+            }
+            guard let resolved = try resolveLMSubdirectory(
+                at: checkpointsRoot,
+                explicit: explicitSubdirectory
+            ) else {
+                throw ACEStepPreparationIssue("--lm-subdirectory not found: \(explicitSubdirectory)")
+            }
+            return LMResolution(
+                rootURL: checkpointsRoot.appendingPathComponent(resolved, isDirectory: true),
+                source: resolved
+            )
+        }
+
+        if let explicitModel = nonEmpty(lmModel) {
+            return try await resolveManagedLM(
+                requestedModel: explicitModel,
+                defaultModelID: ModelResolver.ModelID.aceStepLM17B.rawValue
+            )
+        }
+
+        if let local = try resolveLMSubdirectory(at: checkpointsRoot, explicit: nil) {
+            return LMResolution(
+                rootURL: checkpointsRoot.appendingPathComponent(local, isDirectory: true),
+                source: local
+            )
+        }
+
+        for installedModelID in [
+            ModelResolver.ModelID.aceStepLM17B.rawValue,
+            ModelResolver.ModelID.aceStep.rawValue,
+        ] {
+            guard let installedRoot = ManagedModelResolver.resolveInstalledModel(id: installedModelID),
+                  let resolvedRoot = resolveLMRoot(at: installedRoot)
+            else {
+                continue
+            }
+            return LMResolution(rootURL: resolvedRoot, source: installedModelID)
+        }
+
+        return try await resolveManagedLM(
+            requestedModel: nil,
+            defaultModelID: ModelResolver.ModelID.aceStepLM17B.rawValue
+        )
+    }
+
+    public static func resolveLMRoot(at root: URL) -> URL? {
+        let normalized = root.standardizedFileURL
+        if isUsableLMDirectory(normalized, fileManager: .default) {
+            return normalized
+        }
+        guard let subdirectory = try? resolveLMSubdirectory(at: normalized, explicit: nil) else {
+            return nil
+        }
+        return normalized.appendingPathComponent(subdirectory, isDirectory: true)
+    }
+
+    private static func resolveManagedLM(
+        requestedModel: String?,
+        defaultModelID: String
+    ) async throws -> LMResolution {
+        do {
+            let resolution = try await ManagedModelResolver.resolveForRuntime(
+                requestedModel: requestedModel,
+                defaultModelID: defaultModelID
+            )
+            guard let root = resolveLMRoot(at: resolution.url) else {
+                throw ACEStepPreparationIssue(
+                    "ACE-Step planner \(resolution.spec.id) does not contain a usable 5Hz LM."
+                )
+            }
+            let source = resolution.source == .explicitPath
+                ? "local"
+                : resolution.spec.id
+            return LMResolution(rootURL: root, source: source)
+        } catch let error as ManagedModelResolver.ResolverError {
+            throw ACEStepPreparationIssue(error.localizedDescription)
+        }
+    }
+
+    private static func nonEmpty(_ value: String?) -> String? {
+        let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    public static func resolveTextSubdirectory(at root: URL, explicit: String?) throws -> String? {
+        let fm = FileManager.default
+
+        if let explicit, !explicit.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            let explicitNormalized = explicit.trimmingCharacters(in: .whitespacesAndNewlines)
+            let explicitRoot = root.appendingPathComponent(explicitNormalized, isDirectory: true)
+            guard isDirectory(explicitRoot, fileManager: fm) else {
+                throw ACEStepPreparationIssue("--text-subdirectory not found: \(explicitNormalized)")
+            }
+            return explicitNormalized
+        }
+
+        let preferredCandidates = [
+            "Qwen3-Embedding-0.6B",
+            "qwen3-embedding-0.6b",
+            "Qwen3-Embedding-4B",
+            "qwen3-embedding-4b",
+            "Qwen3-Embedding",
+            "qwen3-embedding",
+            "text_encoder",
+            "text-encoder"
+        ]
+
+        for candidate in preferredCandidates {
+            if isDirectory(root.appendingPathComponent(candidate, isDirectory: true), fileManager: fm) {
+                return candidate
+            }
+        }
+
+        let discovered = (try? fm.contentsOfDirectoryResolvingSymlinks(
+            at: root,
+            includingPropertiesForKeys: [.isDirectoryKey],
+            options: [.skipsHiddenFiles]
+        ))?.first(where: { directory in
+            let isDirectory = (try? directory.resourceValues(forKeys: [.isDirectoryKey]))?.isDirectory == true
+            let name = directory.lastPathComponent.lowercased()
+            return isDirectory && (
+                (name.contains("qwen3") && name.contains("embedding"))
+                || name == "text_encoder"
+                || name == "text-encoder"
+            )
+        })
+
+        return discovered?.lastPathComponent
+    }
+
+    public static func buildCheckpointCandidates(
+        model: String,
+        checkpointsRoot: String?
+    ) -> [URL] {
+        var candidates: [URL] = []
+
+        if let explicit = checkpointsRoot?.trimmingCharacters(in: .whitespacesAndNewlines), !explicit.isEmpty {
+            candidates.append(URL(fileURLWithPath: explicit).standardizedFileURL)
+        }
+
+        var modelPathExists = false
+        let explicitModel = model.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !explicitModel.isEmpty {
+            let url = URL(fileURLWithPath: explicitModel).standardizedFileURL
+            if FileManager.default.fileExists(atPath: url.path) {
+                modelPathExists = true
+                candidates.append(url)
+            }
+        }
+
+        if let envRoot = ProcessInfo.processInfo.environment["MERERUN_MUSIC_ACESTEP_ROOT"]?
+            .trimmingCharacters(in: .whitespacesAndNewlines),
+            !envRoot.isEmpty
+        {
+            candidates.append(URL(fileURLWithPath: envRoot).standardizedFileURL)
+        }
+
+        let managedModelID = explicitModel.lowercased()
+        if !managedModelID.isEmpty && !modelPathExists {
+            let requestedRoot = MereRunModelPaths.modelsDir
+                .appendingPathComponent(managedModelID, isDirectory: true)
+                .standardizedFileURL
+            candidates.append(requestedRoot)
+            candidates.append(requestedRoot.appendingPathComponent("checkpoints", isDirectory: true))
+        }
+
+        if managedModelID.isEmpty {
+            let localModelRoot = MereRunModelPaths.modelsDir
+                .appendingPathComponent(ModelResolver.ModelID.aceStep.rawValue, isDirectory: true)
+                .standardizedFileURL
+            candidates.append(localModelRoot)
+            candidates.append(localModelRoot.appendingPathComponent("checkpoints", isDirectory: true))
+        }
+
+        return candidates
+    }
+
+    private static func isUsableCheckpointsRoot(
+        _ root: URL,
+        turboSubdirectory: String,
+        vaeSubdirectory: String,
+        lmSubdirectory: String?,
+        textSubdirectory: String?
+    ) -> Bool {
+        let fm = FileManager.default
+
+        guard isDirectory(root, fileManager: fm) else {
+            return false
+        }
+        let turboCandidates = turboSubdirectory == "acestep-v15-turbo"
+            ? [
+                "acestep-v15-turbo",
+                "music-acestep-v15-turbo",
+                "acestep-v15-xl-turbo",
+                "acestep-v15-xl-sft",
+                "acestep-v15-xl-base",
+                "acestep-v15-sft",
+                "acestep-v15-base",
+            ]
+            : [turboSubdirectory]
+        guard turboCandidates.contains(where: {
+            isUsableDecoderDirectory(root.appendingPathComponent($0, isDirectory: true), fileManager: fm)
+        }) else {
+            return false
+        }
+        guard isDirectory(root.appendingPathComponent(vaeSubdirectory), fileManager: fm) else {
+            return false
+        }
+
+        if let lmSubdirectory, !lmSubdirectory.isEmpty {
+            guard isDirectory(root.appendingPathComponent(lmSubdirectory), fileManager: fm) else {
+                return false
+            }
+        }
+
+        if let textSubdirectory, !textSubdirectory.isEmpty {
+            guard isDirectory(root.appendingPathComponent(textSubdirectory), fileManager: fm) else {
+                return false
+            }
+        }
+
+        return true
+    }
+
+    private static func isUsableDecoderDirectory(_ url: URL, fileManager: FileManager) -> Bool {
+        isDirectory(url, fileManager: fileManager)
+            && ACEStepResources(rootURL: url).validate(fileManager: fileManager).isEmpty
+    }
+
+    private static func isUsableLMDirectory(_ url: URL, fileManager: FileManager) -> Bool {
+        isDirectory(url, fileManager: fileManager)
+            && ACEStep5HzLMResources(rootURL: url).validate(fileManager: fileManager).isEmpty
+    }
+
+    private static func isDirectory(_ url: URL, fileManager: FileManager) -> Bool {
+        var isDir: ObjCBool = false
+        return fileManager.fileExists(atPath: url.path, isDirectory: &isDir) && isDir.boolValue
+    }
+}
+
+public struct ACEStepPreparationIssue: LocalizedError, Sendable {
+    public let message: String
+
+    public init(_ message: String) { self.message = message }
+
+    public var errorDescription: String? { message }
+}

--- a/Sources/MereRunCore/ACEStep/README.md
+++ b/Sources/MereRunCore/ACEStep/README.md
@@ -3,6 +3,11 @@
 Music generation pipeline and ACE-Step model resources.
 
 - `ACEStepPipeline*.swift`: prompt preparation and generation orchestration.
+- `ACEStepRuntimePreparation.swift`: shared checkpoint discovery and audio decoding.
+- `ACEStepAdapterTrainingOptions.swift` and `ACEStepAdapterTrainingPlan.swift`:
+  validated inputs and typed JSON/JSONL manifest preparation.
+- `ACEStepAdapterTrainingOperation*.swift`: audio preparation, native dispatch,
+  progress, and terminal training events. Callers own machine admission.
 - `ACEStep5HzLM*.swift`: language-model token path for audio codes.
 - `ACEStepTurboScheduler.swift`: scheduler behavior.
 - `Model/` and `VAE/`: native model building blocks.

--- a/Sources/MereRunCore/ImageGenerationOperation.swift
+++ b/Sources/MereRunCore/ImageGenerationOperation.swift
@@ -50,11 +50,12 @@ public enum ImageGenerationOperation {
             try recording?.succeed(outcome)
             eventHandler?(.succeeded(outcome))
             return outcome
-        } catch is CancellationError {
-            try recording?.fail(CancellationError())
-            eventHandler?(.cancelled(id))
-            throw CancellationError()
         } catch {
+            if error is CancellationError || Task.isCancelled {
+                try recording?.fail(CancellationError())
+                eventHandler?(.cancelled(id))
+                throw CancellationError()
+            }
             try recording?.fail(error)
             let issue = error as? ImageGenerationIssue
                 ?? ImageGenerationIssue("generation_failed", error.localizedDescription)

--- a/Sources/MereRunCore/ImageRunRecord.swift
+++ b/Sources/MereRunCore/ImageRunRecord.swift
@@ -38,7 +38,7 @@ public struct ImageRunRecord: Codable, Equatable, Sendable {
         let recordURL = recordURL(at: url)
         let lease = try RunDirectoryLease.acquire(in: recordURL.deletingLastPathComponent(), filename: ".image-run.lock")
         defer { lease?.release() }
-        var record = try decode(Data(contentsOf: recordURL))
+        var record = try decode(RunRecordCodec.readData(at: recordURL))
         if lease != nil, !record.state.isTerminal {
             record.state = .interrupted
             record.updatedAt = timestamp()

--- a/Sources/MereRunCore/LoRA/ImageLoRATrainingIssue.swift
+++ b/Sources/MereRunCore/LoRA/ImageLoRATrainingIssue.swift
@@ -1,0 +1,35 @@
+import Foundation
+
+public enum ImageLoRATrainingIssue: LocalizedError, Sendable {
+    public enum ModelRole: Sendable { case defaultTraining, training, sample }
+
+    case invalid(String)
+    case modelUnavailable(id: String, role: ModelRole)
+
+    public init(_ message: String) { self = .invalid(message) }
+
+    public var errorDescription: String? {
+        message { id in
+            let acknowledgement = ManagedModelCatalog.spec(for: id)?.usageRestriction == nil
+                ? "" : " --accept-model-license"
+            return "mere.run model pull \(id)\(acknowledgement)"
+        }
+    }
+
+    public func message(modelPullCommand: (String) -> String) -> String {
+        switch self {
+        case .invalid(let message):
+            return message
+        case .modelUnavailable(let id, let role):
+            let command = modelPullCommand(id)
+            switch role {
+            case .defaultTraining:
+                return "Krea 2 Raw model \(id) not found. Pull it with `\(command)` or point --model at a local Raw model path."
+            case .training:
+                return "Model \(id) not found. Pull it with `\(command)` or point --model at a local path."
+            case .sample:
+                return "Sample model \(id) not found. Pull it with `\(command)` or pass --sample-model."
+            }
+        }
+    }
+}

--- a/Sources/MereRunCore/LoRA/ImageLoRATrainingOperation+Native.swift
+++ b/Sources/MereRunCore/LoRA/ImageLoRATrainingOperation+Native.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+extension ImageLoRATrainingOperation {
+    public static func train(
+        _ plan: ImageLoRATrainingPlan,
+        progress: (@Sendable (ImageLoRATrainingProgress) -> Void)?
+    ) async throws {
+        try Task.checkCancellation()
+        switch plan.training {
+        case .krea(let examples, let configuration):
+            try await Krea2LoRATrainer.train(
+                modelPath: plan.modelRoot.path, examples: examples,
+                outputURL: plan.outputURL, config: configuration,
+                progressHandler: { progress?(.krea($0)) }
+            )
+        case .klein(let examples, let configuration, let resumeFrom, let sample):
+            let sampleHandler = sample.map {
+                makeSampleHandler($0, outputURL: plan.outputURL, progress: progress)
+            }
+            try await Flux2KleinLoRATrainer.train(
+                modelPath: plan.modelRoot.path, examples: examples,
+                outputURL: plan.outputURL, config: configuration,
+                resumeFromLoRA: resumeFrom,
+                progressHandler: { progress?(.klein($0)) }, sampleHandler: sampleHandler
+            )
+        }
+    }
+
+    private static func makeSampleHandler(
+        _ sample: ImageLoRATrainingPlan.Sample, outputURL: URL,
+        progress: (@Sendable (ImageLoRATrainingProgress) -> Void)?
+    ) -> @Sendable (Int, URL) async -> Void {
+        let generator = Flux2KleinGenerator()
+        let outputBaseName = outputURL.deletingPathExtension().lastPathComponent
+        let sampleDirectory = outputURL.deletingLastPathComponent().appendingPathComponent("samples", isDirectory: true)
+        return { step, checkpointURL in
+            do {
+                try Task.checkCancellation()
+                try FileManager.default.createDirectory(at: sampleDirectory, withIntermediateDirectories: true)
+                let sampleURL = sampleDirectory.appendingPathComponent("\(outputBaseName)-step\(step)-sample.png")
+                let request = GenerationRequest(
+                    prompt: sample.prompt, width: sample.width, height: sample.height,
+                    steps: sample.steps, guidanceScale: sample.guidanceScale,
+                    seed: sample.seed, outputURL: sampleURL, model: sample.modelPath,
+                    lora: .local(path: checkpointURL.path, scale: sample.loraScale)
+                )
+                _ = try await generator.generate(request, progressHandler: nil)
+                try Task.checkCancellation()
+                progress?(.sampleSaved(step: step, url: sampleURL, checkpoint: checkpointURL))
+            } catch {
+                progress?(.sampleFailed(step: step, message: error.localizedDescription, checkpoint: checkpointURL))
+            }
+        }
+    }
+}

--- a/Sources/MereRunCore/LoRA/ImageLoRATrainingOperation.swift
+++ b/Sources/MereRunCore/LoRA/ImageLoRATrainingOperation.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+public enum ImageLoRATrainingProgress: Sendable {
+    case krea(Krea2LoRATrainingProgress)
+    case klein(Flux2KleinLoRATrainingProgress)
+    case sampleSaved(step: Int, url: URL, checkpoint: URL)
+    case sampleFailed(step: Int, message: String, checkpoint: URL)
+}
+
+public enum ImageLoRATrainingOutcome: Sendable, Equatable {
+    case saved(URL)
+    case benchmark
+}
+
+/// Executes a prepared family-specific plan. The caller owns admission and any
+/// dashboard lifecycle; the native trainer owns optimizer state and artifacts.
+public enum ImageLoRATrainingOperation {
+    public typealias Trainer = @Sendable (
+        ImageLoRATrainingPlan, (@Sendable (ImageLoRATrainingProgress) -> Void)?
+    ) async throws -> Void
+
+    public static func execute(
+        _ plan: ImageLoRATrainingPlan,
+        progress: (@Sendable (ImageLoRATrainingProgress) -> Void)? = nil,
+        trainer: Trainer = train
+    ) async throws -> ImageLoRATrainingOutcome {
+        try Task.checkCancellation()
+        try FileManager.default.createDirectory(at: plan.outputURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        do {
+            try await trainer(plan, progress)
+            try Task.checkCancellation()
+        } catch {
+            if error is CancellationError || Task.isCancelled { throw CancellationError() }
+            throw error
+        }
+        return plan.isBenchmark ? .benchmark : .saved(plan.outputURL)
+    }
+}

--- a/Sources/MereRunCore/LoRA/ImageLoRATrainingOptions+Models.swift
+++ b/Sources/MereRunCore/LoRA/ImageLoRATrainingOptions+Models.swift
@@ -1,0 +1,46 @@
+import Foundation
+
+extension ImageLoRATrainingOptions {
+    func resolveModelRoot(model: String?) throws -> URL {
+        let resolver = ModelResolver()
+        guard let model else {
+            do {
+                return try resolver.resolve(Self.defaultManagedModelID).rootURL
+            } catch {
+                throw ImageLoRATrainingIssue.modelUnavailable(id: Self.defaultManagedModelID.rawValue, role: .defaultTraining)
+            }
+        }
+
+        let url = URL(fileURLWithPath: model).standardizedFileURL
+        if FileManager.default.fileExists(atPath: url.path) {
+            return url
+        }
+        if let id = ModelResolver.ModelID(rawValue: model) {
+            do {
+                return try resolver.resolve(id).rootURL
+            } catch {
+                throw ImageLoRATrainingIssue.modelUnavailable(id: id.rawValue, role: .training)
+            }
+        }
+        throw ImageLoRATrainingIssue("Model path not found: \(model). Pass a local model path or a known model id.")
+    }
+
+    func resolveKleinSampleModelPath() throws -> String {
+        let spec = sampleModel ?? ModelResolver.ModelID.klein9B.rawValue
+        let url = URL(fileURLWithPath: spec).standardizedFileURL
+        if FileManager.default.fileExists(atPath: url.path) {
+            return url.path
+        }
+
+        if let id = ModelResolver.ModelID(rawValue: spec) {
+            do {
+                return try ModelResolver().resolve(id).rootURL.path
+            } catch {
+                throw ImageLoRATrainingIssue.modelUnavailable(id: id.rawValue, role: .sample)
+            }
+        }
+
+        throw ImageLoRATrainingIssue("Sample model path not found: \(spec). Pass a local path or known model id.")
+    }
+
+}

--- a/Sources/MereRunCore/LoRA/ImageLoRATrainingOptions+Preparation.swift
+++ b/Sources/MereRunCore/LoRA/ImageLoRATrainingOptions+Preparation.swift
@@ -1,0 +1,174 @@
+import Foundation
+
+extension ImageLoRATrainingOptions {
+    func prepareKrea(options: Resolved) throws -> ImageLoRATrainingPlan.Training {
+        if options.checkpointInterval != nil {
+            throw ImageLoRATrainingIssue("--checkpoint-interval is only supported for FLUX.2 Klein LoRA training")
+        }
+        if hasKleinOnlyTrainingOptions(options: options) {
+            throw ImageLoRATrainingIssue("Klein training options require a FLUX.2 Klein base model.")
+        }
+
+        let examples: [Krea2LoRATrainingExample]
+        let datasetRoot: String?
+        if syntheticSamples != nil {
+            examples = []
+            datasetRoot = nil
+        } else {
+            guard let data else {
+                throw ImageLoRATrainingIssue("--data is required unless --synthetic-samples is set")
+            }
+            let dataURL = URL(fileURLWithPath: data).standardizedFileURL
+            let pairs = try DatasetLoader.loadImageCaptionPairs(
+                from: dataURL,
+                excludePreviewImages: excludePreviewImages
+            )
+            examples = pairs.map { pair in
+                Krea2LoRATrainingExample(imageURL: pair.imageURL, caption: pair.caption)
+            }
+            datasetRoot = dataURL.path
+        }
+
+        var config = Krea2LoRATrainingConfig()
+        config.width = options.width
+        config.height = options.height
+        config.maxTextLength = maxTextLength
+        config.schedulerSteps = schedulerSteps
+        config.trainingSteps = options.trainingSteps
+        config.batchSize = batchSize
+        config.learningRate = options.learningRate
+        config.seed = seed
+        config.loraRank = options.rank
+        config.loraAlpha = options.alpha
+        config.captionDropout = options.captionDropout
+        config.loraTargetSuffixes = lite ? Krea2LoRAInjector.liteTargetSuffixes : nil
+        config.baseQuantizationBits = baseQuantizationBits
+        config.syntheticSampleCount = syntheticSamples
+        config.datasetRoot = datasetRoot
+        config.useCompile = !options.noCompile
+        if let lrWarmupSteps = options.lrWarmupSteps {
+            config.lrWarmupSteps = lrWarmupSteps
+        }
+        if let useCosineScheduler = options.useCosineScheduler {
+            config.useCosineScheduler = useCosineScheduler
+        }
+        if let lrMinFactor = options.lrMinFactor {
+            config.lrMinFactor = lrMinFactor
+        }
+
+        return .krea(examples: examples, configuration: config)
+    }
+
+    func prepareKlein(options: Resolved) throws -> ImageLoRATrainingPlan.Training {
+        if baseQuantizationBits != nil {
+            throw ImageLoRATrainingIssue("--base-quantization-bits is only supported for Krea 2 LoRA training")
+        }
+        if syntheticSamples != nil {
+            throw ImageLoRATrainingIssue("--synthetic-samples is only supported for Krea 2 LoRA smoke tests")
+        }
+        guard let data else {
+            throw ImageLoRATrainingIssue("--data is required")
+        }
+
+        let dataURL = URL(fileURLWithPath: data).standardizedFileURL
+        let pairs = try DatasetLoader.loadImageCaptionPairs(
+            from: dataURL,
+            excludePreviewImages: excludePreviewImages
+        )
+        let examples = pairs.map { pair in
+            Flux2KleinLoRATrainingExample(imageURL: pair.imageURL, caption: pair.caption)
+        }
+
+        var config = Flux2KleinLoRATrainingConfig()
+        let rankPreset = try Self.resolveKleinRankPreset(loraRankPreset)
+        let resolvedRank = rankPreset?.rank ?? options.rank
+        let targetRanks = try Self.resolveKleinTargetPreset(options.loraTargetPreset, rank: resolvedRank)
+        let targetRankSuffixes = try loraTargetRanks.map(Self.parseKleinTargetRankSuffixes) ?? rankPreset?.targetRankSuffixes
+        config.width = options.width
+        config.height = options.height
+        config.maxResolution = options.maxResolution
+        config.maxTextLength = maxTextLength
+        config.schedulerSteps = schedulerSteps
+        config.trainingSteps = benchmarkSteps.map { benchmarkWarmupSteps + $0 } ?? options.trainingSteps
+        config.batchSize = batchSize
+        config.learningRate = options.learningRate
+        config.seed = seed
+        config.loraRank = resolvedRank
+        config.loraAlpha = options.alpha ?? rankPreset?.alpha ?? Float(config.loraRank)
+        config.loraTargetMode = try Self.resolveKleinLoRATargetMode(loraTargetMode)
+        config.captionDropout = options.captionDropout
+        config.loraTargetSuffixes = lite ? Self.kleinLiteTargetSuffixes : nil
+        config.loraTargetRanks = targetRanks
+        config.loraTargetRankSuffixes = targetRankSuffixes
+        config.checkpointInterval = options.checkpointInterval
+        config.sampleInterval = sampleInterval
+        config.samplePrompt = samplePrompt
+        config.progressive = progressive
+        config.lowRam = options.lowRam
+        config.gradientCheckpointing = gradientCheckpointing
+        config.benchmarkSteps = benchmarkSteps
+        config.benchmarkWarmupSteps = benchmarkWarmupSteps
+        if options.noCompile || gradientCheckpointing {
+            config.useCompile = false
+        }
+        config.datasetRoot = dataURL.path
+        if let raw = timestepSampling {
+            guard let parsed = Flux2TimestepSamplingStrategy(rawValue: raw) else {
+                throw ImageLoRATrainingIssue("Unsupported --timestep-sampling '\(raw)'")
+            }
+            config.timestepSampling = parsed
+        }
+        if let raw = timestepLossWeighting {
+            guard let parsed = Flux2TimestepLossWeightingStrategy(rawValue: raw) else {
+                throw ImageLoRATrainingIssue("Unsupported --timestep-loss-weighting '\(raw)'")
+            }
+            config.timestepLossWeighting = parsed
+        }
+        if let raw = lossWeighting {
+            guard let parsed = Flux2LossWeightingStrategy(rawValue: raw) else {
+                throw ImageLoRATrainingIssue("Unsupported --loss-weighting '\(raw)'")
+            }
+            config.lossWeighting = parsed
+        }
+        if let timestepLow {
+            config.timestepLow = timestepLow
+        }
+        if let timestepHigh {
+            config.timestepHigh = timestepHigh
+        }
+        if let lrWarmupSteps {
+            config.lrWarmupSteps = lrWarmupSteps
+        }
+        if noCosineScheduler {
+            config.useCosineScheduler = false
+        }
+        if let lrMinFactor {
+            config.lrMinFactor = lrMinFactor
+        }
+        if let adamWeightDecay {
+            config.adamWeightDecay = adamWeightDecay
+        }
+
+        let sample = try prepareSample(fallbackPrompt: examples.first?.caption ?? "", options: options)
+        return .klein(
+            examples: examples, configuration: config,
+            resumeFrom: resumeFrom.map { URL(fileURLWithPath: $0).standardizedFileURL }, sample: sample
+        )
+    }
+
+    private func prepareSample(
+        fallbackPrompt: String, options: Resolved
+    ) throws -> ImageLoRATrainingPlan.Sample? {
+        guard sampleInterval != nil else { return nil }
+        let modelPath = try resolveKleinSampleModelPath()
+        let prompt = (samplePrompt ?? fallbackPrompt).trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !prompt.isEmpty else {
+            throw ImageLoRATrainingIssue("--sample-prompt is empty and the first caption is empty")
+        }
+        return .init(
+            modelPath: modelPath, prompt: prompt, width: options.width, height: options.height,
+            steps: sampleSteps, guidanceScale: sampleGuidanceScale, loraScale: sampleLoRAScale,
+            seed: sampleSeed ?? (seed == 0 ? 42 : seed)
+        )
+    }
+}

--- a/Sources/MereRunCore/LoRA/ImageLoRATrainingOptions.swift
+++ b/Sources/MereRunCore/LoRA/ImageLoRATrainingOptions.swift
@@ -1,0 +1,447 @@
+import Foundation
+
+/// Inputs shared by image training callers. Dashboard and console settings
+/// remain owned by the caller.
+public struct ImageLoRATrainingOptions: Sendable {
+    public static let defaultManagedModelID: ModelResolver.ModelID = .krea2Raw
+    public static let defaultWidth = 1024
+    public static let defaultHeight = 1024
+    public static let defaultTrainingSteps = 1000
+    public static let defaultLearningRate: Float = 1e-4
+    public static let defaultRank = 16
+    public static let defaultCaptionDropout: Float = 0.05
+
+    public var data: String? = nil
+    public var output: String
+    public var model: String? = nil
+    public var widthOverride: Int? = nil
+    public var heightOverride: Int? = nil
+    public var trainingStepsOverride: Int? = nil
+    public var batchSize: Int = 1
+    public var learningRateOverride: Float? = nil
+    public var rankOverride: Int? = nil
+    public var alphaOverride: Float? = nil
+    public var maxTextLength: Int = 512
+    public var schedulerSteps: Int = 1000
+    public var captionDropoutOverride: Float? = nil
+    public var seed: UInt64 = 0
+    public var lite: Bool = false
+    public var baseQuantizationBits: Int? = nil
+    public var excludePreviewImages: Bool = false
+    public var checkpointInterval: Int? = nil
+    public var resumeFrom: String? = nil
+    public var maxResolution: Int? = nil
+    public var progressive: Bool = false
+    public var lowRam: Bool = false
+    public var noCompile: Bool = false
+    public var gradientCheckpointing: Bool = false
+    public var recipe: String? = nil
+    public var benchmarkSteps: Int? = nil
+    public var benchmarkWarmupSteps: Int = 5
+    public var sampleInterval: Int? = nil
+    public var samplePrompt: String? = nil
+    public var sampleModel: String? = nil
+    public var sampleSteps: Int = 8
+    public var sampleGuidanceScale: Double = 1.0
+    public var sampleLoRAScale: Double = 1.0
+    public var sampleSeed: UInt64? = nil
+    public var loraTargetRanks: String? = nil
+    public var loraRankPreset: String? = nil
+    public var loraTargetPreset: String? = nil
+    public var loraTargetMode: String? = nil
+    public var timestepSampling: String? = nil
+    public var timestepLossWeighting: String? = nil
+    public var lossWeighting: String? = nil
+    public var timestepLow: Int? = nil
+    public var timestepHigh: Int? = nil
+    public var lrWarmupSteps: Int? = nil
+    public var noCosineScheduler: Bool = false
+    public var lrMinFactor: Float? = nil
+    public var adamWeightDecay: Float? = nil
+    public var syntheticSamples: Int? = nil
+
+    public init(data: String? = nil, output: String) {
+        self.data = data
+        self.output = output
+    }
+
+    var width: Int { widthOverride ?? Self.defaultWidth }
+    var height: Int { heightOverride ?? Self.defaultHeight }
+    var trainingSteps: Int { trainingStepsOverride ?? Self.defaultTrainingSteps }
+    var learningRate: Float { learningRateOverride ?? Self.defaultLearningRate }
+    var rank: Int { rankOverride ?? Self.defaultRank }
+    var alpha: Float? { alphaOverride }
+    var captionDropout: Float { captionDropoutOverride ?? Self.defaultCaptionDropout }
+
+    public struct Resolved: Sendable {
+        public let model: String?
+        public let width: Int
+        public let height: Int
+        public let trainingSteps: Int
+        public let learningRate: Float
+        public let rank: Int
+        public let alpha: Float?
+        public let captionDropout: Float
+        public let checkpointInterval: Int?
+        public let maxResolution: Int?
+        public let lowRam: Bool
+        public let noCompile: Bool
+        public let loraTargetPreset: String?
+        public let lrWarmupSteps: Int?
+        public let useCosineScheduler: Bool?
+        public let lrMinFactor: Float?
+    }
+
+    public func validate(_ resolvedOptions: Resolved) throws {
+        guard resolvedOptions.width > 0,
+              resolvedOptions.height > 0,
+              resolvedOptions.width % 16 == 0,
+              resolvedOptions.height % 16 == 0 else {
+            throw ImageLoRATrainingIssue("--width/--height must be > 0 and divisible by 16")
+        }
+        guard resolvedOptions.trainingSteps >= 1 else {
+            throw ImageLoRATrainingIssue("--training-steps must be >= 1")
+        }
+        guard batchSize >= 1 else {
+            throw ImageLoRATrainingIssue("--batch-size must be >= 1")
+        }
+        guard schedulerSteps >= 1 else {
+            throw ImageLoRATrainingIssue("--scheduler-steps must be >= 1")
+        }
+        guard resolvedOptions.rank >= 1 else {
+            throw ImageLoRATrainingIssue("--rank must be >= 1")
+        }
+        guard (0.0...1.0).contains(resolvedOptions.captionDropout) else {
+            throw ImageLoRATrainingIssue("--caption-dropout must be between 0.0 and 1.0")
+        }
+        if let syntheticSamples, syntheticSamples < 1 {
+            throw ImageLoRATrainingIssue("--synthetic-samples must be >= 1")
+        }
+        if let checkpointInterval = resolvedOptions.checkpointInterval, checkpointInterval < 1 {
+            throw ImageLoRATrainingIssue("--checkpoint-interval must be >= 1")
+        }
+        if let resumeFrom {
+            let resumeURL = URL(fileURLWithPath: resumeFrom).standardizedFileURL
+            guard FileManager.default.fileExists(atPath: resumeURL.path) else {
+                throw ImageLoRATrainingIssue("--resume-from checkpoint not found: \(resumeURL.path)")
+            }
+        }
+        if let maxResolution = resolvedOptions.maxResolution, maxResolution < 1 {
+            throw ImageLoRATrainingIssue("--max-resolution must be >= 1")
+        }
+        if let benchmarkSteps, benchmarkSteps < 1 {
+            throw ImageLoRATrainingIssue("--benchmark-steps must be >= 1")
+        }
+        guard benchmarkWarmupSteps >= 0 else {
+            throw ImageLoRATrainingIssue("--benchmark-warmup-steps must be >= 0")
+        }
+        if resolvedOptions.maxResolution != nil, progressive {
+            throw ImageLoRATrainingIssue("--max-resolution cannot be combined with --progressive")
+        }
+        if let sampleInterval, sampleInterval < 1 {
+            throw ImageLoRATrainingIssue("--sample-interval must be >= 1")
+        }
+        guard sampleSteps >= 1 else {
+            throw ImageLoRATrainingIssue("--sample-steps must be >= 1")
+        }
+        guard sampleGuidanceScale >= 0 else {
+            throw ImageLoRATrainingIssue("--sample-cfg must be >= 0")
+        }
+        guard sampleLoRAScale >= 0 else {
+            throw ImageLoRATrainingIssue("--sample-lora-scale must be >= 0")
+        }
+        if loraTargetRanks != nil, loraRankPreset != nil {
+            throw ImageLoRATrainingIssue("--lora-target-ranks cannot be combined with --lora-rank-preset")
+        }
+        if let loraTargetPreset = resolvedOptions.loraTargetPreset {
+            if lite {
+                throw ImageLoRATrainingIssue("--lite cannot be combined with --lora-target-preset")
+            }
+            if loraTargetRanks != nil || loraRankPreset != nil {
+                throw ImageLoRATrainingIssue("--lora-target-preset cannot be combined with --lora-target-ranks or --lora-rank-preset")
+            }
+            _ = try Self.resolveKleinTargetPreset(loraTargetPreset, rank: resolvedOptions.rank)
+        }
+        let parsedLoRATargetMode = try Self.resolveKleinLoRATargetMode(loraTargetMode)
+        if parsedLoRATargetMode == .transformerLinearWalk {
+            if lite {
+                throw ImageLoRATrainingIssue("--lite cannot be combined with --lora-target-mode transformer-linear-walk")
+            }
+            if loraTargetRanks != nil || loraRankPreset != nil || resolvedOptions.loraTargetPreset != nil {
+                throw ImageLoRATrainingIssue("--lora-target-mode transformer-linear-walk cannot be combined with LoRA target/rank presets")
+            }
+        }
+        if let timestepLow, timestepLow < 0 {
+            throw ImageLoRATrainingIssue("--timestep-low must be >= 0")
+        }
+        if let timestepHigh, timestepHigh < 1 {
+            throw ImageLoRATrainingIssue("--timestep-high must be >= 1")
+        }
+        if let timestepLow, let timestepHigh, timestepHigh <= timestepLow {
+            throw ImageLoRATrainingIssue("--timestep-high must be greater than --timestep-low")
+        }
+        if let timestepHigh, timestepHigh > schedulerSteps {
+            throw ImageLoRATrainingIssue("--timestep-high must be <= --scheduler-steps")
+        }
+        if let lrWarmupSteps, lrWarmupSteps < 0 {
+            throw ImageLoRATrainingIssue("--lr-warmup-steps must be >= 0")
+        }
+        if let lrMinFactor, !(0.0...1.0).contains(lrMinFactor) {
+            throw ImageLoRATrainingIssue("--lr-min-factor must be between 0.0 and 1.0")
+        }
+        if let adamWeightDecay, adamWeightDecay < 0 {
+            throw ImageLoRATrainingIssue("--adam-weight-decay must be >= 0")
+        }
+        if let baseQuantizationBits, baseQuantizationBits != 4, baseQuantizationBits != 8 {
+            throw ImageLoRATrainingIssue("--base-quantization-bits must be 4 or 8")
+        }
+    }
+
+    private struct LoRATrainingRecipe {
+        let model: String?
+        let width: Int?
+        let height: Int?
+        let trainingSteps: Int?
+        let learningRate: Float?
+        let rank: Int?
+        let alpha: Float?
+        let captionDropout: Float?
+        let checkpointInterval: Int?
+        let maxResolution: Int?
+        let lowRam: Bool
+        let noCompile: Bool
+        let loraTargetPreset: String?
+        let lrWarmupSteps: Int?
+        let useCosineScheduler: Bool?
+        let lrMinFactor: Float?
+    }
+
+    public func resolve() throws -> Resolved {
+        let recipe = try Self.resolveLoRATrainingRecipe(recipe)
+        let explicitSchedulerRequested = lrWarmupSteps != nil || lrMinFactor != nil
+        return Resolved(
+            model: model ?? recipe?.model,
+            width: widthOverride ?? recipe?.width ?? Self.defaultWidth,
+            height: heightOverride ?? recipe?.height ?? Self.defaultHeight,
+            trainingSteps: trainingStepsOverride ?? recipe?.trainingSteps ?? Self.defaultTrainingSteps,
+            learningRate: learningRateOverride ?? recipe?.learningRate ?? Self.defaultLearningRate,
+            rank: rankOverride ?? recipe?.rank ?? Self.defaultRank,
+            alpha: alphaOverride ?? recipe?.alpha,
+            captionDropout: captionDropoutOverride ?? recipe?.captionDropout ?? Self.defaultCaptionDropout,
+            checkpointInterval: checkpointInterval ?? recipe?.checkpointInterval,
+            maxResolution: maxResolution ?? recipe?.maxResolution,
+            lowRam: lowRam || recipe?.lowRam == true,
+            noCompile: noCompile || recipe?.noCompile == true,
+            loraTargetPreset: loraTargetPreset ?? recipe?.loraTargetPreset,
+            lrWarmupSteps: lrWarmupSteps ?? recipe?.lrWarmupSteps,
+            useCosineScheduler: noCosineScheduler ? false : recipe?.useCosineScheduler ?? (explicitSchedulerRequested ? true : nil),
+            lrMinFactor: lrMinFactor ?? recipe?.lrMinFactor
+        )
+    }
+
+    private static func resolveLoRATrainingRecipe(_ raw: String?) throws -> LoRATrainingRecipe? {
+        guard let raw else { return nil }
+        switch raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "krea-fast-style", "local-krea-style", "fal-krea-style", "krea2-fast-style":
+            return LoRATrainingRecipe(
+                model: ModelResolver.ModelID.krea2Raw.rawValue,
+                width: 768,
+                height: 768,
+                trainingSteps: 100,
+                learningRate: 0.0005,
+                rank: 32,
+                alpha: 32,
+                captionDropout: Self.defaultCaptionDropout,
+                checkpointInterval: nil,
+                maxResolution: nil,
+                lowRam: false,
+                noCompile: false,
+                loraTargetPreset: nil,
+                lrWarmupSteps: 10,
+                useCosineScheduler: true,
+                lrMinFactor: 0
+            )
+        case "krea-cinematic-style", "krea-movie-style", "krea-wide-style":
+            return LoRATrainingRecipe(
+                model: ModelResolver.ModelID.krea2Raw.rawValue,
+                width: 768,
+                height: 416,
+                trainingSteps: 200,
+                learningRate: 0.0001,
+                rank: 32,
+                alpha: 32,
+                captionDropout: Self.defaultCaptionDropout,
+                checkpointInterval: nil,
+                maxResolution: nil,
+                lowRam: false,
+                noCompile: true,
+                loraTargetPreset: nil,
+                lrWarmupSteps: 20,
+                useCosineScheduler: true,
+                lrMinFactor: 0
+            )
+        case "klein-fast-style", "local-klein-style", "flux2-klein-fast-style":
+            return LoRATrainingRecipe(
+                model: ModelResolver.ModelID.kleinBase9B.rawValue,
+                width: nil,
+                height: nil,
+                trainingSteps: 1000,
+                learningRate: 0.00005,
+                rank: nil,
+                alpha: nil,
+                captionDropout: nil,
+                checkpointInterval: 250,
+                maxResolution: 512,
+                lowRam: true,
+                noCompile: true,
+                loraTargetPreset: "fal-klein-fast",
+                lrWarmupSteps: nil,
+                useCosineScheduler: nil,
+                lrMinFactor: nil
+            )
+        default:
+            throw ImageLoRATrainingIssue(
+                "Unsupported --recipe '\(raw)'. Supported recipes: krea-fast-style, krea-cinematic-style, klein-fast-style"
+            )
+        }
+    }
+
+    struct KleinRankPreset {
+        let rank: Int
+        let alpha: Float
+        let targetRankSuffixes: [String: Int]
+    }
+
+    static func resolveKleinRankPreset(_ raw: String?) throws -> KleinRankPreset? {
+        guard let raw else { return nil }
+        switch raw.lowercased() {
+        case "flux2-style-128", "style-128":
+            return KleinRankPreset(
+                rank: 128,
+                alpha: 64,
+                targetRankSuffixes: Dictionary(
+                    uniqueKeysWithValues: Flux2LoRAInjector.defaultTargetSuffixes.map { ($0, 128) }
+                )
+            )
+        default:
+            throw ImageLoRATrainingIssue("Unsupported --lora-rank-preset '\(raw)'. Supported preset: flux2-style-128")
+        }
+    }
+
+    static func resolveKleinLoRATargetMode(_ raw: String?) throws -> Flux2LoRAInjector.TargetMode {
+        guard let raw else { return .suffix }
+        switch raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "suffix", "default":
+            return .suffix
+        case "transformer-linear-walk", "linear-walk", "all-linear", "walk":
+            return .transformerLinearWalk
+        default:
+            throw ImageLoRATrainingIssue("Unsupported --lora-target-mode '\(raw)'. Supported modes: suffix, transformer-linear-walk")
+        }
+    }
+
+    public static func resolveKleinTargetPreset(_ raw: String?, rank: Int) throws -> [String: Int]? {
+        guard let raw else { return nil }
+        switch raw.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
+        case "fal-klein-fast", "fal-fast", "flux2-klein-fal-fast":
+            return falKleinFastTargetRanks(rank: rank)
+        default:
+            throw ImageLoRATrainingIssue("Unsupported --lora-target-preset '\(raw)'. Supported preset: fal-klein-fast")
+        }
+    }
+
+    static func falKleinFastTargetRanks(rank: Int) -> [String: Int] {
+        var ranks: [String: Int] = [
+            "x_embedder": rank,
+            "context_embedder": rank,
+            "time_guidance_embed.timestep_embedder.linear_1": rank,
+            "time_guidance_embed.timestep_embedder.linear_2": rank,
+            "double_stream_modulation_img.linear": rank,
+            "double_stream_modulation_txt.linear": rank,
+            "single_stream_modulation.linear": rank,
+            "proj_out": rank,
+        ]
+
+        for block in 0..<8 {
+            for suffix in [
+                "attn.to_q",
+                "attn.to_k",
+                "attn.to_v",
+                "attn.to_out.0",
+                "attn.add_q_proj",
+                "attn.add_k_proj",
+                "attn.add_v_proj",
+                "attn.to_add_out",
+            ] {
+                ranks["transformer_blocks.\(block).\(suffix)"] = rank
+            }
+        }
+
+        for block in 0..<24 {
+            ranks["single_transformer_blocks.\(block).attn.to_qkv_mlp_proj"] = rank
+            ranks["single_transformer_blocks.\(block).attn.to_out"] = rank
+        }
+
+        return ranks
+    }
+
+    static func parseKleinTargetRankSuffixes(_ raw: String) throws -> [String: Int] {
+        let entries = raw
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        guard !entries.isEmpty else {
+            throw ImageLoRATrainingIssue("--lora-target-ranks cannot be empty")
+        }
+
+        var ranks: [String: Int] = [:]
+        for entry in entries {
+            let parts = entry
+                .split(separator: "=", maxSplits: 1)
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            guard parts.count == 2, !parts[0].isEmpty, let rank = Int(parts[1]) else {
+                throw ImageLoRATrainingIssue("Invalid --lora-target-ranks entry '\(entry)'; use suffix=rank")
+            }
+            guard rank >= 1 else {
+                throw ImageLoRATrainingIssue("--lora-target-ranks entry '\(entry)' must use rank >= 1")
+            }
+            ranks[parts[0]] = rank
+        }
+        return ranks
+    }
+
+    public func hasKleinOnlyTrainingOptions(options: Resolved) -> Bool {
+        options.maxResolution != nil ||
+            resumeFrom != nil ||
+            progressive ||
+            options.lowRam ||
+            gradientCheckpointing ||
+            benchmarkSteps != nil ||
+            benchmarkWarmupSteps != 5 ||
+            sampleInterval != nil ||
+            samplePrompt != nil ||
+            sampleModel != nil ||
+            sampleSteps != 8 ||
+            sampleGuidanceScale != 1.0 ||
+            sampleLoRAScale != 1.0 ||
+            sampleSeed != nil ||
+            loraTargetRanks != nil ||
+            loraRankPreset != nil ||
+            options.loraTargetPreset != nil ||
+            loraTargetMode != nil ||
+            timestepSampling != nil ||
+            timestepLossWeighting != nil ||
+            lossWeighting != nil ||
+            timestepLow != nil ||
+            timestepHigh != nil ||
+            adamWeightDecay != nil
+    }
+
+    static let kleinLiteTargetSuffixes: [String] = [
+        ".attn.to_q",
+        ".attn.to_v",
+        ".attn.add_q_proj",
+        ".attn.add_v_proj",
+    ]
+
+}

--- a/Sources/MereRunCore/LoRA/ImageLoRATrainingPlan.swift
+++ b/Sources/MereRunCore/LoRA/ImageLoRATrainingPlan.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+/// Prepared metadata, dataset captions and native trainer configuration.
+/// Weight loading and optimizer checkpoint compatibility stay in the trainers.
+public struct ImageLoRATrainingPlan: Sendable {
+    public enum Training: Sendable {
+        case krea(examples: [Krea2LoRATrainingExample], configuration: Krea2LoRATrainingConfig)
+        case klein(
+            examples: [Flux2KleinLoRATrainingExample], configuration: Flux2KleinLoRATrainingConfig,
+            resumeFrom: URL?, sample: Sample?
+        )
+    }
+
+    public struct Sample: Sendable {
+        public let modelPath: String
+        public let prompt: String
+        public let width: Int
+        public let height: Int
+        public let steps: Int
+        public let guidanceScale: Double
+        public let loraScale: Double
+        public let seed: UInt64
+    }
+
+    public let options: ImageLoRATrainingOptions.Resolved
+    public let modelRoot: URL
+    public let modelManifest: MereRunModelManifest
+    public let outputURL: URL
+    public let training: Training
+
+    public static func resolve(_ input: ImageLoRATrainingOptions) throws -> Self {
+        try Task.checkCancellation()
+        let options = try input.resolve()
+        try input.validate(options)
+        let outputURL = try outputURL(for: input.output)
+        let modelRoot = try input.resolveModelRoot(model: options.model)
+        let manifest = try MereRunModelManifest.loadRequired(from: modelRoot)
+        let training: Training
+        switch manifest.family {
+        case .krea:
+            training = try input.prepareKrea(options: options)
+        case .klein:
+            training = try input.prepareKlein(options: options)
+        default:
+            let family = manifest.family?.rawValue ?? "unknown"
+            throw ImageLoRATrainingIssue("Unsupported LoRA training model family: \(family). Use a Krea 2 Raw or FLUX.2 Klein base model.")
+        }
+        return Self(options: options, modelRoot: modelRoot, modelManifest: manifest,
+                    outputURL: outputURL, training: training)
+    }
+
+    public static func outputURL(for output: String) throws -> URL {
+        let url = URL(fileURLWithPath: output).standardizedFileURL
+        guard url.pathExtension.lowercased() == "safetensors" else {
+            throw ImageLoRATrainingIssue("--output must end in .safetensors")
+        }
+        return url
+    }
+
+    public var isBenchmark: Bool {
+        if case .klein(_, let config, _, _) = training { return config.benchmarkSteps != nil }
+        return false
+    }
+}

--- a/Sources/MereRunCore/LoRA/README.md
+++ b/Sources/MereRunCore/LoRA/README.md
@@ -7,3 +7,9 @@ This directory owns LoRA checkpoint loading, artifact management, and compatibil
 - compatibility helpers adapt external or legacy formats into mere.run's canonical shape
 
 This area is boundary-heavy. Prefer typed compatibility structs and narrow shims over pushing raw JSON dictionaries deeper into the runtime.
+
+`ImageLoRATrainingOptions` owns image recipe and training-option resolution.
+`ImageLoRATrainingPlan` prepares model metadata, datasets, and native trainer
+configurations. `ImageLoRATrainingOperation` owns dispatch and preview execution;
+callers own machine admission, dashboard tasks, and console output. See
+[shared image training execution](../../../docs/internals/image-training-execution.md).

--- a/Sources/MereRunCore/README.md
+++ b/Sources/MereRunCore/README.md
@@ -14,6 +14,9 @@ live in `MereRunQwenModel`. Gemma layers, caches, and draft computation live in
 Core retains resource loading and generation for these families.
 
 - `Generation.swift`: image and chat request/response contracts.
+- `TextLoRATrainingOptions.swift`, `TextLoRATrainingPlan.swift`, and
+  `TextLoRATrainingOperation.swift`: training validation, dataset snapshots,
+  native pipeline dispatch, and adapter-manifest publication.
 - `ChatRequestResolution.swift`: shared chat sampling defaults and numeric
   validation, with explicit CLI and OpenAI compatibility policies.
 - `NativeChatRuntime*.swift` and `ChatGenerationOperation.swift`: shared native

--- a/Sources/MereRunCore/TextLoRATrainingOperation+Native.swift
+++ b/Sources/MereRunCore/TextLoRATrainingOperation+Native.swift
@@ -1,0 +1,119 @@
+import Foundation
+
+extension TextLoRATrainingOperation {
+    /// Dispatches to the existing native pipelines without changing model math,
+    /// checkpoint loading or machine admission.
+    public static func train(
+        _ plan: TextLoRATrainingPlan,
+        progressHandler: (@Sendable (ChatProgress) -> Void)?,
+        trainingProgressHandler: (@Sendable (TextLoRATrainingProgress) -> Void)?
+    ) async throws -> TextLoRATrainingReport {
+        let options = plan.options
+        let config = TextLoRATrainingConfig(
+            trainingSteps: options.trainingSteps, batchSize: options.batchSize,
+            learningRate: options.learningRate, seed: options.seed,
+            resumeFrom: options.resumeFrom.map { URL(fileURLWithPath: $0).standardizedFileURL },
+            resumeStep: options.resumeStep
+        )
+        var metadata = ["adapter_name": options.adapterName, "dataset_fingerprint": plan.dataset.summary.fingerprint]
+        if let imageFingerprint = plan.dataset.summary.imageFingerprint {
+            metadata["dataset_image_fingerprint"] = imageFingerprint
+        }
+        switch plan.family {
+        case .gemma4:
+            return try await Gemma4TextLoRATrainingPipeline.train(
+                Gemma4TextLoRATrainingPipelineRequest(
+                    modelId: options.model,
+                    modelPath: options.modelPath,
+                    examples: plan.dataset.examples,
+                    evaluationExamples: plan.evaluationDataset?.examples ?? [],
+                    outputURL: plan.outputURL,
+                    trainingConfig: config,
+                    maxSequenceLength: options.maxSequenceLength,
+                    rank: options.rank,
+                    alpha: options.alpha ?? Float(options.rank),
+                    targetSuffixes: options.resolvedTargetModules(),
+                    metadata: metadata
+                ),
+                progressHandler: progressHandler,
+                trainingProgressHandler: trainingProgressHandler
+            )
+        case .gemma4VLM:
+            return try await Gemma4VLMLoRATrainingPipeline.train(
+                Gemma4VLMLoRATrainingPipelineRequest(
+                    modelId: options.model,
+                    modelPath: options.modelPath,
+                    examples: plan.dataset.examples,
+                    evaluationExamples: plan.evaluationDataset?.examples ?? [],
+                    trainingImageDigestsByPath: plan.dataset.imageDigestsByPath,
+                    evaluationImageDigestsByPath: plan.evaluationDataset?
+                        .imageDigestsByPath ?? [:],
+                    outputURL: plan.outputURL,
+                    trainingConfig: config,
+                    maxSequenceLength: options.maxSequenceLength,
+                    rank: options.rank,
+                    alpha: options.alpha ?? Float(options.rank),
+                    targetSuffixes: options.resolvedTargetModules(),
+                    metadata: metadata
+                ),
+                progressHandler: progressHandler,
+                trainingProgressHandler: trainingProgressHandler
+            )
+        case .lagunaXS:
+            return try await LagunaTextLoRATrainingPipeline.train(
+                LagunaTextLoRATrainingPipelineRequest(
+                    modelId: options.model,
+                    modelPath: options.modelPath,
+                    examples: plan.dataset.examples,
+                    evaluationExamples: plan.evaluationDataset?.examples ?? [],
+                    outputURL: plan.outputURL,
+                    trainingConfig: config,
+                    maxSequenceLength: options.maxSequenceLength,
+                    rank: options.rank,
+                    alpha: options.alpha ?? Float(options.rank),
+                    targetSuffixes: options.resolvedTargetModules(),
+                    metadata: metadata
+                ),
+                progressHandler: progressHandler,
+                trainingProgressHandler: trainingProgressHandler
+            )
+        case .inkling:
+            return try await InklingTextLoRATrainingPipeline.train(
+                InklingTextLoRATrainingPipelineRequest(
+                    modelId: options.model,
+                    modelPath: options.modelPath,
+                    examples: plan.dataset.examples,
+                    evaluationExamples: plan.evaluationDataset?.examples ?? [],
+                    outputURL: plan.outputURL,
+                    trainingConfig: config,
+                    maxSequenceLength: options.maxSequenceLength,
+                    reasoningEffort: options.reasoningEffort,
+                    rank: options.rank,
+                    alpha: options.alpha ?? Float(options.rank),
+                    targetSuffixes: options.resolvedTargetModules(),
+                    metadata: metadata
+                ),
+                progressHandler: progressHandler,
+                trainingProgressHandler: trainingProgressHandler
+            )
+        case .lfm2A1B:
+            return try await LFM2TextLoRATrainingPipeline.train(
+                LFM2TextLoRATrainingPipelineRequest(
+                    modelId: options.model,
+                    modelPath: options.modelPath,
+                    examples: plan.dataset.examples,
+                    evaluationExamples: plan.evaluationDataset?.examples ?? [],
+                    outputURL: plan.outputURL,
+                    trainingConfig: config,
+                    maxSequenceLength: options.maxSequenceLength,
+                    rank: options.rank,
+                    alpha: options.alpha ?? Float(options.rank),
+                    targetSuffixes: options.resolvedTargetModules(),
+                    metadata: metadata
+                ),
+                progressHandler: progressHandler,
+                trainingProgressHandler: trainingProgressHandler
+            )
+        }
+    }
+}

--- a/Sources/MereRunCore/TextLoRATrainingOperation.swift
+++ b/Sources/MereRunCore/TextLoRATrainingOperation.swift
@@ -1,0 +1,39 @@
+import Foundation
+
+public struct TextLoRATrainingOutcome: Sendable {
+    public let manifest: TextLoRATrainingManifest
+    public let report: TextLoRATrainingReport?
+}
+
+/// Owns training execution and adapter-manifest publication. Existing optimizer
+/// checkpoints remain the source of resumable training state.
+public enum TextLoRATrainingOperation {
+    public typealias Trainer = @Sendable (
+        TextLoRATrainingPlan, (@Sendable (ChatProgress) -> Void)?,
+        (@Sendable (TextLoRATrainingProgress) -> Void)?
+    ) async throws -> TextLoRATrainingReport
+
+    public static func execute(
+        _ plan: TextLoRATrainingPlan,
+        progressHandler: (@Sendable (ChatProgress) -> Void)? = nil,
+        trainingProgressHandler: (@Sendable (TextLoRATrainingProgress) -> Void)? = nil,
+        trainer: Trainer = train
+    ) async throws -> TextLoRATrainingOutcome {
+        try Task.checkCancellation()
+        try FileManager.default.createDirectory(at: plan.outputURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        let report: TextLoRATrainingReport?
+        do {
+            report = plan.options.dryRun ? nil : try await trainer(plan, progressHandler, trainingProgressHandler)
+            try Task.checkCancellation()
+        } catch {
+            if error is CancellationError || Task.isCancelled { throw CancellationError() }
+            throw error
+        }
+        let manifest = plan.options.makeManifest(
+            family: plan.family, outputURL: plan.outputURL, datasetSummary: plan.dataset.summary,
+            evalPromptCount: plan.evalPromptCount, status: plan.options.dryRun ? "prepared" : "trained"
+        )
+        try manifest.write(nextTo: plan.outputURL)
+        return TextLoRATrainingOutcome(manifest: manifest, report: report)
+    }
+}

--- a/Sources/MereRunCore/TextLoRATrainingOptions.swift
+++ b/Sources/MereRunCore/TextLoRATrainingOptions.swift
@@ -1,0 +1,226 @@
+import Foundation
+
+/// Training inputs shared by command and library callers. Viewer and output
+/// presentation options belong to the caller.
+public struct TextLoRATrainingOptions: Sendable {
+    public let data: String
+    public let output: String
+    public let model: String
+    public let modelPath: String?
+    public let eval: String?
+    public let adapterName: String
+    public let trainingSteps: Int
+    public let batchSize: Int
+    public let learningRate: Float
+    public let rank: Int
+    public let alpha: Float?
+    public let maxSequenceLength: Int
+    public let reasoningEffort: Double
+    public let seed: UInt64
+    public let resumeFrom: String?
+    public let resumeStep: Int?
+    public let targetModules: String?
+    public let dryRun: Bool
+
+    public init(
+        data: String,
+        output: String,
+        model: String = Gemma4Resources.twelveB4BitModelId,
+        modelPath: String? = nil,
+        eval: String? = nil,
+        adapterName: String = "local-assistant",
+        trainingSteps: Int = 600,
+        batchSize: Int = 1,
+        learningRate: Float = 0.0001,
+        rank: Int = 16,
+        alpha: Float? = nil,
+        maxSequenceLength: Int = 4096,
+        reasoningEffort: Double = 0.9,
+        seed: UInt64 = 42,
+        resumeFrom: String? = nil,
+        resumeStep: Int? = nil,
+        targetModules: String? = nil,
+        dryRun: Bool = false
+    ) {
+        self.data = data
+        self.output = output
+        self.model = model
+        self.modelPath = modelPath
+        self.eval = eval
+        self.adapterName = adapterName
+        self.trainingSteps = trainingSteps
+        self.batchSize = batchSize
+        self.learningRate = learningRate
+        self.rank = rank
+        self.alpha = alpha
+        self.maxSequenceLength = maxSequenceLength
+        self.reasoningEffort = reasoningEffort
+        self.seed = seed
+        self.resumeFrom = resumeFrom
+        self.resumeStep = resumeStep
+        self.targetModules = targetModules
+        self.dryRun = dryRun
+    }
+
+    public func validate() throws {
+        guard trainingSteps >= 1 else {
+            throw TextLoRATrainingIssue("--training-steps must be >= 1")
+        }
+        guard batchSize >= 1 else {
+            throw TextLoRATrainingIssue("--batch-size must be >= 1")
+        }
+        guard learningRate > 0 else {
+            throw TextLoRATrainingIssue("--learning-rate must be > 0")
+        }
+        guard rank >= 1 else {
+            throw TextLoRATrainingIssue("--rank must be >= 1")
+        }
+        if let alpha {
+            guard alpha > 0 else {
+                throw TextLoRATrainingIssue("--alpha must be > 0")
+            }
+        }
+        guard maxSequenceLength >= 128 else {
+            throw TextLoRATrainingIssue("--max-sequence-length must be >= 128")
+        }
+        guard (0...0.99).contains(reasoningEffort) else {
+            throw TextLoRATrainingIssue("--reasoning-effort must be between 0 and 0.99")
+        }
+        guard !resolvedTargetModules().isEmpty else {
+            throw TextLoRATrainingIssue("--target-modules must include at least one target suffix")
+        }
+        if let resumeStep {
+            guard resumeFrom != nil else {
+                throw TextLoRATrainingIssue("--resume-step requires --resume-from")
+            }
+            guard resumeStep > 0, resumeStep < trainingSteps else {
+                throw TextLoRATrainingIssue(
+                    "--resume-step must be greater than zero and below --training-steps"
+                )
+            }
+        }
+        if let resumeFrom {
+            guard !dryRun else {
+                throw TextLoRATrainingIssue("--resume-from cannot be combined with --dry-run")
+            }
+            let resumeURL = URL(fileURLWithPath: resumeFrom).standardizedFileURL
+            guard FileManager.default.fileExists(atPath: resumeURL.path) else {
+                throw TextLoRATrainingIssue("--resume-from checkpoint does not exist: \(resumeURL.path)")
+            }
+            guard resumeURL.pathExtension.lowercased() == "safetensors"
+                    || resumeURL.pathExtension.lowercased() == "zip" else {
+                throw TextLoRATrainingIssue("--resume-from must be a .safetensors or .zip checkpoint")
+            }
+            let outputURL = URL(fileURLWithPath: output).standardizedFileURL
+            guard resumeURL != outputURL else {
+                throw TextLoRATrainingIssue("--resume-from and --output must be different files")
+            }
+        }
+    }
+
+    func makeManifest(
+        family: TextLoRATrainingFamily,
+        outputURL: URL,
+        datasetSummary: TextSFTDatasetSummary,
+        evalPromptCount: Int?,
+        status: String
+    ) -> TextLoRATrainingManifest {
+        TextLoRATrainingManifest(
+            format: family.manifestFormat,
+            baseModel: model,
+            outputFile: outputURL.lastPathComponent,
+            adapterName: adapterName,
+            modality: family == .gemma4VLM ? "image" : nil,
+            trainingScope: family == .gemma4VLM ? "language_attention" : nil,
+            training: TextLoRATrainingManifest.Training(
+                trainingSteps: trainingSteps,
+                batchSize: batchSize,
+                learningRate: learningRate,
+                maxSequenceLength: maxSequenceLength,
+                reasoningEffort: family == .inkling ? reasoningEffort : nil,
+                seed: seed,
+                dataset: datasetSummary
+            ),
+            lora: TextLoRATrainingManifest.LoRA(
+                rank: rank,
+                alpha: alpha ?? Float(rank),
+                targetModules: resolvedTargetModules()
+            ),
+            evalPromptCount: evalPromptCount,
+            status: status
+        )
+    }
+
+    public func resolvedTargetModules() -> [String] {
+        let value = targetModules ?? Self.defaultTargetModules(for: model).joined(separator: ",")
+        return value
+            .split(separator: ",")
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+    }
+
+    public static func defaultTargetModules(for model: String) -> [String] {
+        if InklingResources.handles(modelSpec: model) {
+            return InklingTextLoRAInjector.defaultTargetSuffixes
+        }
+        if LFM2Resources.supportsTextLoRATraining(modelSpec: model) {
+            return LFM2TextLoRAInjector.defaultTargetSuffixes
+        }
+        return ["q_proj", "k_proj", "v_proj", "o_proj"]
+    }
+
+    public func resolvedTrainingFamily() throws -> TextLoRATrainingFamily {
+        if Gemma4Resources.handles(modelSpec: model) {
+            let family: TextLoRATrainingFamily = Gemma4Resources.supportsVision(modelSpec: model) ? .gemma4VLM : .gemma4
+            if family == .gemma4VLM, batchSize != 1 {
+                throw TextLoRATrainingIssue("Gemma 4 VLM LoRA training currently requires --batch-size 1")
+            }
+            return family
+        }
+        if LagunaResources.managedModelID(for: model) == LagunaResources.xsModelID {
+            return .lagunaXS
+        }
+        if InklingResources.handles(modelSpec: model) {
+            return .inkling
+        }
+        if LFM2Resources.supportsTextLoRATraining(modelSpec: model) {
+            return .lfm2A1B
+        }
+        throw TextLoRATrainingIssue(
+            "--model must be a supported Gemma 4 text or vision model, \(LagunaResources.xsModelID), "
+                + "\(InklingResources.modelID), or \(LFM2Resources.defaultModelId)."
+        )
+    }
+
+}
+
+public enum TextLoRATrainingFamily: Sendable, Equatable {
+    case gemma4
+    case gemma4VLM
+    case lagunaXS
+    case inkling
+    case lfm2A1B
+
+    public var manifestFormat: String {
+        switch self {
+        case .gemma4:
+            TextLoRATrainingManifest.gemma4Format
+        case .gemma4VLM:
+            TextLoRATrainingManifest.gemma4VLMFormat
+        case .lagunaXS:
+            TextLoRATrainingManifest.lagunaFormat
+        case .inkling:
+            TextLoRATrainingManifest.inklingFormat
+        case .lfm2A1B:
+            TextLoRATrainingManifest.lfm2Format
+        }
+    }
+}
+
+public struct TextLoRATrainingIssue: Error, LocalizedError, Sendable, CustomStringConvertible {
+    public let message: String
+
+    public init(_ message: String) { self.message = message }
+    public var errorDescription: String? { message }
+    public var description: String { message }
+}

--- a/Sources/MereRunCore/TextLoRATrainingPlan.swift
+++ b/Sources/MereRunCore/TextLoRATrainingPlan.swift
@@ -1,0 +1,28 @@
+import Foundation
+
+/// A validated dataset snapshot. Tensor loading, tokenization and optimizer
+/// checkpoint compatibility remain owned by each native training pipeline.
+public struct TextLoRATrainingPlan: Sendable {
+    public let options: TextLoRATrainingOptions
+    public let family: TextLoRATrainingFamily
+    public let dataURL: URL
+    public let outputURL: URL
+    public let dataset: TextSFTPreparedDataset
+    public let evaluationDataset: TextSFTPreparedDataset?
+
+    public var evalPromptCount: Int? { evaluationDataset?.examples.count }
+
+    public static func resolve(_ options: TextLoRATrainingOptions) throws -> Self {
+        try options.validate()
+        let family = try options.resolvedTrainingFamily()
+        let dataURL = URL(fileURLWithPath: options.data).standardizedFileURL
+        let outputURL = URL(fileURLWithPath: options.output).standardizedFileURL
+        let policy: TextSFTMediaPolicy = family == .gemma4VLM ? .requireSingleLocalImage : .forbid
+        let dataset = try TextSFTDataset.loadForTraining(from: dataURL, mediaPolicy: policy)
+        let evaluation = try options.eval.map {
+            try TextSFTDataset.loadForTraining(from: URL(fileURLWithPath: $0).standardizedFileURL, mediaPolicy: policy)
+        }
+        return Self(options: options, family: family, dataURL: dataURL, outputURL: outputURL,
+                    dataset: dataset, evaluationDataset: evaluation)
+    }
+}

--- a/Sources/MereRunExecution/README.md
+++ b/Sources/MereRunExecution/README.md
@@ -14,12 +14,15 @@ when its owner releases it. Recovery acquires the same lease before changing
 a nonterminal record to interrupted.
 
 `RunArtifact` hashes file contents in bounded chunks. `RunRecordCodec` writes
-records atomically with private file permissions. On Apple platforms it protects
-a new private temporary file with `completeUnlessOpen`, writes and synchronizes
-through its open descriptor, then renames it over the previous record and
-synchronizes the directory. Replacement does not open the previous protected
-record. `writeArtifact` returns the committed bytes' hash and size without
-reopening the new file.
+records atomically with private file permissions. On Apple volumes that report
+support for file protection, it applies `completeUnlessOpen` to a new private
+temporary file before writing sensitive bytes. On every filesystem, it writes
+and synchronizes through the open descriptor, then renames the file over the
+previous record and synchronizes the directory. Volumes without file protection
+retain private permissions (`0600`); they do not provide protection based on the
+device's lock state. Errors when applying supported protection propagate to the
+caller. Replacement does not open the previous protected record. `writeArtifact`
+returns the committed bytes' hash and size without reopening the new file.
 
 `readData` reports permission-denied reads with an unlock-or-permissions
 instruction. A failed read never establishes interruption or authorizes a
@@ -28,3 +31,8 @@ version must remain untouched. Reading closed protected records and assets can
 still require unlocking the device. Storage unit tests cover atomic replacement,
 permissions, protection metadata, hashes, and failure cleanup; they do not
 simulate device lock transitions.
+
+To exercise storage on a mounted test volume, set `MERERUN_TEST_STORAGE_ROOT`
+when running `swift test --filter RunStorageTests`. The tests create and remove
+their own directories under that path. Use a volume that supports file
+protection and one that does not to cover both storage capabilities.

--- a/Sources/MereRunExecution/README.md
+++ b/Sources/MereRunExecution/README.md
@@ -14,5 +14,17 @@ when its owner releases it. Recovery acquires the same lease before changing
 a nonterminal record to interrupted.
 
 `RunArtifact` hashes file contents in bounded chunks. `RunRecordCodec` writes
-records atomically with private file permissions. Callers validate the record
-version before recovery; an unknown version must remain untouched.
+records atomically with private file permissions. On Apple platforms it protects
+a new private temporary file with `completeUnlessOpen`, writes and synchronizes
+through its open descriptor, then renames it over the previous record and
+synchronizes the directory. Replacement does not open the previous protected
+record. `writeArtifact` returns the committed bytes' hash and size without
+reopening the new file.
+
+`readData` reports permission-denied reads with an unlock-or-permissions
+instruction. A failed read never establishes interruption or authorizes a
+record rewrite. Callers validate the record version before recovery; an unknown
+version must remain untouched. Reading closed protected records and assets can
+still require unlocking the device. Storage unit tests cover atomic replacement,
+permissions, protection metadata, hashes, and failure cleanup; they do not
+simulate device lock transitions.

--- a/Sources/MereRunExecution/RunFileWriter.swift
+++ b/Sources/MereRunExecution/RunFileWriter.swift
@@ -6,7 +6,7 @@ import Darwin
 import Glibc
 #endif
 
-/// Publishes a complete protected file without opening the previous version.
+/// Publishes a complete private file without opening the previous version.
 /// Operation owners retain their run lease around this write.
 enum RunFileWriter {
     static func write(_ data: Data, to destination: URL) throws -> RunArtifact {
@@ -24,9 +24,12 @@ enum RunFileWriter {
 #if canImport(Darwin)
         // Set protection before writing sensitive bytes. Keeping this descriptor
         // open lets the write finish if the device locks in the meantime.
-        try FileManager.default.setAttributes(
-            [.protectionKey: FileProtectionType.completeUnlessOpen], ofItemAtPath: temporary.path
-        )
+        let volume = try temporary.resourceValues(forKeys: [.volumeSupportsFileProtectionKey])
+        if volume.allValues[.volumeSupportsFileProtectionKey] as? Bool == true {
+            try FileManager.default.setAttributes(
+                [.protectionKey: FileProtectionType.completeUnlessOpen], ofItemAtPath: temporary.path
+            )
+        }
 #endif
         try handle.write(contentsOf: data)
         try handle.synchronize()

--- a/Sources/MereRunExecution/RunFileWriter.swift
+++ b/Sources/MereRunExecution/RunFileWriter.swift
@@ -1,0 +1,50 @@
+import Crypto
+import Foundation
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+/// Publishes a complete protected file without opening the previous version.
+/// Operation owners retain their run lease around this write.
+enum RunFileWriter {
+    static func write(_ data: Data, to destination: URL) throws -> RunArtifact {
+        let directory = destination.deletingLastPathComponent()
+        let temporary = directory.appendingPathComponent(".run-write-\(UUID().uuidString).tmp")
+        let descriptor = temporary.path.withCString {
+            open($0, O_CREAT | O_EXCL | O_RDWR | O_CLOEXEC | O_NOFOLLOW, S_IRUSR | S_IWUSR)
+        }
+        guard descriptor >= 0 else { throw posixError() }
+        let handle = FileHandle(fileDescriptor: descriptor, closeOnDealloc: true)
+        defer {
+            try? handle.close()
+            try? FileManager.default.removeItem(at: temporary)
+        }
+#if canImport(Darwin)
+        // Set protection before writing sensitive bytes. Keeping this descriptor
+        // open lets the write finish if the device locks in the meantime.
+        try FileManager.default.setAttributes(
+            [.protectionKey: FileProtectionType.completeUnlessOpen], ofItemAtPath: temporary.path
+        )
+#endif
+        try handle.write(contentsOf: data)
+        try handle.synchronize()
+        let result = temporary.path.withCString { source in
+            destination.path.withCString { target in rename(source, target) }
+        }
+        guard result == 0 else { throw posixError() }
+        let directoryDescriptor = directory.path.withCString { open($0, O_RDONLY | O_DIRECTORY | O_CLOEXEC) }
+        guard directoryDescriptor >= 0 else { throw posixError() }
+        defer { close(directoryDescriptor) }
+        guard fsync(directoryDescriptor) == 0 else { throw posixError() }
+        return RunArtifact(
+            url: destination, sha256: SHA256.hash(data: data).map { String(format: "%02x", $0) }.joined(),
+            byteCount: UInt64(data.count)
+        )
+    }
+
+    private static func posixError() -> POSIXError {
+        POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+    }
+}

--- a/Sources/MereRunExecution/RunRecordCodec.swift
+++ b/Sources/MereRunExecution/RunRecordCodec.swift
@@ -25,8 +25,33 @@ public enum RunRecordCodec {
         SHA256.hash(data: try encoder().encode(value)).map { String(format: "%02x", $0) }.joined()
     }
 
+    /// Reading a closed protected record can require unlocking the device.
+    /// Permission failures do not establish that a run was interrupted.
+    public static func readData(at url: URL) throws -> Data {
+        do {
+            return try Data(contentsOf: url)
+        } catch let error as CocoaError where error.code == .fileReadNoPermission {
+            throw RunRecordReadIssue(url: url)
+        } catch let error as POSIXError where error.code == .EACCES || error.code == .EPERM {
+            throw RunRecordReadIssue(url: url)
+        }
+    }
+
     public static func write(_ value: some Encodable, to url: URL) throws {
-        try encoder().encode(value).write(to: url, options: [.atomic, .completeFileProtectionUnlessOpen])
-        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: url.path)
+        _ = try writeArtifact(value, to: url)
+    }
+
+    /// Returns provenance from the bytes committed through the open writer.
+    /// A protected artifact need not be reopened after the device locks.
+    public static func writeArtifact(_ value: some Encodable, to url: URL) throws -> RunArtifact {
+        try RunFileWriter.write(encoder().encode(value), to: url)
+    }
+}
+
+public struct RunRecordReadIssue: LocalizedError, Sendable {
+    public let url: URL
+
+    public var errorDescription: String? {
+        "Cannot read run record: \(url.path). Unlock the device or check the file permissions, then retry."
     }
 }

--- a/Tests/MereRunCLITests/ImageTrainLoRACommandParsingTests.swift
+++ b/Tests/MereRunCLITests/ImageTrainLoRACommandParsingTests.swift
@@ -912,6 +912,70 @@ final class ImageTrainLoRACommandParsingTests: XCTestCase {
         return temp
     }
 
+    func testSavedRunPlanPreservesQuantizationAndReadsOlderPlans() throws {
+        for bits in [4, 8] {
+            let command = try ImageTrainLoRA.parse([
+                "--output", "/tmp/adapter.safetensors", "--synthetic-samples", "2",
+                "--base-quantization-bits", String(bits), "--recipe", "krea-fast-style",
+            ])
+            let plan = command.makeRunPlan(options: try command.resolvedTrainingOptions())
+            let encoded = try JSONEncoder().encode(plan.arguments)
+            let decoded = try JSONDecoder().decode(LoRATrainingRunPlanArguments.self, from: encoded)
+            let relocated = decoded.relocatingOutput(to: "/tmp/new/adapter.safetensors")
+            let replay = try ImageTrainLoRA.parse(relocated.trainLoRAArguments())
+            XCTAssertEqual(replay.trainingOptions().baseQuantizationBits, bits)
+            XCTAssertEqual(replay.output, "/tmp/new/adapter.safetensors")
+            XCTAssertEqual(try replay.resolvedTrainingOptions().learningRate, 0.0005)
+            // Removing an optional key reproduces a schema-v1 plan from before this field existed.
+            let text = String(decoding: encoded, as: UTF8.self)
+            let legacy = text.replacingOccurrences(of: "\"base_quantization_bits\":\(bits),", with: "")
+                .replacingOccurrences(of: ",\"base_quantization_bits\":\(bits)", with: "")
+            let older = try JSONDecoder().decode(LoRATrainingRunPlanArguments.self, from: Data(legacy.utf8))
+            XCTAssertNil(older.baseQuantizationBits)
+        }
+    }
+
+    func testCommandBuildsSharedKleinPlanWithNativeOverrides() throws {
+        let root = try makeTemporaryDirectory()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let model = root.appendingPathComponent("model")
+        try writeManifest(id: ModelResolver.ModelID.kleinBase9B.rawValue, family: .klein, to: model)
+        let data = root.appendingPathComponent("data")
+        try FileManager.default.createDirectory(at: data, withIntermediateDirectories: true)
+        try Data().write(to: data.appendingPathComponent("one.png"))
+        try "caption".write(to: data.appendingPathComponent("one.txt"), atomically: true, encoding: .utf8)
+        let command = try ImageTrainLoRA.parse([
+            "--data", data.path, "--model", model.path,
+            "--output", root.appendingPathComponent("adapter.safetensors").path,
+            "--rank", "8", "--alpha", "4", "--steps", "25", "--batch-size", "2",
+            "--width", "512", "--height", "256", "--max-text-length", "128",
+            "--lr", "0.0002", "--caption-dropout", "0.2", "--seed", "77",
+            "--gradient-checkpointing", "--low-ram", "--sample-interval", "5",
+            "--sample-model", model.path, "--sample-prompt", "explicit preview", "--sample-seed", "9",
+            "--lora-target-ranks", ".attn.to_q=32", "--timestep-sampling", "shift",
+        ])
+        let plan = try ImageLoRATrainingPlan.resolve(command.trainingOptions())
+        guard case .klein(_, let config, _, let sample) = plan.training else { return XCTFail("Expected Klein") }
+        XCTAssertEqual(config.width, 512)
+        XCTAssertEqual(config.height, 256)
+        XCTAssertEqual(config.trainingSteps, 25)
+        XCTAssertEqual(config.batchSize, 2)
+        XCTAssertEqual(config.maxTextLength, 128)
+        XCTAssertEqual(config.loraRank, 8)
+        XCTAssertEqual(config.loraAlpha, 4)
+        XCTAssertEqual(config.learningRate, 0.0002)
+        XCTAssertEqual(config.captionDropout, 0.2)
+        XCTAssertEqual(config.seed, 77)
+        XCTAssertTrue(config.gradientCheckpointing)
+        XCTAssertTrue(config.lowRam)
+        XCTAssertFalse(config.useCompile)
+        XCTAssertEqual(config.sampleInterval, 5)
+        XCTAssertEqual(config.loraTargetRankSuffixes?[".attn.to_q"], 32)
+        XCTAssertEqual(config.timestepSampling, .shift)
+        XCTAssertEqual(sample?.prompt, "explicit preview")
+        XCTAssertEqual(sample?.seed, 9)
+    }
+
     private func writeManifest(
         id: String,
         family: MereRunModelManifest.Family,

--- a/Tests/MereRunCLITests/MusicTrainingCompatibilityTests.swift
+++ b/Tests/MereRunCLITests/MusicTrainingCompatibilityTests.swift
@@ -1,0 +1,77 @@
+import ArgumentParser
+import Foundation
+import MereRunCore
+import XCTest
+@testable import MereRunCLI
+
+final class MusicTrainingCompatibilityTests: XCTestCase {
+    func testDefaults() throws {
+        let command = try MusicTrainAdapter.parse(["--dataset", "data.json", "--output", "out.safetensors"])
+        XCTAssertEqual(command.model, ModelResolver.ModelID.aceStep.rawValue)
+        XCTAssertEqual(command.kind, .lora)
+        XCTAssertEqual(command.rank, 8)
+        XCTAssertEqual(command.alpha, 16)
+        XCTAssertEqual(command.factor, -1)
+        XCTAssertEqual(command.steps, 1_000)
+        XCTAssertEqual(command.learningRate, 1e-4)
+        XCTAssertEqual(command.weightDecay, 1e-4)
+        XCTAssertEqual(command.seed, 42)
+        XCTAssertEqual(command.maxDurationSeconds, 30)
+        XCTAssertEqual(command.logEvery, 10)
+        XCTAssertEqual(command.decoderSubdirectory, "acestep-v15-turbo")
+        XCTAssertEqual(command.vaeSubdirectory, "vae")
+        XCTAssertNil(command.textSubdirectory)
+        XCTAssertNil(command.checkpointsRoot)
+    }
+
+    func testInvalidOptionsFailBeforeOpeningDataset() async throws {
+        for (arguments, message) in [
+            (["--kind", "auto"], "--kind must be lora or lokr."),
+            (["--max-duration", "0"], "--max-duration must be in (0, 600]."),
+            (["--max-duration", "601"], "--max-duration must be in (0, 600]."),
+            (["--log-every", "0"], "--log-every must be greater than zero."),
+        ] {
+            let command = try MusicTrainAdapter.parse(["--dataset", "/missing.json", "--output", "out.safetensors"] + arguments)
+            do {
+                try await command.run()
+                XCTFail("Expected validation failure")
+            } catch let error as ValidationError {
+                XCTAssertEqual(error.message, message)
+            }
+        }
+    }
+
+    func testArrayAndJSONLPreserveCaptionsAndLyrics() throws {
+        let record = #"{"audio":"sub/one.wav","caption":" caption ","lyrics":" lyric "}"#
+        for source in ["[\(record)]", "\n\(record)\n\n"] {
+            try withManifest(source) { url in
+                let records = try MusicTrainAdapter.loadManifest(from: url)
+                XCTAssertEqual(records.count, 1)
+                XCTAssertEqual(records[0].audio, "sub/one.wav")
+                XCTAssertEqual(records[0].caption, " caption ")
+                XCTAssertEqual(records[0].lyrics, " lyric ")
+            }
+        }
+    }
+
+    func testEmptyAndInvalidRecords() throws {
+        for (source, message) in [
+            ("[]", "Dataset manifest contains no examples."),
+            (#"[{"audio":" ","caption":"caption"}]"#, "Dataset record 1 has an empty audio path."),
+            (#"[{"audio":"one.wav","caption":" "}]"#, "Dataset record 1 has an empty caption."),
+        ] {
+            try withManifest(source) { url in
+                XCTAssertThrowsError(try MusicTrainAdapter.loadManifest(from: url)) { error in
+                    XCTAssertEqual((error as? ValidationError)?.message, message)
+                }
+            }
+        }
+    }
+
+    private func withManifest(_ source: String, body: (URL) throws -> Void) throws {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("music-training-\(UUID()).json")
+        defer { try? FileManager.default.removeItem(at: url) }
+        try source.write(to: url, atomically: true, encoding: .utf8)
+        try body(url)
+    }
+}

--- a/Tests/MereRunCLITests/SharedTranscriptionTests.swift
+++ b/Tests/MereRunCLITests/SharedTranscriptionTests.swift
@@ -26,6 +26,30 @@ final class SharedTranscriptionTests: XCTestCase {
         }
     }
 
+    func testExplicitModelIDsNeverBorrowAnInstalledDefaultCheckpoint() throws {
+        let audio = try audioFixture()
+        let root = try temporaryDirectory()
+        MereRunModelPaths.setProcessModelsDirOverride(root)
+        defer { MereRunModelPaths.setProcessModelsDirOverride(nil) }
+        for (id, backend, otherID) in [
+            (Qwen3ASRResources.defaultModelId, ASRBackend.qwen, "fixture/custom-qwen-asr"),
+            (ParakeetResources.defaultModelId, ASRBackend.parakeet, "fixture/custom-parakeet-asr")
+        ] {
+            let installed = MereRunModelPaths.modelDir(id)
+            try FileManager.default.createDirectory(at: installed, withIntermediateDirectories: true)
+            try Data("{}".utf8).write(to: installed.appendingPathComponent("config.json"))
+            let builtIn = try SpeechTranscriptionResolver.resolve(
+                request: .init(audioURL: audio, language: "en"), preferredBackend: backend, modelOverride: id
+            )
+            XCTAssertEqual(builtIn.modelPath, installed.path)
+            let explicit = try SpeechTranscriptionResolver.resolve(
+                request: .init(audioURL: audio, language: "en"), preferredBackend: backend, modelOverride: otherID
+            )
+            XCTAssertEqual(explicit.modelID, otherID)
+            XCTAssertNil(explicit.modelPath, "An explicit model ID must reach native resolution instead of loading the default weights")
+        }
+    }
+
     func testTranslationSwitchesBothBackendAndBuiltInModelIdentity() throws {
         let audio = try audioFixture()
         let request = ASRRequest(audioURL: audio, language: "en", task: .translate)

--- a/Tests/MereRunCLITests/TextTrainingCompatibilityTests.swift
+++ b/Tests/MereRunCLITests/TextTrainingCompatibilityTests.swift
@@ -1,0 +1,107 @@
+import ArgumentParser
+import Foundation
+import XCTest
+@testable import MereRunCLI
+@testable import MereRunCore
+
+final class TextTrainingCompatibilityTests: XCTestCase {
+    func testDashboardStopWaitsForServerCleanup() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let logger = try LoRATrainingEventLogger(baseOutputURL: root.appendingPathComponent("adapter.safetensors"))
+        let cleanup = TrainingViewerCleanup()
+        let server = Task {
+            do { try await Task.sleep(for: .seconds(30)) } catch { }
+            await cleanup.finish()
+        }
+        let visualization = TextLoRATrainingVisualization(logger: logger, serverTask: server)
+        await visualization.stop()
+        let finished = await cleanup.finished
+        XCTAssertTrue(finished)
+    }
+
+    func testTrainingKeepsProcessAdmissionAndDryRunBypass() {
+        let arguments = ["mere.run", "text", "train-lora", "--data", "pairs.jsonl", "--output", "adapter.safetensors"]
+        XCTAssertEqual(CLIInferenceAdmissionClassifier.request(arguments: arguments)?.resourceClass, .large)
+        XCTAssertNil(CLIInferenceAdmissionClassifier.request(arguments: arguments + ["--dry-run"]))
+    }
+
+    func testInvalidOptionsFailBeforeReadingData() async throws {
+        let cases: [([String], String)] = [
+            (["--steps", "0"], "--training-steps must be >= 1"),
+            (["--batch-size", "0"], "--batch-size must be >= 1"),
+            (["--lr", "0"], "--learning-rate must be > 0"),
+            (["--rank", "0"], "--rank must be >= 1"),
+            (["--alpha", "0"], "--alpha must be > 0"),
+            (["--max-sequence-length", "127"], "--max-sequence-length must be >= 128"),
+            (["--reasoning-effort", "1"], "--reasoning-effort must be between 0 and 0.99"),
+            (["--target-modules", " , "], "--target-modules must include at least one target suffix"),
+            (["--resume-step", "1"], "--resume-step requires --resume-from"),
+            (["--resume-from", "/missing.safetensors"], "--resume-from cannot be combined with --dry-run"),
+            (["--visualize"], "--visualize cannot be combined with --dry-run"),
+        ]
+        for (options, message) in cases {
+            let command = try TextTrainLoRA.parse([
+                "--data", "/missing.jsonl", "--output", "/missing.safetensors", "--dry-run",
+            ] + options)
+            do {
+                try await command.run()
+                XCTFail("Expected validation: \(message)")
+            } catch {
+                XCTAssertTrue(error is ValidationError)
+                XCTAssertEqual(String(describing: error), message)
+            }
+        }
+    }
+
+    func testDryRunPreservesAdapterAndWritesExistingManifestContract() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let data = root.appendingPathComponent("pairs.jsonl")
+        try Data(#"{"sources":["test"],"messages":[{"role":"system","content":"Be helpful"},{"role":"user","content":"Hello"},{"role":"assistant","content":"Hello there"}]}"#.utf8).write(to: data)
+        let output = root.appendingPathComponent("adapter.safetensors")
+        let original = Data("existing adapter".utf8)
+        try original.write(to: output)
+        let command = try TextTrainLoRA.parse([
+            "--data", data.path, "--eval", data.path, "--output", output.path,
+            "--rank", "8", "--target-modules", " q_proj, ,v_proj,q_proj ", "--dry-run", "--json",
+        ])
+        try await command.run()
+        XCTAssertEqual(try Data(contentsOf: output), original)
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let manifest = try decoder.decode(TextLoRATrainingManifest.self, from: Data(contentsOf: TextLoRATrainingManifest.url(nextTo: output)))
+        XCTAssertEqual(manifest.status, "prepared")
+        XCTAssertEqual(manifest.baseModel, Gemma4Resources.twelveB4BitModelId)
+        XCTAssertEqual(manifest.training.seed, 42)
+        XCTAssertEqual(manifest.training.learningRate, 0.0001)
+        XCTAssertEqual(manifest.lora.alpha, 8)
+        XCTAssertEqual(manifest.lora.targetModules, ["q_proj", "v_proj", "q_proj"])
+        XCTAssertEqual(manifest.evalPromptCount, 1)
+    }
+
+    func testEmptyDatasetFailsWithoutCreatingOutputDirectory() async throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        let data = root.appendingPathComponent("empty.jsonl")
+        try Data().write(to: data)
+        let outputDirectory = root.appendingPathComponent("output")
+        let command = try TextTrainLoRA.parse([
+            "--data", data.path, "--output", outputDirectory.appendingPathComponent("adapter.safetensors").path, "--dry-run",
+        ])
+        do {
+            try await command.run()
+            XCTFail("Expected an empty dataset error")
+        } catch {
+            XCTAssertTrue(error is TextSFTDatasetError)
+        }
+        XCTAssertFalse(FileManager.default.fileExists(atPath: outputDirectory.path))
+    }
+}
+
+private actor TrainingViewerCleanup {
+    var finished = false
+    func finish() { finished = true }
+}

--- a/Tests/MereRunCLITests/WorkflowOwnershipTests.swift
+++ b/Tests/MereRunCLITests/WorkflowOwnershipTests.swift
@@ -1,0 +1,158 @@
+import Foundation
+import XCTest
+@testable import MereRunCLI
+@testable import MereRunRelayKit
+
+final class WorkflowOwnershipTests: XCTestCase {
+    func testThrowingStreamCallbackStopsChildGroupAndRemovesRegistration() throws {
+        let root = try temporaryDirectory()
+        let node = root.appendingPathComponent("run/nodes/000-fixture")
+        try FileManager.default.createDirectory(at: node, withIntermediateDirectories: true)
+        let started = Date()
+        XCTAssertThrowsError(try WorkflowProcessRunner().run(
+            executable: URL(fileURLWithPath: "/bin/sh"),
+            arguments: ["-c", "(trap '' TERM; sleep 1; printf leaked > escaped.txt) & printf 'ready\\n'; wait"],
+            currentDirectory: node, timeoutSeconds: 5,
+            stdoutLineHandler: { _ in throw FixtureError.rejected }
+        )) { error in XCTAssertTrue(error is FixtureError) }
+        XCTAssertLessThan(Date().timeIntervalSince(started), 2)
+        XCTAssertTrue(WorkflowChildProcessRegistry.processIDs(in: root.appendingPathComponent("run")).isEmpty)
+        Thread.sleep(forTimeInterval: 1.1)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: node.appendingPathComponent("escaped.txt").path))
+    }
+
+    func testUnterminatedStdoutIsBoundedAndNeverReturnedAsSuccess() throws {
+        let root = try temporaryDirectory()
+        let node = root.appendingPathComponent("run/nodes/000-fixture")
+        try FileManager.default.createDirectory(at: node, withIntermediateDirectories: true)
+        XCTAssertThrowsError(try WorkflowProcessRunner(maximumStdoutBytes: 4096).run(
+            executable: URL(fileURLWithPath: "/bin/sh"),
+            arguments: ["-c", "head -c 1048576 /dev/zero; sleep 30"],
+            currentDirectory: node, timeoutSeconds: 5, stdoutLineHandler: { _ in XCTFail("No complete line") }
+        )) { error in XCTAssertEqual((error as? WorkflowProcessOutputLimitError)?.limit, 4096) }
+        XCTAssertTrue(WorkflowChildProcessRegistry.processIDs(in: root.appendingPathComponent("run")).isEmpty)
+    }
+
+    func testCancellationWithoutDeadlineStopsSilentProcess() async throws {
+        let root = try temporaryDirectory()
+        let run = root.appendingPathComponent("run")
+        let node = run.appendingPathComponent("nodes/000-fixture")
+        try FileManager.default.createDirectory(at: node, withIntermediateDirectories: true)
+        let task = Task.detached {
+            try WorkflowProcessRunner().run(
+                executable: URL(fileURLWithPath: "/bin/sleep"), arguments: ["30"],
+                currentDirectory: node, timeoutSeconds: nil, stdoutLineHandler: nil
+            )
+        }
+        defer { task.cancel() }
+        for _ in 0..<200 {
+            if !WorkflowChildProcessRegistry.processIDs(in: run).isEmpty { break }
+            try await Task.sleep(nanoseconds: 10_000_000)
+        }
+        XCTAssertFalse(WorkflowChildProcessRegistry.processIDs(in: run).isEmpty)
+        task.cancel()
+        do {
+            _ = try await task.value
+            XCTFail("Expected cancellation")
+        } catch { XCTAssertTrue(error is WorkflowCancellationError) }
+        XCTAssertTrue(WorkflowChildProcessRegistry.processIDs(in: run).isEmpty)
+    }
+
+    func testRunLeaseRejectsSecondOwnerWithoutClearingCancellationOrEvents() throws {
+        let fixture = try bundleFixture()
+        let run = fixture.root.appendingPathComponent("run")
+        let first = store(bundle: fixture.bundle, run: run, resume: false)
+        let session = try first.prepare(graph: fixture.bundle.graph, job: fixture.bundle.job, order: ["text"])
+        defer { session.lease.release() }
+        try first.persist(session.manifest)
+        let cancel = run.appendingPathComponent("cancel.request")
+        try Data("cancel".utf8).write(to: cancel)
+        let marker = run.appendingPathComponent("events.jsonl")
+        try Data("previous event\n".utf8).write(to: marker)
+        let record = run.appendingPathComponent(GraphRunManifest.filename)
+        let original = try Data(contentsOf: record)
+        let second = store(bundle: fixture.bundle, run: run, resume: true)
+        XCTAssertThrowsError(try second.prepare(graph: fixture.bundle.graph, job: fixture.bundle.job, order: ["text"])) { error in
+            XCTAssertTrue(String(describing: error).contains("active worker"))
+        }
+        XCTAssertEqual(try Data(contentsOf: record), original)
+        XCTAssertEqual(try String(contentsOf: marker, encoding: .utf8), "previous event\n")
+        XCTAssertTrue(FileManager.default.fileExists(atPath: cancel.path))
+        session.lease.release()
+        let livePID = ProcessInfo.processInfo.processIdentifier
+        try WorkflowChildProcessRegistry.register(livePID, in: run)
+        XCTAssertThrowsError(try second.prepare(graph: fixture.bundle.graph, job: fixture.bundle.job, order: ["text"])) { error in
+            XCTAssertTrue(String(describing: error).contains("active child processes"))
+        }
+        XCTAssertTrue(FileManager.default.fileExists(atPath: cancel.path))
+        WorkflowChildProcessRegistry.unregister(livePID, in: run)
+        let resumed = try second.prepare(graph: fixture.bundle.graph, job: fixture.bundle.job, order: ["text"])
+        defer { resumed.lease.release() }
+        XCTAssertEqual(resumed.manifest.attempt, 2)
+    }
+
+    func testResumeRejectsChangedInputBeforeMutatingPreviousRun() throws {
+        let fixture = try bundleFixture()
+        let run = fixture.root.appendingPathComponent("run")
+        let first = store(bundle: fixture.bundle, run: run, resume: false)
+        let session = try first.prepare(graph: fixture.bundle.graph, job: fixture.bundle.job, order: ["text"])
+        try first.persist(session.manifest)
+        session.lease.release()
+        let cancel = run.appendingPathComponent("cancel.request")
+        try Data().write(to: cancel)
+        let record = run.appendingPathComponent(GraphRunManifest.filename)
+        let original = try Data(contentsOf: record)
+        let different = try WorkflowBundleMaterializer(
+            graph: fixture.bundle.graph, suppliedInputs: .init(values: ["prompt": .string("different")]),
+            destination: fixture.root.appendingPathComponent("other-bundle"), seed: { 42 }
+        ).materialize()
+        XCTAssertThrowsError(try store(bundle: different, run: run, resume: true).prepare(
+            graph: different.graph, job: different.job, order: ["text"]
+        )) { error in XCTAssertTrue(String(describing: error).contains("input fingerprint changed")) }
+        XCTAssertEqual(try Data(contentsOf: record), original)
+        XCTAssertTrue(FileManager.default.fileExists(atPath: cancel.path))
+    }
+
+    func testArtifactOwnershipRejectsSymlinkEscapesBeforeCleanup() throws {
+        let root = try temporaryDirectory()
+        let run = root.appendingPathComponent("run")
+        let node = run.appendingPathComponent("nodes/000-fixture")
+        let outside = root.appendingPathComponent("outside")
+        try FileManager.default.createDirectory(at: node, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: outside, withIntermediateDirectories: true)
+        let keep = outside.appendingPathComponent("keep.txt")
+        try Data("keep".utf8).write(to: keep)
+        try FileManager.default.createSymbolicLink(at: node.appendingPathComponent("escape"), withDestinationURL: outside)
+        let artifacts = WorkflowArtifactStore(bundleDirectory: root, runDirectory: run, cacheDirectory: nil, resume: false, fileManager: .default)
+        let outputs = ["file": WorkflowInvocationOutput(type: .asset, path: "escape/keep.txt", optional: false, contentTypes: [])]
+        XCTAssertThrowsError(try artifacts.invocationOutputURL("escape/keep.txt", nodeDirectory: node))
+        XCTAssertThrowsError(try artifacts.clearAttemptOutputs(outputs, nodeDirectory: node))
+        XCTAssertThrowsError(try artifacts.artifactURL(for: "nodes/000-fixture/escape/keep.txt"))
+        XCTAssertEqual(try Data(contentsOf: keep), Data("keep".utf8))
+    }
+
+    private enum FixtureError: Error { case rejected }
+
+    private func store(bundle: WorkflowBundleMaterialization, run: URL, resume: Bool) -> WorkflowRunStore {
+        .init(bundleDirectory: bundle.directory, runDirectory: run, resume: resume,
+              executor: .init(kind: "local", profile: nil, jobReference: nil),
+              fileManager: .default, now: Date.init, eventHandler: nil)
+    }
+
+    private func bundleFixture() throws -> (root: URL, bundle: WorkflowBundleMaterialization) {
+        let root = try temporaryDirectory()
+        let graph = try JSONDecoder().decode(WorkflowGraphDocument.self, from: Data(#"{"schema_version":1,"kind":"mere.run/workflow-graph","name":"ownership","inputs":{"prompt":{"type":"string"}},"nodes":[{"id":"text","kind":"text.value","arguments":{"value":{"$ref":"inputs.prompt"}}}],"outputs":{"text":{"$ref":"nodes.text.outputs.text"}}}"#.utf8))
+        let bundle = try WorkflowBundleMaterializer(
+            graph: graph, suppliedInputs: .init(values: ["prompt": .string("hello")]),
+            destination: root.appendingPathComponent("bundle"), seed: { 42 }
+        ).materialize()
+        return (root, bundle)
+    }
+
+    private func temporaryDirectory() throws -> URL {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: root) }
+        return root
+    }
+}

--- a/Tests/MereRunCoreTests/ACEStepAdapterTrainingOperationTests.swift
+++ b/Tests/MereRunCoreTests/ACEStepAdapterTrainingOperationTests.swift
@@ -1,0 +1,126 @@
+import Foundation
+import MediaIO
+import XCTest
+@testable import MereRunCore
+
+final class ACEStepAdapterTrainingOperationTests: XCTestCase {
+    func testPlanResolvesPathsWithoutLoadingAudioOrModel() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let plan = fixture.plan
+        XCTAssertEqual(plan.audioURL(for: plan.records[0]), fixture.root.appendingPathComponent("one.wav"))
+        XCTAssertEqual(plan.audioURL(for: .init(audio: "~/one.wav", caption: "a")),
+                       URL(fileURLWithPath: NSHomeDirectory()).appendingPathComponent("one.wav"))
+        XCTAssertEqual(plan.audioURL(for: .init(audio: "/tmp/one.wav", caption: "a")), URL(fileURLWithPath: "/tmp/one.wav"))
+        XCTAssertFalse(FileManager.default.fileExists(atPath: plan.outputURL.deletingLastPathComponent().path))
+        XCTAssertEqual(plan.options.maximumAudioFrames, 480)
+    }
+
+    func testAudioPreparationPreservesStereoAndCrops() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let source = fixture.root.appendingPathComponent("one.wav")
+        try MediaAudioIO.writeFloatWAV(
+            samples: (0..<960).flatMap { _ in [Float(0.25), Float(-0.5)] },
+            sampleRate: 48_000, channels: 2, to: source
+        )
+        let examples = try ACEStepAdapterTrainingOperation.prepareExamples(fixture.plan)
+        XCTAssertEqual(examples.count, 1)
+        XCTAssertEqual(examples[0].audio48kHz.shape, [1, 480, 2])
+        XCTAssertEqual(Array(examples[0].audio48kHz.asArray(Float.self).prefix(2)), [0.25, -0.5])
+        XCTAssertEqual(examples[0].caption, " caption ")
+        XCTAssertEqual(examples[0].lyrics, "")
+    }
+
+    func testExecutionForwardsPlanAndProgressThenFinishes() async throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let received = expectation(description: "Progress forwarded")
+        let report = try await ACEStepAdapterTrainingOperation.execute(
+            fixture.plan, progress: { update in
+                XCTAssertEqual(update.step, 3)
+                received.fulfill()
+            }, trainer: { plan, progress in
+                XCTAssertEqual(plan.options.configuration.kind, .lokr)
+                XCTAssertEqual(plan.options.configuration.rank, 4)
+                XCTAssertEqual(plan.options.configuration.factor, 2)
+                XCTAssertEqual(plan.options.model, "/fixture/model")
+                XCTAssertEqual(plan.records[0].caption, " caption ")
+                progress?(.init(step: 3, totalSteps: 3, loss: 0.5))
+                try Data("adapter".utf8).write(to: plan.outputURL)
+                return Self.report()
+            }
+        )
+        XCTAssertEqual(report.finalLoss, 0.5)
+        let events = try events(fixture.plan)
+        XCTAssertEqual(events.map(\.type), ["run_started", "progress", "run_finished"])
+        XCTAssertEqual(events.last?.metadata["sha256"], "fixture-digest")
+        await fulfillment(of: [received], timeout: 1)
+    }
+
+    func testFailureAndCancellationDoNotRecordSuccess() async throws {
+        for cancellation in [false, true] {
+            let fixture = try makeFixture()
+            defer { try? FileManager.default.removeItem(at: fixture.root) }
+            let task = Task {
+                try await ACEStepAdapterTrainingOperation.execute(fixture.plan, trainer: { _, _ in
+                    if cancellation { withUnsafeCurrentTask { $0?.cancel() } }
+                    throw FixtureError.failed
+                })
+            }
+            do {
+                _ = try await task.value
+                XCTFail("Expected failure")
+            } catch {
+                XCTAssertEqual(error is CancellationError, cancellation)
+            }
+            XCTAssertEqual(try events(fixture.plan).map(\.type), ["run_started", "run_failed"])
+            XCTAssertFalse(FileManager.default.fileExists(atPath: fixture.plan.outputURL.path))
+        }
+    }
+
+    func testCancelledTaskCannotStartOrPublishSuccess() async throws {
+        for cancelBefore in [true, false] {
+            let fixture = try makeFixture()
+            defer { try? FileManager.default.removeItem(at: fixture.root) }
+            let trainer: ACEStepAdapterTrainingOperation.Trainer = { _, _ in
+                XCTAssertFalse(cancelBefore)
+                withUnsafeCurrentTask { $0?.cancel() }
+                return Self.report()
+            }
+            let plan = fixture.plan
+            let task = Task {
+                if cancelBefore { withUnsafeCurrentTask { $0?.cancel() } }
+                return try await ACEStepAdapterTrainingOperation.execute(plan, trainer: trainer)
+            }
+            do {
+                _ = try await task.value
+                XCTFail("Expected cancellation")
+            } catch { XCTAssertTrue(error is CancellationError) }
+            XCTAssertEqual(try events(fixture.plan).map(\.type), cancelBefore ? [] : ["run_started", "run_failed"])
+        }
+    }
+
+    private enum FixtureError: Error { case failed }
+
+    private static func report() -> ACEStepAdapterTrainingReport {
+        .init(kind: .lokr, layerCount: 2, trainingSteps: 3, initialLoss: 1, finalLoss: 0.5, outputSHA256: "fixture-digest")
+    }
+
+    private func events(_ plan: ACEStepAdapterTrainingPlan) throws -> [LoRATrainingRunEvent] {
+        try LoRATrainingRunEvent.load(from: LoRATrainingRunEvent.url(nextTo: plan.outputURL))
+    }
+
+    private func makeFixture() throws -> (root: URL, plan: ACEStepAdapterTrainingPlan) {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let manifest = root.appendingPathComponent("data.json")
+        try #"[{"audio":"one.wav","caption":" caption "}]"#.write(to: manifest, atomically: true, encoding: .utf8)
+        let plan = try ACEStepAdapterTrainingPlan.resolve(.init(
+            dataset: manifest.path, output: root.appendingPathComponent("output/adapter.safetensors").path,
+            model: "/fixture/model", configuration: .init(kind: .lokr, rank: 4, factor: 2, trainingSteps: 3),
+            maxDurationSeconds: 0.01
+        ))
+        return (root, plan)
+    }
+}

--- a/Tests/MereRunCoreTests/ImageLoRATrainingOperationTests.swift
+++ b/Tests/MereRunCoreTests/ImageLoRATrainingOperationTests.swift
@@ -1,0 +1,227 @@
+import Foundation
+import XCTest
+@testable import MereRunCore
+
+final class ImageLoRATrainingOperationTests: XCTestCase {
+    func testKreaPlanPreservesRecipeAndSyntheticConfiguration() throws {
+        let fixture = try makeFixture(family: .krea)
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        var options = fixture.options
+        options.recipe = "krea-cinematic-style"
+        options.syntheticSamples = 2
+        options.baseQuantizationBits = 4
+        options.lite = true
+        options.seed = 7
+        let plan = try ImageLoRATrainingPlan.resolve(options)
+        guard case .krea(let examples, let config) = plan.training else { return XCTFail("Expected Krea") }
+        XCTAssertTrue(examples.isEmpty)
+        XCTAssertNil(config.datasetRoot)
+        XCTAssertEqual(config.width, 768)
+        XCTAssertEqual(config.height, 416)
+        XCTAssertEqual(config.trainingSteps, 200)
+        XCTAssertEqual(config.learningRate, 0.0001)
+        XCTAssertEqual(config.loraRank, 32)
+        XCTAssertEqual(config.loraAlpha, 32)
+        XCTAssertEqual(config.lrWarmupSteps, 20)
+        XCTAssertTrue(config.useCosineScheduler)
+        XCTAssertEqual(config.lrMinFactor, 0)
+        XCTAssertFalse(config.useCompile)
+        XCTAssertEqual(config.syntheticSampleCount, 2)
+        XCTAssertEqual(config.baseQuantizationBits, 4)
+        XCTAssertEqual(config.loraTargetSuffixes, Krea2LoRAInjector.liteTargetSuffixes)
+        XCTAssertEqual(config.seed, 7)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: plan.outputURL.deletingLastPathComponent().path))
+    }
+
+    func testKleinPlanPreservesRankPresetResumeAndBenchmarkInputs() throws {
+        let fixture = try makeFixture(family: .klein)
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        var options = fixture.options
+        let resume = fixture.root.appendingPathComponent("resume.safetensors")
+        try Data("optimizer state fixture".utf8).write(to: resume)
+        options.resumeFrom = resume.path
+        options.loraRankPreset = "flux2-style-128"
+        options.gradientCheckpointing = true
+        options.progressive = true
+        options.lowRam = true
+        options.benchmarkSteps = 3
+        options.benchmarkWarmupSteps = 2
+        options.timestepSampling = "logitNormal"
+        options.timestepLossWeighting = "weighted"
+        options.lossWeighting = "minSNR"
+        options.timestepLow = 10
+        options.timestepHigh = 900
+        options.lrWarmupSteps = 4
+        options.lrMinFactor = 0.2
+        options.adamWeightDecay = 0.03
+        let plan = try ImageLoRATrainingPlan.resolve(options)
+        guard case .klein(let examples, let config, let checkpoint, let sample) = plan.training else {
+            return XCTFail("Expected Klein")
+        }
+        XCTAssertEqual(examples.map(\.caption), ["training caption"])
+        XCTAssertEqual(config.datasetRoot, options.data)
+        XCTAssertEqual(config.loraRank, 128)
+        XCTAssertEqual(config.loraAlpha, 64)
+        XCTAssertEqual(config.loraTargetRankSuffixes?[".attn.to_q"], 128)
+        XCTAssertEqual(checkpoint, resume)
+        XCTAssertNil(sample)
+        XCTAssertTrue(plan.isBenchmark)
+        XCTAssertEqual(config.trainingSteps, 5)
+        XCTAssertEqual(config.benchmarkSteps, 3)
+        XCTAssertEqual(config.benchmarkWarmupSteps, 2)
+        XCTAssertTrue(config.gradientCheckpointing)
+        XCTAssertFalse(config.useCompile)
+        XCTAssertTrue(config.progressive)
+        XCTAssertTrue(config.lowRam)
+        XCTAssertEqual(config.timestepSampling, .logitNormal)
+        XCTAssertEqual(config.timestepLossWeighting, .weighted)
+        XCTAssertEqual(config.lossWeighting, .minSNR)
+        XCTAssertEqual(config.timestepLow, 10)
+        XCTAssertEqual(config.timestepHigh, 900)
+        XCTAssertEqual(config.lrWarmupSteps, 4)
+        XCTAssertEqual(config.lrMinFactor, 0.2)
+        XCTAssertEqual(config.adamWeightDecay, 0.03)
+    }
+
+    func testKleinRecipeAndPreviewPlanUseCaptionFallbackAndExplicitOverrides() throws {
+        let fixture = try makeFixture(family: .klein)
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        var options = fixture.options
+        options.recipe = "klein-fast-style"
+        options.widthOverride = 512
+        options.heightOverride = 256
+        options.rankOverride = 8
+        options.sampleInterval = 3
+        options.sampleModel = options.model
+        options.sampleSteps = 4
+        options.sampleGuidanceScale = 1.5
+        options.sampleLoRAScale = 0.7
+        options.sampleSeed = 11
+        let plan = try ImageLoRATrainingPlan.resolve(options)
+        guard case .klein(_, let config, _, let sample) = plan.training else { return XCTFail("Expected Klein") }
+        XCTAssertEqual(config.loraRank, 8)
+        XCTAssertEqual(config.loraAlpha, 8)
+        XCTAssertEqual(config.loraTargetRanks?.count, 120)
+        XCTAssertEqual(config.loraTargetRanks?["x_embedder"], 8)
+        XCTAssertEqual(config.checkpointInterval, 250)
+        XCTAssertEqual(config.maxResolution, 512)
+        XCTAssertTrue(config.lowRam)
+        XCTAssertFalse(config.useCompile)
+        let preview = try XCTUnwrap(sample)
+        XCTAssertEqual(preview.prompt, "training caption")
+        XCTAssertEqual(preview.modelPath, options.model)
+        XCTAssertEqual(preview.width, 512)
+        XCTAssertEqual(preview.height, 256)
+        XCTAssertEqual(preview.steps, 4)
+        XCTAssertEqual(preview.guidanceScale, 1.5)
+        XCTAssertEqual(preview.loraScale, 0.7)
+        XCTAssertEqual(preview.seed, 11)
+    }
+
+    func testPlanRetainsCaptionSnapshotAndExcludesPreviews() throws {
+        let fixture = try makeFixture(family: .krea)
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let data = URL(fileURLWithPath: try XCTUnwrap(fixture.options.data))
+        try Data().write(to: data.appendingPathComponent("preview1.png"))
+        try "preview".write(to: data.appendingPathComponent("preview1.txt"), atomically: true, encoding: .utf8)
+        var options = fixture.options
+        options.excludePreviewImages = true
+        let plan = try ImageLoRATrainingPlan.resolve(options)
+        try "changed".write(to: data.appendingPathComponent("one.txt"), atomically: true, encoding: .utf8)
+        guard case .krea(let examples, let config) = plan.training else { return XCTFail("Expected Krea") }
+        XCTAssertEqual(examples.map(\.caption), ["training caption"])
+        XCTAssertEqual(config.datasetRoot, data.path)
+    }
+
+    func testFamilyAndTargetValidationRunWithoutLoadingWeights() throws {
+        let krea = try makeFixture(family: .krea)
+        defer { try? FileManager.default.removeItem(at: krea.root) }
+        var invalid = krea.options
+        invalid.checkpointInterval = 2
+        XCTAssertThrowsError(try ImageLoRATrainingPlan.resolve(invalid)) { error in
+            XCTAssertEqual(error.localizedDescription, "--checkpoint-interval is only supported for FLUX.2 Klein LoRA training")
+        }
+        invalid = krea.options
+        invalid.samplePrompt = "preview"
+        XCTAssertThrowsError(try ImageLoRATrainingPlan.resolve(invalid)) { error in
+            XCTAssertEqual(error.localizedDescription, "Klein training options require a FLUX.2 Klein base model.")
+        }
+        let klein = try makeFixture(family: .klein)
+        defer { try? FileManager.default.removeItem(at: klein.root) }
+        invalid = klein.options
+        invalid.baseQuantizationBits = 4
+        XCTAssertThrowsError(try ImageLoRATrainingPlan.resolve(invalid)) { error in
+            XCTAssertEqual(error.localizedDescription, "--base-quantization-bits is only supported for Krea 2 LoRA training")
+        }
+        invalid = klein.options
+        invalid.timestepSampling = "unsupported"
+        XCTAssertThrowsError(try ImageLoRATrainingPlan.resolve(invalid)) { error in
+            XCTAssertEqual(error.localizedDescription, "Unsupported --timestep-sampling 'unsupported'")
+        }
+    }
+
+    func testOperationForwardsPreparedInputsAndReturnsSavedOrBenchmarkOutcome() async throws {
+        for benchmark in [false, true] {
+            let fixture = try makeFixture(family: .klein)
+            defer { try? FileManager.default.removeItem(at: fixture.root) }
+            var options = fixture.options
+            if benchmark { options.benchmarkSteps = 2 }
+            let plan = try ImageLoRATrainingPlan.resolve(options)
+            let progressReceived = expectation(description: "Training progress forwarded")
+            let outcome = try await ImageLoRATrainingOperation.execute(plan, progress: { update in
+                if case .klein = update { progressReceived.fulfill() }
+            }, trainer: { received, progress in
+                XCTAssertEqual(received.outputURL, plan.outputURL)
+                XCTAssertEqual(received.modelRoot, plan.modelRoot)
+                XCTAssertEqual(received.isBenchmark, benchmark)
+                progress?(.klein(.init(stage: .saving, fraction: 1)))
+                if !benchmark { try Data("adapter".utf8).write(to: received.outputURL) }
+            })
+            XCTAssertEqual(outcome, benchmark ? .benchmark : .saved(plan.outputURL))
+            XCTAssertEqual(FileManager.default.fileExists(atPath: plan.outputURL.path), !benchmark)
+            await fulfillment(of: [progressReceived], timeout: 1)
+        }
+    }
+
+    func testCancellationCannotStartTrainerOrReturnSavedOutcome() async throws {
+        for cancelBefore in [false, true] {
+            let fixture = try makeFixture(family: .krea)
+            defer { try? FileManager.default.removeItem(at: fixture.root) }
+            let plan = try ImageLoRATrainingPlan.resolve(fixture.options)
+            let trainer: ImageLoRATrainingOperation.Trainer = { _, _ in
+                XCTAssertFalse(cancelBefore)
+                withUnsafeCurrentTask { $0?.cancel() }
+            }
+            let task = Task {
+                if cancelBefore { withUnsafeCurrentTask { $0?.cancel() } }
+                return try await ImageLoRATrainingOperation.execute(plan, trainer: trainer)
+            }
+            do {
+                _ = try await task.value
+                XCTFail("Expected cancellation")
+            } catch { XCTAssertTrue(error is CancellationError) }
+            XCTAssertFalse(FileManager.default.fileExists(atPath: plan.outputURL.path))
+            if cancelBefore {
+                XCTAssertFalse(FileManager.default.fileExists(atPath: plan.outputURL.deletingLastPathComponent().path))
+            }
+        }
+    }
+
+    private func makeFixture(family: MereRunModelManifest.Family) throws -> (root: URL, options: ImageLoRATrainingOptions) {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let model = root.appendingPathComponent("model")
+        let data = root.appendingPathComponent("data")
+        try FileManager.default.createDirectory(at: model, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: data, withIntermediateDirectories: true)
+        let manifest = MereRunModelManifest(
+            id: family == .krea ? ModelResolver.ModelID.krea2Raw.rawValue : ModelResolver.ModelID.kleinBase9B.rawValue,
+            family: family, variant: .base, precision: .bf16, supports: [.loraTraining]
+        )
+        try JSONEncoder().encode(manifest).write(to: model.appendingPathComponent(MereRunModelManifest.filename))
+        try Data().write(to: data.appendingPathComponent("one.png"))
+        try "training caption".write(to: data.appendingPathComponent("one.txt"), atomically: true, encoding: .utf8)
+        var options = ImageLoRATrainingOptions(data: data.path, output: root.appendingPathComponent("output/adapter.safetensors").path)
+        options.model = model.path
+        return (root, options)
+    }
+}

--- a/Tests/MereRunCoreTests/ImageRunRecordTests.swift
+++ b/Tests/MereRunCoreTests/ImageRunRecordTests.swift
@@ -95,6 +95,30 @@ final class ImageRunRecordTests: XCTestCase {
         }
     }
 
+    func testCancelledExecutorErrorRetainsCancelledRunState() async throws {
+        let root = try temporaryDirectory()
+        let options = ImageGenerationOptions(prompt: "A camera", outputURL: root.appendingPathComponent("result.png"), seed: 42)
+        let plan = try ImageGenerationPlan.resolve(options, modelRoot: root, manifest: .init(id: "fixture", family: .zimage))
+        let directory = root.appendingPathComponent("cancelled")
+        let session = try ImageRunSession(directory: directory, requested: options, modelSelector: "fixture")
+        let task = Task {
+            try await ImageGenerationOperation.execute(plan, recording: session, executor: { _, _, _ in
+                withUnsafeCurrentTask { $0?.cancel() }
+                throw URLError(.cancelled)
+            })
+        }
+        do {
+            _ = try await task.value
+            XCTFail("Expected cancellation")
+        } catch {
+            XCTAssertTrue(error is CancellationError)
+        }
+        let record = try ImageRunRecord.inspect(at: directory)
+        XCTAssertEqual(record.state, .cancelled)
+        XCTAssertEqual(record.issue?.code, "cancelled")
+        XCTAssertTrue(record.artifacts.isEmpty)
+    }
+
     func testOutputFailureCannotCreateSuccessfulRecord() async throws {
         let root = try temporaryDirectory()
         let options = ImageGenerationOptions(prompt: "A camera", outputURL: root.appendingPathComponent("missing.png"), seed: 1)

--- a/Tests/MereRunCoreTests/TextLoRATrainingOperationTests.swift
+++ b/Tests/MereRunCoreTests/TextLoRATrainingOperationTests.swift
@@ -1,0 +1,171 @@
+import Foundation
+import XCTest
+@testable import MereRunCore
+
+final class TextLoRATrainingOperationTests: XCTestCase {
+    func testDryRunSkipsTrainerAndCreatesOnlyManifest() async throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let plan = try TextLoRATrainingPlan.resolve(TextLoRATrainingOptions(
+            data: fixture.data.path, output: fixture.output.path, dryRun: true
+        ))
+        let outcome = try await TextLoRATrainingOperation.execute(plan, trainer: { _, _, _ in
+            XCTFail("Dry runs must not enter a native trainer")
+            throw FixtureError.failed
+        })
+        XCTAssertNil(outcome.report)
+        XCTAssertEqual(outcome.manifest.status, "prepared")
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fixture.output.path))
+        XCTAssertTrue(FileManager.default.fileExists(atPath: TextLoRATrainingManifest.url(nextTo: fixture.output).path))
+    }
+
+    func testTrainingReceivesSnapshotAndPublishesAfterSuccess() async throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let plan = try TextLoRATrainingPlan.resolve(TextLoRATrainingOptions(
+            data: fixture.data.path, output: fixture.output.path, model: InklingResources.modelID,
+            modelPath: "/explicit/model", eval: fixture.data.path, trainingSteps: 7, rank: 4, reasoningEffort: 0.2
+        ))
+        let progressReceived = expectation(description: "Loading progress forwarded")
+        let trainingProgressReceived = expectation(description: "Training progress forwarded")
+        let outcome = try await TextLoRATrainingOperation.execute(
+            plan,
+            progressHandler: { _ in progressReceived.fulfill() },
+            trainingProgressHandler: { _ in trainingProgressReceived.fulfill() },
+            trainer: { received, progress, trainingProgress in
+                XCTAssertEqual(received.family, .inkling)
+                XCTAssertEqual(received.options.modelPath, "/explicit/model")
+                XCTAssertEqual(received.dataset.examples.count, 1)
+                XCTAssertEqual(received.evaluationDataset?.summary.fingerprint, received.dataset.summary.fingerprint)
+                XCTAssertFalse(FileManager.default.fileExists(atPath: TextLoRATrainingManifest.url(nextTo: received.outputURL).path))
+                progress?(ChatProgress(stage: .generating, message: "Fixture"))
+                trainingProgress?(TextLoRATrainingProgress(stage: .saving))
+                try Data("adapter".utf8).write(to: received.outputURL)
+                return Self.report(output: received.outputURL)
+        })
+        XCTAssertEqual(outcome.manifest.status, "trained")
+        XCTAssertEqual(outcome.manifest.training.reasoningEffort, 0.2)
+        XCTAssertEqual(outcome.manifest.lora.alpha, 4)
+        XCTAssertEqual(outcome.manifest.evalPromptCount, 1)
+        XCTAssertEqual(outcome.report?.steps, 7)
+        await fulfillment(of: [progressReceived, trainingProgressReceived], timeout: 1)
+    }
+
+    func testCancellationBeforeExecutionDoesNotCreateOutputDirectory() async throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let plan = try TextLoRATrainingPlan.resolve(TextLoRATrainingOptions(
+            data: fixture.data.path, output: fixture.output.path, dryRun: true
+        ))
+        let task = Task {
+            withUnsafeCurrentTask { $0?.cancel() }
+            return try await TextLoRATrainingOperation.execute(plan)
+        }
+        do {
+            _ = try await task.value
+            XCTFail("Expected cancellation")
+        } catch {
+            XCTAssertTrue(error is CancellationError)
+        }
+        XCTAssertFalse(FileManager.default.fileExists(atPath: fixture.output.deletingLastPathComponent().path))
+    }
+
+    func testFailurePreservesPreviousManifest() async throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let manifestURL = TextLoRATrainingManifest.url(nextTo: fixture.output)
+        try FileManager.default.createDirectory(at: manifestURL.deletingLastPathComponent(), withIntermediateDirectories: true)
+        let previous = Data("previous manifest".utf8)
+        try previous.write(to: manifestURL)
+        let plan = try TextLoRATrainingPlan.resolve(TextLoRATrainingOptions(data: fixture.data.path, output: fixture.output.path))
+        do {
+            _ = try await TextLoRATrainingOperation.execute(plan, trainer: { _, _, _ in throw FixtureError.failed })
+            XCTFail("Expected trainer failure")
+        } catch {
+            XCTAssertTrue(error is FixtureError)
+        }
+        XCTAssertEqual(try Data(contentsOf: manifestURL), previous)
+    }
+
+    func testCancelledTrainerCannotPublishTrainedManifest() async throws {
+        for throwsError in [false, true] {
+            let fixture = try makeFixture()
+            defer { try? FileManager.default.removeItem(at: fixture.root) }
+            let plan = try TextLoRATrainingPlan.resolve(TextLoRATrainingOptions(data: fixture.data.path, output: fixture.output.path))
+            let trainer: TextLoRATrainingOperation.Trainer = { received, _, _ in
+                withUnsafeCurrentTask { $0?.cancel() }
+                if throwsError { throw FixtureError.failed }
+                return Self.report(output: received.outputURL)
+            }
+            let task = Task { try await TextLoRATrainingOperation.execute(plan, trainer: trainer) }
+            do {
+                _ = try await task.value
+                XCTFail("Expected cancellation")
+            } catch {
+                XCTAssertTrue(error is CancellationError)
+            }
+            XCTAssertFalse(FileManager.default.fileExists(atPath: TextLoRATrainingManifest.url(nextTo: fixture.output).path))
+        }
+    }
+
+    func testResumeValidationProtectsSourceAndPreservesGlobalStep() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let checkpoint = fixture.root.appendingPathComponent("resume.safetensors")
+        try Data("optimizer fixture".utf8).write(to: checkpoint)
+        let options = TextLoRATrainingOptions(data: fixture.data.path, output: fixture.output.path,
+                                            trainingSteps: 10, resumeFrom: checkpoint.path, resumeStep: 4)
+        let plan = try TextLoRATrainingPlan.resolve(options)
+        XCTAssertEqual(plan.options.resumeStep, 4)
+        XCTAssertEqual(plan.options.trainingSteps, 10)
+        XCTAssertEqual(plan.options.resumeFrom, checkpoint.path)
+        XCTAssertThrowsError(try TextLoRATrainingPlan.resolve(TextLoRATrainingOptions(
+            data: fixture.data.path, output: checkpoint.path, resumeFrom: checkpoint.path
+        ))) { error in
+            XCTAssertEqual(String(describing: error), "--resume-from and --output must be different files")
+        }
+    }
+
+    func testAllTextFamiliesKeepManifestAndTargetDefaults() throws {
+        let fixture = try makeFixture()
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let cases: [(String, TextLoRATrainingFamily, String, String)] = [
+            (Gemma4Resources.twelveB4BitModelId, .gemma4, TextLoRATrainingManifest.gemma4Format, "o_proj"),
+            ("", .gemma4, TextLoRATrainingManifest.gemma4Format, "o_proj"),
+            ("  ", .gemma4, TextLoRATrainingManifest.gemma4Format, "o_proj"),
+            (LagunaResources.xsModelID, .lagunaXS, TextLoRATrainingManifest.lagunaFormat, "o_proj"),
+            (InklingResources.modelID, .inkling, TextLoRATrainingManifest.inklingFormat, "lm_head"),
+            (LFM2Resources.defaultModelId, .lfm2A1B, TextLoRATrainingManifest.lfm2Format, "out_proj"),
+        ]
+        for (model, family, format, lastTarget) in cases {
+            let plan = try TextLoRATrainingPlan.resolve(TextLoRATrainingOptions(
+                data: fixture.data.path, output: fixture.output.path, model: model, dryRun: true
+            ))
+            XCTAssertEqual(plan.family, family)
+            XCTAssertEqual(plan.family.manifestFormat, format)
+            XCTAssertEqual(plan.options.resolvedTargetModules().last, lastTarget)
+        }
+    }
+
+    private enum FixtureError: Error { case failed }
+
+    private static func report(output: URL) -> TextLoRATrainingReport {
+        TextLoRATrainingReport(steps: 7, initialLoss: 1, finalLoss: 0.5,
+                               initialEvaluationLoss: nil, finalEvaluationLoss: nil,
+                               evaluationExampleCount: 0, evaluationTargetTokenCount: 0,
+                               layerCount: 1, outputPath: output.path)
+    }
+
+    private func makeFixture() throws -> (root: URL, data: URL, output: URL) {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let data = root.appendingPathComponent("pairs.jsonl")
+        let example = TextSFTExample(id: nil, sources: ["test"], messages: [
+            ChatMessage(role: .system, content: "Be helpful"),
+            ChatMessage(role: .user, content: "Hello"),
+            ChatMessage(role: .assistant, content: "Hello there"),
+        ])
+        try JSONEncoder().encode(example).write(to: data)
+        return (root, data, root.appendingPathComponent("output/adapter.safetensors"))
+    }
+}

--- a/Tests/MereRunExecutionTests/RunStorageTests.swift
+++ b/Tests/MereRunExecutionTests/RunStorageTests.swift
@@ -62,7 +62,7 @@ final class RunStorageTests: XCTestCase {
         XCTAssertEqual(try FileManager.default.attributesOfItem(atPath: file.path)[.posixPermissions] as? Int, 0o600)
     }
 
-    func testReplacementKeepsOldReaderAndPublishesCompleteProtectedArtifact() throws {
+    func testReplacementKeepsOldReaderAndPublishesCompletePrivateArtifact() throws {
         let file = try root().appendingPathComponent("record.json")
         try RunRecordCodec.write(["value": "original"], to: file)
         let original = try Data(contentsOf: file)
@@ -77,7 +77,10 @@ final class RunStorageTests: XCTestCase {
         let attributes = try FileManager.default.attributesOfItem(atPath: file.path)
         XCTAssertEqual(attributes[.posixPermissions] as? Int, 0o600)
 #if canImport(Darwin)
-        XCTAssertEqual(attributes[.protectionKey] as? FileProtectionType, .completeUnlessOpen)
+        let volume = try file.resourceValues(forKeys: [.volumeSupportsFileProtectionKey])
+        if volume.allValues[.volumeSupportsFileProtectionKey] as? Bool == true {
+            XCTAssertEqual(attributes[.protectionKey] as? FileProtectionType, .completeUnlessOpen)
+        }
 #endif
     }
 
@@ -110,7 +113,9 @@ final class RunStorageTests: XCTestCase {
     }
 
     private func root() throws -> URL {
-        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let base = ProcessInfo.processInfo.environment["MERERUN_TEST_STORAGE_ROOT"]
+            .map { URL(fileURLWithPath: $0, isDirectory: true) } ?? FileManager.default.temporaryDirectory
+        let root = base.appendingPathComponent(UUID().uuidString)
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
         addTeardownBlock { try? FileManager.default.removeItem(at: root) }
         return root

--- a/Tests/MereRunExecutionTests/RunStorageTests.swift
+++ b/Tests/MereRunExecutionTests/RunStorageTests.swift
@@ -62,6 +62,53 @@ final class RunStorageTests: XCTestCase {
         XCTAssertEqual(try FileManager.default.attributesOfItem(atPath: file.path)[.posixPermissions] as? Int, 0o600)
     }
 
+    func testReplacementKeepsOldReaderAndPublishesCompleteProtectedArtifact() throws {
+        let file = try root().appendingPathComponent("record.json")
+        try RunRecordCodec.write(["value": "original"], to: file)
+        let original = try Data(contentsOf: file)
+        let reader = try FileHandle(forReadingFrom: file)
+        defer { try? reader.close() }
+        try FileManager.default.setAttributes([.posixPermissions: 0], ofItemAtPath: file.path)
+        let updated = ["value": String(repeating: "replacement", count: 100_000)]
+        let artifact = try RunRecordCodec.writeArtifact(updated, to: file)
+        XCTAssertEqual(try reader.readToEnd(), original)
+        XCTAssertEqual(try RunRecordCodec.decoder().decode([String: String].self, from: Data(contentsOf: file)), updated)
+        XCTAssertEqual(try RunArtifact.read(file), artifact)
+        let attributes = try FileManager.default.attributesOfItem(atPath: file.path)
+        XCTAssertEqual(attributes[.posixPermissions] as? Int, 0o600)
+#if canImport(Darwin)
+        XCTAssertEqual(attributes[.protectionKey] as? FileProtectionType, .completeUnlessOpen)
+#endif
+    }
+
+    func testFailedReplacementPreservesDestinationAndRemovesTemporaryFile() throws {
+        let directory = try root()
+        let destination = directory.appendingPathComponent("occupied")
+        try FileManager.default.createDirectory(at: destination, withIntermediateDirectories: false)
+        let keep = destination.appendingPathComponent("keep.txt")
+        try Data("keep".utf8).write(to: keep)
+        XCTAssertThrowsError(try RunRecordCodec.write(["value": "replacement"], to: destination))
+        XCTAssertEqual(try Data(contentsOf: keep), Data("keep".utf8))
+        XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: directory.path), ["occupied"])
+    }
+
+    func testUnreadableRecordExplainsRecoveryAndPreservesBytes() throws {
+        let file = try root().appendingPathComponent("record.json")
+        let original = Data("original".utf8)
+        try original.write(to: file)
+        try FileManager.default.setAttributes([.posixPermissions: 0], ofItemAtPath: file.path)
+        defer { try? FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: file.path) }
+        XCTAssertThrowsError(try RunRecordCodec.readData(at: file)) { error in
+            XCTAssertEqual((error as? RunRecordReadIssue)?.url, file)
+            XCTAssertTrue(error.localizedDescription.contains("Unlock the device or check the file permissions"))
+        }
+        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: file.path)
+        XCTAssertEqual(try RunRecordCodec.readData(at: file), original)
+        XCTAssertThrowsError(try RunRecordCodec.readData(at: file.appendingPathExtension("missing"))) { error in
+            XCTAssertFalse(error is RunRecordReadIssue)
+        }
+    }
+
     private func root() throws -> URL {
         let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
         try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -37,6 +37,13 @@ native runtime selection, and cleanup. Core owns the common request and
 generation path. CLI and API adapters own presentation, tool authorization,
 wire compatibility, and admission or model-residency scope.
 
+## Shared text training
+
+Read [shared text training](./internals/text-training-execution.md) for typed
+options, dataset preparation, native pipeline dispatch, and manifest publication.
+The CLI owns presentation and the optional dashboard; native trainers retain
+optimizer and checkpoint behavior.
+
 ## Shared autoregressive decoding
 
 Read [shared decode boundaries](./internals/decode-runtime-boundaries.md) before

--- a/docs/internals/image-training-execution.md
+++ b/docs/internals/image-training-execution.md
@@ -1,0 +1,51 @@
+# Shared image training execution
+
+`image train-lora` uses `ImageLoRATrainingOptions`, `ImageLoRATrainingPlan`, and
+`ImageLoRATrainingOperation` in `MereRunCore`. Library callers can prepare and
+execute the same Krea and Klein training paths without importing the CLI or
+starting a dashboard.
+
+## Prepare a plan
+
+Options resolve recipes and explicit overrides, validate training controls,
+and select LoRA targets. Plan resolution finds the model manifest, reads image
+and caption pairs, and prepares a family-specific native trainer configuration.
+It does not load weights or create output directories. Captions are retained in
+the plan; native trainers read image bytes during execution.
+
+Krea keeps its synthetic-data and frozen-base quantization options. Klein keeps
+its resume checkpoint, target ranks, timestep settings, progressive resolution,
+latent-cache settings, preview settings, and benchmark mode. Native trainers
+continue to validate model and optimizer checkpoint compatibility.
+
+The CLI performs numeric validation and preflight before checking MLX. For an
+actual run, it checks MLX and prepares the plan before starting the dashboard.
+Dataset, family, or preview-model validation failures therefore do not start a
+viewer. The viewer task is cancelled and awaited when execution finishes or
+fails.
+
+## Execute a plan
+
+The operation dispatches the prepared configuration and examples to the
+existing native trainer and forwards typed progress. Klein preview generation
+uses the prepared prompt, model, seed, and adapter settings. A benchmark returns
+a benchmark outcome; a completed training run returns the adapter path.
+Cancellation cannot return a successful outcome, but it does not remove
+checkpoints or adapters already written by a native trainer.
+
+Callers own machine admission. The CLI retains its process-level reservation;
+the operation does not acquire a second permit. Native optimizers, checkpoint
+formats, and sampling math remain unchanged.
+
+## Saved plans and validation
+
+The CLI's existing schema-v1 run plan remains the portable replay format. It
+now retains optional `base_quantization_bits` when you request Krea frozen-base
+quantization. Older plans without this field still decode and use the existing
+unquantized default. Output relocation retains the requested quantization.
+
+Command and operation tests cover recipes, explicit overrides, native
+configurations, caption snapshots, preview preparation, benchmark outcomes,
+cancellation, preflight, and saved-plan replay. Model-manifest fixtures and
+injected trainers exercise these boundaries without loading real weights. They
+do not establish checkpoint training quality or GPU performance.

--- a/docs/internals/text-training-execution.md
+++ b/docs/internals/text-training-execution.md
@@ -1,0 +1,51 @@
+# Shared text training execution
+
+`text train-lora` uses `TextLoRATrainingOptions`, `TextLoRATrainingPlan`, and
+`TextLoRATrainingOperation` in `MereRunCore`. Library callers can resolve and run
+the same operation without importing ArgumentParser or the dashboard server.
+
+## Resolve a training plan
+
+Options own numeric and resume validation, model-family selection, and default
+LoRA targets. Plan resolution reads the training and optional evaluation JSONL
+into typed dataset snapshots. Gemma vision training retains its single-image
+policy and image digests. Text families reject media. Resolution does not load
+weights or create output directories.
+
+The CLI translates option errors to ArgumentParser validation errors and checks
+MLX availability before reading datasets for an actual training run. Viewer
+flags, stdout formatting, and diagnostic progress remain in the CLI.
+
+## Execute and publish
+
+The operation creates the output directory, invokes the selected native
+pipeline, and writes the existing adapter manifest after successful completion.
+A dry run writes a `prepared` manifest without invoking a trainer or replacing
+an existing adapter. The default model, training settings,
+target ordering, and manifest format remain unchanged.
+
+Native pipelines own model loading, tokenization, image integrity checks,
+optimizer state, metrics, and tensor artifacts. The shared operation preserves
+the training and evaluation examples, image digests, metadata, resume inputs,
+and progress callbacks passed to those pipelines. Failure or cancellation does
+not publish a new `trained` manifest. Existing checkpoints remain available for
+resume; cancellation does not roll back tensor files written by a trainer.
+
+The CLI acquires its machine reservation at process startup. The operation does
+not acquire another permit. Library callers own admission around their training
+work. The optional CLI dashboard starts after its initial event is written and
+its server task is cancelled and awaited when the command exits.
+
+## Resume and validation boundaries
+
+Training continues to use optimizer-bearing checkpoints and existing LoRA
+manifests. It does not use the image and transcription `run inspect` or `run
+retry` record formats. `--resume-step` retains its global-step meaning for legacy
+checkpoints; native trainers validate actual optimizer compatibility.
+
+`TextTrainingCompatibilityTests` covers CLI validation order, empty datasets,
+dry-run artifacts, and target handling. `TextLoRATrainingOperationTests` covers
+family resolution, dataset snapshots, publication, failure, cancellation, and
+resume inputs with injected trainers. Existing vision and optimizer tests cover
+their respective contracts. These tests do not qualify real model checkpoints
+or measure training quality.

--- a/docs/internals/workflow-execution.md
+++ b/docs/internals/workflow-execution.md
@@ -1,0 +1,52 @@
+# Workflow execution ownership
+
+`WorkflowRunner` schedules nodes, applies retry policy, and orders run events.
+Three support types own the resources used by that scheduler:
+
+- `WorkflowRunStore` initializes and resumes a run, persists its manifest, and
+  appends synchronized events. A run-directory lease excludes a second worker
+  before cancellation markers or child registrations can be cleared.
+- `WorkflowArtifactStore` localizes inputs, verifies declared outputs, manages
+  node-cache entries, and checks output digests before reuse. Resolved artifact
+  paths must remain within their owning directories, including through symlinks.
+- `WorkflowProcessRunner` registers each child and adapts output to workflow
+  events. It uses `BoundedProcessRunner` for nonblocking pipe drainage, deadlines,
+  cancellation, and process-group cleanup.
+
+## Resume a run
+
+A resumed worker validates the run contract, graph fingerprint, and input
+fingerprints before resetting run state. It rejects an active run lease or live
+registered children. Rejected resumes preserve the previous manifest, events,
+and cancellation marker. The lease remains held until the execution driver
+finishes its children and terminal persistence.
+
+Each node still requires matching provider pins, normalized arguments, model
+provenance, and output digests for reuse. Existing localized input files must
+match the bundle's declared digests. Cache formats and relay wire contracts
+remain unchanged.
+
+## Own child processes
+
+The shared runner drains stdout and stderr without blocking cancellation on a
+silent pipe. A throwing start or output callback terminates and waits for the
+process group before propagating the error. Timeouts and cancellation also
+terminate descendants that retain a pipe after the group leader exits.
+
+Workflow child stdout has a 16 MiB limit. Exceeding it fails the node and stops
+the child; partial output is never returned as a successful value. Write larger
+results as declared artifacts. Stderr retains its existing 16 KiB diagnostic
+tail while streaming diagnostics to the worker's stderr.
+
+The workflow parent orchestrates child commands without acquiring their model
+reservation. Each native CLI child retains its existing process admission.
+This extraction does not introduce an in-process inference path or another
+admission policy.
+
+## Validation boundaries
+
+Tests use local shell children to cover timeouts, cancellation, output limits,
+callback failures, and descendant cleanup. Run and artifact fixtures cover
+exclusive ownership, rejected resumes, cache reuse, changed inputs, and
+symlink confinement. They do not establish remote-worker availability or real
+model execution quality.

--- a/docs/runtime/image.md
+++ b/docs/runtime/image.md
@@ -332,6 +332,12 @@ checkpoints, and the fast Klein target surface. Use
 comparison that trains every transformer Linear/QuantizedLinear layer instead
 of the default suffix allowlist.
 
+Image training uses the shared [image training operation](../internals/image-training-execution.md)
+for recipe resolution, dataset preparation, native configuration, and execution.
+Saved schema-v1 training plans retain `--base-quantization-bits`, including when
+you relocate the output path. Older plans without that field retain the
+unquantized default.
+
 Core `train-lora` hyperparameters and their defaults:
 
 - `--training-steps` / `--steps`: number of optimizer steps; default `1000`

--- a/docs/runtime/music.md
+++ b/docs/runtime/music.md
@@ -379,8 +379,17 @@ format with `music train-adapter`; its objective matches ACE-Step flow
 matching, and its output is directly reloadable by `music generate` or the
 resident server. Adapter training writes the same durable `run_started`,
 per-step loss/progress, `run_finished`, and `run_failed` event stream the
-Studio's Train tasks read, so a music run has live feedback and survives app
-relaunch.
+Studio's Train tasks read. You can reopen the recorded progress after an app
+relaunch. Events begin before audio decoding and model loading, so preparation
+failures also produce `run_failed` events. Cancellation stops at the next
+preparation or training-step boundary and is checked before saving the adapter.
+It does not roll back files already written.
+
+Library callers use `ACEStepAdapterTrainingPlan.resolve` and
+`ACEStepAdapterTrainingOperation.execute` for the same manifest preparation,
+audio cropping, checkpoint discovery, and training path. Callers own machine
+admission; the CLI retains its process-level reservation. These training events
+remain separate from image and transcription run records.
 
 `music serve` holds the complete pipeline and its adapters in memory. It
 provides `GET /health`, `POST /v1/audio/music`, and serialized

--- a/docs/runtime/text.md
+++ b/docs/runtime/text.md
@@ -873,6 +873,9 @@ demonstrate this deterministic receptivity task, not broad downstream quality.
 - `Sources/MereRunCLI/Commands/TextAnonymizeCommand.swift`
 - `Sources/MereRunCLI/Commands/TextTrainLoRACommand.swift`
 
+Text training uses [shared options and execution](../internals/text-training-execution.md)
+in Core. The command owns output formatting and the optional dashboard.
+
 ### Chat families
 
 - `Sources/MereRunCore/Q35/`

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -259,6 +259,17 @@ cross-run content-addressed cache. Cache keys include normalized arguments,
 provider identity, model provenance, and directly referenced artifact digests.
 `cache: refresh` recomputes and replaces an entry; `cache: never` bypasses it.
 
+Each run permits one active worker. A second worker cannot reset its
+cancellation marker or child registrations. Resume rejects changed graph or
+input fingerprints before modifying the previous run. If registered children
+are still running after an interruption, wait for them to stop before resuming.
+
+Workflow child stdout is limited to 16 MiB. Exceeding the limit fails the node;
+write larger results as declared artifacts. Cancellation, timeout, and output
+callback failures stop the child process group. See
+[workflow execution ownership](internals/workflow-execution.md) for storage and
+process boundaries.
+
 `--resume` reuses a finished node only when its provider pin, normalized
 arguments, exact model provenance, directly referenced upstream outputs, and
 every output digest still match. Unrelated branches do not invalidate each


### PR DESCRIPTION
## Changes

Training commands duplicated preparation and execution, protected run records could be reopened during publication, and workflow callbacks and resume paths did not consistently own their processes or run directories. This change gives those resources explicit owners while preserving native model implementations and the existing CLI and relay contracts.

- Share text, image, and ACE-Step training options, dataset preparation, and native execution in Core. Preserve recipes, family-specific configuration, optimizer/resume inputs, progress, and output formats. Await image/text dashboard shutdown. Saved image training plans now retain Krea base quantization and continue decoding older schema-v1 plans.
- Publish image and transcription records through new private temporary files and open descriptors, then atomically rename them. Apply `completeUnlessOpen` only when the volume reports file protection support; retain `0600` permissions on every filesystem and propagate errors when applying supported protection. Compute result provenance from committed bytes instead of reopening the protected result. Give permission-denied record reads an unlock-or-permissions diagnostic without treating them as interrupted runs.
- Separate workflow scheduling from run persistence, artifact/cache ownership, and child execution. Reuse the shared bounded process runner, kill and await child groups on callback failure/cancellation/timeout, and fail on stdout exceeding 16 MiB rather than returning truncated success. Run leases, live-child checks, resume fingerprints, localized-input hashes, and resolved artifact confinement protect existing runs and files.
- Preserve transcription model identity and image cancellation outcomes from the earlier changes on this branch.

The CLI retains machine admission and presentation. Native optimizer and inference implementations, checkpoint formats, and relay wire contracts remain unchanged apart from cooperative ACE-Step cancellation checks. Music training now records preparation failures in its existing event stream. Image plan validation completes before a dashboard starts.

## Validation

- Full `./scripts/check.sh`: passed; 4,170 XCTest cases, 314 skipped, zero failures; 51 Swift Testing cases. Includes strict lint, builds, CLI help coverage, and repository hygiene checks.
- Compatibility baselines before extraction: music (4 tests), image (25 tests), workflow/process (64 tests).
- Storage compatibility: all 7 storage tests pass on the host volume with file protection, an APFS disk image without it, and an HFS+ disk image. The APFS image reproduced the CI `EINVAL` failure before the fix.
- Added focused coverage for WAV decoding/cropping, training plans and native configuration, cancellation, event outcomes, saved-plan replay, protected atomic writes, process-group cleanup, exclusive run ownership, rejected resume preservation, and artifact confinement.
- Built CLI workflow run and resume: both finished; attempts advanced from 1 to 2, and the expected output artifact and SHA-256 were verified.
- Documentation build: passed.
- iOS Release build-for-testing: passed. Hosted iOS unit tests remain a separate check.

Real-checkpoint training, GPU quality/performance qualification, an actual device lock/unlock transition, and non-loopback relay execution were not run. Protected closed records and assets can still require unlocking; fixture tests do not establish locked-session runtime support. Hosted checks on the updated head are separate from the local results above.
