### PR TITLE
Share speech synthesis planning and execution across CLI and API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+- Share speech synthesis validation, model selection, native waveform generation,
+  and WAV export between the CLI and resident API. Reject empty text and invalid
+  temperatures before model loading or clone preparation.
+- Finalize streaming speech WAV headers before publishing the file or receipt.
+  Preserve existing output on failure or cooperative cancellation, cancel the
+  producer when its stream consumer terminates, and retain float32 streaming
+  output alongside PCM16 offline output.
+- Emit streaming speech token progress with `--quiet --progress-json`.
 - Share `video generate` model selection, option validation, geometry, and
   native request construction between preflight and execution in Core.
   Preflight now applies H3 conditioning rules, reads HDR IC-LoRA canvas

--- a/CODEBASE.md
+++ b/CODEBASE.md
@@ -27,7 +27,7 @@ lookup. `AudioCore` and `AudioCodecs` own audio primitives; `AudioSTT` and
 - `Sources/MereRunQwenModel/` and `Sources/MereRunGemmaModel/`: text/vision layers, caches, and draft state
 - `Sources/MereRunDecode/`: shared sampling, pipelined token decoding, streaming, and logprob diagnostics
 - `Sources/MereRunTensor/`, `Sources/MereRunTextEncoder/`, and `Sources/MereRunImageModels/`: checkpoint loading, tensor kernels, and image model layers
-- `Sources/MereRunCore/*Generation*.swift` and `Sources/AudioCore/SpeechTranscriptionOperation.swift`: shared plans, validation, execution, and outcomes
+- `Sources/MereRunCore/*Generation*.swift` and `Sources/AudioCore/Speech*Operation.swift`: shared plans, validation, execution, and outcomes
 - `Sources/MereRunLTXModel/`: LTX transformers, VAEs, upsamplers, and model caches
 - `Sources/MereRunCore/LTX/`: video loading, conditioning, generation, and output
 - `Sources/MereRunH3Model/`, `Sources/MereRunLagunaModel/`, and `Sources/MereRunAudioModels/`: H3, Laguna, and shared vocoder computation

--- a/Sources/AudioCore/AudioExportPlan.swift
+++ b/Sources/AudioCore/AudioExportPlan.swift
@@ -11,6 +11,12 @@ public enum AudioNormalizationMode: String, CaseIterable, Codable, Sendable {
     case none, peak
 }
 
+public enum AudioClippingMode: Sendable, Hashable {
+    case unitRange
+    /// Retains finite float WAV samples outside [-1, 1]. Integer WAV encodings cannot use this policy.
+    case preserveFloatHeadroom
+}
+
 /// Serializable options. Construct a plan to validate them before inference.
 /// Coding keys retain the existing music recipe representation.
 public struct AudioExportOptions: Codable, Hashable, Sendable {
@@ -37,6 +43,10 @@ public struct AudioExportOptions: Codable, Hashable, Sendable {
     public static let music = AudioExportOptions()
     public static let referencePCM16 = AudioExportOptions(
         format: .pcm16, normalization: .none, targetPeakDB: 0,
+        fadeInMilliseconds: 0, fadeOutMilliseconds: 0, dither: false
+    )
+    public static let speechStreaming = AudioExportOptions(
+        format: .float32, normalization: .none, targetPeakDB: 0,
         fadeInMilliseconds: 0, fadeOutMilliseconds: 0, dither: false
     )
 }
@@ -84,6 +94,7 @@ public struct AudioExportOverrides: Codable, Sendable {
 public enum AudioExportError: Error, LocalizedError, Sendable {
     case invalidChannels(Int), invalidSampleRate(Int), incompleteFrame(samples: Int, channels: Int)
     case invalidPeak(Float), invalidFade(Float), wavSizeLimit
+    case invalidClippingMode, unsupportedStreamingProcessing, streamClosed
 
     public var errorDescription: String? {
         switch self {
@@ -93,21 +104,29 @@ public enum AudioExportError: Error, LocalizedError, Sendable {
         case .invalidPeak(let peak): "Target peak must be finite and at most 0 dBFS; got \(peak)."
         case .invalidFade(let milliseconds): "Output fade duration must be finite and nonnegative; got \(milliseconds) ms."
         case .wavSizeLimit: "Audio exceeds the size or byte-rate limits of a RIFF WAV file."
+        case .invalidClippingMode: "Preserving float headroom requires float32 WAV output."
+        case .unsupportedStreamingProcessing: "Incremental WAV output requires no normalization or fades."
+        case .streamClosed: "The WAV export stream is closed."
         }
     }
 }
 
 public struct AudioExportPlan: Sendable, Hashable {
     public let options: AudioExportOptions
+    public let clipping: AudioClippingMode
 
-    public init(options: AudioExportOptions) throws {
+    public init(options: AudioExportOptions, clipping: AudioClippingMode = .unitRange) throws {
         guard options.targetPeakDB.isFinite, options.targetPeakDB <= 0 else {
             throw AudioExportError.invalidPeak(options.targetPeakDB)
         }
         for milliseconds in [options.fadeInMilliseconds, options.fadeOutMilliseconds] {
             guard milliseconds.isFinite, milliseconds >= 0 else { throw AudioExportError.invalidFade(milliseconds) }
         }
+        guard clipping != .preserveFloatHeadroom || options.format == .float32 else {
+            throw AudioExportError.invalidClippingMode
+        }
         self.options = options
+        self.clipping = clipping
     }
 }
 

--- a/Sources/AudioCore/AudioExportProcessor.swift
+++ b/Sources/AudioCore/AudioExportProcessor.swift
@@ -12,7 +12,7 @@ public struct AudioExportStatistics: Codable, Sendable, Equatable {
     public let outputRMS: Double
 }
 
-/// Only the processor constructs this value, so the encoder receives finite, bounded samples.
+/// Only the processor constructs this value, so the encoder receives finite samples with the plan's clipping policy applied.
 public struct ProcessedAudio: Sendable {
     public let waveform: AudioWaveform
     public let plan: AudioExportPlan
@@ -64,8 +64,10 @@ public enum AudioExportProcessor {
         var sumSquares = 0.0
         for index in samples.indices {
                 if index.isMultiple(of: 16_384) { try Task.checkCancellation() }
-            if abs(samples[index]) > 1 { clipped += 1 }
-            samples[index] = max(-1, min(1, samples[index]))
+            if plan.clipping == .unitRange {
+                if abs(samples[index]) > 1 { clipped += 1 }
+                samples[index] = max(-1, min(1, samples[index]))
+            }
             outputPeak = max(outputPeak, abs(samples[index]))
             sumSquares += Double(samples[index]) * Double(samples[index])
         }

--- a/Sources/AudioCore/AudioExportStream.swift
+++ b/Sources/AudioCore/AudioExportStream.swift
@@ -1,0 +1,108 @@
+import Foundation
+#if canImport(Darwin)
+import Darwin
+#elseif canImport(Glibc)
+import Glibc
+#endif
+
+/// Encodes incremental audio with the shared processor and WAV encoder.
+/// The caller serializes access. Only `finish()` publishes the destination.
+public final class AudioExportStream {
+    private let plan: AudioExportPlan
+    private let destination: URL
+    private let temporary: URL
+    private let sampleRate: Int
+    private let channels: Int
+    private var handle: FileHandle?
+    private var sampleCount = 0
+    private var replacements = 0
+    private var clippedSamples = 0
+    private var inputPeak: Float = 0
+    private var outputPeak: Float = 0
+    private var sumSquares = 0.0
+
+    public init(plan: AudioExportPlan, to destination: URL, sampleRate: Int, channels: Int = 1) throws {
+        try Task.checkCancellation()
+        guard plan.options.normalization == .none,
+              plan.options.fadeInMilliseconds == 0, plan.options.fadeOutMilliseconds == 0 else {
+            throw AudioExportError.unsupportedStreamingProcessing
+        }
+        let layout = try AudioWAVLayout(sampleCount: 0, channels: channels, sampleRate: sampleRate, encoding: plan.options.format)
+        self.plan = plan
+        self.destination = destination
+        self.sampleRate = sampleRate
+        self.channels = channels
+        temporary = destination.deletingLastPathComponent().appendingPathComponent(".audio-export-\(UUID().uuidString).tmp")
+        let descriptor = temporary.path.withCString { open($0, O_CREAT | O_EXCL | O_WRONLY | O_CLOEXEC, 0o666) }
+        guard descriptor >= 0 else { throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO) }
+        let file = FileHandle(fileDescriptor: descriptor, closeOnDealloc: true)
+        handle = file
+        do {
+            try file.write(contentsOf: AudioWAVEncoder.header(layout: layout, channels: channels, sampleRate: sampleRate, encoding: plan.options.format))
+        } catch {
+            cancel()
+            throw error
+        }
+    }
+
+    deinit { cancel() }
+
+    public func append(samples: [Float]) throws {
+        do {
+            try appendPayload(samples)
+        } catch {
+            cancel()
+            throw error
+        }
+    }
+
+    private func appendPayload(_ samples: [Float]) throws {
+        guard let handle else { throw AudioExportError.streamClosed }
+        try Task.checkCancellation()
+        let (count, overflow) = sampleCount.addingReportingOverflow(samples.count)
+        guard !overflow else { throw AudioExportError.wavSizeLimit }
+        _ = try AudioWAVLayout(sampleCount: count, channels: channels, sampleRate: sampleRate, encoding: plan.options.format)
+        let waveform = try AudioWaveform(interleaved: samples, channels: channels, sampleRate: sampleRate)
+        let processed = try AudioExportProcessor.process(waveform, plan: plan)
+        try AudioWAVEncoder.payloadChunks(processed, sampleOffset: sampleCount) { try handle.write(contentsOf: $0) }
+        sampleCount = count
+        replacements += processed.statistics.replacedNonfiniteSamples
+        clippedSamples += processed.statistics.clippedSamples
+        inputPeak = max(inputPeak, processed.statistics.inputPeak)
+        outputPeak = max(outputPeak, processed.statistics.outputPeak)
+        sumSquares += pow(processed.statistics.outputRMS, 2) * Double(samples.count)
+    }
+
+    public func finish() throws -> AudioExportFile {
+        guard let handle else { throw AudioExportError.streamClosed }
+        do {
+            try Task.checkCancellation()
+            let layout = try AudioWAVLayout(sampleCount: sampleCount, channels: channels, sampleRate: sampleRate, encoding: plan.options.format)
+            if layout.paddingBytes == 1 { try handle.write(contentsOf: Data([0])) }
+            try handle.seek(toOffset: 0)
+            try handle.write(contentsOf: AudioWAVEncoder.header(layout: layout, channels: channels, sampleRate: sampleRate, encoding: plan.options.format))
+            try handle.synchronize()
+            try handle.close()
+            self.handle = nil
+            try Task.checkCancellation()
+            let renamed = temporary.path.withCString { source in destination.path.withCString { rename(source, $0) } }
+            guard renamed == 0 else { throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO) }
+            return AudioExportFile(url: destination, byteCount: layout.fileBytes, statistics: AudioExportStatistics(
+                sampleCount: sampleCount, replacedNonfiniteSamples: replacements, clippedSamples: clippedSamples,
+                fadeInFrames: 0, fadeOutFrames: 0, normalizationGain: 1,
+                inputPeak: inputPeak, outputPeak: outputPeak,
+                outputRMS: sampleCount == 0 ? 0 : sqrt(sumSquares / Double(sampleCount))
+            ))
+        } catch {
+            cancel()
+            throw error
+        }
+    }
+
+    /// Discards only this stream's temporary file, preserving an existing destination.
+    public func cancel() {
+        try? handle?.close()
+        handle = nil
+        try? FileManager.default.removeItem(at: temporary)
+    }
+}

--- a/Sources/AudioCore/AudioGeneration.swift
+++ b/Sources/AudioCore/AudioGeneration.swift
@@ -27,6 +27,11 @@ public struct TTSCloneReference: Sendable, Hashable, Codable {
 }
 
 public struct TTSRequest: Sendable, Hashable {
+    public static let defaultVoiceDescription = "A calm female voice with clear pronunciation"
+    public static let defaultLanguage = "auto"
+    public static let defaultSpeed: Float = 1
+    public static let defaultTemperature: Float = 0.6
+
     public var text: String
     public var voiceDescription: String
     public var voiceMode: TTSVoiceMode
@@ -38,12 +43,12 @@ public struct TTSRequest: Sendable, Hashable {
 
     public init(
         text: String,
-        voiceDescription: String = "A calm female voice with clear pronunciation",
+        voiceDescription: String = TTSRequest.defaultVoiceDescription,
         voiceMode: TTSVoiceMode = .style,
         cloneReference: TTSCloneReference? = nil,
-        language: String = "auto",
-        speed: Float = 1.0,
-        temperature: Float = 0.6,
+        language: String = TTSRequest.defaultLanguage,
+        speed: Float = TTSRequest.defaultSpeed,
+        temperature: Float = TTSRequest.defaultTemperature,
         outputURL: URL
     ) {
         self.text = text

--- a/Sources/AudioCore/AudioWAVEncoder.swift
+++ b/Sources/AudioCore/AudioWAVEncoder.swift
@@ -72,20 +72,31 @@ public enum AudioWAVEncoder {
 
     private static func chunks(_ audio: ProcessedAudio, layout: AudioWAVLayout, sink: (Data) throws -> Void) throws {
         try Task.checkCancellation()
-        let options = audio.plan.options
+        try sink(header(layout: layout, channels: audio.waveform.channels,
+                        sampleRate: audio.waveform.sampleRate, encoding: audio.plan.options.format))
+        try payloadChunks(audio, sampleOffset: 0, sink: sink)
+        try Task.checkCancellation()
+        if layout.paddingBytes == 1 { try sink(Data([0])) }
+    }
+
+    static func header(layout: AudioWAVLayout, channels: Int, sampleRate: Int, encoding: AudioWAVEncoding) -> Data {
         var header = Data("RIFF".utf8)
         append(UInt32(36 + layout.dataBytes + layout.paddingBytes), to: &header)
         header.append(Data("WAVEfmt ".utf8))
         append(UInt32(16), to: &header)
-        append(UInt16(options.format == .float32 ? 3 : 1), to: &header)
-        append(UInt16(audio.waveform.channels), to: &header)
-        append(UInt32(audio.waveform.sampleRate), to: &header)
+        append(UInt16(encoding == .float32 ? 3 : 1), to: &header)
+        append(UInt16(channels), to: &header)
+        append(UInt32(sampleRate), to: &header)
         append(layout.byteRate, to: &header)
         append(layout.blockAlign, to: &header)
-        append(options.format.bitsPerSample, to: &header)
+        append(encoding.bitsPerSample, to: &header)
         header.append(Data("data".utf8))
         append(UInt32(layout.dataBytes), to: &header)
-        try sink(header)
+        return header
+    }
+
+    static func payloadChunks(_ audio: ProcessedAudio, sampleOffset: Int, sink: (Data) throws -> Void) throws {
+        let options = audio.plan.options
         let samples = audio.waveform.samples
         let chunkSamples = 16_384
         for start in stride(from: 0, to: samples.count, by: chunkSamples) {
@@ -97,10 +108,10 @@ public enum AudioWAVEncoder {
                 let sample = samples[index]
                 switch options.format {
                 case .pcm16:
-                    let noise = options.dither ? dither(index) / 32_768 : 0
+                    let noise = options.dither ? dither(sampleOffset + index) / 32_768 : 0
                     append(Int16(max(-1, min(1, sample + noise)) * 32_767), to: &chunk)
                 case .pcm24:
-                    let noise = options.dither ? dither(index) / 8_388_608 : 0
+                    let noise = options.dither ? dither(sampleOffset + index) / 8_388_608 : 0
                     let value = Int32(max(-1, min(1, sample + noise)) * 8_388_607)
                     chunk.append(UInt8(truncatingIfNeeded: value))
                     chunk.append(UInt8(truncatingIfNeeded: value >> 8))
@@ -111,8 +122,6 @@ public enum AudioWAVEncoder {
             }
             try sink(chunk)
         }
-        try Task.checkCancellation()
-        if layout.paddingBytes == 1 { try sink(Data([0])) }
     }
 
     private static func append<T: FixedWidthInteger>(_ value: T, to data: inout Data) {

--- a/Sources/AudioCore/README.md
+++ b/Sources/AudioCore/README.md
@@ -5,6 +5,8 @@ speech transcription, and CLI streaming sessions.
 
 - `AudioExportPlan.swift`, `AudioExportProcessor.swift`, and `AudioWAVEncoder.swift`: validated WAV export, explicit interleaved waveforms, fades, normalization, statistics, and atomic chunked file encoding. These types have no MLX dependency.
 - `AudioGeneration.swift`: request, response, progress, and streaming protocols.
+- `SpeechSynthesisPlan.swift` and `SpeechSynthesisOperation.swift`: validated synthesis requests, waveform executors, and completed audio artifacts.
+- `AudioExportStream.swift`: incremental WAV encoding with explicit completion and atomic publication; cancellation preserves an existing destination.
 - `ASRBackendRouting.swift`: speech-to-text backend selection policy.
 - `SpeechTranscriptionOperation.swift`: typed file transcription plans, validation, executors, events, and outcomes.
 - `SpeechTranscriptionRunRecord.swift` and `SpeechTranscriptionRunSession.swift`: retained file inputs, versioned outcomes, recovery, and retry.

--- a/Sources/AudioCore/SpeechSynthesisOperation.swift
+++ b/Sources/AudioCore/SpeechSynthesisOperation.swift
@@ -103,6 +103,8 @@ public enum SpeechSynthesisOperation {
                     continuation.yield(.completed(result: result))
                     continuation.finish()
                 } catch {
+                    writer?.cancel()
+                    writer = nil
                     continuation.finish(throwing: error)
                 }
             }

--- a/Sources/AudioCore/SpeechSynthesisOperation.swift
+++ b/Sources/AudioCore/SpeechSynthesisOperation.swift
@@ -1,0 +1,118 @@
+import Foundation
+
+/// Supplies model audio without publishing output files or acquiring admission permits.
+public protocol SpeechSynthesisExecutor: Sendable {
+    func generate(
+        _ request: TTSRequest,
+        progressHandler: (@Sendable (TTSProgress) -> Void)?
+    ) async throws -> AudioWaveform
+
+    func generateStream(
+        _ request: TTSRequest,
+        options: TTSStreamingOptions
+    ) -> AsyncThrowingStream<TTSStreamingEvent, Error>
+}
+
+public extension SpeechSynthesisExecutor {
+    func generateStream(
+        _ request: TTSRequest,
+        options: TTSStreamingOptions
+    ) -> AsyncThrowingStream<TTSStreamingEvent, Error> {
+        AsyncThrowingStream { $0.finish(throwing: SpeechSynthesisError.streamingUnsupported) }
+    }
+}
+
+public struct SpeechSynthesisOutcome: Sendable {
+    public let result: TTSResult
+    public let artifact: AudioExportFile
+}
+
+/// Owns validated execution and artifact publication. The caller owns model residency and admission.
+public enum SpeechSynthesisOperation {
+    public static func execute(
+        _ plan: SpeechSynthesisPlan,
+        executor: any SpeechSynthesisExecutor,
+        progressHandler: (@Sendable (TTSProgress) -> Void)? = nil
+    ) async throws -> SpeechSynthesisOutcome {
+        guard plan.streamingOptions == nil else { throw SpeechSynthesisError.wrongExecutionMode }
+        try plan.validateForExecution()
+        let audio = try await executor.generate(plan.request, progressHandler: progressHandler)
+        try Task.checkCancellation()
+        guard !audio.samples.isEmpty else { throw SpeechSynthesisError.emptyAudio }
+        progressHandler?(TTSProgress(stage: .saving, message: "Saving audio..."))
+        try createOutputDirectory(plan.request.outputURL)
+        let artifact = try AudioExportService.write(audio, plan: plan.exportPlan, to: plan.request.outputURL)
+        return SpeechSynthesisOutcome(
+            result: TTSResult(audioURL: artifact.url, duration: audio.duration, sampleRate: audio.sampleRate),
+            artifact: artifact
+        )
+    }
+
+    public static func stream(
+        _ plan: SpeechSynthesisPlan,
+        executor: any SpeechSynthesisExecutor
+    ) throws -> AsyncThrowingStream<TTSStreamingEvent, Error> {
+        guard let options = plan.streamingOptions else { throw SpeechSynthesisError.wrongExecutionMode }
+        try plan.validateForExecution()
+        return AsyncThrowingStream { continuation in
+            let task = Task {
+                var writer: AudioExportStream?
+                defer { writer?.cancel() }
+                do {
+                    var sampleRate: Int?
+                    var completion: TTSResult?
+                    for try await event in executor.generateStream(plan.request, options: options) {
+                        try Task.checkCancellation()
+                        guard completion == nil else {
+                            throw SpeechSynthesisError.invalidStream("Speech stream emitted events after its final result.")
+                        }
+                        switch event {
+                        case .token:
+                            if case .terminated = continuation.yield(event) { throw CancellationError() }
+                        case .audioChunk(let samples, let rate):
+                            if let sampleRate, sampleRate != rate {
+                                throw SpeechSynthesisError.invalidStream("Speech stream changed its sample rate.")
+                            }
+                            guard !samples.isEmpty else { continue }
+                            if writer == nil {
+                                // Validate the format before creating the output directory.
+                                _ = try AudioWaveform(interleaved: samples, channels: 1, sampleRate: rate)
+                                try createOutputDirectory(plan.request.outputURL)
+                                writer = try AudioExportStream(plan: plan.exportPlan, to: plan.request.outputURL, sampleRate: rate)
+                                sampleRate = rate
+                            }
+                            try writer?.append(samples: samples)
+                            if case .terminated = continuation.yield(event) { throw CancellationError() }
+                        case .completed(let result):
+                            completion = result
+                        }
+                    }
+                    try Task.checkCancellation()
+                    guard let completion else {
+                        throw SpeechSynthesisError.invalidStream("Streaming TTS completed without a final result.")
+                    }
+                    guard let writer, let sampleRate else { throw SpeechSynthesisError.emptyAudio }
+                    guard completion.sampleRate == sampleRate,
+                          completion.audioURL.standardizedFileURL == plan.request.outputURL.standardizedFileURL else {
+                        throw SpeechSynthesisError.invalidStream("Speech stream result does not match its output file and sample rate.")
+                    }
+                    let artifact = try writer.finish()
+                    let result = TTSResult(audioURL: artifact.url,
+                                           duration: Double(artifact.statistics.sampleCount) / Double(sampleRate),
+                                           sampleRate: sampleRate)
+                    continuation.yield(.completed(result: result))
+                    continuation.finish()
+                } catch {
+                    continuation.finish(throwing: error)
+                }
+            }
+            continuation.onTermination = { @Sendable reason in
+                if case .cancelled = reason { task.cancel() }
+            }
+        }
+    }
+
+    private static func createOutputDirectory(_ output: URL) throws {
+        try FileManager.default.createDirectory(at: output.deletingLastPathComponent(), withIntermediateDirectories: true)
+    }
+}

--- a/Sources/AudioCore/SpeechSynthesisPlan.swift
+++ b/Sources/AudioCore/SpeechSynthesisPlan.swift
@@ -1,0 +1,94 @@
+import Foundation
+
+public enum SpeechSynthesisField: String, Sendable {
+    case text, temperature, speed, cloneReference, output, streamChunkTokens
+}
+
+public enum SpeechSynthesisError: LocalizedError, Sendable {
+    case invalidInput(SpeechSynthesisField, String)
+    case streamingUnsupported
+    case wrongExecutionMode
+    case emptyAudio
+    case invalidStream(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidInput(_, let message), .invalidStream(let message): message
+        case .streamingUnsupported: "The speech executor does not support streaming."
+        case .wrongExecutionMode: "Use the synthesis operation that matches the plan's streaming mode."
+        case .emptyAudio: "Speech synthesis produced no audio samples."
+        }
+    }
+}
+
+/// Retains the validated request and the entry point's explicit WAV policy.
+/// Model selection and loading belong to AudioTTS; transport aliases belong to adapters.
+public struct SpeechSynthesisPlan: Sendable, Hashable {
+    public let request: TTSRequest
+    public let streamingOptions: TTSStreamingOptions?
+    public let exportPlan: AudioExportPlan
+
+    public init(request: TTSRequest, streamingOptions: TTSStreamingOptions? = nil) throws {
+        try Self.validateParameters(text: request.text, temperature: request.temperature, speed: request.speed)
+        guard request.outputURL.isFileURL else {
+            throw SpeechSynthesisError.invalidInput(.output, "Speech output must be a local file URL.")
+        }
+        if request.voiceMode == .clone {
+            guard let reference = request.cloneReference else {
+                throw SpeechSynthesisError.invalidInput(.cloneReference, "Clone mode requires a reference audio file and transcript.")
+            }
+            guard reference.audioURL.isFileURL else {
+                throw SpeechSynthesisError.invalidInput(.cloneReference, "Reference audio must be a local file URL.")
+            }
+            guard !reference.transcript.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                throw SpeechSynthesisError.invalidInput(.cloneReference, "Reference transcript must not be empty.")
+            }
+        }
+        try Self.validateStreamingOptions(streamingOptions)
+        self.request = request
+        self.streamingOptions = streamingOptions
+        exportPlan = try AudioExportPlan(
+            options: streamingOptions == nil ? .referencePCM16 : .speechStreaming,
+            clipping: streamingOptions == nil ? .unitRange : .preserveFloatHeadroom
+        )
+    }
+
+    /// Validates scalar input before profile lookup, reference transcription, or model loading.
+    public static func validateParameters(text: String, temperature: Float, speed: Float) throws {
+        guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw SpeechSynthesisError.invalidInput(.text, "Speech text must not be empty.")
+        }
+        guard temperature.isFinite, (0...2).contains(temperature) else {
+            throw SpeechSynthesisError.invalidInput(.temperature, "Temperature must be finite and between 0 and 2.")
+        }
+        _ = try validatedSpeed(Double(speed))
+    }
+
+    /// Checks the wire value before narrowing it to the native Float field.
+    public static func validatedSpeed(_ speed: Double) throws -> Float {
+        guard speed.isFinite, (0.25...4).contains(speed) else {
+            throw SpeechSynthesisError.invalidInput(.speed, "Speed must be finite and between 0.25 and 4.0.")
+        }
+        return Float(speed)
+    }
+
+    public static func validateStreamingOptions(_ options: TTSStreamingOptions?) throws {
+        if let options, options.chunkTokenInterval <= 0 {
+            throw SpeechSynthesisError.invalidInput(.streamChunkTokens, "Streaming token interval must be greater than zero.")
+        }
+    }
+
+    public func validateForExecution(fileManager: FileManager = .default) throws {
+        try Task.checkCancellation()
+        if request.voiceMode == .clone, let reference = request.cloneReference {
+            var isDirectory: ObjCBool = false
+            guard fileManager.fileExists(atPath: reference.audioURL.path, isDirectory: &isDirectory), !isDirectory.boolValue else {
+                throw SpeechSynthesisError.invalidInput(.cloneReference, "Reference audio not found: \(reference.audioURL.path)")
+            }
+        }
+        var isDirectory: ObjCBool = false
+        if fileManager.fileExists(atPath: request.outputURL.path, isDirectory: &isDirectory), isDirectory.boolValue {
+            throw SpeechSynthesisError.invalidInput(.output, "Speech output is a directory: \(request.outputURL.path)")
+        }
+    }
+}

--- a/Sources/AudioTTS/Qwen3TTS/Qwen3TTSGenerator+Generation.swift
+++ b/Sources/AudioTTS/Qwen3TTS/Qwen3TTSGenerator+Generation.swift
@@ -33,6 +33,7 @@ extension Qwen3TTSGenerator {
         onToken: ((Int) -> Void)? = nil,
         onAudioDelta: (([Float]) -> Void)? = nil
     ) throws -> MLXArray {
+        try Task.checkCancellation()
         guard let reference = request.cloneReference else {
             throw Qwen3TTSError.invalidCloneReference("Missing clone reference. Provide --profile or --ref-audio.")
         }
@@ -48,6 +49,7 @@ extension Qwen3TTSGenerator {
             targetSampleRate: config.sampleRate
         )
 
+        try Task.checkCancellation()
         progressHandler?(TTSProgress(stage: .encodingReference, message: "Encoding speaker reference..."))
         guard speechTokenizer.hasEncoder else {
             throw Qwen3TTSError.cloneAssetsMissing(["speech tokenizer encoder"])
@@ -173,6 +175,7 @@ extension Qwen3TTSGenerator {
             var trailingIndex = 0
 
             for step in 0..<effectiveMaxTokens {
+                try Task.checkCancellation()
                 let (logits, hidden) = talker(inputEmbedsVar, cache: cache)
                 let nextToken = sampleToken(
                     logits: logits,
@@ -246,6 +249,7 @@ extension Qwen3TTSGenerator {
             )
         }
 
+        try Task.checkCancellation()
         progressHandler?(TTSProgress(stage: .decoding, message: "Decoding audio..."))
 
         let codes = MLX.stacked(generatedCodes, axis: 1)
@@ -330,6 +334,7 @@ extension Qwen3TTSGenerator {
             var trailingIndex = 0
 
             for step in 0..<effectiveMaxTokens {
+                try Task.checkCancellation()
                 let (logits, hidden) = talker(inputEmbedsVar, cache: cache)
                 let nextToken = sampleToken(
                     logits: logits,
@@ -403,6 +408,7 @@ extension Qwen3TTSGenerator {
             )
         }
 
+        try Task.checkCancellation()
         progressHandler?(TTSProgress(stage: .decoding, message: "Decoding audio..."))
 
         let generated = MLX.stacked(generatedCodes, axis: 1)

--- a/Sources/AudioTTS/Qwen3TTS/Qwen3TTSGenerator+TokenGeneration.swift
+++ b/Sources/AudioTTS/Qwen3TTS/Qwen3TTSGenerator+TokenGeneration.swift
@@ -70,6 +70,7 @@ extension Qwen3TTSGenerator {
         let cache = talker.makeCache()
 
         func confirm(_ step: PipelinedTalkerStep) throws -> Bool {
+            try Task.checkCancellation()
             let tokenValue = step.token.item(Int.self)
             if tokenValue == eosTokenId {
                 return false
@@ -93,6 +94,7 @@ extension Qwen3TTSGenerator {
         }
 
         for step in 0..<effectiveMaxTokens {
+            try Task.checkCancellation()
             let (logits, hidden) = talker(inputEmbedsVar, cache: cache)
             let tokenArray = sampleTokenArrayTTS(logits: logits, context: samplerContext)
             samplerContext.appendHistory(tokenArray)

--- a/Sources/AudioTTS/Qwen3TTS/Qwen3TTSGenerator.swift
+++ b/Sources/AudioTTS/Qwen3TTS/Qwen3TTSGenerator.swift
@@ -7,9 +7,7 @@ import AudioCore
 import AudioCodecs
 import MereRunCore
 
-/// Owns the public Qwen3 TTS entrypoints and loaded runtime state.
-/// Model loading and generation internals live in companion files so the
-/// speech flow reads from entrypoint to implementation in a predictable order.
+/// Owns Qwen model state and the shared native style/clone waveform path.
 public actor Qwen3TTSGenerator: TTSGenerator {
     var talker: Qwen3TTSTalkerForConditionalGeneration?
     var speechTokenizer: Qwen3TTSSpeechTokenizer?
@@ -18,6 +16,7 @@ public actor Qwen3TTSGenerator: TTSGenerator {
     var modelConfig: Qwen3TTSModelConfig?
     var loadedModelPath: String?
     let modelId: String
+    private let streams = Stream.Context()
 
     public init(modelId: String = Qwen3TTSResources.defaultModelId) {
         self.modelId = modelId
@@ -30,69 +29,27 @@ public actor Qwen3TTSGenerator: TTSGenerator {
         try await generate(request, modelPath: nil, progressHandler: progressHandler)
     }
 
+    /// Preserves the public file-generation entry point through shared PCM16 export.
     public func generate(
         _ request: TTSRequest,
         modelPath: String?,
         progressHandler: (@Sendable (TTSProgress) -> Void)? = nil
     ) async throws -> TTSResult {
-        let rootURL = try await resolveModelRoot(modelPath: modelPath, progressHandler: progressHandler)
+        let plan = try SpeechSynthesisPlan(request: request)
+        return try await SpeechSynthesisOperation.execute(
+            plan, executor: Qwen3TTSSynthesisExecutor(generator: self, modelPath: modelPath),
+            progressHandler: progressHandler
+        ).result
+    }
 
-        if loadedModelPath != rootURL.path {
-            progressHandler?(TTSProgress(stage: .loadingModel, message: "Loading Qwen3-TTS model..."))
-            try await loadModels(from: rootURL, progressHandler: progressHandler)
-        }
-
-        guard let talker, let speechTokenizer, let tokenizer, let modelConfig else {
-            throw Qwen3TTSError.modelsNotLoaded
-        }
-
-        if request.voiceMode == .clone {
-            let cloneMissing = Qwen3TTSResources(rootURL: rootURL).validateCloneAssets()
-            if !cloneMissing.isEmpty && speakerEncoder == nil {
-                throw Qwen3TTSError.cloneAssetsMissing(cloneMissing.map { $0.lastPathComponent })
-            }
-        }
-
-        let audio: MLXArray
-        switch request.voiceMode {
-        case .style:
-            progressHandler?(TTSProgress(stage: .tokenizing, message: "Preparing inputs..."))
-            audio = try generateVoiceDesign(
-                text: request.text,
-                language: request.language,
-                instruct: request.voiceDescription,
-                speakerHintTokens: nil,
-                referencePromptTokens: nil,
-                talker: talker,
-                tokenizer: tokenizer,
-                speechTokenizer: speechTokenizer,
-                config: modelConfig,
-                temperature: request.temperature,
-                progressHandler: progressHandler
-            )
-        case .clone:
-            audio = try generateVoiceClone(
-                request: request,
-                talker: talker,
-                tokenizer: tokenizer,
-                speechTokenizer: speechTokenizer,
-                speakerEncoder: speakerEncoder,
-                config: modelConfig,
-                progressHandler: progressHandler
-            )
-        }
-
-        progressHandler?(TTSProgress(stage: .saving, message: "Saving audio..."))
-        try SNACAudioWriter.writeWAV(audio, to: request.outputURL, sampleRate: modelConfig.sampleRate)
-
-        let duration = TimeInterval(audio.size) / TimeInterval(modelConfig.sampleRate)
-        Memory.clearCache()
-
-        return TTSResult(
-            audioURL: request.outputURL,
-            duration: duration,
-            sampleRate: modelConfig.sampleRate
-        )
+    /// Returns evaluated host samples. The shared operation owns file publication.
+    public func generateAudio(
+        _ request: TTSRequest,
+        modelPath: String? = nil,
+        progressHandler: (@Sendable (TTSProgress) -> Void)? = nil
+    ) async throws -> AudioWaveform {
+        let plan = try SpeechSynthesisPlan(request: request)
+        return try await synthesizeAudio(plan, modelPath: modelPath, progressHandler: progressHandler, continuation: nil)
     }
 
     nonisolated public func generateStream(
@@ -102,122 +59,124 @@ public actor Qwen3TTSGenerator: TTSGenerator {
         generateStream(request, options: options, modelPath: nil)
     }
 
+    /// Preserves the public sample-event stream. Use SpeechSynthesisOperation to publish a WAV.
     nonisolated public func generateStream(
         _ request: TTSRequest,
         options: TTSStreamingOptions,
         modelPath: String? = nil
     ) -> AsyncThrowingStream<TTSStreamingEvent, Error> {
         AsyncThrowingStream { continuation in
-            Task { [self] in
+            let task = Task { [self] in
                 do {
-                    try await streamGenerate(
-                        request: request,
-                        options: options,
-                        modelPath: modelPath,
-                        continuation: continuation
-                    )
+                    let plan = try SpeechSynthesisPlan(request: request, streamingOptions: options)
+                    let audio = try await synthesizeAudio(plan, modelPath: modelPath, progressHandler: nil, continuation: continuation)
+                    try Task.checkCancellation()
+                    continuation.yield(.completed(result: TTSResult(
+                        audioURL: request.outputURL, duration: audio.duration, sampleRate: audio.sampleRate
+                    )))
+                    continuation.finish()
                 } catch {
                     continuation.finish(throwing: error)
                 }
             }
+            continuation.onTermination = { @Sendable reason in
+                if case .cancelled = reason { task.cancel() }
+            }
         }
     }
 
-    func streamGenerate(
-        request: TTSRequest,
-        options: TTSStreamingOptions,
+    private func synthesizeAudio(
+        _ plan: SpeechSynthesisPlan,
         modelPath: String?,
-        continuation: AsyncThrowingStream<TTSStreamingEvent, Error>.Continuation
-    ) async throws {
-        guard options.chunkTokenInterval > 0 else {
-            throw ASRStreamingError.invalidInput("chunkTokenInterval must be > 0.")
+        progressHandler: (@Sendable (TTSProgress) -> Void)?,
+        continuation: AsyncThrowingStream<TTSStreamingEvent, Error>.Continuation?
+    ) async throws -> AudioWaveform {
+        try plan.validateForExecution()
+        return try await Stream.withDefaultStream(streams) {
+            defer {
+                streams.synchronize()
+                Memory.clearCache()
+            }
+            let rootURL = try await resolveModelRoot(modelPath: modelPath, progressHandler: progressHandler)
+            try Task.checkCancellation()
+            if loadedModelPath != rootURL.path {
+                progressHandler?(TTSProgress(stage: .loadingModel, message: "Loading Qwen3-TTS model..."))
+                try await loadModels(from: rootURL, progressHandler: progressHandler)
+            }
+            try Task.checkCancellation()
+            return try generateLoadedAudio(plan, rootURL: rootURL, progressHandler: progressHandler, continuation: continuation)
         }
+    }
 
-        let rootURL = try await resolveModelRoot(modelPath: modelPath, progressHandler: nil)
-        if loadedModelPath != rootURL.path {
-            try await loadModels(from: rootURL, progressHandler: nil)
-        }
-
+    private func generateLoadedAudio(
+        _ plan: SpeechSynthesisPlan,
+        rootURL: URL,
+        progressHandler: (@Sendable (TTSProgress) -> Void)?,
+        continuation: AsyncThrowingStream<TTSStreamingEvent, Error>.Continuation?
+    ) throws -> AudioWaveform {
         guard let talker, let speechTokenizer, let tokenizer, let modelConfig else {
             throw Qwen3TTSError.modelsNotLoaded
         }
-
+        let request = plan.request
         if request.voiceMode == .clone {
-            let cloneMissing = Qwen3TTSResources(rootURL: rootURL).validateCloneAssets()
-            if !cloneMissing.isEmpty && speakerEncoder == nil {
-                throw Qwen3TTSError.cloneAssetsMissing(cloneMissing.map { $0.lastPathComponent })
+            let missing = Qwen3TTSResources(rootURL: rootURL).validateCloneAssets()
+            if !missing.isEmpty && speakerEncoder == nil {
+                throw Qwen3TTSError.cloneAssetsMissing(missing.map { $0.lastPathComponent })
             }
         }
-
-        let onToken: ((Int) -> Void)? = options.emitTokenEvents
-            ? { tokenId in continuation.yield(.token(id: tokenId)) }
+        let onToken: ((Int) -> Void)? = plan.streamingOptions?.emitTokenEvents == true
+            ? { token in continuation?.yield(.token(id: token)) }
             : nil
-        let onAudioDelta: ([Float]) -> Void = { samples in
-            guard !samples.isEmpty else { return }
-            continuation.yield(.audioChunk(samples: samples, sampleRate: modelConfig.sampleRate))
+        let onAudioDelta: (([Float]) -> Void)? = continuation.map { continuation in
+            { samples in
+                if !samples.isEmpty {
+                    continuation.yield(.audioChunk(samples: samples, sampleRate: modelConfig.sampleRate))
+                }
+            }
         }
-
         let audio: MLXArray
         switch request.voiceMode {
         case .style:
+            progressHandler?(TTSProgress(stage: .tokenizing, message: "Preparing inputs..."))
             audio = try generateVoiceDesign(
-                text: request.text,
-                language: request.language,
-                instruct: request.voiceDescription,
-                speakerHintTokens: nil,
-                referencePromptTokens: nil,
-                talker: talker,
-                tokenizer: tokenizer,
-                speechTokenizer: speechTokenizer,
-                config: modelConfig,
-                temperature: request.temperature,
-                progressHandler: nil,
-                streamingChunkTokenInterval: options.chunkTokenInterval,
-                onToken: onToken,
-                onAudioDelta: onAudioDelta
+                text: request.text, language: request.language, instruct: request.voiceDescription,
+                speakerHintTokens: nil, referencePromptTokens: nil,
+                talker: talker, tokenizer: tokenizer, speechTokenizer: speechTokenizer, config: modelConfig,
+                temperature: request.temperature, progressHandler: progressHandler,
+                streamingChunkTokenInterval: plan.streamingOptions?.chunkTokenInterval,
+                onToken: onToken, onAudioDelta: onAudioDelta
             )
         case .clone:
             audio = try generateVoiceClone(
-                request: request,
-                talker: talker,
-                tokenizer: tokenizer,
-                speechTokenizer: speechTokenizer,
-                speakerEncoder: speakerEncoder,
-                config: modelConfig,
-                progressHandler: nil,
-                streamingChunkTokenInterval: options.chunkTokenInterval,
-                onToken: onToken,
-                onAudioDelta: onAudioDelta
+                request: request, talker: talker, tokenizer: tokenizer, speechTokenizer: speechTokenizer,
+                speakerEncoder: speakerEncoder, config: modelConfig, progressHandler: progressHandler,
+                streamingChunkTokenInterval: plan.streamingOptions?.chunkTokenInterval,
+                onToken: onToken, onAudioDelta: onAudioDelta
             )
         }
-
-        let duration = TimeInterval(audio.size) / TimeInterval(modelConfig.sampleRate)
-        Memory.clearCache()
-
-        continuation.yield(
-            .completed(
-                result: TTSResult(
-                    audioURL: request.outputURL,
-                    duration: duration,
-                    sampleRate: modelConfig.sampleRate
-                )
-            )
-        )
-        continuation.finish()
+        try Task.checkCancellation()
+        MLX.eval(audio)
+        return try AudioWaveform(interleaved: audio.reshaped(-1).asArray(Float.self), channels: 1, sampleRate: modelConfig.sampleRate)
     }
 
     public func prepare(
         modelPath: String? = nil,
         progressHandler: (@Sendable (TTSProgress) -> Void)? = nil
     ) async throws {
-        let rootURL = try await resolveModelRoot(modelPath: modelPath, progressHandler: progressHandler)
-        if loadedModelPath != rootURL.path {
-            progressHandler?(TTSProgress(stage: .loadingModel, message: "Loading Qwen3-TTS model..."))
-            try await loadModels(from: rootURL, progressHandler: progressHandler)
+        try Task.checkCancellation()
+        try await Stream.withDefaultStream(streams) {
+            defer { streams.synchronize() }
+            let rootURL = try await resolveModelRoot(modelPath: modelPath, progressHandler: progressHandler)
+            try Task.checkCancellation()
+            if loadedModelPath != rootURL.path {
+                progressHandler?(TTSProgress(stage: .loadingModel, message: "Loading Qwen3-TTS model..."))
+                try await loadModels(from: rootURL, progressHandler: progressHandler)
+            }
         }
     }
 
     public func unload() {
+        streams.synchronize()
         talker = nil
         speechTokenizer = nil
         speakerEncoder = nil

--- a/Sources/AudioTTS/Qwen3TTS/README.md
+++ b/Sources/AudioTTS/Qwen3TTS/README.md
@@ -4,6 +4,8 @@ Use this directory when changing model loading, prompt preparation, or speech
 generation. `AudioQwen3TTSModel` owns neural layers and typed configuration.
 
 - `Qwen3TTSGenerator.swift`: public entry points and loaded actor state.
+- `SpeechSynthesisModelSelection.swift`: shared CLI/API model selection and the
+  Qwen waveform executor for `AudioCore.SpeechSynthesisOperation`.
 - `Qwen3TTSGenerator+Loading.swift`: model resolution and checkpoint loading.
 - `Qwen3TTSGenerator+Generation.swift`: voice-design and voice-clone flows.
 - `Qwen3TTSGenerator+PromptPreparation.swift`: text and reference-code prompts.
@@ -17,3 +19,9 @@ Keep typed ingestion at the tokenizer and config boundaries. Preserve the
 pipelined loop's evaluation order, delayed token confirmation, and sampling
 policy when reorganizing execution code. The SNAC helpers remain separate
 from the Qwen speech tokenizer.
+
+Offline and streaming synthesis share loading, clone validation, and native
+generation. The actor retains its MLX streams and synchronizes before releasing
+model state. Keep WAV publication in AudioCore: offline output uses PCM16, and
+streaming output uses float32. The public generator's raw sample stream does
+not publish a file; its file-generation entry point uses the shared operation.

--- a/Sources/AudioTTS/Qwen3TTS/SNACDecoder.swift
+++ b/Sources/AudioTTS/Qwen3TTS/SNACDecoder.swift
@@ -1,3 +1,4 @@
+import AudioCore
 import Foundation
 import MLX
 import MLXNN
@@ -189,59 +190,12 @@ public enum SNACAudioTokenParser {
 
 // MARK: - Audio Utilities
 
+/// Compatibility entry point for callers that already hold an MLX waveform.
+/// Speech operations use AudioExportService directly after native decoding.
 public enum SNACAudioWriter {
-    /// Write audio samples to WAV file
-    /// - Parameters:
-    ///   - samples: Audio samples in range [-1, 1]
-    ///   - url: Output URL for WAV file
-    ///   - sampleRate: Sample rate (default 24000 for SNAC)
     public static func writeWAV(_ samples: MLXArray, to url: URL, sampleRate: Int = 24000) throws {
-        // Evaluate and get samples
         MLX.eval(samples)
-        let flatSamples = samples.reshaped(-1).asArray(Float.self)
-
-        // Convert to 16-bit PCM
-        let int16Samples = flatSamples.map { sample -> Int16 in
-            let clamped = max(-1.0, min(1.0, sample))
-            return Int16(clamped * 32767.0)
-        }
-
-        // Build WAV file
-        var data = Data()
-
-        // RIFF header
-        data.append(contentsOf: "RIFF".utf8)
-        let fileSize = UInt32(36 + int16Samples.count * 2)
-        data.append(contentsOf: withUnsafeBytes(of: fileSize.littleEndian) { Array($0) })
-        data.append(contentsOf: "WAVE".utf8)
-
-        // Format chunk
-        data.append(contentsOf: "fmt ".utf8)
-        let fmtSize = UInt32(16)
-        data.append(contentsOf: withUnsafeBytes(of: fmtSize.littleEndian) { Array($0) })
-        let audioFormat = UInt16(1)  // PCM
-        data.append(contentsOf: withUnsafeBytes(of: audioFormat.littleEndian) { Array($0) })
-        let numChannels = UInt16(1)  // Mono
-        data.append(contentsOf: withUnsafeBytes(of: numChannels.littleEndian) { Array($0) })
-        let sampleRateU32 = UInt32(sampleRate)
-        data.append(contentsOf: withUnsafeBytes(of: sampleRateU32.littleEndian) { Array($0) })
-        let byteRate = UInt32(sampleRate * 2)  // sampleRate * numChannels * bytesPerSample
-        data.append(contentsOf: withUnsafeBytes(of: byteRate.littleEndian) { Array($0) })
-        let blockAlign = UInt16(2)  // numChannels * bytesPerSample
-        data.append(contentsOf: withUnsafeBytes(of: blockAlign.littleEndian) { Array($0) })
-        let bitsPerSample = UInt16(16)
-        data.append(contentsOf: withUnsafeBytes(of: bitsPerSample.littleEndian) { Array($0) })
-
-        // Data chunk
-        data.append(contentsOf: "data".utf8)
-        let dataSize = UInt32(int16Samples.count * 2)
-        data.append(contentsOf: withUnsafeBytes(of: dataSize.littleEndian) { Array($0) })
-
-        // Audio samples
-        for sample in int16Samples {
-            data.append(contentsOf: withUnsafeBytes(of: sample.littleEndian) { Array($0) })
-        }
-
-        try data.write(to: url)
+        let waveform = try AudioWaveform(interleaved: samples.reshaped(-1).asArray(Float.self), channels: 1, sampleRate: sampleRate)
+        _ = try AudioExportService.write(waveform, plan: AudioExportPlan(options: .referencePCM16), to: url)
     }
 }

--- a/Sources/AudioTTS/Qwen3TTS/SpeechSynthesisModelSelection.swift
+++ b/Sources/AudioTTS/Qwen3TTS/SpeechSynthesisModelSelection.swift
@@ -1,0 +1,57 @@
+import AudioCore
+import Foundation
+import MereRunCore
+
+/// Resolves the common CLI/API selector without loading or downloading a model.
+public struct SpeechSynthesisModelSelection: Sendable, Hashable {
+    public let modelID: String
+    public let modelPath: String?
+
+    public static func resolve(_ selector: String, fileManager: FileManager = .default) throws -> Self {
+        let normalized = selector.trimmingCharacters(in: .whitespacesAndNewlines)
+        let selected = normalized.isEmpty ? Qwen3TTSResources.defaultModelId : normalized
+        let path = URL(fileURLWithPath: selected).standardizedFileURL
+        var isDirectory: ObjCBool = false
+        if fileManager.fileExists(atPath: path.path, isDirectory: &isDirectory) {
+            guard isDirectory.boolValue else { throw Qwen3TTSError.unsupportedModelId(selected) }
+            return Self(modelID: Qwen3TTSResources.defaultModelId, modelPath: path.path)
+        }
+        guard let spec = ManagedModelCatalog.spec(for: selected),
+              spec.category == .speechTTS, Qwen3TTSResources.supportedModelIds.contains(spec.id) else {
+            throw Qwen3TTSError.unsupportedModelId(selected)
+        }
+        return Self(modelID: spec.id, modelPath: nil)
+    }
+
+    public func makeGenerator() -> Qwen3TTSGenerator { Qwen3TTSGenerator(modelId: modelID) }
+
+    public func executor(using generator: Qwen3TTSGenerator) -> Qwen3TTSSynthesisExecutor {
+        Qwen3TTSSynthesisExecutor(generator: generator, modelPath: modelPath)
+    }
+}
+
+/// Adapts a caller-owned Qwen generator to the shared synthesis operation.
+/// The API keeps its resident generator; the CLI unloads its generator after use.
+public struct Qwen3TTSSynthesisExecutor: SpeechSynthesisExecutor {
+    private let generator: Qwen3TTSGenerator
+    private let modelPath: String?
+
+    public init(generator: Qwen3TTSGenerator, modelPath: String?) {
+        self.generator = generator
+        self.modelPath = modelPath
+    }
+
+    public func generate(
+        _ request: TTSRequest,
+        progressHandler: (@Sendable (TTSProgress) -> Void)?
+    ) async throws -> AudioWaveform {
+        try await generator.generateAudio(request, modelPath: modelPath, progressHandler: progressHandler)
+    }
+
+    public func generateStream(
+        _ request: TTSRequest,
+        options: TTSStreamingOptions
+    ) -> AsyncThrowingStream<TTSStreamingEvent, Error> {
+        generator.generateStream(request, options: options, modelPath: modelPath)
+    }
+}

--- a/Sources/MereRunCLI/Commands/README.md
+++ b/Sources/MereRunCLI/Commands/README.md
@@ -5,6 +5,9 @@ This directory owns the public CLI surface.
 - one command file per modality or command cluster
 - parser defaults and public flags are covered in `Tests/MereRunCLITests/`
 - stdout should remain machine-readable where possible; diagnostics belong on stderr
+- `speech synthesize` owns profiles, optional reference transcription, progress,
+  and receipts. AudioTTS resolves models; AudioCore validates synthesis and
+  publishes completed audio through the shared operation.
 - `video generate` translates flags and compound arguments into Core video
   options. Keep model defaults and compatibility in `VideoGenerationOptions`
   and `VideoGenerationPlan`; keep preflight JSON and filesystem diagnostics in

--- a/Sources/MereRunCLI/Commands/SpeechSynthesizeCommand.swift
+++ b/Sources/MereRunCLI/Commands/SpeechSynthesizeCommand.swift
@@ -8,18 +8,6 @@ import MereRunCore
 
 // MARK: - Speech Synthesize Command
 
-/// The one non-streaming synthesis call `speech synthesize` makes, so a test
-/// can substitute a fixture generator for Qwen3-TTS.
-protocol CLISpeechSynthesizing {
-    func generate(
-        _ request: TTSRequest,
-        modelPath: String?,
-        progressHandler: (@Sendable (TTSProgress) -> Void)?
-    ) async throws -> TTSResult
-}
-
-extension Qwen3TTSGenerator: CLISpeechSynthesizing {}
-
 enum TalkModeOption: String, ExpressibleByArgument {
     case style
     case clone
@@ -49,7 +37,7 @@ struct SpeechSynthesize: AsyncParsableCommand {
     var model: String = Qwen3TTSResources.defaultModelId
 
     @Option(name: [.customShort("v"), .long], help: "Voice description for speech style.")
-    var voice: String = "A calm female voice with clear pronunciation"
+    var voice: String = TTSRequest.defaultVoiceDescription
 
     @Option(name: [.long], help: "Voice mode: style or clone.")
     var mode: TalkModeOption = .style
@@ -64,13 +52,13 @@ struct SpeechSynthesize: AsyncParsableCommand {
     var refText: String?
 
     @Option(name: [.long], help: "Language hint (default: auto).")
-    var language: String = "auto"
+    var language: String = TTSRequest.defaultLanguage
 
     @Option(name: [.long], help: "Save this reference as a reusable profile name.")
     var saveProfile: String?
 
     @Option(name: [.long], help: "Sampling temperature (default: 0.6).")
-    var temperature: Float = 0.6
+    var temperature: Float = TTSRequest.defaultTemperature
 
     @Flag(name: [.long], help: "Enable streaming TTS mode.")
     var stream: Bool = false
@@ -87,109 +75,89 @@ struct SpeechSynthesize: AsyncParsableCommand {
     @Flag(name: [.customLong(RunReceipt.flagName)], help: RunReceipt.flagHelp)
     var receipt: Bool = false
 
-    /// Test seam: replaces the Qwen3-TTS generator on the non-streaming path so
-    /// the command's output contract can be exercised without a model. Setting
-    /// it also skips the Metal bundle check, which the fixture does not need.
-    /// Tests set and clear it around one `run()`; the CLI never touches it.
-    nonisolated(unsafe) static var synthesizerOverride: (any CLISpeechSynthesizing)?
+    /// Supplies fixture audio without loading a model. Tests restore it after each run.
+    nonisolated(unsafe) static var synthesizerOverride: (any SpeechSynthesisExecutor)?
 
-    private var synthesizer: (any CLISpeechSynthesizing)? { Self.synthesizerOverride }
+    private var streamingOptions: TTSStreamingOptions? {
+        stream ? TTSStreamingOptions(chunkTokenInterval: streamChunkTokens, emitTokenEvents: !quiet || progressJson) : nil
+    }
+
+    func synthesisPlan(outputURL: URL, cloneReference: TTSCloneReference? = nil) throws -> SpeechSynthesisPlan {
+        try SpeechSynthesisPlan(
+            request: TTSRequest(
+                text: text, voiceDescription: voice, voiceMode: mode == .clone ? .clone : .style,
+                cloneReference: cloneReference, language: normalizedLanguageOrAuto(language),
+                temperature: temperature, outputURL: outputURL
+            ),
+            streamingOptions: streamingOptions
+        )
+    }
 
     func run() async throws {
-        if stream {
-            guard streamChunkTokens > 0 else {
-                throw ValidationError("--stream-chunk-tokens must be > 0.")
-            }
-        }
-
-        if synthesizer == nil {
+        try SpeechSynthesisPlan.validateParameters(text: text, temperature: temperature, speed: TTSRequest.defaultSpeed)
+        try SpeechSynthesisPlan.validateStreamingOptions(streamingOptions)
+        let selection = try SpeechSynthesisModelSelection.resolve(model)
+        if Self.synthesizerOverride == nil {
             try MLXBundleSupport.ensureAvailable(quiet: quiet)
         }
         let outputURL = URL(fileURLWithPath: output).standardizedFileURL
-
-        // Ensure output directory exists
-        let outputDir = outputURL.deletingLastPathComponent()
-        try FileManager.default.createDirectory(at: outputDir, withIntermediateDirectories: true)
-
-        let modelSelection = try resolveModelSelection()
-        let qwenGenerator = Qwen3TTSGenerator(modelId: modelSelection.modelId)
-        let profileStore = VoiceProfileStore()
-
-        let request = try await buildRequest(outputURL: outputURL, profileStore: profileStore)
-
-        if stream {
-            try await runStreaming(request: request, generator: qwenGenerator, modelPath: modelSelection.modelPath)
+        let reference = mode == .clone ? try await resolveCloneReference(profileStore: VoiceProfileStore()) : nil
+        let plan = try synthesisPlan(outputURL: outputURL, cloneReference: reference)
+        try plan.validateForExecution()
+        if let executor = Self.synthesizerOverride {
+            try await run(plan: plan, executor: executor)
             return
         }
-        let generator: any CLISpeechSynthesizing = synthesizer ?? qwenGenerator
+        let generator = selection.makeGenerator()
+        do {
+            try await run(plan: plan, executor: selection.executor(using: generator))
+            await generator.unload()
+        } catch {
+            await generator.unload()
+            throw error
+        }
+    }
 
+    private func run(plan: SpeechSynthesisPlan, executor: any SpeechSynthesisExecutor) async throws {
         if !quiet {
-            FileHandle.standardError.write(Data("Generating speech with native Qwen3-TTS...\n".utf8))
+            let suffix = plan.streamingOptions == nil ? "" : " (streaming)"
+            FileHandle.standardError.write(Data("Generating speech with native Qwen3-TTS\(suffix)...\n".utf8))
         }
-
-        let progressHandler: (@Sendable (TTSProgress) -> Void)?
-        if progressJson {
-            // Qwen3-TTS reports stage changes and a running token count with no
-            // known total, so every event is indeterminate (`total_steps: 0`).
-            let progressStream = JSONProgressStream()
-            progressHandler = { progress in
-                progressStream.report(stage: progress.stage.rawValue, step: progress.tokensGenerated, totalSteps: 0)
-            }
-        } else if quiet {
-            progressHandler = nil
+        let result: TTSResult
+        if plan.streamingOptions != nil {
+            result = try await runStreaming(plan: plan, executor: executor)
         } else {
-            progressHandler = { progress in
-                var message = "[\(progress.stage.rawValue)]"
-                if progress.tokensGenerated > 0 {
-                    message += " \(progress.tokensGenerated) tokens"
-                }
-                if let msg = progress.message {
-                    message += " \(msg)"
-                }
-                FileHandle.standardError.write(Data("\(message)\n".utf8))
-            }
+            result = try await SpeechSynthesisOperation.execute(plan, executor: executor, progressHandler: progressHandler()).result
         }
-
-        let result = try await generator.generate(
-            request,
-            modelPath: modelSelection.modelPath,
-            progressHandler: progressHandler
-        )
-
         if !quiet {
             let durationStr = String(format: "%.2f", result.duration)
             FileHandle.standardError.write(Data("Audio saved to: \(result.audioURL.path)\n".utf8))
             FileHandle.standardError.write(Data("Duration: \(durationStr)s @ \(result.sampleRate)Hz\n".utf8))
         }
-
         print(result.audioURL.path)
         try RunReceipt.emit(RunReceipt.generatedAudioOutputs(audio: result.audioURL), enabled: receipt)
     }
 
-    private func runStreaming(
-        request: TTSRequest,
-        generator: Qwen3TTSGenerator,
-        modelPath: String?
-    ) async throws {
-        if !quiet {
-            FileHandle.standardError.write(Data("Generating speech with native Qwen3-TTS (streaming)...\n".utf8))
+    private func progressHandler() -> (@Sendable (TTSProgress) -> Void)? {
+        if progressJson {
+            let progressStream = JSONProgressStream()
+            return { progress in
+                progressStream.report(stage: progress.stage.rawValue, step: progress.tokensGenerated, totalSteps: 0)
+            }
         }
+        if quiet { return nil }
+        return { progress in
+            var message = "[\(progress.stage.rawValue)]"
+            if progress.tokensGenerated > 0 { message += " \(progress.tokensGenerated) tokens" }
+            if let detail = progress.message { message += " \(detail)" }
+            FileHandle.standardError.write(Data("\(message)\n".utf8))
+        }
+    }
 
-        let stream = generator.generateStream(
-            request,
-            options: TTSStreamingOptions(
-                chunkTokenInterval: streamChunkTokens,
-                emitTokenEvents: !quiet
-            ),
-            modelPath: modelPath
-        )
-
-        var writer: StreamingWAVWriter?
+    private func runStreaming(plan: SpeechSynthesisPlan, executor: any SpeechSynthesisExecutor) async throws -> TTSResult {
         var tokenCount = 0
-        var result: TTSResult?
         let progressStream = progressJson ? JSONProgressStream() : nil
-
-        for try await event in stream {
+        for try await event in try SpeechSynthesisOperation.stream(plan, executor: executor) {
             switch event {
             case .token:
                 tokenCount += 1
@@ -197,66 +165,17 @@ struct SpeechSynthesize: AsyncParsableCommand {
                     if let progressStream {
                         progressStream.report(stage: TTSStage.generating.rawValue, step: tokenCount, totalSteps: 0)
                     } else if !quiet {
-                        FileHandle.standardError.write(
-                            Data("[generating] \(tokenCount) tokens\n".utf8)
-                        )
+                        FileHandle.standardError.write(Data("[generating] \(tokenCount) tokens\n".utf8))
                     }
                 }
-
-            case .audioChunk(let samples, let sampleRate):
-                if writer == nil {
-                    writer = try StreamingWAVWriter(outputURL: request.outputURL, sampleRate: sampleRate)
-                }
-                try writer?.append(samples: samples)
-
-            case .completed(let completed):
-                result = completed
+            case .audioChunk:
+                break
+            case .completed(let result):
+                return result
             }
         }
-
-        guard let result else {
-            throw ValidationError("Streaming TTS completed without a final result.")
-        }
-
-        if !quiet {
-            let durationStr = String(format: "%.2f", result.duration)
-            FileHandle.standardError.write(Data("Audio saved to: \(result.audioURL.path)\n".utf8))
-            FileHandle.standardError.write(Data("Duration: \(durationStr)s @ \(result.sampleRate)Hz\n".utf8))
-        }
-
-        print(result.audioURL.path)
-        try RunReceipt.emit(RunReceipt.generatedAudioOutputs(audio: result.audioURL), enabled: receipt)
-    }
-
-    private func buildRequest(
-        outputURL: URL,
-        profileStore: VoiceProfileStore
-    ) async throws -> TTSRequest {
-        switch mode {
-        case .style:
-            return TTSRequest(
-                text: text,
-                voiceDescription: voice,
-                voiceMode: .style,
-                cloneReference: nil,
-                language: normalizedLanguageOrAuto(language),
-                speed: 1.0,
-                temperature: temperature,
-                outputURL: outputURL
-            )
-        case .clone:
-            let cloneReference = try await resolveCloneReference(profileStore: profileStore)
-            return TTSRequest(
-                text: text,
-                voiceDescription: voice,
-                voiceMode: .clone,
-                cloneReference: cloneReference,
-                language: normalizedLanguageOrAuto(language),
-                speed: 1.0,
-                temperature: temperature,
-                outputURL: outputURL
-            )
-        }
+        try Task.checkCancellation()
+        throw SpeechSynthesisError.invalidStream("Streaming TTS completed without a final result.")
     }
 
     private func resolveCloneReference(profileStore: VoiceProfileStore) async throws -> TTSCloneReference {
@@ -343,16 +262,6 @@ struct SpeechSynthesize: AsyncParsableCommand {
             throw ValidationError("Auto-transcription returned empty text. Use --ref-text.")
         }
         return transcript
-    }
-
-    private func resolveModelSelection() throws -> (modelId: String, modelPath: String?) {
-        let trimmed = model.trimmingCharacters(in: .whitespacesAndNewlines)
-        let fm = FileManager.default
-        let asPath = URL(fileURLWithPath: trimmed).standardizedFileURL
-        if fm.fileExists(atPath: asPath.path) {
-            return (Qwen3TTSResources.defaultModelId, asPath.path)
-        }
-        return (trimmed.isEmpty ? Qwen3TTSResources.defaultModelId : trimmed, nil)
     }
 
     private func normalized(_ value: String?) -> String? {

--- a/Sources/MereRunCLI/Support/APIServer.swift
+++ b/Sources/MereRunCLI/Support/APIServer.swift
@@ -1188,7 +1188,11 @@ actor CodeGenServer {
             let plan = try APIServerContract.speechPlan(from: openaiRequest)
             return try await withRuntimeRequestAdmission(using: requestAdmission) {
                 let outputURL = try await synthesizeSpeech(plan)
+                defer { try? FileManager.default.removeItem(at: outputURL) }
                 let responseURL = try speechResponseURL(outputURL, responseFormat: plan.responseFormat)
+                defer {
+                    if responseURL != outputURL { try? FileManager.default.removeItem(at: responseURL) }
+                }
                 let data = try Data(contentsOf: responseURL)
                 let response = binaryResponse(
                     data,
@@ -1483,23 +1487,12 @@ actor CodeGenServer {
     }
 
     private func synthesizeSpeech(_ plan: APIServerContract.SpeechPlan) async throws -> URL {
+        let selection = try plan.modelSelection()
         try MLXBundleSupport.ensureAvailable(quiet: true)
-        let selection = try resolveSpeechModel(plan.modelID)
         let outputURL = try temporaryOutputURL(directoryName: "mere-run-api-speech", extension: "wav")
-        let request = TTSRequest(
-            text: plan.input,
-            voiceDescription: plan.voiceDescription,
-            voiceMode: .style,
-            cloneReference: nil,
-            language: "auto",
-            speed: plan.speed,
-            temperature: plan.temperature,
-            outputURL: outputURL
-        )
         _ = try await sidecarPool.synthesizeSpeech(
-            modelID: selection.modelID,
-            modelPath: selection.modelPath,
-            request: request
+            selection: selection,
+            plan: plan.synthesisPlan(outputURL: outputURL)
         )
         return outputURL
     }
@@ -1512,7 +1505,12 @@ actor CodeGenServer {
             directoryName: "mere-run-api-speech",
             extension: responseFormat
         )
-        try MediaAudioIO.transcode(wavURL, to: outputURL, format: responseFormat)
+        do {
+            try MediaAudioIO.transcode(wavURL, to: outputURL, format: responseFormat)
+        } catch {
+            try? FileManager.default.removeItem(at: outputURL)
+            throw error
+        }
         return outputURL
     }
 
@@ -1536,24 +1534,6 @@ actor CodeGenServer {
         let manifest = try MereRunModelManifest.loadRequired(from: root)
         if case .managed(let id) = selection { return (id.rawValue, root, manifest) }
         return (manifest.id, root, manifest)
-    }
-
-    private func resolveSpeechModel(
-        _ requestedModel: String
-    ) throws -> (modelID: String, modelPath: String?) {
-        let normalized = requestedModel.trimmingCharacters(in: .whitespacesAndNewlines)
-        let asPath = URL(fileURLWithPath: normalized).standardizedFileURL
-        if FileManager.default.fileExists(atPath: asPath.path) {
-            return (Qwen3TTSResources.defaultModelId, asPath.path)
-        }
-        if let spec = ManagedModelCatalog.spec(for: normalized),
-           spec.category == .speechTTS {
-            return (spec.id, nil)
-        }
-        throw APIRequestValidationError.invalidField(
-            "model",
-            "use a mere.run TTS model id or a local Qwen3-TTS model path"
-        )
     }
 
     private nonisolated func temporaryOutputURL(

--- a/Sources/MereRunCLI/Support/APIServerContract.swift
+++ b/Sources/MereRunCLI/Support/APIServerContract.swift
@@ -616,6 +616,23 @@ enum APIServerContract {
         let responseFormat: String
         let speed: Float
         let temperature: Float
+
+        func synthesisPlan(outputURL: URL) throws -> SpeechSynthesisPlan {
+            try SpeechSynthesisPlan(request: TTSRequest(
+                text: input, voiceDescription: voiceDescription, speed: speed,
+                temperature: temperature, outputURL: outputURL
+            ))
+        }
+
+        func modelSelection() throws -> SpeechSynthesisModelSelection {
+            do {
+                return try SpeechSynthesisModelSelection.resolve(modelID)
+            } catch Qwen3TTSError.unsupportedModelId {
+                throw APIRequestValidationError.invalidField(
+                    "model", "use a mere.run TTS model id or a local Qwen3-TTS model path"
+                )
+            }
+        }
     }
 
     struct TranscriptionPlan: Equatable, Sendable {
@@ -1867,14 +1884,13 @@ enum APIServerContract {
 
     static func speechPlan(from request: OpenAIAudioSpeechRequest) throws -> SpeechPlan {
         let input = request.input.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !input.isEmpty else {
-            throw APIRequestValidationError.invalidField("input", "must not be empty")
-        }
         let responseFormat = try speechResponseFormat(request.response_format)
         let speed = try speechSpeed(request.speed)
-        let temperature = request.temperature ?? 0.6
-        guard temperature.isFinite, (0...2).contains(temperature) else {
-            throw APIRequestValidationError.invalidField("temperature", "must be between 0 and 2")
+        let temperature = request.temperature ?? TTSRequest.defaultTemperature
+        do {
+            try SpeechSynthesisPlan.validateParameters(text: input, temperature: temperature, speed: speed)
+        } catch SpeechSynthesisError.invalidInput(let field, let message) {
+            throw APIRequestValidationError.invalidField(field == .text ? "input" : field.rawValue, message)
         }
         let voiceDescription = voiceDescription(for: request.voice, instructions: request.instructions)
         var promptUTF8Bytes = 0
@@ -2736,11 +2752,11 @@ enum APIServerContract {
     }
 
     private static func speechSpeed(_ rawValue: Double?) throws -> Float {
-        let value = rawValue ?? 1.0
-        guard value.isFinite, (0.25...4.0).contains(value) else {
-            throw APIRequestValidationError.invalidField("speed", "must be between 0.25 and 4.0")
+        do {
+            return try SpeechSynthesisPlan.validatedSpeed(rawValue ?? Double(TTSRequest.defaultSpeed))
+        } catch SpeechSynthesisError.invalidInput(_, let message) {
+            throw APIRequestValidationError.invalidField("speed", message)
         }
-        return Float(value)
     }
 
     private static func transcriptionResponseFormat(_ rawValue: String?) throws -> String {
@@ -2905,7 +2921,7 @@ enum APIServerContract {
         case "fable":
             base = "A warm narrative voice with a measured pace"
         case "nova":
-            base = "A calm female voice with clear pronunciation"
+            base = TTSRequest.defaultVoiceDescription
         case "onyx":
             base = "A deep, confident voice with crisp articulation"
         case "sage":
@@ -2914,7 +2930,7 @@ enum APIServerContract {
             base = "A bright, gentle voice with smooth pronunciation"
         default:
             base = rawVoice?.trimmingCharacters(in: .whitespacesAndNewlines)
-                ?? "A calm female voice with clear pronunciation"
+                ?? TTSRequest.defaultVoiceDescription
         }
         if let instructionText {
             return "\(base). \(instructionText)"

--- a/Sources/MereRunCLI/Support/APISidecarModelPool.swift
+++ b/Sources/MereRunCLI/Support/APISidecarModelPool.swift
@@ -291,10 +291,12 @@ struct APISidecarModelPool: Sendable, CLIASRTranscriptionExecutor {
     }
 
     func synthesizeSpeech(
-        modelID: String,
-        modelPath: String?,
-        request: TTSRequest
+        selection: SpeechSynthesisModelSelection,
+        plan: SpeechSynthesisPlan
     ) async throws -> TTSResult {
+        try plan.validateForExecution()
+        let modelID = selection.modelID
+        let modelPath = selection.modelPath
         let key = APISidecarSpeechKey(
             modelID: modelID,
             modelPath: modelPath.map(normalizedPath)
@@ -326,14 +328,10 @@ struct APISidecarModelPool: Sendable, CLIASRTranscriptionExecutor {
                         )
                     )
                 },
-                make: { Qwen3TTSGenerator(modelId: modelID) },
+                make: { selection.makeGenerator() },
                 unload: { generator in await generator.unload() },
                 operation: { generator in
-                    try await generator.generate(
-                        request,
-                        modelPath: modelPath,
-                        progressHandler: nil
-                    )
+                    try await SpeechSynthesisOperation.execute(plan, executor: selection.executor(using: generator)).result
                 }
             )
         }

--- a/Sources/MereRunCLI/Support/README.md
+++ b/Sources/MereRunCLI/Support/README.md
@@ -4,6 +4,9 @@ Shared helpers and runtime adapters for the public command surface.
 
 - `APIServerContract.swift`: API wire types, model policy, and request/response contracts.
 - `APIServer.swift`: HTTP routing, authentication, transport, and streaming ownership.
+- Speech API model aliases and voice descriptions belong to `APIServerContract`.
+  `APISidecarModelPool` retains admission and residency around the shared
+  `AudioCore.SpeechSynthesisOperation`.
 
 - `CLIModelStoreBootstrap.swift`: global model-root handling.
 - `CLIOutput.swift` and `CLIStderr.swift`: output channel discipline.

--- a/Tests/AudioCoreTests/AudioExportStreamTests.swift
+++ b/Tests/AudioCoreTests/AudioExportStreamTests.swift
@@ -1,0 +1,122 @@
+import Foundation
+import XCTest
+@testable import AudioCore
+
+final class AudioExportStreamTests: XCTestCase {
+    func testIncrementalEncodingMatchesWholeFileAcrossFormatsAndChunkBoundaries() throws {
+        let directory = try directory()
+        let samples: [Float] = [-1, -0.75, -0.5, 0, 0.25, 0.5, 1]
+        for format in AudioWAVEncoding.allCases {
+            let plan = try AudioExportPlan(options: AudioExportOptions(
+                format: format, normalization: .none, targetPeakDB: 0,
+                fadeInMilliseconds: 0, fadeOutMilliseconds: 0, dither: true
+            ))
+            let waveform = try AudioWaveform(interleaved: samples, channels: 1, sampleRate: 24_000)
+            let expected = try AudioExportService.data(waveform, plan: plan)
+            let output = directory.appendingPathComponent("\(format.rawValue).wav")
+            let writer = try AudioExportStream(plan: plan, to: output, sampleRate: 24_000)
+            try writer.append(samples: Array(samples[..<1]))
+            try writer.append(samples: Array(samples[1..<4]))
+            try writer.append(samples: Array(samples[4...]))
+            let result = try writer.finish()
+            XCTAssertEqual(try Data(contentsOf: output), expected.data)
+            XCTAssertEqual(result.byteCount, expected.data.count)
+            XCTAssertEqual(result.statistics.sampleCount, samples.count)
+            XCTAssertEqual(result.statistics.outputRMS, expected.statistics.outputRMS, accuracy: 1e-12)
+            XCTAssertThrowsError(try writer.finish())
+            XCTAssertThrowsError(try writer.append(samples: [0]))
+        }
+    }
+
+    func testFloatHeadroomAndNonfinitePolicyAreExplicit() throws {
+        let directory = try directory()
+        let output = directory.appendingPathComponent("float.wav")
+        let plan = try AudioExportPlan(options: .speechStreaming, clipping: .preserveFloatHeadroom)
+        let writer = try AudioExportStream(plan: plan, to: output, sampleRate: 24_000)
+        try writer.append(samples: [2, -2, .nan, .infinity, 0.25])
+        let result = try writer.finish()
+        let data = try Data(contentsOf: output)
+        XCTAssertEqual(data[20], 3)
+        XCTAssertEqual(data[34], 32)
+        XCTAssertEqual((0..<5).map { Float(bitPattern: read32(data, 44 + $0 * 4)) }, [2, -2, 0, 0, 0.25])
+        XCTAssertEqual(result.statistics.replacedNonfiniteSamples, 2)
+        XCTAssertEqual(result.statistics.clippedSamples, 0)
+        XCTAssertEqual(result.statistics.outputPeak, 2)
+        XCTAssertThrowsError(try AudioExportPlan(options: .referencePCM16, clipping: .preserveFloatHeadroom))
+        let defaultFloat = try AudioExportService.data(
+            AudioWaveform(interleaved: [2, -2], channels: 1, sampleRate: 24_000),
+            plan: AudioExportPlan(options: .speechStreaming)
+        )
+        XCTAssertEqual(defaultFloat.statistics.clippedSamples, 2)
+    }
+
+    func testOnlyFinishedStreamsReplaceTheDestination() throws {
+        let directory = try directory()
+        let output = directory.appendingPathComponent("existing.wav")
+        let original = Data("previous audio".utf8)
+        try original.write(to: output)
+        let plan = try AudioExportPlan(options: .speechStreaming)
+        let discarded = try AudioExportStream(plan: plan, to: output, sampleRate: 24_000)
+        try discarded.append(samples: [0.5])
+        XCTAssertEqual(try Data(contentsOf: output), original)
+        discarded.cancel()
+        XCTAssertEqual(try Data(contentsOf: output), original)
+        XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: directory.path), ["existing.wav"])
+        let completed = try AudioExportStream(plan: plan, to: output, sampleRate: 24_000)
+        try completed.append(samples: [0.5])
+        _ = try completed.finish()
+        XCTAssertEqual(try Data(contentsOf: output).count, 48)
+        XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: directory.path), ["existing.wav"])
+    }
+
+    func testCancelledFinishPreservesExistingOutputAndRemovesTemporaryFile() async throws {
+        let directory = try directory()
+        let output = directory.appendingPathComponent("existing.wav")
+        let original = Data("previous audio".utf8)
+        try original.write(to: output)
+        let task = Task {
+            let writer = try AudioExportStream(plan: AudioExportPlan(options: .speechStreaming), to: output, sampleRate: 24_000)
+            try writer.append(samples: [0.5])
+            withUnsafeCurrentTask { $0?.cancel() }
+            XCTAssertThrowsError(try writer.finish()) { XCTAssertTrue($0 is CancellationError) }
+        }
+        try await task.value
+        XCTAssertEqual(try Data(contentsOf: output), original)
+        XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: directory.path), ["existing.wav"])
+    }
+
+    func testInvalidChunkDiscardsTheStreamAndPreservesExistingOutput() throws {
+        let directory = try directory()
+        let output = directory.appendingPathComponent("existing.wav")
+        let original = Data("previous audio".utf8)
+        try original.write(to: output)
+        let writer = try AudioExportStream(plan: AudioExportPlan(options: .speechStreaming),
+                                           to: output, sampleRate: 24_000, channels: 2)
+        try writer.append(samples: [0.25, -0.25])
+        XCTAssertThrowsError(try writer.append(samples: [0.5]))
+        XCTAssertThrowsError(try writer.finish())
+        XCTAssertEqual(try Data(contentsOf: output), original)
+        XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: directory.path), ["existing.wav"])
+    }
+
+    func testUnsupportedStreamProcessingAndInvalidFormatsDoNotCreateFiles() throws {
+        let directory = try directory()
+        let output = directory.appendingPathComponent("invalid.wav")
+        XCTAssertThrowsError(try AudioExportStream(plan: AudioExportPlan(options: .music), to: output, sampleRate: 24_000))
+        let plan = try AudioExportPlan(options: .speechStreaming)
+        XCTAssertThrowsError(try AudioExportStream(plan: plan, to: output, sampleRate: Int.max))
+        XCTAssertThrowsError(try AudioExportStream(plan: plan, to: output, sampleRate: 24_000, channels: 0))
+        XCTAssertTrue(try FileManager.default.contentsOfDirectory(atPath: directory.path).isEmpty)
+    }
+
+    private func directory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: url) }
+        return url
+    }
+
+    private func read32(_ data: Data, _ offset: Int) -> UInt32 {
+        (0..<4).reduce(0) { $0 | UInt32(data[offset + $1]) << ($1 * 8) }
+    }
+}

--- a/Tests/AudioCoreTests/SpeechSynthesisOperationTests.swift
+++ b/Tests/AudioCoreTests/SpeechSynthesisOperationTests.swift
@@ -1,0 +1,307 @@
+import Foundation
+import XCTest
+import AudioCore
+
+final class SpeechSynthesisOperationTests: XCTestCase {
+    func testPlansPreserveRequestValuesAndExplicitEncodingDefaults() throws {
+        var request = TTSRequest(text: "  Say this exactly.  ", outputURL: URL(fileURLWithPath: "/fixture/output.wav"))
+        let file = try SpeechSynthesisPlan(request: request)
+        XCTAssertEqual(file.request.text, "  Say this exactly.  ")
+        XCTAssertEqual(file.request.voiceDescription, "A calm female voice with clear pronunciation")
+        XCTAssertEqual(file.request.language, "auto")
+        XCTAssertEqual(file.request.temperature, 0.6)
+        XCTAssertEqual(file.request.speed, 1)
+        XCTAssertEqual(file.exportPlan.options.format, .pcm16)
+        XCTAssertEqual(file.exportPlan.options.normalization, .none)
+        XCTAssertEqual(file.exportPlan.options.fadeInMilliseconds, 0)
+        XCTAssertEqual(file.exportPlan.options.fadeOutMilliseconds, 0)
+        XCTAssertFalse(file.exportPlan.options.dither)
+        request.text = "A later edit"
+        XCTAssertEqual(file.request.text, "  Say this exactly.  ")
+        let stream = try SpeechSynthesisPlan(request: file.request, streamingOptions: TTSStreamingOptions(chunkTokenInterval: 17, emitTokenEvents: false))
+        XCTAssertEqual(stream.streamingOptions?.chunkTokenInterval, 17)
+        XCTAssertEqual(stream.streamingOptions?.emitTokenEvents, false)
+        XCTAssertEqual(stream.exportPlan.options.format, .float32)
+        XCTAssertEqual(stream.exportPlan.clipping, .preserveFloatHeadroom)
+        var speedHint = file.request
+        speedHint.speed = 1.25
+        XCTAssertEqual(try SpeechSynthesisPlan(request: speedHint).request.speed, 1.25)
+    }
+
+    func testInvalidParametersAndCloneReferencesAreRejectedBeforeExecution() throws {
+        let output = URL(fileURLWithPath: "/fixture/output.wav")
+        XCTAssertThrowsError(try SpeechSynthesisPlan(request: TTSRequest(text: " \n ", outputURL: output)))
+        for temperature: Float in [-1, 2.1, .nan, .infinity, -.infinity] {
+            XCTAssertThrowsError(try SpeechSynthesisPlan(request: TTSRequest(text: "hello", temperature: temperature, outputURL: output)))
+        }
+        for speed: Double in [0, 0.249999999999, 4.000000000001, .nan, .infinity] {
+            XCTAssertThrowsError(try SpeechSynthesisPlan.validatedSpeed(speed))
+        }
+        let request = TTSRequest(text: "hello", outputURL: output)
+        XCTAssertThrowsError(try SpeechSynthesisPlan(request: request, streamingOptions: TTSStreamingOptions(chunkTokenInterval: 0)))
+        XCTAssertThrowsError(try SpeechSynthesisPlan(request: TTSRequest(text: "hello", voiceMode: .clone, outputURL: output)))
+        XCTAssertThrowsError(try SpeechSynthesisPlan(request: TTSRequest(
+            text: "hello", voiceMode: .clone,
+            cloneReference: TTSCloneReference(audioURL: output, transcript: "  "), outputURL: output
+        )))
+    }
+
+    func testExecutionUsesTheExactPlanAndWritesLiteralPCM16Samples() async throws {
+        let output = try directory().appendingPathComponent("nested/output.wav")
+        let plan = try SpeechSynthesisPlan(request: TTSRequest(text: "hello", temperature: 0, outputURL: output))
+        let probe = SynthesisProbe()
+        let executor = SynthesisFixture(generate: { request in
+            await probe.record(request)
+            return try AudioWaveform(interleaved: [-2, -0.5, 0, 0.5, 2, .nan], channels: 1, sampleRate: 24_000)
+        })
+        let outcome = try await SpeechSynthesisOperation.execute(plan, executor: executor)
+        let calls = await probe.requests
+        XCTAssertEqual(calls, [plan.request])
+        XCTAssertEqual(outcome.result.audioURL, output)
+        XCTAssertEqual(outcome.result.sampleRate, 24_000)
+        XCTAssertEqual(outcome.result.duration, 6.0 / 24_000)
+        XCTAssertEqual(outcome.artifact.statistics.replacedNonfiniteSamples, 1)
+        XCTAssertEqual(outcome.artifact.statistics.clippedSamples, 2)
+        let data = try Data(contentsOf: output)
+        XCTAssertEqual(data[20], 1)
+        XCTAssertEqual(data[34], 16)
+        XCTAssertEqual(read32(data, 40), 12)
+        let values = (0..<6).map { Int16(bitPattern: UInt16(data[44 + $0 * 2]) | UInt16(data[45 + $0 * 2]) << 8) }
+        XCTAssertEqual(values, [-32_767, -16_383, 0, 16_383, 32_767, 0])
+    }
+
+    func testDeletedCloneReferenceDoesNotCallTheExecutorOrCreateOutputDirectories() async throws {
+        let folder = try directory()
+        let reference = folder.appendingPathComponent("reference.wav")
+        try Data("reference".utf8).write(to: reference)
+        let output = folder.appendingPathComponent("not-created/output.wav")
+        let plan = try SpeechSynthesisPlan(request: TTSRequest(text: "hello", voiceMode: .clone,
+            cloneReference: TTSCloneReference(audioURL: reference, transcript: "reference text"), outputURL: output))
+        try FileManager.default.removeItem(at: reference)
+        let probe = SynthesisProbe()
+        do {
+            _ = try await SpeechSynthesisOperation.execute(plan, executor: fixture(probe: probe))
+            XCTFail("Deleted reference was accepted")
+        } catch SpeechSynthesisError.invalidInput(let field, _) {
+            XCTAssertEqual(field, .cloneReference)
+        }
+        let calls = await probe.requests
+        XCTAssertTrue(calls.isEmpty)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: output.deletingLastPathComponent().path))
+    }
+
+    func testFailureAndEmptyAudioPreserveExistingOutput() async throws {
+        let folder = try directory()
+        let output = folder.appendingPathComponent("existing.wav")
+        let original = Data("existing audio".utf8)
+        try original.write(to: output)
+        let plan = try SpeechSynthesisPlan(request: TTSRequest(text: "hello", outputURL: output))
+        for executor in [SynthesisFixture(generate: { _ in throw SynthesisFixtureError.expected }),
+                         SynthesisFixture(generate: { _ in try AudioWaveform(interleaved: [], channels: 1, sampleRate: 24_000) })] {
+            do {
+                _ = try await SpeechSynthesisOperation.execute(plan, executor: executor)
+                XCTFail("Invalid executor result succeeded")
+            } catch {}
+            XCTAssertEqual(try Data(contentsOf: output), original)
+            XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: folder.path), ["existing.wav"])
+        }
+    }
+
+    func testCancellationBeforeExecutionDoesNotCallTheExecutor() async throws {
+        let output = try directory().appendingPathComponent("output.wav")
+        let plan = try SpeechSynthesisPlan(request: TTSRequest(text: "hello", outputURL: output))
+        let probe = SynthesisProbe()
+        let executor = fixture(probe: probe)
+        let task = Task {
+            withUnsafeCurrentTask { $0?.cancel() }
+            return try await SpeechSynthesisOperation.execute(plan, executor: executor)
+        }
+        do { _ = try await task.value; XCTFail("Cancelled operation succeeded") } catch is CancellationError {}
+        let calls = await probe.requests
+        XCTAssertTrue(calls.isEmpty)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: output.path))
+    }
+
+    func testCancellationAfterUncooperativeGenerationDoesNotPublish() async throws {
+        let output = try directory().appendingPathComponent("output.wav")
+        let original = Data("previous audio".utf8)
+        try original.write(to: output)
+        let plan = try SpeechSynthesisPlan(request: TTSRequest(text: "hello", outputURL: output))
+        let gate = SynthesisGate()
+        let executor = SynthesisFixture(generate: { _ in
+            await gate.wait()
+            return try AudioWaveform(interleaved: [0.5], channels: 1, sampleRate: 24_000)
+        })
+        let task = Task { try await SpeechSynthesisOperation.execute(plan, executor: executor) }
+        try await waitUntil { await gate.entered }
+        task.cancel()
+        await gate.open()
+        do { _ = try await task.value; XCTFail("Cancelled audio was published") } catch is CancellationError {}
+        XCTAssertEqual(try Data(contentsOf: output), original)
+    }
+
+    func testStreamingPublishesFinalizedFloatAudioBeforeCompletion() async throws {
+        let output = try directory().appendingPathComponent("stream.wav")
+        let plan = try streamingPlan(output)
+        let events: [TTSStreamingEvent] = [.token(id: 7), .audioChunk(samples: [2, -2], sampleRate: 24_000),
+            .audioChunk(samples: [0.25], sampleRate: 24_000), .completed(result: TTSResult(audioURL: output, duration: 3.0 / 24_000))]
+        var names: [String] = []
+        for try await event in try SpeechSynthesisOperation.stream(plan, executor: eventFixture(events)) {
+            switch event {
+            case .token: names.append("token")
+            case .audioChunk: names.append("audio")
+            case .completed(let result):
+                names.append("completed")
+                let data = try Data(contentsOf: output)
+                XCTAssertEqual(read32(data, 40), 12)
+                XCTAssertEqual(data[20], 3)
+                XCTAssertEqual(data[34], 32)
+                XCTAssertEqual((0..<3).map { Float(bitPattern: read32(data, 44 + $0 * 4)) }, [2, -2, 0.25])
+                XCTAssertEqual(result.duration, 3.0 / 24_000)
+            }
+        }
+        XCTAssertEqual(names, ["token", "audio", "audio", "completed"])
+    }
+
+    func testMalformedAndFailedStreamsPreserveExistingOutputAndRemoveTemporaryFiles() async throws {
+        for variant in 0..<5 {
+            let folder = try directory()
+            let output = folder.appendingPathComponent("existing.wav")
+            let original = Data("existing audio".utf8)
+            try original.write(to: output)
+            let completed = TTSStreamingEvent.completed(result: TTSResult(audioURL: output, duration: 1.0 / 24_000))
+            let first = TTSStreamingEvent.audioChunk(samples: [0.5], sampleRate: 24_000)
+            let cases: [[TTSStreamingEvent]] = [
+                [first],
+                [first, .audioChunk(samples: [0.5], sampleRate: 48_000), completed],
+                [first, completed, .token(id: 1)],
+                [first, .completed(result: TTSResult(audioURL: output, duration: 0, sampleRate: 48_000))],
+                [first, completed]
+            ]
+            let executor = eventFixture(cases[variant], failure: variant == 4)
+            do {
+                for try await _ in try SpeechSynthesisOperation.stream(streamingPlan(output), executor: executor) {}
+                XCTFail("Malformed stream succeeded")
+            } catch {}
+            XCTAssertEqual(try Data(contentsOf: output), original)
+            XCTAssertEqual(try FileManager.default.contentsOfDirectory(atPath: folder.path), ["existing.wav"])
+        }
+    }
+
+    func testCancellingStreamConsumerStopsProducerAndDiscardsPartialOutput() async throws {
+        let folder = try directory()
+        let output = folder.appendingPathComponent("existing.wav")
+        let original = Data("existing audio".utf8)
+        try original.write(to: output)
+        let plan = try streamingPlan(output)
+        let probe = SynthesisProbe()
+        let executor = SynthesisFixture(stream: { _, _ in
+            AsyncThrowingStream { continuation in
+                let producer = Task {
+                    do {
+                        continuation.yield(.audioChunk(samples: [0.5], sampleRate: 24_000))
+                        try await Task.sleep(for: .seconds(30))
+                        XCTFail("Producer was not cancelled")
+                        continuation.finish()
+                    } catch {
+                        await probe.markStopped()
+                        continuation.finish(throwing: error)
+                    }
+                }
+                continuation.onTermination = { @Sendable reason in
+                    if case .cancelled = reason { producer.cancel() }
+                }
+            }
+        })
+        let consumer = Task {
+            for try await event in try SpeechSynthesisOperation.stream(plan, executor: executor) {
+                if case .audioChunk = event { await probe.markReceived() }
+                if case .completed = event { XCTFail("Cancelled stream emitted success") }
+            }
+            try Task.checkCancellation()
+        }
+        try await waitUntil { await probe.received }
+        consumer.cancel()
+        do { try await consumer.value; XCTFail("Cancelled consumer succeeded") } catch is CancellationError {}
+        try await waitUntil { await probe.stopped }
+        try await waitUntil {
+            (try? FileManager.default.contentsOfDirectory(atPath: folder.path)) == ["existing.wav"]
+        }
+        XCTAssertEqual(try Data(contentsOf: output), original)
+    }
+
+    private func directory() throws -> URL {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: url, withIntermediateDirectories: true)
+        addTeardownBlock { try? FileManager.default.removeItem(at: url) }
+        return url
+    }
+
+    private func streamingPlan(_ output: URL) throws -> SpeechSynthesisPlan {
+        try SpeechSynthesisPlan(request: TTSRequest(text: "hello", outputURL: output), streamingOptions: TTSStreamingOptions())
+    }
+
+    private func fixture(probe: SynthesisProbe) -> SynthesisFixture {
+        SynthesisFixture(generate: { request in
+            await probe.record(request)
+            return try AudioWaveform(interleaved: [0.25], channels: 1, sampleRate: 24_000)
+        })
+    }
+
+    private func eventFixture(_ events: [TTSStreamingEvent], failure: Bool = false) -> SynthesisFixture {
+        SynthesisFixture(stream: { _, _ in
+            AsyncThrowingStream { continuation in
+                for event in events { continuation.yield(event) }
+                if failure { continuation.finish(throwing: SynthesisFixtureError.expected) }
+                else { continuation.finish() }
+            }
+        })
+    }
+
+    private func read32(_ data: Data, _ offset: Int) -> UInt32 {
+        (0..<4).reduce(0) { $0 | UInt32(data[offset + $1]) << ($1 * 8) }
+    }
+
+    private func waitUntil(_ predicate: @escaping @Sendable () async -> Bool) async throws {
+        let deadline = ContinuousClock.now + .seconds(3)
+        while !(await predicate()) {
+            guard ContinuousClock.now < deadline else { throw SynthesisFixtureError.timeout }
+            try await Task.sleep(for: .milliseconds(5))
+        }
+    }
+}
+
+private enum SynthesisFixtureError: Error { case expected, timeout }
+
+private struct SynthesisFixture: SpeechSynthesisExecutor {
+    var generate: @Sendable (TTSRequest) async throws -> AudioWaveform = { _ in throw SynthesisFixtureError.expected }
+    var stream: @Sendable (TTSRequest, TTSStreamingOptions) -> AsyncThrowingStream<TTSStreamingEvent, Error> = { _, _ in
+        AsyncThrowingStream { $0.finish(throwing: SynthesisFixtureError.expected) }
+    }
+
+    func generate(_ request: TTSRequest, progressHandler: (@Sendable (TTSProgress) -> Void)?) async throws -> AudioWaveform {
+        try await generate(request)
+    }
+    func generateStream(_ request: TTSRequest, options: TTSStreamingOptions) -> AsyncThrowingStream<TTSStreamingEvent, Error> {
+        stream(request, options)
+    }
+}
+
+private actor SynthesisProbe {
+    private(set) var requests: [TTSRequest] = []
+    private(set) var received = false
+    private(set) var stopped = false
+    func record(_ request: TTSRequest) { requests.append(request) }
+    func markReceived() { received = true }
+    func markStopped() { stopped = true }
+}
+
+private actor SynthesisGate {
+    private(set) var entered = false
+    private var continuation: CheckedContinuation<Void, Never>?
+    func wait() async {
+        entered = true
+        await withCheckedContinuation { continuation = $0 }
+    }
+    func open() { continuation?.resume(); continuation = nil }
+}

--- a/Tests/AudioTTSTests/SpeechSynthesisModelSelectionTests.swift
+++ b/Tests/AudioTTSTests/SpeechSynthesisModelSelectionTests.swift
@@ -1,0 +1,30 @@
+import AudioTTS
+import Foundation
+import XCTest
+
+final class SpeechSynthesisModelSelectionTests: XCTestCase {
+    func testManagedDefaultsAndSupportedModelsResolveWithoutLoading() throws {
+        XCTAssertEqual(try SpeechSynthesisModelSelection.resolve("  ").modelID, "speech-tts-qwen3-nano")
+        for id in ["speech-tts-qwen3-nano", "speech-tts-qwen3-customvoice"] {
+            let selected = try SpeechSynthesisModelSelection.resolve("  \(id)  ")
+            XCTAssertEqual(selected.modelID, id)
+            XCTAssertNil(selected.modelPath)
+        }
+    }
+
+    func testLocalPathsRetainTheSharedDefaultIDAndNormalizedPath() throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let selected = try SpeechSynthesisModelSelection.resolve(directory.path + "/./")
+        XCTAssertEqual(selected.modelID, "speech-tts-qwen3-nano")
+        XCTAssertEqual(selected.modelPath, directory.standardizedFileURL.path)
+        XCTAssertTrue(try FileManager.default.contentsOfDirectory(atPath: directory.path).isEmpty)
+    }
+
+    func testNonTTSModelsAndWireOnlyAliasesDoNotReachTheNativeRuntime() {
+        for selector in ["tts-1", "speech-asr-qwen3", "unknown-speech-fixture"] {
+            XCTAssertThrowsError(try SpeechSynthesisModelSelection.resolve(selector))
+        }
+    }
+}

--- a/Tests/MereRunCLITests/ReceiptCommandRunTests.swift
+++ b/Tests/MereRunCLITests/ReceiptCommandRunTests.swift
@@ -25,15 +25,24 @@ final class ReceiptCommandRunTests: XCTestCase {
         }
     }
 
-    private struct FixtureTTS: CLISpeechSynthesizing {
+    private struct FixtureTTS: SpeechSynthesisExecutor {
         func generate(
             _ request: TTSRequest,
-            modelPath: String?,
             progressHandler: (@Sendable (TTSProgress) -> Void)?
-        ) async throws -> TTSResult {
+        ) async throws -> AudioWaveform {
             progressHandler?(TTSProgress(stage: .generating, tokensGenerated: 25))
-            try Data("RIFF".utf8).write(to: request.outputURL)
-            return TTSResult(audioURL: request.outputURL, duration: 1.0)
+            return try AudioWaveform(interleaved: [0, 0.25, -0.25], channels: 1, sampleRate: 24_000)
+        }
+
+        func generateStream(_ request: TTSRequest, options: TTSStreamingOptions) -> AsyncThrowingStream<TTSStreamingEvent, Error> {
+            AsyncThrowingStream { continuation in
+                if options.emitTokenEvents {
+                    for token in 0..<25 { continuation.yield(.token(id: token)) }
+                }
+                continuation.yield(.audioChunk(samples: [0, 0.25, -0.25], sampleRate: 24_000))
+                continuation.yield(.completed(result: TTSResult(audioURL: request.outputURL, duration: 3.0 / 24_000)))
+                continuation.finish()
+            }
         }
     }
 
@@ -165,5 +174,19 @@ final class ReceiptCommandRunTests: XCTestCase {
         XCTAssertEqual(outputs.map { $0["kind"] as? String }, ["audio"])
         XCTAssertEqual(outputs[0]["path"] as? String, outputURL.standardizedFileURL.path)
         XCTAssertNil(outputs[0]["role"])
+    }
+
+    func testStreamingSynthesizeReceiptNamesACompletedFloatWAV() async throws {
+        let (command, outputURL) = try synthesizeCommand(["--stream", "--receipt", "--progress-json"])
+        let stdout = try await capturingStandardOutput { try await command.run() }
+        XCTAssertEqual(stdout.split(separator: "\n").count, 2)
+        let receipt = try receipt(fromLastLineOf: stdout)
+        let outputs = try XCTUnwrap(receipt["outputs"] as? [[String: Any]])
+        XCTAssertEqual(outputs[0]["path"] as? String, outputURL.standardizedFileURL.path)
+        let data = try Data(contentsOf: outputURL)
+        XCTAssertEqual(data.count, 56)
+        XCTAssertEqual(data[20], 3)
+        XCTAssertEqual(data[34], 32)
+        XCTAssertEqual(data[40], 12)
     }
 }

--- a/Tests/MereRunCLITests/SpeechSynthesizeCommandParsingTests.swift
+++ b/Tests/MereRunCLITests/SpeechSynthesizeCommandParsingTests.swift
@@ -1,7 +1,73 @@
 import XCTest
+import AudioCore
+import MereRunCore
 @testable import MereRunCLI
 
 final class SpeechSynthesizeCommandParsingTests: XCTestCase {
+    func testCLIAndAPIUseEquivalentDefaultAndExplicitSynthesisPlans() throws {
+        let output = URL(fileURLWithPath: "/fixture/output.wav")
+        let defaults = try SpeechSynthesize.parse(["hello", "--output", output.path])
+        let apiDefaults = try APIServerContract.speechPlan(from: OpenAIAudioSpeechRequest(input: "hello"))
+        XCTAssertEqual(try defaults.synthesisPlan(outputURL: output), try apiDefaults.synthesisPlan(outputURL: output))
+
+        let description = "A deep, confident voice with crisp articulation. Use a friendly pace."
+        let explicit = try SpeechSynthesize.parse([
+            "hello", "--output", output.path, "--voice", description, "--temperature", "0.7"
+        ])
+        let apiExplicit = try APIServerContract.speechPlan(from: OpenAIAudioSpeechRequest(
+            model: "tts-1", input: "hello", voice: "onyx", instructions: "Use a friendly pace.", temperature: 0.7
+        ))
+        XCTAssertEqual(try explicit.synthesisPlan(outputURL: output), try apiExplicit.synthesisPlan(outputURL: output))
+        XCTAssertEqual(try apiExplicit.modelSelection().modelID, "speech-tts-qwen3-nano")
+    }
+
+    func testAPIInputTrimmingAndCLITextPreservationRemainExplicit() throws {
+        let output = URL(fileURLWithPath: "/fixture/output.wav")
+        let cli = try SpeechSynthesize.parse(["  hello  ", "--output", output.path])
+        let api = try APIServerContract.speechPlan(from: OpenAIAudioSpeechRequest(input: "  hello  "))
+        XCTAssertEqual(try cli.synthesisPlan(outputURL: output).request.text, "  hello  ")
+        XCTAssertEqual(try api.synthesisPlan(outputURL: output).request.text, "hello")
+    }
+
+    func testQuietStreamingStillEmitsTokensWhenJSONProgressIsRequested() throws {
+        let output = URL(fileURLWithPath: "/fixture/output.wav")
+        let cli = try SpeechSynthesize.parse([
+            "hello", "--output", output.path, "--stream", "--quiet", "--progress-json", "--stream-chunk-tokens", "17"
+        ])
+        let plan = try cli.synthesisPlan(outputURL: output)
+        XCTAssertEqual(plan.streamingOptions?.emitTokenEvents, true)
+        XCTAssertEqual(plan.streamingOptions?.chunkTokenInterval, 17)
+        XCTAssertEqual(plan.exportPlan.options.format, .float32)
+    }
+
+    func testInvalidScalarsFailBeforeModelLookupAndOutputCreation() async throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        defer {
+            if FileManager.default.fileExists(atPath: directory.path) {
+                try? FileManager.default.removeItem(at: directory)
+            }
+        }
+        let output = directory.appendingPathComponent("output.wav")
+        for temperature in ["nan", "inf", "-1", "2.1"] {
+            let cli = try SpeechSynthesize.parse([
+                "hello", "--output", output.path, "--model", "missing-speech-fixture", "--temperature=\(temperature)"
+            ])
+            do {
+                try await cli.run()
+                XCTFail("Invalid temperature was accepted")
+            } catch SpeechSynthesisError.invalidInput(let field, _) {
+                XCTAssertEqual(field, .temperature)
+            }
+            XCTAssertFalse(FileManager.default.fileExists(atPath: directory.path))
+        }
+        let invalidStream = try SpeechSynthesize.parse([
+            "hello", "--output", output.path, "--model", "missing-speech-fixture", "--stream", "--stream-chunk-tokens", "0"
+        ])
+        do { try await invalidStream.run(); XCTFail("Invalid stream interval was accepted") }
+        catch SpeechSynthesisError.invalidInput(let field, _) { XCTAssertEqual(field, .streamChunkTokens) }
+        XCTAssertFalse(FileManager.default.fileExists(atPath: directory.path))
+    }
+
     func testSpeechSynthesizeDefaultsToStyleMode() throws {
         let cmd = try SpeechSynthesize.parse([
             "Hello from mere.run",

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -165,6 +165,9 @@ the dependency map. Qwen ASR, Qwen TTS, Parakeet, and Sortformer build independe
 
 Speech synthesis command path:
 
+- [Shared synthesis](./internals/speech-synthesis-operation.md): validated plans,
+  waveform execution, and WAV publication in `AudioCore`
+- Model selection and native adapter: `Sources/AudioTTS/Qwen3TTS/SpeechSynthesisModelSelection.swift`
 - CLI: `Sources/MereRunCLI/Commands/SpeechSynthesizeCommand.swift`
 - Runtime entry point: `Sources/AudioTTS/Qwen3TTS/Qwen3TTSGenerator.swift`
 - Read next:

--- a/docs/internals/speech-synthesis-operation.md
+++ b/docs/internals/speech-synthesis-operation.md
@@ -1,0 +1,61 @@
+# Shared speech synthesis
+
+The CLI and speech API use `SpeechSynthesisPlan` and
+`SpeechSynthesisOperation` in AudioCore. The plan retains a validated copy of
+the request and an explicit WAV export policy. The operation consumes waveform
+samples from a `SpeechSynthesisExecutor` and publishes a completed artifact.
+AudioCore has no MLX dependency.
+
+## Request ownership
+
+The CLI owns flags, profile lookup, reference transcription, language hints,
+progress, and receipts. The API owns input trimming, model aliases, voice-name
+mapping, its 32 KiB prompt limit, and response transcoding. Both use
+`SpeechSynthesisModelSelection` in AudioTTS for managed IDs and local model
+directories. Selection does not load or download a model.
+
+Shared validation rejects empty text, nonfinite or out-of-range temperature and
+speed, invalid streaming intervals, and incomplete clone references. Execution
+rechecks reference-file existence and destination type before calling the
+executor. CLI scalar validation runs before profile or reference preparation.
+The API continues accepting speed values that the Qwen runtime does not apply.
+
+## Native execution and lifetime
+
+`Qwen3TTSSynthesisExecutor` adapts a caller-owned `Qwen3TTSGenerator`. The actor
+shares model loading, clone-asset checks, prompt preparation, and generation
+between offline and streaming synthesis. It retains MLX CPU/GPU streams,
+evaluates output before returning host samples, and synchronizes on completion,
+failure, and unloading. Token loops check for cooperative task cancellation.
+
+The CLI unloads its generator after completion or failure. The API keeps its
+generator in `APISidecarModelPool`; existing admission and residency leases
+surround the shared operation. AudioCore does not acquire a second permit.
+
+Public `Qwen3TTSGenerator.generate` still returns a file result through the
+shared operation. Its public `generateStream` still emits raw sample events
+without writing a file. `SNACAudioWriter` retains its PCM16 compatibility entry
+point through the shared export service.
+
+## Artifact publication
+
+Offline output uses PCM16 with no normalization, fades, or dither. Streaming
+output uses float32 with finite headroom preserved. Both replace nonfinite
+samples with zero. `AudioExportStream` shares processing and WAV encoding with
+offline export, writes incremental payloads to a temporary sibling, then fixes
+the header and atomically publishes the destination.
+
+The streaming operation requires a stable sample rate, audio samples, and one
+matching final result. It waits for the producer to finish before publishing
+and emitting completion. Failure or cancellation discards temporary output.
+Consumer cancellation propagates to the operation and native producer tasks;
+cleanup completes when the producer reaches a cancellation boundary.
+
+## Validation boundaries
+
+Portable fixtures cover request equivalence, byte-level encoding, malformed
+streams, final receipt metadata, producer cancellation, and existing-file
+preservation. Native baseline comparisons cover deterministic style and clone
+requests across offline, streaming, and repeated API synthesis. These are
+separate from qualification of GPU cancellation recovery, long-running
+synthesis, or perceptual voice quality.

--- a/docs/runtime/api-server.md
+++ b/docs/runtime/api-server.md
@@ -811,6 +811,15 @@ whole-image conditioning rather than strict masked inpainting.
 The normalized input and voice instructions may total at most 32 KiB of UTF-8
 text.
 
+`temperature` defaults to 0.6 and must be finite and between 0 and 2. `speed`
+defaults to 1 and accepts finite values from 0.25 through 4 for compatibility.
+The current Qwen3-TTS generator does not apply speed changes.
+
+Speech requests use the same validation, native generation, and PCM16 WAV
+export as offline `speech synthesize`. The API retains its resident model and
+request admission. It removes temporary audio files after materializing the
+response body, including partial transcoding output on failure.
+
 `POST /v1/audio/transcriptions` accepts multipart form fields:
 
 - `file`: required audio file part

--- a/docs/runtime/speech.md
+++ b/docs/runtime/speech.md
@@ -271,7 +271,7 @@ swift run mere.run speech synthesize \
 ```
 
 If `--ref-text` is omitted, the speech transcriber automatically transcribes the
-speech transcriber. `--language` hints the language (default `auto`). Add
+reference audio. `--language` hints the language (default `auto`). Add
 `--stream` to emit audio incrementally while generating; `--stream-chunk-tokens`
 sets the chunk interval (default 25).
 
@@ -316,17 +316,28 @@ Tokenizer internals:
 
 At a high level:
 
-1. The CLI resolves the selected text-to-speech (TTS) model.
-2. The runtime loads the optional profile or voice configuration.
-3. The runtime converts text into the model's intermediate token representation.
-4. The generator produces waveform data.
-5. The codec and output helpers write the audio to disk.
+1. The CLI validates text, temperature, and streaming options before resolving
+   the model or preparing a clone reference.
+2. The CLI resolves profiles and optional reference transcription. The API
+   maps model and voice aliases. Both construct a shared synthesis plan.
+3. AudioTTS loads the model and generates host waveform samples through one
+   native path for offline and streaming requests.
+4. AudioCore encodes the samples and publishes the completed WAV. CLI progress
+   and receipts and API response formatting remain in their adapters.
 
-`MediaAudioIO` can write float WAV output incrementally from chunk providers,
-including device-backed producers, which avoids constructing a second
-whole-file `Data` copy. Individual TTS generators may still produce a complete
-waveform before handing it to the output helper; the streaming writer API does
-not by itself make every synthesis model incremental.
+`--temperature` must be finite and between 0 and 2. Streaming chunk intervals
+must be greater than zero. Offline output remains unnormalized, undithered
+PCM16. `--stream` retains float32 output, including finite samples outside
+the unit range. Both replace nonfinite samples with zero.
+
+Streaming writes to a temporary sibling file and publishes the destination
+after generation ends and the WAV header is complete. Failure or cooperative
+cancellation removes the temporary file and preserves an existing destination.
+The receipt therefore describes the finalized file. With `--progress-json`,
+streaming token progress is emitted even when you also specify `--quiet`.
+
+See [shared speech synthesis](../internals/speech-synthesis-operation.md) for
+execution, export, and model lifetime ownership.
 
 ## How transcription flows
 


### PR DESCRIPTION
## Summary

Speech synthesis selected models and constructed requests separately in the CLI and API, while offline and streaming Qwen generation duplicated setup. Streaming WAV headers were finalized when the command's writer was released, after receipt emission.

Both entry points now use a validated AudioCore synthesis plan and operation, a shared AudioTTS model selector, and one native waveform path. AudioCore publishes completed WAVs atomically. Offline PCM16 and streaming float32 defaults remain explicit, and public Qwen generator entry points retain compatibility. API admission and model residency remain in the existing pool; the CLI unloads its generator after use.

The change also rejects invalid text and temperatures before loading or clone preparation, propagates stream-consumer cancellation to producers, completes temporary-file cleanup before delivering stream errors, preserves existing output on failures, removes API response temporaries, and emits requested JSON token progress under quiet mode. Documentation identifies the existing accepted-but-unapplied API speed behavior.

## Validation

- [x] `./scripts/check.sh`: passed; 4,223 XCTest cases with 314 skips and zero failures, plus 51 Swift Testing cases. Lint, package policy, help sweep, and hygiene scans passed.
- [x] Focused regression tests passed, including CLI/API request parity, export bytes, finalized receipts, malformed streams, cancellation, and destination preservation.
- [x] Public behavior documentation, docs build, and explicit target dependency import checks for AudioCore and AudioTTS passed. No targets, products, dependencies, or vendor assets changed.
- [x] Six native candidate outputs from `90be0a22` match baseline `a294b73f4fc5d245e310b4a79837ae95bb1005ff` byte for byte: style offline/streaming, API first/repeat, and clone offline/streaming. WAV headers, decoded samples, four CLI receipts, and model metadata match. Tests used unchanged installed checkpoints, temperature zero, and a fixed clone reference.

- [x] All required hosted checks passed on `90be0a22`: Swift, iOS, Linux, macOS bundle, docs, compatibility documentation, dependency review, and secret scanning. The cleanup-order regression passed with its immediate assertion unchanged.

Native GPU cancellation recovery, API disconnect handling, non-WAV transcoding, profile auto-transcription, long-form and perceptual quality, and performance remain unqualified. Cancellation lifetime is fixture-tested. This completes the speech portion of roadmap step five; remaining API vision/video construction is separate.

Vendored artifacts and package pins are unchanged; no third-party notice update is required.
