### PR TITLE
Share remaining vision execution across CLI and API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+- Reject TripoSR foreground padding that exceeds the VFX image budget before
+  integer conversion or allocation, including extremely small positive ratios.
+
 - Share Depth Anything 3 view/camera validation, generation, scene-export settings,
   and awaited cleanup between the multiview geometry CLI and API.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+- Share Depth Anything 3 view/camera validation, generation, scene-export settings,
+  and awaited cleanup between the multiview geometry CLI and API.
+
 - Share bounded video-depth settings, preflight, execution, and awaited unloading
   between the CLI and API. Check cancellation between native temporal windows.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+- Share bounded video-depth settings, preflight, execution, and awaited unloading
+  between the CLI and API. Check cancellation between native temporal windows.
+
 - Share InstantMesh view and camera validation, reconstruction execution, and
   awaited cleanup across the CLI and API while preserving ordered inputs.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+- Share InstantMesh view and camera validation, reconstruction execution, and
+  awaited cleanup across the CLI and API while preserving ordered inputs.
+
 - Share TripoSR settings and execution between both reconstruction commands and
   the API, with current-input checks and awaited cleanup before returning.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on Keep a Changelog.
 
 ## Unreleased
 
+- Share TripoSR settings and execution between both reconstruction commands and
+  the API, with current-input checks and awaited cleanup before returning.
+
 - Share MoGe-2 geometry settings, execution, and awaited unloading between the
   CLI and API. Make `vision geometry --dry-run` apply the native dimension and
   derived token-grid limits before model loading, and recheck inputs at execution.

--- a/Sources/MereRunCLI/Commands/ImageReconstruct3DCommand.swift
+++ b/Sources/MereRunCLI/Commands/ImageReconstruct3DCommand.swift
@@ -19,13 +19,13 @@ struct ImageReconstruct3D: AsyncParsableCommand {
     var model: String?
 
     @Option(name: [.long], help: "Native density-grid resolution from 2 through 512.")
-    var resolution: Int = 256
+    var resolution: Int = TripoSRGenerationSettings.defaultResolution
 
     @Option(name: [.long], help: "Activated-density isosurface threshold.")
     var densityThreshold: Float = TripoSRConfiguration.production.densityThreshold
 
     @Option(name: [.long], help: "Transparent foreground occupancy ratio in (0, 1].")
-    var foregroundRatio: Float = 0.85
+    var foregroundRatio: Float = TripoSRGenerationSettings.defaultForegroundRatio
 
     @Flag(name: [.long], help: "Skip transparent-foreground crop/pad and treat the image as already framed.")
     var alreadyFramed = false

--- a/Sources/MereRunCLI/Commands/ImageReconstruct3DMultiviewCommand.swift
+++ b/Sources/MereRunCLI/Commands/ImageReconstruct3DMultiviewCommand.swift
@@ -1,6 +1,5 @@
 import ArgumentParser
 import Foundation
-import MediaIO
 import MereRunCore
 
 struct InstantMeshCameraDocument: Codable, Equatable {
@@ -68,64 +67,66 @@ struct ImageReconstruct3DMultiview: AsyncParsableCommand {
         dryRun: Bool,
         json: Bool
     ) async throws {
-        guard views.count == 4 || views.count == 6 else {
-            throw ValidationError("Repeat --view exactly 4 or 6 times")
-        }
-        guard (2...256).contains(resolution) else {
-            throw ValidationError("--resolution must be between 2 and 256")
-        }
-        let inputURLs = views.map { URL(fileURLWithPath: $0).standardizedFileURL }
-        for inputURL in inputURLs where !FileManager.default.fileExists(atPath: inputURL.path) {
-            throw ValidationError("Input view not found: \(inputURL.path)")
-        }
-        do {
-            _ = try VFXImageInputValidator.inspectAndValidate(inputURLs)
-        } catch {
-            throw ValidationError(error.localizedDescription)
-        }
-        let cameraValues = try loadCameras(cameras, expectedCount: inputURLs.count)
-        let outputURL = resolveOutputURL(output, firstViewURL: inputURLs[0])
+        let request = try makeGenerationRequest(
+            views: views, output: output, model: model, cameras: cameras,
+            resolution: resolution, noVertexColors: noVertexColors
+        )
+        let sourceDimensions = try InstantMeshGenerationOperation.prepare(request)
+        let inputURLs = request.viewURLs
+        let outputURL = request.outputDirectory
 
         if dryRun {
             let checkpoint = try await InstantMeshResources.resolve(requestedModel: model)
-            let dimensions = try inputURLs.map { url in
-                let size = try MediaImageIO.size(of: url)
-                return InstantMeshSourceDimensions(width: size.width, height: size.height)
+            let dimensions = sourceDimensions.map {
+                InstantMeshSourceDimensions(width: $0.width, height: $0.height)
             }
             print(try jsonString(InstantMeshPlanPayload(
                 inputPaths: inputURLs.map(\.path),
                 sourceDimensions: dimensions,
                 outputDirectory: outputURL.path,
                 checkpoint: checkpoint,
-                usesSuppliedCameras: cameraValues != nil,
+                usesSuppliedCameras: request.settings.cameras != nil,
                 extractionResolution: resolution,
                 includesVertexColors: !noVertexColors
             )))
             return
         }
 
-        try MLXBundleSupport.ensureAvailable(quiet: true)
-        let generator = InstantMeshGenerator()
-        do {
-            let result = try await generator.generate(
-                viewURLs: inputURLs,
-                outputDirectory: outputURL,
-                model: model,
-                cameras: cameraValues,
-                extractionResolution: resolution,
-                includeVertexColors: !noVertexColors,
-                progress: { event in CLIStderr.write("[image-to-3d-multiview] \(event.message)\n") }
-            )
-            await generator.unload()
-            if json {
-                print(try jsonString(try InstantMeshRunPayload(result: result)))
-            } else {
-                print(result.runManifest.manifestURL.path)
-            }
-        } catch {
-            await generator.unload()
-            throw error
+        let result = try await InstantMeshGenerationOperation.execute(
+            request,
+            prepareRuntime: { try MLXBundleSupport.ensureAvailable(quiet: true) },
+            progress: { event in CLIStderr.write("[image-to-3d-multiview] \(event.message)\n") }
+        )
+        if json {
+            print(try jsonString(try InstantMeshRunPayload(result: result)))
+        } else {
+            print(result.runManifest.manifestURL.path)
         }
+    }
+
+    static func makeGenerationRequest(
+        views: [String], output: String?, model: String?, cameras: String?,
+        resolution: Int, noVertexColors: Bool
+    ) throws -> InstantMeshGenerationRequest {
+        do {
+            try InstantMeshGenerationSettings.validateViewCount(views.count)
+        } catch {
+            throw ValidationError("Repeat --view exactly 4 or 6 times")
+        }
+        let settings: InstantMeshGenerationSettings
+        do {
+            settings = try InstantMeshGenerationSettings(
+                extractionResolution: resolution, includesVertexColors: !noVertexColors,
+                cameras: loadCameras(cameras, expectedCount: views.count)
+            )
+        } catch InstantMeshGeneratorError.invalidExtractionResolution {
+            throw ValidationError("--resolution must be between 2 and 256")
+        }
+        let inputURLs = views.map { URL(fileURLWithPath: $0).standardizedFileURL }
+        return InstantMeshGenerationRequest(
+            viewURLs: inputURLs, outputDirectory: resolveOutputURL(output, firstViewURL: inputURLs[0]),
+            model: model, settings: settings
+        )
     }
 
     static func resolveOutputURL(_ raw: String?, firstViewURL: URL) -> URL {
@@ -151,11 +152,11 @@ struct ImageReconstruct3DMultiview: AsyncParsableCommand {
         guard document.schemaVersion == 1 else {
             throw ValidationError("InstantMesh camera JSON schemaVersion must be 1")
         }
-        guard document.cameras.count == expectedCount else {
+        do {
+            try InstantMeshGenerationSettings(cameras: document.cameras).validate(viewCount: expectedCount)
+        } catch InstantMeshPreprocessingError.cameraCountMismatch {
             throw ValidationError("Camera JSON must contain exactly \(expectedCount) cameras")
-        }
-        for (index, camera) in document.cameras.enumerated()
-        where camera.count != 16 || !camera.allSatisfy(\.isFinite) {
+        } catch InstantMeshPreprocessingError.invalidCamera(let index) {
             throw ValidationError("Camera \(index) must contain 16 finite values")
         }
         return document.cameras

--- a/Sources/MereRunCLI/Commands/InstantMeshAPIContract.swift
+++ b/Sources/MereRunCLI/Commands/InstantMeshAPIContract.swift
@@ -143,9 +143,17 @@ extension APIServerContract {
 
     struct InstantMeshPlan: Equatable, Sendable {
         let modelID: String
-        let extractionResolution: Int
-        let includesVertexColors: Bool
-        let cameras: [[Float]]?
+        let settings: InstantMeshGenerationSettings
+
+        var extractionResolution: Int { settings.extractionResolution }
+        var includesVertexColors: Bool { settings.includesVertexColors }
+        var cameras: [[Float]]? { settings.cameras }
+
+        func request(viewURLs: [URL], outputDirectory: URL) -> InstantMeshGenerationRequest {
+            InstantMeshGenerationRequest(
+                viewURLs: viewURLs, outputDirectory: outputDirectory, model: modelID, settings: settings
+            )
+        }
     }
 
     static func instantMeshPlan(from form: MultipartFormData) throws -> InstantMeshPlan {
@@ -178,7 +186,9 @@ extension APIServerContract {
         let uploads = form.parts
             .filter { $0.filename != nil && ($0.name == "image" || $0.name == "image[]") }
             .filter { !$0.body.isEmpty }
-        guard uploads.count == 4 || uploads.count == 6 else {
+        do {
+            try InstantMeshGenerationSettings.validateViewCount(uploads.count)
+        } catch {
             throw APIRequestValidationError.invalidField(
                 "image[]",
                 "exactly 4 or 6 non-empty uploaded image views are required"
@@ -211,7 +221,7 @@ extension APIServerContract {
 
         let extractionResolution: Int
         if let raw = form.field("resolution")?.trimmingCharacters(in: .whitespacesAndNewlines), !raw.isEmpty {
-            guard let value = Int(raw), (2...256).contains(value) else {
+            guard let value = Int(raw) else {
                 throw APIRequestValidationError.invalidField(
                     "resolution",
                     "must be an integer between 2 and 256"
@@ -233,28 +243,26 @@ extension APIServerContract {
                     "must be schemaVersion 1 JSON with one 16-value camera per uploaded view"
                 )
             }
-            for (index, camera) in document.cameras.enumerated()
-            where camera.count != 16 || !camera.allSatisfy(\.isFinite) {
-                throw APIRequestValidationError.invalidField(
-                    "cameras",
-                    "camera \(index) must contain 16 finite values"
-                )
-            }
             cameras = document.cameras
         } else {
             cameras = nil
         }
 
-        return InstantMeshPlan(
-            modelID: defaultInstantMeshModelID,
-            extractionResolution: extractionResolution,
-            includesVertexColors: try instantMeshBoolean(
-                form.field("vertex_colors"),
-                field: "vertex_colors",
-                defaultValue: true
-            ),
-            cameras: cameras
-        )
+        do {
+            let settings = try InstantMeshGenerationSettings(
+                extractionResolution: extractionResolution,
+                includesVertexColors: try instantMeshBoolean(
+                    form.field("vertex_colors"), field: "vertex_colors", defaultValue: true
+                ),
+                cameras: cameras
+            )
+            try settings.validate(viewCount: uploads.count)
+            return InstantMeshPlan(modelID: defaultInstantMeshModelID, settings: settings)
+        } catch InstantMeshGeneratorError.invalidExtractionResolution {
+            throw APIRequestValidationError.invalidField("resolution", "must be an integer between 2 and 256")
+        } catch InstantMeshPreprocessingError.invalidCamera(let index) {
+            throw APIRequestValidationError.invalidField("cameras", "camera \(index) must contain 16 finite values")
+        }
     }
 
     static func instantMeshResponse(

--- a/Sources/MereRunCLI/Commands/README.md
+++ b/Sources/MereRunCLI/Commands/README.md
@@ -16,4 +16,8 @@ This directory owns the public CLI surface.
 - `vision geometry` translates options into Core MoGe-2 settings. Its dry-run
   presents the shared token-grid plan; execution uses `MoGe2GenerationOperation`.
 
+- Reconstruction, multiview geometry, and video-depth commands translate options
+  into the corresponding Core generation request. Keep shared validation and
+  runtime cleanup in those operations; commands own paths and presentation.
+
 If you change a flag, subcommand name, or help contract, update the nearest parsing tests and any affected user-facing docs in the same change.

--- a/Sources/MereRunCLI/Commands/VisionDepthVideoCommand.swift
+++ b/Sources/MereRunCLI/Commands/VisionDepthVideoCommand.swift
@@ -39,28 +39,12 @@ struct VisionDepthVideo: AsyncParsableCommand {
     var json = false
 
     mutating func run() async throws {
-        do {
-            _ = try VideoDepthAnythingLimits.validateRequest(
-                inputSize: inputSize,
-                maximumFrameCount: maxFrames
-            )
-        } catch {
-            throw ValidationError(error.localizedDescription)
-        }
-
-        let inputURL = URL(fileURLWithPath: input).standardizedFileURL
-        guard FileManager.default.fileExists(atPath: inputURL.path) else {
-            throw ValidationError("Input video not found: \(inputURL.path)")
-        }
-        let outputURL = Self.resolveOutputURL(output, inputURL: inputURL)
+        let request = try makeGenerationRequest()
+        let inputURL = request.videoURL
+        let outputURL = request.outputDirectory
 
         if dryRun {
-            let preflight = try await VideoDepthAnythingGenerator.preflight(
-                videoURL: inputURL,
-                model: model,
-                inputSize: inputSize,
-                maximumFrameCount: maxFrames
-            )
+            let preflight = try await VideoDepthAnythingGenerationOperation.preflight(request)
             print(try Self.jsonString(Self.makePlan(
                 inputURL: inputURL,
                 outputURL: outputURL,
@@ -71,26 +55,29 @@ struct VisionDepthVideo: AsyncParsableCommand {
             return
         }
 
-        let generator = VideoDepthAnythingGenerator()
-        do {
-            let result = try await generator.generate(
-                videoURL: inputURL,
-                outputDirectory: outputURL,
-                model: model,
-                inputSize: inputSize,
-                maximumFrameCount: maxFrames,
-                progress: { event in CLIStderr.write("[depth-video] \(event.message)\n") }
-            )
-            await generator.unload()
-            if json {
-                print(try Self.jsonString(VisionDepthVideoRunPayload(result: result)))
-            } else {
-                print(result.export.manifestURL.path)
-            }
-        } catch {
-            await generator.unload()
-            throw error
+        let result = try await VideoDepthAnythingGenerationOperation.execute(
+            request,
+            progress: { event in CLIStderr.write("[depth-video] \(event.message)\n") }
+        )
+        if json {
+            print(try Self.jsonString(VisionDepthVideoRunPayload(result: result)))
+        } else {
+            print(result.export.manifestURL.path)
         }
+    }
+
+    func makeGenerationRequest() throws -> VideoDepthAnythingGenerationRequest {
+        let settings: VideoDepthAnythingGenerationSettings
+        do {
+            settings = try VideoDepthAnythingGenerationSettings(inputSize: inputSize, maximumFrameCount: maxFrames)
+        } catch {
+            throw ValidationError(error.localizedDescription)
+        }
+        let inputURL = URL(fileURLWithPath: input).standardizedFileURL
+        return VideoDepthAnythingGenerationRequest(
+            videoURL: inputURL, outputDirectory: Self.resolveOutputURL(output, inputURL: inputURL),
+            model: model, settings: settings
+        )
     }
 
     static func resolveOutputURL(_ raw: String?, inputURL: URL) -> URL {

--- a/Sources/MereRunCLI/Commands/VisionGeometryMultiViewCommand.swift
+++ b/Sources/MereRunCLI/Commands/VisionGeometryMultiViewCommand.swift
@@ -31,7 +31,7 @@ struct VisionGeometryMultiView: AsyncParsableCommand {
     var cameras: String?
 
     @Option(name: [.long], help: "Upper bound for the longest processed image side. (default: 504)")
-    var processResolution: Int = 504
+    var processResolution: Int = DepthAnything3GenerationSettings.defaultProcessResolution
 
     @Option(
         name: [.long],
@@ -40,10 +40,10 @@ struct VisionGeometryMultiView: AsyncParsableCommand {
     var referenceView: String = DepthAnything3ReferenceViewStrategy.saddleBalanced.rawValue
 
     @Option(name: [.long], help: "Discard points below this confidence percentile. (default: 40)")
-    var confidencePercentile: Double = 40
+    var confidencePercentile: Double = MultiViewGeometryExportConfiguration.defaultConfidencePercentile
 
     @Option(name: [.long], help: "Maximum deterministic colored points in scene exports. (default: 1000000)")
-    var maxPoints: Int = 1_000_000
+    var maxPoints: Int = MultiViewGeometryExportConfiguration.defaultMaximumPointCount
 
     @Flag(name: [.long], help: "Verify model and inputs, then print the execution plan without inference.")
     var dryRun = false
@@ -52,41 +52,15 @@ struct VisionGeometryMultiView: AsyncParsableCommand {
     var json = false
 
     mutating func run() async throws {
-        guard !images.isEmpty else { throw ValidationError("Provide at least one image path.") }
-        try Self.validateRequestLimits(
-            viewCount: images.count,
-            processResolution: processResolution
-        )
-        guard confidencePercentile.isFinite, (0...100).contains(confidencePercentile) else {
-            throw ValidationError("--confidence-percentile must be between 0 and 100")
+        let request = try makeGenerationRequest()
+        do {
+            try DepthAnything3GenerationOperation.prepare(request)
+        } catch {
+            throw ValidationError(error.localizedDescription)
         }
-        guard maxPoints > 0 else { throw ValidationError("--max-points must be positive") }
-        guard let strategy = DepthAnything3ReferenceViewStrategy(rawValue: referenceView.lowercased()) else {
-            throw ValidationError("Unsupported --reference-view value: \(referenceView)")
-        }
-        let inputURLs = images.map { URL(fileURLWithPath: $0).standardizedFileURL }
-        for url in inputURLs where !FileManager.default.fileExists(atPath: url.path) {
-            throw ValidationError("Input image not found: \(url.path)")
-        }
-        let sourceDimensions = try Self.validateResourceLimits(
-            imageURLs: inputURLs,
-            processResolution: processResolution
-        )
-        let knownCameras = try Self.loadCameras(cameras, expectedCount: inputURLs.count)
-        if let knownCameras {
-            for index in knownCameras.indices {
-                let dimensions = sourceDimensions[index]
-                let intrinsics = knownCameras[index].intrinsics
-                guard intrinsics.imageWidth == dimensions.width,
-                      intrinsics.imageHeight == dimensions.height else {
-                    throw ValidationError(
-                        "Camera \(index) describes \(intrinsics.imageWidth)x\(intrinsics.imageHeight), "
-                            + "not its \(dimensions.width)x\(dimensions.height) image"
-                    )
-                }
-            }
-        }
-        let outputURL = Self.resolveOutputURL(output, firstInput: inputURLs[0])
+        let inputURLs = request.imageURLs
+        let outputURL = request.outputDirectory
+        let settings = request.settings
 
         if dryRun {
             let checkpoint = try await DepthAnything3Resources.resolve(requestedModel: model)
@@ -95,43 +69,51 @@ struct VisionGeometryMultiView: AsyncParsableCommand {
                 outputDirectory: outputURL.path,
                 checkpoint: checkpoint,
                 processResolution: processResolution,
-                referenceViewStrategy: strategy,
-                poseConditioned: knownCameras != nil,
+                referenceViewStrategy: settings.referenceViewStrategy,
+                poseConditioned: settings.knownCameras != nil,
                 confidencePercentile: confidencePercentile,
                 maximumPointCount: maxPoints
             )))
             return
         }
 
-        try MLXBundleSupport.ensureAvailable(quiet: true)
-        let generator = DepthAnything3Generator()
-        do {
-            let run = try await generator.generate(
-                imageURLs: inputURLs,
-                model: model,
-                knownCameras: knownCameras,
-                referenceViewStrategy: strategy,
-                processResolution: processResolution,
-                progress: { event in CLIStderr.write("[geometry-multiview] \(event.message)\n") }
-            )
-            let export = try MultiViewGeometryExporter.export(
-                run: run,
-                outputDirectory: outputURL,
-                configuration: try MultiViewGeometryExportConfiguration(
-                    confidencePercentile: confidencePercentile,
-                    maximumPointCount: maxPoints
-                )
-            )
-            await generator.unload()
-            if json {
-                print(try Self.jsonString(try VisionGeometryMultiViewRunPayload(run: run, export: export)))
-            } else {
-                print(export.manifestURL.path)
-            }
-        } catch {
-            await generator.unload()
-            throw error
+        let result = try await DepthAnything3GenerationOperation.execute(
+            request,
+            prepareRuntime: { try MLXBundleSupport.ensureAvailable(quiet: true) },
+            progress: { event in CLIStderr.write("[geometry-multiview] \(event.message)\n") }
+        )
+        if json {
+            print(try Self.jsonString(try VisionGeometryMultiViewRunPayload(run: result.run, export: result.export)))
+        } else {
+            print(result.export.manifestURL.path)
         }
+    }
+
+    func makeGenerationRequest() throws -> DepthAnything3GenerationRequest {
+        guard !images.isEmpty else { throw ValidationError("Provide at least one image path.") }
+        guard let strategy = DepthAnything3ReferenceViewStrategy(rawValue: referenceView.lowercased()) else {
+            throw ValidationError("Unsupported --reference-view value: \(referenceView)")
+        }
+        let settings: DepthAnything3GenerationSettings
+        do {
+            settings = try DepthAnything3GenerationSettings(
+                processResolution: processResolution, referenceViewStrategy: strategy,
+                knownCameras: Self.loadCameras(cameras, expectedCount: images.count),
+                confidencePercentile: confidencePercentile, maximumPointCount: maxPoints
+            )
+            try settings.validate(viewCount: images.count)
+        } catch MultiViewGeometryExportConfigurationError.invalidConfidencePercentile {
+            throw ValidationError("--confidence-percentile must be between 0 and 100")
+        } catch MultiViewGeometryExportConfigurationError.invalidMaximumPointCount {
+            throw ValidationError("--max-points must be positive")
+        } catch {
+            throw ValidationError(error.localizedDescription)
+        }
+        let inputURLs = images.map { URL(fileURLWithPath: $0).standardizedFileURL }
+        return DepthAnything3GenerationRequest(
+            imageURLs: inputURLs, outputDirectory: Self.resolveOutputURL(output, firstInput: inputURLs[0]),
+            model: model, settings: settings
+        )
     }
 
     static func resolveOutputURL(_ raw: String?, firstInput: URL) -> URL {

--- a/Sources/MereRunCLI/Commands/VisionImageTo3DCommand.swift
+++ b/Sources/MereRunCLI/Commands/VisionImageTo3DCommand.swift
@@ -1,6 +1,5 @@
 import ArgumentParser
 import Foundation
-import MediaIO
 import MereRunCore
 
 struct VisionImageTo3D: AsyncParsableCommand {
@@ -19,13 +18,13 @@ struct VisionImageTo3D: AsyncParsableCommand {
     var model: String?
 
     @Option(name: [.long], help: "Native density-grid resolution from 2 through 512.")
-    var resolution: Int = 256
+    var resolution: Int = TripoSRGenerationSettings.defaultResolution
 
     @Option(name: [.long], help: "Activated-density isosurface threshold.")
     var densityThreshold: Float = TripoSRConfiguration.production.densityThreshold
 
     @Option(name: [.long], help: "Transparent foreground occupancy ratio in (0, 1].")
-    var foregroundRatio: Float = 0.85
+    var foregroundRatio: Float = TripoSRGenerationSettings.defaultForegroundRatio
 
     @Flag(name: [.long], help: "Skip transparent-foreground crop/pad and treat the image as already framed.")
     var alreadyFramed = false
@@ -66,38 +65,22 @@ struct VisionImageTo3D: AsyncParsableCommand {
         dryRun: Bool,
         json: Bool
     ) async throws {
-        guard (2...512).contains(resolution) else {
-            throw ValidationError("--resolution must be between 2 and 512")
-        }
-        guard densityThreshold.isFinite else {
-            throw ValidationError("--density-threshold must be finite")
-        }
-        guard foregroundRatio.isFinite, foregroundRatio > 0, foregroundRatio <= 1 else {
-            throw ValidationError("--foreground-ratio must be greater than 0 and at most 1")
-        }
-
-        let inputURL = URL(fileURLWithPath: input).standardizedFileURL
-        guard FileManager.default.fileExists(atPath: inputURL.path) else {
-            throw ValidationError("Input image not found: \(inputURL.path)")
-        }
-        do {
-            _ = try VFXImageInputValidator.inspectAndValidate([inputURL])
-        } catch {
-            throw ValidationError(error.localizedDescription)
-        }
-        let outputURL = resolveOutputURL(output, inputURL: inputURL)
-        let foregroundPolicy: TripoSRForegroundPolicy = alreadyFramed
-            ? .alreadyFramed
-            : .automaticTransparentAlpha(foregroundRatio: foregroundRatio)
+        let request = try makeGenerationRequest(
+            input: input, output: output, model: model, resolution: resolution,
+            densityThreshold: densityThreshold, foregroundRatio: foregroundRatio,
+            alreadyFramed: alreadyFramed, noVertexColors: noVertexColors
+        )
+        let dimensions = try TripoSRGenerationOperation.prepare(request)
+        let inputURL = request.imageURL
+        let outputURL = request.outputDirectory
 
         if dryRun {
             let checkpoint = try await TripoSRResources.resolve(requestedModel: model)
-            let size = try MediaImageIO.size(of: inputURL)
             print(try jsonString(VisionImageTo3DPlanPayload(
                 inputPath: inputURL.path,
                 outputDirectory: outputURL.path,
-                inputWidth: size.width,
-                inputHeight: size.height,
+                inputWidth: dimensions.width,
+                inputHeight: dimensions.height,
                 checkpoint: checkpoint,
                 extractionResolution: resolution,
                 densityThreshold: densityThreshold,
@@ -108,29 +91,41 @@ struct VisionImageTo3D: AsyncParsableCommand {
             return
         }
 
-        try MLXBundleSupport.ensureAvailable(quiet: true)
-        let generator = TripoSRGenerator()
-        do {
-            let result = try await generator.generate(
-                imageURL: inputURL,
-                outputDirectory: outputURL,
-                model: model,
-                foregroundPolicy: foregroundPolicy,
-                extractionResolution: resolution,
-                densityThreshold: densityThreshold,
-                includeVertexColors: !noVertexColors,
-                progress: { event in CLIStderr.write("[image-to-3d] \(event.message)\n") }
-            )
-            await generator.unload()
-            if json {
-                print(try jsonString(try VisionImageTo3DRunPayload(result: result)))
-            } else {
-                print(result.runManifest.manifestURL.path)
-            }
-        } catch {
-            await generator.unload()
-            throw error
+        let result = try await TripoSRGenerationOperation.execute(
+            request,
+            prepareRuntime: { try MLXBundleSupport.ensureAvailable(quiet: true) },
+            progress: { event in CLIStderr.write("[image-to-3d] \(event.message)\n") }
+        )
+        if json {
+            print(try jsonString(try VisionImageTo3DRunPayload(result: result)))
+        } else {
+            print(result.runManifest.manifestURL.path)
         }
+    }
+
+    static func makeGenerationRequest(
+        input: String, output: String?, model: String?, resolution: Int,
+        densityThreshold: Float, foregroundRatio: Float, alreadyFramed: Bool, noVertexColors: Bool
+    ) throws -> TripoSRGenerationRequest {
+        let settings: TripoSRGenerationSettings
+        do {
+            settings = try TripoSRGenerationSettings(
+                extractionResolution: resolution, densityThreshold: densityThreshold,
+                foregroundRatio: foregroundRatio, alreadyFramed: alreadyFramed,
+                includesVertexColors: !noVertexColors
+            )
+        } catch TripoSRGeneratorError.invalidExtractionResolution {
+            throw ValidationError("--resolution must be between 2 and 512")
+        } catch TripoSRGeneratorError.invalidDensityThreshold {
+            throw ValidationError("--density-threshold must be finite")
+        } catch TripoSRPreprocessingError.invalidForegroundRatio {
+            throw ValidationError("--foreground-ratio must be greater than 0 and at most 1")
+        }
+        let inputURL = URL(fileURLWithPath: input).standardizedFileURL
+        return TripoSRGenerationRequest(
+            imageURL: inputURL, outputDirectory: resolveOutputURL(output, inputURL: inputURL),
+            model: model, settings: settings
+        )
     }
 
     static func resolveOutputURL(_ raw: String?, inputURL: URL) -> URL {

--- a/Sources/MereRunCLI/Support/APIServer.swift
+++ b/Sources/MereRunCLI/Support/APIServer.swift
@@ -78,7 +78,8 @@ enum APIVFXArtifactRoutePolicy {
 enum APIVFXClientErrorPolicy {
     static func status(for error: Error) -> HTTPResponse.Status? {
         switch error {
-        case is TripoSRGeneratorError,
+        case is InstantMeshGeneratorError,
+             is TripoSRGeneratorError,
              is MoGe2TokenGridError,
              is MoGe2GenerationError,
              is VideoDepthAnythingLimitError,
@@ -1017,25 +1018,16 @@ actor CodeGenServer {
                 let outputDirectory = try temporaryOutputDirectory(
                     directoryName: "mere-run-api-instantmesh"
                 )
-                try MLXBundleSupport.ensureAvailable(quiet: true)
-                let generator = InstantMeshGenerator()
                 do {
-                    let result = try await generator.generate(
-                        viewURLs: inputURLs,
-                        outputDirectory: outputDirectory,
-                        model: plan.modelID,
-                        cameras: plan.cameras,
-                        extractionResolution: plan.extractionResolution,
-                        includeVertexColors: plan.includesVertexColors,
-                        progress: nil
+                    let result = try await InstantMeshGenerationOperation.execute(
+                        plan.request(viewURLs: inputURLs, outputDirectory: outputDirectory),
+                        prepareRuntime: { try MLXBundleSupport.ensureAvailable(quiet: true) }
                     )
-                    await generator.unload()
                     return try retainedArtifactJSONResponse(
                         APIServerContract.instantMeshResponse(from: result),
                         outputDirectory: outputDirectory
                     )
                 } catch {
-                    await generator.unload()
                     try? FileManager.default.removeItem(at: outputDirectory)
                     throw error
                 }

--- a/Sources/MereRunCLI/Support/APIServer.swift
+++ b/Sources/MereRunCLI/Support/APIServer.swift
@@ -78,7 +78,9 @@ enum APIVFXArtifactRoutePolicy {
 enum APIVFXClientErrorPolicy {
     static func status(for error: Error) -> HTTPResponse.Status? {
         switch error {
-        case VideoDepthAnythingGeneratorError.inputVideoNotFound:
+        case VideoDepthAnythingGeneratorError.inputVideoNotFound,
+             DepthAnything3GeneratorError.imageNotFound,
+             DepthAnything3GeneratorError.cameraCountMismatch:
             return .badRequest
         case is InstantMeshGeneratorError,
              is TripoSRGeneratorError,
@@ -837,38 +839,20 @@ actor CodeGenServer {
                 let outputDirectory = try temporaryOutputDirectory(
                     directoryName: "mere-run-api-geometry-multiview"
                 )
-                try MLXBundleSupport.ensureAvailable(quiet: true)
-                let generator = DepthAnything3Generator()
                 do {
-                    let result = try await generator.generate(
-                        imageURLs: inputURLs,
-                        model: plan.modelID,
-                        knownCameras: plan.knownCameras,
-                        referenceViewStrategy: plan.referenceViewStrategy,
-                        processResolution: plan.processResolution,
-                        progress: nil
+                    let result = try await DepthAnything3GenerationOperation.execute(
+                        plan.request(imageURLs: inputURLs, outputDirectory: outputDirectory),
+                        prepareRuntime: { try MLXBundleSupport.ensureAvailable(quiet: true) }
                     )
-                    let exportStart = Date()
-                    let export = try MultiViewGeometryExporter.export(
-                        run: result,
-                        outputDirectory: outputDirectory,
-                        configuration: try MultiViewGeometryExportConfiguration(
-                            confidencePercentile: plan.confidencePercentile,
-                            maximumPointCount: plan.maximumPointCount
-                        )
-                    )
-                    let exportSeconds = Date().timeIntervalSince(exportStart)
-                    await generator.unload()
                     return try retainedArtifactJSONResponse(
                         APIServerContract.multiViewGeometryResponse(
-                            from: result,
-                            export: export,
-                            exportSeconds: exportSeconds
+                            from: result.run,
+                            export: result.export,
+                            exportSeconds: result.exportSeconds
                         ),
                         outputDirectory: outputDirectory
                     )
                 } catch {
-                    await generator.unload()
                     try? FileManager.default.removeItem(at: outputDirectory)
                     throw error
                 }

--- a/Sources/MereRunCLI/Support/APIServer.swift
+++ b/Sources/MereRunCLI/Support/APIServer.swift
@@ -78,7 +78,8 @@ enum APIVFXArtifactRoutePolicy {
 enum APIVFXClientErrorPolicy {
     static func status(for error: Error) -> HTTPResponse.Status? {
         switch error {
-        case is MoGe2TokenGridError,
+        case is TripoSRGeneratorError,
+             is MoGe2TokenGridError,
              is MoGe2GenerationError,
              is VideoDepthAnythingLimitError,
              is VideoGenerationError,
@@ -934,26 +935,16 @@ actor CodeGenServer {
                 let outputDirectory = try temporaryOutputDirectory(
                     directoryName: "mere-run-api-image-to-3d"
                 )
-                try MLXBundleSupport.ensureAvailable(quiet: true)
-                let generator = TripoSRGenerator()
                 do {
-                    let result = try await generator.generate(
-                        imageURL: inputURL,
-                        outputDirectory: outputDirectory,
-                        model: plan.modelID,
-                        foregroundPolicy: plan.foregroundPolicy,
-                        extractionResolution: plan.extractionResolution,
-                        densityThreshold: plan.densityThreshold,
-                        includeVertexColors: plan.includesVertexColors,
-                        progress: nil
+                    let result = try await TripoSRGenerationOperation.execute(
+                        plan.request(imageURL: inputURL, outputDirectory: outputDirectory),
+                        prepareRuntime: { try MLXBundleSupport.ensureAvailable(quiet: true) }
                     )
-                    await generator.unload()
                     return try retainedArtifactJSONResponse(
                         APIServerContract.imageTo3DResponse(from: result),
                         outputDirectory: outputDirectory
                     )
                 } catch {
-                    await generator.unload()
                     try? FileManager.default.removeItem(at: outputDirectory)
                     throw error
                 }

--- a/Sources/MereRunCLI/Support/APIServer.swift
+++ b/Sources/MereRunCLI/Support/APIServer.swift
@@ -78,6 +78,8 @@ enum APIVFXArtifactRoutePolicy {
 enum APIVFXClientErrorPolicy {
     static func status(for error: Error) -> HTTPResponse.Status? {
         switch error {
+        case VideoDepthAnythingGeneratorError.inputVideoNotFound:
+            return .badRequest
         case is InstantMeshGeneratorError,
              is TripoSRGeneratorError,
              is MoGe2TokenGridError,
@@ -1097,24 +1099,16 @@ actor CodeGenServer {
                 let outputDirectory = try temporaryOutputDirectory(
                     directoryName: "mere-run-api-depth-video"
                 )
-                try MLXBundleSupport.ensureAvailable(quiet: true)
-                let generator = VideoDepthAnythingGenerator()
                 do {
-                    let result = try await generator.generate(
-                        videoURL: inputURL,
-                        outputDirectory: outputDirectory,
-                        model: plan.modelID,
-                        inputSize: plan.inputSize,
-                        maximumFrameCount: plan.maximumFrameCount,
-                        progress: nil
+                    let result = try await VideoDepthAnythingGenerationOperation.execute(
+                        plan.request(videoURL: inputURL, outputDirectory: outputDirectory),
+                        prepareRuntime: { try MLXBundleSupport.ensureAvailable(quiet: true) }
                     )
-                    await generator.unload()
                     return try retainedArtifactJSONResponse(
                         APIServerContract.depthVideoResponse(from: result),
                         outputDirectory: outputDirectory
                     )
                 } catch {
-                    await generator.unload()
                     try? FileManager.default.removeItem(at: outputDirectory)
                     throw error
                 }

--- a/Sources/MereRunCLI/Support/APIServerContract.swift
+++ b/Sources/MereRunCLI/Support/APIServerContract.swift
@@ -651,16 +651,19 @@ enum APIServerContract {
 
     struct ImageTo3DPlan: Equatable, Sendable {
         let modelID: String
-        let extractionResolution: Int
-        let densityThreshold: Float
-        let foregroundRatio: Float
-        let alreadyFramed: Bool
-        let includesVertexColors: Bool
+        let settings: TripoSRGenerationSettings
 
-        var foregroundPolicy: TripoSRForegroundPolicy {
-            alreadyFramed
-                ? .alreadyFramed
-                : .automaticTransparentAlpha(foregroundRatio: foregroundRatio)
+        var extractionResolution: Int { settings.extractionResolution }
+        var densityThreshold: Float { settings.densityThreshold }
+        var foregroundRatio: Float { settings.foregroundRatio }
+        var alreadyFramed: Bool { settings.alreadyFramed }
+        var includesVertexColors: Bool { settings.includesVertexColors }
+        var foregroundPolicy: TripoSRForegroundPolicy { settings.foregroundPolicy }
+
+        func request(imageURL: URL, outputDirectory: URL) -> TripoSRGenerationRequest {
+            TripoSRGenerationRequest(
+                imageURL: imageURL, outputDirectory: outputDirectory, model: modelID, settings: settings
+            )
         }
     }
 
@@ -1343,59 +1346,43 @@ enum APIServerContract {
             )
         }
 
-        let extractionResolution = try optionalPositiveIntField(
-            form.field("resolution"),
-            field: "resolution"
-        ) ?? 256
-        guard (2...512).contains(extractionResolution) else {
-            throw APIRequestValidationError.invalidField(
-                "resolution",
-                "must be an integer between 2 and 512"
-            )
-        }
-
-        let densityThreshold: Float
+        let resolution = try optionalPositiveIntField(form.field("resolution"), field: "resolution")
+            ?? TripoSRGenerationSettings.defaultResolution
+        let density: Float
         if let raw = normalizedOptional(form.field("density_threshold")) {
-            guard let value = Float(raw), value.isFinite else {
-                throw APIRequestValidationError.invalidField(
-                    "density_threshold",
-                    "must be a finite number"
-                )
+            guard let value = Float(raw) else {
+                throw APIRequestValidationError.invalidField("density_threshold", "must be a finite number")
             }
-            densityThreshold = value
+            density = value
         } else {
-            densityThreshold = TripoSRConfiguration.production.densityThreshold
+            density = TripoSRConfiguration.production.densityThreshold
         }
-
-        let foregroundRatio: Float
+        let ratio: Float
         if let raw = normalizedOptional(form.field("foreground_ratio")) {
-            guard let value = Float(raw), value.isFinite, value > 0, value <= 1 else {
-                throw APIRequestValidationError.invalidField(
-                    "foreground_ratio",
-                    "must be greater than 0 and at most 1"
-                )
+            guard let value = Float(raw) else {
+                throw APIRequestValidationError.invalidField("foreground_ratio", "must be greater than 0 and at most 1")
             }
-            foregroundRatio = value
+            ratio = value
         } else {
-            foregroundRatio = 0.85
+            ratio = TripoSRGenerationSettings.defaultForegroundRatio
         }
-
-        return ImageTo3DPlan(
-            modelID: modelID,
-            extractionResolution: extractionResolution,
-            densityThreshold: densityThreshold,
-            foregroundRatio: foregroundRatio,
-            alreadyFramed: try multipartBoolean(
-                form.field("already_framed"),
-                field: "already_framed",
-                defaultValue: false
-            ),
-            includesVertexColors: try multipartBoolean(
-                form.field("vertex_colors"),
-                field: "vertex_colors",
-                defaultValue: true
-            )
-        )
+        do {
+            return ImageTo3DPlan(modelID: modelID, settings: try TripoSRGenerationSettings(
+                extractionResolution: resolution, densityThreshold: density, foregroundRatio: ratio,
+                alreadyFramed: try multipartBoolean(
+                    form.field("already_framed"), field: "already_framed", defaultValue: false
+                ),
+                includesVertexColors: try multipartBoolean(
+                    form.field("vertex_colors"), field: "vertex_colors", defaultValue: true
+                )
+            ))
+        } catch TripoSRGeneratorError.invalidExtractionResolution {
+            throw APIRequestValidationError.invalidField("resolution", "must be an integer between 2 and 512")
+        } catch TripoSRGeneratorError.invalidDensityThreshold {
+            throw APIRequestValidationError.invalidField("density_threshold", "must be a finite number")
+        } catch TripoSRPreprocessingError.invalidForegroundRatio {
+            throw APIRequestValidationError.invalidField("foreground_ratio", "must be greater than 0 and at most 1")
+        }
     }
 
     static func imageTo3DResponse(

--- a/Sources/MereRunCLI/Support/APIServerContract.swift
+++ b/Sources/MereRunCLI/Support/APIServerContract.swift
@@ -640,13 +640,20 @@ enum APIServerContract {
 
     struct MultiViewGeometryPlan: Equatable, Sendable {
         let modelID: String
-        let processResolution: Int
-        let referenceViewStrategy: DepthAnything3ReferenceViewStrategy
-        let confidencePercentile: Double
-        let maximumPointCount: Int
-        let knownCameras: [DepthAnything3KnownCamera]?
+        let settings: DepthAnything3GenerationSettings
 
+        var processResolution: Int { settings.processResolution }
+        var referenceViewStrategy: DepthAnything3ReferenceViewStrategy { settings.referenceViewStrategy }
+        var confidencePercentile: Double { settings.export.confidencePercentile }
+        var maximumPointCount: Int { settings.export.maximumPointCount }
+        var knownCameras: [DepthAnything3KnownCamera]? { settings.knownCameras }
         var poseConditioned: Bool { knownCameras != nil }
+
+        func request(imageURLs: [URL], outputDirectory: URL) -> DepthAnything3GenerationRequest {
+            DepthAnything3GenerationRequest(
+                imageURLs: imageURLs, outputDirectory: outputDirectory, model: modelID, settings: settings
+            )
+        }
     }
 
     struct ImageTo3DPlan: Equatable, Sendable {
@@ -1036,7 +1043,7 @@ enum APIServerContract {
         let processResolution = try optionalPositiveIntField(
             form.field("process_resolution"),
             field: "process_resolution"
-        ) ?? 504
+        ) ?? DepthAnything3GenerationSettings.defaultProcessResolution
         do {
             try DepthAnything3Limits.validateRequest(
                 viewCount: imageUploads.count,
@@ -1058,11 +1065,11 @@ enum APIServerContract {
         let maximumPointCount = try optionalPositiveIntField(
             form.field("max_points"),
             field: "max_points"
-        ) ?? 1_000_000
+        ) ?? MultiViewGeometryExportConfiguration.defaultMaximumPointCount
 
         let confidencePercentile: Double
         if let raw = normalizedOptional(form.field("confidence_percentile")) {
-            guard let value = Double(raw), value.isFinite, (0...100).contains(value) else {
+            guard let value = Double(raw) else {
                 throw APIRequestValidationError.invalidField(
                     "confidence_percentile",
                     "must be a finite number between 0 and 100"
@@ -1070,7 +1077,7 @@ enum APIServerContract {
             }
             confidencePercentile = value
         } else {
-            confidencePercentile = 40
+            confidencePercentile = MultiViewGeometryExportConfiguration.defaultConfidencePercentile
         }
 
         let referenceViewRaw = normalizedOptional(form.field("reference_view"))?.lowercased()
@@ -1121,14 +1128,18 @@ enum APIServerContract {
             try decodeMultiViewCameraDocument($0, expectedCount: imageUploads.count)
         }
 
-        return MultiViewGeometryPlan(
-            modelID: modelID,
-            processResolution: processResolution,
-            referenceViewStrategy: referenceViewStrategy,
-            confidencePercentile: confidencePercentile,
-            maximumPointCount: maximumPointCount,
-            knownCameras: knownCameras
-        )
+        do {
+            let settings = try DepthAnything3GenerationSettings(
+                processResolution: processResolution, referenceViewStrategy: referenceViewStrategy,
+                knownCameras: knownCameras, confidencePercentile: confidencePercentile,
+                maximumPointCount: maximumPointCount
+            )
+            return MultiViewGeometryPlan(modelID: modelID, settings: settings)
+        } catch MultiViewGeometryExportConfigurationError.invalidConfidencePercentile {
+            throw APIRequestValidationError.invalidField(
+                "confidence_percentile", "must be a finite number between 0 and 100"
+            )
+        }
     }
 
     static func multiViewGeometryResponse(

--- a/Sources/MereRunCLI/Support/APIServerContract.swift
+++ b/Sources/MereRunCLI/Support/APIServerContract.swift
@@ -669,8 +669,16 @@ enum APIServerContract {
 
     struct DepthVideoPlan: Equatable, Sendable {
         let modelID: String
-        let inputSize: Int
-        let maximumFrameCount: Int
+        let settings: VideoDepthAnythingGenerationSettings
+
+        var inputSize: Int { settings.inputSize }
+        var maximumFrameCount: Int { settings.maximumFrameCount }
+
+        func request(videoURL: URL, outputDirectory: URL) -> VideoDepthAnythingGenerationRequest {
+            VideoDepthAnythingGenerationRequest(
+                videoURL: videoURL, outputDirectory: outputDirectory, model: modelID, settings: settings
+            )
+        }
     }
 
     static func healthStatus() -> APIHealthStatus {
@@ -1559,8 +1567,9 @@ enum APIServerContract {
                 form.field("max_frames"),
                 field: "max_frames"
             ) ?? VideoDepthAnythingLimits.defaultMaximumFrameCount
+        let settings: VideoDepthAnythingGenerationSettings
         do {
-            _ = try VideoDepthAnythingLimits.validateRequest(
+            settings = try VideoDepthAnythingGenerationSettings(
                 inputSize: inputSize,
                 maximumFrameCount: maximumFrameCount
             )
@@ -1576,11 +1585,7 @@ enum APIServerContract {
         } catch {
             throw APIRequestValidationError.invalidField("video", error.localizedDescription)
         }
-        return DepthVideoPlan(
-            modelID: modelID,
-            inputSize: inputSize,
-            maximumFrameCount: maximumFrameCount
-        )
+        return DepthVideoPlan(modelID: modelID, settings: settings)
     }
 
     static func depthVideoResponse(

--- a/Sources/MereRunCLI/Support/README.md
+++ b/Sources/MereRunCLI/Support/README.md
@@ -4,9 +4,9 @@ Shared helpers and runtime adapters for the public command surface.
 
 - `APIServerContract.swift`: API wire types, model policy, and request/response contracts.
 - `APIServer.swift`: HTTP routing, authentication, transport, and streaming ownership.
-- The single-image geometry route calls `MoGe2GenerationOperation` for shared
-  settings, execution, and unloading. The HTTP handler retains admission,
-  upload and output cleanup, and artifact retention.
+- Geometry, reconstruction, and video-depth routes call their Core generation
+  operations for shared settings, execution, and awaited unloading. HTTP handlers
+  retain admission, upload and output cleanup, and artifact retention.
 - Speech API model aliases and voice descriptions belong to `APIServerContract`.
   `APISidecarModelPool` retains admission and residency around the shared
   `AudioCore.SpeechSynthesisOperation`.

--- a/Sources/MereRunCore/DepthAnything3/DepthAnything3GenerationOperation.swift
+++ b/Sources/MereRunCore/DepthAnything3/DepthAnything3GenerationOperation.swift
@@ -1,0 +1,135 @@
+import Foundation
+
+/// Shares native view limits, camera conditioning, and validated scene-export settings.
+public struct DepthAnything3GenerationSettings: Equatable, Sendable {
+    public static let defaultProcessResolution = 504
+    public let processResolution: Int
+    public let referenceViewStrategy: DepthAnything3ReferenceViewStrategy
+    public let knownCameras: [DepthAnything3KnownCamera]?
+    public let export: MultiViewGeometryExportConfiguration
+
+    public init(
+        processResolution: Int = defaultProcessResolution,
+        referenceViewStrategy: DepthAnything3ReferenceViewStrategy = .saddleBalanced,
+        knownCameras: [DepthAnything3KnownCamera]? = nil,
+        confidencePercentile: Double = MultiViewGeometryExportConfiguration.defaultConfidencePercentile,
+        maximumPointCount: Int = MultiViewGeometryExportConfiguration.defaultMaximumPointCount
+    ) throws {
+        try DepthAnything3Limits.validateRequest(viewCount: 1, processResolution: processResolution)
+        if let knownCameras {
+            for (index, camera) in knownCameras.enumerated() {
+                try DepthAnything3CameraValidation.validate(camera, index: index)
+            }
+        }
+        self.processResolution = processResolution
+        self.referenceViewStrategy = referenceViewStrategy
+        self.knownCameras = knownCameras
+        self.export = try MultiViewGeometryExportConfiguration(
+            confidencePercentile: confidencePercentile, maximumPointCount: maximumPointCount
+        )
+    }
+
+    public func validate(viewCount: Int) throws {
+        try DepthAnything3Limits.validateRequest(viewCount: viewCount, processResolution: processResolution)
+        if let knownCameras, knownCameras.count != viewCount {
+            throw DepthAnything3GeneratorError.cameraCountMismatch(images: viewCount, cameras: knownCameras.count)
+        }
+    }
+}
+
+public struct DepthAnything3GenerationRequest: Equatable, Sendable {
+    public let imageURLs: [URL]
+    public let outputDirectory: URL
+    public let model: String?
+    public let settings: DepthAnything3GenerationSettings
+
+    public init(imageURLs: [URL], outputDirectory: URL, model: String? = nil, settings: DepthAnything3GenerationSettings) {
+        self.imageURLs = imageURLs.map(\.standardizedFileURL)
+        self.outputDirectory = outputDirectory.standardizedFileURL
+        self.model = model
+        self.settings = settings
+    }
+}
+
+public struct DepthAnything3GenerationResult: Sendable {
+    public let run: DepthAnything3RunResult
+    public let export: MultiViewGeometryExportResult
+    public let exportSeconds: Double
+}
+
+/// Owns per-request execution and awaited cleanup within the caller's admission.
+public enum DepthAnything3GenerationOperation {
+    public typealias ProgressHandler = @Sendable (DepthAnything3Progress) -> Void
+
+    public struct Runtime: Sendable {
+        public let generate: @Sendable (DepthAnything3GenerationRequest, ProgressHandler?) async throws -> DepthAnything3RunResult
+        public let unload: @Sendable () async -> Void
+
+        public init(
+            generate: @escaping @Sendable (DepthAnything3GenerationRequest, ProgressHandler?) async throws -> DepthAnything3RunResult,
+            unload: @escaping @Sendable () async -> Void
+        ) {
+            self.generate = generate
+            self.unload = unload
+        }
+    }
+
+    /// Inspects current headers without creating output or resolving a checkpoint.
+    public static func prepare(_ request: DepthAnything3GenerationRequest) throws {
+        try Task.checkCancellation()
+        try request.settings.validate(viewCount: request.imageURLs.count)
+        for url in request.imageURLs where !FileManager.default.fileExists(atPath: url.path) {
+            throw DepthAnything3GeneratorError.imageNotFound(url.path)
+        }
+        let dimensions = try DepthAnything3Limits.validateImageURLs(request.imageURLs)
+        try DepthAnything3CameraValidation.validate(
+            request.settings.knownCameras, sourceDimensions: dimensions
+        )
+    }
+
+    public static func execute(
+        _ request: DepthAnything3GenerationRequest,
+        prepareRuntime: @Sendable () throws -> Void = {},
+        progress: ProgressHandler? = nil,
+        makeRuntime: @Sendable () -> Runtime = nativeRuntime
+    ) async throws -> DepthAnything3GenerationResult {
+        try prepare(request)
+        try prepareRuntime()
+        try Task.checkCancellation()
+        let runtime = makeRuntime()
+        let result: DepthAnything3GenerationResult
+        do {
+            let run = try await runtime.generate(request, progress)
+            try Task.checkCancellation()
+            let exportStart = Date()
+            let export = try MultiViewGeometryExporter.export(
+                run: run, outputDirectory: request.outputDirectory, configuration: request.settings.export
+            )
+            result = DepthAnything3GenerationResult(
+                run: run, export: export, exportSeconds: Date().timeIntervalSince(exportStart)
+            )
+            try Task.checkCancellation()
+        } catch {
+            await runtime.unload()
+            throw error
+        }
+        await runtime.unload()
+        try Task.checkCancellation()
+        return result
+    }
+
+    public static func nativeRuntime() -> Runtime {
+        let generator = DepthAnything3Generator()
+        return Runtime(
+            generate: { request, progress in
+                try await generator.generate(
+                    imageURLs: request.imageURLs, model: request.model,
+                    knownCameras: request.settings.knownCameras,
+                    referenceViewStrategy: request.settings.referenceViewStrategy,
+                    processResolution: request.settings.processResolution, progress: progress
+                )
+            },
+            unload: { await generator.unload() }
+        )
+    }
+}

--- a/Sources/MereRunCore/DepthAnything3/DepthAnything3Generator.swift
+++ b/Sources/MereRunCore/DepthAnything3/DepthAnything3Generator.swift
@@ -134,9 +134,10 @@ public actor DepthAnything3Generator {
         model requestedModel: String? = nil,
         knownCameras: [DepthAnything3KnownCamera]? = nil,
         referenceViewStrategy: DepthAnything3ReferenceViewStrategy = .saddleBalanced,
-        processResolution: Int = 504,
+        processResolution: Int = DepthAnything3GenerationSettings.defaultProcessResolution,
         progress: (@Sendable (DepthAnything3Progress) -> Void)? = nil
     ) async throws -> DepthAnything3RunResult {
+        try Task.checkCancellation()
         guard !imageURLs.isEmpty else { throw DepthAnything3GeneratorError.noImages }
         try DepthAnything3Limits.validateRequest(
             viewCount: imageURLs.count,
@@ -165,29 +166,14 @@ public actor DepthAnything3Generator {
             (width: $0.width, height: $0.height)
         }
         try DepthAnything3Limits.validateSourceDimensions(sourceDimensions)
-        if let knownCameras {
-            for index in knownCameras.indices {
-                try DepthAnything3CameraValidation.validate(knownCameras[index], index: index)
-                let size = sourceDimensions[index]
-                let intrinsics = knownCameras[index].intrinsics
-                guard intrinsics.imageWidth == size.width,
-                      intrinsics.imageHeight == size.height else {
-                    throw DepthAnything3PreprocessingError.cameraImageDimensionMismatch(
-                        index: index,
-                        expectedWidth: size.width,
-                        expectedHeight: size.height,
-                        actualWidth: intrinsics.imageWidth,
-                        actualHeight: intrinsics.imageHeight
-                    )
-                }
-            }
-        }
+        try DepthAnything3CameraValidation.validate(knownCameras, sourceDimensions: sourceDimensions)
 
         progress?(.verifyingCheckpoint)
         let verificationStart = Date()
         let checkpoint = try await DepthAnything3Resources.resolve(requestedModel: requestedModel)
         let checkpointVerificationSeconds = Date().timeIntervalSince(verificationStart)
 
+        try Task.checkCancellation()
         progress?(.decodingImages)
         let decodingStart = Date()
         let inputIdentities = admittedInputs.inputRecords.map(DepthAnything3InputIdentity.init)
@@ -208,11 +194,13 @@ public actor DepthAnything3Generator {
         )
         let preprocessingSeconds = Date().timeIntervalSince(preprocessingStart)
 
+        try Task.checkCancellation()
         progress?(.loadingModel)
         let loadStart = Date()
         let nativeModel = try loadModelIfNeeded(checkpoint)
         let modelLoadSeconds = Date().timeIntervalSince(loadStart)
 
+        try Task.checkCancellation()
         progress?(.runningInference)
         let inferenceStart = Date()
         let raw = nativeModel(
@@ -230,6 +218,7 @@ public actor DepthAnything3Generator {
         )
         let inferenceSeconds = Date().timeIntervalSince(inferenceStart)
 
+        try Task.checkCancellation()
         progress?(.postprocessingGeometry)
         let postprocessingStart = Date()
         let processed = try DepthAnything3Postprocessor.process(

--- a/Sources/MereRunCore/DepthAnything3/DepthAnything3Validation.swift
+++ b/Sources/MereRunCore/DepthAnything3/DepthAnything3Validation.swift
@@ -198,6 +198,28 @@ public enum DepthAnything3CameraValidation {
         }
     }
 
+    /// Validates camera conditioning against the exact admitted image dimensions.
+    public static func validate(
+        _ cameras: [DepthAnything3KnownCamera]?,
+        sourceDimensions: [(width: Int, height: Int)]
+    ) throws {
+        guard let cameras else { return }
+        guard cameras.count == sourceDimensions.count else {
+            throw DepthAnything3GeneratorError.cameraCountMismatch(images: sourceDimensions.count, cameras: cameras.count)
+        }
+        for (index, camera) in cameras.enumerated() {
+            try validate(camera, index: index)
+            let size = sourceDimensions[index]
+            let intrinsics = camera.intrinsics
+            guard intrinsics.imageWidth == size.width, intrinsics.imageHeight == size.height else {
+                throw DepthAnything3PreprocessingError.cameraImageDimensionMismatch(
+                    index: index, expectedWidth: size.width, expectedHeight: size.height,
+                    actualWidth: intrinsics.imageWidth, actualHeight: intrinsics.imageHeight
+                )
+            }
+        }
+    }
+
     public static func issue(for camera: DepthAnything3KnownCamera) -> String? {
         let intrinsics = camera.intrinsics
         guard intrinsics.imageWidth > 0, intrinsics.imageHeight > 0 else {

--- a/Sources/MereRunCore/DepthAnything3/README.md
+++ b/Sources/MereRunCore/DepthAnything3/README.md
@@ -19,3 +19,9 @@ solving.
 The public output is camera-aware point geometry, not a claimed mesh or trained
 3D Gaussian field. The 3DGS handoff contains transforms plus a colored point
 cloud and explicitly records that Gaussian parameters are absent.
+
+`DepthAnything3GenerationOperation` shares validated settings, current-image and
+camera checks, native execution, transactional scene export, and awaited
+unloading across CLI and API. `DepthAnything3CameraValidation` checks supplied
+cameras against the current headers during planning and the admitted snapshot
+dimensions during execution. Callers retain model and transport policy.

--- a/Sources/MereRunCore/Geometry/MultiViewGeometryExporter.swift
+++ b/Sources/MereRunCore/Geometry/MultiViewGeometryExporter.swift
@@ -95,12 +95,14 @@ public enum MultiViewGeometryExportConfigurationError: Error, Equatable, Localiz
 }
 
 public struct MultiViewGeometryExportConfiguration: Equatable, Sendable {
+    public static let defaultConfidencePercentile: Double = 40
+    public static let defaultMaximumPointCount = 1_000_000
     public let confidencePercentile: Double
     public let maximumPointCount: Int
 
     public init(
-        confidencePercentile: Double = 40,
-        maximumPointCount: Int = 1_000_000
+        confidencePercentile: Double = defaultConfidencePercentile,
+        maximumPointCount: Int = defaultMaximumPointCount
     ) throws {
         guard confidencePercentile.isFinite, (0...100).contains(confidencePercentile) else {
             throw MultiViewGeometryExportConfigurationError.invalidConfidencePercentile(

--- a/Sources/MereRunCore/InstantMesh/InstantMeshGenerationOperation.swift
+++ b/Sources/MereRunCore/InstantMesh/InstantMeshGenerationOperation.swift
@@ -1,0 +1,120 @@
+import Foundation
+
+/// Validates extraction controls and supplied camera rows without loading weights.
+public struct InstantMeshGenerationSettings: Equatable, Sendable {
+    public let extractionResolution: Int
+    public let includesVertexColors: Bool
+    public let cameras: [[Float]]?
+
+    public init(
+        extractionResolution: Int = InstantMeshConfiguration.production.gridResolution,
+        includesVertexColors: Bool = true,
+        cameras: [[Float]]? = nil
+    ) throws {
+        guard (2...256).contains(extractionResolution) else {
+            throw InstantMeshGeneratorError.invalidExtractionResolution(extractionResolution)
+        }
+        if let cameras {
+            for (index, camera) in cameras.enumerated()
+            where camera.count != 16 || !camera.allSatisfy(\.isFinite) {
+                throw InstantMeshPreprocessingError.invalidCamera(index: index)
+            }
+        }
+        self.extractionResolution = extractionResolution
+        self.includesVertexColors = includesVertexColors
+        self.cameras = cameras
+    }
+
+    public static func validateViewCount(_ count: Int) throws {
+        guard count == 4 || count == 6 else {
+            throw InstantMeshGeneratorError.invalidViewCount(count)
+        }
+    }
+
+    public func validate(viewCount: Int) throws {
+        try Self.validateViewCount(viewCount)
+        if let cameras, cameras.count != viewCount {
+            throw InstantMeshPreprocessingError.cameraCountMismatch(expected: viewCount, actual: cameras.count)
+        }
+    }
+}
+
+public struct InstantMeshGenerationRequest: Equatable, Sendable {
+    public let viewURLs: [URL]
+    public let outputDirectory: URL
+    public let model: String?
+    public let settings: InstantMeshGenerationSettings
+
+    public init(viewURLs: [URL], outputDirectory: URL, model: String? = nil, settings: InstantMeshGenerationSettings) {
+        self.viewURLs = viewURLs.map(\.standardizedFileURL)
+        self.outputDirectory = outputDirectory.standardizedFileURL
+        self.model = model
+        self.settings = settings
+    }
+}
+
+/// Owns per-request execution and awaited cleanup within the caller's admission.
+public enum InstantMeshGenerationOperation {
+    public typealias ProgressHandler = @Sendable (InstantMeshProgress) -> Void
+
+    public struct Runtime: Sendable {
+        public let generate: @Sendable (InstantMeshGenerationRequest, ProgressHandler?) async throws -> InstantMeshRunResult
+        public let unload: @Sendable () async -> Void
+
+        public init(
+            generate: @escaping @Sendable (InstantMeshGenerationRequest, ProgressHandler?) async throws -> InstantMeshRunResult,
+            unload: @escaping @Sendable () async -> Void
+        ) {
+            self.generate = generate
+            self.unload = unload
+        }
+    }
+
+    /// Inspects current headers without creating output or resolving a checkpoint.
+    public static func prepare(_ request: InstantMeshGenerationRequest) throws -> [VFXImageInputDimensions] {
+        try Task.checkCancellation()
+        try request.settings.validate(viewCount: request.viewURLs.count)
+        for url in request.viewURLs where !FileManager.default.fileExists(atPath: url.path) {
+            throw InstantMeshGeneratorError.inputViewNotFound(url.path)
+        }
+        return try VFXImageInputValidator.inspectAndValidate(request.viewURLs)
+    }
+
+    public static func execute(
+        _ request: InstantMeshGenerationRequest,
+        prepareRuntime: @Sendable () throws -> Void = {},
+        progress: ProgressHandler? = nil,
+        makeRuntime: @Sendable () -> Runtime = nativeRuntime
+    ) async throws -> InstantMeshRunResult {
+        _ = try prepare(request)
+        try prepareRuntime()
+        try Task.checkCancellation()
+        let runtime = makeRuntime()
+        let result: InstantMeshRunResult
+        do {
+            result = try await runtime.generate(request, progress)
+            try Task.checkCancellation()
+        } catch {
+            await runtime.unload()
+            throw error
+        }
+        await runtime.unload()
+        try Task.checkCancellation()
+        return result
+    }
+
+    public static func nativeRuntime() -> Runtime {
+        let generator = InstantMeshGenerator()
+        return Runtime(
+            generate: { request, progress in
+                try await generator.generate(
+                    viewURLs: request.viewURLs, outputDirectory: request.outputDirectory,
+                    model: request.model, cameras: request.settings.cameras,
+                    extractionResolution: request.settings.extractionResolution,
+                    includeVertexColors: request.settings.includesVertexColors, progress: progress
+                )
+            },
+            unload: { await generator.unload() }
+        )
+    }
+}

--- a/Sources/MereRunCore/InstantMesh/InstantMeshGenerator.swift
+++ b/Sources/MereRunCore/InstantMesh/InstantMeshGenerator.swift
@@ -121,12 +121,11 @@ public actor InstantMeshGenerator {
         includeVertexColors: Bool = true,
         progress: (@Sendable (InstantMeshProgress) -> Void)? = nil
     ) async throws -> InstantMeshRunResult {
-        guard viewURLs.count == 4 || viewURLs.count == 6 else {
-            throw InstantMeshGeneratorError.invalidViewCount(viewURLs.count)
-        }
-        guard (2...256).contains(extractionResolution) else {
-            throw InstantMeshGeneratorError.invalidExtractionResolution(extractionResolution)
-        }
+        try Task.checkCancellation()
+        let settings = try InstantMeshGenerationSettings(
+            extractionResolution: extractionResolution, includesVertexColors: includeVertexColors, cameras: cameras
+        )
+        try settings.validate(viewCount: viewURLs.count)
         let inputs = viewURLs.map(\.standardizedFileURL)
         for input in inputs where !FileManager.default.fileExists(atPath: input.path) {
             throw InstantMeshGeneratorError.inputViewNotFound(input.path)
@@ -160,17 +159,20 @@ public actor InstantMeshGenerator {
         let prepared = try InstantMeshPreprocessor.prepare(sourceImages: images, cameras: cameras)
         let preprocessingSeconds = Date().timeIntervalSince(preprocessingStart)
 
+        try Task.checkCancellation()
         progress?(.loadingModel)
         let loadStart = Date()
         let nativeModel = try loadModelIfNeeded(checkpoint)
         let modelLoadSeconds = Date().timeIntervalSince(loadStart)
 
+        try Task.checkCancellation()
         progress?(.encodingScene)
         let encodingStart = Date()
         let sceneCode = nativeModel(images: prepared.images, cameras: prepared.cameras)
         MLX.eval(sceneCode.planes)
         let sceneEncodingSeconds = Date().timeIntervalSince(encodingStart)
 
+        try Task.checkCancellation()
         progress?(.extractingMesh)
         let extractionStart = Date()
         let extraction = try InstantMeshIsosurfaceExtractor.extractMeshWithMetadata(
@@ -184,6 +186,7 @@ public actor InstantMeshGenerator {
         let mesh = extraction.mesh
         let meshExtractionSeconds = Date().timeIntervalSince(extractionStart)
 
+        try Task.checkCancellation()
         progress?(.exportingAssets)
         let exportStart = Date()
         let export = try InstantMeshAssetExporter.export(

--- a/Sources/MereRunCore/InstantMesh/InstantMeshPreprocessor.swift
+++ b/Sources/MereRunCore/InstantMesh/InstantMeshPreprocessor.swift
@@ -131,16 +131,7 @@ public enum InstantMeshPreprocessor {
         let cameraValues: [[Float]]
         let usedOfficialCameraRig: Bool
         if let suppliedCameras {
-            guard suppliedCameras.count == sourceImages.count else {
-                throw InstantMeshPreprocessingError.cameraCountMismatch(
-                    expected: sourceImages.count,
-                    actual: suppliedCameras.count
-                )
-            }
-            for (index, camera) in suppliedCameras.enumerated()
-                where camera.count != 16 || !camera.allSatisfy(\.isFinite) {
-                throw InstantMeshPreprocessingError.invalidCamera(index: index)
-            }
+            try InstantMeshGenerationSettings(cameras: suppliedCameras).validate(viewCount: sourceImages.count)
             cameraValues = suppliedCameras
             usedOfficialCameraRig = false
         } else {

--- a/Sources/MereRunCore/InstantMesh/README.md
+++ b/Sources/MereRunCore/InstantMesh/README.md
@@ -18,3 +18,9 @@ reconstruction stage.
 
 The runtime uses its own clean-room isosurface implementation. NVIDIA's
 proprietary FlexiCubes source is not included or executed.
+
+`InstantMeshGenerationSettings` owns extraction and camera-row validation.
+`InstantMeshGenerationOperation` checks ordered views and camera counts before
+runtime construction, then awaits unloading after generation or failure. Native
+execution retains immutable snapshots; CLI and API retain model and transport
+policy. Preflight preserves the supplied view order without creating output.

--- a/Sources/MereRunCore/README.md
+++ b/Sources/MereRunCore/README.md
@@ -41,6 +41,9 @@ Core retains resource loading and generation for these families.
   compatibility shared by image, text, video, and evaluation adapters.
 - `VisionGeometry/MoGe2/MoGe2GenerationOperation.swift`: shared single-image
   geometry settings, observational plans, execution, and awaited unloading.
+- Family `*GenerationOperation.swift` files under `TripoSR/`, `InstantMesh/`,
+  `DepthAnything3/`, and `VideoDepth/VDA/`: shared CLI/API settings, preparation,
+  execution, and awaited per-request cleanup. DA3 also owns scene export.
 - `ManagedModel*.swift`: public managed-model catalog and install metadata.
 - `ModelResolver.swift`: adapts the catalog and family validators to ModelKit lookup.
 - `MereRunModelManifest+Templates.swift`: runtime-dependent manifest templates.

--- a/Sources/MereRunCore/TripoSR/README.md
+++ b/Sources/MereRunCore/TripoSR/README.md
@@ -16,3 +16,8 @@ TripoSR single-image reconstruction checkpoint.
 
 Configuration and memory limits are throwing public APIs so malformed external
 requests cannot terminate the process through a precondition trap.
+
+`TripoSRGenerationSettings` owns scalar validation for CLI, API, and native
+execution. `TripoSRGenerationOperation` rechecks current image headers, invokes
+the snapshot-based generator, and awaits unloading on success, failure, and
+cancellation. Callers retain admission and artifact-retention policy.

--- a/Sources/MereRunCore/TripoSR/README.md
+++ b/Sources/MereRunCore/TripoSR/README.md
@@ -21,3 +21,7 @@ requests cannot terminate the process through a precondition trap.
 execution. `TripoSRGenerationOperation` rechecks current image headers, invokes
 the snapshot-based generator, and awaits unloading on success, failure, and
 cancellation. Callers retain admission and artifact-retention policy.
+
+Transparent-foreground padding uses the VFX image budget for its intermediate
+square canvas. Ratios that exceed that budget fail before integer conversion or
+allocation; ordinary ratios retain the native truncation and compositing rules.

--- a/Sources/MereRunCore/TripoSR/TripoSRGenerationOperation.swift
+++ b/Sources/MereRunCore/TripoSR/TripoSRGenerationOperation.swift
@@ -1,0 +1,119 @@
+import Foundation
+
+/// Validated controls shared by reconstruction adapters and the native generator.
+public struct TripoSRGenerationSettings: Equatable, Sendable {
+    public static let defaultResolution = 256
+    public static let defaultForegroundRatio: Float = 0.85
+    public let extractionResolution: Int
+    public let densityThreshold: Float
+    public let foregroundRatio: Float
+    public let alreadyFramed: Bool
+    public let includesVertexColors: Bool
+
+    public var foregroundPolicy: TripoSRForegroundPolicy {
+        alreadyFramed ? .alreadyFramed : .automaticTransparentAlpha(foregroundRatio: foregroundRatio)
+    }
+
+    public init(
+        extractionResolution: Int = defaultResolution,
+        densityThreshold: Float = TripoSRConfiguration.production.densityThreshold,
+        foregroundRatio: Float = defaultForegroundRatio,
+        alreadyFramed: Bool = false,
+        includesVertexColors: Bool = true
+    ) throws {
+        guard (2...512).contains(extractionResolution) else {
+            throw TripoSRGeneratorError.invalidExtractionResolution(extractionResolution)
+        }
+        guard densityThreshold.isFinite else {
+            throw TripoSRGeneratorError.invalidDensityThreshold(densityThreshold)
+        }
+        guard foregroundRatio.isFinite, foregroundRatio > 0, foregroundRatio <= 1 else {
+            throw TripoSRPreprocessingError.invalidForegroundRatio(foregroundRatio)
+        }
+        self.extractionResolution = extractionResolution
+        self.densityThreshold = densityThreshold
+        self.foregroundRatio = foregroundRatio
+        self.alreadyFramed = alreadyFramed
+        self.includesVertexColors = includesVertexColors
+    }
+}
+
+public struct TripoSRGenerationRequest: Equatable, Sendable {
+    public let imageURL: URL
+    public let outputDirectory: URL
+    public let model: String?
+    public let settings: TripoSRGenerationSettings
+
+    public init(imageURL: URL, outputDirectory: URL, model: String? = nil, settings: TripoSRGenerationSettings) {
+        self.imageURL = imageURL.standardizedFileURL
+        self.outputDirectory = outputDirectory.standardizedFileURL
+        self.model = model
+        self.settings = settings
+    }
+}
+
+/// Owns per-request execution and awaited cleanup within the caller's admission.
+public enum TripoSRGenerationOperation {
+    public typealias ProgressHandler = @Sendable (TripoSRProgress) -> Void
+
+    public struct Runtime: Sendable {
+        public let generate: @Sendable (TripoSRGenerationRequest, ProgressHandler?) async throws -> TripoSRRunResult
+        public let unload: @Sendable () async -> Void
+
+        public init(
+            generate: @escaping @Sendable (TripoSRGenerationRequest, ProgressHandler?) async throws -> TripoSRRunResult,
+            unload: @escaping @Sendable () async -> Void
+        ) {
+            self.generate = generate
+            self.unload = unload
+        }
+    }
+
+    /// Inspects current headers without creating output or resolving a checkpoint.
+    public static func prepare(_ request: TripoSRGenerationRequest) throws -> VFXImageInputDimensions {
+        try Task.checkCancellation()
+        guard FileManager.default.fileExists(atPath: request.imageURL.path) else {
+            throw TripoSRGeneratorError.inputImageNotFound(request.imageURL.path)
+        }
+        return try VFXImageInputValidator.inspectAndValidate([request.imageURL])[0]
+    }
+
+    public static func execute(
+        _ request: TripoSRGenerationRequest,
+        prepareRuntime: @Sendable () throws -> Void = {},
+        progress: ProgressHandler? = nil,
+        makeRuntime: @Sendable () -> Runtime = nativeRuntime
+    ) async throws -> TripoSRRunResult {
+        _ = try prepare(request)
+        try prepareRuntime()
+        try Task.checkCancellation()
+        let runtime = makeRuntime()
+        let result: TripoSRRunResult
+        do {
+            result = try await runtime.generate(request, progress)
+            try Task.checkCancellation()
+        } catch {
+            await runtime.unload()
+            throw error
+        }
+        await runtime.unload()
+        try Task.checkCancellation()
+        return result
+    }
+
+    public static func nativeRuntime() -> Runtime {
+        let generator = TripoSRGenerator()
+        return Runtime(
+            generate: { request, progress in
+                try await generator.generate(
+                    imageURL: request.imageURL, outputDirectory: request.outputDirectory,
+                    model: request.model, foregroundPolicy: request.settings.foregroundPolicy,
+                    extractionResolution: request.settings.extractionResolution,
+                    densityThreshold: request.settings.densityThreshold,
+                    includeVertexColors: request.settings.includesVertexColors, progress: progress
+                )
+            },
+            unload: { await generator.unload() }
+        )
+    }
+}

--- a/Sources/MereRunCore/TripoSR/TripoSRGenerator.swift
+++ b/Sources/MereRunCore/TripoSR/TripoSRGenerator.swift
@@ -119,11 +119,12 @@ public actor TripoSRGenerator {
         outputDirectory: URL,
         model requestedModel: String? = nil,
         foregroundPolicy: TripoSRForegroundPolicy = .automaticTransparentAlpha(),
-        extractionResolution: Int = 256,
+        extractionResolution: Int = TripoSRGenerationSettings.defaultResolution,
         densityThreshold: Float = TripoSRConfiguration.production.densityThreshold,
         includeVertexColors: Bool = true,
         progress: (@Sendable (TripoSRProgress) -> Void)? = nil
     ) async throws -> TripoSRRunResult {
+        try Task.checkCancellation()
         let inputURL = imageURL.standardizedFileURL
         guard FileManager.default.fileExists(atPath: inputURL.path) else {
             throw TripoSRGeneratorError.inputImageNotFound(inputURL.path)
@@ -134,12 +135,20 @@ public actor TripoSRGenerator {
         let admittedInput = try VFXImageInputSnapshotBatch.capture([inputURL])
         defer { admittedInput.cleanup() }
         let snapshotURL = admittedInput.snapshotURLs[0]
-        guard (2...512).contains(extractionResolution) else {
-            throw TripoSRGeneratorError.invalidExtractionResolution(extractionResolution)
+        let ratio: Float
+        let alreadyFramed: Bool
+        switch foregroundPolicy {
+        case .automaticTransparentAlpha(let value):
+            ratio = value
+            alreadyFramed = false
+        case .alreadyFramed:
+            ratio = TripoSRGenerationSettings.defaultForegroundRatio
+            alreadyFramed = true
         }
-        guard densityThreshold.isFinite else {
-            throw TripoSRGeneratorError.invalidDensityThreshold(densityThreshold)
-        }
+        _ = try TripoSRGenerationSettings(
+            extractionResolution: extractionResolution, densityThreshold: densityThreshold,
+            foregroundRatio: ratio, alreadyFramed: alreadyFramed, includesVertexColors: includeVertexColors
+        )
         let foregroundPolicyName: String
         let foregroundRatio: Float?
         switch foregroundPolicy {
@@ -174,17 +183,20 @@ public actor TripoSRGenerator {
         )
         let preprocessingSeconds = Date().timeIntervalSince(preprocessingStart)
 
+        try Task.checkCancellation()
         progress?(.loadingModel)
         let loadStart = Date()
         let nativeModel = try loadModelIfNeeded(checkpoint)
         let modelLoadSeconds = Date().timeIntervalSince(loadStart)
 
+        try Task.checkCancellation()
         progress?(.encodingScene)
         let encodingStart = Date()
         let sceneCode = nativeModel(prepared.image)
         MLX.eval(sceneCode.planes)
         let sceneEncodingSeconds = Date().timeIntervalSince(encodingStart)
 
+        try Task.checkCancellation()
         progress?(.extractingMesh)
         let extractionStart = Date()
         let mesh = try TripoSRIsosurfaceExtractor.extractMesh(
@@ -198,6 +210,7 @@ public actor TripoSRGenerator {
         )
         let meshExtractionSeconds = Date().timeIntervalSince(extractionStart)
 
+        try Task.checkCancellation()
         progress?(.exportingAssets)
         let exportStart = Date()
         let export = try TripoSRAssetExporter.export(

--- a/Sources/MereRunCore/TripoSR/TripoSRPreprocessor.swift
+++ b/Sources/MereRunCore/TripoSR/TripoSRPreprocessor.swift
@@ -15,6 +15,7 @@ public enum TripoSRPreprocessingError: Error, Equatable, LocalizedError, Sendabl
     case emptyForeground
     case invalidForegroundRatio(Float)
     case invalidImageSize(Int)
+    case foregroundPaddingLimitExceeded(maximumSide: Int)
 
     public var errorDescription: String? {
         switch self {
@@ -24,6 +25,8 @@ public enum TripoSRPreprocessingError: Error, Equatable, LocalizedError, Sendabl
             "TripoSR foreground ratio must be in (0, 1], found \(ratio)."
         case .invalidImageSize(let size):
             "TripoSR conditioning image size must be positive; received \(size)."
+        case .foregroundPaddingLimitExceeded(let maximumSide):
+            "TripoSR foreground padding exceeds the \(maximumSide)-pixel square image limit. Increase the foreground ratio."
         }
     }
 }
@@ -126,7 +129,7 @@ public enum TripoSRPreprocessor {
         let cropWidth = max(1, maximumX - minimumX)
         let cropHeight = max(1, maximumY - minimumY)
         let squareSize = max(cropWidth, cropHeight)
-        let paddedSize = max(squareSize, Int(Float(squareSize) / foregroundRatio))
+        let paddedSize = try foregroundPaddingSize(squareSize: squareSize, foregroundRatio: foregroundRatio)
         var canvas = [UInt8](repeating: 0, count: paddedSize * paddedSize * 4)
         let destinationX = (paddedSize - cropWidth) / 2
         let destinationY = (paddedSize - cropHeight) / 2
@@ -145,6 +148,19 @@ public enum TripoSRPreprocessor {
             height: paddedSize,
             values: compositeRGBA(canvas, width: paddedSize, height: paddedSize)
         )
+    }
+
+    /// Applies the existing VFX image budget to the square foreground canvas.
+    static func foregroundPaddingSize(squareSize: Int, foregroundRatio: Float) throws -> Int {
+        let limits = VFXImageInputLimits.production
+        let maximumSide = min(limits.maximumDimension, Int(Double(limits.maximumPixelsPerImage).squareRoot()))
+        let requestedSize = Float(squareSize) / foregroundRatio
+        // Bound the floating-point result before integer conversion or allocation.
+        // The exclusive upper bound preserves the native truncation toward zero.
+        guard requestedSize.isFinite, requestedSize < Float(maximumSide + 1) else {
+            throw TripoSRPreprocessingError.foregroundPaddingLimitExceeded(maximumSide: maximumSide)
+        }
+        return max(squareSize, Int(requestedSize))
     }
 
     private static func compositeRGBA(_ rgba: [UInt8], width: Int, height: Int) -> [Float] {

--- a/Sources/MereRunCore/VideoDepth/VDA/README.md
+++ b/Sources/MereRunCore/VideoDepth/VDA/README.md
@@ -19,3 +19,9 @@ Video Depth Anything Small relative and metric variants.
 
 Inference is native MLX. Python is used only by the offline, exact-version
 conversion and parity tooling under `scripts/`.
+
+`VideoDepthAnythingGenerationSettings` resolves the shared bounded defaults.
+`VideoDepthAnythingGenerationOperation` owns CLI/API execution and awaited
+unloading. Dry-run uses the generator's bounded snapshot/decode preflight;
+execution performs its own admission once against current bytes. CLI and API
+retain presentation and transport policy without loading a second runtime.

--- a/Sources/MereRunCore/VideoDepth/VDA/VideoDepthAnythingGenerationOperation.swift
+++ b/Sources/MereRunCore/VideoDepth/VDA/VideoDepthAnythingGenerationOperation.swift
@@ -1,0 +1,111 @@
+import Foundation
+
+/// Resolves bounded frame defaults through the native video-depth limits.
+public struct VideoDepthAnythingGenerationSettings: Equatable, Sendable {
+    public let inputSize: Int
+    public let maximumFrameCount: Int
+
+    public init(
+        inputSize: Int = VideoDepthAnythingLimits.defaultInputSize,
+        maximumFrameCount: Int? = nil
+    ) throws {
+        self.maximumFrameCount = try VideoDepthAnythingLimits.validateRequest(
+            inputSize: inputSize, maximumFrameCount: maximumFrameCount
+        )
+        self.inputSize = inputSize
+    }
+}
+
+public struct VideoDepthAnythingGenerationRequest: Equatable, Sendable {
+    public let videoURL: URL
+    public let outputDirectory: URL
+    public let model: String?
+    public let settings: VideoDepthAnythingGenerationSettings
+
+    public init(videoURL: URL, outputDirectory: URL, model: String? = nil, settings: VideoDepthAnythingGenerationSettings) {
+        self.videoURL = videoURL.standardizedFileURL
+        self.outputDirectory = outputDirectory.standardizedFileURL
+        self.model = model
+        self.settings = settings
+    }
+}
+
+/// Owns per-request execution and awaited cleanup within the caller's admission.
+public enum VideoDepthAnythingGenerationOperation {
+    public typealias ProgressHandler = @Sendable (VideoDepthAnythingProgress) -> Void
+
+    public struct Runtime: Sendable {
+        public let generate: @Sendable (VideoDepthAnythingGenerationRequest, ProgressHandler?) async throws -> VideoDepthAnythingRunResult
+        public let unload: @Sendable () async -> Void
+
+        public init(
+            generate: @escaping @Sendable (VideoDepthAnythingGenerationRequest, ProgressHandler?) async throws -> VideoDepthAnythingRunResult,
+            unload: @escaping @Sendable () async -> Void
+        ) {
+            self.generate = generate
+            self.unload = unload
+        }
+    }
+
+    /// Checks the current file and byte ceiling without decoding or creating output.
+    public static func prepare(_ request: VideoDepthAnythingGenerationRequest) throws {
+        try Task.checkCancellation()
+        guard FileManager.default.fileExists(atPath: request.videoURL.path) else {
+            throw VideoDepthAnythingGeneratorError.inputVideoNotFound(request.videoURL.path)
+        }
+        let bytes = try ModelArtifactPin.fileByteCount(request.videoURL)
+        guard bytes <= VideoDepthAnythingLimits.maximumEncodedVideoBytes else {
+            throw VFXImageInputValidationError.encodedByteLimitExceeded(
+                path: request.videoURL.path, bytes: bytes, maximum: VideoDepthAnythingLimits.maximumEncodedVideoBytes
+            )
+        }
+    }
+
+    /// Uses native bounded snapshot/decode admission and releases its temporary inputs.
+    public static func preflight(
+        _ request: VideoDepthAnythingGenerationRequest
+    ) async throws -> VideoDepthAnythingPreflightResult {
+        try prepare(request)
+        return try await VideoDepthAnythingGenerator.preflight(
+            videoURL: request.videoURL, model: request.model,
+            inputSize: request.settings.inputSize, maximumFrameCount: request.settings.maximumFrameCount
+        )
+    }
+
+    public static func execute(
+        _ request: VideoDepthAnythingGenerationRequest,
+        prepareRuntime: @Sendable () throws -> Void = {},
+        progress: ProgressHandler? = nil,
+        makeRuntime: @Sendable () -> Runtime = nativeRuntime
+    ) async throws -> VideoDepthAnythingRunResult {
+        try prepare(request)
+        try prepareRuntime()
+        try Task.checkCancellation()
+        let runtime = makeRuntime()
+        let result: VideoDepthAnythingRunResult
+        do {
+            result = try await runtime.generate(request, progress)
+            try Task.checkCancellation()
+        } catch {
+            await runtime.unload()
+            throw error
+        }
+        await runtime.unload()
+        try Task.checkCancellation()
+        return result
+    }
+
+    public static func nativeRuntime() -> Runtime {
+        let generator = VideoDepthAnythingGenerator()
+        return Runtime(
+            generate: { request, progress in
+                try await generator.generate(
+                    videoURL: request.videoURL, outputDirectory: request.outputDirectory,
+                    model: request.model, inputSize: request.settings.inputSize,
+                    maximumFrameCount: request.settings.maximumFrameCount, progress: progress
+                )
+            },
+            unload: { await generator.unload() }
+        )
+    }
+}

--- a/Sources/MereRunCore/VideoDepth/VDA/VideoDepthAnythingGenerator.swift
+++ b/Sources/MereRunCore/VideoDepth/VDA/VideoDepthAnythingGenerator.swift
@@ -172,10 +172,10 @@ private struct VideoDepthAnythingAdmission: Sendable {
         maximumFrameCount requestedMaximumFrameCount: Int?,
         progress: (@Sendable (VideoDepthAnythingProgress) -> Void)?
     ) async throws -> Self {
-        let maximumFrameCount = try VideoDepthAnythingLimits.validateRequest(
-            inputSize: inputSize,
-            maximumFrameCount: requestedMaximumFrameCount
-        )
+        try Task.checkCancellation()
+        let maximumFrameCount = try VideoDepthAnythingGenerationSettings(
+            inputSize: inputSize, maximumFrameCount: requestedMaximumFrameCount
+        ).maximumFrameCount
         let inputURL = videoURL.standardizedFileURL
         guard FileManager.default.fileExists(atPath: inputURL.path) else {
             throw VideoDepthAnythingGeneratorError.inputVideoNotFound(inputURL.path)
@@ -194,6 +194,7 @@ private struct VideoDepthAnythingAdmission: Sendable {
             )
             let checkpointVerificationSeconds = Date().timeIntervalSince(verificationStart)
 
+            try Task.checkCancellation()
             progress?(.extractingFrames)
             let extractionStart = Date()
             let sequence = try MediaVideoIO.extractFrames(
@@ -299,6 +300,7 @@ public actor VideoDepthAnythingGenerator {
         let checkpointVerificationSeconds = admission.checkpointVerificationSeconds
         let frameExtractionSeconds = admission.frameExtractionSeconds
 
+        try Task.checkCancellation()
         progress?(.loadingModel)
         let loadStart = Date()
         let nativeModel = try loadModelIfNeeded(checkpoint)
@@ -333,6 +335,7 @@ public actor VideoDepthAnythingGenerator {
         let inferenceStart = Date()
         var finalizedFrameIndex = 0
         for (index, plan) in plans.enumerated() {
+            try Task.checkCancellation()
             progress?(.runningWindow(current: index + 1, total: plans.count))
             let frames = try plan.sourceFrameIndices.map {
                 try MediaImageIO.decode(sequence.frameURLs[$0])
@@ -353,6 +356,7 @@ public actor VideoDepthAnythingGenerator {
                 width: sequence.frameWidth,
                 height: sequence.frameHeight
             )
+            try Task.checkCancellation()
             let aligned = try aligner.append(
                 window: window,
                 isFinal: index == plans.count - 1
@@ -375,10 +379,12 @@ public actor VideoDepthAnythingGenerator {
         progress?(.aligningWindows)
         let inferenceSeconds = Date().timeIntervalSince(inferenceStart)
 
+        try Task.checkCancellation()
         progress?(.exportingDepth)
         let exportStart = Date()
         let export = try streamingExporter.finalize()
 
+        try Task.checkCancellation()
         progress?(.writingReviewVideo)
         let previewURLs = try export.manifest.frames.map { frame -> URL in
             guard let relativePath = frame.previewPath else {

--- a/Tests/MereRunCLITests/DepthAnything3GenerationOperationTests.swift
+++ b/Tests/MereRunCLITests/DepthAnything3GenerationOperationTests.swift
@@ -1,0 +1,226 @@
+import Foundation
+import MediaIO
+import XCTest
+@testable import MereRunCore
+@testable import MereRunCLI
+
+final class DepthAnything3GenerationOperationTests: XCTestCase {
+    private enum Expected: Error { case failure }
+
+    func testCLIAndAPIShareCameraConditioningAndExportSettings() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        for explicit in [false, true] {
+            let cameras = try (0..<2).map { try Self.camera(index: $0) }
+            let document = try JSONEncoder().encode(DepthAnything3CameraDocument(cameras: cameras))
+            let cameraURL = root.appendingPathComponent("cameras.json")
+            try document.write(to: cameraURL)
+            let fields = explicit ? ["process_resolution": "112", "reference_view": "first",
+                                     "confidence_percentile": "65", "max_points": "3",
+                                     "cameras": String(decoding: document, as: UTF8.self)] : [:]
+            let api = try APIServerContract.multiViewGeometryPlan(from: Self.form(fields))
+            let images = ["/input-0.png", "/input-1.png"]
+            let args = images + ["--output", "/output", "--model", api.modelID]
+                + (explicit ? ["--process-resolution", "112", "--reference-view", "first",
+                               "--confidence-percentile", "65", "--max-points", "3", "--cameras", cameraURL.path] : [])
+            let cli = try VisionGeometryMultiView.parse(args).makeGenerationRequest()
+            XCTAssertEqual(cli, api.request(imageURLs: images.map { URL(fileURLWithPath: $0) },
+                                           outputDirectory: URL(fileURLWithPath: "/output")))
+        }
+    }
+
+    func testInvalidSettingsAndCombinedViewBudgetFailBeforeInputAccess() throws {
+        for fields in [["process_resolution": "13"], ["process_resolution": "1009"],
+                       ["confidence_percentile": "nan"], ["confidence_percentile": "101"], ["max_points": "0"]] {
+            XCTAssertThrowsError(try APIServerContract.multiViewGeometryPlan(from: Self.form(fields)))
+        }
+        XCTAssertThrowsError(try DepthAnything3GenerationSettings(processResolution: 1008).validate(viewCount: 16))
+        XCTAssertThrowsError(try DepthAnything3GenerationSettings(knownCameras: [Self.camera(index: 0)]).validate(viewCount: 2))
+        XCTAssertThrowsError(try APIServerContract.multiViewGeometryPlan(from: Self.form(["model": "/custom/model"])))
+    }
+
+    func testCameraDimensionsAreRecheckedAgainstCurrentImages() async throws {
+        let original = try Self.request()
+        defer { try? FileManager.default.removeItem(at: original.imageURLs[0].deletingLastPathComponent()) }
+        let request = DepthAnything3GenerationRequest(
+            imageURLs: original.imageURLs, outputDirectory: original.outputDirectory,
+            settings: try DepthAnything3GenerationSettings(knownCameras: (0..<2).map { try Self.camera(index: $0) })
+        )
+        try DepthAnything3GenerationOperation.prepare(request)
+        try MediaImageIO.writePNG(try MediaImage(width: 3, height: 2, rgba8: Array(repeating: 255, count: 24)),
+                                 to: request.imageURLs[1])
+        do {
+            _ = try await DepthAnything3GenerationOperation.execute(request, makeRuntime: {
+                XCTFail("Camera dimensions must fail before runtime construction")
+                return .init(generate: { _, _ in throw Expected.failure }, unload: {})
+            })
+            XCTFail("Expected camera/image mismatch")
+        } catch DepthAnything3PreprocessingError.cameraImageDimensionMismatch(let index, _, _, _, _) {
+            XCTAssertEqual(index, 1)
+        }
+        XCTAssertFalse(FileManager.default.fileExists(atPath: request.outputDirectory.path))
+    }
+
+    func testExecutionRechecksInputBeforeRuntimePreparation() async throws {
+        let request = try Self.request()
+        defer { try? FileManager.default.removeItem(at: request.imageURLs[0].deletingLastPathComponent()) }
+        try DepthAnything3GenerationOperation.prepare(request)
+        try Data("invalid replacement".utf8).write(to: request.imageURLs[0])
+        do {
+            _ = try await DepthAnything3GenerationOperation.execute(request, prepareRuntime: {
+                XCTFail("Changed input must fail before runtime preparation")
+            }, makeRuntime: {
+                XCTFail("Changed input must fail before construction")
+                return .init(generate: { _, _ in throw Expected.failure }, unload: {})
+            })
+            XCTFail("Expected image validation failure")
+        } catch { XCTAssertFalse(error is Expected) }
+        XCTAssertFalse(FileManager.default.fileExists(atPath: request.outputDirectory.path))
+    }
+
+    func testGenerationAndExportFailuresAwaitOneUnloadWithinAdmission() async throws {
+        for failureStage in ["none", "generation", "export"] {
+            let request = try Self.request()
+            defer { try? FileManager.default.removeItem(at: request.imageURLs[0].deletingLastPathComponent()) }
+            let trace = DepthAnything3OperationTrace()
+            let admission = RuntimeRequestAdmission(maxActiveRequests: 1)
+            let runtime = DepthAnything3GenerationOperation.Runtime(generate: { actual, _ in
+                XCTAssertEqual(actual, request)
+                await trace.record("generate")
+                if failureStage == "generation" { throw Expected.failure }
+                return try DepthAnything3GenerationOperationTests.fixtureResult(actual, invalidFocal: failureStage == "export")
+            }, unload: {
+                let state = await admission.snapshot()
+                XCTAssertEqual(state.activeRequests, 1)
+                await Task.yield()
+                await trace.record("unload")
+            })
+            do {
+                let result = try await withVFXRequestAdmission(using: admission) {
+                    try await DepthAnything3GenerationOperation.execute(request, makeRuntime: { runtime })
+                }
+                XCTAssertEqual(failureStage, "none")
+                XCTAssertLessThanOrEqual(result.export.manifest.pointCount, request.settings.export.maximumPointCount)
+                XCTAssertEqual(result.run.views.count, 2)
+                for artifact in result.export.manifest.artifacts {
+                    let url = request.outputDirectory.appendingPathComponent(artifact.relativePath)
+                    XCTAssertEqual(try ModelArtifactPin.fileSHA256(url), artifact.sha256)
+                }
+            } catch Expected.failure { XCTAssertEqual(failureStage, "generation") }
+            catch is GeometryError { XCTAssertEqual(failureStage, "export") }
+            let events = await trace.events
+            XCTAssertEqual(events, ["generate", "unload"])
+            let state = await admission.snapshot()
+            XCTAssertEqual(state.activeRequests, 0)
+            XCTAssertEqual(state.totalAdmittedRequests, 1)
+            if failureStage != "none" {
+                XCTAssertFalse(FileManager.default.fileExists(atPath: request.outputDirectory.path))
+            }
+        }
+    }
+
+    func testCancellationDuringGenerationOrUnloadCannotReturnSuccess() async throws {
+        for cancelInUnload in [false, true] {
+            let request = try Self.request()
+            defer { try? FileManager.default.removeItem(at: request.imageURLs[0].deletingLastPathComponent()) }
+            let trace = DepthAnything3OperationTrace()
+            let runtime = DepthAnything3GenerationOperation.Runtime(generate: { actual, _ in
+                if !cancelInUnload { withUnsafeCurrentTask { $0?.cancel() } }
+                return try DepthAnything3GenerationOperationTests.fixtureResult(actual)
+            }, unload: {
+                if cancelInUnload { withUnsafeCurrentTask { $0?.cancel() } }
+                await trace.record("unload")
+            })
+            let task = Task { @Sendable in
+                try await DepthAnything3GenerationOperation.execute(request, makeRuntime: { runtime })
+            }
+            do { _ = try await task.value; XCTFail("Cancellation must propagate") }
+            catch is CancellationError {}
+            let events = await trace.events
+            XCTAssertEqual(events, ["unload"])
+        }
+    }
+
+    private static func form(_ fields: [String: String]) -> MultipartFormData {
+        MultipartFormData(parts: fields.map {
+            .init(name: $0.key, filename: nil, contentType: nil, body: Data($0.value.utf8))
+        } + (0..<2).map { index in
+            .init(name: "image[]", filename: "input-\(index).png", contentType: "image/png", body: Data([1]))
+        })
+    }
+
+    private static func request() throws -> DepthAnything3GenerationRequest {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent("da3-operation-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let images = try (0..<2).map { index in
+            let url = root.appendingPathComponent("input-\(index).png")
+            try MediaImageIO.writePNG(try MediaImage(width: 2, height: 2, rgba8: Array(repeating: 255, count: 16)), to: url)
+            return url
+        }
+        return DepthAnything3GenerationRequest(
+            imageURLs: images, outputDirectory: root.appendingPathComponent("output"),
+            settings: try DepthAnything3GenerationSettings(maximumPointCount: 3)
+        )
+    }
+
+    private static func camera(index: Int) throws -> DepthAnything3KnownCamera {
+        DepthAnything3KnownCamera(
+            intrinsics: GeometryCameraIntrinsics(imageWidth: 2, imageHeight: 2, normalizedFX: 1, normalizedFY: 1),
+            extrinsics: try GeometryCameraExtrinsics(rotation: [1, 0, 0, 0, 1, 0, 0, 0, 1], translation: [Double(index), 0, 0])
+        )
+    }
+
+    private static func fixtureResult(
+        _ request: DepthAnything3GenerationRequest, invalidFocal: Bool = false
+    ) throws -> DepthAnything3RunResult {
+        let image = try MediaImage(width: 2, height: 2, rgba8: Array(repeating: 255, count: 16))
+        let intrinsics = GeometryCameraIntrinsics(
+            imageWidth: 2, imageHeight: 2, normalizedFX: invalidFocal ? 0 : 1, normalizedFY: invalidFocal ? 0 : 1
+        )
+        let views = try request.imageURLs.enumerated().map { index, source in
+            let extrinsics = try Self.camera(index: index).extrinsics
+            return DepthAnything3ViewResult(
+                index: index, sourceURL: source, inputIdentity: try DepthAnything3InputIdentity.capture(source),
+                sourceImage: image, processedImage: image,
+                preprocessingPlan: DepthAnything3PreprocessingPlan(
+                    sourceWidth: 2, sourceHeight: 2, processResolution: 504,
+                    boundaryWidth: 504, boundaryHeight: 504, divisibleWidth: 504, divisibleHeight: 504,
+                    batchCropLeft: 0, batchCropTop: 0, processedWidth: 2, processedHeight: 2
+                ),
+                depth: [1, 2, 3, 4], confidence: [1, 1, 1, 1], intrinsics: intrinsics, extrinsics: extrinsics,
+                predictedIntrinsics: intrinsics, predictedExtrinsics: extrinsics, suppliedCamera: nil
+            )
+        }
+        return DepthAnything3RunResult(
+            views: views, checkpoint: checkpoint(root: request.outputDirectory), referenceViewStrategy: .saddleBalanced,
+            cameraSemantics: .predictedRelative, cameraScaleAlignment: "predicted-relative", depthScaleDivisor: 1,
+            processResolution: 504, checkpointVerificationSeconds: 0, decodingSeconds: 0,
+            preprocessingSeconds: 0, modelLoadSeconds: 0, inferenceSeconds: 0, postprocessingSeconds: 0
+        )
+    }
+
+    private static func checkpoint(root: URL) -> DepthAnything3Checkpoint {
+        DepthAnything3Checkpoint(
+            modelID: "vision-geometry-da3-small",
+            repository: "depth-anything/DA3-SMALL",
+            revision: String(repeating: "a", count: 40),
+            sourceRepository: "ByteDance-Seed/Depth-Anything-3",
+            sourceRevision: String(repeating: "b", count: 40),
+            license: "Apache-2.0",
+            rootURL: root,
+            weightsURL: root.appendingPathComponent("model.safetensors"),
+            configurationURL: root.appendingPathComponent("config.json"),
+            weightsByteCount: 137_248_940,
+            weightsSHA256: String(repeating: "c", count: 64),
+            configurationByteCount: 1_202,
+            configurationSHA256: String(repeating: "d", count: 64)
+        )
+    }
+
+}
+
+private actor DepthAnything3OperationTrace {
+    var events: [String] = []
+    func record(_ event: String) { events.append(event) }
+}

--- a/Tests/MereRunCLITests/InstantMeshGenerationOperationTests.swift
+++ b/Tests/MereRunCLITests/InstantMeshGenerationOperationTests.swift
@@ -1,0 +1,232 @@
+import Foundation
+import MediaIO
+import XCTest
+@testable import MereRunCore
+@testable import MereRunCLI
+
+final class InstantMeshGenerationOperationTests: XCTestCase {
+    private enum Expected: Error { case failure }
+
+    func testCLIAndAPIShareDefaultsAndOrderedSuppliedCameras() throws {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        for explicit in [false, true] {
+            let cameras = try InstantMeshCameraRig.official(viewCount: 4)
+            let document = try JSONEncoder().encode(InstantMeshCameraDocument(schemaVersion: 1, cameras: cameras))
+            let cameraURL = root.appendingPathComponent("cameras.json")
+            try document.write(to: cameraURL)
+            let fields = explicit ? ["resolution": "16", "vertex_colors": "false",
+                                     "cameras": String(decoding: document, as: UTF8.self)] : [:]
+            let api = try APIServerContract.instantMeshPlan(from: Self.form(fields))
+            let views = (0..<4).map { "/input-\($0).png" }
+            let cli = try ImageReconstruct3DMultiview.makeGenerationRequest(
+                views: views, output: "/output", model: api.modelID,
+                cameras: explicit ? cameraURL.path : nil,
+                resolution: explicit ? 16 : InstantMeshConfiguration.production.gridResolution,
+                noVertexColors: explicit
+            )
+            XCTAssertEqual(cli, api.request(viewURLs: views.map { URL(fileURLWithPath: $0) },
+                                           outputDirectory: URL(fileURLWithPath: "/output")))
+            if explicit { XCTAssertEqual(cli.settings.cameras, cameras) }
+        }
+    }
+
+    func testInvalidResolutionCameraCountAndRowsFailBeforeInputAccess() throws {
+        for resolution in [1, 257, Int.max] {
+            XCTAssertThrowsError(try InstantMeshGenerationSettings(extractionResolution: resolution))
+            XCTAssertThrowsError(try APIServerContract.instantMeshPlan(from: Self.form(["resolution": String(resolution)])))
+        }
+        let cameras = try InstantMeshCameraRig.official(viewCount: 4)
+        XCTAssertThrowsError(try InstantMeshGenerationSettings(cameras: cameras).validate(viewCount: 6))
+        XCTAssertThrowsError(try InstantMeshGenerationSettings(cameras: [[Float](repeating: 0, count: 15)]))
+        XCTAssertThrowsError(try InstantMeshGenerationSettings(cameras: [[Float](repeating: .nan, count: 16)]))
+        XCTAssertThrowsError(try InstantMeshGenerationSettings().validate(viewCount: 5))
+        XCTAssertThrowsError(try APIServerContract.instantMeshPlan(from: Self.form(["model": "/custom/model"])))
+    }
+
+    func testPreparationPreservesViewOrderAndCreatesNoOutput() throws {
+        let request = try Self.request()
+        defer { try? FileManager.default.removeItem(at: request.viewURLs[0].deletingLastPathComponent()) }
+        XCTAssertEqual(try InstantMeshGenerationOperation.prepare(request).map(\.width), [2, 3, 4, 5])
+        XCTAssertFalse(FileManager.default.fileExists(atPath: request.outputDirectory.path))
+    }
+
+    func testExecutionRechecksInputBeforeRuntimePreparation() async throws {
+        let request = try Self.request()
+        defer { try? FileManager.default.removeItem(at: request.viewURLs[0].deletingLastPathComponent()) }
+        _ = try InstantMeshGenerationOperation.prepare(request)
+        try Data("invalid replacement".utf8).write(to: request.viewURLs[0])
+        do {
+            _ = try await InstantMeshGenerationOperation.execute(request, prepareRuntime: {
+                XCTFail("Changed input must fail before runtime preparation")
+            }, makeRuntime: {
+                XCTFail("Changed input must fail before construction")
+                return .init(generate: { _, _ in throw Expected.failure }, unload: {})
+            })
+            XCTFail("Expected image validation failure")
+        } catch { XCTAssertFalse(error is Expected) }
+        XCTAssertFalse(FileManager.default.fileExists(atPath: request.outputDirectory.path))
+    }
+
+    func testSuccessAndFailureAwaitOneUnloadWithinAdmission() async throws {
+        for fail in [false, true] {
+            let request = try Self.request()
+            defer { try? FileManager.default.removeItem(at: request.viewURLs[0].deletingLastPathComponent()) }
+            let trace = InstantMeshOperationTrace()
+            let admission = RuntimeRequestAdmission(maxActiveRequests: 1)
+            let runtime = InstantMeshGenerationOperation.Runtime(generate: { actual, _ in
+                XCTAssertEqual(actual, request)
+                await trace.record("generate")
+                if fail { throw Expected.failure }
+                return try InstantMeshGenerationOperationTests.fixtureResult(actual)
+            }, unload: {
+                let state = await admission.snapshot()
+                XCTAssertEqual(state.activeRequests, 1)
+                await Task.yield()
+                await trace.record("unload")
+            })
+            do {
+                let result = try await withVFXRequestAdmission(using: admission) {
+                    try await InstantMeshGenerationOperation.execute(request, makeRuntime: { runtime })
+                }
+                XCTAssertFalse(fail)
+                for artifact in result.runManifest.manifest.artifacts {
+                    let url = request.outputDirectory.appendingPathComponent(artifact.relativePath)
+                    XCTAssertEqual(try ModelArtifactPin.fileSHA256(url), artifact.sha256)
+                }
+            } catch Expected.failure { XCTAssertTrue(fail) }
+            let events = await trace.events
+            XCTAssertEqual(events, ["generate", "unload"])
+            let state = await admission.snapshot()
+            XCTAssertEqual(state.activeRequests, 0)
+            XCTAssertEqual(state.totalAdmittedRequests, 1)
+        }
+    }
+
+    func testCancellationDuringGenerationOrUnloadCannotReturnSuccess() async throws {
+        for cancelInUnload in [false, true] {
+            let request = try Self.request()
+            defer { try? FileManager.default.removeItem(at: request.viewURLs[0].deletingLastPathComponent()) }
+            let trace = InstantMeshOperationTrace()
+            let runtime = InstantMeshGenerationOperation.Runtime(generate: { actual, _ in
+                if !cancelInUnload { withUnsafeCurrentTask { $0?.cancel() } }
+                return try InstantMeshGenerationOperationTests.fixtureResult(actual)
+            }, unload: {
+                if cancelInUnload { withUnsafeCurrentTask { $0?.cancel() } }
+                await trace.record("unload")
+            })
+            let task = Task { @Sendable in
+                try await InstantMeshGenerationOperation.execute(request, makeRuntime: { runtime })
+            }
+            do { _ = try await task.value; XCTFail("Cancellation must propagate") }
+            catch is CancellationError {}
+            let events = await trace.events
+            XCTAssertEqual(events, ["unload"])
+        }
+    }
+
+    private static func form(_ fields: [String: String]) -> MultipartFormData {
+        MultipartFormData(parts: fields.map {
+            .init(name: $0.key, filename: nil, contentType: nil, body: Data($0.value.utf8))
+        } + (0..<4).map { index in
+            .init(name: "image[]", filename: "input-\(index).png", contentType: "image/png", body: Data([1]))
+        })
+    }
+
+    private static func request() throws -> InstantMeshGenerationRequest {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent("instantmesh-operation-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let views = try (0..<4).map { index in
+            let image = root.appendingPathComponent("input-\(index).png")
+            let width = index + 2
+            try MediaImageIO.writePNG(
+                try MediaImage(width: width, height: 2, rgba8: Array(repeating: 255, count: width * 8)), to: image
+            )
+            return image
+        }
+        return InstantMeshGenerationRequest(viewURLs: views, outputDirectory: root.appendingPathComponent("output"),
+                                           settings: try InstantMeshGenerationSettings())
+    }
+
+    private static func fixtureResult(_ request: InstantMeshGenerationRequest) throws -> InstantMeshRunResult {
+        let checkpoint = checkpoint(root: request.outputDirectory)
+        let mesh = try MeshAsset(
+            vertices: [0, 0, 0, 1, 0, 0, 0, 1, 0],
+            indices: [0, 1, 2],
+            normals: [0, 0, 1, 0, 0, 1, 0, 0, 1],
+            colorsRGBA8: [255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255],
+            inferredUnseenGeometry: true
+        )
+        let inputs = request.viewURLs
+        let export = try InstantMeshAssetExporter.export(
+            mesh: mesh,
+            inputURLs: inputs,
+            checkpoint: checkpoint,
+            outputDirectory: request.outputDirectory,
+            stem: "object",
+            createdAt: Date(timeIntervalSince1970: 0)
+        )
+        let dimensions = (0..<4).map { _ in InstantMeshSourceDimensions(width: 640, height: 480) }
+        let prepared = (0..<4).map { _ in InstantMeshSourceDimensions(width: 320, height: 320) }
+        let cameras = try InstantMeshCameraRig.official(viewCount: 4)
+        let runManifest = try InstantMeshRunManifestExporter.export(
+            meshExport: export,
+            checkpoint: checkpoint,
+            inputURLs: inputs,
+            sourceDimensions: dimensions,
+            preparedDimensions: prepared,
+            cameraValues: cameras,
+            usedOfficialCameraRig: true,
+            extractionResolution: 128,
+            includesVertexColors: true,
+            upstreamEmptyFieldRepairApplied: false
+        )
+        return InstantMeshRunResult(
+            export: export,
+            runManifest: runManifest,
+            checkpoint: checkpoint,
+            sourceDimensions: dimensions,
+            viewCount: 4,
+            usedOfficialCameraRig: true,
+            extractionResolution: 128,
+            includesVertexColors: true,
+            upstreamEmptyFieldRepairApplied: false,
+            checkpointVerificationSeconds: 0.1,
+            decodingSeconds: 0.2,
+            preprocessingSeconds: 0.3,
+            modelLoadSeconds: 0.4,
+            sceneEncodingSeconds: 0.5,
+            meshExtractionSeconds: 0.6,
+            exportSeconds: 0.7
+        )
+
+    }
+
+    private static func checkpoint(root: URL) -> InstantMeshCheckpoint {
+        InstantMeshCheckpoint(
+            modelID: ModelResolver.ModelID.image3DInstantMeshBase.rawValue,
+            repository: "TencentARC/InstantMesh",
+            revision: "b785b4ecfb6636ef34a08c748f96f6a5686244d0",
+            sourceRepository: "TencentARC/InstantMesh",
+            sourceRevision: "08822c52fdc399b93ea00e4fa9e596344ed52ccc",
+            license: "Apache-2.0 reconstruction weights; view generation excluded",
+            format: .convertedSafetensors,
+            rootURL: root,
+            weightsURL: root.appendingPathComponent("model.safetensors"),
+            configurationURL: root.appendingPathComponent("config.json"),
+            sourceManifestURL: root.appendingPathComponent("SOURCE.json"),
+            weightsByteCount: 1_253_463_832,
+            weightsSHA256: "2380601d17f6a817de0bf5328188ccea397af9d75c07b4b3cc476322dcca76af",
+            sourceSHA256: "22701cd25201d624ebb1568b93cf91b43a2c32006835c08fe73e1f3c9f6c44b5",
+            configurationSHA256: "33f89581172ab2d46759a1632b6e57ca9f9f1c6c23567468157cb4b48a3bc781",
+            sourceManifestSHA256: "9fbda0d3875744353a4ca6ee9ee836182cb46f72aa0d241c30ee62b746d60061",
+            viewGenerationIncluded: false
+        )
+    }
+}
+
+private actor InstantMeshOperationTrace {
+    var events: [String] = []
+    func record(_ event: String) { events.append(event) }
+}

--- a/Tests/MereRunCLITests/TripoSRGenerationOperationTests.swift
+++ b/Tests/MereRunCLITests/TripoSRGenerationOperationTests.swift
@@ -1,0 +1,208 @@
+import Foundation
+import MediaIO
+import XCTest
+@testable import MereRunCore
+@testable import MereRunCLI
+
+final class TripoSRGenerationOperationTests: XCTestCase {
+    private enum Expected: Error { case failure }
+
+    func testCLIAndAPIShareDefaultAndExplicitSettings() throws {
+        for explicit in [false, true] {
+            let fields = explicit ? ["resolution": "32", "density_threshold": "18", "foreground_ratio": "0.9",
+                                     "already_framed": "true", "vertex_colors": "false"] : [:]
+            let api = try APIServerContract.imageTo3DPlan(from: Self.form(fields))
+            let cli = try VisionImageTo3D.makeGenerationRequest(
+                input: "/input.png", output: "/output", model: api.modelID,
+                resolution: explicit ? 32 : TripoSRGenerationSettings.defaultResolution,
+                densityThreshold: explicit ? 18 : TripoSRConfiguration.production.densityThreshold,
+                foregroundRatio: explicit ? 0.9 : TripoSRGenerationSettings.defaultForegroundRatio,
+                alreadyFramed: explicit, noVertexColors: explicit
+            )
+            XCTAssertEqual(cli, api.request(imageURL: URL(fileURLWithPath: "/input.png"),
+                                            outputDirectory: URL(fileURLWithPath: "/output")))
+        }
+    }
+
+    func testInvalidSettingsFailBeforeInputAccessIncludingUnusedRatio() throws {
+        for fields in [["resolution": "1"], ["resolution": "513"], ["density_threshold": "nan"],
+                       ["foreground_ratio": "0"], ["foreground_ratio": "inf", "already_framed": "true"]] {
+            XCTAssertThrowsError(try APIServerContract.imageTo3DPlan(from: Self.form(fields)))
+        }
+        XCTAssertThrowsError(try TripoSRGenerationSettings(extractionResolution: Int.max))
+        XCTAssertThrowsError(try TripoSRGenerationSettings(densityThreshold: .infinity))
+        XCTAssertThrowsError(try TripoSRGenerationSettings(foregroundRatio: .nan, alreadyFramed: true))
+        XCTAssertThrowsError(try APIServerContract.imageTo3DPlan(from: Self.form(["model": "/custom/model"])))
+    }
+
+    func testExecutionRechecksInputBeforeRuntimePreparation() async throws {
+        let request = try Self.request()
+        defer { try? FileManager.default.removeItem(at: request.imageURL.deletingLastPathComponent()) }
+        _ = try TripoSRGenerationOperation.prepare(request)
+        try Data("invalid replacement".utf8).write(to: request.imageURL)
+        do {
+            _ = try await TripoSRGenerationOperation.execute(request, prepareRuntime: {
+                XCTFail("Changed input must fail before runtime preparation")
+            }, makeRuntime: {
+                XCTFail("Changed input must fail before construction")
+                return .init(generate: { _, _ in throw Expected.failure }, unload: {})
+            })
+            XCTFail("Expected image validation failure")
+        } catch { XCTAssertFalse(error is Expected) }
+        XCTAssertFalse(FileManager.default.fileExists(atPath: request.outputDirectory.path))
+    }
+
+    func testSuccessAndFailureAwaitOneUnloadWithinAdmission() async throws {
+        for fail in [false, true] {
+            let request = try Self.request()
+            defer { try? FileManager.default.removeItem(at: request.imageURL.deletingLastPathComponent()) }
+            let trace = TripoSROperationTrace()
+            let admission = RuntimeRequestAdmission(maxActiveRequests: 1)
+            let runtime = TripoSRGenerationOperation.Runtime(generate: { actual, _ in
+                XCTAssertEqual(actual, request)
+                await trace.record("generate")
+                if fail { throw Expected.failure }
+                return try TripoSRGenerationOperationTests.fixtureResult(actual)
+            }, unload: {
+                let state = await admission.snapshot()
+                XCTAssertEqual(state.activeRequests, 1)
+                await Task.yield()
+                await trace.record("unload")
+            })
+            do {
+                let result = try await withVFXRequestAdmission(using: admission) {
+                    try await TripoSRGenerationOperation.execute(request, makeRuntime: { runtime })
+                }
+                XCTAssertFalse(fail)
+                for artifact in result.runManifest.manifest.artifacts {
+                    let url = request.outputDirectory.appendingPathComponent(artifact.relativePath)
+                    XCTAssertEqual(try ModelArtifactPin.fileSHA256(url), artifact.sha256)
+                }
+            } catch Expected.failure { XCTAssertTrue(fail) }
+            let events = await trace.events
+            XCTAssertEqual(events, ["generate", "unload"])
+            let state = await admission.snapshot()
+            XCTAssertEqual(state.activeRequests, 0)
+            XCTAssertEqual(state.totalAdmittedRequests, 1)
+        }
+    }
+
+    func testCancellationDuringGenerationOrUnloadCannotReturnSuccess() async throws {
+        for cancelInUnload in [false, true] {
+            let request = try Self.request()
+            defer { try? FileManager.default.removeItem(at: request.imageURL.deletingLastPathComponent()) }
+            let trace = TripoSROperationTrace()
+            let runtime = TripoSRGenerationOperation.Runtime(generate: { actual, _ in
+                if !cancelInUnload { withUnsafeCurrentTask { $0?.cancel() } }
+                return try TripoSRGenerationOperationTests.fixtureResult(actual)
+            }, unload: {
+                if cancelInUnload { withUnsafeCurrentTask { $0?.cancel() } }
+                await trace.record("unload")
+            })
+            let task = Task { @Sendable in
+                try await TripoSRGenerationOperation.execute(request, makeRuntime: { runtime })
+            }
+            do { _ = try await task.value; XCTFail("Cancellation must propagate") }
+            catch is CancellationError {}
+            let events = await trace.events
+            XCTAssertEqual(events, ["unload"])
+        }
+    }
+
+    private static func form(_ fields: [String: String]) -> MultipartFormData {
+        MultipartFormData(parts: fields.map {
+            .init(name: $0.key, filename: nil, contentType: nil, body: Data($0.value.utf8))
+        } + [.init(name: "image", filename: "input.png", contentType: "image/png", body: Data([1]))])
+    }
+
+    private static func request() throws -> TripoSRGenerationRequest {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent("triposr-operation-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let image = root.appendingPathComponent("input.png")
+        try MediaImageIO.writePNG(try MediaImage(width: 2, height: 2, rgba8: Array(repeating: 255, count: 16)), to: image)
+        return TripoSRGenerationRequest(imageURL: image, outputDirectory: root.appendingPathComponent("output"),
+                                       settings: try TripoSRGenerationSettings())
+    }
+
+    private static func fixtureResult(_ request: TripoSRGenerationRequest) throws -> TripoSRRunResult {
+        let mesh = try MeshAsset(
+            vertices: [0, 0, 0, 1, 0, 0, 0, 1, 0],
+            indices: [0, 1, 2],
+            normals: [0, 0, 1, 0, 0, 1, 0, 0, 1],
+            colorsRGBA8: [255, 0, 0, 255, 0, 255, 0, 255, 0, 0, 255, 255],
+            inferredUnseenGeometry: true
+        )
+        let inputURL = request.imageURL
+        let checkpoint = checkpoint()
+        let export = try TripoSRAssetExporter.export(
+            mesh: mesh,
+            inputURL: inputURL,
+            checkpoint: checkpoint,
+            outputDirectory: request.outputDirectory,
+            stem: "chair",
+            createdAt: Date(timeIntervalSince1970: 0)
+        )
+        let runManifest = try TripoSRRunManifestExporter.export(
+            meshExport: export,
+            checkpoint: checkpoint,
+            inputURL: inputURL,
+            sourceWidth: 640,
+            sourceHeight: 480,
+            preparedWidth: 512,
+            preparedHeight: 512,
+            foregroundPolicy: "automatic-transparent-alpha",
+            foregroundRatio: 0.85,
+            croppedTransparentForeground: true,
+            extractionResolution: 256,
+            densityThreshold: 25,
+            includesVertexColors: true
+        )
+        return TripoSRRunResult(
+            export: export,
+            runManifest: runManifest,
+            checkpoint: checkpoint,
+            sourceWidth: 640,
+            sourceHeight: 480,
+            preparedWidth: 512,
+            preparedHeight: 512,
+            foregroundPolicy: "automatic-transparent-alpha",
+            foregroundRatio: 0.85,
+            croppedTransparentForeground: true,
+            extractionResolution: 256,
+            densityThreshold: 25,
+            includesVertexColors: true,
+            checkpointVerificationSeconds: 0.1,
+            decodingSeconds: 0.2,
+            preprocessingSeconds: 0.3,
+            modelLoadSeconds: 0.4,
+            sceneEncodingSeconds: 0.5,
+            meshExtractionSeconds: 0.6,
+            exportSeconds: 0.7
+        )
+
+    }
+
+    private static func checkpoint() -> TripoSRCheckpoint {
+        TripoSRCheckpoint(
+            modelID: ModelResolver.ModelID.image3DTripoSR.rawValue,
+            repository: "stabilityai/TripoSR",
+            revision: "5b521936b01fbe1890f6f9baed0254ab6351c04a",
+            sourceRepository: "VAST-AI-Research/TripoSR",
+            sourceRevision: "107cefdc244c39106fa830359024f6a2f1c78871",
+            license: "MIT",
+            format: .pinnedPyTorch,
+            rootURL: URL(fileURLWithPath: "/tmp/triposr"),
+            weightsURL: URL(fileURLWithPath: "/tmp/triposr/model.ckpt"),
+            configurationURL: URL(fileURLWithPath: "/tmp/triposr/config.yaml"),
+            weightsByteCount: 1_677_246_742,
+            weightsSHA256: "429e2c6b22a0923967459de24d67f05962b235f79cde6b032aa7ed2ffcd970ee",
+            sourceSHA256: "429e2c6b22a0923967459de24d67f05962b235f79cde6b032aa7ed2ffcd970ee",
+            configurationSHA256: "74ca708ce086bf68e97709ea6b3d91f14717921c04691e84043f0eb8fcc68e62"
+        )
+    }
+}
+
+private actor TripoSROperationTrace {
+    var events: [String] = []
+    func record(_ event: String) { events.append(event) }
+}

--- a/Tests/MereRunCLITests/VideoDepthAnythingGenerationOperationTests.swift
+++ b/Tests/MereRunCLITests/VideoDepthAnythingGenerationOperationTests.swift
@@ -1,0 +1,169 @@
+import Foundation
+import XCTest
+@testable import MereRunCore
+@testable import MereRunCLI
+
+final class VideoDepthAnythingGenerationOperationTests: XCTestCase {
+    private enum Expected: Error { case failure }
+
+    func testCLIAndAPIShareDefaultsAndMetricModelPolicy() throws {
+        for explicit in [false, true] {
+            let model = explicit ? "vision-depth-vda-small-metric" : "vision-depth-vda-small"
+            let fields = explicit ? ["model": model, "input_size": "112", "max_frames": "2"] : [:]
+            let api = try APIServerContract.depthVideoPlan(from: Self.form(fields))
+            let args = ["/input.mp4", "--output", "/output", "--model", model]
+                + (explicit ? ["--input-size", "112", "--max-frames", "2"] : [])
+            let cli = try VisionDepthVideo.parse(args).makeGenerationRequest()
+            XCTAssertEqual(cli, api.request(videoURL: URL(fileURLWithPath: "/input.mp4"),
+                                           outputDirectory: URL(fileURLWithPath: "/output")))
+        }
+        XCTAssertEqual(try VideoDepthAnythingGenerationSettings().maximumFrameCount, 240)
+        XCTAssertThrowsError(try APIServerContract.depthVideoPlan(from: Self.form(["model": "/custom/model"])))
+        let custom = try VisionDepthVideo.parse(["input.mp4", "--model", "/custom/model"]).makeGenerationRequest()
+        XCTAssertEqual(custom.model, "/custom/model")
+    }
+
+    func testInvalidLimitsFailBeforeInputAccess() throws {
+        for fields in [["input_size": "13"], ["input_size": "1009"], ["max_frames": "0"], ["max_frames": "2401"]] {
+            XCTAssertThrowsError(try APIServerContract.depthVideoPlan(from: Self.form(fields)))
+        }
+        XCTAssertThrowsError(try VideoDepthAnythingGenerationSettings(inputSize: Int.max))
+        XCTAssertThrowsError(try VideoDepthAnythingGenerationSettings(maximumFrameCount: Int.max))
+    }
+
+    func testExecutionRechecksDeletedOrOversizedFileBeforeRuntimePreparation() async throws {
+        for oversized in [false, true] {
+            let request = try Self.request()
+            defer { try? FileManager.default.removeItem(at: request.videoURL.deletingLastPathComponent()) }
+            try VideoDepthAnythingGenerationOperation.prepare(request)
+            if oversized {
+                let handle = try FileHandle(forWritingTo: request.videoURL)
+                try handle.truncate(atOffset: UInt64(VideoDepthAnythingLimits.maximumEncodedVideoBytes) + 1)
+                try handle.close()
+            } else {
+                try FileManager.default.removeItem(at: request.videoURL)
+            }
+            do {
+                _ = try await VideoDepthAnythingGenerationOperation.execute(request, prepareRuntime: {
+                    XCTFail("Changed file must fail before runtime preparation")
+                }, makeRuntime: {
+                    XCTFail("Changed file must fail before construction")
+                    return .init(generate: { _, _ in throw Expected.failure }, unload: {})
+                })
+                XCTFail("Expected file validation failure")
+            } catch {
+                if oversized { XCTAssertTrue(error is VFXImageInputValidationError) }
+                else { XCTAssertTrue(error is VideoDepthAnythingGeneratorError) }
+            }
+            XCTAssertFalse(FileManager.default.fileExists(atPath: request.outputDirectory.path))
+        }
+    }
+
+    func testSuccessAndFailureAwaitOneUnloadWithinAdmission() async throws {
+        for fail in [false, true] {
+            let request = try Self.request()
+            defer { try? FileManager.default.removeItem(at: request.videoURL.deletingLastPathComponent()) }
+            let trace = VideoDepthAnythingOperationTrace()
+            let admission = RuntimeRequestAdmission(maxActiveRequests: 1)
+            let runtime = VideoDepthAnythingGenerationOperation.Runtime(generate: { actual, _ in
+                XCTAssertEqual(actual, request)
+                await trace.record("generate")
+                if fail { throw Expected.failure }
+                return try VideoDepthAnythingGenerationOperationTests.fixtureResult(actual)
+            }, unload: {
+                let state = await admission.snapshot()
+                XCTAssertEqual(state.activeRequests, 1)
+                await Task.yield()
+                await trace.record("unload")
+            })
+            do {
+                let result = try await withVFXRequestAdmission(using: admission) {
+                    try await VideoDepthAnythingGenerationOperation.execute(request, makeRuntime: { runtime })
+                }
+                XCTAssertFalse(fail)
+                for artifact in result.export.manifest.frames.flatMap(\.artifacts) {
+                    let url = request.outputDirectory.appendingPathComponent(artifact.relativePath)
+                    XCTAssertEqual(try ModelArtifactPin.fileSHA256(url), artifact.sha256)
+                }
+            } catch Expected.failure { XCTAssertTrue(fail) }
+            let events = await trace.events
+            XCTAssertEqual(events, ["generate", "unload"])
+            let state = await admission.snapshot()
+            XCTAssertEqual(state.activeRequests, 0)
+            XCTAssertEqual(state.totalAdmittedRequests, 1)
+        }
+    }
+
+    func testCancellationDuringGenerationOrUnloadCannotReturnSuccess() async throws {
+        for cancelInUnload in [false, true] {
+            let request = try Self.request()
+            defer { try? FileManager.default.removeItem(at: request.videoURL.deletingLastPathComponent()) }
+            let trace = VideoDepthAnythingOperationTrace()
+            let runtime = VideoDepthAnythingGenerationOperation.Runtime(generate: { actual, _ in
+                if !cancelInUnload { withUnsafeCurrentTask { $0?.cancel() } }
+                return try VideoDepthAnythingGenerationOperationTests.fixtureResult(actual)
+            }, unload: {
+                if cancelInUnload { withUnsafeCurrentTask { $0?.cancel() } }
+                await trace.record("unload")
+            })
+            let task = Task { @Sendable in
+                try await VideoDepthAnythingGenerationOperation.execute(request, makeRuntime: { runtime })
+            }
+            do { _ = try await task.value; XCTFail("Cancellation must propagate") }
+            catch is CancellationError {}
+            let events = await trace.events
+            XCTAssertEqual(events, ["unload"])
+        }
+    }
+
+    private static func form(_ fields: [String: String]) -> MultipartFormData {
+        MultipartFormData(parts: fields.map {
+            .init(name: $0.key, filename: nil, contentType: nil, body: Data($0.value.utf8))
+        } + [.init(name: "video", filename: "input.mp4", contentType: "video/mp4", body: Data([1]))])
+    }
+
+    private static func request() throws -> VideoDepthAnythingGenerationRequest {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent("video-depth-operation-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        let video = root.appendingPathComponent("input.mp4")
+        // The injected runtime isolates lifecycle tests from native media decoding.
+        try Data("video fixture identity".utf8).write(to: video)
+        return VideoDepthAnythingGenerationRequest(
+            videoURL: video, outputDirectory: root.appendingPathComponent("output"),
+            settings: try VideoDepthAnythingGenerationSettings()
+        )
+    }
+
+    private static func fixtureResult(_ request: VideoDepthAnythingGenerationRequest) throws -> VideoDepthAnythingRunResult {
+        let checkpoint = VideoDepthAnythingCheckpoint(
+            variant: .relative, format: .pinnedPyTorch, weightsURL: URL(fileURLWithPath: "/fixture/relative.pth"),
+            weightsByteCount: 1, weightsSHA256: String(repeating: "a", count: 64),
+            sourceSHA256: String(repeating: "a", count: 64)
+        )
+        let export = try DepthSequenceArtifactExporter.export(
+            frames: [try DepthSequenceFrame(index: 0, timeSeconds: 0, width: 2, height: 2, depth: [1, 2, 3, 4])],
+            inputURL: request.videoURL, outputDirectory: request.outputDirectory,
+            fps: 24, semantics: .affineRelative,
+            provenance: GeometryModelProvenance(
+                modelID: checkpoint.variant.modelID, upstreamRepository: "fixture",
+                upstreamRevision: "fixture", license: "Apache-2.0"
+            )
+        )
+        let reviewURL = request.outputDirectory.appendingPathComponent("depth-review.mp4")
+        try Data("review fixture".utf8).write(to: reviewURL)
+        let review = VideoDepthReviewArtifact(
+            relativePath: reviewURL.lastPathComponent, byteCount: try ModelArtifactPin.fileByteCount(reviewURL),
+            sha256: try ModelArtifactPin.fileSHA256(reviewURL)
+        )
+        return VideoDepthAnythingRunResult(
+            export: export, reviewVideo: review, checkpoint: checkpoint, sourceFPS: 24, windowCount: 1,
+            checkpointVerificationSeconds: 0, frameExtractionSeconds: 0, modelLoadSeconds: 0,
+            inferenceSeconds: 0, exportSeconds: 0
+        )
+    }
+}
+
+private actor VideoDepthAnythingOperationTrace {
+    var events: [String] = []
+    func record(_ event: String) { events.append(event) }
+}

--- a/Tests/MereRunCoreTests/TripoSRPreprocessorTests.swift
+++ b/Tests/MereRunCoreTests/TripoSRPreprocessorTests.swift
@@ -46,6 +46,11 @@ final class TripoSRPreprocessorTests: MereRunCoreTestCase {
         XCTAssertFalse(result.croppedTransparentForeground)
         XCTAssertEqual(result.preparedWidth, 2)
         XCTAssertEqual(result.image.asArray(Float.self).prefix(3), [1, 0, 0])
+        let tinyRatio = try TripoSRPreprocessor.prepare(
+            image: image, size: 2,
+            foregroundPolicy: .automaticTransparentAlpha(foregroundRatio: .leastNonzeroMagnitude)
+        )
+        XCTAssertEqual(tinyRatio.image.asArray(Float.self), result.image.asArray(Float.self))
     }
 
     func testRejectsNonPositivePublicConditioningSize() throws {
@@ -53,6 +58,31 @@ final class TripoSRPreprocessorTests: MereRunCoreTestCase {
         XCTAssertThrowsError(try TripoSRPreprocessor.prepare(image: image, size: 0)) {
             XCTAssertEqual($0 as? TripoSRPreprocessingError, .invalidImageSize(0))
         }
+    }
+
+    func testTinyForegroundRatiosRejectPaddingBeforeIntegerConversionOrAllocation() throws {
+        let image = try MediaImage(
+            width: 2, height: 2,
+            rgba8: [255, 0, 0, 255, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+        )
+        for ratio: Float in [.leastNonzeroMagnitude, 1e-30, 1 / 8192] {
+            XCTAssertThrowsError(try TripoSRPreprocessor.prepare(
+                image: image, size: 2,
+                foregroundPolicy: .automaticTransparentAlpha(foregroundRatio: ratio)
+            )) {
+                XCTAssertEqual(
+                    $0 as? TripoSRPreprocessingError,
+                    .foregroundPaddingLimitExceeded(maximumSide: 8000)
+                )
+            }
+        }
+    }
+
+    func testForegroundPaddingPreservesTruncationAtTheImageBudgetBoundary() throws {
+        XCTAssertEqual(try TripoSRPreprocessor.foregroundPaddingSize(squareSize: 8000, foregroundRatio: 1), 8000)
+        XCTAssertEqual(try TripoSRPreprocessor.foregroundPaddingSize(squareSize: 8000, foregroundRatio: 0.9999), 8000)
+        XCTAssertThrowsError(try TripoSRPreprocessor.foregroundPaddingSize(squareSize: 8000, foregroundRatio: 0.9998))
+        XCTAssertEqual(try TripoSRPreprocessor.foregroundPaddingSize(squareSize: 2, foregroundRatio: 0.85), 2)
     }
 
     func testAntialiasedBilinearDownsampleMatchesPinnedPyTorchFixture() {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -93,6 +93,14 @@ computation, and geometry export. Read the
 [shared single-image geometry operation](./internals/geometry-generation-operation.md)
 for caller admission, transport policy, cancellation, and validation boundaries.
 
+## Reconstruction and video depth
+
+TripoSR, InstantMesh, Depth Anything 3, and Video Depth Anything use Core
+operations for shared CLI/API settings, preparation, execution, and awaited
+cleanup. DA3 also owns scene export. Read the
+[shared vision generation operations](./internals/vision-generation-operations.md)
+for input snapshots, camera validation, transport policy, and acceptance boundaries.
+
 ## Image families
 
 Read the [shared image operation](./internals/image-generation-operation.md)

--- a/docs/internals/vision-generation-operations.md
+++ b/docs/internals/vision-generation-operations.md
@@ -1,0 +1,73 @@
+# Shared vision generation operations
+
+This guide is for contributors changing reconstruction and video-depth execution.
+Use the Core operation for each family when adding a CLI or API adapter.
+
+The following operations own the shared request and execution decisions:
+
+| Family | Core operation | CLI entry points |
+| --- | --- | --- |
+| TripoSR | `TripoSRGenerationOperation` | `image reconstruct-3d`, `vision image-to-3d` |
+| InstantMesh | `InstantMeshGenerationOperation` | `image reconstruct-3d-multiview`, `vision image-to-3d-multiview` |
+| Video Depth Anything | `VideoDepthAnythingGenerationOperation` | `vision depth-video` |
+| Depth Anything 3 | `DepthAnything3GenerationOperation` | `vision geometry-multiview` |
+
+For MoGe-2 token-grid planning and execution, see the
+[shared single-image geometry operation](./geometry-generation-operation.md).
+
+## Translate requests at the adapter boundary
+
+CLI commands parse flags and camera documents, select output paths, and format
+progress and results. The API parses multipart fields and retains its managed
+model restrictions. Core requests preserve custom CLI model paths and the API's
+managed model IDs; the operation does not expand either adapter's model policy.
+
+Construct the family's immutable settings before execution. TripoSR settings
+validate extraction resolution, density threshold, and foreground ratio.
+InstantMesh settings validate extraction resolution and supplied camera rows;
+preparation checks view and camera counts without changing view order. Video
+depth settings resolve the bounded frame-count default through the native limits.
+DA3 settings combine native view limits, camera conditioning, and the existing
+throwing scene-export configuration.
+
+## Preserve planning and input identity
+
+Image preparation checks current headers and resource limits without loading
+weights or creating output. DA3 also compares supplied camera dimensions with
+the corresponding image. CLI dry-run continues to verify the checkpoint through
+the family's resource resolver.
+
+Video-depth dry-run uses the native bounded snapshot and decode admission. It
+hashes the admitted video, validates decoded and network dimensions, verifies
+the checkpoint, and removes temporary inputs before returning its plan.
+
+Execution rechecks current input state. Each native generator retains its
+immutable snapshots for decoding and provenance; a preceding plan does not
+authorize later bytes. Video-depth execution performs its bounded admission
+once, without first running a second full decode through dry-run.
+
+## Keep resource and transport ownership explicit
+
+Each operation owns one per-request runtime. It awaits unloading after successful
+generation or an error, including scene-export failure. Cancellation is checked
+before construction, at native stage boundaries, and before returning success.
+DA3 scene export runs inside the operation, using the same validated export
+configuration for CLI and API results.
+
+The caller owns admission. HTTP upload cleanup, failed-output cleanup, local
+artifact URLs, retention, and response formatting stay in the API handler.
+Unload completes within the existing request slot; operations do not acquire
+another permit or add a resident model cache.
+
+## Validate behavior at each boundary
+
+Test adapter settings, current-input changes, camera ordering and dimensions,
+generation and export errors, cancellation, awaited unloading, and artifact
+hashes. Compare representative native CLI and API outputs against the same
+checkpoint and input before changing a family. Keep model identities, defaults,
+output schemas, and geometry semantics explicit in those comparisons.
+
+Unit lifecycle tests do not establish cancellation recovery during a GPU kernel
+or actual HTTP disconnect behavior. Native artifact comparisons do not establish
+perceptual quality or performance. A review MP4 can have different container
+creation timestamps even when every decoded frame is identical.

--- a/docs/internals/vision-generation-operations.md
+++ b/docs/internals/vision-generation-operations.md
@@ -24,6 +24,8 @@ managed model IDs; the operation does not expand either adapter's model policy.
 
 Construct the family's immutable settings before execution. TripoSR settings
 validate extraction resolution, density threshold, and foreground ratio.
+Native transparent-foreground preparation also bounds the padded canvas by the
+VFX image budget before converting its size to an integer or allocating it.
 InstantMesh settings validate extraction resolution and supplied camera rows;
 preparation checks view and camera counts without changing view order. Video
 depth settings resolve the bounded frame-count default through the native limits.

--- a/docs/runtime/api-server.md
+++ b/docs/runtime/api-server.md
@@ -899,6 +899,12 @@ and creates a MoGe-2 runtime for each request. It awaits unloading before
 publishing the artifact response. See the
 [shared single-image geometry operation](../internals/geometry-generation-operation.md).
 
+The multiview geometry, TripoSR, InstantMesh, and video-depth routes also share
+Core operations with their CLI commands. The operations await runtime cleanup
+within the API's existing admission slot. HTTP handlers retain upload cleanup,
+failed-output removal, and artifact retention. See
+[shared vision generation operations](../internals/vision-generation-operations.md).
+
 `POST /v1/vision/geometry/multiview` accepts:
 
 - `image` / `image[]`: one or more image file parts; multipart order is the


### PR DESCRIPTION
## Summary

TripoSR, InstantMesh, Video Depth Anything, and Depth Anything 3 now share Core requests and operations across their CLI and API entry points. Shared settings and current-input checks replace adapter-owned decisions; operations own native execution and awaited unloading. DA3 also shares scene export. Adapters retain model restrictions, ordered uploads, admission, artifact retention, and response formats. No package, product, dependency, or vendor changes.

The four migrations are separate commits in this PR. A follow-up correction bounds TripoSR's transparent-foreground canvas before integer conversion or allocation: extremely small positive foreground ratios now return an error instead of overflowing, using the existing VFX image budget. Ordinary padding retains native rounding and output.

## Validation

- [x] `./scripts/check.sh` on `34ad8521`: 4,266 XCTest cases, 314 skips, zero failures; all 51 Swift Testing cases pass.
- [x] Focused tests for shared settings, ordered cameras, changed inputs, generation/export errors, cancellation, awaited unloading inside admission, and artifact hashes. Padding regressions cover floating-point overflow and the image-budget boundary.
- [x] Docs updated and built; Core explicit target dependency import check passes.
- [x] All hosted checks pass on `34ad8521`: Swift, macOS app bundle, Linux CLI, iOS release build/tests/metadata, docs, compatibility docs, and security. PR documentation deployment is skipped as expected.
- Vendored artifacts and package pins are unchanged.

Twelve native before/after pairs cover CLI and first/repeated API execution: TripoSR at resolution 32; four-view InstantMesh at resolution 16; two-frame relative VDA at input size 112; and two-view DA3 at process resolution 112 with 1,000 maximum points. Mesh/depth artifact bytes and normalized manifests, responses, and dry-run output match. VDA review MP4s differ in creation timestamps; decoded frames and other container metadata match.

All 27 invalid HTTP probes return 400 and leave no new upload or output paths, including both excessive-padding cases. The tiny-ratio CLI probe exits with an error without creating its output directory.

These are bounded native compatibility checks. Actual GPU cancellation recovery, HTTP disconnects, performance, perceptual quality, and untested workload variants remain unqualified.
