### PR TITLE
Share MoGe-2 geometry execution across CLI and API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+- Share MoGe-2 geometry settings, execution, and awaited unloading between the
+  CLI and API. Make `vision geometry --dry-run` apply the native dimension and
+  derived token-grid limits before model loading, and recheck inputs at execution.
+
 - Share native video preparation, execution, unloading, and media output between
   the CLI and video API through a Core operation. Preserve API defaults,
   optional argument syntax, request admission, and artifact retention without

--- a/Sources/MereRunCLI/Commands/README.md
+++ b/Sources/MereRunCLI/Commands/README.md
@@ -13,5 +13,7 @@ This directory owns the public CLI surface.
   and `VideoGenerationPlan`. `VideoGenerationOperation` owns execution; the CLI
   formats progress, timings, and receipts. Keep preflight JSON and filesystem
   diagnostics in `Support/VideoGenerationPreflight.swift`.
+- `vision geometry` translates options into Core MoGe-2 settings. Its dry-run
+  presents the shared token-grid plan; execution uses `MoGe2GenerationOperation`.
 
 If you change a flag, subcommand name, or help contract, update the nearest parsing tests and any affected user-facing docs in the same change.

--- a/Sources/MereRunCLI/Commands/VisionGeometryCommand.swift
+++ b/Sources/MereRunCLI/Commands/VisionGeometryCommand.swift
@@ -1,6 +1,5 @@
 import ArgumentParser
 import Foundation
-import MediaIO
 import MereRunCore
 
 struct VisionGeometry: AsyncParsableCommand {
@@ -19,7 +18,7 @@ struct VisionGeometry: AsyncParsableCommand {
     var model: String?
 
     @Option(name: [.long], help: "Quality level from 0 through 9. (default: 9)")
-    var resolutionLevel: Int = 9
+    var resolutionLevel: Int = MoGe2GenerationSettings.defaultResolutionLevel
 
     @Option(name: [.long], help: "Override the DINO base-token count (1...3600).")
     var tokenCount: Int?
@@ -34,60 +33,45 @@ struct VisionGeometry: AsyncParsableCommand {
     var json = false
 
     mutating func run() async throws {
-        guard (0...9).contains(resolutionLevel) else {
-            throw ValidationError("--resolution-level must be between 0 and 9")
-        }
-        if let tokenCount,
-           (tokenCount < MoGe2InferenceConfiguration.minimumTokenCount
-            || tokenCount > MoGe2InferenceConfiguration.maximumTokenCount) {
-            throw ValidationError("--token-count must be between 1 and 3600")
-        }
-        if let maxPoints, maxPoints <= 0 { throw ValidationError("--max-points must be positive") }
-
-        let inputURL = URL(fileURLWithPath: input).standardizedFileURL
-        guard FileManager.default.fileExists(atPath: inputURL.path) else {
-            throw ValidationError("Input image not found: \(inputURL.path)")
-        }
-        let outputURL = Self.resolveOutputURL(output, inputURL: inputURL)
-        let size = try MediaImageIO.size(of: inputURL)
-        let configuration = MoGe2InferenceConfiguration(
-            resolutionLevel: resolutionLevel,
-            tokenCount: tokenCount,
-            maximumPointCount: maxPoints
-        )
-        let plan = Self.makePlan(
-            inputURL: inputURL,
-            outputURL: outputURL,
-            imageWidth: size.width,
-            imageHeight: size.height,
-            model: model,
-            configuration: configuration
-        )
-        if dryRun {
-            print(try Self.jsonString(plan))
-            return
-        }
-
-        let generator = MoGe2Generator()
         do {
-            let result = try await generator.generate(
-                imageURL: inputURL,
-                outputDirectory: outputURL,
-                model: model,
-                configuration: configuration,
-                progress: { message in CLIStderr.write("[geometry] \(message)\n") }
+            let request = try makeGenerationRequest()
+            if dryRun {
+                let plan = try MoGe2GenerationOperation.prepare(request)
+                print(try Self.jsonString(Self.makePlan(plan)))
+                return
+            }
+            let result = try await MoGe2GenerationOperation.execute(
+                request, progress: { message in CLIStderr.write("[geometry] \(message)\n") }
             )
-            await generator.unload()
-            let payload = VisionGeometryRunPayload(result: result)
             if json {
-                print(try Self.jsonString(payload))
+                print(try Self.jsonString(VisionGeometryRunPayload(result: result)))
             } else {
                 print(result.export.manifestURL.path)
             }
-        } catch {
-            await generator.unload()
-            throw error
+        } catch let error as MoGe2GenerationError {
+            switch error {
+            case .invalidResolutionLevel:
+                throw ValidationError("--resolution-level must be between 0 and 9")
+            case .invalidTokenCount:
+                throw ValidationError("--token-count must be between 1 and 3600")
+            case .invalidMaximumPointCount:
+                throw ValidationError("--max-points must be positive")
+            case .inputNotFound:
+                throw ValidationError(error.localizedDescription)
+            }
         }
+    }
+
+    func makeGenerationRequest() throws -> MoGe2GenerationRequest {
+        let inputURL = URL(fileURLWithPath: input).standardizedFileURL
+        return MoGe2GenerationRequest(
+            imageURL: inputURL,
+            outputDirectory: Self.resolveOutputURL(output, inputURL: inputURL),
+            model: model,
+            settings: try MoGe2GenerationSettings(
+                resolutionLevel: resolutionLevel, tokenCount: tokenCount, maximumPointCount: maxPoints
+            )
+        )
     }
 
     static func resolveOutputURL(_ raw: String?, inputURL: URL) -> URL {
@@ -100,34 +84,25 @@ struct VisionGeometry: AsyncParsableCommand {
         )
     }
 
-    static func makePlan(
-        inputURL: URL,
-        outputURL: URL,
-        imageWidth: Int,
-        imageHeight: Int,
-        model: String?,
-        configuration: MoGe2InferenceConfiguration
-    ) -> VisionGeometryPlanPayload {
-        let aspect = Double(imageWidth) / Double(imageHeight)
-        let tokens = configuration.effectiveTokenCount
-        let tokenRows = max(1, Int(round(sqrt(Double(tokens) / aspect))))
-        let tokenColumns = max(1, Int(round(sqrt(Double(tokens) * aspect))))
+    static func makePlan(_ plan: MoGe2GenerationPlan) -> VisionGeometryPlanPayload {
+        let request = plan.request
+        let tokenGrid = plan.tokenGrid
         let installed = ManagedModelResolver.resolveInstalledModel(
-            id: ModelResolver.ModelID.visionGeometryMoGe2Small.rawValue
+            id: MoGe2GenerationRequest.defaultModelID
         )
         return VisionGeometryPlanPayload(
             status: "planned",
-            inputPath: inputURL.path,
-            outputDirectory: outputURL.path,
-            model: model ?? ModelResolver.ModelID.visionGeometryMoGe2Small.rawValue,
+            inputPath: request.imageURL.path,
+            outputDirectory: request.outputDirectory.path,
+            model: request.model ?? MoGe2GenerationRequest.defaultModelID,
             managedModelInstalled: installed != nil,
-            imageWidth: imageWidth,
-            imageHeight: imageHeight,
-            tokenCount: tokens,
-            tokenRows: tokenRows,
-            tokenColumns: tokenColumns,
-            networkWidth: tokenColumns * 14,
-            networkHeight: tokenRows * 14,
+            imageWidth: plan.dimensions.width,
+            imageHeight: plan.dimensions.height,
+            tokenCount: request.settings.configuration.effectiveTokenCount,
+            tokenRows: tokenGrid.rows,
+            tokenColumns: tokenGrid.columns,
+            networkWidth: tokenGrid.columns * 14,
+            networkHeight: tokenGrid.rows * 14,
             outputKinds: [
                 "metric-depth-exr", "depth-preview-png", "normal-exr", "normal-preview-png",
                 "validity-mask-png", "camera-json", "point-cloud-ply", "manifest-json",

--- a/Sources/MereRunCLI/Support/APIServer.swift
+++ b/Sources/MereRunCLI/Support/APIServer.swift
@@ -79,6 +79,7 @@ enum APIVFXClientErrorPolicy {
     static func status(for error: Error) -> HTTPResponse.Status? {
         switch error {
         case is MoGe2TokenGridError,
+             is MoGe2GenerationError,
              is VideoDepthAnythingLimitError,
              is VideoGenerationError,
              is VideoGenerationIssue,
@@ -752,23 +753,16 @@ actor CodeGenServer {
                 )
                 defer { try? FileManager.default.removeItem(at: inputURL) }
                 let outputDirectory = try temporaryOutputDirectory(directoryName: "mere-run-api-geometry")
-                try MLXBundleSupport.ensureAvailable(quiet: true)
-                let generator = MoGe2Generator()
                 do {
-                    let result = try await generator.generate(
-                        imageURL: inputURL,
-                        outputDirectory: outputDirectory,
-                        model: nil,
-                        configuration: plan.configuration,
-                        progress: nil
+                    let result = try await MoGe2GenerationOperation.execute(
+                        plan.request(imageURL: inputURL, outputDirectory: outputDirectory),
+                        prepareRuntime: { try MLXBundleSupport.ensureAvailable(quiet: true) }
                     )
-                    await generator.unload()
                     return try retainedArtifactJSONResponse(
                         APIServerContract.geometryResponse(from: result),
                         outputDirectory: outputDirectory
                     )
                 } catch {
-                    await generator.unload()
                     try? FileManager.default.removeItem(at: outputDirectory)
                     throw error
                 }

--- a/Sources/MereRunCLI/Support/APIServerContract.swift
+++ b/Sources/MereRunCLI/Support/APIServerContract.swift
@@ -505,7 +505,7 @@ enum APIServerContract {
     static let defaultVideoModelID = ModelResolver.ModelID.ltxVideo25DistilledBF16.rawValue
     static let defaultSpeechModelID = Qwen3TTSResources.defaultModelId
     static let defaultTranscriptionModelID = ParakeetResources.defaultModelId
-    static let defaultGeometryModelID = ModelResolver.ModelID.visionGeometryMoGe2Small.rawValue
+    static let defaultGeometryModelID = MoGe2GenerationRequest.defaultModelID
     static let defaultMultiViewGeometryModelID = ModelResolver.ModelID.visionGeometryDA3Small.rawValue
     static let defaultImageTo3DModelID = ModelResolver.ModelID.image3DTripoSR.rawValue
     static let defaultDepthVideoModelID = ModelResolver.ModelID.visionDepthVDASmall.rawValue
@@ -626,16 +626,15 @@ enum APIServerContract {
 
     struct GeometryPlan: Equatable, Sendable {
         let modelID: String
-        let resolutionLevel: Int
-        let tokenCount: Int?
-        let maximumPointCount: Int?
+        let settings: MoGe2GenerationSettings
 
-        var configuration: MoGe2InferenceConfiguration {
-            MoGe2InferenceConfiguration(
-                resolutionLevel: resolutionLevel,
-                tokenCount: tokenCount,
-                maximumPointCount: maximumPointCount
-            )
+        var resolutionLevel: Int { settings.configuration.resolutionLevel }
+        var tokenCount: Int? { settings.configuration.tokenCount }
+        var maximumPointCount: Int? { settings.configuration.maximumPointCount }
+
+        func request(imageURL: URL, outputDirectory: URL) -> MoGe2GenerationRequest {
+            // The API accepts only the managed model; retain its default lookup.
+            MoGe2GenerationRequest(imageURL: imageURL, outputDirectory: outputDirectory, settings: settings)
         }
     }
 
@@ -859,33 +858,40 @@ enum APIServerContract {
                 "only \(defaultGeometryModelID) is supported"
             )
         }
-        let resolutionLevel: Int
-        if let raw = normalizedOptional(form.field("resolution_level")) {
-            guard let value = Int(raw), (0...9).contains(value) else {
-                throw APIRequestValidationError.invalidField(
-                    "resolution_level",
-                    "must be an integer between 0 and 9"
+        let resolutionLevel = try optionalGeometryIntField(
+            form.field("resolution_level"), field: "resolution_level", message: "must be an integer between 0 and 9"
+        ) ?? MoGe2GenerationSettings.defaultResolutionLevel
+        let tokenCount = try optionalGeometryIntField(form.field("token_count"), field: "token_count")
+        let maximumPointCount = try optionalGeometryIntField(form.field("max_points"), field: "max_points")
+        do {
+            return GeometryPlan(
+                modelID: modelID,
+                settings: try MoGe2GenerationSettings(
+                    resolutionLevel: resolutionLevel, tokenCount: tokenCount, maximumPointCount: maximumPointCount
                 )
-            }
-            resolutionLevel = value
-        } else {
-            resolutionLevel = 9
-        }
-        let tokenCount = try optionalPositiveIntField(form.field("token_count"), field: "token_count")
-        if let tokenCount,
-           (tokenCount < MoGe2InferenceConfiguration.minimumTokenCount
-            || tokenCount > MoGe2InferenceConfiguration.maximumTokenCount) {
-            throw APIRequestValidationError.invalidField(
-                "token_count",
-                "must be an integer between 1 and 3600"
             )
+        } catch let error as MoGe2GenerationError {
+            switch error {
+            case .invalidResolutionLevel:
+                throw APIRequestValidationError.invalidField("resolution_level", "must be an integer between 0 and 9")
+            case .invalidTokenCount(let value):
+                throw APIRequestValidationError.invalidField(
+                    "token_count", value <= 0 ? "must be greater than zero" : "must be an integer between 1 and 3600"
+                )
+            case .invalidMaximumPointCount:
+                throw APIRequestValidationError.invalidField("max_points", "must be greater than zero")
+            case .inputNotFound:
+                throw error
+            }
         }
-        return GeometryPlan(
-            modelID: modelID,
-            resolutionLevel: resolutionLevel,
-            tokenCount: tokenCount,
-            maximumPointCount: try optionalPositiveIntField(form.field("max_points"), field: "max_points")
-        )
+    }
+
+    private static func optionalGeometryIntField(
+        _ raw: String?, field: String, message: String = "must be greater than zero"
+    ) throws -> Int? {
+        guard let raw = normalizedOptional(raw) else { return nil }
+        guard let value = Int(raw) else { throw APIRequestValidationError.invalidField(field, message) }
+        return value
     }
 
     static func geometryResponse(

--- a/Sources/MereRunCLI/Support/README.md
+++ b/Sources/MereRunCLI/Support/README.md
@@ -4,6 +4,9 @@ Shared helpers and runtime adapters for the public command surface.
 
 - `APIServerContract.swift`: API wire types, model policy, and request/response contracts.
 - `APIServer.swift`: HTTP routing, authentication, transport, and streaming ownership.
+- The single-image geometry route calls `MoGe2GenerationOperation` for shared
+  settings, execution, and unloading. The HTTP handler retains admission,
+  upload and output cleanup, and artifact retention.
 - Speech API model aliases and voice descriptions belong to `APIServerContract`.
   `APISidecarModelPool` retains admission and residency around the shared
   `AudioCore.SpeechSynthesisOperation`.

--- a/Sources/MereRunCore/README.md
+++ b/Sources/MereRunCore/README.md
@@ -39,6 +39,8 @@ Core retains resource loading and generation for these families.
   compound input parsing and checkpoint lookup shared by preflight and execution.
 - `ManagedAdapterArgumentResolver.swift`: installed adapter lookup and base-model
   compatibility shared by image, text, video, and evaluation adapters.
+- `VisionGeometry/MoGe2/MoGe2GenerationOperation.swift`: shared single-image
+  geometry settings, observational plans, execution, and awaited unloading.
 - `ManagedModel*.swift`: public managed-model catalog and install metadata.
 - `ModelResolver.swift`: adapts the catalog and family validators to ModelKit lookup.
 - `MereRunModelManifest+Templates.swift`: runtime-dependent manifest templates.

--- a/Sources/MereRunCore/VisionGeometry/MoGe2/MoGe2GenerationOperation.swift
+++ b/Sources/MereRunCore/VisionGeometry/MoGe2/MoGe2GenerationOperation.swift
@@ -1,0 +1,142 @@
+import Foundation
+import MediaIO
+
+public enum MoGe2GenerationError: Error, Equatable, LocalizedError, Sendable {
+    case invalidResolutionLevel(Int)
+    case invalidTokenCount(Int)
+    case invalidMaximumPointCount(Int)
+    case inputNotFound(String)
+
+    public var errorDescription: String? {
+        switch self {
+        case .invalidResolutionLevel: "Resolution level must be between 0 and 9."
+        case .invalidTokenCount: "Token count must be between 1 and 3600."
+        case .invalidMaximumPointCount: "Maximum point count must be positive."
+        case .inputNotFound(let path): "Input image not found: \(path)"
+        }
+    }
+}
+
+/// Validates caller values before constructing the compatibility configuration.
+public struct MoGe2GenerationSettings: Equatable, Sendable {
+    public static let defaultResolutionLevel = MoGe2InferenceConfiguration.defaultResolutionLevel
+    public let configuration: MoGe2InferenceConfiguration
+
+    public init(
+        resolutionLevel: Int = defaultResolutionLevel,
+        tokenCount: Int? = nil,
+        maximumPointCount: Int? = nil
+    ) throws {
+        guard (0...9).contains(resolutionLevel) else {
+            throw MoGe2GenerationError.invalidResolutionLevel(resolutionLevel)
+        }
+        if let tokenCount,
+           !(MoGe2TokenGrid.minimumTokenCount...MoGe2TokenGrid.maximumTokenCount).contains(tokenCount) {
+            throw MoGe2GenerationError.invalidTokenCount(tokenCount)
+        }
+        if let maximumPointCount, maximumPointCount <= 0 {
+            throw MoGe2GenerationError.invalidMaximumPointCount(maximumPointCount)
+        }
+        configuration = MoGe2InferenceConfiguration(
+            resolutionLevel: resolutionLevel, tokenCount: tokenCount, maximumPointCount: maximumPointCount
+        )
+    }
+}
+
+/// Carries the same settings from CLI or API translation into native execution.
+public struct MoGe2GenerationRequest: Equatable, Sendable {
+    public static let defaultModelID = ModelResolver.ModelID.visionGeometryMoGe2Small.rawValue
+    public let imageURL: URL
+    public let outputDirectory: URL
+    public let model: String?
+    public let settings: MoGe2GenerationSettings
+
+    public init(imageURL: URL, outputDirectory: URL, model: String? = nil, settings: MoGe2GenerationSettings) {
+        self.imageURL = imageURL.standardizedFileURL
+        self.outputDirectory = outputDirectory.standardizedFileURL
+        self.model = model
+        self.settings = settings
+    }
+}
+
+/// Describes an observational plan without loading weights or creating output.
+public struct MoGe2GenerationPlan: Equatable, Sendable {
+    public let request: MoGe2GenerationRequest
+    public let dimensions: VFXImageInputDimensions
+    public let tokenGrid: MoGe2TokenGrid
+
+    public init(request: MoGe2GenerationRequest, imageWidth: Int, imageHeight: Int) throws {
+        self.request = request
+        dimensions = try VFXImageInputValidator.validate(
+            width: imageWidth, height: imageHeight, path: request.imageURL.path
+        )
+        tokenGrid = try MoGe2TokenGrid.resolve(
+            imageWidth: imageWidth, imageHeight: imageHeight,
+            requestedTokenCount: request.settings.configuration.effectiveTokenCount
+        )
+    }
+}
+
+/// Owns one request's runtime and awaited release. Admission stays with the caller.
+public enum MoGe2GenerationOperation {
+    public typealias ProgressHandler = @Sendable (String) -> Void
+
+    public struct Runtime: Sendable {
+        public let generate: @Sendable (MoGe2GenerationRequest, ProgressHandler?) async throws -> MoGe2RunResult
+        public let unload: @Sendable () async -> Void
+
+        public init(
+            generate: @escaping @Sendable (MoGe2GenerationRequest, ProgressHandler?) async throws -> MoGe2RunResult,
+            unload: @escaping @Sendable () async -> Void
+        ) {
+            self.generate = generate
+            self.unload = unload
+        }
+    }
+
+    public static func prepare(_ request: MoGe2GenerationRequest) throws -> MoGe2GenerationPlan {
+        try Task.checkCancellation()
+        guard FileManager.default.fileExists(atPath: request.imageURL.path) else {
+            throw MoGe2GenerationError.inputNotFound(request.imageURL.path)
+        }
+        let size = try MediaImageIO.size(of: request.imageURL)
+        return try MoGe2GenerationPlan(request: request, imageWidth: size.width, imageHeight: size.height)
+    }
+
+    public static func execute(
+        _ request: MoGe2GenerationRequest,
+        prepareRuntime: @Sendable () throws -> Void = {},
+        progress: ProgressHandler? = nil,
+        makeRuntime: @Sendable () -> Runtime = nativeRuntime
+    ) async throws -> MoGe2RunResult {
+        // Recheck mutable input headers even when the caller previously planned.
+        _ = try prepare(request)
+        try prepareRuntime()
+        try Task.checkCancellation()
+        let runtime = makeRuntime()
+        let result: MoGe2RunResult
+        do {
+            result = try await runtime.generate(request, progress)
+            try Task.checkCancellation()
+        } catch {
+            await runtime.unload()
+            throw error
+        }
+        await runtime.unload()
+        try Task.checkCancellation()
+        return result
+    }
+
+    public static func nativeRuntime() -> Runtime {
+        let generator = MoGe2Generator()
+        return Runtime(
+            generate: { request, progress in
+                try await generator.generate(
+                    imageURL: request.imageURL, outputDirectory: request.outputDirectory,
+                    model: request.model, configuration: request.settings.configuration, progress: progress
+                )
+            },
+            unload: { await generator.unload() }
+        )
+    }
+}

--- a/Sources/MereRunCore/VisionGeometry/MoGe2/MoGe2Generator.swift
+++ b/Sources/MereRunCore/VisionGeometry/MoGe2/MoGe2Generator.swift
@@ -3,6 +3,7 @@ import MediaIO
 @preconcurrency import MLX
 
 public struct MoGe2InferenceConfiguration: Equatable, Sendable {
+    public static let defaultResolutionLevel = 9
     public static let minimumTokenCount = MoGe2TokenGrid.minimumTokenCount
     public static let maximumTokenCount = MoGe2TokenGrid.maximumTokenCount
 
@@ -11,7 +12,7 @@ public struct MoGe2InferenceConfiguration: Equatable, Sendable {
     public let maximumPointCount: Int?
 
     public init(
-        resolutionLevel: Int = 9,
+        resolutionLevel: Int = defaultResolutionLevel,
         tokenCount: Int? = nil,
         maximumPointCount: Int? = nil
     ) {
@@ -63,6 +64,7 @@ public actor MoGe2Generator {
         configuration: MoGe2InferenceConfiguration = MoGe2InferenceConfiguration(),
         progress: (@Sendable (String) -> Void)? = nil
     ) async throws -> MoGe2RunResult {
+        try Task.checkCancellation()
         let tokenCount = configuration.effectiveTokenCount
         guard tokenCount >= MoGe2InferenceConfiguration.minimumTokenCount,
               tokenCount <= MoGe2InferenceConfiguration.maximumTokenCount else {
@@ -93,20 +95,24 @@ public actor MoGe2Generator {
 
         progress?("Resolving pinned MoGe-2 weights")
         let loadStart = Date()
+        try Task.checkCancellation()
         let nativeModel = try await loadModelIfNeeded(requestedModel: model)
         let loadSeconds = Date().timeIntervalSince(loadStart)
 
         progress?("Running native MLX geometry inference at \(tokenCount) tokens")
         let inferenceStart = Date()
+        try Task.checkCancellation()
         let raw = nativeModel(input, tokenGrid: tokenGrid)
         MLX.eval(raw.points, raw.normals, raw.maskProbability, raw.metricScale)
         let inferenceSeconds = Date().timeIntervalSince(inferenceStart)
 
+        try Task.checkCancellation()
         progress?("Recovering camera and metric geometry")
         let postprocessStart = Date()
         let processed = try MoGe2Postprocessor.process(raw)
         let postprocessSeconds = Date().timeIntervalSince(postprocessStart)
 
+        try Task.checkCancellation()
         progress?("Writing EXR, PNG, camera, and point-cloud artifacts")
         let provenance = GeometryModelProvenance(
             modelID: GeometryModelPins.moge2Small.modelID,
@@ -147,7 +153,7 @@ public actor MoGe2Generator {
     private func loadModelIfNeeded(requestedModel: String?) async throws -> MoGe2Model {
         let resolved = try await ManagedModelResolver.resolveForRuntime(
             requestedModel: requestedModel,
-            defaultModelID: ModelResolver.ModelID.visionGeometryMoGe2Small.rawValue,
+            defaultModelID: MoGe2GenerationRequest.defaultModelID,
             allowAutoDownload: true
         )
         var isDirectory: ObjCBool = false

--- a/Sources/MereRunCore/VisionGeometry/MoGe2/README.md
+++ b/Sources/MereRunCore/VisionGeometry/MoGe2/README.md
@@ -12,3 +12,9 @@ input/checkpoint provenance, and artifact hashes.
 
 Token count is centrally capped for CLI and API requests so image resolution
 cannot create an unbounded attention workload.
+
+`MoGe2GenerationOperation` owns complete CLI/API request execution and awaited
+unloading. Its validated settings and observational plan share dimension and
+token-grid rules with native execution. Callers retain admission, transport,
+and presentation. The generator retains its public compatibility interface,
+immutable input snapshots, checkpoint validation, model computation, and export.

--- a/Tests/MereRunCLITests/MoGe2GenerationOperationTests.swift
+++ b/Tests/MereRunCLITests/MoGe2GenerationOperationTests.swift
@@ -1,0 +1,241 @@
+import Foundation
+import MediaIO
+import XCTest
+@testable import MereRunCLI
+@testable import MereRunCore
+
+private actor GeometryOperationTrace {
+    var events: [String] = []
+    func record(_ event: String) { events.append(event) }
+}
+
+final class MoGe2GenerationOperationTests: XCTestCase {
+    func testCLIAndAPIUseTheSameDefaultsAndExplicitSettings() throws {
+        let input = URL(fileURLWithPath: "/tmp/geometry-input.png")
+        let output = URL(fileURLWithPath: "/tmp/geometry-output")
+        for fields in [[:], ["resolution_level": "3", "token_count": "256", "max_points": "1000"]] {
+            var arguments = [input.path, "--output", output.path]
+            for (field, flag) in [("resolution_level", "--resolution-level"), ("token_count", "--token-count"), ("max_points", "--max-points")] {
+                if let value = fields[field] { arguments += [flag, value] }
+            }
+            let cli = try VisionGeometry.parse(arguments).makeGenerationRequest()
+            let api = try APIServerContract.geometryPlan(from: Self.form(fields))
+                .request(imageURL: input, outputDirectory: output)
+            XCTAssertEqual(cli, api)
+            XCTAssertNil(api.model)
+        }
+        let defaults = try MoGe2GenerationSettings()
+        XCTAssertEqual(defaults.configuration.effectiveTokenCount, 3_600)
+        XCTAssertNil(defaults.configuration.maximumPointCount)
+    }
+
+    func testBothAdaptersRejectInvalidSettingsWithoutCompatibilityClamping() throws {
+        for (field, flag, values) in [
+            ("resolution_level", "--resolution-level", [-1, 10, Int.max]),
+            ("token_count", "--token-count", [0, -1, 3_601, Int.max]),
+            ("max_points", "--max-points", [0, -1]),
+        ] {
+            for value in values {
+                let cli = try VisionGeometry.parse(["/missing/input.png", "\(flag)=\(value)"])
+                XCTAssertThrowsError(try cli.makeGenerationRequest()) { XCTAssertTrue($0 is MoGe2GenerationError) }
+                XCTAssertThrowsError(try APIServerContract.geometryPlan(from: Self.form([field: String(value)]))) { error in
+                    guard case APIRequestValidationError.invalidField(let actual, _) = error else {
+                        return XCTFail("Expected a field validation error, got \(error)")
+                    }
+                    XCTAssertEqual(actual, field)
+                }
+            }
+        }
+        XCTAssertEqual(APIVFXClientErrorPolicy.status(for: MoGe2GenerationError.inputNotFound("missing")), .badRequest)
+    }
+
+    func testModelSelectionKeepsTransportPolicy() throws {
+        let cli = try VisionGeometry.parse(["input.png", "--model", "/custom/model.onnx"]).makeGenerationRequest()
+        XCTAssertEqual(cli.model, "/custom/model.onnx")
+        XCTAssertThrowsError(try APIServerContract.geometryPlan(from: Self.form(["model": "/custom/model.onnx"])))
+        XCTAssertThrowsError(try APIServerContract.geometryPlan(from: Self.form(["model": "VISION-GEOMETRY-MOGE2-SMALL"])))
+        let api = try APIServerContract.geometryPlan(from: Self.form(["model": " vision-geometry-moge2-small "]))
+        XCTAssertEqual(api.modelID, MoGe2GenerationRequest.defaultModelID)
+    }
+
+    func testExecutionRechecksChangedDimensionsBeforeRuntimeSetup() async throws {
+        let root = try Self.makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let request = try Self.request(root)
+        let plan = try MoGe2GenerationOperation.prepare(request)
+        XCTAssertEqual(plan.tokenGrid.count, 3_600)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: request.outputDirectory.path))
+        try Self.writeImage(request.imageURL, width: 2_000, height: 1_080)
+        do {
+            _ = try await MoGe2GenerationOperation.execute(request, prepareRuntime: {
+                XCTFail("The changed input must be rejected before runtime setup")
+            }, makeRuntime: Self.unexpectedRuntime)
+            XCTFail("Expected the rounded patch grid to exceed the workload limit")
+        } catch MoGe2TokenGridError.tokenGridExceedsLimit(let rows, let columns, let actual, let maximum) {
+            XCTAssertEqual(rows * columns, 3_608)
+            XCTAssertEqual(actual, 3_608)
+            XCTAssertEqual(maximum, 3_600)
+        }
+        XCTAssertFalse(FileManager.default.fileExists(atPath: request.outputDirectory.path))
+    }
+
+    func testDeletedInputIsRejectedAfterPlanning() async throws {
+        let root = try Self.makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let request = try Self.request(root)
+        _ = try MoGe2GenerationOperation.prepare(request)
+        try FileManager.default.removeItem(at: request.imageURL)
+        do {
+            _ = try await MoGe2GenerationOperation.execute(request, makeRuntime: Self.unexpectedRuntime)
+            XCTFail("Expected a missing input error")
+        } catch MoGe2GenerationError.inputNotFound(let path) {
+            XCTAssertEqual(path, request.imageURL.path)
+        }
+    }
+
+    func testSuccessAwaitsUnloadInsideOneAdmissionAndPreservesArtifactProof() async throws {
+        let root = try Self.makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let request = try Self.request(root)
+        let admission = RuntimeRequestAdmission(maxActiveRequests: 1)
+        let trace = GeometryOperationTrace()
+        let result = try await withVFXRequestAdmission(using: admission) {
+            try await MoGe2GenerationOperation.execute(request, makeRuntime: {
+                MoGe2GenerationOperation.Runtime(generate: { actual, progress in
+                    XCTAssertEqual(actual, request)
+                    XCTAssertNil(progress)
+                    let state = await admission.snapshot()
+                    XCTAssertEqual(state.activeRequests, 1)
+                    XCTAssertEqual(state.totalAdmittedRequests, 1)
+                    await trace.record("generated")
+                    return try Self.fixtureResult(actual)
+                }, unload: {
+                    let state = await admission.snapshot()
+                    XCTAssertEqual(state.activeRequests, 1)
+                    await trace.record("unloaded")
+                })
+            })
+        }
+        let events = await trace.events
+        XCTAssertEqual(events, ["generated", "unloaded"])
+        let response = try APIServerContract.geometryResponse(from: result)
+        for artifact in response.artifacts {
+            let url = try XCTUnwrap(URL(string: artifact.url))
+            XCTAssertEqual(artifact.sha256, try ModelArtifactPin.fileSHA256(url))
+            XCTAssertEqual(artifact.byteCount, try ModelArtifactPin.fileByteCount(url))
+        }
+        let state = await admission.snapshot()
+        XCTAssertEqual(state.activeRequests, 0)
+        XCTAssertEqual(state.totalAdmittedRequests, 1)
+    }
+
+    func testFailureAwaitsOneUnloadAndReleasesAdmission() async throws {
+        let root = try Self.makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let request = try Self.request(root)
+        let trace = GeometryOperationTrace()
+        let admission = RuntimeRequestAdmission(maxActiveRequests: 1)
+        do {
+            _ = try await withVFXRequestAdmission(using: admission) {
+                try await MoGe2GenerationOperation.execute(request, makeRuntime: {
+                    MoGe2GenerationOperation.Runtime(generate: { _, _ in
+                        await trace.record("failed")
+                        throw FixtureError.expected
+                    }, unload: { await trace.record("unloaded") })
+                })
+            }
+            XCTFail("Expected the runtime failure")
+        } catch FixtureError.expected {}
+        let events = await trace.events
+        XCTAssertEqual(events, ["failed", "unloaded"])
+        let state = await admission.snapshot()
+        XCTAssertEqual(state.activeRequests, 0)
+    }
+
+    func testCancellationDuringGenerationCannotReturnSuccess() async throws {
+        try await assertCancellation(cancelDuringUnload: false)
+    }
+
+    func testCancellationDuringUnloadCannotReturnSuccess() async throws {
+        try await assertCancellation(cancelDuringUnload: true)
+    }
+
+    private func assertCancellation(cancelDuringUnload: Bool) async throws {
+        let root = try Self.makeRoot()
+        defer { try? FileManager.default.removeItem(at: root) }
+        let request = try Self.request(root)
+        let trace = GeometryOperationTrace()
+        let admission = RuntimeRequestAdmission(maxActiveRequests: 1)
+        let runtime = MoGe2GenerationOperation.Runtime(generate: { actual, _ in
+            let result = try MoGe2GenerationOperationTests.fixtureResult(actual)
+            if !cancelDuringUnload { withUnsafeCurrentTask { $0?.cancel() } }
+            return result
+        }, unload: {
+            if cancelDuringUnload { withUnsafeCurrentTask { $0?.cancel() } }
+            await trace.record("unloaded")
+        })
+        let task = Task { @Sendable in
+            try await withVFXRequestAdmission(using: admission) {
+                try await MoGe2GenerationOperation.execute(request, makeRuntime: { runtime })
+            }
+        }
+        do {
+            _ = try await task.value
+            XCTFail("Cancellation must win over the runtime result")
+        } catch is CancellationError {}
+        let events = await trace.events
+        XCTAssertEqual(events, ["unloaded"])
+        let state = await admission.snapshot()
+        XCTAssertEqual(state.activeRequests, 0)
+        XCTAssertEqual(state.totalCancelledRequests, 1)
+    }
+
+    private enum FixtureError: Error { case expected }
+
+    private static func unexpectedRuntime() -> MoGe2GenerationOperation.Runtime {
+        XCTFail("Invalid input must prevent runtime construction")
+        return .init(generate: { _, _ in throw FixtureError.expected }, unload: {})
+    }
+
+    private static func form(_ fields: [String: String]) -> MultipartFormData {
+        MultipartFormData(parts: fields.map { .init(name: $0.key, filename: nil, contentType: nil, body: Data($0.value.utf8)) })
+    }
+
+    private static func makeRoot() throws -> URL {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent("geometry-operation-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        return root
+    }
+
+    private static func writeImage(_ url: URL, width: Int = 2, height: Int = 2) throws {
+        try MediaImageIO.writePNG(try MediaImage(width: width, height: height, rgba8: [UInt8](repeating: 255, count: width * height * 4)), to: url)
+    }
+
+    private static func request(_ root: URL) throws -> MoGe2GenerationRequest {
+        let image = root.appendingPathComponent("input.png")
+        try writeImage(image)
+        return MoGe2GenerationRequest(
+            imageURL: image, outputDirectory: root.appendingPathComponent("output"), settings: try MoGe2GenerationSettings()
+        )
+    }
+
+    private static func fixtureResult(_ request: MoGe2GenerationRequest) throws -> MoGe2RunResult {
+        let intrinsics = GeometryCameraIntrinsics(imageWidth: 2, imageHeight: 2, normalizedFX: 1, normalizedFY: 1)
+        let frame = try DenseGeometryFrame(
+            width: 2, height: 2, units: .meters, intrinsics: intrinsics,
+            depth: [1, 2, 3, 4], points: [-0.25, -0.25, 1, 0.5, -0.5, 2, -0.75, 0.75, 3, 1, 1, 4],
+            normals: [Float](repeating: 0, count: 12), validity: [1, 1, 1, 1], confidence: [1, 1, 1, 1]
+        )
+        let export = try GeometryArtifactExporter.export(
+            frame: frame, inputURL: request.imageURL, outputDirectory: request.outputDirectory,
+            provenance: GeometryModelProvenance(
+                modelID: MoGe2GenerationRequest.defaultModelID, upstreamRepository: "fixture", upstreamRevision: "fixture", license: "MIT"
+            ), createdAt: Date(timeIntervalSince1970: 0)
+        )
+        return MoGe2RunResult(
+            export: export, focalShift: MoGe2FocalShiftSolution(focal: 1.5, shift: 0.1, iterationCount: 3, residualMeanSquare: 0),
+            metricScale: 2, tokenCount: request.settings.configuration.effectiveTokenCount,
+            modelLoadSeconds: 0, inferenceSeconds: 0, postprocessSeconds: 0
+        )
+    }
+}

--- a/Tests/MereRunCLITests/VisionGeometryCommandTests.swift
+++ b/Tests/MereRunCLITests/VisionGeometryCommandTests.swift
@@ -23,18 +23,17 @@ final class VisionGeometryCommandTests: XCTestCase {
         XCTAssertTrue(command.json)
     }
 
-    func testDefaultOutputAndPlanAreDeterministic() {
+    func testDefaultOutputAndPlanAreDeterministic() throws {
         let input = URL(fileURLWithPath: "/tmp/shot.001.png")
         let output = VisionGeometry.resolveOutputURL(nil, inputURL: input)
         XCTAssertEqual(output.path, "/tmp/shot.001-geometry")
-        let plan = VisionGeometry.makePlan(
-            inputURL: input,
-            outputURL: output,
-            imageWidth: 1920,
-            imageHeight: 1080,
-            model: nil,
-            configuration: MoGe2InferenceConfiguration(resolutionLevel: 0)
+        let request = MoGe2GenerationRequest(
+            imageURL: input, outputDirectory: output,
+            settings: try MoGe2GenerationSettings(resolutionLevel: 0)
         )
+        let plan = VisionGeometry.makePlan(try MoGe2GenerationPlan(
+            request: request, imageWidth: 1920, imageHeight: 1080
+        ))
         XCTAssertEqual(plan.tokenCount, 1_200)
         XCTAssertEqual(plan.tokenRows, 26)
         XCTAssertEqual(plan.tokenColumns, 46)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -84,6 +84,15 @@ H3 computation lives in `Sources/MereRunH3Model`; Laguna computation lives in
 `Sources/MereRunLagunaModel`. Their Core generator extensions own loading,
 request execution, conditioning or batching, and cleanup.
 
+## Single-image geometry
+
+`vision geometry` and its API route use Core's `MoGe2GenerationOperation` for
+validated settings, token-grid planning, execution, and awaited unloading.
+The native generator owns immutable input snapshots, pinned weights, model
+computation, and geometry export. Read the
+[shared single-image geometry operation](./internals/geometry-generation-operation.md)
+for caller admission, transport policy, cancellation, and validation boundaries.
+
 ## Image families
 
 Read the [shared image operation](./internals/image-generation-operation.md)

--- a/docs/internals/geometry-generation-operation.md
+++ b/docs/internals/geometry-generation-operation.md
@@ -1,0 +1,61 @@
+# Shared single-image geometry operation
+
+Use `MoGe2GenerationOperation` in `MereRunCore` when running a complete MoGe-2
+request. Both `vision geometry` and `POST /v1/vision/geometry` call this operation.
+
+## Settings and planning
+
+`MoGe2GenerationSettings` validates resolution level, target token count, and
+maximum point count before constructing `MoGe2InferenceConfiguration`. The
+existing configuration initializer retains its compatibility clamping behavior
+for direct runtime callers; CLI and API values pass through the validated settings.
+
+`MoGe2GenerationRequest` carries the input, output directory, model selection,
+and settings. The CLI accepts managed model IDs and local paths. The API retains
+its restriction to `vision-geometry-moge2-small` and uses the default managed
+lookup. Both adapters default to resolution level 9 and 3,600 target tokens.
+
+`MoGe2GenerationOperation.prepare` reads input dimensions and returns an
+observational `MoGe2GenerationPlan`. It uses `VFXImageInputValidator` and
+`MoGe2TokenGrid` to enforce the same dimension and derived-grid bounds as native
+execution. It does not load weights, download models, or create output files.
+The CLI formats this plan for `--dry-run`.
+
+The derived grid can exceed the target token count because rows and columns
+are rounded independently. For example, a 2,000 × 1,080 image at 3,600 target
+tokens requires 3,608 grid tokens. Both planning and execution reject this
+request before loading a model. Select a lower token count to stay within the
+3,600-token workload ceiling.
+
+## Execution and ownership
+
+Execution reads the current input dimensions again before runtime setup. The
+native generator then captures a bounded immutable input snapshot and verifies
+the pinned checkpoint before inference. Its preprocessing, model computation,
+postprocessing, and geometry exporters retain their existing implementations.
+
+The operation creates one runtime for the request and awaits its unload on
+success, failure, or cooperative cancellation. It checks cancellation before
+accepting a result and after cleanup. The native generator checks cancellation
+between preparation, inference, postprocessing, and artifact export. These
+checks do not establish recovery from a GPU failure or immediate interruption
+of an active GPU kernel.
+
+The caller owns request admission. The operation acquires no additional permit
+and does not borrow a runtime from a resident model pool. The API retains upload
+validation, temporary-file cleanup, failed-output cleanup, hashed artifact
+responses, loopback access, and one-hour artifact retention. Its runtime-setup
+callback checks the executable's MLX resources. The CLI retains progress on
+stderr and its existing JSON or manifest-path output on stdout.
+
+## Validation boundaries
+
+Fixture tests cover equivalent CLI/API requests, invalid settings, changing
+input dimensions, missing inputs, awaited runtime cleanup, cancellation, single
+request admission, and artifact hashes. Native compatibility comparisons must
+identify their source revision, executable, input, checkpoint, settings, and
+output normalization. Fixture results alone do not qualify GPU recovery,
+performance, or geometry quality.
+
+Multi-view geometry, TripoSR, InstantMesh, and video depth retain their separate
+execution paths. This operation does not change their ownership.

--- a/docs/runtime/api-server.md
+++ b/docs/runtime/api-server.md
@@ -892,6 +892,13 @@ default model ID (depth video also accepts its metric variant).
 - `token_count`: optional integer 1 through 3,600
 - `max_points`: optional positive point-count cap
 
+This route and `vision geometry` use the same validated settings and native
+operation. The derived patch grid must fit within 3,600 tokens after rounding;
+the CLI dry-run checks this limit too. The API retains its single request slot
+and creates a MoGe-2 runtime for each request. It awaits unloading before
+publishing the artifact response. See the
+[shared single-image geometry operation](../internals/geometry-generation-operation.md).
+
 `POST /v1/vision/geometry/multiview` accepts:
 
 - `image` / `image[]`: one or more image file parts; multipart order is the


### PR DESCRIPTION
## Summary

Both `vision geometry` and `POST /v1/vision/geometry` now use one Core operation for validated settings, current-image planning, native execution, and awaited runtime cleanup. CLI/API adapters retain their model-selection, admission, upload, presentation, and artifact-retention policies. No package boundary or other vision family changes.

CLI dry-run now rejects derived token grids that native execution already rejects. For example, a 2,000 × 1,080 image at 3,600 target tokens produces 3,608 grid tokens; planning and execution both reject it before loading weights. Valid dry-run JSON and existing response/artifact contracts are preserved.

## Validation

- [x] `./scripts/check.sh`: 4,242 XCTest cases, 314 skips, zero failures; all 51 Swift Testing cases pass.
- [x] 135 focused tests with one skip, including shared settings, mutable-input rechecks, cancellation, cleanup, admission, and artifact hashes.
- [x] Docs updated and built; Core explicit target dependency import check passes.
- Vendored artifacts and package pins are unchanged.

Native CLI and first/repeated API runs reproduce all eight baseline geometry artifact bytes, normalized manifests/responses, and valid dry-run JSON with the same image and pinned installed MoGe-2 Small checkpoint. Eight invalid HTTP probes retain status 400 and leave no new output directories.

The initial local gate reproduced protected-file read failures on the unchanged baseline. Password unlock restored access, and the full gate passed on the same commit without changing storage code, permissions, or tests.

Actual GPU cancellation recovery, API disconnects, performance, perceptual geometry quality, and the four other vision paths remain unqualified.
